### PR TITLE
Enhancement benchmark boot time

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -14,6 +14,7 @@ runs:
     shell: bash
   - name: Run micro-benchmarks (MicroVM)
     run: |
+      ./bin/nanvix-bench.elf -benchmark boot-time -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_boot_time_microvm.txt
       ./bin/nanvix-bench.elf -benchmark cold-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_cold_start_microvm.txt
       ./bin/nanvix-bench.elf -benchmark warm-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_microvm.txt
     shell: bash
@@ -25,6 +26,7 @@ runs:
     shell: bash
   - name: Run micro-benchmarks (Hyperlight)
     run: |
+      ./bin/nanvix-bench.elf -benchmark boot-time -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_boot_time_hyperlight.txt
       ./bin/nanvix-bench.elf -benchmark cold-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_cold_start_hyperlight.txt
       ./bin/nanvix-bench.elf -benchmark warm-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_hyperlight.txt
     shell: bash
@@ -35,11 +37,17 @@ runs:
     run: |
       # First concatenate the latest `dev` results with the current PRs'.
       paste -d '\t' \
+        $HOME/ubench-results-dev/bench_boot_time_microvm.txt bench_boot_time_microvm.txt \
+        > /tmp/bench_boot_time_microvm_combined.txt
+      paste -d '\t' \
         $HOME/ubench-results-dev/bench_cold_start_microvm.txt bench_cold_start_microvm.txt \
         > /tmp/bench_cold_start_microvm_combined.txt
       paste -d '\t' \
         $HOME/ubench-results-dev/bench_warm_start_microvm.txt bench_warm_start_microvm.txt \
         > /tmp/bench_warm_start_microvm_combined.txt
+      paste -d '\t' \
+        $HOME/ubench-results-dev/bench_boot_time_hyperlight.txt bench_boot_time_hyperlight.txt \
+        > /tmp/bench_boot_time_hyperlight_combined.txt
       paste -d '\t' \
         $HOME/ubench-results-dev/bench_cold_start_hyperlight.txt bench_cold_start_hyperlight.txt \
         > /tmp/bench_cold_start_hyperlight_combined.txt
