### PR TITLE
[kernel] Preserve Order in Process Queues

### DIFF
--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -91,6 +91,7 @@ pub fn kcall_handler(
                             KcallResult::Error(ErrorCode::InvalidSysCall.into())
                         },
                     };
+
                     // SAFETY: the calling process does not hold a reference to the inner state of the process manager.
                     if let Err(e) = unsafe { scoreboard.handled(ret) } {
                         warn!("failed to signal kernel call handled: {:?}", e)

--- a/src/kernel/src/pm/kcall/create_thread.rs
+++ b/src/kernel/src/pm/kcall/create_thread.rs
@@ -59,7 +59,10 @@ pub fn create_thread(
     }
 
     match do_create_thread(pm, mm, args.pid, user_wrapper_fn, user_fn, user_fn_arg) {
-        Ok(tid) => KcallResult::Success(Into::<usize>::into(tid).into()),
+        Ok(tid) => {
+            debug!("create_thread(): thread {tid:?} created");
+            KcallResult::Success(Into::<usize>::into(tid).into())
+        },
         Err(e) => KcallResult::Error(e.code.into()),
     }
 }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -767,6 +767,11 @@ impl ProcessManagerInner {
         status: ExitStatus,
     ) -> (*mut ContextInformation, *mut ContextInformation) {
         let running_process: RunningProcess = self.take_running();
+        trace!(
+            "exit(): pid={:?}, tid={:?}, status={status:?}",
+            running_process.state().pid(),
+            running_process.get_tid(),
+        );
 
         // Check if kernel is trying to exit.
         if running_process.state().pid() == ProcessIdentifier::KERNEL {

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -359,9 +359,7 @@ impl ProcessManagerInner {
             suspended.push_back(process);
         }
         // Process is not in the list of sleeping processes, rollback list to its original state.
-        while let Some(process) = suspended.pop_front() {
-            self.suspended.push_back(process);
-        }
+        self.suspended = suspended;
 
         // Search process in the list of ready processes.
         let mut ready: LinkedList<RunnableProcess> = LinkedList::new();
@@ -380,9 +378,7 @@ impl ProcessManagerInner {
             ready.push_back(process);
         }
         // Process is not in the list of ready processes, rollback list to its original state.
-        while let Some(process) = ready.pop_front() {
-            self.ready.push_back(process);
-        }
+        self.ready = ready;
 
         unreachable!("process must be either sleeping or runnable")
     }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -722,9 +722,8 @@ impl ProcessManagerInner {
                 suspended.push_back(process)
             }
         }
-        while let Some(process) = suspended.pop_front() {
-            self.suspended.push_back(process);
-        }
+        // Process is not in the list of sleeping processes, rollback list to its original state.
+        self.suspended = suspended;
 
         // Search for the process in the list of ready processes.
         let mut ready: LinkedList<RunnableProcess> = LinkedList::new();
@@ -744,9 +743,8 @@ impl ProcessManagerInner {
                 ready.push_back(process)
             }
         }
