### PR TITLE
[scripts] Improve Randomness on Unix Socket Names

### DIFF
--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -16,6 +16,11 @@ LOGS_DIR=${NANVIX_HOME}/logs/nanvixd-$(basename "${PROGRAM_NAME}")
 TENANT_ID="foo"
 APP_NAME="bar"
 
+# Temporary Directory
+TMP_DIR_PATH="/tmp/nanvixd"
+TMP_DIR=$(mktemp -d ${TMP_DIR_PATH}-XXXXXX)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
 mkdir -p ${LOGS_DIR}
 
 # Run nanvixd.
@@ -23,7 +28,7 @@ CONSOLE_FILE_NAME="${LOGS_DIR}/kernel_$(date "+%Y_%m_%d_%H_%M").log"
 RUST_LOG=trace timeout -s SIGINT --preserve-status --foreground ${TIMEOUT} \
     ./bin/nanvixd.elf \
         -http-addr ${NANVIXD_SOCKADDR} \
-        -tmp-dir ${NANVIX_HOME} \
+        -tmp-dir ${TMP_DIR} \
         -console-file ${CONSOLE_FILE_NAME} &
 NANVIXD_PID=$!
 

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -46,6 +46,7 @@ use microvm::{
     Gateway,
     Vmm,
 };
+use nanvixd::config::DEFAULT_TMP_DIRECTORY;
 use nix::{
     sys::signal::{
         Signal,
@@ -127,7 +128,7 @@ impl Benchmark {
             "-http-addr".to_string(),
             NANVIXD_ADDRESS.to_string(),
             "-tmp-dir".to_string(),
-            get_proj_root(),
+            DEFAULT_TMP_DIRECTORY.to_string(),
         ];
         if let Some(hwloc_file) = &self.hwloc_file {
             nanvixd_args.push("-hwloc".to_string());

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -16,8 +16,8 @@
 //==================================================================================================
 
 mod args;
-mod env;
 mod benchmark;
+mod env;
 
 //==================================================================================================
 // Imports
@@ -31,6 +31,7 @@ use crate::{
     },
     env::get_proj_root,
 };
+use ::sys::ipc::Message;
 use anyhow::Result;
 use flexi_logger::Logger;
 use hwloc::HwLoc;
@@ -54,8 +55,10 @@ use nix::{
     },
     unistd::Pid,
 };
-use reqwest::header::{HeaderMap, CONTENT_TYPE};
-use ::sys::ipc::Message;
+use reqwest::header::{
+    CONTENT_TYPE,
+    HeaderMap,
+};
 use std::{
     fs::File,
     io::{
@@ -109,7 +112,7 @@ impl Benchmark {
         new_msg_headers.insert(CONTENT_TYPE, "application/json".parse()?);
         new_msg_headers.insert(
             nanvixd::config::HTTP_HEADER_MESSAGE_TYPE,
-            format!("{}", nanvixd::message::MessageType::New).parse()?
+            format!("{}", nanvixd::message::MessageType::New).parse()?,
         );
 
         let new_msg = nanvixd::message::New {
@@ -193,8 +196,11 @@ impl Benchmark {
 
         while TcpStream::connect_timeout(
             &NANVIXD_ADDRESS.to_string().parse().unwrap(),
-            Duration::from_millis(10)).is_err() {
-            continue
+            Duration::from_millis(10),
+        )
+        .is_err()
+        {
+            continue;
         }
 
         debug!("nanvixd is ready to serve requests");
@@ -202,8 +208,13 @@ impl Benchmark {
 
     /// Starts the Nano VM via POST request to nanvixd. Returns the user VM ID as well as an open
     /// socket to interact with the VMs stdin/stdout.
-    pub async fn start(&mut self, payload: nanvixd::message::New, headers: HeaderMap) -> Result<(String, SocketStream)> {
-        let response: nanvixd::message::NewResponse = self.nanvixd_client
+    pub async fn start(
+        &mut self,
+        payload: nanvixd::message::New,
+        headers: HeaderMap,
+    ) -> Result<(String, SocketStream)> {
+        let response: nanvixd::message::NewResponse = self
+            .nanvixd_client
             .post(format!("http://{}", NANVIXD_ADDRESS))
             .headers(headers)
             .json(&payload)
@@ -233,11 +244,14 @@ impl Benchmark {
         kill_msg_headers.insert(CONTENT_TYPE, "application/json".parse()?);
         kill_msg_headers.insert(
             nanvixd::config::HTTP_HEADER_MESSAGE_TYPE,
-            format!("{}", nanvixd::message::MessageType::Kill).parse()?
+            format!("{}", nanvixd::message::MessageType::Kill).parse()?,
         );
 
-        let kill_msg = nanvixd::message::Kill { user_vm_id: user_vm_id.clone() };
-        let response: nanvixd::message::KillResponse = self.nanvixd_client
+        let kill_msg = nanvixd::message::Kill {
+            user_vm_id: user_vm_id.clone(),
+        };
+        let response: nanvixd::message::KillResponse = self
+            .nanvixd_client
             .post(format!("http://{}", NANVIXD_ADDRESS))
             .headers(kill_msg_headers)
             .json(&kill_msg)

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -2,6 +2,13 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::log::error;
+
+//==================================================================================================
 // Constants
 //==================================================================================================
 
@@ -19,18 +26,76 @@ pub const DEFAULT_TMP_DIRECTORY: &str = "/tmp";
 
 pub const HTTP_HEADER_MESSAGE_TYPE: &str = "X-NVX-Message-Type";
 
+/// Maximum length for a Unix socket name, including the null terminator.
+/// This is a workaround for the fact that `libc::UNIX_PATH_MAX` is not available.
+/// On Linux, this is defined in `<linux/un.h>`.
+/// TODO: replace this with `libc::UNIX_PATH_MAX` when it becomes available.
+const UNIX_PATH_MAX: usize = 108;
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-pub fn control_plane_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> String {
-    format!("{tmp_str}/control-plane:{tenant_id}:cp{UNIX_SOCKET_SUFFIX}")
+pub fn control_plane_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<String> {
+    let unix_socket_name: String =
+        format!("{tmp_str}/control-plane:{tenant_id}:cp{UNIX_SOCKET_SUFFIX}");
+
+    // Check if socket name exceeds the maximum length.
+    if unix_socket_name.len() > UNIX_PATH_MAX {
+        let error: String = format!(
+            "unix socket name '{unix_socket_name}' exceeds maximum length ({:?} > {:?})",
+            unix_socket_name.len(),
+            UNIX_PATH_MAX
+        );
+        error!("control_plane_sockaddr_builder(): {error}");
+        anyhow::bail!(error);
+    }
+
+    Ok(unix_socket_name)
 }
 
-pub fn user_vm_sockaddr_builder(tmp_str: &str, tenant_id: &str, app_name: &str, sandbox_id: &str) -> String {
-    format!("{tmp_str}/{tenant_id}:{app_name}:{sandbox_id}:uvm{UNIX_SOCKET_SUFFIX}")
+pub fn user_vm_sockaddr_builder(
+    tmp_str: &str,
+    tenant_id: &str,
+    app_name: &str,
+    sandbox_id: &str,
+) -> Result<String> {
+    let unix_socket_name: String =
+        format!("{tmp_str}/{tenant_id}:{app_name}:{sandbox_id}:uvm{UNIX_SOCKET_SUFFIX}");
+
+    // Check if socket name exceeds the maximum length.
+    if unix_socket_name.len() > UNIX_PATH_MAX {
+        let error: String = format!(
+            "unix socket name '{unix_socket_name}' exceeds maximum length ({:?} > {:?})",
+            unix_socket_name.len(),
+            UNIX_PATH_MAX
+        );
+        error!("user_vm_sockaddr_builder(): {error}");
+        anyhow::bail!(error);
+    }
+
+    Ok(unix_socket_name)
 }
 
-pub fn gateway_sockaddr_builder(tmp_str: &str, tenant_id: &str, app_name: &str, sandbox_id: &str) -> String {
-    format!("{tmp_str}/{tenant_id}:{app_name}:{sandbox_id}:gw{UNIX_SOCKET_SUFFIX}")
+pub fn gateway_sockaddr_builder(
+    tmp_str: &str,
+    tenant_id: &str,
+    app_name: &str,
+    sandbox_id: &str,
+) -> Result<String> {
+    let unix_socket_name: String =
+        format!("{tmp_str}/{tenant_id}:{app_name}:{sandbox_id}:gw{UNIX_SOCKET_SUFFIX}");
+
+    // Check if socket name exceeds the maximum length.
+    if unix_socket_name.len() > UNIX_PATH_MAX {
+        let error: String = format!(
+            "unix socket name '{unix_socket_name}' exceeds maximum length ({:?} > {:?})",
+            unix_socket_name.len(),
+            UNIX_PATH_MAX
+        );
+        error!("gateway_sockaddr_builder(): {error}");
+        anyhow::bail!(error);
+    }
+
+    Ok(unix_socket_name)
 }

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -36,6 +36,20 @@ const UNIX_PATH_MAX: usize = 108;
 // Standalone Functions
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Builds the control plane Unix socket address for a given tenant ID.
+///
+/// # Arguments
+///
+/// - tmp_str: Temporary directory path.
+/// - tenant_id: Tenant ID.
+///
+/// # Returns
+///
+/// On success, returns the name of the control plane Unix socket. On failure, returns an error.
+///
 pub fn control_plane_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<String> {
     let unix_socket_name: String =
         format!("{tmp_str}/control-plane:{tenant_id}:cp{UNIX_SOCKET_SUFFIX}");
@@ -54,6 +68,22 @@ pub fn control_plane_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<
     Ok(unix_socket_name)
 }
 
+///
+/// # Description
+///
+/// Builds the user VM Unix socket address for a given tenant ID, application name, and sandbox ID.
+///
+/// # Arguments
+///
+/// - tmp_str: Temporary directory path.
+/// - tenant_id: Tenant ID.
+/// - app_name: Application name.
+/// - sandbox_id: Sandbox ID.
+///
+/// # Returns
+///
+/// On success, returns the name of the user VM Unix socket. On failure, returns an error.
+///
 pub fn user_vm_sockaddr_builder(
     tmp_str: &str,
     tenant_id: &str,
@@ -77,6 +107,22 @@ pub fn user_vm_sockaddr_builder(
     Ok(unix_socket_name)
 }
 
+///
+/// # Description
+///
+/// Builds the gateway Unix socket address for a given tenant ID, application name, and sandbox ID.
+///
+/// # Arguments
+///
+/// - tmp_str: Temporary directory path.
+/// - tenant_id: Tenant ID.
+/// - app_name: Application name.
+/// - sandbox_id: Sandbox ID.
+///
+/// # Returns
+///
+/// On success, returns the name of the gateway Unix socket. On failure, returns an error.
+///
 pub fn gateway_sockaddr_builder(
     tmp_str: &str,
     tenant_id: &str,

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -13,6 +13,7 @@ use ::log::error;
 //==================================================================================================
 
 /// Path to the binary directory.
+/// FIXME: Do not hardcode current directory here. (https://github.com/nanvix/nanvix/issues/736)
 pub const BINARY_DIRECTORY: &str = "./bin";
 
 /// Suffix for Unix sockets.

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -78,7 +78,6 @@ pub fn control_plane_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<
 ///
 /// - tmp_str: Temporary directory path.
 /// - tenant_id: Tenant ID.
-/// - app_name: Application name.
 /// - sandbox_id: Sandbox ID.
 ///
 /// # Returns
@@ -88,11 +87,10 @@ pub fn control_plane_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<
 pub fn user_vm_sockaddr_builder(
     tmp_str: &str,
     tenant_id: &str,
-    app_name: &str,
     sandbox_id: &str,
 ) -> Result<String> {
     let unix_socket_name: String =
-        format!("{tmp_str}/{tenant_id}:{app_name}:{sandbox_id}:uvm{UNIX_SOCKET_SUFFIX}");
+        format!("{tmp_str}/{tenant_id}:{sandbox_id}:uvm{UNIX_SOCKET_SUFFIX}");
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {
@@ -117,7 +115,6 @@ pub fn user_vm_sockaddr_builder(
 ///
 /// - tmp_str: Temporary directory path.
 /// - tenant_id: Tenant ID.
-/// - app_name: Application name.
 /// - sandbox_id: Sandbox ID.
 ///
 /// # Returns
@@ -127,11 +124,10 @@ pub fn user_vm_sockaddr_builder(
 pub fn gateway_sockaddr_builder(
     tmp_str: &str,
     tenant_id: &str,
-    app_name: &str,
     sandbox_id: &str,
 ) -> Result<String> {
     let unix_socket_name: String =
-        format!("{tmp_str}/{tenant_id}:{app_name}:{sandbox_id}:gw{UNIX_SOCKET_SUFFIX}");
+        format!("{tmp_str}/{tenant_id}:{sandbox_id}:gw{UNIX_SOCKET_SUFFIX}");
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -108,16 +108,10 @@ impl HttpClient {
 
         let control_plane_sockaddr: String =
             config::control_plane_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
-        let gateway_sockaddr: String = config::gateway_sockaddr_builder(
-            &tmp_directory,
-            tag.tenant_id(),
-            &tag.sandbox_id()[0..4],
-        )?;
-        let user_vm_sockaddr: String = config::user_vm_sockaddr_builder(
-            &tmp_directory,
-            tag.tenant_id(),
-            &tag.sandbox_id()[0..4],
-        )?;
+        let gateway_sockaddr: String =
+            config::gateway_sockaddr_builder(&tmp_directory, tag.tenant_id(), tag.sandbox_id())?;
+        let user_vm_sockaddr: String =
+            config::user_vm_sockaddr_builder(&tmp_directory, tag.tenant_id(), tag.sandbox_id())?;
         let program_args = match message.program_args.len() {
             0 => None,
             _ => Some(message.program_args.clone()),

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -111,13 +111,11 @@ impl HttpClient {
         let gateway_sockaddr: String = config::gateway_sockaddr_builder(
             &tmp_directory,
             tag.tenant_id(),
-            tag.app_name(),
             &tag.sandbox_id()[0..4],
         )?;
         let user_vm_sockaddr: String = config::user_vm_sockaddr_builder(
             &tmp_directory,
             tag.tenant_id(),
-            tag.app_name(),
             &tag.sandbox_id()[0..4],
         )?;
         let program_args = match message.program_args.len() {

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -107,19 +107,19 @@ impl HttpClient {
         let tag: SandboxTag = SandboxTag::new(&message.tenant_id, &message.app_name);
 
         let control_plane_sockaddr: String =
-            config::control_plane_sockaddr_builder(&tmp_directory, tag.tenant_id());
+            config::control_plane_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
         let gateway_sockaddr: String = config::gateway_sockaddr_builder(
             &tmp_directory,
             tag.tenant_id(),
             tag.app_name(),
             &tag.sandbox_id()[0..4],
-        );
+        )?;
         let user_vm_sockaddr: String = config::user_vm_sockaddr_builder(
             &tmp_directory,
             tag.tenant_id(),
             tag.app_name(),
             &tag.sandbox_id()[0..4],
-        );
+        )?;
         let program_args = match message.program_args.len() {
             0 => None,
             _ => Some(message.program_args.clone()),

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -102,16 +102,24 @@ impl HttpClient {
         message: &message::New,
         tmp_directory: String,
         console_file: Option<String>,
-        hwloc: Option<HwLoc>
+        hwloc: Option<HwLoc>,
     ) -> Result<message::NewResponse> {
         let tag: SandboxTag = SandboxTag::new(&message.tenant_id, &message.app_name);
 
         let control_plane_sockaddr: String =
             config::control_plane_sockaddr_builder(&tmp_directory, tag.tenant_id());
-        let gateway_sockaddr: String =
-            config::gateway_sockaddr_builder(&tmp_directory, tag.tenant_id(), tag.app_name(), &tag.sandbox_id()[0..4]);
-        let user_vm_sockaddr: String =
-            config::user_vm_sockaddr_builder(&tmp_directory, tag.tenant_id(), tag.app_name(), &tag.sandbox_id()[0..4]);
+        let gateway_sockaddr: String = config::gateway_sockaddr_builder(
+            &tmp_directory,
+            tag.tenant_id(),
+            tag.app_name(),
+            &tag.sandbox_id()[0..4],
+        );
+        let user_vm_sockaddr: String = config::user_vm_sockaddr_builder(
+            &tmp_directory,
+            tag.tenant_id(),
+            tag.app_name(),
+            &tag.sandbox_id()[0..4],
+        );
         let program_args = match message.program_args.len() {
             0 => None,
             _ => Some(message.program_args.clone()),
@@ -124,7 +132,7 @@ impl HttpClient {
             &message.program,
             program_args.clone(),
             console_file.clone(),
-            hwloc.clone()
+            hwloc.clone(),
         );
 
         // This method will create a sandbox if it is not in the cache.
@@ -139,9 +147,8 @@ impl HttpClient {
 
     async fn serve_kill(
         sandbox_cache: Arc<Mutex<SandboxCache>>,
-        message: &message::Kill
+        message: &message::Kill,
     ) -> Result<message::KillResponse> {
-
         let mut locked_sandbox_cache = sandbox_cache.lock().await;
         let exit_code = match locked_sandbox_cache.kill(message.user_vm_id.clone()).await {
             Ok(_) => 0,
@@ -166,15 +173,17 @@ impl Service<Request<Incoming>> for HttpClient {
         let sandbox_cache: Arc<Mutex<SandboxCache>> = self.sandbox_cache.clone();
         let future = async move {
             // Get the request headers before consuming the body.
-            let message_type: MessageType = match request.headers()
+            let message_type: MessageType = match request
+                .headers()
                 .get(config::HTTP_HEADER_MESSAGE_TYPE)
                 .and_then(|val| val.to_str().ok())
-                .and_then(|s| s.parse::<MessageType>().ok()) {
+                .and_then(|s| s.parse::<MessageType>().ok())
+            {
                 Some(message_type) => message_type,
                 None => {
                     error!("{} is a mandatory header", config::HTTP_HEADER_MESSAGE_TYPE);
                     return Ok(Self::bad_request());
-                }
+                },
             };
 
             let body: Bytes = match request.collect().await {
@@ -210,7 +219,9 @@ impl Service<Request<Incoming>> for HttpClient {
                         tmp_directory.clone(),
                         console_file.clone(),
                         hwloc.clone(),
-                    ).await {
+                    )
+                    .await
+                    {
                         Ok(response) => message::MessageResponse::New(response),
                         Err(_) => {
                             error!("error processing NEW request");
@@ -230,17 +241,14 @@ impl Service<Request<Incoming>> for HttpClient {
                     debug!("serving KILL message:");
                     debug!("- user vm id: {}", msg.user_vm_id);
 
-                    match Self::serve_kill(
-                        sandbox_cache,
-                        &msg,
-                    ).await {
+                    match Self::serve_kill(sandbox_cache, &msg).await {
                         Ok(response) => message::MessageResponse::Kill(response),
                         Err(_) => {
                             error!("error processing KILL request");
                             return Ok(Self::internal_server_error());
                         },
                     }
-                }
+                },
             };
 
             // Convert response JSON to string.

--- a/src/utils/nanvixd/src/sandbox/tag.rs
+++ b/src/utils/nanvixd/src/sandbox/tag.rs
@@ -33,10 +33,6 @@ impl SandboxTag {
         &self.tenant_id
     }
 
-    pub fn app_name(&self) -> &str {
-        &self.app_name
-    }
-
     pub fn sandbox_id(&self) -> &str {
         &self.sandbox_id
     }


### PR DESCRIPTION
## Description

This PR improves the randomness of Unix domain socket names by:
- Removing fixed name prefixes, which previously limited entropy.
- Using a temporary, randomly generated directory for TMP_DIR, increasing uniqueness across runs.
- Incorporating the full uuid sandbox ID string into the socket name, further reducing the risk of collisions.

This PR closes #737