### PR TITLE
[microvm] Add states and transitions to MicroVM snapshotting protocol

### DIFF
--- a/src/microvm/src/vmm/microvm/io.rs
+++ b/src/microvm/src/vmm/microvm/io.rs
@@ -195,17 +195,18 @@ impl IoThread {
     ///
     /// # Returns
     ///
-    /// Upon success, the received message is returned. Otherwise, an error is returned.
+    /// Upon success, the received message is pushed into the `incoming` queue, and `true` is returned.
+    /// Otherwise, if it would block, `false` is returned. Otherwise, an error is returned.
     ///
-    fn try_receive_from_gateway(&mut self) -> Result<()> {
+    fn try_receive_from_gateway(&mut self) -> Result<bool> {
         match self.gateway.try_receive() {
             Ok(message) => {
                 self.incoming.push_back(message);
-                Ok(())
+                Ok(true)
             },
             Err(e) => {
                 if e.kind() == ErrorKind::WouldBlock {
-                    Ok(())
+                    Ok(false)
                 } else {
                     let reason: String =
                         format!("failed to receive message from the gateway (error={e:?})");
@@ -223,9 +224,10 @@ impl IoThread {
     ///
     /// # Returns
     ///
-    /// Upon success, the received message is returned. Otherwise, an error is returned.
+    /// Upon success, the received message is pushed into the `outgoing` queue, and `true`is returned.
+    /// Otherwise, if the channel is empty, `false` is returned. Otherwise, an error is returned.
     ///
-    fn try_receive_from_microvm(&mut self) -> Result<()> {
+    fn try_receive_from_microvm(&mut self) -> Result<bool> {
         match self.microvm_rx.try_recv() {
             Ok(mut message) => {
                 profiler::timestamp_message!(
@@ -234,9 +236,9 @@ impl IoThread {
                         + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
                 );
                 self.outgoing.push_back(message);
-                Ok(())
+                Ok(true)
             },
-            Err(TryRecvError::Empty) => Ok(()),
+            Err(TryRecvError::Empty) => Ok(false),
             Err(TryRecvError::Disconnected) => {
                 let reason: String = "the microvm has disconnected".to_string();
                 // When the guest finishes , the vCPU thread will disconnect from this thread. This

--- a/src/microvm/src/vmm/microvm/io.rs
+++ b/src/microvm/src/vmm/microvm/io.rs
@@ -5,7 +5,10 @@
 // Imports
 //==================================================================================================
 
-use crate::Gateway;
+use crate::{
+    Gateway,
+    vmm::ControlCommand,
+};
 use ::anyhow::Result;
 use ::std::{
     collections::VecDeque,
@@ -42,12 +45,10 @@ pub struct IoThread {
     incoming: VecDeque<Message>,
     /// Queue of outgoing messages.
     outgoing: VecDeque<Message>,
-    /// State in the snapshotting protocol.
-    _state: OrchestratorState,
     /// Command sender to the VMM.
-    _control_input_tx: Sender<ControlCommand>,
+    _vmm_control_tx: Sender<ControlCommand>,
     /// Response receiver from the VMM.
-    _control_output_rx: Receiver<ControlCommandResponse>,
+    vmm_control_rx: Receiver<ControlCommandResponse>,
     // TODO: channels to an outside issuer of snapshot commands and to linuxd.
 }
 
@@ -58,30 +59,15 @@ pub struct IoThread {
 ///
 /// # Description
 ///
-/// States relating to snapshots functionality. Snapshots may be loaded at PreBoot, and created at Paused.
-/// TODO: add `Running`, `Pausing`, `PausingAndOutputFlushed`, and `Paused` states.
-///
-enum OrchestratorState {
-    PreBoot,
-}
-
-///
-/// # Description
-///
-/// Control plane commands.
-/// TODO:
-/// Add commands relating to snapshots: `StartMicroVM`, `LoadAndRun`, `ResumeMicroVM`, `PauseMicroVM`, `PauseAndCreateSnapshot`, `LinuxDaemonFlushed`, `CreateSnapshot`, `LoadSnapshot`.
-///
-pub enum ControlCommand {}
-
-///
-/// # Description
-///
 /// Control plane command responses.
-/// TODO:
-/// Add `MicroVmPaused` response.
 ///
-pub enum ControlCommandResponse {}
+#[derive(PartialEq)]
+pub enum ControlCommandResponse {
+    MicroVmPaused,
+    SnapshotCreated,
+    FlushOutput,
+    FlushInput,
+}
 
 //==================================================================================================
 // Implementations
@@ -98,8 +84,8 @@ impl IoThread {
     /// - `gateway`: Connection to gateway.
     /// - `microvm_rx`: MicroVM receiver.
     /// - `microvm_tx`: MicroVM sender.
-    /// - `control_input_tx`: Command sender.
-    /// - `control_output_rx`: Response receiver.
+    /// - `vmm_control_tx`: Command sender.
+    /// - `vmm_control_rx`: Response receiver.
     ///
     /// # Returns
     ///
@@ -109,17 +95,12 @@ impl IoThread {
         gateway: Gateway,
         microvm_rx: Receiver<Message>,
         microvm_tx: Sender<Message>,
-        control_input_tx: Sender<ControlCommand>,
-        control_output_rx: Receiver<ControlCommandResponse>,
+        vmm_control_tx: Sender<ControlCommand>,
+        vmm_control_rx: Receiver<ControlCommandResponse>,
     ) -> JoinHandle<Result<()>> {
         thread::spawn(move || {
-            let mut io_thread: IoThread = IoThread::new(
-                gateway,
-                microvm_rx,
-                microvm_tx,
-                control_input_tx,
-                control_output_rx,
-            )?;
+            let mut io_thread: IoThread =
+                IoThread::new(gateway, microvm_rx, microvm_tx, vmm_control_tx, vmm_control_rx)?;
             io_thread.run()?;
             Ok(())
         })
@@ -135,8 +116,8 @@ impl IoThread {
     /// - `gateway`: Connection to gateway.
     /// - `microvm_rx`: MicroVM receiver.
     /// - `microvm_tx`: MicroVM sender.
-    /// - `control_input_tx`: Command sender.
-    /// - `control_output_rx`: Response receiver.
+    /// - `vmm_control_tx`: Command sender.
+    /// - `vmm_control_rx`: Response receiver.
     ///
     /// # Returns
     ///
@@ -146,8 +127,8 @@ impl IoThread {
         gateway: Gateway,
         microvm_rx: Receiver<Message>,
         microvm_tx: Sender<Message>,
-        control_input_tx: Sender<ControlCommand>,
-        control_output_rx: Receiver<ControlCommandResponse>,
+        vmm_control_tx: Sender<ControlCommand>,
+        vmm_control_rx: Receiver<ControlCommandResponse>,
     ) -> Result<Self> {
         Ok(Self {
             gateway,
@@ -155,36 +136,27 @@ impl IoThread {
             microvm_tx,
             incoming: VecDeque::new(),
             outgoing: VecDeque::new(),
-            _state: OrchestratorState::PreBoot,
-            _control_input_tx: control_input_tx,
-            _control_output_rx: control_output_rx,
+            _vmm_control_tx: vmm_control_tx,
+            vmm_control_rx,
         })
     }
 
     ///
     /// # Description
     ///
-    /// Runs the I/O thread.
+    /// Runs the I/O thread according to the state in the snapshotting protocol state machine.
     ///
     /// # Returns
     ///
     /// Upon success, empty is returned. Otherwise, an error is returned instead.
     ///
     fn run(&mut self) -> Result<()> {
-        let mut round: usize = 0;
-
-        // Cycle through actions to avoid starvation.
         loop {
-            if round % 4 == 0 {
-                self.try_receive_from_microvm()?;
-            } else if round % 4 == 1 {
-                self.try_send_to_gateway()?;
-            } else if round % 4 == 2 {
-                self.try_receive_from_gateway()?;
-            } else {
-                self.try_send_to_microvm()?;
-            }
-            round += 1;
+            self.try_receive_from_microvm()?;
+            self.try_send_to_gateway()?;
+            self.try_receive_from_gateway()?;
+            self.try_send_to_microvm()?;
+            self.try_receive_from_vmm_control()?;
         }
     }
 
@@ -309,5 +281,64 @@ impl IoThread {
             },
             None => Ok(()),
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to receive a response from the VMM.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned.
+    ///
+    fn try_receive_from_vmm_control(&mut self) -> Result<()> {
+        match self.vmm_control_rx.try_recv() {
+            Ok(response) => match response {
+                ControlCommandResponse::FlushOutput => self.flush_microvm_output(),
+                ControlCommandResponse::FlushInput => self.flush_linuxd_input(),
+                _ => Ok(()), // TODO: forward to whoever is interested. This requires having control channels.
+            },
+            Err(TryRecvError::Empty) => Ok(()),
+            Err(TryRecvError::Disconnected) => {
+                let reason: String = "the vmm has disconnected".to_string();
+                // When the guest finishes , the vCPU thread will disconnect from this thread. This
+                // situation is normal and should not create an error log.
+                anyhow::bail!(reason)
+            },
+        }
+    }
+
+    /// # Description
+    ///
+    /// Attempts to flush all outstanding output from the MicroVM to the Linux daemon.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned.
+    ///
+    fn flush_microvm_output(&mut self) -> Result<()> {
+        while self.try_receive_from_microvm()? {
+            // Keep looping until `microvm_rx` is empty, which breaks the loop.
+        }
+        while !self.outgoing.is_empty() {
+            self.try_send_to_gateway()?;
+        }
+        Ok(())
+    }
+
+    /// # Description
+    ///
+    /// Attempts to flush all outstanding input from the the Linux daemon to the MicroVM.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned.
+    ///
+    fn flush_linuxd_input(&mut self) -> Result<()> {
+        while self.try_receive_from_gateway()? {
+            // Keep looping until receiving from the gateway would block, which breaks the loop.
+        }
+        Ok(())
     }
 }

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -29,7 +29,6 @@ use crate::{
     Gateway,
     vmm::microvm::{
         io::{
-            ControlCommand,
             ControlCommandResponse,
             IoThread,
         },
@@ -55,11 +54,19 @@ use ::std::{
         },
     },
     thread::JoinHandle,
+    time::Instant,
 };
 use ::sys::ipc::{
     Message,
     MessageType,
 };
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// This value was chosen so it catches issues without polluting the logs with too many warnings.
+const TIMEOUT_WARNING_INTERVAL_IN_MS: usize = 10;
 
 //==================================================================================================
 // Structure
@@ -72,7 +79,36 @@ pub struct Vmm {
     vcpu_thread: JoinHandle<Result<u16>>,
     _microvm: Arc<Mutex<MicroVm>>,
     control_input_rx: Receiver<ControlCommand>,
-    _control_output_tx: Sender<ControlCommandResponse>,
+    control_output_tx: Sender<ControlCommandResponse>,
+    orchestrator_state: OrchestratorState,
+}
+
+///
+/// # Description
+///
+/// States relating to snapshots functionality. Snapshots may be loaded at PreBoot, and created at Paused.
+///
+#[derive(PartialEq)]
+enum OrchestratorState {
+    PreBoot,
+    Running,
+    Paused,
+}
+
+///
+/// # Description
+///
+/// Control plane commands.
+///
+#[derive(PartialEq)]
+pub enum ControlCommand {
+    _StartMicroVm,
+    _LoadSnapshotAndRun,
+    _PauseMicroVm,
+    _PauseAndCreateSnapshot,
+    _CreateSnapshot,
+    _ResumeMicroVm,
+    LinuxDaemonFlushed,
 }
 
 //==================================================================================================
@@ -215,7 +251,8 @@ impl Vmm {
             vcpu_thread,
             _microvm: microvm,
             control_input_rx,
-            _control_output_tx: control_output_tx,
+            control_output_tx,
+            orchestrator_state: OrchestratorState::PreBoot,
         };
 
         if vmm.io_thread.is_some() {
@@ -371,9 +408,105 @@ impl Vmm {
         Box::new(output)
     }
 
+    ///
+    /// # Description
+    ///
+    /// Attempts to handle a command from the control input.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned.
+    ///
     fn handle_command(&mut self) -> Result<()> {
         match self.control_input_rx.try_recv() {
-            Ok(_command) => Ok(()), // TODO: handle commands.
+            Ok(command) => match command {
+                ControlCommand::_StartMicroVm => {
+                    if self.orchestrator_state == OrchestratorState::PreBoot {
+                        // TODO: separate starting logic from `spawn()` and put it here
+                        // This TODO could be done right now, but it's a major refactor.
+                        self.orchestrator_state = OrchestratorState::Running;
+                        trace!("OrchestratorState: PreBoot -> Running");
+                    }
+                    Ok(())
+                },
+                ControlCommand::_LoadSnapshotAndRun => {
+                    if self.orchestrator_state == OrchestratorState::PreBoot {
+                        // TODO: load snapshot
+                        // This TODO requires being able to create snapshots.
+
+                        // The Linux daemon should send messages to PreBoot VMMs by default,
+                        // so there's no need to tell it to resume sending messages.
+
+                        if let Err(e) = self.resume_microvm() {
+                            let reason: String =
+                                format!("LoadSnapshotAndRun: failed to resume microvm: {e:?}");
+                            error!("handle_command(): {reason}");
+                            anyhow::bail!(reason);
+                        }
+                        trace!("OrchestratorState: PreBoot -> Running");
+                    }
+                    Ok(())
+                },
+                ControlCommand::_PauseMicroVm => {
+                    if self.orchestrator_state == OrchestratorState::Running {
+                        if let Err(e) = self.pause_protocol() {
+                            let reason: String =
+                                format!("PauseMicroVm: failed to pause microvm: {e:?}");
+                            error!("handle_command(): {reason}");
+                            anyhow::bail!(reason);
+                        }
+                    }
+                    Ok(())
+                },
+                ControlCommand::_PauseAndCreateSnapshot => {
+                    if self.orchestrator_state == OrchestratorState::Running {
+                        if let Err(e) = self.pause_protocol() {
+                            let reason: String =
+                                format!("PauseAndCreateSnapshot: failed to pause microvm: {e:?}");
+                            error!("handle_command(): {reason}");
+                            anyhow::bail!(reason);
+                        }
+                        if let Err(e) = self.create_snapshot() {
+                            let reason: String =
+                                format!("PauseAndCreateSnapshot: failed to create snapshot: {e:?}");
+                            error!("handle_command(): {reason}");
+                            anyhow::bail!(reason);
+                        }
+                    }
+                    Ok(())
+                },
+                ControlCommand::_CreateSnapshot => {
+                    if self.orchestrator_state == OrchestratorState::Paused {
+                        if let Err(e) = self.create_snapshot() {
+                            let reason: String =
+                                format!("CreateSnapshot: failed to create snapshot: {e:?}");
+                            error!("handle_command(): {reason}");
+                            anyhow::bail!(reason);
+                        }
+                    }
+                    Ok(())
+                },
+                ControlCommand::_ResumeMicroVm => {
+                    if self.orchestrator_state == OrchestratorState::Paused {
+                        // TODO: tell linuxd it's fine to send more messages
+                        // This TODO requires having a control plane connection with linuxd
+                        if let Err(e) = self.resume_microvm() {
+                            let reason: String =
+                                format!("ResumeMicroVm: failed to resume microvm: {e:?}");
+                            error!("handle_command(): {reason}");
+                            anyhow::bail!(reason);
+                        }
+                        trace!("OrchestratorState: Paused -> Running");
+                    }
+                    Ok(())
+                },
+                ControlCommand::LinuxDaemonFlushed => {
+                    // NOTE: this will be unreachable once the communication is fully implemented
+                    // `LinuxDaemonFlushed` should only be sent in the middle of `pause_protocol`.
+                    // In fact, it should already be unreachable, but it cannot be tested ATM.
+                    Ok(())
+                },
+            },
             Err(TryRecvError::Empty) => Ok(()),
             Err(TryRecvError::Disconnected) => {
                 let reason: String =
@@ -382,5 +515,86 @@ impl Vmm {
                 anyhow::bail!(reason);
             },
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to pause the execution of the MicroVM and the communication with the Linux daemon.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned.
+    ///
+    fn pause_protocol(&mut self) -> Result<()> {
+        // TODO: pause MicroVM (Running -> Paused)
+        // and tell linuxd to flush (Running -> Flushing)
+        // This TODO requires pausing the vCPU and a control plane communication with linuxd
+        trace!("MicroVM paused");
+        // Flush output to linuxd
+        self.control_output_tx
+            .send(ControlCommandResponse::FlushOutput)?;
+        // TODO: tell linuxd to stop sending messages (Flushing -> Paused)
+        // TODO: get a response from linuxd
+        // These TODOs require a control plane communication with linuxd
+        self.control_output_tx
+            .send(ControlCommandResponse::FlushInput)?;
+        self.receive_linux_daemon_flushed()?;
+        self.orchestrator_state = OrchestratorState::Paused;
+        self.control_output_tx
+            .send(ControlCommandResponse::MicroVmPaused)?;
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to receive a `LinuxDaemonFlushed` message from the control input.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned instead.
+    ///
+    fn receive_linux_daemon_flushed(&mut self) -> Result<()> {
+        // Check how long it takes to receive a response
+        let start: Instant = Instant::now();
+        let mut counter: usize = 1;
+        // Loop until `LinuxDaemonFlushed` arrives.
+        // Different kinds of messages can be ignored,
+        // as they wouldn't do anything while the VMM is pausing.
+        while match self.control_input_rx.try_recv() {
+            Ok(command) => command != ControlCommand::LinuxDaemonFlushed,
+            Err(TryRecvError::Empty) => true,
+            Err(TryRecvError::Disconnected) => {
+                let reason: String = "the vmm has disconnected".to_string();
+                error!("receive_linux_daemon_flushed(): {reason}");
+                anyhow::bail!(reason)
+            },
+        } {
+            // Log a warning and increment the counter every TIMEOUT_WARNING_INTERVAL_IN_MS ms.
+            let elapsed_time: usize = start.elapsed().as_millis() as usize;
+            if elapsed_time > TIMEOUT_WARNING_INTERVAL_IN_MS * counter {
+                warn!(
+                    "{}ms have passed waiting for `LinuxDaemonFlushed`",
+                    TIMEOUT_WARNING_INTERVAL_IN_MS * counter
+                );
+                counter += 1;
+            }
+        }
+        Ok(())
+    }
+
+    fn create_snapshot(&self) -> Result<()> {
+        // TODO: create snapshot
+        trace!("Snapshot created");
+        self.control_output_tx
+            .send(ControlCommandResponse::SnapshotCreated)?;
+        Ok(())
+    }
+
+    fn resume_microvm(&self) -> Result<()> {
+        // TODO: resume MicroVM
+        trace!("MicroVM resumed");
+        Ok(())
     }
 }


### PR DESCRIPTION
# What the PR aims to do
This sets up the protocol for snapshots. All the states are traversed, and all channels send and receive messages. It still needs to build a connection to a client that sends the snapshot commands, and it doesn't actually pause and resume the MicroVM. It's just setting up the state transitions with a mocked up implementation.

# How it's done
`IoThread::run()` now has a different behavior depending on the state in the protocol. This method has a few TODOs related to the control connection to the Linux daemon, which isn't set up yet.

`IoThread::*_receive_from_outside_control()` are mocked methods. They simulate how a client might send commands to advance the protocol. The `blocking` version does communicate with the VMM, so the channels between the `IoThread` and the `Vmm` are tested by this method. `Vmm::handle_command()` is mocked on the other end to make this test possible.

The rest of the methods are self explanatory by their names.

# What I'd like feedback on
1. As is, this PR does not break anything. However, it changes the tail-latency in `IoThread::run()`. Instead of just polling all channels, it keeps transitioning between states, and only polls them in the `Running` state. Is this ok?

    When the protocol is fully implemented with the missing connections, then the `IoThread` will poll most of the time, since it will be in the `Running` state most of the time. This performance degradation wouldn't be permanent.

    The alternative I see is having dead code for the transitions. I believe the temporary slowdown is preferrable.

2. Are logging messages necessary during state transitions or when sending / receiving messages through channels?

3. I split the changes over three semantic commits. I hope they're clear. Should I squash them when it's time to merge?

NOTE: all TODOs are a staying part of this PR. I plan on working on them on the following PRs.