@@ -49,6 +57,17 @@ runs:
 
        # Prepare the text for the PR comment.
       {
+        echo "### Boot-Time"
+        echo '```'
+        echo "========== MicroVM ==========" | cat
+        echo -e "dev\t${TARGET_BRANCH}" | cat
+        cat /tmp/bench_boot_time_microvm_combined.txt
+        echo ""
+        echo "========== Hyperlight ==========" | cat
+        echo -e "dev\t${TARGET_BRANCH}" | cat
+        cat /tmp/bench_boot_time_hyperlight_combined.txt
+        echo '```'
+        echo ""
         echo "### Cold-Starts"
         echo '```'
         echo "========== MicroVM ==========" | cat
@@ -117,6 +136,11 @@ runs:
     if: github.ref_name == 'dev'
     run: |
       mkdir -p $HOME/ubench-results-dev
+      # Copy boot-time results.
+      cp bench_boot_time_microvm.txt $HOME/ubench-results-dev/${GITHUB_SHA}_bench_boot_time_microvm.txt
+      cp $HOME/ubench-results-dev/${GITHUB_SHA}_bench_boot_time_microvm.txt $HOME/ubench-results-dev/bench_boot_time_microvm.txt
+      cp bench_boot_time_hyperlight.txt $HOME/ubench-results-dev/${GITHUB_SHA}_bench_boot_time_hyperlight.txt
+      cp $HOME/ubench-results-dev/${GITHUB_SHA}_bench_boot_time_hyperlight.txt $HOME/ubench-results-dev/bench_boot_time_hyperlight.txt
 
       # Copy cold-start results.
       cp bench_cold_start_microvm.txt $HOME/ubench-results-dev/${GITHUB_SHA}_bench_cold_start_microvm.txt

--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -40,8 +40,8 @@ impl Args {
 
     fn usage() -> String {
         format!(
-            "usage: ./bin/nanvix-bench.elf {} [cold-start,warm-start,echo-breakdown] [{} \
-             <path_to_hwloc.json> {} <iterations>]",
+            "usage: ./bin/nanvix-bench.elf {} [boot-time,cold-start,warm-start,echo-breakdown] \
+             [{} <path_to_hwloc.json> {} <iterations>]",
             Self::OPT_BENCHMARK,
             Self::OPT_HWLOC,
             Self::OPT_ITERATIONS,

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -19,6 +19,7 @@ use std::{
 
 #[derive(Clone)]
 pub enum BenchmarkFlavour {
+    BootTime,
     ColdStart,
     WarmStart,
     WarmStartVMM,
@@ -28,6 +29,7 @@ pub enum BenchmarkFlavour {
 impl fmt::Display for BenchmarkFlavour {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
+            BenchmarkFlavour::BootTime => "boot-time",
             BenchmarkFlavour::ColdStart => "cold-start",
             BenchmarkFlavour::WarmStart => "warm-start",
             BenchmarkFlavour::WarmStartVMM => "warm-start-vmm",
@@ -42,6 +44,7 @@ impl FromStr for BenchmarkFlavour {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
+            "boot-time" => Ok(BenchmarkFlavour::BootTime),
             "cold-start" => Ok(BenchmarkFlavour::ColdStart),
             "warm-start" => Ok(BenchmarkFlavour::WarmStart),
             "warm-start-vmm" => Ok(BenchmarkFlavour::WarmStartVMM),

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -86,6 +86,13 @@ use syscall::{
 };
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Sleep duration (in ms) to wait for the system to clean up after a benchmark run.
+const CLEANUP_SLEEP_DURATION: u64 = 10;
+
+//==================================================================================================
 
 const NANVIX_LINUXD_UNIX_SOCKET: &str = "/tmp/nanvix_ubench.socket";
 const GATEWAY_ADDRESS: &str = "127.0.0.1:9999";
@@ -169,6 +176,9 @@ impl Benchmark {
             format!("{}/bin/kernel.elf", get_proj_root()),
             "-initrd".to_string(),
             match self.flavour {
+                BenchmarkFlavour::BootTime => {
+                    format!("{}/bin/noop-rust-nostd.elf", get_proj_root())
+                },
                 BenchmarkFlavour::ColdStart => {
                     format!("{}/bin/echo-rust-nostd.elf", get_proj_root())
                 },
@@ -271,6 +281,53 @@ impl Benchmark {
         }
 
         // Gateway will be closed when dropped.
+    }
+
+    /// This function runs the boot-time experiment, where we measure the time to start a user VM
+    /// with a noop application and exit.
+    pub fn run_boot_time(&mut self) -> Result<()> {
+        // In the cold start experiment we cleanup and set-up at every iteration.
+        self.cleanup();
+
+        // Display a progress bar
+        let pb = ProgressBar::new(self.iterations.try_into().unwrap());
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{msg} [{bar:40.cyan/blue}] {pos}/{len} ({percent}%)")
+                .expect("error creating progress bar")
+                .progress_chars("#>-"),
+        );
+        pb.set_message("Benchmark progress:");
+
+        // We don't use the send_to/recv_from gateway methods to prevent the data initialization
+        // from being included in the cold-start time.
+        let mut latencies: Vec<u128> = Vec::with_capacity(self.iterations);
+        for iter in 0..self.iterations {
+            self.linuxd_address = format!("/tmp/nanvix_boottime_ubench_{iter}.socket");
+
+            // Start the clock
+            let start = Instant::now();
+            self.start();
+
+            // Wait for the user VM to finish and die.
+            self.nanovm.as_mut().unwrap().wait()?;
+
+            latencies.push(start.elapsed().as_micros());
+
+            self.nanovm = None;
+            pb.inc(1);
+
+            // Need to give some time to clean-up
+            thread::sleep(Duration::from_millis(CLEANUP_SLEEP_DURATION));
+        }
+
+        pb.finish();
+        latencies.sort();
+        println!("p50: {} us", latencies[(self.iterations * 50) / 100]);
+        println!("p95: {} us", latencies[(self.iterations * 95) / 100]);
+        println!("p99: {} us", latencies[(self.iterations * 99) / 100]);
+
+        Ok(())
     }
 
     /// This function runs the cold-start experiment, where we measure the time to start linuxd,
@@ -619,6 +676,20 @@ fn main() -> Result<()> {
     println!("done!");
 
     let result = match benchmark.flavour {
+        BenchmarkFlavour::BootTime => {
+            #[cfg(feature = "timestamp-messages")]
+            {
+                error!(
+                    "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
+                );
+                return Ok(());
+            }
+
+            #[cfg(not(feature = "timestamp-messages"))]
+            {
+                benchmark.run_boot_time()
+            }
+        },
         BenchmarkFlavour::EchoBreakdown => {
             #[cfg(not(feature = "timestamp-messages"))]
             {


### PR DESCRIPTION
This pull request introduces a new "boot-time" benchmark to the `nanvix-bench` utility and integrates its results into the benchmarking workflow for both MicroVM and Hyperlight environments. The changes span across the benchmarking tool's implementation and the GitHub Actions workflow configuration. Below are the most important changes grouped by theme:

### Benchmarking Tool Enhancements:
* Added support for the "boot-time" benchmark in `BenchmarkFlavour` enum, including its display and parsing logic in `src/utils/nanvix-bench/src/benchmark.rs`. [[1]](diffhunk://#diff-6ed8757d486b1d24e0b21a9acbea66aafea26f01be0134ed027a858ff7713fa0R22) [[2]](diffhunk://#diff-6ed8757d486b1d24e0b21a9acbea66aafea26f01be0134ed027a858ff7713fa0R32) [[3]](diffhunk://#diff-6ed8757d486b1d24e0b21a9acbea66aafea26f01be0134ed027a858ff7713fa0R47)
* Implemented the `run_boot_time` method in `src/utils/nanvix-bench/src/main.rs` to measure the time taken to start a user VM with a noop application and exit.
* Updated the main execution logic to handle the "boot-time" benchmark, ensuring compatibility with the `timestamp-messages` feature flag.

### GitHub Actions Workflow Updates:
* Integrated "boot-time" benchmarks for MicroVM and Hyperlight environments into `.github/actions/benchmark/action.yml`. Results are extracted and saved to respective files. [[1]](diffhunk://#diff-c1b8f2d3cf8c180ad2941e2c4ec06bf7dc56c5faba45b3153ebf4ad7014c64c6R17) [[2]](diffhunk://#diff-c1b8f2d3cf8c180ad2941e2c4ec06bf7dc56c5faba45b3153ebf4ad7014c64c6R29)
* Combined "boot-time" results from the latest `dev` branch and the current pull request for comparison.
* Added "boot-time" section to the PR comment generation logic, displaying results for both MicroVM and Hyperlight environments.
* Ensured "boot-time" results are stored and updated in the `ubench-results-dev` directory when the `dev` branch is updated.

These changes collectively enhance the benchmarking capabilities of `nanvix-bench` and improve the visibility of boot-time performance metrics in the CI pipeline.