### PR TITLE
cmos-rtc

### DIFF
--- a/include/nanvix/clock.h
+++ b/include/nanvix/clock.h
@@ -1,5 +1,6 @@
 /*
  * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2016-2016 Subhra S. Sarkar <rurtle.coder@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -27,6 +28,26 @@
 	
 	/* Current time. */
 	#define CURRENT_TIME (startup_time + ticks/CLOCK_FREQ)
+
+	/* CMOS data structure */
+	struct cmos {
+		unsigned int cmos_sec;		/** Second			*/
+		unsigned int cmos_min;		/** Minutes			*/
+		unsigned int cmos_hour;		/** Hour			*/
+		unsigned int cmos_dom;		/** Day of month	*/
+		unsigned int cmos_mon;		/** Month			*/
+		unsigned int cmos_year;		/** Year			*/
+	};
+
+	/*
+ 	 * Initializes the CMOS timer
+ 	 */
+	EXTERN void cmos_init(void);
+
+	/*
+ 	 * Get the current time
+ 	 */
+	EXTERN int cmos_read(void);
 
 	/*
 	 * Initializes the timer interrupt.

--- a/include/nanvix/clock.h
+++ b/include/nanvix/clock.h
@@ -59,5 +59,6 @@
 	
 	/* Time at system startup. */
 	EXTERN unsigned startup_time;
+	EXTERN struct cmos *start_time;
 	
 #endif /* TIMER_H_ */

--- a/include/nanvix/clock.h
+++ b/include/nanvix/clock.h
@@ -31,12 +31,12 @@
 
 	/* CMOS data structure */
 	struct cmos {
-		unsigned int cmos_sec;		/** Second			*/
-		unsigned int cmos_min;		/** Minutes			*/
-		unsigned int cmos_hour;		/** Hour			*/
-		unsigned int cmos_dom;		/** Day of month	*/
-		unsigned int cmos_mon;		/** Month			*/
-		unsigned int cmos_year;		/** Year			*/
+		unsigned int sec;		/** Second       */
+		unsigned int min;		/** Minutes      */
+		unsigned int hour;		/** Hour         */
+		unsigned int dom;		/** Day of month */
+		unsigned int mon;		/** Month        */
+		unsigned int year;		/** Year         */
 	};
 
 	/*

--- a/src/kernel/arch/x86/cmos.c
+++ b/src/kernel/arch/x86/cmos.c
@@ -33,24 +33,37 @@ static unsigned int read_cmos_reg(unsigned int addr)
 PUBLIC void cmos_init(void)
 {
 	struct cmos cmos_tm;
+	unsigned int registerB;		/* Controls format of RTC bytes */
 	/* Well, ideally we should add checks for all cmos attributes */
  	/* to ensure we don't get the same value twice                */
 	/* NOTE: Need to discuss this with the group                  */
 	do
 	{
-		cmos_tm.cmos_sec  = read_cmos_reg(0x00);
-		cmos_tm.cmos_min  = read_cmos_reg(0x02);
-		cmos_tm.cmos_hour = read_cmos_reg(0x04);
-		cmos_tm.cmos_dom  = read_cmos_reg(0x07);
-		cmos_tm.cmos_mon  = read_cmos_reg(0x08);
-		cmos_tm.cmos_year = read_cmos_reg(0x09);
-	} while (cmos_tm.cmos_sec != read_cmos_reg(0));
+		cmos_tm.sec  = read_cmos_reg(0x00);
+		cmos_tm.min  = read_cmos_reg(0x02);
+		cmos_tm.hour = read_cmos_reg(0x04);
+		cmos_tm.dom  = read_cmos_reg(0x07);
+		cmos_tm.mon  = read_cmos_reg(0x08);
+		cmos_tm.year = read_cmos_reg(0x09);
+	} while (cmos_tm.sec != read_cmos_reg(0));
 
-	/* Copied from linux-0.01. Thanks Mr. Torvalds! */
-	BCD_TO_BIN(cmos_tm.cmos_sec);
-	BCD_TO_BIN(cmos_tm.cmos_min);
-	BCD_TO_BIN(cmos_tm.cmos_hour);
-	BCD_TO_BIN(cmos_tm.cmos_dom);
-	BCD_TO_BIN(cmos_tm.cmos_mon);
-	BCD_TO_BIN(cmos_tm.cmos_year);
+	/* Read output format information from CMOS registers */
+	registerB = read_cmos_reg(0x0B);
+
+	/* If output is in BCD format, convert it to binary */
+	if (!(registerB & 0x04))
+	{
+		cmos_tm.sec  = (cmos_tm.sec & 0x0F) + ((cmos_tm.sec / 16) * 10);
+		cmos_tm.min  = (cmos_tm.min & 0x0F) + ((cmos_tm.min / 16) * 10);
+		cmos_tm.hour = ( (cmos_tm.hour & 0x0F) + \
+						(((cmos_tm.hour & 0x70) / 16) * 10) ) | \
+						(cmos_tm.hour & 0x80);
+		cmos_tm.dom  = (cmos_tm.dom & 0x0F) + ((cmos_tm.dom / 16) * 10);
+		cmos_tm.mon  = (cmos_tm.mon & 0x0F) + ((cmos_tm.mon / 16) * 10);
+		cmos_tm.year = (cmos_tm.year & 0x0F) + ((cmos_tm.year / 16) * 10);
+	}
+
+	/* Convert 12 hr clock to 24 hr clock if necessary */
+	if (!(registerB & 0x02) && (cmos_tm.hour & 0x80))
+		cmos_tm.hour = ((cmos_tm.hour & 0x7F) + 12) % 24;
 }

