### PR TITLE
[libs] Thread Safe Allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.9"
+version = "0.8.10"
 license-file = "LICENSE.txt"
 authors = ["The Maintainers of Nanvix"]
 edition = "2021"

--- a/src/libs/sysalloc/Cargo.toml
+++ b/src/libs/sysalloc/Cargo.toml
@@ -11,15 +11,16 @@ description = "System Allocator"
 homepage.workspace = true
 
 [dependencies]
-arch = { workspace = true }
-talc = { workspace = true }
-cfg-if = { workspace = true }
-config = { workspace = true }
-syslog = { workspace = true }
-sys = { workspace = true, features = ["kcall"] }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
-core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+arch = { workspace = true }
+cfg-if = { workspace = true }
 compiler_builtins = { version = "0.1", optional = true }
+config = { workspace = true }
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+spin = { workspace = true, features = ["lazy", "spin_mutex"] }
+sys = { workspace = true, features = ["kcall"] }
+syslog = { workspace = true }
+talc = { workspace = true }
 
 [features]
 default = []

--- a/src/libs/sysalloc/src/allocator.rs
+++ b/src/libs/sysalloc/src/allocator.rs
@@ -19,6 +19,10 @@ use ::arch::mem::{
     PAGE_SIZE,
 };
 use ::core::ptr;
+use ::spin::{
+    Mutex,
+    MutexGuard,
+};
 use ::sys::{
     config::memory_layout::USER_HEAP_BASE,
     error::{
@@ -63,7 +67,7 @@ pub const BREAK_BASE_RAW: usize = config::memory_layout::USER_HEAP_BASE_RAW + RU
 #[cfg(not(feature = "rustc-dep-of-std"))]
 struct Allocator;
 
-static mut HEAP: Option<Talc<NanvixOomHandler>> = None;
+static HEAP: Mutex<Option<Talc<NanvixOomHandler>>> = Mutex::new(None);
 
 #[cfg_attr(not(feature = "rustc-dep-of-std"), global_allocator)]
 #[cfg(not(feature = "rustc-dep-of-std"))]
@@ -188,22 +192,21 @@ pub fn init() -> Result<(), Error> {
     let size: usize = PAGE_SIZE;
     let capacity: usize = RUST_HEAP_SIZE;
 
-    unsafe {
-        // Check if the heap was already initialized.
-        if HEAP.is_some() {
-            return Err(Error::new(ErrorCode::ResourceBusy, "heap already initialized"));
-        }
-
-        HEAP = Some(NanvixOomHandler::new(pid, addr, size, capacity)?);
+    let mut locked_heap: MutexGuard<'_, Option<Talc<NanvixOomHandler>>> = HEAP.lock();
+    // Check if the heap was already initialized.
+    if locked_heap.is_some() {
+        return Err(Error::new(ErrorCode::ResourceBusy, "heap already initialized"));
     }
+
+    *locked_heap = Some(NanvixOomHandler::new(pid, addr, size, capacity)?);
 
     Ok(())
 }
 
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn alloc(layout: Layout) -> *mut u8 {
-    let heap = ptr::addr_of_mut!(HEAP);
-    if let Some(heap) = &mut *heap {
+    let mut locked_heap: MutexGuard<'_, Option<Talc<NanvixOomHandler>>> = HEAP.lock();
+    if let Some(heap) = locked_heap.as_mut() {
         match heap.malloc(layout) {
             Ok(ptr) => ptr.as_ptr(),
             Err(_) => core::ptr::null_mut(),
@@ -216,8 +219,8 @@ pub unsafe fn alloc(layout: Layout) -> *mut u8 {
 
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
-    let heap = ptr::addr_of_mut!(HEAP);
-    if let Some(heap) = &mut *heap {
+    let mut locked_heap: MutexGuard<'_, Option<Talc<NanvixOomHandler>>> = HEAP.lock();
+    if let Some(heap) = locked_heap.as_mut() {
         if let Some(ptr) = ptr::NonNull::new(ptr) {
             heap.free(ptr, layout)
         }


### PR DESCRIPTION
This pull request introduces changes to the `sysalloc` library to improve thread safety by replacing an unsafe static variable with a `Mutex`. It also includes dependency updates in the `Cargo.toml` files and minor version increment for the workspace package.

### Thread safety improvements in `sysalloc`:

* Replaced the unsafe static `HEAP` variable with a `Mutex` to ensure safe concurrent access to the heap (`src/libs/sysalloc/src/allocator.rs`).
* Updated the `init`, `alloc`, and `dealloc` functions to use `MutexGuard` for accessing the heap, ensuring thread-safe operations (`src/libs/sysalloc/src/allocator.rs`). [[1]](diffhunk://#diff-c1aa162d25a40e8009df074558798f801b86d2c7276f29478bec20b634dd05acL191-R209) [[2]](diffhunk://#diff-c1aa162d25a40e8009df074558798f801b86d2c7276f29478bec20b634dd05acL219-R223)
* Added imports for `Mutex` and `MutexGuard` from the `spin` crate to support the new thread-safe implementation (`src/libs/sysalloc/src/allocator.rs`).

### Dependency updates:

* Updated `Cargo.toml` in the `sysalloc` library to include the `spin` crate with features `lazy` and `spin_mutex`. Reorganized and adjusted other dependencies (`src/libs/sysalloc/Cargo.toml`).

### Version increment:

* Incremented the workspace package version from `0.8.9` to `0.8.10` in the root `Cargo.toml` file (`Cargo.toml`).