### PR TITLE
Debug driver update & Simple tests for example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ doc/*-kernel
 *.iso
 nanvix-iso/*
 
+# C Tags
+tags
+
 # ISO Images
 nanvix.iso
 nanvix-iso/*

--- a/include/dev/klog.h
+++ b/include/dev/klog.h
@@ -1,5 +1,6 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -26,6 +27,11 @@
 	 * @author Pedro H. Penna
 	 */
 	extern void klog_init(void);
+
+	/**
+	 * @brief Tests for klog functions. Used for debug
+	 */
+	extern void test_klog(void);
 
 #endif /* KLOG_H_ */
 

--- a/include/dev/ramdisk.h
+++ b/include/dev/ramdisk.h
@@ -1,5 +1,6 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -34,5 +35,7 @@
 	 *   No errors are defined.
 	 */
 	EXTERN void ramdisk_init(void);
+
+	EXTERN void test_rmd(void);
 
 #endif /* RAMDISK_H_ */

--- a/include/nanvix/debug.h
+++ b/include/nanvix/debug.h
@@ -46,6 +46,6 @@
 	EXTERN void dbg_execute(void);
 	EXTERN void tst_passed(void);
 	EXTERN void tst_failed(void);
-	EXTERN void tst_skiped(void);
+	EXTERN void tst_skipped(void);
 
 #endif /* NANVIX_DEBUG_H */

--- a/include/nanvix/debug.h
+++ b/include/nanvix/debug.h
@@ -28,6 +28,13 @@
 
 	#include <nanvix/klib.h>
 
+	/* counters */
+	struct tst_count {
+		unsigned int tst_pass;
+		unsigned int tst_fail;
+		unsigned int tst_skip;
+	};
+
 	/**
 	 * @brief Opaque pointer to a debug function.
 	 */
@@ -36,6 +43,9 @@
 	/* Forward definitions */
 	EXTERN void dbg_init(void);
 	EXTERN void dbg_register(debug_fn fn);
-	EXTERN void dbg_execute();
+	EXTERN void dbg_execute(void);
+	EXTERN void tst_passed(void);
+	EXTERN void tst_failed(void);
+	EXTERN void tst_skiped(void);
 
 #endif /* NANVIX_DEBUG_H */

--- a/include/nanvix/debug.h
+++ b/include/nanvix/debug.h
@@ -42,7 +42,7 @@
 	
 	/* Forward definitions */
 	EXTERN void dbg_init(void);
-	EXTERN void dbg_register(debug_fn fn);
+	EXTERN void dbg_register(debug_fn fn, char *fn_name);
 	EXTERN void dbg_execute(void);
 	EXTERN void tst_passed(void);
 	EXTERN void tst_failed(void);

--- a/include/nanvix/dev.h
+++ b/include/nanvix/dev.h
@@ -1,5 +1,6 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -28,7 +29,7 @@
 	 * @brief Device types
 	 */
 	/**@{*/
-	#define CHRDEV 0 /**<  Charecter device. */
+	#define CHRDEV 0 /**< Character device.  */
 	#define BLKDEV 1 /**< Block device.      */
 	/**@}*/
 
@@ -90,6 +91,7 @@
 	EXTERN int cdev_open(dev_t);
 	EXTERN int cdev_close(dev_t);
 	EXTERN int cdev_ioctl(dev_t, unsigned, unsigned);
+	EXTERN void cdev_test(void);
 	
 	/*========================================================================*
 	 *                               block device                             *
@@ -120,5 +122,5 @@
 	EXTERN ssize_t bdev_read(dev_t, char *, size_t, off_t);
 	EXTERN void bdev_writeblk(struct buffer *);
 	EXTERN void bdev_readblk(struct buffer *);
-	
+	EXTERN void bdev_test(void);
 #endif /* DEV_H_ */

--- a/include/nanvix/region.h
+++ b/include/nanvix/region.h
@@ -142,6 +142,8 @@
 	EXTERN void initreg(void);
 	EXTERN void lockreg(struct region *);
 	EXTERN void unlockreg(struct region *);
