### PR TITLE
[linuxd] Move Gateway Listener to Linuxd

### DIFF
--- a/doc/run.md
+++ b/doc/run.md
@@ -33,7 +33,7 @@ make run
 Open a terminal and run the Linux Daemon:
 
 ```bash
-./bin/linuxd.elf -bind-addr 127.0.0.1:1234
+./bin/linuxd.elf -user-vm-bind-addr 127.0.0.1:1234
 ```
 
 ### Step 2: Run the MicroVM
@@ -53,7 +53,7 @@ To enable logging, set the `RUST_LOG` environment variable to `trace` when runni
 RUST_LOG=trace sudo -E ./bin/microvm.elf -kernel bin/kernel.elf -initrd bin/hello-rust-nostd.elf -gateway 127.0.0.1:1234
 
 # Open a scond terminal and run the MicroVM.
-RUST_LOG=trace ./bin/linuxd.elf -bind-addr 127.0.0.1:1234
+RUST_LOG=trace ./bin/linuxd.elf -user-vm-bind-addr 127.0.0.1:1234
 ```
 
 ### Redirecting Standard Error (Optional)

--- a/scripts/test-linuxd.sh
+++ b/scripts/test-linuxd.sh
@@ -15,7 +15,7 @@ mkdir -p ${LOGS_DIR}
 # Run linuxd.
 LINUXD_STDOUT_FILE_NAME="${LOGS_DIR}/linuxd-stdout_$(date "+%Y_%m_%d_%H_%M").log"
 LINUXD_STDERR_FILE_NAME="${LOGS_DIR}/linuxd-stderr_$(date "+%Y_%m_%d_%H_%M").log"
-RUST_LOG=trace ./bin/linuxd.elf -bind-addr ${SOCKADDR} \
+RUST_LOG=trace ./bin/linuxd.elf -user-vm-bind-addr ${SOCKADDR} \
     -log-to-file \
     1> ${LINUXD_STDOUT_FILE_NAME} \
     2> ${LINUXD_STDERR_FILE_NAME} &

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -49,21 +49,21 @@ NANVIXD_PID=$!
 # Extract port number from nanvixd.
 NANVIXD_PORT_NUMBER=$(echo ${NANVIXD_SOCKADDR} | cut -d: -f2)
 
-# Wait for nanvixd to start by checking sandbox socket exists.
+# Wait for nanvixd to start by checking if the HTTP socket is listening.
 MAX_TRIALS=10
 SLEEP_INTERVAL=0.1
 for i in $(seq 1 $MAX_TRIALS); do
     echo "Waiting for nanvixd to start ... ($(echo "$i * $SLEEP_INTERVAL" | bc) s elapsed)"
     sleep ${SLEEP_INTERVAL}
 
-    if ls /tmp/${SANDBOX_SOCKADDR}*.socket 1>/dev/null 2>&1; then
+    if ss -tln | grep -q ":${NANVIXD_PORT_NUMBER} "; then
         echo "nanvixd started after ${i} ms."
         break
     fi
 done
 
 # Check again after waiting.
-if ! ls /tmp/${SANDBOX_SOCKADDR}*.socket 1>/dev/null 2>&1; then
+if ! ss -tln | grep -q ":${NANVIXD_PORT_NUMBER} "; then
     echo "nanvixd failed to start"
     exit 2 # Error Code 2: No such file or directory (ENOENT)
 fi

--- a/src/daemons/linuxd/src/args.rs
+++ b/src/daemons/linuxd/src/args.rs
@@ -21,10 +21,10 @@ pub struct Args {
     user_vm_bind_sockaddr: String,
     /// Server socket address type.
     user_vm_bind_sockaddr_type: Option<String>,
-    /// Gateway socket address.
-    gateway_sockaddr: Option<String>,
+    /// Socket address linuxd listens to for messages from the gateway.
+    gateway_bind_sockaddr: Option<String>,
     /// Gateway socket address type.
-    gateway_sockaddr_type: Option<String>,
+    gateway_bind_sockaddr_type: Option<String>,
     /// Log to file?
     log_to_file: bool,
 }
@@ -41,9 +41,9 @@ impl Args {
     /// Command-line option for setting the socket address type of the bind socket.
     const OPT_USER_VM_BIND_SOCKET_TYPE: &'static str = "-user-vm-bind-socket-type";
     /// Command-line option for setting socket address of gateway.
-    const OPT_GATEWAY_SOCKADDR: &'static str = "-gateway-addr";
+    const OPT_GATEWAY_BIND_SOCKADDR: &'static str = "-gateway-bind-addr";
     /// Command-line option for setting the socket address type of the gateway socket.
-    const OPT_GATEWAY_SOCKET_TYPE: &'static str = "-gateway-socket-type";
+    const OPT_GATEWAY_BIND_SOCKET_TYPE: &'static str = "-gateway-bind-socket-type";
     /// Command-line option for log redirecting.
     const OPT_LOGFILE: &'static str = "-log-to-file";
 
@@ -64,8 +64,8 @@ impl Args {
     pub fn parse(args: Vec<String>) -> Result<Self> {
         let mut user_vm_bind_sockaddr: String = String::new();
         let mut user_vm_bind_sockaddr_type: Option<String> = None;
-        let mut gateway_sockaddr: Option<String> = None;
-        let mut gateway_sockaddr_type: Option<String> = None;
+        let mut gateway_bind_sockaddr: Option<String> = None;
+        let mut gateway_bind_sockaddr_type: Option<String> = None;
         let mut log_to_file: bool = false;
 
         let mut i: usize = 1;
@@ -79,13 +79,13 @@ impl Args {
                     i += 1;
                     user_vm_bind_sockaddr = args[i].clone();
                 },
-                Self::OPT_GATEWAY_SOCKADDR => {
+                Self::OPT_GATEWAY_BIND_SOCKADDR => {
                     i += 1;
-                    gateway_sockaddr = Some(args[i].clone());
+                    gateway_bind_sockaddr = Some(args[i].clone());
                 },
-                Self::OPT_GATEWAY_SOCKET_TYPE => {
+                Self::OPT_GATEWAY_BIND_SOCKET_TYPE => {
                     i += 1;
-                    gateway_sockaddr_type = Some(args[i].clone());
+                    gateway_bind_sockaddr_type = Some(args[i].clone());
                 },
                 Self::OPT_USER_VM_BIND_SOCKET_TYPE => {
                     i += 1;
@@ -94,8 +94,8 @@ impl Args {
                 Self::OPT_LOGFILE => {
                     log_to_file = true;
                 },
-                _ => {
-                    return Err(anyhow::anyhow!("invalid argument"));
+                invalid_arg => {
+                    return Err(anyhow::anyhow!("invalid argument: {invalid_arg}"));
                 },
             }
 
@@ -110,8 +110,8 @@ impl Args {
         Ok(Self {
             user_vm_bind_sockaddr,
             user_vm_bind_sockaddr_type,
-            gateway_sockaddr,
-            gateway_sockaddr_type,
+            gateway_bind_sockaddr,
+            gateway_bind_sockaddr_type,
             log_to_file,
         })
     }
@@ -132,8 +132,8 @@ impl Args {
             Self::OPT_LOGFILE,
             Self::OPT_USER_VM_BIND_SOCKADDR,
             Self::OPT_USER_VM_BIND_SOCKET_TYPE,
-            Self::OPT_GATEWAY_SOCKADDR,
-            Self::OPT_GATEWAY_SOCKET_TYPE
+            Self::OPT_GATEWAY_BIND_SOCKADDR,
+            Self::OPT_GATEWAY_BIND_SOCKET_TYPE
         );
     }
 
@@ -172,8 +172,8 @@ impl Args {
     ///
     /// The socket address of the gateway.
     ///
-    pub fn gateway_sockaddr(&self) -> Option<String> {
-        self.gateway_sockaddr.clone()
+    pub fn gateway_bind_sockaddr(&self) -> Option<String> {
+        self.gateway_bind_sockaddr.clone()
     }
 
     ///
@@ -185,8 +185,8 @@ impl Args {
     ///
     /// The socket address type of the gateway socket.
     ///
-    pub fn gateway_socket_type(&self) -> Option<String> {
-        self.gateway_sockaddr_type.clone()
+    pub fn gateway_bind_socket_type(&self) -> Option<String> {
+        self.gateway_bind_sockaddr_type.clone()
     }
 
     ///

--- a/src/daemons/linuxd/src/args.rs
+++ b/src/daemons/linuxd/src/args.rs
@@ -17,10 +17,10 @@ use ::anyhow::Result;
 /// This structure packs the command-line arguments that were passed to the program.
 ///
 pub struct Args {
-    /// Server socket address.
-    bind_sockaddr: String,
+    /// Socket address linuxd listens to for messages from User VM.
+    user_vm_bind_sockaddr: String,
     /// Server socket address type.
-    bind_sockaddr_type: Option<String>,
+    user_vm_bind_sockaddr_type: Option<String>,
     /// Gateway socket address.
     gateway_sockaddr: Option<String>,
     /// Gateway socket address type.
@@ -37,9 +37,9 @@ impl Args {
     /// Command-line option for printing the help message.
     const OPT_HELP: &'static str = "-help";
     /// Command-line option for setting bind socket address.
-    const OPT_BIND_SOCKADDR: &'static str = "-bind-addr";
+    const OPT_USER_VM_BIND_SOCKADDR: &'static str = "-user-vm-bind-addr";
     /// Command-line option for setting the socket address type of the bind socket.
-    const OPT_BIND_SOCKET_TYPE: &'static str = "-bind-socket-type";
+    const OPT_USER_VM_BIND_SOCKET_TYPE: &'static str = "-user-vm-bind-socket-type";
     /// Command-line option for setting socket address of gateway.
     const OPT_GATEWAY_SOCKADDR: &'static str = "-gateway-addr";
     /// Command-line option for setting the socket address type of the gateway socket.
@@ -62,8 +62,8 @@ impl Args {
     /// program. Upon failure, the function returns an error.
     ///
     pub fn parse(args: Vec<String>) -> Result<Self> {
-        let mut bind_sockaddr: String = String::new();
-        let mut bind_sockaddr_type: Option<String> = None;
+        let mut user_vm_bind_sockaddr: String = String::new();
+        let mut user_vm_bind_sockaddr_type: Option<String> = None;
         let mut gateway_sockaddr: Option<String> = None;
         let mut gateway_sockaddr_type: Option<String> = None;
         let mut log_to_file: bool = false;
@@ -75,9 +75,9 @@ impl Args {
                     Self::usage(args[0].as_str());
                     return Err(anyhow::anyhow!("help message"));
                 },
-                Self::OPT_BIND_SOCKADDR => {
+                Self::OPT_USER_VM_BIND_SOCKADDR => {
                     i += 1;
-                    bind_sockaddr = args[i].clone();
+                    user_vm_bind_sockaddr = args[i].clone();
                 },
                 Self::OPT_GATEWAY_SOCKADDR => {
                     i += 1;
@@ -87,9 +87,9 @@ impl Args {
                     i += 1;
                     gateway_sockaddr_type = Some(args[i].clone());
                 },
-                Self::OPT_BIND_SOCKET_TYPE => {
+                Self::OPT_USER_VM_BIND_SOCKET_TYPE => {
                     i += 1;
-                    bind_sockaddr_type = Some(args[i].clone());
+                    user_vm_bind_sockaddr_type = Some(args[i].clone());
                 },
                 Self::OPT_LOGFILE => {
                     log_to_file = true;
@@ -103,13 +103,13 @@ impl Args {
         }
 
         // Check if server socket address was set.
-        if bind_sockaddr.is_empty() {
+        if user_vm_bind_sockaddr.is_empty() {
             return Err(anyhow::anyhow!("server socket address not set"));
         }
 
         Ok(Self {
-            bind_sockaddr,
-            bind_sockaddr_type,
+            user_vm_bind_sockaddr,
+            user_vm_bind_sockaddr_type,
             gateway_sockaddr,
             gateway_sockaddr_type,
             log_to_file,
@@ -127,38 +127,40 @@ impl Args {
     ///
     pub fn usage(program_name: &str) {
         println!(
-            "Usage: {} {} {} <server-sockaddr> {} <gateway-sockaddr>",
+            "Usage: {} {} {} <user-vm-sockaddr> {} <user-vm-socktype> {} <gateway-sockaddr> {} <gateway-socktype>",
             program_name,
             Self::OPT_LOGFILE,
-            Self::OPT_BIND_SOCKADDR,
-            Self::OPT_GATEWAY_SOCKADDR
+            Self::OPT_USER_VM_BIND_SOCKADDR,
+            Self::OPT_USER_VM_BIND_SOCKET_TYPE,
+            Self::OPT_GATEWAY_SOCKADDR,
+            Self::OPT_GATEWAY_SOCKET_TYPE
         );
     }
 
     ///
     /// # Description
     ///
-    /// Returns the bind socket address.
+    /// Returns the bind socket address for the User VM.
     ///
     /// # Returns
     ///
     /// The socket address of the bind socket.
     ///
-    pub fn bind_sockaddr(&self) -> String {
-        self.bind_sockaddr.to_string()
+    pub fn user_vm_bind_sockaddr(&self) -> String {
+        self.user_vm_bind_sockaddr.to_string()
     }
 
     ///
     /// # Description
     ///
-    /// Returns the socket address type of the bind socket.
+    /// Returns the socket address type of the bind socket for the User VM.
     ///
     /// # Returns
     ///
     /// The socket address type of the bind socket.
     ///
-    pub fn bind_socket_type(&self) -> Option<String> {
-        self.bind_sockaddr_type.clone()
+    pub fn user_vm_bind_socket_type(&self) -> Option<String> {
+        self.user_vm_bind_sockaddr_type.clone()
     }
 
     ///

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -122,7 +122,7 @@ use ::syscomm::SocketStream;
 pub struct LinuxDaemon<'a> {
     pid: ProcessIdentifier,
     assembler: RequestAssembler,
-    stream: SocketStream,
+    uvm_stream: SocketStream,
     gateway_conn: &'a mut Option<SocketStream>,
     venv: VirtualEnviromentDirectory,
 }
@@ -133,13 +133,13 @@ pub struct LinuxDaemon<'a> {
 
 impl<'a> LinuxDaemon<'a> {
     pub fn init(
-        stream: SocketStream,
+        uvm_stream: SocketStream,
         gateway_conn: &'a mut Option<SocketStream>,
     ) -> Result<Self, Error> {
         Ok(Self {
             pid: ProcessIdentifier::from(0),
             assembler: RequestAssembler::default(),
-            stream,
+            uvm_stream,
             gateway_conn,
             venv: VirtualEnviromentDirectory::new(),
         })
@@ -541,7 +541,7 @@ impl<'a> LinuxDaemon<'a> {
     fn recv(&mut self) -> Result<Option<Message>> {
         let mut buf: [u8; config::kernel::IPC_MESSAGE_SIZE] =
             [0u8; config::kernel::IPC_MESSAGE_SIZE];
-        let buf_reader: &mut SocketStream = &mut self.stream;
+        let buf_reader: &mut SocketStream = &mut self.uvm_stream;
         if let Err(e) = buf_reader.read_exact(&mut buf) {
             match e.kind() {
                 ErrorKind::UnexpectedEof => return Ok(None),
@@ -566,7 +566,7 @@ impl<'a> LinuxDaemon<'a> {
     // Send a message to the TCP stream.
     fn send(&mut self, message: Message) -> Result<()> {
         let bytes = message.to_bytes();
-        match self.stream.write_all(&bytes) {
+        match self.uvm_stream.write_all(&bytes) {
             Ok(_) => Ok(()),
             Err(e) => {
                 let reason: String = format!("failed to write message (error={e:?})");

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -42,19 +42,10 @@ use ::flexi_logger::{
     FileSpec,
     Logger,
 };
-use ::signal_hook::{
-    consts::SIGINT,
-    iterator::{
-        Signals,
-        SignalsInfo,
-    },
-};
 use ::std::{
     env,
-    fs,
     str::FromStr,
     sync::Once,
-    thread,
 };
 use ::sys::{
     error::ErrorCode,
@@ -88,9 +79,13 @@ const DEFAULT_GATEWAY_SOCKET_TYPE: SocketType = SocketType::Unix;
 pub fn main() -> Result<()> {
     // Parse and retrieve command-line arguments.
     let args: Args = args::Args::parse(env::args().collect())?;
-    let user_vm_sockaddr: String = args.user_vm_bind_sockaddr();
     initialize(args.log_to_file());
 
+    // Work-out the socket addresses.
+    let user_vm_sockaddr: String = args.user_vm_bind_sockaddr();
+    let gateway_sockaddr: Option<String> = args.gateway_bind_sockaddr();
+
+    // Work-out the socket-types for the user VM and gateway sockets.
     let user_vm_bind_socket_type: SocketType = match args.user_vm_bind_socket_type() {
         Some(typ) => match SocketType::from_str(typ.as_str()) {
             Ok(typ) => typ,
@@ -102,87 +97,85 @@ pub fn main() -> Result<()> {
         None => DEFAULT_BIND_SOCKET_TYPE,
     };
 
+    let gateway_bind_socket_type: SocketType = match args.gateway_bind_socket_type() {
+        Some(typ) => match SocketType::from_str(typ.as_str()) {
+            Ok(typ) => typ,
+            Err(error) => {
+                error!("{error} (type={typ:?})");
+                anyhow::bail!("failed to parse socket address type");
+            },
+        },
+        None => DEFAULT_GATEWAY_SOCKET_TYPE,
+    };
+
     let user_vm_listener: SocketListener = match Socket::bind(user_vm_bind_socket_type, user_vm_sockaddr.clone()) {
         Ok(listener) => listener,
         Err(e) => {
-            error!("failed to bind to uVM socket address (error={e:?})");
-            anyhow::bail!("failed to bind to uVM socket address");
+            error!("failed to bind to user VM socket address (address={}, error={e:?})", user_vm_sockaddr.clone());
+            anyhow::bail!("failed to bind to user VM socket address");
         },
     };
 
-    // Install signal handler.
-    let path: Option<String> = match user_vm_bind_socket_type {
-        SocketType::Tcp => None,
-        SocketType::Unix => Some(user_vm_sockaddr.clone()),
+    let gateway_listener: Option<SocketListener> = match gateway_sockaddr {
+        Some(ref sockaddr) => {
+            match Socket::bind(gateway_bind_socket_type, sockaddr.clone()) {
+                Ok(stream) => Some(stream),
+                Err(e) => {
+                    error!("failed to bind to gateway (address={}, error={e:?})", sockaddr.clone());
+                    anyhow::bail!("failed to bind to gateway");
+                },
+            }
+        },
+        None => None
     };
-    let mut signals: SignalsInfo = Signals::new([SIGINT])?;
-    thread::spawn(move || {
-        #[allow(clippy::never_loop)]
-        for sig in signals.forever() {
-            println!("Received signal {sig:?}");
-            if let Some(path) = path {
-                if let Err(e) = fs::remove_file(path.clone()) {
-                    error!("failed to remove socket file (error={e:?})");
+
+    // Accepct connection from gateway after binding the socket to listen from user VMs,
+    // but before accepting any connection.
+    let mut gateway_stream: Option<SocketStream> = match gateway_listener {
+        Some(gateway_listener) => {
+            info!("Listening to gateway on: {:?}", gateway_sockaddr);
+            loop {
+                match gateway_listener.accept() {
+                    Ok(stream) => {
+                        info!("Connected to gateway in: {:?}", stream.peer_addr());
+                        break Some(stream);
+                    },
+                    Err(error) => {
+                        error!("Failed to accept connection: {error:?}");
+                        continue;
+                    },
                 }
             }
-            // Exit process.
-            std::process::exit(0);
         }
-    });
+        None => None,
+    };
 
-    loop {
-        // Connect to gateway after binding to socket address, as a connection to the gateway will
-        // signal we are ready to accept commands.
-        let mut gateway_conn: Option<SocketStream> = match args.gateway_sockaddr() {
-            Some(sockaddr) => {
-                let getway_socket_type: SocketType = match args.gateway_socket_type() {
-                    Some(typ) => match SocketType::from_str(typ.as_str()) {
-                        Ok(typ) => typ,
-                        Err(error) => {
-                            error!("{error} (type={typ:?})");
-                            anyhow::bail!("failed to parse socket address type");
-                        },
-                    },
-                    None => DEFAULT_GATEWAY_SOCKET_TYPE,
-                };
-                match SocketStream::connect(getway_socket_type, sockaddr) {
-                    Ok(stream) => Some(stream),
-                    Err(e) => {
-                        error!("failed to connect to gateway (error={e:?})");
-                        anyhow::bail!("failed to connect to gateway");
-                    },
-                }
-            },
-            None => None,
-        };
-
-        info!("Listening to user VMs on: {user_vm_sockaddr:?}");
-        let user_vm_stream: SocketStream = match user_vm_listener.accept() {
+    info!("Listening to user VMs on: {user_vm_sockaddr:?}");
+    let user_vm_stream: SocketStream = loop {
+        match user_vm_listener.accept() {
             Ok(stream) => {
-                info!("Connected to: {:?}", stream.peer_addr());
-                stream
+                info!("Connected to user VM in: {:?}", stream.peer_addr());
+                break stream;
             },
             Err(error) => {
                 error!("Failed to accept connection: {error:?}");
                 continue;
             },
         };
-
-        let mut procd: LinuxDaemon = match LinuxDaemon::init(user_vm_stream, &mut gateway_conn) {
-            Ok(procd) => procd,
-            Err(e) => panic!("failed to initialize process manager daemon (error={e:?})"),
-        };
-
-        if procd.run().is_err() {
-            break;
-        }
-    }
-
-    // We only need to remove the socket file when using a UNIX socket.
-    match user_vm_bind_socket_type {
-        SocketType::Tcp => {},
-        SocketType::Unix => fs::remove_file(user_vm_sockaddr)?,
     };
+
+    let mut procd: LinuxDaemon = match LinuxDaemon::init(user_vm_stream, &mut gateway_stream) {
+        Ok(procd) => procd,
+        Err(e) => panic!("failed to initialize process manager daemon (error={e:?})"),
+    };
+
+    // Run main procd loop.
+    let procd_ret = procd.run();
+
+    // Do not panic here as we have already exitted the loop. Instead, continue with clean-up.
+    if procd_ret.is_err() {
+        error!("error running procd (error={procd_ret:?})");
+    }
 
     Ok(())
 }

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -88,10 +88,10 @@ const DEFAULT_GATEWAY_SOCKET_TYPE: SocketType = SocketType::Unix;
 pub fn main() -> Result<()> {
     // Parse and retrieve command-line arguments.
     let args: Args = args::Args::parse(env::args().collect())?;
-    let sockaddr: String = args.bind_sockaddr();
+    let user_vm_sockaddr: String = args.user_vm_bind_sockaddr();
     initialize(args.log_to_file());
 
-    let bind_socket_type: SocketType = match args.bind_socket_type() {
+    let user_vm_bind_socket_type: SocketType = match args.user_vm_bind_socket_type() {
         Some(typ) => match SocketType::from_str(typ.as_str()) {
             Ok(typ) => typ,
             Err(error) => {
@@ -102,18 +102,18 @@ pub fn main() -> Result<()> {
         None => DEFAULT_BIND_SOCKET_TYPE,
     };
 
-    let listener: SocketListener = match Socket::bind(bind_socket_type, sockaddr.clone()) {
+    let user_vm_listener: SocketListener = match Socket::bind(user_vm_bind_socket_type, user_vm_sockaddr.clone()) {
         Ok(listener) => listener,
         Err(e) => {
-            error!("failed to bind to socket address (error={e:?})");
-            anyhow::bail!("failed to bind to socket address");
+            error!("failed to bind to uVM socket address (error={e:?})");
+            anyhow::bail!("failed to bind to uVM socket address");
         },
     };
 
     // Install signal handler.
-    let path: Option<String> = match bind_socket_type {
+    let path: Option<String> = match user_vm_bind_socket_type {
         SocketType::Tcp => None,
-        SocketType::Unix => Some(sockaddr.clone()),
+        SocketType::Unix => Some(user_vm_sockaddr.clone()),
     };
     let mut signals: SignalsInfo = Signals::new([SIGINT])?;
     thread::spawn(move || {
@@ -156,8 +156,8 @@ pub fn main() -> Result<()> {
             None => None,
         };
 
-        info!("Listening on: {sockaddr:?}");
-        let stream: SocketStream = match listener.accept() {
+        info!("Listening to user VMs on: {user_vm_sockaddr:?}");
+        let user_vm_stream: SocketStream = match user_vm_listener.accept() {
             Ok(stream) => {
                 info!("Connected to: {:?}", stream.peer_addr());
                 stream
@@ -168,7 +168,7 @@ pub fn main() -> Result<()> {
             },
         };
 
-        let mut procd: LinuxDaemon = match LinuxDaemon::init(stream, &mut gateway_conn) {
+        let mut procd: LinuxDaemon = match LinuxDaemon::init(user_vm_stream, &mut gateway_conn) {
             Ok(procd) => procd,
             Err(e) => panic!("failed to initialize process manager daemon (error={e:?})"),
         };
@@ -178,7 +178,11 @@ pub fn main() -> Result<()> {
         }
     }
 
-    fs::remove_file(sockaddr)?;
+    // We only need to remove the socket file when using a UNIX socket.
+    match user_vm_bind_socket_type {
+        SocketType::Tcp => {},
+        SocketType::Unix => fs::remove_file(user_vm_sockaddr)?,
+    };
 
     Ok(())
 }

--- a/src/libs/syscomm/Cargo.toml
+++ b/src/libs/syscomm/Cargo.toml
@@ -13,3 +13,4 @@ homepage.workspace = true
 [dependencies]
 config = { workspace = true }
 anyhow = { workspace = true }
+log = { workspace = true }

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -8,9 +8,12 @@
 extern crate alloc;
 
 use ::anyhow::Result;
+use ::log::error;
 use ::std::{
+    fs,
     io::{
         self,
+        ErrorKind,
         Read,
         Write,
     },
@@ -45,7 +48,7 @@ impl Socket {
     pub fn bind(typ: SocketType, addr: String) -> Result<SocketListener> {
         match typ {
             SocketType::Tcp => Ok(SocketListener::Tcp(TcpListener::bind(addr)?)),
-            SocketType::Unix => Ok(SocketListener::Unix(UnixListener::bind(addr)?)),
+            SocketType::Unix => Ok(SocketListener::Unix { listener: UnixListener::bind(&addr)?, path: addr.clone() }),
         }
     }
 }
@@ -54,7 +57,10 @@ impl Socket {
 #[derive(Debug)]
 pub enum SocketListener {
     Tcp(TcpListener),
-    Unix(UnixListener),
+    Unix {
+        listener: UnixListener,
+        path: String,
+    },
 }
 
 impl ::std::str::FromStr for SocketType {
@@ -77,11 +83,26 @@ impl SocketListener {
                 let (stream, _sockaddr): (TcpStream, std::net::SocketAddr) = listener.accept()?;
                 Ok(SocketStream::Tcp(stream))
             },
-            SocketListener::Unix(listener) => {
+            SocketListener::Unix { listener, path: _ } => {
                 let (stream, _sockaddr): (UnixStream, std::os::unix::net::SocketAddr) =
                     listener.accept()?;
                 Ok(SocketStream::Unix(stream))
             },
+        }
+    }
+}
+
+impl Drop for SocketListener {
+    fn drop(&mut self) {
+        match self {
+            SocketListener::Tcp(_) => {},
+            SocketListener::Unix { listener: _, path } => {
+                match fs::remove_file(path.clone()) {
+                    Ok(_) => {},
+                    Err(ref e) if e.kind() == ErrorKind::NotFound => {},
+                    Err(e) => error!("error removing UNIX socket (path={path}, error={e:?})"),
+                }
+            }
         }
     }
 }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -179,10 +179,8 @@ impl Benchmark {
         Ok(nanovm_cmd)
     }
 
-    /// Main entrypoint to set-up the benchmark. It starts the gateway,
-    /// linuxd and the nanovm.
+    /// Configures teh set-up by starting linuxd and the gateway server.
     pub fn setup(&mut self) {
-        // This starts linuxd under the hood.
         match self.start_linuxd() {
             Ok(linuxd) => self.linuxd = Some(linuxd),
             Err(_) => {
@@ -199,6 +197,10 @@ impl Benchmark {
                 process::exit(1);
             },
         }
+    }
+
+    /// Starts the Nano VM.
+    pub fn start(&mut self) {
         match self.start_nanovm() {
             Ok(nanovm) => self.nanovm = Some(nanovm),
             Err(_) => {
@@ -281,6 +283,7 @@ impl Benchmark {
             // Start the clock
             let start = Instant::now();
             self.setup();
+            self.start();
             self.gateway.as_mut().unwrap().write_all(&payload)?;
 
             let mut response_payload: Vec<u8> = vec![0u8; mem::size_of::<u32>() + data.len()];

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -57,10 +57,7 @@ use std::{
         Write,
     },
     mem,
-    net::{
-        TcpListener,
-        TcpStream,
-    },
+    net::TcpStream,
     process::{
         self,
         Child,
@@ -85,14 +82,16 @@ fn get_proj_root() -> String {
 
 impl Benchmark {
     fn start_gateway(&mut self) -> Result<TcpStream> {
-        debug!("Binding gateway to {}...", &self.gateway_address);
-        let listener = TcpListener::bind(&self.gateway_address)?;
-
-        self.linuxd = Some(self.start_linuxd()?);
-
-        // When connect returns, linuxd is ready to serve requests.
-        let (stream, connect) = listener.accept()?;
-        debug!("Connected gateway to: {connect}");
+        debug!("Connecting gateway to {}...", &self.gateway_address);
+        let stream: TcpStream = loop {
+            match TcpStream::connect(&self.gateway_address) {
+                Ok(stream) => break stream,
+                Err(_) => {
+                    continue;
+                }
+            };
+        };
+        debug!("Connected!");
 
         Ok(stream)
     }
@@ -124,11 +123,11 @@ impl Benchmark {
             "-ac".to_string(),
             self.hwloc.linuxd_core_str.to_string(),
             format!("{}/bin/linuxd.elf", get_proj_root()),
-            "-bind-addr".to_string(),
+            "-user-vm-bind-addr".to_string(),
             self.linuxd_address.clone(),
-            "-gateway-addr".to_string(),
+            "-gateway-bind-addr".to_string(),
             self.gateway_address.to_string(),
-            "-gateway-socket-type".to_string(),
+            "-gateway-bind-socket-type".to_string(),
             "tcp".to_string(),
         ];
 
@@ -184,10 +183,18 @@ impl Benchmark {
     /// linuxd and the nanovm.
     pub fn setup(&mut self) {
         // This starts linuxd under the hood.
+        match self.start_linuxd() {
+            Ok(linuxd) => self.linuxd = Some(linuxd),
+            Err(_) => {
+                error!("error starting up linuxd");
+                self.cleanup();
+                process::exit(1);
+            },
+        }
         match self.start_gateway() {
             Ok(gateway) => self.gateway = Some(gateway),
             Err(_) => {
-                error!("error starting up linuxd and the gateway");
+                error!("error starting up the gateway");
                 self.cleanup();
                 process::exit(1);
             },

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -68,8 +68,8 @@ impl Args {
                     i += 1;
                     keep_alive_timeout = Duration::from_secs(args[i].parse::<u64>()?);
                 },
-                _ => {
-                    return Err(anyhow::anyhow!("invalid argument"));
+                arg => {
+                    return Err(anyhow::anyhow!("invalid argument: {arg}"));
                 },
             }
 

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -20,9 +20,6 @@ const UNIX_SOCKET_SUFFIX: &str = ".socket";
 /// Default keep-alive timeout.
 pub const DEFAULT_KEEP_ALIVE_TIMEOUT: u64 = 60;
 
-/// Backlog for Linux Daemon sockets.
-pub const LINUXD_SOCKET_BACKLOG: u32 = 1024;
-
 /// Default Linux Daemon socket address.
 pub const DEFAULT_LINUXD_SOCKADDR: &str = "127.0.0.1:1234";
 
@@ -40,8 +37,8 @@ pub const MAX_PAYLOAD_SIZE: usize = 32;
 // Standalone Functions
 //==================================================================================================
 
-pub fn sandbox_sockaddr_builder(sandbox_sockaddr: &str) -> String {
-    format!("{TMP_DIRECTORY}/{sandbox_sockaddr}{UNIX_SOCKET_SUFFIX}")
+pub fn sandbox_sockaddr_builder(sandbox_sockaddr: &str, clientid: usize, requestid: usize) -> String {
+    format!("{TMP_DIRECTORY}/{sandbox_sockaddr}:{clientid}:{requestid}{UNIX_SOCKET_SUFFIX}")
 }
 
 pub fn linuxd_sockaddr_builder(linuxd_sockaddr: &str, clientid: usize, requestid: usize) -> String {

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -38,17 +38,13 @@ use ::std::{
     future::Future,
     mem,
     pin::Pin,
-    sync::Arc,
 };
 use ::tokio::{
     io::{
         AsyncReadExt,
         AsyncWriteExt,
     },
-    net::{
-        UnixListener,
-        UnixStream,
-    },
+    net::UnixStream,
 };
 
 //==================================================================================================
@@ -65,7 +61,6 @@ struct MessageJson {
 pub struct HttpClient {
     sandboxes: SandboxCache,
     requestid: usize,
-    linuxd_listener: Arc<UnixListener>,
     linuxd_sockaddr: String,
     sandbox_sockaddr: String,
     console_file: String,
@@ -75,7 +70,6 @@ impl HttpClient {
     pub fn new(
         sandboxes: SandboxCache,
         requestid: usize,
-        linuxd_listener: Arc<UnixListener>,
         linuxd_sockaddr: String,
         sandbox_sockaddr: String,
         console_file: String,
@@ -83,7 +77,6 @@ impl HttpClient {
         Self {
             sandboxes,
             requestid,
-            linuxd_listener,
             linuxd_sockaddr,
             sandbox_sockaddr,
             console_file,
@@ -128,14 +121,15 @@ impl HttpClient {
         linuxd_sockaddr: String,
         console_file: String,
         sandbox_sockaddr: String,
-        linuxd_listener: Arc<UnixListener>,
     ) -> Result<Vec<u8>> {
         let linuxd_sockaddr: String =
             config::linuxd_sockaddr_builder(&linuxd_sockaddr, request.clientid, requestid);
+        let sandbox_sockaddr: String =
+            config::sandbox_sockaddr_builder(&sandbox_sockaddr, request.clientid, requestid);
 
         let tag: SandboxTag = SandboxTag::new(request.clientid, &request.program);
         let config: SandboxConfig =
-            SandboxConfig::new(linuxd_listener, &linuxd_sockaddr, &sandbox_sockaddr, &console_file);
+            SandboxConfig::new(&linuxd_sockaddr, &sandbox_sockaddr, &console_file);
         let mut sandbox: SandboxHandle = sandbox_cache.get(&tag, &config).await?;
 
         let mut locked_sandbox: LockedSandbox = sandbox.get_sandbox().await?;
@@ -230,7 +224,6 @@ impl Service<Request<Incoming>> for HttpClient {
         let sandbox_sockaddr: String = self.sandbox_sockaddr.clone();
         let linuxd_sockaddr: String = self.linuxd_sockaddr.clone();
         let nanvix_console: String = self.console_file.clone();
-        let linuxd_listener: Arc<UnixListener> = self.linuxd_listener.clone();
         let sandboxes: SandboxCache = self.sandboxes.clone();
         let future = async move {
             let body: Bytes = match request.collect().await {
@@ -275,7 +268,6 @@ impl Service<Request<Incoming>> for HttpClient {
                 linuxd_sockaddr,
                 nanvix_console,
                 sandbox_sockaddr,
-                linuxd_listener,
             )
             .await
             {

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -36,19 +36,14 @@ use crate::{
 use ::anyhow::Result;
 use ::hyper::server::conn::http1;
 use ::hyper_util::rt::TokioIo;
-use ::std::{
-    fs,
-    sync::{
-        atomic::AtomicUsize,
-        Arc,
-    },
+use ::std::sync::{
+    atomic::AtomicUsize,
+    Arc,
 };
 use ::tokio::{
     net::{
         TcpListener,
         TcpStream,
-        UnixListener,
-        UnixSocket,
     },
     signal::unix::{
         signal,
@@ -64,14 +59,9 @@ pub async fn main() -> Result<()> {
     logging::initialize();
 
     let args: Args = Args::parse(std::env::args().collect())?;
-    let sandbox_sockaddr: String = config::sandbox_sockaddr_builder(args.sandbox_sockaddr());
 
     let mut signals: Signal = signal(SignalKind::interrupt())?;
     let http_listener: TcpListener = TcpListener::bind(args.http_sockaddr()).await?;
-    let socket: UnixSocket = UnixSocket::new_stream()?;
-    socket.bind(&sandbox_sockaddr)?;
-    let linuxd_listener: Arc<UnixListener> =
-        Arc::new(socket.listen(config::LINUXD_SOCKET_BACKLOG)?);
     let requestid: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
     let sandbox_cache: SandboxCache = SandboxCache::new(args.keep_alive_timeout());
 
@@ -81,9 +71,8 @@ pub async fn main() -> Result<()> {
                 match result {
                     Ok((stream, sockaddr)) => {
                         debug!("accepted connection from {sockaddr:?}");
-                        let linuxd_listener: Arc<UnixListener> = linuxd_listener.clone();
                         let linuxd_sockaddr: String = args.linuxd_sockaddr().to_string();
-                        let sandbox_sockaddr: String = sandbox_sockaddr.clone();
+                        let sandbox_sockaddr: String = args.sandbox_sockaddr().to_string();
                         let console_file: String = args.nanvix_console().to_string();
                         let requestid: Arc<AtomicUsize> = requestid.clone();
                         let sandboxe_cache: SandboxCache = sandbox_cache.clone();
@@ -91,7 +80,7 @@ pub async fn main() -> Result<()> {
                             let requestid: usize = requestid
                                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                             let client =
-                                HttpClient::new(sandboxe_cache, requestid, linuxd_listener, linuxd_sockaddr, sandbox_sockaddr, console_file);
+                                HttpClient::new(sandboxe_cache, requestid, linuxd_sockaddr, sandbox_sockaddr, console_file);
                             let io: TokioIo<TcpStream> = TokioIo::new(stream);
                             if let Err(e) = http1::Builder::new().serve_connection(io, client).await  {
                                 error!("failed to serve connection (requestid={requestid:?}, error={e:?})");
@@ -110,10 +99,6 @@ pub async fn main() -> Result<()> {
                 break;
             },
         }
-    }
-
-    if let Err(e) = fs::remove_file(&sandbox_sockaddr) {
-        error!("failed to remove socket file ({e:?})")
     }
 
     Ok(())

--- a/src/utils/nanvixd/src/sandbox/config.rs
+++ b/src/utils/nanvixd/src/sandbox/config.rs
@@ -2,21 +2,12 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
-// Modules
-//==================================================================================================
-
-use ::std::sync::Arc;
-use ::tokio::net::UnixListener;
-
-//==================================================================================================
 // Structures
 //==================================================================================================
 
 /// Packs configuration for a sandbox.
 #[derive(Debug, Clone)]
 pub struct SandboxConfig {
-    /// Listener for the Linux daemon.
-    linuxd_listener: Arc<UnixListener>,
     /// Socket address for the Linux daemon.
     linuxd_sockaddr: String,
     /// Socket address for the Sandbox.
@@ -37,7 +28,6 @@ impl SandboxConfig {
     ///
     /// # Parameters
     ///
-    /// - `linuxd_listener`: Listener for the Linux daemon.
     /// - `linuxd_sockaddr`: Socket address for the Linux daemon.
     /// - `sandbox_sockaddr`: Socket address for the Sandbox.
     /// - `console_file`: File for console output.
@@ -47,30 +37,15 @@ impl SandboxConfig {
     /// A new sandbox configuration.
     ///
     pub fn new(
-        linuxd_listener: Arc<UnixListener>,
         linuxd_sockaddr: &str,
         sandbox_sockaddr: &str,
         console_file: &str,
     ) -> Self {
         Self {
-            linuxd_listener,
             linuxd_sockaddr: linuxd_sockaddr.to_string(),
             sandbox_sockaddr: sandbox_sockaddr.to_string(),
             console_file: console_file.to_string(),
         }
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Returns the listener for the Linux daemon.
-    ///
-    /// # Returns
-    ///
-    /// The listener for the Linux daemon.
-    ///
-    pub fn linuxd_listener(&self) -> &Arc<UnixListener> {
-        &self.linuxd_listener
     }
 
     ///

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -28,9 +28,9 @@ impl LinuxDaemon {
         debug!("spawning linux daemon {linuxd_sockaddr} {sandbox_sockaddr}");
         let child = Command::new(format!("{}/linuxd.elf", config::BINARY_DIRECTORY))
             .arg("-log-to-file")
-            .arg("-bind-addr")
+            .arg("-user-vm-bind-addr")
             .arg(linuxd_sockaddr)
-            .arg("-gateway-addr")
+            .arg("-gateway-bind-addr")
             .arg(sandbox_sockaddr)
             .stdout(Stdio::piped())
             .spawn()?;

--- a/src/utils/nanvixd/src/sandbox/mod.rs
+++ b/src/utils/nanvixd/src/sandbox/mod.rs
@@ -35,7 +35,7 @@ pub use tag::SandboxTag;
 //==================================================================================================
 
 pub struct Sandbox {
-    _linuxd: LinuxDaemon,
+    linuxd: Option<LinuxDaemon>,
     linuxd_socket: Option<UnixStream>,
     microvm: Option<Microvm>,
     config: SandboxConfig,
@@ -44,7 +44,7 @@ pub struct Sandbox {
 impl Sandbox {
     pub fn new(config: &SandboxConfig) -> Result<Self> {
         Ok(Self {
-            _linuxd: LinuxDaemon::spawn(config.linuxd_sockaddr(), config.sandbox_sockaddr())?,
+            linuxd: None,
             linuxd_socket: None,
             microvm: None,
             config: config.clone(),
@@ -52,18 +52,23 @@ impl Sandbox {
     }
 
     pub async fn load(&mut self, program: &str) -> Result<()> {
-        if self.linuxd_socket.is_none() {
-            match self.config.linuxd_listener().accept().await {
-                Ok((socket, _)) => {
-                    debug!("accepted connection from linux daemon {:?}", socket.peer_addr());
-                    self.linuxd_socket = Some(socket);
-                },
+        if self.linuxd.is_none() {
+            self.linuxd = Some(LinuxDaemon::spawn(self.config.linuxd_sockaddr(), self.config.sandbox_sockaddr())?);
+        }
 
-                Err(_) => {
-                    let reason: String = "failed to accept connection".to_string();
-                    error!("{reason}");
-                    anyhow::bail!(reason)
-                },
+        if self.linuxd_socket.is_none() {
+            debug!("connecting to gateway at: {}", self.config.sandbox_sockaddr());
+            loop {
+                match UnixStream::connect(self.config.sandbox_sockaddr()).await {
+                    Ok(socket) => {
+                        self.linuxd_socket = Some(socket);
+                        debug!("connected to linuxd");
+                        break;
+                    }
+                    Err(_) => {
+                        continue;
+                    }
+                }
             };
         }
 
@@ -93,6 +98,7 @@ impl Sandbox {
     pub fn unload(&mut self) -> Result<()> {
         self.microvm.take();
         self.linuxd_socket.take();
+        self.linuxd.take();
         Ok(())
     }
 


### PR DESCRIPTION
In this PR I change the communication pattern between the gateway and linuxd by moving the listener socket inside linuxd and `connect`-ing from the gateway.

This means that we now have two listener sockets inside linuxd: one for the user VM, and one for the gateway. This forced a rename of the arguments in linuxd. We cannot use `bind-addr` anymore, as both sockets `bind`. I have picked `-uvm-bind-addr` and `-gateway-bind-addr`. I know user VM is not an extended terminology in the codebase, but iiuc we are converging towards it, so might as well rename it to the right thing. I am happy to use another name, though.

When refactoring `nanvixd` I ran into a few race conditions about UNIX socket files not being cleaned-up after executions (when things went wrong). This was a long-standing issue when benchmarking Nanvix. To address it cleanly, I implement the `Drop` trait for the `SocketListener` enum in `syscomm`. This forced a small API change, but nothing too majer.