### PR TITLE
[libs] Dummy Implementation for `posix_memalign()`

### DIFF
--- a/src/libs/posix/src/lib.rs
+++ b/src/libs/posix/src/lib.rs
@@ -62,6 +62,9 @@ pub mod utime;
 /// Execution scheduling.
 pub mod sched;
 
+/// Standard library definitions.
+pub mod stdlib;
+
 /// Signals
 pub mod signal;
 

--- a/src/libs/posix/src/stdlib/mod.rs
+++ b/src/libs/posix/src/stdlib/mod.rs
@@ -1,0 +1,31 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::char_lit_as_u8,
+    clippy::fn_to_numeric_cast,
+    clippy::fn_to_numeric_cast_with_truncation,
+    clippy::ptr_as_ptr,
+    clippy::unnecessary_cast,
+    invalid_reference_casting
+)]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+mod posix_memalign;
+
+//==================================================================================================
+// Exports
+//==================================================================================================
+
+pub use self::posix_memalign::posix_memalign;

--- a/src/libs/posix/src/stdlib/posix_memalign.rs
+++ b/src/libs/posix/src/stdlib/posix_memalign.rs
@@ -1,0 +1,109 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_void,
+    },
+    sys_types::c_size_t,
+};
+
+unsafe extern "C" {
+    pub fn malloc(size: c_size_t) -> *mut c_void;
+    pub fn free(ptr: *mut c_void);
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Allocates memory with a specified alignment.
+///
+/// # Parameters
+///
+/// - `memptr`: Pointer to a pointer where the allocated memory address will be stored.
+/// - `alignment`: The alignment requirement for the allocated memory.
+/// - `size`: The size of the memory block to be allocated.
+///
+/// # Returns
+///
+/// On success, returns `0`. On failure, returns an error code.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if all the following conditions are met:
+///
+/// - `memptr` points to a valid memory location that can store a `*mut c_void`.
+///
+#[unsafe(no_mangle)]
+pub unsafe fn posix_memalign(
+    memptr: *mut *mut c_void,
+    alignment: c_size_t,
+    size: c_size_t,
+) -> c_int {
+    ::syslog::trace!("posix_memalign(): alignment={alignment:?}, size={size:?}");
+
+    // TODO: Implement proper aligned memory allocation instead of using malloc.
+    // See: https://github.com/nanvix/nanvix/issues/648.
+
+    // Check if memptr is null.
+    if memptr.is_null() {
+        ::syslog::error!(
+            "posix_memalign(): invalid storage location (alignment={alignment:?}, size={size:?})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if size is invalid.
+    if size == 0 {
+        ::syslog::error!(
+            "posix_memalign(): invalid allocation size (alignment={alignment:?}, size={size:?})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if alignment is a power of two.
+    if alignment == 0 || (alignment & (alignment - 1)) != 0 {
+        ::syslog::error!(
+            "posix_memalign(): invalid alignment (alignment={alignment:?}, size={size:?})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Allocate memory.
+    let ptr: *mut c_void = malloc(size);
+
+    // Check if allocation was successful.
+    if ptr.is_null() {
+        ::syslog::error!(
+            "posix_memalign(): memory allocation failed (alignment={alignment:?}, size={size:?})"
+        );
+        return ErrorCode::OutOfMemory.get();
+    }
+
+    // Check if the allocated memory address is aligned.
+    if (ptr as usize) & (alignment as usize - 1) != 0 {
+        free(ptr);
+        ::syslog::warn!(
+            "posix_memalign(): failed to allocate aligned memory area (alignment={alignment:?}, \
+             size={size:?})"
+        );
+        return ErrorCode::OutOfMemory.get();
+    }
+
+    // Set the allocated memory address.
+    *memptr = ptr;
+
+    0
+}


### PR DESCRIPTION
This pull request introduces a new `stdlib` module to the POSIX library, which includes the implementation of the `posix_memalign` function for aligned memory allocation. The changes add a new module structure, enforce linting rules, and provide a partially implemented memory alignment function with error handling and logging.

### Addition of the `stdlib` module:

* [`src/libs/posix/src/lib.rs`](diffhunk://#diff-611f57ebdcb01574cf5216c7644eb94b126ca64fbcb8ad391f353ab3d44801e1R65-R67): Added a reference to the new `stdlib` module in the POSIX library.
* [`src/libs/posix/src/stdlib/mod.rs`](diffhunk://#diff-e87f0d09f75f5b99a36e623909e89052037a954e7ac8ff720960f2995de1b3adR1-R31): Introduced the `stdlib` module, including a lint configuration to enforce stricter code quality and an export for the `posix_memalign` function.

### Implementation of `posix_memalign`:

* [`src/libs/posix/src/stdlib/posix_memalign.rs`](diffhunk://#diff-7b46779c5ca21f05efdd50c0066ad8d572dc44ef74cb9be29d05da8dc7cf8765R1-R109): Added the `posix_memalign` function, which provides aligned memory allocation with error handling, logging, and validation for alignment and size constraints. The function uses `malloc` and `free` for memory management but includes a TODO to implement proper alignment.