### PR TITLE
Using other segment registers as data segment

### DIFF
--- a/src/kernel/arch/x86/utilities.S
+++ b/src/kernel/arch/x86/utilities.S
@@ -270,6 +270,9 @@ user_mode:
 	/* Load data segment selector. */
 	movw $USER_DS, %ax
 	movw %ax, %ds
+	movw %ax, %es
+	movw %ax, %fs
+	movw %ax, %gs
 	
 	/* Build fake interrupt stack. */
 	pushl $USER_DS


### PR DESCRIPTION
Sometimes the compiler may generate code that refers to other segment registers other than CS and DS, as instructions like 'stos/stosb...', then, it is assumed that they also belong to the segment data, although, there is assurance that FS and GS are free to the user.