### PR TITLE
[ci] Refine CI Triggers

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -30,6 +30,9 @@ jobs:
     name: "Nanvix CI/CD (self-hosted)"
     runs-on: [self-hosted]
     timeout-minutes: 240
+    strategy:
+      matrix:
+        build-type: [debug, release]
 
     # Only run the CI if it is a push to 'dev' (enforced above) or, if the
     # event trigger is a PR, we must make sure that: (i) it is not draft,
@@ -50,40 +53,23 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Debug
-    - name: "Lint (debug)"
+    - name: "Lint"
       uses: ./.github/actions/lint
       with:
-        release: 'debug'
+        release: '${{ matrix.build-type }}'
         log-level: 'trace'
-    - name: "Build (debug)"
+    - name: "Build"
       uses: ./.github/actions/build
       with:
-        release: 'debug'
+        release: '${{ matrix.build-type }}'
         log-level: 'trace'
-    - name: "Test (debug)"
+    - name: "Test"
       uses: ./.github/actions/test
       with:
-        release: 'debug'
+        release: '${{ matrix.build-type }}'
         log-level: 'trace'
 
-    # Release
-    - name: "Lint (release)"
-      uses: ./.github/actions/lint
-      with:
-        release: 'release'
-        log-level: 'trace'
-    - name: "Build (release)"
-      uses: ./.github/actions/build
-      with:
-        release: 'release'
-        log-level: 'trace'
-    - name: "Test (release)"
-      uses: ./.github/actions/test
-      with:
-        release: 'release'
-        log-level: 'trace'
-
-    # Benchmark
-    - name: "Benchmark (release)"
+    # Benchmark (only for release builds)
+    - name: "Benchmark"
+      if: matrix.build-type == 'release'
       uses: ./.github/actions/benchmark

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -4,14 +4,18 @@
 name: "Nanvix CI/CD (Self-Hosted)"
 
 on:
+  pull_request:
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
+      - 'ready_for_review'
+    branches:
+      - 'dev'
+
   push:
     branches:
-      - 'enhancement-*'
-      - 'feature-*'
-      - 'bugfix-*'
       - 'dev'
-      - 'dependabot-*'
-      - 'dependabot/*'
 
 # Cancel previous running actions for the same PR
 concurrency:
@@ -26,6 +30,23 @@ jobs:
     name: "Nanvix CI/CD (self-hosted)"
     runs-on: [self-hosted]
     timeout-minutes: 240
+
+    # Only run the CI if it is a push to 'dev' (enforced above) or, if the
+    # event trigger is a PR, we must make sure that: (i) it is not draft,
+    # and (ii) the source branch matches one of the accepted source branches.
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        !github.event.pull_request.draft &&
+        (
+          startsWith(github.head_ref, 'enhancement-') ||
+          startsWith(github.head_ref, 'feature-') ||
+          startsWith(github.head_ref, 'bugfix-') ||
+          startsWith(github.head_ref, 'dependabot-') ||
+          startsWith(github.head_ref, 'dependabot/')
+        )
+      )
+
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -13,6 +13,11 @@ on:
       - 'dependabot-*'
       - 'dependabot/*'
 
+# Cancel previous running actions for the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   TARGET_BRANCH: ${{ github.ref_name }}
 

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -41,6 +41,7 @@ RUST_LOG=trace timeout -s SIGINT --preserve-status --foreground ${TIMEOUT} \
         -linuxd-addr ${LINUXD_SOCKADDR} \
         -sandbox-addr ${SANDBOX_SOCKADDR} \
         -console-file ${CONSOLE_FILE_NAME} \
+        -tmp-dir ${NANVIX_HOME} \
         -keep-alive 0 \
         1> ${NANVIXD_STDOUT_FILE_NAME} \
         2> ${NANVIXD_STDERR_FILE_NAME} &

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -17,6 +17,7 @@ pub struct Args {
     http_sockaddr: String,
     linuxd_sockaddr: String,
     sandbox_sockaddr: String,
+    tmp_directory: String,
     console_file: String,
     keep_alive_timeout: Duration,
 }
