### PR TITLE
[kernel] Performance Counters

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -162,6 +162,10 @@ pub unsafe fn puts(message: &str) {
 ///
 #[cfg(feature = "stdio")]
 pub unsafe fn vmbus_write(addr: *const u8) {
+    use crate::PERF_VMBUS_WRITE;
+
+    PERF_VMBUS_WRITE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+
     let data = core::slice::from_raw_parts(addr, config::kernel::IPC_MESSAGE_SIZE);
     let _ = ProcessEnvironmentBlock::vmbus_write(data);
 }
@@ -184,6 +188,10 @@ pub unsafe fn vmbus_write(addr: *const u8) {
 ///
 #[cfg(feature = "stdio")]
 pub unsafe fn vmbus_read(addr: *mut u8) {
+    use crate::PERF_VMBUS_READ;
+
+    PERF_VMBUS_READ.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+
     let data = core::slice::from_raw_parts_mut(addr, config::kernel::IPC_MESSAGE_SIZE);
     let bytes = ProcessEnvironmentBlock::vmbus_read();
     if let Ok(bytes) = bytes {

--- a/src/kernel/src/hal/platform/microvm.rs
+++ b/src/kernel/src/hal/platform/microvm.rs
@@ -150,7 +150,10 @@ pub unsafe fn putb(b: u8) {
 ///
 #[cfg(feature = "stdio")]
 pub unsafe fn vmbus_write(addr: *const u8) {
+    use crate::PERF_VMBUS_WRITE;
     use core::hint;
+
+    PERF_VMBUS_WRITE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 
     #[allow(clippy::unit_arg)]
     hint::black_box(::arch::io::out32(::config::microvm::DEFAULT_STDOUT_PORT, addr as u32));
@@ -174,7 +177,10 @@ pub unsafe fn vmbus_write(addr: *const u8) {
 ///
 #[cfg(feature = "stdio")]
 pub unsafe fn vmbus_read(addr: *mut u8) {
+    use crate::PERF_VMBUS_READ;
     use core::hint;
+
+    PERF_VMBUS_READ.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 
     #[allow(clippy::unit_arg)]
     hint::black_box(::arch::io::out32(::config::microvm::DEFAULT_STDIN_PORT, addr as u32))

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -151,6 +151,30 @@ mod startup {
 /// Counts the number of cores online.
 static mut CORES_ONLINE: AtomicUsize = AtomicUsize::new(1);
 
+/// Performance counter for the number of times the kernel was idle.
+pub static PERF_SCHED_KERNEL_IDLE: AtomicUsize = AtomicUsize::new(0);
+
+/// Performance counter for the number of soft context switches that occurred.
+pub static PERF_SCHED_SOFT_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+
+/// Performance counter for the number of involuntary context switches that occurred.
+pub static PERF_SCHED_HARD_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+
+/// Performance counter for the number of context switches that  were triggered by `exit`.
+pub static PERF_SCHED_EXIT_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+
+/// Performance counter for the number of context switches that were triggered by `exit_thread`.
+pub static PERF_SCHED_EXIT_THREAD_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+
+/// Performance counter for the number of context switches that were triggered by `sleep`.
+pub static PERF_SCHED_SLEEP_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+
+/// Performance counter for the number of context switches that were triggered by `giveup`.
+pub static PERF_SCHED_GIVEUP_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+
+/// Performance counter for the number of times `wakeup` was called.
+pub static PERF_SCHED_WAKEUP: AtomicUsize = AtomicUsize::new(0);
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -394,6 +418,36 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
 
     #[cfg(feature = "smp")]
     startup::wait().expect("failed to synchronize application cores");
+
+    // Dump system statistics.
+    info!("System Statistics:");
+    info!("- No. Times Kernel Was Idle: {:?}", PERF_SCHED_KERNEL_IDLE.load(Ordering::Relaxed));
+    info!(
+        "- No. Soft Context Switches: {:?}",
+        PERF_SCHED_SOFT_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+    );
+    info!(
+        "- No. Hard Context Switches: {:?}",
+        PERF_SCHED_HARD_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+    );
+    info!(
+        "- No. Exit Context Switches: {:?}",
+        PERF_SCHED_EXIT_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+    );
+    info!(
+        "- No. Exit Thread Context Switches: {:?}",
+        PERF_SCHED_EXIT_THREAD_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+    );
+    info!(
+        "- No. Sleep Context Switches: {:?}",
+        PERF_SCHED_SLEEP_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+    );
+    info!(
+        "- No. Giveup Context Switches: {:?}",
+        PERF_SCHED_GIVEUP_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+    );
+    info!("- No. Wakeup Calls: {:?}", PERF_SCHED_WAKEUP.load(Ordering::Relaxed));
+    info!("- Ticks: {:?}", pm::ticks());
 
     trace!("the system will shutdown now!");
     kernel_magic_string(status);

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -175,6 +175,12 @@ pub static PERF_SCHED_GIVEUP_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0)
 /// Performance counter for the number of times `wakeup` was called.
 pub static PERF_SCHED_WAKEUP: AtomicUsize = AtomicUsize::new(0);
 
+/// Number of times that `vmbus_read` was called.
+pub static PERF_VMBUS_READ: AtomicUsize = AtomicUsize::new(0);
+
+/// Number of times that `vmbus_write` was called.
+pub static PERF_VMBUS_WRITE: AtomicUsize = AtomicUsize::new(0);
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -448,6 +454,8 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     );
     info!("- No. Wakeup Calls: {:?}", PERF_SCHED_WAKEUP.load(Ordering::Relaxed));
     info!("- Ticks: {:?}", pm::ticks());
+    info!("- No. Times VMBus Read Was Called: {:?}", PERF_VMBUS_READ.load(Ordering::Relaxed));
+    info!("- No. Times VMBus Write Was Called: {:?}", PERF_VMBUS_WRITE.load(Ordering::Relaxed));
 
     trace!("the system will shutdown now!");
     kernel_magic_string(status);

--- a/src/kernel/src/pm/clock.rs
+++ b/src/kernel/src/pm/clock.rs
@@ -119,6 +119,19 @@ pub unsafe fn timer_handler(_intnum: InterruptNumber) {
 ///
 /// Returns the number of timer ticks since the system started.
 ///
+/// # Returns
+///
+/// The number of timer ticks since the system started.
+pub fn ticks() -> u64 {
+    let (major_ticks, minor_ticks): (u32, u32) = TIMER_TICKS.get();
+    ((major_ticks as u64) << 32) + (minor_ticks as u64)
+}
+
+///
+/// # Description
+///
+/// Returns the number of timer ticks since the system started.
+///
 pub fn now() -> SystemTime {
     #[cfg(feature = "pit")]
     let timer_freq: u32 = crate::hal::platform::pit::get_timer_frequency();

--- a/src/kernel/src/pm/mod.rs
+++ b/src/kernel/src/pm/mod.rs
@@ -47,6 +47,7 @@ const ORDER: Ordering = Ordering::Relaxed;
 // Exports
 //==================================================================================================
 
+pub use clock::ticks;
 pub use kcall::*;
 pub use process::{
     ProcessManager,

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -43,6 +43,14 @@ use crate::{
         SleepError,
         ORDER,
     },
+    PERF_SCHED_EXIT_CONTEXT_SWITCHES,
+    PERF_SCHED_EXIT_THREAD_CONTEXT_SWITCHES,
+    PERF_SCHED_GIVEUP_CONTEXT_SWITCHES,
+    PERF_SCHED_HARD_CONTEXT_SWITCHES,
+    PERF_SCHED_KERNEL_IDLE,
+    PERF_SCHED_SLEEP_CONTEXT_SWITCHES,
+    PERF_SCHED_SOFT_CONTEXT_SWITCHES,
+    PERF_SCHED_WAKEUP,
 };
 use ::alloc::rc::Rc;
 use ::arch::mem::PAGE_SIZE;
@@ -218,6 +226,7 @@ impl ProcessManager {
 
         // SAFETY: `from` and `to` point to valid context information structures, and the processor
         // is running with interrupts disabled.
+        PERF_SCHED_EXIT_CONTEXT_SWITCHES.fetch_add(1, ORDER);
         Self::switch(next_pid, next_tid, from, to);
 
         // SAFETY: Self::switch() performs a context switch and never returns. If this line is ever
@@ -279,6 +288,7 @@ impl ProcessManager {
 
         // SAFETY: `from` and `to` point to valid context information structures, and the processor
         // is running with interrupts disabled.
+        PERF_SCHED_EXIT_THREAD_CONTEXT_SWITCHES.fetch_add(1, ORDER);
         Self::switch(next_pid, next_tid, from, to);
 
         // SAFETY: Self::switch() performs a context switch and never returns. If this line is ever
@@ -427,6 +437,7 @@ impl ProcessManager {
 
         // SAFETY: `from` and `to` point to valid context information structures, and the processor
         // is running with interrupts disabled.
+        PERF_SCHED_SLEEP_CONTEXT_SWITCHES.fetch_add(1, ORDER);
         Self::switch(next_pid, next_tid, from, to);
 
         // Check the reason why the thread was woken up.
@@ -487,6 +498,7 @@ impl ProcessManager {
             // Switch to the next thread and updating the remaining quantum accordingly.
             // SAFETY: `from` and `to` point to valid context information structures, and the
             // processor is running with interrupts disabled.
+            PERF_SCHED_GIVEUP_CONTEXT_SWITCHES.fetch_add(1, ORDER);
             Self::switch(next_pid, next_tid, from, to);
         }
 
@@ -648,6 +660,7 @@ impl ProcessManager {
     /// - The calling process does not hold a reference to the process manager.
     ///
     pub unsafe fn wakeup(tid: ThreadIdentifier) -> Result<(), Error> {
+        PERF_SCHED_WAKEUP.fetch_add(1, ORDER);
         Self::get_mut().try_borrow_mut()?.wakeup(tid)
     }
 
@@ -731,6 +744,7 @@ impl ProcessManager {
         // Check if we need to perform a context switch.
         if next_tid != previous_tid {
             // We need to perform a context switch.
+            PERF_SCHED_HARD_CONTEXT_SWITCHES.fetch_add(1, ORDER);
 
             // Check whether we need to reset the quantum for the next thread.
             if next_pid != previous_pid {
@@ -742,9 +756,12 @@ impl ProcessManager {
             ContextInformation::switch(from, to);
         } else {
             // We do not need to perform a context switch, the same thread will continue running.
+            PERF_SCHED_SOFT_CONTEXT_SWITCHES.fetch_add(1, ORDER);
 
             // Check if the kernel thread will continue running.
             if next_tid == ThreadIdentifier::KERNEL {
+                PERF_SCHED_KERNEL_IDLE.fetch_add(1, ORDER);
+
                 // The kernel thread will continue running. This means there are no other ready
                 // threads to run, and the kernel has no work to do at the moment. Enable interrupts
                 // and wait for an external event (such as a timer or hardware interrupt) to wake up


### PR DESCRIPTION
This pull request introduces performance counters throughout the kernel to track various system events, such as context switches, VMBus operations, and kernel idle states. Additionally, it adds functionality to retrieve timer ticks and logs system statistics during kernel startup. Below are the most important changes grouped by theme:

### Performance Counters

* Added multiple performance counters (`PERF_SCHED_*` and `PERF_VMBUS_*`) to track system events, including context switches, VMBus reads and writes, and kernel idle states. These counters are defined in `src/kernel/src/kmain.rs`.
* Integrated performance counters into the `ProcessManager` for tracking context switches triggered by operations like `exit`, `exit_thread`, `sleep`, `giveup`, and `wakeup`. [[1]](diffhunk://#diff-3c168802fdb484fb4438ab269e8abab4a313ee2c0fb2c16f8bb7f8aed2bcfabbR228) [[2]](diffhunk://#diff-3c168802fdb484fb4438ab269e8abab4a313ee2c0fb2c16f8bb7f8aed2bcfabbR290) [[3]](diffhunk://#diff-3c168802fdb484fb4438ab269e8abab4a313ee2c0fb2c16f8bb7f8aed2bcfabbR439) [[4]](diffhunk://#diff-3c168802fdb484fb4438ab269e8abab4a313ee2c0fb2c16f8bb7f8aed2bcfabbR500) [[5]](diffhunk://#diff-3c168802fdb484fb4438ab269e8abab4a313ee2c0fb2c16f8bb7f8aed2bcfabbR662)
* Updated VMBus read and write operations in `src/kernel/src/hal/platform/hyperlight/mod.rs` and `src/kernel/src/hal/platform/microvm.rs` to increment respective performance counters. [[1]](diffhunk://#diff-43171bb5ac9a97f5483ae1e974f64ec7c70221d6c6c657f874cab96e16b3827eR165-R168) [[2]](diffhunk://#diff-43171bb5ac9a97f5483ae1e974f64ec7c70221d6c6c657f874cab96e16b3827eR191-R194) [[3]](diffhunk://#diff-5c03467c2549a23baec4b11b238fdcfa08a117e3efe8e634af5acdb38fedbe2eR153-R157) [[4]](diffhunk://#diff-5c03467c2549a23baec4b11b238fdcfa08a117e3efe8e634af5acdb38fedbe2eR180-R184)

### System Statistics Logging

* Enhanced the `kmain` function in `src/kernel/src/kmain.rs` to log system statistics, including the values of performance counters and timer ticks, during kernel startup.

### Timer Ticks

* Added a new `ticks` function in `src/kernel/src/pm/clock.rs` to retrieve the number of timer ticks since the system started.
* Exported the `ticks` function in `src/kernel/src/pm/mod.rs` for use across the kernel.