### PR TITLE
[libs] Safe Conversions for Process Identifier

### DIFF
--- a/src/kernel/src/kcall/mod.rs
+++ b/src/kernel/src/kcall/mod.rs
@@ -89,7 +89,7 @@ impl ScoreBoard {
                 dispatched: Semaphore::new(0),
                 handled: Semaphore::new(0),
                 args: KcallArgs {
-                    pid: ProcessIdentifier::from(u32::MAX),
+                    pid: ProcessIdentifier::from(i32::MAX),
                     tid: ThreadIdentifier::from(i32::MAX),
                     arg0: 0,
                     arg1: 0,

--- a/src/kernel/src/pm/kcall/mcopy.rs
+++ b/src/kernel/src/pm/kcall/mcopy.rs
@@ -80,13 +80,25 @@ pub fn mcopy(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
     }
 
     // Unpack kernel call arguments.
-    let src_pid: ProcessIdentifier = ProcessIdentifier::from(args.arg0);
+    let src_pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
+        Ok(pid) => pid,
+        Err(error) => {
+            error!("mcopy(): {error:?}");
+            return KcallResult::Error(error.code.into());
+        },
+    };
     let src_vaddr: PageAligned<VirtualAddress> =
         match PageAligned::from_raw_value(args.arg1 as usize) {
             Ok(vaddr) => vaddr,
             Err(e) => return KcallResult::Error(e.code.into()),
         };
-    let dst_pid: ProcessIdentifier = ProcessIdentifier::from(args.arg2);
+    let dst_pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg2) {
+        Ok(pid) => pid,
+        Err(error) => {
+            error!("mcopy(): {error:?}");
+            return KcallResult::Error(error.code.into());
+        },
+    };
     let dst_vaddr: PageAligned<VirtualAddress> =
         match PageAligned::from_raw_value(args.arg3 as usize) {
             Ok(vaddr) => vaddr,

--- a/src/kernel/src/pm/kcall/mctrl.rs
+++ b/src/kernel/src/pm/kcall/mctrl.rs
@@ -58,7 +58,13 @@ pub fn mctrl(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
     }
 
     // Unpack kernel call arguments.
-    let pid: ProcessIdentifier = ProcessIdentifier::from(args.arg0);
+    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
+        Ok(pid) => pid,
+        Err(error) => {
+            error!("mctrl(): {error:?}");
+            return KcallResult::Error(error.code.into());
+        },
+    };
     let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(args.arg1 as usize) {
         Ok(vaddr) => vaddr,
         Err(e) => return KcallResult::Error(e.code.into()),

--- a/src/kernel/src/pm/kcall/mmap.rs
+++ b/src/kernel/src/pm/kcall/mmap.rs
@@ -46,7 +46,13 @@ fn do_mmap(
 
 pub fn mmap(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallArgs) -> KcallResult {
     // Unpack kernel call arguments.
-    let pid: ProcessIdentifier = ProcessIdentifier::from(args.arg0);
+    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
+        Ok(pid) => pid,
+        Err(error) => {
+            error!("mmap(): {error:?}");
+            return KcallResult::Error(error.code.into());
+        },
+    };
     let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(args.arg1 as usize) {
         Ok(vaddr) => vaddr,
         Err(e) => return KcallResult::Error(e.code.into()),

--- a/src/kernel/src/pm/kcall/munmap.rs
+++ b/src/kernel/src/pm/kcall/munmap.rs
@@ -48,7 +48,13 @@ pub fn munmap(
     args: &KcallArgs,
 ) -> KcallResult {
     // Unpack kernel call arguments.
-    let pid: ProcessIdentifier = ProcessIdentifier::from(args.arg0);
+    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
+        Ok(pid) => pid,
+        Err(error) => {
+            error!("munmap(): {error:?}");
+            return KcallResult::Error(error.code.into());
+        },
+    };
     let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(args.arg1 as usize) {
         Ok(vaddr) => vaddr,
         Err(e) => return KcallResult::Error(e.code.into()),

--- a/src/kernel/src/pm/kcall/terminate.rs
+++ b/src/kernel/src/pm/kcall/terminate.rs
@@ -19,7 +19,15 @@ use ::sys::pm::ProcessIdentifier;
 //==================================================================================================
 
 pub fn terminate(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
-    match pm.terminate(ProcessIdentifier::from(args.arg0)) {
+    // Unpack kernel call arguments.
+    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
+        Ok(pid) => pid,
+        Err(error) => {
+            error!("terminate(): {error:?}");
+            return KcallResult::Error(error.code.into());
+        },
+    };
+    match pm.terminate(pid) {
         Ok(()) => KcallResult::ok(),
         Err(e) => KcallResult::Error(e.code.into()),
     }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -518,7 +518,7 @@ impl ProcessManagerInner {
 
         // Create process.
         let pid: ProcessIdentifier = self.next_pid;
-        self.next_pid = ProcessIdentifier::from(Into::<u32>::into(pid) + 1);
+        self.next_pid = ProcessIdentifier::from(i32::from(pid) + 1);
         let process: RunnableProcess =
             RunnableProcess::new(pid, thread, vmem, Some(user_stack_allocator));
 

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -61,7 +61,7 @@ use ::core::{
         unlikely,
     },
     sync::atomic::{
-        AtomicU32,
+        AtomicI32,
         Ordering,
     },
 };
@@ -83,7 +83,7 @@ use ::sys::{
 //==================================================================================================
 
 /// PID of the current process.
-static CURRENT_PID: AtomicU32 = AtomicU32::new(ProcessIdentifier::KERNEL_RAW);
+static CURRENT_PID: AtomicI32 = AtomicI32::new(ProcessIdentifier::KERNEL_RAW);
 
 //==================================================================================================
 // Implementations

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -118,8 +118,15 @@ impl ProcessDaemon {
 
     fn handle_process_termination_event(&mut self, message: Message) -> Result<bool, Error> {
         // Deserialize process identifier.
-        let pid: ProcessIdentifier =
-            ProcessIdentifier::from(u32::from_le_bytes(message.payload[0..4].try_into().unwrap()));
+        let raw_pid_bytes: [u8; 4] = match message.payload[0..4].try_into() {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                let reason: &str = "invalid process termination message payload";
+                ::syslog::error!("handle_process_termination_event(): {reason:?}");
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
+        };
+        let pid: ProcessIdentifier = ProcessIdentifier::from(i32::from_le_bytes(raw_pid_bytes));
 
         ::syslog::info!("received scheduling event (pid={:?})", pid);
 
@@ -212,7 +219,7 @@ impl ProcessDaemon {
                 Err(_) => {
                     let message: Message = message::lookup_response(
                         destination,
-                        ProcessIdentifier::from(u32::MAX),
+                        ProcessIdentifier::from(i32::MAX),
                         ErrorCode::InvalidArgument.get(),
                     )?;
                     return Ok(message);
@@ -221,7 +228,7 @@ impl ProcessDaemon {
             Err(_) => {
                 let message: Message = message::lookup_response(
                     destination,
-                    ProcessIdentifier::from(u32::MAX),
+                    ProcessIdentifier::from(i32::MAX),
                     ErrorCode::InvalidArgument.get(),
                 )?;
                 return Ok(message);
@@ -239,7 +246,7 @@ impl ProcessDaemon {
         }
         let message: Message = message::lookup_response(
             destination,
-            ProcessIdentifier::from(u32::MAX),
+            ProcessIdentifier::from(i32::MAX),
             ErrorCode::NoSuchEntry.get(),
         )?;
 
@@ -262,7 +269,7 @@ impl ProcessDaemon {
                 Ok(message) => {
                     if message.message_type == MessageType::ProcessTerminationEvent {
                         // Deserialize process identifier.
-                        let pid: ProcessIdentifier = ProcessIdentifier::from(u32::from_le_bytes(
+                        let pid: ProcessIdentifier = ProcessIdentifier::from(i32::from_le_bytes(
                             message.payload[0..4].try_into().unwrap(),
                         ));
 

--- a/src/libs/sys/src/sys/kcall/mm/kcalls.rs
+++ b/src/libs/sys/src/sys/kcall/mm/kcalls.rs
@@ -32,7 +32,7 @@ pub fn mmap(
 ) -> Result<(), Error> {
     let result: i64 = kcall3!(
         KcallNumber::MemoryMap.into(),
-        pid.into(),
+        pid.try_into()?,
         vaddr.into_raw_value() as u32,
         access.into()
     );
@@ -50,7 +50,7 @@ pub fn mmap(
 
 pub fn munmap(pid: ProcessIdentifier, vaddr: VirtualAddress) -> Result<(), Error> {
     let result: i64 =
-        kcall2!(KcallNumber::MemoryUnmap.into(), pid.into(), vaddr.into_raw_value() as u32);
+        kcall2!(KcallNumber::MemoryUnmap.into(), pid.try_into()?, vaddr.into_raw_value() as u32);
 
     if result == 0 {
         Ok(())

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -109,7 +109,7 @@ pub fn capctl(capability: Capability, value: bool) -> Result<(), Error> {
 //==================================================================================================
 
 pub fn terminate(pid: ProcessIdentifier) -> Result<(), Error> {
-    let result: i64 = kcall1!(KcallNumber::Terminate.into(), usize::from(pid) as u32);
+    let result: i64 = kcall1!(KcallNumber::Terminate.into(), u32::try_from(pid)?);
 
     if result == 0 {
         Ok(())

--- a/src/libs/sys/src/sys/pm/pid.rs
+++ b/src/libs/sys/src/sys/pm/pid.rs
@@ -2,6 +2,23 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::char_lit_as_u8,
+    clippy::fn_to_numeric_cast,
+    clippy::fn_to_numeric_cast_with_truncation,
+    clippy::ptr_as_ptr,
+    clippy::unnecessary_cast,
+    invalid_reference_casting
+)]
+
+//==================================================================================================
 // Imports
 //==================================================================================================
 
@@ -21,8 +38,9 @@ use crate::error::{
 ///
 #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(C)]
-pub struct ProcessIdentifier(u32);
+pub struct ProcessIdentifier(i32);
 ::static_assert::assert_eq_size!(ProcessIdentifier, 4);
+::static_assert::assert_eq_align!(ProcessIdentifier, 4);
 
 //==================================================================================================
 // Implementations
@@ -30,73 +48,147 @@ pub struct ProcessIdentifier(u32);
 
 impl ProcessIdentifier {
     // Raw identifier for the kernel process.
-    pub const KERNEL_RAW: u32 = 0;
+    pub const KERNEL_RAW: i32 = 0;
 
     /// Identifier of the kernel process.
     pub const KERNEL: ProcessIdentifier = ProcessIdentifier(Self::KERNEL_RAW);
 
+    /// Error message for conversion failures.
+    const PARSE_ERROR_MESSAGE: &'static str = "invalid process identifier";
+
     /// Identifier of the init daemon process.
     pub const INITD: ProcessIdentifier = ProcessIdentifier(1);
 
-    pub fn to_ne_bytes(&self) -> [u8; core::mem::size_of::<u32>()] {
+    pub fn to_ne_bytes(&self) -> [u8; core::mem::size_of::<i32>()] {
         self.0.to_ne_bytes()
     }
 
-    pub fn from_ne_bytes(bytes: [u8; core::mem::size_of::<u32>()]) -> Self {
-        Self(u32::from_ne_bytes(bytes))
+    pub fn from_ne_bytes(bytes: [u8; core::mem::size_of::<i32>()]) -> Self {
+        Self(i32::from_ne_bytes(bytes))
     }
 }
 
-impl core::fmt::Debug for ProcessIdentifier {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:?}", self.0)
-    }
-}
-
-impl From<u32> for ProcessIdentifier {
-    fn from(id: u32) -> ProcessIdentifier {
-        ProcessIdentifier(id)
-    }
-}
-
-impl From<ProcessIdentifier> for usize {
-    fn from(pid: ProcessIdentifier) -> usize {
-        pid.0 as usize
+impl From<ProcessIdentifier> for isize {
+    fn from(tid: ProcessIdentifier) -> isize {
+        tid.0 as isize
     }
 }
 
 impl From<ProcessIdentifier> for i32 {
-    fn from(pid: ProcessIdentifier) -> i32 {
-        pid.0 as i32
+    fn from(tid: ProcessIdentifier) -> i32 {
+        tid.0
     }
 }
 
-impl From<ProcessIdentifier> for u32 {
-    fn from(pid: ProcessIdentifier) -> u32 {
-        pid.0
+impl From<ProcessIdentifier> for i64 {
+    fn from(tid: ProcessIdentifier) -> i64 {
+        tid.0 as i64
     }
 }
 
-impl TryFrom<i32> for ProcessIdentifier {
+impl TryFrom<ProcessIdentifier> for usize {
     type Error = Error;
 
-    fn try_from(raw_pid: i32) -> Result<Self, Self::Error> {
-        if raw_pid < 0 {
-            Err(Error::new(ErrorCode::InvalidArgument, "invalid process identifier"))
-        } else {
-            Ok(ProcessIdentifier(raw_pid as u32))
-        }
+    fn try_from(tid: ProcessIdentifier) -> Result<Self, Self::Error> {
+        tid.0.try_into().map_err(|_| {
+            Error::new(ErrorCode::InvalidArgument, ProcessIdentifier::PARSE_ERROR_MESSAGE)
+        })
+    }
+}
+
+impl TryFrom<ProcessIdentifier> for u32 {
+    type Error = Error;
+
+    fn try_from(tid: ProcessIdentifier) -> Result<Self, Self::Error> {
+        tid.0.try_into().map_err(|_| {
+            Error::new(ErrorCode::InvalidArgument, ProcessIdentifier::PARSE_ERROR_MESSAGE)
+        })
+    }
+}
+
+impl TryFrom<ProcessIdentifier> for u64 {
+    type Error = Error;
+
+    fn try_from(tid: ProcessIdentifier) -> Result<Self, Self::Error> {
+        tid.0.try_into().map_err(|_| {
+            Error::new(ErrorCode::InvalidArgument, ProcessIdentifier::PARSE_ERROR_MESSAGE)
+        })
+    }
+}
+
+impl TryFrom<isize> for ProcessIdentifier {
+    type Error = Error;
+
+    fn try_from(raw_tid: isize) -> Result<Self, Self::Error> {
+        raw_tid
+            .try_into()
+            .map_err(|_| {
+                Error::new(ErrorCode::InvalidArgument, ProcessIdentifier::PARSE_ERROR_MESSAGE)
+            })
+            .map(ProcessIdentifier)
+    }
+}
+
+impl From<i32> for ProcessIdentifier {
+    fn from(raw_tid: i32) -> ProcessIdentifier {
+        ProcessIdentifier(raw_tid)
     }
 }
 
 impl TryFrom<i64> for ProcessIdentifier {
     type Error = Error;
 
-    fn try_from(raw_pid: i64) -> Result<Self, Self::Error> {
-        if raw_pid < 0 {
-            Err(Error::new(ErrorCode::InvalidArgument, "invalid process identifier"))
-        } else {
-            Ok(ProcessIdentifier(raw_pid as u32))
-        }
+    fn try_from(raw_tid: i64) -> Result<Self, Self::Error> {
+        raw_tid
+            .try_into()
+            .map_err(|_| {
+                Error::new(ErrorCode::InvalidArgument, ProcessIdentifier::PARSE_ERROR_MESSAGE)
+            })
+            .map(ProcessIdentifier)
+    }
+}
+
+impl TryFrom<usize> for ProcessIdentifier {
+    type Error = Error;
+
+    fn try_from(raw_tid: usize) -> Result<Self, Self::Error> {
+        raw_tid
+            .try_into()
+            .map_err(|_| {
+                Error::new(ErrorCode::InvalidArgument, ProcessIdentifier::PARSE_ERROR_MESSAGE)
+            })
+            .map(ProcessIdentifier)
+    }
+}
+
+impl TryFrom<u32> for ProcessIdentifier {
+    type Error = Error;
+
+    fn try_from(raw_tid: u32) -> Result<Self, Self::Error> {
+        raw_tid
+            .try_into()
+            .map_err(|_| {
+                Error::new(ErrorCode::InvalidArgument, ProcessIdentifier::PARSE_ERROR_MESSAGE)
+            })
+            .map(ProcessIdentifier)
+    }
+}
+
+impl TryFrom<u64> for ProcessIdentifier {
+    type Error = Error;
+
+    fn try_from(raw_tid: u64) -> Result<Self, Self::Error> {
+        raw_tid
+            .try_into()
+            .map_err(|_| {
+                Error::new(ErrorCode::InvalidArgument, ProcessIdentifier::PARSE_ERROR_MESSAGE)
+            })
+            .map(ProcessIdentifier)
+    }
+}
+
+impl core::fmt::Debug for ProcessIdentifier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self.0)
     }
 }


### PR DESCRIPTION
## Description

This pull request introduces a significant refactor to the `ProcessIdentifier` type, changing its internal representation from `u32` to `i32` for improved compatibility and error handling. Additionally, it implements comprehensive error handling for kernel calls and updates related code to reflect the new `ProcessIdentifier` type. Below are the most important changes grouped by theme:

### Refactor of `ProcessIdentifier` Type

* Changed the internal representation of `ProcessIdentifier` from `u32` to `i32` and updated associated constants, methods, and conversions. This includes adding `TryFrom` implementations for various types to handle conversion errors gracefully. (`src/libs/sys/src/sys/pm/pid.rs`)
* Updated the `CURRENT_PID` static variable to use `AtomicI32` instead of `AtomicU32` to align with the new `ProcessIdentifier` type. (`src/kernel/src/pm/process/manager/unsafe.rs`)

### Error Handling Improvements

* Replaced direct `ProcessIdentifier::from` calls with `ProcessIdentifier::try_from` in kernel call implementations to handle invalid process identifiers more robustly. This change applies to functions such as `mcopy`, `mctrl`, `mmap`, `munmap`, and `terminate`. (`src/kernel/src/pm/kcall/mcopy.rs`, `src/kernel/src/pm/kcall/mctrl.rs`, `src/kernel/src/pm/kcall/mmap.rs`, `src/kernel/src/pm/kcall/munmap.rs`, `src/kernel/src/pm/kcall/terminate.rs`) [[1]](diffhunk://#diff-7c3c178b4c303ad9e88cbf771016eef4d528ad95ab1f096fb4949d8bfd4e2ff3L83-R101) [[2]](diffhunk://#diff-046f07afc80cacae8ab973faab83e530adc1a3181ce9a35486c6048c6019639dL61-R67) [[3]](diffhunk://#diff-8524dbf7b45a6a59f857bc680c2b71484b3f0434f7b71e0ef99d4f04f50c2482L49-R55) [[4]](diffhunk://#diff-f38cee56746c68ef98ac479335da5db500194dcb3de64526a9e8af61344a8e14L51-R57) [[5]](diffhunk://#diff-ee2d47139db5a5f829bcddc32ac3b94801e87e96547b4473ffa3ea9b4a0b8cf7L22-R30)
* Updated the `ProcessDaemon` to validate and handle invalid process termination messages gracefully. (`src/libs/proc/src/daemon/mod.rs`) [[1]](diffhunk://#diff-96ee5eb61f7514f2083219c1ecd728e1fc615f72151c64542eb1cf4cd789da14L121-R129) [[2]](diffhunk://#diff-96ee5eb61f7514f2083219c1ecd728e1fc615f72151c64542eb1cf4cd789da14L265-R272)

### Code Updates for Compatibility

* Updated all instances where `ProcessIdentifier` was constructed or converted to align with the new `i32` representation, including kernel calls, process management, and inter-process communication. (`src/kernel/src/kcall/mod.rs`, `src/kernel/src/pm/process/manager/mod.rs`, `src/libs/sys/src/sys/kcall/mm/kcalls.rs`, `src/libs/sys/src/sys/kcall/pm.rs`) [[1]](diffhunk://#diff-88ec5e3fd0650612a067ac6d75869d16cd286510a2633bc245630a0318a45f06L92-R92) [[2]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L521-R521) [[3]](diffhunk://#diff-778cb324bb5755407b2ea8bcf57721d6aba6f21eb42d386997a2ed9c14a23a57L35-R35) [[4]](diffhunk://#diff-00d36abbf8d129ffff8c55571e54ba0c1bafcb760e2279ed08cbb34c3ca3598bL112-R112)

### Linting and Code Quality

* Added strict Clippy linting rules to the `ProcessIdentifier` implementation file to enforce safe casting and prevent common pitfalls. (`src/libs/sys/src/sys/pm/pid.rs`)

These changes collectively enhance the robustness of process management by improving type safety, error handling, and compatibility across the kernel and user-space components.