### PR TITLE
[kernel] Fix Kernel Scheduler

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -18,9 +18,7 @@ kstack_size = 32768
 timer_freq = 10000
 
 # Scheduler frequency (in ticks)
-# Notes:
-# - This should be a power of two.
-scheduler_freq = 1024
+scheduler_freq = 1000
 
 # Maximum number of messages that can be buffered by the kernel
 # Notes:

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -120,7 +120,7 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
             }
         },
         // SAFETY: The calling thread does not hold any resources.
-        KcallNumber::SchedulerYield => match unsafe { ProcessManager::switch() } {
+        KcallNumber::SchedulerYield => match unsafe { ProcessManager::giveup() } {
             Ok(()) => KcallResult::ok(),
             Err(e) => KcallResult::Error(e.code.into()),
         },

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -179,7 +179,7 @@ pub fn kcall_handler(
         // No work to do, so yield the CPU.
         if !kcall_handled && !message_received && !harvested_process {
             // SAFETY: the kernel process does not hold any resources.
-            if let Err(error) = unsafe { ProcessManager::switch() } {
+            if let Err(error) = unsafe { ProcessManager::giveup() } {
                 error!("context switch failed (error={:?})", error);
             }
         }

--- a/src/kernel/src/pm/clock.rs
+++ b/src/kernel/src/pm/clock.rs
@@ -20,12 +20,12 @@
 
 use crate::{
     hal::arch::InterruptNumber,
-    pm::ProcessManager,
+    pm::{
+        ProcessManager,
+        ORDER,
+    },
 };
-use ::core::sync::atomic::{
-    AtomicU32,
-    Ordering,
-};
+use ::core::sync::atomic::AtomicU32;
 use ::sys::time::{
     SystemTime,
     NANOSECONDS_PER_SECOND,
@@ -62,21 +62,21 @@ impl TimerTicks {
 
     /// Returns the number of ticks since the system started.
     fn get(&self) -> (u32, u32) {
-        (self.major.load(Ordering::SeqCst), self.minor.load(Ordering::SeqCst))
+        (self.major.load(ORDER), self.minor.load(ORDER))
     }
 
     /// Increments the number of ticks and returns the minor tick.
     fn increment(&self) -> u32 {
         // Safely increment `TIMER_TICKS`, assuming single-writer.
-        let minor: u32 = self.minor.load(Ordering::SeqCst);
+        let minor: u32 = self.minor.load(ORDER);
         let new_minor: u32 = minor.wrapping_add(1);
-        self.minor.store(new_minor, Ordering::SeqCst);
+        self.minor.store(new_minor, ORDER);
 
         // Check if the minor tick overflowed.
         if new_minor == 0 {
             // Safely increment `TIMER_TICKS_MAJOR`, assuming single-writer.
-            let major: u32 = self.major.load(Ordering::SeqCst);
-            self.major.store(major.wrapping_add(1), Ordering::SeqCst);
+            let major: u32 = self.major.load(ORDER);
+            self.major.store(major.wrapping_add(1), ORDER);
         }
 
         new_minor
@@ -103,12 +103,12 @@ impl TimerTicks {
 /// - It modifies global variables.
 ///
 pub unsafe fn timer_handler(_intnum: InterruptNumber) {
-    let timer_ticks: usize = TIMER_TICKS.increment() as usize;
+    TIMER_TICKS.increment();
 
     // Determine if a context switch is required. The kernel's running state is checked first to
     // prevent reentrant calls to the scheduler, which could lead to undefined behavior.
-    if !ProcessManager::is_kernel_running() && timer_ticks % config::kernel::SCHEDULER_FREQ == 0 {
-        if let Err(error) = ProcessManager::switch() {
+    if !ProcessManager::is_kernel_running() {
+        if let Err(error) = ProcessManager::giveup() {
             error!("context switch failed: {:?}", error);
         }
     }

--- a/src/kernel/src/pm/mod.rs
+++ b/src/kernel/src/pm/mod.rs
@@ -28,10 +28,20 @@ use crate::{
         ThreadManager,
     },
 };
+use ::core::sync::atomic::Ordering;
 use ::sys::{
     error::Error,
     pm::ProcessIdentifier,
 };
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Use relaxed ordering for all atomic operations to mitigate synchronization overhead. It is safe
+// to use this ordering semantics because Nanvix is a single-core system, and the kernel runs with
+// interrupts disabled.
+const ORDER: Ordering = Ordering::Relaxed;
 
 //==================================================================================================
 // Exports
@@ -74,27 +84,9 @@ pub fn copy_to_user<T>(
     pm.vmcopy_to_user(pid, dst, src, size)
 }
 
-///
-/// # Description
-///
-/// Checks the configuration of the processor manager.
-///
-/// # Notes
-///
-/// If the configuration is not correct, this function panics the kernel.
-///
-fn check_config() {
-    // Check if scheduler frequency is a power of two.
-    if !config::kernel::SCHEDULER_FREQ.is_power_of_two() {
-        panic!("scheduler frequency is not a power of two and it should");
-    }
-}
-
 /// Initializes the processor manager.
 pub fn init(hal: &mut Hal, root: Vmem) -> Result<ProcessManager, Error> {
     info!("initializing the processor manager...");
-
-    check_config();
 
     let interrupt_capable: bool = hal.intman.is_some();
 

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -554,15 +554,14 @@ impl ProcessManagerInner {
 
         self.check_alarm();
 
+        // Process all interrupted processes.
+        while let Some(interrupted_process) = self.interrupted.pop_front() {
+            let ready_process: RunnableProcess = interrupted_process.resume();
+            self.ready.push_back(ready_process);
+        }
+
         // Select next process to run.
-        let next_process: RunnableProcess = if let Some(next_process) = self.interrupted.pop_front()
-        {
-            // Schedule a thread from an interrupted process.
-            next_process.resume()
-        } else {
-            // Schedule a thread from a ready process.
-            self.take_ready()
-        };
+        let next_process: RunnableProcess = self.take_ready();
 
         let (next_process, reason, next_context): (
             RunningProcess,

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -82,7 +82,10 @@ use ::sys::{
         ErrorCode,
     },
     event::Event,
-    ipc::Message,
+    ipc::{
+        Message,
+        MessageReceiver,
+    },
     pm::{
         Capability,
         ConditionAddress,
@@ -94,7 +97,6 @@ use ::sys::{
     ExitStatus,
 };
 use ::type_safe::NonEmptyVecDeque;
-use sys::ipc::MessageReceiver;
 
 //==================================================================================================
 // Sleep Error
@@ -561,7 +563,7 @@ impl ProcessManagerInner {
         }
 
         // Select next process to run.
-        let next_process: RunnableProcess = self.take_ready();
+        let next_process: RunnableProcess = self.take_earliest_ready();
 
         let (next_process, reason, next_context): (
             RunningProcess,
@@ -647,7 +649,7 @@ impl ProcessManagerInner {
         };
 
         // Schedule another thread to run.
-        let next_process: RunnableProcess = self.take_ready();
+        let next_process: RunnableProcess = self.take_earliest_ready();
 
         let (next_process, reason, next_context): (
             RunningProcess,
@@ -815,7 +817,7 @@ impl ProcessManagerInner {
         };
 
         // Schedule another thread to run.
-        let next_process: RunnableProcess = self.take_ready();
+        let next_process: RunnableProcess = self.take_earliest_ready();
 
         let (next_process, reason, next_context): (
             RunningProcess,
@@ -900,7 +902,7 @@ impl ProcessManagerInner {
             };
 
         // Schedule another thread to run.
-        let next_process: RunnableProcess = self.take_ready();
+        let next_process: RunnableProcess = self.take_earliest_ready();
 
         let (next_process, reason, next_context): (
             RunningProcess,
@@ -1169,14 +1171,26 @@ impl ProcessManagerInner {
         Ok(mutex_guard)
     }
 
-    fn take_ready(&mut self) -> RunnableProcess {
-        match self.ready.pop_front() {
-            Some(runnable_process) => runnable_process,
-            None => {
-                // SAFETY: The follow statement is unreachable because the kernel process is always runnable.
-                unreachable!("the kernel process must be runnable")
-            },
+    fn take_earliest_ready(&mut self) -> RunnableProcess {
+        // SAFETY: As the kernel process is always runnable, the following statement will never panic.
+        let mut selected: (usize, SystemTime) = (
+            0,
+            self.ready
+                .front()
+                .expect("there should always be a process ready to run")
+                .earliest_admission_time(),
+        );
+
+        // Select process with the earliest admission time.
+        for (i, process) in self.ready.iter().enumerate() {
+            let process_admission_time: SystemTime = process.earliest_admission_time();
+            if process_admission_time < selected.1 {
+                selected = (i, process_admission_time);
+            }
         }
+
+        // Remove the selected process from the list of ready processes.
+        self.ready.remove(selected.0)
     }
 
     fn take_running(&mut self) -> RunningProcess {

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -529,58 +529,60 @@ impl ProcessManagerInner {
         Ok(pid)
     }
 
-    /// Schedule a process to run.
+    ///
+    /// # Description
+    ///
+    /// Schedule a thread to run.
+    ///
+    /// # Returns
+    ///
+    /// Returns a tuple containing:
+    /// - The process identifier of the next thread to run.
+    /// - The thread identifier of the next thread to run.
+    /// - A pointer to the context information of the previous thread.
+    /// - A pointer to the context information of the next thread.
+    ///
     fn schedule(
         &mut self,
-    ) -> Option<(ProcessIdentifier, *mut ContextInformation, *mut ContextInformation)> {
+    ) -> (ProcessIdentifier, ThreadIdentifier, *mut ContextInformation, *mut ContextInformation)
+    {
         // Reschedule running process.
         let previous_process: RunningProcess = self.take_running();
-
-        let previous_pid: ProcessIdentifier = previous_process.state().pid();
-        let previous_tid: ThreadIdentifier = previous_process.get_tid();
 
         let (previous_process, previous_context) = previous_process.schedule();
         self.ready.push_back(previous_process);
 
         self.check_alarm();
 
-        // Select next ready process to run.
-        if let Some(next_process) = self.interrupted.pop_front() {
+        // Select next process to run.
+        let (next_process, reason, next_context): (
+            RunningProcess,
+            Option<InterruptReason>,
+            *mut ContextInformation,
+        ) = if let Some(next_process) = self.interrupted.pop_front() {
+            // Schedule a thread from an interrupted process.
             let (next_process, reason, next_context): (
                 RunningProcess,
                 InterruptReason,
                 *mut ContextInformation,
             ) = next_process.resume();
-
-            let next_pid: ProcessIdentifier = next_process.state().pid();
-            self.interrupt_reason = Some(reason);
-            self.running = Some(next_process);
-            Some((next_pid, previous_context, next_context))
+            (next_process, Some(reason), next_context)
         } else {
+            // Schedule a thread from a ready process.
             let next_process: RunnableProcess = self.take_ready();
-            let (next_process, reason, next_context): (
-                RunningProcess,
-                Option<InterruptReason>,
-                *mut ContextInformation,
-            ) = next_process.run();
 
-            self.interrupt_reason = reason;
-            let next_pid: ProcessIdentifier = next_process.state().pid();
-            let next_tid: ThreadIdentifier = next_process.get_tid();
-            self.running = Some(next_process);
+            next_process.run()
+        };
 
-            if previous_tid == next_tid && previous_pid == next_pid {
-                if previous_pid != ProcessIdentifier::KERNEL {
-                    panic!("schedule(): rescheduling non kernel thread (pid={previous_pid:?})");
-                }
-                return None;
-            }
-
-            Some((next_pid, previous_context, next_context))
-        }
+        let next_pid: ProcessIdentifier = next_process.state().pid();
+        let next_tid: ThreadIdentifier = next_process.get_tid();
+        self.interrupt_reason = reason;
+        self.running = Some(next_process);
+        (next_pid, next_tid, previous_context, next_context)
     }
 
-    // Traverses list of sleeping processes checking for alarms.
+    // Traverses the list of sleeping processes, checking for expired alarms and moving processes
+    // whose alarms have expired from the `suspended` to `interrupted` list.
     fn check_alarm(&mut self) {
         let now: SystemTime = clock::now();
 
@@ -609,7 +611,7 @@ impl ProcessManagerInner {
     ///
     /// # Description
     ///
-    /// Puts the calling thread to sleep.
+    /// Suspends the execution of the calling thread and schedules another thread to run.
     ///
     /// # Parameters
     ///
@@ -617,30 +619,41 @@ impl ProcessManagerInner {
     ///
     /// # Returns
     ///
-    /// Upon successful completion, empty is returned. Otherwise, an error code is returned instead.
+    /// Returns a tuple containing:
+    /// - The process identifier of the next thread to run.
+    /// - The thread identifier of the next thread to run.
+    /// - A pointer to the context information of the previous thread.
+    /// - A pointer to the context information of the next thread.
     ///
     fn sleep(
         &mut self,
         alarm: Option<SystemTime>,
-    ) -> (*mut ContextInformation, *mut ContextInformation) {
+    ) -> (ProcessIdentifier, ThreadIdentifier, *mut ContextInformation, *mut ContextInformation)
+    {
         let running_process: RunningProcess = self.take_running();
 
         // Check if kernel is trying to sleep.
         if running_process.state().pid() == ProcessIdentifier::KERNEL {
-            panic!("kernel process cannot sleep");
+            panic!("sleep(): kernel process cannot sleep");
         }
 
-        match running_process.sleep(alarm) {
+        // Suspend the execution of the calling thread and schedule another thread to run.
+        let (next_process, reason, previous_context, next_context): (
+            RunningProcess,
+            Option<InterruptReason>,
+            *mut ContextInformation,
+            *mut ContextInformation,
+        ) = match running_process.sleep(alarm) {
+            // The calling process still has runnable threads, schedule one of them.
             Ok((runnable_process, previous_context)) => {
                 let (next_process, reason, next_context): (
                     RunningProcess,
                     Option<InterruptReason>,
                     *mut ContextInformation,
                 ) = runnable_process.run();
-                self.interrupt_reason = reason;
-                self.running = Some(next_process);
-                (previous_context, next_context)
+                (next_process, reason, previous_context, next_context)
             },
+            // The calling process has only sleeping threads left, schedule a thread from another process.
             Err((suspended_process, previous_context)) => {
                 self.suspended.push_back(suspended_process);
                 let next_process: RunnableProcess = self.take_ready();
@@ -649,11 +662,15 @@ impl ProcessManagerInner {
                     Option<InterruptReason>,
                     *mut ContextInformation,
                 ) = next_process.run();
-                self.interrupt_reason = reason;
-                self.running = Some(next_process);
-                (previous_context, next_context)
+                (next_process, reason, previous_context, next_context)
             },
-        }
+        };
+
+        let next_pid: ProcessIdentifier = next_process.state().pid();
+        let next_tid: ThreadIdentifier = next_process.get_tid();
+        self.interrupt_reason = reason;
+        self.running = Some(next_process);
+        (next_pid, next_tid, previous_context, next_context)
     }
 
     ///
@@ -760,10 +777,28 @@ impl ProcessManagerInner {
         None
     }
 
-    pub fn exit(
+    ///
+    /// # Description
+    ///
+    /// Terminates the calling process.
+    ///
+    /// # Parameters
+    ///
+    /// - `status`: Exit status.
+    ///
+    /// # Returns
+    ///
+    /// Returns a tuple containing:
+    /// - The process identifier of the next thread to run.
+    /// - The thread identifier of the next thread to run.
+    /// - A pointer to the context information of the previous thread.
+    /// - A pointer to the context information of the next thread.
+    ///
+    fn exit(
         &mut self,
         status: ExitStatus,
-    ) -> (*mut ContextInformation, *mut ContextInformation) {
+    ) -> (ProcessIdentifier, ThreadIdentifier, *mut ContextInformation, *mut ContextInformation)
+    {
         let running_process: RunningProcess = self.take_running();
         trace!(
             "exit(): pid={:?}, tid={:?}, status={status:?}",
@@ -776,33 +811,46 @@ impl ProcessManagerInner {
             panic!("kernel process cannot exit");
         }
 
-        match running_process.exit(status) {
+        // Terminate the calling thread and schedule another thread to run.
+        let (next_process, reason, previous_context, next_context): (
+            RunningProcess,
+            Option<InterruptReason>,
+            *mut ContextInformation,
+            *mut ContextInformation,
+        ) = match running_process.exit(status) {
+            // The calling process still has runnable threads, schedule one of them.
             Ok((runnable_process, previous_context)) => {
-                let (running_process, reason, next_context) = runnable_process.run();
-                self.interrupt_reason = reason;
-                self.running = Some(running_process);
-                (previous_context, next_context)
+                let (next_process, reason, next_context): (
+                    RunningProcess,
+                    Option<InterruptReason>,
+                    *mut ContextInformation,
+                ) = runnable_process.run();
+                (next_process, reason, previous_context, next_context)
             },
+            // The calling process has only sleeping threads left, schedule a thread from another process.
             Err((zombie_process, previous_context)) => {
                 self.zombies.push_back(zombie_process);
-
-                match self.ready.pop_front() {
-                    Some(runnable_process) => {
-                        let (running_process, reason, next_context) = runnable_process.run();
-                        self.interrupt_reason = reason;
-                        self.running = Some(running_process);
-                        (previous_context, next_context)
-                    },
-                    None => unreachable!("the kernel process is always ready to run"),
-                }
+                let next_process: RunnableProcess = self.take_ready();
+                let (next_process, reason, next_context): (
+                    RunningProcess,
+                    Option<InterruptReason>,
+                    *mut ContextInformation,
+                ) = next_process.run();
+                (next_process, reason, previous_context, next_context)
             },
-        }
+        };
+
+        let next_pid: ProcessIdentifier = next_process.state().pid();
+        let next_tid: ThreadIdentifier = next_process.get_tid();
+        self.interrupt_reason = reason;
+        self.running = Some(next_process);
+        (next_pid, next_tid, previous_context, next_context)
     }
 
     ///
     /// # Description
     ///
-    /// Exits the calling thread.
+    /// Terminates the calling thread.
     ///
     /// # Parameters
     ///
@@ -810,8 +858,11 @@ impl ProcessManagerInner {
     ///
     /// # Returns
     ///
-    /// Upon successful completion, this function does not return. Otherwise, an error code is
-    /// returned instead.
+    /// Returns a tuple containing:
+    /// - The process identifier of the next thread to run.
+    /// - The thread identifier of the next thread to run.
+    /// - A pointer to the context information of the previous thread.
+    /// - A pointer to the context information of the next thread.
     ///
     /// # Safety
     ///
@@ -821,10 +872,16 @@ impl ProcessManagerInner {
     ///
     /// - The calling process is not the kernel process.
     ///
-    pub(super) unsafe fn exit_thread(
+    fn exit_thread(
         &mut self,
         status: ExitStatus,
-    ) -> (Condvar, *mut ContextInformation, *mut ContextInformation) {
+    ) -> (
+        ProcessIdentifier,
+        ThreadIdentifier,
+        Condvar,
+        *mut ContextInformation,
+        *mut ContextInformation,
+    ) {
         let running_process: RunningProcess = self.take_running();
 
         trace!(
@@ -836,43 +893,60 @@ impl ProcessManagerInner {
 
         // Check if kernel is trying to exit.
         if running_process.state().pid() == ProcessIdentifier::KERNEL {
-            panic!("kernel process cannot exit");
+            panic!("exit_thread(): kernel process cannot exit (status={status:?})");
         }
 
-        match running_process.exit_thread(status) {
+        // Terminate the calling thread and schedule another thread to run.
+        let (join_cond, next_process, reason, previous_context, next_context): (
+            Condvar,
+            RunningProcess,
+            Option<InterruptReason>,
+            *mut ContextInformation,
+            *mut ContextInformation,
+        ) = match running_process.exit_thread(status) {
+            // The calling process still has runnable threads, schedule one of them.
             Ok((join_cond, runnable_process, previous_context)) => {
-                let (running_process, reason, next_context) = runnable_process.run();
-                self.interrupt_reason = reason;
-                self.running = Some(running_process);
-                (join_cond, previous_context, next_context)
+                let (next_process, reason, next_context): (
+                    RunningProcess,
+                    Option<InterruptReason>,
+                    *mut ContextInformation,
+                ) = runnable_process.run();
+                (join_cond, next_process, reason, previous_context, next_context)
             },
+            // The calling process has only sleeping threads left, schedule a thread from another process.
             Err(Ok((join_cond, sleeping_process, previous_context))) => {
                 self.suspended.push_back(sleeping_process);
 
-                match self.ready.pop_front() {
-                    Some(runnable_process) => {
-                        let (running_process, reason, next_context) = runnable_process.run();
-                        self.interrupt_reason = reason;
-                        self.running = Some(running_process);
-                        (join_cond, previous_context, next_context)
-                    },
-                    None => unreachable!("the kernel process is always ready to run"),
-                }
+                let next_process: RunnableProcess = self.take_ready();
+
+                let (next_process, reason, next_context): (
+                    RunningProcess,
+                    Option<InterruptReason>,
+                    *mut ContextInformation,
+                ) = next_process.run();
+                (join_cond, next_process, reason, previous_context, next_context)
             },
+            // The calling process has only zombie threads left, schedule a thread from another process.
             Err(Err((join_cond, zombie_process, previous_context))) => {
                 self.zombies.push_back(zombie_process);
 
-                match self.ready.pop_front() {
-                    Some(runnable_process) => {
-                        let (running_process, reason, next_context) = runnable_process.run();
-                        self.interrupt_reason = reason;
-                        self.running = Some(running_process);
-                        (join_cond, previous_context, next_context)
-                    },
-                    None => unreachable!("the kernel process is always ready to run"),
-                }
+                let next_process: RunnableProcess = self.take_ready();
+
+                let (next_process, reason, next_context): (
+                    RunningProcess,
+                    Option<InterruptReason>,
+                    *mut ContextInformation,
+                ) = next_process.run();
+
+                (join_cond, next_process, reason, previous_context, next_context)
             },
-        }
+        };
+
+        let next_pid: ProcessIdentifier = next_process.state().pid();
+        let next_tid: ThreadIdentifier = next_process.get_tid();
+        self.interrupt_reason = reason;
+        self.running = Some(next_process);
+        (next_pid, next_tid, join_cond, previous_context, next_context)
     }
 
     pub fn terminate(&mut self, pid: ProcessIdentifier) -> Result<(), Error> {
@@ -1129,10 +1203,13 @@ impl ProcessManagerInner {
     }
 
     fn take_ready(&mut self) -> RunnableProcess {
-        // NOTE: it is safe to call unwrap because there is always a process ready to run.
-        self.ready
-            .pop_front()
-            .expect("the kernel should be ready to run")
+        match self.ready.pop_front() {
+            Some(runnable_process) => runnable_process,
+            None => {
+                // SAFETY: The follow statement is unreachable because the kernel process is always runnable.
+                unreachable!("the kernel process must be runnable")
+            },
+        }
     }
 
     fn take_running(&mut self) -> RunningProcess {

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -555,24 +555,20 @@ impl ProcessManagerInner {
         self.check_alarm();
 
         // Select next process to run.
+        let next_process: RunnableProcess = if let Some(next_process) = self.interrupted.pop_front()
+        {
+            // Schedule a thread from an interrupted process.
+            next_process.resume()
+        } else {
+            // Schedule a thread from a ready process.
+            self.take_ready()
+        };
+
         let (next_process, reason, next_context): (
             RunningProcess,
             Option<InterruptReason>,
             *mut ContextInformation,
-        ) = if let Some(next_process) = self.interrupted.pop_front() {
-            // Schedule a thread from an interrupted process.
-            let (next_process, reason, next_context): (
-                RunningProcess,
-                InterruptReason,
-                *mut ContextInformation,
-            ) = next_process.resume();
-            (next_process, Some(reason), next_context)
-        } else {
-            // Schedule a thread from a ready process.
-            let next_process: RunnableProcess = self.take_ready();
-
-            next_process.run()
-        };
+        ) = next_process.run();
 
         let next_pid: ProcessIdentifier = next_process.state().pid();
         let next_tid: ThreadIdentifier = next_process.get_tid();

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -934,7 +934,8 @@ impl ProcessManagerInner {
         if let Some(process) = self.ready.iter().position(|p| p.state().pid() == pid) {
             let process: RunnableProcess = self.ready.remove(process);
             match process.terminate() {
-                Ok(runnable_process) => {
+                Ok(interrupted_process) => {
+                    let runnable_process: RunnableProcess = interrupted_process.resume();
                     self.ready.push_back(runnable_process);
                     return Ok(());
                 },

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -637,34 +637,28 @@ impl ProcessManagerInner {
             panic!("sleep(): kernel process cannot sleep");
         }
 
-        // Suspend the execution of the calling thread and schedule another thread to run.
-        let (next_process, reason, previous_context, next_context): (
+        // Suspend the execution of the calling thread.
+        let previous_context: *mut ContextInformation = match running_process.sleep(alarm) {
+            // The calling process still has runnable threads, put it in the list of ready processes.
+            Ok((runnable_process, previous_context)) => {
+                self.ready.push_back(runnable_process);
+                previous_context
+            },
+            // The calling process has only sleeping threads left, put it in the list of suspended processes.
+            Err((suspended_process, previous_context)) => {
+                self.suspended.push_back(suspended_process);
+                previous_context
+            },
+        };
+
+        // Schedule another thread to run.
+        let next_process: RunnableProcess = self.take_ready();
+
+        let (next_process, reason, next_context): (
             RunningProcess,
             Option<InterruptReason>,
             *mut ContextInformation,
-            *mut ContextInformation,
-        ) = match running_process.sleep(alarm) {
-            // The calling process still has runnable threads, schedule one of them.
-            Ok((runnable_process, previous_context)) => {
-                let (next_process, reason, next_context): (
-                    RunningProcess,
-                    Option<InterruptReason>,
-                    *mut ContextInformation,
-                ) = runnable_process.run();
-                (next_process, reason, previous_context, next_context)
-            },
-            // The calling process has only sleeping threads left, schedule a thread from another process.
-            Err((suspended_process, previous_context)) => {
-                self.suspended.push_back(suspended_process);
-                let next_process: RunnableProcess = self.take_ready();
-                let (next_process, reason, next_context): (
-                    RunningProcess,
-                    Option<InterruptReason>,
-                    *mut ContextInformation,
-                ) = next_process.run();
-                (next_process, reason, previous_context, next_context)
-            },
-        };
+        ) = next_process.run();
 
         let next_pid: ProcessIdentifier = next_process.state().pid();
         let next_tid: ThreadIdentifier = next_process.get_tid();
@@ -811,34 +805,28 @@ impl ProcessManagerInner {
             panic!("kernel process cannot exit");
         }
 
-        // Terminate the calling thread and schedule another thread to run.
-        let (next_process, reason, previous_context, next_context): (
+        // Terminate the calling thread.
+        let previous_context: *mut ContextInformation = match running_process.exit(status) {
+            // The calling process still has runnable threads, put it in the list of ready processes.
+            Ok((runnable_process, previous_context)) => {
+                self.ready.push_back(runnable_process);
+                previous_context
+            },
+            // The calling process has only sleeping threads left, put it in the list of zombies processes.
+            Err((zombie_process, previous_context)) => {
+                self.zombies.push_back(zombie_process);
+                previous_context
+            },
+        };
+
+        // Schedule another thread to run.
+        let next_process: RunnableProcess = self.take_ready();
+
+        let (next_process, reason, next_context): (
             RunningProcess,
             Option<InterruptReason>,
             *mut ContextInformation,
-            *mut ContextInformation,
-        ) = match running_process.exit(status) {
-            // The calling process still has runnable threads, schedule one of them.
-            Ok((runnable_process, previous_context)) => {
-                let (next_process, reason, next_context): (
-                    RunningProcess,
-                    Option<InterruptReason>,
-                    *mut ContextInformation,
-                ) = runnable_process.run();
-                (next_process, reason, previous_context, next_context)
-            },
-            // The calling process has only sleeping threads left, schedule a thread from another process.
-            Err((zombie_process, previous_context)) => {
-                self.zombies.push_back(zombie_process);
-                let next_process: RunnableProcess = self.take_ready();
-                let (next_process, reason, next_context): (
-                    RunningProcess,
-                    Option<InterruptReason>,
-                    *mut ContextInformation,
-                ) = next_process.run();
-                (next_process, reason, previous_context, next_context)
-            },
-        };
+        ) = next_process.run();
 
         let next_pid: ProcessIdentifier = next_process.state().pid();
         let next_tid: ThreadIdentifier = next_process.get_tid();
@@ -897,50 +885,33 @@ impl ProcessManagerInner {
         }
 
         // Terminate the calling thread and schedule another thread to run.
-        let (join_cond, next_process, reason, previous_context, next_context): (
-            Condvar,
+        let (join_cond, previous_context): (Condvar, *mut ContextInformation) =
+            match running_process.exit_thread(status) {
+                // The calling process still has runnable threads, put it in the list of ready processes.
+                Ok((join_cond, runnable_process, previous_context)) => {
+                    self.ready.push_back(runnable_process);
+                    (join_cond, previous_context)
+                },
+                // The calling process has only sleeping threads left, put it in the list of suspended processes.
+                Err(Ok((join_cond, sleeping_process, previous_context))) => {
+                    self.suspended.push_back(sleeping_process);
+                    (join_cond, previous_context)
+                },
+                // The calling process has only zombie threads left, put it in the list of zombies processes.
+                Err(Err((join_cond, zombie_process, previous_context))) => {
+                    self.zombies.push_back(zombie_process);
+                    (join_cond, previous_context)
+                },
+            };
+
+        // Schedule another thread to run.
+        let next_process: RunnableProcess = self.take_ready();
+
+        let (next_process, reason, next_context): (
             RunningProcess,
             Option<InterruptReason>,
             *mut ContextInformation,
-            *mut ContextInformation,
-        ) = match running_process.exit_thread(status) {
-            // The calling process still has runnable threads, schedule one of them.
-            Ok((join_cond, runnable_process, previous_context)) => {
-                let (next_process, reason, next_context): (
-                    RunningProcess,
-                    Option<InterruptReason>,
-                    *mut ContextInformation,
-                ) = runnable_process.run();
-                (join_cond, next_process, reason, previous_context, next_context)
-            },
-            // The calling process has only sleeping threads left, schedule a thread from another process.
-            Err(Ok((join_cond, sleeping_process, previous_context))) => {
-                self.suspended.push_back(sleeping_process);
-
-                let next_process: RunnableProcess = self.take_ready();
-
-                let (next_process, reason, next_context): (
-                    RunningProcess,
-                    Option<InterruptReason>,
-                    *mut ContextInformation,
-                ) = next_process.run();
-                (join_cond, next_process, reason, previous_context, next_context)
-            },
-            // The calling process has only zombie threads left, schedule a thread from another process.
-            Err(Err((join_cond, zombie_process, previous_context))) => {
-                self.zombies.push_back(zombie_process);
-
-                let next_process: RunnableProcess = self.take_ready();
-
-                let (next_process, reason, next_context): (
-                    RunningProcess,
-                    Option<InterruptReason>,
-                    *mut ContextInformation,
-                ) = next_process.run();
-
-                (join_cond, next_process, reason, previous_context, next_context)
-            },
-        };
+        ) = next_process.run();
 
         let next_pid: ProcessIdentifier = next_process.state().pid();
         let next_tid: ThreadIdentifier = next_process.get_tid();

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -2,12 +2,6 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
-// Global Variables
-//==================================================================================================
-
-static mut PROCESS_MANAGER: Option<ProcessManager> = None;
-
-//==================================================================================================
 // Imports
 //==================================================================================================
 
@@ -47,10 +41,12 @@ use crate::{
             ZombieThread,
         },
         SleepError,
+        ORDER,
     },
 };
 use ::alloc::rc::Rc;
 use ::arch::mem::PAGE_SIZE;
+use ::config::kernel::SCHEDULER_FREQ;
 use ::core::{
     cell::{
         RefCell,
@@ -62,7 +58,7 @@ use ::core::{
     },
     sync::atomic::{
         AtomicI32,
-        Ordering,
+        AtomicUsize,
     },
 };
 use ::sys::{
@@ -82,8 +78,17 @@ use ::sys::{
 // Global Variables
 //==================================================================================================
 
-/// PID of the current process.
+/// Process manager.
+static mut PROCESS_MANAGER: Option<ProcessManager> = None;
+
+/// ID of the current process.
 static CURRENT_PID: AtomicI32 = AtomicI32::new(ProcessIdentifier::KERNEL_RAW);
+
+// ID of the current thread.
+static CURRENT_TID: AtomicI32 = AtomicI32::new(ProcessIdentifier::KERNEL_RAW);
+
+/// Remaining quantum for the current thread.
+static REMAINING_QUANTUM: AtomicUsize = AtomicUsize::new(SCHEDULER_FREQ);
 
 //==================================================================================================
 // Implementations
@@ -177,35 +182,7 @@ impl ProcessManager {
     ///
     /// # Description
     ///
-    /// Exits the calling process.
-    ///
-    /// # Returns
-    ///
-    /// Upon successful completion, this function does not return. Otherwise, an error code is
-    /// returned instead.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe because it may cause the calling process to exit.
-    ///
-    /// This function is safe to use if an only if the following conditions are met:
-    ///
-    /// - The calling process is not the kernel process.
-    ///
-    pub unsafe fn exit(status: ExitStatus) -> Result<!, Error> {
-        trace!("exit(): status={:?}", status);
-        // SAFETY: This is the only thread running, thus access to the process manager is synchronized.
-        let (from, to): (*mut ContextInformation, *mut ContextInformation) =
-            unsafe { Self::get_mut() }.try_borrow_mut()?.exit(status);
-
-        ContextInformation::switch(from, to);
-        core::hint::unreachable_unchecked()
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Exits the calling thread.
+    /// Terminates the calling process.
     ///
     /// # Parameters
     ///
@@ -213,33 +190,100 @@ impl ProcessManager {
     ///
     /// # Returns
     ///
-    /// Upon successful completion, this function does not return. Otherwise, an error code is
-    /// returned instead.
+    /// Upon successful completion, this function does not return. The current thread terminates,
+    /// and any other threads in the calling process are scheduled for termination. Once all threads
+    /// in the process have terminated, the kernel will clean up any resources associated with the
+    /// process.  If an error occurs, an error code is returned instead.
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it operates on global variables and it may panic.
+    /// This function is unsafe because it may terminate the calling thread.
     ///
-    /// This function is safe to use if and only if the following conditions are met:
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - The calling thread is not a kernel thread.
+    /// - The process manager is initialized.
+    /// - The calling thread does not hold a reference to the process manager.
+    /// - Access to the process manager is synchronized.
     ///
-    /// - The calling process is not the kernel process.
-    /// - The calling process does not hold a reference to the process manager.
+    pub unsafe fn exit(status: ExitStatus) -> Result<!, Error> {
+        trace!("exit(): status={status:?}");
+
+        // Terminate the calling process and select another process to run next.
+        let (next_pid, next_tid, from, to): (
+            ProcessIdentifier,
+            ThreadIdentifier,
+            *mut ContextInformation,
+            *mut ContextInformation,
+        ) = Self::get_mut().try_borrow_mut()?.exit(status);
+
+        // SAFETY: `from` and `to` point to valid context information structures, and the processor
+        // is running with interrupts disabled.
+        Self::switch(next_pid, next_tid, from, to);
+
+        // SAFETY: Self::switch() performs a context switch and never returns. If this line is ever
+        // reached, it indicates a critical bug and undefined behavior. This is considered
+        // unreachable by design.
+        core::hint::unreachable_unchecked()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Terminates the calling thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `status`: Exit status.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return on success: the current thread is terminated, and its exit
+    /// status is made available to any threads waiting for it. If the calling thread is the last
+    /// thread in its process, the process is also terminated and all associated resources are
+    /// cleaned up. If an error occurs, an error code is returned instead.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it may terminate the calling thread.
+    ///
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - The calling thread is not a kernel thread.
+    /// - The process manager is initialized.
+    /// - The calling thread does not hold a reference to the process manager.
+    /// - Access to the process manager is synchronized.
     ///
     pub unsafe fn exit_thread(status: ExitStatus) -> Result<!, Error> {
-        let (from, to): (*mut ContextInformation, *mut ContextInformation) = {
+        // Terminate the calling thread and select another thread to run next.
+        let (next_pid, next_tid, from, to): (
+            ProcessIdentifier,
+            ThreadIdentifier,
+            *mut ContextInformation,
+            *mut ContextInformation,
+        ) = {
             // Create a scope so the join condition variable is dropped before we context switch.
             // If we do not do this, the condition variable the reference count for the condition
             // variable will not be decremented, causing a memory leak.
 
-            let (join_cond, from, to): (Condvar, *mut ContextInformation, *mut ContextInformation) =
-                Self::get_mut().try_borrow_mut()?.exit_thread(status);
+            let (next_pid, next_tid, join_cond, from, to): (
+                ProcessIdentifier,
+                ThreadIdentifier,
+                Condvar,
+                *mut ContextInformation,
+                *mut ContextInformation,
+            ) = Self::get_mut().try_borrow_mut()?.exit_thread(status);
 
             join_cond.notify_all()?;
 
-            (from, to)
+            (next_pid, next_tid, from, to)
         };
 
-        ContextInformation::switch(from, to);
+        // SAFETY: `from` and `to` point to valid context information structures, and the processor
+        // is running with interrupts disabled.
+        Self::switch(next_pid, next_tid, from, to);
+
+        // SAFETY: Self::switch() performs a context switch and never returns. If this line is ever
+        // reached, it indicates a critical bug and undefined behavior. This is considered
+        // unreachable by design.
         core::hint::unreachable_unchecked()
     }
 
@@ -346,7 +390,8 @@ impl ProcessManager {
     ///
     /// # Description
     ///
-    /// Puts the calling thread to sleep.
+    /// Suspends the execution of the calling thread until it is woken up by another thread or until
+    /// the specified alarm time is reached.
     ///
     /// # Parameters
     ///
@@ -358,28 +403,41 @@ impl ProcessManager {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it performs a context switch, causing the current thread to
-    /// block until it is woken up by another thread.
+    /// This function is unsafe because it performs a context switch, suspending the execution of
+    /// the current thread until it is woken up by another thread or until the specified alarm time
+    /// is reached.
     ///
-    /// This function is safe to use if and only if the following conditions are met:
-    ///
-    /// - The calling process is not the kernel process.
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - The calling thread is not a kernel thread.
+    /// - The process manager is initialized.
+    /// - The calling thread does not hold a reference to the process manager.
+    /// - Access to the process manager is synchronized.
     ///
     pub unsafe fn sleep(alarm: Option<SystemTime>) -> Result<(), SleepError> {
-        let (from, to): (*mut ContextInformation, *mut ContextInformation) = Self::get_mut()
+        // Suspend the execution of the calling thread and select another thread to run next.
+        let (next_pid, next_tid, from, to): (
+            ProcessIdentifier,
+            ThreadIdentifier,
+            *mut ContextInformation,
+            *mut ContextInformation,
+        ) = Self::get_mut()
             .try_borrow_mut()
             .map_err(SleepError::Generic)?
             .sleep(alarm);
 
-        ContextInformation::switch(from, to);
+        // SAFETY: `from` and `to` point to valid context information structures, and the processor
+        // is running with interrupts disabled.
+        Self::switch(next_pid, next_tid, from, to);
 
+        // Check the reason why the thread was woken up.
         let interrupt_reason: Option<InterruptReason> = Self::get_mut()
             .try_borrow_mut()
             .map_err(SleepError::Generic)?
             .interrupt_reason();
 
+        // Check if the thread was interrupted.
         if let Some(reason) = interrupt_reason {
-            error!("sleep(): interrupted (reason={:?})", reason);
+            warn!("sleep(): interrupted (reason={:?})", reason);
             return Err(SleepError::Interrupted(reason));
         }
 
@@ -389,39 +447,47 @@ impl ProcessManager {
     ///
     /// # Description
     ///
-    /// Switches the context of the calling thread with the next ready thread.
+    /// Gives up the processor and schedules another ready thread to run.
     ///
     /// # Returns
     ///
     /// Upon successful completion, empty is returned. Otherwise, an error code is returned instead.
+    /// This function may not return immediately, as the scheduler algorithm may select another
+    /// thread to run before of the calling thread.
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it performs a context switch, causing the current thread to
-    /// block until it is woken up by another thread.
+    /// This function is unsafe because it performs a context switch, suspending the execution of
+    /// the current thread until it is re-scheduled for execution.
     ///
-    pub unsafe fn switch() -> Result<(), Error> {
-        // Schedule the next thread within a limited scope to ensure the process manager is
-        // properly released before performing the context switch.
-        let result: Option<(ProcessIdentifier, *mut ContextInformation, *mut ContextInformation)> =
-            { Self::get_mut().try_borrow_mut()?.schedule() };
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - The process manager is initialized.
+    /// - The calling thread does not hold a reference to the process manager.
+    /// - Access to the process manager is synchronized.
+    ///
+    pub unsafe fn giveup() -> Result<(), Error> {
+        // Check the remaining quantum for the current thread to decide whether to perform a context switch.
+        let remaining_ticks: usize = REMAINING_QUANTUM.load(ORDER);
+        if remaining_ticks > 1 {
+            // The current thread still has remaining quantum, no context switch is required.
+            REMAINING_QUANTUM.store(remaining_ticks - 1, ORDER);
+        } else {
+            // The current thread has no remaining quantum, perform a context switch.
 
-        match result {
-            Some((next_pid, from, to)) => {
-                // SAFETY: `from` and `to` point to valid context information structures. The
-                // processor is running with interrupts disabled.
-                CURRENT_PID.store(next_pid.into(), Ordering::SeqCst);
-                ContextInformation::switch(from, to);
-            },
-            None => {
-                // SAFETY: Enabling interrupts in this scope will not cause unwanted side effects.
-                let interrupts: Interrupts = Interrupts::enable();
+            cold_path();
 
-                // SAFETY: Waiting for interrupts will not cause unwanted side effects.
-                interrupts.wait();
+            // Re-schedule the calling thread and select another thread to run next.
+            let (next_pid, next_tid, from, to): (
+                ProcessIdentifier,
+                ThreadIdentifier,
+                *mut ContextInformation,
+                *mut ContextInformation,
+            ) = Self::get_mut().try_borrow_mut()?.schedule();
 
-                // Interrupts are automatically disabled when we leave this scope.
-            },
+            // Switch to the next thread and updating the remaining quantum accordingly.
+            // SAFETY: `from` and `to` point to valid context information structures, and the
+            // processor is running with interrupts disabled.
+            Self::switch(next_pid, next_tid, from, to);
         }
 
         Ok(())
@@ -628,11 +694,70 @@ impl ProcessManager {
     ///
     /// Returns true if the kernel is running, false otherwise.
     ///
+    pub fn is_kernel_running() -> bool {
+        CURRENT_TID.load(ORDER) == ThreadIdentifier::KERNEL_RAW
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Switches the execution to another thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `next_pid`: Process identifier of the next thread to run.
+    /// - `next_tid`: Thread identifier of the next thread to run.
+    /// - `from`: Pointer to the context information of the current thread.
+    /// - `to`: Pointer to the context information of the next thread.
+    ///
     /// # Safety
     ///
-    /// This function is unsafe because it access global variables.
+    /// This function is unsafe because it performs a context switch.
     ///
-    pub unsafe fn is_kernel_running() -> bool {
-        CURRENT_PID.load(Ordering::SeqCst) == ProcessIdentifier::KERNEL_RAW
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - `from` and `to` point to valid context information structures.
+    /// - The processor is running with interrupts disabled.
+    ///
+    #[inline(always)]
+    unsafe fn switch(
+        next_pid: ProcessIdentifier,
+        next_tid: ThreadIdentifier,
+        from: *mut ContextInformation,
+        to: *mut ContextInformation,
+    ) {
+        let previous_pid: ProcessIdentifier = ProcessIdentifier::from(CURRENT_PID.load(ORDER));
+        let previous_tid: ThreadIdentifier = ThreadIdentifier::from(CURRENT_TID.load(ORDER));
+
+        // Check if we need to perform a context switch.
+        if next_tid != previous_tid {
+            // We need to perform a context switch.
+
+            // Check whether we need to reset the quantum for the next thread.
+            if next_pid != previous_pid {
+                REMAINING_QUANTUM.store(SCHEDULER_FREQ, ORDER);
+                CURRENT_PID.store(next_pid.into(), ORDER);
+            }
+            CURRENT_TID.store(next_tid.into(), ORDER);
+
+            ContextInformation::switch(from, to);
+        } else {
+            // We do not need to perform a context switch, the same thread will continue running.
+
+            // Check if the kernel thread will continue running.
+            if next_tid == ThreadIdentifier::KERNEL {
+                // The kernel thread will continue running. This means there are no other ready
+                // threads to run, and the kernel has no work to do at the moment. Enable interrupts
+                // and wait for an external event (such as a timer or hardware interrupt) to wake up
+                // the kernel.
+
+                // SAFETY: Enabling interrupts in this scope will not cause unwanted side effects.
+                let interrupts: Interrupts = Interrupts::enable();
+
+                // SAFETY: Waiting for interrupts will not cause unwanted side effects.
+                interrupts.wait();
+
+                // Interrupts are automatically disabled when we leave this scope.
+            }
+        }
     }
 }

--- a/src/kernel/src/pm/process/state/interrupted.rs
+++ b/src/kernel/src/pm/process/state/interrupted.rs
@@ -5,19 +5,16 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    hal::arch::ContextInformation,
-    pm::{
-        process::state::{
-            ProcessState,
-            RunningProcess,
-        },
-        thread::{
-            InterruptReason,
-            InterruptedThread,
-            SleepingThread,
-            ZombieThread,
-        },
+use crate::pm::{
+    process::state::{
+        ProcessState,
+        RunnableProcess,
+    },
+    thread::{
+        InterruptReason,
+        InterruptedThread,
+        SleepingThread,
+        ZombieThread,
     },
 };
 use ::alloc::{
@@ -80,22 +77,28 @@ impl InterruptedProcess {
         &mut self.state
     }
 
-    pub fn resume(mut self) -> (RunningProcess, InterruptReason, *mut ContextInformation) {
+    pub fn resume(mut self) -> RunnableProcess {
         let (interrupted_threads, next_thread): (VecDeque<InterruptedThread>, InterruptedThread) =
             self.interrupted_threads.pop_front();
-        let (thread, reason, ctx) = next_thread.resume();
-        (
-            RunningProcess::new(
+        let ready_thread = next_thread.resume();
+
+        if let Some(interrupted_threads) = NonEmptyVecDeque::from(interrupted_threads) {
+            RunnableProcess::from_state_with_ready_and_interrupted_threads(
                 self.state,
-                thread,
-                None,
-                NonEmptyVecDeque::from(interrupted_threads),
+                NonEmptyVecDeque::new(ready_thread),
+                interrupted_threads,
                 self.sleeping_threads.take(),
                 self.zombie_threads.take(),
-            ),
-            reason,
-            ctx,
-        )
+            )
+        } else {
+            RunnableProcess::from_state_with_ready_thread(
+                self.state,
+                NonEmptyVecDeque::new(ready_thread),
+                None,
+                self.sleeping_threads.take(),
+                self.zombie_threads.take(),
+            )
+        }
     }
 
     pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {

--- a/src/kernel/src/pm/process/state/interrupted.rs
+++ b/src/kernel/src/pm/process/state/interrupted.rs
@@ -82,23 +82,13 @@ impl InterruptedProcess {
             self.interrupted_threads.pop_front();
         let ready_thread = next_thread.resume();
 
-        if let Some(interrupted_threads) = NonEmptyVecDeque::from(interrupted_threads) {
-            RunnableProcess::from_state_with_ready_and_interrupted_threads(
-                self.state,
-                NonEmptyVecDeque::new(ready_thread),
-                interrupted_threads,
-                self.sleeping_threads.take(),
-                self.zombie_threads.take(),
-            )
-        } else {
-            RunnableProcess::from_state_with_ready_thread(
-                self.state,
-                NonEmptyVecDeque::new(ready_thread),
-                None,
-                self.sleeping_threads.take(),
-                self.zombie_threads.take(),
-            )
-        }
+        RunnableProcess::from_state(
+            self.state,
+            NonEmptyVecDeque::new(ready_thread),
+            NonEmptyVecDeque::from(interrupted_threads),
+            self.sleeping_threads.take(),
+            self.zombie_threads.take(),
+        )
     }
 
     pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -90,7 +90,7 @@ impl RunnableProcessWithReadyThread {
 
     fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
         let (ready_threads, next_thread) = self.ready_threads.pop_front();
-        let (running_thread, next_context) = next_thread.resume();
+        let (running_thread, interrupt_reason, next_context) = next_thread.resume();
         (
             RunningProcess::new(
                 self.state,
@@ -100,7 +100,7 @@ impl RunnableProcessWithReadyThread {
                 self.sleeping_threads.take(),
                 self.zombie_threads.take(),
             ),
-            None,
+            interrupt_reason,
             next_context,
         )
     }
@@ -243,7 +243,8 @@ impl RunnableProcessWithInterruptedThreads {
 
     fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
         let (interrupted_threads, next_thread) = self.interrupted_threads.pop_front();
-        let (running_thread, reason, next_context) = next_thread.resume();
+        let ready_thread: ReadyThread = next_thread.resume();
+        let (running_thread, interrupt_reason, next_context) = ready_thread.resume();
         (
             RunningProcess::new(
                 self.state,
@@ -253,7 +254,7 @@ impl RunnableProcessWithInterruptedThreads {
                 self.sleeping_threads.take(),
                 self.zombie_threads.take(),
             ),
-            Some(reason),
+            interrupt_reason,
             next_context,
         )
     }
@@ -418,7 +419,7 @@ impl RunnableProcessWithReadyAndInteruptThread {
 
     fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
         let (ready_threads, next_thread) = self.ready_threads.pop_front();
-        let (running_thread, next_context) = next_thread.resume();
+        let (running_thread, interrupt_reason, next_context) = next_thread.resume();
         (
             RunningProcess::new(
                 self.state,
@@ -428,7 +429,7 @@ impl RunnableProcessWithReadyAndInteruptThread {
                 self.sleeping_threads.take(),
                 self.zombie_threads.take(),
             ),
-            None,
+            interrupt_reason,
             next_context,
         )
     }

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -12,6 +12,7 @@ use crate::{
         Vmem,
     },
     pm::{
+        clock,
         process::state::{
             interrupted::interrupt,
             InterruptedProcess,
@@ -31,9 +32,11 @@ use crate::{
 use ::alloc::boxed::Box;
 use ::sys::pm::ProcessIdentifier;
 use ::type_safe::NonEmptyVecDeque;
+use alloc::collections::vec_deque::VecDeque;
 use sys::{
     error::ErrorCode,
     pm::ThreadIdentifier,
+    time::SystemTime,
 };
 
 //==================================================================================================
@@ -95,7 +98,24 @@ impl RunnableProcess {
     }
 
     pub fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
-        let (ready_threads, next_thread) = self.ready_threads.pop_front();
+        let mut ready_threads: VecDeque<ReadyThread> = self.ready_threads.into();
+
+        // Select thread with the earliest admission time.
+        let mut index_selected_thread: usize = 0;
+        for (i, thread) in ready_threads.iter().enumerate() {
+            if thread.admission_time() < ready_threads[index_selected_thread].admission_time() {
+                index_selected_thread = i;
+            }
+        }
+        let next_thread: ReadyThread = match ready_threads.remove(index_selected_thread) {
+            Some(thread) => thread,
+            None => {
+                // SAFETY: the following statement is unreachable because there should always be at
+                // least one ready thread in a runnable process.
+                unreachable!("no ready threads in runnable process");
+            },
+        };
+
         let (running_thread, interrupt_reason, next_context) = next_thread.run();
         (
             RunningProcess::new(
@@ -203,5 +223,13 @@ impl RunnableProcess {
         }
 
         false
+    }
+
+    pub fn earliest_admission_time(&self) -> SystemTime {
+        self.ready_threads
+            .iter()
+            .map(|thread| thread.admission_time())
+            .min()
+            .unwrap_or(clock::now())
     }
 }

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -14,6 +14,7 @@ use crate::{
     pm::{
         process::state::{
             interrupted::interrupt,
+            InterruptedProcess,
             ProcessState,
             RunningProcess,
             ZombieProcess,
@@ -39,8 +40,13 @@ use sys::{
 // Runnable Process
 //==================================================================================================
 
+///
+/// # Description
+///
+/// A type that represents a process that is ready to run.
+///
 #[derive(Debug)]
-pub struct RunnableProcessWithReadyThread {
+pub struct RunnableProcess {
     state: Box<ProcessState>,
     ready_threads: NonEmptyVecDeque<ReadyThread>,
     interrupted_threads: Option<NonEmptyVecDeque<InterruptedThread>>,
@@ -48,8 +54,8 @@ pub struct RunnableProcessWithReadyThread {
     zombie_threads: Option<NonEmptyVecDeque<ZombieThread>>,
 }
 
-impl RunnableProcessWithReadyThread {
-    fn new(
+impl RunnableProcess {
+    pub fn new(
         pid: ProcessIdentifier,
         ready_thread: ReadyThread,
         vmem: Vmem,
@@ -64,7 +70,7 @@ impl RunnableProcessWithReadyThread {
         }
     }
 
-    fn from_state(
+    pub(super) fn from_state(
         state: Box<ProcessState>,
         ready_threads: NonEmptyVecDeque<ReadyThread>,
         interrupted_threads: Option<NonEmptyVecDeque<InterruptedThread>>,
@@ -80,15 +86,15 @@ impl RunnableProcessWithReadyThread {
         }
     }
 
-    fn state(&self) -> &ProcessState {
+    pub fn state(&self) -> &ProcessState {
         &self.state
     }
 
-    fn state_mut(&mut self) -> &mut ProcessState {
+    pub(super) fn state_mut(&mut self) -> &mut ProcessState {
         &mut self.state
     }
 
-    fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
+    pub fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
         let (ready_threads, next_thread) = self.ready_threads.pop_front();
         let (running_thread, interrupt_reason, next_context) = next_thread.run();
         (
@@ -105,7 +111,7 @@ impl RunnableProcessWithReadyThread {
         )
     }
 
-    fn terminate(mut self) -> Result<RunnableProcessWithInterruptedThreads, ZombieProcess> {
+    pub fn terminate(mut self) -> Result<InterruptedProcess, ZombieProcess> {
         // Terminate all ready threads.
         let mut more_zombie_threads: NonEmptyVecDeque<ZombieThread> =
             NonEmptyVecDeque::map(self.ready_threads, ReadyThread::terminate);
@@ -133,19 +139,13 @@ impl RunnableProcessWithReadyThread {
         }
 
         if let Some(interrupted_threads) = interrupted_threads {
-            Ok(RunnableProcessWithInterruptedThreads::new(
-                self.state,
-                None,
-                interrupted_threads,
-                None,
-                Some(zombie_threads),
-            ))
+            Ok(InterruptedProcess::new(self.state, interrupted_threads, Some(zombie_threads)))
         } else {
             Err(ZombieProcess::new(self.state, zombie_threads, ErrorCode::Interrupted.into()))
         }
     }
 
-    fn wakeup(mut self, tid: ThreadIdentifier) -> Result<Self, Self> {
+    pub fn wakeup(mut self, tid: ThreadIdentifier) -> Result<Self, Self> {
         if let Some(sleeping_threads) = self.sleeping_threads.take() {
             match sleeping_threads.remove_if(|thread| thread.id() == tid) {
                 Ok((sleeping_threads, sleeping_thread)) => {
@@ -169,14 +169,13 @@ impl RunnableProcessWithReadyThread {
         }
     }
 
-    fn add_thread(mut self, ready_thread: ReadyThread) -> Self {
+    pub fn add_thread(mut self, ready_thread: ReadyThread) -> Self {
         trace!("add_thread(): self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
         self.ready_threads.push_back(ready_thread);
-
         self
     }
 
-    fn has_thread(&self, tid: ThreadIdentifier) -> bool {
+    pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {
         // Search in the list of ready threads.
         if self.ready_threads.iter().any(|thread| thread.tid() == tid) {
             return true;
@@ -204,490 +203,5 @@ impl RunnableProcessWithReadyThread {
         }
 
         false
-    }
-}
-
-#[derive(Debug)]
-pub struct RunnableProcessWithInterruptedThreads {
-    state: Box<ProcessState>,
-    ready_threads: Option<NonEmptyVecDeque<ReadyThread>>,
-    interrupted_threads: NonEmptyVecDeque<InterruptedThread>,
-    sleeping_threads: Option<NonEmptyVecDeque<SleepingThread>>,
-    zombie_threads: Option<NonEmptyVecDeque<ZombieThread>>,
-}
-
-impl RunnableProcessWithInterruptedThreads {
-    fn new(
-        state: Box<ProcessState>,
-        ready_threads: Option<NonEmptyVecDeque<ReadyThread>>,
-        interrupted_threads: NonEmptyVecDeque<InterruptedThread>,
-        sleeping_threads: Option<NonEmptyVecDeque<SleepingThread>>,
-        zombie_threads: Option<NonEmptyVecDeque<ZombieThread>>,
-    ) -> Self {
-        Self {
-            state,
-            ready_threads,
-            interrupted_threads,
-            sleeping_threads,
-            zombie_threads,
-        }
-    }
-
-    fn state(&self) -> &ProcessState {
-        &self.state
-    }
-
-    fn state_mut(&mut self) -> &mut ProcessState {
-        &mut self.state
-    }
-
-    fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
-        let (interrupted_threads, next_thread) = self.interrupted_threads.pop_front();
-        let ready_thread: ReadyThread = next_thread.resume();
-        let (running_thread, interrupt_reason, next_context) = ready_thread.run();
-        (
-            RunningProcess::new(
-                self.state,
-                running_thread,
-                self.ready_threads.take(),
-                NonEmptyVecDeque::from(interrupted_threads),
-                self.sleeping_threads.take(),
-                self.zombie_threads.take(),
-            ),
-            interrupt_reason,
-            next_context,
-        )
-    }
-
-    fn interrupt(thread: SleepingThread) -> InterruptedThread {
-        thread.interrupt(InterruptReason::Killed)
-    }
-
-    fn terminate(mut self) -> Result<Self, ZombieProcess> {
-        // Terminate all ready threads.
-        let mut more_zombie_threads: Option<NonEmptyVecDeque<ZombieThread>> = self
-            .ready_threads
-            .take()
-            .map(|ready_threads| NonEmptyVecDeque::map(ready_threads, ReadyThread::terminate));
-        // Collect zombie threads.
-        let zombie_threads: Option<NonEmptyVecDeque<ZombieThread>> =
-            match self.zombie_threads.take() {
-                Some(zombie_threads) => match more_zombie_threads.take() {
-                    Some(mut more_zombie_threads) => {
-                        more_zombie_threads.append(zombie_threads);
-                        Some(more_zombie_threads)
-                    },
-                    None => Some(zombie_threads),
-                },
-                None => more_zombie_threads.take(),
-            };
-
-        // Collect interrupted threads.
-        let mut interrupted_threads: NonEmptyVecDeque<InterruptedThread> = self.interrupted_threads;
-
-        // Terminate all sleeping threads.
-        if let Some(sleeping_threads) = self.sleeping_threads.take() {
-            let more_interrupted_threads = NonEmptyVecDeque::map(sleeping_threads, Self::interrupt);
-            interrupted_threads.append(more_interrupted_threads);
-        }
-
-        Ok(Self::new(self.state, None, interrupted_threads, None, zombie_threads))
-    }
-
-    fn wakeup(
-        mut self,
-        tid: ThreadIdentifier,
-    ) -> Result<RunnableProcessWithReadyAndInteruptThread, Self> {
-        if let Some(sleeping_threads) = self.sleeping_threads.take() {
-            match sleeping_threads.remove_if(|thread| thread.id() == tid) {
-                Ok((sleeping_threads, sleeping_thread)) => {
-                    let ready_thread: ReadyThread = sleeping_thread.wakeup();
-                    let ready_threads = match self.ready_threads.take() {
-                        Some(mut ready_threads) => {
-                            ready_threads.push_back(ready_thread);
-                            ready_threads
-                        },
-                        None => NonEmptyVecDeque::new(ready_thread),
-                    };
-                    Ok(RunnableProcessWithReadyAndInteruptThread::new(
-                        self.state,
-                        ready_threads,
-                        self.interrupted_threads,
-                        NonEmptyVecDeque::from(sleeping_threads),
-                        self.zombie_threads.take(),
-                    ))
-                },
-                Err(sleeping_threads) => {
-                    self.sleeping_threads = Some(sleeping_threads);
-                    Err(self)
-                },
-            }
-        } else {
-            Err(self)
-        }
-    }
-
-    fn add_thread(
-        mut self,
-        ready_thread: ReadyThread,
-    ) -> RunnableProcessWithReadyAndInteruptThread {
-        trace!("add_thread(): self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
-        let ready_threads = match self.ready_threads.take() {
-            Some(mut ready_threads) => {
-                ready_threads.push_back(ready_thread);
-                ready_threads
-            },
-            None => NonEmptyVecDeque::new(ready_thread),
-        };
-        RunnableProcessWithReadyAndInteruptThread::new(
-            self.state,
-            ready_threads,
-            self.interrupted_threads,
-            self.sleeping_threads.take(),
-            self.zombie_threads.take(),
-        )
-    }
-
-    fn has_thread(&self, tid: ThreadIdentifier) -> bool {
-        // Search in the list of interrupted threads.
-        if self
-            .interrupted_threads
-            .iter()
-            .any(|thread| thread.tid() == tid)
-        {
-            return true;
-        }
-
-        // Search in the list of ready threads.
-        if let Some(ready_threads) = &self.ready_threads {
-            if ready_threads.iter().any(|thread| thread.tid() == tid) {
-                return true;
-            }
-        }
-
-        // Search in the list of sleeping threads.
-        if let Some(sleeping_threads) = &self.sleeping_threads {
-            if sleeping_threads.iter().any(|thread| thread.id() == tid) {
-                return true;
-            }
-        }
-
-        // Search in the list of zombie threads.
-        if let Some(zombie_threads) = &self.zombie_threads {
-            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
-                return true;
-            }
-        }
-
-        false
-    }
-}
-
-#[derive(Debug)]
-pub struct RunnableProcessWithReadyAndInteruptThread {
-    state: Box<ProcessState>,
-    ready_threads: NonEmptyVecDeque<ReadyThread>,
-    interrupted_threads: NonEmptyVecDeque<InterruptedThread>,
-    sleeping_threads: Option<NonEmptyVecDeque<SleepingThread>>,
-    zombie_threads: Option<NonEmptyVecDeque<ZombieThread>>,
-}
-
-impl RunnableProcessWithReadyAndInteruptThread {
-    fn new(
-        state: Box<ProcessState>,
-        ready_threads: NonEmptyVecDeque<ReadyThread>,
-        interrupted_threads: NonEmptyVecDeque<InterruptedThread>,
-        sleeping_threads: Option<NonEmptyVecDeque<SleepingThread>>,
-        zombie_threads: Option<NonEmptyVecDeque<ZombieThread>>,
-    ) -> Self {
-        Self {
-            state,
-            ready_threads,
-            interrupted_threads,
-            sleeping_threads,
-            zombie_threads,
-        }
-    }
-
-    fn state(&self) -> &ProcessState {
-        &self.state
-    }
-
-    fn state_mut(&mut self) -> &mut ProcessState {
-        &mut self.state
-    }
-
-    fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
-        let (ready_threads, next_thread) = self.ready_threads.pop_front();
-        let (running_thread, interrupt_reason, next_context) = next_thread.run();
-        (
-            RunningProcess::new(
-                self.state,
-                running_thread,
-                NonEmptyVecDeque::from(ready_threads),
-                Some(self.interrupted_threads),
-                self.sleeping_threads.take(),
-                self.zombie_threads.take(),
-            ),
-            interrupt_reason,
-            next_context,
-        )
-    }
-
-    fn interrupt(thread: SleepingThread) -> InterruptedThread {
-        thread.interrupt(InterruptReason::Killed)
-    }
-
-    fn terminate(mut self) -> Result<RunnableProcessWithInterruptedThreads, ZombieProcess> {
-        // Terminate all ready threads.
-        let mut more_zombie_threads: NonEmptyVecDeque<ZombieThread> =
-            NonEmptyVecDeque::map(self.ready_threads, ReadyThread::terminate);
-
-        // Collect zombie threads.
-        let zombie_threads: NonEmptyVecDeque<ZombieThread> = match self.zombie_threads.take() {
-            Some(zombie_threads) => {
-                more_zombie_threads.append(zombie_threads);
-                more_zombie_threads
-            },
-            None => more_zombie_threads,
-        };
-
-        // Collect interrupted threads.
-        let mut interrupted_threads: NonEmptyVecDeque<InterruptedThread> = self.interrupted_threads;
-
-        // Terminate all sleeping threads.
-        if let Some(sleeping_threads) = self.sleeping_threads.take() {
-            let more_interrupted_threads = NonEmptyVecDeque::map(sleeping_threads, Self::interrupt);
-            interrupted_threads.append(more_interrupted_threads);
-        }
-
-        Ok(RunnableProcessWithInterruptedThreads::new(
-            self.state,
-            None,
-            interrupted_threads,
-            None,
-            Some(zombie_threads),
-        ))
-    }
-
-    fn wakeup(
-        mut self,
-        tid: ThreadIdentifier,
-    ) -> Result<RunnableProcessWithReadyAndInteruptThread, Self> {
-        if let Some(sleeping_threads) = self.sleeping_threads.take() {
-            match sleeping_threads.remove_if(|thread| thread.id() == tid) {
-                Ok((sleeping_threads, sleeping_thread)) => {
-                    let ready_thread: ReadyThread = sleeping_thread.wakeup();
-                    self.ready_threads.push_back(ready_thread);
-                    Ok(RunnableProcessWithReadyAndInteruptThread::new(
-                        self.state,
-                        self.ready_threads,
-                        self.interrupted_threads,
-                        NonEmptyVecDeque::from(sleeping_threads),
-                        self.zombie_threads.take(),
-                    ))
-                },
-                Err(sleeping_threads) => {
-                    self.sleeping_threads = Some(sleeping_threads);
-                    Err(self)
-                },
-            }
-        } else {
-            Err(self)
-        }
-    }
-
-    fn add_thread(mut self, ready_thread: ReadyThread) -> Self {
-        trace!("add_thread(): self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
-        self.ready_threads.push_back(ready_thread);
-        self
-    }
-
-    fn has_thread(&self, tid: ThreadIdentifier) -> bool {
-        // Search in the list of ready threads.
-        if self.ready_threads.iter().any(|thread| thread.tid() == tid) {
-            return true;
-        }
-
-        // Search in the list of interrupted threads.
-        if self
-            .interrupted_threads
-            .iter()
-            .any(|thread| thread.tid() == tid)
-        {
-            return true;
-        }
-
-        // Search in the list of sleeping threads.
-        if let Some(sleeping_threads) = &self.sleeping_threads {
-            if sleeping_threads.iter().any(|thread| thread.id() == tid) {
-                return true;
-            }
-        }
-
-        // Search in the list of zombie threads.
-        if let Some(zombie_threads) = &self.zombie_threads {
-            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
-                return true;
-            }
-        }
-
-        false
-    }
-}
-
-///
-/// # Description
-///
-/// A type that represents a process that is ready to run.
-///
-#[derive(Debug)]
-pub enum RunnableProcess {
-    WithReadyThread(RunnableProcessWithReadyThread),
-    WithInterruptedThreads(RunnableProcessWithInterruptedThreads),
-    ReadyAndInteruptThread(RunnableProcessWithReadyAndInteruptThread),
-}
-
-impl RunnableProcess {
-    pub fn new(
-        pid: ProcessIdentifier,
-        ready_thread: ReadyThread,
-        vmem: Vmem,
-        user_stack_allocator: Option<UserStackAllocator>,
-    ) -> Self {
-        RunnableProcess::WithReadyThread(RunnableProcessWithReadyThread::new(
-            pid,
-            ready_thread,
-            vmem,
-            user_stack_allocator,
-        ))
-    }
-
-    pub fn from_state_with_ready_thread(
-        state: Box<ProcessState>,
-        ready_threads: NonEmptyVecDeque<ReadyThread>,
-        interrupted_threads: Option<NonEmptyVecDeque<InterruptedThread>>,
-        sleeping_threads: Option<NonEmptyVecDeque<SleepingThread>>,
-        zombie_threads: Option<NonEmptyVecDeque<ZombieThread>>,
-    ) -> Self {
-        RunnableProcess::WithReadyThread(RunnableProcessWithReadyThread::from_state(
-            state,
-            ready_threads,
-            interrupted_threads,
-            sleeping_threads,
-            zombie_threads,
-        ))
-    }
-
-    pub fn from_state_with_interrupted_threads(
-        state: Box<ProcessState>,
-        ready_threads: Option<NonEmptyVecDeque<ReadyThread>>,
-        interrupted_threads: NonEmptyVecDeque<InterruptedThread>,
-        sleeping_threads: Option<NonEmptyVecDeque<SleepingThread>>,
-        zombie_threads: Option<NonEmptyVecDeque<ZombieThread>>,
-    ) -> Self {
-        RunnableProcess::WithInterruptedThreads(RunnableProcessWithInterruptedThreads::new(
-            state,
-            ready_threads,
-            interrupted_threads,
-            sleeping_threads,
-            zombie_threads,
-        ))
-    }
-
-    pub fn from_state_with_ready_and_interrupted_threads(
-        state: Box<ProcessState>,
-        ready_threads: NonEmptyVecDeque<ReadyThread>,
-        interrupted_threads: NonEmptyVecDeque<InterruptedThread>,
-        sleeping_threads: Option<NonEmptyVecDeque<SleepingThread>>,
-        zombie_threads: Option<NonEmptyVecDeque<ZombieThread>>,
-    ) -> Self {
-        RunnableProcess::ReadyAndInteruptThread(RunnableProcessWithReadyAndInteruptThread::new(
-            state,
-            ready_threads,
-            interrupted_threads,
-            sleeping_threads,
-            zombie_threads,
-        ))
-    }
-
-    pub fn state(&self) -> &ProcessState {
-        match self {
-            RunnableProcess::WithReadyThread(process) => process.state(),
-            RunnableProcess::WithInterruptedThreads(process) => process.state(),
-            RunnableProcess::ReadyAndInteruptThread(process) => process.state(),
-        }
-    }
-
-    pub fn state_mut(&mut self) -> &mut ProcessState {
-        match self {
-            RunnableProcess::WithReadyThread(process) => process.state_mut(),
-            RunnableProcess::WithInterruptedThreads(process) => process.state_mut(),
-            RunnableProcess::ReadyAndInteruptThread(process) => process.state_mut(),
-        }
-    }
-
-    pub fn terminate(self) -> Result<RunnableProcess, ZombieProcess> {
-        match self {
-            RunnableProcess::WithReadyThread(process) => match process.terminate() {
-                Ok(process) => Ok(RunnableProcess::WithInterruptedThreads(process)),
-                Err(process) => Err(process),
-            },
-            RunnableProcess::WithInterruptedThreads(process) => match process.terminate() {
-                Ok(process) => Ok(RunnableProcess::WithInterruptedThreads(process)),
-                Err(process) => Err(process),
-            },
-            RunnableProcess::ReadyAndInteruptThread(process) => match process.terminate() {
-                Ok(process) => Ok(RunnableProcess::WithInterruptedThreads(process)),
-                Err(process) => Err(process),
-            },
-        }
-    }
-
-    pub fn run(self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
-        match self {
-            RunnableProcess::WithReadyThread(process) => process.run(),
-            RunnableProcess::WithInterruptedThreads(process) => process.run(),
-            RunnableProcess::ReadyAndInteruptThread(process) => process.run(),
-        }
-    }
-
-    pub fn wakeup(self, tid: ThreadIdentifier) -> Result<RunnableProcess, RunnableProcess> {
-        match self {
-            RunnableProcess::WithReadyThread(process) => match process.wakeup(tid) {
-                Ok(process) => Ok(RunnableProcess::WithReadyThread(process)),
-                Err(process) => Err(RunnableProcess::WithReadyThread(process)),
-            },
-            RunnableProcess::WithInterruptedThreads(process) => match process.wakeup(tid) {
-                Ok(process) => Ok(RunnableProcess::ReadyAndInteruptThread(process)),
-                Err(process) => Err(RunnableProcess::WithInterruptedThreads(process)),
-            },
-            RunnableProcess::ReadyAndInteruptThread(process) => match process.wakeup(tid) {
-                Ok(process) => Ok(RunnableProcess::ReadyAndInteruptThread(process)),
-                Err(process) => Err(RunnableProcess::ReadyAndInteruptThread(process)),
-            },
-        }
-    }
-
-    pub fn add_thread(self, ready_thread: ReadyThread) -> Self {
-        match self {
-            RunnableProcess::WithReadyThread(process) => {
-                RunnableProcess::WithReadyThread(process.add_thread(ready_thread))
-            },
-            RunnableProcess::WithInterruptedThreads(process) => {
-                RunnableProcess::ReadyAndInteruptThread(process.add_thread(ready_thread))
-            },
-            RunnableProcess::ReadyAndInteruptThread(process) => {
-                RunnableProcess::ReadyAndInteruptThread(process.add_thread(ready_thread))
-            },
-        }
-    }
-
-    pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {
-        match self {
-            RunnableProcess::WithReadyThread(process) => process.has_thread(tid),
-            RunnableProcess::WithInterruptedThreads(process) => process.has_thread(tid),
-            RunnableProcess::ReadyAndInteruptThread(process) => process.has_thread(tid),
-        }
     }
 }

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -90,7 +90,7 @@ impl RunnableProcessWithReadyThread {
 
     fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
         let (ready_threads, next_thread) = self.ready_threads.pop_front();
-        let (running_thread, interrupt_reason, next_context) = next_thread.resume();
+        let (running_thread, interrupt_reason, next_context) = next_thread.run();
         (
             RunningProcess::new(
                 self.state,
@@ -244,7 +244,7 @@ impl RunnableProcessWithInterruptedThreads {
     fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
         let (interrupted_threads, next_thread) = self.interrupted_threads.pop_front();
         let ready_thread: ReadyThread = next_thread.resume();
-        let (running_thread, interrupt_reason, next_context) = ready_thread.resume();
+        let (running_thread, interrupt_reason, next_context) = ready_thread.run();
         (
             RunningProcess::new(
                 self.state,
@@ -419,7 +419,7 @@ impl RunnableProcessWithReadyAndInteruptThread {
 
     fn run(mut self) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation) {
         let (ready_threads, next_thread) = self.ready_threads.pop_front();
-        let (running_thread, interrupt_reason, next_context) = next_thread.resume();
+        let (running_thread, interrupt_reason, next_context) = next_thread.run();
         (
             RunningProcess::new(
                 self.state,

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -216,7 +216,7 @@ impl RunningProcess {
                 self.state,
                 self.sleeping_threads.take(),
                 interrupted_threads,
-                self.zombie.take(),
+                Some(zombie_threads),
             );
 
             Ok((interrupted_process.resume(), ctx))

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -11,6 +11,7 @@ use crate::{
         process::state::{
             interrupted::interrupt,
             sleeping::SleepingProcess,
+            InterruptedProcess,
             ProcessState,
             RunnableProcess,
             ZombieProcess,
@@ -119,7 +120,7 @@ impl RunningProcess {
         };
 
         (
-            RunnableProcess::from_state_with_ready_thread(
+            RunnableProcess::from_state(
                 self.state,
                 ready_threads,
                 self.interrupted_threads.take(),
@@ -151,7 +152,7 @@ impl RunningProcess {
         // Check if there are ready threads.
         if let Some(ready_threads) = self.ready.take() {
             return Ok((
-                RunnableProcess::from_state_with_ready_thread(
+                RunnableProcess::from_state(
                     self.state,
                     ready_threads,
                     self.interrupted_threads.take(),
@@ -164,16 +165,14 @@ impl RunningProcess {
 
         // Check if there are interrupted threads.
         if let Some(interrupted_threads) = self.interrupted_threads.take() {
-            return Ok((
-                RunnableProcess::from_state_with_interrupted_threads(
-                    self.state,
-                    None,
-                    interrupted_threads,
-                    Some(sleeping_threads),
-                    self.zombie.take(),
-                ),
-                ctx,
-            ));
+            let interrupted_process: InterruptedProcess = InterruptedProcess::from_sleeping(
+                self.state,
+                Some(sleeping_threads),
+                interrupted_threads,
+                self.zombie.take(),
+            );
+
+            return Ok((interrupted_process.resume(), ctx));
         }
 
         Err((SleepingProcess::new(self.state, sleeping_threads, self.zombie.take()), ctx))
@@ -213,16 +212,14 @@ impl RunningProcess {
         }
 
         if let Some(interrupted_threads) = interrupted_threads {
-            Ok((
-                RunnableProcess::from_state_with_interrupted_threads(
-                    self.state,
-                    None,
-                    interrupted_threads,
-                    None,
-                    Some(zombie_threads),
-                ),
-                ctx,
-            ))
+            let interrupted_process: InterruptedProcess = InterruptedProcess::from_sleeping(
+                self.state,
+                self.sleeping_threads.take(),
+                interrupted_threads,
+                self.zombie.take(),
+            );
+
+            Ok((interrupted_process.resume(), ctx))
         } else {
             Err((ZombieProcess::new(self.state, zombie_threads, status), ctx))
         }
@@ -268,43 +265,26 @@ impl RunningProcess {
         };
 
         if let Some(ready_threads) = self.ready.take() {
-            if let Some(interrupted_threads) = self.interrupted_threads.take() {
-                Ok((
-                    join_cond,
-                    RunnableProcess::from_state_with_ready_and_interrupted_threads(
-                        self.state,
-                        ready_threads,
-                        interrupted_threads,
-                        self.sleeping_threads.take(),
-                        Some(zombie_threads),
-                    ),
-                    ctx,
-                ))
-            } else {
-                Ok((
-                    join_cond,
-                    RunnableProcess::from_state_with_ready_thread(
-                        self.state,
-                        ready_threads,
-                        self.interrupted_threads.take(),
-                        self.sleeping_threads.take(),
-                        Some(zombie_threads),
-                    ),
-                    ctx,
-                ))
-            }
-        } else if let Some(interrupted_threads) = self.interrupted_threads.take() {
             Ok((
                 join_cond,
-                RunnableProcess::from_state_with_interrupted_threads(
+                RunnableProcess::from_state(
                     self.state,
-                    self.ready.take(),
-                    interrupted_threads,
+                    ready_threads,
+                    self.interrupted_threads.take(),
                     self.sleeping_threads.take(),
                     Some(zombie_threads),
                 ),
                 ctx,
             ))
+        } else if let Some(interrupted_threads) = self.interrupted_threads.take() {
+            let interrupted_process: InterruptedProcess = InterruptedProcess::from_sleeping(
+                self.state,
+                self.sleeping_threads.take(),
+                interrupted_threads,
+                self.zombie.take(),
+            );
+
+            Ok((join_cond, interrupted_process.resume(), ctx))
         } else if let Some(sleeping_threads) = self.sleeping_threads.take() {
             Err(Ok((
                 join_cond,

--- a/src/kernel/src/pm/process/state/sleeping.rs
+++ b/src/kernel/src/pm/process/state/sleeping.rs
@@ -87,7 +87,7 @@ impl SleepingProcess {
         match sleeping_threads.remove_if(|thread| thread.id() == tid) {
             Ok((sleeping_threads, sleeping_thread)) => {
                 let ready_thread: ReadyThread = sleeping_thread.wakeup();
-                Ok(RunnableProcess::from_state_with_ready_thread(
+                Ok(RunnableProcess::from_state(
                     self.state,
                     NonEmptyVecDeque::new(ready_thread),
                     None,
@@ -175,7 +175,7 @@ impl SleepingProcess {
 
     pub fn add_thread(mut self, ready_thread: ReadyThread) -> RunnableProcess {
         trace!("add_thread(): self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
-        RunnableProcess::from_state_with_ready_thread(
+        RunnableProcess::from_state(
             self.state,
             NonEmptyVecDeque::new(ready_thread),
             None,

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -212,7 +212,7 @@ impl ReadyThread {
         self.0.id
     }
 
-    pub fn resume(mut self) -> (RunningThread, Option<InterruptReason>, *mut ContextInformation) {
+    pub fn run(mut self) -> (RunningThread, Option<InterruptReason>, *mut ContextInformation) {
         let ctx: *mut ContextInformation = self.0.context_mut();
         let interrupt_reason: Option<InterruptReason> = self.0.interrupt_reason.take();
         (RunningThread(self.0), interrupt_reason, ctx)

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -52,6 +52,8 @@ struct ThreadState {
     context: Pin<Box<ContextInformation>>,
     /// Lookup table of locked mutexes.
     locked_mutexes: BTreeMap<MutexAddress, MutexGuard>,
+    /// Interrupt reason, if any.
+    interrupt_reason: Option<InterruptReason>,
 }
 
 impl ThreadState {
@@ -68,6 +70,7 @@ impl ThreadState {
             user_stack,
             join_cond: Condvar::new(),
             locked_mutexes: BTreeMap::new(),
+            interrupt_reason: None,
         }
     }
 
@@ -209,9 +212,10 @@ impl ReadyThread {
         self.0.id
     }
 
-    pub fn resume(mut self) -> (RunningThread, *mut ContextInformation) {
+    pub fn resume(mut self) -> (RunningThread, Option<InterruptReason>, *mut ContextInformation) {
         let ctx: *mut ContextInformation = self.0.context_mut();
-        (RunningThread(self.0), ctx)
+        let interrupt_reason: Option<InterruptReason> = self.0.interrupt_reason.take();
+        (RunningThread(self.0), interrupt_reason, ctx)
     }
 
     pub fn terminate(self) -> ZombieThread {
@@ -284,9 +288,9 @@ impl InterruptedThread {
         self.thread.id
     }
 
-    pub fn resume(mut self) -> (RunningThread, InterruptReason, *mut ContextInformation) {
-        let ctx: *mut ContextInformation = self.thread.context_mut();
-        (RunningThread(self.thread), self.reason, ctx)
+    pub fn resume(mut self) -> ReadyThread {
+        self.thread.interrupt_reason = Some(self.reason);
+        ReadyThread(self.thread)
     }
 
     pub fn join_cond(&self) -> Condvar {

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -11,9 +11,12 @@ use crate::{
         kstack::KernelStack,
         ustack::UserStack,
     },
-    pm::sync::{
-        condvar::Condvar,
-        mutex::MutexGuard,
+    pm::{
+        clock,
+        sync::{
+            condvar::Condvar,
+            mutex::MutexGuard,
+        },
     },
 };
 use ::alloc::{
@@ -118,7 +121,7 @@ impl RunningThread {
 
     pub fn schedule(mut self) -> (ReadyThread, *mut ContextInformation) {
         let ctx: *mut ContextInformation = self.0.context_mut();
-        (ReadyThread(self.0), ctx)
+        (ReadyThread::from_state(self.0), ctx)
     }
 
     ///
@@ -196,7 +199,10 @@ impl RunningThread {
 //==================================================================================================
 
 #[derive(Debug)]
-pub struct ReadyThread(Box<ThreadState>);
+pub struct ReadyThread {
+    state: Box<ThreadState>,
+    admission_time: SystemTime,
+}
 
 impl ReadyThread {
     pub fn new(
@@ -205,28 +211,42 @@ impl ReadyThread {
         user_stack: Option<UserStack>,
         context: ContextInformation,
     ) -> Self {
-        Self(Box::new(ThreadState::new(id, kernel_stack, user_stack, context)))
+        Self {
+            state: Box::new(ThreadState::new(id, kernel_stack, user_stack, context)),
+            admission_time: clock::now(),
+        }
+    }
+
+    fn from_state(state: Box<ThreadState>) -> Self {
+        Self {
+            state,
+            admission_time: clock::now(),
+        }
     }
 
     pub fn tid(&self) -> ThreadIdentifier {
-        self.0.id
+        self.state.id
     }
 
     pub fn run(mut self) -> (RunningThread, Option<InterruptReason>, *mut ContextInformation) {
-        let ctx: *mut ContextInformation = self.0.context_mut();
-        let interrupt_reason: Option<InterruptReason> = self.0.interrupt_reason.take();
-        (RunningThread(self.0), interrupt_reason, ctx)
+        let ctx: *mut ContextInformation = self.state.context_mut();
+        let interrupt_reason: Option<InterruptReason> = self.state.interrupt_reason.take();
+        (RunningThread(self.state), interrupt_reason, ctx)
     }
 
     pub fn terminate(self) -> ZombieThread {
         ZombieThread {
-            state: self.0,
+            state: self.state,
             status: ErrorCode::Interrupted.into(),
         }
     }
 
     pub fn join_cond(&self) -> Condvar {
-        self.0.join_cond.clone()
+        self.state.join_cond.clone()
+    }
+
+    pub fn admission_time(&self) -> SystemTime {
+        self.admission_time
     }
 }
 
@@ -242,7 +262,7 @@ pub struct SleepingThread {
 
 impl SleepingThread {
     pub fn wakeup(self) -> ReadyThread {
-        ReadyThread(self.thread)
+        ReadyThread::from_state(self.thread)
     }
 
     pub fn interrupt(self, reason: InterruptReason) -> InterruptedThread {
@@ -290,7 +310,7 @@ impl InterruptedThread {
 
     pub fn resume(mut self) -> ReadyThread {
         self.thread.interrupt_reason = Some(self.reason);
-        ReadyThread(self.thread)
+        ReadyThread::from_state(self.thread)
     }
 
     pub fn join_cond(&self) -> Condvar {
@@ -351,7 +371,7 @@ impl ThreadManager {
         let id: ThreadIdentifier = self.next_id;
         self.next_id = ThreadIdentifier::from(<i32>::from(self.next_id) + 1);
 
-        ReadyThread(Box::new(ThreadState::new(id, kernel_stack, user_stack, context)))
+        ReadyThread::new(id, kernel_stack, user_stack, context)
     }
 }
 


### PR DESCRIPTION
This pull request introduces several changes to the kernel's process management and scheduling system, focusing on improving thread scheduling, atomic operation consistency, and code clarity. Key updates include replacing the `ProcessManager::switch` method with `ProcessManager::giveup`, introducing relaxed atomic ordering for performance optimization, and enhancing thread scheduling logic to handle different process states more effectively.

### Process Management and Scheduling Enhancements:
* Replaced `ProcessManager::switch` with `ProcessManager::giveup` to better reflect the behavior of yielding the CPU. This change affects `do_kcall`, `kcall_handler`, and the timer interrupt handler. [[1]](diffhunk://#diff-eab92d2fac774562ed16ad7820f87f6344accfdba6fb364d3d15c66f930ec7d8L123-R123) [[2]](diffhunk://#diff-cab264a0b755a96c8487aca060ca8b7edf7f70a1caf09a1007926297b9a4ae85L182-R182) [[3]](diffhunk://#diff-e80e532b7f13a992054f83a8d94e779688698303e5586301916cd32fa2b7e3f2L106-R111)
* Refactored the `schedule`, `sleep`, `exit`, and `exit_thread` methods in `ProcessManagerInner` to handle process states (ready, suspended, zombie) more explicitly and ensure proper scheduling of the next thread to run. These methods now return detailed tuples for the next thread and context information. [[1]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L532-R582) [[2]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L612-R664) [[3]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L763-R792) [[4]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L824-R869)

### Atomic Operation Optimization:
* Introduced a constant `ORDER` with relaxed atomic ordering for all atomic operations in the kernel, given the single-core nature of the system. Updated atomic operations in `TimerTicks` to use this relaxed ordering. [[1]](diffhunk://#diff-e80e532b7f13a992054f83a8d94e779688698303e5586301916cd32fa2b7e3f2L23-R28) [[2]](diffhunk://#diff-e80e532b7f13a992054f83a8d94e779688698303e5586301916cd32fa2b7e3f2L65-R79) [[3]](diffhunk://#diff-631ebfb6f617241310fa8fb7464061cc4c9a1a4c682feb725d04d426059460a1R31-R45)

### Code Simplifications and Cleanup:
* Removed the `check_config` function, which enforced a power-of-two constraint on the scheduler frequency, as this constraint is no longer necessary.
* Updated imports in multiple files to improve readability and maintain consistency. [[1]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L85-R88) [[2]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L97)

### Configuration Adjustments:
* Changed the scheduler frequency from `1024` to `1000` in `kernel_config.toml` to align with standard timing intervals.