### PR TITLE
[ci] E: Add CI Script for GHA

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Set-up Nanvix build and test environment"
+
+runs:
+  using: "composite"
+  steps:
+  - name: "Install APT dependencies"
+    shell: bash
+    run: |
+      sudo -E ./scripts/setup/ubuntu.sh --extra
+
+  - name: "Install Rust"
+    shell: bash
+    run: |
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+  - name: "Add rust toolchains"
+    shell: bash
+    run: |
+      source $HOME/.cargo/env
+      rustup component add rust-src
+      rustup target add wasm32-wasip1

--- a/.github/workflows/github-hosted-ci.yml
+++ b/.github/workflows/github-hosted-ci.yml
@@ -1,0 +1,103 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Nanvix CI/CD (GitHub Hosted)"
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+defaults:
+  run:
+    shell: bash
+
+# Cancel previous running actions for the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  setup-toolchain:
+    runs-on: ubuntu-24.04
+    outputs:
+      cache-key: ${{ steps.extract-version.outputs.cache_key }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Extract version"
+        id: extract-version
+        run: |
+          # This uses the MAJOR.MINOR as key in the cache
+          VERSION=$(grep '^version' Cargo.toml | head -n1 | sed 's/.*"\(.*\)".*/\1/')
+          echo $VERSION
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          echo "cache_key=toolchain-${MAJOR_MINOR}" >> $GITHUB_OUTPUT
+
+      - name: "Restore toolchain cache"
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ./toolchain
+          key: ${{ steps.extract-version.outputs.cache_key }}
+
+      - name: "Prepare build environemnt if not cached"
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup
+
+      - name: "Build toolchain if not cached"
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          export TOOLCHAIN_DIR=$(pwd)/toolchain
+          ./scripts/setup/toolchain.sh ${TOOLCHAIN_DIR}
+
+  tests:
+    needs: setup-toolchain
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        mode: [debug, release]
+        target: [qemu-isapc, qemu-pc, qemu-baremetal, microvm, hyperlight]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Restore toolchain cache"
+        uses: actions/cache@v4
+        with:
+          path: ./toolchain
+          key: ${{ needs.setup-toolchain.outputs.cache-key }}
+          fail-on-cache-miss: 'true'
+
+      - name: "Prepare build environemnt"
+        uses: ./.github/actions/setup
+
+      # Test
+      - name: "Run ${{ matrix.mode }} (test on ${{ matrix.target }})"
+        run: |
+          export TOOLCHAIN_DIR=$(pwd)/toolchain
+          echo "Running '${{ matrix.mode }}' in 'test' mode for '${{ matrix.target }}'"
+
+          # Check if KVM is enabled
+          sudo kvm-ok
+          sudo lsmod | grep kvm
+          # Add user to kvm group
+          sudo usermod -aG kvm $USER
+
+          # Must run tests in sudo to use KVM.
+          sudo -E --user $USER -- python3 scripts/ci.py --${{ matrix.mode }} --toolchain-dir=${TOOLCHAIN_DIR} --target-arch=x86 --log-level=trace --target-machine=${{ matrix.target }} --lint --build --test
+        timeout-minutes: 60
+
+      - name: "Upload logs in case of (test) failures"
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nanvix-test-logs-${{ github.event.pull_request.number }}-${{ matrix.mode }}-${{ matrix.target }}
+          # Overwrite to limit the amoutn of storage we use
+          overwrite: 'true'
+          path: |
+            **/*.log

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -1,10 +1,10 @@
 # Copyright(c) 2011-2024 The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
-name: x86
+name: "Nanvix CI/CD (Self-Hosted)"
 
 concurrency:
-  group: x86
+  group: self-hosted
   cancel-in-progress: false
 
 on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.47"
+version = "0.5.48"
 license-file = "LICENSE.txt"
 authors = ["The Maintainers of Nanvix"]
 edition = "2021"


### PR DESCRIPTION
In this commit I add a GHA workflow script that replicates the behaviour of ./scripts/pipeline.sh and caches the built toolchain for subsequent runs.

The toolchain cache is invalidated once we bump a minor or major version (not patch).

A few gotchas:
* The tests are, currently, skipping the javy related stuff. We need to address #541 first.
* We could do more fine-grained caching (e.g. we could cache the `./opt` repo in `debug` and `release` modes, indexed by the submodule hash, and only re-build them if the submodule changes). I have done things like this in the past.

To-Do:
* The toolchain is not versioned correctly (empty version string).