### PR TITLE
[libs] Refactor `iovec` Structure

### DIFF
--- a/src/libs/posix/src/sys/uio/mod.rs
+++ b/src/libs/posix/src/sys/uio/mod.rs
@@ -16,9 +16,10 @@ use ::syscall::unistd;
 use sysapi::{
     limits::IOV_MAX,
     sys_types::{
-        off_t,
         c_size_t,
         c_ssize_t,
+        off_t,
+        size_t,
     },
     sys_uio::iovec,
 };
@@ -97,7 +98,7 @@ pub unsafe extern "C" fn pwritev(
             }
 
             let iov_base: *mut u8 = unsafe { (*iov).iov_base };
-            let iov_len: c_size_t = unsafe { (*iov).iov_len };
+            let iov_len: size_t = unsafe { (*iov).iov_len };
 
             // Check if `iov_base` is invalid.
             if iov_base.is_null() {
@@ -187,7 +188,12 @@ pub unsafe extern "C" fn pwritev(
 /// // - This function is called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn preadv(fd: i32, iov: *const iovec, iovcnt: i32, offset: off_t) -> c_ssize_t {
+pub unsafe extern "C" fn preadv(
+    fd: i32,
+    iov: *const iovec,
+    iovcnt: i32,
+    offset: off_t,
+) -> c_ssize_t {
     ::syslog::trace!("preadv(): fd={fd}, iov={iov:?}, iovcnt={iovcnt}, offset={offset}");
 
     // Check if number of elements in the vector is valid.
@@ -224,7 +230,7 @@ pub unsafe extern "C" fn preadv(fd: i32, iov: *const iovec, iovcnt: i32, offset:
             }
 
             let iov_base: *mut u8 = unsafe { (*iov).iov_base };
-            let iov_len: c_size_t = unsafe { (*iov).iov_len };
+            let iov_len: size_t = unsafe { (*iov).iov_len };
 
             // Check if base address is invalid.
             if iov_base.is_null() {
@@ -341,7 +347,7 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssi
             }
 
             let iov_base: *mut u8 = unsafe { (*iov).iov_base };
-            let iov_len: c_size_t = unsafe { (*iov).iov_len };
+            let iov_len: size_t = unsafe { (*iov).iov_len };
 
             // Check if base address is invalid.
             if iov_base.is_null() {
@@ -453,7 +459,7 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
             }
 
             let iov_base: *mut u8 = unsafe { (*iov).iov_base };
-            let iov_len: c_size_t = unsafe { (*iov).iov_len };
+            let iov_len: size_t = unsafe { (*iov).iov_len };
 
             // Check if `iov_base` is invalid.
             if iov_base.is_null() {

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -27,9 +27,11 @@ use crate::{
         sched_policy::SCHED_OTHER,
     },
     sys_socket::socklen_t,
-    sys_uio::iovec,
 };
 use ::core::mem::size_of;
+
+#[cfg(target_pointer_width = "32")]
+use crate::sys_uio::iovec;
 
 //==================================================================================================
 // Types
@@ -299,6 +301,7 @@ impl pthread_once_t {
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
+#[cfg(target_pointer_width = "32")]
 pub struct msghdr {
     /// Optional address.
     pub msg_name: *mut c_void,
@@ -315,8 +318,10 @@ pub struct msghdr {
     /// Flags.
     pub msg_flags: c_int,
 }
+#[cfg(target_pointer_width = "32")]
 ::static_assert::assert_eq_size!(msghdr, msghdr::SIZE);
 
+#[cfg(target_pointer_width = "32")]
 impl msghdr {
     /// Size of the `msg_name` field.
     const SIZE_OF_MSG_NAME: usize = size_of::<*mut c_void>();

--- a/src/libs/sysapi/src/sys_uio.rs
+++ b/src/libs/sysapi/src/sys_uio.rs
@@ -11,14 +11,18 @@
 // Imports
 //==================================================================================================
 
-use crate::sys_types::c_size_t;
+#[cfg(target_pointer_width = "32")]
+use crate::sys_types::size_t;
 
 //==================================================================================================
 
 /// An I/O vector.
+#[cfg(target_pointer_width = "32")]
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
 pub struct iovec {
     /// Base address of a memory region for input or output.
     pub iov_base: *mut u8,
     /// The size of the memory pointer to by `iov_base`.
-    pub iov_len: c_size_t,
+    pub iov_len: size_t,
 }


### PR DESCRIPTION
## Description

This pull request makes several updates to improve compatibility with 32-bit architectures and refactors type usage for consistency in the POSIX library. The most significant changes include replacing `c_size_t` with `size_t` in multiple functions, adding conditional compilation for 32-bit architecture-specific types, and restructuring the `msghdr` and `iovec` structs to align with 32-bit requirements.

### Compatibility Improvements for 32-bit Architectures:

* **Refactored `iovec` struct**: Changed the type of `iov_len` from `c_size_t` to `size_t` and added conditional compilation (`#[cfg(target_pointer_width = "32")]`) to ensure compatibility with 32-bit systems in `src/libs/sysapi/src/sys_uio.rs`.

* **Added conditional compilation for `msghdr` struct**: Introduced `#[cfg(target_pointer_width = "32")]` for the `msghdr` struct and its associated methods and constants in `src/libs/sysapi/src/sys_types.rs`. This ensures the struct is defined appropriately for 32-bit systems. [[1]](diffhunk://#diff-c7817b2924eba52f9422d187e731d99e6de55d0b6960b5f6bab18929059d8895R304) [[2]](diffhunk://#diff-c7817b2924eba52f9422d187e731d99e6de55d0b6960b5f6bab18929059d8895R321-R324)

### Type Consistency Updates:

* **Replaced `c_size_t` with `size_t`**: Updated the type of `iov_len` in multiple functions (`preadv`, `pwritev`, `readv`, and `writev`) in `src/libs/posix/src/sys/uio/mod.rs` to use `size_t` instead of `c_size_t` for consistency and alignment with the updated `iovec` struct. [[1]](diffhunk://#diff-3a883bbd5fd1e301fb7c096077b00d1702c799ffbeea23a8446f35501771af8cL100-R101) [[2]](diffhunk://#diff-3a883bbd5fd1e301fb7c096077b00d1702c799ffbeea23a8446f35501771af8cL227-R233) [[3]](diffhunk://#diff-3a883bbd5fd1e301fb7c096077b00d1702c799ffbeea23a8446f35501771af8cL344-R350) [[4]](diffhunk://#diff-3a883bbd5fd1e301fb7c096077b00d1702c799ffbeea23a8446f35501771af8cL456-R462)

* **Reorganized imports**: Adjusted imports in `src/libs/posix/src/sys/uio/mod.rs` and `src/libs/sysapi/src/sys_types.rs` to include `size_t` and conditionally include `iovec` for 32-bit architectures. [[1]](diffhunk://#diff-3a883bbd5fd1e301fb7c096077b00d1702c799ffbeea23a8446f35501771af8cL19-R22) [[2]](diffhunk://#diff-c7817b2924eba52f9422d187e731d99e6de55d0b6960b5f6bab18929059d8895L30-R35)

These changes collectively improve the maintainability and portability of the codebase, particularly for 32-bit systems.