### PR TITLE
[libs] Dummy Implementation for POSIX Symbols

### DIFF
--- a/src/libs/posix/src/arpa/inet.rs
+++ b/src/libs/posix/src/arpa/inet.rs
@@ -1,0 +1,154 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    errno::__errno_location,
+    ffi::{
+        c_char,
+        c_int,
+        c_void,
+    },
+};
+use ::sys::error::ErrorCode;
+use ::syscall::{
+    arpa::inet::{
+        in_addr,
+        in_addr_t,
+    },
+    sys::socket::socklen_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Converts an IPv4 address from the dotted-decimal string format to a 32-bit binary representation.
+///
+/// # Parameters
+///
+/// - `cp`: Pointer to a null-terminated string containing the IPv4 address in dotted-decimal notation.
+///
+/// # Returns
+///
+/// The `inet_addr()` function returns the address in network byte order as an `in_addr_t` on
+/// success.  On error, it returns `-1` cast to `in_addr_t`.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `cp` points to a valid null-terminated string.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inet_addr(cp: *const c_char) -> in_addr_t {
+    ::syslog::trace!("inet_addr(): cp={cp:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/594.
+    ::syslog::error!("inet_addr(): not implemented");
+    in_addr_t::MAX
+}
+
+///
+/// # Description
+///
+/// Converts an IPv4 address from a 32-bit binary representation to a dotted-decimal string.
+///
+/// # Parameters
+///
+/// - `in_addr`: Structure containing the IPv4 address in network byte order.
+///
+/// # Returns
+///
+/// The `inet_ntoa()` function returns a pointer to a statically allocated string containing the
+/// dotted-decimal representation of the address. On error, it returns null.
+///
+/// # Safety
+///
+/// This function is unsafe because it may return a pointer to a static buffer and does not guarantee thread safety.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inet_ntoa(in_addr: in_addr) -> *const c_char {
+    ::syslog::trace!("inet_ntoa(): in_addr={in_addr:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/595.
+    ::syslog::error!("inet_ntoa(): not implemented");
+    core::ptr::null()
+}
+
+///
+/// # Description
+///
+/// Converts an IP address from binary form to text form.
+///
+/// # Parameters
+///
+/// - `af`: Address family (e.g., AF_INET or AF_INET6).
+/// - `src`: Pointer to the binary address.
+/// - `dst`: Pointer to the buffer where the text representation will be stored.
+/// - `size`: Size of the buffer.
+///
+/// # Returns
+///
+/// The `inet_ntop()` function returns a pointer to the buffer containing the text representation of the address on success.
+/// On error, it returns null and sets `errno` to indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `src` points to a valid address structure.
+/// - `dst` points to a valid buffer of at least `size` bytes.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inet_ntop(
+    af: c_int,
+    src: *const c_void,
+    dst: *mut c_char,
+    size: socklen_t,
+) -> *const c_char {
+    ::syslog::trace!("inet_ntop(): af={af:?}, src={src:?}, dst={dst:?}, size={size:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/592.
+    ::syslog::error!("inet_ntop(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    core::ptr::null()
+}
+
+///
+/// # Description
+///
+/// Converts an IP address from text form to binary form.
+///
+/// # Parameters
+///
+/// - `af`: Address family (e.g., AF_INET or AF_INET6).
+/// - `src`: Pointer to the null-terminated string containing the IP address in text form.
+/// - `dst`: Pointer to the buffer where the binary address will be stored.
+///
+/// # Returns
+///
+/// The `inet_pton()` function returns `1` on success, `0` if the input is not a valid address, and `-1` on error
+/// (setting `errno` to indicate the error).
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `src` points to a valid null-terminated string.
+/// - `dst` points to a valid buffer for the binary address.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inet_pton(af: c_int, src: *const c_char, dst: *mut c_void) -> c_int {
+    ::syslog::trace!("inet_pton(): af={af:?}, src={src:?}, dst={dst:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/593.
+    ::syslog::error!("inet_pton(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
+}

--- a/src/libs/posix/src/arpa/mod.rs
+++ b/src/libs/posix/src/arpa/mod.rs
@@ -1,0 +1,5 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Definitions for internet operations.
+pub mod inet;

--- a/src/libs/posix/src/dirent/dirfd.rs
+++ b/src/libs/posix/src/dirent/dirfd.rs
@@ -1,0 +1,29 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    errno::__errno_location,
+    ffi::c_int,
+};
+use ::sys::error::ErrorCode;
+use ::syscall::dirent::DirectoryStream;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dirfd(dirp: *mut DirectoryStream) -> c_int {
+    ::syslog::trace!("dirfd(): dirp={dirp:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/596
+    ::syslog::error!("dirfd(): not implemented");
+    unsafe {
+        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    }
+    -1
+}

--- a/src/libs/posix/src/dirent/mod.rs
+++ b/src/libs/posix/src/dirent/mod.rs
@@ -6,5 +6,6 @@
 //==================================================================================================
 
 pub mod closedir;
+pub mod dirfd;
 pub mod opendir;
 pub mod readdir;

--- a/src/libs/posix/src/lib.rs
+++ b/src/libs/posix/src/lib.rs
@@ -21,7 +21,7 @@ extern crate nvx;
 extern crate alloc;
 
 // Address and routing parameter area.
-pub use ::syscall::arpa;
+pub mod arpa;
 
 /// Format of directory entries
 pub mod dirent;
@@ -43,6 +43,12 @@ pub mod venv;
 
 /// File control operations.
 pub mod fcntl;
+
+/// Definitions for network database operations.
+pub mod netdb;
+
+/// Definitions for the poll() function.
+pub mod poll;
 
 /// Posix threads.
 pub mod pthread;

--- a/src/libs/posix/src/netdb.rs
+++ b/src/libs/posix/src/netdb.rs
@@ -1,0 +1,380 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::ffi::{
+    c_char,
+    c_int,
+    c_void,
+};
+use ::sys::error::ErrorCode;
+use ::syscall::sys::{
+    socket::{
+        sockaddr,
+        socklen_t,
+    },
+    types::size_t,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+#[repr(C, packed)]
+pub struct hostent {
+    pub h_name: *const c_char,
+    pub h_aliases: *const *const c_char,
+    pub h_addrtype: c_int,
+    pub h_length: c_int,
+    pub h_addr_list: *const *const c_char,
+}
+
+#[repr(C, packed)]
+pub struct netent {
+    pub n_name: *const c_char,
+    pub n_aliases: *const *const c_char,
+    pub n_addrtype: c_int,
+    pub n_net: u32,
+}
+
+#[repr(C, packed)]
+pub struct servent {
+    pub s_name: *const c_char,
+    pub s_aliases: *const *const c_char,
+    pub s_port: c_int,
+    pub s_proto: *const c_char,
+}
+
+#[repr(C, packed)]
+pub struct protoent {
+    pub p_name: *const c_char,
+    pub p_aliases: *const *const c_char,
+    pub p_proto: c_int,
+}
+
+#[repr(C, packed)]
+pub struct addrinfo {
+    pub ai_flags: c_int,
+    pub ai_family: c_int,
+    pub ai_socktype: c_int,
+    pub ai_protocol: c_int,
+    pub ai_addrlen: socklen_t,
+    pub ai_canonname: *const c_char,
+    pub ai_addr: *const sockaddr,
+    pub ai_next: *mut addrinfo,
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Frees the memory allocated for the linked list of addrinfo structures returned by `getaddrinfo()`.
+///
+/// # Parameters
+///
+/// - `res`: Pointer to the linked list of addrinfo structures to be freed.
+///
+/// # Returns
+///
+/// This function does not return a value.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `res` points to a valid linked list of addrinfo structures previously allocated by `getaddrinfo()`.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn freeaddrinfo(res: *mut addrinfo) {
+    ::syslog::trace!("freeaddrinfo(): res={res:?}");
+    ::syslog::error!("freeaddrinfo(): not implemented");
+}
+
+///
+/// # Description
+///
+/// Translates the name of a service location (such as a host name) and/or a service name
+/// into a set of socket addresses.
+///
+/// # Parameters
+///
+/// - `node`: Pointer to a null-terminated string containing a host name or address string.
+/// - `service`: Pointer to a null-terminated string containing a service name or port number.
+/// - `hints`: Pointer to an addrinfo structure that specifies criteria for selecting the socket address structures returned.
+/// - `res`: Pointer to a pointer where the resulting list of addrinfo structures will be stored.
+///
+/// # Returns
+///
+/// The `getaddrinfo()` function returns `0` on success. On error, it returns a nonzero error code.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `node` and `service` are valid null-terminated strings (if not null).
+/// - `hints` points to a valid addrinfo structure (if not null).
+/// - `res` points to a valid pointer to store the result.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn getaddrinfo(
+    node: *const c_char,
+    service: *const c_char,
+    hints: *const addrinfo,
+    res: *mut *mut addrinfo,
+) -> c_int {
+    ::syslog::trace!(
+        "getaddrinfo(): node={node:?}, service={service:?}, hints={hints:?}, res={res:?}"
+    );
+    ::syslog::error!("getaddrinfo(): not implemented");
+    ErrorCode::InvalidSysCall.get()
+}
+
+///
+/// # Description
+///
+/// Retrieves host information corresponding to a network address.
+///
+/// # Parameters
+///
+/// - `addr`: Pointer to the network address.
+/// - `len`: Length of the address.
+/// - `type_`: Address type.
+///
+/// # Returns
+///
+/// Returns a pointer to a hostent structure on success, or null on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `addr` points to a valid network address of length `len`.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn gethostbyaddr(
+    addr: *const c_void,
+    len: size_t,
+    type_: c_int,
+) -> *mut c_void {
+    ::syslog::trace!("gethostbyaddr(): addr={addr:?}, len={len:?}, type_={type_:?}");
+    ::syslog::error!("gethostbyaddr(): not implemented");
+    ::core::ptr::null_mut()
+}
+
+///
+/// # Description
+///
+/// Retrieves host information corresponding to a host name.
+///
+/// # Parameters
+///
+/// - `name`: Pointer to a null-terminated string containing the host name.
+///
+/// # Returns
+///
+/// Returns a pointer to a hostent structure on success, or null on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `name` points to a valid null-terminated string.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn gethostbyname(name: *const c_char) -> *mut c_void {
+    ::syslog::trace!("gethostbyname(): name={name:?}");
+    ::syslog::error!("gethostbyname(): not implemented");
+    ::core::ptr::null_mut()
+}
+
+///
+/// # Description
+///
+/// Retrieves protocol information corresponding to a protocol name.
+///
+/// # Parameters
+///
+/// - `name`: Pointer to a null-terminated string containing the protocol name.
+///
+/// # Returns
+///
+/// Returns a pointer to a protoent structure on success, or null on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `name` points to a valid null-terminated string.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn getprotobyname(name: *const c_char) -> *mut c_void {
+    ::syslog::trace!("getprotobyname(): name={name:?}");
+    ::syslog::error!("getprotobyname(): not implemented");
+    ::core::ptr::null_mut()
+}
+
+///
+/// # Description
+///
+/// Retrieves service information corresponding to a service name and protocol.
+///
+/// # Parameters
+///
+/// - `name`: Pointer to a null-terminated string containing the service name.
+/// - `proto`: Pointer to a null-terminated string containing the protocol name.
+///
+/// # Returns
+///
+/// Returns a pointer to a servent structure on success, or null on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `name` and `proto` point to valid null-terminated strings.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn getservbyname(name: *const c_char, proto: *const c_char) -> *mut c_void {
+    ::syslog::trace!("getservbyname(): name={name:?}, proto={proto:?}");
+    ::syslog::error!("getservbyname(): not implemented");
+    ::core::ptr::null_mut()
+}
+
+///
+/// # Description
+///
+/// Retrieves service information corresponding to a port and protocol.
+///
+/// # Parameters
+///
+/// - `port`: Port number.
+/// - `proto`: Pointer to a null-terminated string containing the protocol name.
+///
+/// # Returns
+///
+/// Returns a pointer to a servent structure on success, or null on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `proto` points to a valid null-terminated string.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn getservbyport(port: c_int, proto: *const c_char) -> *mut c_void {
+    ::syslog::trace!("getservbyport(): port={port:?}, proto={proto:?}");
+    ::syslog::error!("getservbyport(): not implemented");
+    ::core::ptr::null_mut()
+}
+
+///
+/// # Description
+///
+/// Converts a socket address to a corresponding host and service, in a protocol-independent manner.
+///
+/// # Parameters
+///
+/// - `sa`: Pointer to the socket address structure.
+/// - `salen`: Length of the socket address structure.
+/// - `host`: Pointer to a buffer to store the host name.
+/// - `hostlen`: Length of the host buffer.
+/// - `serv`: Pointer to a buffer to store the service name.
+/// - `servlen`: Length of the service buffer.
+/// - `flags`: Flags to modify function behavior.
+///
+/// # Returns
+///
+/// Returns `0` on success, or a nonzero error code on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `sa` points to a valid socket address structure of length `salen`.
+/// - `host` and `serv` point to valid buffers of length `hostlen` and `servlen`, respectively.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn getnameinfo(
+    sa: *const c_void,
+    salen: socklen_t,
+    host: *mut c_char,
+    hostlen: socklen_t,
+    serv: *mut c_char,
+    servlen: socklen_t,
+    flags: c_int,
+) -> c_int {
+    ::syslog::trace!(
+        "getnameinfo(): sa={sa:?}, salen={salen:?}, host={host:?}, hostlen={hostlen:?}, \
+         serv={serv:?}, servlen={servlen:?}, flags={flags:?}"
+    );
+    ::syslog::error!("getnameinfo(): not implemented");
+    ErrorCode::InvalidSysCall.get()
+}
+
+///
+/// # Description
+///
+/// Returns a string describing a network-related error code.
+///
+/// # Parameters
+///
+/// - `errcode`: The error code to describe.
+///
+/// # Returns
+///
+/// Returns a pointer to a null-terminated string describing the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may return a pointer to a static string.
+///
+/// It is safe to call this function with any valid error code.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn gai_strerror(errcode: c_int) -> *const c_char {
+    ::syslog::trace!("gai_strerror(): errcode={errcode:?}");
+    ::syslog::error!("gai_strerror(): not implemented");
+    ::core::ptr::null()
+}
+
+///
+/// # Description
+///
+/// Returns a pointer to the location where the error code for network database operations is stored.
+///
+/// # Returns
+///
+/// Returns a pointer to an integer containing the error code.
+///
+/// # Safety
+///
+/// This function is unsafe because it returns a raw pointer.
+///
+/// It is safe to call this function if the caller expects a pointer to a thread-local or global error variable.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __h_errno() -> *mut c_int {
+    ::syslog::trace!("__h_errno()");
+    ::syslog::error!("__h_errno(): not implemented");
+    ::core::ptr::null_mut()
+}

