### PR TITLE
[enhancement] Update hyperlight dependency across microvm and kernel crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ fastrand = { version = "2.3.0", default-features = false }
 flexi_logger = "0.30.0"
 goblin = { version = "0.9.3", default-features = false }
 http-body-util = "0.1.3"
-hyperlight_common = { git = "https://github.com/nanvix/hyperlight", default-features = false, package = "hyperlight-common" }
-hyperlight_host = { git = "https://github.com/nanvix/hyperlight/", default-features = false, package = "hyperlight-host" }
+hyperlight_common = { git = "https://github.com/nanvix/hyperlight", rev = "ce4ad858ab04c4f781a1d59298661fc90fda7a01", default-features = false, package = "hyperlight-common" }
+hyperlight_host = { git = "https://github.com/nanvix/hyperlight/", rev = "ce4ad858ab04c4f781a1d59298661fc90fda7a01", default-features = false, features = ["kvm", "gdb"], package = "hyperlight-host" } # we use the gdb feature to remove the timeout mechanism
 hyper = { version = "1.6.0", default-features = false }
 hyper-util = { version = "0.1.11", default-features = false }
 kvm-bindings = "0.11.1"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export MACHINE ?= microvm
 export RELEASE ?= no
 
 # Timeout
-export TIMEOUT ?= 90
+export TIMEOUT ?= 300
 
 # Enable Microvm profiler?
 export PROFILER ?= no

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -332,7 +332,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--verbose", action="store_true", help="Enable verbose build", default=True
     )
-    parser.add_argument("--timeout", type=int, help="Set test timeout", default=90)
+    parser.add_argument("--timeout", type=int, help="Set test timeout", default=300)
     parser.add_argument(
         "--lint", action="store_true", help="Lint Nanvix source code", default=False
     )

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -13,7 +13,7 @@ TOOLCHAIN_DIR=${1:-$(pwd)/toolchain}
 TTY=${2:-/dev/null}
 
 # Timeout for each step.
-TIMEOUT=90
+TIMEOUT=300
 
 # Padding to force aligned formatting.
 PADDING=40

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -288,44 +288,8 @@ pub fn init(
     )?;
     memory_regions.push_back(peb);
 
-    // Register host function definitions.
-    let host_functions_base: usize = peb_base + PEB_SIZE;
-    const HOST_FUNCTIONS_SIZE: usize = mem::PAGE_SIZE;
-    let host_functions: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-        "host functions",
-        VirtualAddress::from_raw_value(host_functions_base),
-        HOST_FUNCTIONS_SIZE,
-        MemoryRegionType::Reserved,
-        AccessPermission::RDWR,
-    )?;
-    memory_regions.push_back(host_functions);
-
-    // Register host exception handlers.
-    let host_exceptions_base: usize = host_functions_base + HOST_FUNCTIONS_SIZE;
-    const HOST_EXCEPTIONS_SIZE: usize = 4 * mem::PAGE_SIZE;
-    let host_exceptions: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-        "host exceptions",
-        VirtualAddress::from_raw_value(host_exceptions_base),
-        HOST_EXCEPTIONS_SIZE,
-        MemoryRegionType::Mmio,
-        AccessPermission::RDONLY,
-    )?;
-    memory_regions.push_back(host_exceptions);
-
-    // Register guest error log.
-    let guest_error_log_base: usize = host_exceptions_base + HOST_EXCEPTIONS_SIZE;
-    const GUEST_ERROR_LOG_SIZE: usize = mem::PAGE_SIZE;
-    let guest_error_log: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-        "guest error log",
-        VirtualAddress::from_raw_value(guest_error_log_base),
-        GUEST_ERROR_LOG_SIZE,
-        MemoryRegionType::Mmio,
-        AccessPermission::RDWR,
-    )?;
-    memory_regions.push_back(guest_error_log);
-
     // Register input data buffer.
-    let input_data_base: usize = guest_error_log_base + GUEST_ERROR_LOG_SIZE;
+    let input_data_base: usize = peb_base + PEB_SIZE;
     const INPUT_DATA_BUFFER_SIZE: usize = 4 * mem::PAGE_SIZE;
     let input_data_buffer: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "input data buffer",
@@ -348,20 +312,8 @@ pub fn init(
     )?;
     memory_regions.push_back(output_data_buffer);
 
