### PR TITLE
[libs] Improvements in `dirent` Library

### DIFF
--- a/src/libs/syscall/src/dirent/message/getdents.rs
+++ b/src/libs/syscall/src/dirent/message/getdents.rs
@@ -12,7 +12,6 @@ use crate::{
         c_int,
         c_uchar,
     },
-    limits::NAME_MAX,
     message::{
         LinuxDaemonMessagePart,
         MessageDeserializer,
@@ -145,9 +144,10 @@ impl MessageSerializer for GetDirectoryEntriesResponse {
             bytes.extend_from_slice(&entry.d_ino.to_le_bytes());
             bytes.extend_from_slice(&entry.d_reclen.to_le_bytes());
             bytes.push(entry.d_type);
-            bytes.extend_from_slice(unsafe {
-                mem::transmute::<&[i8], &[u8]>(entry.d_name.as_slice())
-            });
+            let d_name: &[i8] = entry.d_name.as_slice();
+            let d_name_len: u32 = d_name.len() as u32;
+            bytes.extend_from_slice(&d_name_len.to_le_bytes());
+            bytes.extend_from_slice(unsafe { mem::transmute::<&[i8], &[u8]>(d_name) });
         }
 
         bytes
@@ -200,10 +200,22 @@ impl MessageDeserializer for GetDirectoryEntriesResponse {
             entry.d_type = bytes[offset];
             offset += mem::size_of::<c_uchar>();
 
-            entry.d_name.copy_from_slice(unsafe {
-                mem::transmute::<&[u8], &[i8]>(&bytes[offset..offset + NAME_MAX + 1])
+            let d_name_len: usize = u32::from_le_bytes(
+                bytes[offset..offset + mem::size_of::<u32>()]
+                    .try_into()
+                    .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid length of name"))?,
+            ) as usize;
+            offset += mem::size_of::<u32>();
+
+            // Check if the length of the name is valid.
+            if d_name_len > entry.d_name.len() {
+                return Err(Error::new(ErrorCode::InvalidMessage, "invalid length of name"));
+            }
+
+            entry.d_name[..d_name_len].copy_from_slice(unsafe {
+                mem::transmute::<&[u8], &[i8]>(&bytes[offset..offset + d_name_len])
             });
-            offset += (NAME_MAX + 1) * (mem::size_of::<c_char>());
+            offset += d_name_len * mem::size_of::<c_char>();
 
             entries.push(entry);
         }

--- a/src/libs/syscall/src/dirent/mod.rs
+++ b/src/libs/syscall/src/dirent/mod.rs
@@ -142,7 +142,6 @@ pub type DIR = DirectoryStream;
 ///
 /// A type representing a directory entry.
 ///
-#[derive(Debug)]
 #[repr(C, packed)]
 pub struct dirent {
     /// File serial number.
@@ -167,6 +166,19 @@ impl From<posix_dent> for dirent {
             d_ino: posix_dent.d_ino,
             d_name: posix_dent.d_name,
         }
+    }
+}
+
+impl fmt::Debug for dirent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let d_name = self
+            .d_name
+            .iter()
+            .map(|&c| c as u8 as char)
+            .collect::<String>()
+            .trim_end_matches('\0')
+            .to_string();
+        write!(f, "dirent {{ d_ino: {}, d_name: {:?} }}", { self.d_ino }, d_name)
     }
 }
 

--- a/src/libs/syscall/src/dirent/syscall/readdir.rs
+++ b/src/libs/syscall/src/dirent/syscall/readdir.rs
@@ -22,7 +22,7 @@ use ::sys::error::Error;
 //==================================================================================================
 
 /// Minimum number of entries to get when refilling buffers.
-const REFILL_COUNT: usize = 8;
+const REFILL_COUNT: usize = 1;
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/dirent/syscall/readdir.rs
+++ b/src/libs/syscall/src/dirent/syscall/readdir.rs
@@ -29,13 +29,21 @@ const REFILL_COUNT: usize = 1;
 //==================================================================================================
 
 pub fn readdir(dir: &mut Box<DirectoryStream>) -> Result<Option<dirent>, Error> {
+    ::syslog::trace!("readdir(): dir.fd={:?}", dir.fd());
+
     if let Some(posix_dirent) = dir.pop() {
         let dirent: dirent = posix_dirent.into();
         return Ok(Some(dirent));
     }
 
     // Refill buffer.
-    let mut entries: Vec<posix_dent> = posix_getdents(dir.fd, REFILL_COUNT)?;
+    let mut entries: Vec<posix_dent> = match posix_getdents(dir.fd, REFILL_COUNT) {
+        Ok(entries) => entries,
+        Err(error) => {
+            ::syslog::warn!("readdir(): {error:?} (dir.fd={:?})", dir.fd());
+            return Err(error);
+        },
+    };
 
     // Get next entry.
     let dirent: dirent = match entries.pop() {


### PR DESCRIPTION
## Description

This PR adds the following improvements to the `dirent`library:

- Better logging on error path.
- Custom debut trait for `dirent`
- Reduced refill count in `readdir`
- Improved serialization for `getdents`