### PR TITLE
[kernel] Switch Threads of Same Process

### DIFF
--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -536,6 +536,7 @@ impl ProcessManagerInner {
         let previous_process: RunningProcess = self.take_running();
 
         let previous_pid: ProcessIdentifier = previous_process.state().pid();
+        let previous_tid: ThreadIdentifier = previous_process.get_tid();
 
         let (previous_process, previous_context) = previous_process.schedule();
         self.ready.push_back(previous_process);
@@ -564,9 +565,10 @@ impl ProcessManagerInner {
 
             self.interrupt_reason = reason;
             let next_pid: ProcessIdentifier = next_process.state().pid();
+            let next_tid: ThreadIdentifier = next_process.get_tid();
             self.running = Some(next_process);
 
-            if previous_pid == next_pid {
+            if previous_tid == next_tid && previous_pid == next_pid {
                 if previous_pid != ProcessIdentifier::KERNEL {
                     panic!("schedule(): rescheduling non kernel thread (pid={previous_pid:?})");
                 }


### PR DESCRIPTION
## Description

This pull request introduces changes to the `ProcessManagerInner` implementation in `src/kernel/src/pm/process/manager/mod.rs` to enhance thread-level scheduling by incorporating thread identifiers (`ThreadIdentifier`) into the scheduling logic. The most important changes are as follows:

### Thread-level scheduling improvements:

* Added retrieval of the thread identifier (`ThreadIdentifier`) for the previously running process by calling `previous_process.get_tid()`. This allows thread-level context to be considered during scheduling.
* Integrated thread identifier comparison (`previous_tid == next_tid`) into the scheduling logic to ensure that rescheduling decisions account for both process and thread identifiers. This prevents unintended rescheduling of the same thread.