### PR TITLE
[kernel] Drop Join CondVar when Exiting Thread 

### DIFF
--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -226,10 +226,18 @@ impl ProcessManager {
     /// - The calling process does not hold a reference to the process manager.
     ///
     pub unsafe fn exit_thread(status: ExitStatus) -> Result<!, Error> {
-        let (join_cond, from, to): (Condvar, *mut ContextInformation, *mut ContextInformation) =
-            Self::get_mut().try_borrow_mut()?.exit_thread(status);
+        let (from, to): (*mut ContextInformation, *mut ContextInformation) = {
+            // Create a scope so the join condition variable is dropped before we context switch.
+            // If we do not do this, the condition variable the reference count for the condition
+            // variable will not be decremented, causing a memory leak.
 
-        join_cond.notify_all()?;
+            let (join_cond, from, to): (Condvar, *mut ContextInformation, *mut ContextInformation) =
+                Self::get_mut().try_borrow_mut()?.exit_thread(status);
+
+            join_cond.notify_all()?;
+
+            (from, to)
+        };
 
         ContextInformation::switch(from, to);
         core::hint::unreachable_unchecked()

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -82,6 +82,18 @@ impl fmt::Debug for ThreadState {
     }
 }
 
+impl Drop for ThreadState {
+    fn drop(&mut self) {
+        if !self.locked_mutexes.is_empty() {
+            error!(
+                "drop(): dropping thread state with locked mutexes (self.id={:?}, \
+                 self.locked_mutexes={:?})",
+                self.id, self.locked_mutexes
+            );
+        }
+    }
+}
+
 //==================================================================================================
 // Running Thread
 //==================================================================================================


### PR DESCRIPTION
## Description

This pull request introduces safety and debugging improvements to the process and thread management components of the kernel. The most important changes include addressing potential memory leaks during thread exit and adding a debug mechanism to detect improper mutex handling when a thread state is dropped.

### Safety improvements:

* [`src/kernel/src/pm/process/manager/unsafe.rs`](diffhunk://#diff-3c168802fdb484fb4438ab269e8abab4a313ee2c0fb2c16f8bb7f8aed2bcfabbR229-R241): Added a scoped block in the `exit_thread` method to ensure the join condition variable is dropped before the context switch, preventing a memory leak caused by an undecremented reference count.

### Debugging enhancements:

* [`src/kernel/src/pm/thread/mod.rs`](diffhunk://#diff-68a79ef631e0c173295d4bfe400ddcd7c2aae177bb7e2028097a2e8a07192425R85-R96): Implemented the `Drop` trait for `ThreadState` to log an error if the thread state is dropped while still holding locked mutexes, aiding in the detection of improper mutex handling.