### PR TITLE
[kernel] Remove Process from Sleeping Queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export MACHINE ?= microvm
 export RELEASE ?= no
 
 # Timeout
-export TIMEOUT ?= 300
+export TIMEOUT ?= 600
 
 # Enable Microvm profiler?
 export PROFILER ?= no

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -332,7 +332,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--verbose", action="store_true", help="Enable verbose build", default=True
     )
-    parser.add_argument("--timeout", type=int, help="Set test timeout", default=300)
+    parser.add_argument("--timeout", type=int, help="Set test timeout", default=600)
     parser.add_argument(
         "--lint", action="store_true", help="Lint Nanvix source code", default=False
     )

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -13,7 +13,7 @@ TOOLCHAIN_DIR=${1:-$(pwd)/toolchain}
 TTY=${2:-/dev/null}
 
 # Timeout for each step.
-TIMEOUT=300
+TIMEOUT=600
 
 # Padding to force aligned formatting.
 PADDING=40

--- a/src/kernel/src/pm/sync/condvar.rs
+++ b/src/kernel/src/pm/sync/condvar.rs
@@ -239,7 +239,17 @@ impl Condvar {
 
         self.inner.sleeping.borrow_mut().push_back((pid, tid));
 
-        ProcessManager::sleep(alarm)
+        match ProcessManager::sleep(alarm) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                // Remove the thread from the sleeping queue if it was not woken up.
+                self.inner
+                    .sleeping
+                    .borrow_mut()
+                    .retain(|&(p, t)| p != pid || t != tid);
+                Err(error)
+            },
+        }
     }
 }
 
@@ -247,8 +257,22 @@ unsafe impl Send for CondvarInner {}
 
 unsafe impl Sync for CondvarInner {}
 
+impl fmt::Debug for CondvarInner {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        write!(f, "CondvarInner {{ sleeping: {:?} }}", self.sleeping.borrow())
+    }
+}
+
 impl fmt::Debug for Condvar {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         write!(f, "Condvar {{ sleeping: {:?} }}", self.inner.sleeping.borrow())
+    }
+}
+
+impl Drop for CondvarInner {
+    fn drop(&mut self) {
+        if !self.sleeping.borrow().is_empty() {
+            panic!("drop(): {self:?}");
+        }
     }
 }


### PR DESCRIPTION
## Description

This pull request includes changes to increase timeout values across the project and enhance the robustness and debugging capabilities of the `Condvar` implementation in the kernel. The most important changes are grouped below by theme.

### Timeout Adjustments:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L20-R20): Increased the default timeout for tests from 300 seconds to 600 seconds by modifying the `TIMEOUT` environment variable.
* [`scripts/ci.py`](diffhunk://#diff-3bfb26bc1a4ea20de267d5903273b932f65826e329ad493c74a3ffa012f706ebL335-R335): Updated the default timeout for the `--timeout` argument in the CI script from 300 seconds to 600 seconds.
* [`scripts/pipeline.sh`](diffhunk://#diff-dbcccb175f62ef04b8277733ad2cfa42c897b5c3a59e4ba607d3b776d59bad6dL16-R16): Adjusted the hardcoded timeout for pipeline steps from 300 seconds to 600 seconds.

### Kernel Synchronization Improvements:

* [`src/kernel/src/pm/sync/condvar.rs`](diffhunk://#diff-0b8144d6e69a39f4e7b02d5447f348bd71986d5d4ae8d0df0bfc89cf9a6f8099L242-R278): Enhanced the `Condvar` implementation by adding error handling to ensure that threads are removed from the sleeping queue if they fail to sleep, implemented a `Debug` trait for `CondvarInner` to improve debugging, and added a `Drop` implementation to ensure the sleeping queue is empty when the `CondvarInner` is dropped.