### PR TITLE
[libs] F: implemented getpid syscall in Rust backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository hosts the source code of Nanvix, a research operating system.
 - For instructions on development environment setup, see [doc/setup.md](doc/setup.md).
 - For instructions on building, see [doc/build.md](doc/build.md).
 - For instructions on running, see [doc/run.md](doc/run.md).
+- For dev instructions (e.g., testing), see [doc/dev.md](doc/dev.md).
 
 ## Usage Statement
 

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -1,0 +1,16 @@
+# Developing Nanvix
+
+## Testing syscalls
+
+Tests for syscalls can be found in `src/benchmarks/linux-app`.
+
+To run these tests, you can use the following commands:
+
+```bash
+# (1) Build the project
+make MACHINE=<some machine> LOG_LEVEL=trace all
+# (2) Run nanvixd
+RUST_LOG=debug ./bin/nanvixd.elf -http-addr 127.0.0.1:8080 -linuxd-addr 127.0.0.1:7070 -sandbox-addr 127.0.0.1:1234 -keep-alive 0
+# (3) Send a curl to nanvixd specifying the program to run (e.g., linux-app.elf)
+curl -w "\n" --header "Content-Type: application/json" --request POST --data '{"clientid":1, "program":"bin/linux-app.elf", "args":[]}' http://localhost:8080
+```

--- a/src/benchmarks/linux-app/src/main.rs
+++ b/src/benchmarks/linux-app/src/main.rs
@@ -84,6 +84,16 @@ pub fn main() -> Result<(), Error> {
         },
     }
 
