### PR TITLE
DDD support

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,21 @@
+# 
+# Copyright(C) 2016 Davidson Francis <davidsondfgl@gmail.com>
+#
+# This file is part of Nanvix.
+#
+# Nanvix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Nanvix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Nanvix.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+symbol-file bin/kernel.sym
+target remote localhost:1234

--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
 # 
-# Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com> 
+# Copyright(C) 2011-2016 Pedro H. Penna   <pedrohenriquepenna@gmail.com> 
+#              2016-2016 Davidson Francis <davidsondfgl@gmail.com>
 #
 # This file is part of Nanvix.
 #
@@ -60,6 +61,11 @@ nanvix:
 	mkdir -p $(SBINDIR)
 	mkdir -p $(UBINDIR)
 	cd $(SRCDIR) && $(MAKE) all
+
+# Builds Nanvix with debug flags.
+nanvix-debug:
+	$(eval export DBGFLAGS += -g -fno-omit-frame-pointer)
+	$(MAKE) nanvix
 
 # Builds system's image.
 image: $(BINDIR)/kernel tools

--- a/src/kernel/makefile
+++ b/src/kernel/makefile
@@ -60,11 +60,11 @@ export LDFLAGS = -T arch/$(ARCH)/link.ld
 
 # Builds object file from C source file.
 %.o: %.c
-	$(CC) $< $(CFLAGS) -c -o $@
+	$(CC) $< $(CFLAGS) $(DBGFLAGS) -c -o $@
 
 # Builds object file from assembly source file.
 %.o: %.S
-	$(CC) $< $(CFLAGS) -c $(ASMFLAGS) -o $@
+	$(CC) $< $(CFLAGS) $(DBGFLAGS) -c $(ASMFLAGS) -o $@
 
 # Builds Nanvix kernel.
 all: $(OBJ)

--- a/tools/build/build-img.sh
+++ b/tools/build/build-img.sh
@@ -1,5 +1,6 @@
 # 
-# Copyright(C) 2011-2014 Pedro H. Penna <pedrohenriquepenna@gmail.com> 
+# Copyright(C) 2011-2014 Pedro H. Penna   <pedrohenriquepenna@gmail.com> 
+#              2016-2016 Davidson Francis <davidsondfgl@gmail.com>
 #
 # This file is part of Nanvix.
 #
@@ -103,6 +104,12 @@ function copy_files
 		bin/cp.minix $1 $file /bin/$filename $ROOTUID $ROOTGID
 	done
 }
+
+# Get debug symbols from kernel
+objcopy --only-keep-debug bin/kernel bin/kernel.sym
+
+# Remove debug symbols from kernel
+strip --strip-debug bin/kernel
 
 # Build HDD image.
 dd if=/dev/zero of=hdd.img bs=1024 count=65536

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -1,5 +1,6 @@
 # 
-# Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com> 
+# Copyright(C) 2011-2016 Pedro H. Penna   <pedrohenriquepenna@gmail.com> 
+#              2016-2016 Davidson Francis <davidsondfgl@gmail.com>
 #
 # This file is part of Nanvix.
 #
@@ -23,12 +24,14 @@ export WORKDIR=$CURDIR/nanvix-toolchain
 mkdir -p $WORKDIR
 cd $WORKDIR
 
-# Get binutils and GCC.
+# Get binutils, GDB and GCC.
 wget "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.bz2"
 wget "http://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
+wget "http://ftp.gnu.org/gnu/gdb/gdb-7.11.tar.xz"
 
 # Get required packages.
 apt-get install g++
+apt-get install ddd
 
 # Export variables.
 export PREFIX=/usr/local/cross
@@ -51,6 +54,14 @@ cd gcc-5.3.0/
 ./configure --target=$TARGET --prefix=$PREFIX --disable-nls --enable-languages=c --without-headers
 make all-gcc
 make install-gcc
+
+# Build GDB.
+cd $WORKDIR
+tar -Jxf gdb-7.11.tar.xz
+cd gdb-7.11/
+./configure --target=$TARGET --prefix=$PREFIX --with-auto-load-safe-path=/
+make
+make install
 
 # Cleans files.
 cd $WORKDIR

--- a/tools/run/run-qemu.sh
+++ b/tools/run/run-qemu.sh
@@ -1,5 +1,6 @@
 # 
-# Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com> 
+# Copyright(C) 2011-2016 Pedro H. Penna   <pedrohenriquepenna@gmail.com> 
+#              2016-2016 Davidson Francis <davidsondfgl@gmail.com>
 #
 # This file is part of Nanvix.
 #
@@ -22,7 +23,15 @@
 #   - You should run this script with superuser privileges.
 #
 
-qemu-system-i386                                \
-	-drive file=nanvix.img,format=raw,if=floppy \
-	-m size=256                                 \
-	-mem-prealloc
+if [ "$1" = "--dbg" ]; then
+	qemu-system-i386 -s -S                              \
+		-drive file=nanvix.img,format=raw,if=floppy \
+		-m 256M                                 \
+		-mem-prealloc &
+	ddd --debugger "/usr/local/cross/bin/i386-elf-gdb"
+else
+	qemu-system-i386                                \
+		-drive file=nanvix.img,format=raw,if=floppy \
+		-m 256M                                 \
+		-mem-prealloc		
+fi


### PR DESCRIPTION
This pull adds the DDD (Data Display Debugger) to the Nanvix toolchain. This debugger works as a graphical front-end for debuggers like gdb, in particular, DDD will be very helpful with the use of Qemu, since it has gdb support.

As a front-end, obviously all gdb commands are supported, but with a much greater ease of being used allied to the graphical interface that makes it possible to view structures, linked lists, functions, variables, and so on...