### PR TITLE
[libs] Double Self Lock in Mutex Initialization

### DIFF
--- a/src/libs/syscall/src/pthread/syscall/mutex.rs
+++ b/src/libs/syscall/src/pthread/syscall/mutex.rs
@@ -35,21 +35,19 @@ pub fn pthread_mutex_init(
     mutex: &mut pthread_mutex_t,
     attr: &pthread_mutexattr_t,
 ) -> Result<(), Error> {
-    // Check if mutex is already initialized.
-    if MUTEXES
+    // Check if mutex is not initialized.
+    if let Entry::Vacant(entry) = MUTEXES
         .lock()
-        .contains_key(&(mutex as *const pthread_mutex_t as usize))
+        .entry(mutex as *const pthread_mutex_t as usize)
     {
-        let reason: &str = "mutex is already initialized";
+        // Mutex was is not initialized.
+        entry.insert(*attr);
+        Ok(())
+    } else {
+        let reason: &str = "mutex is not initialized";
         ::syslog::error!("pthread_mutex_init(): {}", reason);
-        return Err(Error::new(ErrorCode::ResourceBusy, reason));
+        Err(Error::new(ErrorCode::InvalidArgument, reason))
     }
-
-    MUTEXES
-        .lock()
-        .insert(mutex as *const pthread_mutex_t as usize, *attr);
-
-    Ok(())
 }
 
 pub fn pthread_mutex_destroy(mutex: &mut pthread_mutex_t) -> Result<(), Error> {

--- a/src/libs/syscall/src/pthread/syscall/mutex.rs
+++ b/src/libs/syscall/src/pthread/syscall/mutex.rs
@@ -159,18 +159,14 @@ pub fn pthread_mutex_trylock(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
 }
 
 pub fn pthread_mutex_unlock(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
-    // Check if mutex is not initialized.
-    if *mutex != PTHREAD_MUTEX_INITIALIZER
-        && !MUTEXES
-            .lock()
-            .contains_key(&(mutex as *const pthread_mutex_t as usize))
+    if let Entry::Vacant(entry) = MUTEXES
+        .lock()
+        .entry(mutex as *const pthread_mutex_t as usize)
     {
         // Check if mutex was statically initialized.
         if *mutex == PTHREAD_MUTEX_INITIALIZER {
             // Lazily register mutex.
-            MUTEXES
-                .lock()
-                .insert(mutex as *const pthread_mutex_t as usize, pthread_mutexattr_t::default());
+            entry.insert(pthread_mutexattr_t::default());
         } else {
             let reason: &str = "mutex is not initialized";
             ::syslog::error!("pthread_mutex_unlock(): {}", reason);

--- a/src/libs/syscall/src/pthread/syscall/mutex.rs
+++ b/src/libs/syscall/src/pthread/syscall/mutex.rs
@@ -6,7 +6,11 @@
 //==================================================================================================
 
 use crate::pthread::syscall::MUTEXES;
-use ::alloc::collections::btree_map::Entry;
+use ::alloc::collections::btree_map::{
+    BTreeMap,
+    Entry,
+};
+use ::spin::MutexGuard;
 use ::sys::{
     error::{
         Error,
@@ -51,26 +55,22 @@ pub fn pthread_mutex_init(
 }
 
 pub fn pthread_mutex_destroy(mutex: &mut pthread_mutex_t) -> Result<(), Error> {
+    let mut mutexes: MutexGuard<'_, BTreeMap<usize, pthread_mutexattr_t>> = MUTEXES.lock();
+
     // Check if mutex is not initialized.
-    if !MUTEXES
-        .lock()
-        .contains_key(&(mutex as *const pthread_mutex_t as usize))
-    {
+    if !mutexes.contains_key(&(mutex as *const pthread_mutex_t as usize)) {
         // Check if mutex was statically initialized.
         if *mutex == PTHREAD_MUTEX_INITIALIZER {
-            // No ned to remove in this case, as it was not lazily registered.
+            // No need to remove in this case, as it was not lazily registered.
             return Ok(());
         } else {
-            // Check if mutex was statically initialized.
             let reason: &str = "mutex is not initialized";
             ::syslog::error!("pthread_mutex_destroy(): {}", reason);
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
     }
 
-    MUTEXES
-        .lock()
-        .remove(&(mutex as *const pthread_mutex_t as usize));
+    mutexes.remove(&(mutex as *const pthread_mutex_t as usize));
 
     Ok(())
 }


### PR DESCRIPTION
This pull request refactors the mutex handling logic in `pthread` to improve clarity, consistency, and efficiency. Key changes include replacing redundant checks with `Entry` API usage, introducing `MutexGuard` for better lock handling, and simplifying the logic for mutex initialization and destruction.

### Refactoring of Mutex Handling Logic:

* **Use of `Entry` API for Mutex Initialization and Unlocking**:
  - Replaced `contains_key` checks with `Entry::Vacant` to streamline the logic for detecting uninitialized mutexes. This change reduces redundant operations and makes the code more idiomatic. (`src/libs/syscall/src/pthread/syscall/mutex.rs`, [[1]](diffhunk://#diff-6430f2ff8471de7ef5df29c1609edc56669bb7b09b72c9da802d5a7b2c8901ecL38-R73) [[2]](diffhunk://#diff-6430f2ff8471de7ef5df29c1609edc56669bb7b09b72c9da802d5a7b2c8901ecL164-R169)

* **Introduction of `MutexGuard`**:
  - Added `MutexGuard` for managing `MUTEXES` locks, ensuring better lock handling and reducing repetitive calls to `.lock()`. (`src/libs/syscall/src/pthread/syscall/mutex.rs`, [src/libs/syscall/src/pthread/syscall/mutex.rsL38-R73](diffhunk://#diff-6430f2ff8471de7ef5df29c1609edc56669bb7b09b72c9da802d5a7b2c8901ecL38-R73))

### Simplification of Mutex Lifecycle Methods:

* **Streamlined `pthread_mutex_init` Logic**:
  - Simplified the initialization process by directly inserting attributes into `MUTEXES` when the mutex is uninitialized, and adjusted error handling for better clarity. (`src/libs/syscall/src/pthread/syscall/mutex.rs`, [src/libs/syscall/src/pthread/syscall/mutex.rsL38-R73](diffhunk://#diff-6430f2ff8471de7ef5df29c1609edc56669bb7b09b72c9da802d5a7b2c8901ecL38-R73))

* **Improved `pthread_mutex_destroy` Logic**:
  - Simplified the destruction logic by using `MutexGuard` and removing redundant checks, ensuring the mutex is properly removed from `MUTEXES` when applicable. (`src/libs/syscall/src/pthread/syscall/mutex.rs`, [src/libs/syscall/src/pthread/syscall/mutex.rsL38-R73](diffhunk://#diff-6430f2ff8471de7ef5df29c1609edc56669bb7b09b72c9da802d5a7b2c8901ecL38-R73))

### Code Style Enhancements:

* **Reorganized Imports**:
  - Grouped and formatted imports for better readability, including the addition of `BTreeMap` and `MutexGuard`. (`src/libs/syscall/src/pthread/syscall/mutex.rs`, [src/libs/syscall/src/pthread/syscall/mutex.rsL9-R13](diffhunk://#diff-6430f2ff8471de7ef5df29c1609edc56669bb7b09b72c9da802d5a7b2c8901ecL9-R13))