### PR TITLE
[daemons] Use `eprint` for Writes to Standard Error

### DIFF
--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -638,10 +638,11 @@ impl<'a> LinuxDaemon<'a> {
                 let count: usize = request.count as usize;
                 let buffer: &[u8] = &request.buffer[..count];
                 let string: String = String::from_utf8_lossy(buffer).to_string();
-                print!("{string}");
                 if request.fd == ::syscall::unistd::STDERR_FILENO {
+                    eprint!("{string}");
                     let _ = io::stderr().lock().flush();
                 } else {
+                    print!("{string}");
                     let _ = io::stdout().lock().flush();
                 }
                 WriteResponse::build(source, count as ssize_t)


### PR DESCRIPTION
## Description

This pull request includes a small but important change to the `LinuxDaemon` implementation in `src/daemons/linuxd/src/linuxd/mod.rs`. The change ensures that output to `STDERR_FILENO` uses `eprint!` instead of `print!`, improving clarity and correctness in handling standard error output.