### PR TITLE
Log levels implementation for kprintf

### DIFF
--- a/include/nanvix/klib.h
+++ b/include/nanvix/klib.h
@@ -1,5 +1,9 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>Joe Perches <joe@perches.com>
+ *              2012-2016 Linus Torvalds <torvalds@linux-foundation.org>
+ *              2012-2012 Kay Sievers <kay.sievers@vrfy.org>
+ *
  * 
  * This file is part of Nanvix.
  * 
@@ -235,6 +239,23 @@
 	/*========================================================================*
 	 *                           logging and debugging                        *
 	 *========================================================================*/
+	
+	/* This char declares that following one is a log level */
+	#define KERN_SOH	"\001"
+	#define KERN_SOH_ASCII	'\001'
+
+	/* Log levels */
+	#define KERN_EMERG      KERN_SOH "0"    /* system is unusable */
+	#define KERN_ALERT      KERN_SOH "1"    /* action must be taken immediately */
+	#define KERN_CRIT       KERN_SOH "2"    /* critical conditions */
+	#define KERN_ERR        KERN_SOH "3"    /* error conditions */
+	#define KERN_WARNING    KERN_SOH "4"    /* warning conditions */
+	#define KERN_NOTICE     KERN_SOH "5"    /* normal but significant condition */
+	#define KERN_INFO       KERN_SOH "6"    /* informational */
+	#define KERN_DEBUG      KERN_SOH "7"    /* debug-level messages */
+	
+	/* default log level is no log level, 
+	   useful to avoid printing log level in early boot */
 
 	/**
 	 * @brief Kernel log size (in characters).
@@ -251,6 +272,8 @@
 	EXTERN ssize_t klog_write(unsigned, const char *, size_t);
 	EXTERN void kpanic(const char *, ...);
 	EXTERN void kmemdump(const void *s, size_t n);
+	EXTERN const char *skip_code(const char *buffer, int *i);
+	EXTERN char get_code(const char *buffer);
 	/**@}*/
 
 	/*========================================================================*

--- a/src/kernel/debug/debug.c
+++ b/src/kernel/debug/debug.c
@@ -70,14 +70,14 @@ PUBLIC void dbg_register(debug_fn fn, char *fn_name)
 	/* Nothing to do. */
 	if (!is_debug)
 	{
-		kprintf("debug-driver: debug mode disabled");
+		kprintf(KERN_INFO "debug-driver: debug mode disabled");
 		return;
 	}
 
 	/* Sanity check. */
 	if (fn == NULL)
 	{
-		kprintf("debug-driver: register null debug function?");
+		kprintf(KERN_WARNING "debug-driver: register null debug function?");
 		return;
 	}
 
@@ -93,7 +93,7 @@ PUBLIC void dbg_register(debug_fn fn, char *fn_name)
 		}
 	}
 
-	kprintf("debug-driver: too many debug functions");
+	kprintf(KERN_ERR "debug-driver: too many debug functions");
 }
 
 /**
@@ -102,7 +102,7 @@ PUBLIC void dbg_register(debug_fn fn, char *fn_name)
 PUBLIC void dbg_init(void)
 {
 	is_debug = 1;
-	kprintf("debug-diver: debug driver intialized");
+	kprintf(KERN_INFO "debug-diver: debug driver intialized");
 }
 
 /**
@@ -116,7 +116,7 @@ PUBLIC void dbg_execute(void)
 	/* Nothing to do. */
 	if (!is_debug)
 	{
-		kprintf("debug-driver: debug mode disabled");
+		kprintf(KERN_INFO "debug-driver: debug mode disabled");
 		return;
 	}
 
@@ -129,23 +129,23 @@ PUBLIC void dbg_execute(void)
 
 		current_fn = i;
 
-		kprintf("debug-driver: executing debug function %d: %s", ++nexecuted, fn_names[i]);
+		kprintf(KERN_DEBUG "debug-driver: executing debug function %d: %s", ++nexecuted, fn_names[i]);
 		debug_fns[i]();
 	}
 
