### PR TITLE
Semaphores : User table / Unlinking / Prefix / Testing

### DIFF
--- a/include/nanvix/fs.h
+++ b/include/nanvix/fs.h
@@ -137,6 +137,7 @@
 	EXTERN struct inode *inode_alloc(struct superblock *);
 	EXTERN struct inode *inode_get(dev_t dev, ino_t);
 	EXTERN void inode_put(struct inode *);
+	EXTERN const char* break_path(const char *pathname, char *filename);
 	EXTERN struct inode *inode_dname(const char *, const char **);
 	EXTERN struct inode *inode_name(const char *);
 	EXTERN struct inode *inode_pipe(void);

--- a/include/nanvix/fs.h
+++ b/include/nanvix/fs.h
@@ -144,6 +144,7 @@
 	EXTERN int mount (char*, char*);
 	EXTERN int unmount (char*, char*);
 	EXTERN struct inode *inode_semaphore(const char* name, int mode);
+	EXTERN int inode_rename(const char* pathname, const char* newname);
 
 /*============================================================================*
  *                            Super Block Library                             *

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -17,6 +17,8 @@
  * along with Nanvix. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <limits.h>
+
 #ifndef SEMAPHORE_H_
 #define SEMAPHORE_H_
 
@@ -30,6 +32,8 @@
 	{
 		int semid; 	/**< Semaphore ID.  */
 	} sem_t;
+
+	extern sem_t *usem[OPEN_MAX];
 
 	/* Forward definitions. */
 	extern sem_t *sem_open(const char *, int, ...);

--- a/include/sys/sem.h
+++ b/include/sys/sem.h
@@ -50,7 +50,7 @@
 	 * 	Searching if a semaphore descriptor exists from its name
 	 * 	by searching in the file system
 	 */
-	int existence_semaphore(const char* semname);
+	int existence_semaphore(const char* path);
 
 	/** 	
 	 *	@brief Searching if a sempahore exists in the semaphore table 
@@ -61,7 +61,11 @@
 	int search_semaphore (const char* semname);
 
 	int remove_semaphore (const char *pathname);
+	
+	int sem_path(const char* pathname, char *sempathname);
 
+	int sem_name(const char *sempathname, char *filename);
+	
 
 #endif
 

--- a/include/sys/sem.h
+++ b/include/sys/sem.h
@@ -23,9 +23,7 @@
 	/* Kernel semaphores */
 	struct ksem {
 		char name[MAX_SEM_NAME];				/* Semaphore name 										*/
-		struct inode *seminode; 				/* necessary to unlink to avoid multiple inode_get		*/
 		short value;              				/* Value of the semaphore                    			*/
-		unsigned short state;           		/* last bit used as boolean, first bits are free 		*/ /* LOOK TO CHANGE THAT */
 		pid_t currprocs[PROC_MAX];				/* Processes using the semaphores						*/
 		struct process* semwaiters[PROC_MAX];	/* The size should be higher if threads are implemented */
 		int nbproc;

--- a/include/sys/sem.h
+++ b/include/sys/sem.h
@@ -26,7 +26,6 @@
 		short value;              				/* Value of the semaphore                    			*/
 		pid_t currprocs[PROC_MAX];				/* Processes using the semaphores						*/
 		struct process* semwaiters[PROC_MAX];	/* The size should be higher if threads are implemented */
-		int nbproc;
 	};
 
 	/* Semaphores table */

--- a/include/sys/sem.h
+++ b/include/sys/sem.h
@@ -10,10 +10,10 @@
 #define PERMISSIONS 0000777
 
 #define SEM_IS_VALID(idx) \
-		( (idx>=0 && idx<SEM_OPEN_MAX) && semtable[idx].name[0]!='\0')
+		(idx>=0 && idx<SEM_OPEN_MAX)
 
 #define SEM_IS_FREE(idx) \
-		(semtable[idx].nbproc=-1)
+		(semtable[idx].num=0)
 
 #define SEM_VALID_VALUE(val) \
 		(val<=SEM_VALUE_MAX)
@@ -26,6 +26,8 @@
 		short value;              				/* Value of the semaphore                    			*/
 		pid_t currprocs[PROC_MAX];				/* Processes using the semaphores						*/
 		struct process* semwaiters[PROC_MAX];	/* The size should be higher if threads are implemented */
+		dev_t dev;								/* Semaphore descriptor device							*/
+		ino_t num;								/* Semaphore descriptor inode number					*/
 	};
 
 	/* Semaphores table */

--- a/src/kernel/fs/inode.c
+++ b/src/kernel/fs/inode.c
@@ -798,7 +798,7 @@ PUBLIC void inode_put(struct inode *ip)
  *          remainder of the path. Upon failure, a #NULL pointer is returned 
  *          instead.
  */
