### PR TITLE
Log levels implementation for kprintf & gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # 
-# Copyright(C) 2011-2014 Pedro H. Penna <pedrohenriquepenna@gmail.com> 
+# Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com> 
+#              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
 #
 # This file is part of Nanvix.
 #
@@ -20,7 +21,6 @@
 # Default rules.
 *.o
 *.a
-*.img
 *.pdf
 bochsout.txt
 bin/*
@@ -39,6 +39,12 @@ doc/*-kernel
 *.fdb_latexmk
 *.out
 *.dvi
+*.ini
+
+# ISO Images
+*.img
+*.iso
+nanvix-iso/*
 
 # Exceptions.
 !doc/paper/img/*.pdf

--- a/CREDITS
+++ b/CREDITS
@@ -21,6 +21,11 @@ E: contato@fjorgemota.com
 W: https://fjorgemota.com
 D: Bachelor Student in Computer Science at UFSC
 
+N: Clement Rouquier
+E: clementrouquier@gmail.com
+W: https://github.com/turbolay
+D: Student at UGA, Boustricoule's fan
+
 N: Subhra S. Sarkar
 E: rurtle.coder@gmail.com
 W: https://www.linkedin.com/in/subhrasankhasarkar

--- a/include/nanvix/klib.h
+++ b/include/nanvix/klib.h
@@ -1,5 +1,8 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>Joe Perches <joe@perches.com>
+ *              2012-2016 Linus Torvalds <torvalds@linux-foundation.org>
+ *              2012-2012 Kay Sievers <kay.sievers@vrfy.org>
  * 
  * This file is part of Nanvix.
  * 
@@ -235,6 +238,22 @@
 	/*========================================================================*
 	 *                           logging and debugging                        *
 	 *========================================================================*/
+	/* This char declares that following one is a log level */
+	#define KERN_SOH        "\001"
+	#define KERN_SOH_ASCII  '\001'
+
+	/* Log levels */
+	#define KERN_EMERG      KERN_SOH "0"    /* system is unusable */
+	#define KERN_ALERT      KERN_SOH "1"    /* action must be taken immediately */
+	#define KERN_CRIT       KERN_SOH "2"    /* critical conditions */
+	#define KERN_ERR        KERN_SOH "3"    /* error conditions */
+	#define KERN_WARNING    KERN_SOH "4"    /* warning conditions */
+	#define KERN_NOTICE     KERN_SOH "5"    /* normal but significant condition */
+	#define KERN_INFO       KERN_SOH "6"    /* informational */
+	#define KERN_DEBUG      KERN_SOH "7"    /* debug-level messages */
+
+	/* default log level is no log level, 
+	   useful to avoid printing log level in early boot */
 
 	/**
 	 * @brief Kernel log size (in characters).
@@ -251,6 +270,8 @@
 	EXTERN ssize_t klog_write(unsigned, const char *, size_t);
 	EXTERN void kpanic(const char *, ...);
 	EXTERN void kmemdump(const void *s, size_t n);
+	EXTERN const char *skip_code(const char *buffer, int *i);
+	EXTERN char get_code(const char *buffer);
 	/**@}*/
 
 	/*========================================================================*

--- a/src/kernel/init/main.c
+++ b/src/kernel/init/main.c
@@ -1,5 +1,6 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -123,6 +124,7 @@ PUBLIC void kmain(void)
 	fs_init();
 	
 	chkout(DEVID(TTY_MAJOR, 0, CHRDEV));
+	kprintf(KERN_INFO "kout is now initialized");
 	
 	/* Spawn init process. */
 	if ((pid = fork()) < 0)
@@ -130,7 +132,7 @@ PUBLIC void kmain(void)
 	else if (pid == 0)
 	{	
 		init();
-		kprintf("failed to execute init");
+		kprintf(KERN_EMERG "failed to execute init");
 		_exit(-1);
 	}
 	

--- a/src/kernel/lib/kprintf.c
+++ b/src/kernel/lib/kprintf.c
@@ -1,5 +1,6 @@
 /*
- * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * Copyright(C) 2011-2017 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *              2017-2017 Clement Rouquier <clementrouquier@gmail.com>
  * 
  * This file is part of Nanvix.
  * 
@@ -47,15 +48,52 @@ PUBLIC void chkout(dev_t dev)
 }
 
 /**
+ * @brief Skip log_level from a buffer and update it's size
+ * 
+ * @return Buffer without log_level code at the beginning
+ */
+PUBLIC const char *skip_code(const char *buffer, int *i)
+{
+	if (get_code(buffer))
+	{
+		*i = *i-2;
+		return buffer+2;
+	}
+	return buffer;
+}
+
+/**
+ * @brief Get log_level from a buffer
+ * 
+ * @return log_level or 0 if default log_level
+ */
+PUBLIC char get_code(const char *buffer)
+{
+	if ((buffer[0] == KERN_SOH_ASCII) && !(&buffer[1] == NULL))
+	{
+		if ((buffer[1] >= '0' && buffer[1] <= '7'))
+			return buffer[1];	
+
+		else
+		{
+			kpanic("log level error: invalid log level");
+			return -1;
+		}
+	}
+	return 0;
+}
+
+/**
  * @brief Writes on the screen a formated string.
  * 
  * @param fmt Formated string.
  */
 PUBLIC void kprintf(const char *fmt, ...)
 {
-	int i;                         /* Loop index.              */
-	va_list args;                  /* Variable arguments list. */
-	char buffer[KBUFFER_SIZE + 1]; /* Temporary buffer.        */
+	int i;                         /* Loop index.                              */
+	va_list args;                  /* Variable arguments list.                 */
+	char buffer[KBUFFER_SIZE + 1]; /* Temporary buffer.                        */
+	const char *buffer_no_code;    /* Temporary buffer for log level printing. */
 	
 	/* Convert to raw string. */
 	va_start(args, fmt);
@@ -63,7 +101,8 @@ PUBLIC void kprintf(const char *fmt, ...)
 	buffer[i++] = '\n';
 	va_end(args);
 
-	/* Save on kernel log and write on kout. */
-	cdev_write(kout, buffer, i);
+	/* Save on kernel log, skip code in case it's not correctly done and write on kout. */
 	klog_write(0, buffer, i);
+	buffer_no_code = skip_code(buffer, &i);
+	cdev_write(kout, buffer_no_code, i);
 }


### PR DESCRIPTION
Now kprintf can be called like this: kprintf([OPTIONAL: LOV_LEVEL] "[MESSAGE]",[PARAM])
With 8 possible logs levels, which can be find in klib.h
Log levels have an influence only on klog and no on kout
Default log level is no log level, this is mandatory to print early boot infos in console without log_levels
Some kprintf in main.c uses it for example.

Also update CREDITS and .gitinore