### PR TITLE
[libs] Duplicate `__errno_location()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 license-file = "LICENSE.txt"
 authors = ["The Maintainers of Nanvix"]
 edition = "2021"

--- a/src/libs/posix/Cargo.toml
+++ b/src/libs/posix/Cargo.toml
@@ -19,7 +19,12 @@ sys = { workspace = true }
 cfg-if = { workspace = true }
 num_enum = { workspace = true }
 spin = { workspace = true, features = ["lazy", "spin_mutex"] }
-syscall = { workspace = true, features = ["syscall", "dlfcn", "sbrk"] }
+syscall = { workspace = true, features = [
+    "staticlib",
+    "syscall",
+    "dlfcn",
+    "sbrk",
+] }
 static_assert = { workspace = true }
 sysapi = { workspace = true }
 sysalloc = { workspace = true, optional = true }

--- a/src/libs/posix/src/errno.rs
+++ b/src/libs/posix/src/errno.rs
@@ -5,31 +5,4 @@
 // Imports
 //==================================================================================================
 
-cfg_if::cfg_if! {
-    if #[cfg(all(feature = "syscall", feature = "staticlib"))] {
-        use ::sysapi::ffi::c_int;
-
-        unsafe extern "C" {
-            pub fn __errno() -> *mut c_int;
-        }
-
-        ///
-        /// # Description
-        ///
-        /// Returns a pointer to `errno` variable.
-        ///
-        /// # Returns
-        ///
-        /// A mutable pointer to the `errno` variable.
-        ///
-        /// # Safety
-        ///
-        /// This function is unsafe because it may interoperate with external code.
-        ///
-        pub unsafe fn  __errno_location() -> *mut c_int {
-            __errno()
-        }
-    } else {
-        pub use ::syscall::errno::__errno_location;
-    }
-}
+pub use ::syscall::errno::__errno_location;

--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -39,6 +39,8 @@ compiler_builtins = { version = "0.1", optional = true }
 
 [features]
 default = ["syscall", "dlfcn", "sbrk"]
+# Enable this, if this library is to be used as a static library.
+staticlib = []
 syscall = ["dep:syslog", "sys/kcall"]
 std = []
 dlfcn = ["dep:sysalloc", "dep:arch", "dep:elf", "dep:goblin"]

--- a/src/libs/syscall/src/errno.rs
+++ b/src/libs/syscall/src/errno.rs
@@ -11,22 +11,47 @@ use ::sysapi::ffi::c_int;
 // Global Variables
 //==================================================================================================
 
-#[allow(non_upper_case_globals)]
-static mut errno: c_int = 0;
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "syscall", feature = "staticlib"))] {
+        unsafe extern "C" {
+            pub fn __errno() -> *mut c_int;
+        }
 
-///
-/// # Description
-///
-/// Returns a pointer to `errno` variable.
-///
-/// # Returns
-///
-/// A mutable pointer to the `errno` variable.
-///
-/// # Safety
-///
-/// This function is unsafe because it may interoperate with external code.
-///
-pub unsafe fn __errno_location() -> *mut c_int {
-    &raw mut errno as *mut c_int
+        ///
+        /// # Description
+        ///
+        /// Returns a pointer to `errno` variable.
+        ///
+        /// # Returns
+        ///
+        /// A mutable pointer to the `errno` variable.
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe because it may interoperate with external code.
+        ///
+        pub unsafe fn  __errno_location() -> *mut c_int {
+            __errno()
+        }
+    } else {
+        #[allow(non_upper_case_globals)]
+        static mut errno: c_int = 0;
+
+        ///
+        /// # Description
+        ///
+        /// Returns a pointer to `errno` variable.
+        ///
+        /// # Returns
+        ///
+        /// A mutable pointer to the `errno` variable.
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe because it may interoperate with external code.
+        ///
+        pub unsafe fn __errno_location() -> *mut c_int {
+            &raw mut errno as *mut c_int
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces updates to versioning, feature flags, and the handling of the `errno` variable across the project. The changes aim to support static library builds, improve modularity, and centralize the implementation of `errno`-related functionality.

### Versioning Update:
* Updated the workspace package version in `Cargo.toml` from `0.8.4` to `0.8.5`.

### Feature Flags and Dependencies:
* Enhanced the `syscall` dependency in `src/libs/posix/Cargo.toml` by adding a `staticlib` feature flag alongside existing features (`syscall`, `dlfcn`, `sbrk`) to support static library builds.
* Introduced a new `staticlib` feature in `src/libs/syscall/Cargo.toml` to enable static library usage for the `syscall` library.

### `errno` Handling Refactor:
* Removed the `cfg_if` block and associated `__errno` function implementation from `src/libs/posix/src/errno.rs`, delegating the handling of `errno` to the `syscall` library.
* Added a `cfg_if` block in `src/libs/syscall/src/errno.rs` to conditionally define the `__errno` function and `__errno_location` based on the `staticlib` and `syscall` features. This centralizes the `errno` implementation within the `syscall` library. [[1]](diffhunk://#diff-1bd6f5e4cdd0fed9d8cc107790854d1448d709ce651dbe1ac7b914c58022484fR14-R36) [[2]](diffhunk://#diff-1bd6f5e4cdd0fed9d8cc107790854d1448d709ce651dbe1ac7b914c58022484fR56-R57)