### PR TITLE
[opt] Remove OpenBLAS Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,9 +5,6 @@
 [submodule "opt/zlib"]
 	path = opt/zlib
 	url = https://github.com/nanvix/zlib.git
-[submodule "opt/openblas"]
-	path = opt/openblas
-	url = https://github.com/nanvix/OpenBLAS
 [submodule "opt/sqlite"]
 	path = opt/sqlite
 	url = https://github.com/nanvix/sqlite.git

--- a/Makefile
+++ b/Makefile
@@ -418,22 +418,22 @@ endif
 all-openblas: init all-guest-staticlibs
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
 	echo "Building OpenBLAS..."
-	bash $(SCRIPTS_DIR)/build-openblas.sh build $(ROOT_DIR) $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
+	bash $(SCRIPTS_DIR)/build-openblas.sh build $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
 endif
 
 clean-openblas: clean-zlib
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
-	bash $(SCRIPTS_DIR)/build-openblas.sh clean $(ROOT_DIR) $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
+	bash $(SCRIPTS_DIR)/build-openblas.sh clean $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
 endif
 
 distclean-openblas: distclean-zlib
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
-	bash $(SCRIPTS_DIR)/build-openblas.sh distclean $(ROOT_DIR) $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
+	bash $(SCRIPTS_DIR)/build-openblas.sh distclean $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
 endif
 
 init-openblas: init-repo
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
-	bash $(SCRIPTS_DIR)/build-openblas.sh init $(ROOT_DIR) $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
+	bash $(SCRIPTS_DIR)/build-openblas.sh init $(TOOLCHAIN_DIR) $(SYSROOT_DIR)
 endif
 
 #===================================================================================================

--- a/scripts/build-openblas.sh
+++ b/scripts/build-openblas.sh
@@ -8,35 +8,45 @@
 #===================================================================================================
 
 RULE=${1:-build}
-NANVIX_HOME=${2:-`git rev-parse --show-toplevel`}
-TOOLCHAIN_DIR=${3:-$PWD/toolchain}
-SYSROOT_DIR=${4:-$PWD/sysroot}
+TOOLCHAIN_DIR=${2:-$PWD/toolchain}
+SYSROOT_DIR=${3:-$PWD/sysroot}
 
 #===================================================================================================
 # Global Variables
 #===================================================================================================
 
-OPT_DIR=${NANVIX_HOME}/opt
-OPENBLAS_HOME=${OPT_DIR}/openblas
-OPENBLAS_MAKE_OPTIONS="\
-    CC=${TOOLCHAIN_DIR}/bin/i686-nanvix-gcc \
-    FC=${TOOLCHAIN_DIR}/bin/i686-nanvix-gfortran \
-    PREFIX=${SYSROOT_DIR} \
-    HOSTCC=gcc \
-    TARGET=P2 \
-    BINARY=32 \
-    CROSS=1 \
-    NO_SHARED=1 \
-    USE_OPENMP=0 \
-    USE_THREAD=0 \
-    USE_LOCKING=1 \
-    USE_TLS=0"
+export CONTRIB_DIR=${SYSROOT_DIR}/src
+export OPENBLAS_HOME=${CONTRIB_DIR}/openblas
+export OPENBLAS_REPOSITORY=https://github.com/nanvix/openblas
+export OPENBLAS_BRANCH=nanvix/v0.3.29
+
+#===================================================================================================
+# Configure
+#===================================================================================================
+
+configure() {
+    # OpenBLAS uses make variables instead of configure script
+    export OPENBLAS_MAKE_OPTIONS="\
+        CC=${TOOLCHAIN_DIR}/bin/i686-nanvix-gcc \
+        FC=${TOOLCHAIN_DIR}/bin/i686-nanvix-gfortran \
+        PREFIX=${SYSROOT_DIR} \
+        HOSTCC=gcc \
+        TARGET=P2 \
+        BINARY=32 \
+        CROSS=1 \
+        NO_SHARED=1 \
+        USE_OPENMP=0 \
+        USE_THREAD=0 \
+        USE_LOCKING=1 \
+        USE_TLS=0"
+}
 
 #===================================================================================================
 # Clean
 #===================================================================================================
 
 make_clean() {
+    cd ${OPENBLAS_HOME}
     make ${OPENBLAS_MAKE_OPTIONS} clean
 }
 