--- a/src/libs/posix/src/poll.rs
+++ b/src/libs/posix/src/poll.rs
@@ -1,0 +1,74 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::ffi::{
+    c_int,
+    c_short,
+    c_uint,
+};
+use sys::error::ErrorCode;
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+// Used for the number of file descriptors.
+pub type nfds_t = c_uint;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct pollfd {
+    /// The following descriptor being polled.
+    pub fd: c_int,
+    /// Input event flags.
+    pub events: c_short,
+    /// Output event flags.
+    pub revents: c_short,
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Waits for one of a set of file descriptors to become ready to perform I/O.
+///
+/// # Parameters
+///
+/// - `fds`: Pointer to an array of pollfd structures describing the file descriptors to poll.
+/// - `nfds`: Number of file descriptors in the array.
+/// - `timeout`: Timeout in milliseconds. A negative value means infinite timeout.
+///
+/// # Returns
+///
+/// Returns the number of file descriptors with events, `0` if timed out, or `-1` on error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `fds` points to a valid array of pollfd structures of length `nfds`.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: c_int) -> c_int {
+    ::syslog::trace!("poll(): fds={fds:?}, nfds={nfds:?}, timeout={timeout:?}");
+    ::syslog::error!("poll(): not implemented");
+    ErrorCode::InvalidSysCall.get()
+}