+	EXTERN void test_mm(void);
+	EXTERN struct region regtab[NR_REGIONS];
 	EXTERN struct region *allocreg(mode_t, size_t, int);
 	EXTERN struct region *dupreg(struct region *);
 	EXTERN struct pregion *findreg(struct process *, addr_t);

--- a/include/nanvix/region.h
+++ b/include/nanvix/region.h
@@ -1,6 +1,7 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna   <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna   <pedrohenriquepenna@gmail.com>
  *              2015-2016 Davidson Francis <davidsondfgl@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -143,7 +144,6 @@
 	EXTERN void lockreg(struct region *);
 	EXTERN void unlockreg(struct region *);
 	EXTERN void test_mm(void);
-	EXTERN struct region regtab[NR_REGIONS];
 	EXTERN struct region *allocreg(mode_t, size_t, int);
 	EXTERN struct region *dupreg(struct region *);
 	EXTERN struct pregion *findreg(struct process *, addr_t);

--- a/include/nanvix/region.h
+++ b/include/nanvix/region.h
@@ -42,7 +42,7 @@
 	#define REGION_SIZE   ((size_t)REGION_PGTABS*MREGIONS*PGTAB_SIZE)
 
  	/* Mini region dimensions. */
-	#define NR_MINIREGIONS (32) /* # Mini regions.            */
+	#define NR_MINIREGIONS (128) /* # Mini regions.            */
 	#define MREGIONS       (8)  /* # Mini regions per region. */
 	#define MREGION_SHIFT  (26) /* Mini region shift.         */
 

--- a/src/kernel/debug/debug.c
+++ b/src/kernel/debug/debug.c
@@ -19,25 +19,53 @@
  */
 
 #include <nanvix/config.h>
-#include <nanvix/klib.h>
 #include <nanvix/debug.h>
+#include <nanvix/dev.h>
+#include <nanvix/klib.h>
+
 
 /**
  * @brief Registered debugging functions.
  */
 PRIVATE debug_fn debug_fns[DEBUG_MAX];
 
+PRIVATE char *fn_names[DEBUG_MAX];
+/**
+ * @brief Registered debugging functions.
+ */
+PRIVATE int failed_fns[DEBUG_MAX];
+
+static int current_fn;
+
+static struct tst_count tst_cnt;
+
 /**
  * @brief Is debug mode enabled?
  */
 PRIVATE int is_debug = 0;
+
+PUBLIC void tst_passed(void) 
+{ 
+	tst_cnt.tst_pass++; 
+}
+
+PUBLIC void tst_failed(void) 
+{ 
+	tst_cnt.tst_fail++;
+	failed_fns[(tst_cnt.tst_fail)-1] = current_fn;
+}
+
+PUBLIC void tst_skiped(void) 
+{
+	tst_cnt.tst_skip++; 
+}
 
 /**
  * @brief Registers a function in the debug driver.
  *
  * @param fn Function to register.
  */
-PUBLIC void dbg_register(debug_fn fn)
+PUBLIC void dbg_register(debug_fn fn, char *fn_name)
 {
 	/* Nothing to do. */
 	if (!is_debug)
@@ -59,6 +87,7 @@ PUBLIC void dbg_register(debug_fn fn)
 		/* Found. */
 		if (debug_fns[i] == NULL)
 		{
+			fn_names[i] = fn_name;
 			debug_fns[i] = fn;
 			return;
 		}
@@ -68,7 +97,7 @@ PUBLIC void dbg_register(debug_fn fn)
 }
 
 /**
- * @brief Initoalizes the debug driver
+ * @brief Initializes the debug driver
  */
 PUBLIC void dbg_init(void)
 {
@@ -81,6 +110,7 @@ PUBLIC void dbg_init(void)
  */
 PUBLIC void dbg_execute(void)
 {
+	int i;
 	int nexecuted = 0;
 
 	/* Nothing to do. */
@@ -97,11 +127,26 @@ PUBLIC void dbg_execute(void)
 		if (debug_fns[i] == NULL)
 			continue;
 
-		kprintf("debug-driver: executing debug function %d", ++nexecuted);
+		current_fn = i;
 
+		kprintf("debug-driver: executing debug function %d: %s", ++nexecuted, fn_names[i]);
 		debug_fns[i]();
 	}
 
-	kprintf("debug-driver: done");
+	kprintf("debug-driver: done - test passed: %d - test failed: %d - test skiped: %d", tst_cnt.tst_pass, tst_cnt.tst_fail, tst_cnt.tst_skip);
+
+	if (tst_cnt.tst_fail > 0)
+	{
+		kprintf("debug-driver: list of failed functions:");
+		for(i = 0; i < (int)(tst_cnt.tst_fail); i++)
+		{
+			kprintf("debug-driver: failed function %d:  %s", (i+1),fn_names[failed_fns[i]]);
+		}
+		kpanic("debug-driver: failed tests could create instability in the system");
+	}
+
+	kprintf("debug-driver: debug complete - press ENTER to continue standard boot");
+
+	cdev_read(kout, NULL, 1);
 }
 

