### PR TITLE
[scripts] Improving Test Scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,7 @@ run-unit-tests: all \
 	test-guest-rlibs
 
 run-nanvixd-tests: | \
+	init-repo \
 	test-echo-c \
 	test-echo-cpp \
 	test-echo-rust-nostd \
@@ -364,6 +365,7 @@ run-nanvixd-tests: | \
 
 # TODO: enable wasm tests, enable thread test.
 run-linuxd-tests: | \
+	init-repo \
 	test-linuxd-hello-c \
 	test-linuxd-hello-cpp \
 	test-linuxd-linux-app \

--- a/scripts/test-linuxd.sh
+++ b/scripts/test-linuxd.sh
@@ -8,7 +8,9 @@ PROGRAM_EXPECTED_OUTPUT=$5
 TIMEOUT=${6:-90}
 
 NANVIX_HOME=`git rev-parse --show-toplevel`
-LOGS_DIR=${NANVIX_HOME}/logs
+LOGS_DIR=${NANVIX_HOME}/logs/linuxd-$(basename "${PROGRAM_NAME}")
+
+mkdir -p ${LOGS_DIR}
 
 # Run linuxd.
 LINUXD_STDOUT_FILE_NAME="${LOGS_DIR}/linuxd-stdout_$(date "+%Y_%m_%d_%H_%M").log"

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -49,8 +49,24 @@ NANVIXD_PID=$!
 # Extract port number from nanvixd.
 NANVIXD_PORT_NUMBER=$(echo ${NANVIXD_SOCKADDR} | cut -d: -f2)
 
-# Wait for nanvixd to start.
-sleep 0.1
+# Wait for nanvixd to start by checking sandbox socket exists.
+MAX_TRIALS=10
+SLEEP_INTERVAL=0.1
+for i in $(seq 1 $MAX_TRIALS); do
+    echo "Waiting for nanvixd to start ... ($(echo "$i * $SLEEP_INTERVAL" | bc) s elapsed)"
+    sleep ${SLEEP_INTERVAL}
+
+    if ls /tmp/${SANDBOX_SOCKADDR}*.socket 1>/dev/null 2>&1; then
+        echo "nanvixd started after ${i} ms."
+        break
+    fi
+done
+
+# Check again after waiting.
+if ! ls /tmp/${SANDBOX_SOCKADDR}*.socket 1>/dev/null 2>&1; then
+    echo "nanvixd failed to start"
+    exit 2 # Error Code 2: No such file or directory (ENOENT)
+fi
 
 # Run a client.
 CURL_STDOUT_FILE_NAME="${LOGS_DIR}/curl-stdout_$(date "+%Y_%m_%d_%H_%M").log"

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -9,7 +9,9 @@ PROGRAM_EXPECTED_OUTPUT=$6
 TIMEOUT=${7:-90}
 
 NANVIX_HOME=`git rev-parse --show-toplevel`
-LOGS_DIR=${NANVIX_HOME}/logs
+LOGS_DIR=${NANVIX_HOME}/logs/nanvixd-$(basename "${PROGRAM_NAME}")
+
+mkdir -p ${LOGS_DIR}
 
 kill_children() {
     local parent_pid=$1

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -67,21 +67,18 @@ curl \
 # FIXME: https://github.com/nanvix/nanvix/issues/543
 mv *.log ${LOGS_DIR}/
 
+kill_children $NANVIXD_PID
+sudo -E rm -f /tmp/${NANVIXD_SOCKADDR}*.socket
+sudo -E rm -f /tmp/${LINUXD_SOCKADDR}*.socket
+sudo -E rm -f /tmp/${SANDBOX_SOCKADDR}*.socket
+
 # Check if curl.log contains the expected output.
 grep -q "${PROGRAM_EXPECTED_OUTPUT}" ${CURL_STDOUT_FILE_NAME}
 GREP_EXIT_CODE=$?
 if [ ${GREP_EXIT_CODE} -eq 0 ]; then
     echo "Test passed."
-    kill_children $NANVIXD_PID
-    sudo -E rm -f /tmp/${NANVIXD_SOCKADDR}*.socket
-    sudo -E rm -f /tmp/${LINUXD_SOCKADDR}*.socket
-    sudo -E rm -f /tmp/${SANDBOX_SOCKADDR}*.socket
     exit 0
 else
     echo "Test failed: expected output '${PROGRAM_EXPECTED_OUTPUT}' not in program output"
-    kill_children $NANVIXD_PID
-    sudo -E rm -f /tmp/${NANVIXD_SOCKADDR}*.socket
-    sudo -E rm -f /tmp/${LINUXD_SOCKADDR}*.socket
-    sudo -E rm -f /tmp/${SANDBOX_SOCKADDR}*.socket
     exit 1
 fi

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -51,6 +51,7 @@ NANVIXD_PORT_NUMBER=$(echo ${NANVIXD_SOCKADDR} | cut -d: -f2)
 sleep 0.1
 
 # Run a client.
+CURL_STDOUT_FILE_NAME="${LOGS_DIR}/curl-stdout_$(date "+%Y_%m_%d_%H_%M").log"
 curl \
     --silent \
     --header \
@@ -58,14 +59,14 @@ curl \
     --request POST \
     --data "{\"clientid\":1, \"program\": \"${PROGRAM_NAME}\", \"args\":${PROGRAM_ARGS}}" \
     http://localhost:${NANVIXD_PORT_NUMBER} \
-    > curl.log
+    > ${CURL_STDOUT_FILE_NAME}
 
 # Move all Rust logs to the logs directory.
 # FIXME: https://github.com/nanvix/nanvix/issues/543
 mv *.log ${LOGS_DIR}/
 
 # Check if curl.log contains the expected output.
-grep -q "${PROGRAM_EXPECTED_OUTPUT}" ${LOGS_DIR}/curl.log
+grep -q "${PROGRAM_EXPECTED_OUTPUT}" ${CURL_STDOUT_FILE_NAME}
 GREP_EXIT_CODE=$?
 if [ ${GREP_EXIT_CODE} -eq 0 ]; then
     echo "Test passed."


### PR DESCRIPTION
## Description

This PR introduces improvements to the testing infrastructure for `nanvixd` and `linuxd`, including better initialization, logging, and error handling. The changes enhance test reliability and provide more detailed logs for debugging.

### Test Initialization Enhancements:
* Added `init-repo` as a prerequisite for `run-nanvixd-tests` and `run-linuxd-tests` in the `Makefile`, ensuring the repository is properly initialized before running tests.

### Logging Improvements:
* Updated `scripts/test-linuxd.sh` and `scripts/test-nanvixd.sh` to create separate log directories for each test run, using the format `logs/linuxd-<program_name>` and `logs/nanvixd-<program_name>`, respectively. This ensures logs are organized and easier to locate.
* Modified `test-nanvixd.sh` to save `curl` output to a timestamped log file (`curl-stdout_<timestamp>.log`) in the designated log directory.

### Error Handling and Reliability:
* Replaced a fixed `sleep` with a loop that checks for the existence of the sandbox socket file, ensuring `nanvixd` has started before proceeding. If the socket file is not found after multiple attempts, the script exits with an appropriate error code.
* Improved cleanup logic by consolidating socket removal commands and ensuring they execute regardless of test success or failure.