--- a/src/libs/posix/src/pthread/mod.rs
+++ b/src/libs/posix/src/pthread/mod.rs
@@ -20,7 +20,10 @@ use ::syscall::{
         pthread_t,
     },
     sched::sched_param,
-    sys::types::size_t,
+    sys::types::{
+        pthread_once_t,
+        size_t,
+    },
 };
 
 //==================================================================================================
@@ -623,6 +626,46 @@ pub unsafe extern "C" fn pthread_join(thread: pthread_t, retval_ptr: *mut *mut c
         },
         Err(error) => error.code.get(),
     }
+}
+
+//==================================================================================================
+// pthread_once()
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Calls the specified initialization function exactly once, even if called from multiple threads.
+///
+/// # Parameters
+///
+/// - `once_control`: Pointer to a control variable that determines whether the initialization function has been called.
+/// - `init_routine`: Pointer to the initialization function to be called.
+///
+/// # Returns
+///
+/// The `pthread_once()` function always returns `0` on success. On error, it returns an error number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers and call a function pointer.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `once_control` points to a valid `pthread_once_t` object.
+/// - `init_routine` is a valid function pointer.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_once(
+    once_control: *mut pthread_once_t,
+    init_routine: Option<unsafe extern "C" fn()>,
+) -> c_int {
+    ::syslog::trace!(
+        "pthread_once(): once_control={once_control:?}, init_routine={:?}",
+        init_routine
+    );
+    // TODO: https://github.com/nanvix/nanvix/issues/513
+    ::syslog::error!("pthread_once(): not implemented");
+    0
 }
 
 //==================================================================================================

