### PR TITLE
[ci] Set hwloc.json for Benchmarks

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -14,8 +14,8 @@ runs:
     shell: bash
   - name: Run micro-benchmarks (MicroVM)
     run: |
-      ./bin/nanvix-bench.elf -benchmark cold-start | grep -E '^(p50:|p95:|p99:)' > bench_cold_start_microvm.txt
-      ./bin/nanvix-bench.elf -benchmark warm-start | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_microvm.txt
+      ./bin/nanvix-bench.elf -benchmark cold-start -hwloc $HOME/hwloc.json | grep -E '^(p50:|p95:|p99:)' > bench_cold_start_microvm.txt
+      ./bin/nanvix-bench.elf -benchmark warm-start -hwloc $HOME/hwloc.json | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_microvm.txt
     shell: bash
 
   # Hyperlight benchmarks
@@ -25,8 +25,8 @@ runs:
     shell: bash
   - name: Run micro-benchmarks (Hyperlight)
     run: |
-      ./bin/nanvix-bench.elf -benchmark cold-start | grep -E '^(p50:|p95:|p99:)' > bench_cold_start_hyperlight.txt
-      ./bin/nanvix-bench.elf -benchmark warm-start | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_hyperlight.txt
+      ./bin/nanvix-bench.elf -benchmark cold-start -hwloc $HOME/hwloc.json | grep -E '^(p50:|p95:|p99:)' > bench_cold_start_hyperlight.txt
+      ./bin/nanvix-bench.elf -benchmark warm-start -hwloc $HOME/hwloc.json | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_hyperlight.txt
     shell: bash
 
   # Post-process the results


### PR DESCRIPTION

This pull request updates the benchmarking scripts in the `.github/actions/benchmark/action.yml` file to include hardware locality (`hwloc`) information during micro-benchmark runs. This change ensures that benchmarks are executed with additional context about the hardware topology, which can improve the accuracy and relevance of performance measurements.

Enhancements to benchmarking scripts:

* **MicroVM benchmarks**: Updated the cold-start and warm-start micro-benchmark commands to include the `-hwloc $HOME/hwloc.json` parameter, enabling the use of hardware locality data during execution.
* **Hyperlight benchmarks**: Similarly updated the cold-start and warm-start Hyperlight benchmark commands to incorporate the `-hwloc $HOME/hwloc.json` parameter for hardware locality support.