--- a/src/kernel/arch/x86/cmos.c
+++ b/src/kernel/arch/x86/cmos.c
@@ -32,8 +32,9 @@ static unsigned int read_cmos_reg(unsigned int addr)
 
 PUBLIC void cmos_init(void)
 {
-	struct cmos cmos_tm;
+	PRIVATE struct cmos cmos_tm;
 	unsigned int registerB;		/* Controls format of RTC bytes */
+	PUBLIC struct cmos *start_time = &cmos_tm;
 	/* Well, ideally we should add checks for all cmos attributes */
  	/* to ensure we don't get the same value twice                */
 	/* NOTE: Need to discuss this with the group                  */
@@ -66,4 +67,10 @@ PUBLIC void cmos_init(void)
 	/* Convert 12 hr clock to 24 hr clock if necessary */
 	if (!(registerB & 0x02) && (cmos_tm.hour & 0x80))
 		cmos_tm.hour = ((cmos_tm.hour & 0x7F) + 12) % 24;
+
+#if 0
+	/* Finally, making the global start time structure point to this cmos_tm structure */
+	start_time = &cmos_tm;
+	((void)start_time);
+#endif
 }

--- a/src/kernel/arch/x86/cmos.c
+++ b/src/kernel/arch/x86/cmos.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * 				2016-2016 Subhra S. Sarkar <rurtle.coder@gmail.com>
+ * 
+ * This file is part of Nanvix.
+ * 
+ * Nanvix is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Nanvix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Nanvix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <nanvix/hal.h>
+#include <nanvix/clock.h>
+
+#define BCD_TO_BIN(value)	((value)=((value)&15)+((value)>>4)*10)
+
+static unsigned int read_cmos_reg(unsigned int addr)
+{
+	/* Don't forget to disable NMI at the highest order bit */
+	outputb(0x80 | addr, 0x70);
+	return inputb(0x71);
+}
+
+PUBLIC void cmos_init(void)
+{
+	struct cmos cmos_tm;
+	/* Well, ideally we should add checks for all cmos attributes */
+ 	/* to ensure we don't get the same value twice                */
+	/* NOTE: Need to discuss this with the group                  */
+	do
+	{
+		cmos_tm.cmos_sec  = read_cmos_reg(0x00);
+		cmos_tm.cmos_min  = read_cmos_reg(0x02);
+		cmos_tm.cmos_hour = read_cmos_reg(0x04);
+		cmos_tm.cmos_dom  = read_cmos_reg(0x07);
+		cmos_tm.cmos_mon  = read_cmos_reg(0x08);
+		cmos_tm.cmos_year = read_cmos_reg(0x09);
+	} while (cmos_tm.cmos_sec != read_cmos_reg(0));
+
+	/* Copied from linux-0.01. Thanks Mr. Torvalds! */
+	BCD_TO_BIN(cmos_tm.cmos_sec);
+	BCD_TO_BIN(cmos_tm.cmos_min);
+	BCD_TO_BIN(cmos_tm.cmos_hour);
+	BCD_TO_BIN(cmos_tm.cmos_dom);
+	BCD_TO_BIN(cmos_tm.cmos_mon);
+	BCD_TO_BIN(cmos_tm.cmos_year);
+}

--- a/src/kernel/dev/dev.c
+++ b/src/kernel/dev/dev.c
@@ -307,6 +307,7 @@ PUBLIC void dev_init(void)
 {
 	klog_init();
 	ata_init();
+	cmos_init();
 	clock_init(CLOCK_FREQ);
 	fpu_init();
 	tty_init();

--- a/src/kernel/dev/tty/tty.c
+++ b/src/kernel/dev/tty/tty.c
@@ -495,9 +495,9 @@ PRIVATE int tty_clear(struct tty *tty)
 {
 	UNUSED(tty);
 	console_clear();
-	kprintf("HH:%d MM:%d SS:%d MON:%d DATE:%d YEAR: %d\n", \
-			start_time->hour, start_time->min, start_time->sec, \
-			start_time->mon, start_time->dom, start_time->year);
+	kprintf("Bootup time(GMT): %d:%d:%d %d/%d/20%d\n", start_time->hour, \
+		start_time->min, start_time->sec, start_time->mon, \
+		start_time->dom, start_time->year);
 	return (0);
 }
 

--- a/src/kernel/dev/tty/tty.c
+++ b/src/kernel/dev/tty/tty.c
@@ -26,6 +26,7 @@
 #include <nanvix/mm.h>
 #include <nanvix/pm.h>
 #include <nanvix/syscall.h>
+#include <nanvix/clock.h>
 #include <errno.h>
 #include <termios.h>
 #include <stropts.h>
@@ -494,6 +495,9 @@ PRIVATE int tty_clear(struct tty *tty)
 {
 	UNUSED(tty);
 	console_clear();
+	kprintf("HH:%d MM:%d SS:%d MON:%d DATE:%d YEAR: %d\n", \
+			start_time->hour, start_time->min, start_time->sec, \
+			start_time->mon, start_time->dom, start_time->year);
 	return (0);
 }
 


### PR DESCRIPTION
Fixed a bug so Nanvix is able to read CMOS register values properly. Added log in TTY driver to display bootup time (only supports GMT at the moment). Will remove this log once time system call is functional.