### PR TITLE
Adding genisoimage in toolchain.

### DIFF
--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -63,6 +63,9 @@ cd gdb-7.11/
 make
 make install
 
+# Install genisoimage.
+apt-get install genisoimage
+
 # Cleans files.
 cd $WORKDIR
 cd ..


### PR DESCRIPTION
It is necessary to use genisoimage for creating ISO images and we can not assume that the program already exists in the system, which occurs in Ubuntu but not in Debian, for instance.

Although we assume that we are in a Debian-like environment, the program (as well as the others) are easily found in other Linux distributions so the programmer should be able to find an equivalent package.