@@ -30,6 +31,7 @@ impl Args {
     const OPT_HTTP_SOCKADDR: &'static str = "-http-addr";
     const OPT_LINUXD_SOCKADDR: &'static str = "-linuxd-addr";
     const OPT_SANDBOX_SOCKADDR: &'static str = "-sandbox-addr";
+    const OPT_TMP_DIRECTORY: &'static str = "-tmp-dir";
     const OPT_CONSOLE_FILE: &'static str = "-console-file";
     const OPT_KEEP_ALIVE_TIMEOUT: &'static str = "-keep-alive";
 
@@ -37,6 +39,7 @@ impl Args {
         let mut http_sockaddr: String = String::new();
         let mut linuxd_sockaddr: String = config::DEFAULT_LINUXD_SOCKADDR.to_string();
         let mut sandbox_sockaddr: String = config::DEFAULT_SANDBOX_SOCKADDR.to_string();
+        let mut tmp_directory: String = config::DEFAULT_TMP_DIRECTORY.to_string();
         let mut console_file: String = config::DEFAULT_CONSOLE_FILE.to_string();
         let mut keep_alive_timeout: Duration =
             Duration::from_secs(config::DEFAULT_KEEP_ALIVE_TIMEOUT);
@@ -60,6 +63,10 @@ impl Args {
                     i += 1;
                     sandbox_sockaddr = args[i].clone();
                 },
+                Self::OPT_TMP_DIRECTORY => {
+                    i += 1;
+                    tmp_directory = args[i].clone();
+                },
                 Self::OPT_CONSOLE_FILE => {
                     i += 1;
                     console_file = args[i].clone();
@@ -80,6 +87,7 @@ impl Args {
             http_sockaddr,
             linuxd_sockaddr,
             sandbox_sockaddr,
+            tmp_directory,
             console_file,
             keep_alive_timeout,
         })
@@ -87,13 +95,15 @@ impl Args {
 
     pub fn usage(program_name: &str) {
         println!(
-            "Usage: {} {} <sockaddr> {} <sockaddr> {} <sockaddr> {} <file> {} <duration>",
+            "Usage: {} {} <sockaddr> {} <sockaddr> {} <sockaddr> {} <file> {} <duration> \
+            [{} <tmp_dir>]",
             program_name,
             Self::OPT_HTTP_SOCKADDR,
             Self::OPT_LINUXD_SOCKADDR,
             Self::OPT_SANDBOX_SOCKADDR,
             Self::OPT_CONSOLE_FILE,
-            Self::OPT_KEEP_ALIVE_TIMEOUT
+            Self::OPT_KEEP_ALIVE_TIMEOUT,
+            Self::OPT_TMP_DIRECTORY
         );
     }
 
@@ -107,6 +117,10 @@ impl Args {
 
     pub fn sandbox_sockaddr(&self) -> &str {
         &self.sandbox_sockaddr
+    }
+
+    pub fn tmp_directory(&self) -> &str {
+        &self.tmp_directory
     }
 
     pub fn nanvix_console(&self) -> &str {

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -5,9 +5,6 @@
 // Constants
 //==================================================================================================
 
-/// Path to the temporary directory.
-const TMP_DIRECTORY: &str = "/tmp";
-
 /// Path to the binary directory.
 pub const BINARY_DIRECTORY: &str = "./bin";
 
@@ -26,6 +23,9 @@ pub const DEFAULT_LINUXD_SOCKADDR: &str = "127.0.0.1:1234";
 /// Default sandbox socket address.
 pub const DEFAULT_SANDBOX_SOCKADDR: &str = "127.0.0.1:7070";
 
+/// Path to the temporary directory.
+pub const DEFAULT_TMP_DIRECTORY: &str = "/tmp";
+
 /// Default console file.
 pub const DEFAULT_CONSOLE_FILE: &str = "/dev/null";
 
@@ -37,12 +37,12 @@ pub const MAX_PAYLOAD_SIZE: usize = 32;
 // Standalone Functions
 //==================================================================================================
 
-pub fn sandbox_sockaddr_builder(sandbox_sockaddr: &str, clientid: usize, requestid: usize) -> String {
-    format!("{TMP_DIRECTORY}/{sandbox_sockaddr}:{clientid}:{requestid}{UNIX_SOCKET_SUFFIX}")
+pub fn sandbox_sockaddr_builder(tmp_dir: &str, sandbox_sockaddr: &str, clientid: usize, requestid: usize) -> String {
+    format!("{tmp_dir}/{sandbox_sockaddr}:{clientid}:{requestid}{UNIX_SOCKET_SUFFIX}")
 }
 
-pub fn linuxd_sockaddr_builder(linuxd_sockaddr: &str, clientid: usize, requestid: usize) -> String {
+pub fn linuxd_sockaddr_builder(tmp_dir: &str, linuxd_sockaddr: &str, clientid: usize, requestid: usize) -> String {
         format!(
-          "{TMP_DIRECTORY}/{linuxd_sockaddr}:{clientid}:{requestid}{UNIX_SOCKET_SUFFIX}",
+          "{tmp_dir}/{linuxd_sockaddr}:{clientid}:{requestid}{UNIX_SOCKET_SUFFIX}",
       )
 }

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -63,6 +63,7 @@ pub struct HttpClient {
     requestid: usize,
     linuxd_sockaddr: String,
     sandbox_sockaddr: String,
+    tmp_directory: String,
     console_file: String,
 }
 
@@ -72,6 +73,7 @@ impl HttpClient {
         requestid: usize,
         linuxd_sockaddr: String,
         sandbox_sockaddr: String,
+        tmp_directory: String,
         console_file: String,
     ) -> Self {
         Self {
@@ -79,6 +81,7 @@ impl HttpClient {
             requestid,
             linuxd_sockaddr,
             sandbox_sockaddr,
+            tmp_directory,
             console_file,
         }
     }
@@ -119,13 +122,14 @@ impl HttpClient {
         request: MessageJson,
         requestid: usize,
         linuxd_sockaddr: String,
+        tmp_directory: String,
         console_file: String,
         sandbox_sockaddr: String,
     ) -> Result<Vec<u8>> {
         let linuxd_sockaddr: String =
-            config::linuxd_sockaddr_builder(&linuxd_sockaddr, request.clientid, requestid);
+            config::linuxd_sockaddr_builder(&tmp_directory, &linuxd_sockaddr, request.clientid, requestid);
         let sandbox_sockaddr: String =
-            config::sandbox_sockaddr_builder(&sandbox_sockaddr, request.clientid, requestid);
+            config::sandbox_sockaddr_builder(&tmp_directory, &sandbox_sockaddr, request.clientid, requestid);
 
         let tag: SandboxTag = SandboxTag::new(request.clientid, &request.program);
         let config: SandboxConfig =
@@ -223,6 +227,7 @@ impl Service<Request<Incoming>> for HttpClient {
         let requestid: usize = self.requestid;
         let sandbox_sockaddr: String = self.sandbox_sockaddr.clone();
         let linuxd_sockaddr: String = self.linuxd_sockaddr.clone();
+        let tmp_directory: String = self.tmp_directory.clone();
         let nanvix_console: String = self.console_file.clone();
         let sandboxes: SandboxCache = self.sandboxes.clone();
         let future = async move {
@@ -266,6 +271,7 @@ impl Service<Request<Incoming>> for HttpClient {
                 request,
                 requestid,
                 linuxd_sockaddr,
+                tmp_directory,
                 nanvix_console,
                 sandbox_sockaddr,
             )

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -73,6 +73,7 @@ pub async fn main() -> Result<()> {
                         debug!("accepted connection from {sockaddr:?}");
                         let linuxd_sockaddr: String = args.linuxd_sockaddr().to_string();
                         let sandbox_sockaddr: String = args.sandbox_sockaddr().to_string();
+                        let tmp_directory: String = args.tmp_directory().to_string();
                         let console_file: String = args.nanvix_console().to_string();
                         let requestid: Arc<AtomicUsize> = requestid.clone();
                         let sandboxe_cache: SandboxCache = sandbox_cache.clone();
@@ -80,7 +81,7 @@ pub async fn main() -> Result<()> {
                             let requestid: usize = requestid
                                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                             let client =
-                                HttpClient::new(sandboxe_cache, requestid, linuxd_sockaddr, sandbox_sockaddr, console_file);
+                                HttpClient::new(sandboxe_cache, requestid, linuxd_sockaddr, sandbox_sockaddr, tmp_directory, console_file);
                             let io: TokioIo<TcpStream> = TokioIo::new(stream);
                             if let Err(e) = http1::Builder::new().serve_connection(io, client).await  {
                                 error!("failed to serve connection (requestid={requestid:?}, error={e:?})");


### PR DESCRIPTION
In this PR I refine the CI trigger logic such that:
1. Newer commits on the same branch cancel CI runs of previous commits of the same PR.
2. CI runs are only triggered by either:
    * Pushes to `dev`.
    * Non-draft PRs with a source branch matching: `bugfix-*`, `enhancement-*`, `feature-*`, `dependabot*`.