--- a/src/libs/posix/src/pthread/mutex.rs
+++ b/src/libs/posix/src/pthread/mutex.rs
@@ -20,6 +20,68 @@ use ::syscall::{
 };
 
 //==================================================================================================
+// pthread_mutexattr_init()
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Initializes a mutex attributes object with default values.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the mutex attributes object to be initialized.
+///
+/// # Returns
+///
+/// The `pthread_mutexattr_init()` function returns `0` on success. On error, it returns an error number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `attr` points to a valid `pthread_mutexattr_t` object.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_mutexattr_init(attr: *mut pthread_mutexattr_t) -> c_int {
+    ::syslog::trace!("pthread_mutexattr_init(): attr={attr:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/511.
+    0
+}
+
+//==================================================================================================
+// pthread_mutexattr_destroy()
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Destroys a mutex attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the mutex attributes object to be destroyed.
+///
+/// # Returns
+///
+/// The `pthread_mutexattr_destroy()` function returns `0` on success. On error, it returns an error number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `attr` points to a valid `pthread_mutexattr_t` object.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut pthread_mutexattr_t) -> c_int {
+    ::syslog::trace!("pthread_mutexattr_destroy(): attr={attr:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/509
+    0
+}
+
+//==================================================================================================
 // pthread_mutex_destroy()
 //==================================================================================================
 

--- a/src/libs/posix/src/sys/socket/mod.rs
+++ b/src/libs/posix/src/sys/socket/mod.rs
@@ -25,6 +25,7 @@ use ::syscall::{
             SocketType,
         },
         types::{
+            msghdr,
             size_t,
             ssize_t,
         },
@@ -273,6 +274,52 @@ pub unsafe extern "C" fn getsockname(
     }
 }
 
