### PR TITLE
[utils] Remove Hard-Coded Core-Pinning in `nanvix-bench`

### DIFF
--- a/doc/benchmark.md
+++ b/doc/benchmark.md
@@ -2,7 +2,17 @@
 
 Nanvix ships with a small benchmarking tool, `nanvix-bench`, that you can use to measure the system's baseline performance.
 
-The experiments pin threads to cores. We recommend pinning `linuxd`, the Nanvix VM, and the client on a different set of cores, the latter preferably in a different NUMA domain. You may see, and modify, the current pinning strategy in [`./src/utils/nanvix-bench/src/hwloc.rs`](./src/utils/nanvix-bench/src/hwloc.rs).
+To get the best performance out of Nanvix, we recommend pinning different components to different sets of cores. In particular, we recommend pinning `linuxd`, the Nanvix VM, and the client to different core dies, the latter preferably in a different NUMA domain. For example, in a server with 4 CPU dies, each with 5 cores, the following is a good pinning strategy:
+
+```json
+{
+    "client_core_str": "0-9",
+    "linuxd_core_str": "10-14",
+    "nanovm_core_str": "15-19"
+}
+```
+
+You will need to save this JSON file.
 
 `nanvix-bench` currently supports the following benchmarks:
 
@@ -15,6 +25,12 @@ you may run each experiment with:
 
 ```bash
 ./bin/nanvix-bench.elf -benchmark [cold-start,warm-start,warm-start-vmm,echo-breakdown]
+```
+
+if you are pinning cores, make sure to also pass the path to your JSON config file:
+
+```bash
+./bin/nanvix-bench.elf -benchmark [cold-start,warm-start,warm-start-vmm,echo-breakdown] -hwloc <path_to_file.json>
 ```
 
 > ℹ️ **Note:** To run `cold-start`, `warm-start`, and `warm-start-vmm`, compile Nanvix with `make all RELEASE=yes LOG_LEVEL=panic`.

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -19,6 +19,8 @@ log = { workspace = true }
 microvm = { workspace = true }
 nix = { workspace = true }
 profiler = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["std"] }
 sys = { workspace = true, features = ["std"] }
 syscall = { workspace = true, features = ["std"] }
 syscomm = { workspace = true }

--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -5,10 +5,15 @@
 // Imports
 //==================================================================================================
 
-use crate::benchmark::BenchmarkFlavour;
+use crate::{
+    benchmark::BenchmarkFlavour,
+    hwloc::HwLoc,
+};
 use anyhow::Result;
 use log::error;
 use std::{
+    fs::File,
+    io::BufReader,
     process,
     str::FromStr,
 };
