### PR TITLE
[scripts] Fix Concurrency Semantics

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -3,10 +3,6 @@
 
 name: "Nanvix CI/CD (Self-Hosted)"
 
-concurrency:
-  group: self-hosted
-  cancel-in-progress: false
-
 on:
   push:
     branches:

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   ci:
     name: "Nanvix CI/CD (self-hosted)"
-    runs-on: self-hosted
+    runs-on: [self-hosted]
     timeout-minutes: 240
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes small adjustments to the `.github/workflows/self-hosted-ci.yml` file to refine the CI/CD configuration for self-hosted runners.

The most important changes include:

### Workflow Configuration Updates:
* Removed the `concurrency` block, which previously grouped self-hosted jobs and prevented simultaneous runs.
* Modified the `runs-on` parameter to use an array format instead of a single string for specifying the runner type.