### PR TITLE
Add python lint checks

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+set -euo pipefail
+
+make python-lint > /dev/null
+
+if ! git diff --quiet; then
+  echo "Post-commit: python formatting introduced changes, consider ammending your commit"
+fi

--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,24 @@ clippy: \
 	clippy-host-rlibs \
 	clippy-microvm
 
+# Python lint variables
+PY_CHECK :=
+ifeq ($(check),true)
+PY_CHECK += --check
+endif
+PY_VERBOSE :=
+ifneq ($(VERBOSE),yes)
+PY_VERBOSE += >> /dev/null 2>&1
+endif
+
+python-lint:
+	@rm -rf /tmp/venv
+	@python3 -m venv /tmp/venv
+	@/tmp/venv/bin/pip3 install "black>=24.0.0" "flake8>=7.0.0" > /dev/null
+	@/tmp/venv/bin/python3 -m black $(PY_CHECK) $(shell git ls-files -- "*.py") $(PY_VERBOSE)
+	@/tmp/venv/bin/python3 -m flake8 $(shell git ls-files -- "*.py") $(PY_VERBOSE)
+	@rm -rf /tmp/venv
+
 check: \
 	check-kernel \
 	check-guest-binaries \

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -13,8 +13,6 @@ import requests
 import os
 import signal
 import argparse
-import argparse
-import signal
 from datetime import timedelta
 
 # ======================================================================================================================
@@ -44,32 +42,58 @@ def parse_args() -> argparse.Namespace:
     """
 
     parser = argparse.ArgumentParser(
-        description="CLI for benchmarking Nanvix.", allow_abbrev=False)
+        description="CLI for benchmarking Nanvix.", allow_abbrev=False
+    )
 
     # Required arguments.
-    parser.add_argument("--nanvixd-sockaddr", type=str,
-                        help="Set socket address for nanvixd", required=True)
-    parser.add_argument("--linuxd-sockaddr", type=str,
-                        help="Set socket address for linuxd", required=True)
-    parser.add_argument("--sandbox-sockaddr", type=str,
-                        help="Set socket address for sandbox", required=True)
-    parser.add_argument("--program-name", type=str,
-                        help="Set program name", required=True)
-    parser.add_argument("--program-args", type=str,
-                        help="Set program args", required=True)
+    parser.add_argument(
+        "--nanvixd-sockaddr",
+        type=str,
+        help="Set socket address for nanvixd",
+        required=True,
+    )
+    parser.add_argument(
+        "--linuxd-sockaddr",
+        type=str,
+        help="Set socket address for linuxd",
+        required=True,
+    )
+    parser.add_argument(
+        "--sandbox-sockaddr",
+        type=str,
+        help="Set socket address for sandbox",
+        required=True,
+    )
+    parser.add_argument(
+        "--program-name", type=str, help="Set program name", required=True
+    )
+    parser.add_argument(
+        "--program-args", type=str, help="Set program args", required=True
+    )
 
     # Optional arguments.
-    parser.add_argument("--timeout", type=int,
-                        help="Set test request timeout", default=TIMEOUT)
-    parser.add_argument("--nrequests", type=int,
-                        help="Set number of requests to send", default=NREQUESTS)
-    parser.add_argument("--core-affinity", type=str,
-                        help="Set core affinity for nanvixd", default=CORE_AFFINITY)
+    parser.add_argument(
+        "--timeout", type=int, help="Set test request timeout", default=TIMEOUT
+    )
+    parser.add_argument(
+        "--nrequests",
+        type=int,
+        help="Set number of requests to send",
+        default=NREQUESTS,
+    )
+    parser.add_argument(
+        "--core-affinity",
+        type=str,
+        help="Set core affinity for nanvixd",
+        default=CORE_AFFINITY,
+    )
 
     return parser.parse_args()
 
 
-def cleanup_socket_files(nanvixd_sockaddr: str, linuxd_sockaddr: str, sandbox_sockaddr: str) -> None:
+def cleanup_socket_files(
+    nanvixd_sockaddr: str, linuxd_sockaddr: str, sandbox_sockaddr: str
+) -> None:
     """
     Removes socket files.
 
