### PR TITLE
[daemons] Make linuxd Support Multiple User VM Connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ kvm-ioctls = "0.22.0"
 libc = "0.2.172"
 log = "0.4.27"
 microvm = { path = "src/microvm", default-features = false }
+mio = { version = "1", features = ["net", "os-poll"] }
 nix = { version = "0.30.1", default-features = false, features = [
         "process",
         "signal",
@@ -94,6 +95,7 @@ serde_json = { version = "1.0.140", default-features = false, features = [
 ] }
 signal-hook = "0.3.18"
 slab = { path = "src/libs/slab", default-features = false }
+slab_external = { package = "slab", version = "0.4" }
 spin = { git = "https://github.com/nanvix/spin-rs", package = "spin", branch = "nanvix/v0.10.0", default-features = false }
 static_assert = { path = "src/libs/static_assert", default-features = false }
 sysapi = { path = "src/libs/sysapi", default-features = false }

--- a/src/daemons/linuxd/Cargo.toml
+++ b/src/daemons/linuxd/Cargo.toml
@@ -16,8 +16,10 @@ config = { workspace = true }
 flexi_logger = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
+mio = { workspace = true }
 profiler = { workspace = true }
 signal-hook = { workspace = true }
+slab_external = { workspace = true }
 sys = { workspace = true, features = ["std"] }
 sysapi = { workspace = true, features = ["std"] }
 syscall = { workspace = true, features = ["std"] }

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -29,6 +29,8 @@ use crate::{
     },
 };
 use ::anyhow::Result;
+use ::mio::{Events, Interest, Poll, Token};
+use ::slab_external::Slab;
 use ::std::{
     io,
     io::{
@@ -137,15 +139,16 @@ use ::syscall::{
     LinuxDaemonMessageHeader,
     LINUXD,
 };
-use ::syscomm::SocketStream;
+use ::syscomm::{SocketListener, SocketStream};
 
 //==================================================================================================
 // Structures
 //==================================================================================================
 
 pub struct LinuxDaemon {
+    // The user VM listener socket should not be accessed by different worker threads.
+    user_vm_listener: SocketListener,
     assembler: Arc<Mutex<RequestAssembler>>,
-    uvm_stream: Arc<Mutex<SocketStream>>,
     gateway_conn: Arc<Mutex<Option<SocketStream>>>,
     venv: Arc<Mutex<VirtualEnviromentDirectory>>,
 }
@@ -156,110 +159,197 @@ pub struct LinuxDaemon {
 
 impl LinuxDaemon {
     pub fn init(
-        uvm_stream: SocketStream,
+        user_vm_listener: SocketListener,
         gateway_conn: Option<SocketStream>,
     ) -> Result<Self, Error> {
-        if let Err(error) = uvm_stream.set_nonblocking(true) {
-            let reason: &str = "failed to set UVM stream to non-blocking mode";
-            error!("init(): {reason:?} (error={error:?})");
-            return Err(Error::new(ErrorCode::InvalidArgument, reason));
-        }
-
         Ok(Self {
+            user_vm_listener,
             assembler: Arc::new(Mutex::new(RequestAssembler::default())),
-            uvm_stream: Arc::new(Mutex::new(uvm_stream)),
             gateway_conn: Arc::new(Mutex::new(gateway_conn)),
             venv: Arc::new(Mutex::new(VirtualEnviromentDirectory::new())),
         })
     }
 
-    pub fn run(&mut self) -> Result<(), Error> {
+    fn accept_connections(
+        &mut self,
+        user_vm_connections: &mut Slab<Arc<Mutex<SocketStream>>>,
+        poll: &Poll,
+        start_token: usize
+    ) ->Result<(), Error> {
+        // Accept new connection in a loop, as we have a non-blocking socket, and
+        // we may have more than one connection pending to be accepted.
         loop {
-            let uvm_stream: Arc<Mutex<SocketStream>> = self.uvm_stream.clone();
+            match self.user_vm_listener.accept() {
+                Ok(mut stream) => {
+                    let entry = user_vm_connections.vacant_entry();
+                    let token = Token(start_token + entry.key());
+
+                    poll.registry().register(&mut stream, token, Interest::READABLE | Interest::WRITABLE)
+                        .map_err(|_| Error::new(ErrorCode::IoErr, "failed to register new user VM to poll"))?;
+                    entry.insert(Arc::new(Mutex::new(stream)));
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    break;
+                }
+                Err(e) => {
+                    // This is a fatal error for the user VM, but we don't want to
+                    // kill linuxd.
+                    error!("Error accepting connection from user VM: {e:?}");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Wrapper around the extraction of the connection from the slab, as we need a mutable
+    /// reference, and with the function call we ensure we return the borrow.
+    fn process_connection(
+        &mut self,
+        user_vm_connections: &mut Slab<Arc<Mutex<SocketStream>>>,
+        conn_id: usize
+    ) ->Result<Arc<Mutex<SocketStream>>, Error> {
+        match user_vm_connections.get_mut(conn_id) {
+            Some(user_vm_stream) => Ok(user_vm_stream.clone()),
+            None => Err(Error::new(ErrorCode::InvalidArgument, "Invalid connection ID")),
+        }
+    }
+
+    /// This is the main run loop for linuxd. It uses a listener socket to
+    /// accept connections from multiple user VMs, and it polls over all
+    /// active connections to serve requests.
+    pub fn run(&mut self) -> Result<(), Error> {
+        // We keep a slab of tokens to active connections from user VMs. We
+        // reserve the first token for the main listener socket, that should
+        // out-live user VMs.
+        //
+        // We use a slab because it is better suited to index a highly-dense
+        // collection with usize keys.
+        const LISTENER: Token = Token(0);
+        const START_TOKEN: usize = 1;
+        let mut user_vm_connections: Slab<Arc<Mutex<SocketStream>>> = Slab::new();
+
+        let mut poll = Poll::new().map_err(|_| Error::new(ErrorCode::IoErr, "failed to create Poll"))?;
+        let mut events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+
+        poll
+            .registry()
+            .register(&mut self.user_vm_listener, LISTENER, Interest::READABLE)
+            .map_err(|_| Error::new(ErrorCode::IoErr, "failed to register user VM listener to poll"))?;
+
+        loop {
             let gateway_conn: Arc<Mutex<Option<SocketStream>>> = self.gateway_conn.clone();
             let venv: Arc<Mutex<VirtualEnviromentDirectory>> = self.venv.clone();
             let assembler: Arc<Mutex<RequestAssembler>> = self.assembler.clone();
 
-            // Receive a message from the user virtual machine.
-            let message: Message = match Self::recv(uvm_stream.clone()) {
-                Ok(message) => message,
+            poll.poll(&mut events, None)
+                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to poll user VM events"))?;
 
-                Err(error_kind) => match error_kind {
-                    ErrorKind::WouldBlock => continue,
-                    ErrorKind::UnexpectedEof => {
-                        info!("connection closed");
-                        break;
-                    },
-                    _ => {
-                        let reason: String =
-                            format!("failed to read message (error={error_kind:?})");
-                        unimplemented!("handle: {reason}");
-                    },
-                },
-            };
-
-            trace!(
-                "message.source={:?}, message.destination={:?}, message.type={:?}",
-                { message.source },
-                { message.destination },
-                message.message_type,
-            );
-
-            let source: ThreadIdentifier = match { message.source }.as_id() {
-                Err(tid) => tid,
-                Ok(pid) => {
-                    unimplemented!("received message from process {pid:?} instead of thread");
-                },
-            };
-
-            // Check if process is associated with a virtual environment.
-            let (channel_tx, channel_rx): (Sender<Message>, Option<Receiver<Message>>) = {
-                let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
-                let env = venv.get(source);
-                if let Some(env) = env {
-                    (env.get_channel_tx(), None)
-                } else {
-                    // Join a new virtual environment.
-                    match venv.join(source, VirtualEnvironmentIdentifier::NEW) {
-                        Ok((_, channel_tx, channel_rx)) => (channel_tx, Some(channel_rx)),
-                        Err(error) => {
-                            warn!("failed to join new virtual environment (error={error:?})");
-                            let message: Message = crate::build_error(source, error.code);
-                            Self::send(uvm_stream.clone(), message).unwrap();
-                            continue;
-                        },
+            for event in events.iter() {
+                match event.token() {
+                    // First we see if we have received any messages on the main listener socket.
+                    // These indicate new user VMs connecting to linuxd.
+                    LISTENER => {
+                        self.accept_connections(&mut user_vm_connections, &poll, START_TOKEN)?;
                     }
-                }
-            };
 
-            // Spawn a new worker thread, if necessary.
-            if let Some(channel_rx) = channel_rx {
-                // Spawn a thread to handle the message.
-                let venv: Arc<Mutex<VirtualEnviromentDirectory>> = venv.clone();
-                let _ = std::thread::spawn(move || {
-                    Self::handle_message(channel_rx, uvm_stream, gateway_conn, venv, assembler);
-                });
-            }
+                    // Now we process events from active connections.
+                    Token(t) => {
+                        let conn_id = t - START_TOKEN;
 
-            // Dispatch message to worker thread.
-            if let Err(error) = channel_tx.send(message) {
-                error!(
-                    "run(): failed to dispatch message to worker thread (tid={source:?}, \
-                     error={error:?})"
-                );
-                // Remove thread from the virtual environment.
-                let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
-                if let Err(error) = venv.leave(source) {
-                    warn!(
-                        "run(): failed to remove thread from virtual environment (tid={source:?}, \
-                         error={error:?})",
-                    );
+                        // Receive a message from the user virtual machine.
+                        let user_vm_stream = self.process_connection(&mut user_vm_connections, conn_id)?;
+                        let message: Message = match Self::recv(user_vm_stream.clone()) {
+                            Ok(message) => message,
+
+                            Err(error_kind) => match error_kind {
+                                ErrorKind::WouldBlock => continue,
+                                ErrorKind::UnexpectedEof => {
+                                    info!("connection closed");
+
+                                    let mut locked_user_vm_stream: MutexGuard<'_, SocketStream> =
+                                        user_vm_stream.lock().unwrap();
+                                    poll.registry().deregister(&mut *locked_user_vm_stream)
+                                        .map_err(|_| Error::new(ErrorCode::IoErr, "failed to de-register user VM from poll"))?;
+                                    user_vm_connections.remove(conn_id);
+                                    continue;
+                                },
+                                _ => {
+                                    let reason: String =
+                                        format!("failed to read message (error={error_kind:?})");
+                                    unimplemented!("handle: {reason}");
+                                },
+                            },
+                        };
+
+                        trace!(
+                            "message.source={:?}, message.destination={:?}, message.type={:?}",
+                            { message.source },
+                            { message.destination },
+                            message.message_type,
+                        );
+
+                        let source: ThreadIdentifier = match { message.source }.as_id() {
+                            Err(tid) => tid,
+                            Ok(pid) => {
+                                unimplemented!("received message from process {pid:?} instead of thread");
+                            },
+                        };
+
+                        // Check if process is associated with a virtual environment.
+                        let (channel_tx, channel_rx): (Sender<Message>, Option<Receiver<Message>>) = {
+                            let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
+                            let env = venv.get(source);
+                            if let Some(env) = env {
+                                (env.get_channel_tx(), None)
+                            } else {
+                                // Join a new virtual environment.
+                                match venv.join(source, VirtualEnvironmentIdentifier::NEW) {
+                                    Ok((_, channel_tx, channel_rx)) => (channel_tx, Some(channel_rx)),
+                                    Err(error) => {
+                                        warn!("failed to join new virtual environment (error={error:?})");
+                                        let message: Message = crate::build_error(source, error.code);
+                                        Self::send(user_vm_stream.clone(), message).unwrap();
+                                        continue;
+                                    },
+                                }
+                            }
+                        };
+
+                        // Spawn a new worker thread, if necessary.
+                        if let Some(channel_rx) = channel_rx {
+                            // Spawn a thread to handle the message.
+                            let venv: Arc<Mutex<VirtualEnviromentDirectory>> = venv.clone();
+                            let gateway_conn = gateway_conn.clone();
+                            let assembler = assembler.clone();
+                            let _ = std::thread::spawn(move || {
+                                Self::handle_message(channel_rx, user_vm_stream.clone(), gateway_conn, venv, assembler);
+                            });
+                        }
+
+                        // Dispatch message to worker thread.
+                        if let Err(error) = channel_tx.send(message) {
+                            error!(
+                                "run(): failed to dispatch message to worker thread (tid={source:?}, \
+                                 error={error:?})"
+                            );
+                            // Remove thread from the virtual environment.
+                            let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
+                            if let Err(error) = venv.leave(source) {
+                                warn!(
+                                    "run(): failed to remove thread from virtual environment (tid={source:?}, \
+                                     error={error:?})",
+                                );
+                            }
+                        }
+                    }
                 }
             }
         }
 
         // TODO: https://github.com/nanvix/nanvix/issues/639
-
+        #[allow(unreachable_code)]
         self.send_eof()
     }
 

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -113,7 +113,10 @@ pub fn main() -> Result<()> {
 
     let user_vm_listener: SocketListener =
         match Socket::bind(user_vm_bind_socket_type, user_vm_sockaddr.clone()) {
-            Ok(listener) => listener,
+            Ok(listener) => {
+                info!("Listening to user VMs on: {user_vm_sockaddr:?}");
+                listener
+            }
             Err(e) => {
                 error!(
                     "failed to bind to user VM socket address (address={}, error={e:?})",
@@ -155,21 +158,7 @@ pub fn main() -> Result<()> {
         None => None,
     };
 
-    info!("Listening to user VMs on: {user_vm_sockaddr:?}");
-    let user_vm_stream: SocketStream = loop {
-        match user_vm_listener.accept() {
-            Ok(stream) => {
-                info!("Connected to user VM in: {:?}", stream.peer_addr());
-                break stream;
-            },
-            Err(error) => {
-                error!("Failed to accept connection: {error:?}");
-                continue;
-            },
-        };
-    };
-
-    let mut procd: LinuxDaemon = match LinuxDaemon::init(user_vm_stream, gateway_stream) {
+    let mut procd: LinuxDaemon = match LinuxDaemon::init(user_vm_listener, gateway_stream) {
         Ok(procd) => procd,
         Err(e) => panic!("failed to initialize process manager daemon (error={e:?})"),
     };

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -65,6 +65,13 @@ pub mod syscomm {
     /// Provides the length of the temporary bufer we use to read messages from the gateway.
     ///
     pub const GW_READ_BUFFER_LEN: usize = 4 * 1024;
+
+    ///
+    /// # Description
+    ///
+    /// Provides the maximum number of poll events we can buffer.
+    ///
+    pub const MAX_NUM_POLL_EVENTS: usize = 128;
 }
 
 //==================================================================================================

--- a/src/libs/syscomm/Cargo.toml
+++ b/src/libs/syscomm/Cargo.toml
@@ -11,6 +11,7 @@ description = "System Communication Library"
 homepage.workspace = true
 
 [dependencies]
-config = { workspace = true }
 anyhow = { workspace = true }
+config = { workspace = true }
 log = { workspace = true }
+mio = { version = "1", features = ["net", "os-poll"] }

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -293,6 +293,29 @@ impl Read for SocketStream {
     }
 }
 
+impl mio::event::Source for SocketStream {
+    fn register(&mut self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+        match self {
+            SocketStream::Tcp(stream) => stream.register(registry, token, interests),
+            SocketStream::Unix(stream) => stream.register(registry, token, interests),
+        }
+    }
+
+    fn reregister(&mut self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+        match self {
+            SocketStream::Tcp(stream) => stream.reregister(registry, token, interests),
+            SocketStream::Unix(stream) => stream.reregister(registry, token, interests),
+        }
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        match self {
+            SocketStream::Tcp(stream) => stream.deregister(registry),
+            SocketStream::Unix(stream) => stream.deregister(registry),
+        }
+    }
+}
+
 /// A struct representing a socket address.
 #[derive(Debug)]
 pub enum SocketAddr {

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -9,6 +9,14 @@ extern crate alloc;
 
 use ::anyhow::Result;
 use ::log::error;
+use ::mio::{
+    net::{
+        TcpListener,
+        TcpStream,
+        UnixListener,
+        UnixStream,
+    },
+};
 use ::std::{
     fs,
     io::{
@@ -18,14 +26,6 @@ use ::std::{
         Write,
     },
     mem,
-    net::{
-        TcpListener,
-        TcpStream,
-    },
-    os::unix::net::{
-        UnixListener,
-        UnixStream,
-    },
 };
 
 //==================================================================================================
@@ -47,7 +47,7 @@ pub struct Socket;
 impl Socket {
     pub fn bind(typ: SocketType, addr: String) -> Result<SocketListener> {
         match typ {
-            SocketType::Tcp => Ok(SocketListener::Tcp(TcpListener::bind(addr)?)),
+            SocketType::Tcp => Ok(SocketListener::Tcp(TcpListener::bind(addr.parse()?)?)),
             SocketType::Unix => Ok(SocketListener::Unix { listener: UnixListener::bind(&addr)?, path: addr.clone() }),
         }
     }
@@ -121,21 +121,13 @@ impl SocketStream {
     pub fn connect(typ: SocketType, addr: String) -> Result<SocketStream> {
         match typ {
             SocketType::Tcp => {
-                let stream: TcpStream = TcpStream::connect(addr)?;
+                let stream: TcpStream = TcpStream::connect(addr.parse()?)?;
                 Ok(SocketStream::Tcp(stream))
             },
             SocketType::Unix => {
                 let stream: UnixStream = UnixStream::connect(addr)?;
                 Ok(SocketStream::Unix(stream))
             },
-        }
-    }
-
-    /// Sets a socket stream to non-blocking mode.
-    pub fn set_nonblocking(&self, nonblocking: bool) -> Result<(), ::std::io::Error> {
-        match self {
-            SocketStream::Tcp(stream) => stream.set_nonblocking(nonblocking),
-            SocketStream::Unix(stream) => stream.set_nonblocking(nonblocking),
         }
     }
 

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -252,8 +252,9 @@ impl SocketStream {
                     // Otherwise, continue reading.
                 },
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                    // Non-blocking mode: no data yet, return error or retry.
-                    return Err(e);
+                    // WARNING: The worker thread will spin here waiting for the gateway to send
+                    // data.
+                    continue;
                 },
                 Err(e) => return Err(e),
             }

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -80,7 +80,7 @@ impl ::std::str::FromStr for SocketType {
 
 impl SocketListener {
     /// Accepts a connection on a socket.
-    pub fn accept(&self) -> Result<SocketStream> {
+    pub fn accept(&self) -> io::Result<SocketStream> {
         match self {
             SocketListener::Tcp(listener) => {
                 let (stream, _sockaddr): (TcpStream, std::net::SocketAddr) = listener.accept()?;

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -10,6 +10,9 @@ extern crate alloc;
 use ::anyhow::Result;
 use ::log::error;
 use ::mio::{
+    Interest,
+    Registry,
+    Token,
     net::{
         TcpListener,
         TcpStream,
@@ -103,6 +106,29 @@ impl Drop for SocketListener {
                     Err(e) => error!("error removing UNIX socket (path={path}, error={e:?})"),
                 }
             }
+        }
+    }
+}
+
+impl mio::event::Source for SocketListener {
+    fn register(&mut self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+        match self {
+            SocketListener::Tcp(listener) => listener.register(registry, token, interests),
+            SocketListener::Unix { listener, path: _ } => listener.register(registry, token, interests),
+        }
+    }
+
+    fn reregister(&mut self, registry: &Registry, token: Token, interests: Interest) -> io::Result<()> {
+        match self {
+            SocketListener::Tcp(listener) => listener.reregister(registry, token, interests),
+            SocketListener::Unix { listener, path: _ } => listener.reregister(registry, token, interests),
+        }
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        match self {
+            SocketListener::Tcp(listener) => listener.deregister(registry),
+            SocketListener::Unix { listener, path: _ } => listener.deregister(registry),
         }
     }
 }

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -84,10 +84,7 @@ fn main() -> Result<ExitCode> {
 
     let gateway: Option<Gateway> = match &gateway_addr {
         Some(addr) => match SocketStream::connect(gateway_socket_type, addr.clone()) {
-            Ok(stream) => {
-                stream.set_nonblocking(true)?;
-                Some(Gateway::new(stream))
-            },
+            Ok(stream) => Some(Gateway::new(stream)),
             Err(e) => {
                 let reason: String =
                     format!("failed to connect to gateway (gateway_addr={addr:?}, error={e:?})",);

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -17,6 +17,7 @@ flexi_logger = { workspace = true }
 indicatif = { workspace = true }
 log = { workspace = true }
 microvm = { workspace = true }
+mio = { version = "1", features = ["net", "os-poll"] }
 nix = { workspace = true }
 profiler = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -45,6 +45,7 @@ use microvm::{
     Gateway,
     Vmm,
 };
+use mio::net::UnixStream;
 use nix::{
     sys::signal::{
         Signal,
@@ -62,7 +63,6 @@ use std::{
     },
     mem,
     net::TcpStream,
-    os::unix::net::UnixStream,
     process::{
         self,
         Child,
@@ -430,7 +430,6 @@ impl Benchmark {
 
             // Spawn the VMM in a separate thread.
             let vmm_handle = std::thread::spawn(move || -> Result<()> {
-                vmm_stream.set_nonblocking(true)?;
                 let mut vmm: Vmm = Vmm::new(
                     config::kernel::MEMORY_SIZE,
                     format!("{}/bin/kernel.elf", get_proj_root()).as_str(),


### PR DESCRIPTION
In this PR I make linuxd support multiple user VM connections by maintaining a slab of active connections, and asynchronously polling over all of them.

The reason why the tests are not passing is because linuxd now never sends an EOF back to the gateway, so nanvixd tests hang forever. We could patch this by sending an EOF after a user VM is de-registered, but we will wait to have a more solid re-design of the control-plane to merge this one in.

Closes #674 