+    // Try to get PID
+    match unistd::getpid() {
+        Ok(pid) => {
+            ::nvx::log!("got PID {:#?}", pid);
+        },
+        Err(err) => {
+            panic!("failed to get PID: {:?}", err);
+        },
+    };
+
     // Create a file named `foo.tmp`.
     let fd: i32 = match fcntl::openat(
         fcntl::AT_FDCWD,

--- a/src/libs/posix/src/unistd/bindings.rs
+++ b/src/libs/posix/src/unistd/bindings.rs
@@ -196,7 +196,7 @@ pub unsafe extern "C" fn getentropy(_buffer: *mut c_void, _length: size_t) -> c_
 
 #[no_mangle]
 pub extern "C" fn getpid() -> pid_t {
-    match nvx::sys::kcall::pm::getpid() {
+    match crate::unistd::getpid() {
         Ok(pid) => pid.into(),
         Err(e) => {
             unsafe {

--- a/src/libs/posix/src/unistd/mod.rs
+++ b/src/libs/posix/src/unistd/mod.rs
@@ -45,6 +45,7 @@ cfg_if::cfg_if! {
             fchown,
             ftruncate,
             fsync,
+            getpid,
             lchmod,
             lchown,
             link,

--- a/src/libs/posix/src/unistd/syscall/close.rs
+++ b/src/libs/posix/src/unistd/syscall/close.rs
@@ -24,7 +24,7 @@ use ::nvx::{
 //==================================================================================================
 
 pub fn close(fd: i32) -> i32 {
-    let pid: ProcessIdentifier = match ::nvx::pm::getpid() {
+    let pid: ProcessIdentifier = match crate::unistd::getpid() {
         Ok(pid) => pid,
         Err(e) => return e.code.into_errno(),
     };

--- a/src/libs/posix/src/unistd/syscall/fchmod.rs
+++ b/src/libs/posix/src/unistd/syscall/fchmod.rs
@@ -43,7 +43,7 @@ use ::nvx::{
 pub fn fchmod(fd: c_int, mode: mode_t) -> Result<(), Error> {
     ::nvx::log!("fchmod(): fd={:?}, mode={:o}", fd, mode);
 
-    let pid: ProcessIdentifier = ::nvx::pm::getpid()?;
+    let pid: ProcessIdentifier = crate::unistd::getpid()?;
 
     // Build request and send it
     let request: Message = FileChmodRequest::build(pid, fd, mode);

--- a/src/libs/posix/src/unistd/syscall/fchown.rs
+++ b/src/libs/posix/src/unistd/syscall/fchown.rs
@@ -47,7 +47,7 @@ use ::nvx::{
 pub fn fchown(fd: c_int, owner: uid_t, group: gid_t) -> Result<(), Error> {
     ::nvx::log!("fchown(): fd={:?}, owner={:?}, group={:?}", fd, owner, group);
 
-    let pid: ProcessIdentifier = ::nvx::pm::getpid()?;
+    let pid: ProcessIdentifier = crate::unistd::getpid()?;
 
     // Build request and send it
     let request: Message = FileChownRequest::build(pid, fd, owner, group);

--- a/src/libs/posix/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/posix/src/unistd/syscall/fdatasync.rs
@@ -37,7 +37,7 @@ use ::nvx::{
 /// Upon successful completion, zero is returned. Otherwise, a negative error code is returned.
 ///
 pub fn fdatasync(fd: i32) -> i32 {
-    let pid: ProcessIdentifier = match ::nvx::pm::getpid() {
+    let pid: ProcessIdentifier = match crate::unistd::getpid() {
         Ok(pid) => pid,
         Err(e) => return e.code.into_errno(),
     };

--- a/src/libs/posix/src/unistd/syscall/fsync.rs
+++ b/src/libs/posix/src/unistd/syscall/fsync.rs
@@ -38,7 +38,7 @@ use ::nvx::{
 /// Upon successful completion, empty is returned. Otherwise, an error is returned.
 ///
 pub fn fsync(fd: c_int) -> Result<(), Error> {
-    let pid: ProcessIdentifier = ::nvx::pm::getpid()?;
+    let pid: ProcessIdentifier = crate::unistd::getpid()?;
 
     // Build request and send it.
     let request: Message = FileSyncRequest::build(pid, fd);

--- a/src/libs/posix/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/posix/src/unistd/syscall/ftruncate.rs
@@ -40,7 +40,7 @@ use ::nvx::{
 /// Upon successful completion, empty is returned. Otherwise, an error is returned.
 ///
 pub fn ftruncate(fd: c_int, length: off_t) -> Result<(), Error> {
-    let pid: ProcessIdentifier = ::nvx::pm::getpid()?;
+    let pid: ProcessIdentifier = crate::unistd::getpid()?;
 
     // Build request and send it.
     let request: Message = FileTruncateRequest::build(pid, fd, length);

--- a/src/libs/posix/src/unistd/syscall/getpid.rs
+++ b/src/libs/posix/src/unistd/syscall/getpid.rs
@@ -1,0 +1,21 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::nvx::{pm::ProcessIdentifier, sys::error::Error};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================///
+
+/// # Description
+///
+/// `getpid()` returns the process ID (PID) of the calling process.
+///
+pub fn getpid() -> Result<ProcessIdentifier, Error> {
+    ::nvx::log!("getpid()");
+    ::nvx::sys::kcall::pm::getpid()
+}

--- a/src/libs/posix/src/unistd/syscall/linkat.rs
+++ b/src/libs/posix/src/unistd/syscall/linkat.rs
@@ -40,7 +40,7 @@ pub fn linkat(olddirfd: i32, oldpath: &str, newdirfd: i32, newpath: &str, flags:
 }
 
 fn linkat_request(olddirfd: i32, oldpath: &str, newdirfd: i32, newpath: &str, flags: i32) -> i32 {
-    let pid: ProcessIdentifier = match ::nvx::pm::getpid() {
+    let pid: ProcessIdentifier = match crate::unistd::getpid() {
         Ok(pid) => pid,
         Err(e) => return e.code.into_errno(),
     };

--- a/src/libs/posix/src/unistd/syscall/lseek.rs
+++ b/src/libs/posix/src/unistd/syscall/lseek.rs
@@ -24,7 +24,7 @@ use ::nvx::{
 //==================================================================================================
 
 pub fn lseek(fd: i32, offset: i64, whence: i32) -> i64 {
-    let pid: ProcessIdentifier = match ::nvx::pm::getpid() {
+    let pid: ProcessIdentifier = match crate::unistd::getpid() {
         Ok(pid) => pid,
         Err(e) => return e.code.into_errno() as i64,
     };

--- a/src/libs/posix/src/unistd/syscall/mod.rs
+++ b/src/libs/posix/src/unistd/syscall/mod.rs
@@ -13,6 +13,7 @@ mod fchown;
 mod fdatasync;
 mod fsync;
 mod ftruncate;
+mod getpid;
 mod lchmod;
 mod lchown;
 mod link;
@@ -39,6 +40,7 @@ pub use self::{
     fdatasync::fdatasync,
     fsync::fsync,
     ftruncate::ftruncate,
+    getpid::getpid,
     lchmod::lchmod,
     lchown::lchown,
     link::link,

--- a/src/libs/posix/src/unistd/syscall/pread.rs
+++ b/src/libs/posix/src/unistd/syscall/pread.rs
@@ -31,7 +31,7 @@ use ::nvx::{
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)] // TODO: Wrap this in a safe function.
 pub fn pread(fd: i32, buffer: *mut u8, count: size_t, offset: off_t) -> ssize_t {
-    let pid: ProcessIdentifier = match ::nvx::pm::getpid() {
+    let pid: ProcessIdentifier = match crate::unistd::getpid() {
         Ok(pid) => pid,
         Err(e) => return e.code.into_errno(),
     };

--- a/src/libs/posix/src/unistd/syscall/pwrite.rs
+++ b/src/libs/posix/src/unistd/syscall/pwrite.rs
@@ -31,7 +31,7 @@ use ::nvx::{
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)] // TODO: Wrap this in a safe function.
 pub fn pwrite(fd: i32, buffer: *const u8, count: size_t, offset: off_t) -> ssize_t {
-    let pid: ProcessIdentifier = match ::nvx::pm::getpid() {
+    let pid: ProcessIdentifier = match crate::unistd::getpid() {
         Ok(pid) => pid,
         Err(e) => return e.code.into_errno(),
     };

--- a/src/libs/posix/src/unistd/syscall/read.rs
+++ b/src/libs/posix/src/unistd/syscall/read.rs
@@ -30,7 +30,7 @@ use ::nvx::{
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)] // TODO: Wrap this in a safe function.
 pub fn read(fd: i32, buffer: *mut u8, count: size_t) -> ssize_t {
-    let pid: ProcessIdentifier = match ::nvx::pm::getpid() {
+    let pid: ProcessIdentifier = match crate::unistd::getpid() {
         Ok(pid) => pid,
         Err(e) => return e.code.into_errno(),
     };

--- a/src/libs/posix/src/unistd/syscall/write.rs
+++ b/src/libs/posix/src/unistd/syscall/write.rs
@@ -30,7 +30,7 @@ use ::nvx::{
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)] // TODO: Wrap this in a safe function.
 pub fn write(fd: i32, buffer: *const u8, count: size_t) -> ssize_t {
-    let pid: ProcessIdentifier = match ::nvx::pm::getpid() {
+    let pid: ProcessIdentifier = match crate::unistd::getpid() {
         Ok(pid) => pid,
         Err(e) => return e.code.into_errno(),
     };


### PR DESCRIPTION
closes #322 

Notes:
- `getpid` was already implemented for the C API, so I implemented it for the Rust backend and routed the C API to use the C interface instead of directly making a kernel call.
- added a test for `getpid` inside `linux-app` and ran it locally to confirm it works.
- added a development doc to document useful things to know while developing Nanvix (e.g., how to run tests).