### PR TITLE
[libs] Use Fixed-Size Types in IKC Messages

### DIFF
--- a/src/libs/syscall/src/dirent/message/getdents.rs
+++ b/src/libs/syscall/src/dirent/message/getdents.rs
@@ -57,7 +57,7 @@ const MAX_ENTRIES: usize = 1024;
 #[repr(C, packed)]
 pub struct GetDirectoryEntriesRequest {
     pub fd: c_int,
-    pub count: size_t,
+    pub count: u32,
     _padding: [u8; Self::PADDING_SIZE],
 }
 ::static_assert::assert_eq_size!(GetDirectoryEntriesRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
@@ -65,7 +65,7 @@ pub struct GetDirectoryEntriesRequest {
 impl GetDirectoryEntriesRequest {
     pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
         - core::mem::size_of::<c_int>()
-        - core::mem::size_of::<size_t>();
+        - core::mem::size_of::<u32>();
 
     /// Maximum number of entries in the request.
     pub const MAX_ENTRIES: usize = MAX_ENTRIES;

--- a/src/libs/syscall/src/sys/socket/message/send.rs
+++ b/src/libs/syscall/src/sys/socket/message/send.rs
@@ -85,15 +85,15 @@ impl SendSocketRequest {
 #[derive(Debug)]
 #[repr(C, packed)]
 pub struct SendSocketResponse {
-    pub count: ssize_t,
+    pub count: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
 ::static_assert::assert_eq_size!(SendSocketResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
 
 impl SendSocketResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<ssize_t>();
+    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
-    pub fn new(count: ssize_t) -> Self {
+    pub fn new(count: i32) -> Self {
         Self {
             count,
             _padding: [0; Self::PADDING_SIZE],

--- a/src/libs/syscall/src/sys/socket/message/send.rs
+++ b/src/libs/syscall/src/sys/socket/message/send.rs
@@ -30,7 +30,7 @@ use ::sysapi::sys_types::{
 #[repr(C, packed)]
 pub struct SendSocketRequest {
     pub sockfd: i32,
-    pub count: size_t,
+    pub count: u32,
     pub flags: i32,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
@@ -39,10 +39,10 @@ pub struct SendSocketRequest {
 impl SendSocketRequest {
     pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
-        - mem::size_of::<size_t>()
+        - mem::size_of::<u32>()
         - mem::size_of::<i32>();
 
-    pub fn new(sockfd: i32, count: size_t, flags: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
+    pub fn new(sockfd: i32, count: u32, flags: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self {
             sockfd,
             count,

--- a/src/libs/syscall/src/unistd/message/pread.rs
+++ b/src/libs/syscall/src/unistd/message/pread.rs
@@ -79,15 +79,15 @@ impl PartialReadRequest {
 #[derive(Debug)]
 #[repr(C, packed)]
 pub struct PartialReadResponse {
-    pub count: ssize_t,
+    pub count: i32,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
 ::static_assert::assert_eq_size!(PartialReadResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
 
 impl PartialReadResponse {
-    pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<ssize_t>();
+    pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
-    fn new(count: ssize_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
+    fn new(count: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self { count, buffer }
     }
 

--- a/src/libs/syscall/src/unistd/message/pread.rs
+++ b/src/libs/syscall/src/unistd/message/pread.rs
@@ -31,7 +31,7 @@ use ::sysapi::sys_types::{
 #[repr(C, packed)]
 pub struct PartialReadRequest {
     pub fd: i32,
-    pub count: size_t,
+    pub count: u32,
     pub offset: off_t,
     _padding: [u8; Self::PADDING_SIZE],
 }
@@ -40,10 +40,10 @@ pub struct PartialReadRequest {
 impl PartialReadRequest {
     pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
-        - mem::size_of::<i32>()
+        - mem::size_of::<u32>()
         - mem::size_of::<off_t>();
 
-    fn new(fd: i32, count: size_t, offset: off_t) -> Self {
+    fn new(fd: i32, count: u32, offset: off_t) -> Self {
         Self {
             fd,
             count,

--- a/src/libs/syscall/src/unistd/message/pwrite.rs
+++ b/src/libs/syscall/src/unistd/message/pwrite.rs
@@ -85,15 +85,15 @@ impl PartialWriteRequest {
 #[derive(Debug)]
 #[repr(C, packed)]
 pub struct PartialWriteResponse {
-    pub count: ssize_t,
+    pub count: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
 ::static_assert::assert_eq_size!(PartialWriteResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
 
 impl PartialWriteResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<ssize_t>();
+    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
-    fn new(count: ssize_t) -> Self {
+    fn new(count: i32) -> Self {
         Self {
             count,
             _padding: [0; Self::PADDING_SIZE],

--- a/src/libs/syscall/src/unistd/message/pwrite.rs
+++ b/src/libs/syscall/src/unistd/message/pwrite.rs
@@ -31,7 +31,7 @@ use sysapi::sys_types::ssize_t;
 #[repr(C, packed)]
 pub struct PartialWriteRequest {
     pub fd: i32,
-    pub count: size_t,
+    pub count: u32,
     pub offset: off_t,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
@@ -40,10 +40,10 @@ pub struct PartialWriteRequest {
 impl PartialWriteRequest {
     pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
         - mem::size_of::<i32>()
-        - mem::size_of::<i32>()
+        - mem::size_of::<u32>()
         - mem::size_of::<off_t>();
 
-    fn new(fd: i32, count: size_t, offset: off_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
+    fn new(fd: i32, count: u32, offset: off_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self {
             fd,
             count,

--- a/src/libs/syscall/src/unistd/message/read.rs
+++ b/src/libs/syscall/src/unistd/message/read.rs
@@ -27,16 +27,16 @@ use ::sysapi::sys_types::size_t;
 #[repr(C, packed)]
 pub struct ReadRequest {
     pub fd: i32,
-    pub count: size_t,
+    pub count: u32,
     _padding: [u8; Self::PADDING_SIZE],
 }
 ::static_assert::assert_eq_size!(ReadRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
 
 impl ReadRequest {
     pub const PADDING_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<i32>();
+        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u32>();
 
-    fn new(fd: i32, count: size_t) -> Self {
+    fn new(fd: i32, count: u32) -> Self {
         Self {
             fd,
             count,

--- a/src/libs/syscall/src/unistd/message/write.rs
+++ b/src/libs/syscall/src/unistd/message/write.rs
@@ -74,15 +74,15 @@ impl WriteRequest {
 #[derive(Debug)]
 #[repr(C, packed)]
 pub struct WriteResponse {
-    pub count: ssize_t,
+    pub count: i32,
     _padding: [u8; Self::PADDING_SIZE],
 }
 ::static_assert::assert_eq_size!(WriteResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
 
 impl WriteResponse {
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<ssize_t>();
+    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
-    fn new(count: ssize_t) -> Self {
+    fn new(count: i32) -> Self {
         Self {
             count,
             _padding: [0; Self::PADDING_SIZE],

--- a/src/libs/syscall/src/unistd/message/write.rs
+++ b/src/libs/syscall/src/unistd/message/write.rs
@@ -30,16 +30,16 @@ use ::sysapi::sys_types::{
 #[repr(C, packed)]
 pub struct WriteRequest {
     pub fd: i32,
-    pub count: size_t,
+    pub count: u32,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
 ::static_assert::assert_eq_size!(WriteRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
 
 impl WriteRequest {
     pub const BUFFER_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<size_t>();
+        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u32>();
 
-    fn new(fd: i32, count: size_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
+    fn new(fd: i32, count: u32, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self { fd, count, buffer }
     }
 


### PR DESCRIPTION
## Description

This pull request updates several system call message structures to replace the use of `size_t` and `ssize_t` types with `u32` and `i32`, respectively. These changes aim to standardize type usage and improve compatibility across the codebase. The updates affect request and response structures in multiple files.

### Type Standardization Changes:

* **Directory Entries (`getdents.rs`)**:
  - Replaced `size_t` with `u32` in `GetDirectoryEntriesRequest` for the `count` field and adjusted padding size calculations accordingly.

* **Socket Messages (`send.rs`)**:
  - Updated `SendSocketRequest` to use `u32` instead of `size_t` for the `count` field and modified padding size calculations. [[1]](diffhunk://#diff-4708fd6765001d5f29d9436f3dc3d6230bc79ac14289fd6a69d6537d53d876bbL33-R33) [[2]](diffhunk://#diff-4708fd6765001d5f29d9436f3dc3d6230bc79ac14289fd6a69d6537d53d876bbL42-R42)
  - Changed `SendSocketResponse` to use `i32` instead of `ssize_t` for the `count` field and adjusted padding size.

* **Partial Read (`pread.rs`)**:
  - Replaced `size_t` with `u32` in `PartialReadRequest` for the `count` field and updated padding size calculations. [[1]](diffhunk://#diff-3b0d5d660bb62014a3ba957ec25b3f53a2fded0779f5238bb10562ead52b5891L34-R34) [[2]](diffhunk://#diff-3b0d5d660bb62014a3ba957ec25b3f53a2fded0779f5238bb10562ead52b5891L43-R43)
  - Changed `PartialReadResponse` to use `i32` instead of `ssize_t` for the `count` field and adjusted buffer size calculations.

* **Partial Write (`pwrite.rs`)**:
  - Updated `PartialWriteRequest` to use `u32` instead of `size_t` for the `count` field and modified padding size calculations. [[1]](diffhunk://#diff-a61bf72bb4f7c719c98d6c790b14a0de4c769c6aac3f7ff449fa6400857f7bfdL34-R34) [[2]](diffhunk://#diff-a61bf72bb4f7c719c98d6c790b14a0de4c769c6aac3f7ff449fa6400857f7bfdL43-R43)
  - Changed `PartialWriteResponse` to use `i32` instead of `ssize_t` for the `count` field and adjusted padding size.

* **Read and Write (`read.rs` and `write.rs`)**:
  - Standardized `count` field in `ReadRequest` and `WriteRequest` to use `u32` instead of `size_t`, and updated padding or buffer size calculations. [[1]](diffhunk://#diff-e155d795d4f76dd7571f14e8d7844b32018b1ed2c43a6b62e4a3c4b21fa1833bL30-R37) [[2]](diffhunk://#diff-5e62da49fe588aea0539b4e3c1a72c190884df5ef8bf0e7e34add69bc58bd537L33-R40)
  - Updated `WriteResponse` to use `i32` instead of `ssize_t` for the `count` field and adjusted padding size.