+///
+/// # Description
+///
+/// Gets options on sockets.
+///
+/// # Parameters
+///
+/// - `sockfd`: File descriptor of the socket.
+/// - `level`: The protocol level at which the option resides.
+/// - `optname`: The name of the option.
+/// - `optval`: Pointer to the buffer where the option value will be stored.
+/// - `optlen`: Pointer to the length of the option value.
+///
+/// # Returns
+///
+/// The `getsockopt()` function returns `0` on success. On error, it returns `-1`
+/// and sets `errno` to indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `optval` points to a valid buffer of length `*optlen` (if not null).
+/// - `optlen` points to a valid length (if not null).
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn getsockopt(
+    sockfd: c_int,
+    level: c_int,
+    optname: c_int,
+    optval: *mut c_void,
+    optlen: *mut socklen_t,
+) -> c_int {
+    ::syslog::trace!(
+        "getsockopt(): sockfd={sockfd:?}, level={level:?}, optname={optname:?}, \
+         optval={optval:?}, optlen={optlen:?}"
+    );
+    // TODO: https://github.com/nanvix/nanvix/issues/591
+    ::syslog::error!("getsockopt(): not implemented");
+    unsafe {
+        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    }
+    -1
+}
+
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn listen(sockfd: c_int, backlog: c_int) -> c_int {
@@ -329,6 +376,86 @@ pub unsafe extern "C" fn recv(
     }
 }
 
+///
+/// # Description
+///
+/// Receives data from a specific address.
+///
+/// # Parameters
+///
+/// - `sockfd`: File descriptor of the socket.
+/// - `buf`: Pointer to the buffer where the received data will be stored.
+/// - `len`: Length of the buffer.
+/// - `flags`: Flags for receiving data.
+/// - `sockaddr`: Pointer to the socket address structure to store the source address.
+/// - `addrlen`: Pointer to the length of the socket address structure.
+///
+/// # Returns
+///
+/// The `recvfrom()` function returns the number of bytes received on success. On error, it returns `-1`
+/// and sets `errno` to indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `sockaddr` points to a valid socket address structure (if not null).
+/// - `addrlen` points to a valid length (if not null).
+/// - `buf` points to a valid buffer of length `len`.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn recvfrom(
+    sockfd: c_int,
+    buf: *mut c_void,
+    len: size_t,
+    flags: c_int,
+    sockaddr: *mut sockaddr,
+    addrlen: *mut socklen_t,
+) -> ssize_t {
+    ::syslog::trace!(
+        "recvfrom(): sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?}, \
+         sockaddr={sockaddr:?}, addrlen={addrlen:?}"
+    );
+    // TODO: https://github.com/nanvix/nanvix/issues/590
+    unsafe {
+        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    }
+    -1
+}
+
+///
+/// # Description
+///
+/// Receives a message from a socket.
+///
+/// # Parameters
+///
+/// - `sockfd`: File descriptor of the socket.
+/// - `msg`: Pointer to the msghdr structure describing the message buffer.
+/// - `flags`: Flags for receiving the message.
+///
+/// # Returns
+///
+/// The `recvmsg()` function returns the number of bytes received on success. On error, it returns `-1`
+/// and sets `errno` to indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `msg` points to a valid `msghdr` structure.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn recvmsg(sockfd: c_int, msg: *mut msghdr, flags: c_int) -> ssize_t {
+    ::syslog::trace!("recvmsg(): sockfd={sockfd:?}, msg={msg:?}, flags={flags:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/600
+    ::syslog::error!("recvmsg(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
+}
+
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn send(
@@ -369,6 +496,133 @@ pub unsafe extern "C" fn send(
             -1
         },
     }
+}
+
+///
+/// # Description
+///
+/// Sends a message on a socket.
+///
+/// # Parameters
+///
+/// - `sockfd`: File descriptor of the socket.
+/// - `msg`: Pointer to the msghdr structure describing the message to send.
+/// - `flags`: Flags for sending the message.
+///
+/// # Returns
+///
+/// The `sendmsg()` function returns the number of bytes sent on success. On error, it returns `-1`
+/// and sets `errno` to indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `msg` points to a valid `msghdr` structure.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sendmsg(sockfd: c_int, msg: *const msghdr, flags: c_int) -> ssize_t {
+    ::syslog::trace!("sendmsg(): sockfd={sockfd:?}, msg={msg:?}, flags={flags:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/599.
+    ::syslog::error!("sendmsg(): not implemented");
+    unsafe {
+        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    }
+    -1
+}
+
+///
+/// # Description
+///
+/// Sends data to a specific address.
+///
+/// # Parameters
+///
+/// - `sockfd`: File descriptor of the socket.
+/// - `buf`: Pointer to the buffer containing the data to be sent.
+/// - `len`: Length of the data to be sent.
+/// - `flags`: Flags for sending data.
+/// - `sockaddr`: Pointer to the socket address structure.
+/// - `addrlen`: Length of the socket address structure.
+///
+/// # Returns
+///
+/// The `sendto()` function returns the number of bytes sent on success. On error, it returns `-1`
+/// and sets `errno` to indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function is the following conditions are met:
+/// - `sockaddr` points to a valid socket address structure.
+/// - `buf` points to a valid buffer of length `len`.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sendto(
+    sockfd: c_int,
+    buf: *const c_void,
+    len: size_t,
+    flags: c_int,
+    sockaddr: *const sockaddr,
+    addrlen: socklen_t,
+) -> ssize_t {
+    ::syslog::trace!(
+        "sendto(): sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?}, \
+         sockaddr={sockaddr:?}, addrlen={addrlen:?}"
+    );
+    // TODO: https://github.com/nanvix/nanvix/issues/589
+    ::syslog::error!("sendto(): not implemented");
+    unsafe {
+        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    }
+    -1
+}
+
+///
+/// # Description
+///
+/// Sets options on sockets.
+///
+/// # Parameters
+///
+/// - `sockfd`: File descriptor of the socket.
+/// - `level`: The protocol level at which the option resides.
+/// - `optname`: The name of the option.
+/// - `optval`: Pointer to the option value.
+/// - `optlen`: Length of the option value.
+///
+/// # Returns
+///
+/// The `setsockopt()` function returns `0` on success. On error, it returns `-1` and sets `errno`
+/// to indicate the error.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+/// - `optval` points to a valid buffer of length `optlen` (if not null).
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn setsockopt(
+    sockfd: c_int,
+    level: c_int,
+    optname: c_int,
+    optval: *const c_void,
+    optlen: socklen_t,
+) -> c_int {
+    ::syslog::trace!(
+        "setsockopt(): sockfd={sockfd:?}, level={level:?}, optname={optname:?}, \
+         optval={optval:?}, optlen={optlen:?}"
+    );
+    // TODO: https://github.com/nanvix/nanvix/issues/471
+    ::syslog::error!("setsockopt(): not implemented");
+    unsafe {
+        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    }
+    -1
 }
 
 #[allow(clippy::missing_safety_doc)]

