### PR TITLE
[devops] Use Deploy Key in Release Workflow

### DIFF
--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -22,15 +22,20 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v4
         with:
-          # Use a personal access token to allow pushing back to the repository
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_PRIVATE_SSH_KEY }}
           fetch-depth: 0
 
       - name: "Configure Git"
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin git@github.com:${{ github.repository }}.git
 
       - name: "Create minor release"
+        # This step runs the minor release script, which:
+        # - Increments the minor version, updates changelogs, and tags the release.
+        # - Requires the following secret to be available in the workflow:
+        #   - DEPLOY_PRIVATE_SSH_KEY: used in the checkout step for SSH-based operations.
+        # - The script must be executable and located at ./scripts/create-minor-release.sh.
         run: |
           ./scripts/create-minor-release.sh --push


### PR DESCRIPTION
## Description

This update modifies the minor release workflow to use a private deploy key, allowing it to bypass branch protection rules. This change ensures smoother automation for minor releases by enabling direct deployment without manual intervention.