### PR TITLE
[kernel] Box Thread State

### DIFF
--- a/src/kernel/src/pm/process/state/interrupted.rs
+++ b/src/kernel/src/pm/process/state/interrupted.rs
@@ -36,6 +36,7 @@ use ::type_safe::NonEmptyVecDeque;
 ///
 /// A type that represents a process that was interrupted.
 ///
+#[derive(Debug)]
 pub struct InterruptedProcess {
     state: Box<ProcessState>,
     sleeping_threads: Option<NonEmptyVecDeque<SleepingThread>>,

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -39,6 +39,7 @@ use sys::{
 // Runnable Process
 //==================================================================================================
 
+#[derive(Debug)]
 pub struct RunnableProcessWithReadyThread {
     state: Box<ProcessState>,
     ready_threads: NonEmptyVecDeque<ReadyThread>,
@@ -206,6 +207,7 @@ impl RunnableProcessWithReadyThread {
     }
 }
 
+#[derive(Debug)]
 pub struct RunnableProcessWithInterruptedThreads {
     state: Box<ProcessState>,
     ready_threads: Option<NonEmptyVecDeque<ReadyThread>>,
@@ -380,6 +382,7 @@ impl RunnableProcessWithInterruptedThreads {
     }
 }
 
+#[derive(Debug)]
 pub struct RunnableProcessWithReadyAndInteruptThread {
     state: Box<ProcessState>,
     ready_threads: NonEmptyVecDeque<ReadyThread>,
@@ -537,6 +540,7 @@ impl RunnableProcessWithReadyAndInteruptThread {
 ///
 /// A type that represents a process that is ready to run.
 ///
+#[derive(Debug)]
 pub enum RunnableProcess {
     WithReadyThread(RunnableProcessWithReadyThread),
     WithInterruptedThreads(RunnableProcessWithInterruptedThreads),

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -46,6 +46,7 @@ use ::type_safe::NonEmptyVecDeque;
 ///
 /// A type that represents a process that is running.
 ///
+#[derive(Debug)]
 pub struct RunningProcess {
     /// Process state.
     state: Box<ProcessState>,

--- a/src/kernel/src/pm/process/state/sleeping.rs
+++ b/src/kernel/src/pm/process/state/sleeping.rs
@@ -38,6 +38,7 @@ use ::type_safe::NonEmptyVecDeque;
 ///
 /// A type that represents a process that is waiting for a condition to be satisfied.
 ///
+#[derive(Debug)]
 pub struct SleepingProcess {
     state: Box<ProcessState>,
     sleeping_threads: NonEmptyVecDeque<SleepingThread>,

--- a/src/kernel/src/pm/process/state/zombie.rs
+++ b/src/kernel/src/pm/process/state/zombie.rs
@@ -26,6 +26,7 @@ use ::type_safe::NonEmptyVecDeque;
 /// A type that represents a process that finished its execution and is waiting for its parent
 /// to collect its exit status and release its resources.
 ///
+#[derive(Debug)]
 pub struct ZombieProcess {
     zombie_threads: NonEmptyVecDeque<ZombieThread>,
     process: Box<ProcessState>,

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -99,7 +99,7 @@ impl Drop for ThreadState {
 //==================================================================================================
 
 #[derive(Debug)]
-pub struct RunningThread(ThreadState);
+pub struct RunningThread(Box<ThreadState>);
 
 impl RunningThread {
     pub fn sleep(mut self, alarm: Option<SystemTime>) -> (SleepingThread, *mut ContextInformation) {
@@ -193,7 +193,7 @@ impl RunningThread {
 //==================================================================================================
 
 #[derive(Debug)]
-pub struct ReadyThread(ThreadState);
+pub struct ReadyThread(Box<ThreadState>);
 
 impl ReadyThread {
     pub fn new(
@@ -202,7 +202,7 @@ impl ReadyThread {
         user_stack: Option<UserStack>,
         context: ContextInformation,
     ) -> Self {
-        Self(ThreadState::new(id, kernel_stack, user_stack, context))
+        Self(Box::new(ThreadState::new(id, kernel_stack, user_stack, context)))
     }
 
     pub fn tid(&self) -> ThreadIdentifier {
@@ -232,7 +232,7 @@ impl ReadyThread {
 
 #[derive(Debug)]
 pub struct SleepingThread {
-    thread: ThreadState,
+    thread: Box<ThreadState>,
     alarm: Option<SystemTime>,
 }
 
@@ -275,7 +275,7 @@ pub enum InterruptReason {
 
 #[derive(Debug)]
 pub struct InterruptedThread {
-    thread: ThreadState,
+    thread: Box<ThreadState>,
     reason: InterruptReason,
 }
 
@@ -301,7 +301,7 @@ impl InterruptedThread {
 #[derive(Debug)]
 pub struct ZombieThread {
     status: ExitStatus,
-    state: ThreadState,
+    state: Box<ThreadState>,
 }
 
 impl ZombieThread {
@@ -347,7 +347,7 @@ impl ThreadManager {
         let id: ThreadIdentifier = self.next_id;
         self.next_id = ThreadIdentifier::from(<i32>::from(self.next_id) + 1);
 
-        ReadyThread(ThreadState::new(id, kernel_stack, user_stack, context))
+        ReadyThread(Box::new(ThreadState::new(id, kernel_stack, user_stack, context)))
     }
 }
 


### PR DESCRIPTION
This pull request introduces changes to improve debugging capabilities by adding `#[derive(Debug)]` to various process and thread structures and transitions several thread-related structs to use `Box<ThreadState>` for better memory management and consistency. 

### Debugging Enhancements:
* Added `#[derive(Debug)]` to the following structs to enable the use of the `Debug` trait for easier debugging:
  - `InterruptedProcess` in `src/kernel/src/pm/process/state/interrupted.rs`
  - `RunnableProcessWithReadyThread`, `RunnableProcessWithInterruptedThreads`, `RunnableProcessWithReadyAndInteruptThread`, and `RunnableProcess` in `src/kernel/src/pm/process/state/runnable.rs` [[1]](diffhunk://#diff-1a6f19fc3663704d151cd3c35eac68445f86b604613f5fc814747d027cfe33aaR42) [[2]](diffhunk://#diff-1a6f19fc3663704d151cd3c35eac68445f86b604613f5fc814747d027cfe33aaR210) [[3]](diffhunk://#diff-1a6f19fc3663704d151cd3c35eac68445f86b604613f5fc814747d027cfe33aaR385) [[4]](diffhunk://#diff-1a6f19fc3663704d151cd3c35eac68445f86b604613f5fc814747d027cfe33aaR543)
  - `RunningProcess` in `src/kernel/src/pm/process/state/running.rs`
  - `SleepingProcess` in `src/kernel/src/pm/process/state/sleeping.rs`
  - `ZombieProcess` in `src/kernel/src/pm/process/state/zombie.rs`

### Memory Management Improvements:
* Transitioned thread-related structs to use `Box<ThreadState>` instead of directly embedding `ThreadState`:
  - `RunningThread` in `src/kernel/src/pm/thread/mod.rs`
  - `ReadyThread` in `src/kernel/src/pm/thread/mod.rs` [[1]](diffhunk://#diff-68a79ef631e0c173295d4bfe400ddcd7c2aae177bb7e2028097a2e8a07192425L196-R196) [[2]](diffhunk://#diff-68a79ef631e0c173295d4bfe400ddcd7c2aae177bb7e2028097a2e8a07192425L205-R205) [[3]](diffhunk://#diff-68a79ef631e0c173295d4bfe400ddcd7c2aae177bb7e2028097a2e8a07192425L350-R350)
  - `SleepingThread` in `src/kernel/src/pm/thread/mod.rs`
  - `InterruptedThread` in `src/kernel/src/pm/thread/mod.rs`
  - `ZombieThread` in `src/kernel/src/pm/thread/mod.rs`