### PR TITLE
[opt] Integration with OpenSSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,14 +389,14 @@ run-linuxd-tests: | \
 
 ifneq ($(strip $(filter yes,$(BUILD_OPT))),)
 
-all-opt: init all-openblas all-python all-sqlite all-zlib
+all-opt: init all-openblas all-openssl all-python all-sqlite all-zlib
 
-clean-opt: clean-openblas clean-python clean-sqlite clean-zlib
+clean-opt: clean-openblas clean-openssl clean-python clean-sqlite clean-zlib
 
-distclean-opt: distclean-openblas distclean-python distclean-sqlite distclean-zlib
+distclean-opt: distclean-openblas distclean-openssl distclean-python distclean-sqlite distclean-zlib
 	$(FORCE_RM_CMD) $(SYSROOT_DIR)
 
-init-opt: init-openblas init-python init-zlib
+init-opt: init-openblas init-openssl init-python init-zlib
 
 else
 
@@ -434,6 +434,31 @@ endif
 init-openblas: init-repo
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
 	bash $(SCRIPTS_DIR)/build-openblas.sh init $(ROOT_DIR) $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
+endif
+
+#===================================================================================================
+# Build Rules for OpenSSL
+#===================================================================================================
+
+all-openssl: init
+ifneq ($(strip $(filter $(MACHINE),microvm)),)
+	echo "Building openssl..."
+	bash $(SCRIPTS_DIR)/build-openssl.sh build $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
+endif
+
+clean-openssl:
+ifneq ($(strip $(filter $(MACHINE),microvm)),)
+	bash $(SCRIPTS_DIR)/build-openssl.sh clean $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
+endif
+
+distclean-openssl:
+ifneq ($(strip $(filter $(MACHINE),microvm)),)
+	bash $(SCRIPTS_DIR)/build-openssl.sh distclean $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
+endif
+
+init-openssl: init-repo
+ifneq ($(strip $(filter $(MACHINE),microvm)),)
+	bash $(SCRIPTS_DIR)/build-openssl.sh init $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
 endif
 
 #===================================================================================================

--- a/Makefile
+++ b/Makefile
@@ -465,18 +465,18 @@ endif
 # Build Rules for Python
 #===================================================================================================
 
-all-python: init all-guest-staticlibs all-sqlite all-zlib
+all-python: init all-guest-staticlibs all-sqlite all-openssl all-zlib
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
 	echo "Building Python..."
 	bash $(SCRIPTS_DIR)/build-python.sh build $(ROOT_DIR) $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
 endif
 
-clean-python: all-sqlite clean-zlib
+clean-python: clean-sqlite clean-openssl clean-zlib
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
 	bash $(SCRIPTS_DIR)/build-python.sh clean $(ROOT_DIR) $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
 endif
 
-distclean-python: distclean-sqlite distclean-zlib
+distclean-python: distclean-sqlite distclean-openssl distclean-zlib
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
 	bash $(SCRIPTS_DIR)/build-python.sh distclean $(ROOT_DIR) $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
 endif

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Nanvix is a microkernel-based research operating system.
 ### Libraries
 
 - [x] `OpenBlas v0.3.29`
+- [x] `OpenSSL v3.5.0`
 - [x] `SQLite v3.49.0`
 - [x] `Zlib v1.3.1`
 