--- a/src/kernel/debug/debug.c
+++ b/src/kernel/debug/debug.c
@@ -55,7 +55,7 @@ PUBLIC void tst_failed(void)
 	failed_fns[(tst_cnt.tst_fail)-1] = current_fn;
 }
 
-PUBLIC void tst_skiped(void) 
+PUBLIC void tst_skipped(void) 
 {
 	tst_cnt.tst_skip++; 
 }
@@ -133,7 +133,7 @@ PUBLIC void dbg_execute(void)
 		debug_fns[i]();
 	}
 
-	kprintf("debug-driver: done - test passed: %d - test failed: %d - test skiped: %d", tst_cnt.tst_pass, tst_cnt.tst_fail, tst_cnt.tst_skip);
+	kprintf("debug-driver: done - test passed: %d - test failed: %d - test skipped: %d", tst_cnt.tst_pass, tst_cnt.tst_fail, tst_cnt.tst_skip);
 
 	if (tst_cnt.tst_fail > 0)
 	{

--- a/src/kernel/dev/ramdisk/ramdisk.c
+++ b/src/kernel/dev/ramdisk/ramdisk.c
@@ -1,5 +1,6 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -20,6 +21,7 @@
 #include <nanvix/config.h>
 #include <nanvix/const.h>
 #include <nanvix/dev.h>
+#include <nanvix/debug.h>
 #include <nanvix/fs.h>
 #include <nanvix/hal.h>
 #include <nanvix/klib.h>
@@ -168,6 +170,83 @@ PRIVATE const struct bdev ramdisk_driver = {
 	&ramdisk_writeblk  /* writeblk() */
 };
 
+/**
+ * @brief Used for debugging
+ * @details Tests if all RAM disks are correctly registered
+ * 
+ * @returns Upon successful completion one is returned. Upon failure, a 
+ *          zero is returned instead.
+ */
+PRIVATE int rmdtst_register(void)
+{
+	int i;
+	for (i=0;i<NR_RAMDISKS;i++)
+	{
+		if (&(ramdisks[i].start) == NULL)
+		{
+			kprintf("rmdsk test: register of disk number %d failed", i);
+			return 0;
+		}
+	}
+	return 1;
+}
+
+/**
+ * @brief Used for debugging
+ * @details Tests if ramdisk_write and ramdisk_read works correctly
+ * 
+ * @param buffer Buffer to be written in the RAM disk.
+ * @param tstrmd_lenght Number of characters to be written in the RAM disk.
+ * 
+ * @returns Upon successful completion one is returned. Upon failure, a 
+ *          zero is returned instead.
+ */
+PRIVATE int rmdtst_rw(char *buffer, int tstrmd_lenght)
+{
+	int char_count, char_count2;
+	if ((char_count = ramdisk_write(0, buffer, tstrmd_lenght, 0)) != tstrmd_lenght)
+	{
+		if (char_count <= 0)
+			kprintf("rmdsk test: ramdisk_write failed: nothing has been written");
+		else
+			kprintf("rmdsk test: ramdisk_write failed: what has been written is not what it has to be write");
+
+		return 0;
+	}
+
+	if ((char_count2 = ramdisk_read(0,buffer,tstrmd_lenght, 0)) != char_count)
+	{
+		if (char_count2 <= 0)
+			kprintf("rmdsk test: ramdisk_read failed: nothing has been read");
+		else
+			kprintf("rmdsk test: ramdisk_read failed: what has been read is not what has to be read");
+		return 0;
+	}
+
+	return 1;
+}
+
+PUBLIC void test_rmd(void)
+{
+	char buffer[KBUFFER_SIZE]; /* Temporary buffer.        */
+	int tstrmd_lenght = 38; /* Size of message to write in the log */
+	kstrncpy(buffer, "rmdsk test: test data input in ramdisk", tstrmd_lenght);
+
+	if(!rmdtst_register())
+	{
+		tst_failed();
+		return;
+	}
+
+	if(!rmdtst_rw(buffer, tstrmd_lenght))
+	{
+		tst_failed();
+		return;
+	}
+	tst_passed();
+	return;
+}
+
 /*
  * Initializes the RAM disk device driver.
  */
@@ -187,4 +266,6 @@ PUBLIC void ramdisk_init(void)
 	/* Failed to register ramdisk device driver. */
 	if (err)
 		kpanic("failed to register RAM disk device driver. ");
+
+	dbg_register(test_rmd, "test_rmd");
 }

