### PR TITLE
[kernel] Poll Batch of IKC Messages

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -41,3 +41,6 @@ mutex_open_max = 32
 # Notes:
 # - This number was arbitrarily chosen.
 cond_open_max = 32
+
+# Number of IKC messages to poll at a time.
+ikc_poll_batch_size = 1

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -24,6 +24,7 @@ use crate::{
         ProcessManager,
     },
 };
+use ::config::kernel::IKC_POLL_BATCH_SIZE;
 use ::sys::{
     error::ErrorCode,
     event::ProcessTerminationInfo,
@@ -119,26 +120,28 @@ pub fn kcall_handler(
         cfg_if::cfg_if! {
             if #[cfg(feature = "stdio")] {
                 let mut message_received: bool = false;
-                // Check if the number of buffered messages in the kernel is not too high. We don't
-                // want to keep pushing messages to the kernel and then run out of memory.
-                if let Ok(number_buffered_messages) = pm.number_buffered_messages() {
-                    if number_buffered_messages < config::kernel::MAX_IKC_MESSAGES {
-                        // The number of messages that are buffered in the kernel is not too high,
-                        // So attempt to read an inter-kernel communication message from the
-                        // kernel's standard input.
-                        match crate::stdio::read() {
-                            // No message is available.
-                            Ok(None) => {},
-                            // A message is available.
-                            Ok(Some(message)) => {
-                                if let Err(e) = EventManager::post_message(pm, message.destination, message) {
-                                    warn!("failed to post message (error={:?})", e);
+                for _ in 0..IKC_POLL_BATCH_SIZE {
+                    // Check if the number of buffered messages in the kernel is not too high. We don't
+                    // want to keep pushing messages to the kernel and then run out of memory.
+                    if let Ok(number_buffered_messages) = pm.number_buffered_messages() {
+                        if number_buffered_messages < config::kernel::MAX_IKC_MESSAGES {
+                            // The number of messages that are buffered in the kernel is not too high,
+                            // So attempt to read an inter-kernel communication message from the
+                            // kernel's standard input.
+                            match crate::stdio::read() {
+                                // No message is available.
+                                Ok(None) => break,
+                                // A message is available.
+                                Ok(Some(message)) => {
+                                    if let Err(e) = EventManager::post_message(pm, message.destination, message) {
+                                        warn!("failed to post message (error={:?})", e);
+                                    }
+                                    message_received = true;
                                 }
-                                message_received = true;
-                            }
-                            // Failed to read message.
-                            Err(e) => {
-                                warn!("failed to read message (error={:?})", e);
+                                // Failed to read message.
+                                Err(e) => {
+                                    warn!("failed to read message (error={:?})", e);
+                                }
                             }
                         }
                     }

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -90,6 +90,11 @@ fn main() {
             constants.push_str(&format!("pub const COND_OPEN_MAX: usize = {val};\n"));
         }
     }
+    if let Some(ikc_poll_batch_size) = config.get("ikc_poll_batch_size") {
+        if let Ok(val) = ikc_poll_batch_size.parse::<usize>() {
+            constants.push_str(&format!("pub const IKC_POLL_BATCH_SIZE: usize = {val};\n"));
+        }
+    }
     constants.push_str("}\n");
 
     // Write the generated file


### PR DESCRIPTION
This pull request introduces a new configuration parameter, `ikc_poll_batch_size`, to control the number of inter-kernel communication (IKC) messages polled at a time. The changes span configuration, kernel handler logic, and build scripts to integrate this new parameter effectively.

### Configuration Changes:
* [`build/kernel_config.toml`](diffhunk://#diff-cc25da34874c715cab05265760a95f170e0b53406054d493754447cf76d3cb21R44-R46): Added `ikc_poll_batch_size` parameter with an initial value of `1`. This parameter determines the batch size for polling IKC messages.

### Kernel Handler Logic Updates:
* [`src/kernel/src/kcall/handler.rs`](diffhunk://#diff-cab264a0b755a96c8487aca060ca8b7edf7f70a1caf09a1007926297b9a4ae85R123): Integrated `IKC_POLL_BATCH_SIZE` in the kernel call handler to limit the number of IKC messages processed in a single loop iteration. This ensures better control over resource usage.
* [`src/kernel/src/kcall/handler.rs`](diffhunk://#diff-cab264a0b755a96c8487aca060ca8b7edf7f70a1caf09a1007926297b9a4ae85L131-R133): Modified the message polling logic to break early if no message is available, improving efficiency.

### Build Script Enhancements:
* [`src/libs/config/build.rs`](diffhunk://#diff-85cf4e6b52d36f60bcdb1da3ae1bda729b02a4b0b6115636d6bdbe54b90ecc76R93-R97): Updated the build script to parse and include `ikc_poll_batch_size` from the configuration file, generating the corresponding constant in the `config` module.

### Dependency Updates:
* [`src/kernel/src/kcall/handler.rs`](diffhunk://#diff-cab264a0b755a96c8487aca060ca8b7edf7f70a1caf09a1007926297b9a4ae85R27): Added an import for `IKC_POLL_BATCH_SIZE` from the `config` module to enable its usage in the kernel handler logic.