### PR TITLE
[ci] Check VM Return Status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,6 +378,7 @@ run-linuxd-tests: | \
 	test-linuxd-dlfcn-c \
 	test-linuxd-file-rust \
 	test-linuxd-file-c \
+	test-linuxd-thread-c \
 	test-linuxd-memory-c \
 	test-linuxd-misc-c \
 	test-linuxd-network-c \
@@ -906,6 +907,7 @@ $(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),linux-app,.elf,'','','ok',0))
 $(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),dlfcn-c,.elf,'','','ok',0))
 $(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),file-c,.elf,'','','ok',0))
 $(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),file-rust,.elf,'','','ok',0))
+$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),thread-c,.elf,'','','ok',4))
 $(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),network-c,.elf,'','','ok',0))
 $(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),misc-c,.elf,'','','ok',0))
 $(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),memory-c,.elf,'','','ok',0))

--- a/Makefile
+++ b/Makefile
@@ -896,17 +896,17 @@ define LINUXD_TEST_RULE
 test-linuxd-$(2): all
 ifneq ($(strip $(filter $(MACHINE),microvm)),)
 	@echo "Running Linuxd test $(2)..."
-	$(SCRIPTS_DIR)/test-linuxd.sh $(LINUXD_SOCKADDR) $(1)/$(2)$(3) $(4) $(5) $(6) $(TIMEOUT)
+	$(SCRIPTS_DIR)/test-linuxd.sh $(LINUXD_SOCKADDR) $(1)/$(2)$(3) $(4) $(5) $(6) $(7) $(TIMEOUT)
 endif
 endef
 
-$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),hello-c,.elf,'','','Hello$(comma) world from C!'))
-$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),hello-cpp,.elf,'','','Hello$(comma) world from C++!'))
-$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),linux-app,.elf,'','','ok'))
-$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),dlfcn-c,.elf,'','','ok'))
-$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),file-c,.elf,'','','ok'))
-$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),file-rust,.elf,'','','ok'))
-$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),network-c,.elf,'','','ok'))
-$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),misc-c,.elf,'','','ok'))
-$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),memory-c,.elf,'','','ok'))
-$(eval $(call LINUXD_TEST_RULE,$(SYSROOT_DIR)/bin,python3,,'$(SOURCES_DIR)/user/hello-python/__main__.py','','Hello$(comma) from Python!'))
+$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),hello-c,.elf,'','','Hello$(comma) world from C!',0))
+$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),hello-cpp,.elf,'','','Hello$(comma) world from C++!,0'))
+$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),linux-app,.elf,'','','ok',0))
+$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),dlfcn-c,.elf,'','','ok',0))
+$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),file-c,.elf,'','','ok',0))
+$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),file-rust,.elf,'','','ok',0))
+$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),network-c,.elf,'','','ok',0))
+$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),misc-c,.elf,'','','ok',0))
+$(eval $(call LINUXD_TEST_RULE,$(BINARIES_DIR),memory-c,.elf,'','','ok',0))
+$(eval $(call LINUXD_TEST_RULE,$(SYSROOT_DIR)/bin,python3,,'$(SOURCES_DIR)/user/hello-python/__main__.py','','Hello$(comma) from Python!',0))

--- a/scripts/test-linuxd.sh
+++ b/scripts/test-linuxd.sh
@@ -5,7 +5,8 @@ PROGRAM_NAME=$2
 PROGRAM_ARGS=$3
 PROGRAM_ENV=$4
 PROGRAM_EXPECTED_OUTPUT=$5
-TIMEOUT=${6:-90}
+PROGRAM_EXPECTED_EXIT_CODE=$6
+TIMEOUT=${7:-90}
 
 NANVIX_HOME=`git rev-parse --show-toplevel`
 LOGS_DIR=${NANVIX_HOME}/logs/linuxd-$(basename "${PROGRAM_NAME}")
@@ -47,7 +48,7 @@ sudo -E rm -f ${SOCKADDR}
 mv *.log ${LOGS_DIR}/
 
 # Check microvm status to see if it exited successfully.
