### PR TITLE
[build] Upgrade `type_safe` Crate to Rust Edition 2024 Edition (#560)

### DIFF
--- a/src/libs/type-safe/Cargo.toml
+++ b/src/libs/type-safe/Cargo.toml
@@ -5,7 +5,7 @@
 name = "type-safe"
 version.workspace = true
 license-file.workspace = true
-edition.workspace = true
+edition = "2024"
 authors.workspace = true
 description = "Type Safe Data Structures"
 homepage.workspace = true

--- a/src/libs/type-safe/src/unaligned_pointer.rs
+++ b/src/libs/type-safe/src/unaligned_pointer.rs
@@ -55,7 +55,7 @@ impl<T> UnalignedPointer<T> {
     /// - `self` points to a valid memory location.
     ///
     pub unsafe fn read_unaligned(&self) -> T {
-        self.ptr.read_unaligned()
+        unsafe { self.ptr.read_unaligned() }
     }
 
     ///
@@ -75,7 +75,9 @@ impl<T> UnalignedPointer<T> {
     /// - `self` points to a valid memory location.
     ///
     pub unsafe fn write_unaligned(&mut self, value: T) {
-        self.ptr.write_unaligned(value);
+        unsafe {
+            self.ptr.write_unaligned(value);
+        }
     }
 
     ///


### PR DESCRIPTION
## Description

This commit upgrades the `type_safe` crate to Rust Edition 2024.

This commit is a partial fix for https://github.com/nanvix/nanvix/issues/560.