### PR TITLE
[kernel] Use TIDs for IPC

### DIFF
--- a/src/daemons/linuxd/src/dirent.rs
+++ b/src/daemons/linuxd/src/dirent.rs
@@ -14,7 +14,7 @@ use ::std::ffi::CStr;
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::syscall::{
     dirent::message::{
@@ -102,16 +102,16 @@ impl linux_dirent {
 //==================================================================================================
 
 /// Handles a getdents() system call request.
-pub fn do_getdents(pid: ProcessIdentifier, request: GetDirectoryEntriesRequest) -> Vec<Message> {
-    trace!("do_getdents(): pid={pid:?}, request,count={:#x?}", { request.count });
+pub fn do_getdents(tid: ThreadIdentifier, request: GetDirectoryEntriesRequest) -> Vec<Message> {
+    trace!("do_getdents(): tid={tid:?}, request,count={:#x?}", { request.count });
 
     // Check if `request.count` is not valid.
     if request.count == 0 {
         error!("do_getdents(): invalid buffer count");
-        return vec![crate::build_error(pid, ErrorCode::InvalidArgument)];
+        return vec![crate::build_error(tid, ErrorCode::InvalidArgument)];
     } else if request.count as usize > GetDirectoryEntriesRequest::MAX_ENTRIES {
         error!("do_getdents(): request is too large");
-        return vec![crate::build_error(pid, ErrorCode::TooBig)];
+        return vec![crate::build_error(tid, ErrorCode::TooBig)];
     }
 
     let bufsize: usize =
@@ -130,7 +130,7 @@ pub fn do_getdents(pid: ProcessIdentifier, request: GetDirectoryEntriesRequest) 
             error!("libc::getdents(): errno={}", { errno });
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            return vec![crate::build_error(pid, error)];
+            return vec![crate::build_error(tid, error)];
         },
         // Success.
         n => {
@@ -187,11 +187,11 @@ pub fn do_getdents(pid: ProcessIdentifier, request: GetDirectoryEntriesRequest) 
 
     // Build response and check for errors.
     let response: GetDirectoryEntriesResponse = GetDirectoryEntriesResponse::new(buf);
-    match response.into_parts(pid) {
+    match response.into_parts(tid) {
         Ok(messages) => messages,
         Err(error) => {
             warn!("do_getdents(): failed to build response (error={error:?})");
-            vec![crate::build_error(pid, error.code)]
+            vec![crate::build_error(tid, error.code)]
         },
     }
 }

--- a/src/daemons/linuxd/src/fcntl.rs
+++ b/src/daemons/linuxd/src/fcntl.rs
@@ -14,7 +14,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     fcntl::{
@@ -143,8 +143,8 @@ use sysapi::fcntl::file_descriptor_flags::{
 // do_openat
 //==================================================================================================
 
-pub fn do_openat(pid: ProcessIdentifier, request: OpenAtRequest) -> Vec<Message> {
-    trace!("openat(): pid={pid:?}, request={request:?}");
+pub fn do_openat(tid: ThreadIdentifier, request: OpenAtRequest) -> Vec<Message> {
+    trace!("openat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
     let flags: ffi::c_int = request.flags;
@@ -152,17 +152,17 @@ pub fn do_openat(pid: ProcessIdentifier, request: OpenAtRequest) -> Vec<Message>
 
     let pathname: CString = match CString::new(request.pathname.as_str()) {
         Ok(pathname) => pathname,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
     let flags: LibcFileOpenFlags = match LibcFileOpenFlags::try_from_nanvix_flags(flags) {
         Ok(flags) => flags,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
     let mode: LibcFileMode = match LibcFileMode::try_from(mode) {
         Ok(mode) => mode,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     debug!(
@@ -174,14 +174,14 @@ pub fn do_openat(pid: ProcessIdentifier, request: OpenAtRequest) -> Vec<Message>
     match unsafe { libc::openat(dirfd.inner(), pathname.as_ptr(), flags.inner(), mode.inner()) } {
         fd if fd >= 0 => {
             debug!("libc::openat(): fd={fd:?}");
-            vec![OpenAtResponse::build(pid, fd)]
+            vec![OpenAtResponse::build(tid, fd)]
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::openat(): errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }
@@ -190,15 +190,15 @@ pub fn do_openat(pid: ProcessIdentifier, request: OpenAtRequest) -> Vec<Message>
 // do_unlink_at
 //==================================================================================================
 
-pub fn do_unlinkat(pid: ProcessIdentifier, request: UnlinkAtRequest) -> Vec<Message> {
-    trace!("unlinkat(): pid={pid:?}, request={request:?}");
+pub fn do_unlinkat(tid: ThreadIdentifier, request: UnlinkAtRequest) -> Vec<Message> {
+    trace!("unlinkat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
     let flags: c_int = request.flags;
 
     let pathname: CString = match CString::new(request.pathname.as_str()) {
         Ok(pathname) => pathname,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
@@ -213,12 +213,12 @@ pub fn do_unlinkat(pid: ProcessIdentifier, request: UnlinkAtRequest) -> Vec<Mess
     {
         ret if ret == 0 => {
             debug!("libc::unlinkat(): success");
-            vec![UnlinkAtResponse::build(pid, ret)]
+            vec![UnlinkAtResponse::build(tid, ret)]
         },
         errno => {
             debug!("libc::unlinkat(): errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno).expect("unknown error code {error}");
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }
@@ -227,20 +227,20 @@ pub fn do_unlinkat(pid: ProcessIdentifier, request: UnlinkAtRequest) -> Vec<Mess
 // do_rename_at
 //==================================================================================================
 
-pub fn do_renameat(pid: ProcessIdentifier, request: RenameAtRequest) -> Vec<Message> {
-    trace!("renameat(): pid={pid:?}, request={request:?}");
+pub fn do_renameat(tid: ThreadIdentifier, request: RenameAtRequest) -> Vec<Message> {
+    trace!("renameat(): tid={tid:?}, request={request:?}");
 
     let olddirfd: i32 = request.olddirfd;
     let newdirfd: i32 = request.newdirfd;
 
     let oldpath: CString = match CString::new(request.oldpath.as_str()) {
         Ok(oldpath) => oldpath,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let newpath: CString = match CString::new(request.newpath.as_str()) {
         Ok(newpath) => newpath,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let olddirfd: LibcAtFlags = LibcAtFlags::from(olddirfd);
@@ -261,12 +261,12 @@ pub fn do_renameat(pid: ProcessIdentifier, request: RenameAtRequest) -> Vec<Mess
     } {
         ret if ret == 0 => {
             debug!("libc::renameat(): success");
-            vec![RenameAtResponse::build(pid, ret)]
+            vec![RenameAtResponse::build(tid, ret)]
         },
         errno => {
             debug!("libc::renameat(): errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno).expect("unknown error code {error}");
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }
@@ -275,8 +275,8 @@ pub fn do_renameat(pid: ProcessIdentifier, request: RenameAtRequest) -> Vec<Mess
 // do_fstatat
 //==================================================================================================
 
-pub fn do_fstat_at(pid: ProcessIdentifier, request: FileStatAtRequest) -> Vec<Message> {
-    trace!("fstatat(): pid={pid:?}, request={request:?}");
+pub fn do_fstat_at(tid: ThreadIdentifier, request: FileStatAtRequest) -> Vec<Message> {
+    trace!("fstatat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
@@ -287,7 +287,7 @@ pub fn do_fstat_at(pid: ProcessIdentifier, request: FileStatAtRequest) -> Vec<Me
     };
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(c_string) => c_string,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let mut st: libc::stat = unsafe { core::mem::zeroed() };
@@ -311,7 +311,7 @@ pub fn do_fstat_at(pid: ProcessIdentifier, request: FileStatAtRequest) -> Vec<Me
                     tv_nsec: match st.st_atime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(pid, ErrorCode::ValueOutOfRange)];
+                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
                         },
                     },
                 },
@@ -320,7 +320,7 @@ pub fn do_fstat_at(pid: ProcessIdentifier, request: FileStatAtRequest) -> Vec<Me
                     tv_nsec: match st.st_mtime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(pid, ErrorCode::ValueOutOfRange)];
+                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
                         },
                     },
                 },
@@ -329,7 +329,7 @@ pub fn do_fstat_at(pid: ProcessIdentifier, request: FileStatAtRequest) -> Vec<Me
                     tv_nsec: match st.st_ctime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(pid, ErrorCode::ValueOutOfRange)];
+                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
                         },
                     },
                 },
@@ -341,9 +341,9 @@ pub fn do_fstat_at(pid: ProcessIdentifier, request: FileStatAtRequest) -> Vec<Me
             debug!("libc::fstatat(): size of stat={:?}", core::mem::size_of::<stat>());
             let response = FileStatAtResponse::new(stat);
 
-            match response.into_parts(pid) {
+            match response.into_parts(tid) {
                 Ok(messages) => messages,
-                Err(e) => vec![crate::build_error(pid, e.code)],
+                Err(e) => vec![crate::build_error(tid, e.code)],
             }
         },
         _ => {
@@ -351,7 +351,7 @@ pub fn do_fstat_at(pid: ProcessIdentifier, request: FileStatAtRequest) -> Vec<Me
             debug!("libc::fstatat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }
@@ -360,8 +360,8 @@ pub fn do_fstat_at(pid: ProcessIdentifier, request: FileStatAtRequest) -> Vec<Me
 // do_posix_fallocate
 //==================================================================================================
 
-pub fn do_posix_fallocate(pid: ProcessIdentifier, request: FileSpaceControlRequest) -> Message {
-    trace!("posix_fallocate(): pid={pid:?}, request={request:?}");
+pub fn do_posix_fallocate(tid: ThreadIdentifier, request: FileSpaceControlRequest) -> Message {
+    trace!("posix_fallocate(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
     let offset: off_t = request.offset;
@@ -371,13 +371,13 @@ pub fn do_posix_fallocate(pid: ProcessIdentifier, request: FileSpaceControlReque
     match unsafe { libc::posix_fallocate(fd, offset, len) } {
         0 => {
             debug!("libc::posix_fallocate(): success");
-            FileSpaceControlResponse::build(pid, 0)
+            FileSpaceControlResponse::build(tid, 0)
         },
         errno => {
             debug!("libc::posix_fallocate(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
     }
 }
@@ -386,18 +386,15 @@ pub fn do_posix_fallocate(pid: ProcessIdentifier, request: FileSpaceControlReque
 // do_posix_fadvise
 //==================================================================================================
 
-pub fn do_posix_fadvise(
-    pid: ProcessIdentifier,
-    request: FileAdvisoryInformationRequest,
-) -> Message {
-    trace!("posix_fadvise(): pid={pid:?}, request={request:?}");
+pub fn do_posix_fadvise(tid: ThreadIdentifier, request: FileAdvisoryInformationRequest) -> Message {
+    trace!("posix_fadvise(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
     let offset: off_t = request.offset;
     let len: off_t = request.len;
     let advice: LibcFileAdvice = match LibcFileAdvice::try_from(request.advice) {
         Ok(advice) => advice,
-        Err(e) => return crate::build_error(pid, e.code),
+        Err(e) => return crate::build_error(tid, e.code),
     };
 
     debug!(
@@ -407,13 +404,13 @@ pub fn do_posix_fadvise(
     match unsafe { libc::posix_fadvise(fd, offset, len, advice.inner()) } {
         0 => {
             debug!("libc::posix_fadvise(): success");
-            FileAdvisoryInformationResponse::build(pid, 0)
+            FileAdvisoryInformationResponse::build(tid, 0)
         },
         errno => {
             debug!("libc::posix_fadvise(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
     }
 }
@@ -422,8 +419,8 @@ pub fn do_posix_fadvise(
 // do_fstat()
 //==================================================================================================
 
-pub fn do_fstat(pid: ProcessIdentifier, request: FileStatRequest) -> Vec<Message> {
-    trace!("fstatat(): pid={pid:?}, request={request:?}");
+pub fn do_fstat(tid: ThreadIdentifier, request: FileStatRequest) -> Vec<Message> {
+    trace!("fstatat(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
 
@@ -448,7 +445,7 @@ pub fn do_fstat(pid: ProcessIdentifier, request: FileStatRequest) -> Vec<Message
                     tv_nsec: match st.st_atime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(pid, ErrorCode::ValueOutOfRange)];
+                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
                         },
                     },
                 },
@@ -457,7 +454,7 @@ pub fn do_fstat(pid: ProcessIdentifier, request: FileStatRequest) -> Vec<Message
                     tv_nsec: match st.st_mtime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(pid, ErrorCode::ValueOutOfRange)];
+                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
                         },
                     },
                 },
@@ -466,7 +463,7 @@ pub fn do_fstat(pid: ProcessIdentifier, request: FileStatRequest) -> Vec<Message
                     tv_nsec: match st.st_ctime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(pid, ErrorCode::ValueOutOfRange)];
+                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
                         },
                     },
                 },
@@ -478,9 +475,9 @@ pub fn do_fstat(pid: ProcessIdentifier, request: FileStatRequest) -> Vec<Message
             debug!("libc::fstatat(): size of stat={:?}", core::mem::size_of::<stat>());
             let response = FileStatAtResponse::new(stat);
 
-            match response.into_parts(pid) {
+            match response.into_parts(tid) {
                 Ok(messages) => messages,
-                Err(e) => vec![crate::build_error(pid, e.code)],
+                Err(e) => vec![crate::build_error(tid, e.code)],
             }
         },
         _ => {
@@ -488,7 +485,7 @@ pub fn do_fstat(pid: ProcessIdentifier, request: FileStatRequest) -> Vec<Message
             debug!("libc::fstatat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }
@@ -497,12 +494,12 @@ pub fn do_fstat(pid: ProcessIdentifier, request: FileStatRequest) -> Vec<Message
 // do_symlinkat()
 //==================================================================================================
 
-pub fn do_symlinkat(pid: ProcessIdentifier, request: SymbolicLinkAtRequest) -> Vec<Message> {
-    trace!("symlinkat(): pid={pid:?}, request={request:?}");
+pub fn do_symlinkat(tid: ThreadIdentifier, request: SymbolicLinkAtRequest) -> Vec<Message> {
+    trace!("symlinkat(): tid={tid:?}, request={request:?}");
 
     let target: CString = match CString::new(request.target.as_str()) {
         Ok(target) => target,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let newdirfd: i32 = request.dirfd;
@@ -510,7 +507,7 @@ pub fn do_symlinkat(pid: ProcessIdentifier, request: SymbolicLinkAtRequest) -> V
 
     let linkpath: CString = match CString::new(request.linkpath.as_str()) {
         Ok(linkpath) => linkpath,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     debug!(
@@ -520,14 +517,14 @@ pub fn do_symlinkat(pid: ProcessIdentifier, request: SymbolicLinkAtRequest) -> V
     match unsafe { libc::symlinkat(target.as_ptr(), newdirfd.inner(), linkpath.as_ptr()) } {
         0 => {
             debug!("libc::symlinkat(): success");
-            vec![SymbolicLinkAtResponse::build(pid, 0)]
+            vec![SymbolicLinkAtResponse::build(tid, 0)]
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::symlinkat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }
@@ -536,15 +533,15 @@ pub fn do_symlinkat(pid: ProcessIdentifier, request: SymbolicLinkAtRequest) -> V
 // do_readlinkat()
 //==================================================================================================
 
-pub fn do_readlinkat(pid: ProcessIdentifier, request: ReadLinkAtRequest) -> Vec<Message> {
-    trace!("readlinkat(): pid={pid:?}, request={request:?}");
+pub fn do_readlinkat(tid: ThreadIdentifier, request: ReadLinkAtRequest) -> Vec<Message> {
+    trace!("readlinkat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
 
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     // TODO: Have a system-wide constant for this.
@@ -565,12 +562,12 @@ pub fn do_readlinkat(pid: ProcessIdentifier, request: ReadLinkAtRequest) -> Vec<
 
             let response: ReadLinkAtResponse = match ReadLinkAtResponse::new(buf) {
                 Ok(response) => response,
-                Err(e) => return vec![crate::build_error(pid, e.code)],
+                Err(e) => return vec![crate::build_error(tid, e.code)],
             };
 
-            match response.into_parts(pid) {
+            match response.into_parts(tid) {
                 Ok(messages) => messages,
-                Err(e) => vec![crate::build_error(pid, e.code)],
+                Err(e) => vec![crate::build_error(tid, e.code)],
             }
         },
         _ => {
@@ -578,7 +575,7 @@ pub fn do_readlinkat(pid: ProcessIdentifier, request: ReadLinkAtRequest) -> Vec<
             debug!("libc::readlinkat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }
@@ -587,20 +584,20 @@ pub fn do_readlinkat(pid: ProcessIdentifier, request: ReadLinkAtRequest) -> Vec<
 // do_mkdirat()
 //==================================================================================================
 
-pub fn do_mkdirat(pid: ProcessIdentifier, request: MakeDirectoryAtRequest) -> Vec<Message> {
-    trace!("mkdirat(): pid={pid:?}, request={request:?}");
+pub fn do_mkdirat(tid: ThreadIdentifier, request: MakeDirectoryAtRequest) -> Vec<Message> {
+    trace!("mkdirat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
 
     let pathname: CString = match CString::new(request.pathname.as_str()) {
         Ok(pathname) => pathname,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let mode: LibcFileMode = match LibcFileMode::try_from(request.mode) {
         Ok(mode) => mode,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     debug!(
@@ -611,14 +608,14 @@ pub fn do_mkdirat(pid: ProcessIdentifier, request: MakeDirectoryAtRequest) -> Ve
     match unsafe { libc::mkdirat(dirfd.inner(), pathname.as_ptr(), mode.inner()) } {
         0 => {
             debug!("libc::mkdirat(): success");
-            vec![MakeDirectoryAtResponse::build(pid, 0)]
+            vec![MakeDirectoryAtResponse::build(tid, 0)]
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::mkdirat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }
@@ -627,18 +624,15 @@ pub fn do_mkdirat(pid: ProcessIdentifier, request: MakeDirectoryAtRequest) -> Ve
 // do_utimensat()
 //==================================================================================================
 
-pub fn do_utimensat(
-    pid: ProcessIdentifier,
-    request: UpdateFileAccessTimeAtRequest,
-) -> Vec<Message> {
-    trace!("utimensat(): pid={pid:?}, request={request:?}");
+pub fn do_utimensat(tid: ThreadIdentifier, request: UpdateFileAccessTimeAtRequest) -> Vec<Message> {
+    trace!("utimensat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
 
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let times: [timespec; 2] = request.times;
@@ -667,14 +661,14 @@ pub fn do_utimensat(
     match unsafe { libc::utimensat(dirfd.inner(), path.as_ptr(), libc_times.as_ptr(), flag) } {
         0 => {
             debug!("libc::utimensat(): success");
-            vec![UpdateFileAccessTimeAtResponse::build(pid, 0)]
+            vec![UpdateFileAccessTimeAtResponse::build(tid, 0)]
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::utimensat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }
@@ -683,8 +677,8 @@ pub fn do_utimensat(
 // do_futimens()
 //==================================================================================================
 
-pub fn do_futimens(pid: ProcessIdentifier, request: UpdateFileAccessTimeRequest) -> Message {
-    trace!("futimens(): pid={pid:?}, request={request:?}");
+pub fn do_futimens(tid: ThreadIdentifier, request: UpdateFileAccessTimeRequest) -> Message {
+    trace!("futimens(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
 
@@ -703,14 +697,14 @@ pub fn do_futimens(pid: ProcessIdentifier, request: UpdateFileAccessTimeRequest)
     match unsafe { libc::futimens(fd, libc_times.as_ptr()) } {
         0 => {
             debug!("libc::futimens(): success");
-            UpdateFileAccessTimeResponse::build(pid, 0)
+            UpdateFileAccessTimeResponse::build(tid, 0)
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::futimens(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
     }
 }
@@ -719,13 +713,13 @@ pub fn do_futimens(pid: ProcessIdentifier, request: UpdateFileAccessTimeRequest)
 // do_fcntl()
 //==================================================================================================
 
-pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message {
-    trace!("fcntl(): pid={pid:?}, request={request:?}");
+pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
+    trace!("fcntl(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
     let cmd: LibcFileControlCommand = match LibcFileControlCommand::try_from(request.cmd) {
         Ok(cmd) => cmd,
-        Err(e) => return crate::build_error(pid, e.code),
+        Err(e) => return crate::build_error(tid, e.code),
     };
 
     debug!("libc::fcntl(): fd={fd:?}, cmd={:?}, arg={:?}", cmd.inner(), { request.arg });
@@ -738,7 +732,7 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
             Ok(flags) => flags.inner(),
             Err(error) => {
                 error!("do_fcntl(): {error:?} (cmd={cmd:#x?}, arg={:?})", { request.arg });
-                return crate::build_error(pid, error.code);
+                return crate::build_error(tid, error.code);
             },
         },
         libc::F_GETFL => 0,
@@ -749,7 +743,7 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
                 Ok(flags) => flags.inner(),
                 Err(error) => {
                     error!("do_fcntl(): {error:?} (cmd={cmd:#x?}), arg={:?})", { request.arg });
-                    return crate::build_error(pid, error.code);
+                    return crate::build_error(tid, error.code);
                 },
             }
         },
@@ -759,7 +753,7 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
             if arg < 0 {
                 if arg == -1 {
                     error!("do_fcntl(): invalid owner (cmd={cmd:#x?}, arg={arg:?})");
-                    return crate::build_error(pid, ErrorCode::InvalidArgument);
+                    return crate::build_error(tid, ErrorCode::InvalidArgument);
                 } else {
                     -arg
                 }
@@ -770,17 +764,17 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
         libc::F_GETLK => {
             let reason: &str = "unsupported file lock command";
             error!("do_fcntl(): {reason:?} (cmd={cmd:#x?}, arg={:?})", { request.arg });
-            return crate::build_error(pid, ErrorCode::InvalidArgument);
+            return crate::build_error(tid, ErrorCode::InvalidArgument);
         },
         libc::F_SETLK => {
             let reason: &str = "unsupported file lock command";
             error!("do_fcntl(): {reason:?} (cmd={cmd:#x?}, arg={:?})", { request.arg });
-            return crate::build_error(pid, ErrorCode::InvalidArgument);
+            return crate::build_error(tid, ErrorCode::InvalidArgument);
         },
         libc::F_SETLKW => {
             let reason: &str = "unsupported file lock command";
             error!("do_fcntl(): {reason:?} (cmd={cmd:#x?}, arg={:?})", { request.arg });
-            return crate::build_error(pid, ErrorCode::InvalidArgument);
+            return crate::build_error(tid, ErrorCode::InvalidArgument);
         },
         unsupported_cmd => {
             // The following statement is unreachable because any unsupported commands were already
@@ -799,13 +793,13 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
         libc::F_DUPFD | libc::F_DUPFD_CLOEXEC => {
             if ret >= 0 {
                 debug!("libc::fcntl(): F_DUPFD | F_DUPFD_CLOEXEC success");
-                FileControlResponse::build(pid, ret)
+                FileControlResponse::build(tid, ret)
             } else {
                 let errno: i32 = unsafe { *libc::__errno_location() };
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
                 let error: ErrorCode = ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("unknown error code {errno}"));
-                crate::build_error(pid, error)
+                crate::build_error(tid, error)
             }
         },
         libc::F_GETFD => {
@@ -814,13 +808,13 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
                 let nanvix_file_descritor_flags: c_int = LibcFileDescriptorFlags(ret)
                     .try_into_nanvix_flags()
                     .unwrap_or_else(|_| panic!("unexpected file descriptor flags: {ret:?}"));
-                FileControlResponse::build(pid, nanvix_file_descritor_flags)
+                FileControlResponse::build(tid, nanvix_file_descritor_flags)
             } else {
                 let errno: i32 = unsafe { *libc::__errno_location() };
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
                 let error: ErrorCode = ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("unknown error code {errno}"));
-                crate::build_error(pid, error)
+                crate::build_error(tid, error)
             }
         },
         libc::F_GETFL => {
@@ -851,7 +845,7 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
                 );
 
                 FileControlResponse::build(
-                    pid,
+                    tid,
                     nanvix_file_status_flags | nanvix_file_creation_flags,
                 )
             } else {
@@ -859,13 +853,13 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
                 let error: ErrorCode = ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("unknown error code {errno}"));
-                crate::build_error(pid, error)
+                crate::build_error(tid, error)
             }
         },
         libc::F_GETOWN => {
             if ret != -1 {
                 debug!("libc::fcntl(): F_GETOWN success");
-                FileControlResponse::build(pid, ret)
+                FileControlResponse::build(tid, ret)
             } else {
                 // The following statement is unreachable because `libc::fcntl()` should never
                 // return -1 for `F_GETOWN`.
@@ -878,13 +872,13 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
         libc::F_SETFD | libc::F_SETFL | libc::F_SETOWN => {
             if ret == 0 {
                 debug!("libc::fcntl(): libc::F_SETFD | libc::F_SETFL | libc::F_SETOWN success");
-                FileControlResponse::build(pid, ret)
+                FileControlResponse::build(tid, ret)
             } else if ret == -1 {
                 let errno: i32 = unsafe { *libc::__errno_location() };
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
                 let error: ErrorCode = ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("unknown error code {errno}"));
-                crate::build_error(pid, error)
+                crate::build_error(tid, error)
             } else {
                 // The following statement is unreachable because `libc::fcntl()` should return
                 // either 0 on success or -1 on error for `F_SETFD`, `F_SETFL`, and `F_SETOWN`.
@@ -909,15 +903,15 @@ pub fn do_fcntl(pid: ProcessIdentifier, request: FileControlRequest) -> Message 
 // do_fchownat()
 //==================================================================================================
 
-pub fn do_fchownat(pid: ProcessIdentifier, request: FileChownAtRequest) -> Vec<Message> {
-    trace!("fchownat(): pid={pid:?}, request={request:?}");
+pub fn do_fchownat(tid: ThreadIdentifier, request: FileChownAtRequest) -> Vec<Message> {
+    trace!("fchownat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
 
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let owner: u32 = request.owner;
@@ -932,14 +926,14 @@ pub fn do_fchownat(pid: ProcessIdentifier, request: FileChownAtRequest) -> Vec<M
     match unsafe { libc::fchownat(dirfd.inner(), path.as_ptr(), owner, group, flag.inner()) } {
         0 => {
             debug!("libc::fchownat(): success");
-            vec![FileChownAtResponse::build(pid)]
+            vec![FileChownAtResponse::build(tid)]
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::fchownat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }
@@ -948,19 +942,19 @@ pub fn do_fchownat(pid: ProcessIdentifier, request: FileChownAtRequest) -> Vec<M
 // do_fchmod
 //==================================================================================================
 
-pub fn do_fchmod(pid: ProcessIdentifier, request: FileChmodRequest) -> Message {
-    trace!("fchmod(): pid={pid:?}, request={request:?}");
+pub fn do_fchmod(tid: ThreadIdentifier, request: FileChmodRequest) -> Message {
+    trace!("fchmod(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
     let mode: u32 = request.mode;
 
     debug!("libc::fchmod(): fd={fd:?}, mode={mode:?}");
     match unsafe { libc::fchmod(fd, mode) } {
-        0 => FileChmodResponse::build(pid),
+        0 => FileChmodResponse::build(tid),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -973,20 +967,20 @@ pub fn do_fchmod(pid: ProcessIdentifier, request: FileChmodRequest) -> Message {
 // do_fchmodat()
 //==================================================================================================
 
-pub fn do_fchmodat(pid: ProcessIdentifier, request: FileChmodAtRequest) -> Vec<Message> {
-    trace!("fchmodat(): pid={pid:?}, request={request:?}");
+pub fn do_fchmodat(tid: ThreadIdentifier, request: FileChmodAtRequest) -> Vec<Message> {
+    trace!("fchmodat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
 
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let mode: LibcFileMode = match LibcFileMode::try_from(request.mode) {
         Ok(mode) => mode,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidMessage)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
     };
 
     let flag: LibcAtFlags = LibcAtFlags::from(request.flag);
@@ -1001,14 +995,14 @@ pub fn do_fchmodat(pid: ProcessIdentifier, request: FileChmodAtRequest) -> Vec<M
     match unsafe { libc::fchmodat(dirfd.inner(), path.as_ptr(), mode.inner(), flag.inner()) } {
         0 => {
             debug!("libc::fchmodat(): success");
-            vec![FileChmodAtResponse::build(pid)]
+            vec![FileChmodAtResponse::build(tid)]
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::fchmodat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(pid, error)]
+            vec![crate::build_error(tid, error)]
         },
     }
 }

--- a/src/daemons/linuxd/src/linuxd/assemble.rs
+++ b/src/daemons/linuxd/src/linuxd/assemble.rs
@@ -20,7 +20,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::syscall::{
     fcntl::message::{
@@ -84,7 +84,7 @@ impl RequestAssemblerTrait for FileStatAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         fcntl::do_fstat_at(source, request)
     }
 }
@@ -121,7 +121,7 @@ impl RequestAssemblerTrait for SymbolicLinkAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         fcntl::do_symlinkat(source, request)
     }
 }
@@ -162,7 +162,7 @@ impl RequestAssemblerTrait for LinkAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         unistd::do_linkat(source, request)
     }
 }
@@ -199,7 +199,7 @@ impl RequestAssemblerTrait for ReadLinkAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         fcntl::do_readlinkat(source, request)
     }
 }
@@ -236,7 +236,7 @@ impl RequestAssemblerTrait for MakeDirectoryAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         fcntl::do_mkdirat(source, request)
     }
 }
@@ -279,7 +279,7 @@ impl RequestAssemblerTrait for UpdateFileAccessTimeAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         fcntl::do_utimensat(source, request)
     }
 }
@@ -316,7 +316,7 @@ impl RequestAssemblerTrait for FileChownAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         fcntl::do_fchownat(source, request)
     }
 }
@@ -353,7 +353,7 @@ impl RequestAssemblerTrait for FileChmodAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         fcntl::do_fchmodat(source, request)
     }
 }
@@ -390,7 +390,7 @@ impl RequestAssemblerTrait for OpenAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         fcntl::do_openat(source, request)
     }
 }
@@ -427,7 +427,7 @@ impl RequestAssemblerTrait for RenameAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         fcntl::do_renameat(source, request)
     }
 }
@@ -464,7 +464,7 @@ impl RequestAssemblerTrait for UnlinkAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         fcntl::do_unlinkat(source, request)
     }
 }
@@ -501,7 +501,7 @@ impl RequestAssemblerTrait for ChangeDirectoryRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         unistd::do_chdir(source, request)
     }
 }
@@ -538,7 +538,7 @@ impl RequestAssemblerTrait for FileAccessAtRequest {
         }
     }
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
         unistd::do_faccessat(source, request)
     }
 }

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -177,7 +177,18 @@ impl<'a> LinuxDaemon<'a> {
                 message.message_type,
             );
 
-            let source: ProcessIdentifier = message.source.into();
+            let source: ProcessIdentifier = match { message.source }.as_id() {
+                Ok (pid) => pid,
+                Err(_tid) => {
+                    error!("invalid source process identifier");
+                    let message: Message = self.do_error(
+                        ProcessIdentifier::from(syscall::LINUXD),
+                        ErrorCode::InvalidMessage,
+                    );
+                    self.send(message).unwrap();
+                    continue;
+                },
+            };
 
             // Check if process is associated with a virtual environment.
             if self.venv.get(source).is_none() {

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -49,7 +49,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::sysapi::{
     sys_types::c_ssize_t,
@@ -177,16 +180,10 @@ impl<'a> LinuxDaemon<'a> {
                 message.message_type,
             );
 
-            let source: ProcessIdentifier = match { message.source }.as_id() {
-                Ok (pid) => pid,
-                Err(_tid) => {
-                    error!("invalid source process identifier");
-                    let message: Message = self.do_error(
-                        ProcessIdentifier::from(syscall::LINUXD),
-                        ErrorCode::InvalidMessage,
-                    );
-                    self.send(message).unwrap();
-                    continue;
+            let source: ThreadIdentifier = match { message.source }.as_id() {
+                Err(tid) => tid,
+                Ok(pid) => {
+                    unimplemented!("received message from process {pid:?} instead of thread");
                 },
             };
 
@@ -330,7 +327,7 @@ impl<'a> LinuxDaemon<'a> {
 
     fn handle_special_messages(
         &mut self,
-        source: ProcessIdentifier,
+        source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Message {
         match message.header {
@@ -356,7 +353,7 @@ impl<'a> LinuxDaemon<'a> {
 
     fn handle_short_request_messages(
         &mut self,
-        source: ProcessIdentifier,
+        source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Message {
         match message.header {
@@ -490,7 +487,7 @@ impl<'a> LinuxDaemon<'a> {
 
     fn handle_long_request_messages(
         &mut self,
-        source: ProcessIdentifier,
+        source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) {
         match message.header {
@@ -543,7 +540,7 @@ impl<'a> LinuxDaemon<'a> {
 
     fn handle_long_response_messages(
         &mut self,
-        source: ProcessIdentifier,
+        source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) {
         match message.header {
@@ -602,7 +599,7 @@ impl<'a> LinuxDaemon<'a> {
         }
     }
 
-    fn do_error(&self, source: ProcessIdentifier, code: ErrorCode) -> Message {
+    fn do_error(&self, source: ThreadIdentifier, code: ErrorCode) -> Message {
         Message::new(
             MessageSender::from(self.pid),
             MessageReceiver::from(source),
@@ -612,11 +609,7 @@ impl<'a> LinuxDaemon<'a> {
         )
     }
 
-    fn handle_close_request(
-        &mut self,
-        source: ProcessIdentifier,
-        request: CloseRequest,
-    ) -> Message {
+    fn handle_close_request(&mut self, source: ThreadIdentifier, request: CloseRequest) -> Message {
         // Inspect file descriptor that is being closed, as we need to
         // handle standard file descriptors specially.
         match request.fd {
@@ -633,7 +626,7 @@ impl<'a> LinuxDaemon<'a> {
 
     fn handle_write_request(
         &mut self,
-        source: ProcessIdentifier,
+        source: ThreadIdentifier,
         mut request: WriteRequest,
     ) -> Message {
         trace!("handle_write_request(): source={source:?}, request={request:?}");
@@ -682,7 +675,7 @@ impl<'a> LinuxDaemon<'a> {
         }
     }
 
-    fn handle_read_request(&mut self, source: ProcessIdentifier, request: ReadRequest) -> Message {
+    fn handle_read_request(&mut self, source: ThreadIdentifier, request: ReadRequest) -> Message {
         trace!("handle_read_request(): source={source:?}, request={request:?}");
         // Check if reading from gateway.
         if request.fd == STDIN_FILENO {
@@ -780,7 +773,7 @@ impl<'a> LinuxDaemon<'a> {
         }
     }
 
-    fn handle_fstat_request(&mut self, source: ProcessIdentifier, message: LinuxDaemonMessage) {
+    fn handle_fstat_request(&mut self, source: ThreadIdentifier, message: LinuxDaemonMessage) {
         let request: FileStatRequest = FileStatRequest::from_bytes(message.payload);
 
         let messages: Vec<Message> = fcntl::do_fstat(source, request);
@@ -791,7 +784,7 @@ impl<'a> LinuxDaemon<'a> {
         }
     }
 
-    fn handle_getcwd_request(&mut self, source: ProcessIdentifier) {
+    fn handle_getcwd_request(&mut self, source: ThreadIdentifier) {
         let messages: Vec<Message> = unistd::do_getcwd(source);
         for message in messages {
             if let Err(e) = self.send(message) {
@@ -800,7 +793,7 @@ impl<'a> LinuxDaemon<'a> {
         }
     }
 
-    fn handle_getdents_request(&mut self, source: ProcessIdentifier, message: LinuxDaemonMessage) {
+    fn handle_getdents_request(&mut self, source: ThreadIdentifier, message: LinuxDaemonMessage) {
         let request: GetDirectoryEntriesRequest =
             GetDirectoryEntriesRequest::from_bytes(message.payload);
 
@@ -812,7 +805,7 @@ impl<'a> LinuxDaemon<'a> {
         }
     }
 
-    fn handle_long_request<T>(&mut self, source: ProcessIdentifier, message: &LinuxDaemonMessage)
+    fn handle_long_request<T>(&mut self, source: ThreadIdentifier, message: &LinuxDaemonMessage)
     where
         T: RequestAssemblerTrait,
     {

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -45,6 +45,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -175,7 +177,7 @@ impl<'a> LinuxDaemon<'a> {
                 message.message_type,
             );
 
-            let source: ProcessIdentifier = message.source;
+            let source: ProcessIdentifier = message.source.into();
 
             // Check if process is associated with a virtual environment.
             if self.venv.get(source).is_none() {
@@ -590,7 +592,13 @@ impl<'a> LinuxDaemon<'a> {
     }
 
     fn do_error(&self, source: ProcessIdentifier, code: ErrorCode) -> Message {
-        Message::new(self.pid, source, MessageType::Ikc, Some(code), [0u8; Message::PAYLOAD_SIZE])
+        Message::new(
+            MessageSender::from(self.pid),
+            MessageReceiver::from(source),
+            MessageType::Ikc,
+            Some(code),
+            [0u8; Message::PAYLOAD_SIZE],
+        )
     }
 
     fn handle_close_request(

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -56,7 +56,6 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
 };
 use ::syscomm::{
     Socket,
@@ -64,6 +63,7 @@ use ::syscomm::{
     SocketStream,
     SocketType,
 };
+use sys::pm::ThreadIdentifier;
 
 //==================================================================================================
 // Constants
@@ -216,17 +216,17 @@ pub fn initialize(logfile: bool) {
 ///
 /// # Parameters
 ///
-/// - `pid`: Process identifier.
+/// - `tid`: Thread identifier.
 /// - `error`: Error code.
 ///
 /// # Returns
 ///
 /// A message with the error response.
 ///
-pub fn build_error(pid: ProcessIdentifier, error: ErrorCode) -> Message {
+pub fn build_error(tid: ThreadIdentifier, error: ErrorCode) -> Message {
     Message::new(
         MessageSender::from(::syscall::LINUXD),
-        MessageReceiver::from(pid),
+        MessageReceiver::from(tid),
         MessageType::Ikc,
         Some(error),
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -52,6 +52,8 @@ use ::sys::{
     error::ErrorCode,
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -223,8 +225,8 @@ pub fn initialize(logfile: bool) {
 ///
 pub fn build_error(pid: ProcessIdentifier, error: ErrorCode) -> Message {
     Message::new(
-        ::syscall::LINUXD,
-        pid,
+        MessageSender::from(::syscall::LINUXD),
+        MessageReceiver::from(pid),
         MessageType::Ikc,
         Some(error),
         [0u8; Message::PAYLOAD_SIZE],

--- a/src/daemons/linuxd/src/message.rs
+++ b/src/daemons/linuxd/src/message.rs
@@ -9,7 +9,7 @@ use ::alloc::collections::BTreeMap;
 use ::sys::{
     error::Error,
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::syscall::message::{
     LinuxDaemonLongMessage,
@@ -23,13 +23,13 @@ use ::syscall::message::{
 
 #[derive(Default)]
 pub struct RequestAssembler {
-    inflight: BTreeMap<ProcessIdentifier, RequestAssemblerType>,
+    inflight: BTreeMap<ThreadIdentifier, RequestAssemblerType>,
 }
 
 impl RequestAssembler {
     pub fn process_message<T: RequestAssemblerTrait>(
         &mut self,
-        source: ProcessIdentifier,
+        source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
     ) -> Result<Option<Vec<Message>>, Error> {
         match self.process_message_internal::<T>(source, part) {
@@ -43,7 +43,7 @@ impl RequestAssembler {
 
     fn process_message_internal<T: RequestAssemblerTrait>(
         &mut self,
-        source: ProcessIdentifier,
+        source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
     ) -> Result<Option<Vec<Message>>, Error> {
         let message_complete: bool = {
@@ -67,7 +67,7 @@ impl RequestAssembler {
 
     fn assemble_parts<T: RequestAssemblerTrait>(
         &mut self,
-        source: ProcessIdentifier,
+        source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
     ) -> Result<bool, Error> {
         let assembler: &mut RequestAssemblerType = self
@@ -80,7 +80,7 @@ impl RequestAssembler {
 
     fn process_request<T: RequestAssemblerTrait>(
         &mut self,
-        source: ProcessIdentifier,
+        source: ThreadIdentifier,
     ) -> Result<Vec<Message>, Error> {
         let assembler: RequestAssemblerType = self
             .inflight
@@ -126,5 +126,5 @@ where
 
     fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart>;
 
-    fn process_request(source: ProcessIdentifier, request: Self) -> Vec<Message>;
+    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message>;
 }

--- a/src/daemons/linuxd/src/poll.rs
+++ b/src/daemons/linuxd/src/poll.rs
@@ -8,7 +8,7 @@
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::poll::{
     poll_errors::{
@@ -36,13 +36,13 @@ use ::syscall::poll::message::{
 // do_poll()
 //==================================================================================================
 
-pub fn do_poll(pid: ProcessIdentifier, request: PollRequest) -> Message {
-    trace!("poll(): pid={pid:?}, request={request:?}");
+pub fn do_poll(tid: ThreadIdentifier, request: PollRequest) -> Message {
+    trace!("poll(): tid={tid:?}, request={request:?}");
 
     // Check if request is not valid.
     if request.nfds == 0 || request.nfds as usize > NFDS_MAX {
         error!("poll(): invalid request ({request:?})");
-        return crate::build_error(pid, ErrorCode::InvalidArgument);
+        return crate::build_error(tid, ErrorCode::InvalidArgument);
     }
 
     // Unpack request.
@@ -77,7 +77,7 @@ pub fn do_poll(pid: ProcessIdentifier, request: PollRequest) -> Message {
                     }
 
                     // Build response.
-                    match PollResponse::build(pid, nready, &ready_fds, &revents) {
+                    match PollResponse::build(tid, nready, &ready_fds, &revents) {
                         Ok(response) => response,
                         Err(error) => {
                             unreachable!("poll(): failed to build response ({error:?})");
@@ -96,7 +96,7 @@ pub fn do_poll(pid: ProcessIdentifier, request: PollRequest) -> Message {
             error!("poll(): errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
     }
 }

--- a/src/daemons/linuxd/src/socket.rs
+++ b/src/daemons/linuxd/src/socket.rs
@@ -15,7 +15,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     netinet_in::message_flags::{
@@ -72,12 +72,12 @@ use ::syscall::{
 // do_socket
 //==================================================================================================
 
-pub fn do_socket(pid: ProcessIdentifier, request: CreateSocketRequest) -> Message {
-    trace!("socket(): pid={pid:?}, request={request:?}");
+pub fn do_socket(tid: ThreadIdentifier, request: CreateSocketRequest) -> Message {
+    trace!("socket(): tid={tid:?}, request={request:?}");
 
     let domain: LibcSocketDomain = match LibcSocketDomain::try_from(request.domain) {
         Ok(domain) => domain,
-        Err(e) => return crate::build_error(pid, e.code),
+        Err(e) => return crate::build_error(tid, e.code),
     };
 
     let typ: LibcSocketType = LibcSocketType::from(request.typ);
@@ -95,11 +95,11 @@ pub fn do_socket(pid: ProcessIdentifier, request: CreateSocketRequest) -> Messag
             error!("libc::socket(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
         sockfd => {
             debug!("libc::socket(): fd={sockfd:?}");
-            CreateSocketResponse::build(pid, sockfd)
+            CreateSocketResponse::build(tid, sockfd)
         },
     }
 }
@@ -108,12 +108,12 @@ pub fn do_socket(pid: ProcessIdentifier, request: CreateSocketRequest) -> Messag
 // do_socketpair
 //==================================================================================================
 
-pub fn do_socketpair(pid: ProcessIdentifier, request: CreateSocketPairRequest) -> Message {
-    trace!("socketpair(): pid={pid:?}, request={request:?}");
+pub fn do_socketpair(tid: ThreadIdentifier, request: CreateSocketPairRequest) -> Message {
+    trace!("socketpair(): tid={tid:?}, request={request:?}");
 
     let domain: LibcSocketDomain = match LibcSocketDomain::try_from(request.domain) {
         Ok(domain) => domain,
-        Err(e) => return crate::build_error(pid, e.code),
+        Err(e) => return crate::build_error(tid, e.code),
     };
 
     let typ: LibcSocketType = LibcSocketType::from(request.typ);
@@ -135,11 +135,11 @@ pub fn do_socketpair(pid: ProcessIdentifier, request: CreateSocketPairRequest) -
             error!("libc::socketpair(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
         _ => {
             debug!("libc::socketpair(): fds={sv:?}");
-            CreateSocketPairResponse::build(pid, sv[0], sv[1])
+            CreateSocketPairResponse::build(tid, sv[0], sv[1])
         },
     }
 }
@@ -148,13 +148,13 @@ pub fn do_socketpair(pid: ProcessIdentifier, request: CreateSocketPairRequest) -
 // do_bind
 //==================================================================================================
 
-pub fn do_bind(pid: ProcessIdentifier, request: BindSocketRequest) -> Message {
-    trace!("bind(): pid={pid:?}, request={request:?}");
+pub fn do_bind(tid: ThreadIdentifier, request: BindSocketRequest) -> Message {
+    trace!("bind(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
     let sockaddr: LibcSocketAddress = match LibcSocketAddress::try_from(request.sockaddr) {
         Ok(sockaddr) => sockaddr,
-        Err(e) => return crate::build_error(pid, e.code),
+        Err(e) => return crate::build_error(tid, e.code),
     };
     let socklen: socklen_t = mem::size_of_val(&sockaddr) as socklen_t;
 
@@ -170,9 +170,9 @@ pub fn do_bind(pid: ProcessIdentifier, request: BindSocketRequest) -> Message {
             error!("libc::bind(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
-        _ => BindSocketResponse::build(pid),
+        _ => BindSocketResponse::build(tid),
     }
 }
 
@@ -180,13 +180,13 @@ pub fn do_bind(pid: ProcessIdentifier, request: BindSocketRequest) -> Message {
 // do_connect
 //==================================================================================================
 
-pub fn do_connect(pid: ProcessIdentifier, request: ConnectSocketRequest) -> Message {
-    trace!("connect(): pid={pid:?}, request={request:?}");
+pub fn do_connect(tid: ThreadIdentifier, request: ConnectSocketRequest) -> Message {
+    trace!("connect(): tid={tid:?}, request={request:?}");
 
     let sockfd: libc::c_int = request.sockfd;
     let sockaddr: LibcSocketAddress = match LibcSocketAddress::try_from(request.sockaddr) {
         Ok(sockaddr) => sockaddr,
-        Err(e) => return crate::build_error(pid, e.code),
+        Err(e) => return crate::build_error(tid, e.code),
     };
     let socklen: socklen_t = request.socklen;
 
@@ -209,9 +209,9 @@ pub fn do_connect(pid: ProcessIdentifier, request: ConnectSocketRequest) -> Mess
             error!("libc::connect(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
-        _ => ConnectSocketResponse::build(pid),
+        _ => ConnectSocketResponse::build(tid),
     }
 }
 
@@ -219,8 +219,8 @@ pub fn do_connect(pid: ProcessIdentifier, request: ConnectSocketRequest) -> Mess
 // do_listen
 //==================================================================================================
 
-pub fn do_listen(pid: ProcessIdentifier, request: ListenSocketRequest) -> Message {
-    trace!("listen(): pid={pid:?}, request={request:?}");
+pub fn do_listen(tid: ThreadIdentifier, request: ListenSocketRequest) -> Message {
+    trace!("listen(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
     let backlog: i32 = request.backlog;
@@ -232,9 +232,9 @@ pub fn do_listen(pid: ProcessIdentifier, request: ListenSocketRequest) -> Messag
             error!("libc::listen(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
-        _ => ListenSocketResponse::build(pid),
+        _ => ListenSocketResponse::build(tid),
     }
 }
 
@@ -242,8 +242,8 @@ pub fn do_listen(pid: ProcessIdentifier, request: ListenSocketRequest) -> Messag
 // do_getpeername
 //==================================================================================================
 
-pub fn do_getpeername(pid: ProcessIdentifier, request: GetPeerNameRequest) -> Message {
-    trace!("getpeername(): pid={pid:?}, request={request:?}");
+pub fn do_getpeername(tid: ThreadIdentifier, request: GetPeerNameRequest) -> Message {
+    trace!("getpeername(): tid={tid:?}, request={request:?}");
 
     let sockfd: libc::c_int = request.sockfd;
     let mut address: libc::sockaddr = unsafe { core::mem::zeroed() };
@@ -257,7 +257,7 @@ pub fn do_getpeername(pid: ProcessIdentifier, request: GetPeerNameRequest) -> Me
             error!("libc::getpeername(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
         _ => {
             let sockaddr: sockaddr = sockaddr {
@@ -265,7 +265,7 @@ pub fn do_getpeername(pid: ProcessIdentifier, request: GetPeerNameRequest) -> Me
                 sa_family: address.sa_family as u8,
                 sa_data: unsafe { core::mem::transmute::<[i8; 14], [u8; 14]>(address.sa_data) },
             };
-            GetPeerNameResponse::build(pid, &sockaddr)
+            GetPeerNameResponse::build(tid, &sockaddr)
         },
     }
 }
@@ -274,8 +274,8 @@ pub fn do_getpeername(pid: ProcessIdentifier, request: GetPeerNameRequest) -> Me
 // do_getsockname
 //==================================================================================================
 
-pub fn do_getsockname(pid: ProcessIdentifier, request: GetSockNameRequest) -> Message {
-    trace!("getsockname(): pid={pid:?}, request={request:?}");
+pub fn do_getsockname(tid: ThreadIdentifier, request: GetSockNameRequest) -> Message {
+    trace!("getsockname(): tid={tid:?}, request={request:?}");
 
     let sockfd: libc::c_int = request.sockfd;
     let mut address: libc::sockaddr = unsafe { core::mem::zeroed() };
@@ -290,7 +290,7 @@ pub fn do_getsockname(pid: ProcessIdentifier, request: GetSockNameRequest) -> Me
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
             error!("libc::getsockname(): {error:?}");
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
         _ => {
             let sockaddr: sockaddr = sockaddr {
@@ -298,7 +298,7 @@ pub fn do_getsockname(pid: ProcessIdentifier, request: GetSockNameRequest) -> Me
                 sa_family: address.sa_family as u8,
                 sa_data: unsafe { core::mem::transmute::<[i8; 14], [u8; 14]>(address.sa_data) },
             };
-            GetSockNameResponse::build(pid, &sockaddr)
+            GetSockNameResponse::build(tid, &sockaddr)
         },
     }
 }
@@ -307,8 +307,8 @@ pub fn do_getsockname(pid: ProcessIdentifier, request: GetSockNameRequest) -> Me
 // do_accept
 //==================================================================================================
 
-pub fn do_accept(pid: ProcessIdentifier, request: AcceptSocketRequest) -> Message {
-    trace!("accept(): pid={pid:?}, request={request:?}");
+pub fn do_accept(tid: ThreadIdentifier, request: AcceptSocketRequest) -> Message {
+    trace!("accept(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
     let mut address: libc::sockaddr = unsafe { core::mem::zeroed() };
@@ -322,7 +322,7 @@ pub fn do_accept(pid: ProcessIdentifier, request: AcceptSocketRequest) -> Messag
             error!("libc::accept(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
         sockfd => {
             let sockaddr: sockaddr = sockaddr {
@@ -330,7 +330,7 @@ pub fn do_accept(pid: ProcessIdentifier, request: AcceptSocketRequest) -> Messag
                 sa_family: address.sa_family as u8,
                 sa_data: unsafe { core::mem::transmute::<[i8; 14], [u8; 14]>(address.sa_data) },
             };
-            AcceptSocketResponse::build(pid, sockfd, &sockaddr)
+            AcceptSocketResponse::build(tid, sockfd, &sockaddr)
         },
     }
 }
@@ -339,13 +339,13 @@ pub fn do_accept(pid: ProcessIdentifier, request: AcceptSocketRequest) -> Messag
 // do_recv
 //==================================================================================================
 
-pub fn do_recv(pid: ProcessIdentifier, request: ReceiveSocketRequest) -> Message {
-    trace!("recv(): pid={pid:?}, request={request:?}");
+pub fn do_recv(tid: ThreadIdentifier, request: ReceiveSocketRequest) -> Message {
+    trace!("recv(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
     let flags: LibcMessageFlags = match LibcMessageFlags::try_from(request.flags) {
         Ok(flags) => flags,
-        Err(e) => return crate::build_error(pid, e.code),
+        Err(e) => return crate::build_error(tid, e.code),
     };
 
     let recv_len: usize = cmp::min(ReceiveSocketResponse::BUFFER_SIZE, request.count as usize);
@@ -359,14 +359,14 @@ pub fn do_recv(pid: ProcessIdentifier, request: ReceiveSocketRequest) -> Message
     } {
         count if count >= 0 => {
             debug!("libc::recv(): count={count:?}");
-            ReceiveSocketResponse::build(pid, count as c_size_t, buffer)
+            ReceiveSocketResponse::build(tid, count as c_size_t, buffer)
         },
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             error!("libc::recv(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
         _ => unreachable!("libc::recv() returned invalid value"),
     }
@@ -376,21 +376,21 @@ pub fn do_recv(pid: ProcessIdentifier, request: ReceiveSocketRequest) -> Message
 // do_shutdown
 //==================================================================================================
 
-pub fn do_shutdown(pid: ProcessIdentifier, request: ShutdownSocketRequest) -> Message {
-    trace!("shutdown(): pid={pid:?}, request={request:?}");
+pub fn do_shutdown(tid: ThreadIdentifier, request: ShutdownSocketRequest) -> Message {
+    trace!("shutdown(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
     let how: LibcShutdownReason = LibcShutdownReason::from(request.how);
 
     debug!("libc::shutdown(): sockfd={sockfd:?}, how={:?}", how.inner());
     match unsafe { libc::shutdown(sockfd, how.inner()) } {
-        0 => ShutdownSocketResponse::build(pid),
+        0 => ShutdownSocketResponse::build(tid),
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             error!("libc::shutdown(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
         ret => unreachable!("libc::shutdown() returned invalid value {ret:?}"),
     }
@@ -400,14 +400,14 @@ pub fn do_shutdown(pid: ProcessIdentifier, request: ShutdownSocketRequest) -> Me
 // do_send
 //==================================================================================================
 
-pub fn do_send(pid: ProcessIdentifier, request: SendSocketRequest) -> Message {
-    trace!("send(): pid={pid:?}, request={request:?}");
+pub fn do_send(tid: ThreadIdentifier, request: SendSocketRequest) -> Message {
+    trace!("send(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
     let count: c_size_t = request.count;
     let flags: LibcMessageFlags = match LibcMessageFlags::try_from(request.flags) {
         Ok(flags) => flags,
-        Err(e) => return crate::build_error(pid, e.code),
+        Err(e) => return crate::build_error(tid, e.code),
     };
     let buffer: [u8; SendSocketRequest::BUFFER_SIZE] = request.buffer;
 
@@ -420,14 +420,14 @@ pub fn do_send(pid: ProcessIdentifier, request: SendSocketRequest) -> Message {
     } {
         count if count >= 0 => {
             debug!("libc::send(): count={count:?}");
-            SendSocketResponse::build(pid, count as c_ssize_t)
+            SendSocketResponse::build(tid, count as c_ssize_t)
         },
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             error!("libc::send(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
         _ => unreachable!("libc::send() returned invalid value"),
     }

--- a/src/daemons/linuxd/src/times.rs
+++ b/src/daemons/linuxd/src/times.rs
@@ -8,7 +8,7 @@
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_times::tms;
 use ::syscall::sys::times::message::{
@@ -20,8 +20,8 @@ use ::syscall::sys::times::message::{
 // do_times()
 //==================================================================================================
 
-pub fn do_times(pid: ProcessIdentifier, _request: TimesRequest) -> Message {
-    trace!("times(): pid={pid:?}");
+pub fn do_times(tid: ThreadIdentifier, _request: TimesRequest) -> Message {
+    trace!("times(): tid={tid:?}");
 
     let mut libc_buffer: libc::tms = libc::tms {
         tms_utime: 0,
@@ -37,7 +37,7 @@ pub fn do_times(pid: ProcessIdentifier, _request: TimesRequest) -> Message {
             let errno: i32 = unsafe { *libc::__errno_location() };
             error!("libc::clock_getres(): errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno).expect("unknown error code {error}");
-            crate::build_error(pid, error)
+            crate::build_error(tid, error)
         },
         elapsed => {
             debug!(
@@ -57,7 +57,7 @@ pub fn do_times(pid: ProcessIdentifier, _request: TimesRequest) -> Message {
                 tms_cstime: libc_buffer.tms_cstime,
             };
 
-            TimesResponse::build(pid, elapsed, nanvix_buffer)
+            TimesResponse::build(tid, elapsed, nanvix_buffer)
         },
     }
 }

--- a/src/daemons/linuxd/src/unistd.rs
+++ b/src/daemons/linuxd/src/unistd.rs
@@ -17,15 +17,15 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
     limits::PATH_MAX,
     sys_types::{
         c_size_t,
-        off_t,
         c_ssize_t,
+        off_t,
     },
     unistd::file_seek::{
         SEEK_CUR,
@@ -77,14 +77,14 @@ use ::syscall::{
 // do_chdir
 //==================================================================================================
 
-pub fn do_chdir(pid: ProcessIdentifier, request: ChangeDirectoryRequest) -> Vec<Message> {
-    trace!("do_chdir(): pid={pid:?}, request={request:?}");
+pub fn do_chdir(tid: ThreadIdentifier, request: ChangeDirectoryRequest) -> Vec<Message> {
+    trace!("do_chdir(): tid={tid:?}, request={request:?}");
 
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
         Err(error) => {
             error!("do_chdir(): invalid path (error={error:?})");
-            return vec![crate::build_error(pid, ErrorCode::InvalidArgument)];
+            return vec![crate::build_error(tid, ErrorCode::InvalidArgument)];
         },
     };
 
@@ -92,13 +92,13 @@ pub fn do_chdir(pid: ProcessIdentifier, request: ChangeDirectoryRequest) -> Vec<
     match unsafe { libc::chdir(path.as_ptr()) } {
         0 => {
             debug!("do_chdir(): chdir() succeeded");
-            vec![ChangeDirectoryResponse::build(pid)]
+            vec![ChangeDirectoryResponse::build(tid)]
         },
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::chdir(): errno={errno:?}");
             vec![crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )]
@@ -110,15 +110,15 @@ pub fn do_chdir(pid: ProcessIdentifier, request: ChangeDirectoryRequest) -> Vec<
 // do_close
 //==================================================================================================
 
-pub fn do_close(pid: ProcessIdentifier, request: CloseRequest) -> Message {
-    trace!("close(): pid={pid:?}, request={request:?}");
+pub fn do_close(tid: ThreadIdentifier, request: CloseRequest) -> Message {
+    trace!("close(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
 
     debug!("libc::close(): fd={fd:?}");
     match unsafe { libc::close(fd) } {
-        ret if ret == 0 => CloseResponse::build(pid, ret),
-        _ => crate::build_error(pid, ErrorCode::InvalidArgument),
+        ret if ret == 0 => CloseResponse::build(tid, ret),
+        _ => crate::build_error(tid, ErrorCode::InvalidArgument),
     }
 }
 
@@ -126,14 +126,14 @@ pub fn do_close(pid: ProcessIdentifier, request: CloseRequest) -> Message {
 // do_faccessat
 //==================================================================================================
 
-pub fn do_faccessat(pid: ProcessIdentifier, request: FileAccessAtRequest) -> Vec<Message> {
-    trace!("faccessat(): pid={request:?}, request={pid:?}");
+pub fn do_faccessat(tid: ThreadIdentifier, request: FileAccessAtRequest) -> Vec<Message> {
+    trace!("faccessat(): tid={request:?}, request={tid:?}");
 
     let dirfd: c_int = request.dirfd;
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidArgument)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidArgument)],
     };
     let amode: i32 = request.mode;
     let flag: LibcAtFlags = LibcAtFlags::from(request.flag);
@@ -144,12 +144,12 @@ pub fn do_faccessat(pid: ProcessIdentifier, request: FileAccessAtRequest) -> Vec
         flag.inner()
     );
     match unsafe { libc::faccessat(dirfd.inner(), path.as_ptr(), amode, flag.inner()) } {
-        0 => vec![FileAccessAtResponse::build(pid)],
+        0 => vec![FileAccessAtResponse::build(tid)],
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::faccessat(): errno={errno:?}");
             vec![crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )]
@@ -161,19 +161,19 @@ pub fn do_faccessat(pid: ProcessIdentifier, request: FileAccessAtRequest) -> Vec
 // do_fdatasync
 //==================================================================================================
 
-pub fn do_fdatasync(pid: ProcessIdentifier, request: FileDataSyncRequest) -> Message {
-    trace!("fdatasync(): pid={pid:?}, request={request:?}");
+pub fn do_fdatasync(tid: ThreadIdentifier, request: FileDataSyncRequest) -> Message {
+    trace!("fdatasync(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
 
     debug!("libc::fdatasync(): fd={fd:?}");
     match unsafe { libc::fdatasync(fd) } {
-        ret if ret == 0 => FileDataSyncResponse::build(pid, ret),
+        ret if ret == 0 => FileDataSyncResponse::build(tid, ret),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::fdatasync(): errno={errno:?}");
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -185,8 +185,8 @@ pub fn do_fdatasync(pid: ProcessIdentifier, request: FileDataSyncRequest) -> Mes
 // do_getids
 //==================================================================================================
 
-pub fn do_getids(pid: ProcessIdentifier, _request: GetIdsRequest) -> Message {
-    trace!("getids(): pid={pid:?}");
+pub fn do_getids(tid: ThreadIdentifier, _request: GetIdsRequest) -> Message {
+    trace!("getids(): tid={tid:?}");
 
     // Get user ID.
     let uid: libc::uid_t = unsafe { libc::getuid() };
@@ -205,15 +205,15 @@ pub fn do_getids(pid: ProcessIdentifier, _request: GetIdsRequest) -> Message {
     debug!("libc::getegid(): egid={egid:?}");
 
     // Build response.
-    GetIdsResponse::build(pid, uid, gid, euid, egid)
+    GetIdsResponse::build(tid, uid, gid, euid, egid)
 }
 
 //==================================================================================================
 // do_getcwd
 //==================================================================================================
 
-pub fn do_getcwd(pid: ProcessIdentifier) -> Vec<Message> {
-    trace!("getcwd(): pid={pid:?}");
+pub fn do_getcwd(tid: ThreadIdentifier) -> Vec<Message> {
+    trace!("getcwd(): tid={tid:?}");
 
     let mut buf: Vec<u8> = Vec::with_capacity(PATH_MAX as libc::size_t);
 
@@ -230,31 +230,31 @@ pub fn do_getcwd(pid: ProcessIdentifier) -> Vec<Message> {
                         Ok(response) => response,
                         Err(error) => {
                             warn!("do_getcwd(): {error:?}");
-                            return vec![crate::build_error(pid, error.code)];
+                            return vec![crate::build_error(tid, error.code)];
                         },
                     }
                 },
                 // Failure.
                 Err(error) => {
                     error!("do_getcwd(): invalid path (error={error:?})");
-                    return vec![crate::build_error(pid, ErrorCode::InvalidArgument)];
+                    return vec![crate::build_error(tid, ErrorCode::InvalidArgument)];
                 },
             };
 
         // Build response parts and check for errors.
-        match response.into_parts(pid) {
+        match response.into_parts(tid) {
             Ok(messages) => messages,
             Err(error) => {
                 warn!("do_getcwd(): {error:?}");
-                vec![crate::build_error(pid, error.code)]
+                vec![crate::build_error(tid, error.code)]
             },
         }
     } else {
         let errno: i32 = unsafe { *libc::__errno_location() };
-        debug!("libc::getcwd(): errno={pid:?}");
+        debug!("libc::getcwd(): errno={tid:?}");
         let error: ErrorCode =
             ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-        vec![crate::build_error(pid, error)]
+        vec![crate::build_error(tid, error)]
     }
 }
 
@@ -262,19 +262,19 @@ pub fn do_getcwd(pid: ProcessIdentifier) -> Vec<Message> {
 // do_fsync
 //==================================================================================================
 
-pub fn do_fsync(pid: ProcessIdentifier, request: FileSyncRequest) -> Message {
-    trace!("fsync(): pid={pid:?}, request={request:?}");
+pub fn do_fsync(tid: ThreadIdentifier, request: FileSyncRequest) -> Message {
+    trace!("fsync(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
 
     debug!("libc::fsync(): fd={fd:?}");
     match unsafe { libc::fsync(fd) } {
-        ret if ret == 0 => FileSyncResponse::build(pid, ret),
+        ret if ret == 0 => FileSyncResponse::build(tid, ret),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::fsync(): errno={errno:?}");
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -286,24 +286,24 @@ pub fn do_fsync(pid: ProcessIdentifier, request: FileSyncRequest) -> Message {
 // do_lseek
 //==================================================================================================
 
-pub fn do_lseek(pid: ProcessIdentifier, request: SeekRequest) -> Message {
-    trace!("lseek(): pid={pid:?}, request={request:?}");
+pub fn do_lseek(tid: ThreadIdentifier, request: SeekRequest) -> Message {
+    trace!("lseek(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
     let offset: i64 = request.offset;
     let whence: LibcSeek = match LibcSeek::try_from(request.whence) {
         Ok(whence) => whence,
-        Err(_) => return crate::build_error(pid, ErrorCode::InvalidMessage),
+        Err(_) => return crate::build_error(tid, ErrorCode::InvalidMessage),
     };
 
     debug!("libc::lseek(): fd={:?}, offset={:?}, whence={:?}", fd, offset, whence.inner());
     match unsafe { libc::lseek(fd, offset, whence.inner()) } {
-        ret if ret >= 0 => SeekResponse::build(pid, ret),
+        ret if ret >= 0 => SeekResponse::build(tid, ret),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::lseek(): errno={errno:?}");
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -315,20 +315,20 @@ pub fn do_lseek(pid: ProcessIdentifier, request: SeekRequest) -> Message {
 // do_ftruncate
 //==================================================================================================
 
-pub fn do_ftruncate(pid: ProcessIdentifier, request: FileTruncateRequest) -> Message {
-    trace!("ftruncate(): pid={pid:?}, request={request:?}");
+pub fn do_ftruncate(tid: ThreadIdentifier, request: FileTruncateRequest) -> Message {
+    trace!("ftruncate(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
     let length: off_t = request.length;
 
     debug!("libc::ftruncate(): fd={fd:?}, length={length:?}");
     match unsafe { libc::ftruncate(fd, length) } {
-        ret if ret == 0 => FileTruncateResponse::build(pid, ret),
+        ret if ret == 0 => FileTruncateResponse::build(tid, ret),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::ftruncate(): errno={errno:?}");
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -340,12 +340,12 @@ pub fn do_ftruncate(pid: ProcessIdentifier, request: FileTruncateRequest) -> Mes
 // do_write
 //==================================================================================================
 
-pub fn do_write(pid: ProcessIdentifier, request: WriteRequest) -> Message {
-    trace!("write(): pid={pid:?}, request={request:?}");
+pub fn do_write(tid: ThreadIdentifier, request: WriteRequest) -> Message {
+    trace!("write(): tid={tid:?}, request={request:?}");
 
     // Check if count is invalid.
     if request.count > WriteRequest::BUFFER_SIZE as c_size_t {
-        return crate::build_error(pid, ErrorCode::InvalidArgument);
+        return crate::build_error(tid, ErrorCode::InvalidArgument);
     }
     let fd: i32 = request.fd;
     let count: usize = request.count as usize;
@@ -354,12 +354,12 @@ pub fn do_write(pid: ProcessIdentifier, request: WriteRequest) -> Message {
 
     debug!("libc::write(): fd={fd:?}, buffer={buffer:?}");
     match unsafe { libc::write(fd, buffer.as_ptr() as *const _, count) } {
-        ret if ret >= 0 => WriteResponse::build(pid, ret as i32),
+        ret if ret >= 0 => WriteResponse::build(tid, ret as i32),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::write(): errno={errno:?}");
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -371,12 +371,12 @@ pub fn do_write(pid: ProcessIdentifier, request: WriteRequest) -> Message {
 // do_read
 //==================================================================================================
 
-pub fn do_read(pid: ProcessIdentifier, request: ReadRequest) -> Message {
-    trace!("read(): pid={pid:?}, request={request:?}");
+pub fn do_read(tid: ThreadIdentifier, request: ReadRequest) -> Message {
+    trace!("read(): tid={tid:?}, request={request:?}");
 
     // Check if count is invalid.
     if request.count > ReadResponse::BUFFER_SIZE as c_size_t {
-        return crate::build_error(pid, ErrorCode::InvalidArgument);
+        return crate::build_error(tid, ErrorCode::InvalidArgument);
     }
     let fd: i32 = request.fd;
     let count: usize = request.count as usize;
@@ -385,12 +385,12 @@ pub fn do_read(pid: ProcessIdentifier, request: ReadRequest) -> Message {
 
     debug!("libc::read(): fd={fd:?}, buffer={buffer:?}");
     match unsafe { libc::read(fd, buffer.as_mut_ptr() as *mut _, count) } {
-        ret if ret >= 0 => ReadResponse::build(pid, ret as i32, buffer),
+        ret if ret >= 0 => ReadResponse::build(tid, ret as i32, buffer),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::read(): errno={errno:?}");
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -402,12 +402,12 @@ pub fn do_read(pid: ProcessIdentifier, request: ReadRequest) -> Message {
 // do_pwrite
 //==================================================================================================
 
-pub fn do_pwrite(pid: ProcessIdentifier, request: PartialWriteRequest) -> Message {
-    trace!("pwrite(): pid={pid:?}, request={request:?}");
+pub fn do_pwrite(tid: ThreadIdentifier, request: PartialWriteRequest) -> Message {
+    trace!("pwrite(): tid={tid:?}, request={request:?}");
 
     // Check if count is invalid.
     if request.count > PartialWriteRequest::BUFFER_SIZE as c_size_t {
-        return crate::build_error(pid, ErrorCode::InvalidArgument);
+        return crate::build_error(tid, ErrorCode::InvalidArgument);
     }
     let fd: i32 = request.fd;
     let count: usize = request.count as usize;
@@ -417,12 +417,12 @@ pub fn do_pwrite(pid: ProcessIdentifier, request: PartialWriteRequest) -> Messag
 
     debug!("libc::pwrite(): fd={fd:?}, count={count:?}, offset={offset:?}, buffer={buffer:?}",);
     match unsafe { libc::pwrite(fd, buffer.as_ptr() as *const _, count, offset) } {
-        ret if ret >= 0 => PartialWriteResponse::build(pid, ret as c_ssize_t),
+        ret if ret >= 0 => PartialWriteResponse::build(tid, ret as c_ssize_t),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::pwrite(): errno={errno:?}");
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -434,12 +434,12 @@ pub fn do_pwrite(pid: ProcessIdentifier, request: PartialWriteRequest) -> Messag
 // do_pread
 //==================================================================================================
 
-pub fn do_pread(pid: ProcessIdentifier, request: PartialReadRequest) -> Message {
-    trace!("pread(): pid={pid:?}, request={request:?}");
+pub fn do_pread(tid: ThreadIdentifier, request: PartialReadRequest) -> Message {
+    trace!("pread(): tid={tid:?}, request={request:?}");
 
     // Check if count is invalid.
     if request.count > PartialReadResponse::BUFFER_SIZE as c_size_t {
-        return crate::build_error(pid, ErrorCode::InvalidArgument);
+        return crate::build_error(tid, ErrorCode::InvalidArgument);
     }
     let fd: i32 = request.fd;
     let count: usize = request.count as usize;
@@ -449,12 +449,12 @@ pub fn do_pread(pid: ProcessIdentifier, request: PartialReadRequest) -> Message 
 
     debug!("libc::pread(): fd={fd:?}, count={count:?}, offset={offset:?}, buffer={buffer:?}",);
     match unsafe { libc::pread(fd, buffer.as_mut_ptr() as *mut _, count, offset) } {
-        ret if ret >= 0 => PartialReadResponse::build(pid, ret as c_ssize_t, buffer),
+        ret if ret >= 0 => PartialReadResponse::build(tid, ret as c_ssize_t, buffer),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::pread(): errno={errno:?}");
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -466,18 +466,18 @@ pub fn do_pread(pid: ProcessIdentifier, request: PartialReadRequest) -> Message 
 // do_linkat
 //==================================================================================================
 
-pub fn do_linkat(pid: ProcessIdentifier, request: LinkAtRequest) -> Vec<Message> {
-    trace!("linkat(): pid={pid:?}, request={request:?}");
+pub fn do_linkat(tid: ThreadIdentifier, request: LinkAtRequest) -> Vec<Message> {
+    trace!("linkat(): tid={tid:?}, request={request:?}");
 
     let olddirfd: i32 = request.olddirfd;
     let oldpath: CString = match CString::new(request.oldpath.as_str()) {
         Ok(oldpath) => oldpath,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidArgument)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidArgument)],
     };
     let newdirfd: i32 = request.newdirfd;
     let newpath: CString = match CString::new(request.newpath.as_str()) {
         Ok(newpath) => newpath,
-        Err(_) => return vec![crate::build_error(pid, ErrorCode::InvalidArgument)],
+        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidArgument)],
     };
     let flags: i32 = request.flags;
 
@@ -486,12 +486,12 @@ pub fn do_linkat(pid: ProcessIdentifier, request: LinkAtRequest) -> Vec<Message>
          newpath={newpath:?}, flags={flags:?}",
     );
     match unsafe { libc::linkat(olddirfd, oldpath.as_ptr(), newdirfd, newpath.as_ptr(), flags) } {
-        ret if ret == 0 => vec![LinkAtResponse::build(pid, ret)],
+        ret if ret == 0 => vec![LinkAtResponse::build(tid, ret)],
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::linkat(): errno={errno:?}");
             vec![crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )]
@@ -504,18 +504,18 @@ pub fn do_linkat(pid: ProcessIdentifier, request: LinkAtRequest) -> Vec<Message>
 //==================================================================================================
 
 /// Changes the current working directory.
-pub fn do_fchdir(pid: ProcessIdentifier, request: FileChdirRequest) -> Message {
-    trace!("fchdir(): pid={pid:?}, request={request:?}");
+pub fn do_fchdir(tid: ThreadIdentifier, request: FileChdirRequest) -> Message {
+    trace!("fchdir(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
 
     debug!("libc::fchdir(): fd={fd:?}");
     match unsafe { libc::fchdir(fd) } {
-        0 => FileChdirResponse::build(pid),
+        0 => FileChdirResponse::build(tid),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -528,8 +528,8 @@ pub fn do_fchdir(pid: ProcessIdentifier, request: FileChdirRequest) -> Message {
 // do_fchown
 //==================================================================================================
 
-pub fn do_fchown(pid: ProcessIdentifier, request: FileChownRequest) -> Message {
-    trace!("fchown(): pid={pid:?}, request={request:?}");
+pub fn do_fchown(tid: ThreadIdentifier, request: FileChownRequest) -> Message {
+    trace!("fchown(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
     let owner: u32 = request.owner;
@@ -537,11 +537,11 @@ pub fn do_fchown(pid: ProcessIdentifier, request: FileChownRequest) -> Message {
 
     debug!("libc::fchown(): fd={fd:?}, owner={owner:?}, group={group:?}");
     match unsafe { libc::fchown(fd, owner, group) } {
-        0 => FileChownResponse::build(pid),
+        0 => FileChownResponse::build(tid),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )
@@ -554,8 +554,8 @@ pub fn do_fchown(pid: ProcessIdentifier, request: FileChownRequest) -> Message {
 // do_pipe
 //==================================================================================================
 
-pub fn do_pipe(pid: ProcessIdentifier) -> Message {
-    trace!("pipe(): pid={pid:?}");
+pub fn do_pipe(tid: ThreadIdentifier) -> Message {
+    trace!("pipe(): tid={tid:?}");
 
     let mut fds: [i32; 2] = [0; 2];
 
@@ -566,13 +566,13 @@ pub fn do_pipe(pid: ProcessIdentifier) -> Message {
             let write_fd: i32 = fds[1];
 
             debug!("pipe(): read_fd={read_fd:?}, write_fd={write_fd:?}");
-            PipeResponse::build(pid, read_fd, write_fd)
+            PipeResponse::build(tid, read_fd, write_fd)
         },
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
             debug!("libc::pipe(): errno={errno:?}");
             crate::build_error(
-                pid,
+                tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
             )

--- a/src/daemons/linuxd/src/venv.rs
+++ b/src/daemons/linuxd/src/venv.rs
@@ -15,7 +15,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::syscall::venv::VirtualEnvironmentIdentifier;
 
@@ -45,7 +45,7 @@ pub struct VirtualEnviromentDirectory {
     /// Next environment identifier.
     next_env: VirtualEnvironmentIdentifier,
     /// Virtual environments.
-    processes: BTreeMap<ProcessIdentifier, VirtualEnvironment>,
+    processes: BTreeMap<ThreadIdentifier, VirtualEnvironment>,
 }
 
 //==================================================================================================
@@ -125,7 +125,7 @@ impl VirtualEnviromentDirectory {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `envid`: Virtual environment identifier.
     ///
     /// # Returns
@@ -135,14 +135,14 @@ impl VirtualEnviromentDirectory {
     ///
     pub fn join(
         &mut self,
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         mut envid: VirtualEnvironmentIdentifier,
     ) -> Result<VirtualEnvironmentIdentifier, Error> {
-        trace!("join(): pid={pid:?}, envid={envid:?}");
+        trace!("join(): tid={tid:?}, envid={envid:?}");
 
         // Check if the process is already in an environment.
-        if self.processes.contains_key(&pid) {
-            error!("process {:?} is previously joined environment {:?}", pid, self.processes[&pid]);
+        if self.processes.contains_key(&tid) {
+            error!("process {:?} is previously joined environment {:?}", tid, self.processes[&tid]);
             return Err(Error::new(
                 ErrorCode::ResourceBusy,
                 "process is already in an environment",
@@ -151,17 +151,17 @@ impl VirtualEnviromentDirectory {
 
         // Check wether the process requested to join a new environment or an existing one.
         if envid == VirtualEnvironmentIdentifier::NEW {
-            // Process requested to join a new environment.
+            // Thread requested to join a new environment.
             envid = self.next_env;
             self.next_env = self.next_env.next();
-            self.processes.insert(pid, VirtualEnvironment::new(envid));
-            info!("process {pid:?} joined new environment {envid:?}");
+            self.processes.insert(tid, VirtualEnvironment::new(envid));
+            info!("process {tid:?} joined new environment {envid:?}");
         } else {
-            // Process requested to join an existing environment.
+            // Thread requested to join an existing environment.
 
             // Check if environment exists.
             if !self.processes.values().any(|v| v.id() == envid) {
-                error!("process {pid:?} requested to join non-existing environment {envid:?}");
+                error!("process {tid:?} requested to join non-existing environment {envid:?}");
                 return Err(Error::new(
                     ErrorCode::NoSuchEntry,
                     "virtual environment does not exist",
@@ -169,7 +169,7 @@ impl VirtualEnviromentDirectory {
             }
 
             // Join environment.
-            self.processes.insert(pid, VirtualEnvironment::new(envid));
+            self.processes.insert(tid, VirtualEnvironment::new(envid));
         }
 
         Ok(envid)
@@ -182,7 +182,7 @@ impl VirtualEnviromentDirectory {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `envid`: Virtual environment identifier.
     ///
     /// # Returns
@@ -193,14 +193,14 @@ impl VirtualEnviromentDirectory {
     #[allow(dead_code)]
     pub fn leave(
         &mut self,
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         envid: VirtualEnvironmentIdentifier,
     ) -> Result<VirtualEnvironmentIdentifier, Error> {
-        trace!("leave(): pid={pid:?}, envid={envid:?}");
+        trace!("leave(): tid={tid:?}, envid={envid:?}");
 
         // Check if the process has joined an environment.
-        if !self.processes.contains_key(&pid) {
-            error!("process {pid:?} has not joined an environment");
+        if !self.processes.contains_key(&tid) {
+            error!("process {tid:?} has not joined an environment");
             return Err(Error::new(
                 ErrorCode::NoSuchEntry,
                 "process has not joined an environment",
@@ -208,8 +208,8 @@ impl VirtualEnviromentDirectory {
         }
 
         // Check if the process has previously joined the environment.
-        if self.processes[&pid].id() != envid {
-            error!("process {pid:?} has not previously joined environment {envid:?}");
+        if self.processes[&tid].id() != envid {
+            error!("process {tid:?} has not previously joined environment {envid:?}");
             return Err(Error::new(
                 ErrorCode::InvalidArgument,
                 "process has not previously joined environment",
@@ -217,7 +217,7 @@ impl VirtualEnviromentDirectory {
         }
 
         // Leave environment.
-        self.processes.remove(&pid);
+        self.processes.remove(&tid);
 
         Ok(envid)
     }
@@ -229,15 +229,15 @@ impl VirtualEnviromentDirectory {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     ///
     /// # Returns
     ///
     /// If there is a virtual environment associated with the process, the function returns a
     /// reference to the virtual environment. Otherwise, it returns `None`.
     ///
-    pub fn get(&self, pid: ProcessIdentifier) -> Option<&VirtualEnvironment> {
-        self.processes.get(&pid)
+    pub fn get(&self, tid: ThreadIdentifier) -> Option<&VirtualEnvironment> {
+        self.processes.get(&tid)
     }
 
     ///
@@ -247,14 +247,14 @@ impl VirtualEnviromentDirectory {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     ///
     /// # Returns
     ///
     /// If there is a virtual environment associated with the process, the function returns a
     /// mutable reference to the virtual environment. Otherwise, it returns `None`.
     ///
-    pub fn get_mut(&mut self, pid: ProcessIdentifier) -> Option<&mut VirtualEnvironment> {
-        self.processes.get_mut(&pid)
+    pub fn get_mut(&mut self, tid: ThreadIdentifier) -> Option<&mut VirtualEnvironment> {
+        self.processes.get_mut(&tid)
     }
 }

--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -604,10 +604,15 @@ impl EventManagerInner {
     ) -> Result<(), Error> {
         pm.post_message(receiver, message)?;
 
-        let pid: ProcessIdentifier = receiver.into();
-
-        // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
-        unsafe { self.get_wait().notify_process(pid) }
+        match receiver.as_id() {
+            Ok(pid) => {
+                // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
+                unsafe { self.get_wait().notify_process(pid) }
+            },
+            Err(_tid) => {
+                unimplemented!("notify thread");
+            },
+        }
     }
 
     ///

--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -53,6 +53,10 @@ use ::sys::{
         ProcessIdentifier,
     },
 };
+use sys::ipc::{
+    MessageReceiver,
+    MessageSender,
+};
 
 //==================================================================================================
 // Structures
@@ -347,8 +351,8 @@ impl EventManagerInner {
                         let idx: usize = i as usize;
                         if let Some(_event) = self.pending_interrupts[idx].pop_front() {
                             let message: Message = Message {
-                                source: ProcessIdentifier::KERNEL,
-                                destination: pid,
+                                source: MessageSender::from(ProcessIdentifier::KERNEL),
+                                destination: MessageReceiver::from(pid),
                                 message_type: MessageType::Interrupt,
                                 ..Message::default()
                             };
@@ -374,7 +378,7 @@ impl EventManagerInner {
                             info.instruction = Some(entry.1.info.instruction() as usize);
 
                             let mut message: Message = Message::from(info);
-                            message.destination = pid;
+                            message.destination = MessageReceiver::from(pid);
                             message.message_type = MessageType::Exception;
 
                             self.pending_exceptions[idx].push_back(entry);
@@ -391,8 +395,8 @@ impl EventManagerInner {
                     if (scheduling & (1 << i)) != 0 {
                         if let Some((_ev, info)) = self.pending_scheduling[i].pop_front() {
                             let message: Message = Message {
-                                source: ProcessIdentifier::KERNEL,
-                                destination: pid,
+                                source: MessageSender::from(ProcessIdentifier::KERNEL),
+                                destination: MessageReceiver::from(pid),
                                 message_type: MessageType::ProcessTerminationEvent,
                                 status: 0,
                                 payload: {
@@ -595,10 +599,12 @@ impl EventManagerInner {
     fn post_message(
         &mut self,
         pm: &mut ProcessManager,
-        pid: ProcessIdentifier,
+        receiver: MessageReceiver,
         message: Message,
     ) -> Result<(), Error> {
-        pm.post_message(pid, message)?;
+        pm.post_message(receiver, message)?;
+
+        let pid: ProcessIdentifier = receiver.into();
 
         // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
         unsafe { self.get_wait().notify_process(pid) }
@@ -831,12 +837,12 @@ impl EventManager {
 
     pub fn post_message(
         pm: &mut ProcessManager,
-        pid: ProcessIdentifier,
+        receiver: MessageReceiver,
         message: Message,
     ) -> Result<(), Error> {
         Self::get_mut()?
             .try_borrow_mut()?
-            .post_message(pm, pid, message)
+            .post_message(pm, receiver, message)
     }
 
     ///

--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -46,16 +46,15 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::{
         Capability,
         ProcessIdentifier,
+        ThreadIdentifier,
     },
-};
-use sys::ipc::{
-    MessageReceiver,
-    MessageSender,
 };
 
 //==================================================================================================
@@ -317,6 +316,7 @@ impl EventManagerInner {
     ///
     /// # Parameters
     ///
+    /// - `tid`: Identifier of the target thread.
     /// - `pid`: Identifier of the target process.
     /// - `interrupts`: Bit mask of interrupts.
     /// - `exceptions`: Bit mask of exceptions.
@@ -337,6 +337,7 @@ impl EventManagerInner {
     ///
     pub unsafe fn try_wait(
         &mut self,
+        tid: ThreadIdentifier,
         pid: ProcessIdentifier,
         interrupts: usize,
         exceptions: usize,
@@ -418,7 +419,7 @@ impl EventManagerInner {
         // FIXME: Delivery of IPC messages will starve if exception / interrupt rate is to high.
 
         // Check if any messages were delivered.
-        match ProcessManager::try_recv() {
+        match ProcessManager::try_recv(tid) {
             Ok(Some(message)) => Ok(Some(message)),
             Ok(None) => Ok(None),
             Err(e) => Err(e),
@@ -609,8 +610,9 @@ impl EventManagerInner {
                 // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
                 unsafe { self.get_wait().notify_process(pid) }
             },
-            Err(_tid) => {
-                unimplemented!("notify thread");
+            Err(tid) => {
+                // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
+                unsafe { self.get_wait().notify_thread(tid) }
             },
         }
     }
@@ -731,7 +733,10 @@ impl EventManager {
     /// - The calling process is not the kernel process.
     /// - This function is invoked without holding any resources.
     ///
-    pub unsafe fn wait(pid: ProcessIdentifier) -> Result<Message, SleepError> {
+    pub unsafe fn wait(
+        tid: ThreadIdentifier,
+        pid: ProcessIdentifier,
+    ) -> Result<Message, SleepError> {
         // Get the interrupts that the process owns.
         let mut interrupts: usize = 0;
         for i in 0..usize::BITS {
@@ -791,7 +796,7 @@ impl EventManager {
                 .map_err(SleepError::Generic)?
                 .try_borrow_mut()
                 .map_err(SleepError::Generic)?
-                .try_wait(pid, interrupts, exceptions, scheduling)
+                .try_wait(tid, pid, interrupts, exceptions, scheduling)
                 .map_err(SleepError::Generic)?;
 
             if let Some(message) = message {

--- a/src/kernel/src/ipc/kcall.rs
+++ b/src/kernel/src/ipc/kcall.rs
@@ -28,6 +28,7 @@ use ::sys::{
     },
     pm::ProcessIdentifier,
 };
+use sys::ipc::MessageSender;
 
 //==================================================================================================
 // Standalone Functions
@@ -52,7 +53,7 @@ pub fn send(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
     }
 
     // Sanity check message source.
-    if { message.source } != src {
+    if { message.source } != MessageSender::from(src) {
         let reason: &str = "invalid message source";
         error!("do_send(): {}", reason);
         return KcallResult::Error(ErrorCode::InvalidArgument.into());

--- a/src/kernel/src/ipc/kcall.rs
+++ b/src/kernel/src/ipc/kcall.rs
@@ -18,24 +18,24 @@ use crate::{
     },
 };
 use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
+    error::Error,
     ipc::{
         Message,
+        MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
-use sys::ipc::MessageSender;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-fn do_send(pm: &mut ProcessManager, src: ProcessIdentifier, message: Message) -> Result<(), Error> {
-    trace!("do_send(): src={:?}, dst={:?}", src, { message.destination });
+fn do_send(pm: &mut ProcessManager, message: Message) -> Result<(), Error> {
+    trace!("do_send(): src={:?}, dst={:?}", { message.source }, { message.destination });
 
     // TODO: Check if source process has permission to send message to destination process.
 
@@ -44,19 +44,21 @@ fn do_send(pm: &mut ProcessManager, src: ProcessIdentifier, message: Message) ->
 }
 
 pub fn send(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
-    let src: ProcessIdentifier = args.pid;
+    let src_pid: ProcessIdentifier = args.pid;
+    let src_tid: ThreadIdentifier = args.tid;
 
     // Copy message to kernel space.
     let mut message: Message = Message::default();
-    if let Err(e) = pm::copy_from_user(pm, src, &mut message, args.arg0 as *const Message) {
+    if let Err(e) = pm::copy_from_user(pm, src_pid, &mut message, args.arg0 as *const Message) {
         return KcallResult::Error(e.code.into());
     }
 
-    // Sanity check message source.
-    if { message.source } != MessageSender::from(src) {
+    // Check if message source is invalid.
+    if { message.source } != MessageSender::from(src_tid) && { message.source }
+        != MessageSender::from(src_pid)
+    {
         let reason: &str = "invalid message source";
-        error!("do_send(): {}", reason);
-        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+        error!("do_send(): {reason:?} (message={:?})", message);
     }
 
     // Route message based on its type.
@@ -74,27 +76,31 @@ pub fn send(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
                 } else {
                     // Standard input/output is not available.
                     error!("send(): stdio is not available");
-                    KcallResult::Error(ErrorCode::ProtocolNotSupported.into())
+                    KcallResult::Error(sys::error::ErrorCode::ProtocolNotSupported.into())
                 }
             }
         },
         // Local-host communication.
         _ => {
             // Post message.
-            match do_send(pm, src, message) {
-                Ok(_) => KcallResult::ok(),
+            match do_send(pm, message) {
+                Ok(()) => KcallResult::ok(),
                 Err(e) => KcallResult::Error(e.code.into()),
             }
         },
     }
 }
 
-pub unsafe fn recv(pid: ProcessIdentifier, msg: usize) -> Result<(), SleepError> {
+pub unsafe fn recv(
+    tid: ThreadIdentifier,
+    pid: ProcessIdentifier,
+    msg: usize,
+) -> Result<(), SleepError> {
     if pid != ProcessIdentifier::INITD {
         trace!("do_recv(): pid={:?}", pid);
     }
 
-    match EventManager::wait(pid) {
+    match EventManager::wait(tid, pid) {
         Ok(message) => {
             pm::copy_to_user(ProcessManager::get_mut(), pid, msg as *mut Message, &message)
                 .map_err(SleepError::Generic)

--- a/src/kernel/src/ipc/mbx/mailbox.rs
+++ b/src/kernel/src/ipc/mbx/mailbox.rs
@@ -6,7 +6,10 @@
 //==================================================================================================
 
 use ::alloc::collections::LinkedList;
-use ::sys::ipc::Message;
+use ::sys::{
+    ipc::Message,
+    pm::ThreadIdentifier,
+};
 
 //==================================================================================================
 //  Structures
@@ -26,7 +29,29 @@ impl Mailbox {
         self.buffer.push_back(message);
     }
 
-    pub fn receive(&mut self) -> Option<Message> {
-        self.buffer.pop_front()
+    pub fn receive(&mut self, tid: ThreadIdentifier) -> Option<Message> {
+        // Locate the first message that the given thread received.
+        let message_index = self
+            .buffer
+            .iter()
+            .position(|msg| { msg.destination }.as_id() == Err(tid));
+
+        // If a message was found, remove it from the buffer and return it.
+        if let Some(index) = message_index {
+            return Some(self.buffer.remove(index));
+        }
+
+        // Locate the first message that the current thread received.
+        let message_index = self
+            .buffer
+            .iter()
+            .position(|msg| { msg.destination }.as_id().is_ok());
+
+        // If a message was found, remove it from the buffer and return it.
+        if let Some(index) = message_index {
+            return Some(self.buffer.remove(index));
+        }
+
+        None
     }
 }

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -85,7 +85,7 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
             KcallResult::Error(e.code.into())
         },
         // SAFETY: The calling thread is not the kernel and no resources are held.
-        KcallNumber::Recv => match unsafe { ipc::recv(pid, arg0 as usize) } {
+        KcallNumber::Recv => match unsafe { ipc::recv(tid, pid, arg0 as usize) } {
             Ok(()) => KcallResult::ok(),
             Err(sleep_error) => handle_sleep_error(sleep_error),
         },

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -663,16 +663,15 @@ impl ProcessManagerInner {
     ///
     /// # Parameters
     ///
-    /// - `pid`: ID of the process to wake up.
     /// - `tid`: ID of the thread to wake up.
     ///
     /// # Returns
     ///
     /// Upon successful completion, empty is returned. Otherwise, an error code is returned instead.
     ///
-    pub fn wakeup(&mut self, pid: ProcessIdentifier, tid: ThreadIdentifier) -> Result<(), Error> {
+    pub fn wakeup(&mut self, tid: ThreadIdentifier) -> Result<(), Error> {
         // Check if thread belongs to the running process.
-        if self.get_running().state().pid() == pid {
+        if self.get_running().has_thread(tid) {
             let running_process: RunningProcess = self.take_running();
             match running_process.wakeup(tid) {
                 Ok(running_process) => {
@@ -682,18 +681,18 @@ impl ProcessManagerInner {
                 Err(running_process) => {
                     self.running = Some(running_process);
                     let reason: &str = "thread not found";
-                    error!("wake_up(): {reason} (pid={pid:?}. tid={tid:?})");
+                    error!("wake_up(): {reason} (tid={tid:?})");
                     return Err(Error::new(ErrorCode::NoSuchEntry, reason));
                 },
             }
         }
 
         // Check if thread belongs to a suspended process.
-        let runnable_process: RunnableProcess = match self.try_wakeup(pid, tid) {
+        let runnable_process: RunnableProcess = match self.try_wakeup(tid) {
             Some(runnable_process) => runnable_process,
             None => {
                 let reason: &str = "thread not found";
-                error!("wake_up(): {reason} (pid={pid:?}, tid={tid:?})");
+                error!("wake_up(): {reason} (tid={tid:?})");
                 return Err(Error::new(ErrorCode::NoSuchEntry, reason));
             },
         };
@@ -703,16 +702,12 @@ impl ProcessManagerInner {
         Ok(())
     }
 
-    fn try_wakeup(
-        &mut self,
-        pid: ProcessIdentifier,
-        tid: ThreadIdentifier,
-    ) -> Option<RunnableProcess> {
+    fn try_wakeup(&mut self, tid: ThreadIdentifier) -> Option<RunnableProcess> {
         // Search for the process in the list of sleeping processes.
         let mut suspended: LinkedList<SleepingProcess> = LinkedList::new();
         while let Some(process) = self.suspended.pop_front() {
             // Found.
-            if process.state().pid() == pid {
+            if process.has_thread(tid) {
                 match process.wakeup(tid) {
                     Ok(runnable_process) => {
                         while let Some(process) = suspended.pop_back() {
@@ -739,7 +734,7 @@ impl ProcessManagerInner {
         let mut ready: LinkedList<RunnableProcess> = LinkedList::new();
         while let Some(process) = self.ready.pop_front() {
             // Found.
-            if process.state().pid() == pid {
+            if process.has_thread(tid) {
                 match process.wakeup(tid) {
                     Ok(runnable_process) => {
                         while let Some(process) = ready.pop_back() {

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1190,6 +1190,24 @@ impl ProcessManagerInner {
             Err(Error::new(ErrorCode::NoSuchProcess, reason))
         }
     }
+
+    fn find_thread_mut(&mut self, tid: ThreadIdentifier) -> Result<ProcessRefMut, Error> {
+        if self.get_running_mut().has_thread(tid) {
+            Ok(ProcessRefMut::Running(self.get_running_mut()))
+        } else if let Some(process) = self.ready.iter_mut().find(|p| p.has_thread(tid)) {
+            Ok(ProcessRefMut::Runnable(process))
+        } else if let Some(process) = self.suspended.iter_mut().find(|p| p.has_thread(tid)) {
+            Ok(ProcessRefMut::Sleeping(process))
+        } else if let Some(process) = self.interrupted.iter_mut().find(|p| p.has_thread(tid)) {
+            Ok(ProcessRefMut::Interrupted(process))
+        } else if let Some(process) = self.zombies.iter_mut().find(|p| p.has_thread(tid)) {
+            Ok(ProcessRefMut::Zombie(process))
+        } else {
+            let reason: &str = "thread not found";
+            error!("find_process(): {} (tid={:?})", reason, tid);
+            Err(Error::new(ErrorCode::NoSuchEntry, reason))
+        }
+    }
 }
 
 //==================================================================================================
@@ -1500,8 +1518,10 @@ impl ProcessManager {
         message: Message,
     ) -> Result<(), Error> {
         let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
-        let pid: ProcessIdentifier = receiver.into();
-        let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
+        let mut process: ProcessRefMut = match receiver.as_id() {
+            Ok(pid) => pm.find_process_mut(pid)?,
+            Err(tid) => pm.find_thread_mut(tid)?,
+        };
         process.state_mut().post_message(message);
         pm.number_buffered_messages += 1;
         Ok(())

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -94,6 +94,7 @@ use ::sys::{
     ExitStatus,
 };
 use ::type_safe::NonEmptyVecDeque;
+use sys::ipc::MessageReceiver;
 
 //==================================================================================================
 // Sleep Error
@@ -1482,19 +1483,24 @@ impl ProcessManager {
     ///
     /// # Description
     ///
-    /// Sends a message to a process.
+    /// Posts a message.
     ///
     /// # Parameters
     ///
-    /// - `pid`: ID of the target process.
+    /// - `receiver`: ID of the receiver.
     /// - `message`: Message to send.
     ///
     /// # Returns
     ///
     /// Upon successful completion, empty is returned. Otherwise, an error code is returned instead.
     ///
-    pub fn post_message(&mut self, pid: ProcessIdentifier, message: Message) -> Result<(), Error> {
+    pub fn post_message(
+        &mut self,
+        receiver: MessageReceiver,
+        message: Message,
+    ) -> Result<(), Error> {
         let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
+        let pid: ProcessIdentifier = receiver.into();
         let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
         process.state_mut().post_message(message);
         pm.number_buffered_messages += 1;

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -571,7 +571,6 @@ impl ProcessManager {
     ///
     /// # Parameters
     ///
-    /// - `pid`: ID of the process to wake up.
     /// - `tid`: ID of the thread to wake up.
     ///
     /// # Safety
@@ -582,8 +581,8 @@ impl ProcessManager {
     ///
     /// - The calling process does not hold a reference to the process manager.
     ///
-    pub unsafe fn wakeup(pid: ProcessIdentifier, tid: ThreadIdentifier) -> Result<(), Error> {
-        Self::get_mut().try_borrow_mut()?.wakeup(pid, tid)
+    pub unsafe fn wakeup(tid: ThreadIdentifier) -> Result<(), Error> {
+        Self::get_mut().try_borrow_mut()?.wakeup(tid)
     }
 
     ///

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -552,10 +552,10 @@ impl ProcessManager {
     ///
     /// - The calling process does not hold a reference to the process manager.
     ///
-    pub unsafe fn try_recv() -> Result<Option<Message>, Error> {
+    pub unsafe fn try_recv(tid: ThreadIdentifier) -> Result<Option<Message>, Error> {
         let mut pm: RefMut<ProcessManagerInner> = unsafe { Self::get_mut() }.try_borrow_mut()?;
         let running: &mut RunningProcess = pm.get_running_mut();
-        match running.state_mut().receive_message() {
+        match running.state_mut().receive_message(tid) {
             Some(message) => {
                 pm.number_buffered_messages -= 1;
                 Ok(Some(message))

--- a/src/kernel/src/pm/process/state/interrupted.rs
+++ b/src/kernel/src/pm/process/state/interrupted.rs
@@ -24,6 +24,7 @@ use ::alloc::{
     boxed::Box,
     collections::vec_deque::VecDeque,
 };
+use ::sys::pm::ThreadIdentifier;
 use ::type_safe::NonEmptyVecDeque;
 
 //==================================================================================================
@@ -94,6 +95,33 @@ impl InterruptedProcess {
             reason,
             ctx,
         )
+    }
+
+    pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {
+        // Search in the list of interrupted threads.
+        if self
+            .interrupted_threads
+            .iter()
+            .any(|thread| thread.tid() == tid)
+        {
+            return true;
+        }
+
+        // Search in the list of sleeping threads.
+        if let Some(sleeping_threads) = &self.sleeping_threads {
+            if sleeping_threads.iter().any(|thread| thread.id() == tid) {
+                return true;
+            }
+        }
+
+        // Search in the list of zombie threads.
+        if let Some(zombie_threads) = &self.zombie_threads {
+            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
+                return true;
+            }
+        }
+
+        false
     }
 }
 

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -68,6 +68,7 @@ use ::sys::{
         ConditionAddress,
         MutexAddress,
         ProcessIdentifier,
+        ThreadIdentifier,
     },
 };
 
@@ -231,8 +232,8 @@ impl ProcessState {
         self.mailbox.send(message)
     }
 
-    pub fn receive_message(&mut self) -> Option<Message> {
-        self.mailbox.receive()
+    pub fn receive_message(&mut self, tid: ThreadIdentifier) -> Option<Message> {
+        self.mailbox.receive(tid)
     }
 
     pub fn add_mmio(&mut self, region: IoMemoryRegion) {

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -174,6 +174,36 @@ impl RunnableProcessWithReadyThread {
 
         self
     }
+
+    fn has_thread(&self, tid: ThreadIdentifier) -> bool {
+        // Search in the list of ready threads.
+        if self.ready_threads.iter().any(|thread| thread.tid() == tid) {
+            return true;
+        }
+
+        // Search in the list of interrupted threads.
+        if let Some(interrupted_threads) = &self.interrupted_threads {
+            if interrupted_threads.iter().any(|thread| thread.tid() == tid) {
+                return true;
+            }
+        }
+
+        // Search in the list of sleeping threads.
+        if let Some(sleeping_threads) = &self.sleeping_threads {
+            if sleeping_threads.iter().any(|thread| thread.id() == tid) {
+                return true;
+            }
+        }
+
+        // Search in the list of zombie threads.
+        if let Some(zombie_threads) = &self.zombie_threads {
+            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 pub struct RunnableProcessWithInterruptedThreads {
@@ -314,6 +344,40 @@ impl RunnableProcessWithInterruptedThreads {
             self.zombie_threads.take(),
         )
     }
+
+    fn has_thread(&self, tid: ThreadIdentifier) -> bool {
+        // Search in the list of interrupted threads.
+        if self
+            .interrupted_threads
+            .iter()
+            .any(|thread| thread.tid() == tid)
+        {
+            return true;
+        }
+
+        // Search in the list of ready threads.
+        if let Some(ready_threads) = &self.ready_threads {
+            if ready_threads.iter().any(|thread| thread.tid() == tid) {
+                return true;
+            }
+        }
+
+        // Search in the list of sleeping threads.
+        if let Some(sleeping_threads) = &self.sleeping_threads {
+            if sleeping_threads.iter().any(|thread| thread.id() == tid) {
+                return true;
+            }
+        }
+
+        // Search in the list of zombie threads.
+        if let Some(zombie_threads) = &self.zombie_threads {
+            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 pub struct RunnableProcessWithReadyAndInteruptThread {
@@ -433,6 +497,38 @@ impl RunnableProcessWithReadyAndInteruptThread {
         trace!("add_thread(): self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
         self.ready_threads.push_back(ready_thread);
         self
+    }
+
+    fn has_thread(&self, tid: ThreadIdentifier) -> bool {
+        // Search in the list of ready threads.
+        if self.ready_threads.iter().any(|thread| thread.tid() == tid) {
+            return true;
+        }
+
+        // Search in the list of interrupted threads.
+        if self
+            .interrupted_threads
+            .iter()
+            .any(|thread| thread.tid() == tid)
+        {
+            return true;
+        }
+
+        // Search in the list of sleeping threads.
+        if let Some(sleeping_threads) = &self.sleeping_threads {
+            if sleeping_threads.iter().any(|thread| thread.id() == tid) {
+                return true;
+            }
+        }
+
+        // Search in the list of zombie threads.
+        if let Some(zombie_threads) = &self.zombie_threads {
+            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
+                return true;
+            }
+        }
+
+        false
     }
 }
 
@@ -579,6 +675,14 @@ impl RunnableProcess {
             RunnableProcess::ReadyAndInteruptThread(process) => {
                 RunnableProcess::ReadyAndInteruptThread(process.add_thread(ready_thread))
             },
+        }
+    }
+
+    pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {
+        match self {
+            RunnableProcess::WithReadyThread(process) => process.has_thread(tid),
+            RunnableProcess::WithInterruptedThreads(process) => process.has_thread(tid),
+            RunnableProcess::ReadyAndInteruptThread(process) => process.has_thread(tid),
         }
     }
 }

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -410,4 +410,41 @@ impl RunningProcess {
         error!("join_thread(): {:?} (state={:?})", reason, self.state());
         Err(Err(Error::new(ErrorCode::NoSuchProcess, reason)))
     }
+
+    pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {
+        // Check if the running thread matches.
+        if self.running.id() == tid {
+            return true;
+        }
+
+        // Search in the list of ready threads.
+        if let Some(ready_threads) = &self.ready {
+            if ready_threads.iter().any(|thread| thread.tid() == tid) {
+                return true;
+            }
+        }
+
+        // Search in the list of interrupted threads.
+        if let Some(interrupted_threads) = &self.interrupted_threads {
+            if interrupted_threads.iter().any(|thread| thread.tid() == tid) {
+                return true;
+            }
+        }
+
+        // Search in the list of sleeping threads.
+        if let Some(sleeping_threads) = &self.sleeping_threads {
+            if sleeping_threads.iter().any(|thread| thread.id() == tid) {
+                return true;
+            }
+        }
+
+        // Search in the list of zombie threads.
+        if let Some(zombie_threads) = &self.zombie {
+            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
+                return true;
+            }
+        }
+
+        false
+    }
 }

--- a/src/kernel/src/pm/process/state/sleeping.rs
+++ b/src/kernel/src/pm/process/state/sleeping.rs
@@ -182,4 +182,24 @@ impl SleepingProcess {
             self.zombie_threads.take(),
         )
     }
+
+    pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {
+        // Search in the list of sleeping threads.
+        if self
+            .sleeping_threads
+            .iter()
+            .any(|thread| thread.id() == tid)
+        {
+            return true;
+        }
+
+        // Search in the list of zombie threads.
+        if let Some(zombie_threads) = &self.zombie_threads {
+            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
+                return true;
+            }
+        }
+
+        false
+    }
 }

--- a/src/kernel/src/pm/process/state/zombie.rs
+++ b/src/kernel/src/pm/process/state/zombie.rs
@@ -10,7 +10,10 @@ use crate::pm::{
     thread::ZombieThread,
 };
 use ::alloc::boxed::Box;
-use ::sys::ExitStatus;
+use ::sys::{
+    pm::ThreadIdentifier,
+    ExitStatus,
+};
 use ::type_safe::NonEmptyVecDeque;
 
 //==================================================================================================
@@ -52,5 +55,9 @@ impl ZombieProcess {
 
     pub fn bury(self) -> (NonEmptyVecDeque<ZombieThread>, Box<ProcessState>, ExitStatus) {
         (self.zombie_threads, self.process, self.status)
+    }
+
+    pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {
+        self.zombie_threads.iter().any(|thread| thread.tid() == tid)
     }
 }

--- a/src/kernel/src/pm/sync/condvar.rs
+++ b/src/kernel/src/pm/sync/condvar.rs
@@ -161,6 +161,52 @@ impl Condvar {
     ///
     /// # Description
     ///
+    /// Wakes up a specific thread that is waiting on the target condition variable.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Identifier of the target thread.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, empty is returned. Otherwise, an error is returned instead.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it operates on global variables.
+    ///
+    /// This function is safe to use if and only if the following conditions are met:
+    ///
+    /// - The calling process does not hold a reference to the process manager.
+    ///
+    pub unsafe fn notify_thread(&self, tid: ThreadIdentifier) -> Result<(), Error> {
+        // Find thread.
+        let idx: Option<usize> = self
+            .inner
+            .sleeping
+            .borrow()
+            .iter()
+            .position(|&(_p, t)| t == tid);
+
+        // Remove thread from sleeping queue.
+        if let Some(at) = idx {
+            let (_notified_pid, notified_tid): (ProcessIdentifier, ThreadIdentifier) =
+                self.inner.sleeping.borrow_mut().remove(at);
+            debug_assert!(
+                notified_tid == tid,
+                "notify_thread(): pid and tid do not match (expected: tid={:?}, got tid={:?})",
+                tid,
+                notified_tid
+            );
+            ProcessManager::wakeup(tid)?;
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
     /// Wakes up all threads waiting on the target condition variable.
     ///
     /// # Returns

--- a/src/kernel/src/pm/sync/condvar.rs
+++ b/src/kernel/src/pm/sync/condvar.rs
@@ -112,8 +112,8 @@ impl Condvar {
     /// - The calling process does not hold a reference to the process manager.
     ///
     pub unsafe fn notify_first(&self) -> Result<(), Error> {
-        if let Some((pid, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
-            ProcessManager::wakeup(pid, tid)?;
+        if let Some((_, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
+            ProcessManager::wakeup(tid)?;
         }
 
         Ok(())
@@ -151,8 +151,8 @@ impl Condvar {
 
         // Remove process from sleeping queue.
         if let Some(at) = idx {
-            let (pid, tid) = self.inner.sleeping.borrow_mut().remove(at);
-            ProcessManager::wakeup(pid, tid)?;
+            let (_, tid) = self.inner.sleeping.borrow_mut().remove(at);
+            ProcessManager::wakeup(tid)?;
         }
 
         Ok(())
@@ -179,8 +179,8 @@ impl Condvar {
     pub unsafe fn notify_all(&self) -> Result<usize, Error> {
         let mut awakened: usize = 0;
 
-        while let Some((pid, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
-            ProcessManager::wakeup(pid, tid)?;
+        while let Some((_pid, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
+            ProcessManager::wakeup(tid)?;
             awakened += 1;
         }
 

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -147,7 +147,7 @@ impl ProcessDaemon {
     }
 
     fn handle_ipc_message(&mut self, message: Message) -> Result<(), Error> {
-        let destionation: ProcessIdentifier = message.source;
+        let destination: ProcessIdentifier = message.source.into();
         let message: SystemMessage = SystemMessage::from_bytes(message.payload)?;
 
         ::syslog::info!("received system message (header={:?})", message.header);
@@ -161,12 +161,12 @@ impl ProcessDaemon {
             match message.header {
                 ProcessManagementMessageHeader::Signup => {
                     let message: SignupMessage = SignupMessage::from_bytes(message.payload);
-                    let message: Message = self.handle_signup(destionation, message)?;
+                    let message: Message = self.handle_signup(destination, message)?;
                     ::sys::kcall::ipc::send(&message)?;
                 },
                 ProcessManagementMessageHeader::Lookup => {
                     let message: LookupMessage = LookupMessage::from_bytes(message.payload);
-                    let message: Message = self.handle_lookup(destionation, message)?;
+                    let message: Message = self.handle_lookup(destination, message)?;
                     ::sys::kcall::ipc::send(&message)?;
                 },
                 // Ignore all other messages.

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -147,7 +147,14 @@ impl ProcessDaemon {
     }
 
     fn handle_ipc_message(&mut self, message: Message) -> Result<(), Error> {
-        let destination: ProcessIdentifier = message.source.into();
+        let destination: ProcessIdentifier = match { message.source }.as_id() {
+            Ok(pid) => pid,
+            Err(tid) => {
+                let reason: &str = "invalid IPC message source";
+                ::syslog::error!("handle_ipc_message(): {reason:?} (tid={:?})", tid);
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
+        };
         let message: SystemMessage = SystemMessage::from_bytes(message.payload)?;
 
         ::syslog::info!("received system message (header={:?})", message.header);

--- a/src/libs/proc/src/message/lookup.rs
+++ b/src/libs/proc/src/message/lookup.rs
@@ -20,6 +20,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
         SystemMessage,
         SystemMessageHeader,
@@ -241,8 +243,13 @@ pub fn lookup_request(name: &str, pid: ProcessIdentifier) -> Result<Message, Err
         SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
 
     // Construct an IPC  message.
-    let ipc_message: Message =
-        Message::new(pid, crate::PROCD, MessageType::Ipc, None, system_message.into_bytes());
+    let ipc_message: Message = Message::new(
+        MessageSender::from(pid),
+        MessageReceiver::from(crate::PROCD),
+        MessageType::Ipc,
+        None,
+        system_message.into_bytes(),
+    );
 
     Ok(ipc_message)
 }
@@ -282,8 +289,8 @@ pub fn lookup_response(
 
     // Construct an IPC  message.
     let ipc_message: Message = Message::new(
-        crate::PROCD,
-        destination,
+        MessageSender::from(crate::PROCD),
+        MessageReceiver::from(destination),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),

--- a/src/libs/proc/src/message/shutdown.rs
+++ b/src/libs/proc/src/message/shutdown.rs
@@ -14,6 +14,8 @@ use ::sys::{
     error::Error,
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
         SystemMessage,
         SystemMessageHeader,
@@ -132,8 +134,13 @@ pub fn shutdown_request(destination: ProcessIdentifier, code: u8) -> Result<Mess
         SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
 
     // Construct an IPC message.
-    let ipc_message: Message =
-        Message::new(crate::PROCD, destination, MessageType::Ipc, None, sys_message.into_bytes());
+    let ipc_message: Message = Message::new(
+        MessageSender::from(crate::PROCD),
+        MessageReceiver::from(destination),
+        MessageType::Ipc,
+        None,
+        sys_message.into_bytes(),
+    );
 
     Ok(ipc_message)
 }

--- a/src/libs/proc/src/message/signup.rs
+++ b/src/libs/proc/src/message/signup.rs
@@ -20,6 +20,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
         SystemMessage,
         SystemMessageHeader,
@@ -252,8 +254,13 @@ pub fn signup_request(pid: ProcessIdentifier, name: &str) -> Result<Message, Err
         SystemMessage::new(SystemMessageHeader::ProcessManagement, pm_message.into_bytes());
 
     // Construct an IPC  message.
-    let ipc_message: Message =
-        Message::new(pid, crate::PROCD, MessageType::Ipc, None, system_message.into_bytes());
+    let ipc_message: Message = Message::new(
+        MessageSender::from(pid),
+        MessageReceiver::from(crate::PROCD),
+        MessageType::Ipc,
+        None,
+        system_message.into_bytes(),
+    );
 
     Ok(ipc_message)
 }
@@ -294,8 +301,8 @@ pub fn signup_response(
 
     // Construct an IPC message.
     let ipc_message: Message = Message::new(
-        crate::PROCD,
-        destination,
+        MessageSender::from(crate::PROCD),
+        MessageReceiver::from(destination),
         MessageType::Ipc,
         None,
         system_message.into_bytes(),

--- a/src/libs/sys/src/sys/event/information.rs
+++ b/src/libs/sys/src/sys/event/information.rs
@@ -9,6 +9,8 @@ use crate::{
     event::EventDescriptor,
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -65,7 +67,13 @@ impl From<EventInformation> for Message {
                 .copy_from_slice(&instruction.to_ne_bytes());
         }
 
-        Message::new(info.pid, info.pid, MessageType::Exception, None, payload)
+        Message::new(
+            MessageSender::from(info.pid),
+            MessageReceiver::from(info.pid),
+            MessageType::Exception,
+            None,
+            payload,
+        )
     }
 }
 

--- a/src/libs/sys/src/sys/ipc/message/kernel.rs
+++ b/src/libs/sys/src/sys/ipc/message/kernel.rs
@@ -19,6 +19,46 @@ use ::core::mem;
 // Structures
 //==================================================================================================
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct MessageSender(i32);
+
+impl MessageSender {
+    /// The kernel process is the sender of the message.
+    pub const KERNEL: Self = MessageSender(ProcessIdentifier::KERNEL_RAW);
+}
+
+impl From<ProcessIdentifier> for MessageSender {
+    fn from(pid: ProcessIdentifier) -> Self {
+        Self(pid.into())
+    }
+}
+
+impl From<MessageSender> for ProcessIdentifier {
+    fn from(sender: MessageSender) -> ProcessIdentifier {
+        ProcessIdentifier::from(sender.0)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct MessageReceiver(i32);
+
+impl MessageReceiver {
+    /// The kernel process is the receiver of the message.
+    pub const KERNEL: Self = MessageReceiver(ProcessIdentifier::KERNEL_RAW);
+}
+
+impl From<ProcessIdentifier> for MessageReceiver {
+    fn from(pid: ProcessIdentifier) -> Self {
+        Self(pid.into())
+    }
+}
+
+impl From<MessageReceiver> for ProcessIdentifier {
+    fn from(receiver: MessageReceiver) -> ProcessIdentifier {
+        ProcessIdentifier::from(receiver.0)
+    }
+}
+
 ///
 /// # Description
 ///
@@ -34,9 +74,9 @@ pub struct Message {
     /// Type of the message.
     pub message_type: MessageType,
     /// Process that sent the message.
-    pub source: ProcessIdentifier,
+    pub source: MessageSender,
     /// Process that should receive the message.
-    pub destination: ProcessIdentifier,
+    pub destination: MessageReceiver,
     /// Message status.
     pub status: i32,
     /// Payload of the message.
@@ -62,8 +102,8 @@ impl Message {
     ///
     /// # Parameters
     ///
-    /// - `source`: The source process.
-    /// - `destination`: The destination process.
+    /// - `source`: The sender of the message.
+    /// - `destination`: The recipient of the message.
     /// - `message_type`: The type of the message.
     /// - `status`: Error status of the message (`None` for success).
     /// - `payload`: The message payload.
@@ -73,8 +113,8 @@ impl Message {
     /// The new message.
     ///
     pub fn new(
-        source: ProcessIdentifier,
-        destination: ProcessIdentifier,
+        source: MessageSender,
+        destination: MessageReceiver,
         message_type: MessageType,
         status: Option<ErrorCode>,
         payload: [u8; Self::PAYLOAD_SIZE],
@@ -129,8 +169,8 @@ impl Default for Message {
     fn default() -> Self {
         Self {
             message_type: MessageType::Empty,
-            source: ProcessIdentifier::KERNEL,
-            destination: ProcessIdentifier::KERNEL,
+            source: MessageSender::KERNEL,
+            destination: MessageReceiver::KERNEL,
             status: 0,
             payload: [0; Self::PAYLOAD_SIZE],
         }

--- a/src/libs/sys/src/sys/ipc/message/kernel.rs
+++ b/src/libs/sys/src/sys/ipc/message/kernel.rs
@@ -11,7 +11,10 @@ use crate::{
         ErrorCode,
     },
     ipc::typ::MessageType,
-    pm::ProcessIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 use ::core::mem;
 
@@ -27,20 +30,41 @@ impl MessageSender {
     pub const KERNEL: Self = MessageSender(ProcessIdentifier::KERNEL_RAW);
 }
 
+impl MessageSender {
+    pub fn as_id(&self) -> Result<ProcessIdentifier, ThreadIdentifier> {
+        if self.0 >= 0 {
+            Ok(ProcessIdentifier::from(self.0))
+        } else {
+            Err(ThreadIdentifier::from(-self.0))
+        }
+    }
+}
+
 impl From<ProcessIdentifier> for MessageSender {
     fn from(pid: ProcessIdentifier) -> Self {
         Self(pid.into())
     }
 }
 
-impl From<MessageSender> for ProcessIdentifier {
-    fn from(sender: MessageSender) -> ProcessIdentifier {
-        ProcessIdentifier::from(sender.0)
+impl From<ThreadIdentifier> for MessageSender {
+    fn from(tid: ThreadIdentifier) -> Self {
+        let tid: i32 = tid.into();
+        Self(-tid)
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct MessageReceiver(i32);
+
+impl MessageReceiver {
+    pub fn as_id(&self) -> Result<ProcessIdentifier, ThreadIdentifier> {
+        if self.0 >= 0 {
+            Ok(ProcessIdentifier::from(self.0))
+        } else {
+            Err(ThreadIdentifier::from(-self.0))
+        }
+    }
+}
 
 impl MessageReceiver {
     /// The kernel process is the receiver of the message.
@@ -53,9 +77,10 @@ impl From<ProcessIdentifier> for MessageReceiver {
     }
 }
 
-impl From<MessageReceiver> for ProcessIdentifier {
-    fn from(receiver: MessageReceiver) -> ProcessIdentifier {
-        ProcessIdentifier::from(receiver.0)
+impl From<ThreadIdentifier> for MessageReceiver {
+    fn from(tid: ThreadIdentifier) -> Self {
+        let tid: i32 = tid.into();
+        Self(-tid)
     }
 }
 

--- a/src/libs/sys/src/sys/ipc/message/mod.rs
+++ b/src/libs/sys/src/sys/ipc/message/mod.rs
@@ -12,7 +12,11 @@ mod system;
 // Exports
 //==================================================================================================
 
-pub use kernel::Message;
+pub use kernel::{
+    Message,
+    MessageReceiver,
+    MessageSender,
+};
 pub use system::{
     SystemMessage,
     SystemMessageHeader,

--- a/src/libs/sys/src/sys/pm/tid.rs
+++ b/src/libs/sys/src/sys/pm/tid.rs
@@ -46,6 +46,25 @@ pub struct ThreadIdentifier(i32);
 // Implementations
 //==================================================================================================
 
+impl ThreadIdentifier {
+    // Raw identifier for the kernel thread.
+    pub const KERNEL_RAW: i32 = 0;
+
+    /// Identifier of the kernel thread.
+    pub const KERNEL: ThreadIdentifier = ThreadIdentifier(Self::KERNEL_RAW);
+
+    /// Identifier of the init daemon thread.
+    pub const INITD: ThreadIdentifier = ThreadIdentifier(1);
+
+    pub fn to_ne_bytes(&self) -> [u8; core::mem::size_of::<i32>()] {
+        self.0.to_ne_bytes()
+    }
+
+    pub fn from_ne_bytes(bytes: [u8; core::mem::size_of::<i32>()]) -> Self {
+        Self(i32::from_ne_bytes(bytes))
+    }
+}
+
 impl From<ThreadIdentifier> for isize {
     fn from(tid: ThreadIdentifier) -> isize {
         tid.0 as isize

--- a/src/libs/syscall/src/dirent/message/getdents.rs
+++ b/src/libs/syscall/src/dirent/message/getdents.rs
@@ -29,7 +29,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::{
@@ -95,14 +95,14 @@ impl GetDirectoryEntriesRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: c_int, count: usize) -> Result<Message, Error> {
+    pub fn build(tid: ThreadIdentifier, fd: c_int, count: usize) -> Result<Message, Error> {
         let message: GetDirectoryEntriesRequest = GetDirectoryEntriesRequest::new(fd, count)?;
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::GetDirectoryEntriesRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -239,7 +239,7 @@ impl MessagePartitioner for GetDirectoryEntriesResponse {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -249,13 +249,13 @@ impl MessagePartitioner for GetDirectoryEntriesResponse {
     /// Upon success, the partitioned message is returned. Upon failure, an error is returned.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_response(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::GetDirectoryEntriesResponsePart,
             part_number,
             payload_size,

--- a/src/libs/syscall/src/dirent/message/getdents.rs
+++ b/src/libs/syscall/src/dirent/message/getdents.rs
@@ -25,6 +25,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -99,8 +101,13 @@ impl GetDirectoryEntriesRequest {
             LinuxDaemonMessageHeader::GetDirectoryEntriesRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         Ok(message)
     }

--- a/src/libs/syscall/src/dirent/syscall/getdents.rs
+++ b/src/libs/syscall/src/dirent/syscall/getdents.rs
@@ -28,7 +28,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -57,16 +57,16 @@ pub fn posix_getdents(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Error>
     posix_getdents_response()
 }
 
-/// Processes the request of the `posix_getdents()` system call.
+/// Handles the request of the `posix_getdents()` system call.
 fn posix_getdents_request(fd: c_int, count: usize) -> Result<(), Error> {
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
-    let request: Message = GetDirectoryEntriesRequest::build(pid, fd, count)?;
+    let request: Message = GetDirectoryEntriesRequest::build(tid, fd, count)?;
 
     ::sys::kcall::ipc::send(&request)
 }
 
-/// Processes the response of the `posix_getdents()` system call.
+/// Handles the response of the `posix_getdents()` system call.
 fn posix_getdents_response() -> Result<Vec<posix_dent>, Error> {
     let capacity: usize =
         GetDirectoryEntriesResponse::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);

--- a/src/libs/syscall/src/fcntl/message/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/message/fadvise.rs
@@ -20,7 +20,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::off_t;
 
@@ -65,7 +65,7 @@ impl FileAdvisoryInformationRequest {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         fd: i32,
         offset: off_t,
         len: off_t,
@@ -78,7 +78,7 @@ impl FileAdvisoryInformationRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -119,7 +119,7 @@ impl FileAdvisoryInformationResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileAdvisoryInformationResponse = FileAdvisoryInformationResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileAdvisoryInformationResponse,
@@ -127,7 +127,7 @@ impl FileAdvisoryInformationResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/message/fadvise.rs
@@ -16,6 +16,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -75,8 +77,13 @@ impl FileAdvisoryInformationRequest {
             LinuxDaemonMessageHeader::FileAdvisoryInformationRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -118,8 +125,13 @@ impl FileAdvisoryInformationResponse {
             LinuxDaemonMessageHeader::FileAdvisoryInformationResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/fcntl/message/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/message/fallocate.rs
@@ -21,7 +21,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::off_t;
 
@@ -63,7 +63,7 @@ impl FileSpaceControlRequest {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         fd: i32,
         offset: off_t,
         len: off_t,
@@ -74,7 +74,7 @@ impl FileSpaceControlRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -114,7 +114,7 @@ impl FileSpaceControlResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileSpaceControlResponse = FileSpaceControlResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileSpaceControlResponse,
@@ -122,7 +122,7 @@ impl FileSpaceControlResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/message/fallocate.rs
@@ -17,6 +17,8 @@ use ::sys::{
     error::Error,
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -71,8 +73,13 @@ impl FileSpaceControlRequest {
             LinuxDaemonMessageHeader::FileSpaceControlRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         Ok(message)
     }
 }
@@ -113,8 +120,13 @@ impl FileSpaceControlResponse {
             LinuxDaemonMessageHeader::FileSpaceControlResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/fcntl/message/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/message/fcntl.rs
@@ -20,7 +20,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -61,14 +61,14 @@ impl FileControlRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32, cmd: i32, arg: c_int) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: i32, cmd: i32, arg: c_int) -> Message {
         let message: FileControlRequest = FileControlRequest::new(fd, cmd, arg);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileControlRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -109,7 +109,7 @@ impl FileControlResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileControlResponse = FileControlResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileControlResponse,
@@ -117,7 +117,7 @@ impl FileControlResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/message/fcntl.rs
@@ -16,6 +16,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -65,8 +67,13 @@ impl FileControlRequest {
             LinuxDaemonMessageHeader::FileControlRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -108,8 +115,13 @@ impl FileControlResponse {
             LinuxDaemonMessageHeader::FileControlResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/fcntl/message/openat.rs
+++ b/src/libs/syscall/src/fcntl/message/openat.rs
@@ -28,7 +28,12 @@ use ::sys::{
         Error,
         ErrorCode,
     },
-    ipc::Message,
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
     pm::ProcessIdentifier,
 };
 use ::sysapi::{
@@ -251,9 +256,9 @@ impl OpenAtResponse {
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::OpenAtResponse, message.into_bytes());
         let message: Message = Message::new(
-            crate::LINUXD,
-            pid,
-            sys::ipc::MessageType::Ikc,
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
             None,
             message.into_bytes(),
         );

--- a/src/libs/syscall/src/fcntl/message/openat.rs
+++ b/src/libs/syscall/src/fcntl/message/openat.rs
@@ -34,7 +34,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -207,13 +207,13 @@ impl MessageDeserializer for OpenAtRequest {
 impl MessagePartitioner for OpenAtRequest {
     /// Creates a new message part for the `openat()` system call.
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::OpenAtRequestPart,
             part_number,
             payload_size,
@@ -251,13 +251,13 @@ impl OpenAtResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: OpenAtResponse = OpenAtResponse::new(ret);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::OpenAtResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/renameat.rs
+++ b/src/libs/syscall/src/fcntl/message/renameat.rs
@@ -34,7 +34,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::limits::NAME_MAX;
 
@@ -279,13 +279,13 @@ impl MessageDeserializer for RenameAtRequest {
 impl MessagePartitioner for RenameAtRequest {
     /// Creates a new message for the `renameat()` system call.
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::RenameAtRequestPart,
             part_number,
             payload_size,
@@ -323,7 +323,7 @@ impl RenameAtResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: RenameAtResponse = RenameAtResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::RenameAtResponse,
@@ -331,7 +331,7 @@ impl RenameAtResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/renameat.rs
+++ b/src/libs/syscall/src/fcntl/message/renameat.rs
@@ -30,11 +30,13 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
 };
-use sysapi::limits::NAME_MAX;
+use ::sysapi::limits::NAME_MAX;
 
 //==================================================================================================
 // RenameAtRequest
@@ -327,8 +329,13 @@ impl RenameAtResponse {
             LinuxDaemonMessageHeader::RenameAtResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/fcntl/message/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/message/unlinkat.rs
@@ -34,7 +34,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -207,13 +207,13 @@ impl MessageDeserializer for UnlinkAtRequest {
 impl MessagePartitioner for UnlinkAtRequest {
     /// Creates a new message part for the `unlinkat()` system call.
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::UnlinkAtRequestPart,
             part_number,
             payload_size,
@@ -251,7 +251,7 @@ impl UnlinkAtResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: UnlinkAtResponse = UnlinkAtResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::UnlinkAtResponse,
@@ -259,7 +259,7 @@ impl UnlinkAtResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/fcntl/message/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/message/unlinkat.rs
@@ -30,6 +30,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -255,8 +257,13 @@ impl UnlinkAtResponse {
             LinuxDaemonMessageHeader::UnlinkAtResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/fcntl/syscall/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fadvise.rs
@@ -17,7 +17,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 use sysapi::sys_types::off_t;
@@ -56,10 +56,10 @@ pub fn posix_fadvise(
         advice
     );
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = FileAdvisoryInformationRequest::build(pid, fd, offset, len, advice);
+    let request: Message = FileAdvisoryInformationRequest::build(tid, fd, offset, len, advice);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/fcntl/syscall/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fallocate.rs
@@ -17,7 +17,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::sys_types::off_t;
 
@@ -43,10 +43,10 @@ use sysapi::sys_types::off_t;
 pub fn posix_fallocate(fd: RawFileDescriptor, offset: off_t, len: off_t) -> Result<(), Error> {
     ::syslog::error!("posix_fallocate(): fd={:?}, offset={:?}, len={:?}", fd, offset, len);
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = FileSpaceControlRequest::build(pid, fd, offset, len)?;
+    let request: Message = FileSpaceControlRequest::build(tid, fd, offset, len)?;
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/fcntl/syscall/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fcntl.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -30,10 +30,10 @@ use ::sysapi::ffi::c_int;
 pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
     ::syslog::trace!("fcntl(): fd={:?}, cmd={:?}, arg={:?}", fd, cmd, arg);
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = FileControlRequest::build(pid, fd, cmd, arg.unwrap_or(0));
+    let request: Message = FileControlRequest::build(tid, fd, cmd, arg.unwrap_or(0));
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -21,7 +21,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -37,11 +37,11 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
         "openat(): dirfd={dirfd:?}, pathname={pathname:?}, flags={flags:?}, mode={mode:?}"
     );
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
     let request: OpenAtRequest = OpenAtRequest::new(dirfd, pathname, flags, mode)?;
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
     for request in requests {
         ::sys::kcall::ipc::send(&request)?;
     }

--- a/src/libs/syscall/src/fcntl/syscall/renameat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/renameat.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -57,11 +57,11 @@ pub fn renameat(
         newpath
     );
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
     let request: RenameAtRequest = RenameAtRequest::new(olddirfd, oldpath, newdirfd, newpath)?;
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
     for request in requests {
         ::sys::kcall::ipc::send(&request)?;
     }

--- a/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -46,11 +46,11 @@ use ::sysapi::ffi::c_int;
 pub fn unlinkat(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Result<(), Error> {
     ::syslog::trace!("unlinkat(): dirfd={}, pathname={}, flags={}", dirfd, pathname, flags);
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
     let request: UnlinkAtRequest = UnlinkAtRequest::new(dirfd, pathname, flags)?;
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
     for request in requests {
         ::sys::kcall::ipc::send(&request)?;
     }

--- a/src/libs/syscall/src/message/mod.rs
+++ b/src/libs/syscall/src/message/mod.rs
@@ -16,7 +16,7 @@ use ::alloc::vec::Vec;
 use ::sys::{
     error::Error,
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -80,7 +80,7 @@ where
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Part number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -90,7 +90,7 @@ where
     /// Upon success, the new message part is returned. Upon failure, an error is returned instead.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
@@ -103,14 +103,14 @@ where
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     ///
     /// # Returns
     ///
     /// Upon success, a vector containing the message parts is returned. Upon failure, an error is
     /// returned instead.
     ///
-    fn into_parts(self, pid: ProcessIdentifier) -> Result<Vec<Message>, Error> {
+    fn into_parts(self, tid: ThreadIdentifier) -> Result<Vec<Message>, Error> {
         let bytes: Vec<u8> = self.to_bytes();
         let num_parts: usize = bytes.len().div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         let mut parts: Vec<Message> = Vec::with_capacity(num_parts);
@@ -122,7 +122,7 @@ where
             let mut payload = [0; LinuxDaemonMessagePart::PAYLOAD_SIZE];
             payload[..chunk.len()].copy_from_slice(chunk);
             parts.push(Self::new_part(
-                pid,
+                tid,
                 (num_parts - part_number - 1) as u32,
                 chunk.len() as u8,
                 payload,

--- a/src/libs/syscall/src/message/part.rs
+++ b/src/libs/syscall/src/message/part.rs
@@ -20,6 +20,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -161,9 +163,21 @@ impl LinuxDaemonMessagePart {
         let message: LinuxDaemonMessagePart = Self::new(part_number, payload_size, payload)?;
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(header, message.into_bytes());
         if is_response {
-            Ok(Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes()))
+            Ok(Message::new(
+                MessageSender::from(crate::LINUXD),
+                MessageReceiver::from(pid),
+                MessageType::Ikc,
+                None,
+                message.into_bytes(),
+            ))
         } else {
-            Ok(Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes()))
+            Ok(Message::new(
+                MessageSender::from(pid),
+                MessageReceiver::from(crate::LINUXD),
+                MessageType::Ikc,
+                None,
+                message.into_bytes(),
+            ))
         }
     }
 

--- a/src/libs/syscall/src/message/part.rs
+++ b/src/libs/syscall/src/message/part.rs
@@ -24,7 +24,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -59,7 +59,7 @@ impl LinuxDaemonMessagePart {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `header`: Message header.
     /// - `part_number`: Part number.
     /// - `payload_size`: Payload size.
@@ -70,13 +70,13 @@ impl LinuxDaemonMessagePart {
     /// Upon success, the request message is returned. Upon failure, an error is returned instead.
     ///
     pub fn build_request(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         header: LinuxDaemonMessageHeader,
         part_number: u32,
         payload_size: u8,
         payload: [u8; Self::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        Self::build(pid, header, part_number, payload_size, payload, false)
+        Self::build(tid, header, part_number, payload_size, payload, false)
     }
 
     ///
@@ -86,7 +86,7 @@ impl LinuxDaemonMessagePart {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `header`: Message header.
     /// - `part_number`: Part number.
     /// - `payload_size`: Payload size.
@@ -97,13 +97,13 @@ impl LinuxDaemonMessagePart {
     /// Upon success, the response message is returned. Upon failure, an error is returned instead.
     ///
     pub fn build_response(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         header: LinuxDaemonMessageHeader,
         part_number: u32,
         payload_size: u8,
         payload: [u8; Self::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        Self::build(pid, header, part_number, payload_size, payload, true)
+        Self::build(tid, header, part_number, payload_size, payload, true)
     }
 
     ///
@@ -143,7 +143,7 @@ impl LinuxDaemonMessagePart {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `header`: Message header.
     /// - `part_number`: Part number.
     /// - `payload_size`: Payload size.
@@ -153,7 +153,7 @@ impl LinuxDaemonMessagePart {
     ///
     /// Upon success, the message is returned. Upon failure, an error is returned instead.
     fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         header: LinuxDaemonMessageHeader,
         part_number: u32,
         payload_size: u8,
@@ -165,14 +165,14 @@ impl LinuxDaemonMessagePart {
         if is_response {
             Ok(Message::new(
                 MessageSender::from(crate::LINUXD),
-                MessageReceiver::from(pid),
+                MessageReceiver::from(tid),
                 MessageType::Ikc,
                 None,
                 message.into_bytes(),
             ))
         } else {
             Ok(Message::new(
-                MessageSender::from(pid),
+                MessageSender::from(tid),
                 MessageReceiver::from(crate::LINUXD),
                 MessageType::Ikc,
                 None,

--- a/src/libs/syscall/src/poll/message.rs
+++ b/src/libs/syscall/src/poll/message.rs
@@ -19,6 +19,8 @@ use ::sys::{
 };
 use sys::ipc::{
     Message,
+    MessageReceiver,
+    MessageSender,
     MessageType,
 };
 
@@ -158,7 +160,15 @@ impl PollRequest {
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PollRequest, message.into_bytes());
 
-        Ok(Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes()))
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
+
+        Ok(message)
     }
 }
 
@@ -258,6 +268,15 @@ impl PollResponse {
         let message: PollResponse = Self::new(nready, fds, revents);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PollResponse, message.into_bytes());
-        Ok(Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes()))
+
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
+
+        Ok(message)
     }
 }

--- a/src/libs/syscall/src/poll/message.rs
+++ b/src/libs/syscall/src/poll/message.rs
@@ -15,7 +15,7 @@ use ::sys::{
         Error,
         ErrorCode,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sys::ipc::{
     Message,
@@ -110,7 +110,7 @@ impl PollRequest {
 
     /// Builds a `Message` from a `PollRequest`.
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         fds: &[i32],
         events: &[i16],
         timeout: i32,
@@ -161,7 +161,7 @@ impl PollRequest {
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PollRequest, message.into_bytes());
 
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -236,7 +236,7 @@ impl PollResponse {
 
     /// Builds a `Message` from a `PollResponse`.
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         nready: u8,
         fds: &[i32],
         revents: &[i16],
@@ -271,7 +271,7 @@ impl PollResponse {
 
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/poll/syscall.rs
+++ b/src/libs/syscall/src/poll/syscall.rs
@@ -18,7 +18,7 @@ use ::alloc::vec::Vec;
 use ::sys::{
     error::Error,
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::{
     c_int,
@@ -132,13 +132,13 @@ pub fn poll(
 ) -> Result<Vec<(RawFileDescriptor, PollEvents)>, Error> {
     ::syslog::trace!("poll(): fds={fds:?}, timeout={timeout:?}");
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
     let events: Vec<i16> = fds.iter().map(|fd| fd.events.0).collect();
     let poll_fds: Vec<RawFileDescriptor> = fds.iter().map(|fd| fd.fd).collect();
     let timeout: i32 = timeout.into();
-    let request: Message = PollRequest::build(pid, &poll_fds, &events, timeout)?;
+    let request: Message = PollRequest::build(tid, &poll_fds, &events, timeout)?;
     ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/socket/message/accept.rs
+++ b/src/libs/syscall/src/sys/socket/message/accept.rs
@@ -20,7 +20,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_socket::sockaddr;
 
@@ -54,14 +54,14 @@ impl AcceptSocketRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockfd: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockfd: i32) -> Message {
         let message: Self = Self::new(sockfd);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::AcceptSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -104,7 +104,7 @@ impl AcceptSocketResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockfd: i32, sockaddr: &sockaddr) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockfd: i32, sockaddr: &sockaddr) -> Message {
         let message: Self = Self::new(sockfd, sockaddr);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::AcceptSocketResponse,
@@ -112,7 +112,7 @@ impl AcceptSocketResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/accept.rs
+++ b/src/libs/syscall/src/sys/socket/message/accept.rs
@@ -16,11 +16,13 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
 };
-use sysapi::sys_socket::sockaddr;
+use ::sysapi::sys_socket::sockaddr;
 
 //==================================================================================================
 // AcceptSocketRequest
@@ -58,8 +60,13 @@ impl AcceptSocketRequest {
             LinuxDaemonMessageHeader::AcceptSocketRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -103,8 +110,13 @@ impl AcceptSocketResponse {
             LinuxDaemonMessageHeader::AcceptSocketResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/socket/message/bind.rs
+++ b/src/libs/syscall/src/sys/socket/message/bind.rs
@@ -21,7 +21,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -57,14 +57,14 @@ impl BindSocketRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockfd: c_int, sockaddr: &sockaddr) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockfd: c_int, sockaddr: &sockaddr) -> Message {
         let message: Self = Self::new(sockfd, sockaddr);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::BindSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -114,7 +114,7 @@ impl BindSocketResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: Self = Self::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::BindSocketResponse,
@@ -122,7 +122,7 @@ impl BindSocketResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/bind.rs
+++ b/src/libs/syscall/src/sys/socket/message/bind.rs
@@ -17,6 +17,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -61,8 +63,13 @@ impl BindSocketRequest {
             LinuxDaemonMessageHeader::BindSocketRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -113,8 +120,13 @@ impl BindSocketResponse {
             LinuxDaemonMessageHeader::BindSocketResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/socket/message/connect.rs
+++ b/src/libs/syscall/src/sys/socket/message/connect.rs
@@ -24,7 +24,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -65,7 +65,7 @@ impl ConnectSocketRequest {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         sockfd: c_int,
         sockaddr: &sockaddr,
         socklen: socklen_t,
@@ -76,7 +76,7 @@ impl ConnectSocketRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -120,7 +120,7 @@ impl ConnectSocketResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: Self = Self::default();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::ConnectSocketResponse,
@@ -128,7 +128,7 @@ impl ConnectSocketResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/connect.rs
+++ b/src/libs/syscall/src/sys/socket/message/connect.rs
@@ -20,6 +20,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -73,8 +75,13 @@ impl ConnectSocketRequest {
             LinuxDaemonMessageHeader::ConnectSocketRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -119,8 +126,13 @@ impl ConnectSocketResponse {
             LinuxDaemonMessageHeader::ConnectSocketResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/socket/message/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/message/getpeername.rs
@@ -17,6 +17,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -59,8 +61,13 @@ impl GetPeerNameRequest {
             LinuxDaemonMessageHeader::GetPeerNameRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }
@@ -100,8 +107,13 @@ impl GetPeerNameResponse {
             LinuxDaemonMessageHeader::GetPeerNameResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/sys/socket/message/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/message/getpeername.rs
@@ -21,7 +21,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -55,14 +55,14 @@ impl GetPeerNameRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockfd: c_int) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockfd: c_int) -> Message {
         let message: Self = Self::new(sockfd);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::GetPeerNameRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -101,7 +101,7 @@ impl GetPeerNameResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockaddr: &sockaddr) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockaddr: &sockaddr) -> Message {
         let message: Self = Self::new(sockaddr);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::GetPeerNameResponse,
@@ -109,7 +109,7 @@ impl GetPeerNameResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/message/getsockname.rs
@@ -17,6 +17,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -59,8 +61,13 @@ impl GetSockNameRequest {
             LinuxDaemonMessageHeader::GetSockNameRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }
@@ -100,8 +107,13 @@ impl GetSockNameResponse {
             LinuxDaemonMessageHeader::GetSockNameResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/sys/socket/message/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/message/getsockname.rs
@@ -21,7 +21,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -55,14 +55,14 @@ impl GetSockNameRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockfd: c_int) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockfd: c_int) -> Message {
         let message: Self = Self::new(sockfd);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::GetSockNameRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -101,7 +101,7 @@ impl GetSockNameResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockaddr: &sockaddr) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockaddr: &sockaddr) -> Message {
         let message: Self = Self::new(sockaddr);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::GetSockNameResponse,
@@ -109,7 +109,7 @@ impl GetSockNameResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/listen.rs
+++ b/src/libs/syscall/src/sys/socket/message/listen.rs
@@ -20,7 +20,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -56,14 +56,14 @@ impl ListenSocketRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockfd: i32, backlog: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockfd: i32, backlog: i32) -> Message {
         let message: Self = Self::new(sockfd, backlog);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::ListenSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -102,7 +102,7 @@ impl ListenSocketResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: Self = Self::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::ListenSocketResponse,
@@ -110,7 +110,7 @@ impl ListenSocketResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/listen.rs
+++ b/src/libs/syscall/src/sys/socket/message/listen.rs
@@ -16,6 +16,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -60,8 +62,13 @@ impl ListenSocketRequest {
             LinuxDaemonMessageHeader::ListenSocketRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -101,8 +108,13 @@ impl ListenSocketResponse {
             LinuxDaemonMessageHeader::ListenSocketResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/socket/message/recv.rs
+++ b/src/libs/syscall/src/sys/socket/message/recv.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::c_size_t;
 
@@ -58,14 +58,14 @@ impl ReceiveSocketRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockfd: i32, count: u32, flags: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockfd: i32, count: u32, flags: i32) -> Message {
         let message: ReceiveSocketRequest = ReceiveSocketRequest::new(sockfd, count, flags);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::ReceiveSocketRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -103,7 +103,7 @@ impl ReceiveSocketResponse {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         count: c_size_t,
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {
@@ -114,7 +114,7 @@ impl ReceiveSocketResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/recv.rs
+++ b/src/libs/syscall/src/sys/socket/message/recv.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -62,8 +64,13 @@ impl ReceiveSocketRequest {
             LinuxDaemonMessageHeader::ReceiveSocketRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }
@@ -105,8 +112,13 @@ impl ReceiveSocketResponse {
             LinuxDaemonMessageHeader::ReceiveSocketResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/sys/socket/message/send.rs
+++ b/src/libs/syscall/src/sys/socket/message/send.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -71,8 +73,13 @@ impl SendSocketRequest {
             LinuxDaemonMessageHeader::SendSocketRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -114,8 +121,13 @@ impl SendSocketResponse {
             LinuxDaemonMessageHeader::SendSocketResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/socket/message/send.rs
+++ b/src/libs/syscall/src/sys/socket/message/send.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::{
     c_size_t,
@@ -62,7 +62,7 @@ impl SendSocketRequest {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         sockfd: i32,
         count: c_size_t,
         flags: i32,
@@ -74,7 +74,7 @@ impl SendSocketRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -115,7 +115,7 @@ impl SendSocketResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, count: c_ssize_t) -> Message {
+    pub fn build(tid: ThreadIdentifier, count: c_ssize_t) -> Message {
         let message: SendSocketResponse = SendSocketResponse::new(count);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::SendSocketResponse,
@@ -123,7 +123,7 @@ impl SendSocketResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/message/shutdown.rs
@@ -17,6 +17,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -62,8 +64,13 @@ impl ShutdownSocketRequest {
             message.into_bytes(),
         );
 
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -103,8 +110,13 @@ impl ShutdownSocketResponse {
             LinuxDaemonMessageHeader::ShutdownSocketResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/socket/message/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/message/shutdown.rs
@@ -21,7 +21,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -57,7 +57,7 @@ impl ShutdownSocketRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockfd: i32, how: Shutdown) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockfd: i32, how: Shutdown) -> Message {
         let message: Self = Self::new(sockfd, how);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::ShutdownSocketRequest,
@@ -65,7 +65,7 @@ impl ShutdownSocketRequest {
         );
 
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -104,7 +104,7 @@ impl ShutdownSocketResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: Self = Self::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::ShutdownSocketResponse,
@@ -112,7 +112,7 @@ impl ShutdownSocketResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/socket.rs
+++ b/src/libs/syscall/src/sys/socket/message/socket.rs
@@ -21,6 +21,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -74,8 +76,13 @@ impl CreateSocketRequest {
             LinuxDaemonMessageHeader::CreateSocketRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -117,8 +124,13 @@ impl CreateSocketResponse {
             LinuxDaemonMessageHeader::CreateSocketResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/socket/message/socket.rs
+++ b/src/libs/syscall/src/sys/socket/message/socket.rs
@@ -25,7 +25,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -66,7 +66,7 @@ impl CreateSocketRequest {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         domain: AddressFamily,
         typ: SocketType,
         protocol: Protocol,
@@ -77,7 +77,7 @@ impl CreateSocketRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -118,7 +118,7 @@ impl CreateSocketResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockfd: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockfd: i32) -> Message {
         let message: Self = Self::new(sockfd);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::CreateSocketResponse,
@@ -126,7 +126,7 @@ impl CreateSocketResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/message/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/message/socketpair.rs
@@ -21,6 +21,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -75,8 +77,13 @@ impl CreateSocketPairRequest {
             LinuxDaemonMessageHeader::CreateSocketPairRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -121,8 +128,13 @@ impl CreateSocketPairResponse {
             LinuxDaemonMessageHeader::CreateSocketPairResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/socket/message/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/message/socketpair.rs
@@ -25,7 +25,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -67,7 +67,7 @@ impl CreateSocketPairRequest {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         domain: AddressFamily,
         typ: SocketType,
         protocol: Protocol,
@@ -78,7 +78,7 @@ impl CreateSocketPairRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -122,7 +122,7 @@ impl CreateSocketPairResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, sockfd_0: c_int, sockfd_1: c_int) -> Message {
+    pub fn build(tid: ThreadIdentifier, sockfd_0: c_int, sockfd_1: c_int) -> Message {
         let message: Self = Self::new(sockfd_0, sockfd_1);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::CreateSocketPairResponse,
@@ -130,7 +130,7 @@ impl CreateSocketPairResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/socket/syscall/accept.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/accept.rs
@@ -22,7 +22,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -31,10 +31,10 @@ use ::sysapi::ffi::c_int;
 //==================================================================================================
 
 pub fn accept(sockfd: c_int) -> Result<(c_int, SocketAddr), Error> {
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = AcceptSocketRequest::build(pid, sockfd);
+    let request: Message = AcceptSocketRequest::build(tid, sockfd);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/socket/syscall/bind.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/bind.rs
@@ -20,7 +20,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -29,12 +29,12 @@ use ::sysapi::ffi::c_int;
 //==================================================================================================
 
 pub fn bind(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let sockaddr: sockaddr = sockaddr::from(sockaddr);
 
     // Build request and send it.
-    let request: Message = BindSocketRequest::build(pid, sockfd, &sockaddr);
+    let request: Message = BindSocketRequest::build(tid, sockfd, &sockaddr);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/socket/syscall/connect.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/connect.rs
@@ -24,7 +24,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -48,12 +48,12 @@ use ::sysapi::ffi::c_int;
 ///
 pub fn connect(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
     ::syslog::trace!("connect(): fd={:?}, sockaddr={:?}", sockfd, sockaddr);
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let (sockaddr, socklen): (sockaddr, socklen_t) = From::<&SocketAddr>::from(sockaddr);
 
     // Build request and send it.
-    let request: Message = ConnectSocketRequest::build(pid, sockfd, &sockaddr, socklen);
+    let request: Message = ConnectSocketRequest::build(tid, sockfd, &sockaddr, socklen);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
@@ -22,7 +22,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -46,10 +46,10 @@ use ::sysapi::ffi::c_int;
 ///
 pub fn getpeername(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error> {
     ::syslog::trace!("getpeername(): sockfd={:?}, sockaddr={:?}", sockfd, sockaddr);
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = GetPeerNameRequest::build(pid, sockfd);
+    let request: Message = GetPeerNameRequest::build(tid, sockfd);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
@@ -22,7 +22,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -46,10 +46,10 @@ use ::sysapi::ffi::c_int;
 ///
 pub fn getsockname(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error> {
     ::syslog::trace!("getsockname(): sockfd={:?}, sockaddr={:?}", sockfd, sockaddr);
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = GetSockNameRequest::build(pid, sockfd);
+    let request: Message = GetSockNameRequest::build(tid, sockfd);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/socket/syscall/listen.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/listen.rs
@@ -16,7 +16,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -25,10 +25,10 @@ use ::sysapi::ffi::c_int;
 //==================================================================================================
 
 pub fn listen(sockfd: c_int, backlog: c_int) -> Result<(), Error> {
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = ListenSocketRequest::build(pid, sockfd, backlog);
+    let request: Message = ListenSocketRequest::build(tid, sockfd, backlog);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/socket/syscall/recv.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recv.rs
@@ -20,7 +20,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -29,7 +29,7 @@ use ::sysapi::ffi::c_int;
 //==================================================================================================
 
 pub fn recv(sockfd: i32, buffer: &mut [u8], flags: c_int) -> Result<usize, Error> {
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Check if count is invalid.
     if buffer.is_empty() {
@@ -44,7 +44,7 @@ pub fn recv(sockfd: i32, buffer: &mut [u8], flags: c_int) -> Result<usize, Error
             cmp::min(ReceiveSocketResponse::BUFFER_SIZE, buffer.len() - buffer_offset);
 
         // Build request and send it.
-        let request: Message = ReceiveSocketRequest::build(pid, sockfd, recv_len as u32, flags);
+        let request: Message = ReceiveSocketRequest::build(tid, sockfd, recv_len as u32, flags);
         ::sys::kcall::ipc::send(&request)?;
 
         // Receive response.

--- a/src/libs/syscall/src/sys/socket/syscall/send.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/send.rs
@@ -20,7 +20,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -32,7 +32,7 @@ use ::sysapi::{
 //==================================================================================================
 
 pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> {
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Check if count is invalid.
     if buffer.is_empty() {
@@ -49,7 +49,7 @@ pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> 
 
         // Build request and send it.
         let request: Message =
-            SendSocketRequest::build(pid, sockfd, chunk_size as c_size_t, flags, chunk);
+            SendSocketRequest::build(tid, sockfd, chunk_size as c_size_t, flags, chunk);
         ::sys::kcall::ipc::send(&request)?;
 
         // Receive response.

--- a/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -28,10 +28,10 @@ use ::sysapi::ffi::c_int;
 //==================================================================================================
 
 pub fn shutdown(sockfd: c_int, how: Shutdown) -> Result<(), Error> {
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = ShutdownSocketRequest::build(pid, sockfd, how);
+    let request: Message = ShutdownSocketRequest::build(tid, sockfd, how);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/socket/syscall/socket.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socket.rs
@@ -24,7 +24,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -33,10 +33,10 @@ use ::sysapi::ffi::c_int;
 //==================================================================================================
 
 pub fn socket(domain: AddressFamily, typ: SocketType, protocol: Protocol) -> Result<c_int, Error> {
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = CreateSocketRequest::build(pid, domain, typ, protocol);
+    let request: Message = CreateSocketRequest::build(tid, domain, typ, protocol);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
@@ -24,7 +24,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -55,7 +55,7 @@ pub fn socketpair(
     socket_fds: &mut [c_int],
 ) -> Result<(), Error> {
     ::syslog::trace!("socketpair(): domain={:?}, type={:?}, protocol={:?}", domain, typ, protocol);
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Check if array of file descriptors has expected length.
     if socket_fds.len() != 2 {
@@ -65,7 +65,7 @@ pub fn socketpair(
     }
 
     // Build request and send it.
-    let request: Message = CreateSocketPairRequest::build(pid, domain, typ, protocol);
+    let request: Message = CreateSocketPairRequest::build(tid, domain, typ, protocol);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/stat/message/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/message/fchmod.rs
@@ -20,7 +20,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -63,14 +63,14 @@ impl FileChmodRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: c_int, mode: mode_t) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: c_int, mode: mode_t) -> Message {
         let message: FileChmodRequest = FileChmodRequest::new(fd, mode);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileChmodRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -106,7 +106,7 @@ impl FileChmodResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileChmodResponse = FileChmodResponse::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileChmodResponse,
@@ -114,7 +114,7 @@ impl FileChmodResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/message/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/message/fchmod.rs
@@ -16,6 +16,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -67,8 +69,13 @@ impl FileChmodRequest {
             LinuxDaemonMessageHeader::FileChmodRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -105,8 +112,13 @@ impl FileChmodResponse {
             LinuxDaemonMessageHeader::FileChmodResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/stat/message/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fchmodat.rs
@@ -37,7 +37,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -221,7 +221,7 @@ impl MessagePartitioner for FileChmodAtRequest {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -231,13 +231,13 @@ impl MessagePartitioner for FileChmodAtRequest {
     /// Upon success, the partitioned message is returned. Upon failure, an error is returned instead.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::FileChmodAtRequestPart,
             part_number,
             payload_size,
@@ -271,7 +271,7 @@ impl FileChmodAtResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileChmodAtResponse = FileChmodAtResponse::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileChmodAtResponse,
@@ -279,7 +279,7 @@ impl FileChmodAtResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/message/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fchmodat.rs
@@ -33,6 +33,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -275,8 +277,13 @@ impl FileChmodAtResponse {
             LinuxDaemonMessageHeader::FileChmodAtResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/stat/message/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fstat.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -60,14 +60,14 @@ impl FileStatRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: i32) -> Message {
         let message: FileStatRequest = FileStatRequest::new(fd);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileStatRequest,
             message.into_bytes(),
         );
         Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,

--- a/src/libs/syscall/src/sys/stat/message/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fstat.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -64,6 +66,12 @@ impl FileStatRequest {
             LinuxDaemonMessageHeader::FileStatRequest,
             message.into_bytes(),
         );
-        Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes())
+        Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        )
     }
 }

--- a/src/libs/syscall/src/sys/stat/message/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fstatat.rs
@@ -28,7 +28,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::{
     limits::PATH_MAX,
@@ -186,7 +186,7 @@ impl MessagePartitioner for FileStatAtRequest {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -196,13 +196,13 @@ impl MessagePartitioner for FileStatAtRequest {
     /// Upon success, the new message partition is returned. Upon failure, an error is returned.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::FileStatAtRequestPart,
             part_number,
             payload_size,
@@ -377,7 +377,7 @@ impl MessagePartitioner for FileStatAtResponse {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -387,13 +387,13 @@ impl MessagePartitioner for FileStatAtResponse {
     /// Upon success, the new message partition is returned. Upon failure, an error is returned.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_response(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::FileStatAtResponsePart,
             part_number,
             payload_size,

--- a/src/libs/syscall/src/sys/stat/message/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/message/futimens.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -54,8 +56,13 @@ impl UpdateFileAccessTimeRequest {
             LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -96,8 +103,13 @@ impl UpdateFileAccessTimeResponse {
             LinuxDaemonMessageHeader::UpdateFileAccessTimeResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/stat/message/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/message/futimens.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::time::timespec;
 
@@ -46,7 +46,7 @@ impl UpdateFileAccessTimeRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32, times: &[timespec; 2]) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: i32, times: &[timespec; 2]) -> Message {
         let message: UpdateFileAccessTimeRequest = UpdateFileAccessTimeRequest {
             fd,
             times: *times,
@@ -57,7 +57,7 @@ impl UpdateFileAccessTimeRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -97,7 +97,7 @@ impl UpdateFileAccessTimeResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: UpdateFileAccessTimeResponse = UpdateFileAccessTimeResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::UpdateFileAccessTimeResponse,
@@ -105,7 +105,7 @@ impl UpdateFileAccessTimeResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/message/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/message/mkdirat.rs
@@ -34,7 +34,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::{
     limits::PATH_MAX,
@@ -221,7 +221,7 @@ impl MessagePartitioner for MakeDirectoryAtRequest {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -231,13 +231,13 @@ impl MessagePartitioner for MakeDirectoryAtRequest {
     /// Upon success, the new message partition is returned. Upon failure, an error is returned.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart,
             part_number,
             payload_size,
@@ -275,7 +275,7 @@ impl MakeDirectoryAtResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: MakeDirectoryAtResponse = MakeDirectoryAtResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::MakeDirectoryAtResponse,
@@ -283,7 +283,7 @@ impl MakeDirectoryAtResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/message/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/message/mkdirat.rs
@@ -30,6 +30,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -279,8 +281,13 @@ impl MakeDirectoryAtResponse {
             LinuxDaemonMessageHeader::MakeDirectoryAtResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/sys/stat/message/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/message/utimensat.rs
@@ -30,6 +30,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -305,8 +307,13 @@ impl UpdateFileAccessTimeAtResponse {
             LinuxDaemonMessageHeader::UpdateFileAccessTimeAtResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/stat/message/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/message/utimensat.rs
@@ -34,7 +34,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::{
     limits::PATH_MAX,
@@ -242,7 +242,7 @@ impl MessagePartitioner for UpdateFileAccessTimeAtRequest {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -252,13 +252,13 @@ impl MessagePartitioner for UpdateFileAccessTimeAtRequest {
     /// Upon success, the new message partition is returned. Upon failure, an error is returned.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart,
             part_number,
             payload_size,
@@ -301,7 +301,7 @@ impl UpdateFileAccessTimeAtResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: UpdateFileAccessTimeAtResponse = UpdateFileAccessTimeAtResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::UpdateFileAccessTimeAtResponse,
@@ -309,7 +309,7 @@ impl UpdateFileAccessTimeAtResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
@@ -17,7 +17,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::sys_types::mode_t;
 
@@ -42,10 +42,10 @@ use sysapi::sys_types::mode_t;
 pub fn fchmod(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
     ::syslog::trace!("fchmod(): fd={:?}, mode={:o}", fd, mode);
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it
-    let request: Message = FileChmodRequest::build(pid, fd, mode);
+    let request: Message = FileChmodRequest::build(tid, fd, mode);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
@@ -18,7 +18,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -57,11 +57,11 @@ pub fn fchmodat(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Result<(
 }
 
 fn chmodat_request(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Result<(), Error> {
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: FileChmodAtRequest = FileChmodAtRequest::new(dirfd, mode, flag, path)?;
 
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
 
     for request in requests {
         ::sys::kcall::ipc::send(&request)?;

--- a/src/libs/syscall/src/sys/stat/syscall/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstat.rs
@@ -9,7 +9,7 @@ use crate::sys::stat::message::FileStatRequest;
 use ::sys::{
     error::Error,
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::sys_stat;
 
@@ -57,9 +57,9 @@ pub fn fstat(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
 /// instead.
 ///
 fn fstat_request(fd: i32) -> Result<(), Error> {
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
-    let message: Message = FileStatRequest::build(pid, fd);
+    let message: Message = FileStatRequest::build(tid, fd);
 
     ::sys::kcall::ipc::send(&message)
 }

--- a/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
@@ -16,7 +16,7 @@ use ::alloc::{
 use ::sys::{
     error::Error,
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_stat;
 
@@ -67,11 +67,11 @@ pub fn fstatat(dirfd: i32, path: &str, buf: &mut sys_stat::stat, flag: i32) -> R
 /// instead.
 ///
 fn fstatat_request(dirfd: i32, path: &str, flag: i32) -> Result<(), Error> {
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: FileStatAtRequest = FileStatAtRequest::new(dirfd, path.to_string(), flag)?;
 
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
 
     for request in requests {
         ::sys::kcall::ipc::send(&request)?;

--- a/src/libs/syscall/src/sys/stat/syscall/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/futimens.rs
@@ -17,7 +17,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::time::timespec;
 
@@ -42,10 +42,10 @@ use ::sysapi::time::timespec;
 pub fn futimens(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), Error> {
     ::syslog::error!("futimens(): fd={:?}, times={:?}", fd, times);
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = UpdateFileAccessTimeRequest::build(pid, fd, times);
+    let request: Message = UpdateFileAccessTimeRequest::build(tid, fd, times);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
@@ -22,7 +22,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::mode_t;
 
@@ -49,12 +49,12 @@ use ::sysapi::sys_types::mode_t;
 pub fn mkdirat(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Result<(), Error> {
     ::syslog::trace!("mkdirat(): dirfd={:?}, pathname={:?}, mode={:?}", dirfd, pathname, mode);
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: MakeDirectoryAtRequest =
         MakeDirectoryAtRequest::new(dirfd, pathname.to_string(), mode)?;
 
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
 
     // Send request.
     for request in requests {

--- a/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
@@ -21,7 +21,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::time::timespec;
 
@@ -60,12 +60,12 @@ pub fn utimensat(
         flags
     );
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: UpdateFileAccessTimeAtRequest =
         UpdateFileAccessTimeAtRequest::new(dirfd, pathname.to_string(), flags, times)?;
 
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
 
     // Send request.
     for request in requests {

--- a/src/libs/syscall/src/sys/time/message/mod.rs
+++ b/src/libs/syscall/src/sys/time/message/mod.rs
@@ -18,7 +18,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     sys_times::tms,
@@ -52,12 +52,12 @@ impl TimesRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Result<Message, Error> {
+    pub fn build(tid: ThreadIdentifier) -> Result<Message, Error> {
         let message: TimesRequest = TimesRequest::new();
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -100,13 +100,13 @@ impl TimesResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, elapsed: clock_t, buffer: tms) -> Message {
+    pub fn build(tid: ThreadIdentifier, elapsed: clock_t, buffer: tms) -> Message {
         let message: TimesResponse = TimesResponse::new(elapsed, buffer);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/time/message/mod.rs
+++ b/src/libs/syscall/src/sys/time/message/mod.rs
@@ -14,6 +14,8 @@ use ::sys::{
     error::Error,
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -54,8 +56,13 @@ impl TimesRequest {
         let message: TimesRequest = TimesRequest::new();
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesRequest, message.into_bytes());
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         Ok(message)
     }
@@ -97,9 +104,13 @@ impl TimesResponse {
         let message: TimesResponse = TimesResponse::new(elapsed, buffer);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesResponse, message.into_bytes());
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
-
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/sys/times/message/mod.rs
+++ b/src/libs/syscall/src/sys/times/message/mod.rs
@@ -14,6 +14,8 @@ use ::sys::{
     error::Error,
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -54,8 +56,13 @@ impl TimesRequest {
         let message: TimesRequest = TimesRequest::new();
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesRequest, message.into_bytes());
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         Ok(message)
     }
@@ -97,8 +104,13 @@ impl TimesResponse {
         let message: TimesResponse = TimesResponse::new(elapsed, buffer);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesResponse, message.into_bytes());
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/sys/times/message/mod.rs
+++ b/src/libs/syscall/src/sys/times/message/mod.rs
@@ -18,7 +18,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::{
     sys_times::tms,
@@ -52,12 +52,12 @@ impl TimesRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Result<Message, Error> {
+    pub fn build(tid: ThreadIdentifier) -> Result<Message, Error> {
         let message: TimesRequest = TimesRequest::new();
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -100,13 +100,13 @@ impl TimesResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, elapsed: clock_t, buffer: tms) -> Message {
+    pub fn build(tid: ThreadIdentifier, elapsed: clock_t, buffer: tms) -> Message {
         let message: TimesResponse = TimesResponse::new(elapsed, buffer);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::TimesResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/sys/times/syscall/times.rs
+++ b/src/libs/syscall/src/sys/times/syscall/times.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::{
     sys_times::tms,
@@ -47,10 +47,10 @@ use sysapi::{
 pub fn times(buffer: &mut Option<&mut tms>) -> Result<clock_t, Error> {
     ::syslog::trace!("times(): {:?}", buffer);
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = TimesRequest::build(pid)?;
+    let request: Message = TimesRequest::build(tid)?;
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/message/chdir.rs
+++ b/src/libs/syscall/src/unistd/message/chdir.rs
@@ -37,7 +37,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::limits::PATH_MAX;
 
@@ -162,7 +162,7 @@ impl MessagePartitioner for ChangeDirectoryRequest {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -172,13 +172,13 @@ impl MessagePartitioner for ChangeDirectoryRequest {
     /// Upon success, the partitioned message is returned. Upon failure, an error is returned instead.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::ChangeDirectoryRequestPart,
             part_number,
             payload_size,
@@ -211,7 +211,7 @@ impl ChangeDirectoryResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: ChangeDirectoryResponse = ChangeDirectoryResponse::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::ChangeDirectoryResponse,
@@ -219,7 +219,7 @@ impl ChangeDirectoryResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/chdir.rs
+++ b/src/libs/syscall/src/unistd/message/chdir.rs
@@ -33,6 +33,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -215,8 +217,13 @@ impl ChangeDirectoryResponse {
             LinuxDaemonMessageHeader::ChangeDirectoryResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/message/close.rs
+++ b/src/libs/syscall/src/unistd/message/close.rs
@@ -16,6 +16,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -54,8 +56,13 @@ impl CloseRequest {
         let message: CloseRequest = CloseRequest::new(fd);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::CloseRequest, message.into_bytes());
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -101,8 +108,13 @@ impl CloseResponse {
         let message: CloseResponse = CloseResponse::new(ret);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::CloseResponse, message.into_bytes());
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/message/close.rs
+++ b/src/libs/syscall/src/unistd/message/close.rs
@@ -20,7 +20,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -52,12 +52,12 @@ impl CloseRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: i32) -> Message {
         let message: CloseRequest = CloseRequest::new(fd);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::CloseRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -104,13 +104,13 @@ impl CloseResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: CloseResponse = CloseResponse::new(ret);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::CloseResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/faccessat.rs
+++ b/src/libs/syscall/src/unistd/message/faccessat.rs
@@ -37,7 +37,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 use sysapi::limits::PATH_MAX;
@@ -218,7 +218,7 @@ impl MessagePartitioner for FileAccessAtRequest {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -228,13 +228,13 @@ impl MessagePartitioner for FileAccessAtRequest {
     /// Upon success, the partitioned message is returned. Upon failure, an error is returned instead.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::FileAccessAtRequestPart,
             part_number,
             payload_size,
@@ -267,7 +267,7 @@ impl FileAccessAtResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileAccessAtResponse = FileAccessAtResponse::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileAccessAtResponse,
@@ -275,7 +275,7 @@ impl FileAccessAtResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/faccessat.rs
+++ b/src/libs/syscall/src/unistd/message/faccessat.rs
@@ -33,6 +33,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -271,8 +273,13 @@ impl FileAccessAtResponse {
             LinuxDaemonMessageHeader::FileAccessAtResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/message/fchdir.rs
+++ b/src/libs/syscall/src/unistd/message/fchdir.rs
@@ -20,7 +20,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -56,14 +56,14 @@ impl FileChdirRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: c_int) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: c_int) -> Message {
         let message: FileChdirRequest = FileChdirRequest::new(fd);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileChdirRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -103,7 +103,7 @@ impl FileChdirResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileChdirResponse = FileChdirResponse::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileChdirResponse,
@@ -111,7 +111,7 @@ impl FileChdirResponse {
         );
         Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/fchdir.rs
+++ b/src/libs/syscall/src/unistd/message/fchdir.rs
@@ -16,6 +16,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -60,7 +62,15 @@ impl FileChdirRequest {
             LinuxDaemonMessageHeader::FileChdirRequest,
             message.into_bytes(),
         );
-        Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes())
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
+
+        message
     }
 }
 
@@ -99,6 +109,12 @@ impl FileChdirResponse {
             LinuxDaemonMessageHeader::FileChdirResponse,
             message.into_bytes(),
         );
-        Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes())
+        Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        )
     }
 }

--- a/src/libs/syscall/src/unistd/message/fchown.rs
+++ b/src/libs/syscall/src/unistd/message/fchown.rs
@@ -16,6 +16,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -73,8 +75,13 @@ impl FileChownRequest {
             LinuxDaemonMessageHeader::FileChownRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -111,8 +118,13 @@ impl FileChownResponse {
             LinuxDaemonMessageHeader::FileChownResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/message/fchown.rs
+++ b/src/libs/syscall/src/unistd/message/fchown.rs
@@ -20,7 +20,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 use sysapi::sys_types::{
@@ -69,14 +69,14 @@ impl FileChownRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: c_int, owner: uid_t, group: gid_t) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: c_int, owner: uid_t, group: gid_t) -> Message {
         let message: FileChownRequest = FileChownRequest::new(fd, owner, group);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileChownRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -112,7 +112,7 @@ impl FileChownResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileChownResponse = FileChownResponse::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileChownResponse,
@@ -120,7 +120,7 @@ impl FileChownResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/fchownat.rs
+++ b/src/libs/syscall/src/unistd/message/fchownat.rs
@@ -37,7 +37,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -248,7 +248,7 @@ impl MessagePartitioner for FileChownAtRequest {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -258,13 +258,13 @@ impl MessagePartitioner for FileChownAtRequest {
     /// Upon success, the partitioned message is returned. Upon failure, an error is returned instead.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::FileChownAtRequestPart,
             part_number,
             payload_size,
@@ -297,7 +297,7 @@ impl FileChownAtResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: FileChownAtResponse = FileChownAtResponse::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileChownAtResponse,
@@ -305,7 +305,7 @@ impl FileChownAtResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/fchownat.rs
+++ b/src/libs/syscall/src/unistd/message/fchownat.rs
@@ -33,6 +33,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -301,8 +303,13 @@ impl FileChownAtResponse {
             LinuxDaemonMessageHeader::FileChownAtResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/message/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/message/fdatasync.rs
@@ -20,7 +20,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -52,14 +52,14 @@ impl FileDataSyncRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: i32) -> Message {
         let message: FileDataSyncRequest = FileDataSyncRequest::new(fd);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileDataSyncRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -105,7 +105,7 @@ impl FileDataSyncResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileDataSyncResponse = FileDataSyncResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileDataSyncResponse,
@@ -113,7 +113,7 @@ impl FileDataSyncResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/message/fdatasync.rs
@@ -16,6 +16,8 @@ use ::core::{
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -56,8 +58,13 @@ impl FileDataSyncRequest {
             LinuxDaemonMessageHeader::FileDataSyncRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -104,8 +111,13 @@ impl FileDataSyncResponse {
             LinuxDaemonMessageHeader::FileDataSyncResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/message/fsync.rs
+++ b/src/libs/syscall/src/unistd/message/fsync.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -54,8 +56,13 @@ impl FileSyncRequest {
             LinuxDaemonMessageHeader::FileSyncRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }
@@ -101,8 +108,13 @@ impl FileSyncResponse {
             LinuxDaemonMessageHeader::FileSyncResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/unistd/message/fsync.rs
+++ b/src/libs/syscall/src/unistd/message/fsync.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use core::fmt::Debug;
 
@@ -50,14 +50,14 @@ impl FileSyncRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: i32) -> Message {
         let message: FileSyncRequest = FileSyncRequest::new(fd);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileSyncRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -102,7 +102,7 @@ impl FileSyncResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileSyncResponse = FileSyncResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileSyncResponse,
@@ -110,7 +110,7 @@ impl FileSyncResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/message/ftruncate.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::off_t;
 
@@ -54,14 +54,14 @@ impl FileTruncateRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32, length: off_t) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: i32, length: off_t) -> Message {
         let message: FileTruncateRequest = FileTruncateRequest::new(fd, length);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileTruncateRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -101,7 +101,7 @@ impl FileTruncateResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: FileTruncateResponse = FileTruncateResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::FileTruncateResponse,
@@ -109,7 +109,7 @@ impl FileTruncateResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/message/ftruncate.rs
@@ -13,11 +13,13 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
 };
-use sysapi::sys_types::off_t;
+use ::sysapi::sys_types::off_t;
 
 //==================================================================================================
 // FileTruncateRequest
@@ -58,8 +60,13 @@ impl FileTruncateRequest {
             LinuxDaemonMessageHeader::FileTruncateRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -100,8 +107,13 @@ impl FileTruncateResponse {
             LinuxDaemonMessageHeader::FileTruncateResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/message/getcwd.rs
+++ b/src/libs/syscall/src/unistd/message/getcwd.rs
@@ -29,6 +29,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -67,8 +69,13 @@ impl GetCurrentWorkingDirectoryRequest {
             crate::LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/message/getcwd.rs
+++ b/src/libs/syscall/src/unistd/message/getcwd.rs
@@ -33,7 +33,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::limits::PATH_MAX;
 
@@ -63,14 +63,14 @@ impl GetCurrentWorkingDirectoryRequest {
         unsafe { core::mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: GetCurrentWorkingDirectoryRequest = GetCurrentWorkingDirectoryRequest::new();
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             crate::LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -162,13 +162,13 @@ impl MessageDeserializer for GetCurrentWorkingDirectoryResponse {
 
 impl MessagePartitioner for GetCurrentWorkingDirectoryResponse {
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_response(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryResponsePart,
             part_number,
             payload_size,

--- a/src/libs/syscall/src/unistd/message/getids.rs
+++ b/src/libs/syscall/src/unistd/message/getids.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -53,7 +55,13 @@ impl GetIdsRequest {
         let message: GetIdsRequest = GetIdsRequest::new();
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::GetIdsRequest, message.into_bytes());
-        Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes())
+        Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        )
     }
 }
 
@@ -104,6 +112,12 @@ impl GetIdsResponse {
         let message: GetIdsResponse = GetIdsResponse::new(uid, gid, euid, egid);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::GetIdsResponse, message.into_bytes());
-        Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes())
+        Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        )
     }
 }

--- a/src/libs/syscall/src/unistd/message/getids.rs
+++ b/src/libs/syscall/src/unistd/message/getids.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::sys_types::{
     gid_t,
@@ -51,12 +51,12 @@ impl GetIdsRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: GetIdsRequest = GetIdsRequest::new();
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::GetIdsRequest, message.into_bytes());
         Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -103,7 +103,7 @@ impl GetIdsResponse {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         uid: uid_t,
         gid: gid_t,
         euid: uid_t,
@@ -114,7 +114,7 @@ impl GetIdsResponse {
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::GetIdsResponse, message.into_bytes());
         Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/linkat.rs
+++ b/src/libs/syscall/src/unistd/message/linkat.rs
@@ -34,7 +34,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::limits::PATH_MAX;
 
@@ -253,7 +253,7 @@ impl MessagePartitioner for LinkAtRequest {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -263,13 +263,13 @@ impl MessagePartitioner for LinkAtRequest {
     /// Upon success, the partitioned message is returned. Upon failure, an error is returned.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::LinkAtRequestPart,
             part_number,
             payload_size,
@@ -307,13 +307,13 @@ impl LinkAtResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: LinkAtResponse = LinkAtResponse::new(ret);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::LinkAtResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/linkat.rs
+++ b/src/libs/syscall/src/unistd/message/linkat.rs
@@ -30,6 +30,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -309,8 +311,13 @@ impl LinkAtResponse {
         let message: LinkAtResponse = LinkAtResponse::new(ret);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::LinkAtResponse, message.into_bytes());
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/unistd/message/lseek.rs
+++ b/src/libs/syscall/src/unistd/message/lseek.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -57,12 +57,12 @@ impl SeekRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32, offset: i64, whence: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: i32, offset: i64, whence: i32) -> Message {
         let message: SeekRequest = SeekRequest::new(fd, offset, whence);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::SeekRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -102,13 +102,13 @@ impl SeekResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, offset: i64) -> Message {
+    pub fn build(tid: ThreadIdentifier, offset: i64) -> Message {
         let message: SeekResponse = SeekResponse::new(offset);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::SeekResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/lseek.rs
+++ b/src/libs/syscall/src/unistd/message/lseek.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -59,8 +61,13 @@ impl SeekRequest {
         let message: SeekRequest = SeekRequest::new(fd, offset, whence);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::SeekRequest, message.into_bytes());
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -99,8 +106,13 @@ impl SeekResponse {
         let message: SeekResponse = SeekResponse::new(offset);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::SeekResponse, message.into_bytes());
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/message/pipe.rs
+++ b/src/libs/syscall/src/unistd/message/pipe.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -47,12 +47,12 @@ impl PipeRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier) -> Message {
+    pub fn build(tid: ThreadIdentifier) -> Message {
         let message: PipeRequest = PipeRequest::new();
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PipeRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -94,13 +94,13 @@ impl PipeResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, read_fd: i32, write_fd: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, read_fd: i32, write_fd: i32) -> Message {
         let message: PipeResponse = PipeResponse::new(read_fd, write_fd);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PipeResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/pipe.rs
+++ b/src/libs/syscall/src/unistd/message/pipe.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -49,8 +51,13 @@ impl PipeRequest {
         let message: PipeRequest = PipeRequest::new();
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PipeRequest, message.into_bytes());
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -91,8 +98,13 @@ impl PipeResponse {
         let message: PipeResponse = PipeResponse::new(read_fd, write_fd);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PipeResponse, message.into_bytes());
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/message/pread.rs
+++ b/src/libs/syscall/src/unistd/message/pread.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -66,8 +68,13 @@ impl PartialReadRequest {
             LinuxDaemonMessageHeader::PartialReadRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }
@@ -109,8 +116,13 @@ impl PartialReadResponse {
             LinuxDaemonMessageHeader::PartialReadResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/unistd/message/pread.rs
+++ b/src/libs/syscall/src/unistd/message/pread.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::{
     c_size_t,
@@ -62,14 +62,14 @@ impl PartialReadRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32, count: c_size_t, offset: off_t) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: i32, count: c_size_t, offset: off_t) -> Message {
         let message: PartialReadRequest = PartialReadRequest::new(fd, count, offset);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::PartialReadRequest,
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -107,7 +107,7 @@ impl PartialReadResponse {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         count: c_ssize_t,
         buffer: [u8; Self::BUFFER_SIZE],
     ) -> Message {
@@ -118,7 +118,7 @@ impl PartialReadResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/pwrite.rs
+++ b/src/libs/syscall/src/unistd/message/pwrite.rs
@@ -13,15 +13,17 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
 };
 use ::sysapi::sys_types::{
     c_size_t,
+    c_ssize_t,
     off_t,
 };
-use sysapi::sys_types::c_ssize_t;
 
 //==================================================================================================
 // PartialWriteRequest
@@ -72,8 +74,13 @@ impl PartialWriteRequest {
             LinuxDaemonMessageHeader::PartialWriteRequest,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }
@@ -114,8 +121,13 @@ impl PartialWriteResponse {
             LinuxDaemonMessageHeader::PartialWriteResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/unistd/message/pwrite.rs
+++ b/src/libs/syscall/src/unistd/message/pwrite.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::{
     c_size_t,
@@ -63,7 +63,7 @@ impl PartialWriteRequest {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         fd: i32,
         count: c_size_t,
         offset: off_t,
@@ -75,7 +75,7 @@ impl PartialWriteRequest {
             message.into_bytes(),
         );
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -115,7 +115,7 @@ impl PartialWriteResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, count: c_ssize_t) -> Message {
+    pub fn build(tid: ThreadIdentifier, count: c_ssize_t) -> Message {
         let message: PartialWriteResponse = PartialWriteResponse::new(count);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::PartialWriteResponse,
@@ -123,7 +123,7 @@ impl PartialWriteResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/read.rs
+++ b/src/libs/syscall/src/unistd/message/read.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -56,8 +58,13 @@ impl ReadRequest {
         let message: ReadRequest = ReadRequest::new(fd, count);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::ReadRequest, message.into_bytes());
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }
@@ -93,8 +100,13 @@ impl ReadResponse {
         let message: ReadResponse = ReadResponse::new(count, buffer);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::ReadResponse, message.into_bytes());
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/unistd/message/read.rs
+++ b/src/libs/syscall/src/unistd/message/read.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::c_size_t;
 
@@ -54,12 +54,12 @@ impl ReadRequest {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, fd: i32, count: c_size_t) -> Message {
+    pub fn build(tid: ThreadIdentifier, fd: i32, count: c_size_t) -> Message {
         let message: ReadRequest = ReadRequest::new(fd, count);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::ReadRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -96,13 +96,13 @@ impl ReadResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, count: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Message {
+    pub fn build(tid: ThreadIdentifier, count: i32, buffer: [u8; Self::BUFFER_SIZE]) -> Message {
         let message: ReadResponse = ReadResponse::new(count, buffer);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::ReadResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/message/readlinkat.rs
@@ -28,7 +28,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::limits::{
     PATH_MAX,
@@ -197,7 +197,7 @@ impl MessagePartitioner for ReadLinkAtRequest {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -207,13 +207,13 @@ impl MessagePartitioner for ReadLinkAtRequest {
     /// Upon success, the partitioned message is returned. Upon failure, an error is returned instead.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::ReadLinkAtRequestPart,
             part_number,
             payload_size,
@@ -343,7 +343,7 @@ impl MessagePartitioner for ReadLinkAtResponse {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -353,13 +353,13 @@ impl MessagePartitioner for ReadLinkAtResponse {
     /// Upon success, the partitioned message is returned. Upon failure, an error is returned instead.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_response(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::ReadLinkAtResponsePart,
             part_number,
             payload_size,

--- a/src/libs/syscall/src/unistd/message/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/message/symlinkat.rs
@@ -30,6 +30,8 @@ use ::sys::{
     },
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -265,8 +267,13 @@ impl SymbolicLinkAtResponse {
             LinuxDaemonMessageHeader::SymbolicLinkAtResponse,
             message.into_bytes(),
         );
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
         message
     }
 }

--- a/src/libs/syscall/src/unistd/message/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/message/symlinkat.rs
@@ -34,7 +34,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::limits::PATH_MAX;
 
@@ -207,7 +207,7 @@ impl MessagePartitioner for SymbolicLinkAtRequest {
     ///
     /// # Parameters
     ///
-    /// - `pid`: Process identifier.
+    /// - `tid`: Thread identifier.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -217,13 +217,13 @@ impl MessagePartitioner for SymbolicLinkAtRequest {
     /// Upon success, the new message partition is returned. Upon failure, an error is returned.
     ///
     fn new_part(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         part_number: u32,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
-            pid,
+            tid,
             LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart,
             part_number,
             payload_size,
@@ -261,7 +261,7 @@ impl SymbolicLinkAtResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, ret: i32) -> Message {
+    pub fn build(tid: ThreadIdentifier, ret: i32) -> Message {
         let message: SymbolicLinkAtResponse = SymbolicLinkAtResponse::new(ret);
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(
             LinuxDaemonMessageHeader::SymbolicLinkAtResponse,
@@ -269,7 +269,7 @@ impl SymbolicLinkAtResponse {
         );
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/write.rs
+++ b/src/libs/syscall/src/unistd/message/write.rs
@@ -17,7 +17,7 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::{
     c_size_t,
@@ -54,7 +54,7 @@ impl WriteRequest {
     }
 
     pub fn build(
-        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         fd: i32,
         count: c_size_t,
         buffer: [u8; Self::BUFFER_SIZE],
@@ -63,7 +63,7 @@ impl WriteRequest {
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::WriteRequest, message.into_bytes());
         let message: Message = Message::new(
-            MessageSender::from(pid),
+            MessageSender::from(tid),
             MessageReceiver::from(crate::LINUXD),
             MessageType::Ikc,
             None,
@@ -104,13 +104,13 @@ impl WriteResponse {
         unsafe { mem::transmute(self) }
     }
 
-    pub fn build(pid: ProcessIdentifier, count: c_ssize_t) -> Message {
+    pub fn build(tid: ThreadIdentifier, count: c_ssize_t) -> Message {
         let message: WriteResponse = WriteResponse::new(count);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::WriteResponse, message.into_bytes());
         let message: Message = Message::new(
             MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(pid),
+            MessageReceiver::from(tid),
             MessageType::Ikc,
             None,
             message.into_bytes(),

--- a/src/libs/syscall/src/unistd/message/write.rs
+++ b/src/libs/syscall/src/unistd/message/write.rs
@@ -13,6 +13,8 @@ use ::core::mem;
 use ::sys::{
     ipc::{
         Message,
+        MessageReceiver,
+        MessageSender,
         MessageType,
     },
     pm::ProcessIdentifier,
@@ -60,8 +62,13 @@ impl WriteRequest {
         let message: WriteRequest = WriteRequest::new(fd, count, buffer);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::WriteRequest, message.into_bytes());
-        let message: Message =
-            Message::new(pid, crate::LINUXD, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(pid),
+            MessageReceiver::from(crate::LINUXD),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }
@@ -101,8 +108,13 @@ impl WriteResponse {
         let message: WriteResponse = WriteResponse::new(count);
         let message: LinuxDaemonMessage =
             LinuxDaemonMessage::new(LinuxDaemonMessageHeader::WriteResponse, message.into_bytes());
-        let message: Message =
-            Message::new(crate::LINUXD, pid, MessageType::Ikc, None, message.into_bytes());
+        let message: Message = Message::new(
+            MessageSender::from(crate::LINUXD),
+            MessageReceiver::from(pid),
+            MessageType::Ikc,
+            None,
+            message.into_bytes(),
+        );
 
         message
     }

--- a/src/libs/syscall/src/unistd/syscall/chdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/chdir.rs
@@ -18,7 +18,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -42,11 +42,11 @@ use ::sys::{
 pub fn chdir(path: &str) -> Result<(), Error> {
     ::syslog::trace!("chdir(): path={:?}", path);
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
     let request: ChangeDirectoryRequest = ChangeDirectoryRequest::new(path)?;
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
     for request in requests {
         ::sys::kcall::ipc::send(&request)?;
     }

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -27,10 +27,10 @@ use ::sys::{
 //==================================================================================================
 
 pub fn close(fd: i32) -> Result<(), Error> {
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = CloseRequest::build(pid, fd);
+    let request: Message = CloseRequest::build(tid, fd);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -18,7 +18,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -51,11 +51,11 @@ pub fn faccessat(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Result<(
         flag
     );
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: FileAccessAtRequest = FileAccessAtRequest::new(dirfd, path, mode, flag)?;
 
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
 
     for request in requests {
         ::sys::kcall::ipc::send(&request)?;

--- a/src/libs/syscall/src/unistd/syscall/fchdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchdir.rs
@@ -12,7 +12,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -37,10 +37,10 @@ use ::sysapi::ffi::c_int;
 pub fn fchdir(fd: c_int) -> Result<(), Error> {
     ::syslog::trace!("fchdir(): fd={:?}", fd);
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it
-    let request: Message = FileChdirRequest::build(pid, fd);
+    let request: Message = FileChdirRequest::build(tid, fd);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -17,7 +17,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::{
     gid_t,
@@ -46,10 +46,10 @@ use ::sysapi::sys_types::{
 pub fn fchown(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<(), Error> {
     ::syslog::trace!("fchown(): fd={:?}, owner={:?}, group={:?}", fd, owner, group);
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it
-    let request: Message = FileChownRequest::build(pid, fd, owner, group);
+    let request: Message = FileChownRequest::build(tid, fd, owner, group);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/fchownat.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchownat.rs
@@ -18,7 +18,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -65,11 +65,11 @@ pub fn fchownat(
         flag
     );
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: FileChownAtRequest = FileChownAtRequest::new(dirfd, owner, group, flag, path)?;
 
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
 
     for request in requests {
         ::sys::kcall::ipc::send(&request)?;

--- a/src/libs/syscall/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fdatasync.rs
@@ -17,7 +17,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -40,10 +40,10 @@ use ::sys::{
 pub fn fdatasync(fd: RawFileDescriptor) -> Result<(), Error> {
     ::syslog::trace!("fdatasync(): fd={:?}", fd);
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = FileDataSyncRequest::build(pid, fd);
+    let request: Message = FileDataSyncRequest::build(tid, fd);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/fsync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fsync.rs
@@ -16,7 +16,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -38,10 +38,10 @@ use ::sysapi::ffi::c_int;
 /// Upon successful completion, empty is returned. Otherwise, an error is returned.
 ///
 pub fn fsync(fd: c_int) -> Result<(), Error> {
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = FileSyncRequest::build(pid, fd);
+    let request: Message = FileSyncRequest::build(tid, fd);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/syscall/ftruncate.rs
@@ -16,7 +16,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -44,10 +44,10 @@ use ::sysapi::{
 pub fn ftruncate(fd: c_int, length: off_t) -> Result<(), Error> {
     ::syslog::debug!("ftruncate(): fd={}, length={}", fd, length);
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = FileTruncateRequest::build(pid, fd, length);
+    let request: Message = FileTruncateRequest::build(tid, fd, length);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/getcwd.rs
+++ b/src/libs/syscall/src/unistd/syscall/getcwd.rs
@@ -28,7 +28,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -44,17 +44,17 @@ pub fn getcwd() -> Result<String, Error> {
     getcwd_response()
 }
 
-/// Processes the request of the `getcwd()` system call.
+/// Handles the request of the `getcwd()` system call.
 fn getcwd_request() -> Result<(), Error> {
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
-    let request: Message = GetCurrentWorkingDirectoryRequest::build(pid);
+    let request: Message = GetCurrentWorkingDirectoryRequest::build(tid);
 
     // Send request.
     ::sys::kcall::ipc::send(&request)
 }
 
-/// Processes the response of the `getcwd()` system call.
+/// Handles the response of the `getcwd()` system call.
 fn getcwd_response() -> Result<String, Error> {
     // Compute the maximum number of parts in the response.
     let capacity: usize =

--- a/src/libs/syscall/src/unistd/syscall/getegid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getegid.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::sys_types::gid_t;
 
@@ -40,10 +40,10 @@ use sysapi::sys_types::gid_t;
 pub fn getegid() -> Result<gid_t, Error> {
     ::syslog::trace!("getegid()");
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it
-    let request: Message = GetIdsRequest::build(pid);
+    let request: Message = GetIdsRequest::build(tid);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response
@@ -51,7 +51,7 @@ pub fn getegid() -> Result<gid_t, Error> {
 
     // Check whether system call succeeded or not
     if response.status != 0 {
-        ::syslog::error!("getegid(): failed (pid={:?}, status={:?})", pid, { response.status });
+        ::syslog::error!("getegid(): failed (tid={:?}, status={:?})", tid, { response.status });
 
         match ErrorCode::try_from(response.status) {
             // System call failed, return error
@@ -71,8 +71,8 @@ pub fn getegid() -> Result<gid_t, Error> {
             // Invalid response
             header => {
                 ::syslog::error!(
-                    "getegid(): invalid response (pid={:?}, header={:?})",
-                    pid,
+                    "getegid(): invalid response (tid={:?}, header={:?})",
+                    tid,
                     header
                 );
                 Err(Error::new(ErrorCode::InvalidMessage, "invalid response"))

--- a/src/libs/syscall/src/unistd/syscall/geteuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/geteuid.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::sys_types::uid_t;
 
@@ -40,10 +40,10 @@ use sysapi::sys_types::uid_t;
 pub fn geteuid() -> Result<uid_t, Error> {
     ::syslog::trace!("geteuid()");
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it
-    let request: Message = GetIdsRequest::build(pid);
+    let request: Message = GetIdsRequest::build(tid);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response
@@ -51,7 +51,7 @@ pub fn geteuid() -> Result<uid_t, Error> {
 
     // Check whether system call succeeded or not
     if response.status != 0 {
-        ::syslog::error!("geteuid(): failed (pid={:?}, status={:?})", pid, { response.status });
+        ::syslog::error!("geteuid(): failed (tid={:?}, status={:?})", tid, { response.status });
 
         match ErrorCode::try_from(response.status) {
             // System call failed, return error
@@ -71,8 +71,8 @@ pub fn geteuid() -> Result<uid_t, Error> {
             // Invalid response
             header => {
                 ::syslog::error!(
-                    "geteuid(): invalid response (pid={:?}, header={:?})",
-                    pid,
+                    "geteuid(): invalid response (tid={:?}, header={:?})",
+                    tid,
                     header
                 );
                 Err(Error::new(ErrorCode::InvalidMessage, "invalid response"))

--- a/src/libs/syscall/src/unistd/syscall/getgid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getgid.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::sys_types::gid_t;
 
@@ -40,10 +40,10 @@ use sysapi::sys_types::gid_t;
 pub fn getgid() -> Result<gid_t, Error> {
     ::syslog::trace!("getgid()");
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it
-    let request: Message = GetIdsRequest::build(pid);
+    let request: Message = GetIdsRequest::build(tid);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response
@@ -51,7 +51,7 @@ pub fn getgid() -> Result<gid_t, Error> {
 
     // Check whether system call succeeded or not
     if response.status != 0 {
-        ::syslog::error!("getgid(): failed (pid={:?}, status={:?})", pid, { response.status });
+        ::syslog::error!("getgid(): failed (tid={:?}, status={:?})", tid, { response.status });
 
         match ErrorCode::try_from(response.status) {
             // System call failed, return error
@@ -70,7 +70,7 @@ pub fn getgid() -> Result<gid_t, Error> {
             },
             // Invalid response
             header => {
-                ::syslog::error!("getgid(): invalid response (pid={:?}, header={:?})", pid, header);
+                ::syslog::error!("getgid(): invalid response (tid={:?}, header={:?})", tid, header);
                 Err(Error::new(ErrorCode::InvalidMessage, "invalid response"))
             },
         }

--- a/src/libs/syscall/src/unistd/syscall/getpid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getpid.rs
@@ -14,6 +14,7 @@ use ::sys::{
 // Standalone Functions
 //==================================================================================================///
 
+///
 /// # Description
 ///
 /// `getpid()` returns the process ID (PID) of the calling process.

--- a/src/libs/syscall/src/unistd/syscall/getuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getuid.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::uid_t;
 
@@ -40,10 +40,10 @@ use ::sysapi::sys_types::uid_t;
 pub fn getuid() -> Result<uid_t, Error> {
     ::syslog::trace!("getuid()");
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it
-    let request: Message = GetIdsRequest::build(pid);
+    let request: Message = GetIdsRequest::build(tid);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response
@@ -51,7 +51,7 @@ pub fn getuid() -> Result<uid_t, Error> {
 
     // Check whether system call succeeded or not
     if response.status != 0 {
-        ::syslog::error!("getuid(): failed (pid={:?}, status={:?})", pid, { response.status });
+        ::syslog::error!("getuid(): failed (tid={:?}, status={:?})", tid, { response.status });
 
         match ErrorCode::try_from(response.status) {
             // System call failed, return error
@@ -70,7 +70,7 @@ pub fn getuid() -> Result<uid_t, Error> {
             },
             // Invalid response
             header => {
-                ::syslog::error!("getuid(): invalid response (pid={:?}, header={:?})", pid, header);
+                ::syslog::error!("getuid(): invalid response (tid={:?}, header={:?})", tid, header);
                 Err(Error::new(ErrorCode::InvalidMessage, "invalid response"))
             },
         }

--- a/src/libs/syscall/src/unistd/syscall/linkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/linkat.rs
@@ -22,7 +22,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::ffi::c_int;
 
@@ -63,12 +63,12 @@ pub fn linkat(
         flags
     );
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: LinkAtRequest =
         LinkAtRequest::new(olddirfd, oldpath.to_string(), newdirfd, newpath.to_string(), flags)?;
 
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
 
     // Send request.
     for request in requests {

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -20,7 +20,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     ffi::c_int,
@@ -34,10 +34,10 @@ use ::sysapi::{
 pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_t, Error> {
     ::syslog::trace!("lseek(): fd={:?}, offset={}, whence={}", fd, offset, whence);
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = SeekRequest::build(pid, fd, offset, whence);
+    let request: Message = SeekRequest::build(tid, fd, offset, whence);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -19,7 +19,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -29,10 +29,10 @@ use ::sys::{
 pub fn pipe() -> Result<[i32; 2], Error> {
     ::syslog::trace!("pipe()");
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.
-    let request: Message = PipeRequest::build(pid);
+    let request: Message = PipeRequest::build(tid);
     ::sys::kcall::ipc::send(&request)?;
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -21,11 +21,11 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::sys_types::{
-    off_t,
     c_size_t,
+    off_t,
 };
 
 //==================================================================================================
@@ -51,7 +51,7 @@ use sysapi::sys_types::{
 pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<c_size_t, Error> {
     ::syslog::trace!("pread(): fd={}, buffer={:?}, offset={}", fd, buffer, offset);
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let mut total_read: c_size_t = 0;
     let mut buffer_offset: usize = 0;
@@ -62,7 +62,7 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
 
         // Build request and send it.
         let request: Message = PartialReadRequest::build(
-            pid,
+            tid,
             fd,
             chunk_size as c_size_t,
             offset + buffer_offset as off_t,

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -21,11 +21,11 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::{
-    off_t,
     c_size_t,
+    off_t,
 };
 
 //==================================================================================================
@@ -54,7 +54,7 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
     let mut total_written: c_size_t = 0;
     let mut buffer_offset: usize = 0;
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     while buffer_offset < buffer.len() {
         let chunk_size: usize =
@@ -65,7 +65,7 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
 
         // Build request and send it.
         let request: Message = PartialWriteRequest::build(
-            pid,
+            tid,
             fd,
             chunk_size as c_size_t,
             offset + buffer_offset as off_t,

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -22,7 +22,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use sysapi::{
     sys_types::c_size_t,
@@ -54,7 +54,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
         ::syslog::trace!("read(): fd={:?}, buffer.len={:?}", fd, buffer.len());
     }
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let mut total_read: c_size_t = 0;
     let mut offset: usize = 0;
@@ -63,7 +63,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
         let chunk_size: usize = cmp::min(ReadResponse::BUFFER_SIZE, buffer.len() - offset);
 
         // Build request and send it.
-        let request: Message = ReadRequest::build(pid, fd, chunk_size as c_size_t);
+        let request: Message = ReadRequest::build(tid, fd, chunk_size as c_size_t);
         ::sys::kcall::ipc::send(&request)?;
 
         // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -28,7 +28,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::sys_types::c_ssize_t;
 
@@ -55,11 +55,11 @@ use ::sysapi::sys_types::c_ssize_t;
 pub fn readlinkat(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, Error> {
     ::syslog::trace!("readlinkat(): dirfd={:?}, path={:?}, buf.len={:?}", dirfd, path, buf.len());
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: ReadLinkAtRequest = ReadLinkAtRequest::new(dirfd, path.to_string(), buf.len())?;
 
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
 
     for request in requests {
         ::sys::kcall::ipc::send(&request)?;

--- a/src/libs/syscall/src/unistd/syscall/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/symlinkat.rs
@@ -21,7 +21,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -51,12 +51,12 @@ pub fn symlinkat(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Error> 
         linkpath
     );
 
-    let pid: ProcessIdentifier = ::sys::kcall::pm::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: SymbolicLinkAtRequest =
         SymbolicLinkAtRequest::new(target.to_string(), dirfd, linkpath.to_string())?;
 
-    let requests: Vec<Message> = request.into_parts(pid)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
 
     // Send request.
     for request in requests {

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -21,7 +21,7 @@ use ::sys::{
         ErrorCode,
     },
     ipc::Message,
-    pm::ProcessIdentifier,
+    pm::ThreadIdentifier,
 };
 use ::sysapi::{
     sys_types::c_size_t,
@@ -56,7 +56,7 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
         ::syslog::trace!("write(): fd={:?}, buffer.len={:?}", fd, buffer.len());
     }
 
-    let pid: ProcessIdentifier = crate::unistd::getpid()?;
+    let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let mut total_written: c_size_t = 0;
     let mut offset: usize = 0;
@@ -67,7 +67,7 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
         chunk[..chunk_size].copy_from_slice(&buffer[offset..offset + chunk_size]);
 
         // Build request and send it.
-        let request: Message = WriteRequest::build(pid, fd, chunk_size as c_size_t, chunk);
+        let request: Message = WriteRequest::build(tid, fd, chunk_size as c_size_t, chunk);
         ::sys::kcall::ipc::send(&request)?;
 
         // Receive response.

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -31,6 +31,10 @@ use crate::{
     },
     hwloc::HwLoc,
 };
+use ::sys::{
+    ipc::Message,
+    pm::ProcessIdentifier,
+};
 use anyhow::Result;
 use flexi_logger::Logger;
 use indicatif::{
@@ -75,14 +79,13 @@ use std::{
         Instant,
     },
 };
-use sys::ipc::Message;
 use syscall::{
+    LinuxDaemonMessage,
     unistd::message::{
         ReadRequest,
         ReadResponse,
         WriteResponse,
     },
-    LinuxDaemonMessage,
 };
 
 //==================================================================================================
@@ -102,7 +105,7 @@ impl Benchmark {
                 Ok(stream) => break stream,
                 Err(_) => {
                     continue;
-                }
+                },
             };
         };
         debug!("Connected!");
@@ -424,25 +427,25 @@ impl Benchmark {
             // Spawn the VMM in a separate thread.
             let vmm_handle = std::thread::spawn(move || -> Result<()> {
                 vmm_stream.set_nonblocking(true)?;
-                let mut vmm: Vmm =
-                    Vmm::new(
-                        config::kernel::MEMORY_SIZE,
-                        format!("{}/bin/kernel.elf", get_proj_root()).as_str(),
-                        Some(format!("{}/bin/echo-single-rust-nostd.elf", get_proj_root())),
-                        None,
-                        None,
-                        Some(Gateway::new(syscomm::SocketStream::Unix(vmm_stream))))?;
+                let mut vmm: Vmm = Vmm::new(
+                    config::kernel::MEMORY_SIZE,
+                    format!("{}/bin/kernel.elf", get_proj_root()).as_str(),
+                    Some(format!("{}/bin/echo-single-rust-nostd.elf", get_proj_root())),
+                    None,
+                    None,
+                    Some(Gateway::new(syscomm::SocketStream::Unix(vmm_stream))),
+                )?;
                 debug!("VMM: returned from new!");
 
                 match vmm.run()? {
                     e if e != 0 => {
                         error!("error running VMM, exited with status: {e}");
                         Err(anyhow::anyhow!("VMM error"))
-                    }
+                    },
                     _ => {
                         debug!("VMM: done running");
                         Ok(())
-                    }
+                    },
                 }
             });
 
@@ -454,12 +457,22 @@ impl Benchmark {
                 Ok(message) => message,
                 Err(_) => return Err(anyhow::anyhow!("Error parsing buffer to IPC Read message")),
             };
-            let linuxd_message: LinuxDaemonMessage = match LinuxDaemonMessage::try_from_bytes(ipc_read_message.payload) {
-                Ok(message) => message,
-                Err(_) => return Err(anyhow::anyhow!("Error parsing IPC message to LinuxDaemon message")),
+            let linuxd_message: LinuxDaemonMessage =
+                match LinuxDaemonMessage::try_from_bytes(ipc_read_message.payload) {
+                    Ok(message) => message,
+                    Err(_) => {
+                        return Err(anyhow::anyhow!(
+                            "Error parsing IPC message to LinuxDaemon message"
+                        ));
+                    },
+                };
+            let pid: ProcessIdentifier = match { ipc_read_message.source }.as_id() {
+                Ok(pid) => pid,
+                Err(_tid) => return Err(anyhow::anyhow!("IPC message source is not a PID")),
             };
             let _read_request: ReadRequest = ReadRequest::from_bytes(linuxd_message.payload);
-            let read_response: Message = ReadResponse::build(ipc_read_message.source.into(), payload.len() as i32, response_buf);
+            let read_response: Message =
+                ReadResponse::build(pid, payload.len() as i32, response_buf);
 
             // Now we are ready to push the ReadResponse, and wait for a WriteRequest as a reply.
             let start = Instant::now();
@@ -468,7 +481,7 @@ impl Benchmark {
             latencies.push(start.elapsed().as_micros());
 
             // After receiving the WriteRequest, we need to acknowledge it by sending a WriteResponse.
-            let write_response: Message = WriteResponse::build(ipc_read_message.source.into(), payload.len() as i32);
+            let write_response: Message = WriteResponse::build(pid, payload.len() as i32);
             input_stream.write_all(&write_response.to_bytes())?;
 
             // Wait for the VMM to exit.

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -31,10 +31,7 @@ use crate::{
     },
     hwloc::HwLoc,
 };
-use ::sys::{
-    ipc::Message,
-    pm::ProcessIdentifier,
-};
+use ::sys::ipc::Message;
 use anyhow::Result;
 use flexi_logger::Logger;
 use indicatif::{
@@ -79,6 +76,7 @@ use std::{
         Instant,
     },
 };
+use sys::pm::ThreadIdentifier;
 use syscall::{
     LinuxDaemonMessage,
     unistd::message::{
@@ -466,13 +464,13 @@ impl Benchmark {
                         ));
                     },
                 };
-            let pid: ProcessIdentifier = match { ipc_read_message.source }.as_id() {
-                Ok(pid) => pid,
-                Err(_tid) => return Err(anyhow::anyhow!("IPC message source is not a PID")),
+            let tid: ThreadIdentifier = match { ipc_read_message.source }.as_id() {
+                Err(tid) => tid,
+                Ok(pid) => return Err(anyhow::anyhow!("unexpected message source: {pid:?}")),
             };
             let _read_request: ReadRequest = ReadRequest::from_bytes(linuxd_message.payload);
             let read_response: Message =
-                ReadResponse::build(pid, payload.len() as i32, response_buf);
+                ReadResponse::build(tid, payload.len() as i32, response_buf);
 
             // Now we are ready to push the ReadResponse, and wait for a WriteRequest as a reply.
             let start = Instant::now();
@@ -481,7 +479,7 @@ impl Benchmark {
             latencies.push(start.elapsed().as_micros());
 
             // After receiving the WriteRequest, we need to acknowledge it by sending a WriteResponse.
-            let write_response: Message = WriteResponse::build(pid, payload.len() as i32);
+            let write_response: Message = WriteResponse::build(tid, payload.len() as i32);
             input_stream.write_all(&write_response.to_bytes())?;
 
             // Wait for the VMM to exit.

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -459,7 +459,7 @@ impl Benchmark {
                 Err(_) => return Err(anyhow::anyhow!("Error parsing IPC message to LinuxDaemon message")),
             };
             let _read_request: ReadRequest = ReadRequest::from_bytes(linuxd_message.payload);
-            let read_response: Message = ReadResponse::build(ipc_read_message.source, payload.len() as i32, response_buf);
+            let read_response: Message = ReadResponse::build(ipc_read_message.source.into(), payload.len() as i32, response_buf);
 
             // Now we are ready to push the ReadResponse, and wait for a WriteRequest as a reply.
             let start = Instant::now();
@@ -468,7 +468,7 @@ impl Benchmark {
             latencies.push(start.elapsed().as_micros());
 
             // After receiving the WriteRequest, we need to acknowledge it by sending a WriteResponse.
-            let write_response: Message = WriteResponse::build(ipc_read_message.source, payload.len() as i32);
+            let write_response: Message = WriteResponse::build(ipc_read_message.source.into(), payload.len() as i32);
             input_stream.write_all(&write_response.to_bytes())?;
 
             // Wait for the VMM to exit.


### PR DESCRIPTION
## Description

This pull request updates several system call handlers in the `linuxd` daemon to replace `ProcessIdentifier` (`pid`) with `ThreadIdentifier` (`tid`) for improved granularity and accuracy in thread-level operations. The changes span multiple files and functions, ensuring consistent use of `ThreadIdentifier` across the codebase.

### Transition from `ProcessIdentifier` to `ThreadIdentifier`:

#### Updates in `dirent.rs`:
* Replaced `pid` with `tid` in the `do_getdents` function, including parameter names, trace logs, and error handling. (`[[1]](diffhunk://#diff-62ea281e709ac303b7bb76d6ccae10b185ac7a9a9fc08203c092b36648187d70L17-R17)`, `[[2]](diffhunk://#diff-62ea281e709ac303b7bb76d6ccae10b185ac7a9a9fc08203c092b36648187d70L105-R114)`, `[[3]](diffhunk://#diff-62ea281e709ac303b7bb76d6ccae10b185ac7a9a9fc08203c092b36648187d70L133-R133)`, `[[4]](diffhunk://#diff-62ea281e709ac303b7bb76d6ccae10b185ac7a9a9fc08203c092b36648187d70L190-R194)`)

#### Updates in `fcntl.rs`:
* Replaced `pid` with `tid` in multiple functions, such as `do_openat`, `do_unlinkat`, `do_renameat`, `do_fstat_at`, `do_posix_fallocate`, `do_posix_fadvise`, and `do_fstat`. Changes include parameter names, trace logs, error handling, and response construction. (`[[1]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L17-R17)`, `[[2]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L146-R165)`, `[[3]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L177-R184)`, `[[4]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L193-R201)`, `[[5]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L216-R221)`, `[[6]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L230-R243)`, `[[7]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L264-R269)`, `[[8]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L278-R279)`, `[[9]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L290-R290)`, `[[10]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L314-R314)`, `[[11]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L323-R323)`, `[[12]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L332-R332)`, `[[13]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L344-R354)`, `[[14]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L363-R364)`, `[[15]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L374-R380)`, `[[16]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L389-R397)`, `[[17]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L410-R413)`, `[[18]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L425-R423)`, `[[19]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L451-R448)`, `[[20]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L460-R457)`, `[[21]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L469-R466)`)