### PR TITLE
[scripts] Fix GCC build and Rust Toolchain Setup

### DIFF
--- a/scripts/setup/gcc.sh
+++ b/scripts/setup/gcc.sh
@@ -47,8 +47,8 @@ stage0() {
         --disable-libquadmath-support \
         --with-newlib
 
-    make -j `nproc` all-gcc all-target-libgcc all-target-libgfortran
-    make install-gcc install-target-libgcc install-target-libgfortran
+    make -j `nproc` all-gcc all-target-libgcc
+    make install-gcc install-target-libgcc
 }
 
 #===================================================================================================

--- a/scripts/setup/rust.sh
+++ b/scripts/setup/rust.sh
@@ -65,4 +65,6 @@ export DESTDIR=${TOOLCHAIN_DIR}
 # Build the toolchain.
 ./x build --incremental --target x86_64-unknown-linux-gnu,wasm32-wasip1
 
+# Set nightly cargo and link toolchain to make it available.
+rustup override set nightly
 rustup toolchain link nanvix-x86 build/host/stage2


### PR DESCRIPTION
# Description

This pull request includes updates to the setup scripts for GCC and Rust toolchains. The changes focus on simplifying the GCC build process and enhancing the Rust toolchain setup for better usability.

### Updates to GCC setup:

* [`scripts/setup/gcc.sh`](diffhunk://#diff-867de69dc5e1bb43def158a78b9f5aaf693564485948f0a3192900ec32f55e07L50-R51): Removed the build and installation steps for `libgfortran` from the `stage0` function, streamlining the GCC build process.

### Enhancements to Rust setup:

* [`scripts/setup/rust.sh`](diffhunk://#diff-25af995b690ea3464d0522672d52f274dda67eb35e48738420f188d82deff93dR68-R69): Added a step to set the nightly version of Cargo using `rustup override set nightly` and linked the Rust toolchain for availability with `rustup toolchain link nanvix-x86`.