@@ -93,12 +117,13 @@ def kill_nanvixd(nanvixd_process: subprocess.Popen) -> None:
     """
 
     print(f"Killing nanvixd (pid={nanvixd_process.pid})")
-    subprocess.run(["sudo", "/usr/bin/kill", "-s",
-                   "SIGINT", f"{nanvixd_process.pid}"])
+    subprocess.run(["sudo", "/usr/bin/kill", "-s", "SIGINT", f"{nanvixd_process.pid}"])
     print(f"Killed nanvixd (pid={nanvixd_process.pid})")
 
 
-def print_progress_bar(iteration: int, total: int, prefix: str = "", length: int = 50, fill: str = "#") -> None:
+def print_progress_bar(
+    iteration: int, total: int, prefix: str = "", length: int = 50, fill: str = "#"
+) -> None:
     """
     Prints a progress bar to the console.
 
@@ -118,7 +143,12 @@ def print_progress_bar(iteration: int, total: int, prefix: str = "", length: int
         print()
 
 
-def abort_execution(nanvixd_process: subprocess.Popen = None, nanvixd_sockaddr: str = "", linuxd_sockaddr: str = "", sandbox_sockaddr: str = "") -> None:
+def abort_execution(
+    nanvixd_process: subprocess.Popen = None,
+    nanvixd_sockaddr: str = "",
+    linuxd_sockaddr: str = "",
+    sandbox_sockaddr: str = "",
+) -> None:
     """
     Aborts execution.
 
@@ -131,8 +161,7 @@ def abort_execution(nanvixd_process: subprocess.Popen = None, nanvixd_sockaddr: 
     if nanvixd_process:
         kill_nanvixd(nanvixd_process)
     if nanvixd_sockaddr or linuxd_sockaddr or sandbox_sockaddr:
-        cleanup_socket_files(
-            nanvixd_sockaddr, linuxd_sockaddr, sandbox_sockaddr)
+        cleanup_socket_files(nanvixd_sockaddr, linuxd_sockaddr, sandbox_sockaddr)
     sys.exit(1)
 
 
@@ -174,8 +203,9 @@ def main() -> None:
     # Install signal handler for cleaning up state.
     def signal_handler(sig, frame):
         print(f"Caught signal {sig}")
-        abort_execution(nanvixd_process, nanvixd_sockaddr,
-                        linuxd_sockaddr, sandbox_sockaddr)
+        abort_execution(
+            nanvixd_process, nanvixd_sockaddr, linuxd_sockaddr, sandbox_sockaddr
+        )
 
     signal.signal(signal.SIGINT, signal_handler)
 
@@ -185,14 +215,24 @@ def main() -> None:
         abort_execution()
 
     command = [
-        "sudo", "-E",
-        "nice", "-n", "-20",
-        "taskset", "-a", "-c", core_affinity,
+        "sudo",
+        "-E",
+        "nice",
+        "-n",
+        "-20",
+        "taskset",
+        "-a",
+        "-c",
+        core_affinity,
         nanvixd_path,
-        "-http-addr", nanvixd_sockaddr,
-        "-linuxd-addr", linuxd_sockaddr,
-        "-sandbox-addr", sandbox_sockaddr,
-        "-keep-alive", "0"
+        "-http-addr",
+        nanvixd_sockaddr,
+        "-linuxd-addr",
+        linuxd_sockaddr,
+        "-sandbox-addr",
+        sandbox_sockaddr,
+        "-keep-alive",
+        "0",
     ]
 
     # Run nanvixd. Note we set process group to be able to kill all processes
@@ -218,20 +258,25 @@ def main() -> None:
             response = requests.post(
                 f"http://localhost:{nanvixd_port_number}",
                 headers={"Content-Type": "application/json"},
-                json={"clientid": 1, "program": program_name,
-                      "args": program_args.split()},
-                timeout=timeout
+                json={
+                    "clientid": 1,
+                    "program": program_name,
+                    "args": program_args.split(),
+                },
+                timeout=timeout,
             )
         except requests.Timeout:
             print("Request timed out, aborting execution.")
-            abort_execution(nanvixd_process, nanvixd_sockaddr,
-                            linuxd_sockaddr, sandbox_sockaddr)
+            abort_execution(
+                nanvixd_process, nanvixd_sockaddr, linuxd_sockaddr, sandbox_sockaddr
+            )
 
         # Check if response is successful.
         if not response.ok:
             print(f"Request failed with status code {response.status_code}")
-            abort_execution(nanvixd_process, nanvixd_sockaddr,
-                            linuxd_sockaddr, sandbox_sockaddr)
+            abort_execution(
+                nanvixd_process, nanvixd_sockaddr, linuxd_sockaddr, sandbox_sockaddr
+            )
         else:
             elapsed_times.append(response.elapsed / timedelta(microseconds=1))
 
@@ -252,8 +297,7 @@ def main() -> None:
     print(f"p99 elapsed time: {p99} us")
 
     kill_nanvixd(nanvixd_process)
-    cleanup_socket_files(
-        nanvixd_sockaddr, linuxd_sockaddr, sandbox_sockaddr)
+    cleanup_socket_files(nanvixd_sockaddr, linuxd_sockaddr, sandbox_sockaddr)
 
 
 if __name__ == "__main__":

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -151,6 +151,7 @@ def lint(
     """
 
     make("clippy", machine, arch, release, toolchain_dir, log_level, verbose)
+    make("python-lint", machine, arch, release, None, log_level, verbose)
 
 
 def build(

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -7,15 +7,20 @@
 
 import subprocess
 import argparse
-from typing import List, Tuple
+from typing import List
 
 # ======================================================================================================================
 # Constants
 # ======================================================================================================================
 
 # List of supported target machines.
-TARGET_MACHINES: List[str] = ["qemu-isapc",
-                              "qemu-pc", "qemu-baremetal", "microvm", "hyperlight"]
+TARGET_MACHINES: List[str] = [
+    "qemu-isapc",
+    "qemu-pc",
+    "qemu-baremetal",
+    "microvm",
+    "hyperlight",
+]
 
 # List of supported target architectures.
 TARGET_ARCHS: List[str] = ["x86"]
@@ -48,15 +53,16 @@ def run_command(command: List[str], stdout_log_file: str, stderr_log_file: str) 
     # Echo command.
     print(f"Running command: {' '.join(command)}")
 
-    with open(stdout_log_file, 'w') as stdout_file, open(stderr_log_file, 'w') as stderr_file:
+    with open(stdout_log_file, "w") as stdout_file, open(stderr_log_file, "w"):
         process = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        )
 
         # Poll stdout and stderr
         while True:
             stdout = process.stdout.readline()
 
-            if process.poll() is not None and stdout == '':
+            if process.poll() is not None and stdout == "":
                 break
 
             if stdout:
@@ -73,7 +79,17 @@ def run_command(command: List[str], stdout_log_file: str, stderr_log_file: str) 
     return return_code
 
 
-def make(target: str, machine: str, arch: str, release: bool, toolchain_dir: str = None, log_level: str = None, verbose: bool = False, timeout: int = None, build_opt=True) -> None:
+def make(
+    target: str,
+    machine: str,
+    arch: str,
+    release: bool,
+    toolchain_dir: str = None,
+    log_level: str = None,
+    verbose: bool = False,
+    timeout: int = None,
+    build_opt=True,
+) -> None:
     """
     Runs make command.
 
@@ -107,15 +123,21 @@ def make(target: str, machine: str, arch: str, release: bool, toolchain_dir: str
 
     command.append("BUILD_OPT=yes" if build_opt else "BUILD_OPT=no")
 
-    return_code = run_command(
-        command, f"{target}-stdout.log", f"{target}-stderr.log")
+    return_code = run_command(command, f"{target}-stdout.log", f"{target}-stderr.log")
 
     if return_code:
         print(f"Make failed with code={return_code}.")
         exit(1)
 
 
-def lint(machine: str, arch: str, release: bool, toolchain_dir: str = None, log_level: str = None, verbose: bool = False) -> None:
+def lint(
+    machine: str,
+    arch: str,
+    release: bool,
+    toolchain_dir: str = None,
+    log_level: str = None,
+    verbose: bool = False,
+) -> None:
     """
     Lints Nanvix source code.
 
@@ -131,7 +153,14 @@ def lint(machine: str, arch: str, release: bool, toolchain_dir: str = None, log_
     make("clippy", machine, arch, release, toolchain_dir, log_level, verbose)
 
 
-def build(machine: str, arch: str, release: bool, toolchain_dir: str = None, log_level: str = None, verbose: bool = False) -> None:
+def build(
+    machine: str,
+    arch: str,
+    release: bool,
+    toolchain_dir: str = None,
+    log_level: str = None,
+    verbose: bool = False,
+) -> None:
     """
     Builds Nanvix for a target machine and architecture.
 
@@ -147,7 +176,15 @@ def build(machine: str, arch: str, release: bool, toolchain_dir: str = None, log
     make("all", machine, arch, release, toolchain_dir, log_level, verbose)
 
 
-def test(machine: str, arch: str, release: bool, toolchain_dir: str = None, log_level: str = None, verbose: bool = False, timeout: int = None) -> None:
+def test(
+    machine: str,
+    arch: str,
+    release: bool,
+    toolchain_dir: str = None,
+    log_level: str = None,
+    verbose: bool = False,
+    timeout: int = None,
+) -> None:
     """
     Tests Nanvix for a target machine and architecture.
 
@@ -161,11 +198,29 @@ def test(machine: str, arch: str, release: bool, toolchain_dir: str = None, log_
         timeout (int, optional): Timeout. Defaults to None.
     """
 
-    make("run-unit-tests", machine, arch, release,
-         toolchain_dir, log_level, verbose, timeout, build_opt=False)
+    make(
+        "run-unit-tests",
+        machine,
+        arch,
+        release,
+        toolchain_dir,
+        log_level,
+        verbose,
+        timeout,
+        build_opt=False,
+    )
 
-    make("run", machine, arch, release,
-         toolchain_dir, log_level, verbose, timeout, build_opt=False)
+    make(
+        "run",
+        machine,
+        arch,
+        release,
+        toolchain_dir,
+        log_level,
+        verbose,
+        timeout,
+        build_opt=False,
+    )
 
     # Check if last line of "test-stdout.log" contains the magic string.
     with open("run-stdout.log", "r") as file:
@@ -180,13 +235,31 @@ def test(machine: str, arch: str, release: bool, toolchain_dir: str = None, log_
 
     # Check if linuxd tests are supported.
     if has_linuxd_tests(machine):
-        make("run-linuxd-tests", machine, arch, release,
-             toolchain_dir, log_level, verbose, timeout, build_opt=False)
+        make(
+            "run-linuxd-tests",
+            machine,
+            arch,
+            release,
+            toolchain_dir,
+            log_level,
+            verbose,
+            timeout,
+            build_opt=False,
+        )
 
     # Check if nanvixd tests are supported.
     if has_nanvixd_tests(machine):
-        make("run-nanvixd-tests", machine, arch, release,
-             toolchain_dir, log_level, verbose, timeout, build_opt=False)
+        make(
+            "run-nanvixd-tests",
+            machine,
+            arch,
+            release,
+            toolchain_dir,
+            log_level,
+            verbose,
+            timeout,
+            build_opt=False,
+        )
 
 
 def has_linuxd_tests(machine: str) -> bool:
@@ -226,34 +299,51 @@ def parse_args() -> argparse.Namespace:
     """
 
     parser = argparse.ArgumentParser(
-        description="A simple CLI program.", allow_abbrev=False)
+        description="A simple CLI program.", allow_abbrev=False
+    )
 
     # Required arguments.
-    parser.add_argument("--target-machine", type=str,
-                        help=f"Set target machine {TARGET_MACHINES}", required=True)
-    parser.add_argument("--target-arch", type=str,
-                        help=f"Set target architecture {TARGET_ARCHS}", required=True)
+    parser.add_argument(
+        "--target-machine",
+        type=str,
+        help=f"Set target machine {TARGET_MACHINES}",
+        required=True,
+    )
+    parser.add_argument(
+        "--target-arch",
+        type=str,
+        help=f"Set target architecture {TARGET_ARCHS}",
+        required=True,
+    )
 
     # Optional arguments.
     group = parser.add_mutually_exclusive_group()
-    group.add_argument("--release", action="store_true",
-                       help="Build in release mode", default=False)
-    group.add_argument("--debug", action="store_true",
-                       help="Build in debug mode", default=True)
-    parser.add_argument("--toolchain-dir", type=str,
-                        help="Set toolchain directory")
-    parser.add_argument("--log-level", type=str,
-                        help=f"Set log level {LOG_LEVELS}", default="trace")
-    parser.add_argument("--verbose", action="store_true",
-                        help="Enable verbose build", default=True)
-    parser.add_argument("--timeout", type=int,
-                        help="Set test timeout", default=90)
-    parser.add_argument("--lint", action="store_true",
-                        help="Lint Nanvix source code", default=False)
-    parser.add_argument("--build", action="store_true",
-                        help="Build Nanvix", default=False)
-    parser.add_argument("--test", action="store_true",
-                        help="Test Nanvix (implies --build)", default=False)
+    group.add_argument(
+        "--release", action="store_true", help="Build in release mode", default=False
+    )
+    group.add_argument(
+        "--debug", action="store_true", help="Build in debug mode", default=True
+    )
+    parser.add_argument("--toolchain-dir", type=str, help="Set toolchain directory")
+    parser.add_argument(
+        "--log-level", type=str, help=f"Set log level {LOG_LEVELS}", default="trace"
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Enable verbose build", default=True
+    )
+    parser.add_argument("--timeout", type=int, help="Set test timeout", default=90)
+    parser.add_argument(
+        "--lint", action="store_true", help="Lint Nanvix source code", default=False
+    )
+    parser.add_argument(
+        "--build", action="store_true", help="Build Nanvix", default=False
+    )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Test Nanvix (implies --build)",
+        default=False,
+    )
 
     return parser.parse_args()
 
@@ -276,18 +366,37 @@ def main() -> None:
 
     # Lint source code.
     if args.lint:
-        lint(args.target_machine, args.target_arch, args.release or not args.debug, args.toolchain_dir,
-             args.log_level, args.verbose)
+        lint(
+            args.target_machine,
+            args.target_arch,
+            args.release or not args.debug,
+            args.toolchain_dir,
+            args.log_level,
+            args.verbose,
+        )
 
     # Build source code.
     if args.build:
-        build(args.target_machine, args.target_arch, args.release or not args.debug,
-              args.toolchain_dir, args.log_level, args.verbose)
+        build(
+            args.target_machine,
+            args.target_arch,
+            args.release or not args.debug,
+            args.toolchain_dir,
+            args.log_level,
+            args.verbose,
+        )
 
     # Test Nanvix.
     if args.test:
-        test(args.target_machine, args.target_arch, args.release or not args.debug,
-             args.toolchain_dir, args.log_level, args.verbose, args.timeout)
+        test(
+            args.target_machine,
+            args.target_arch,
+            args.release or not args.debug,
+            args.toolchain_dir,
+            args.log_level,
+            args.verbose,
+            args.timeout,
+        )
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT license.
+
+# Unfortunately, we need to add both options to circunvent a black-flake8
+# incompatibility:
+# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
+[flake8]
+max-line-length = 100
+extend-ignore = E203
+[pycodestyle]
+max-line-length = 100

--- a/src/user/hello-python/__main__.py
+++ b/src/user/hello-python/__main__.py
@@ -1,9 +1,10 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
+
 def main():
     print("Hello, from Python!")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
In this PR I add a make target to lint python files using a combination of `black` and `flake8`. I then use this target to (i) lint all python files, (ii) set-up a post-commit hook, and (iii) include it in the `lint` function in `scripts/ci.py`.