### PR TITLE
[daemons] Make Linuxd Support Multiple User VM Connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ kvm-ioctls = "0.23.0"
 libc = "0.2.172"
 log = "0.4.27"
 microvm = { path = "src/microvm", default-features = false }
+mio = { version = "1", default-features = false }
 nanvixd = { path = "src/utils/nanvixd", default-features = false }
 num_enum = { version = "0.7.3", default-features = false }
 nvx = { path = "src/libs/nvx", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ serde_json = { version = "1.0.140", default-features = false, features = [
 ] }
 signal-hook = "0.3.18"
 slab = { path = "src/libs/slab", default-features = false }
+slab_external = { package = "slab", version = "0.4" }
 spin = { git = "https://github.com/nanvix/spin-rs", package = "spin", branch = "nanvix/v0.10.0", default-features = false }
 static_assert = { path = "src/libs/static_assert", default-features = false }
 sysapi = { path = "src/libs/sysapi", default-features = false }

--- a/src/daemons/linuxd/Cargo.toml
+++ b/src/daemons/linuxd/Cargo.toml
@@ -16,8 +16,11 @@ config = { workspace = true }
 flexi_logger = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
+mio = { workspace = true }
+nanvixd = { workspace = true }
 profiler = { workspace = true }
 signal-hook = { workspace = true }
+slab_external = { workspace = true }
 sys = { workspace = true, features = ["std"] }
 sysapi = { workspace = true, features = ["std"] }
 syscall = { workspace = true, features = ["std"] }

--- a/src/daemons/linuxd/src/gateway.rs
+++ b/src/daemons/linuxd/src/gateway.rs
@@ -1,0 +1,179 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! This file implements the gateway poll thread, a background thread that polls the gateway socket
+//! and monitors new connections to it. It will then, upon request from the main linuxd thread,
+//! send the accepted connections, in the form of socket streams, to the main linuxd thread.
+//!
+//! Most importantly, this module does nothing else than accepting connections.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::log::debug;
+use ::mio::{
+    Events,
+    Interest,
+    Poll,
+    Token,
+    Waker,
+};
+use ::std::{
+    collections::VecDeque,
+    sync::mpsc::{
+        channel,
+        Receiver,
+        Sender,
+    },
+    thread::{
+        self,
+        JoinHandle,
+    },
+};
+use ::syscomm::{
+    SocketListener,
+    SocketStream,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+pub enum GatewayCommand {
+    AcceptConn,
+    Shutdown,
+}
+
+pub struct GatewayHandle {
+    // Handle to send commands to the gateway thread.
+    pub gw_cmd_tx: Sender<GatewayCommand>,
+    // Handle to receive accepted connections from the gateway thread.
+    pub gw_conn_rx: Receiver<SocketStream>,
+    // Handle to force the gateway thread to wake-up and process pending connections.
+    pub waker: Waker,
+    // Handle to the underlying polling thread.
+    pub gw_thread: JoinHandle<()>,
+}
+
+pub struct GatewayPollThread {
+    listener: SocketListener,
+    poll: Poll,
+    events: Events,
+    gw_cmd_rx: Receiver<GatewayCommand>,
+    gw_conn_tx: Sender<SocketStream>,
+    pending_conns: VecDeque<SocketStream>,
+    pending_accepts: i32,
+}
+
+impl GatewayPollThread {
+    pub fn spawn(
+        mut listener: SocketListener,
+        listener_token: Token,
+        waker_token: Token,
+    ) -> std::io::Result<GatewayHandle> {
+        let poll = Poll::new()?;
+        poll.registry().register(
+            &mut listener,
+            listener_token,
+            Interest::READABLE | Interest::WRITABLE,
+        )?;
+
+        let waker = Waker::new(poll.registry(), waker_token)?;
+
+        let (gw_cmd_tx, gw_cmd_rx) = channel::<GatewayCommand>();
+        let (gw_conn_tx, gw_conn_rx) = channel::<SocketStream>();
+
+        let gw_thread = thread::spawn(move || {
+            let reactor = GatewayPollThread {
+                listener,
+                poll,
+                events: Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS),
+                gw_cmd_rx,
+                gw_conn_tx,
+                pending_conns: VecDeque::new(),
+                pending_accepts: 0,
+            };
+
+            reactor
+                .run(listener_token, waker_token)
+                .expect("gateway failed");
+        });
+
+        Ok(GatewayHandle {
+            gw_cmd_tx,
+            gw_conn_rx,
+            waker,
+            gw_thread,
+        })
+    }
+
+    /// The main linuxd thread accepts connections from user VMs, and the gateway thread
+    /// accepts connections from clients.
+    ///
+    /// To match a client connection to a user VM connection, at the moment, we rely on
+    /// both connections being initiatied roughly at the same time (in the future we will
+    /// refine the protocol). In particular, we rely on no other user VM, or no other client
+    /// trying to connect before this match has been established.
+    ///
+    /// Still, there is a race between the user VM and the client on who connects first.
+    /// To address this race, we keep track of both the pending connections we have
+    /// accepted but have not delivered to linuxd, and the connections that linuxd has
+    /// requested but we have not delivered yet.
+    ///
+    pub fn run(mut self, listener_token: Token, waker_token: Token) -> std::io::Result<()> {
+        loop {
+            self.poll.poll(&mut self.events, None)?;
+
+            for event in self.events.iter() {
+                match event.token() {
+                    _token if _token == listener_token => {
+                        loop {
+                            match self.listener.accept() {
+                                Ok(mut stream) => {
+                                    // We need reads from the gateway threads to block.
+                                    stream.set_blocking()?;
+
+                                    // If linuxd is waiting for a connection, send it over the
+                                    // channel. If not, push it back to the queue.
+                                    if self.pending_accepts > 0 {
+                                        let _ = self.gw_conn_tx.send(stream);
+                                        self.pending_accepts -= 1;
+                                    } else {
+                                        self.pending_conns.push_back(stream);
+                                    }
+                                },
+                                // No more connections to accept.
+                                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                                Err(e) => return Err(e.into()),
+                            }
+                        }
+                    },
+                    _token if _token == waker_token => {
+                        while let Ok(cmd) = self.gw_cmd_rx.try_recv() {
+                            match cmd {
+                                // Linuxd has requested a connection from the gateway.
+                                GatewayCommand::AcceptConn => {
+                                    if let Some(conn) = self.pending_conns.pop_front() {
+                                        let _ = self.gw_conn_tx.send(conn);
+                                    } else {
+                                        self.pending_accepts += 1;
+                                        // The calling thread is blocked on a `recv` command in the
+                                        // reception queue. We will send the connection as soon as
+                                        // we accept one.
+                                    }
+                                },
+                                // Linuxd has requested us to shut down.
+                                GatewayCommand::Shutdown => {
+                                    debug!("gateway thread shutting down");
+                                    return Ok(());
+                                },
+                            }
+                        }
+                    },
+                    _ => {},
+                }
+            }
+        }
+    }
+}

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -12,7 +12,13 @@ mod assemble;
 //==================================================================================================
 
 use crate::{
+    gateway::{
+        GatewayCommand,
+        GatewayHandle,
+        GatewayPollThread,
+    },
     message::RequestAssembler,
+    user_vm_handle::UserVmHandle,
     venv::{
         VenvCommand,
         VirtualEnviromentDirectory,
@@ -20,24 +26,29 @@ use crate::{
     worker_thread::WorkerThreadHandle,
 };
 use ::anyhow::Result;
+use ::mio::{
+    Events,
+    Interest,
+    Poll,
+    Token,
+};
+use ::nanvixd::control_plane;
+use ::slab_external::Slab;
 use ::std::{
-    collections::VecDeque,
-    io::{
-        ErrorKind,
-        Read,
+    collections::{
+        HashMap,
+        VecDeque,
     },
+    io::ErrorKind,
     sync::{
-        mpsc,
         mpsc::{
             Receiver,
-            RecvError,
             Sender,
         },
         Arc,
         Mutex,
         MutexGuard,
     },
-    thread::JoinHandle,
 };
 use ::sys::{
     error::{
@@ -47,25 +58,23 @@ use ::sys::{
     ipc::Message,
     pm::ThreadIdentifier,
 };
-use ::sysapi::sys_types::c_ssize_t;
-use ::syscall::{
-    unistd::message::{
-        ReadRequest,
-        ReadResponse,
-        WriteRequest,
-    },
-    venv::VirtualEnvironmentIdentifier,
+use ::syscall::venv::VirtualEnvironmentIdentifier;
+use ::syscomm::{
+    SocketListener,
+    SocketStream,
 };
-use ::syscomm::SocketStream;
 
 //==================================================================================================
 // Structures
 //==================================================================================================
 
 pub struct LinuxDaemon {
+    // We guard with a mutex the members  that will be accessed by all worker threads. The
+    // other members will only be accessed by the main thread.
+    control_plane_socket: SocketStream,
+    user_vm_listener: SocketListener,
+    gateway_listener: Option<SocketListener>,
     assembler: Arc<Mutex<RequestAssembler>>,
-    uvm_stream: Arc<Mutex<SocketStream>>,
-    gateway_stream: Option<SocketStream>,
     venv: Arc<Mutex<VirtualEnviromentDirectory>>,
 }
 
@@ -75,258 +84,407 @@ pub struct LinuxDaemon {
 
 impl LinuxDaemon {
     pub fn init(
-        uvm_stream: SocketStream,
-        gateway_stream: Option<SocketStream>,
+        control_plane_socket: SocketStream,
+        user_vm_listener: SocketListener,
+        gateway_listener: Option<SocketListener>,
     ) -> Result<Self, Error> {
-        if let Err(error) = uvm_stream.set_nonblocking(true) {
-            let reason: &str = "failed to set UVM stream to non-blocking mode";
-            error!("init(): {reason:?} (error={error:?})");
-            return Err(Error::new(ErrorCode::InvalidArgument, reason));
-        }
-
         Ok(Self {
+            control_plane_socket,
+            user_vm_listener,
+            gateway_listener,
             assembler: Arc::new(Mutex::new(RequestAssembler::default())),
-            uvm_stream: Arc::new(Mutex::new(uvm_stream)),
-            gateway_stream,
             venv: Arc::new(Mutex::new(VirtualEnviromentDirectory::new())),
         })
     }
 
+    /// This helper method accepts connections into the main user VM listener socket, and, if
+    /// necessary, accepts incoming connections for the gateway into this user VM.
+    fn accept_connections(
+        &mut self,
+        user_vm_connections: &mut Slab<UserVmHandle>,
+        poll: &Poll,
+        start_token: usize,
+        gw_handle: &Option<GatewayHandle>,
+    ) -> Result<(), Error> {
+        // Accept new connection in a loop, as we have a non-blocking socket, and
+        // we may have more than one connection pending to be accepted.
+        loop {
+            match self.user_vm_listener.accept() {
+                Ok(mut user_vm_stream) => {
+                    let entry = user_vm_connections.vacant_entry();
+                    let entry_key = entry.key();
+                    let token = Token(start_token + entry_key);
+
+                    poll.registry()
+                        .register(
+                            &mut user_vm_stream,
+                            token,
+                            Interest::READABLE | Interest::WRITABLE,
+                        )
+                        .map_err(|_| {
+                            Error::new(ErrorCode::IoErr, "failed to register new user VM to poll")
+                        })?;
+
+                    // After accepting a connection from the user VM, accept a connection from the
+                    // gateway if necessary.
+                    //
+                    // TODO: we should make this step more flexible to:
+                    // 1. Avoid race conditions when multiple user VMs connect at the same time.
+                    // 2. Support the situation where some user VMs may not have a gateway and
+                    //    others do (within the same linuxd instance).
+                    // 3. Support the situation where user VMs use a gateway lazily.
+                    //
+                    // A possible solution to 1 is for the user VM to send its ID right after connecting to
+                    // linuxd, and we provision a wrapper around netcat that connects to the gateway with
+                    // the same id.
+                    let gw_stream: Option<SocketStream> = if let Some(gw_handle) = gw_handle {
+                        gw_handle
+                            .gw_cmd_tx
+                            .send(GatewayCommand::AcceptConn)
+                            .map_err(|_| {
+                                Error::new(ErrorCode::IoErr, "failed to send message to GW thread")
+                            })?;
+                        gw_handle.waker.wake().map_err(|_| {
+                            Error::new(ErrorCode::IoErr, "failed to wake GW thread")
+                        })?;
+                        Some(gw_handle.gw_conn_rx.recv().map_err(|_| {
+                            Error::new(ErrorCode::IoErr, "failed to read response from GW thread")
+                        })?)
+                    } else {
+                        None
+                    };
+                    if gw_stream.is_some() {
+                        debug!("linuxd accepted gateway connection for user VM");
+                    }
+
+                    entry.insert(UserVmHandle::new(entry_key, user_vm_stream, gw_stream).map_err(
+                        |_| Error::new(ErrorCode::IoErr, "failed to insert user VM handle to slab"),
+                    )?);
+                },
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // No connections to be accepted, break.
+                    break;
+                },
+                Err(e) => {
+                    // This is a fatal error for the user VM, but we don't want to
+                    // kill linuxd.
+                    error!("Error accepting connection from user VM: {e:?}");
+                    break;
+                },
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Wrapper around the extraction of the connection from the slab, as we need a mutable
+    /// reference, and with the function call we ensure we return the borrow.
+    fn process_connection(
+        &mut self,
+        user_vm_connections: &mut Slab<UserVmHandle>,
+        conn_id: usize,
+    ) -> Result<UserVmHandle, Error> {
+        match user_vm_connections.get_mut(conn_id) {
+            Some(user_vm_handle) => Ok(user_vm_handle.clone()),
+            None => Err(Error::new(ErrorCode::InvalidArgument, "Invalid connection ID")),
+        }
+    }
+
+    /// Helper method to close a connection to a user VM identified by the connection id. Closing
+    /// the connection also involes stopping all associated worker threads.
+    fn close_connection(
+        &mut self,
+        uvm_handle: UserVmHandle,
+        poll: &Poll,
+        worker_threads: Option<VecDeque<WorkerThreadHandle>>,
+    ) {
+        // De-register the user VM socket from the poll structure.
+        let user_vm_stream = uvm_handle.get_user_vm_stream();
+        let mut user_vm_stream = user_vm_stream.lock().unwrap();
+        if let Err(e) = poll.registry().deregister(&mut *user_vm_stream) {
+            error!("failed to de-revister user VM from poll (error={e:?})");
+        }
+
+        // Send a shutdown message to all worker threads associated
+        // with this user VM.
+        if let Some(mut worker_threads) = worker_threads {
+            for worker_thread in worker_threads.drain(..) {
+                trace!("sending interrupt to worker thread (thread_id={:?})", worker_thread.id);
+
+                // If any of the commands fail, continue trying to drain the remainnig
+                // threads.
+                match worker_thread.cmd_tx.send(VenvCommand::Shutdown) {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!("error sending shutdown command to worker thread (thread_id={e:?})");
+                        continue;
+                    },
+                }
+                match worker_thread.stop() {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!("error sending interrupt to worker thread (thread_id={e:?})");
+                        continue;
+                    },
+                }
+                match worker_thread.handle.join() {
+                    Ok(_) => {},
+                    Err(e) => {
+                        error!("error joining worker thread (thread_id={e:?})");
+                    },
+                }
+            }
+        }
+    }
+
+    /// This is the main run loop for linuxd. It uses a listener socket to
+    /// accept connections from multiple user VMs, and it polls over all
+    /// active connections to serve requests.
     pub fn run(&mut self) -> Result<(), Error> {
-        // Start the thread that will poll input from the gateway.
-        // TODO: when one linuxd instance manages more than one input stream we should encapsulate
-        // this logic.
-        let (gw_stdin_tx, gw_stdout_tx) = if let Some(gateway_stream) = &self.gateway_stream {
-            // For the STDIN channel senders (TX) need to wait for a response from the IO thread,
-            // hence they send, together with the ReadRequest, the send endpoint of a channel where
-            // they will wait for the response. For STDOUT senders need not to wait, hence no need
-            // to also send the channel endpoint.
-            let (gw_stdin_tx, gw_stdin_rx) = mpsc::channel::<(ReadRequest, Sender<Message>)>();
-            let (gw_stdout_tx, gw_stdout_rx) = mpsc::channel::<WriteRequest>();
+        // We keep a slab of tokens to active connections from user VMs. We
+        // reserve the first token for the main listener socket, that should
+        // out-live user VMs.
+        //
+        // We use a slab because it is better suited to index a highly-dense
+        // collection with usize keys.
+        const LISTENER_TOKEN: Token = Token(0);
+        // The main poll uses token number 1 to monitor commands from the control plane, and the
+        // poll in the gateway thread uses token number 1 to wake-up to respond to commands from
+        // the main linuxd thread.
+        const CONTROL_PLANE_TOKEN: Token = Token(1);
+        const WAKER_TOKEN: Token = Token(1);
+        const START_TOKEN: usize = 2;
+        let mut user_vm_connections: Slab<UserVmHandle> = Slab::new();
 
-            // Make sure that the input stream from the gateway is set to blocking, as otherwise we
-            // would not be able to differentiate between an EOF and a race between the application
-            // code and the gateway.
-            let mut gw_stdin_stream = gateway_stream
-                .try_clone()
-                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to clone stream"))?;
-            gw_stdin_stream
-                .set_nonblocking(false)
-                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to set non-blocing socket"))?;
+        let mut poll =
+            Poll::new().map_err(|_| Error::new(ErrorCode::IoErr, "failed to create Poll"))?;
+        let mut events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+        poll.registry()
+            .register(&mut self.user_vm_listener, LISTENER_TOKEN, Interest::READABLE)
+            .map_err(|_| {
+                Error::new(ErrorCode::IoErr, "failed to register user VM listener to poll")
+            })?;
+        poll.registry()
+            .register(&mut self.control_plane_socket, CONTROL_PLANE_TOKEN, Interest::READABLE)
+            .map_err(|_| {
+                Error::new(ErrorCode::IoErr, "failed to register user VM listener to poll")
+            })?;
 
-            let _gw_stdin_thread: JoinHandle<Result<()>> = std::thread::spawn(move || {
-                loop {
-                    // Block waiting for the user VM to request reading from STDIN.
-                    match gw_stdin_rx.recv() {
-                        Ok((_read_request, response_tx)) => {
-                            let mut response_buf: [u8; ReadResponse::BUFFER_SIZE] =
-                                [0u8; ReadResponse::BUFFER_SIZE];
-                            let num_read = match gw_stdin_stream.read(&mut response_buf) {
-                                Ok(n) => n,
-                                Err(e) => {
-                                    let reason: String =
-                                        format!("failed to read STDIN from gateway: {e:?}");
-                                    error!("{}", reason);
-                                    return Err(anyhow::anyhow!(reason));
-                                },
-                            };
-                            response_tx.send(ReadResponse::build(
-                                0.into(),
-                                num_read as c_ssize_t,
-                                response_buf,
-                            ))?;
-                        },
-                        Err(RecvError) => {
-                            // This may happen during shutdown.
-                            debug!("gateway STDIN channel disconnected");
-                            break Ok(());
-                        },
-                    }
-                }
-            });
-
-            let mut gw_stdout_stream = gateway_stream
-                .try_clone()
-                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to clone stream"))?;
-            let _gw_stdout_thread: JoinHandle<Result<()>> = std::thread::spawn(move || {
-                loop {
-                    // Block waiting the user VM to request writing to stdout.
-                    match gw_stdout_rx.recv() {
-                        Ok(write_request) => {
-                            gw_stdout_stream
-                                .write_all(&write_request.buffer[..write_request.count as usize])?;
-
-                            // We don't need to send anything in response of the write, as the
-                            // writting thread has already moved on.
-                        },
-                        Err(RecvError) => {
-                            // This may happen during shutdown.
-                            debug!("gateway STDOUT channel disconnected");
-                            break Ok(());
-                        },
-                    }
-                }
-            });
-
-            (Some(gw_stdin_tx), Some(gw_stdout_tx))
+        // Start a gateway reactor thread that polls the gateway listener socket for incoming
+        // connections to user VMs.
+        let gw_thread_handle: Option<GatewayHandle> = if let Some(gateway_listener) =
+            self.gateway_listener.take()
+        {
+            Some(
+                GatewayPollThread::spawn(gateway_listener, LISTENER_TOKEN, WAKER_TOKEN)
+                    .map_err(|_| Error::new(ErrorCode::IoErr, "failed to spawn gateway reactor"))?,
+            )
         } else {
-            (None, None)
+            None
         };
 
-        // Map keeping track of the worker threads associated the user VM.
-        let mut worker_threads: VecDeque<WorkerThreadHandle> = VecDeque::new();
+        // Map keeping track of the worker threads associated to each user VM identified by
+        // connection ID. We use a HashMap and not a Slab because we need to support insert/removal
+        // by key.
+        let mut worker_threads: HashMap<usize, VecDeque<WorkerThreadHandle>> = HashMap::new();
 
-        loop {
-            let uvm_stream: Arc<Mutex<SocketStream>> = self.uvm_stream.clone();
+        'main_loop: loop {
             let venv: Arc<Mutex<VirtualEnviromentDirectory>> = self.venv.clone();
             let assembler: Arc<Mutex<RequestAssembler>> = self.assembler.clone();
 
-            // Receive a message from the user virtual machine.
-            let message: Message = match Self::recv(uvm_stream.clone()) {
-                Ok(message) => message,
+            poll.poll(&mut events, None)
+                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to poll user VM events"))?;
 
-                Err(error_kind) => match error_kind {
-                    ErrorKind::WouldBlock => continue,
-                    ErrorKind::UnexpectedEof | ErrorKind::ConnectionReset => {
-                        info!("connection from user VM closed");
+            for event in events.iter() {
+                match event.token() {
+                    // Process control-plane messages before anything else.
+                    CONTROL_PLANE_TOKEN => {
+                        let cmd: control_plane::Command =
+                            control_plane::try_read_command(&mut self.control_plane_socket)
+                                .map_err(|_| {
+                                    Error::new(
+                                        ErrorCode::IoErr,
+                                        "failed read command from control-plane",
+                                    )
+                                })?;
+                        match cmd {
+                            control_plane::Command::Shutdown => {
+                                info!("linuxd received shutdown message from control-plane");
+                                // Close all existing connections to user VMs.
+                                while let Some(uvm_handle) = user_vm_connections.drain().next() {
+                                    let conn_id = uvm_handle.get_conn_id();
+                                    info!("shutting down user VM (conn_id={conn_id})");
 
-                        // Each worker thread may be in one of three states:
-                        // 1. Running
-                        // 2. Blocked on a system call
-                        // 3. Blocked waiting for a new message from the channel
-                        //
-                        // To gracefully shutdown the thread, we enqueue a shutdown message to the
-                        // message channel. In case the thread is blocked on a system call, we also
-                        // send it an interrupt signal and handle EINTR accordingly.
-                        for worker_thread in worker_threads.drain(..) {
-                            trace!(
-                                "sending interrupt to worker thread (thread_id={:?})",
-                                worker_thread.id
-                            );
-
-                            // If any of the commands fail, continue trying to drain the remainnig
-                            // threads.
-                            match worker_thread.cmd_tx.send(VenvCommand::Shutdown) {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    error!(
-                                        "error sending shutdown command to worker thread \
-                                         (thread_id={e:?})"
+                                    self.close_connection(
+                                        uvm_handle,
+                                        &poll,
+                                        worker_threads.remove(&conn_id),
                                     );
-                                    continue;
-                                },
-                            }
-                            match worker_thread.stop() {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    error!(
-                                        "error sending interrupt to worker thread \
-                                         (thread_id={e:?})"
+                                }
+
+                                // Draining the user VM connections should also drain the worker
+                                // threads. Print an error if not.
+                                if !worker_threads.is_empty() {
+                                    error!("finished shutdown with orphaned worker threads");
+                                }
+
+                                break 'main_loop;
+                            },
+                        }
+                    },
+
+                    // Check if we have received any messages on the main listener socket.
+                    // These indicate new user VMs connecting to linuxd.
+                    LISTENER_TOKEN => {
+                        self.accept_connections(
+                            &mut user_vm_connections,
+                            &poll,
+                            START_TOKEN,
+                            &gw_thread_handle,
+                        )?;
+                    },
+
+                    // Now we process events from active connections.
+                    Token(t) => {
+                        let conn_id = t - START_TOKEN;
+
+                        // Receive a message from the user virtual machine.
+                        let uvm_handle =
+                            self.process_connection(&mut user_vm_connections, conn_id)?;
+                        let message: Message = match Self::recv(uvm_handle.get_user_vm_stream()) {
+                            Ok(message) => message,
+
+                            Err(error_kind) => match error_kind {
+                                ErrorKind::WouldBlock => continue,
+                                ErrorKind::UnexpectedEof => {
+                                    info!("connection from user VM closed (conn_id={conn_id})");
+                                    self.close_connection(
+                                        uvm_handle,
+                                        &poll,
+                                        worker_threads.remove(&conn_id.clone()),
                                     );
+                                    user_vm_connections.remove(conn_id);
                                     continue;
                                 },
-                            }
-                            match worker_thread.handle.join() {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    error!("error joining worker thread (thread_id={e:?})");
-                                    continue;
+                                _ => {
+                                    let reason: String =
+                                        format!("failed to read message (error={error_kind:?})");
+                                    unimplemented!("handle: {reason}");
                                 },
+                            },
+                        };
+
+                        trace!(
+                            "message.source={:?}, message.destination={:?}, message.type={:?}",
+                            { message.source },
+                            { message.destination },
+                            message.message_type,
+                        );
+
+                        let source: ThreadIdentifier = match { message.source }.as_id() {
+                            Err(tid) => tid,
+                            Ok(pid) => {
+                                unimplemented!(
+                                    "received message from process {pid:?} instead of thread"
+                                );
+                            },
+                        };
+
+                        // Check if process is associated with a virtual environment.
+                        let (channel_tx, channel_rx): (
+                            Sender<VenvCommand>,
+                            Option<Receiver<VenvCommand>>,
+                        ) = {
+                            let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> =
+                                venv.lock().unwrap();
+                            let env = venv.get(source);
+                            if let Some(env) = env {
+                                (env.get_channel_tx(), None)
+                            } else {
+                                // Join a new virtual environment.
+                                match venv.join(source, VirtualEnvironmentIdentifier::NEW) {
+                                    Ok((_, channel_tx, channel_rx)) => {
+                                        (channel_tx, Some(channel_rx))
+                                    },
+                                    Err(error) => {
+                                        warn!(
+                                            "failed to join new virtual environment \
+                                             (error={error:?})"
+                                        );
+                                        let message: Message =
+                                            crate::build_error(source, error.code);
+                                        uvm_handle
+                                            .get_user_vm_stream()
+                                            .lock()
+                                            .unwrap()
+                                            .write_all(&message.to_bytes())
+                                            .map_err(|_| {
+                                                let reason = "failed to write to user VM stream";
+                                                error!("{reason}");
+                                                Error::new(ErrorCode::IoErr, reason)
+                                            })?;
+                                        continue;
+                                    },
+                                }
                             }
+                        };
+
+                        // Spawn a new worker thread, if necessary.
+                        if let Some(channel_rx) = channel_rx {
+                            // Spawn a thread to handle the message.
+                            let assembler = assembler.clone();
+
+                            // Spawn an interruptible thread to handle the message.
+                            let worker_thread_handle: WorkerThreadHandle =
+                                WorkerThreadHandle::spawn(
+                                    source,
+                                    channel_rx,
+                                    channel_tx.clone(),
+                                    uvm_handle,
+                                    assembler,
+                                )?;
+                            worker_threads
+                                .entry(conn_id)
+                                .or_default()
+                                .push_back(worker_thread_handle);
                         }
 
-                        break;
+                        // Dispatch message to worker thread.
+                        if let Err(error) = channel_tx.send(VenvCommand::Work(message)) {
+                            error!(
+                                "run(): failed to dispatch message to worker thread \
+                                 (tid={source:?}, error={error:?})"
+                            );
+                            // Remove thread from the virtual environment.
+                            let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> =
+                                venv.lock().unwrap();
+                            if let Err(error) = venv.leave(source) {
+                                warn!(
+                                    "run(): failed to remove thread from virtual environment \
+                                     (tid={source:?}, error={error:?})",
+                                );
+                            }
+                        }
                     },
-                    _ => {
-                        let reason: String =
-                            format!("failed to read message (error={error_kind:?})");
-                        unimplemented!("handle: {reason}");
-                    },
-                },
-            };
-
-            trace!(
-                "message.source={:?}, message.destination={:?}, message.type={:?}",
-                { message.source },
-                { message.destination },
-                message.message_type,
-            );
-
-            let source: ThreadIdentifier = match { message.source }.as_id() {
-                Err(tid) => tid,
-                Ok(pid) => {
-                    unimplemented!("received message from process {pid:?} instead of thread");
-                },
-            };
-
-            // Check if process is associated with a virtual environment.
-            let (channel_tx, channel_rx): (Sender<VenvCommand>, Option<Receiver<VenvCommand>>) = {
-                let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
-                let env = venv.get(source);
-                if let Some(env) = env {
-                    (env.get_channel_tx(), None)
-                } else {
-                    // Join a new virtual environment.
-                    match venv.join(source, VirtualEnvironmentIdentifier::NEW) {
-                        Ok((_, channel_tx, channel_rx)) => (channel_tx, Some(channel_rx)),
-                        Err(error) => {
-                            warn!("failed to join new virtual environment (error={error:?})");
-                            let message: Message = crate::build_error(source, error.code);
-                            uvm_stream
-                                .lock()
-                                .unwrap()
-                                .write_all(&message.to_bytes())
-                                .map_err(|_| {
-                                    let reason = "failed to write to user VM stream";
-                                    error!("{reason}");
-                                    Error::new(ErrorCode::IoErr, reason)
-                                })?;
-                            continue;
-                        },
-                    }
-                }
-            };
-
-            // Spawn a new worker thread, if necessary.
-            if let Some(channel_rx) = channel_rx {
-                // Spawn a thread to handle the message.
-                let venv: Arc<Mutex<VirtualEnviromentDirectory>> = venv.clone();
-                let gw_stdin_tx = gw_stdin_tx.clone();
-                let gw_stdout_tx = gw_stdout_tx.clone();
-                let assembler = assembler.clone();
-
-                // Spawn an interruptible thread to handle the message.
-                let worker_thread_handle: WorkerThreadHandle = WorkerThreadHandle::spawn(
-                    source,
-                    channel_rx,
-                    channel_tx.clone(),
-                    uvm_stream,
-                    gw_stdin_tx,
-                    gw_stdout_tx,
-                    venv,
-                    assembler,
-                )?;
-                worker_threads.push_back(worker_thread_handle);
-            }
-
-            // Dispatch message to worker thread.
-            if let Err(error) = channel_tx.send(VenvCommand::Work(message)) {
-                error!(
-                    "run(): failed to dispatch message to worker thread (tid={source:?}, \
-                     error={error:?})"
-                );
-                // Remove thread from the virtual environment.
-                let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
-                if let Err(error) = venv.leave(source) {
-                    warn!(
-                        "run(): failed to remove thread from virtual environment (tid={source:?}, \
-                         error={error:?})",
-                    );
                 }
             }
         }
 
-        // TODO: https://github.com/nanvix/nanvix/issues/639
+        // Stop the gateway thread.
+        if let Some(gw_thread_handle) = gw_thread_handle {
+            // Send the shutdown command and wake the thread. Log errors but do not fail as we are
+            // cleaning up.
+            if let Err(e) = gw_thread_handle.gw_cmd_tx.send(GatewayCommand::Shutdown) {
+                error!("failed to send shutdown command to gateway thread (error={e:?})");
+            }
+            if let Err(e) = gw_thread_handle.waker.wake() {
+                error!("failed to wake gateway thread (error={e:?})");
+            }
+            if let Err(e) = gw_thread_handle.gw_thread.join() {
+                error!("failed to join gateway thread (error={e:?})");
+            }
+        }
+
         Ok(())
     }
 
@@ -337,7 +495,9 @@ impl LinuxDaemon {
 
         let mut locked_uvm_stream: MutexGuard<'_, SocketStream> = uvm_stream.lock().unwrap();
 
-        if let Err(e) = locked_uvm_stream.read_exact(&mut buf) {
+        // If we are trying to read from the user VM stream, it means we have been notified in the
+        // poll structure, so data should be available.
+        if let Err(e) = locked_uvm_stream.try_read_exact(&mut buf) {
             return Err(e.kind());
         };
 

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -16,6 +16,7 @@ mod args;
 mod dirent;
 mod error;
 mod fcntl;
+mod gateway;
 mod linuxd;
 mod message;
 mod poll;
@@ -23,6 +24,7 @@ mod socket;
 mod time;
 mod times;
 mod unistd;
+mod user_vm_handle;
 mod venv;
 mod worker_thread;
 
@@ -129,7 +131,7 @@ pub fn main() -> Result<()> {
     };
 
     // Connect the control-plane socket.
-    let _control_plane_socket: SocketStream =
+    let control_plane_socket: SocketStream =
         match SocketStream::connect(control_plane_socket_type, control_plane_sockaddr.clone()) {
             Ok(socket) => {
                 info!("Connected to control plane on: {:?}", control_plane_sockaddr);
@@ -145,11 +147,12 @@ pub fn main() -> Result<()> {
         };
 
     // Start listening for incoming connections from user VMs associated to this linuxd instance.
-    // TODO: this logic will be moved to inside the main linuxd loop once we support running
-    // multiple user VM instances per linuxd.
     let user_vm_listener: SocketListener =
         match Socket::bind(user_vm_bind_socket_type, user_vm_sockaddr.clone()) {
-            Ok(listener) => listener,
+            Ok(listener) => {
+                info!("Listening to user VMs on: {user_vm_sockaddr:?}");
+                listener
+            },
             Err(e) => {
                 error!(
                     "failed to bind to user VM socket address (address={}, error={e:?})",
@@ -159,23 +162,7 @@ pub fn main() -> Result<()> {
             },
         };
 
-    info!("Listening to user VMs on: {user_vm_sockaddr:?}");
-    let user_vm_stream: SocketStream = loop {
-        match user_vm_listener.accept() {
-            Ok(stream) => {
-                info!("Connected to user VM in: {:?}", stream.peer_addr());
-                break stream;
-            },
-            Err(error) => {
-                error!("Failed to accept connection: {error:?}");
-                continue;
-            },
-        };
-    };
-
-    // Start listening for requests for requests to feed input to the user VM.
-    // TODO: this logic will be moved to inside the main linuxd loop once we support running
-    // multiple user VM instances per linuxd.
+    // Start listening for requests for requests to feed input to the user VMs.
     let gateway_listener: Option<SocketListener> = match gateway_sockaddr {
         Some(ref sockaddr) => match Socket::bind(gateway_bind_socket_type, sockaddr.clone()) {
             Ok(stream) => {
@@ -190,29 +177,11 @@ pub fn main() -> Result<()> {
         None => None,
     };
 
-    let gateway_stream: Option<SocketStream> = match gateway_listener {
-        Some(gateway_listener) => {
-            info!("Listening to gateway on: {:?}", gateway_sockaddr);
-            loop {
-                match gateway_listener.accept() {
-                    Ok(stream) => {
-                        info!("Connected to gateway in: {:?}", stream.peer_addr());
-                        break Some(stream);
-                    },
-                    Err(error) => {
-                        error!("Failed to accept connection: {error:?}");
-                        continue;
-                    },
-                }
-            }
-        },
-        None => None,
-    };
-
-    let mut procd: LinuxDaemon = match LinuxDaemon::init(user_vm_stream, gateway_stream) {
-        Ok(procd) => procd,
-        Err(e) => panic!("failed to initialize process manager daemon (error={e:?})"),
-    };
+    let mut procd: LinuxDaemon =
+        match LinuxDaemon::init(control_plane_socket, user_vm_listener, gateway_listener) {
+            Ok(procd) => procd,
+            Err(e) => panic!("failed to initialize process manager daemon (error={e:?})"),
+        };
 
     // Run main procd loop.
     let procd_ret = procd.run();

--- a/src/daemons/linuxd/src/user_vm_handle.rs
+++ b/src/daemons/linuxd/src/user_vm_handle.rs
@@ -1,0 +1,51 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::std::sync::{
+    Arc,
+    Mutex,
+};
+use ::syscomm::SocketStream;
+use anyhow::Result;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// State associated with a user VM connected to this linuxd instance.
+#[derive(Clone)]
+pub struct UserVmHandle {
+    conn_id: usize,
+    user_vm_stream: Arc<Mutex<SocketStream>>,
+    gw_stream: Option<Arc<Mutex<SocketStream>>>,
+}
+
+impl UserVmHandle {
+    pub fn new(
+        conn_id: usize,
+        user_vm_stream: SocketStream,
+        gw_stream: Option<SocketStream>,
+    ) -> Result<Self> {
+        Ok(Self {
+            conn_id,
+            user_vm_stream: Arc::new(Mutex::new(user_vm_stream)),
+            gw_stream: gw_stream.map(|stream| Arc::new(Mutex::new(stream))),
+        })
+    }
+
+    pub fn get_conn_id(&self) -> usize {
+        self.conn_id
+    }
+
+    pub fn get_user_vm_stream(&self) -> Arc<Mutex<SocketStream>> {
+        self.user_vm_stream.clone()
+    }
+
+    pub fn get_gw_vm_stream(&self) -> Option<Arc<Mutex<SocketStream>>> {
+        self.gw_stream.clone()
+    }
+}

--- a/src/daemons/linuxd/src/venv.rs
+++ b/src/daemons/linuxd/src/venv.rs
@@ -7,13 +7,10 @@
 
 use ::std::{
     collections::BTreeMap,
-    sync::{
-        mpsc,
-        mpsc::{
-            channel,
-            Receiver,
-            Sender,
-        },
+    sync::mpsc::{
+        channel,
+        Receiver,
+        Sender,
     },
 };
 use ::sys::{
@@ -49,10 +46,6 @@ pub enum VenvCommand {
 pub struct VirtualEnvironment {
     /// Identifier.
     id: VirtualEnvironmentIdentifier,
-    /// Channel to receive stdin from the IO thread. For stdout we write to the IO thread and do
-    /// not wait for a reply, so we don't need an auxiliary channel.
-    stdin_response_tx: Sender<Message>,
-    stdin_response_rx: Receiver<Message>,
     /// Input channel to this virtual environment.
     channel_tx: Sender<VenvCommand>,
 }
@@ -80,14 +73,7 @@ impl VirtualEnvironment {
     /// Creates a new virtual environment.
     ///
     fn new(id: VirtualEnvironmentIdentifier, channel_tx: Sender<VenvCommand>) -> Self {
-        let (stdin_response_tx, stdin_response_rx) = mpsc::channel::<Message>();
-
-        Self {
-            id,
-            stdin_response_tx,
-            stdin_response_rx,
-            channel_tx,
-        }
+        Self { id, channel_tx }
     }
 
     ///
@@ -97,26 +83,6 @@ impl VirtualEnvironment {
     ///
     fn id(&self) -> VirtualEnvironmentIdentifier {
         self.id
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Get the sender end of the stdin channel. It can be passed to the gateway IO thread to
-    /// receive stdin input through it.
-    ///
-    pub fn get_stdin_response_tx(&self) -> Sender<Message> {
-        self.stdin_response_tx.clone()
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Get the receiving end of the stdin channel. We need a mutable reference as there can only
-    /// ever be one receiver, which should be the thread in the virtual environment.
-    ///
-    pub fn get_stdin_response_rx(&mut self) -> &mut Receiver<Message> {
-        &mut self.stdin_response_rx
     }
 
     ///
@@ -246,23 +212,5 @@ impl VirtualEnviromentDirectory {
     ///
     pub fn get(&self, tid: ThreadIdentifier) -> Option<&VirtualEnvironment> {
         self.processes.get(&tid)
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Gets a mutable reference to the virtual environment of a process.
-    ///
-    /// # Parameters
-    ///
-    /// - `tid`: Thread identifier.
-    ///
-    /// # Returns
-    ///
-    /// If there is a virtual environment associated with the process, the function returns a
-    /// mutable reference to the virtual environment. Otherwise, it returns `None`.
-    ///
-    pub fn get_mut(&mut self, tid: ThreadIdentifier) -> Option<&mut VirtualEnvironment> {
-        self.processes.get_mut(&tid)
     }
 }

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -24,13 +24,17 @@ use crate::{
     socket,
     times,
     unistd,
-    venv::{
-        VenvCommand,
-        VirtualEnviromentDirectory,
-        VirtualEnvironment,
-    },
+    user_vm_handle::UserVmHandle,
+    venv::VenvCommand,
 };
-use ::anyhow::Result;
+use ::libc::{
+    c_int,
+    pthread_kill,
+    pthread_self,
+    sigaction,
+    sigemptyset,
+    SIGUSR1,
+};
 use ::std::{
     io::ErrorKind,
     mem,
@@ -46,7 +50,6 @@ use ::std::{
         },
         Arc,
         Mutex,
-        MutexGuard,
     },
     thread::{
         self,
@@ -67,10 +70,13 @@ use ::sys::{
     },
     pm::ThreadIdentifier,
 };
-use ::sysapi::unistd::{
-    STDERR_FILENO,
-    STDIN_FILENO,
-    STDOUT_FILENO,
+use ::sysapi::{
+    sys_types::c_ssize_t,
+    unistd::{
+        STDERR_FILENO,
+        STDIN_FILENO,
+        STDOUT_FILENO,
+    },
 };
 use ::syscall::{
     dirent::message::GetDirectoryEntriesRequest,
@@ -140,14 +146,6 @@ use ::syscomm::{
     SocketError,
     SocketStream,
 };
-use libc::{
-    c_int,
-    pthread_kill,
-    pthread_self,
-    sigaction,
-    sigemptyset,
-    SIGUSR1,
-};
 
 const INTERRUPT_SIGNAL: c_int = SIGUSR1;
 
@@ -199,10 +197,7 @@ impl WorkerThreadHandle {
         id: ThreadIdentifier,
         channel_rx: Receiver<VenvCommand>,
         channel_tx: Sender<VenvCommand>,
-        uvm_stream: Arc<Mutex<SocketStream>>,
-        gw_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        gw_stdout_tx: Option<Sender<WriteRequest>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        uvm_handle: UserVmHandle,
         assembler: Arc<Mutex<RequestAssembler>>,
     ) -> Result<Self, Error> {
         // We use an atomic to pass the id of the created thread back to the caller context. We
@@ -218,14 +213,7 @@ impl WorkerThreadHandle {
             let pthread_id = unsafe { pthread_self() };
             pthread_id_holder.store(pthread_id as usize, Ordering::Relaxed);
 
-            Self::handle_message(
-                channel_rx,
-                uvm_stream,
-                gw_stdin_tx,
-                gw_stdout_tx,
-                venv,
-                assembler,
-            );
+            Self::handle_message(channel_rx, uvm_handle, assembler);
 
             trace!("thread shutting down after receiving interrupt (pthread_id={pthread_id})");
         });
@@ -258,13 +246,12 @@ impl WorkerThreadHandle {
 
     fn handle_message(
         channel_rx: Receiver<VenvCommand>,
-        uvm_stream: Arc<Mutex<SocketStream>>,
-        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        gateway_stdout_tx: Option<Sender<WriteRequest>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        uvm_handle: UserVmHandle,
         assembler: Arc<Mutex<RequestAssembler>>,
     ) {
         let worker_tid: ThreadId = thread::current().id();
+        let uvm_stream = uvm_handle.get_user_vm_stream();
+        let gw_stream = uvm_handle.get_gw_vm_stream();
 
         loop {
             let message: Message = match channel_rx.recv() {
@@ -309,9 +296,7 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::ReadRequest
                                 | LinuxDaemonMessageHeader::WriteRequest => {
                                     match Self::handle_special_messages(
-                                        gateway_stdin_tx.clone(),
-                                        gateway_stdout_tx.clone(),
-                                        venv.clone(),
+                                        gw_stream.clone(),
                                         source,
                                         message,
                                     ) {
@@ -462,9 +447,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_special_messages(
-        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        gateway_stdout_tx: Option<Sender<WriteRequest>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        gw_stream: Option<Arc<Mutex<SocketStream>>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<Message, WorkerThreadError> {
@@ -475,11 +458,11 @@ impl WorkerThreadHandle {
             },
             LinuxDaemonMessageHeader::ReadRequest => {
                 let request: ReadRequest = ReadRequest::from_bytes(message.payload);
-                Self::handle_read_request(gateway_stdin_tx, venv, source, request)
+                Self::handle_read_request(gw_stream, source, request)
             },
             LinuxDaemonMessageHeader::WriteRequest => {
                 let request: WriteRequest = WriteRequest::from_bytes(message.payload);
-                Self::handle_write_request(gateway_stdout_tx, source, request)
+                Self::handle_write_request(gw_stream, source, request)
             },
             header => {
                 // The following statement is unreachable, because the matching logic in this
@@ -782,15 +765,15 @@ impl WorkerThreadHandle {
     }
 
     fn handle_write_request(
-        gateway_stdout_tx: Option<Sender<WriteRequest>>,
+        gw_stream: Option<Arc<Mutex<SocketStream>>>,
         source: ThreadIdentifier,
         mut request: WriteRequest,
     ) -> Result<Message, WorkerThreadError> {
         trace!("handle_write_request(): source={source:?}, request={request:?}");
         // Check if writing to gateway.
         if request.fd == STDOUT_FILENO || request.fd == STDERR_FILENO {
-            let gateway_stdout_tx = if let Some(gateway_stdout_tx) = gateway_stdout_tx {
-                gateway_stdout_tx
+            let gw_stream = if let Some(gw_stream) = gw_stream {
+                gw_stream
             } else {
                 error!(
                     "handle_write_request(): trying to write to stdout without a gateway \
@@ -807,14 +790,21 @@ impl WorkerThreadHandle {
             } else {
                 profiler::timestamp_message!(&mut request.buffer, 0);
                 let count: usize = request.count as usize;
-                if let Err(error) = gateway_stdout_tx.send(request) {
-                    debug!("failed to write buffer to the gateway (error={error:?})");
-                    // TODO: Check error conversion.
-                    return Ok(build_error(source, ErrorCode::ConnectionReset));
+                match gw_stream
+                    .lock()
+                    .unwrap()
+                    .write_all(&request.buffer[..count])
+                {
+                    Ok(()) => {},
+                    Err(e) if e.kind() == ErrorKind::Interrupted => {
+                        return Err(WorkerThreadError::Interrupted)
+                    },
+                    Err(e) => {
+                        error!("failed to write to gateway socket (error={e:?})");
+                        return Ok(build_error(source, ErrorCode::IoErr));
+                    },
                 }
 
-                // We don't wait for the IO thread to confirm that the write was correct, as writes
-                // are fully non-blocking.
                 debug!("wrote {count} bytes to the gateway");
                 Ok(WriteResponse::build(source, count as i32))
             }
@@ -825,16 +815,15 @@ impl WorkerThreadHandle {
     }
 
     fn handle_read_request(
-        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        gw_stream: Option<Arc<Mutex<SocketStream>>>,
         source: ThreadIdentifier,
         request: ReadRequest,
     ) -> Result<Message, WorkerThreadError> {
         trace!("handle_read_request(): source={source:?}, request={request:?}");
         // Check if reading from gateway.
         if request.fd == STDIN_FILENO {
-            let gateway_stdin_tx = if let Some(gateway_stdin_tx) = gateway_stdin_tx {
-                gateway_stdin_tx
+            let gw_stream = if let Some(gw_stream) = gw_stream {
+                gw_stream
             } else {
                 error!(
                     "handle_read_request(): process tried to read from stdin but no gateway found"
@@ -842,42 +831,41 @@ impl WorkerThreadHandle {
                 return Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]));
             };
 
-            // Check if the process is associated with a virtual environment.
-            let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
-            let env: &mut VirtualEnvironment = if let Some(env) = venv.get_mut(source) {
-                env
-            } else {
-                warn!(
-                    "handle_read_request(): process is not associated with a virtual environment, \
-                     returning EOF"
-                );
-                return Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]));
-            };
+            // Read from the gateway thread.
+            {
+                let mut gw_stream = gw_stream.lock().unwrap();
+                loop {
+                    let mut response_buf: [u8; ReadResponse::BUFFER_SIZE] =
+                        [0u8; ReadResponse::BUFFER_SIZE];
+                    // Blocking read from the gateway socket to make sure we can be interrupted if
+                    // necessary.
+                    let response = match gw_stream.read(&mut response_buf) {
+                        Ok(0) => {
+                            error!(
+                                "handle_read_request(): error receiving request response from \
+                                 gateway STDIN: EOF"
+                            );
+                            Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]))
+                        },
+                        Ok(n) => {
+                            debug!("read {n} bytes from gateway: {response_buf:?}");
+                            Ok(ReadResponse::build(source, n as c_ssize_t, response_buf))
+                        },
+                        Err(e) if e.kind() == ErrorKind::WouldBlock => continue,
+                        Err(e) if e.kind() == ErrorKind::Interrupted => {
+                            return Err(WorkerThreadError::Interrupted)
+                        },
+                        Err(e) => {
+                            error!(
+                                "handle_read_request(): error reading data from gateway \
+                                 (error={e:?})"
+                            );
+                            Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]))
+                        },
+                    };
 
-            // Send ReadRequest to gateway IO thread.
-            if let Err(error) = gateway_stdin_tx.send((request, env.get_stdin_response_tx())) {
-                error!(
-                    "handle_read_request(): error sending request to gateway STDIN IO thread, \
-                     returning EOF (error={error:?})"
-                );
-                return Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]));
-            }
-
-            // Wait for response from IO thread.
-            match env.get_stdin_response_rx().recv() {
-                Ok(mut read_response) => {
-                    // We don't have access to the source in the gateway IO thread, so we set
-                    // it here.
-                    read_response.destination = source.into();
-                    Ok(read_response)
-                },
-                Err(e) => {
-                    error!(
-                        "handle_read_request(): error receiving request response from gateway \
-                         STDIN IO thread, returning EOF (error={e:?})"
-                    );
-                    Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]))
-                },
+                    return response;
+                }
             }
         } else {
             // Read from other file descriptor.

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -65,6 +65,13 @@ pub mod syscomm {
     /// Provides the length of the temporary bufer we use to read messages from the gateway.
     ///
     pub const GW_READ_BUFFER_LEN: usize = 4 * 1024;
+
+    ///
+    /// # Description
+    ///
+    /// Provides the maximum number of poll events we can buffer.
+    ///
+    pub const MAX_NUM_POLL_EVENTS: usize = 128;
 }
 
 //==================================================================================================

--- a/src/libs/syscomm/Cargo.toml
+++ b/src/libs/syscomm/Cargo.toml
@@ -11,6 +11,7 @@ description = "System Communication Library"
 homepage.workspace = true
 
 [dependencies]
-config = { workspace = true }
 anyhow = { workspace = true }
+config = { workspace = true }
 log = { workspace = true }
+mio = { workspace = true, features = ["net", "os-poll"] }

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -9,6 +9,19 @@ extern crate alloc;
 
 use ::anyhow::Result;
 use ::log::error;
+use ::mio::{
+    net::{
+        TcpListener,
+        TcpStream,
+        UnixListener,
+        UnixStream,
+    },
+    Events,
+    Interest,
+    Poll,
+    Registry,
+    Token,
+};
 use ::std::{
     error::Error,
     fmt,
@@ -19,15 +32,13 @@ use ::std::{
         Read,
         Write,
     },
-    net::{
-        TcpListener,
-        TcpStream,
-    },
-    os::unix::net::{
-        UnixListener,
-        UnixStream,
-    },
 };
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const BLOCKING_THREAD_TOKEN: Token = Token(0);
 
 //==================================================================================================
 // Imports
@@ -48,7 +59,7 @@ pub struct Socket;
 impl Socket {
     pub fn bind(typ: SocketType, addr: String) -> Result<SocketListener> {
         match typ {
-            SocketType::Tcp => Ok(SocketListener::Tcp(TcpListener::bind(addr)?)),
+            SocketType::Tcp => Ok(SocketListener::Tcp(TcpListener::bind(addr.parse()?)?)),
             SocketType::Unix => Ok(SocketListener::Unix {
                 listener: UnixListener::bind(&addr)?,
                 path: addr.clone(),
@@ -85,12 +96,12 @@ impl SocketListener {
         match self {
             SocketListener::Tcp(listener) => {
                 let (stream, _sockaddr): (TcpStream, std::net::SocketAddr) = listener.accept()?;
-                Ok(SocketStream::Tcp(stream))
+                Ok(SocketStream::Tcp(stream, None))
             },
             SocketListener::Unix { listener, path: _ } => {
                 let (stream, _sockaddr): (UnixStream, std::os::unix::net::SocketAddr) =
                     listener.accept()?;
-                Ok(SocketStream::Unix(stream))
+                Ok(SocketStream::Unix(stream, None))
             },
         }
     }
@@ -109,13 +120,50 @@ impl Drop for SocketListener {
     }
 }
 
+impl mio::event::Source for SocketListener {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        match self {
+            SocketListener::Tcp(listener) => listener.register(registry, token, interests),
+            SocketListener::Unix { listener, path: _ } => {
+                listener.register(registry, token, interests)
+            },
+        }
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        match self {
+            SocketListener::Tcp(listener) => listener.reregister(registry, token, interests),
+            SocketListener::Unix { listener, path: _ } => {
+                listener.reregister(registry, token, interests)
+            },
+        }
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        match self {
+            SocketListener::Tcp(listener) => listener.deregister(registry),
+            SocketListener::Unix { listener, path: _ } => listener.deregister(registry),
+        }
+    }
+}
+
 /// A struct representing a socket stream.
 #[derive(Debug)]
 pub enum SocketStream {
     /// TCP socket stream.
-    Tcp(TcpStream),
+    Tcp(TcpStream, Option<Poll>),
     /// Unix socket stream.
-    Unix(UnixStream),
+    Unix(UnixStream, Option<Poll>),
 }
 
 impl SocketStream {
@@ -123,42 +171,76 @@ impl SocketStream {
     pub fn connect(typ: SocketType, addr: String) -> Result<SocketStream> {
         match typ {
             SocketType::Tcp => {
-                let stream: TcpStream = TcpStream::connect(addr)?;
-                Ok(SocketStream::Tcp(stream))
+                let stream: TcpStream = TcpStream::connect(addr.parse()?)?;
+                Ok(SocketStream::Tcp(stream, None))
             },
             SocketType::Unix => {
                 let stream: UnixStream = UnixStream::connect(addr)?;
-                Ok(SocketStream::Unix(stream))
+                Ok(SocketStream::Unix(stream, None))
             },
         }
     }
 
-    pub fn try_clone(&self) -> Result<SocketStream, ::std::io::Error> {
+    ///
+    /// # Description
+    ///
+    /// Set the stream to blocking mode.
+    ///
+    /// We use non-blocking sockets, so to provide a blocking-like behaviour we extend each stream
+    /// with its own poll structure that can be used to wait on data.
+    ///
+    /// This approach is intended to be used when we are only monitoring one stream, potentially
+    /// across different worker threads. To monitor multiple streams, you should use a global poll.
+    ///
+    pub fn set_blocking(&mut self) -> io::Result<()> {
         match self {
-            SocketStream::Tcp(stream) => {
-                let stream: TcpStream = stream.try_clone()?;
-                Ok(SocketStream::Tcp(stream))
-            },
-            SocketStream::Unix(stream) => {
-                let stream: UnixStream = stream.try_clone()?;
-                Ok(SocketStream::Unix(stream))
-            },
-        }
-    }
+            SocketStream::Tcp(stream, ref mut poll) => {
+                // Initialize Poll structure if it's not already set
+                if poll.is_none() {
+                    let poll_instance = Poll::new()
+                        .map_err(|_| io::Error::other("failed to create Poll instance"))?;
 
-    /// Sets a socket stream to non-blocking mode.
-    pub fn set_nonblocking(&self, nonblocking: bool) -> Result<(), ::std::io::Error> {
-        match self {
-            SocketStream::Tcp(stream) => stream.set_nonblocking(nonblocking),
-            SocketStream::Unix(stream) => stream.set_nonblocking(nonblocking),
+                    poll_instance
+                        .registry()
+                        .register(
+                            stream,
+                            BLOCKING_THREAD_TOKEN,
+                            Interest::READABLE | Interest::WRITABLE,
+                        )
+                        .map_err(|_| io::Error::other("failed to register thread to poll"))?;
+
+                    *poll = Some(poll_instance);
+                }
+
+                Ok(())
+            },
+            SocketStream::Unix(stream, ref mut poll) => {
+                if poll.is_none() {
+                    let poll_instance = Poll::new()
+                        .map_err(|_| io::Error::other("failed to create Poll instance"))?;
+
+                    poll_instance
+                        .registry()
+                        .register(
+                            stream,
+                            BLOCKING_THREAD_TOKEN,
+                            Interest::READABLE | Interest::WRITABLE,
+                        )
+                        .map_err(|_| io::Error::other("failed to register thread to poll"))?;
+
+                    *poll = Some(poll_instance);
+                }
+
+                Ok(())
+            },
         }
     }
 
     /// Writes data to a socket stream.
     pub fn write_all(&mut self, buf: &[u8]) -> Result<(), SocketError> {
         let result = match self {
-            SocketStream::Tcp(stream) => stream.write_all(buf),
-            SocketStream::Unix(stream) => stream.write_all(buf),
+            SocketStream::Tcp(stream, _) => stream.write_all(buf),
+            SocketStream::Unix(stream, _) => stream.write_all(buf),
         };
 
         match result {
@@ -167,27 +249,144 @@ impl SocketStream {
         }
     }
 
-    /// Reads data from a socket stream.
-    pub fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), ::std::io::Error> {
-        let result = match self {
-            SocketStream::Tcp(stream) => stream.read_exact(buf),
-            SocketStream::Unix(stream) => stream.read_exact(buf),
-        };
-
-        match result {
-            Ok(_) => Ok(()),
-            Err(error) => Err(error),
+    ///
+    /// # Description
+    ///
+    /// Blocking read implementation.
+    ///
+    /// # Parameters
+    ///
+    /// A mutable buffer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes read into the buffer.
+    ///
+    pub fn try_read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            SocketStream::Tcp(stream, _) => stream.read(buf),
+            SocketStream::Unix(stream, _) => stream.read(buf),
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Blocking read implementation.
+    ///
+    /// # Parameters
+    ///
+    /// A mutable buffer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes read into the buffer.
+    ///
+    pub fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            SocketStream::Tcp(stream, poll) => {
+                if let Some(poll_instance) = poll {
+                    let mut events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+
+                    poll_instance.poll(&mut events, None)?;
+                    stream.read(buf)
+                } else {
+                    let reason = "tried to perform blocking read on a non-blocking thread";
+                    error!("{reason}");
+                    Err(io::Error::new(io::ErrorKind::InvalidData, reason))
+                }
+            },
+            SocketStream::Unix(stream, poll) => {
+                if let Some(poll_instance) = poll {
+                    let mut events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+
+                    poll_instance.poll(&mut events, None)?;
+                    stream.read(buf)
+                } else {
+                    let reason = "tried to perform blocking read on a non-blocking thread";
+                    error!("{reason}");
+                    Err(io::Error::new(io::ErrorKind::InvalidData, reason))
+                }
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Non-blocking read exact implementation.
+    ///
+    /// # Parameters
+    ///
+    /// A mutable buffer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes read into the buffer.
+    ///
+    pub fn try_read_exact(&mut self, buf: &mut [u8]) -> Result<(), SocketError> {
+        let mut total_read = 0;
+
+        while total_read < buf.len() {
+            match self.try_read(&mut buf[total_read..]) {
+                Ok(0) => {
+                    return Err(io::Error::new(ErrorKind::UnexpectedEof, "connection closed").into())
+                },
+                Ok(n) => total_read += n,
+                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                    // Not ready yet — must wait for next Poll notification
+                    break;
+                },
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        // You may return partial reads if needed; or retry later
+        if total_read == buf.len() {
+            Ok(())
+        } else {
+            Err(io::Error::new(ErrorKind::WouldBlock, "need more data").into())
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Blocking read exact implementation.
+    ///
+    /// # Parameters
+    ///
+    /// A mutable buffer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes read into the buffer.
+    ///
+    pub fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), SocketError> {
+        let mut num_read = 0;
+        while num_read < buf.len() {
+            match self.read(&mut buf[num_read..]) {
+                Ok(0) => {
+                    return Err(
+                        io::Error::new(io::ErrorKind::UnexpectedEof, "End of file reached").into()
+                    )
+                },
+                Ok(n) => num_read += n,
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(())
     }
 
     /// Gets the peer address of a socket stream.
     pub fn peer_addr(&self) -> Result<SocketAddr, SocketError> {
         match self {
-            SocketStream::Tcp(stream) => match stream.peer_addr() {
+            SocketStream::Tcp(stream, _) => match stream.peer_addr() {
                 Ok(addr) => Ok(SocketAddr::Tcp(addr)),
                 Err(error) => Err(SocketError { error }),
             },
-            SocketStream::Unix(stream) => match stream.peer_addr() {
+            SocketStream::Unix(stream, _) => match stream.peer_addr() {
                 Ok(addr) => Ok(SocketAddr::Unix(addr)),
                 Err(error) => Err(SocketError { error }),
             },
@@ -195,12 +394,67 @@ impl SocketStream {
     }
 }
 
-/// Implement Read trait for SocketStream.
-impl Read for SocketStream {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+impl mio::event::Source for SocketStream {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         match self {
-            SocketStream::Tcp(stream) => stream.read(buf),
-            SocketStream::Unix(stream) => stream.read(buf),
+            SocketStream::Tcp(stream, poll) => {
+                if poll.is_some() {
+                    let reason = "trying to register a blocking thread to a poll";
+                    error!("{reason}");
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+                }
+
+                stream.register(registry, token, interests)
+            },
+            SocketStream::Unix(stream, poll) => {
+                if poll.is_some() {
+                    let reason = "trying to register a blocking thread to a poll";
+                    error!("{reason}");
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+                }
+
+                stream.register(registry, token, interests)
+            },
+        }
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        match self {
+            SocketStream::Tcp(stream, poll) => {
+                if poll.is_some() {
+                    let reason = "trying to register a blocking thread to a poll";
+                    error!("{reason}");
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+                }
+
+                stream.reregister(registry, token, interests)
+            },
+            SocketStream::Unix(stream, poll) => {
+                if poll.is_some() {
+                    let reason = "trying to register a blocking thread to a poll";
+                    error!("{reason}");
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+                }
+
+                stream.reregister(registry, token, interests)
+            },
+        }
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        match self {
+            SocketStream::Tcp(stream, _) => stream.deregister(registry),
+            SocketStream::Unix(stream, _) => stream.deregister(registry),
         }
     }
 }

--- a/src/microvm/src/gateway.rs
+++ b/src/microvm/src/gateway.rs
@@ -61,7 +61,7 @@ impl Gateway {
     pub fn try_send(&mut self, message: Message) -> Result<(), SocketError> {
         let bytes: [u8; mem::size_of::<Message>()] = message.to_bytes();
         match self.stream.write_all(&bytes) {
-            Ok(_) => Ok(()),
+            Ok(()) => Ok(()),
             Err(e) => {
                 // Print error messages only if it is not a WouldBlock error to avoid spamming the logs.
                 if e.kind() != ErrorKind::WouldBlock {
@@ -85,7 +85,7 @@ impl Gateway {
     ///
     pub fn try_receive(&mut self) -> Result<Message, SocketError> {
         let mut bytes: [u8; mem::size_of::<Message>()] = [0; mem::size_of::<Message>()];
-        match self.stream.read_exact(&mut bytes) {
+        match self.stream.try_read_exact(&mut bytes) {
             Ok(_) => {
                 let mut message: Message = match Message::try_from_bytes(bytes) {
                     Ok(message) => message,
@@ -109,7 +109,7 @@ impl Gateway {
                     error!("receive(): {reason}");
                 }
 
-                Err(SocketError::new(e))
+                Err(e)
             },
         }
     }

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -84,10 +84,7 @@ fn main() -> Result<ExitCode> {
 
     let gateway: Option<Gateway> = match &gateway_addr {
         Some(addr) => match SocketStream::connect(gateway_socket_type, addr.clone()) {
-            Ok(stream) => {
-                stream.set_nonblocking(true)?;
-                Some(Gateway::new(stream))
-            },
+            Ok(stream) => Some(Gateway::new(stream)),
             Err(e) => {
                 let reason: String =
                     format!("failed to connect to gateway (gateway_addr={addr:?}, error={e:?})",);

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -19,6 +19,7 @@ indicatif = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 microvm = { workspace = true }
+mio = { workspace = true, features = ["net", "os-poll"] }
 nanvixd = { workspace = true }
 profiler = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -47,6 +47,7 @@ use microvm::{
     Gateway,
     Vmm,
 };
+use mio::net::UnixStream;
 use nanvixd::config::DEFAULT_TMP_DIRECTORY;
 use reqwest::header::{
     CONTENT_TYPE,
@@ -61,7 +62,6 @@ use std::{
     },
     mem,
     net::TcpStream,
-    os::unix::net::UnixStream,
     process::{
         self,
         Child,
@@ -223,7 +223,15 @@ impl Benchmark {
         // deployment time.
         let gateway_stream: SocketStream = loop {
             match SocketStream::connect(SocketType::Unix, response.gateway_sockaddr.clone()) {
-                Ok(stream) => break stream,
+                Ok(mut stream) => {
+                    debug!(
+                        "connected gateway socket to linuxd (addr={})",
+                        response.gateway_sockaddr.clone()
+                    );
+                    stream.set_blocking()?;
+
+                    break stream;
+                },
                 Err(_) => continue,
             };
         };
@@ -488,14 +496,13 @@ impl Benchmark {
         // Spawn the VMM in a separate thread.
         let program = self.flavour.get_program();
         let vmm_handle = std::thread::spawn(move || -> Result<()> {
-            vmm_stream.set_nonblocking(true)?;
             match Vmm::spawn(
                 config::kernel::MEMORY_SIZE,
                 format!("{}/bin/kernel.elf", get_proj_root()).as_str(),
                 Some(program),
                 None,
                 Some("/dev/null".to_string()),
-                Some(Gateway::new(syscomm::SocketStream::Unix(vmm_stream))),
+                Some(Gateway::new(syscomm::SocketStream::Unix(vmm_stream, None))),
             )? {
                 e if e != 0 => {
                     error!("error running VMM, exited with status: {e}");
@@ -757,7 +764,10 @@ async fn main() -> Result<()> {
     };
     match result {
         Ok(_) => {},
-        Err(e) => error!("error running benchmark: {e:?}"),
+        Err(e) => {
+            error!("error running benchmark: {e:?}");
+            benchmark.cleanup()
+        },
     }
 
     Ok(())

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -201,8 +201,7 @@ impl SandboxCache {
         for (tenant_id, linuxd_instance) in self.linuxd_instances.iter_mut() {
             if let Some(linuxd_instance_mut) = Arc::get_mut(linuxd_instance) {
                 if let Err(e) = linuxd_instance_mut.shutdown().await {
-                    // FIXME: convert to error once linuxd supports a graceful shutdown.
-                    debug!("error cleaning-up linuxd instance for tenant {tenant_id}: {e:?}");
+                    error!("error cleaning-up linuxd instance for tenant {tenant_id}: {e:?}");
                 } else {
                     debug!("cleaned-up linuxd instance for tenant {tenant_id}");
                 }

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -71,25 +71,20 @@ pub fn control_plane_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<
 ///
 /// # Description
 ///
-/// Builds the user VM Unix socket address for a given tenant ID, application name, and sandbox ID.
+/// Builds the user VM Unix socket address for a given tenant ID. All applications for
+/// the same tenant will be multiplexed over this socket.
 ///
 /// # Arguments
 ///
 /// - tmp_str: Temporary directory path.
 /// - tenant_id: Tenant ID.
-/// - sandbox_id: Sandbox ID.
 ///
 /// # Returns
 ///
 /// On success, returns the name of the user VM Unix socket. On failure, returns an error.
 ///
-pub fn user_vm_sockaddr_builder(
-    tmp_str: &str,
-    tenant_id: &str,
-    sandbox_id: &str,
-) -> Result<String> {
-    let unix_socket_name: String =
-        format!("{tmp_str}/{tenant_id}:{sandbox_id}:uvm{UNIX_SOCKET_SUFFIX}");
+pub fn user_vm_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<String> {
+    let unix_socket_name: String = format!("{tmp_str}/{tenant_id}:uvm{UNIX_SOCKET_SUFFIX}");
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {
@@ -108,25 +103,20 @@ pub fn user_vm_sockaddr_builder(
 ///
 /// # Description
 ///
-/// Builds the gateway Unix socket address for a given tenant ID, application name, and sandbox ID.
+/// Builds the gateway Unix socket address for a given tenant ID. All applications of the
+/// same tenant are multiplexed over the same gateway socket.
 ///
 /// # Arguments
 ///
 /// - tmp_str: Temporary directory path.
 /// - tenant_id: Tenant ID.
-/// - sandbox_id: Sandbox ID.
 ///
 /// # Returns
 ///
 /// On success, returns the name of the gateway Unix socket. On failure, returns an error.
 ///
-pub fn gateway_sockaddr_builder(
-    tmp_str: &str,
-    tenant_id: &str,
-    sandbox_id: &str,
-) -> Result<String> {
-    let unix_socket_name: String =
-        format!("{tmp_str}/{tenant_id}:{sandbox_id}:gw{UNIX_SOCKET_SUFFIX}");
+pub fn gateway_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<String> {
+    let unix_socket_name: String = format!("{tmp_str}/{tenant_id}:gw{UNIX_SOCKET_SUFFIX}");
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {

--- a/src/utils/nanvixd/src/control_plane.rs
+++ b/src/utils/nanvixd/src/control_plane.rs
@@ -1,8 +1,8 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
-// This file contains the messages used in the control-plane API between
-// nanvixd and linuxd/user VM.
+//! This file contains the messages used in the control-plane API between
+//! nanvixd and linuxd/user VM.
 
 use ::anyhow::Result;
 use ::num_enum::{
@@ -27,9 +27,9 @@ pub enum Command {
 // This function is actually used by linuxd, consuming nanvixd as a library. It is never used from
 // the main nanvixd binary, hence why we need to add this annotation to silent clippy.
 #[allow(dead_code)]
-pub fn read_command(stream: &mut SocketStream) -> Result<Command, SocketError> {
+pub fn try_read_command(stream: &mut SocketStream) -> Result<Command, SocketError> {
     let mut buf: [u8; 1] = [0u8; 1];
-    stream.read_exact(&mut buf)?;
+    stream.try_read_exact(&mut buf)?;
 
     Command::try_from(buf[0]).map_err(|_| {
         Error::new(ErrorKind::InvalidData, "error parsing control-plane command".to_string()).into()

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -113,9 +113,9 @@ impl HttpClient {
         let control_plane_sockaddr: String =
             config::control_plane_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
         let gateway_sockaddr: String =
-            config::gateway_sockaddr_builder(&tmp_directory, tag.tenant_id(), tag.sandbox_id())?;
+            config::gateway_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
         let user_vm_sockaddr: String =
-            config::user_vm_sockaddr_builder(&tmp_directory, tag.tenant_id(), tag.sandbox_id())?;
+            config::user_vm_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
         let program_args = match message.program_args.len() {
             0 => None,
             _ => Some(message.program_args.clone()),

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -107,41 +107,20 @@ impl LinuxDaemon {
 
     /// Send a shutdown message to linuxd so that it can clean-up its internal resources.
     pub async fn shutdown(&mut self) -> Result<()> {
+        // Send shutdown command to linuxd.
         match control_plane::send_command(
             &mut self.control_plane_stream,
             control_plane::Command::Shutdown,
         ) {
             Ok(()) => {},
             Err(e) => {
-                // FIXME: this send_command is expected to fail until support is implemented in
-                // linuxd.
-                error!("failed to send shutdown command to linuxd (error={e:?})");
-            },
-        };
-
-        // FIXME: when linuxd reacts on shutdown commands, we will be able to get rid of this
-        // manual kill.
-        match self.child.id() {
-            Some(pid) => {
-                let ret_code = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
-
-                if ret_code < 0 {
-                    let reason: String = format!(
-                        "error sending SIGINT to linuxd: {}",
-                        std::io::Error::last_os_error()
-                    );
-                    error!("{reason}");
-
-                    return Err(anyhow::anyhow!(reason));
-                }
-            },
-            None => {
-                let reason: String = "linuxd process has no PID".to_string();
+                let reason: String =
+                    format!("failed to send shutdown command to linuxd (error={e:?})");
                 error!("{reason}");
 
                 return Err(anyhow::anyhow!(reason));
             },
-        }
+        };
 
         // Wait for linuxd instance to finish.
         match self.child.wait().await {
@@ -151,9 +130,7 @@ impl LinuxDaemon {
                         "linuxd returned with non-zero exit status: {:?}",
                         exit_status.code()
                     );
-                    // FIXME: change this debug to error once linuxd dies gracefully after a
-                    // SIGINT.
-                    debug!("{reason}");
+                    error!("{reason}");
 
                     Err(anyhow::anyhow!(reason))
                 } else {


### PR DESCRIPTION
In this PR I implement support in linuxd to manage multiple user VM connections.  There are two places where we poll for incoming connections:
1. The main linuxd thread, that polls for incoming user VM connections.
2. A new `GatewayPollThread` that polls incoming client connections to connect to a user VM's stdin/stdout.

In order to poll over a set of SocketStreams, we need to use non-blocking Metal IO sockets, so in the first commit I move the `syscomm` lib to use those. Unfortunately, in some scenarios we need to perform a blocking read. For example, when we are reading data from the gateway we want to block the caller thread until data is available, but we also want to block in a way that we can be interrupted if needed. I therefore introduce support to perform blocking reads on non-blocking sockets by keeping a per-socket poll structure. This is incompatible with adding the socket to an external poll structure.

Another hairy aspect is that we require the user VM and the gateway to connect roughly at the same time, and no other user VMs or gateways to connect before the match has been made. I have ideas on how to refine this protocol, but they belong in a follow-up PR.

Closes #674 (fixes)