### PR TITLE
[ci] FIx slow and unintended behaviour of python-lint

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -7,6 +7,6 @@ set -euo pipefail
 
 make python-lint > /dev/null
 
-if ! git diff --quiet; then
+if ! git diff --quiet -- "*.py"; then
   echo "Post-commit: python formatting introduced changes, consider ammending your commit"
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin/
 /logs/
 images/
 target/
+venv/
 /sysroot-debug/
 /sysroot-release/
 *.a

--- a/Makefile
+++ b/Makefile
@@ -327,14 +327,13 @@ PY_VERBOSE :=
 ifneq ($(VERBOSE),yes)
 PY_VERBOSE += >> /dev/null 2>&1
 endif
+PYTHON_VENV_DIRECTORY=$(ROOT_DIR)/venv
 
 python-lint:
-	@rm -rf /tmp/venv
-	@python3 -m venv /tmp/venv
-	@/tmp/venv/bin/pip3 install "black>=24.0.0" "flake8>=7.0.0" > /dev/null
-	@/tmp/venv/bin/python3 -m black $(PY_CHECK) $(shell git ls-files -- "*.py") $(PY_VERBOSE)
-	@/tmp/venv/bin/python3 -m flake8 $(shell git ls-files -- "*.py") $(PY_VERBOSE)
-	@rm -rf /tmp/venv
+	@if [ ! -d $(PYTHON_VENV_DIRECTORY) ]; then python3 -m venv $(PYTHON_VENV_DIRECTORY); fi
+	@$(PYTHON_VENV_DIRECTORY)/bin/pip3 install "black>=24.0.0" "flake8>=7.0.0" > /dev/null
+	@$(PYTHON_VENV_DIRECTORY)/bin/python3 -m black $(PY_CHECK) $(shell git ls-files -- "*.py") $(PY_VERBOSE)
+	@$(PYTHON_VENV_DIRECTORY)/bin/python3 -m flake8 $(shell git ls-files -- "*.py") $(PY_VERBOSE)
 
 check: \
 	check-kernel \


### PR DESCRIPTION
In this PR I address two very annoying side-effects of the python-lint post-commit hook I introduced.

In the first commit I make the lint re-use a virtual environment, instead of creating a new one all the time. This should address the latency introduced at each commit.

In the second commit I refine the logic to check whether any files where modified by the lint, by only diffing on `*.py` files.