--- a/scripts/build-openssl.sh
+++ b/scripts/build-openssl.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# Copyright(c) 2011-2024 The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#===================================================================================================
+# Script Arguments
+#===================================================================================================
+
+RULE=${1:-build}
+TOOLCHAIN_DIR=${2:-$PWD/toolchain}
+SYSROOT_DIR=${3:-$PWD/sysroot}
+
+#===================================================================================================
+# Global Variables
+#===================================================================================================
+
+export CONTRIB_DIR=${SYSROOT_DIR}/src
+export OPENSSL_HOME=${CONTRIB_DIR}/openssl
+export OPENSSL_REPOSITORY=https://github.com/nanvix/openssl
+export OPENSSL_COMMIT=b4773b592552f9d3c77fbd0e36509e3fcd030536
+
+#===================================================================================================
+# Configure
+#===================================================================================================
+
+configure() {
+    CFLAGS="-I $TOOLCHAIN_DIR/usr/include/" \
+    CXX=$TOOLCHAIN_DIR/bin/i686-nanvix-g++ \
+    AR=$TOOLCHAIN_DIR/bin/i686-nanvix-ar \
+    RANLIB=$TOOLCHAIN_DIR/bin/i686-nanvix-ranlib \
+    CC=$TOOLCHAIN_DIR/bin/i686-nanvix-gcc \
+    ./Configure \
+        --openssldir=$SYSROOT_DIR \
+        --prefix=$SYSROOT_DIR \
+        nanvix \
+        no-shared \
+        threads \
+        no-dso \
+        no-apps \
+        no-docs \
+        no-rdrand \
+        no-posix-io \
+        no-asm \
+        no-ui-console
+}
+
+#===================================================================================================
+# Clean
+#===================================================================================================
+
+make_clean() {
+    cd ${OPENSSL_HOME}
+    make clean
+}
+
+#===================================================================================================
+# Clean Everything
+#===================================================================================================
+
+distclean() {
+    cd ${OPENSSL_HOME}
+	git clean -fdx
+}
+
+#===================================================================================================
+# Make
+#===================================================================================================
+
+make_all() {
+    cd ${OPENSSL_HOME}
+
+    make -j $(nproc) all
+}
+
+#===================================================================================================
+# Install
+#===================================================================================================
+
+make_install() {
+    cd ${OPENSSL_HOME}
+    make install
+}
+
+#===================================================================================================
+# Build
+#===================================================================================================
+
+
+build() {
+    cd ${OPENSSL_HOME}
+	make_all
+	make_install
+}
+
+#===================================================================================================
+# Init
+#===================================================================================================
+
+init() {
+    mkdir -p ${CONTRIB_DIR}
+    if [ ! -d "${OPENSSL_HOME}/.git" ];
+    then
+        git clone ${OPENSSL_REPOSITORY} ${OPENSSL_HOME}
+        cd ${OPENSSL_HOME}
+    else
+        cd ${OPENSSL_HOME}
+        git fetch origin
+        git reset --hard
+    fi
+    git checkout ${OPENSSL_COMMIT}
+
+    configure
+}
+
+#===================================================================================================
+
+
+# Save current environment variables.
+OLD_AR=$AR
+OLD_AS=$AS
+OLD_CC=$CC
+OLD_CXX=$CXX
+OLD_CPP=$CPP
+OLD_LD=$LD
+OLD_CFLAGS=$CFLAGS
+OLD_CXXFLAGS=$CXXFLAGS
+OLD_LD_FLAGS=$LDFLAGS
+OLD_LIBC=$LIBC
+OLD_LIBM=$LIBM
+
+# Unset variables that might interfere with the build process.
+unset AR
+unset AS
+unset CC
+unset CXX
+unset CPP
+unset LD
+unset CFLAGS
+unset CXXFLAGS
+unset LDFLAGS
+unset LIBC
+unset LIBM
+
+case $RULE in
+	build)
+		build
+		;;
+	clean)
+		make_clean
+		;;
+	distclean)
+		distclean
+		;;
+	init)
+		init
+		;;
+esac
+
+# Restore original environment variables.
+export AR=$OLD_AR
+export AS=$OLD_AS
+export CC=$OLD_CC
+export CXX=$OLD_CXX
+export CPP=$OLD_CPP
+export LD=$OLD_LD
+export CFLAGS=$OLD_CFLAGS
+export CXXFLAGS=$OLD_CXXFLAGS
+export LDFLAGS=$OLD_LD_FLAGS
+export LIBC=$OLD_LIBC
+export LIBM=$OLD_LIBM