-        while let Some(process) = ready.pop_front() {
-            self.ready.push_back(process);
-        }
+        // Process is not in the list of ready processes, rollback list to its original state.
+        self.ready = ready;
 
         None
     }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -571,6 +571,9 @@ impl ProcessManagerInner {
             self.running = Some(next_process);
 
             if previous_pid == next_pid {
+                if previous_pid != ProcessIdentifier::KERNEL {
+                    panic!("schedule(): rescheduling non kernel thread (pid={previous_pid:?})");
+                }
                 return None;
             }
 
@@ -590,6 +593,10 @@ impl ProcessManagerInner {
             // Attempt to wake up process.
             match process.wakeup_alarm(now) {
                 Ok(interrupted_process) => {
+                    trace!(
+                        "check_alarm(): process {:?} interrupted at {now:?}",
+                        interrupted_process.state().pid(),
+                    );
                     self.interrupted.push_back(interrupted_process);
                 },
                 Err(suspended_process) => suspended.push_back(suspended_process),
@@ -665,6 +672,7 @@ impl ProcessManagerInner {
     /// Upon successful completion, empty is returned. Otherwise, an error code is returned instead.
     ///
     pub fn wakeup(&mut self, pid: ProcessIdentifier, tid: ThreadIdentifier) -> Result<(), Error> {
+        // Check if thread belongs to the running process.
         if self.get_running().state().pid() == pid {
             let running_process: RunningProcess = self.take_running();
             match running_process.wakeup(tid) {
@@ -674,15 +682,18 @@ impl ProcessManagerInner {
                 },
                 Err(running_process) => {
                     self.running = Some(running_process);
+                    let reason: &str = "thread not found";
+                    error!("wake_up(): {reason} (pid={pid:?}. tid={tid:?})");
                 },
             }
         }
 
+        // Check if thread belongs to a suspended process.
         let runnable_process: RunnableProcess = match self.try_wakeup(pid, tid) {
             Some(runnable_process) => runnable_process,
             None => {
                 let reason: &str = "thread not found";
-                error!("wake_up(): {} (pid={:?}. tid={:?})", reason, pid, tid);
+                error!("wake_up(): {reason} (pid={pid:?}, tid={tid:?})");
                 return Err(Error::new(ErrorCode::NoSuchEntry, reason));
             },
         };

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -680,6 +680,7 @@ impl ProcessManagerInner {
                     self.running = Some(running_process);
                     let reason: &str = "thread not found";
                     error!("wake_up(): {reason} (pid={pid:?}. tid={tid:?})");
+                    return Err(Error::new(ErrorCode::NoSuchEntry, reason));
                 },
             }
         }
@@ -716,7 +717,13 @@ impl ProcessManagerInner {
                         }
                         return Some(runnable_process);
                     },
-                    Err(suspended_process) => suspended.push_back(suspended_process),
+                    Err(suspended_process) => {
+                        self.suspended.push_front(suspended_process);
+                        while let Some(process) = suspended.pop_back() {
+                            self.suspended.push_front(process);
+                        }
+                        return None;
+                    },
                 }
             } else {
                 suspended.push_back(process)
@@ -737,7 +744,13 @@ impl ProcessManagerInner {
                         }
                         return Some(runnable_process);
                     },
