### PR TITLE
[ci] Run Benchmark Action only on Valid Release Builds

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -76,6 +76,8 @@ jobs:
     - name: "Benchmark"
       if: |
         matrix.build-type == 'release' &&
+        github.event_name == 'pull_request' &&
+        !github.event.pull_request.draft &&
         !startsWith(github.head_ref, 'dependabot/') &&
         !startsWith(github.head_ref, 'dependabot-')
       uses: ./.github/actions/benchmark


### PR DESCRIPTION
## Description

This PR updates the conditions for triggering the benchmark action.
It now runs only for release builds that meet the following criteria:

- The build is associated with an open pull request
- The pull request is not a draft
- The pull request was not created by Dependabot