### PR TITLE
[scripts] Fix Run Script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.19"
+version = "0.8.20"
 license-file = "LICENSE.txt"
 authors = ["The Maintainers of Nanvix"]
 edition = "2021"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -15,7 +15,7 @@ export SCRIPT_NAME=$0
 export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
 
 # Target configuration
-MEMSIZE=$(grep 'memory_size' $SCRIPT_DIR/../build/kernel_config.toml | awk -F'=' '{print $2}' | tr -d ' ')B
+MEMSIZE=$(grep 'memory_size' $SCRIPT_DIR/../build/kernel_config.toml | awk -F'=' '{print $2}' | tr -d ' ')
 echo ">>> Memory Size: $MEMSIZE"
 
 #===================================================================================================
@@ -113,7 +113,7 @@ function run_qemu
 			$smp
 			-display none
 			-cpu pentium2
-			-m $MEMSIZE
+			-m ${MEMSIZE}B
 			-mem-prealloc"
 
 	cmd="$qemu_cmd -cdrom $image"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -13,10 +13,18 @@ TIMEOUT=$5  # Timeout
 # Global Variables
 export SCRIPT_NAME=$0
 export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
+export NANVIX_HOME=${NANVIX_HOME:-`git rev-parse --show-toplevel`}
 
 # Target configuration
 MEMSIZE=$(grep 'memory_size' $SCRIPT_DIR/../build/kernel_config.toml | awk -F'=' '{print $2}' | tr -d ' ')
 echo ">>> Memory Size: $MEMSIZE"
+
+# Check if MEMSIZE is invalid.
+if [[ -z "$MEMSIZE" || ! "$MEMSIZE" =~ ^[0-9]+$ ]];
+then
+	echo "Error: MEMSIZE is not set or is not a valid integer."
+	exit 1
+fi
 
 #===================================================================================================
 # usage()

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -145,25 +145,27 @@ function run_qemu
 #===================================================================================================
 
 # Runs a binary in MicroVm.
-function run_microvm()
+function run_microvm
 {
 	local image=$1   # Image.
 	local timeout=$2 # Timeout for test mode.
 
-	# Base command.
-	local cmd="$MICROVM_PATH/microvm.elf"
+	local microvm="$NANVIX_HOME/bin/microvm.elf"
+	local kernel="$NANVIX_HOME/bin/kernel.elf"
+	local memsize=$(echo "$MEMSIZE / 1024 / 1024" | bc)
 
-	cmd="$cmd -kernel $image -memory $MEMSIZE"
+	# Base command.
+	cmd="$microvm -kernel $kernel -initrd $image -memory ${memsize}M"
 
 	# Run.
 	if [ ! -z $timeout ];
 	then
-		cmd="timeout -s SIGINT --preserve-status --foreground $timeout sudo -E $cmd"
+		cmd="timeout -s SIGINT --preserve-status --foreground $timeout $cmd"
 	fi
 
 	echo "Running: $cmd"
 
-	$cmd
+	eval "$cmd"
 }
 
 #===================================================================================================

--- a/scripts/setup/rust.sh
+++ b/scripts/setup/rust.sh
@@ -68,6 +68,8 @@ then
     tar xvf "${WASI_SDK_FILE}"
 fi
 
+export WASI_SDK_PATH=$(pwd)/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}
+
 # Clone repository.
 if [ ! -d "${REPOSITORY_NAME}" ];
 then


### PR DESCRIPTION
This pull request includes updates to the `Cargo.toml` file and improvements to the `scripts/run.sh` and `scripts/setup/rust.sh` scripts. The changes enhance script reliability, improve memory handling, and update the workspace package version.

### Updates to `Cargo.toml`:

* Updated the workspace package version from `0.8.19` to `0.8.20`.

### Improvements to `scripts/run.sh`:

* Added `NANVIX_HOME` environment variable initialization using `git rev-parse` to determine the repository's root directory. This ensures the variable is set correctly even if not explicitly provided.
* Improved memory size handling:
  - Trimmed unnecessary characters from `MEMSIZE` and added validation to ensure it is a valid integer. If invalid, the script exits with an error message.
  - Corrected memory size formatting in the `run_qemu` function by appending `B` explicitly to `MEMSIZE`.
* Refactored the `run_microvm` function:
  - Removed redundant code and replaced hardcoded paths with dynamically constructed paths using `NANVIX_HOME`.
  - Adjusted memory size calculation to convert bytes to megabytes.
  - Simplified the command execution and removed unnecessary use of `sudo`.

### Improvements to `scripts/setup/rust.sh`:

* Added `WASI_SDK_PATH` environment variable initialization to point to the extracted WASI SDK directory, ensuring consistent access to the SDK files.