### PR TITLE
Command stack in TSH

### DIFF
--- a/include/dev/tty.h
+++ b/include/dev/tty.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011-2013 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *               2015-2015 Davidson Francis <davidsondfgl@gmail.com>
  *
  * tty.h - tty device driver
  */
@@ -10,6 +11,7 @@
 	/* tty ioctl() commands. */
 	#define TTY_CLEAR 0x54000100 /* Clear console.    */
 	#define TTY_GETS  0x54000201 /* Get tty settings. */
+ 	#define TTY_SETS  0x54000301 /* Set tty settings. */
 
 	/*
 	 * Initializes the tty device driver.

--- a/include/termios.h
+++ b/include/termios.h
@@ -1,5 +1,6 @@
 /*
  * Copyright(C) 2011-2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2015-2015 Davidson Francis <davidsondfgl@gmail.com>
  * 
  * <termios.h> - 
  */
@@ -40,6 +41,17 @@
 	/* Size of c_cc[] */
 	#define NCCS 11
 
+	/* tcsetattr uses these */
+	#define	TCSANOW		0 /* The change occurs immediately. */
+	#define	TCSADRAIN	1 /* The change occurs after all output written to the
+	                         object referred to by FileDescriptor has been 
+	                         transmitted. */
+
+	#define	TCSAFLUSH	2 /* The change occurs after all output written to the
+	                         object referred to by FileDescriptor has been 
+	                         transmitted. All input that has been received but
+	                         not read is discarded before the change is made.*/
+
     /* Terminal input output data types. */
     typedef unsigned cc_t;     /* Used for terminal special characters. */
     typedef unsigned speed_t;  /* Used for terminal baud rates.         */
@@ -56,10 +68,25 @@
 		tcflag_t c_lflag;    /* Local mode flags (see above).   */
 		tcflag_t c_cc[NCCS]; /* Control characters.             */
     };
+
+    /*
+     * Aditional parameters from tcsetattr
+     */
+    struct set_termios_attr
+    {
+    	int optional_actions;
+    	const struct termios *termiosp;
+    };
     
 	/*
 	 * Gets the parameters associated with the terminal
 	 */
 	extern int tcgetattr(int fd, struct termios *termiosp);
+
+	/*
+	 * Sets the parameters associated with the terminal
+	 */
+	extern int tcsetattr(int fd, int optional_actions,
+		const struct termios *termiosp);
 
 #endif /* TERMIOS_H_ */

--- a/src/kernel/dev/tty/keyboard.c
+++ b/src/kernel/dev/tty/keyboard.c
@@ -1,5 +1,6 @@
 /*
  * Copyright(C) 2011-2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2015-2015 Davidson Francis <davidsondfgl@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -244,11 +245,17 @@ PUBLIC void do_keyboard_hit(void)
 		case KPGUP:
         case KPGDN:
         case KLEFT:
-        case KUP:
-        case KDOWN:
         case KRIGHT:
         	/*  TODO: implement. */
             break;
+
+        case KUP:
+        	tty_int(ascii_code);
+        	break;
+
+        case KDOWN:
+        	tty_int(ascii_code);
+        	break;
 
 		default:
 		    tty_int(ascii_code);

--- a/src/kernel/dev/tty/tty.c
+++ b/src/kernel/dev/tty/tty.c
@@ -102,7 +102,8 @@ PUBLIC void tty_int(unsigned char ch)
 			if ((ch == ERASE_CHAR(*active)) ||
 				(ch == KILL_CHAR(*active)) ||
 				(ch == EOL_CHAR(*active)) ||
-				(ch == EOF_CHAR(*active)))
+				(ch == EOF_CHAR(*active)) ||
+				((ch > 0x8F) && (ch < 0x9B))) /* Cursor keys */
 				goto out1;
 		}
 		
@@ -344,6 +345,13 @@ PRIVATE ssize_t tty_read(unsigned minor, char *buf, size_t n)
 			{
 				console_put('\n', WHITE);
 				continue;
+			}
+
+			/* Cursor keys, for now, we just ignore them in
+			Canonical mode, yes, it's an ugly solution. */
+			else if ( (ch > 0x8F) && (ch < 0x9B) )
+			{
+				;
 			}
 
 			else

--- a/src/lib/libc/termios/tcsetattr.c
+++ b/src/lib/libc/termios/tcsetattr.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright(C) 2015-2015 Davidson Francis <davidsondfgl@gmail.com>
+ * 
+ * termios/tcsetattr.c - tcsetattr() implementation.
+ */
+
+#include <dev/tty.h>
+#include <stropts.h>
+#include <termios.h>
+
+/*
+ * Sets the parameters associated with the terminal
+ */
+int tcsetattr(int fd, int optional_actions, 
+	const struct termios *termiosp)
+{
+	struct set_termios_attr sta;
+	sta.optional_actions = optional_actions;
+	sta.termiosp = termiosp;
+
+	return (ioctl(fd, TTY_SETS, &sta));
+}

--- a/src/ubin/tsh/tsh.h
+++ b/src/ubin/tsh/tsh.h
@@ -1,5 +1,6 @@
 /*
  * Copyright(C) 2011-2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2015-2015 Davidson Francis <davidsondfgl@gmail.com>
  * 
  * <tsh.h> - Tiny UNIX Shell library.
  */
@@ -42,5 +43,32 @@
 	
 	/* Shell return value. */
 	extern int shret;
+
+	/* Control Characters. */
+	#define ERASE_CHAR(termios) ((termios).c_cc[VERASE])
+	#define KILL_CHAR(termios) ((termios).c_cc[VKILL])
+	#define EOL_CHAR(termios) ((termios).c_cc[VEOL])
+	#define EOF_CHAR(termios) ((termios).c_cc[VEOF])
+
+	/* ASCII characters. */
+	#define ESC         27
+	#define BACKSPACE  '\b'
+	#define TAB        '\t'
+	#define ENTER      '\n'
+	#define NEWLINE   ENTER
+
+	/* Cursor keys. */
+	#define KUP    0x97
+	#define KDOWN  0x98
+
+	/* Command stack. */
+	#define STACK_SIZE  16
+
+	#define CLEAR_BUFFER()             \
+		for(int i=size; i<length; i++) \
+		{                              \
+			*p-- = 0;                  \
+			putchar(BACKSPACE);        \
+		}                
 
 #endif /* TSH_H_ */


### PR DESCRIPTION
The main purpose of this pull is to add the ability to 'command stack' in TSH application, for this a few changes to the system and program were needed:

System:
- tcsetattr() implemented.
- very few bug correction.
- recognize keyup and keydown in raw mode.

Program:
- tsh now works in raw mode and it was necessary to 'rewrite' the canonical behavior in it.
- identification of keys: keyup/keydown and basic manipulation of a circular stack.