### PR TITLE
Modifications to force compilation for 32-bit x86-based targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -35,7 +35,8 @@ export AR = $(TARGET)-ar
 
 # Toolchain configuration.
 export CFLAGS    = -I $(INCDIR)
-export CFLAGS   += -ansi
+export CFLAGS   += -m32
+export CFLAGS   += -std=c99 -pedantic-errors
 export CFLAGS   += -nostdlib -nostdinc -fno-builtin -fno-stack-protector
 export CFLAGS   += -Wall -Wextra -Werror
 export CFLAGS   += -D NDEBUG

--- a/src/kernel/makefile
+++ b/src/kernel/makefile
@@ -52,7 +52,7 @@ OBJ = $(ASM_SRC:.S=.o) \
 EXEC = kernel
 
 # Linker configuration options.
-export LDFLAGS = -T arch/$(ARCH)/link.ld
+export LDFLAGS = -m elf_i386 -T arch/$(ARCH)/link.ld
 
 # Builds object file from C source file.
 %.o: %.c


### PR DESCRIPTION
nanvix being a 32-bit x86-based OS, added relevant flags to force compilation & linking for appropriate targets.
