### PR TITLE
[daemons] Bad Mask for fcntl()

### DIFF
--- a/src/daemons/linuxd/src/fcntl.rs
+++ b/src/daemons/linuxd/src/fcntl.rs
@@ -744,7 +744,7 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
         libc::F_GETFL => 0,
         libc::F_SETFL => {
             match LibcFileStatusFlags::try_from_nanvix_flags(
-                request.arg & LibcFileStatusFlags::libc_mask(),
+                request.arg & LibcFileStatusFlags::nanvix_mask(),
             ) {
                 Ok(flags) => flags.inner(),
                 Err(error) => {


### PR DESCRIPTION
## Description

This pull request updates the `do_fcntl` function in `src/daemons/linuxd/src/fcntl.rs` to fix an issue with flag masking. The change ensures the correct mask is applied when converting file status flags.

Key change:

* Updated the `F_SETFL` case in `do_fcntl` to use `LibcFileStatusFlags::nanvix_mask()` instead of `LibcFileStatusFlags::libc_mask()` for proper flag conversion.