### PR TITLE
[daemons] Improving Performance of `linuxd`

### DIFF
--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -798,12 +798,11 @@ impl LinuxDaemon {
                 // Not connected to the gateway, print to stdout.
                 let count: usize = request.count as usize;
                 let buffer: &[u8] = &request.buffer[..count];
-                let string: String = String::from_utf8_lossy(buffer).to_string();
                 if request.fd == STDERR_FILENO {
-                    eprint!("{string}");
+                    let _ = io::stderr().write_all(buffer);
                     let _ = io::stderr().lock().flush();
                 } else {
-                    print!("{string}");
+                    let _ = io::stdout().write_all(buffer);
                     let _ = io::stdout().lock().flush();
                 }
                 WriteResponse::build(source, count as c_ssize_t)


### PR DESCRIPTION
This pull request refactors how output is written to `stdout` and `stderr` in the `LinuxDaemon` implementation to improve performance and reliability. The change replaces the use of `String::from_utf8_lossy` and formatted printing with direct byte buffer writes using `io::stdout` and `io::stderr`.

### Output handling improvements:
* [`src/daemons/linuxd/src/linuxd/mod.rs`](diffhunk://#diff-3f338666a190ef6bff1ad212b5c6b0e19628053297380dda6077502be41c4c74L801-R805): Replaced `String::from_utf8_lossy` and formatted printing (`eprint!` and `print!`) with direct use of `io::stderr().write_all` and `io::stdout().write_all` for writing byte buffers. This ensures more efficient and error-tolerant handling of non-UTF-8 data.