### PR TITLE
[libs] E: Increase Stack Size

### DIFF
--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -114,7 +114,7 @@ pub mod memory_layout {
     ///
     /// - This size should be a multiple of a page size.
     ///
-    pub const USER_STACK_SIZE: usize = 32 * crate::constants::KILOBYTE;
+    pub const USER_STACK_SIZE: usize = 512 * crate::constants::KILOBYTE;
 
     ///
     /// # Description


### PR DESCRIPTION
This pull request includes a single change to the `USER_STACK_SIZE` constant in the `memory_layout` module of `src/libs/config/src/lib.rs`. The stack size has been increased from 32 KB to 512 KB to accommodate larger user stack requirements.