### PR TITLE
[contrib] Updating Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ hyperlight_host = { git = "https://github.com/nanvix/hyperlight/", rev = "17fd17
 ], package = "hyperlight-host" } # we use the gdb feature to remove the timeout mechanism
 hyper = { version = "1.6.0", default-features = false }
 hyper-util = { version = "0.1.14", default-features = false }
-kvm-bindings = "0.11.1"
-kvm-ioctls = "0.21.0"
+kvm-bindings = "0.12.0"
+kvm-ioctls = "0.22.0"
 libc = "0.2.172"
 log = "0.4.27"
 micromath = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ tokio = { version = "1.45.1", default-features = false }
 type-safe = { path = "src/libs/type-safe", default-features = false }
 syscomm = { path = "src/libs/syscomm", default-features = false }
 syslog = { path = "src/libs/syslog", default-features = false }
-wasmi = { version = "0.46.0", default-features = false }
+wasmi = { version = "0.47.0", default-features = false }
 
 [profile.dev]
 opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ sysalloc = { path = "src/libs/sysalloc", default-features = false }
 syscall = { path = "src/libs/syscall", default-features = false }
 sys = { path = "src/libs/sys", default-features = false }
 talc = { git = "https://github.com/nanvix/talc", rev = "12e66643796be912933a369a2d556aaac4c68771", default-features = false, package = "talc" }
-tokio = { version = "1.45.0", default-features = false }
+tokio = { version = "1.45.1", default-features = false }
 type-safe = { path = "src/libs/type-safe", default-features = false }
 syscomm = { path = "src/libs/syscomm", default-features = false }
 syslog = { path = "src/libs/syslog", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ elf = { path = "src/libs/elf", default-features = false }
 error = { path = "src/libs/error", default-features = false }
 fastrand = { version = "2.3.0", default-features = false }
 flexi_logger = "0.30.2"
-goblin = { version = "0.9.3", default-features = false }
+goblin = { version = "0.10.0", default-features = false }
 indicatif = "0.17.11"
 http-body-util = "0.1.3"
 hyperlight_common = { git = "https://github.com/nanvix/hyperlight", rev = "17fd1773ed22b52cf2956a6f0b120da9cda5b62e", default-features = false, package = "hyperlight-common" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ homepage = "https://github.com/nanvix"
 arch = { path = "src/libs/arch", default-features = false }
 anyhow = "1.0.98"
 bitmap = { path = "src/libs/bitmap", default-features = false }
-cc = "1.2.23"
+cc = "1.2.26"
 cfg-if = "1.0.0"
 config = { path = "src/libs/config", default-features = false }
 elf = { path = "src/libs/elf", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ hyperlight_host = { git = "https://github.com/nanvix/hyperlight/", rev = "17fd17
         "gdb",
 ], package = "hyperlight-host" } # we use the gdb feature to remove the timeout mechanism
 hyper = { version = "1.6.0", default-features = false }
-hyper-util = { version = "0.1.11", default-features = false }
+hyper-util = { version = "0.1.14", default-features = false }
 kvm-bindings = "0.11.1"
 kvm-ioctls = "0.21.0"
 libc = "0.2.172"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ config = { path = "src/libs/config", default-features = false }
 elf = { path = "src/libs/elf", default-features = false }
 error = { path = "src/libs/error", default-features = false }
 fastrand = { version = "2.3.0", default-features = false }
-flexi_logger = "0.30.1"
+flexi_logger = "0.30.2"
 goblin = { version = "0.9.3", default-features = false }
 indicatif = "0.17.11"
 http-body-util = "0.1.3"


### PR DESCRIPTION
## Description

This PR updates several dependencies in the `Cargo.toml` file to newer versions, ensuring compatibility with the latest features and bug fixes. These updates primarily focus on libraries related to logging, virtualization, and asynchronous programming.

### Dependency Updates:

* Updated `cc` from version `1.2.23` to `1.2.26`, `flexi_logger` from `0.30.1` to `0.30.2`, and `goblin` from `0.9.3` to `0.10.0` for improved logging and binary parsing capabilities.
* Upgraded `hyper-util` from `0.1.11` to `0.1.14`, `kvm-bindings` from `0.11.1` to `0.12.0`, and `kvm-ioctls` from `0.21.0` to `0.22.0` for enhanced virtualization and hypervisor support.
* Bumped `tokio` from `1.45.0` to `1.45.1` and `wasmi` from `0.46.0` to `0.47.0` for better asynchronous programming and WebAssembly execution.