### PR TITLE
Miniregions implementation

### DIFF
--- a/include/nanvix/region.h
+++ b/include/nanvix/region.h
@@ -40,7 +40,7 @@
 
 	/* Size (in bytes). */
 	#define REGION_SIZE   ((size_t)REGION_PGTABS*MREGIONS*PGTAB_SIZE)
- 	#define REGION_GAP    0x4000000 /* Region gap, 64 MB. */
+ 	#define REGION_GAP    0x400000 /* Region gap, 4 MB. */
 
  	/* Mini region dimensions. */
 	#define NR_MINIREGIONS (32) /* # Mini regions.            */

--- a/src/kernel/mm/paging.c
+++ b/src/kernel/mm/paging.c
@@ -518,28 +518,7 @@ PUBLIC void freeupg(struct pte *pg)
 		
 	/* Double free. */
 	if (frames[i].count == 0)
-	{
-		struct pregion *preg;
-
-		__asm__ volatile
-		(
-			//"xchg %%bx, %%bx;"
-			"mov (%%ebp), %%eax;"
-			"mov (%%eax), %%eax;"
-			"mov 12(%%eax), %%eax;"
-			"mov %%eax, %0;"
-			"nop;"
-			: "=m" (preg)
-		);
-
-		kprintf("pregstart: %x | maxsize: %x | size: %x | refcount: %x", preg->start,
-			preg->maxsize, preg->reg->size, preg->reg->count);
-
-		if(preg->reg == NULL)
-			kprintf("null");
-
 		kpanic("freeing user page twice");
-	}
 	
 	/* Free user page. */
 	if (--frames[i].count)

--- a/src/kernel/mm/paging.c
+++ b/src/kernel/mm/paging.c
@@ -518,7 +518,28 @@ PUBLIC void freeupg(struct pte *pg)
 		
 	/* Double free. */
 	if (frames[i].count == 0)
+	{
+		struct pregion *preg;
+
+		__asm__ volatile
+		(
+			//"xchg %%bx, %%bx;"
+			"mov (%%ebp), %%eax;"
+			"mov (%%eax), %%eax;"
+			"mov 12(%%eax), %%eax;"
+			"mov %%eax, %0;"
+			"nop;"
+			: "=m" (preg)
+		);
+
+		kprintf("pregstart: %x | maxsize: %x | size: %x | refcount: %x", preg->start,
+			preg->maxsize, preg->reg->size, preg->reg->count);
+
+		if(preg->reg == NULL)
+			kprintf("null");
+
 		kpanic("freeing user page twice");
+	}
 	
 	/* Free user page. */
 	if (--frames[i].count)

--- a/src/kernel/mm/region.c
+++ b/src/kernel/mm/region.c
@@ -626,6 +626,8 @@ PUBLIC int attachreg
 	reg->preg = preg;
 	proc->size += reg->size;
 	
+	kprintf("pid: %d | reg: %x",curr_proc->pid, preg->start);
+
 	return (0);
 }
 

--- a/src/kernel/mm/region.c
+++ b/src/kernel/mm/region.c
@@ -30,6 +30,10 @@
 #include <errno.h>
 #include "mm.h"
 
+#if (REGION_GAP < 0x400000)
+	#error "region gap too small"
+#endif
+
 /**
  * @brief Memory region table.
  */

--- a/src/kernel/mm/region.c
+++ b/src/kernel/mm/region.c
@@ -626,8 +626,6 @@ PUBLIC int attachreg
 	reg->preg = preg;
 	proc->size += reg->size;
 	
-	kprintf("pid: %d | reg: %x",curr_proc->pid, preg->start);
-
 	return (0);
 }
 

--- a/src/kernel/mm/region.c
+++ b/src/kernel/mm/region.c
@@ -486,6 +486,7 @@ PUBLIC void freereg(struct region *reg)
 				freeupg(&reg->mtab[i]->pgtab[j][k]);
 			
 			putkpg(reg->mtab[i]->pgtab[j]);
+			reg->mtab[i]->pgtab[j] = NULL;
 		}
 
 		freemreg(reg->mtab[i]);


### PR DESCRIPTION
With this pull, Nanvix is now able to support an arbitrary amount of memory, for this, global structure called 'miniregions' was added along with a new level of indirection to page tables.

As we discussed yesterday, the region gap size was decreased to 4MB which increases the usable size of the heap to 502MB in 512MB. The only implication is that this is the maximum number of allocatable memory at a time, limited to slightly less than 4MB, this value grows in proportion with the gap size.

I do not see a direct problem with that since this value is easily adjustable and is set in a single constant.