### PR TITLE
[build] Require TOOLCHAIN_DIR Env. Var. To Be Set

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -58,6 +58,6 @@ jobs:
               git fetch origin
               git reset --hard origin/${TARGET_BRANCH}
               rm -rf Cargo.lock
-              make init
+              make init TOOLCHAIN_DIR=$HOME/toolchain
             fi
           fi

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,11 @@ else
 export IMAGE ?= nanvix.iso
 endif
 
+# Make sure toolchain directory is set in the environment.
+ifndef TOOLCHAIN_DIR
+$(error Environment variable TOOLCHAIN_DIR is not set.)
+endif
+
 #===================================================================================================
 # Directories
 #===================================================================================================
@@ -61,7 +66,6 @@ export IMAGE_DIR     := $(BUILD_DIR)/iso
 export LOGS_DIR      := $(ROOT_DIR)/logs
 export SCRIPTS_DIR   := $(ROOT_DIR)/scripts
 export SOURCES_DIR   := $(ROOT_DIR)/src
-export TOOLCHAIN_DIR ?= $(ROOT_DIR)/toolchain
 export SYSROOT_DIR   ?= $(ROOT_DIR)/sysroot$(if $(filter yes,$(RELEASE)),-release,-debug)
 export TARGETS_DIR   := $(BUILD_DIR)/targets
 export OBJECTS_DIR   := $(ROOT_DIR)/target

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -84,7 +84,7 @@ def make(
     machine: str,
     arch: str,
     release: bool,
-    toolchain_dir: str = None,
+    toolchain_dir: str,
     log_level: str = None,
     verbose: bool = False,
     timeout: int = None,
@@ -104,13 +104,16 @@ def make(
         timeout (int, optional): Timeout. Defaults to None.
     """
 
-    command = ["make", target, f"MACHINE={machine}", f"TARGET={arch}"]
+    command = [
+        "make",
+        target,
+        f"MACHINE={machine}",
+        f"TARGET={arch}",
+        f"TOOLCHAIN_DIR={toolchain_dir}",
+    ]
 
     if log_level:
         command.append(f"LOG_LEVEL={log_level}")
-
-    if toolchain_dir:
-        command.append(f"TOOLCHAIN_DIR={toolchain_dir}")
 
     if verbose:
         command.append("VERBOSE=yes")
@@ -151,7 +154,7 @@ def lint(
     """
 
     make("clippy", machine, arch, release, toolchain_dir, log_level, verbose)
-    make("python-lint", machine, arch, release, None, log_level, verbose)
+    make("python-lint", machine, arch, release, toolchain_dir, log_level, verbose)
 
 
 def build(


### PR DESCRIPTION
With the latest toolchain upgrades, it is no longer supported to have the toolchain in `$NANVIX_ROOT/toolchain`, instead it is required (by `./scripts/setup/rust.sh`) for `$TOOLCHAIN_DIR` to be out-of-tree. In the Makefile, however, we still provide a default value for `TOOLCHAIN_DIR` that is invalid.

In this commit I remove the default assignment to `$TOOLCHAIN_DIR`, and instead require the variable to be set in the calling environment.