-if [ ${MICROVM_EXIT_CODE} -eq 0 ]; then
+if [ ${MICROVM_EXIT_CODE} -eq ${PROGRAM_EXPECTED_EXIT_CODE} ]; then
     # Check if LINUXD_STDOUT_FILE_NAME contains the expected output.
     grep -q "${PROGRAM_EXPECTED_OUTPUT}" ${LINUXD_STDOUT_FILE_NAME}
     GREP_EXIT_CODE=$?

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -37,7 +37,9 @@ use ::microvm::{
     Vmm,
 };
 use ::std::{
+    convert::TryInto,
     env,
+    process::ExitCode,
     str::FromStr,
 };
 use ::syscomm::{
@@ -56,7 +58,7 @@ const DEFAULT_BIND_SOCKET_TYPE: SocketType = SocketType::Unix;
 // Standalone Functions
 //==================================================================================================
 
-fn main() -> Result<()> {
+fn main() -> Result<ExitCode> {
     // Parse command-line arguments.
     let mut args: Args = args::Args::parse(env::args().collect())?;
     let kernel_filename: String = args.kernel_filename().to_string();
@@ -87,10 +89,9 @@ fn main() -> Result<()> {
                 Some(Gateway::new(stream))
             },
             Err(e) => {
-                let reason: String = format!(
-                    "failed to connect to gateway (gateway_addr={addr:?}, error={e:?})",
-                );
-                error!("main()(): {reason}");
+                let reason: String =
+                    format!("failed to connect to gateway (gateway_addr={addr:?}, error={e:?})",);
+                error!("main(): {reason}");
                 anyhow::bail!(reason)
             },
         },
@@ -103,9 +104,16 @@ fn main() -> Result<()> {
     // Run virtual machine and check exit status code.
     match vmm.run()? {
         exit_status if exit_status != 0 => {
-            error!("main(): virtual machine exited with status {}", (exit_status as i16));
-            Err(anyhow::anyhow!("virtual machine exited with status {}", exit_status))
+            let exit_code: u8 = match exit_status.try_into() {
+                Ok(code) => code,
+                Err(_) => {
+                    let reason: &str = "failed to convert exit status";
+                    error!("main(): {reason}");
+                    anyhow::bail!(reason)
+                },
+            };
+            Ok(ExitCode::from(exit_code))
         },
-        _ => Ok(()),
+        _ => Ok(ExitCode::from(0)),
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to enhance the testing framework for Linuxd and improve error handling in the `microvm` module. The most notable updates include adding support for specifying expected exit codes in tests, extending the `Makefile` to include a new test, and refactoring the `microvm`'s `main` function to return an `ExitCode`. Below are the key changes grouped by theme:

### Testing Framework Enhancements:
* Added a new `test-linuxd-thread-c` test to the `Makefile` and updated the `LINUXD_TEST_RULE` macro to accept an additional parameter for the expected exit code. This ensures that tests can validate both output and exit status. (`Makefile`, [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R381) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L899-R914)
* Updated `scripts/test-linuxd.sh` to handle an additional argument for the expected exit code (`PROGRAM_EXPECTED_EXIT_CODE`) and modified the microvm status check to validate against this expected value. (`scripts/test-linuxd.sh`, [[1]](diffhunk://#diff-33f4bd84aa5f1c664ddacdb1eb934e1d55530617d94bca51561c524c4800eeb5L8-R9) [[2]](diffhunk://#diff-33f4bd84aa5f1c664ddacdb1eb934e1d55530617d94bca51561c524c4800eeb5L50-R51)

### Refactoring in `microvm` Module:
* Refactored the `main` function in `src/microvm/src/main.rs` to return a `Result<ExitCode>` instead of `Result<()>`. This allows the program to explicitly signal its exit status. (`src/microvm/src/main.rs`, [src/microvm/src/main.rsL59-R61](diffhunk://#diff-be789a13751f33d2d9e2bed8b84d11b70ecfe6d15b81aa205af10170e01e3c99L59-R61))
* Improved error handling in the `main` function by introducing type-safe conversion of exit statuses and logging errors when conversions fail. (`src/microvm/src/main.rs`, [src/microvm/src/main.rsL106-R117](diffhunk://#diff-be789a13751f33d2d9e2bed8b84d11b70ecfe6d15b81aa205af10170e01e3c99L106-R117))

### Minor Code Improvements:
* Added imports for `TryInto` and `ExitCode` in `src/microvm/src/main.rs` to support the new functionality. (`src/microvm/src/main.rs`, [src/microvm/src/main.rsR40-R42](diffhunk://#diff-be789a13751f33d2d9e2bed8b84d11b70ecfe6d15b81aa205af10170e01e3c99R40-R42))
* Simplified the formatting and logging in error messages within the `main` function. (`src/microvm/src/main.rs`, [src/microvm/src/main.rsL90-R94](diffhunk://#diff-be789a13751f33d2d9e2bed8b84d11b70ecfe6d15b81aa205af10170e01e3c99L90-R94))