### PR TITLE
Bug fix: invalid opcode exception on test ipc

### DIFF
--- a/include/nanvix/syscall.h
+++ b/include/nanvix/syscall.h
@@ -32,7 +32,7 @@
 	#include <utime.h>
 	
 	/* Number of system calls. */
-	#define NR_SYSCALLS 52
+	#define NR_SYSCALLS 49
 	
 	/* System call numbers. */
 	#define NR_alarm     0
@@ -83,10 +83,10 @@
 	#define NR_shutdown 45
  	#define NR_ps       46
  	#define NR_gticks   47
- 	#define NR_semget   48
- 	#define NR_semctl   49
- 	#define NR_semop    50
- 	#define NR_time	    51
+ 	#define NR_time	    48
+ 	#define NR_semget   49
+ 	#define NR_semctl   50
+ 	#define NR_semop    51
 
 #ifndef _ASM_FILE_
 

--- a/src/kernel/sys/syscalls.c
+++ b/src/kernel/sys/syscalls.c
@@ -74,8 +74,5 @@ PUBLIC void (*syscalls_table[NR_SYSCALLS])(void)  = {
 	(void (*)(void))&sys_shutdown,
 	(void (*)(void))&sys_ps,
 	(void (*)(void))&sys_gticks,
-	NULL,
-	NULL,
-	NULL,
 	(void (*)(void))&sys_time
 };


### PR DESCRIPTION
The kernel panic on test ipc, ocurred due to a valid syscall number to wrapper functions for semaphore operations, so, the kernel tries to make a function call from a nulled function, so now, the kernel handles semop, semget and semctl as bad_syscalls and can gracefully abort the process.