### PR TITLE
Region gap is no longer needed

### DIFF
--- a/include/nanvix/region.h
+++ b/include/nanvix/region.h
@@ -40,7 +40,6 @@
 
 	/* Size (in bytes). */
 	#define REGION_SIZE   ((size_t)REGION_PGTABS*MREGIONS*PGTAB_SIZE)
- 	#define REGION_GAP    0x400000 /* Region gap, 4 MB. */
 
  	/* Mini region dimensions. */
 	#define NR_MINIREGIONS (32) /* # Mini regions.            */
@@ -94,7 +93,6 @@
 	struct pregion
 	{
 		addr_t start;       /* Starting address.         */
-		size_t maxsize;     /* Max region size.          */
 		struct region *reg; /* Underlying memory region. */
 	};
 	

--- a/include/nanvix/region.h
+++ b/include/nanvix/region.h
@@ -43,7 +43,7 @@
 
  	/* Mini region dimensions. */
 	#define NR_MINIREGIONS (32) /* # Mini regions.            */
-	#define MREGIONS       (32) /* # Mini regions per region. */
+	#define MREGIONS       (8)  /* # Mini regions per region. */
 	#define MREGION_SHIFT  (26) /* Mini region shift.         */
 
 	/* Mini region flags. */

--- a/src/kernel/sys/brk.c
+++ b/src/kernel/sys/brk.c
@@ -1,5 +1,6 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2016 Pedro H. Penna   <pedrohenriquepenna@gmail.com>
+ *              2015-2016 Davidson Francis <davidsondfgl@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -30,14 +31,16 @@ PUBLIC int sys_brk(void *addr)
 	ssize_t size;         /* Increment size.     */
 	struct pregion *heap; /* Heap process region.*/
 	
-	heap = findreg(curr_proc, (addr_t)addr);
-	
-	/* Bad address. */
-	if (heap != HEAP(curr_proc))
-		return (-EFAULT);
-	
+	heap = HEAP(curr_proc);
 	size = (addr_t)addr - (heap->start + heap->reg->size);
 	
+	/* Bad address. */
+	if (size < 0 && findreg(curr_proc, (addr_t)addr) != HEAP(curr_proc))
+		return (-EFAULT);
+
+	else if (findreg(curr_proc, (addr_t)addr) != NULL)
+		return (-EFAULT);
+
 	/*
 	 * There is no need to lock the heap region
 	 * since it is a private region.


### PR DESCRIPTION
As discussed in issue #67, REGION_GAP can become a problem for large memory allocations. To prevent this, was used the very size of the region as a comparison value. 

The only significant change was sys_brk, sys_brk considers that the address to be expanded/contracted will always be found within a region, which works well for region gap and the implementation before miniregion, but now, the region (in case of expansion) will always have a smaller size than new address calculated, and because of this, this address can not be contained to any region before to be expanded, and so, it is guaranteed that there will be no overlapping.

All test cases were executed and there was no problem in any of them.