--- a/src/libs/posix/src/sys/stat/mod.rs
+++ b/src/libs/posix/src/sys/stat/mod.rs
@@ -470,6 +470,31 @@ pub unsafe extern "C" fn truncate(_path: *const c_char, _length: u64) -> c_int {
 ///
 /// # Description
 ///
+/// Sets the calling process's file mode creation mask (umask).
+///
+/// # Parameters
+///
+/// - `mask`: The new file mode creation mask.
+///
+/// # Returns
+///
+/// The `umask()` function returns the previous value of the calling process's file mode creation mask.
+///
+/// # Safety
+///
+/// This function is safe to call with any valid `mask`.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn umask(mask: u16) -> u16 {
+    ::syslog::trace!("umask(): mask={mask:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/597.
+    ::syslog::error!("umask(): not implemented");
+    0
+}
+
+///
+/// # Description
+///
 /// Sets file access and modification times.
 ///
 /// # Parameters

--- a/src/libs/posix/src/unistd/mod.rs
+++ b/src/libs/posix/src/unistd/mod.rs
@@ -186,8 +186,49 @@ pub extern "C" fn close(fd: c_int) -> c_int {
     }
 }
 
+///
+/// # Description
+///
+/// Duplicates a file descriptor.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor to duplicate.
+///
+/// # Returns
+///
+/// Upon successful completion, `dup()` returns a new file descriptor that refers to the same open
+/// file description as `fd`. Otherwise, it returns `-1` and sets `errno` to indicate the error.
+///
 #[unsafe(no_mangle)]
