### PR TITLE
[kernel] Tweaking Scheduler Parameters

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -15,12 +15,12 @@ kpool_size = 4194304
 kstack_size = 32768
 
 # Timer frequency (in Hz)
-timer_freq = 100
+timer_freq = 10000
 
 # Scheduler frequency (in ticks)
 # Notes:
 # - This should be a power of two.
-scheduler_freq = 128
+scheduler_freq = 1024
 
 # Maximum number of messages that can be buffered by the kernel
 # Notes:


### PR DESCRIPTION
## Description

This PR updates kernel scheduling parameters to improve system responsiveness.

Kernel configuration updates:

* Increased `timer_freq` from `100` Hz to `10000` Hz to achieve finer granularity in timer-based operations.
* Increased `scheduler_freq` from `128` ticks to `1024` ticks to reduce context switching frequency.