### PR TITLE
[scripts] Fix Infinite Recursion on Distclean

### DIFF
--- a/scripts/build-openblas.sh
+++ b/scripts/build-openblas.sh
@@ -46,7 +46,11 @@ configure() {
 #===================================================================================================
 
 make_clean() {
-    cd ${OPENBLAS_HOME}
+    if [ ! -d "${OPENBLAS_HOME}" ];
+    then
+        return 0
+    fi
+    cd "${OPENBLAS_HOME}"
     make ${OPENBLAS_MAKE_OPTIONS} clean
 }
 
@@ -55,7 +59,11 @@ make_clean() {
 #===================================================================================================
 
 distclean() {
-    cd ${OPENBLAS_HOME}
+    if [ ! -d "${OPENBLAS_HOME}" ];
+    then
+        return 0
+    fi
+    cd "${OPENBLAS_HOME}"
     git clean -fdx
 }
 
@@ -64,7 +72,7 @@ distclean() {
 #===================================================================================================
 
 make_all() {
-    cd ${OPENBLAS_HOME}
+    cd "${OPENBLAS_HOME}"
     make ${OPENBLAS_MAKE_OPTIONS} all
 }
 
@@ -73,7 +81,7 @@ make_all() {
 #===================================================================================================
 
 make_install() {
-    cd ${OPENBLAS_HOME}
+    cd "${OPENBLAS_HOME}"
     make ${OPENBLAS_MAKE_OPTIONS} install
 }
 
@@ -83,7 +91,7 @@ make_install() {
 
 
 build() {
-    cd ${OPENBLAS_HOME}
+    cd "${OPENBLAS_HOME}"
     configure
     make_all
     make_install
@@ -98,9 +106,9 @@ init() {
     if [ ! -d "${OPENBLAS_HOME}/.git" ];
     then
         git clone ${OPENBLAS_REPOSITORY} ${OPENBLAS_HOME}
-        cd ${OPENBLAS_HOME}
+        cd "${OPENBLAS_HOME}"
     else
-        cd ${OPENBLAS_HOME}
+        cd "${OPENBLAS_HOME}"
         git fetch origin
         git reset --hard
     fi

--- a/scripts/build-openssl.sh
+++ b/scripts/build-openssl.sh
@@ -50,7 +50,11 @@ configure() {
 #===================================================================================================
 
 make_clean() {
-    cd ${OPENSSL_HOME}
+    if [ ! -d "${OPENSSL_HOME}" ];
+    then
+        return 0
+    fi
+    cd "${OPENSSL_HOME}"
     make clean
 }
 
@@ -59,7 +63,11 @@ make_clean() {
 #===================================================================================================
 
 distclean() {
-    cd ${OPENSSL_HOME}
+    if [ ! -d "${OPENSSL_HOME}" ];
+    then
+        return 0
+    fi
+    cd "${OPENSSL_HOME}"
     git clean -fdx
 }
 
@@ -68,8 +76,7 @@ distclean() {
 #===================================================================================================
 
 make_all() {
-    cd ${OPENSSL_HOME}
-
+    cd "${OPENSSL_HOME}"
     make -j $(nproc) all
 }
 
@@ -78,7 +85,7 @@ make_all() {
 #===================================================================================================
 
 make_install() {
-    cd ${OPENSSL_HOME}
+    cd "${OPENSSL_HOME}"
     make install
 }
 
@@ -88,7 +95,7 @@ make_install() {
 
 
 build() {
-    cd ${OPENSSL_HOME}
+    cd "${OPENSSL_HOME}"
     configure
     make_all
     make_install
@@ -103,9 +110,9 @@ init() {
     if [ ! -d "${OPENSSL_HOME}/.git" ];
     then
         git clone ${OPENSSL_REPOSITORY} ${OPENSSL_HOME}
-        cd ${OPENSSL_HOME}
+        cd "${OPENSSL_HOME}"
     else
-        cd ${OPENSSL_HOME}
+        cd "${OPENSSL_HOME}"
         git fetch origin
         git reset --hard
     fi

--- a/scripts/build-python.sh
+++ b/scripts/build-python.sh
@@ -63,7 +63,11 @@ configure() {
 #===================================================================================================
 
 make_clean() {
-    cd ${CPYTHON_HOME}
+    if [ ! -d "${CPYTHON_HOME}" ];
+    then
+        return 0
+    fi
+    cd "${CPYTHON_HOME}"
     make clean
 }
 
@@ -72,7 +76,11 @@ make_clean() {
 #===================================================================================================
 
 distclean() {
-    cd ${CPYTHON_HOME}
+    if [ ! -d "${CPYTHON_HOME}" ];
+    then
+        return 0
+    fi
+    cd "${CPYTHON_HOME}"
     git clean -fdx
 }
 
@@ -81,7 +89,7 @@ distclean() {
 #===================================================================================================
 
 make_all() {
-    cd ${CPYTHON_HOME}
+    cd "${CPYTHON_HOME}"
     make -j `nproc` all
 }
 
@@ -90,7 +98,7 @@ make_all() {
 #===================================================================================================
 
 make_install() {
-    cd ${CPYTHON_HOME}
+    cd "${CPYTHON_HOME}"
     make install
 }
 
@@ -99,7 +107,7 @@ make_install() {
 #===================================================================================================
 
 build() {
-    cd ${CPYTHON_HOME}
+    cd "${CPYTHON_HOME}"
 
     # Check if we need to configure or not.
     if [ ! -f "${CPYTHON_HOME}/Makefile" ]; then
@@ -123,9 +131,9 @@ mkdir -p ${CONTRIB_DIR}
     if [ ! -d "${CPYTHON_HOME}/.git" ];
     then
         git clone ${CPYTHON_REPOSITORY} ${CPYTHON_HOME}
-        cd ${CPYTHON_HOME}
+        cd "${CPYTHON_HOME}"
     else
-        cd ${CPYTHON_HOME}
+        cd "${CPYTHON_HOME}"
         git fetch origin
         git reset --hard
     fi

--- a/scripts/build-sqlite.sh
+++ b/scripts/build-sqlite.sh
@@ -26,7 +26,11 @@ export NANVIX_HOME=${NANVIX_HOME:-`git rev-parse --show-toplevel`}
 #===================================================================================================
 
 make_clean() {
-    cd ${SQLITE_HOME}
+    if [ ! -d "${SQLITE_HOME}" ];
+    then
+        return 0
+    fi
+    cd "${SQLITE_HOME}"
     make clean
 }
 
@@ -35,7 +39,11 @@ make_clean() {
 #===================================================================================================
 
 distclean() {
-    cd ${SQLITE_HOME}
+    if [ ! -d "${SQLITE_HOME}" ];
+    then
+        return 0
+    fi
+    cd "${SQLITE_HOME}"
     git clean -fdx
 }
 
@@ -68,7 +76,7 @@ configure() {
 #===================================================================================================
 
 make_all() {
-    cd ${SQLITE_HOME}
+    cd "${SQLITE_HOME}"
     make all
 }
 
@@ -77,7 +85,7 @@ make_all() {
 #===================================================================================================
 
 make_install() {
-    cd ${SQLITE_HOME}
+    cd "${SQLITE_HOME}"
     make install
 }
 
@@ -86,7 +94,7 @@ make_install() {
 #===================================================================================================
 
 build() {
-    cd ${SQLITE_HOME}
+    cd "${SQLITE_HOME}"
     configure
     make_all
     make_install
@@ -101,9 +109,9 @@ init() {
     if [ ! -d "${SQLITE_HOME}/.git" ];
     then
         git clone ${SQLITE_REPOSITORY} ${SQLITE_HOME}
-        cd ${SQLITE_HOME}
+        cd "${SQLITE_HOME}"
     else
-        cd ${SQLITE_HOME}
+        cd "${SQLITE_HOME}"
         git fetch origin
         git reset --hard
     fi

--- a/scripts/build-zlib.sh
+++ b/scripts/build-zlib.sh
@@ -26,7 +26,11 @@ export NANVIX_HOME=${NANVIX_HOME:-`git rev-parse --show-toplevel`}
 #===================================================================================================
 
 make_clean() {
-    cd ${ZLIB_HOME}
+    if [ ! -d "${ZLIB_HOME}" ];
+    then
+        return 0
+    fi
+    cd "${ZLIB_HOME}"
     make clean
 }
 
@@ -35,7 +39,11 @@ make_clean() {
 #===================================================================================================
 
 distclean() {
-    cd ${ZLIB_HOME}
+    if [ ! -d "${ZLIB_HOME}" ];
+    then
+        return 0
+    fi
+    cd "${ZLIB_HOME}"
     git clean -fdx
 }
 
@@ -63,7 +71,7 @@ configure() {
 #===================================================================================================
 
 make_all() {
-    cd ${ZLIB_HOME}
+    cd "${ZLIB_HOME}"
     make all
 }
 
@@ -72,7 +80,7 @@ make_all() {
 #===================================================================================================
 
 make_install() {
-    cd ${ZLIB_HOME}
+    cd "${ZLIB_HOME}"
     make install
 }
 
@@ -81,7 +89,7 @@ make_install() {
 #===================================================================================================
 
 build() {
-    cd ${ZLIB_HOME}
+    cd "${ZLIB_HOME}"
     configure
     make_all
     make_install
@@ -96,9 +104,9 @@ init() {
     if [ ! -d "${ZLIB_HOME}/.git" ];
     then
         git clone ${ZLIB_REPOSITORY} ${ZLIB_HOME}
-        cd ${ZLIB_HOME}
+        cd "${ZLIB_HOME}"
     else
-        cd ${ZLIB_HOME}
+        cd "${ZLIB_HOME}"
         git fetch origin
         git reset --hard
     fi


### PR DESCRIPTION
This pull request improves the robustness of the `make_clean` and `distclean` functions across multiple build scripts by adding checks to ensure the respective directories exist before attempting operations. Additionally, a minor cleanup was performed in the `make_all` function of the OpenSSL build script.

### Improvements to `make_clean` and `distclean` functions:
* Added a directory existence check in the `make_clean` function for the OpenBLAS build script to prevent errors when the directory `${OPENBLAS_HOME}` does not exist.
* Added a directory existence check in the `distclean` function for the OpenBLAS build script to ensure safe operations when `${OPENBLAS_HOME}` is missing.
* Applied similar directory existence checks in the `make_clean` and `distclean` functions for the OpenSSL, Python, SQLite, and zlib build scripts to handle missing directories gracefully. [[1]](diffhunk://#diff-bddec447b87c1379a02934ed217205e063a9e724eb42b02bfa606d81c99564d0R53-R56) [[2]](diffhunk://#diff-bddec447b87c1379a02934ed217205e063a9e724eb42b02bfa606d81c99564d0R66-R69) [[3]](diffhunk://#diff-b4ec7c42d093e6056090c4e1dc9f1d0fe551942570f049ba64a3b53bbaded29fR66-R69) [[4]](diffhunk://#diff-b4ec7c42d093e6056090c4e1dc9f1d0fe551942570f049ba64a3b53bbaded29fR79-R82) [[5]](diffhunk://#diff-98bbfd9c0760b7130e460fc6efd861f3624811b6b31e53448ab5d85e4c958ca7R29-R32) [[6]](diffhunk://#diff-98bbfd9c0760b7130e460fc6efd861f3624811b6b31e53448ab5d85e4c958ca7R42-R45) [[7]](diffhunk://#diff-a2711796f49cd2040e89f3719d86a950623d70de1871531243d33f91d6cefe3bR29-R32) [[8]](diffhunk://#diff-a2711796f49cd2040e89f3719d86a950623d70de1871531243d33f91d6cefe3bR42-R45)

### Minor cleanup:
* Removed an unnecessary blank line in the `make_all` function of the OpenSSL build script for better readability.