### PR TITLE
Implementation of registerer and executer for debugging functions

### DIFF
--- a/include/nanvix/config.h
+++ b/include/nanvix/config.h
@@ -1,5 +1,6 @@
 /*
  * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -34,18 +35,19 @@
 	 * @brief Kernel configuration.
 	 */
 	/**@{*/
-	#define MULTIUSER                    0 /**< Multiuser support?              */
-	#define KERNEL_VERSION           "2.0" /**< Kernel version.                 */
-	#define PROC_MAX                    64 /**< Maximum number of process.      */
-	#define PROC_SIZE_MAX  (MEMORY_SIZE/8) /**< Maximum process size.           */
-	#define RAMDISK_SIZE          0x400000 /**< RAM disks size.                 */
-	#define INITRD_SIZE           0x140000 /**< Init RAM disk size.             */
-	#define NR_INODES                 1024 /**< Number of in-core inodes.       */
-	#define NR_SUPERBLOCKS               4 /**< Number of in-core super blocks. */
-	#define ROOT_DEV                0x0001 /**< Root device number.             */
-	#define NR_FILES                   256 /**< Number of opened files.         */
-	#define NR_REGIONS                 128 /**< Number of memory regions.       */
-	#define NR_BUFFERS                 256 /**< Number of block buffers.        */
+	#define MULTIUSER                    0 /**< Multiuser support?                 */
+	#define KERNEL_VERSION           "2.0" /**< Kernel version.                    */
+	#define PROC_MAX                    64 /**< Maximum number of process.         */
+	#define PROC_SIZE_MAX  (MEMORY_SIZE/8) /**< Maximum process size.              */
+	#define RAMDISK_SIZE          0x400000 /**< RAM disks size.                    */
+	#define INITRD_SIZE           0x140000 /**< Init RAM disk size.                */
+	#define NR_INODES                 1024 /**< Number of in-core inodes.          */
+	#define NR_SUPERBLOCKS               4 /**< Number of in-core super blocks.    */
+	#define ROOT_DEV                0x0001 /**< Root device number.                */
+	#define NR_FILES                   256 /**< Number of opened files.            */
+	#define NR_REGIONS                 128 /**< Number of memory regions.          */
+	#define NR_BUFFERS                 256 /**< Number of block buffers.           */
+	#define DEBUG_MAX		    64 /**< Maximum number of debug functions. */
 	/**@}*/
 	
 #endif /* CONFIG_H_ */

--- a/include/nanvix/debug.h
+++ b/include/nanvix/debug.h
@@ -28,7 +28,11 @@
 
 	#include <nanvix/klib.h>
 
+	typedef void (*debug_fn)(void);
+	
 	/* Forward definitions */
 	EXTERN void dbg_init(void);
+	EXTERN void dbg_register(debug_fn fn);
+	EXTERN void dbg_execute();
 
 #endif /* NANVIX_DEBUG_H */

--- a/src/kernel/debug/debug.c
+++ b/src/kernel/debug/debug.c
@@ -19,9 +19,69 @@
 
 #include <nanvix/klib.h>
 
+
+typedef void (*debug_fn)(void);
+
+/**
+ * @brief Array containing debugging functions
+ */
+PRIVATE debug_fn debug_fns[DEBUG_MAX];
+
+/**
+ * @brief Is debug mode enabled?
+ */
+PRIVATE int is_debug = 0;
+
+/**
+ * @brief Add a function to the debugging array
+ * @param Function to add to the debugging array
+ */
+PUBLIC void dbg_register(debug_fn fn)
+{
+	if (!is_debug)
+		return;
+
+	int i;
+	for(i=0;i<DEBUG_MAX;i++)
+	{
+		if(debug_fns[i] == NULL)
+		{
+			debug_fns[i] = fn;
+			break;
+		}
+	}
+	if(i == DEBUG_MAX)
+		kprintf("too many debug functions");
+}
 /**
  * @brief Init debug process.
  */
-PUBLIC void dbg_init(void){
-	kprintf("Debug Mode handled but not implemented yet");
+PUBLIC void dbg_init(void)
+{
+	kprintf("debug: debug mode handled");
+	is_debug = 1;
 }
+
+/**
+ * @brief Print number of debugging functions then execute them
+ */
+PUBLIC void dbg_execute(void)
+{
+	if (is_debug)
+	{
+		int i,j;
+		for(i=0;i<DEBUG_MAX;i++)
+		{
+			if(debug_fns[i] == NULL)
+				break;
+
+		}
+		kprintf("debug: %d debug function(s) are going to be executed",i);
+		for(j=0;j<i;j++)
+			debug_fns[i]();
+		kprintf("debug: %d debug functions had successfully been executed",j);
+	}
+	else
+		kprintf("debug: debug mode disabled");
+}
+

--- a/src/kernel/init/main.c
+++ b/src/kernel/init/main.c
@@ -120,6 +120,9 @@ PUBLIC void kmain(const char* cmdline)
 	pid_t pid;         /* Child process ID. */
 	struct process *p; /* Working process.  */
 	
+	if(!kstrcmp(cmdline,"debug"))
+		dbg_init();
+
 	/* Initialize system modules. */
 	dev_init();
 	mm_init();
@@ -128,9 +131,8 @@ PUBLIC void kmain(const char* cmdline)
 	
 	chkout(DEVID(TTY_MAJOR, 0, CHRDEV));
 
-	if(!kstrcmp(cmdline,"debug"))
-		dbg_init();
-	
+	dbg_execute();
+
 	/* Spawn init process. */
 	if ((pid = fork()) < 0)
 		kpanic("failed to fork idle process");


### PR DESCRIPTION
- Added DEBUG_MAX in config.h, representing max debugginf functions, and fixed it to 64
- Added EXTERN functions dbg_register() which added a given function in debugging table and dbg_execute() which prints and execute debugging table only if in debugging mode
- Now kmain launches dgb_execute() after all initializalisations, and this