--- a/src/kernel/mm/mm.c
+++ b/src/kernel/mm/mm.c
@@ -1,5 +1,6 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -22,6 +23,7 @@
 #include <nanvix/region.h>
 #include <nanvix/klib.h>
 #include <nanvix/mm.h>
+#include <nanvix/debug.h>
 
 /*
  * Bad KPOOL_PHYS ?
@@ -79,6 +81,7 @@
 PUBLIC void mm_init(void)
 {
 	initreg();
+	dbg_register(test_mm, "test_mm");
 }
 
 /**

--- a/src/kernel/mm/region.c
+++ b/src/kernel/mm/region.c
@@ -1,6 +1,7 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna   <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna   <pedrohenriquepenna@gmail.com>
  *              2015-2016 Davidson Francis <davidsondfgl@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -1034,7 +1035,6 @@ PRIVATE int count_freereg(void)
 		}
 	}
 
-	kprintf("mm test: free regions: %d - not free regions: %d", free_count,(NR_REGIONS-free_count));
 	return(free_count);
 }
 
@@ -1148,8 +1148,6 @@ PUBLIC void test_mm(void)
 {
 
 	int min_mm = min_regmreg();
-
-	kprintf("mm test: minimum memory size: %d",min_mm);
 
 	if(!mmtst_free(min_mm))
 	{

--- a/tools/dev/setup-qemu.sh
+++ b/tools/dev/setup-qemu.sh
@@ -23,6 +23,9 @@
 #   - You should run this script with superuser privileges.
 #
 
+# QEMU.
+export QEMU_VERSION=2.9.0
+
 # Set working directory.
 export CURDIR=`pwd`
 export WORKDIR=$CURDIR/nanvix-toolchain
@@ -33,7 +36,7 @@ cd $WORKDIR
 num_cores=`grep -c ^processor /proc/cpuinfo`
 
 # Get bochs.
-wget "http://wiki.qemu-project.org/download/qemu-2.5.0.tar.bz2"
+wget "http://wiki.qemu-project.org/download/qemu-$QEMU_VERSION.tar.bz2"
 
 # Get required packages.
 apt-get install libglib2.0-dev
@@ -41,9 +44,9 @@ apt-get install zlib1g-dev
 apt-get install libtool 
 
 # Build Bochs
-tar -xjvf qemu-2.5.0.tar.bz2
-cd qemu-2.5.0
-./configure
+tar -xjvf qemu-$QEMU_VERSION.tar.bz2
+cd qemu-$QEMU_VERSION
+./configure --target-list=i386-softmmu --enable-sdl
 make -j$num_cores all
 make install
 


### PR DESCRIPTION
- Debug driver now prints only informations of failure
- Debug driver now raises kpanic on failure of at least one test & waits for "enter" input when all tests as successfull to continue boot.
- dbg_register now requires (debug_fn,char *) in order to be able to print function name on failure
- Modification of NR_MINIREGIONS in order to be coherent with NR_REGIONS
Simple tests implementations for:
- mm (in regions.c)
- cdev
- bdev
- klog
- rmdisk