### PR TITLE
[libs] Re-Export Libs

### DIFF
--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -51,6 +51,7 @@ rustc-dep-of-std = [
     "sys/rustc-dep-of-std",
     "static_assert/rustc-dep-of-std",
     "sysapi/rustc-dep-of-std",
+    "sysalloc/rustc-dep-of-std",
     "syslog/rustc-dep-of-std",
     "type-safe/rustc-dep-of-std",
     "spin/rustc-dep-of-std",

--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -26,6 +26,7 @@ goblin = { workspace = true, optional = true, features = [
     "mach32",
     "mach64",
 ] }
+nvx = { workspace = true, optional = true }
 spin = { workspace = true, features = ["lazy", "spin_mutex"] }
 static_assert = { workspace = true }
 syslog = { workspace = true, optional = true }
@@ -46,6 +47,7 @@ rustc-dep-of-std = [
     "alloc",
     "cfg-if/rustc-dep-of-std",
     "compiler_builtins/rustc-dep-of-std",
+    "nvx/rustc-dep-of-std",
     "sys/rustc-dep-of-std",
     "static_assert/rustc-dep-of-std",
     "sysapi/rustc-dep-of-std",

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -20,6 +20,10 @@
 extern crate alloc;
 
 #[cfg(feature = "rustc-dep-of-std")]
+#[allow(unused_extern_crates)]
+extern crate nvx;
+
+#[cfg(feature = "rustc-dep-of-std")]
 pub use ::syslog;
 
 #[cfg(feature = "rustc-dep-of-std")]

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -29,6 +29,9 @@ pub use ::syslog;
 #[cfg(feature = "rustc-dep-of-std")]
 pub use ::sysapi;
 
+#[cfg(feature = "rustc-dep-of-std")]
+pub use ::sysalloc;
+
 pub mod errno;
 
 /// Format of directory entries

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -30,6 +30,9 @@ pub use ::syslog;
 pub use ::sysapi;
 
 #[cfg(feature = "rustc-dep-of-std")]
+pub use ::sys::error;
+
+#[cfg(feature = "rustc-dep-of-std")]
 pub use ::sysalloc;
 
 pub mod errno;


### PR DESCRIPTION
## Description

This pull request introduces support for the `nvx` and `sysalloc` dependencies in the `syscall` library, along with updates to their integration within the project. The changes primarily focus on adding these dependencies to the build configuration and making them available under specific feature flags.

### Dependency Additions and Configuration Updates:

* Added the `nvx` dependency to the `Cargo.toml` file as an optional and workspace-enabled dependency. It is also included in the `rustc-dep-of-std` feature list. (`src/libs/syscall/Cargo.toml`, [[1]](diffhunk://#diff-d97ab93cb82679f7061c73c37147ab6a197fc1f682c6b8a471b45f250a5f440aR29) [[2]](diffhunk://#diff-d97ab93cb82679f7061c73c37147ab6a197fc1f682c6b8a471b45f250a5f440aR50-R54)
* Added the `sysalloc` dependency to the `rustc-dep-of-std` feature list in `Cargo.toml`. (`src/libs/syscall/Cargo.toml`, [src/libs/syscall/Cargo.tomlR50-R54](diffhunk://#diff-d97ab93cb82679f7061c73c37147ab6a197fc1f682c6b8a471b45f250a5f440aR50-R54))

### Library Integration:

* Updated `lib.rs` to conditionally include the `nvx` crate when the `rustc-dep-of-std` feature is enabled. (`src/libs/syscall/src/lib.rs`, [src/libs/syscall/src/lib.rsR22-R37](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79R22-R37))
* Exposed `sys::error` and `sysalloc` modules under the `rustc-dep-of-std` feature flag in `lib.rs`. (`src/libs/syscall/src/lib.rs`, [src/libs/syscall/src/lib.rsR22-R37](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79R22-R37))