-PRIVATE const char *break_path(const char *pathname, char *filename)
+PUBLIC const char *break_path(const char *pathname, char *filename)
 {
 	char *p2;       /* Write pointer. */
 	const char *p1; /* Read pointer.  */
@@ -1098,6 +1098,18 @@ PUBLIC struct inode *inode_semaphore(const char* pathsem, int mode)
 
 	/* Initialize Semaphore inode. */
 	directory = inode_dname(pathsem, &name);
+
+	if (directory==NULL)
+	{
+		return NULL;
+	}
+
+	if (	!permission(directory->mode, directory->uid, directory->gid, curr_proc, MAY_WRITE, 0) \
+	 	||	!permission(directory->mode, directory->uid, directory->gid, curr_proc, MAY_READ, 0) )
+	{
+		return NULL;
+	}
+
 	inode = do_creat(directory, name, mode, O_CREAT);
 	inode->time = CURRENT_TIME;
 

--- a/src/kernel/sys/sem.c
+++ b/src/kernel/sys/sem.c
@@ -16,7 +16,6 @@
 void freesem(struct ksem *sem)
 {
 	(sem->name)[0]='\0';
-	sem->state=0;
 
 	for (int i = 0; i<PROC_MAX; i++)
 		sem->currprocs[i] = -1;
@@ -61,6 +60,7 @@ int existence_semaphore(const char* sempath)
 	else
 	{
 		/* Semaphore exists */
+		inode_put(seminode);
 		inode_unlock(seminode);
 		return 0;
 	}

--- a/src/kernel/sys/sem.c
+++ b/src/kernel/sys/sem.c
@@ -64,10 +64,11 @@ int namevalid(const char* pathname)
  *
  *	@parameters sempath The complet semaphore descriptor path
  */
-int existence_semaphore(const char* sempath)
+int existence_semaphore(const char* path)
 {
 	struct inode* seminode;
-
+	char sempath[MAX_SEM_NAME];
+	sem_path(path, sempath);
 	seminode = inode_name(sempath);
 
 	if (seminode == NULL)
@@ -92,7 +93,7 @@ int search_semaphore (const char* semname)
 {
 	for (int idx = 0; idx < SEM_OPEN_MAX; idx++)
 	{
-		if (!kstrcmp(semname,semtable[idx].name))
+		if (!kstrcmp(semtable[idx].name, semname))
 		{
 			return idx;
 		}
@@ -112,8 +113,70 @@ int remove_semaphore (const char *pathname)
 	struct inode *semdirectory;
 
 	semdirectory = inode_dname(pathname, &filename);
+	inode_unlock(semdirectory);
 	dir_remove(semdirectory, filename);
 	inode_unlock(semdirectory);
+
+	return 0;
+}
+
+/* Converts a normal path name into semaphore pathname (add the prefix) */
+int sem_path(const char* pathname, char *sempathname)
+{
+	const char *p;
+	// char *p2;
+	int nbdir = 0;
+
+	p = pathname;
+
+	while (*p != '\0')
+	{
+		if (*p == '/')
+			nbdir++;
+		p++;
+	}
+
+	int currdir = 0;
+	p = pathname;
+
+	while (currdir < nbdir)
+	{
+		if (*p == '/')
+			currdir++;
+		
+		*sempathname++ = *p++;
+	}
+
+	kstrcpy(sempathname,"sem.");
+	sempathname += 4;
+
+	while (*p != '\0')
+	{
+		*sempathname++ = *p++;
+	}
+
+	*sempathname = '\0';
+
+	return 0;
+}
+
+int sem_name(const char *sempathname, char *filename)
+{
+	const char *p;
+
+	p = sempathname;
+
+	p = break_path(p, filename);
+
+	if (p == NULL)
+		return -1;
+
+	kstrcpy(filename,"sem.");
+
+	while (*p != '\0')
+	{
+		p = break_path(p, (filename));
+	}
 
 	return 0;
 }

--- a/src/kernel/sys/sem.c
+++ b/src/kernel/sys/sem.c
@@ -13,7 +13,7 @@
  */
 void freesem(struct ksem *sem)
 {
-	(sem->name)[0]='\0';
+	sem->num = 0;
 
 	for (int i = 0; i<PROC_MAX; i++)
 		sem->currprocs[i] = -1;
@@ -115,7 +115,6 @@ int remove_semaphore (const char *pathname)
 	semdirectory = inode_dname(pathname, &filename);
 	inode_unlock(semdirectory);
 	dir_remove(semdirectory, filename);
-	inode_unlock(semdirectory);
 
 	return 0;
 }
@@ -124,7 +123,6 @@ int remove_semaphore (const char *pathname)
 int sem_path(const char* pathname, char *sempathname)
 {
 	const char *p;
-	// char *p2;
 	int nbdir = 0;
 
 	p = pathname;

--- a/src/kernel/sys/semclose.c
+++ b/src/kernel/sys/semclose.c
@@ -1,12 +1,10 @@
 #include <sys/sem.h>
-#include <nanvix/klib.h>
-#include <semaphore.h>
 #include <errno.h>
 
 /**
  * @brief close a semaphore for a given process
  *		 
- * @param	num		semaphore inode number 
+ * @param num Semaphore inode number 
  *
  * @returns returns 0 in case of successful completion
  *			returns SEM_FAILED otherwise
@@ -34,20 +32,16 @@ PUBLIC int sys_semclose(int idx)
 	}
 
 	if (i > PROC_MAX)
-	{
-		kprintf("Attempting to close a non-opened semaphore");
 		return -1;
-	}
-
-	semtable[idx].nbproc--;
 
 	if (seminode->count == 1 && seminode->nlinks == 0)
 	{		
-		remove_semaphore (semtable[idx].name);
-		semtable[idx].name[0] = '\0';
+		remove_semaphore(semtable[idx].name);
+		freesem(&semtable[idx]);
 	}	
 
 	inode_put(seminode);
+	inode_unlock(seminode);
 
 	return 0;
 }

--- a/src/kernel/sys/semclose.c
+++ b/src/kernel/sys/semclose.c
@@ -14,7 +14,10 @@ PUBLIC int sys_semclose(int idx)
 	struct inode *seminode;
 	int i;
 
-	seminode = inode_name(semtable[idx].name);
+	if (!SEM_IS_VALID(idx))
+		return (-EINVAL);
+
+	seminode = inode_get(semtable[idx].dev, semtable[idx].num);
 
 	if (seminode == NULL)
 		return (-EINVAL);
@@ -57,10 +60,7 @@ PUBLIC int sys_semclose(int idx)
 	else
 	{
 		if (seminode->count == 1 && seminode->nlinks == 0)
-		{		
-			remove_semaphore(semtable[idx].name);
 			freesem(&semtable[idx]);
-		}	
 		
 		inode_put(seminode);
 		inode_unlock(seminode);

--- a/src/kernel/sys/semclose.c
+++ b/src/kernel/sys/semclose.c
@@ -26,12 +26,12 @@ PUBLIC int sys_semclose(int idx)
 		/* Removing the proc pid in the semaphore procs table */
 		if (semtable[idx].currprocs[i] == curr_proc->pid)
 		{
-			semtable[idx].currprocs[i] = -1;
+			semtable[idx].currprocs[i] = 0;
 			break;
 		}
 	}
 
-	if (i > PROC_MAX)
+	if (i == PROC_MAX)
 		return -1;
 
 	if (seminode->count == 1 && seminode->nlinks == 0)

--- a/src/kernel/sys/semclose.c
+++ b/src/kernel/sys/semclose.c
@@ -34,14 +34,36 @@ PUBLIC int sys_semclose(int idx)
 	if (i == PROC_MAX)
 		return -1;
 
-	if (seminode->count == 1 && seminode->nlinks == 0)
-	{		
-		remove_semaphore(semtable[idx].name);
-		freesem(&semtable[idx]);
-	}	
+	char found;
+	found = 0;
+	i++;
+	/* Searching for multiple openings */
+	while (i < PROC_MAX)
+	{
+		if (semtable[idx].currprocs[i] == curr_proc->pid)
+		{
+			found = 1;
+			break;
+		}
+		i++;
+	}
 
-	inode_put(seminode);
-	inode_unlock(seminode);
-
-	return 0;
+	if (found)
+	{
+		inode_put(seminode);
+		inode_unlock(seminode);
+		return 1;
+	}
+	else
+	{
+		if (seminode->count == 1 && seminode->nlinks == 0)
+		{		
+			remove_semaphore(semtable[idx].name);
+			freesem(&semtable[idx]);
+		}	
+		
+		inode_put(seminode);
+		inode_unlock(seminode);
+		return 0;
+	}
 }

--- a/src/kernel/sys/semclose.c
+++ b/src/kernel/sys/semclose.c
@@ -16,8 +16,12 @@ PUBLIC int sys_semclose(int idx)
 	struct inode *seminode;
 	int i;
 
-	if (semtable[idx].name[0] == '\0')
+	seminode = inode_name(semtable[idx].name);
+
+	if (seminode == NULL)
 		return (-EINVAL);
+
+	inode_put(seminode);
 
 	for (i = 0; i < PROC_MAX; i++)
 	{
@@ -37,13 +41,12 @@ PUBLIC int sys_semclose(int idx)
 
 	semtable[idx].nbproc--;
 
-	if (semtable[idx].nbproc == 0 && (semtable[idx].state & UNLINKED)>0)
+	if (seminode->count == 1 && seminode->nlinks == 0)
 	{		
 		remove_semaphore (semtable[idx].name);
 		semtable[idx].name[0] = '\0';
 	}	
 
-	seminode = semtable[idx].seminode;
 	inode_put(seminode);
 
 	return 0;

--- a/src/kernel/sys/semopen.c
+++ b/src/kernel/sys/semopen.c
@@ -11,7 +11,7 @@
  */
 int add_table(int value, const char* semname, int idx)
 {
-	kstrcpy(semtable[idx].name, semname);
+	sem_path(semname, semtable[idx].name);
 	semtable[idx].value = value;
 	semtable[idx].currprocs[0] = curr_proc->pid;
 	return 0;
@@ -44,10 +44,6 @@ PUBLIC int sys_semopen(const char* name, int oflag, ...)
 	if (namevalid(name) == (-1))
 		return (ENAMETOOLONG);
 
-	/*  
-	 *	inode == corresponding semaphore inode if it exists
-	 *  NULL otherwise
-	 */
 	if (existence_semaphore(name) == (-1))	/* This semaphore does not exist */
 	{
 		if(oflag & O_CREAT)	
@@ -99,10 +95,12 @@ PUBLIC int sys_semopen(const char* name, int oflag, ...)
 	}
 	else	/* This semaphore already exists */
 	{
+		char sempath[MAX_SEM_NAME];
+		sem_path(name,sempath);
 		/* Searching the semaphore indice in the semaphore table */
-		semid = search_semaphore (name);
+		semid = search_semaphore (sempath);
 		/* This opening will increment the inode counter */
-		inode = inode_name(name);
+		inode = inode_name(sempath);
 
 		/* Checking if there is WRITE and READ permissions */
 		if (	!permission(inode->mode, inode->uid, inode->gid, curr_proc, MAY_WRITE, 0) \

--- a/src/kernel/sys/semopen.c
+++ b/src/kernel/sys/semopen.c
@@ -9,11 +9,13 @@
  *		   to corresponding value and semname
  *         in the global semaphore table
  */
-int add_table(int value, const char* semname, int idx)
+int add_table(int value, const char* semname, int idx, struct inode* seminode)
 {
 	sem_path(semname, semtable[idx].name);
 	semtable[idx].value = value;
 	semtable[idx].currprocs[0] = curr_proc->pid;
+	semtable[idx].num = seminode->num;
+	semtable[idx].dev = seminode->dev;
 	return 0;
 }
 
@@ -68,7 +70,7 @@ PUBLIC int sys_semopen(const char* name, int oflag, ...)
 
 			for (i = 0; i < SEM_OPEN_MAX; i++)
 			{
-				if (semtable[i].name[0] == '\0')
+				if (semtable[i].num == 0)
 				{
 					semid = i;
 					break;
@@ -88,7 +90,7 @@ PUBLIC int sys_semopen(const char* name, int oflag, ...)
 				return (-EACCES);
 			}
 			/* Add the semaphore in the semaphore table */
-			add_table(value, name, semid);
+			add_table(value, name, semid, inode);
 		}
 		/* O_CREAT not set and sem does not exist */
 		else

--- a/src/kernel/sys/semopen.c
+++ b/src/kernel/sys/semopen.c
@@ -30,6 +30,7 @@ int add_table(int value, const char* semname, int idx)
 
 /* TODO for error detection :
  *			ENOSPC : There is insufficient space on a storage device for the creation of the new named semaphore.
+ *			EINTR : The sem_open() operation was interrupted by a signal.
  */
 PUBLIC int sys_semopen(const char* name, int oflag, ...)
 {

--- a/src/kernel/sys/sempost.c
+++ b/src/kernel/sys/sempost.c
@@ -13,14 +13,24 @@
 PUBLIC int sys_sempost(int idx)
 {
 	struct inode *seminode;
+	int i;
 	seminode = inode_name(semtable[idx].name);
 
 	if (seminode == NULL)
 		return (-EINVAL);
 
+	for (i = 0; i < PROC_MAX; i++)
+	{
+		/* Removing the proc pid in the semaphore procs table */
+		if (semtable[idx].currprocs[i] == curr_proc->pid)
+			break;
+	}
+
+	if (i == PROC_MAX)
+		return (-1);
+
 	semtable[idx].value++;
 	
-
 	if (semtable[idx].value>0)
 		wakeup(semtable[idx].semwaiters);
 

--- a/src/kernel/sys/sempost.c
+++ b/src/kernel/sys/sempost.c
@@ -14,9 +14,8 @@ PUBLIC int sys_sempost(int idx)
 {
 	struct inode *seminode;
 	int i;
-	seminode = inode_name(semtable[idx].name);
 
-	if (seminode == NULL)
+	if (!SEM_IS_VALID(idx))
 		return (-EINVAL);
 
 	for (i = 0; i < PROC_MAX; i++)
@@ -28,6 +27,11 @@ PUBLIC int sys_sempost(int idx)
 
 	if (i == PROC_MAX)
 		return (-1);
+
+	seminode = inode_get(semtable[idx].dev, semtable[idx].num);
+
+	if (seminode == NULL)
+		return (-EINVAL);
 
 	semtable[idx].value++;
 	

--- a/src/kernel/sys/sempost.c
+++ b/src/kernel/sys/sempost.c
@@ -1,16 +1,14 @@
 #include <sys/sem.h>
-#include <nanvix/klib.h>
-#include <semaphore.h>
 #include <errno.h>
 
 /**
- * @brief Close a semaphore for a given process
+ * @brief Closes a semaphore for a given process
  *		 
- * @param	idx	Semaphore index (in semaphore
- *				table to close
+ * @param idx Semaphore index (in semaphore
+ *			  table to close
  *
  * @returns 0 in case of successful completion
- *			SEM_FAILED otherwise
+ *			error code otherwise
  */
 PUBLIC int sys_sempost(int idx)
 {
@@ -21,13 +19,13 @@ PUBLIC int sys_sempost(int idx)
 		return (-EINVAL);
 
 	semtable[idx].value++;
-
-	inode_unlock(seminode);
+	
 
 	if (semtable[idx].value>0)
 		wakeup(semtable[idx].semwaiters);
 
 	inode_put(seminode);
+	inode_unlock(seminode);
 
 	return (0);
 }

--- a/src/kernel/sys/sempost.c
+++ b/src/kernel/sys/sempost.c
@@ -15,17 +15,19 @@
 PUBLIC int sys_sempost(int idx)
 {
 	struct inode *seminode;
-
-	seminode = semtable[idx].seminode;
+	seminode = inode_name(semtable[idx].name);
 
 	if (seminode == NULL)
 		return (-EINVAL);
 
 	semtable[idx].value++;
 
+	inode_unlock(seminode);
 
 	if (semtable[idx].value>0)
 		wakeup(semtable[idx].semwaiters);
+
+	inode_put(seminode);
 
 	return (0);
 }

--- a/src/kernel/sys/semunlink.c
+++ b/src/kernel/sys/semunlink.c
@@ -17,21 +17,19 @@ PUBLIC int sys_semunlink(const char *name)
 {
 	int idx;
 	struct inode* seminode;
+	char semname[MAX_SEM_NAME-4];
 
-	seminode = inode_name(name);
+	/* Name invalid */
+	if (namevalid(name) == (-1))
+		return (ENAMETOOLONG);
+
+	sem_path(name, semname);
+	seminode = inode_name(semname);
 
 	if (seminode == NULL)
 	{
-		/* The semaphore descriptor doesn't exist */
+		kprintf("invalid semaphore");
 		return (-ENOENT);
-	}
-
-	/* Already unlinked, sem_unlink has no effect */
-	if (seminode->nlinks == 0)
-	{
-		inode_put(seminode);
-		inode_unlock(seminode);
-		return -1;
 	}
 
 	if (!permission(seminode->mode, seminode->uid, seminode->gid, curr_proc, MAY_WRITE, 0))
@@ -41,20 +39,38 @@ PUBLIC int sys_semunlink(const char *name)
 		return -(EACCES);
 	}
 
- 	idx = search_semaphore(name);
-	inode_unlock(seminode);
+	idx = search_semaphore(semname);
 
 	if (seminode->count == 1)
 	{
-		remove_semaphore(name);
+		inode_unlock(seminode);
+		remove_semaphore(semname);
 		freesem(&semtable[idx]);
-	}
-	else
-	{
-		/* Unlinking the semaphore */
-		seminode->nlinks = 0;
+		inode_put(seminode);
+		return 0;
 	}
 
+	int len = kstrlen(semname);
+	kstrcpy(&semname[len],".ul");
+
+	if (search_semaphore (semname) != (-1))
+	{
+		inode_unlock(seminode);
+		inode_put(seminode);
+		return -1;
+	}
+
+	char filename[MAX_SEM_NAME-4];
+	sem_name(semname, filename);
+	/* Removing suffixe */
+	semname[len] = '\0';
+	/* Unlinking the semaphore */
+	seminode->nlinks = 0;
+	inode_rename(semname, filename);
+	kstrcpy(&semname[len],".ul");
+	kstrcpy(semtable[idx].name, semname);
+
+	inode_unlock(seminode);
 	inode_put(seminode);
 
 	return 0;	/* Successful completion */

--- a/src/kernel/sys/semunlink.c
+++ b/src/kernel/sys/semunlink.c
@@ -1,29 +1,39 @@
-#include <fcntl.h>
 #include <sys/sem.h>
-#include <nanvix/klib.h>
-#include <semaphore.h>
 #include <errno.h>
 #include <nanvix/syscall.h>
 
+#include <nanvix/klib.h>
+
+
 /**
- * @brief	Unlinks a semaphore for future deletion
+ * @brief Unlinks a semaphore for future deletion
  *		 
- * @param	name Semaphore name
+ * @param name Semaphore name
  *
- * @returns returns 0 in case of successful completion
- *			returns SEM_FAILED otherwise
+ * @returns Returns 0 in case of successful completion
+ *			returns error code otherwise
  */
 PUBLIC int sys_semunlink(const char *name)
 {
 	int idx;
-	struct inode* seminode = inode_name(name);
+	struct inode* seminode;
+
+	seminode = inode_name(name);
 
 	if (seminode == NULL)
 	{
 		/* The semaphore descriptor doesn't exist */
 		return (-ENOENT);
 	}
-	
+
+	/* Already unlinked, sem_unlink has no effect */
+	if (seminode->nlinks == 0)
+	{
+		inode_put(seminode);
+		inode_unlock(seminode);
+		return -1;
+	}
+
 	if (!permission(seminode->mode, seminode->uid, seminode->gid, curr_proc, MAY_WRITE, 0))
 	{
 		inode_put(seminode);
@@ -32,20 +42,20 @@ PUBLIC int sys_semunlink(const char *name)
 	}
 
  	idx = search_semaphore(name);
-	
-	if (semtable[idx].nbproc == 0)
+	inode_unlock(seminode);
+
+	if (seminode->count == 1)
 	{
-		semtable[idx].name[0] = '\0';
-		remove_semaphore (name);
-		// dir_remove(semdirectory, name);
+		remove_semaphore(name);
+		freesem(&semtable[idx]);
 	}
 	else
 	{
+		/* Unlinking the semaphore */
 		seminode->nlinks = 0;
 	}
 
 	inode_put(seminode);
-	inode_unlock(seminode);
 
 	return 0;	/* Successful completion */
 }

--- a/src/kernel/sys/semunlink.c
+++ b/src/kernel/sys/semunlink.c
@@ -41,7 +41,7 @@ PUBLIC int sys_semunlink(const char *name)
 	}
 	else
 	{
-		semtable[idx].state |= UNLINKED;
+		seminode->nlinks = 0;
 	}
 
 	inode_put(seminode);

--- a/src/kernel/sys/semwait.c
+++ b/src/kernel/sys/semwait.c
@@ -19,10 +19,12 @@ PUBLIC int sys_semwait(int idx)
 {
 	struct inode *seminode;
 
-	seminode = semtable[idx].seminode;
+	seminode = inode_name(semtable[idx].name);
 
 	if (seminode == NULL)
 		return (-EINVAL);
+
+	inode_unlock(seminode);
 
 	while (semtable[idx].value <= 0)
 	{
@@ -30,6 +32,7 @@ PUBLIC int sys_semwait(int idx)
 	}
 
 	semtable[idx].value--;
+	inode_put(seminode);
 
 	return (0);
 }

--- a/src/kernel/sys/semwait.c
+++ b/src/kernel/sys/semwait.c
@@ -1,12 +1,10 @@
 #include <sys/sem.h>
-#include <nanvix/klib.h>
-#include <semaphore.h>
 #include <errno.h>
 
 /**
- * @brief	Waits on a semaphore
+ * @brief Waits on a semaphore
  *		 
- * @param	num The inode number of the semaphore
+ * @param num The inode number of the semaphore
  *
  * @returns returns 0 in case of successful completion
  *			returns SEM_FAILED otherwise
@@ -27,9 +25,7 @@ PUBLIC int sys_semwait(int idx)
 	inode_unlock(seminode);
 
 	while (semtable[idx].value <= 0)
-	{
 		sleep(semtable[idx].semwaiters,curr_proc->priority);
-	}
 
 	semtable[idx].value--;
 	inode_put(seminode);

--- a/src/kernel/sys/semwait.c
+++ b/src/kernel/sys/semwait.c
@@ -17,9 +17,8 @@ PUBLIC int sys_semwait(int idx)
 {
 	struct inode *seminode;
 	int i;
-	seminode = inode_name(semtable[idx].name);
-
-	if (seminode == NULL)
+	
+	if (!SEM_IS_VALID(idx))
 		return (-EINVAL);
 
 	for (i = 0; i < PROC_MAX; i++)
@@ -31,6 +30,11 @@ PUBLIC int sys_semwait(int idx)
 
 	if (i == PROC_MAX)
 		return -1;
+
+	seminode = inode_get(semtable[idx].dev, semtable[idx].num);
+
+	if (seminode == NULL)
+		return (-EINVAL);
 
 	inode_unlock(seminode);
 

--- a/src/kernel/sys/semwait.c
+++ b/src/kernel/sys/semwait.c
@@ -16,11 +16,21 @@
 PUBLIC int sys_semwait(int idx)
 {
 	struct inode *seminode;
-
+	int i;
 	seminode = inode_name(semtable[idx].name);
 
 	if (seminode == NULL)
 		return (-EINVAL);
+
+	for (i = 0; i < PROC_MAX; i++)
+	{
+		/* Removing the proc pid in the semaphore procs table */
+		if (semtable[idx].currprocs[i] == curr_proc->pid)
+			break;
+	}
+
+	if (i == PROC_MAX)
+		return -1;
 
 	inode_unlock(seminode);
 

--- a/src/lib/libc/crt0.c
+++ b/src/lib/libc/crt0.c
@@ -19,11 +19,14 @@
 
 #include <stdlib.h>
 #include <unistd.h>
+#include <semaphore.h>
 
 /*
  * Main routine.
  */
 extern int main(int argc, char **argv);
+
+sem_t *usem[OPEN_MAX];
 
 /*
  * Entry point of the program.
@@ -31,9 +34,11 @@ extern int main(int argc, char **argv);
 void _start(int argc, char **argv, char **envp)
 {
 	int ret;
-	
 	environ = envp;
-	
+
+	for (int i = 0; i < OPEN_MAX; i++)
+		usem[i] = NULL;
+
 	ret= main(argc, argv);
 	
 	exit(ret);

--- a/src/lib/libc/sys/sem/semclose.c
+++ b/src/lib/libc/sys/sem/semclose.c
@@ -1,7 +1,7 @@
 #include <nanvix/syscall.h>
 #include <stdlib.h>
 #include <stdio.h>
-
+#include <errno.h>
 /**
  * 	@brief closes a semaphore for calling process
  *
@@ -24,8 +24,17 @@ int sem_close(sem_t* sem)
 		  "b" (sem->semid)
 	);
 
+	if (ret == (-1))
+	{
+		errno = ret;
+		return (-1);
+	}
+
 	if (ret == 0)
 		free(sem);
-	
-	return (ret);
+
+	/* if ret == 1 : do not free because multiple opening */
+
+
+	return (0);
 }	

--- a/src/lib/libc/sys/sem/semclose.c
+++ b/src/lib/libc/sys/sem/semclose.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+
 /**
  * 	@brief closes a semaphore for calling process
  *
@@ -31,10 +32,12 @@ int sem_close(sem_t* sem)
 	}
 
 	if (ret == 0)
+	{
+		usem[sem->semid] = NULL;
 		free(sem);
+	}
 
 	/* if ret == 1 : do not free because multiple opening */
-
 
 	return (0);
 }	

--- a/src/lib/libc/sys/sem/semclose.c
+++ b/src/lib/libc/sys/sem/semclose.c
@@ -13,9 +13,16 @@
  */
 int sem_close(sem_t* sem)
 {	
-	int ret;
+	int ret, i;
 
 	if (sem == NULL)
+		return (-1);
+
+	for (i = 0; i < OPEN_MAX; i++)
+		if (usem[i] == sem)
+			break;
+
+	if (i == OPEN_MAX)
 		return (-1);
 
 	__asm__ volatile (

--- a/src/lib/libc/sys/sem/semopen.c
+++ b/src/lib/libc/sys/sem/semopen.c
@@ -57,7 +57,7 @@ sem_t* sem_open(const char* name, int oflag, ...)
 		  "D" (value)
 	);
 
-	if (ret == (-1))
+	if (ret < 0)
 		return (NULL);
 
 	/* Multiple opening by the same process */

--- a/src/lib/libc/sys/sem/semopen.c
+++ b/src/lib/libc/sys/sem/semopen.c
@@ -60,6 +60,10 @@ sem_t* sem_open(const char* name, int oflag, ...)
 	if (ret == (-1))
 		return (NULL);
 
+	/* Multiple opening by the same process */
+	if (usem[ret] != NULL)
+		return usem[ret];
+
 	sem_t* s;
 	s = malloc(sizeof(sem_t));
 	if (s == NULL)
@@ -69,5 +73,8 @@ sem_t* sem_open(const char* name, int oflag, ...)
 	}
 
 	s->semid=ret;
+
+	usem[ret] = s;
+
 	return (s);
 }

--- a/src/lib/libc/sys/sem/sempost.c
+++ b/src/lib/libc/sys/sem/sempost.c
@@ -14,8 +14,12 @@ int sem_post(sem_t* sem)
 	int ret;
 
 	if (sem == NULL)
-		return -1;
-	
+		return (-1);
+
+	for (int i = 0; i < OPEN_MAX; i++)
+		if (usem[i] == sem)
+			break;
+
 	__asm__ volatile (
 		"int $0x80"
 		: "=a" (ret)

--- a/src/lib/libc/sys/sem/semwait.c
+++ b/src/lib/libc/sys/sem/semwait.c
@@ -12,6 +12,9 @@ int sem_wait(sem_t *sem)
 {	
 	int ret;
 
+	if (sem == NULL)
+		return -1;
+	
 	__asm__ volatile (
 		"int $0x80"
 		: "=a" (ret)

--- a/src/lib/libc/sys/sem/semwait.c
+++ b/src/lib/libc/sys/sem/semwait.c
@@ -13,8 +13,12 @@ int sem_wait(sem_t *sem)
 	int ret;
 
 	if (sem == NULL)
-		return -1;
-	
+		return (-1);
+
+	for (int i = 0; i < OPEN_MAX; i++)
+		if (usem[i] == sem)
+			break;	
+
 	__asm__ volatile (
 		"int $0x80"
 		: "=a" (ret)

--- a/src/sbin/test/test.c
+++ b/src/sbin/test/test.c
@@ -442,15 +442,11 @@ static int sem_test_open_close(void)
     semc3 = sem_open("/home/mysem/sem3",O_CREAT,0777,0); 
 
     sem_unlink("/home/mysem/sem1"); 
-    sem_unlink("/home/mysem/sem2"); 
-
     sem_wait(semc3); 
     sem_post(semc1); 
     sem_close(semc2); 
-
     /* sem3 has not been unlinked -> wont be deleted */ 
     sem_close(semc3); 
-     
     /*
      *  We open a semaphore after sem2 has been closed 
      *  to ensure that the slot is taken 
@@ -459,6 +455,13 @@ static int sem_test_open_close(void)
     sem_unlink("/home/mysem/sem4");
     sem_close(semc4); 
     sem_close(semc1); 
+    sem_unlink("/home/mysem/sem2"); 
+    /* Closing multiple times */
+    sem_close(semc2);
+    sem_close(semc2);
+    sem_close(semc2);
+   	/* Sem_post on a non opened semaphore */
+    sem_post(semc4);
   } 
   else{ 
     /* father */ 
@@ -471,6 +474,10 @@ static int sem_test_open_close(void)
     sem_wait(semf1); 
     sem_close(semf1); 
     sem_close(semf3); 
+    sem_unlink("/home/mysem/sem2");
+    /* Unlinking multiple times */ 
+    sem_unlink("/home/mysem/sem1");
+    sem_unlink("/home/mysem/sem1");
   } 
  
   return (0); 
@@ -588,7 +595,9 @@ static void usage(void)
 	printf("  Paging 		Paging System Test\n");
 	printf("  stack  		Stack growth Test\n");
 	printf("  sched  		Scheduling Test\n");
-	printf("  Semaphore 	Semaphore Test\n");
+	printf("  se 			Open/Close Semaphore Test\n");
+	printf("  prodcons		Producer/Consumer Semaphore Test\n");
+
 
 	exit(EXIT_SUCCESS);
 }
@@ -652,7 +661,7 @@ int main(int argc, char **argv)
 		/* Semaphore test. */
 		else if (!strcmp(argv[i], "se"))
 		{
-			printf("Semaphore testing\n");
+			printf("Semaphore open/close Test\n");
 			printf("  Result [%s]\n",
 				(!sem_test_open_close()) ? "PASSED" : "FAILED");
 		}
@@ -660,7 +669,7 @@ int main(int argc, char **argv)
 		/* Semaphore test. */
 		else if (!strcmp(argv[i], "prodcons"))
 		{
-			printf("Semaphore testing\n");
+			printf("Producer consummer Test\n");
 			printf("  Result [%s]\n",
 				(!sem_test()) ? "PASSED" : "FAILED");
 		}


### PR DESCRIPTION
- Adding sem. prefix for semaphore descriptors.

- Unlinking now makes the name available for new openings (inode is deleted from directory) -> num and dev added into ksem structure.

- User semaphore table for each process -> multiple opening on the same semaphore will result in the same address + avoids wrong address calls.

- Enhancement of test.c to test unexpected situations.