### PR TITLE
[doc] B: Add "rustup target add" step

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -47,6 +47,7 @@ sudo -E ./build/scripts/setup/arch.sh  # Install dependencies.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 exec $SHELL  # Restart shell to update path.
 rustup component add rust-src
+rustup target add wasm32-wasip1
 ```
 
 ### Building QEMU (Optional)


### PR DESCRIPTION
Adding that line fixed this error when running `make all` for building:

> Compiling hello v0.1.0 (/home/{user}/nanvix/src/user/hello) error[E0463]: can't find crate for `std`
>   |
>   = note: the `wasm32-wasip1` target may not be installed
>   = help: consider downloading the target with `rustup target add wasm32-wasip1`
>   = help: consider building the standard library from source with `cargo build -Zbuild-std`
>
> For more information about this error, try `rustc --explain E0463`.