-pub extern "C" fn dup2(_oldfd: c_int, _newfd: c_int) -> c_int {
+pub extern "C" fn dup(fd: c_int) -> c_int {
+    ::syslog::trace!("dup(): fd={fd:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/587
+    ::syslog::error!("dup(): not implemented");
+    unsafe {
+        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    }
+    -1
+}
+
+///
+/// # Description
+///
+/// Duplicates a file descriptor to a specified file descriptor.
+///
+/// # Parameters
+///
+/// - `oldfd`: File descriptor to duplicate.
+/// - `newfd`: File descriptor to duplicate to.
+///
+/// # Returns
+///
+/// Upon successful completion, `dup2()` returns the new file descriptor. Otherwise, it returns
+/// `-1` and sets `errno` to indicate the error.
+///
+#[unsafe(no_mangle)]
+pub extern "C" fn dup2(oldfd: c_int, newfd: c_int) -> c_int {
+    ::syslog::trace!("dup2(): oldfd={oldfd:?}, newfd={newfd:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/354
     ::syslog::error!("dup2(): not implemented");
     unsafe {
@@ -196,12 +237,54 @@ pub extern "C" fn dup2(_oldfd: c_int, _newfd: c_int) -> c_int {
     -1
 }
 
+///
+/// # Description
+///
+/// Executes a program.
+///
+/// # Parameters
+///
+/// - `path`: Path to the executable file.
+/// - `argv`: Argument vector.
+///
+/// # Returns
+///
+/// Upon successful completion, `execv()` does not return. If it fails, it returns `-1` and sets
+/// `errno` to indicate the error.
+#[unsafe(no_mangle)]
+pub extern "C" fn execv(path: *const c_char, argv: *const *const c_char) -> c_int {
+    ::syslog::trace!("execv(): path={path:?}, argv={argv:?}");
+    // TODO:https://github.com/nanvix/nanvix/issues/588
+    ::syslog::error!("execv(): not implemented");
+    unsafe {
+        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    }
+    -1
+}
+
+///
+/// # Description
+///
+/// Executes a program.
+///
+/// # Parameters
+///
+/// - `path`: Path to the executable file.
+/// - `argv`: Argument vector.
+/// - `envp`: Environment variables.
+///
+/// # Returns
+///
+/// Upon successful completion, `execve()` does not return. If it fails, it returns `-1` and sets
+/// `errno` to indicate the error.
+///
 #[unsafe(no_mangle)]
 pub extern "C" fn execve(
-    _path: *const c_char,
-    _argv: *const *const c_char,
-    _envp: *const *const c_char,
+    path: *const c_char,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
 ) -> c_int {
+    ::syslog::trace!("execve(): path={path:?}, argv={argv:?}, envp={envp:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/320
     ::syslog::error!("execve(): not implemented");
     unsafe {
@@ -1861,6 +1944,40 @@ pub unsafe extern "C" fn unlink(path: *const c_char) -> c_int {
             -1
         },
     }
+}
+
+///
+/// # Description
+///
+/// Waits for a process to change state.
+///
+/// # Parameters
+///
+/// - `pid`: Process ID of the process to wait for.
+/// - `status`: Pointer to an integer where the exit status of the process will be stored.
+/// - `options`: Options to control the behavior of the wait operation.
+///
+/// # Returns
+///
+/// Upon successful completion, `waitpid()` returns the process ID of the child process that changed
+/// state. If an error occurs, it returns `-1` and sets `errno` to indicate the error.
+///
+/// # Safety
+///
+/// The function is unsafe because it may dereference pointers.
+///
+/// It is safe to use this function if the following conditions are met:
+/// - `status` points to a valid `c_int`.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waitpid(pid: pid_t, status: *mut c_int, options: c_int) -> pid_t {
+    ::syslog::trace!("waitpid(): pid={pid:?}, status={status:?}, options={options:?}");
+    // TODO: https://github.com/nanvix/nanvix/issues/336.
+    ::syslog::error!("waitpid(): not implemented");
+    unsafe {
+        *__errno_location() = ErrorCode::InvalidSysCall.get();
+    }
+    -1
 }
 
 ///

--- a/src/libs/syscall/src/arpa/inet.rs
+++ b/src/libs/syscall/src/arpa/inet.rs
@@ -1,31 +1,34 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
-use core::mem;
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![allow(non_camel_case_types)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::mem;
 
 //==================================================================================================
 // C Interface
 //==================================================================================================
 
-/// C Bindings for `arpa/inet.h`.
-pub mod bindings {
+/// Used for internet addresses.
+pub type in_addr_t = u32;
 
-    #![allow(non_camel_case_types)]
+/// Describes an internet address.
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct in_addr {
+    pub s_addr: in_addr_t,
+}
+::static_assert::assert_eq_size!(in_addr, in_addr::_SIZE);
 
-    use super::*;
-
-    /// Used for internet addresses.
-    pub type in_addr_t = u32;
-
-    /// Describes an internet address.
-    #[repr(C, packed)]
-    pub struct in_addr {
-        pub s_addr: in_addr_t,
-    }
-    ::static_assert::assert_eq_size!(in_addr, in_addr::_SIZE);
-
-    impl in_addr {
-        /// Size of this structure, used for static assertions.
-        const _SIZE: usize = mem::size_of::<in_addr_t>(); // s_addr
-    }
+impl in_addr {
+    /// Size of this structure, used for static assertions.
+    const _SIZE: usize = mem::size_of::<in_addr_t>(); // s_addr
 }

--- a/src/libs/syscall/src/netinet/in_.rs
+++ b/src/libs/syscall/src/netinet/in_.rs
@@ -6,7 +6,7 @@
 //==================================================================================================
 
 use crate::{
-    arpa::inet::bindings::in_addr,
+    arpa::inet::in_addr,
     sys::socket::{
         sa_family_t,
         sockaddr_storage,

--- a/src/libs/syscall/src/sys/socket/mod.rs
+++ b/src/libs/syscall/src/sys/socket/mod.rs
@@ -12,7 +12,7 @@
 //==================================================================================================
 
 use crate::{
-    arpa::inet::bindings::in_addr,
+    arpa::inet::in_addr,
     ffi::c_uchar,
     netinet::in_::{
         bindings::sockaddr_in,

--- a/src/libs/syscall/src/sys/types/mod.rs
+++ b/src/libs/syscall/src/sys/types/mod.rs
@@ -25,6 +25,10 @@ use crate::{
         self,
         sched_param,
     },
+    sys::{
+        socket::socklen_t,
+        uio::iovec,
+    },
 };
 use ::core::mem;
 
@@ -200,4 +204,96 @@ impl Default for pthread_condattr_t {
             clock: 0,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct pthread_once_t {
+    /// Whether the `pthread_once` is initialized.
+    is_initialized: c_int,
+    /// Whether the `pthread_once` has been executed.
+    init_executed: c_int,
+}
+::static_assert::assert_eq_size!(pthread_once_t, pthread_once_t::SIZE);
+
+impl pthread_once_t {
+    /// Size of the `is_initialized` field.
+    const SIZE_OF_IS_INITIALIZED: usize = mem::size_of::<c_int>();
+    /// Size of the `init_executed` field.
+    const SIZE_OF_INIT_EXECUTED: usize = mem::size_of::<c_int>();
+
+    /// Size of `pthread_once_t` structure.
+    pub const SIZE: usize = Self::SIZE_OF_IS_INITIALIZED + Self::SIZE_OF_INIT_EXECUTED;
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct msghdr {
+    /// Optional address.
+    pub msg_name: *mut c_void,
+    // Size of the address.
+    pub msg_namelen: socklen_t,
+    // Scatter/gather array of message blocks
+    pub msg_iov: *mut iovec,
+    /// Number of member in `msg_iov`.
+    pub msg_iovlen: c_int,
+    /// Ancillary data.
+    pub msg_control: *mut c_void,
+    /// Ancillary data buffer length.
+    pub msg_controllen: socklen_t,
+    /// Flags.
+    pub msg_flags: c_int,
+}
+::static_assert::assert_eq_size!(msghdr, msghdr::SIZE);
+
+impl msghdr {
+    /// Size of the `msg_name` field.
+    const SIZE_OF_MSG_NAME: usize = mem::size_of::<*mut c_void>();
+    /// Size of the `msg_namelen` field.
+    const SIZE_OF_MSG_NAMELEN: usize = mem::size_of::<socklen_t>();
+    /// Size of the `msg_iov` field.
+    const SIZE_OF_MSG_IOV: usize = mem::size_of::<*mut iovec>();
+    /// Size of the `msg_iovlen` field.
+    const SIZE_OF_MSG_IOVLEN: usize = mem::size_of::<c_int>();
+    /// Size of the `msg_control` field.
+    const SIZE_OF_MSG_CONTROL: usize = mem::size_of::<*mut c_void>();
+    /// Size of the `msg_controllen` field.
+    const SIZE_OF_MSG_CONTROLLEN: usize = mem::size_of::<socklen_t>();
+    /// Size of the `msg_flags` field.
+    const SIZE_OF_MSG_FLAGS: usize = mem::size_of::<c_int>();
+
+    /// Size of `msghdr` structure.
+    pub const SIZE: usize = Self::SIZE_OF_MSG_NAME
+        + Self::SIZE_OF_MSG_NAMELEN
+        + Self::SIZE_OF_MSG_IOV
+        + Self::SIZE_OF_MSG_IOVLEN
+        + Self::SIZE_OF_MSG_CONTROL
+        + Self::SIZE_OF_MSG_CONTROLLEN
+        + Self::SIZE_OF_MSG_FLAGS;
+}
+
+/// Header for ancililary data data objects in msg_control buffer in `msghdr`.
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct cmsghdr {
+    /// Data byte count, including the control message header..
+    pub cmsg_len: socklen_t,
+    /// Originating protocol.
+    pub cmsg_level: c_int,
+    /// Protocol-specific type.
+    pub cmsg_type: c_int,
+}
+::static_assert::assert_eq_size!(cmsghdr, cmsghdr::SIZE);
+
+impl cmsghdr {
+    /// Size of the `cmsg_len` field.
+    const SIZE_OF_CMSG_LEN: usize = mem::size_of::<socklen_t>();
+    /// Size of the `cmsg_level` field.
+    const SIZE_OF_CMSG_LEVEL: usize = mem::size_of::<c_int>();
+    /// Size of the `cmsg_type` field.
+    const SIZE_OF_CMSG_TYPE: usize = mem::size_of::<c_int>();
+
+    /// Size of `cmsghdr` structure.
+    pub const SIZE: usize =
+        Self::SIZE_OF_CMSG_LEN + Self::SIZE_OF_CMSG_LEVEL + Self::SIZE_OF_CMSG_TYPE;
 }


### PR DESCRIPTION
## Description

This PR adds dummy implementation for the following POSIX symbols:

- `waitpid()`
- `dup()`
- `dup2()`
- `execve()`
- `execv()`
- `sendto()`
- `recvfrom()`
- `setsockopt()`
- `getsockopt()`
- `inet_ntop()`
- `inet_pton()`
- `inet_addr()`
- `inet_addr()`
- `dirfd()`
- `umask()`
- `pthread_mutexattr_init()`
- `pthread_mutexattr_destroy()`
- `pthread_once_t`
- `pthread_once()`
- `msghdr Structure`
- `cmsghdr Structure`
- `sendmsg()`
- `recvmsg()`
- Some functions from `arpa/init.h`
- Some functions and structures from `netdb.h`
- Some functions and structures from `poll.h`