### PR TITLE
[libs] Improving Tracing for Pipe

### DIFF
--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -109,25 +109,27 @@ pub fn main() -> Result<()> {
         None => DEFAULT_GATEWAY_SOCKET_TYPE,
     };
 
-    let user_vm_listener: SocketListener = match Socket::bind(user_vm_bind_socket_type, user_vm_sockaddr.clone()) {
-        Ok(listener) => listener,
-        Err(e) => {
-            error!("failed to bind to user VM socket address (address={}, error={e:?})", user_vm_sockaddr.clone());
-            anyhow::bail!("failed to bind to user VM socket address");
-        },
-    };
+    let user_vm_listener: SocketListener =
+        match Socket::bind(user_vm_bind_socket_type, user_vm_sockaddr.clone()) {
+            Ok(listener) => listener,
+            Err(e) => {
+                error!(
+                    "failed to bind to user VM socket address (address={}, error={e:?})",
+                    user_vm_sockaddr.clone()
+                );
+                anyhow::bail!("failed to bind to user VM socket address");
+            },
+        };
 
     let gateway_listener: Option<SocketListener> = match gateway_sockaddr {
-        Some(ref sockaddr) => {
-            match Socket::bind(gateway_bind_socket_type, sockaddr.clone()) {
-                Ok(stream) => Some(stream),
-                Err(e) => {
-                    error!("failed to bind to gateway (address={}, error={e:?})", sockaddr.clone());
-                    anyhow::bail!("failed to bind to gateway");
-                },
-            }
+        Some(ref sockaddr) => match Socket::bind(gateway_bind_socket_type, sockaddr.clone()) {
+            Ok(stream) => Some(stream),
+            Err(e) => {
+                error!("failed to bind to gateway (address={}, error={e:?})", sockaddr.clone());
+                anyhow::bail!("failed to bind to gateway");
+            },
         },
-        None => None
+        None => None,
     };
 
     // Accepct connection from gateway after binding the socket to listen from user VMs,
@@ -147,7 +149,7 @@ pub fn main() -> Result<()> {
                     },
                 }
             }
-        }
+        },
         None => None,
     };
 

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -27,6 +27,8 @@ use ::sys::{
 //==================================================================================================
 
 pub fn pipe() -> Result<[i32; 2], Error> {
+    ::syslog::trace!("pipe()");
+
     let pid: ProcessIdentifier = crate::unistd::getpid()?;
 
     // Build request and send it.
@@ -52,6 +54,11 @@ pub fn pipe() -> Result<[i32; 2], Error> {
                     // Parse response.
                     let response: PipeResponse = PipeResponse::from_bytes(message.payload);
 
+                    ::syslog::trace!(
+                        "pipe(): read_fd={:?}, write_fd={:?}",
+                        { response.read_fd },
+                        { response.write_fd },
+                    );
                     Ok([response.read_fd, response.write_fd])
                 },
                 // Response was not successfully parsed.
@@ -83,8 +90,11 @@ pub mod bindings {
     ///
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn pipe(fds: *mut c_int) -> c_int {
+        ::syslog::trace!("pipe(): fds={fds:?}");
+
         match super::pipe() {
             Ok([read_fd, write_fd]) => {
+                ::syslog::trace!("pipe(): read_fd={read_fd:?}, write_fd={write_fd:?}");
                 unsafe {
                     *fds.offset(0) = read_fd;
                     *fds.offset(1) = write_fd;


### PR DESCRIPTION
## Description

This pull request includes changes to improve logging and enhance code readability in the `linuxd` daemon and `syscall` library. The most important updates involve adding detailed trace logs for the `pipe` function and reformatting code for better clarity and consistency.

### Improvements to logging:

* [`src/libs/syscall/src/unistd/syscall/pipe.rs`](diffhunk://#diff-6efb07ee285965a075c9fb39d60d84c298c2f6e9b211bd0913f7ea2aeaaf7e15R30-R31): Added trace logs to the `pipe` function to log key events, including when the function is called, and the file descriptors (`read_fd` and `write_fd`) involved in the operation. This applies to both the Rust implementation and the external `pipe` binding. [[1]](diffhunk://#diff-6efb07ee285965a075c9fb39d60d84c298c2f6e9b211bd0913f7ea2aeaaf7e15R30-R31) [[2]](diffhunk://#diff-6efb07ee285965a075c9fb39d60d84c298c2f6e9b211bd0913f7ea2aeaaf7e15R57-R61) [[3]](diffhunk://#diff-6efb07ee285965a075c9fb39d60d84c298c2f6e9b211bd0913f7ea2aeaaf7e15R93-R97)

### Code readability enhancements:

* [`src/daemons/linuxd/src/main.rs`](diffhunk://#diff-d500df32df8cd908ce7b0bae1f96322191f095d9a8fc8f048702ae2f63398c76L112-R132): Reformatted match expressions for `user_vm_listener` and `gateway_listener` to improve readability by aligning nested blocks and adding consistent indentation. [[1]](diffhunk://#diff-d500df32df8cd908ce7b0bae1f96322191f095d9a8fc8f048702ae2f63398c76L112-R132) [[2]](diffhunk://#diff-d500df32df8cd908ce7b0bae1f96322191f095d9a8fc8f048702ae2f63398c76L150-R152)