### PR TITLE
[utils] Fix Boot-Time Benchmark

### DIFF
--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -107,7 +107,9 @@ impl Vmm {
         stderr: Option<String>,
         gateway_conn: Option<Gateway>,
     ) -> Result<u16> {
+        let start = std::time::Instant::now();
         crate::timer!("vmm_creation");
+
 
         let (vm_tx, gateway_rx) = mpsc::channel::<Message>();
         let (gateway_tx, memory_thread_rx) = mpsc::channel::<Message>();
@@ -155,6 +157,8 @@ impl Vmm {
         }
 
         microvm.reset(rip)?;
+
+        error!("elapsed 1 {} us", start.elapsed().as_micros());
 
         let microvm: Arc<Mutex<MicroVm>> = Arc::new(Mutex::new(microvm));
 
@@ -208,6 +212,8 @@ impl Vmm {
                 .run()
         });
 
+        error!("elapsed 2 {} us", start.elapsed().as_micros());
+
         let mut vmm: Vmm = Self {
             _gateway_tx: gateway_tx,
             io_thread,
@@ -224,8 +230,13 @@ impl Vmm {
             }
         }
 
+        error!("elapsed 3 {} us", start.elapsed().as_micros());
+
         match vmm.vcpu_thread.join() {
-            Ok(exit_code) => exit_code,
+            Ok(exit_code) => {
+                error!("elapsed 4 {} us", start.elapsed().as_micros());
+                exit_code
+            }
             Err(e) => {
                 let reason: String = format!("failed to join vCPU thread (error={e:?})");
                 error!("run(): {reason}");

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -281,20 +281,27 @@ impl Benchmark {
 
         let mut latencies: Vec<u128> = Vec::with_capacity(self.iterations);
         for _ in 0..self.iterations {
-            // Start the clock
             let start = Instant::now();
 
-            // The user VM will run to completion, so after starting we just
-            // wait for the child process to die.
-            let mut user_vm = self.start_user_vm(None)?;
-            user_vm.wait()?;
+            match Vmm::spawn(
+                config::kernel::MEMORY_SIZE,
+                format!("{}/bin/kernel.elf", get_proj_root()).as_str(),
+                Some(self.flavour.get_program()),
+                None,
+                None,
+                None,
+            )? {
+                e if e != 0 => {
+                    error!("error running VMM, exited with status: {e}");
+                    return Err(anyhow::anyhow!("VMM error"));
+                },
+                _ => {
+                    debug!("VMM: done running");
+                },
+            }
 
             latencies.push(start.elapsed().as_micros());
-
             pb.inc(1);
-
-            // Need to give some time to clean-up
-            thread::sleep(Duration::from_millis(CLEANUP_SLEEP_DURATION));
         }
 
         pb.finish();

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -281,6 +281,7 @@ impl Benchmark {
 
         let mut latencies: Vec<u128> = Vec::with_capacity(self.iterations);
         for _ in 0..self.iterations {
+            println!("warming up…");
             let start = Instant::now();
 
             match Vmm::spawn(
@@ -296,9 +297,12 @@ impl Benchmark {
                     return Err(anyhow::anyhow!("VMM error"));
                 },
                 _ => {
+                    error!("elapsed OUT 1 {} us", start.elapsed().as_micros());
                     debug!("VMM: done running");
                 },
             }
+            error!("elapsed OUT 2 {} us", start.elapsed().as_micros());
+
 
             latencies.push(start.elapsed().as_micros());
             pb.inc(1);
@@ -634,6 +638,15 @@ async fn main() -> Result<()> {
     // Initialize logger, and make sure we print error logs.
     Logger::try_with_env_or_str("error")
         .expect("malformed RUST_LOG environment variable")
+        .format(|writer: &mut dyn Write, now: &mut flexi_logger::DeferredNow, record: &flexi_logger::Record| {
+            write!(
+                writer,
+                "[{}] [{}] {}",
+                now.format("%Y-%m-%d %H:%M:%S%.9f"),
+                record.level(),
+                &record.args()
+            )
+        })
         .start()
         .expect("failed to initialize logger");
 


### PR DESCRIPTION
In this commit I modify the `boot-time` benchmark to run a VMM instance to completion, requireing no network requests.

Fixes #691