### PR TITLE
[scripts] Refactor Build Cloud Hypervisor Script

### DIFF
--- a/scripts/build-cloud-hypervisor.sh
+++ b/scripts/build-cloud-hypervisor.sh
@@ -8,19 +8,23 @@
 #===================================================================================================
 
 RULE=${1:-build}
-NANVIX_HOME=${2:-`git rev-parse --show-toplevel`}
+PREFIX=${2:-$PWD/toolchain}
 
 #===================================================================================================
 # Global Variables
 #===================================================================================================
+
+NANVIX_HOME=`git rev-parse --show-toplevel`
+CONTRIB_DIR=${PREFIX}/src
+CLOUD_HYPERVISOR_HOME=${CONTRIB_DIR}/cloud-hypervisor
+CLOUD_HYPERVISOR_REPOSITORY=https://github.com/nanvix/cloud-hypervisor
+CLOUD_HYPERVISOR_COMMIT=3d88996e5b509b0840b8912142104ddf86a10eeb
 
 BINARIES_DIR=${NANVIX_HOME}/bin
 SCRIPTS_DIR=${NANVIX_HOME}/scripts
 SERVICE_FILE=${SCRIPTS_DIR}/linuxd.service
 SERVICE_ELF_BASENAME=linuxd.elf
 SERVICE_ELF=${BINARIES_DIR}/${SERVICE_ELF_BASENAME}
-CONTRIB_DIR=${NANVIX_HOME}/contrib
-CLOUD_HYPERVISOR_HOME=${CONTRIB_DIR}/cloud-hypervisor
 IMAGES_DIR=${NANVIX_HOME}/images
 # The VM will be configure to use the IP 192.168.249.2 when using this specific MAC Address
 GUEST_MAC_ADDRESS=12:34:56:78:90:ab
@@ -35,6 +39,7 @@ IMAGE_NAME=custom-ubuntu.raw
 #===================================================================================================
 
 distclean() {
+	cd ${CLOUD_HYPERVISOR_HOME}
 	git clean -fdx
 }
 
@@ -43,6 +48,7 @@ distclean() {
 #===================================================================================================
 
 clean() {
+	cd ${CLOUD_HYPERVISOR_HOME}
     cargo clean
 }
 
@@ -51,6 +57,7 @@ clean() {
 #===================================================================================================
 
 build() {
+	cd ${CLOUD_HYPERVISOR_HOME}
 	pushd $PWD
 
 	cd $IMAGES_DIR
@@ -128,6 +135,7 @@ EOF
 #===================================================================================================
 
 run() {
+	cd ${CLOUD_HYPERVISOR_HOME}
 	./target/release/cloud-hypervisor \
 		--kernel $IMAGES_DIR/hypervisor-fw \
 		--disk path=$IMAGES_DIR/$IMAGE_NAME path=$IMAGES_DIR/ubuntu-cloudinit.img \
@@ -141,6 +149,19 @@ run() {
 #===================================================================================================
 
 init() {
+
+	mkdir -p ${CONTRIB_DIR}
+	if [ ! -d "${CLOUD_HYPERVISOR_HOME}" ];
+	then
+		git clone ${CLOUD_HYPERVISOR_REPOSITORY} ${CLOUD_HYPERVISOR_HOME}
+		cd ${CLOUD_HYPERVISOR_HOME}
+	else
+		cd ${CLOUD_HYPERVISOR_HOME}
+		git fetch origin
+		git reset --hard ${CLOUD_HYPERVISOR_COMMIT}
+	fi
+	git checkout ${CLOUD_HYPERVISOR_COMMIT}
+
 	cargo build --release
 
 	sudo setcap cap_net_admin+ep ./target/release/cloud-hypervisor
@@ -156,11 +177,7 @@ init() {
 
 #===================================================================================================
 
-# Fetch submodule if needed.
-git submodule update --init $CLOUD_HYPERVISOR_HOME
-
 # Switch to submodule directory.
-cd ${CLOUD_HYPERVISOR_HOME}
 
 case $RULE in
 	build)
@@ -177,5 +194,10 @@ case $RULE in
 		;;
 	run)
 		run
+		;;
+	*)
+		echo "Usage: $0 {build|clean|distclean|init|run} PREFIX"
+		echo "Default PREFIX is $PWD/toolchain"
+		exit 1
 		;;
 esac


### PR DESCRIPTION
## Description

This pull request refactors the `scripts/build-cloud-hypervisor.sh` script to improve modularity and maintainability, replacing the use of submodules with a direct cloning approach for the Cloud Hypervisor repository. It introduces new initialization logic, updates directory management, and enhances error handling for unsupported commands.

### Refactoring of repository management:

* Removed the submodule reference for Cloud Hypervisor (`contrib/cloud-hypervisor`) and replaced it with direct cloning and commit checkout logic in the `init()` function. This includes defining new variables (`CLOUD_HYPERVISOR_REPOSITORY`, `CLOUD_HYPERVISOR_COMMIT`) and ensuring the repository is fetched and reset to the specified commit. [[1]](diffhunk://#diff-68cec840b5bed2a281816ec45d31b3a1e524fd9679880fa67a589dc28124b56dL1) [[2]](diffhunk://#diff-b10bbcb6a19043ff106f01ad06cab7817d3cd0602ca48b8ed92bb9984e98806aR152-R164)

### Directory and environment updates:

* Updated the `PREFIX` variable to default to `$PWD/toolchain` instead of `NANVIX_HOME`, and redefined `CONTRIB_DIR` and `CLOUD_HYPERVISOR_HOME` accordingly. This change decouples the toolchain directory from the Nanvix home directory.
* Added `cd ${CLOUD_HYPERVISOR_HOME}` to multiple functions (`distclean`, `clean`, `build`, `run`) to ensure operations are executed in the correct directory. [[1]](diffhunk://#diff-b10bbcb6a19043ff106f01ad06cab7817d3cd0602ca48b8ed92bb9984e98806aR42) [[2]](diffhunk://#diff-b10bbcb6a19043ff106f01ad06cab7817d3cd0602ca48b8ed92bb9984e98806aR51) [[3]](diffhunk://#diff-b10bbcb6a19043ff106f01ad06cab7817d3cd0602ca48b8ed92bb9984e98806aR60) [[4]](diffhunk://#diff-b10bbcb6a19043ff106f01ad06cab7817d3cd0602ca48b8ed92bb9984e98806aR138)

### New command handling:

* Introduced error handling for unsupported commands by adding a default case in the `case $RULE` block. This provides usage instructions and exits with an error code for invalid inputs.

### Cleanup of legacy code:

* Removed legacy submodule update logic and redundant directory switching commands, as these are now handled by the new initialization process.