### PR TITLE
[utils] Fix Warm Start Experiment In nanvix-bench

### DIFF
--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -480,6 +480,7 @@ fn main() -> Result<()> {
 
     print!("Setting up {} benchmark...", benchmark.flavour);
     benchmark.setup();
+    benchmark.start();
     println!("done!");
 
     let result = match benchmark.flavour {


### PR DESCRIPTION
In a previous PR I separated the setup of a benchmark in nanvix-bench (start linuxd and gateway), from starting the User VM.

I then updated the cold-start experiment, but forgot to update the warm start experiment (and, transitively, the echo-breakdown experiment).