-	kprintf("debug-driver: done - test passed: %d - test failed: %d - test skipped: %d", tst_cnt.tst_pass, tst_cnt.tst_fail, tst_cnt.tst_skip);
+	kprintf(KERN_DEBUG "debug-driver: done - test passed: %d - test failed: %d - test skipped: %d", tst_cnt.tst_pass, tst_cnt.tst_fail, tst_cnt.tst_skip);
 
 	if (tst_cnt.tst_fail > 0)
 	{
-		kprintf("debug-driver: list of failed functions:");
+		kprintf(KERN_DEBUG "debug-driver: list of failed functions:");
 		for(i = 0; i < (int)(tst_cnt.tst_fail); i++)
 		{
-			kprintf("debug-driver: failed function %d:  %s", (i+1),fn_names[failed_fns[i]]);
+			kprintf(KERN_DEBUG "debug-driver: failed function %d:  %s", (i+1),fn_names[failed_fns[i]]);
 		}
-		kpanic("debug-driver: failed tests could create instability in the system");
+		kpanic(KERN_DEBUG "debug-driver: failed tests could create instability in the system");
 	}
 
-	kprintf("debug-driver: debug complete - press ENTER to continue standard boot");
+	kprintf(KERN_DEBUG "debug-driver: debug complete - press ENTER to continue standard boot");
 
 	cdev_read(kout, NULL, 1);
 }

--- a/src/kernel/dev/dev.c
+++ b/src/kernel/dev/dev.c
@@ -206,7 +206,7 @@ PRIVATE int cdevtst_register(void)
 	{
 		if (cdevsw[i] == NULL && i > 0)
 		{
-			kprintf("cdev test: register of device number %d failed", i);
+			kprintf(KERN_DEBUG "cdev test: register of device number %d failed", i);
 			return 0;
 		}
 	}
@@ -232,9 +232,9 @@ PRIVATE int cdevtst_w(char *buffer, int tstcdev_lenght)
 	if (char_count != tstcdev_lenght)
 	{
 		if(char_count <= 0)
-			kprintf("cdev test: cdev_write failed: nothing has been written, code: %d",char_count);
+			kprintf(KERN_DEBUG "cdev test: cdev_write failed: nothing has been written, code: %d",char_count);
 		else
-			kprintf("cdev test: cdev_write failed: what has been written is not what it has to be write, code: %d",char_count);
+			kprintf(KERN_DEBUG "cdev test: cdev_write failed: what has been written is not what it has to be write, code: %d",char_count);
 
 		return 0;
 	}
