### PR TITLE
[scripts] B: Missing WASI_SDK_PATH

### DIFF
--- a/scripts/setup/rust.sh
+++ b/scripts/setup/rust.sh
@@ -68,6 +68,8 @@ then
     tar xvf "${WASI_SDK_FILE}"
 fi
 
+export WASI_SDK_PATH=$(pwd)/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}
+
 # Clone repository.
 if [ ! -d "${REPOSITORY_NAME}" ];
 then


### PR DESCRIPTION
This pull request adds an environment variable to the Rust setup script to define the path to the WASI SDK.

* [`scripts/setup/rust.sh`](diffhunk://#diff-25af995b690ea3464d0522672d52f274dda67eb35e48738420f188d82deff93dR71-R72): Added an `export` statement to set the `WASI_SDK_PATH` variable based on the current working directory and WASI version, architecture, and OS.