### PR TITLE
[microvm] Ensure Page-Aligned Initrd Base Address and Size

### DIFF
--- a/src/microvm/src/vmm/microvm/kvm/vmem.rs
+++ b/src/microvm/src/vmm/microvm/kvm/vmem.rs
@@ -23,6 +23,7 @@ use ::std::{
         Mutex,
     },
 };
+use ::sys::arch::mem::PAGE_SIZE;
 
 //==================================================================================================
 // Structures
@@ -188,9 +189,17 @@ impl VirtualMemory {
             );
         }
 
-        self._initrd = Some((::config::microvm::DEFAULT_INITRD_BASE as u64, initrd.size()));
+        // Ensure initrd size is aligned to page size.
+        let initrd_size: usize = if initrd.size() % PAGE_SIZE != 0 {
+            debug!("load_initrd(): aligning initrd size to page size");
+            initrd.size() + (PAGE_SIZE - (initrd.size() % PAGE_SIZE))
+        } else {
+            initrd.size()
+        };
 
-        Ok((::config::microvm::DEFAULT_INITRD_BASE as u64, initrd.size()))
+        self._initrd = Some((::config::microvm::DEFAULT_INITRD_BASE as u64, initrd_size));
+
+        Ok((::config::microvm::DEFAULT_INITRD_BASE as u64, initrd_size))
     }
 
     ///

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -29,6 +29,7 @@ use ::std::sync::{
     Arc,
     Mutex,
 };
+use ::sys::arch::mem::PAGE_SIZE;
 
 //==================================================================================================
 // Structures
@@ -188,13 +189,19 @@ impl MicroVm {
             }
         }
 
-        // Encode initrd location and size:
-        // - Lower bits encode the size in 4KB pages
-        // - Higher bits encode the base address
+        // Retrieve initrd information.
         let (initrd_base, initrd_size): (u64, u64) = match self.initrd {
             Some((base, size)) => (base, size as u64),
             None => (0, 0),
         };
+
+        // Ensure that the initrd base and size are aligned to page size boundaries.
+        assert_eq!(initrd_base as usize % PAGE_SIZE, 0, "initrd base is not aligned to page size");
+        assert_eq!(initrd_size as usize % PAGE_SIZE, 0, "initrd size is not aligned to page size");
+
+        // Encode initrd location and size:
+        // - Lower bits encode the size in 4KB pages
+        // - Higher bits encode the base address
         let rbx: u64 =
             (initrd_base & !((1 << nzeros) - 1)) | ((initrd_size >> 12) & ((1 << nzeros) - 1));
 


### PR DESCRIPTION
# Description

The initrd base address and size must be page aligned, but they were not.

Commit 3be1f5f91cf76f780911cbc8f895ed1ccf55e68b exposes the bug.
Commit 5062daed9ae85d41c89d411c2e5d317eb700d3ef resolves it.