### PR TITLE
[libs] Renaming libs `size_t` and `ssize_t`

### DIFF
--- a/src/benchmarks/echo-rust-nostd/src/main.rs
+++ b/src/benchmarks/echo-rust-nostd/src/main.rs
@@ -13,7 +13,7 @@ extern crate nvx;
 
 use ::sys::error::Error;
 use ::sysapi::{
-    sys_types::ssize_t,
+    sys_types::c_ssize_t,
     unistd::{
         STDIN_FILENO,
         STDOUT_FILENO,
@@ -39,13 +39,13 @@ pub fn main() -> Result<(), Error> {
     let mut n: usize = 0;
 
     loop {
-        let nread: ssize_t = match unistd::read(stdin, &mut buffer[n..]) {
+        let nread: c_ssize_t = match unistd::read(stdin, &mut buffer[n..]) {
             // Error encountered.
             Err(_error) => break,
             // End of file reached.
             Ok(0) => break,
             // Read some bytes.
-            Ok(n) => n as ssize_t,
+            Ok(n) => n as c_ssize_t,
         };
         n += nread as usize;
     }

--- a/src/benchmarks/echo-rust-server-nostd/src/main.rs
+++ b/src/benchmarks/echo-rust-server-nostd/src/main.rs
@@ -14,7 +14,7 @@ extern crate nvx;
 use ::sys::error::Error;
 use ::sysapi::{
     ffi::c_int,
-    sys_types::ssize_t,
+    sys_types::c_ssize_t,
     unistd::{
         STDIN_FILENO,
         STDOUT_FILENO,
@@ -44,13 +44,13 @@ pub fn main() -> Result<(), Error> {
 
         // Single echo loop where we read from STDIN until EOF.
         loop {
-            let nread: ssize_t = match unistd::read(stdin, &mut buffer[n..]) {
+            let nread: c_ssize_t = match unistd::read(stdin, &mut buffer[n..]) {
                 // Error encountered.
                 Err(_error) => break,
                 // End of file reached.
                 Ok(0) => break,
                 // Read some bytes.
-                Ok(n) => n as ssize_t,
+                Ok(n) => n as c_ssize_t,
             };
             n += nread as usize;
         }

--- a/src/benchmarks/echo-single-rust-nostd/src/main.rs
+++ b/src/benchmarks/echo-single-rust-nostd/src/main.rs
@@ -14,7 +14,7 @@ extern crate nvx;
 use ::sys::error::Error;
 use ::sysapi::{
     ffi::c_int,
-    sys_types::ssize_t,
+    sys_types::c_ssize_t,
     unistd::{
         STDIN_FILENO,
         STDOUT_FILENO,
@@ -39,11 +39,11 @@ pub fn main() -> Result<(), Error> {
     let mut buffer: [u8; MAX_REQUEST_SIZE] = [0; MAX_REQUEST_SIZE];
     let mut n: usize = 0;
 
-    let nread: ssize_t = match unistd::read(stdin, &mut buffer[n..]) {
+    let nread: c_ssize_t = match unistd::read(stdin, &mut buffer[n..]) {
         // Error encountered.
         Err(_error) => 0,
         // Read some bytes.
-        Ok(n) => n as ssize_t,
+        Ok(n) => n as c_ssize_t,
     };
     n += nread as usize;
 

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -49,7 +49,7 @@ use ::sys::{
     pm::ProcessIdentifier,
 };
 use ::sysapi::{
-    sys_types::ssize_t,
+    sys_types::c_ssize_t,
     unistd::{
         STDERR_FILENO,
         STDIN_FILENO,
@@ -648,7 +648,7 @@ impl<'a> LinuxDaemon<'a> {
                     print!("{string}");
                     let _ = io::stdout().lock().flush();
                 }
-                WriteResponse::build(source, count as ssize_t)
+                WriteResponse::build(source, count as c_ssize_t)
             }
         } else {
             // Write to other file descriptor.
@@ -711,7 +711,7 @@ impl<'a> LinuxDaemon<'a> {
                                 response_buf[..end - i].copy_from_slice(&message[i..end]);
                                 env.push_stdin_message(ReadResponse::build(
                                     source,
-                                    (end - i) as ssize_t,
+                                    (end - i) as c_ssize_t,
                                     response_buf,
                                 ));
                             }
@@ -728,7 +728,7 @@ impl<'a> LinuxDaemon<'a> {
                             [0u8; ReadResponse::BUFFER_SIZE],
                         ));
 
-                        ReadResponse::build(source, read_count as ssize_t, response_buf)
+                        ReadResponse::build(source, read_count as c_ssize_t, response_buf)
                     },
                     Err(e) => {
                         debug!("failed to read message from gateway (error={e:?})");
@@ -746,7 +746,7 @@ impl<'a> LinuxDaemon<'a> {
                         0
                     },
                 };
-                ReadResponse::build(source, count as ssize_t, buffer)
+                ReadResponse::build(source, count as c_ssize_t, buffer)
             }
         } else {
             // Read from other file descriptor.

--- a/src/daemons/linuxd/src/socket.rs
+++ b/src/daemons/linuxd/src/socket.rs
@@ -31,7 +31,7 @@ use ::sysapi::{
     },
     sys_types::{
         c_size_t,
-        ssize_t,
+        c_ssize_t,
     },
 };
 use ::syscall::{
@@ -420,7 +420,7 @@ pub fn do_send(pid: ProcessIdentifier, request: SendSocketRequest) -> Message {
     } {
         count if count >= 0 => {
             debug!("libc::send(): count={count:?}");
-            SendSocketResponse::build(pid, count as ssize_t)
+            SendSocketResponse::build(pid, count as c_ssize_t)
         },
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };

--- a/src/daemons/linuxd/src/socket.rs
+++ b/src/daemons/linuxd/src/socket.rs
@@ -30,7 +30,7 @@ use ::sysapi::{
         socklen_t,
     },
     sys_types::{
-        size_t,
+        c_size_t,
         ssize_t,
     },
 };
@@ -359,7 +359,7 @@ pub fn do_recv(pid: ProcessIdentifier, request: ReceiveSocketRequest) -> Message
     } {
         count if count >= 0 => {
             debug!("libc::recv(): count={count:?}");
-            ReceiveSocketResponse::build(pid, count as size_t, buffer)
+            ReceiveSocketResponse::build(pid, count as c_size_t, buffer)
         },
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -404,7 +404,7 @@ pub fn do_send(pid: ProcessIdentifier, request: SendSocketRequest) -> Message {
     trace!("send(): pid={pid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
-    let count: size_t = request.count;
+    let count: c_size_t = request.count;
     let flags: LibcMessageFlags = match LibcMessageFlags::try_from(request.flags) {
         Ok(flags) => flags,
         Err(e) => return crate::build_error(pid, e.code),

--- a/src/daemons/linuxd/src/unistd.rs
+++ b/src/daemons/linuxd/src/unistd.rs
@@ -23,8 +23,8 @@ use ::sysapi::{
     ffi::c_int,
     limits::PATH_MAX,
     sys_types::{
+        c_size_t,
         off_t,
-        size_t,
         ssize_t,
     },
     unistd::file_seek::{
@@ -344,7 +344,7 @@ pub fn do_write(pid: ProcessIdentifier, request: WriteRequest) -> Message {
     trace!("write(): pid={pid:?}, request={request:?}");
 
     // Check if count is invalid.
-    if request.count > WriteRequest::BUFFER_SIZE as size_t {
+    if request.count > WriteRequest::BUFFER_SIZE as c_size_t {
         return crate::build_error(pid, ErrorCode::InvalidArgument);
     }
     let fd: i32 = request.fd;
@@ -375,7 +375,7 @@ pub fn do_read(pid: ProcessIdentifier, request: ReadRequest) -> Message {
     trace!("read(): pid={pid:?}, request={request:?}");
 
     // Check if count is invalid.
-    if request.count > ReadResponse::BUFFER_SIZE as size_t {
+    if request.count > ReadResponse::BUFFER_SIZE as c_size_t {
         return crate::build_error(pid, ErrorCode::InvalidArgument);
     }
     let fd: i32 = request.fd;
@@ -406,7 +406,7 @@ pub fn do_pwrite(pid: ProcessIdentifier, request: PartialWriteRequest) -> Messag
     trace!("pwrite(): pid={pid:?}, request={request:?}");
 
     // Check if count is invalid.
-    if request.count > PartialWriteRequest::BUFFER_SIZE as size_t {
+    if request.count > PartialWriteRequest::BUFFER_SIZE as c_size_t {
         return crate::build_error(pid, ErrorCode::InvalidArgument);
     }
     let fd: i32 = request.fd;
@@ -438,7 +438,7 @@ pub fn do_pread(pid: ProcessIdentifier, request: PartialReadRequest) -> Message 
     trace!("pread(): pid={pid:?}, request={request:?}");
 
     // Check if count is invalid.
-    if request.count > PartialReadResponse::BUFFER_SIZE as size_t {
+    if request.count > PartialReadResponse::BUFFER_SIZE as c_size_t {
         return crate::build_error(pid, ErrorCode::InvalidArgument);
     }
     let fd: i32 = request.fd;

--- a/src/daemons/linuxd/src/unistd.rs
+++ b/src/daemons/linuxd/src/unistd.rs
@@ -25,7 +25,7 @@ use ::sysapi::{
     sys_types::{
         c_size_t,
         off_t,
-        ssize_t,
+        c_ssize_t,
     },
     unistd::file_seek::{
         SEEK_CUR,
@@ -417,7 +417,7 @@ pub fn do_pwrite(pid: ProcessIdentifier, request: PartialWriteRequest) -> Messag
 
     debug!("libc::pwrite(): fd={fd:?}, count={count:?}, offset={offset:?}, buffer={buffer:?}",);
     match unsafe { libc::pwrite(fd, buffer.as_ptr() as *const _, count, offset) } {
-        ret if ret >= 0 => PartialWriteResponse::build(pid, ret as ssize_t),
+        ret if ret >= 0 => PartialWriteResponse::build(pid, ret as c_ssize_t),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::pwrite(): errno={errno:?}");
@@ -449,7 +449,7 @@ pub fn do_pread(pid: ProcessIdentifier, request: PartialReadRequest) -> Message 
 
     debug!("libc::pread(): fd={fd:?}, count={count:?}, offset={offset:?}, buffer={buffer:?}",);
     match unsafe { libc::pread(fd, buffer.as_mut_ptr() as *mut _, count, offset) } {
-        ret if ret >= 0 => PartialReadResponse::build(pid, ret as ssize_t, buffer),
+        ret if ret >= 0 => PartialReadResponse::build(pid, ret as c_ssize_t, buffer),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::pread(): errno={errno:?}");

--- a/src/libs/posix/src/netdb.rs
+++ b/src/libs/posix/src/netdb.rs
@@ -14,7 +14,7 @@ use ::sysapi::{
     },
     netdb::addrinfo,
     sys_socket::socklen_t,
-    sys_types::size_t,
+    sys_types::c_size_t,
 };
 
 //==================================================================================================
@@ -112,7 +112,7 @@ pub unsafe extern "C" fn getaddrinfo(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn gethostbyaddr(
     addr: *const c_void,
-    len: size_t,
+    len: c_size_t,
     type_: c_int,
 ) -> *mut c_void {
     ::syslog::trace!("gethostbyaddr(): addr={addr:?}, len={len:?}, type_={type_:?}");

--- a/src/libs/posix/src/pthread/mod.rs
+++ b/src/libs/posix/src/pthread/mod.rs
@@ -16,10 +16,10 @@ use ::sysapi::{
     },
     sched::sched_param,
     sys_types::{
+        c_size_t,
         pthread_attr_t,
         pthread_once_t,
         pthread_t,
-        size_t,
     },
 };
 use ::syscall::pthread::{
@@ -165,7 +165,7 @@ pub unsafe extern "C" fn pthread_attr_getdetachstate(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pthread_attr_getguardsize(
     attr: *const pthread_attr_t,
-    guardsize: *mut size_t,
+    guardsize: *mut c_size_t,
 ) -> c_int {
     ::syslog::trace!("pthread_attr_getguardsize(): attr={:?}, guardsize={:?}", attr, guardsize);
 
@@ -321,7 +321,7 @@ pub unsafe extern "C" fn pthread_attr_getstackaddr(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pthread_attr_getstacksize(
     attr: *const pthread_attr_t,
-    stacksize: *mut size_t,
+    stacksize: *mut c_size_t,
 ) -> c_int {
     ::syslog::trace!("pthread_attr_getstacksize(): attr={:?}, stacksize={:?}", attr, stacksize);
 
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn pthread_attr_getstacksize(
 pub unsafe extern "C" fn pthread_attr_getstack(
     attr: *const pthread_attr_t,
     stackaddr: *mut *mut c_void,
-    stacksize: *mut size_t,
+    stacksize: *mut c_size_t,
 ) -> c_int {
     ::syslog::trace!(
         "pthread_attr_getstack(): attr={:?}, stackaddr={:?}, stacksize={:?}",
@@ -763,7 +763,7 @@ pub unsafe extern "C" fn pthread_attr_setdetachstate(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pthread_attr_setguardsize(
     attr: *mut pthread_attr_t,
-    guardsize: size_t,
+    guardsize: c_size_t,
 ) -> c_int {
     ::syslog::trace!("pthread_attr_setguardsize(): attr={:?}, guardsize={:?}", attr, guardsize);
 
@@ -860,7 +860,7 @@ pub unsafe extern "C" fn pthread_attr_setschedparam(
 pub unsafe extern "C" fn pthread_attr_setstack(
     attr: *mut pthread_attr_t,
     stackaddr: *mut c_void,
-    stacksize: size_t,
+    stacksize: c_size_t,
 ) -> c_int {
     ::syslog::trace!(
         "pthread_attr_setstack(): attr={:?}, stackaddr={:?}, stacksize={:?}",
@@ -953,7 +953,7 @@ pub unsafe extern "C" fn pthread_attr_setstackaddr(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pthread_attr_setstacksize(
     attr: *mut pthread_attr_t,
-    stacksize: size_t,
+    stacksize: c_size_t,
 ) -> c_int {
     ::syslog::trace!("pthread_attr_setstacksize(): attr={:?}, stacksize={:?}", attr, stacksize);
 

--- a/src/libs/posix/src/sys/socket/mod.rs
+++ b/src/libs/posix/src/sys/socket/mod.rs
@@ -32,7 +32,7 @@ use sysapi::{
     sys_types::{
         msghdr,
         c_size_t,
-        ssize_t,
+        c_ssize_t,
     },
 };
 
@@ -342,7 +342,7 @@ pub unsafe extern "C" fn recv(
     buf: *mut c_void,
     len: c_size_t,
     flags: c_int,
-) -> ssize_t {
+) -> c_ssize_t {
     // Check if `buf` is valid.
     if buf.is_null() {
         ::syslog::error!("recv(): invalid buffer");
@@ -368,7 +368,7 @@ pub unsafe extern "C" fn recv(
     let buf: &mut [u8] = unsafe { slice::from_raw_parts_mut(buf as *mut u8, len as usize) };
 
     match socket::syscall::recv(sockfd, buf, flags) {
-        Ok(bytes_received) => bytes_received as ssize_t,
+        Ok(bytes_received) => bytes_received as c_ssize_t,
         Err(e) => {
             ::syslog::error!("recv(): failed to receive data through socket {:?}", e);
             *__errno_location() = e.code.get();
@@ -413,7 +413,7 @@ pub unsafe extern "C" fn recvfrom(
     flags: c_int,
     sockaddr: *mut sockaddr,
     addrlen: *mut socklen_t,
-) -> ssize_t {
+) -> c_ssize_t {
     ::syslog::trace!(
         "recvfrom(): sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?}, \
          sockaddr={sockaddr:?}, addrlen={addrlen:?}"
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn recvfrom(
 /// - `msg` points to a valid `msghdr` structure.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn recvmsg(sockfd: c_int, msg: *mut msghdr, flags: c_int) -> ssize_t {
+pub unsafe extern "C" fn recvmsg(sockfd: c_int, msg: *mut msghdr, flags: c_int) -> c_ssize_t {
     ::syslog::trace!("recvmsg(): sockfd={sockfd:?}, msg={msg:?}, flags={flags:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/600
     ::syslog::error!("recvmsg(): not implemented");
@@ -464,7 +464,7 @@ pub unsafe extern "C" fn send(
     buf: *const c_void,
     len: c_size_t,
     flags: c_int,
-) -> ssize_t {
+) -> c_ssize_t {
     // Check if `buf` is valid.
     if buf.is_null() {
         ::syslog::error!("send(): invalid buffer");
@@ -490,7 +490,7 @@ pub unsafe extern "C" fn send(
     let buf: &[u8] = unsafe { slice::from_raw_parts(buf as *const u8, len as usize) };
 
     match socket::syscall::send(sockfd, buf, flags) {
-        Ok(bytes_sent) => bytes_sent as ssize_t,
+        Ok(bytes_sent) => bytes_sent as c_ssize_t,
         Err(e) => {
             ::syslog::error!("send(): failed to send data through socket {:?}", e);
             *__errno_location() = e.code.get();
@@ -523,7 +523,7 @@ pub unsafe extern "C" fn send(
 /// - `msg` points to a valid `msghdr` structure.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sendmsg(sockfd: c_int, msg: *const msghdr, flags: c_int) -> ssize_t {
+pub unsafe extern "C" fn sendmsg(sockfd: c_int, msg: *const msghdr, flags: c_int) -> c_ssize_t {
     ::syslog::trace!("sendmsg(): sockfd={sockfd:?}, msg={msg:?}, flags={flags:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/599.
     ::syslog::error!("sendmsg(): not implemented");
@@ -568,7 +568,7 @@ pub unsafe extern "C" fn sendto(
     flags: c_int,
     sockaddr: *const sockaddr,
     addrlen: socklen_t,
-) -> ssize_t {
+) -> c_ssize_t {
     ::syslog::trace!(
         "sendto(): sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?}, \
          sockaddr={sockaddr:?}, addrlen={addrlen:?}"

--- a/src/libs/posix/src/sys/socket/mod.rs
+++ b/src/libs/posix/src/sys/socket/mod.rs
@@ -31,7 +31,7 @@ use sysapi::{
     },
     sys_types::{
         msghdr,
-        size_t,
+        c_size_t,
         ssize_t,
     },
 };
@@ -340,7 +340,7 @@ pub unsafe extern "C" fn listen(sockfd: c_int, backlog: c_int) -> c_int {
 pub unsafe extern "C" fn recv(
     sockfd: c_int,
     buf: *mut c_void,
-    len: size_t,
+    len: c_size_t,
     flags: c_int,
 ) -> ssize_t {
     // Check if `buf` is valid.
@@ -409,7 +409,7 @@ pub unsafe extern "C" fn recv(
 pub unsafe extern "C" fn recvfrom(
     sockfd: c_int,
     buf: *mut c_void,
-    len: size_t,
+    len: c_size_t,
     flags: c_int,
     sockaddr: *mut sockaddr,
     addrlen: *mut socklen_t,
@@ -462,7 +462,7 @@ pub unsafe extern "C" fn recvmsg(sockfd: c_int, msg: *mut msghdr, flags: c_int) 
 pub unsafe extern "C" fn send(
     sockfd: c_int,
     buf: *const c_void,
-    len: size_t,
+    len: c_size_t,
     flags: c_int,
 ) -> ssize_t {
     // Check if `buf` is valid.
@@ -564,7 +564,7 @@ pub unsafe extern "C" fn sendmsg(sockfd: c_int, msg: *const msghdr, flags: c_int
 pub unsafe extern "C" fn sendto(
     sockfd: c_int,
     buf: *const c_void,
-    len: size_t,
+    len: c_size_t,
     flags: c_int,
     sockaddr: *const sockaddr,
     addrlen: socklen_t,

--- a/src/libs/posix/src/sys/uio/mod.rs
+++ b/src/libs/posix/src/sys/uio/mod.rs
@@ -18,7 +18,7 @@ use sysapi::{
     sys_types::{
         off_t,
         c_size_t,
-        ssize_t,
+        c_ssize_t,
     },
     sys_uio::iovec,
 };
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn pwritev(
     iov: *const iovec,
     iovcnt: c_int,
     offset: off_t,
-) -> ssize_t {
+) -> c_ssize_t {
     ::syslog::trace!("pwritev(): fd={fd}, iov={iov:?}, iovcnt={iovcnt}, offset={offset}");
 
     // Check if number of elements in the vector is valid.
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn pwritev(
         Ok(_count) => {
             match do_writev(false) {
                 // Real write was successful.
-                Ok(count) => count as ssize_t,
+                Ok(count) => count as c_ssize_t,
                 // Real write failed.
                 Err(error) => {
                     ::syslog::error!("pwritev(): write failed (errno={:?})", error);
@@ -187,7 +187,7 @@ pub unsafe extern "C" fn pwritev(
 /// // - This function is called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn preadv(fd: i32, iov: *const iovec, iovcnt: i32, offset: off_t) -> ssize_t {
+pub unsafe extern "C" fn preadv(fd: i32, iov: *const iovec, iovcnt: i32, offset: off_t) -> c_ssize_t {
     ::syslog::trace!("preadv(): fd={fd}, iov={iov:?}, iovcnt={iovcnt}, offset={offset}");
 
     // Check if number of elements in the vector is valid.
@@ -261,7 +261,7 @@ pub unsafe extern "C" fn preadv(fd: i32, iov: *const iovec, iovcnt: i32, offset:
         Ok(_count) => {
             // Perform the actual read.
             match do_preadv(false) {
-                Ok(count) => count as ssize_t,
+                Ok(count) => count as c_ssize_t,
                 Err(error) => {
                     ::syslog::error!("preadv(): read failed (errno={:?})", error);
                     *__errno_location() = error.code.get();
@@ -305,7 +305,7 @@ pub unsafe extern "C" fn preadv(fd: i32, iov: *const iovec, iovcnt: i32, offset:
 /// - This function is called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> ssize_t {
+pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssize_t {
     ::syslog::trace!("readv(): fd={fd}, iov={iov:?}, iovcnt={iovcnt}");
 
     // Check if number of elements in the vector is valid.
@@ -373,7 +373,7 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> ssize
         Ok(_count) => {
             // Perform the actual read.
             match do_readv(false) {
-                Ok(count) => count as ssize_t,
+                Ok(count) => count as c_ssize_t,
                 Err(error) => {
                     ::syslog::error!("readv(): read failed (errno={:?})", error);
                     *__errno_location() = error.code.get();
@@ -417,7 +417,7 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> ssize
 /// - This function is called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> ssize_t {
+pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> c_ssize_t {
     ::syslog::trace!("writev(): fd={fd}, iov={iov:?}, iovcnt={iovcnt}");
 
     // Check if number of elements in the vector is valid.
@@ -494,7 +494,7 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
         Ok(_count) => {
             match do_writev(false) {
                 // Real write was successful.
-                Ok(count) => count as ssize_t,
+                Ok(count) => count as c_ssize_t,
                 // Real write failed.
                 Err(error) => {
                     ::syslog::error!("writev(): write failed (errno={:?})", error);

--- a/src/libs/posix/src/sys/uio/mod.rs
+++ b/src/libs/posix/src/sys/uio/mod.rs
@@ -17,7 +17,7 @@ use sysapi::{
     limits::IOV_MAX,
     sys_types::{
         off_t,
-        size_t,
+        c_size_t,
         ssize_t,
     },
     sys_uio::iovec,
@@ -82,9 +82,9 @@ pub unsafe extern "C" fn pwritev(
         return 0;
     }
 
-    let do_writev = |dry_run: bool| -> Result<size_t, Error> {
+    let do_writev = |dry_run: bool| -> Result<c_size_t, Error> {
         let mut offset: off_t = offset;
-        let mut total: size_t = 0;
+        let mut total: c_size_t = 0;
 
         // Traverse i/o vector.
         for i in 0..iovcnt {
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn pwritev(
             }
 
             let iov_base: *mut u8 = unsafe { (*iov).iov_base };
-            let iov_len: size_t = unsafe { (*iov).iov_len };
+            let iov_len: c_size_t = unsafe { (*iov).iov_len };
 
             // Check if `iov_base` is invalid.
             if iov_base.is_null() {
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn pwritev(
                     },
                 }
             } else {
-                iov_len as size_t
+                iov_len as c_size_t
             };
         }
 
@@ -209,9 +209,9 @@ pub unsafe extern "C" fn preadv(fd: i32, iov: *const iovec, iovcnt: i32, offset:
         return 0;
     }
 
-    let do_preadv = |dry_run: bool| -> Result<size_t, Error> {
+    let do_preadv = |dry_run: bool| -> Result<c_size_t, Error> {
         let mut offset: off_t = offset;
-        let mut total: size_t = 0;
+        let mut total: c_size_t = 0;
 
         // Traverse i/o vector.
         for i in 0..iovcnt {
@@ -224,7 +224,7 @@ pub unsafe extern "C" fn preadv(fd: i32, iov: *const iovec, iovcnt: i32, offset:
             }
 
             let iov_base: *mut u8 = unsafe { (*iov).iov_base };
-            let iov_len: size_t = unsafe { (*iov).iov_len };
+            let iov_len: c_size_t = unsafe { (*iov).iov_len };
 
             // Check if base address is invalid.
             if iov_base.is_null() {
@@ -240,7 +240,7 @@ pub unsafe extern "C" fn preadv(fd: i32, iov: *const iovec, iovcnt: i32, offset:
                 match unistd::pread(fd, buffer, offset) {
                     Ok(count) => {
                         offset += count as off_t;
-                        count as size_t
+                        count as c_size_t
                     },
                     Err(error) => {
                         ::syslog::error!("preadv(): read failed (errno={:?})", error);
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn preadv(fd: i32, iov: *const iovec, iovcnt: i32, offset:
                     },
                 }
             } else {
-                iov_len as size_t
+                iov_len as c_size_t
             };
         }
 
@@ -327,8 +327,8 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> ssize
         return 0;
     }
 
-    let do_readv = |dry_run: bool| -> Result<size_t, Error> {
-        let mut total: size_t = 0;
+    let do_readv = |dry_run: bool| -> Result<c_size_t, Error> {
+        let mut total: c_size_t = 0;
 
         // Traverse i/o vector.
         for i in 0..iovcnt {
@@ -341,7 +341,7 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> ssize
             }
 
             let iov_base: *mut u8 = unsafe { (*iov).iov_base };
-            let iov_len: size_t = unsafe { (*iov).iov_len };
+            let iov_len: c_size_t = unsafe { (*iov).iov_len };
 
             // Check if base address is invalid.
             if iov_base.is_null() {
@@ -361,7 +361,7 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> ssize
                     },
                 }
             } else {
-                iov_len as size_t
+                iov_len as c_size_t
             }
         }
 
@@ -439,8 +439,8 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
         return 0;
     }
 
-    let do_writev = |dry_run: bool| -> Result<size_t, Error> {
-        let mut total: size_t = 0;
+    let do_writev = |dry_run: bool| -> Result<c_size_t, Error> {
+        let mut total: c_size_t = 0;
 
         // Traverse i/o vector.
         for i in 0..iovcnt {
@@ -453,7 +453,7 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
             }
 
             let iov_base: *mut u8 = unsafe { (*iov).iov_base };
-            let iov_len: size_t = unsafe { (*iov).iov_len };
+            let iov_len: c_size_t = unsafe { (*iov).iov_len };
 
             // Check if `iov_base` is invalid.
             if iov_base.is_null() {
@@ -481,7 +481,7 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
                     },
                 }
             } else {
-                iov_len as size_t
+                iov_len as c_size_t
             };
         }
 

--- a/src/libs/posix/src/unistd/mod.rs
+++ b/src/libs/posix/src/unistd/mod.rs
@@ -34,10 +34,10 @@ use ::sysapi::{
     },
     sys_types::{
         c_size_t,
+        c_ssize_t,
         gid_t,
         off_t,
         pid_t,
-        ssize_t,
         uid_t,
     },
     unistd::{
@@ -1187,7 +1187,7 @@ pub unsafe extern "C" fn pread(
     buffer: *mut c_void,
     count: c_size_t,
     offset: off_t,
-) -> ssize_t {
+) -> c_ssize_t {
     ::syslog::trace!(
         "pread(): fd={}, buffer={:?}, count={:?}, offset={:?}",
         fd,
@@ -1219,7 +1219,7 @@ pub unsafe extern "C" fn pread(
 
     // Attempt to read from the file descriptor and check for errors.
     match ::syscall::unistd::pread(fd, buffer, offset) {
-        Ok(bytes_read) => bytes_read as ssize_t,
+        Ok(bytes_read) => bytes_read as c_ssize_t,
         Err(error) => {
             ::syslog::error!(
                 "pread(): failed (fd={}, buffer={:?}, count={:?}, offset={:?}, error={:?})",
@@ -1268,7 +1268,7 @@ pub unsafe extern "C" fn pwrite(
     buffer: *const c_void,
     count: c_size_t,
     offset: off_t,
-) -> ssize_t {
+) -> c_ssize_t {
     ::syslog::trace!(
         "pwrite(): fd={}, buffer={:?}, count={:?}, offset={:?}",
         fd,
@@ -1308,7 +1308,7 @@ pub unsafe extern "C" fn pwrite(
 
     // Attempt to write to the file descriptor and check for errors.
     match ::syscall::unistd::pwrite(fd, buffer, offset) {
-        Ok(bytes_written) => bytes_written as ssize_t,
+        Ok(bytes_written) => bytes_written as c_ssize_t,
         Err(error) => {
             ::syslog::error!(
                 "pwrite(): failed (fd={}, buffer={:?}, count={:?}, offset={:?}, error={:?})",
@@ -1351,7 +1351,7 @@ pub unsafe extern "C" fn pwrite(
 /// - This function is not called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn read(fd: c_int, buffer: *mut c_void, count: c_size_t) -> ssize_t {
+pub unsafe extern "C" fn read(fd: c_int, buffer: *mut c_void, count: c_size_t) -> c_ssize_t {
     // Skip logging for stdin to avoid spamming the output.
     if fd != STDIN_FILENO {
         ::syslog::trace!("read(): fd={:?}, buffer={:?}, count={:?}", fd, buffer, count);
@@ -1380,7 +1380,7 @@ pub unsafe extern "C" fn read(fd: c_int, buffer: *mut c_void, count: c_size_t) -
 
     // Attempt to read from the file descriptor and check for errors.
     match ::syscall::unistd::read(fd, buffer) {
-        Ok(bytes_read) => bytes_read as ssize_t,
+        Ok(bytes_read) => bytes_read as c_ssize_t,
         Err(error) => {
             ::syslog::error!(
                 "read(): failed (fd={}, buffer={:?}, count={:?}, error={:?})",
@@ -1426,7 +1426,7 @@ pub unsafe extern "C" fn readlinkat(
     path: *const c_char,
     buf: *mut c_char,
     bufsize: c_size_t,
-) -> ssize_t {
+) -> c_ssize_t {
     ::syslog::trace!(
         "readlinkat(): dirfd={:?}, path={:?}, buf={:?}, bufsize={:?}",
         dirfd,
@@ -1523,7 +1523,7 @@ pub unsafe extern "C" fn readlink(
     path: *const c_char,
     buf: *mut c_char,
     bufsize: c_size_t,
-) -> ssize_t {
+) -> c_ssize_t {
     ::syslog::trace!("readlink(): path={:?}, buf={:?}, bufsize={:?}", path, buf, bufsize);
     readlinkat(AT_FDCWD, path, buf, bufsize)
 }
@@ -1952,7 +1952,7 @@ pub unsafe extern "C" fn waitpid(pid: pid_t, status: *mut c_int, options: c_int)
 /// The function has undefined behavior if the `buffer` points to an invalid memory location.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn write(fd: c_int, buffer: *const c_void, count: c_size_t) -> ssize_t {
+pub unsafe extern "C" fn write(fd: c_int, buffer: *const c_void, count: c_size_t) -> c_ssize_t {
     // Skip logging for stdout and stderr to avoid spamming the output.
     if fd != STDOUT_FILENO && fd != STDERR_FILENO {
         ::syslog::trace!("write(): fd = {}, buffer = {:?}, count = {}", fd, buffer, count);
@@ -1977,7 +1977,7 @@ pub unsafe extern "C" fn write(fd: c_int, buffer: *const c_void, count: c_size_t
 
     // Attempt to write to file descriptor and check for errors.
     match ::syscall::unistd::write(fd, buffer) {
-        Ok(bytes_written) => bytes_written as ssize_t,
+        Ok(bytes_written) => bytes_written as c_ssize_t,
         Err(error) => {
             ::syslog::error!("write(): failed (error={:?})", error);
             *__errno_location() = error.code.get();

--- a/src/libs/posix/src/unistd/mod.rs
+++ b/src/libs/posix/src/unistd/mod.rs
@@ -33,10 +33,10 @@ use ::sysapi::{
         PATH_MAX,
     },
     sys_types::{
+        c_size_t,
         gid_t,
         off_t,
         pid_t,
-        size_t,
         ssize_t,
         uid_t,
     },
@@ -632,7 +632,7 @@ pub unsafe extern "C" fn ftruncate(fd: c_int, length: off_t) -> c_int {
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn getcwd(buf: *mut c_char, size: size_t) -> *mut c_char {
+pub unsafe extern "C" fn getcwd(buf: *mut c_char, size: c_size_t) -> *mut c_char {
     ::syslog::trace!("getcwd(): buf = {:?}, size = {}", buf, size);
 
     // Check if the buffer is valid.
@@ -780,7 +780,7 @@ pub unsafe extern "C" fn getgid() -> gid_t {
 /// The function has undefined behavior if the `path` points to an invalid memory location.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn getentropy(_buffer: *mut c_void, _length: size_t) -> c_int {
+pub unsafe extern "C" fn getentropy(_buffer: *mut c_void, _length: c_size_t) -> c_int {
     ::syslog::trace!("getentropy(): buffer = {:?}, length = {}", _buffer, _length);
 
     // Fill buffer with 1s.
@@ -862,7 +862,7 @@ pub unsafe extern "C" fn getuid() -> uid_t {
 /// - `namelen` is a valid size.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn gethostname(name: *mut c_char, namelen: size_t) -> c_int {
+pub unsafe extern "C" fn gethostname(name: *mut c_char, namelen: c_size_t) -> c_int {
     ::syslog::trace!("gethostname(): name={:?}, namelen={}", name, namelen);
 
     // Check if the buffer is valid.
@@ -1185,7 +1185,7 @@ pub extern "C" fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t {
 pub unsafe extern "C" fn pread(
     fd: c_int,
     buffer: *mut c_void,
-    count: size_t,
+    count: c_size_t,
     offset: off_t,
 ) -> ssize_t {
     ::syslog::trace!(
@@ -1266,7 +1266,7 @@ pub unsafe extern "C" fn pread(
 pub unsafe extern "C" fn pwrite(
     fd: c_int,
     buffer: *const c_void,
-    count: size_t,
+    count: c_size_t,
     offset: off_t,
 ) -> ssize_t {
     ::syslog::trace!(
@@ -1351,7 +1351,7 @@ pub unsafe extern "C" fn pwrite(
 /// - This function is not called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn read(fd: c_int, buffer: *mut c_void, count: size_t) -> ssize_t {
+pub unsafe extern "C" fn read(fd: c_int, buffer: *mut c_void, count: c_size_t) -> ssize_t {
     // Skip logging for stdin to avoid spamming the output.
     if fd != STDIN_FILENO {
         ::syslog::trace!("read(): fd={:?}, buffer={:?}, count={:?}", fd, buffer, count);
@@ -1425,7 +1425,7 @@ pub unsafe extern "C" fn readlinkat(
     dirfd: c_int,
     path: *const c_char,
     buf: *mut c_char,
-    bufsize: size_t,
+    bufsize: c_size_t,
 ) -> ssize_t {
     ::syslog::trace!(
         "readlinkat(): dirfd={:?}, path={:?}, buf={:?}, bufsize={:?}",
@@ -1522,7 +1522,7 @@ pub unsafe extern "C" fn rmdir(_path: *const c_char) -> c_int {
 pub unsafe extern "C" fn readlink(
     path: *const c_char,
     buf: *mut c_char,
-    bufsize: size_t,
+    bufsize: c_size_t,
 ) -> ssize_t {
     ::syslog::trace!("readlink(): path={:?}, buf={:?}, bufsize={:?}", path, buf, bufsize);
     readlinkat(AT_FDCWD, path, buf, bufsize)
@@ -1530,7 +1530,7 @@ pub unsafe extern "C" fn readlink(
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
-pub extern "C" fn setgroups(_size: size_t, _list: *const gid_t) -> c_int {
+pub extern "C" fn setgroups(_size: c_size_t, _list: *const gid_t) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/523
     ::syslog::error!("setgroups(): not implemented");
     unsafe {
@@ -1952,7 +1952,7 @@ pub unsafe extern "C" fn waitpid(pid: pid_t, status: *mut c_int, options: c_int)
 /// The function has undefined behavior if the `buffer` points to an invalid memory location.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn write(fd: c_int, buffer: *const c_void, count: size_t) -> ssize_t {
+pub unsafe extern "C" fn write(fd: c_int, buffer: *const c_void, count: c_size_t) -> ssize_t {
     // Skip logging for stdout and stderr to avoid spamming the output.
     if fd != STDOUT_FILENO && fd != STDERR_FILENO {
         ::syslog::trace!("write(): fd = {}, buffer = {:?}, count = {}", fd, buffer, count);

--- a/src/libs/sysapi/src/limits.rs
+++ b/src/libs/sysapi/src/limits.rs
@@ -5,7 +5,7 @@
 // Imports
 //==================================================================================================
 
-use crate::sys_types::ssize_t;
+use crate::sys_types::c_ssize_t;
 
 //==================================================================================================
 // Constants
@@ -49,7 +49,7 @@ pub const POSIX_PATH_MAX: usize = 256;
 pub const XOPEN_PATH_MAX: usize = 1024;
 
 /// Maximum value for an object of type [`crate::sys::types::ssize_t`].
-pub const SSIZE_MAX: ssize_t = ssize_t::MAX;
+pub const SSIZE_MAX: c_ssize_t = c_ssize_t::MAX;
 
 /// Maximum number of data keys that can be created by a process.
 pub const PTHREAD_KEYS_MAX: usize = _POSIX_THREAD_KEYS_MAX;

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -89,8 +89,14 @@ pub type reclen_t = c_ushort;
 /// Used for object sizes.
 pub type c_size_t = c_uint;
 
+/// Used for object sizes (architecture dependent).
+pub type size_t = usize;
+
 /// Used for a count of bytes or an error indication.
 pub type c_ssize_t = c_int;
+
+/// Used for a count of bytes or an error indication (architecture dependent).
+pub type ssize_t = isize;
 
 /// Used for time in microseconds.
 pub type suseconds_t = c_long;

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -87,7 +87,7 @@ pub type pthread_rwlock_t = u32;
 pub type reclen_t = c_ushort;
 
 /// Used for object sizes.
-pub type size_t = c_uint;
+pub type c_size_t = c_uint;
 
 /// Used for a count of bytes or an error indication.
 pub type ssize_t = c_int;
@@ -111,7 +111,7 @@ pub type uid_t = c_uint;
 pub struct pthread_attr_t {
     pub is_initialized: c_int,
     pub stackaddr: *mut c_void,
-    pub stacksize: size_t,
+    pub stacksize: c_size_t,
     pub contentionscope: c_int,
     pub inheritsched: c_int,
     pub schedpolicy: c_int,
@@ -127,7 +127,7 @@ impl pthread_attr_t {
     /// Size of the `stackaddr` field.
     const SIZE_OF_STACKADDR: usize = size_of::<*mut c_void>();
     /// Size of the `stacksize` field.
-    const SIZE_OF_STACKSIZE: usize = size_of::<size_t>();
+    const SIZE_OF_STACKSIZE: usize = size_of::<c_size_t>();
     /// Size of the `contentionscope` field.
     const SIZE_OF_CONTENTIONSCOPE: usize = size_of::<c_int>();
     /// Size of the `inheritsched` field.

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -90,7 +90,7 @@ pub type reclen_t = c_ushort;
 pub type c_size_t = c_uint;
 
 /// Used for a count of bytes or an error indication.
-pub type ssize_t = c_int;
+pub type c_ssize_t = c_int;
 
 /// Used for time in microseconds.
 pub type suseconds_t = c_long;

--- a/src/libs/sysapi/src/sys_uio.rs
+++ b/src/libs/sysapi/src/sys_uio.rs
@@ -11,7 +11,7 @@
 // Imports
 //==================================================================================================
 
-use crate::sys_types::size_t;
+use crate::sys_types::c_size_t;
 
 //==================================================================================================
 
@@ -20,5 +20,5 @@ pub struct iovec {
     /// Base address of a memory region for input or output.
     pub iov_base: *mut u8,
     /// The size of the memory pointer to by `iov_base`.
-    pub iov_len: size_t,
+    pub iov_len: c_size_t,
 }

--- a/src/libs/syscall/src/dirent/message/getdents.rs
+++ b/src/libs/syscall/src/dirent/message/getdents.rs
@@ -36,9 +36,9 @@ use ::sysapi::{
         c_uchar,
     },
     sys_types::{
+        c_size_t,
         ino_t,
         reclen_t,
-        size_t,
     },
 };
 
@@ -80,7 +80,7 @@ impl GetDirectoryEntriesRequest {
 
         Ok(Self {
             fd,
-            count: count as size_t,
+            count: count as c_size_t,
             _padding: [0; Self::PADDING_SIZE],
         })
     }

--- a/src/libs/syscall/src/safe/fs/mod.rs
+++ b/src/libs/syscall/src/safe/fs/mod.rs
@@ -57,7 +57,7 @@ use sysapi::{
     sys_stat,
     sys_types::{
         mode_t,
-        ssize_t,
+        c_ssize_t,
     },
 };
 
@@ -349,7 +349,7 @@ pub fn open(
 pub fn readlink(path: &FileSystemPath) -> Result<FileSystemPath, Error> {
     let mut buf: Vec<u8> = Vec::with_capacity(PATH_MAX);
 
-    let num_bytes_read: ssize_t = unistd::readlink(path.as_str(), &mut buf)?;
+    let num_bytes_read: c_ssize_t = unistd::readlink(path.as_str(), &mut buf)?;
 
     let num_bytes_read: usize = match num_bytes_read.try_into() {
         Ok(n) => n,

--- a/src/libs/syscall/src/sys/socket/message/recv.rs
+++ b/src/libs/syscall/src/sys/socket/message/recv.rs
@@ -17,7 +17,7 @@ use ::sys::{
     },
     pm::ProcessIdentifier,
 };
-use ::sysapi::sys_types::size_t;
+use ::sysapi::sys_types::c_size_t;
 
 //==================================================================================================
 // ReceiveSocketRequest
@@ -75,15 +75,15 @@ impl ReceiveSocketRequest {
 #[derive(Debug)]
 #[repr(C, packed)]
 pub struct ReceiveSocketResponse {
-    pub count: size_t,
+    pub count: c_size_t,
     pub buffer: [u8; Self::BUFFER_SIZE],
 }
 ::static_assert::assert_eq_size!(ReceiveSocketResponse, LinuxDaemonMessage::PAYLOAD_SIZE);
 
 impl ReceiveSocketResponse {
-    pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<size_t>();
+    pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<c_size_t>();
 
-    pub fn new(count: size_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
+    pub fn new(count: c_size_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self { count, buffer }
     }
 
@@ -97,7 +97,7 @@ impl ReceiveSocketResponse {
 
     pub fn build(
         pid: ProcessIdentifier,
-        count: size_t,
+        count: c_size_t,
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {
         let message: ReceiveSocketResponse = ReceiveSocketResponse::new(count, buffer);

--- a/src/libs/syscall/src/sys/socket/message/send.rs
+++ b/src/libs/syscall/src/sys/socket/message/send.rs
@@ -18,7 +18,7 @@ use ::sys::{
     pm::ProcessIdentifier,
 };
 use ::sysapi::sys_types::{
-    size_t,
+    c_size_t,
     ssize_t,
 };
 
@@ -42,7 +42,7 @@ impl SendSocketRequest {
         - mem::size_of::<u32>()
         - mem::size_of::<i32>();
 
-    pub fn new(sockfd: i32, count: u32, flags: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
+    pub fn new(sockfd: i32, count: c_size_t, flags: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self {
             sockfd,
             count,
@@ -62,7 +62,7 @@ impl SendSocketRequest {
     pub fn build(
         pid: ProcessIdentifier,
         sockfd: i32,
-        count: size_t,
+        count: c_size_t,
         flags: i32,
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {

--- a/src/libs/syscall/src/sys/socket/message/send.rs
+++ b/src/libs/syscall/src/sys/socket/message/send.rs
@@ -19,7 +19,7 @@ use ::sys::{
 };
 use ::sysapi::sys_types::{
     c_size_t,
-    ssize_t,
+    c_ssize_t,
 };
 
 //==================================================================================================
@@ -93,7 +93,7 @@ pub struct SendSocketResponse {
 impl SendSocketResponse {
     pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
-    pub fn new(count: i32) -> Self {
+    pub fn new(count: c_ssize_t) -> Self {
         Self {
             count,
             _padding: [0; Self::PADDING_SIZE],
@@ -108,7 +108,7 @@ impl SendSocketResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, count: ssize_t) -> Message {
+    pub fn build(pid: ProcessIdentifier, count: c_ssize_t) -> Message {
         let message: SendSocketResponse = SendSocketResponse::new(count);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::SendSocketResponse,

--- a/src/libs/syscall/src/sys/socket/syscall/send.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/send.rs
@@ -24,7 +24,7 @@ use ::sys::{
 };
 use ::sysapi::{
     ffi::c_int,
-    sys_types::size_t,
+    sys_types::c_size_t,
 };
 
 //==================================================================================================
@@ -49,7 +49,7 @@ pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> 
 
         // Build request and send it.
         let request: Message =
-            SendSocketRequest::build(pid, sockfd, chunk_size as size_t, flags, chunk);
+            SendSocketRequest::build(pid, sockfd, chunk_size as c_size_t, flags, chunk);
         ::sys::kcall::ipc::send(&request)?;
 
         // Receive response.

--- a/src/libs/syscall/src/unistd/message/pread.rs
+++ b/src/libs/syscall/src/unistd/message/pread.rs
@@ -18,8 +18,8 @@ use ::sys::{
     pm::ProcessIdentifier,
 };
 use ::sysapi::sys_types::{
+    c_size_t,
     off_t,
-    size_t,
     ssize_t,
 };
 
@@ -43,7 +43,7 @@ impl PartialReadRequest {
         - mem::size_of::<u32>()
         - mem::size_of::<off_t>();
 
-    fn new(fd: i32, count: u32, offset: off_t) -> Self {
+    fn new(fd: i32, count: c_size_t, offset: off_t) -> Self {
         Self {
             fd,
             count,
@@ -60,7 +60,7 @@ impl PartialReadRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32, count: size_t, offset: off_t) -> Message {
+    pub fn build(pid: ProcessIdentifier, fd: i32, count: c_size_t, offset: off_t) -> Message {
         let message: PartialReadRequest = PartialReadRequest::new(fd, count, offset);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::PartialReadRequest,

--- a/src/libs/syscall/src/unistd/message/pread.rs
+++ b/src/libs/syscall/src/unistd/message/pread.rs
@@ -19,8 +19,8 @@ use ::sys::{
 };
 use ::sysapi::sys_types::{
     c_size_t,
+    c_ssize_t,
     off_t,
-    ssize_t,
 };
 
 //==================================================================================================
@@ -87,7 +87,7 @@ pub struct PartialReadResponse {
 impl PartialReadResponse {
     pub const BUFFER_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
-    fn new(count: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
+    fn new(count: c_ssize_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self { count, buffer }
     }
 
@@ -101,7 +101,7 @@ impl PartialReadResponse {
 
     pub fn build(
         pid: ProcessIdentifier,
-        count: ssize_t,
+        count: c_ssize_t,
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {
         let message: PartialReadResponse = PartialReadResponse::new(count, buffer);

--- a/src/libs/syscall/src/unistd/message/pwrite.rs
+++ b/src/libs/syscall/src/unistd/message/pwrite.rs
@@ -21,7 +21,7 @@ use ::sysapi::sys_types::{
     c_size_t,
     off_t,
 };
-use sysapi::sys_types::ssize_t;
+use sysapi::sys_types::c_ssize_t;
 
 //==================================================================================================
 // PartialWriteRequest
@@ -93,7 +93,7 @@ pub struct PartialWriteResponse {
 impl PartialWriteResponse {
     pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
-    fn new(count: i32) -> Self {
+    fn new(count: c_ssize_t) -> Self {
         Self {
             count,
             _padding: [0; Self::PADDING_SIZE],
@@ -108,7 +108,7 @@ impl PartialWriteResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, count: ssize_t) -> Message {
+    pub fn build(pid: ProcessIdentifier, count: c_ssize_t) -> Message {
         let message: PartialWriteResponse = PartialWriteResponse::new(count);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::PartialWriteResponse,

--- a/src/libs/syscall/src/unistd/message/pwrite.rs
+++ b/src/libs/syscall/src/unistd/message/pwrite.rs
@@ -18,8 +18,8 @@ use ::sys::{
     pm::ProcessIdentifier,
 };
 use ::sysapi::sys_types::{
+    c_size_t,
     off_t,
-    size_t,
 };
 use sysapi::sys_types::ssize_t;
 
@@ -43,7 +43,7 @@ impl PartialWriteRequest {
         - mem::size_of::<u32>()
         - mem::size_of::<off_t>();
 
-    fn new(fd: i32, count: u32, offset: off_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
+    fn new(fd: i32, count: c_size_t, offset: off_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self {
             fd,
             count,
@@ -63,7 +63,7 @@ impl PartialWriteRequest {
     pub fn build(
         pid: ProcessIdentifier,
         fd: i32,
-        count: size_t,
+        count: c_size_t,
         offset: off_t,
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {

--- a/src/libs/syscall/src/unistd/message/read.rs
+++ b/src/libs/syscall/src/unistd/message/read.rs
@@ -17,7 +17,7 @@ use ::sys::{
     },
     pm::ProcessIdentifier,
 };
-use ::sysapi::sys_types::size_t;
+use ::sysapi::sys_types::c_size_t;
 
 //==================================================================================================
 // ReadRequest
@@ -36,7 +36,7 @@ impl ReadRequest {
     pub const PADDING_SIZE: usize =
         LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u32>();
 
-    fn new(fd: i32, count: u32) -> Self {
+    fn new(fd: i32, count: c_size_t) -> Self {
         Self {
             fd,
             count,
@@ -52,7 +52,7 @@ impl ReadRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32, count: size_t) -> Message {
+    pub fn build(pid: ProcessIdentifier, fd: i32, count: c_size_t) -> Message {
         let message: ReadRequest = ReadRequest::new(fd, count);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::ReadRequest, message.into_bytes());

--- a/src/libs/syscall/src/unistd/message/write.rs
+++ b/src/libs/syscall/src/unistd/message/write.rs
@@ -19,7 +19,7 @@ use ::sys::{
 };
 use ::sysapi::sys_types::{
     c_size_t,
-    ssize_t,
+    c_ssize_t,
 };
 
 //==================================================================================================
@@ -82,7 +82,7 @@ pub struct WriteResponse {
 impl WriteResponse {
     pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>();
 
-    fn new(count: i32) -> Self {
+    fn new(count: c_ssize_t) -> Self {
         Self {
             count,
             _padding: [0; Self::PADDING_SIZE],
@@ -97,7 +97,7 @@ impl WriteResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, count: ssize_t) -> Message {
+    pub fn build(pid: ProcessIdentifier, count: c_ssize_t) -> Message {
         let message: WriteResponse = WriteResponse::new(count);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::WriteResponse, message.into_bytes());

--- a/src/libs/syscall/src/unistd/message/write.rs
+++ b/src/libs/syscall/src/unistd/message/write.rs
@@ -18,7 +18,7 @@ use ::sys::{
     pm::ProcessIdentifier,
 };
 use ::sysapi::sys_types::{
-    size_t,
+    c_size_t,
     ssize_t,
 };
 
@@ -39,7 +39,7 @@ impl WriteRequest {
     pub const BUFFER_SIZE: usize =
         LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u32>();
 
-    fn new(fd: i32, count: u32, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
+    fn new(fd: i32, count: c_size_t, buffer: [u8; Self::BUFFER_SIZE]) -> Self {
         Self { fd, count, buffer }
     }
 
@@ -54,7 +54,7 @@ impl WriteRequest {
     pub fn build(
         pid: ProcessIdentifier,
         fd: i32,
-        count: size_t,
+        count: c_size_t,
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {
         let message: WriteRequest = WriteRequest::new(fd, count, buffer);

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -25,7 +25,7 @@ use ::sys::{
 };
 use sysapi::sys_types::{
     off_t,
-    size_t,
+    c_size_t,
 };
 
 //==================================================================================================
@@ -48,12 +48,12 @@ use sysapi::sys_types::{
 /// Upon successful completion, `pread()` returns the number of bytes read. Otherwise, it
 /// returns an error.
 ///
-pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<size_t, Error> {
+pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<c_size_t, Error> {
     ::syslog::trace!("pread(): fd={}, buffer={:?}, offset={}", fd, buffer, offset);
 
     let pid: ProcessIdentifier = crate::unistd::getpid()?;
 
-    let mut total_read: size_t = 0;
+    let mut total_read: c_size_t = 0;
     let mut buffer_offset: usize = 0;
 
     while buffer_offset < buffer.len() {
@@ -64,7 +64,7 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
         let request: Message = PartialReadRequest::build(
             pid,
             fd,
-            chunk_size as size_t,
+            chunk_size as c_size_t,
             offset + buffer_offset as off_t,
         );
         ::sys::kcall::ipc::send(&request)?;
@@ -110,7 +110,7 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
                     // Copy response buffer to user buffer.
                     buffer[buffer_offset..buffer_offset + chunk_size]
                         .copy_from_slice(&response.buffer[..chunk_size]);
-                    total_read += response.count as size_t;
+                    total_read += response.count as c_size_t;
                     buffer_offset += chunk_size;
 
                     // Check for partial read.

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -25,7 +25,7 @@ use ::sys::{
 };
 use ::sysapi::sys_types::{
     off_t,
-    size_t,
+    c_size_t,
 };
 
 //==================================================================================================
@@ -48,10 +48,10 @@ use ::sysapi::sys_types::{
 /// Upon successful completion, `pwrite()` returns the number of bytes written. Otherwise, it
 /// returns an error.
 ///
-pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<size_t, Error> {
+pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_size_t, Error> {
     ::syslog::trace!("pwrite(): fd={}, buffer={:?}, offset={}", fd, buffer, offset);
 
-    let mut total_written: size_t = 0;
+    let mut total_written: c_size_t = 0;
     let mut buffer_offset: usize = 0;
 
     let pid: ProcessIdentifier = crate::unistd::getpid()?;
@@ -67,7 +67,7 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<siz
         let request: Message = PartialWriteRequest::build(
             pid,
             fd,
-            chunk_size as size_t,
+            chunk_size as c_size_t,
             offset + buffer_offset as off_t,
             chunk,
         );
@@ -106,7 +106,7 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<siz
                         PartialWriteResponse::from_bytes(message.payload);
 
                     // Update total written count.
-                    total_written += message.count as size_t;
+                    total_written += message.count as c_size_t;
                     buffer_offset += message.count as usize;
                 },
                 // Response was not expected.

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -25,7 +25,7 @@ use ::sys::{
     pm::ProcessIdentifier,
 };
 use sysapi::{
-    sys_types::size_t,
+    sys_types::c_size_t,
     unistd::STDIN_FILENO,
 };
 
@@ -48,7 +48,7 @@ use sysapi::{
 /// Upon successful completion, `read()` returns the number of bytes read. Otherwise, it returns an
 /// error.
 ///
-pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<size_t, Error> {
+pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error> {
     // Skip logging for stdin to avoid spamming the output.
     if fd != STDIN_FILENO {
         ::syslog::trace!("read(): fd={:?}, buffer.len={:?}", fd, buffer.len());
@@ -56,14 +56,14 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<size_t, Error> {
 
     let pid: ProcessIdentifier = crate::unistd::getpid()?;
 
-    let mut total_read: size_t = 0;
+    let mut total_read: c_size_t = 0;
     let mut offset: usize = 0;
 
     while offset < buffer.len() {
         let chunk_size: usize = cmp::min(ReadResponse::BUFFER_SIZE, buffer.len() - offset);
 
         // Build request and send it.
-        let request: Message = ReadRequest::build(pid, fd, chunk_size as size_t);
+        let request: Message = ReadRequest::build(pid, fd, chunk_size as c_size_t);
         ::sys::kcall::ipc::send(&request)?;
 
         // Receive response.
@@ -103,7 +103,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<size_t, Error> {
                     let response: ReadResponse = ReadResponse::from_bytes(message.payload);
 
                     // Display progress if not STDIN.
-                    if fd != STDIN_FILENO && total_read % KILOBYTE as size_t == 0 {
+                    if fd != STDIN_FILENO && total_read % KILOBYTE as c_size_t == 0 {
                         let percentage = (total_read as f64 / buffer.len() as f64) * 100.0;
                         ::syslog::trace!(
                             "read(): {:?}/{:?} bytes read from fd={} ({:.2}%)",
@@ -122,7 +122,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<size_t, Error> {
                     // Copy response buffer to user buffer.
                     buffer[offset..offset + chunk_size]
                         .copy_from_slice(&response.buffer[..chunk_size]);
-                    total_read += response.count as size_t;
+                    total_read += response.count as c_size_t;
                     offset += chunk_size;
 
                     // Check for partial read.

--- a/src/libs/syscall/src/unistd/syscall/readlink.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlink.rs
@@ -9,7 +9,7 @@ use crate::unistd;
 use ::sys::error::Error;
 use ::sysapi::{
     fcntl::atflags::AT_FDCWD,
-    sys_types::ssize_t,
+    sys_types::c_ssize_t,
 };
 
 //==================================================================================================
@@ -31,7 +31,7 @@ use ::sysapi::{
 /// Upon successful completion, `readlink()` returns the number of bytes read. Otherwise, it returns
 /// an error.
 ///
-pub fn readlink(path: &str, buf: &mut [u8]) -> Result<ssize_t, Error> {
+pub fn readlink(path: &str, buf: &mut [u8]) -> Result<c_ssize_t, Error> {
     ::syslog::trace!("readlinkat(): path={path:?}, buf.len={}", buf.len());
     unistd::readlinkat(AT_FDCWD, path, buf)
 }

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -30,7 +30,7 @@ use ::sys::{
     ipc::Message,
     pm::ProcessIdentifier,
 };
-use ::sysapi::sys_types::ssize_t;
+use ::sysapi::sys_types::c_ssize_t;
 
 //==================================================================================================
 // Standalone Functions
@@ -52,7 +52,7 @@ use ::sysapi::sys_types::ssize_t;
 /// Upon successful completion, `readlinkat()` returns the number of bytes read. Otherwise, it
 /// returns an error.
 ///
-pub fn readlinkat(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<ssize_t, Error> {
+pub fn readlinkat(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, Error> {
     ::syslog::trace!("readlinkat(): dirfd={:?}, path={:?}, buf.len={:?}", dirfd, path, buf.len());
 
     let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -24,7 +24,7 @@ use ::sys::{
     pm::ProcessIdentifier,
 };
 use ::sysapi::{
-    sys_types::size_t,
+    sys_types::c_size_t,
     unistd::{
         STDERR_FILENO,
         STDOUT_FILENO,
@@ -50,7 +50,7 @@ use ::sysapi::{
 /// Upon successful completion, the `write()` system call returns the number of bytes written.
 /// Otherwise, it returns an error.
 ///
-pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<size_t, Error> {
+pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
     // Skip logging for stdout and stderr to avoid spamming the output.
     if fd != STDOUT_FILENO && fd != STDERR_FILENO {
         ::syslog::trace!("write(): fd={:?}, buffer.len={:?}", fd, buffer.len());
@@ -58,7 +58,7 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<size_t, Error> {
 
     let pid: ProcessIdentifier = crate::unistd::getpid()?;
 
-    let mut total_written: size_t = 0;
+    let mut total_written: c_size_t = 0;
     let mut offset: usize = 0;
 
     while offset < buffer.len() {
@@ -67,7 +67,7 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<size_t, Error> {
         chunk[..chunk_size].copy_from_slice(&buffer[offset..offset + chunk_size]);
 
         // Build request and send it.
-        let request: Message = WriteRequest::build(pid, fd, chunk_size as size_t, chunk);
+        let request: Message = WriteRequest::build(pid, fd, chunk_size as c_size_t, chunk);
         ::sys::kcall::ipc::send(&request)?;
 
         // Receive response.
@@ -102,7 +102,7 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<size_t, Error> {
                     let response: WriteResponse = WriteResponse::from_bytes(message.payload);
 
                     // Update total written count.
-                    total_written += response.count as size_t;
+                    total_written += response.count as c_size_t;
                     offset += chunk_size;
                 },
                 header => {

--- a/src/tests/file-rust/src/unsafe/file/lseek.rs
+++ b/src/tests/file-rust/src/unsafe/file/lseek.rs
@@ -16,9 +16,9 @@ use sysapi::{
         S_IWUSR,
     },
     sys_types::{
+        c_size_t,
         mode_t,
         off_t,
-        size_t,
     },
     unistd::file_seek::{
         SEEK_END,
@@ -130,7 +130,7 @@ pub fn test() {
     }
 
     // Read data back and assert result.
-    let expected_size: size_t = match DATA.len().try_into() {
+    let expected_size: c_size_t = match DATA.len().try_into() {
         Ok(size) => size,
         Err(_) => {
             panic!("failed to convert data length to size_t");


### PR DESCRIPTION
## Description

This pull request refactors the codebase to replace the use of `ssize_t` and `size_t` with their corresponding C-compatible types, `c_ssize_t` and `c_size_t`, across multiple files and modules. This change ensures consistency and improves compatibility with C-style type definitions. The updates primarily affect functions and structures related to system calls, POSIX APIs, and buffer size handling.

### System Type Updates:

* Replaced `ssize_t` with `c_ssize_t` in multiple files, including `src/benchmarks/echo-rust-nostd/src/main.rs`, `src/benchmarks/echo-rust-server-nostd/src/main.rs`, and `src/daemons/linuxd/src/linuxd/mod.rs`. These updates ensure compatibility when handling signed size values in system calls. [[1]](diffhunk://#diff-953190fccc2244b21c855cb98131faf1b156ddf7eea2d5e4097a4eae473938feL16-R16) [[2]](diffhunk://#diff-404fbc914f4f54966ffe8556c2fbdcef777f320b5165d0711f99bf2468812020L17-R17) [[3]](diffhunk://#diff-3f338666a190ef6bff1ad212b5c6b0e19628053297380dda6077502be41c4c74L52-R52) etc.)
* Replaced `size_t` with `c_size_t` in files such as `src/daemons/linuxd/src/socket.rs`, `src/libs/posix/src/netdb.rs`, and `src/libs/posix/src/pthread/mod.rs`. This change standardizes the handling of unsigned size values. [[1]](diffhunk://#diff-af0841366275aa69c082ed3f76cb08c46401da3f48580de9efb43c749da885e9L33-R34) [[2]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL17-R17) [[3]](diffhunk://#diff-751dc5b6cbfb79539e07621a0325556d016422ce3d6c13cc5752f76bbc4dd1ceR19-L22) etc.)

### Function Parameter and Return Type Adjustments:

* Updated function parameters and return types to use `c_ssize_t` and `c_size_t` in system and POSIX API functions, such as `unistd::read`, `unistd::write`, and `socket::recv`. This ensures type correctness and alignment with C standards. [[1]](diffhunk://#diff-953190fccc2244b21c855cb98131faf1b156ddf7eea2d5e4097a4eae473938feL42-R48) [[2]](diffhunk://#diff-af0841366275aa69c082ed3f76cb08c46401da3f48580de9efb43c749da885e9L362-R362) [[3]](diffhunk://#diff-63d8de1484a786e5a1f41bcafe301f3e617785c6c68e02671f52c4a7da44416fL343-R345) etc.)
* Adjusted type casting for variables and return values to match the new type definitions, ensuring seamless integration with existing logic. [[1]](diffhunk://#diff-3f338666a190ef6bff1ad212b5c6b0e19628053297380dda6077502be41c4c74L651-R651) [[2]](diffhunk://#diff-0c2007778a6ca8776a1a9e7166eb4d65c7f077e850ad956df7dedb975110f73dL420-R420) [[3]](diffhunk://#diff-63d8de1484a786e5a1f41bcafe301f3e617785c6c68e02671f52c4a7da44416fL371-R371) etc.)

### POSIX Library Updates:

* Updated POSIX-specific modules, such as `pthread` and `netdb`, to use `c_size_t` for parameters like stack size and buffer length, maintaining consistency across the library. [[1]](diffhunk://#diff-751dc5b6cbfb79539e07621a0325556d016422ce3d6c13cc5752f76bbc4dd1ceL168-R168) [[2]](diffhunk://#diff-751dc5b6cbfb79539e07621a0325556d016422ce3d6c13cc5752f76bbc4dd1ceL324-R324) [[3]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL115-R115) etc.)
* Ensured that all uses of `size_t` and `ssize_t` in POSIX APIs now align with their C-compatible counterparts. [[1]](diffhunk://#diff-751dc5b6cbfb79539e07621a0325556d016422ce3d6c13cc5752f76bbc4dd1ceL766-R766) [[2]](diffhunk://#diff-751dc5b6cbfb79539e07621a0325556d016422ce3d6c13cc5752f76bbc4dd1ceL956-R956) etc.)

These changes improve the maintainability and portability of the codebase, ensuring consistent type usage across modules while aligning with C standards.