### PR TITLE
[libs] Time into System Time

### DIFF
--- a/src/libs/syscall/src/safe/time.rs
+++ b/src/libs/syscall/src/safe/time.rs
@@ -39,6 +39,19 @@ impl Time {
     ///
     /// # Description
     ///
+    /// Converts the `Time` instance into a `SystemTime`.
+    ///
+    /// # Returns
+    ///
+    /// Returns the underlying `SystemTime` instance.
+    ///
+    pub fn into_system_time(self) -> SystemTime {
+        self.0
+    }
+
+    ///
+    /// # Description
+    ///
     /// Gets the current system time.
     ///
     /// # Returns


### PR DESCRIPTION
## Description

This pull request introduces a new utility method to the `Time` implementation in `src/libs/syscall/src/safe/time.rs`. The method provides a way to convert a `Time` instance into its underlying `SystemTime`.

Key change:

* Added a new method `into_system_time` to the `Time` implementation, which converts a `Time` instance into its underlying `SystemTime`. This enhances usability by providing a straightforward way to access the wrapped `SystemTime` object.