### PR TITLE
[libs] Safe Conversions for ThreadIdentifier

### DIFF
--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -63,9 +63,9 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
 
     match KcallNumber::from(number) {
         // Handle `getpid()` locally.
-        KcallNumber::GetPid => KcallResult::Success(Into::<usize>::into(pid).into()),
+        KcallNumber::GetPid => KcallResult::Success(<i32>::from(pid).into()),
         // Handle `gettid()` locally.
-        KcallNumber::GetTid => KcallResult::Success(Into::<usize>::into(tid).into()),
+        KcallNumber::GetTid => KcallResult::Success(<i32>::from(tid).into()),
         KcallNumber::Exit => {
             // SAFETY: the calling process is not the kernel.
             let e: Error = unsafe { ProcessManager::exit(ExitStatus::from(arg0)).unwrap_err() };

--- a/src/kernel/src/kcall/kcall_success.rs
+++ b/src/kernel/src/kcall/kcall_success.rs
@@ -39,6 +39,12 @@ impl From<u32> for KcallSuccess {
     }
 }
 
+impl From<i32> for KcallSuccess {
+    fn from(code: i32) -> Self {
+        KcallSuccess(code)
+    }
+}
+
 impl From<KcallSuccess> for i32 {
     fn from(result: KcallSuccess) -> Self {
         result.0

--- a/src/kernel/src/kcall/mod.rs
+++ b/src/kernel/src/kcall/mod.rs
@@ -90,7 +90,7 @@ impl ScoreBoard {
                 handled: Semaphore::new(0),
                 args: KcallArgs {
                     pid: ProcessIdentifier::from(u32::MAX),
-                    tid: ThreadIdentifier::from(usize::MAX),
+                    tid: ThreadIdentifier::from(i32::MAX),
                     arg0: 0,
                     arg1: 0,
                     arg2: 0,

--- a/src/kernel/src/pm/kcall/create_thread.rs
+++ b/src/kernel/src/pm/kcall/create_thread.rs
@@ -61,7 +61,7 @@ pub fn create_thread(
     match do_create_thread(pm, mm, args.pid, user_wrapper_fn, user_fn, user_fn_arg) {
         Ok(tid) => {
             debug!("create_thread(): thread {tid:?} created");
-            KcallResult::Success(Into::<usize>::into(tid).into())
+            KcallResult::Success(<i32>::from(tid).into())
         },
         Err(e) => KcallResult::Error(e.code.into()),
     }

--- a/src/kernel/src/pm/kcall/join_thread.rs
+++ b/src/kernel/src/pm/kcall/join_thread.rs
@@ -60,7 +60,13 @@ pub unsafe fn join_thread(
     arg1: u32,
 ) -> Result<ExitStatus, SleepError> {
     // Unpack kernel call arguments.
-    let tid: ThreadIdentifier = ThreadIdentifier::from(arg0 as usize);
+    let tid: ThreadIdentifier = match ThreadIdentifier::try_from(arg0) {
+        Ok(tid) => tid,
+        Err(error) => {
+            error!("join_thread(): {error:?}");
+            return Err(SleepError::Generic(error));
+        },
+    };
     let retval: *mut ExitStatus = arg1 as *mut ExitStatus;
 
     let status: ExitStatus = ProcessManager::join_thread(pid, tid)?;

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -325,11 +325,11 @@ pub struct ThreadManager {
 impl ThreadManager {
     fn new() -> (ReadyThread, Self) {
         let kernel: ReadyThread =
-            ReadyThread::new(From::<u32>::from(0), None, None, ContextInformation::default());
+            ReadyThread::new(From::<i32>::from(0), None, None, ContextInformation::default());
         (
             kernel,
             Self {
-                next_id: From::<u32>::from(1),
+                next_id: From::<i32>::from(1),
             },
         )
     }
@@ -341,7 +341,7 @@ impl ThreadManager {
         context: ContextInformation,
     ) -> ReadyThread {
         let id: ThreadIdentifier = self.next_id;
-        self.next_id = ThreadIdentifier::from(Into::<usize>::into(self.next_id) + 1);
+        self.next_id = ThreadIdentifier::from(<i32>::from(self.next_id) + 1);
 
         ReadyThread(ThreadState::new(id, kernel_stack, user_stack, context))
     }

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -175,11 +175,8 @@ pub fn exit_thread(status: usize) -> Result<!, Error> {
 //==================================================================================================
 
 pub fn join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<i64, Error> {
-    let result: i64 = kcall2!(
-        KcallNumber::JoinThread.into(),
-        usize::from(tid) as u32,
-        retval as *mut usize as u32
-    );
+    let result: i64 =
+        kcall2!(KcallNumber::JoinThread.into(), i32::from(tid) as u32, retval as *mut usize as u32);
 
     if result != 0 {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to join thread"))

--- a/src/libs/sys/src/sys/pm/tid.rs
+++ b/src/libs/sys/src/sys/pm/tid.rs
@@ -2,6 +2,23 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::char_lit_as_u8,
+    clippy::fn_to_numeric_cast,
+    clippy::fn_to_numeric_cast_with_truncation,
+    clippy::ptr_as_ptr,
+    clippy::unnecessary_cast,
+    invalid_reference_casting
+)]
+
+//==================================================================================================
 // Imports
 //==================================================================================================
 
@@ -20,69 +37,77 @@ use crate::error::{
 /// A type that represents a thread identifier.
 ///
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ThreadIdentifier(usize);
+#[repr(C)]
+pub struct ThreadIdentifier(i32);
+::static_assert::assert_eq_size!(ThreadIdentifier, 4);
+::static_assert::assert_eq_align!(ThreadIdentifier, 4);
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl From<usize> for ThreadIdentifier {
-    fn from(id: usize) -> ThreadIdentifier {
-        ThreadIdentifier(id)
+impl From<ThreadIdentifier> for isize {
+    fn from(tid: ThreadIdentifier) -> isize {
+        tid.0 as isize
     }
 }
 
-impl From<u32> for ThreadIdentifier {
-    fn from(id: u32) -> ThreadIdentifier {
-        ThreadIdentifier(id as usize)
-    }
-}
-
-impl From<ThreadIdentifier> for usize {
-    fn from(tid: ThreadIdentifier) -> usize {
+impl From<ThreadIdentifier> for i32 {
+    fn from(tid: ThreadIdentifier) -> i32 {
         tid.0
     }
 }
 
-impl From<ThreadIdentifier> for u32 {
-    fn from(tid: ThreadIdentifier) -> u32 {
-        tid.0 as u32
+impl From<ThreadIdentifier> for i64 {
+    fn from(tid: ThreadIdentifier) -> i64 {
+        tid.0 as i64
     }
 }
 
-impl TryFrom<ThreadIdentifier> for i32 {
+impl TryFrom<ThreadIdentifier> for usize {
     type Error = Error;
 
     fn try_from(tid: ThreadIdentifier) -> Result<Self, Self::Error> {
-        if tid.0 > i32::MAX as usize {
-            Err(Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
-        } else {
-            Ok(tid.0 as i32)
-        }
+        tid.0
+            .try_into()
+            .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
     }
 }
 
-impl TryFrom<ThreadIdentifier> for i64 {
+impl TryFrom<ThreadIdentifier> for u32 {
     type Error = Error;
 
     fn try_from(tid: ThreadIdentifier) -> Result<Self, Self::Error> {
-        if tid.0 > i64::MAX as usize {
-            Err(Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
-        } else {
-            Ok(tid.0 as i64)
-        }
+        tid.0
+            .try_into()
+            .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
     }
 }
 
-impl TryFrom<i32> for ThreadIdentifier {
+impl TryFrom<ThreadIdentifier> for u64 {
     type Error = Error;
 
-    fn try_from(raw_tid: i32) -> Result<Self, Self::Error> {
-        if raw_tid < 0 {
-            Err(Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
-        } else {
-            Ok(ThreadIdentifier(raw_tid as usize))
-        }
+    fn try_from(tid: ThreadIdentifier) -> Result<Self, Self::Error> {
+        tid.0
+            .try_into()
+            .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
+    }
+}
+
+impl TryFrom<isize> for ThreadIdentifier {
+    type Error = Error;
+
+    fn try_from(raw_tid: isize) -> Result<Self, Self::Error> {
+        raw_tid
+            .try_into()
+            .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
+            .map(ThreadIdentifier)
+    }
+}
+
+impl From<i32> for ThreadIdentifier {
+    fn from(raw_tid: i32) -> ThreadIdentifier {
+        ThreadIdentifier(raw_tid)
     }
 }
 
@@ -90,11 +115,43 @@ impl TryFrom<i64> for ThreadIdentifier {
     type Error = Error;
 
     fn try_from(raw_tid: i64) -> Result<Self, Self::Error> {
-        if raw_tid < 0 {
-            Err(Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
-        } else {
-            Ok(ThreadIdentifier(raw_tid as usize))
-        }
+        raw_tid
+            .try_into()
+            .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
+            .map(ThreadIdentifier)
+    }
+}
+
+impl TryFrom<usize> for ThreadIdentifier {
+    type Error = Error;
+
+    fn try_from(raw_tid: usize) -> Result<Self, Self::Error> {
+        raw_tid
+            .try_into()
+            .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
+            .map(ThreadIdentifier)
+    }
+}
+
+impl TryFrom<u32> for ThreadIdentifier {
+    type Error = Error;
+
+    fn try_from(raw_tid: u32) -> Result<Self, Self::Error> {
+        raw_tid
+            .try_into()
+            .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
+            .map(ThreadIdentifier)
+    }
+}
+
+impl TryFrom<u64> for ThreadIdentifier {
+    type Error = Error;
+
+    fn try_from(raw_tid: u64) -> Result<Self, Self::Error> {
+        raw_tid
+            .try_into()
+            .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid thread identifier"))
+            .map(ThreadIdentifier)
     }
 }
 

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -65,14 +65,20 @@ pub fn pthread_create(
         ::core::ptr::addr_of!(start_routine),
         arg
     );
-    Ok(create_thread(start_routine, arg)?.into())
+    create_thread(start_routine, arg)?.try_into()
 }
 
 pub fn pthread_join(thread: pthread_t) -> Result<isize, Error> {
     ::syslog::trace!("pthread_join(): _thread={:?}", thread);
 
     let mut retval: usize = 0;
-    let thread: ThreadIdentifier = thread.into();
+    let thread: ThreadIdentifier = match thread.try_into() {
+        Ok(tid) => tid,
+        Err(error) => {
+            ::syslog::error!("pthread_join(): {error:?} (thread={thread:?})");
+            return Err(error);
+        },
+    };
 
     match join_thread(thread, &mut retval) {
         Ok(_) => Ok(retval as isize),
@@ -86,5 +92,8 @@ pub fn pthread_exit(retval: usize) -> Result<!, Error> {
 }
 
 pub fn pthread_self() -> pthread_t {
-    ::sys::kcall::pm::gettid().unwrap().into()
+    ::sys::kcall::pm::gettid()
+        .expect("a thread must be able to get its own identifier")
+        .try_into()
+        .expect("thread identifiers returned by the kernel must be valid")
 }


### PR DESCRIPTION
## Description

This pull request introduces a significant refactor to the handling of thread identifiers (`ThreadIdentifier`) in the kernel and system libraries. The main change is the transition from using `usize` to `i32` for `ThreadIdentifier`, improving type safety and alignment with system conventions. Additionally, several new conversions and error-handling mechanisms have been implemented to support this change.

### Thread Identifier Refactor:

* Changed `ThreadIdentifier`'s internal representation from `usize` to `i32`, ensuring consistent size and alignment across platforms. Updated related conversion implementations to use `i32` and added error handling for invalid conversions. (`src/libs/sys/src/sys/pm/tid.rs`)

* Updated kernel calls and thread management code to use `i32` for thread identifiers, replacing instances of `usize` and `u32`. This includes changes in `create_thread`, `join_thread`, and `exit_thread` functions. (`src/kernel/src/pm/kcall/create_thread.rs`, `src/kernel/src/pm/kcall/join_thread.rs`, `src/kernel/src/pm/thread/mod.rs`) [[1]](diffhunk://#diff-eed0f7dbc92ac6a6b44f54b2ff88eb78d80a57768b46c4cb4b1fa2fe74087548L64-R64) [[2]](diffhunk://#diff-ae1d6c2f7778faaf687aeb548aefd55a3a8d5bf4dfd1ea204117282c987ee408L63-R69) [[3]](diffhunk://#diff-68a79ef631e0c173295d4bfe400ddcd7c2aae177bb7e2028097a2e8a07192425L328-R332) [[4]](diffhunk://#diff-68a79ef631e0c173295d4bfe400ddcd7c2aae177bb7e2028097a2e8a07192425L344-R344)

### Kernel Call Adjustments:

* Updated `KcallSuccess` to support conversions from `i32`, enabling the proper handling of thread identifiers in kernel calls. (`src/kernel/src/kcall/kcall_success.rs`)

* Modified the `do_kcall` dispatcher to use `i32` conversions for `getpid` and `gettid` results, aligning with the new thread identifier type. (`src/kernel/src/kcall/dispatcher.rs`)

### System Call Updates:

* Refactored system calls like `pthread_create`, `pthread_join`, and `pthread_self` to handle `ThreadIdentifier` as `i32` and added error handling for invalid conversions. (`src/libs/syscall/src/pthread/syscall/mod.rs`) [[1]](diffhunk://#diff-340018d20eb8da4c8e8a6b1c481e8d61c1844cb9efae3048fadf1cac7311b314L68-R81) [[2]](diffhunk://#diff-340018d20eb8da4c8e8a6b1c481e8d61c1844cb9efae3048fadf1cac7311b314L89-R95)

### Linting and Safety Improvements:

* Added strict linting rules to `src/libs/sys/src/sys/pm/tid.rs` to prevent unsafe or lossy casts, ensuring better code quality and maintainability.