### PR TITLE
[libs] Missing Binding for __errno_location()

### DIFF
--- a/src/libs/syscall/src/errno.rs
+++ b/src/libs/syscall/src/errno.rs
@@ -2,17 +2,13 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
-// Imports
-//==================================================================================================
-
-use ::sysapi::ffi::c_int;
-
-//==================================================================================================
 // Global Variables
 //==================================================================================================
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "syscall", feature = "staticlib"))] {
+        use ::sysapi::ffi::c_int;
+
         unsafe extern "C" {
             pub fn __errno() -> *mut c_int;
         }
@@ -30,10 +26,13 @@ cfg_if::cfg_if! {
         ///
         /// This function is unsafe because it may interoperate with external code.
         ///
-        pub unsafe fn  __errno_location() -> *mut c_int {
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn __errno_location() -> *mut c_int {
             __errno()
         }
-    } else {
+    } else if #[cfg(feature = "syscall")] {
+        use ::sysapi::ffi::c_int;
+
         #[allow(non_upper_case_globals)]
         static mut errno: c_int = 0;
 
@@ -50,7 +49,8 @@ cfg_if::cfg_if! {
         ///
         /// This function is unsafe because it may interoperate with external code.
         ///
-        pub unsafe fn __errno_location() -> *mut c_int {
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn __errno_location() -> *mut c_int {
             &raw mut errno as *mut c_int
         }
     }


### PR DESCRIPTION
This pull request refactors the `errno.rs` file in the `src/libs/syscall/src` directory to improve code organization and ensure compatibility with external code. The most significant changes involve modifying function definitions and restructuring conditional configurations.

Refactoring for external compatibility:

* [`src/libs/syscall/src/errno.rs`](diffhunk://#diff-1bd6f5e4cdd0fed9d8cc107790854d1448d709ce651dbe1ac7b914c58022484fL33-R35): Changed the `__errno_location` function to use the `extern "C"` calling convention and added the `#[unsafe(no_mangle)]` attribute for better interoperability with external code. [[1]](diffhunk://#diff-1bd6f5e4cdd0fed9d8cc107790854d1448d709ce651dbe1ac7b914c58022484fL33-R35) [[2]](diffhunk://#diff-1bd6f5e4cdd0fed9d8cc107790854d1448d709ce651dbe1ac7b914c58022484fL53-R53)

Code organization improvements:

* [`src/libs/syscall/src/errno.rs`](diffhunk://#diff-1bd6f5e4cdd0fed9d8cc107790854d1448d709ce651dbe1ac7b914c58022484fL4-R11): Moved the `use ::sysapi::ffi::c_int;` statement inside the conditional configuration blocks to reduce unnecessary imports when certain features are disabled. [[1]](diffhunk://#diff-1bd6f5e4cdd0fed9d8cc107790854d1448d709ce651dbe1ac7b914c58022484fL4-R11) [[2]](diffhunk://#diff-1bd6f5e4cdd0fed9d8cc107790854d1448d709ce651dbe1ac7b914c58022484fL33-R35)