--- a/scripts/build-python.sh
+++ b/scripts/build-python.sh
@@ -46,7 +46,7 @@ configure() {
 	LD="$TOOLCHAIN_DIR/bin/i686-nanvix-ld" \
 	LDFLAGS="-static -T $NANVIX_HOME/build/user/linker/x86/user.ld" \
 	CFLAGS="-static -L $SYSROOT_DIR/lib" \
-	LIBS="-Wl,--start-group $NANVIX_HOME/lib/libposix.a $TOOLCHAIN_DIR/i686-nanvix/lib/libc.a $TOOLCHAIN_DIR/i686-nanvix/lib/libm.a -lsqlite3 -Wl,--end-group" \
+	LIBS="-Wl,--start-group $NANVIX_HOME/lib/libposix.a $TOOLCHAIN_DIR/i686-nanvix/lib/libc.a $TOOLCHAIN_DIR/i686-nanvix/lib/libm.a -lsqlite3 -lssl -lcrypto -Wl,--end-group" \
 	LIBSQLITE3_LIBS="-L $SYSROOT_DIR/lib -lsqlite3" \
 	LIBSQLITE3_CFLAGS="-I $SYSROOT_DIR/include" \
 	ZLIB_LIBS="-L $SYSROOT_DIR/lib -lz" \
@@ -63,6 +63,7 @@ configure() {
 		--exec-prefix=$SYSROOT_DIR \
 		--with-ensurepip=no \
 		--with-pkg-config=no \
+		--with-openssl=$SYSROOT_DIR \
 		--disable-ipv6 \
 		ac_cv_file__dev_ptmx=no \
 		ac_cv_file__dev_ptc=no \

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -164,7 +164,7 @@ pub mod memory_layout {
     ///
     /// Size of the user heap.
     ///
-    pub const USER_HEAP_SIZE: usize = 8 * crate::constants::MEGABYTE;
+    pub const USER_HEAP_SIZE: usize = 32 * crate::constants::MEGABYTE;
 }
 
 //==================================================================================================


### PR DESCRIPTION
## Description

This pull request introduces support for OpenSSL in the build system and updates related configurations and dependencies. It also increases the user heap size in the configuration file to accommodate potential new requirements.

### Build system updates:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L392-R399): Added OpenSSL build rules (`all-openssl`, `clean-openssl`, `distclean-openssl`, `init-openssl`) and integrated OpenSSL into existing build targets such as `all-opt`, `clean-opt`, and `distclean-opt`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L392-R399) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R439-R479)
* [`scripts/build-openssl.sh`](diffhunk://#diff-bddec447b87c1379a02934ed217205e063a9e724eb42b02bfa606d81c99564d0R1-R171): Added a new script to handle OpenSSL initialization, configuration, building, cleaning, and installation.

### Dependency updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30): Documented OpenSSL as a new library dependency (`OpenSSL v3.5.0`).
* [`scripts/build-python.sh`](diffhunk://#diff-b4ec7c42d093e6056090c4e1dc9f1d0fe551942570f049ba64a3b53bbaded29fL49-R49): Updated Python build configuration to link against OpenSSL libraries (`-lssl -lcrypto`) and specify the OpenSSL installation directory (`--with-openssl=$SYSROOT_DIR`). [[1]](diffhunk://#diff-b4ec7c42d093e6056090c4e1dc9f1d0fe551942570f049ba64a3b53bbaded29fL49-R49) [[2]](diffhunk://#diff-b4ec7c42d093e6056090c4e1dc9f1d0fe551942570f049ba64a3b53bbaded29fR66)

### Configuration changes:
* [`src/libs/config/src/lib.rs`](diffhunk://#diff-30d631c85a493fa748c248d7f923b54c1b1c1f6bc56b7e5f569cca5f0d711cedL167-R167): Increased `USER_HEAP_SIZE` from 8 MB to 32 MB in the memory layout configuration.

### Submodule update:
* [`opt/cpython`](diffhunk://#diff-88b03fb1e5a4a30bd8eefdc7c6291eba7e0889dd4ad430100d16e787a6e4eaeeL1-R1): Updated the submodule commit to a newer version.