### PR TITLE
[kernel] Deallocate Kernel Stack as Soon as Possible

### DIFF
--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -53,7 +53,6 @@ impl KernelStack {
     ///
     /// Upon success, the function returns the new kernel stack. Upon failure, an error is returned.
     ///
-    #[allow(dead_code)] // TODO: Remove this attribute once the function is used.
     pub fn new(mm: &mut VirtMemoryManager) -> Result<Self, Error> {
         let kpages: Vec<KernelPage> =
             mm.alloc_kpages(true, config::kernel::KSTACK_SIZE / ::arch::mem::PAGE_SIZE)?;
@@ -74,7 +73,6 @@ impl KernelStack {
     ///
     /// The top address of the kernel stack is the address of the first byte after the kernel stack.
     ///
-    #[allow(dead_code)] // TODO: Remove this attribute once the function is used.
     pub fn top(&self) -> PageAligned<VirtualAddress> {
         let base: usize = self.kpages[0].base().into_raw_value();
         let size: usize = config::kernel::KSTACK_SIZE;

--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use ::alloc::vec::Vec;
 use ::arch::mem::PAGE_ALIGNMENT;
+use ::core::fmt;
 use ::sys::{
     error::Error,
     mm::{
@@ -63,6 +64,36 @@ impl KernelStack {
     ///
     /// # Description
     ///
+    /// Returns the size of the target kernel stack.
+    ///
+    /// # Returns
+    ///
+    /// The size of the target kernel stack.
+    ///
+    fn size(&self) -> usize {
+        config::kernel::KSTACK_SIZE
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the base address of the target kernel stack.
+    ///
+    /// # Returns
+    ///
+    /// The base address of the target kernel stack.
+    ///
+    /// # Notes
+    ///
+    /// As stacks grow downwards, the base address is the highest address of the stack.
+    ///
+    fn base(&self) -> PageAligned<VirtualAddress> {
+        PageAligned::from_raw_value(self.kpages[0].base().into_raw_value()).unwrap()
+    }
+
+    ///
+    /// # Description
+    ///
     /// Returns the top address of the target kernel stack.
     ///
     /// # Returns
@@ -88,8 +119,21 @@ impl KernelStack {
 // Trait Implementations
 //==================================================================================================
 
+impl fmt::Debug for KernelStack {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "KernelStack {{ base: {:?}, top: {:?}, size={:?} }}",
+            self.base(),
+            self.top(),
+            self.size()
+        )
+    }
+}
+
 impl Drop for KernelStack {
     fn drop(&mut self) {
+        debug!("drop(): {:?}", &self);
         while let Some(kpage) = self.kpages.pop() {
             drop(kpage);
         }

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -191,11 +191,6 @@ impl Vmem {
         })
     }
 
-    /// Adds a kernel page to the private list of the kernel pages in the target virtual memory space.
-    pub fn add_private_kernel_page(&mut self, kpage: KernelPage) {
-        self.private_kernel_pages.push_back(kpage);
-    }
-
     pub fn load(&self) -> Result<(), Error> {
         let pgdir_addr: FrameAddress = self.pgdir.physical_address()?;
         unsafe { mmu::load_page_directory(pgdir_addr.into_raw_value()) };

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -20,18 +20,17 @@ use crate::{
         mem::{
             AccessPermission,
             Address,
-            PageAddress,
             PageAligned,
             VirtualAddress,
         },
     },
     mm::{
         elf::Elf32Fhdr,
+        kstack::KernelStack,
         ustack::{
             UserStack,
             UserStackAllocator,
         },
-        KernelPage,
         VirtMemoryManager,
         Vmem,
     },
@@ -70,7 +69,6 @@ use ::alloc::{
     },
     ffi::CString,
     rc::Rc,
-    vec::Vec,
 };
 use ::arch::mem::PAGE_SIZE;
 use ::core::cell::{
@@ -179,7 +177,7 @@ impl ProcessManagerInner {
         arg0: usize,
         arg1: usize,
         enable_interrupts: bool,
-    ) -> Result<ContextInformation, Error> {
+    ) -> Result<(KernelStack, ContextInformation), Error> {
         trace!(
             "forge_user_context(): user_stack={:?}, user_wrapper_fn={:#x?}, arg0={:#x?}, \
              arg1={:#x?}, enable_interrupts={:?}",
@@ -211,17 +209,12 @@ impl ProcessManagerInner {
             VirtualAddress::from_raw_value(__leave_kernel_to_user_mode as usize);
 
         // Alloc kernel pages for the kernel stack.
-        // NOTE: if we fail, kernel pages allocated for the kernel stack are deallocated.
-        let mut kpages: Vec<KernelPage> =
-            mm.alloc_kpages(true, config::kernel::KSTACK_SIZE / PAGE_SIZE)?;
-        let base: PageAddress = kpages[0].base();
-        let kernel_stack: usize =
-            unsafe { (base.into_raw_value() as *mut u8).add(config::kernel::KSTACK_SIZE) } as usize;
+        let kernel_stack: KernelStack = KernelStack::new(mm)?;
 
         let cr3: u32 = vmem.pgdir().physical_address()?.into_raw_value() as u32;
         let esp: u32 = unsafe {
             hal::arch::forge_user_stack(
-                kernel_stack as *mut u8,
+                kernel_stack.top().into_raw_value() as *mut u8,
                 user_stack.top().into_raw_value(),
                 user_fn.into_raw_value(),
                 arg0,
@@ -230,7 +223,7 @@ impl ProcessManagerInner {
                 enable_interrupts,
             )
         } as u32;
-        let esp0: u32 = kernel_stack as u32;
+        let esp0: u32 = kernel_stack.top().into_raw_value() as u32;
 
         trace!("forge_context(): cr3={:#x}, esp={:#x}, ebp={:#x}", cr3, esp, esp0);
         let context: ContextInformation = ContextInformation::new(cr3, esp, esp0);
@@ -245,12 +238,7 @@ impl ProcessManagerInner {
 
         // NOTE: if we fail, beyond this point we must unmap kernel pages from `vmem`.
 
-        // Map kernel stack.
-        while let Some(kpage) = kpages.pop() {
-            vmem.add_private_kernel_page(kpage);
-        }
-
-        Ok(context)
+        Ok((kernel_stack, context))
     }
 
     ///
@@ -323,22 +311,24 @@ impl ProcessManagerInner {
             };
 
             // Create a kernel context.
-            let context: ContextInformation = Self::forge_user_context(
-                mm,
-                process.state_mut().vmem_mut(),
-                &user_stack,
-                user_wrapper_fn,
-                user_fn.into_raw_value(),
-                user_fn_arg,
-                enable_interrupts,
-            )?;
+            let (kernel_stack, context): (KernelStack, ContextInformation) =
+                Self::forge_user_context(
+                    mm,
+                    process.state_mut().vmem_mut(),
+                    &user_stack,
+                    user_wrapper_fn,
+                    user_fn.into_raw_value(),
+                    user_fn_arg,
+                    enable_interrupts,
+                )?;
 
             //==============================================================
             // NOTE: if we fail beyond this point we need to page mappings.
             //==============================================================
 
             // Create a new thread.
-            self.tm.create_thread(Some(user_stack), context)
+            self.tm
+                .create_thread(Some(kernel_stack), Some(user_stack), context)
         };
 
         Ok(self.try_add_thread(pid, ready_thread))
@@ -511,7 +501,7 @@ impl ProcessManagerInner {
         let user_fn: VirtualAddress = entry;
         let argp: usize = args_vaddr.into_raw_value();
         let envp: usize = envp_vaddr.into_raw_value();
-        let context: ContextInformation = Self::forge_user_context(
+        let (kernel_stack, context): (KernelStack, ContextInformation) = Self::forge_user_context(
             mm,
             &mut vmem,
             &user_stack,
@@ -525,7 +515,9 @@ impl ProcessManagerInner {
         // NOTE: if we fail beyond this point we need to page mappings.
         //==============================================================
 
-        let thread: ReadyThread = self.tm.create_thread(Some(user_stack), context);
+        let thread: ReadyThread =
+            self.tm
+                .create_thread(Some(kernel_stack), Some(user_stack), context);
 
         // Create process.
         let pid: ProcessIdentifier = self.next_pid;
@@ -1312,7 +1304,7 @@ impl ProcessManager {
         // Traverse the list of zombie threads.
         while let Some(zombie_thread) = zombie_threads.pop_front() {
             // Harvest zombie thread.
-            if let Some(user_stack) = zombie_thread.harvest() {
+            if let (Some(_kernel_stack), Some(user_stack)) = zombie_thread.harvest() {
                 // Traverse pages belonging to user stack.
                 let base: usize = user_stack.base().into_raw_value();
                 let top: usize = user_stack.top().into_raw_value();
@@ -1337,6 +1329,9 @@ impl ProcessManager {
                         );
                     }
                 }
+
+                // Frames allocated to the user stack are freed when we exit this scope.
+                // Frames allocated to the kernel stack are freed when we exit this scope.
             }
         }
 

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -283,7 +283,7 @@ impl ProcessManager {
                     let status: ExitStatus = zombie_thread.status();
 
                     // Harvest zombie thread.
-                    if let Some(user_stack) = zombie_thread.harvest() {
+                    if let (Some(_kernel_stack), Some(user_stack)) = zombie_thread.harvest() {
                         // Traverse pages belonging to user stack.
                         let base: usize = user_stack.base().into_raw_value();
                         let top: usize = user_stack.top().into_raw_value();
@@ -318,6 +318,9 @@ impl ProcessManager {
                                 );
                             }
                         }
+
+                        // Frames allocated to the user stack are freed when we exit this scope.
+                        // Frames allocated to the kernel stack are freed when we exit this scope.
                     }
 
                     break Ok(status);

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -7,7 +7,10 @@
 
 use crate::{
     hal::arch::ContextInformation,
-    mm::ustack::UserStack,
+    mm::{
+        kstack::KernelStack,
+        ustack::UserStack,
+    },
     pm::sync::{
         condvar::Condvar,
         mutex::MutexGuard,
@@ -39,6 +42,8 @@ use ::sys::{
 struct ThreadState {
     /// Thread identifier.
     id: ThreadIdentifier,
+    /// Kernel stack.
+    kernel_stack: Option<KernelStack>,
     /// User stack.
     user_stack: Option<UserStack>,
     /// Condition variable for join.
@@ -52,12 +57,14 @@ struct ThreadState {
 impl ThreadState {
     fn new(
         id: ThreadIdentifier,
+        kernel_stack: Option<KernelStack>,
         user_stack: Option<UserStack>,
         context: ContextInformation,
     ) -> Self {
         Self {
             id,
             context: Box::pin(context),
+            kernel_stack,
             user_stack,
             join_cond: Condvar::new(),
             locked_mutexes: BTreeMap::new(),
@@ -177,10 +184,11 @@ pub struct ReadyThread(ThreadState);
 impl ReadyThread {
     pub fn new(
         id: ThreadIdentifier,
+        kernel_stack: Option<KernelStack>,
         user_stack: Option<UserStack>,
         context: ContextInformation,
     ) -> Self {
-        Self(ThreadState::new(id, user_stack, context))
+        Self(ThreadState::new(id, kernel_stack, user_stack, context))
     }
 
     pub fn tid(&self) -> ThreadIdentifier {
@@ -284,8 +292,8 @@ impl ZombieThread {
         self.state.id
     }
 
-    pub fn harvest(mut self) -> Option<UserStack> {
-        self.state.user_stack.take()
+    pub fn harvest(mut self) -> (Option<KernelStack>, Option<UserStack>) {
+        (self.state.kernel_stack.take(), self.state.user_stack.take())
     }
 
     pub fn status(&self) -> ExitStatus {
@@ -304,7 +312,7 @@ pub struct ThreadManager {
 impl ThreadManager {
     fn new() -> (ReadyThread, Self) {
         let kernel: ReadyThread =
-            ReadyThread::new(From::<u32>::from(0), None, ContextInformation::default());
+            ReadyThread::new(From::<u32>::from(0), None, None, ContextInformation::default());
         (
             kernel,
             Self {
@@ -315,13 +323,14 @@ impl ThreadManager {
 
     pub fn create_thread(
         &mut self,
+        kernel_stack: Option<KernelStack>,
         user_stack: Option<UserStack>,
         context: ContextInformation,
     ) -> ReadyThread {
         let id: ThreadIdentifier = self.next_id;
         self.next_id = ThreadIdentifier::from(Into::<usize>::into(self.next_id) + 1);
 
-        ReadyThread(ThreadState::new(id, user_stack, context))
+        ReadyThread(ThreadState::new(id, kernel_stack, user_stack, context))
     }
 }
 

--- a/src/tests/thread-c/create_join.c
+++ b/src/tests/thread-c/create_join.c
@@ -16,6 +16,9 @@
 // Constants
 //==================================================================================================
 
+// Number of iterations.
+static const int NUMBER_OF_ITERATIONS = 1024;
+
 // Expected argument passed to the worker thread.
 static const size_t EXPECTED_WORKER_ARG = 0xbadcafe;
 
@@ -57,7 +60,9 @@ void test_pthread_create_join(void)
 {
     fprintf(stderr, "testing pthread_create() and pthread_join() ... ");
 
-    main_thread();
+    for (int i = 0; i < NUMBER_OF_ITERATIONS; i++) {
+        main_thread();
+    }
 
     fprintf(stderr, "passed\n");
 }


### PR DESCRIPTION
## Description

This PR introduces significant updates to the kernel's memory and process management systems, focusing on the integration of kernel stacks (`KernelStack`) and improvements to thread management. Key changes include the addition of new methods to the `KernelStack` structure, refactoring process management to use `KernelStack`, and ensuring proper cleanup of kernel and user stacks during thread harvesting.

This PR closes #570 

### Kernel Stack Enhancements:
* Added methods `size`, `base`, and `top` to `KernelStack` to retrieve stack size, base address, and top address respectively. These methods improve stack management and readability.
* Implemented the `Debug` trait for `KernelStack` to facilitate debugging by providing a formatted string representation of the stack's properties.

### Process Management Refactoring:
* Refactored `forge_user_context` in `ProcessManagerInner` to return a tuple `(KernelStack, ContextInformation)` instead of just `ContextInformation`. This ensures the kernel stack is properly allocated and passed to thread creation.
* Updated thread creation to include both kernel and user stacks, ensuring consistent management and cleanup.

### Thread Management Updates:
* Modified `ThreadState` and `ReadyThread` to include an optional `KernelStack`, enabling better tracking and cleanup of kernel stacks during thread lifecycle.
* Updated `ZombieThread::harvest` to return both `KernelStack` and `UserStack`, ensuring proper deallocation of resources.

### Test Enhancements:
* Added a loop in `test_pthread_create_join` to run the test multiple times (`NUMBER_OF_ITERATIONS = 1024`) for better stress testing of thread creation and cleanup.