@@ -248,9 +248,9 @@ PRIVATE int cdevtst_w(char *buffer, int tstcdev_lenght)
 PUBLIC void cdev_test(void)
 {
 	char buffer[KBUFFER_SIZE]; /* Temporary buffer.        */
-	int tstcdev_lenght = 34; /* Size of message to write in the log */
+	int tstcdev_lenght = 35; /* Size of message to write in the log */
 
-	kstrncpy(buffer, "cdev test: test data input in cdev", tstcdev_lenght);
+	kstrncpy(buffer, "cdev test: test data input in cdev\n", tstcdev_lenght);
 
 	if(!cdevtst_register())
 	{
@@ -419,12 +419,12 @@ PRIVATE int bdevtst_register(void)
 		{
 			if(i == ATA_MAJOR)
 			{
-				kprintf("bdev test: warning: ATA device was not registered during initialization");
+				kprintf(KERN_DEBUG "bdev test: warning: ATA device was not registered during initialization");
 				continue;
 			}
 			else
 			{
-				kprintf("bdev test: register of device number %d failed", i);
+				kprintf(KERN_DEBUG "bdev test: register of device number %d failed", i);
 				return 0;
 			}
 		} 
@@ -452,9 +452,9 @@ PRIVATE int bdevtst_w(char *buffer, int tstbdev_lenght)
 	if (char_count != tstbdev_lenght)
 	{
 		if(char_count <= 0)
-			kprintf("bdev test: bdev_write failed: nothing has been written, code: %d",char_count);
+			kprintf(KERN_DEBUG "bdev test: bdev_write failed: nothing has been written, code: %d",char_count);
 		else
-			kprintf("bdev test: bdev_write failed: what has been written is not what it has to be write, code: %d",char_count);
+			kprintf(KERN_DEBUG "bdev test: bdev_write failed: what has been written is not what it has to be write, code: %d",char_count);
 
 		return 0;
 	}
@@ -468,9 +468,9 @@ PRIVATE int bdevtst_w(char *buffer, int tstbdev_lenght)
 PUBLIC void bdev_test(void)
 {
 	char buffer[KBUFFER_SIZE]; /* Temporary buffer.        */
-	int tstbdev_lenght = 34; /* Size of message to write in the log */
+	int tstbdev_lenght = 35; /* Size of message to write in the log */
 
-	kstrncpy(buffer, "bdev test: test data input in bdev", tstbdev_lenght);
+	kstrncpy(buffer, "bdev test: test data input in bdev\n", tstbdev_lenght);
 
 	if(!bdevtst_register())
 	{

--- a/src/kernel/dev/klog/klog.c
+++ b/src/kernel/dev/klog/klog.c
@@ -41,6 +41,46 @@ PRIVATE struct
 } klog = { 0, 0, {0, }};
 
 /**
+ * @brief Add log level code (if present) to buffer and skip it
+ * 
+ * @param buffer        Buffer to be written in the kernel log.
+ * @param n             Pointer on the number of characters to be written in the kernel log. (for updating)
+ * @param head, tail    Pointers on buffer head and tail
+ * @param char_printed  Number of chaf added to buffer for log_level (0 or 3)
+
+ * @returns Buffer with no code, hidden returns with pointers
+ */
+PRIVATE const char *print_code(const char *buffer, int *n, int *head, int *tail, int *char_printed)
+{
+	int i;
+	char p[3];
+	p[0] = get_code(buffer);
+	p[1] = ':';
+	p[2] = ' ';
+
+	/* log level is default one? */
+	if (p[0] == 0)
+	{
+		return buffer;
+	}
+
+	/* Copy data to ring buffer */
+	for (i=0;i<3;i++)
+	{
+		klog.buffer[*tail] = p[i];
+		*tail = (*tail + 1)&(KLOG_SIZE - 1);
+		
+		if (*tail == *head)
+			*head = *head + 1;
+	}
+	/* 3 character had been added to buffer for log_level printing */
+	*char_printed =+ 3;
+
+	return skip_code(buffer,n);
+}
+
+
+/**
  * @brief Writes to kernel log.
  * 
  * @param buffer Buffer to be written in the kernel log.
@@ -53,17 +93,22 @@ PUBLIC ssize_t klog_write(unsigned minor, const char *buffer, size_t n)
 	int head;      /* Log head.        */
 	int tail;      /* Log tail.        */
 	const char *p; /* Writing pointer. */
+
+	int lenght = (int) n;
+	int char_printed = 0; /* Useful for returning size */
+
 	
 	UNUSED(minor);
-	
-	p = buffer;
 	
 	/* Read pointers. */
 	head = klog.head;
 	tail = klog.tail;
+
+	/* If there is a log_level code, add it in buffer and skip it */
+	p = print_code(buffer,&lenght,&head,&tail,&char_printed);
 	
 	/* Copy data to ring buffer. */
-	while (n-- > 0)
+	while (lenght-- > 0)
 	{
 		klog.buffer[tail] = *p++;
 		
@@ -77,7 +122,7 @@ PUBLIC ssize_t klog_write(unsigned minor, const char *buffer, size_t n)
 	klog.head = head;
 	klog.tail = tail;
 	
-	return ((ssize_t)(p - buffer));
+	return ((ssize_t)(char_printed + p - buffer));
 }
 
 /**

--- a/src/kernel/dev/klog/klog.c
+++ b/src/kernel/dev/klog/klog.c
@@ -230,8 +230,8 @@ PRIVATE int klogtst_wr(char *buffer, int tstlog_lenght)
 PUBLIC void test_klog(void)
 {
 	char buffer[KBUFFER_SIZE]; /* Temporary buffer.        */
-	int tstlog_lenght = 34; /* Size of message to write in the log */
-	kstrncpy(buffer, "klog test: test data input in klog", tstlog_lenght);
+	int tstlog_lenght = 35; /* Size of message to write in the log */
+	kstrncpy(buffer, "klog test: test data input in klog\n", tstlog_lenght);
 
 	if(!klogtst_wr(buffer, tstlog_lenght))
 	{

--- a/src/kernel/dev/klog/klog.c
+++ b/src/kernel/dev/klog/klog.c
@@ -204,9 +204,9 @@ PRIVATE int klogtst_wr(char *buffer, int tstlog_lenght)
 	if ((char_count = klog_write(0, buffer, tstlog_lenght)) != tstlog_lenght)
 	{
 		if (char_count <= 0)
-			kprintf("klog test: klog_write failed: nothing has been written");
+			kprintf(KERN_DEBUG "klog test: klog_write failed: nothing has been written");
 		else
-			kprintf("klog test: klog_write failed: what has been written is not what it has to be write");
+			kprintf(KERN_DEBUG "klog test: klog_write failed: what has been written is not what it has to be write");
 
 		return 0;
 	}
@@ -214,9 +214,9 @@ PRIVATE int klogtst_wr(char *buffer, int tstlog_lenght)
 	if ((char_count2 = klog_read(0,buffer2,tstlog_lenght)) != char_count)
 	{
 		if (char_count2 <= 0)
-			kprintf("klog test: klog_read failed: nothing has been read");
+			kprintf(KERN_DEBUG "klog test: klog_read failed: nothing has been read");
 		else
-			kprintf("klog test: klog_read failed: what has been read is not what it has to be read");
+			kprintf(KERN_DEBUG "klog test: klog_read failed: what has been read is not what it has to be read");
 
 		tst_failed();
 	}

--- a/src/kernel/dev/ramdisk/ramdisk.c
+++ b/src/kernel/dev/ramdisk/ramdisk.c
@@ -184,7 +184,7 @@ PRIVATE int rmdtst_register(void)
 	{
 		if (&(ramdisks[i].start) == NULL)
 		{
-			kprintf("rmdsk test: register of disk number %d failed", i);
+			kprintf(KERN_DEBUG "rmdsk test: register of disk number %d failed", i);
 			return 0;
 		}
 	}
@@ -207,7 +207,7 @@ PRIVATE int rmdtst_rw(char *buffer, int tstrmd_lenght)
 	if ((char_count = ramdisk_write(0, buffer, tstrmd_lenght, 0)) != tstrmd_lenght)
 	{
 		if (char_count <= 0)
-			kprintf("rmdsk test: ramdisk_write failed: nothing has been written");
+			kprintf(KERN_DEBUG "rmdsk test: ramdisk_write failed: nothing has been written");
 		else
 			kprintf("rmdsk test: ramdisk_write failed: what has been written is not what it has to be write");
 
@@ -217,9 +217,9 @@ PRIVATE int rmdtst_rw(char *buffer, int tstrmd_lenght)
 	if ((char_count2 = ramdisk_read(0,buffer,tstrmd_lenght, 0)) != char_count)
 	{
 		if (char_count2 <= 0)
-			kprintf("rmdsk test: ramdisk_read failed: nothing has been read");
+			kprintf(KERN_DEBUG "rmdsk test: ramdisk_read failed: nothing has been read");
 		else
-			kprintf("rmdsk test: ramdisk_read failed: what has been read is not what has to be read");
+			kprintf(KERN_DEBUG "rmdsk test: ramdisk_read failed: what has been read is not what has to be read");
 		return 0;
 	}
 
@@ -229,8 +229,8 @@ PRIVATE int rmdtst_rw(char *buffer, int tstrmd_lenght)
 PUBLIC void test_rmd(void)
 {
 	char buffer[KBUFFER_SIZE]; /* Temporary buffer.        */
-	int tstrmd_lenght = 38; /* Size of message to write in the log */
-	kstrncpy(buffer, "rmdsk test: test data input in ramdisk", tstrmd_lenght);
+	int tstrmd_lenght = 39; /* Size of message to write in the log */
+	kstrncpy(buffer, "rmdsk test: test data input in ramdisk\n", tstrmd_lenght);
 
 	if(!rmdtst_register())
 	{

--- a/src/kernel/lib/kprintf.c
+++ b/src/kernel/lib/kprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com>
- * 				2017-2017 Clement Rouquier <clementrouquier@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -47,6 +47,11 @@ PUBLIC void chkout(dev_t dev)
 	cdev_write(kout, buffer, n);
 }
 
+/**
+ * @brief Skip log_level from a buffer and update it's size
+ * 
+ * @return Buffer without log_level code at the beginning
+ */
 PUBLIC const char *skip_code(const char *buffer, int *i)
 {
 	if (get_code(buffer))
@@ -57,6 +62,11 @@ PUBLIC const char *skip_code(const char *buffer, int *i)
 	return buffer;
 }
 
+/**
+ * @brief Get log_level from a buffer
+ * 
+ * @return log_level or 0 if default log_level
+ */
 PUBLIC char get_code(const char *buffer)
 {
 	if ((buffer[0] == KERN_SOH_ASCII) && !(&buffer[1] == NULL))

--- a/src/kernel/mm/region.c
+++ b/src/kernel/mm/region.c
@@ -1056,7 +1056,7 @@ PRIVATE int mmtst_alloc(int min_mm)
 
 		if (( d = allocreg(S_IRUSR | S_IXUSR, 1000, REGION_FREE)) == NULL)
 		{
-			kprintf("mm test: failed to allocate memory region");
+			kprintf(KERN_DEBUG "mm test: failed to allocate memory region");
 		}
 	}
 
@@ -1064,7 +1064,7 @@ PRIVATE int mmtst_alloc(int min_mm)
 
 	if(free_count != NR_REGIONS-(min_mm/2))
 	{
-		kprintf("mm test: region allocation failed");
+		kprintf(KERN_DEBUG "mm test: region allocation failed");
 		return 0;
 	}
 
@@ -1089,7 +1089,7 @@ PRIVATE int mmtst_dup(int min_mm)
 	{
 		if ((d = dupreg(&regtab[i])) == NULL)
 		{
-			kprintf("mm test: failed to duplicate region number %d",i);
+			kprintf(KERN_DEBUG "mm test: failed to duplicate region number %d",i);
 			result = 0;
 		}
 	}
@@ -1099,7 +1099,7 @@ PRIVATE int mmtst_dup(int min_mm)
 
 		if ((d = dupreg(&regtab[i+(min_mm/2)])) == NULL)
 		{
-			kprintf("mm test: failed to duplicate region created by duplication number %d",i);
+			kprintf(KERN_DEBUG "mm test: failed to duplicate region created by duplication number %d",i);
 			result = 0;
 		}
 	}
@@ -1108,7 +1108,7 @@ PRIVATE int mmtst_dup(int min_mm)
 
 	if(free_count != NR_REGIONS-min_mm || !result)
 	{
-		kprintf("mm test: region duplication failed");
+		kprintf(KERN_DEBUG "mm test: region duplication failed");
 		return 0;
 	}
 
@@ -1134,7 +1134,7 @@ PRIVATE int mmtst_free(int min_mm)
 
 	if(free_count != NR_REGIONS)
 	{
-		kprintf("mm test: region freeing failed");
+		kprintf(KERN_DEBUG "mm test: region freeing failed");
 		return 0;
 	}
 


### PR DESCRIPTION
Now kprintf can be called like this: kprintf([OPTIONAL: LOV_LEVEL] "[MESSAGE]",[PARAM])
With 8 possible logs levels, which can be find in klib.h
Log level has an influence only on klog and no on kout
Default log level is no log level, this is mandatory to print early boot infos in console without log_levels
Some kprintf uses it for example.