### PR TITLE
Bug fix for millennium adjustment for year value

### DIFF
--- a/src/kernel/arch/x86/cmos.c
+++ b/src/kernel/arch/x86/cmos.c
@@ -21,6 +21,8 @@
 #include <nanvix/hal.h>
 #include <nanvix/clock.h>
 
+#define CURR_MILLENNIUM 2000
+
 /**
  * @brief CMOS Time Structure.
  */
@@ -50,13 +52,17 @@ PRIVATE unsigned cmos_read(unsigned addr)
 }
 
 /**
- * @brief Returns time in seconds since Epoch (00:00:00 UTC, 1st Jan,1970) till bootup.
+ * @brief Returns time in seconds since Epoch (00:00:00 UTC, 1st Jan,1970) till
+ *        bootup.
+ *
+ * @NOTE  Since register 0x09 gives only last 2 digits of the year, it's our
+ *        responsibility to add it with right offset.
  *
  */
 PRIVATE signed cmos_gettime(void)
 {
 	/* Local variable declarations */
-	int yy  = boot_time.year;
+	int yy  = CURR_MILLENNIUM + boot_time.year;
 	int mm  = boot_time.mon;
 	int dd  = boot_time.dom;
 	int hh  = boot_time.hour;
@@ -108,13 +114,19 @@ PUBLIC void cmos_init(void)
 	/* If output is in BCD format, convert it to binary. */
 	if (!(registerB & 0x04))
 	{
-		boot_time.sec  = (boot_time.sec & 0x0f) + ((boot_time.sec/16)*10);
-		boot_time.min  = (boot_time.min & 0x0f) + ((boot_time.min/16)*10);
-		boot_time.hour = ((boot_time.hour & 0x0f) + (((boot_time.hour & 0x70)/16)*10))
-		               | (boot_time.hour & 0x80);
-		boot_time.dom  = (boot_time.dom & 0x0f) + ((boot_time.dom/16)*10);
-		boot_time.mon  = (boot_time.mon & 0x0f) + ((boot_time.mon/16)*10);
-		boot_time.year = (boot_time.year & 0x0f) + ((boot_time.year/16)*10);
+		boot_time.sec  = (boot_time.sec & 0x0f) +\
+                              ((boot_time.sec / 16) * 10);
+		boot_time.min  = (boot_time.min & 0x0f) +\
+                              ((boot_time.min / 16) * 10);
+		boot_time.hour = ((boot_time.hour & 0x0f) +\
+                   (((boot_time.hour & 0x70) / 16) * 10)) |\
+                                    (boot_time.hour & 0x80);
+		boot_time.dom  = (boot_time.dom & 0x0f) +\
+                              ((boot_time.dom / 16) * 10);
+		boot_time.mon  = (boot_time.mon & 0x0f) +\
+                              ((boot_time.mon / 16) * 10);
+		boot_time.year = (boot_time.year & 0x0f) +\
+                              ((boot_time.year / 16) * 10);
 	}
 
 	/* Convert 12 hr clock to 24 hr clock if necessary. */


### PR DESCRIPTION
Fixes the following - 
1. Serious bug in startup time. Reading CMOS register 0x09 returns only the last 2 digits of current year. We need to add this value to the right offset (CURR_MILLENNIUM) to get the actual year.
2. Minor conformance (80 column rule, space before and after binary operators) to coding rules as described in $NANVIX_HOME/doc/coding_style.