@@ -19,6 +24,7 @@ use std::{
 
 pub struct Args {
     benchmark: BenchmarkFlavour,
+    hwloc: Option<HwLoc>,
 }
 
 //==================================================================================================
@@ -28,16 +34,20 @@ pub struct Args {
 impl Args {
     const OPT_HELP: &'static str = "-help";
     const OPT_BENCHMARK: &'static str = "-benchmark";
+    const OPT_HWLOC: &'static str = "-hwloc";
 
     fn usage() -> String {
         format!(
-            "usage: ./bin/nanvix-bench.elf {} [cold-start,warm-start,echo-breakdown]",
-            Self::OPT_BENCHMARK
+            "usage: ./bin/nanvix-bench.elf {} [cold-start,warm-start,echo-breakdown] [{} \
+             <path_to_hwloc.json>]",
+            Self::OPT_BENCHMARK,
+            Self::OPT_HWLOC,
         )
     }
 
     pub fn parse(args: Vec<String>) -> Result<Self> {
         let mut benchmark_str: String = String::new();
+        let mut hwloc: Option<HwLoc> = None;
 
         let mut i: usize = 1;
         while i < args.len() {
@@ -54,6 +64,18 @@ impl Args {
                     }
                     benchmark_str = args[i].clone();
                 },
+                Self::OPT_HWLOC => {
+                    i += 1;
+                    if i >= args.len() {
+                        error!("{}", Self::usage());
+                        return Err(anyhow::anyhow!("missing value for: {}", Self::OPT_HWLOC));
+                    }
+
+                    // Parse hwloc from JSON file.
+                    let hwloc_file = File::open(args[i].clone())?;
+                    let hwloc_reader = BufReader::new(hwloc_file);
+                    hwloc = Some(serde_json::from_reader(hwloc_reader)?);
+                },
                 _ => {
                     error!("{}", Self::usage());
                     return Err(anyhow::anyhow!("invalid argument"));
@@ -64,7 +86,7 @@ impl Args {
         }
 
         match BenchmarkFlavour::from_str(benchmark_str.as_str()) {
-            Ok(benchmark) => Ok(Self { benchmark }),
+            Ok(benchmark) => Ok(Self { benchmark, hwloc }),
             Err(_) => {
                 error!("{}", Self::usage());
                 Err(anyhow::anyhow!("invalid argument"))
@@ -74,5 +96,9 @@ impl Args {
 
     pub fn benchmark(&self) -> BenchmarkFlavour {
         self.benchmark.clone()
+    }
+
+    pub fn hwloc(&self) -> Option<HwLoc> {
+        self.hwloc.clone()
     }
 }

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -52,7 +52,7 @@ impl FromStr for BenchmarkFlavour {
 }
 
 pub struct Benchmark {
-    pub hwloc: HwLoc,
+    pub hwloc: Option<HwLoc>,
     pub flavour: BenchmarkFlavour,
     pub gateway_address: String,
     pub linuxd_address: String,

--- a/src/utils/nanvix-bench/src/hwloc.rs
+++ b/src/utils/nanvix-bench/src/hwloc.rs
@@ -13,6 +13,7 @@ use nix::libc::{
     cpu_set_t,
     sched_setaffinity,
 };
+use serde::Deserialize;
 use std::{
     mem,
     str::FromStr,
@@ -22,13 +23,25 @@ use std::{
 // Structures
 //==================================================================================================
 
-pub const CLIENT_CORE_STR: &str = "0-9";
-pub const NANVIX_LINUXD_CORE_STR: &str = "10-14";
-pub const NANVIX_NANOVM_CORE_STR: &str = "15-19";
-
+#[derive(Clone, Debug, Deserialize)]
 pub struct HwLoc {
-    pub linuxd_core_str: String,
-    pub nanovm_core_str: String,
+    client_core_str: String,
+    linuxd_core_str: String,
+    nanovm_core_str: String,
+}
+
+impl HwLoc {
+    pub fn get_client_core_str(&self) -> String {
+        self.client_core_str.clone()
+    }
+
+    pub fn get_linuxd_core_str(&self) -> String {
+        self.linuxd_core_str.clone()
+    }
+
+    pub fn get_nanovm_core_str(&self) -> String {
+        self.nanovm_core_str.clone()
+    }
 }
 
 /// Parses a CPU mask string (e.g., "0-3,5,7-8") into a Vec of CPU indices.
@@ -81,6 +94,6 @@ fn pin_current_thread_to_mask(mask: &str) -> Result<()> {
 }
 
 /// This method pins the client (running thread) to a pre-defined CPU core.
-pub fn pin_main_thread() -> Result<()> {
-    pin_current_thread_to_mask(CLIENT_CORE_STR)
+pub fn pin_main_thread(mask: String) -> Result<()> {
+    pin_current_thread_to_mask(&mask)
 }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -29,7 +29,6 @@ use crate::{
         Benchmark,
         BenchmarkFlavour,
     },
-    hwloc::HwLoc,
 };
 use ::sys::ipc::Message;
 use anyhow::Result;
@@ -133,10 +132,7 @@ impl Benchmark {
     }
 
     fn start_linuxd(&self) -> Result<Child> {
-        let linuxd_args: Vec<String> = vec![
-            "taskset".to_string(),
-            "-ac".to_string(),
-            self.hwloc.linuxd_core_str.to_string(),
+        let mut linuxd_args: Vec<String> = vec![
             format!("{}/bin/linuxd.elf", get_proj_root()),
             "-user-vm-bind-addr".to_string(),
             self.linuxd_address.clone(),
@@ -145,6 +141,14 @@ impl Benchmark {
             "-gateway-bind-socket-type".to_string(),
             "tcp".to_string(),
         ];
+        if let Some(hwloc) = &self.hwloc {
+            let taskset: Vec<String> = vec![
+                "taskset".to_string(),
+                "-ac".to_string(),
+                hwloc.get_linuxd_core_str(),
+            ];
+            linuxd_args.splice(0..0, taskset);
+        }
 
         debug!("Starting linuxd with command: {}", linuxd_args.join(" "));
         let linuxd_cmd = Command::new(&linuxd_args[0])
@@ -159,10 +163,7 @@ impl Benchmark {
     }
 
     fn start_nanovm(&self) -> Result<Child> {
-        let nanovm_args: Vec<String> = vec![
-            "taskset".to_string(),
-            "-ac".to_string(),
-            self.hwloc.nanovm_core_str.to_string(),
+        let mut nanovm_args: Vec<String> = vec![
             format!("{}/bin/microvm.elf", get_proj_root()),
             "-kernel".to_string(),
             format!("{}/bin/kernel.elf", get_proj_root()),
@@ -181,6 +182,14 @@ impl Benchmark {
             "-gateway".to_string(),
             self.linuxd_address.clone(),
         ];
+        if self.hwloc.is_some() {
+            let taskset: Vec<String> = vec![
+                "taskset".to_string(),
+                "-ac".to_string(),
+                self.hwloc.clone().unwrap().get_nanovm_core_str(),
+            ];
+            nanovm_args.splice(0..0, taskset);
+        }
 
         debug!("Starting nano VM with command: {}", nanovm_args.join(" "));
         let nanovm_cmd = Command::new(&nanovm_args[0])
@@ -591,11 +600,10 @@ fn main() -> Result<()> {
     let args: Args = Args::parse(std::env::args().collect())?;
 
     // Initialize HwLoc and pin main thread.
-    let hwloc = HwLoc {
-        linuxd_core_str: hwloc::NANVIX_LINUXD_CORE_STR.to_string(),
-        nanovm_core_str: hwloc::NANVIX_NANOVM_CORE_STR.to_string(),
-    };
-    hwloc::pin_main_thread()?;
+    let hwloc = args.hwloc();
+    if hwloc.is_some() {
+        hwloc::pin_main_thread(hwloc.clone().unwrap().get_client_core_str())?;
+    }
 
     let mut benchmark = Benchmark {
         hwloc,


### PR DESCRIPTION
This pull request introduces support for dynamic core pinning in the `nanvix-bench` benchmarking tool, allowing users to specify CPU core configurations via a JSON file. Additionally, it refactors the codebase to integrate this feature seamlessly, improving flexibility and usability.

### Documentation Updates:
* [`doc/benchmark.md`](diffhunk://#diff-eb27f4e4258ffc80b74ac6062c45456e9485df8754c472755ff35afb39647b53L5-R15): Updated instructions to include a new JSON-based core pinning strategy and added examples for configuration. Users can now pass the path to a JSON file specifying core mappings when running benchmarks. [[1]](diffhunk://#diff-eb27f4e4258ffc80b74ac6062c45456e9485df8754c472755ff35afb39647b53L5-R15) [[2]](diffhunk://#diff-eb27f4e4258ffc80b74ac6062c45456e9485df8754c472755ff35afb39647b53R30-R35)

### Dependency Additions:
* [`Cargo.toml`](diffhunk://#diff-007451d36037394710392dd3001751fc278b1664e8999248ea04f32f64c4385eR22-R23): Added `serde` and `serde_json` dependencies to enable JSON parsing for core pinning configurations.

### Code Enhancements:
#### Core Pinning Feature:
* [`src/utils/nanvix-bench/src/args.rs`](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5L8-R16): Modified `Args` struct and parsing logic to include an optional `hwloc` parameter for JSON-based core mappings. Added methods to handle the new `-hwloc` argument and parse the JSON file. [[1]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5L8-R16) [[2]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5R27) [[3]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5R37-R50) [[4]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5R67-R78) [[5]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5L67-R89) [[6]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5R100-R103)
* [`src/utils/nanvix-bench/src/hwloc.rs`](diffhunk://#diff-586cb9220fe7b4a850caac3af6d584147d7c6a4a86d3151a6be19363f62fc966R16): Refactored `HwLoc` struct to dynamically load core mappings from JSON. Added methods to retrieve core strings and updated thread pinning logic to use these dynamic mappings. [[1]](diffhunk://#diff-586cb9220fe7b4a850caac3af6d584147d7c6a4a86d3151a6be19363f62fc966R16) [[2]](diffhunk://#diff-586cb9220fe7b4a850caac3af6d584147d7c6a4a86d3151a6be19363f62fc966L25-R44) [[3]](diffhunk://#diff-586cb9220fe7b4a850caac3af6d584147d7c6a4a86d3151a6be19363f62fc966L84-R98)

#### Integration with Benchmark Execution:
* [`src/utils/nanvix-bench/src/main.rs`](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL136-R135): Updated `Benchmark` struct and methods to optionally use dynamic core mappings for `linuxd` and `nanoVM` processes. Refactored command generation to prepend `taskset` arguments when core mappings are provided. [[1]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL136-R135) [[2]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bR144-R151) [[3]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL162-R166) [[4]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bR185-R192) [[5]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL594-R606)