### PR TITLE
[ci] Run on Non-Draft PR Branches from Copilot

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -98,7 +98,7 @@ runs:
   - name: Get PR number if this push relates to an open PR
     id: pr
     run: |
-      PR_NUM=$(gh pr list --state open --head "$GITHUB_REF_NAME" --json number --jq '.[0].number')
+      PR_NUM=$(gh pr list --state open --head "$GITHUB_HEAD_REF" --json number --jq '.[0].number')
       echo "PR_NUM=$PR_NUM" >> $GITHUB_ENV
       echo "pr_number=$PR_NUM" >> $GITHUB_OUTPUT
     shell: bash

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -36,12 +36,9 @@ jobs:
 
     # Only run the CI for:
     # - Pushes to 'dev' (handled by workflow triggers above)
-    # - Pull requests where:
-    #   - The source branch starts with 'copilot/' (for Copilot-authored PRs)
-    #   - OR the PR is not a draft AND the source branch starts with one of:
-    #     'enhancement-', 'feature-', 'bugfix-', 'dependabot-', or 'dependabot/'
+    # - Non-draft PRs where the source branch starts with one of:
+    #     'enhancement-', 'feature-', 'bugfix-', 'dependabot-', 'dependabot/', or 'copilot/'
     if: |
-      github.event_name == 'pull_request' && startsWith(github.head_ref, 'copilot/') ||
       github.event_name != 'pull_request' ||
       (
         !github.event.pull_request.draft &&
@@ -50,7 +47,8 @@ jobs:
           startsWith(github.head_ref, 'feature-') ||
           startsWith(github.head_ref, 'bugfix-') ||
           startsWith(github.head_ref, 'dependabot-') ||
-          startsWith(github.head_ref, 'dependabot/')
+          startsWith(github.head_ref, 'dependabot/') ||
+          startsWith(github.head_ref, 'copilot/')
         )
       )
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/self-hosted-ci.yml` file to streamline the CI workflow trigger conditions. The changes simplify the logic for identifying eligible pull requests and ensure that Copilot-authored branches are included in the CI runs.

### Workflow trigger updates:

* Removed the special condition for Copilot-authored pull requests (`github.head_ref` starting with `copilot/`) and instead integrated it into the general list of allowed branch prefixes for non-draft PRs. (`[[1]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811L39-L44)`, `[[2]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811L53-R51)`)
* Added `copilot/` as an allowed branch prefix alongside `feature-`, `bugfix-`, `dependabot-`, and `dependabot/` for triggering the CI workflow. (`[.github/workflows/self-hosted-ci.ymlL53-R51](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811L53-R51)`)