-                    Err(ready_process) => ready.push_back(ready_process),
+                    Err(ready_process) => {
+                        self.ready.push_front(ready_process);
+                        while let Some(process) = ready.pop_back() {
+                            self.ready.push_front(process);
+                        }
+                        return None;
+                    },
                 }
             } else {
                 ready.push_back(process)

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -704,13 +704,15 @@ impl ProcessManagerInner {
         pid: ProcessIdentifier,
         tid: ThreadIdentifier,
     ) -> Option<RunnableProcess> {
+        // Search for the process in the list of sleeping processes.
         let mut suspended: LinkedList<SleepingProcess> = LinkedList::new();
         while let Some(process) = self.suspended.pop_front() {
+            // Found.
             if process.state().pid() == pid {
                 match process.wakeup(tid) {
                     Ok(runnable_process) => {
-                        while let Some(process) = suspended.pop_front() {
-                            self.suspended.push_back(process);
+                        while let Some(process) = suspended.pop_back() {
+                            self.suspended.push_front(process);
                         }
                         return Some(runnable_process);
                     },
@@ -724,13 +726,15 @@ impl ProcessManagerInner {
             self.suspended.push_back(process);
         }
 
+        // Search for the process in the list of ready processes.
         let mut ready: LinkedList<RunnableProcess> = LinkedList::new();
         while let Some(process) = self.ready.pop_front() {
+            // Found.
             if process.state().pid() == pid {
                 match process.wakeup(tid) {
                     Ok(runnable_process) => {
-                        while let Some(process) = ready.pop_front() {
-                            self.ready.push_back(process);
+                        while let Some(process) = ready.pop_back() {
+                            self.ready.push_front(process);
                         }
                         return Some(runnable_process);
                     },

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -349,8 +349,8 @@ impl ProcessManagerInner {
             if process.state().pid() == pid {
                 let ready_process: RunnableProcess = process.add_thread(ready_thread);
                 // Rollback list to its original state.
-                while let Some(process) = suspended.pop_front() {
-                    self.suspended.push_back(process);
+                while let Some(process) = suspended.pop_back() {
+                    self.suspended.push_front(process);
                 }
                 // Push process to the list of ready processes.
                 self.ready.push_back(ready_process);
@@ -370,8 +370,8 @@ impl ProcessManagerInner {
             if process.state().pid() == pid {
                 let ready_process: RunnableProcess = process.add_thread(ready_thread);
                 // Rollback list to its original state.
-                while let Some(process) = ready.pop_front() {
-                    self.ready.push_back(process);
+                while let Some(process) = ready.pop_back() {
+                    self.ready.push_front(process);
                 }
                 // Push process to the list of ready processes.
                 self.ready.push_back(ready_process);

--- a/src/kernel/src/pm/sync/condvar.rs
+++ b/src/kernel/src/pm/sync/condvar.rs
@@ -14,7 +14,10 @@ use ::alloc::{
     collections::LinkedList,
     sync::Arc,
 };
-use ::core::cell::RefCell;
+use ::core::{
+    cell::RefCell,
+    fmt,
+};
 use ::sys::{
     error::{
         Error,
@@ -243,3 +246,9 @@ impl Condvar {
 unsafe impl Send for CondvarInner {}
 
 unsafe impl Sync for CondvarInner {}
+
+impl fmt::Debug for Condvar {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        write!(f, "Condvar {{ sleeping: {:?} }}", self.inner.sleeping.borrow())
+    }
+}

--- a/src/kernel/src/pm/sync/mutex.rs
+++ b/src/kernel/src/pm/sync/mutex.rs
@@ -10,9 +10,12 @@ use crate::pm::{
     sync::condvar::Condvar,
 };
 use ::alloc::sync::Arc;
-use ::core::sync::atomic::{
-    AtomicBool,
-    Ordering,
+use ::core::{
+    fmt,
+    sync::atomic::{
+        AtomicBool,
+        Ordering,
+    },
 };
 use ::sys::{
     error::Error,
@@ -183,11 +186,22 @@ impl Mutex {
     }
 }
 
+impl fmt::Debug for MutexGuard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "MutexGuard {{ locked: {:?}, condvar: {:?} }}",
+            self.mutex.locked.load(Ordering::Relaxed),
+            self.mutex.sleeping
+        )
+    }
+}
+
 impl Drop for MutexGuard {
     fn drop(&mut self) {
         // Safety: The lock is ensured to be held by the caller.
-        if let Err(e) = unsafe { self.mutex.unlock_unchecked() } {
-            warn!("failed to unlock mutex: {:?}", e);
+        if let Err(error) = unsafe { self.mutex.unlock_unchecked() } {
+            warn!("drop(): failed to unlock mutex (self={self:?}, error={error:?})");
         }
     }
 }


### PR DESCRIPTION
## Description

This PR refactors the `ProcessManagerInner` implementation to improve code clarity and efficiency, while also enhancing debugging capabilities. The key changes include optimizing list rollback operations, introducing additional safety checks, and adding trace logs for better observability.

### Code Efficiency Improvements:
* Replaced manual rollback loops (`pop_front`/`push_back`) with direct list reassignments (`self.suspended = suspended` and `self.ready = ready`) to simplify and optimize the rollback logic.

* Changed the rollback order of processes from front-to-back to back-to-front in `suspended` and `ready` lists for consistency and potential performance benefits. (`pop_back`/`push_front` used instead of `pop_front`/`push_back`).

### Debugging and Safety Enhancements:
* Added a safety check to prevent rescheduling of non-kernel threads with the same PID, accompanied by a panic message for easier debugging.

* Introduced a trace log in the `check_alarm` method to log when a process is interrupted, providing better visibility into process state changes during alarms.