### PR TITLE
[ci] Add Tags To Self-Hosted Runners

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   ci:
     name: "Nanvix CI/CD (self-hosted)"
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, Linux, X64, baremetal]
     timeout-minutes: 240
     strategy:
       matrix:


### PR DESCRIPTION
In this commit I update our self-hosted CI job to use all available tags for the `runs-on` entry.

This makes it possible to add different runners, with different tags, without affecting the running jobs.