@@ -45,6 +55,7 @@ make_clean() {
 #===================================================================================================
 
 distclean() {
+    cd ${OPENBLAS_HOME}
 	git clean -fdx
 }
 
@@ -53,6 +64,7 @@ distclean() {
 #===================================================================================================
 
 make_all() {
+    cd ${OPENBLAS_HOME}
     make ${OPENBLAS_MAKE_OPTIONS} all
 }
 
@@ -61,6 +73,7 @@ make_all() {
 #===================================================================================================
 
 make_install() {
+    cd ${OPENBLAS_HOME}
     make ${OPENBLAS_MAKE_OPTIONS} install
 }
 
@@ -70,8 +83,8 @@ make_install() {
 
 
 build() {
+    cd ${OPENBLAS_HOME}
 	make_all
-
 	make_install
 }
 
@@ -80,17 +93,22 @@ build() {
 #===================================================================================================
 
 init() {
-	# Nothing to do here.
-	return
+    mkdir -p ${CONTRIB_DIR}
+    if [ ! -d "${OPENBLAS_HOME}/.git" ];
+    then
+        git clone ${OPENBLAS_REPOSITORY} ${OPENBLAS_HOME}
+        cd ${OPENBLAS_HOME}
+    else
+        cd ${OPENBLAS_HOME}
+        git fetch origin
+        git reset --hard
+    fi
+    git checkout ${OPENBLAS_BRANCH}
+
+    configure
 }
 
 #===================================================================================================
-
-# Fetch submodule if needed.
-git submodule update --init $OPENBLAS_HOME
-
-# Switch to submodule directory.
-cd ${OPENBLAS_HOME}
 
 # Save current environment variables.
 OLD_AR=$AR


### PR DESCRIPTION
This pull request removes the OpenBLAS submodule and updates the build process to clone the OpenBLAS repository directly. It simplifies the build script, adjusts the `Makefile` accordingly, and introduces new configuration and initialization logic for OpenBLAS. 

### Removal of OpenBLAS Submodule:
* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L8-L10): Removed the OpenBLAS submodule entry, indicating that OpenBLAS is no longer managed as a submodule.
* [`opt/openblas`](diffhunk://#diff-cd741e3b20bb711cdd66de61f9b77d60461f3f245efbd8f1a8afed2e98aada5eL1): Removed the submodule commit reference, fully detaching OpenBLAS from submodule management.

### Updates to Build Process:
* `scripts/build-openblas.sh`: 
  - Added logic to clone the OpenBLAS repository directly, fetch updates, and check out a specific branch (`nanvix/v0.3.29`).
  - Introduced a new `configure` function to set up OpenBLAS-specific make options. [[1]](diffhunk://#diff-95d392565a93c686d42cab2a06f8b36b294c1910301c25a94195b46fe4845194L11-R29) [[2]](diffhunk://#diff-95d392565a93c686d42cab2a06f8b36b294c1910301c25a94195b46fe4845194R42-R49)
  - Updated all build-related functions (`make_clean`, `distclean`, `make_all`, `make_install`, and `build`) to ensure operations are performed within the cloned OpenBLAS directory. [[1]](diffhunk://#diff-95d392565a93c686d42cab2a06f8b36b294c1910301c25a94195b46fe4845194R58) [[2]](diffhunk://#diff-95d392565a93c686d42cab2a06f8b36b294c1910301c25a94195b46fe4845194R67) [[3]](diffhunk://#diff-95d392565a93c686d42cab2a06f8b36b294c1910301c25a94195b46fe4845194R76) [[4]](diffhunk://#diff-95d392565a93c686d42cab2a06f8b36b294c1910301c25a94195b46fe4845194R86-L74) [[5]](diffhunk://#diff-95d392565a93c686d42cab2a06f8b36b294c1910301c25a94195b46fe4845194L83-L94)

### Adjustments to Makefile:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L421-R436): Removed the `ROOT_DIR` parameter from OpenBLAS-related build commands, aligning with the updated build script logic.