-    // Register guest panic context.
-    let guest_panic_context_base: usize = output_data_base + OUTPUT_DATA_BUFFER_SIZE;
-    const GUEST_PANIC_CONTEXT_SIZE: usize = mem::PAGE_SIZE;
-    let guest_panic_context: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-        "guest panic context",
-        VirtualAddress::from_raw_value(guest_panic_context_base),
-        GUEST_PANIC_CONTEXT_SIZE,
-        MemoryRegionType::Mmio,
-        AccessPermission::RDWR,
-    )?;
-    memory_regions.push_back(guest_panic_context);
-
     // Register reserved area for heap padding.
-    let heap_padding_base: usize = guest_panic_context_base + GUEST_PANIC_CONTEXT_SIZE;
+    let heap_padding_base: usize = output_data_base + OUTPUT_DATA_BUFFER_SIZE;
     debug!("heap_padding_base={:#010x}", heap_padding_base);
     let heap_padding_size: usize = memory_layout::KPOOL_BASE.into_raw_value() - heap_padding_base;
     let heap_padding: MemoryRegion<VirtualAddress> = MemoryRegion::new(
@@ -397,55 +349,6 @@ pub fn init(
         AccessPermission::RDONLY,
     )?;
     memory_regions.push_back(guest_user_stack);
-
-    // Register hyperlight guest user stack guard.
-    let guest_user_stack_guard_base: usize = guest_user_stack_base + guest_user_stack_size;
-    let guest_user_stack_guard_size: usize = mem::PAGE_SIZE;
-    let guest_user_stack_guard: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-        "guest user stack guard",
-        VirtualAddress::from_raw_value(guest_user_stack_guard_base),
-        guest_user_stack_guard_size,
-        MemoryRegionType::Reserved,
-        AccessPermission::RDONLY,
-    )?;
-    memory_regions.push_back(guest_user_stack_guard);
-
-    // Register hyperlight kernel stack.
-    let guest_kernel_stack_base: usize = guest_user_stack_guard_base + guest_user_stack_guard_size;
-    let guest_kernel_stack_size: usize = mem::PAGE_SIZE;
-    let guest_kernel_stack: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-        "guest kernel stack",
-        VirtualAddress::from_raw_value(guest_kernel_stack_base),
-        guest_kernel_stack_size,
-        MemoryRegionType::Reserved,
-        AccessPermission::RDONLY,
-    )?;
-    memory_regions.push_back(guest_kernel_stack);
-
-    // Register hyperlight kernel stack guard.
-    let guest_kernel_stack_guard_base: usize = guest_kernel_stack_base + guest_kernel_stack_size;
-    let guest_kernel_stack_guard_size: usize = mem::PAGE_SIZE;
-    let guest_kernel_stack_guard: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-        "guest kernel stack guard",
-        VirtualAddress::from_raw_value(guest_kernel_stack_guard_base),
-        guest_kernel_stack_guard_size,
-        MemoryRegionType::Reserved,
-        AccessPermission::RDONLY,
-    )?;
-    memory_regions.push_back(guest_kernel_stack_guard);
-
-    // Register hyperlight boot stack.
-    let guest_boot_stack_base: usize =
-        guest_kernel_stack_guard_base + guest_kernel_stack_guard_size;
-    let guest_boot_stack_size: usize = mem::PAGE_SIZE;
-    let guest_boot_stack: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-        "guest boot stack",
-        VirtualAddress::from_raw_value(guest_boot_stack_base),
-        guest_boot_stack_size,
-        MemoryRegionType::Reserved,
-        AccessPermission::RDONLY,
-    )?;
-    memory_regions.push_back(guest_boot_stack);
 
     unsafe {
         ProcessEnvironmentBlock::init(peb_base as *mut HyperlightPEB)?;

--- a/src/kernel/src/hal/platform/hyperlight/peb/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/peb/mod.rs
@@ -52,27 +52,7 @@ pub enum OutBAction {
     _Log = 99,
     CallFunction = 101,
     _Abort = 102,
-    Magic = 103,
-}
-
-#[derive(Debug, Copy, Clone)]
-#[repr(C, packed)]
-pub struct HostFunctionDefinitions {
-    pub fbHostFunctionDetailsSize: u64,
-    pub fbHostFunctionDetails: u64,
-}
-
-#[derive(Debug, Copy, Clone)]
-#[repr(C, packed)]
-pub struct HostException {
-    pub hostExceptionSize: u64,
-}
-
-#[derive(Debug, Copy, Clone)]
-#[repr(C, packed)]
-struct GuestErrorData {
-    pub guestErrorSize: u64,
-    pub guestErrorBuffer: u64,
+    DebugPrint = 103,
 }
 
 #[repr(u64)]
@@ -103,26 +83,15 @@ struct GuestStackData {
 
 #[derive(Debug, Copy, Clone)]
 #[repr(C, packed)]
-struct GuestPanicContextData {
-    pub guestPanicContextDataSize: u64,
-    pub guestPanicContextDataBuffer: u64,
-}
-
-#[derive(Debug, Copy, Clone)]
-#[repr(C, packed)]
 pub struct HyperlightPEB {
     security_cookie_seed: u64,
     guest_function_dispatch_ptr: u64,
-    hostFunctionDefinitions: HostFunctionDefinitions,
-    hostException: HostException,
-    guestErrorData: GuestErrorData,
     pCode: u64,
     pOutb: u64,
     pOutbContext: u64,
     runMode: RunMode,
     inputdata: InputData,
     outputdata: OutputData,
-    guestPanicContextData: GuestPanicContextData,
     guestheapData: GuestHeapData,
     gueststackData: GuestStackData,
 }
@@ -196,15 +165,15 @@ impl ProcessEnvironmentBlock {
     }
 
     fn print(&mut self, message: &str) -> Result<(), Error> {
-        self.print_with_magic_port(message)
+        self.debug_print(message)
         // self.print_with_host_fn(message)
     }
 
     #[allow(dead_code)]
-    fn print_with_magic_port(&mut self, message: &str) -> Result<(), Error> {
+    fn debug_print(&mut self, message: &str) -> Result<(), Error> {
         for byte in message.bytes() {
             unsafe {
-                ::arch::io::out8(OutBAction::Magic as u16, byte);
+                ::arch::io::out32(OutBAction::DebugPrint as u16, byte as u32);
             }
         }
 
@@ -287,7 +256,7 @@ impl ProcessEnvironmentBlock {
         self.push_shared_output_data(host_function_call_buffer)?;
 
         unsafe {
-            ::arch::io::out8(OutBAction::CallFunction as u16, 0);
+            ::arch::io::out32(OutBAction::CallFunction as u16, 0);
         }
 
         Ok(())

--- a/src/microvm/Cargo.toml
+++ b/src/microvm/Cargo.toml
@@ -21,10 +21,7 @@ path = "src/main.rs"
 arch = { workspace = true }
 anyhow = { workspace = true }
 flexi_logger = { workspace = true }
-hyperlight_host = { workspace = true, optional = true, features = [
-    "kvm",
-    "remove-timeout",
-] }
+hyperlight_host = { workspace = true, optional = true }
 log = { workspace = true }
 profiler = { workspace = true, features = ["auto-calibrate"] }
 sys = { workspace = true }

--- a/src/microvm/src/vmm/hyperlight.rs
+++ b/src/microvm/src/vmm/hyperlight.rs
@@ -45,10 +45,7 @@ use ::sys::ipc::{
     MessageType,
 };
 use hyperlight_host::{
-    func::{
-        HostFunction0,
-        HostFunction1,
-    },
+    func::HostFunction,
     sandbox::uninitialized::GuestInitrd,
     HyperlightError,
 };
@@ -106,8 +103,8 @@ impl Vmm {
             initrd_filename.map(GuestInitrd::FilePath),
             Some(config),
             None, // Use default run options.
-            Some(&Arc::new(Mutex::new(writer_fn))),
         )?;
+        sandbox.register_print(writer_fn)?;
 
         let vmbus_write = move |data: Vec<u8>| -> Result<i32, HyperlightError> {
             let bytes = data.as_slice();


### PR DESCRIPTION
`nanvix/hyperlight` was almost 300 commits behind `hyperlight-dev/hyperlight`. This PR updates the Hyperlight dependency for Nanvix.

See individual commits for more info.

To use the new version of  `hyperlight-host/common` locally, after this merges, make sure to run `cargo update` at the root of the repo.

