### PR TITLE
[libs] Support Out of Order Message Part Processing

### DIFF
--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -239,7 +239,6 @@ impl<'a> LinuxDaemon<'a> {
                                 | LinuxDaemonMessageHeader::GetPeerNameRequest
                                 | LinuxDaemonMessageHeader::GetSockNameRequest
                                 | LinuxDaemonMessageHeader::ListenSocketRequest
-                                | LinuxDaemonMessageHeader::OpenAtRequest
                                 | LinuxDaemonMessageHeader::PartialReadRequest
                                 | LinuxDaemonMessageHeader::PartialWriteRequest
                                 | LinuxDaemonMessageHeader::ReceiveSocketRequest

--- a/src/libs/syscall/src/dirent/message/getdents.rs
+++ b/src/libs/syscall/src/dirent/message/getdents.rs
@@ -240,6 +240,7 @@ impl MessagePartitioner for GetDirectoryEntriesResponse {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -250,13 +251,15 @@ impl MessagePartitioner for GetDirectoryEntriesResponse {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_response(
             tid,
             LinuxDaemonMessageHeader::GetDirectoryEntriesResponsePart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/fcntl/message/openat.rs
+++ b/src/libs/syscall/src/fcntl/message/openat.rs
@@ -209,13 +209,15 @@ impl MessagePartitioner for OpenAtRequest {
     /// Creates a new message part for the `openat()` system call.
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::OpenAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/fcntl/message/openat.rs
+++ b/src/libs/syscall/src/fcntl/message/openat.rs
@@ -132,10 +132,11 @@ impl MessageSerializer for OpenAtRequest {
         buffer.extend_from_slice(&self.flags.to_le_bytes());
         // Serialize `mode` field.
         buffer.extend_from_slice(&self.mode.to_le_bytes());
+        let pathname_bytes: &[u8] = self.pathname.as_bytes();
         // Serialize `pathname.len()` field.
-        buffer.extend_from_slice(&(self.pathname.len() as u32).to_le_bytes());
+        buffer.extend_from_slice(&(pathname_bytes.len() as u32).to_le_bytes());
         // Serialize `pathname` field.
-        buffer.extend_from_slice(self.pathname.as_bytes());
+        buffer.extend_from_slice(pathname_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/fcntl/message/renameat.rs
+++ b/src/libs/syscall/src/fcntl/message/renameat.rs
@@ -282,13 +282,15 @@ impl MessagePartitioner for RenameAtRequest {
     /// Creates a new message for the `renameat()` system call.
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::RenameAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/fcntl/message/renameat.rs
+++ b/src/libs/syscall/src/fcntl/message/renameat.rs
@@ -148,14 +148,16 @@ impl MessageSerializer for RenameAtRequest {
         buffer.extend_from_slice(&self.olddirfd.to_le_bytes());
         // Serialize `newdirfd` field.
         buffer.extend_from_slice(&self.newdirfd.to_le_bytes());
+        let old_path_bytes: &[u8] = self.oldpath.as_bytes();
+        let new_path_bytes: &[u8] = self.newpath.as_bytes();
         // Serialize `oldpath.len()` field.
-        buffer.extend_from_slice(&(self.oldpath.len() as u32).to_le_bytes());
+        buffer.extend_from_slice(&(old_path_bytes.len() as u32).to_le_bytes());
         // Serialize `newpath.len()` field.
-        buffer.extend_from_slice(&(self.newpath.len() as u32).to_le_bytes());
+        buffer.extend_from_slice(&(new_path_bytes.len() as u32).to_le_bytes());
         // Serialize `oldpath` field.
-        buffer.extend_from_slice(self.oldpath.as_bytes());
+        buffer.extend_from_slice(old_path_bytes);
         // Serialize `newpath` field.
-        buffer.extend_from_slice(self.newpath.as_bytes());
+        buffer.extend_from_slice(new_path_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/fcntl/message/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/message/unlinkat.rs
@@ -124,10 +124,11 @@ impl MessageSerializer for UnlinkAtRequest {
         buffer.extend_from_slice(&self.dirfd.to_le_bytes());
         // Serialize `flags` field.
         buffer.extend_from_slice(&self.flags.to_le_bytes());
+        let pathname_bytes: &[u8] = self.pathname.as_bytes();
         // Serialize `pathname.len()` field.
-        buffer.extend_from_slice(&(self.pathname.len() as u32).to_le_bytes());
+        buffer.extend_from_slice(&(pathname_bytes.len() as u32).to_le_bytes());
         // Serialize `pathname` field.
-        buffer.extend_from_slice(self.pathname.as_bytes());
+        buffer.extend_from_slice(pathname_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/fcntl/message/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/message/unlinkat.rs
@@ -209,13 +209,15 @@ impl MessagePartitioner for UnlinkAtRequest {
     /// Creates a new message part for the `unlinkat()` system call.
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::UnlinkAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -42,8 +42,8 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
     // Build request and send it.
     let request: OpenAtRequest = OpenAtRequest::new(dirfd, pathname, flags, mode)?;
     let requests: Vec<Message> = request.into_parts(tid)?;
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     // Receive response.

--- a/src/libs/syscall/src/fcntl/syscall/renameat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/renameat.rs
@@ -62,8 +62,8 @@ pub fn renameat(
     // Build request and send it.
     let request: RenameAtRequest = RenameAtRequest::new(olddirfd, oldpath, newdirfd, newpath)?;
     let requests: Vec<Message> = request.into_parts(tid)?;
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     // Receive response.

--- a/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
@@ -51,8 +51,8 @@ pub fn unlinkat(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Resul
     // Build request and send it.
     let request: UnlinkAtRequest = UnlinkAtRequest::new(dirfd, pathname, flags)?;
     let requests: Vec<Message> = request.into_parts(tid)?;
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     // Receive response.

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -101,7 +101,6 @@ use ::sys::{
 #[derive(Debug, PartialEq, Eq)]
 #[repr(u16)]
 pub enum LinuxDaemonMessageHeader {
-    OpenAtRequest,
     OpenAtRequestPart,
     OpenAtResponse,
     UnlinkAtRequestPart,
@@ -206,7 +205,6 @@ impl TryFrom<u16> for LinuxDaemonMessageHeader {
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         use LinuxDaemonMessageHeader::*;
         match value {
-            x if x == OpenAtRequest as u16 => Ok(OpenAtRequest),
             x if x == OpenAtRequestPart as u16 => Ok(OpenAtRequestPart),
             x if x == OpenAtResponse as u16 => Ok(OpenAtResponse),
             x if x == UnlinkAtRequestPart as u16 => Ok(UnlinkAtRequestPart),

--- a/src/libs/syscall/src/message/long.rs
+++ b/src/libs/syscall/src/message/long.rs
@@ -19,8 +19,6 @@ use ::sys::error::{
 /// This structure represents a long message that is split into multiple parts.
 ///
 pub struct LinuxDaemonLongMessage {
-    /// Indicates if the message contains all its parts.
-    is_complete: bool,
     /// Maximum number of parts that the message can contain.
     capacity: usize,
     /// Parts of the message.
@@ -52,7 +50,6 @@ impl LinuxDaemonLongMessage {
         }
 
         Ok(Self {
-            is_complete: false,
             capacity,
             parts: Vec::with_capacity(capacity),
         })
@@ -78,18 +75,15 @@ impl LinuxDaemonLongMessage {
         }
 
         // Check if message is already complete.
-        if self.is_complete {
+        if self.is_complete() {
             return Err(Error::new(ErrorCode::InvalidMessage, "message is already complete"));
         }
 
-        let part_number: u32 = part.part_number;
-        self.check_out_of_order(part_number)?;
         self.parts.push(part);
 
-        // Check if received all parts.
-        if part_number == 0 {
-            self.is_complete = true;
-        }
+        // Keep parts sorted by part number. As vector is almost sorted, this has a linear performance.
+        // TODO: reduce number of copies by manually keeping this property using a linked list.
+        self.parts.sort_by_key(|part| part.part_number);
 
         Ok(())
     }
@@ -104,7 +98,13 @@ impl LinuxDaemonLongMessage {
     /// Returns `true` if the message is complete. Otherwise, it returns `false`.
     ///
     pub fn is_complete(&self) -> bool {
-        self.is_complete
+        if let Some(last) = self.parts.last() {
+            // Check if the last part is the last part of the message.
+            if last.total_parts == self.parts.len() as u16 {
+                return true;
+            }
+        }
+        false
     }
 
     ///
@@ -118,28 +118,5 @@ impl LinuxDaemonLongMessage {
     ///
     pub fn take_parts(self) -> Vec<LinuxDaemonMessagePart> {
         self.parts
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Checks if the part number is out of order.
-    ///
-    /// # Parameters
-    ///
-    /// - `part_number`: Part number.
-    ///
-    /// # Returns
-    ///
-    /// Upon success, the function returns empty. Otherwise, it returns an error.
-    ///
-    fn check_out_of_order(&self, part_number: u32) -> Result<(), Error> {
-        if let Some(last) = self.parts.last() {
-            if last.part_number != part_number + 1 {
-                return Err(Error::new(ErrorCode::InvalidMessage, "out of order segment"));
-            }
-        }
-
-        Ok(())
     }
 }

--- a/src/libs/syscall/src/message/mod.rs
+++ b/src/libs/syscall/src/message/mod.rs
@@ -81,6 +81,7 @@ where
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Part number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -91,7 +92,8 @@ where
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error>;
@@ -112,8 +114,17 @@ where
     ///
     fn into_parts(self, tid: ThreadIdentifier) -> Result<Vec<Message>, Error> {
         let bytes: Vec<u8> = self.to_bytes();
-        let num_parts: usize = bytes.len().div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
-        let mut parts: Vec<Message> = Vec::with_capacity(num_parts);
+        let num_parts: u16 = bytes
+            .len()
+            .div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE)
+            .try_into()
+            .map_err(|_| {
+                Error::new(
+                    ::sys::error::ErrorCode::InvalidMessage,
+                    "message is too large to be partitioned",
+                )
+            })?;
+        let mut parts: Vec<Message> = Vec::with_capacity(num_parts as usize);
 
         for (part_number, chunk) in bytes
             .chunks(LinuxDaemonMessagePart::PAYLOAD_SIZE)
@@ -123,7 +134,8 @@ where
             payload[..chunk.len()].copy_from_slice(chunk);
             parts.push(Self::new_part(
                 tid,
-                (num_parts - part_number - 1) as u32,
+                num_parts,
+                part_number as u16,
                 chunk.len() as u8,
                 payload,
             )?);

--- a/src/libs/syscall/src/message/part.rs
+++ b/src/libs/syscall/src/message/part.rs
@@ -38,8 +38,10 @@ use ::sys::{
 ///
 #[repr(C, packed)]
 pub struct LinuxDaemonMessagePart {
+    /// Total parts.
+    pub total_parts: u16,
     /// Part number.
-    pub part_number: u32,
+    pub part_number: u16,
     /// Payload size.
     pub payload_size: u8,
     /// Payload.
@@ -49,8 +51,10 @@ pub struct LinuxDaemonMessagePart {
 
 impl LinuxDaemonMessagePart {
     /// Maximum size of the payload.
-    pub const PAYLOAD_SIZE: usize =
-        LinuxDaemonMessage::PAYLOAD_SIZE - mem::size_of::<u8>() - mem::size_of::<u32>();
+    pub const PAYLOAD_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
+        - mem::size_of::<u8>()
+        - mem::size_of::<u16>()
+        - mem::size_of::<u16>();
 
     ///
     /// # Description
@@ -61,6 +65,7 @@ impl LinuxDaemonMessagePart {
     ///
     /// - `tid`: Thread identifier.
     /// - `header`: Message header.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Part number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -72,11 +77,12 @@ impl LinuxDaemonMessagePart {
     pub fn build_request(
         tid: ThreadIdentifier,
         header: LinuxDaemonMessageHeader,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; Self::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        Self::build(tid, header, part_number, payload_size, payload, false)
+        Self::build(tid, header, total_parts, part_number, payload_size, payload, false)
     }
 
     ///
@@ -88,6 +94,7 @@ impl LinuxDaemonMessagePart {
     ///
     /// - `tid`: Thread identifier.
     /// - `header`: Message header.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Part number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -99,11 +106,12 @@ impl LinuxDaemonMessagePart {
     pub fn build_response(
         tid: ThreadIdentifier,
         header: LinuxDaemonMessageHeader,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; Self::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        Self::build(tid, header, part_number, payload_size, payload, true)
+        Self::build(tid, header, total_parts, part_number, payload_size, payload, true)
     }
 
     ///
@@ -145,6 +153,7 @@ impl LinuxDaemonMessagePart {
     ///
     /// - `tid`: Thread identifier.
     /// - `header`: Message header.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Part number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -155,12 +164,22 @@ impl LinuxDaemonMessagePart {
     fn build(
         tid: ThreadIdentifier,
         header: LinuxDaemonMessageHeader,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; Self::PAYLOAD_SIZE],
         is_response: bool,
     ) -> Result<Message, Error> {
-        let message: LinuxDaemonMessagePart = Self::new(part_number, payload_size, payload)?;
+        // Check if part number is valid.
+        if part_number >= total_parts {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "part number is greater than or equal to total parts",
+            ));
+        }
+
+        let message: LinuxDaemonMessagePart =
+            Self::new(total_parts, part_number, payload_size, payload)?;
         let message: LinuxDaemonMessage = LinuxDaemonMessage::new(header, message.into_bytes());
         if is_response {
             Ok(Message::new(
@@ -188,12 +207,14 @@ impl LinuxDaemonMessagePart {
     ///
     /// # Parameters
     ///
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Part number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
     ///
     fn new(
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; Self::PAYLOAD_SIZE],
     ) -> Result<Self, Error> {
@@ -203,6 +224,7 @@ impl LinuxDaemonMessagePart {
         }
 
         Ok(Self {
+            total_parts,
             part_number,
             payload_size,
             payload,
@@ -214,8 +236,9 @@ impl Debug for LinuxDaemonMessagePart {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
-            "LinuxDaemonMessagePart {{ part_number: {}, payload_size: {} }}",
+            "LinuxDaemonMessagePart {{ part_number: {}, total_parts={},  payload_size: {} }}",
             { self.part_number },
+            { self.total_parts },
             { self.payload_size }
         )
     }

--- a/src/libs/syscall/src/sys/stat/message/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fchmodat.rs
@@ -136,8 +136,9 @@ impl MessageSerializer for FileChmodAtRequest {
         buffer.extend_from_slice(&self.dirfd.to_ne_bytes());
         buffer.extend_from_slice(&self.mode.to_ne_bytes());
         buffer.extend_from_slice(&self.flag.to_ne_bytes());
-        buffer.extend_from_slice(&(self.path.len() as u32).to_ne_bytes());
-        buffer.extend_from_slice(self.path.as_bytes());
+        let path_bytes: &[u8] = self.path.as_bytes();
+        buffer.extend_from_slice(&(path_bytes.len() as u32).to_ne_bytes());
+        buffer.extend_from_slice(path_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/sys/stat/message/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fchmodat.rs
@@ -223,6 +223,7 @@ impl MessagePartitioner for FileChmodAtRequest {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -233,13 +234,15 @@ impl MessagePartitioner for FileChmodAtRequest {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::FileChmodAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/sys/stat/message/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fstatat.rs
@@ -109,10 +109,11 @@ impl MessageSerializer for FileStatAtRequest {
         bytes.extend_from_slice(&self.dirfd.to_le_bytes());
         // Serialize flags.
         bytes.extend_from_slice(&self.flag.to_le_bytes());
+        let path_bytes: &[u8] = self.path.as_bytes();
         // Serialize path length.
-        bytes.extend_from_slice(&(self.path.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&(path_bytes.len() as u32).to_le_bytes());
         // Serialize path.
-        bytes.extend_from_slice(self.path.as_bytes());
+        bytes.extend_from_slice(path_bytes);
 
         bytes
     }

--- a/src/libs/syscall/src/sys/stat/message/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/message/fstatat.rs
@@ -188,6 +188,7 @@ impl MessagePartitioner for FileStatAtRequest {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -198,13 +199,15 @@ impl MessagePartitioner for FileStatAtRequest {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::FileStatAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,
@@ -379,6 +382,7 @@ impl MessagePartitioner for FileStatAtResponse {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -389,13 +393,15 @@ impl MessagePartitioner for FileStatAtResponse {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_response(
             tid,
             LinuxDaemonMessageHeader::FileStatAtResponsePart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/sys/stat/message/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/message/mkdirat.rs
@@ -223,6 +223,7 @@ impl MessagePartitioner for MakeDirectoryAtRequest {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -233,13 +234,15 @@ impl MessagePartitioner for MakeDirectoryAtRequest {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/sys/stat/message/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/message/mkdirat.rs
@@ -129,12 +129,13 @@ impl MessageSerializer for MakeDirectoryAtRequest {
 
         // Serialize directory file descriptor.
         buffer.extend_from_slice(&self.dirfd.to_ne_bytes());
+        let pathname_bytes: &[u8] = self.pathname.as_bytes();
         // Serialize path length.
-        buffer.extend_from_slice(&(self.pathname.len() as u32).to_ne_bytes());
+        buffer.extend_from_slice(&(pathname_bytes.len() as u32).to_ne_bytes());
         // Serialize mode.
         buffer.extend_from_slice(&self.mode.to_ne_bytes());
         // Serialize path.
-        buffer.extend_from_slice(self.pathname.as_bytes());
+        buffer.extend_from_slice(pathname_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/sys/stat/message/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/message/utimensat.rs
@@ -139,8 +139,10 @@ impl MessageSerializer for UpdateFileAccessTimeAtRequest {
         // Serialize flags.
         buffer.extend_from_slice(&self.flag.to_ne_bytes());
 
+        let path_bytes: &[u8] = self.path.as_bytes();
+
         // Serialize path length.
-        buffer.extend_from_slice(&(self.path.len() as u32).to_ne_bytes());
+        buffer.extend_from_slice(&(path_bytes.len() as u32).to_ne_bytes());
 
         // Serialize access time.
         for time in self.times.iter() {
@@ -148,7 +150,7 @@ impl MessageSerializer for UpdateFileAccessTimeAtRequest {
         }
 
         // Serialize path.
-        buffer.extend_from_slice(self.path.as_bytes());
+        buffer.extend_from_slice(path_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/sys/stat/message/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/message/utimensat.rs
@@ -245,6 +245,7 @@ impl MessagePartitioner for UpdateFileAccessTimeAtRequest {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -255,13 +256,15 @@ impl MessagePartitioner for UpdateFileAccessTimeAtRequest {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
@@ -63,8 +63,8 @@ fn chmodat_request(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Resul
 
     let requests: Vec<Message> = request.into_parts(tid)?;
 
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     Ok(())

--- a/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
@@ -73,8 +73,8 @@ fn fstatat_request(dirfd: i32, path: &str, flag: i32) -> Result<(), Error> {
 
     let requests: Vec<Message> = request.into_parts(tid)?;
 
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     Ok(())

--- a/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
@@ -57,8 +57,8 @@ pub fn mkdirat(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Result
     let requests: Vec<Message> = request.into_parts(tid)?;
 
     // Send request.
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     // Receive response.

--- a/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
@@ -68,8 +68,8 @@ pub fn utimensat(
     let requests: Vec<Message> = request.into_parts(tid)?;
 
     // Send request.
-    for request in requests {
-        sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        sys::kcall::ipc::send(request)?;
     }
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/message/chdir.rs
+++ b/src/libs/syscall/src/unistd/message/chdir.rs
@@ -103,8 +103,9 @@ impl MessageSerializer for ChangeDirectoryRequest {
     fn to_bytes(&self) -> Vec<u8> {
         let mut buffer: Vec<u8> = Vec::new();
 
-        buffer.extend_from_slice(&(self.path.len() as u32).to_ne_bytes());
-        buffer.extend_from_slice(self.path.as_bytes());
+        let path_bytes: &[u8] = self.path.as_bytes();
+        buffer.extend_from_slice(&(path_bytes.len() as u32).to_ne_bytes());
+        buffer.extend_from_slice(path_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/unistd/message/chdir.rs
+++ b/src/libs/syscall/src/unistd/message/chdir.rs
@@ -164,6 +164,7 @@ impl MessagePartitioner for ChangeDirectoryRequest {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -174,13 +175,15 @@ impl MessagePartitioner for ChangeDirectoryRequest {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::ChangeDirectoryRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/unistd/message/faccessat.rs
+++ b/src/libs/syscall/src/unistd/message/faccessat.rs
@@ -131,10 +131,11 @@ impl MessageSerializer for FileAccessAtRequest {
         let mut buffer: Vec<u8> = Vec::new();
 
         buffer.extend_from_slice(&self.dirfd.to_ne_bytes());
-        buffer.extend_from_slice(&(self.path.len() as u32).to_ne_bytes());
+        let path_bytes: &[u8] = self.path.as_bytes();
+        buffer.extend_from_slice(&(path_bytes.len() as u32).to_ne_bytes());
         buffer.extend_from_slice(&self.mode.to_ne_bytes());
         buffer.extend_from_slice(&self.flag.to_ne_bytes());
-        buffer.extend_from_slice(self.path.as_bytes());
+        buffer.extend_from_slice(path_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/unistd/message/faccessat.rs
+++ b/src/libs/syscall/src/unistd/message/faccessat.rs
@@ -220,6 +220,7 @@ impl MessagePartitioner for FileAccessAtRequest {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -230,13 +231,15 @@ impl MessagePartitioner for FileAccessAtRequest {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::FileAccessAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/unistd/message/fchownat.rs
+++ b/src/libs/syscall/src/unistd/message/fchownat.rs
@@ -250,6 +250,7 @@ impl MessagePartitioner for FileChownAtRequest {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -260,13 +261,15 @@ impl MessagePartitioner for FileChownAtRequest {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::FileChownAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/unistd/message/fchownat.rs
+++ b/src/libs/syscall/src/unistd/message/fchownat.rs
@@ -155,8 +155,9 @@ impl MessageSerializer for FileChownAtRequest {
         buffer.extend_from_slice(&self.owner.to_ne_bytes());
         buffer.extend_from_slice(&self.group.to_ne_bytes());
         buffer.extend_from_slice(&self.flag.to_ne_bytes());
-        buffer.extend_from_slice(&(self.path.len() as u32).to_ne_bytes());
-        buffer.extend_from_slice(self.path.as_bytes());
+        let path_bytes: &[u8] = self.path.as_bytes();
+        buffer.extend_from_slice(&(path_bytes.len() as u32).to_ne_bytes());
+        buffer.extend_from_slice(path_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/unistd/message/getcwd.rs
+++ b/src/libs/syscall/src/unistd/message/getcwd.rs
@@ -163,13 +163,15 @@ impl MessageDeserializer for GetCurrentWorkingDirectoryResponse {
 impl MessagePartitioner for GetCurrentWorkingDirectoryResponse {
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_response(
             tid,
             LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryResponsePart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/unistd/message/linkat.rs
+++ b/src/libs/syscall/src/unistd/message/linkat.rs
@@ -137,18 +137,20 @@ impl MessageSerializer for LinkAtRequest {
 
         // Serialize 'old directory file descriptor' field.
         bytes.extend_from_slice(&self.olddirfd.to_ne_bytes());
+        let oldpath_bytes: &[u8] = self.oldpath.as_bytes();
+        let newpath_bytes: &[u8] = self.newpath.as_bytes();
         // Serialize 'old path length' field.
-        bytes.extend_from_slice(&(self.oldpath.len() as u32).to_ne_bytes());
+        bytes.extend_from_slice(&(oldpath_bytes.len() as u32).to_ne_bytes());
         // Serialize 'new directory file descriptor' field.
         bytes.extend_from_slice(&self.newdirfd.to_ne_bytes());
         // Serialize 'new path length' field.
-        bytes.extend_from_slice(&(self.newpath.len() as u32).to_ne_bytes());
+        bytes.extend_from_slice(&(newpath_bytes.len() as u32).to_ne_bytes());
         // Serialize 'flags' field.
         bytes.extend_from_slice(&self.flags.to_ne_bytes());
         // Serialize 'old path' field.
-        bytes.extend_from_slice(self.oldpath.as_bytes());
+        bytes.extend_from_slice(oldpath_bytes);
         // Serialize 'new path' field.
-        bytes.extend_from_slice(self.newpath.as_bytes());
+        bytes.extend_from_slice(newpath_bytes);
 
         bytes
     }

--- a/src/libs/syscall/src/unistd/message/linkat.rs
+++ b/src/libs/syscall/src/unistd/message/linkat.rs
@@ -256,6 +256,7 @@ impl MessagePartitioner for LinkAtRequest {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -266,13 +267,15 @@ impl MessagePartitioner for LinkAtRequest {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::LinkAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/unistd/message/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/message/readlinkat.rs
@@ -118,9 +118,10 @@ impl MessageSerializer for ReadLinkAtRequest {
         let mut buffer: Vec<u8> = Vec::new();
 
         buffer.extend_from_slice(&self.dirfd.to_ne_bytes());
-        buffer.extend_from_slice(&(self.path.len() as u32).to_ne_bytes());
+        let path_bytes: &[u8] = self.path.as_bytes();
+        buffer.extend_from_slice(&(path_bytes.len() as u32).to_ne_bytes());
         buffer.extend_from_slice(&(self.bufsiz as u32).to_ne_bytes());
-        buffer.extend_from_slice(self.path.as_bytes());
+        buffer.extend_from_slice(path_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/unistd/message/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/message/readlinkat.rs
@@ -199,6 +199,7 @@ impl MessagePartitioner for ReadLinkAtRequest {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -209,13 +210,15 @@ impl MessagePartitioner for ReadLinkAtRequest {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::ReadLinkAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,
@@ -345,6 +348,7 @@ impl MessagePartitioner for ReadLinkAtResponse {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Size of the payload.
     /// - `payload`: Payload.
@@ -355,13 +359,15 @@ impl MessagePartitioner for ReadLinkAtResponse {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_response(
             tid,
             LinuxDaemonMessageHeader::ReadLinkAtResponsePart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/unistd/message/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/message/symlinkat.rs
@@ -210,6 +210,7 @@ impl MessagePartitioner for SymbolicLinkAtRequest {
     /// # Parameters
     ///
     /// - `tid`: Thread identifier.
+    /// - `total_parts`: Total number of parts.
     /// - `part_number`: Partition number.
     /// - `payload_size`: Payload size.
     /// - `payload`: Payload.
@@ -220,13 +221,15 @@ impl MessagePartitioner for SymbolicLinkAtRequest {
     ///
     fn new_part(
         tid: ThreadIdentifier,
-        part_number: u32,
+        total_parts: u16,
+        part_number: u16,
         payload_size: u8,
         payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
         LinuxDaemonMessagePart::build_request(
             tid,
             LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart,
+            total_parts,
             part_number,
             payload_size,
             payload,

--- a/src/libs/syscall/src/unistd/message/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/message/symlinkat.rs
@@ -112,14 +112,16 @@ impl MessageSerializer for SymbolicLinkAtRequest {
 
         // Serialize the 'directory file descriptor' field.
         buffer.extend_from_slice(&self.dirfd.to_ne_bytes());
+        let target_bytes: &[u8] = self.target.as_bytes();
         // Serialize the 'target length' field.
-        buffer.extend_from_slice(&(self.target.len() as u32).to_ne_bytes());
+        buffer.extend_from_slice(&(target_bytes.len() as u32).to_ne_bytes());
+        let linkpath_bytes: &[u8] = self.linkpath.as_bytes();
         // Serialize the 'link path length' field.
-        buffer.extend_from_slice(&(self.linkpath.len() as u32).to_ne_bytes());
+        buffer.extend_from_slice(&(linkpath_bytes.len() as u32).to_ne_bytes());
         // Serialize the 'target' field.
-        buffer.extend_from_slice(self.target.as_bytes());
+        buffer.extend_from_slice(target_bytes);
         // Serialize the 'link path' field.
-        buffer.extend_from_slice(self.linkpath.as_bytes());
+        buffer.extend_from_slice(linkpath_bytes);
 
         buffer
     }

--- a/src/libs/syscall/src/unistd/syscall/chdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/chdir.rs
@@ -47,8 +47,8 @@ pub fn chdir(path: &str) -> Result<(), Error> {
     // Build request and send it.
     let request: ChangeDirectoryRequest = ChangeDirectoryRequest::new(path)?;
     let requests: Vec<Message> = request.into_parts(tid)?;
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/fchownat.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchownat.rs
@@ -71,8 +71,8 @@ pub fn fchownat(
 
     let requests: Vec<Message> = request.into_parts(tid)?;
 
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     let response: Message = ::sys::kcall::ipc::recv()?;

--- a/src/libs/syscall/src/unistd/syscall/linkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/linkat.rs
@@ -71,8 +71,8 @@ pub fn linkat(
     let requests: Vec<Message> = request.into_parts(tid)?;
 
     // Send request.
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     // Receive response.

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -61,8 +61,8 @@ pub fn readlinkat(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, E
 
     let requests: Vec<Message> = request.into_parts(tid)?;
 
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     let capacity: usize =

--- a/src/libs/syscall/src/unistd/syscall/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/symlinkat.rs
@@ -59,8 +59,8 @@ pub fn symlinkat(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Error> 
     let requests: Vec<Message> = request.into_parts(tid)?;
 
     // Send request.
-    for request in requests {
-        ::sys::kcall::ipc::send(&request)?;
+    for request in &requests {
+        ::sys::kcall::ipc::send(request)?;
     }
 
     // Receive response.


### PR DESCRIPTION
This pull request introduces several changes to improve message serialization, partitioning, and handling in the Linux daemon and associated system calls. The most significant updates include the addition of a `total_parts` field to message parts, the removal of unnecessary fields and methods, and adjustments to ensure better handling of multipart messages. These changes aim to enhance clarity, efficiency, and maintainability of the codebase.

### Improvements to Message Serialization and Partitioning
* Added a `total_parts` field to `LinuxDaemonMessagePart` to track the total number of parts in a message and updated related methods to handle this new field. (`src/libs/syscall/src/message/part.rs`) [[1]](diffhunk://#diff-d400737787d4dabffd7b6e36829d82f493ac09ea6f83aedad34d97dd693a82c2R41-R44) [[2]](diffhunk://#diff-d400737787d4dabffd7b6e36829d82f493ac09ea6f83aedad34d97dd693a82c2L75-R85) [[3]](diffhunk://#diff-d400737787d4dabffd7b6e36829d82f493ac09ea6f83aedad34d97dd693a82c2L102-R114)
* Updated `new_part` methods across various request types (e.g., `OpenAtRequest`, `RenameAtRequest`, `UnlinkAtRequest`) to include `total_parts` and use `u16` for `part_number` instead of `u32`. (`src/libs/syscall/src/fcntl/message/*.rs`) [[1]](diffhunk://#diff-f28f0db5b88f7d67d5bd8622f955417a64a3a7f7779a8d79e361e7122c31fe80L211-R220) [[2]](diffhunk://#diff-4eab51acc9df60d4824410aa25f9f0723f3c11c16a566de3268b539955152540L283-R293) [[3]](diffhunk://#diff-2e732b004acc1ceb28c1af9f1496e82c06e5a178f3dc81f8dcaee296fd280174L211-R220)

### Enhancements to Multipart Message Handling
* Replaced the `is_complete` field in `LinuxDaemonLongMessage` with a computed `is_complete()` method that checks completeness based on `total_parts` and the number of received parts. (`src/libs/syscall/src/message/long.rs`)
* Removed the `check_out_of_order` method and introduced sorting of parts by `part_number` to ensure order consistency. (`src/libs/syscall/src/message/long.rs`) [[1]](diffhunk://#diff-4b6623e1024c0b59b655969a3f5b4deb7a2e9a4dbabeac98e80306da41cac0d3L81-R86) [[2]](diffhunk://#diff-4b6623e1024c0b59b655969a3f5b4deb7a2e9a4dbabeac98e80306da41cac0d3L122-L144)

### Code Simplifications and Refactoring
* Simplified serialization logic by reusing intermediate variables for pathname byte arrays in multiple request serializers (e.g., `OpenAtRequest`, `RenameAtRequest`). (`src/libs/syscall/src/fcntl/message/*.rs`) [[1]](diffhunk://#diff-f28f0db5b88f7d67d5bd8622f955417a64a3a7f7779a8d79e361e7122c31fe80R135-R139) [[2]](diffhunk://#diff-4eab51acc9df60d4824410aa25f9f0723f3c11c16a566de3268b539955152540R151-R160) [[3]](diffhunk://#diff-2e732b004acc1ceb28c1af9f1496e82c06e5a178f3dc81f8dcaee296fd280174R127-R131)
* Removed the unused `OpenAtRequest` variant from `LinuxDaemonMessageHeader` and its related logic. (`src/libs/syscall/src/lib.rs`) [[1]](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79L104) [[2]](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79L209)

### Bug Fixes and Robustness
* Added error handling for cases where a message is too large to be partitioned, ensuring graceful failure. (`src/libs/syscall/src/message/mod.rs`)
* Updated IPC send loops to use references to avoid unnecessary ownership transfers. (`src/libs/syscall/src/fcntl/syscall/*.rs`) [[1]](diffhunk://#diff-4958384900141ad15d2e84dab0b3862a9594f7bf6d38550536a3d5ef6ed8c4e8L45-R46) [[2]](diffhunk://#diff-1351ac6edb17eeb1f2318c139a3f58898f9beb99774e196c2934d307703457d2L65-R66) [[3]](diffhunk://#diff-ea8a498ad307dadadaa6f8d8a9b98c8723f6bd83898af4dc3110b40861725667L54-R55)