### PR TITLE
Double indirection zone on Minix filesystem

### DIFF
--- a/include/fs/minix.h
+++ b/include/fs/minix.h
@@ -128,6 +128,9 @@
 	
 	/** Number of zones in a double indirect zone. */
 	#define NR_DOUBLE ((BLOCK_SIZE/sizeof(block_t))*NR_SINGLE)
+
+	/** Offset remaining to use in double indirect zone. */
+	#define REMAINING_OFFSET ((NR_ZONES_DIRECT+NR_SINGLE)*BLOCK_SIZE)
 	
 	/**@}*/
 


### PR DESCRIPTION
It was added a double indirection in the Minix file system, thus, Nanvix is now able to handle files up to 64MB instead of 519KB (7 direct blocks + 512kB of the first indirection).