### PR TITLE
[daemons] Support Graceful Interruption of Linuxd Worker Threads

### DIFF
--- a/src/daemons/linuxd/Cargo.toml
+++ b/src/daemons/linuxd/Cargo.toml
@@ -16,6 +16,7 @@ config = { workspace = true }
 flexi_logger = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
+nix = { workspace = true, features = ["pthread", "signal"] }
 profiler = { workspace = true }
 signal-hook = { workspace = true }
 sys = { workspace = true, features = ["std"] }

--- a/src/daemons/linuxd/Cargo.toml
+++ b/src/daemons/linuxd/Cargo.toml
@@ -16,7 +16,6 @@ config = { workspace = true }
 flexi_logger = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
-nix = { workspace = true, features = ["pthread", "signal"] }
 profiler = { workspace = true }
 signal-hook = { workspace = true }
 sys = { workspace = true, features = ["std"] }

--- a/src/daemons/linuxd/src/dirent.rs
+++ b/src/daemons/linuxd/src/dirent.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::error::WorkerThreadError;
 use ::alloc::vec::Vec;
 use ::core::{
     cmp,
@@ -102,16 +103,16 @@ impl linux_dirent {
 //==================================================================================================
 
 /// Handles a getdents() system call request.
-pub fn do_getdents(tid: ThreadIdentifier, request: GetDirectoryEntriesRequest) -> Vec<Message> {
+pub fn do_getdents(tid: ThreadIdentifier, request: GetDirectoryEntriesRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("do_getdents(): tid={tid:?}, request,count={:#x?}", { request.count });
 
     // Check if `request.count` is not valid.
     if request.count == 0 {
         error!("do_getdents(): invalid buffer count");
-        return vec![crate::build_error(tid, ErrorCode::InvalidArgument)];
+        return Ok(vec![crate::build_error(tid, ErrorCode::InvalidArgument)]);
     } else if request.count as usize > GetDirectoryEntriesRequest::MAX_ENTRIES {
         error!("do_getdents(): request is too large");
-        return vec![crate::build_error(tid, ErrorCode::TooBig)];
+        return Ok(vec![crate::build_error(tid, ErrorCode::TooBig)]);
     }
 
     let bufsize: usize =
@@ -127,10 +128,16 @@ pub fn do_getdents(tid: ThreadIdentifier, request: GetDirectoryEntriesRequest) -
         // Failed.
         -1 => {
             let errno = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::getdents(): errno={}", { errno });
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            return vec![crate::build_error(tid, error)];
+            return Ok(vec![crate::build_error(tid, error)]);
         },
         // Success.
         n => {
@@ -188,10 +195,10 @@ pub fn do_getdents(tid: ThreadIdentifier, request: GetDirectoryEntriesRequest) -
     // Build response and check for errors.
     let response: GetDirectoryEntriesResponse = GetDirectoryEntriesResponse::new(buf);
     match response.into_parts(tid) {
-        Ok(messages) => messages,
+        Ok(messages) => Ok(messages),
         Err(error) => {
             warn!("do_getdents(): failed to build response (error={error:?})");
-            vec![crate::build_error(tid, error.code)]
+            Ok(vec![crate::build_error(tid, error.code)])
         },
     }
 }

--- a/src/daemons/linuxd/src/error.rs
+++ b/src/daemons/linuxd/src/error.rs
@@ -1,0 +1,42 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![deny(clippy::all)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::nix::libc;
+use ::std::io;
+use ::syscomm::SocketError;
+
+#[derive(Debug)]
+pub enum WorkerThreadError {
+    Error(io::Error),
+    Interrupted,
+}
+
+impl From<io::Error> for WorkerThreadError {
+    fn from(e: io::Error) -> Self {
+        if e.raw_os_error() == Some(libc::EINTR) {
+            WorkerThreadError::Interrupted
+        } else {
+            WorkerThreadError::Error(e)
+        }
+    }
+}
+
+impl From<SocketError> for WorkerThreadError {
+    fn from(e: SocketError) -> Self {
+        if e.raw_os_error() == Some(libc::EINTR) {
+            WorkerThreadError::Interrupted
+        } else {
+            WorkerThreadError::Error(e.into())
+        }
+    }
+}

--- a/src/daemons/linuxd/src/error.rs
+++ b/src/daemons/linuxd/src/error.rs
@@ -11,32 +11,14 @@
 // Imports
 //==================================================================================================
 
-use ::nix::libc;
-use ::std::io;
-use ::syscomm::SocketError;
-
 #[derive(Debug)]
 pub enum WorkerThreadError {
-    Error(io::Error),
+    Error(sys::error::Error),
     Interrupted,
 }
 
-impl From<io::Error> for WorkerThreadError {
-    fn from(e: io::Error) -> Self {
-        if e.raw_os_error() == Some(libc::EINTR) {
-            WorkerThreadError::Interrupted
-        } else {
-            WorkerThreadError::Error(e)
-        }
-    }
-}
-
-impl From<SocketError> for WorkerThreadError {
-    fn from(e: SocketError) -> Self {
-        if e.raw_os_error() == Some(libc::EINTR) {
-            WorkerThreadError::Interrupted
-        } else {
-            WorkerThreadError::Error(e.into())
-        }
+impl From<sys::error::Error> for WorkerThreadError {
+    fn from(err: sys::error::Error) -> Self {
+        WorkerThreadError::Error(err)
     }
 }

--- a/src/daemons/linuxd/src/fcntl.rs
+++ b/src/daemons/linuxd/src/fcntl.rs
@@ -5,7 +5,10 @@
 // Imports
 //==================================================================================================
 
-use crate::time::LibcTimeSpec;
+use crate::{
+    error::WorkerThreadError,
+    time::LibcTimeSpec,
+};
 use ::alloc::ffi::CString;
 use ::core::ffi;
 use ::sys::{
@@ -143,7 +146,7 @@ use sysapi::fcntl::file_descriptor_flags::{
 // do_openat
 //==================================================================================================
 
-pub fn do_openat(tid: ThreadIdentifier, request: OpenAtRequest) -> Vec<Message> {
+pub fn do_openat(tid: ThreadIdentifier, request: OpenAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("openat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
@@ -152,17 +155,17 @@ pub fn do_openat(tid: ThreadIdentifier, request: OpenAtRequest) -> Vec<Message> 
 
     let pathname: CString = match CString::new(request.pathname.as_str()) {
         Ok(pathname) => pathname,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
     let flags: LibcFileOpenFlags = match LibcFileOpenFlags::try_from_nanvix_flags(flags) {
         Ok(flags) => flags,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
     let mode: LibcFileMode = match LibcFileMode::try_from(mode) {
         Ok(mode) => mode,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     debug!(
@@ -174,14 +177,20 @@ pub fn do_openat(tid: ThreadIdentifier, request: OpenAtRequest) -> Vec<Message> 
     match unsafe { libc::openat(dirfd.inner(), pathname.as_ptr(), flags.inner(), mode.inner()) } {
         fd if fd >= 0 => {
             debug!("libc::openat(): fd={fd:?}");
-            vec![OpenAtResponse::build(tid, fd)]
+            Ok(vec![OpenAtResponse::build(tid, fd)])
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::openat(): errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }
@@ -190,7 +199,7 @@ pub fn do_openat(tid: ThreadIdentifier, request: OpenAtRequest) -> Vec<Message> 
 // do_unlink_at
 //==================================================================================================
 
-pub fn do_unlinkat(tid: ThreadIdentifier, request: UnlinkAtRequest) -> Vec<Message> {
+pub fn do_unlinkat(tid: ThreadIdentifier, request: UnlinkAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("unlinkat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
@@ -198,7 +207,7 @@ pub fn do_unlinkat(tid: ThreadIdentifier, request: UnlinkAtRequest) -> Vec<Messa
 
     let pathname: CString = match CString::new(request.pathname.as_str()) {
         Ok(pathname) => pathname,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
@@ -213,12 +222,17 @@ pub fn do_unlinkat(tid: ThreadIdentifier, request: UnlinkAtRequest) -> Vec<Messa
     {
         ret if ret == 0 => {
             debug!("libc::unlinkat(): success");
-            vec![UnlinkAtResponse::build(tid, ret)]
+            Ok(vec![UnlinkAtResponse::build(tid, ret)])
         },
         errno => {
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::unlinkat(): errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno).expect("unknown error code {error}");
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }
@@ -227,7 +241,7 @@ pub fn do_unlinkat(tid: ThreadIdentifier, request: UnlinkAtRequest) -> Vec<Messa
 // do_rename_at
 //==================================================================================================
 
-pub fn do_renameat(tid: ThreadIdentifier, request: RenameAtRequest) -> Vec<Message> {
+pub fn do_renameat(tid: ThreadIdentifier, request: RenameAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("renameat(): tid={tid:?}, request={request:?}");
 
     let olddirfd: i32 = request.olddirfd;
@@ -235,12 +249,12 @@ pub fn do_renameat(tid: ThreadIdentifier, request: RenameAtRequest) -> Vec<Messa
 
     let oldpath: CString = match CString::new(request.oldpath.as_str()) {
         Ok(oldpath) => oldpath,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let newpath: CString = match CString::new(request.newpath.as_str()) {
         Ok(newpath) => newpath,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let olddirfd: LibcAtFlags = LibcAtFlags::from(olddirfd);
@@ -261,12 +275,18 @@ pub fn do_renameat(tid: ThreadIdentifier, request: RenameAtRequest) -> Vec<Messa
     } {
         ret if ret == 0 => {
             debug!("libc::renameat(): success");
-            vec![RenameAtResponse::build(tid, ret)]
+            Ok(vec![RenameAtResponse::build(tid, ret)])
         },
         errno => {
             debug!("libc::renameat(): errno={errno:?}");
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             let error: ErrorCode = ErrorCode::try_from(errno).expect("unknown error code {error}");
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }
@@ -275,7 +295,7 @@ pub fn do_renameat(tid: ThreadIdentifier, request: RenameAtRequest) -> Vec<Messa
 // do_fstatat
 //==================================================================================================
 
-pub fn do_fstat_at(tid: ThreadIdentifier, request: FileStatAtRequest) -> Vec<Message> {
+pub fn do_fstat_at(tid: ThreadIdentifier, request: FileStatAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("fstatat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
@@ -287,7 +307,7 @@ pub fn do_fstat_at(tid: ThreadIdentifier, request: FileStatAtRequest) -> Vec<Mes
     };
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(c_string) => c_string,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let mut st: libc::stat = unsafe { core::mem::zeroed() };
@@ -311,7 +331,7 @@ pub fn do_fstat_at(tid: ThreadIdentifier, request: FileStatAtRequest) -> Vec<Mes
                     tv_nsec: match st.st_atime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
+                            return Ok(vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)]);
                         },
                     },
                 },
@@ -320,7 +340,7 @@ pub fn do_fstat_at(tid: ThreadIdentifier, request: FileStatAtRequest) -> Vec<Mes
                     tv_nsec: match st.st_mtime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
+                            return Ok(vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)]);
                         },
                     },
                 },
@@ -329,7 +349,7 @@ pub fn do_fstat_at(tid: ThreadIdentifier, request: FileStatAtRequest) -> Vec<Mes
                     tv_nsec: match st.st_ctime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
+                            return Ok(vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)]);
                         },
                     },
                 },
@@ -342,16 +362,22 @@ pub fn do_fstat_at(tid: ThreadIdentifier, request: FileStatAtRequest) -> Vec<Mes
             let response = FileStatAtResponse::new(stat);
 
             match response.into_parts(tid) {
-                Ok(messages) => messages,
-                Err(e) => vec![crate::build_error(tid, e.code)],
+                Ok(messages) => Ok(messages),
+                Err(e) => Ok(vec![crate::build_error(tid, e.code)]),
             }
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::fstatat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }
@@ -360,7 +386,7 @@ pub fn do_fstat_at(tid: ThreadIdentifier, request: FileStatAtRequest) -> Vec<Mes
 // do_posix_fallocate
 //==================================================================================================
 
-pub fn do_posix_fallocate(tid: ThreadIdentifier, request: FileSpaceControlRequest) -> Message {
+pub fn do_posix_fallocate(tid: ThreadIdentifier, request: FileSpaceControlRequest) -> Result<Message, WorkerThreadError> {
     trace!("posix_fallocate(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
@@ -371,13 +397,19 @@ pub fn do_posix_fallocate(tid: ThreadIdentifier, request: FileSpaceControlReques
     match unsafe { libc::posix_fallocate(fd, offset, len) } {
         0 => {
             debug!("libc::posix_fallocate(): success");
-            FileSpaceControlResponse::build(tid, 0)
+            Ok(FileSpaceControlResponse::build(tid, 0))
         },
         errno => {
-            debug!("libc::posix_fallocate(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            crate::build_error(tid, error)
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
+            debug!("libc::posix_fallocate(): errno={errno:?}");
+            Ok(crate::build_error(tid, error))
         },
     }
 }
@@ -386,7 +418,7 @@ pub fn do_posix_fallocate(tid: ThreadIdentifier, request: FileSpaceControlReques
 // do_posix_fadvise
 //==================================================================================================
 
-pub fn do_posix_fadvise(tid: ThreadIdentifier, request: FileAdvisoryInformationRequest) -> Message {
+pub fn do_posix_fadvise(tid: ThreadIdentifier, request: FileAdvisoryInformationRequest) -> Result<Message, WorkerThreadError> {
     trace!("posix_fadvise(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
@@ -394,7 +426,7 @@ pub fn do_posix_fadvise(tid: ThreadIdentifier, request: FileAdvisoryInformationR
     let len: off_t = request.len;
     let advice: LibcFileAdvice = match LibcFileAdvice::try_from(request.advice) {
         Ok(advice) => advice,
-        Err(e) => return crate::build_error(tid, e.code),
+        Err(e) => return Ok(crate::build_error(tid, e.code)),
     };
 
     debug!(
@@ -404,13 +436,18 @@ pub fn do_posix_fadvise(tid: ThreadIdentifier, request: FileAdvisoryInformationR
     match unsafe { libc::posix_fadvise(fd, offset, len, advice.inner()) } {
         0 => {
             debug!("libc::posix_fadvise(): success");
-            FileAdvisoryInformationResponse::build(tid, 0)
+            Ok(FileAdvisoryInformationResponse::build(tid, 0))
         },
         errno => {
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::posix_fadvise(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
     }
 }
@@ -419,7 +456,7 @@ pub fn do_posix_fadvise(tid: ThreadIdentifier, request: FileAdvisoryInformationR
 // do_fstat()
 //==================================================================================================
 
-pub fn do_fstat(tid: ThreadIdentifier, request: FileStatRequest) -> Vec<Message> {
+pub fn do_fstat(tid: ThreadIdentifier, request: FileStatRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("fstatat(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
@@ -445,7 +482,7 @@ pub fn do_fstat(tid: ThreadIdentifier, request: FileStatRequest) -> Vec<Message>
                     tv_nsec: match st.st_atime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
+                            return Ok(vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)]);
                         },
                     },
                 },
@@ -454,7 +491,7 @@ pub fn do_fstat(tid: ThreadIdentifier, request: FileStatRequest) -> Vec<Message>
                     tv_nsec: match st.st_mtime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
+                            return Ok(vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)]);
                         },
                     },
                 },
@@ -463,7 +500,7 @@ pub fn do_fstat(tid: ThreadIdentifier, request: FileStatRequest) -> Vec<Message>
                     tv_nsec: match st.st_ctime_nsec.try_into() {
                         Ok(nsec) => nsec,
                         Err(_) => {
-                            return vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)];
+                            return Ok(vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)]);
                         },
                     },
                 },
@@ -476,16 +513,22 @@ pub fn do_fstat(tid: ThreadIdentifier, request: FileStatRequest) -> Vec<Message>
             let response = FileStatAtResponse::new(stat);
 
             match response.into_parts(tid) {
-                Ok(messages) => messages,
-                Err(e) => vec![crate::build_error(tid, e.code)],
+                Ok(messages) => Ok(messages),
+                Err(e) => Ok(vec![crate::build_error(tid, e.code)]),
             }
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::fstatat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }
@@ -494,12 +537,12 @@ pub fn do_fstat(tid: ThreadIdentifier, request: FileStatRequest) -> Vec<Message>
 // do_symlinkat()
 //==================================================================================================
 
-pub fn do_symlinkat(tid: ThreadIdentifier, request: SymbolicLinkAtRequest) -> Vec<Message> {
+pub fn do_symlinkat(tid: ThreadIdentifier, request: SymbolicLinkAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("symlinkat(): tid={tid:?}, request={request:?}");
 
     let target: CString = match CString::new(request.target.as_str()) {
         Ok(target) => target,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let newdirfd: i32 = request.dirfd;
@@ -507,7 +550,7 @@ pub fn do_symlinkat(tid: ThreadIdentifier, request: SymbolicLinkAtRequest) -> Ve
 
     let linkpath: CString = match CString::new(request.linkpath.as_str()) {
         Ok(linkpath) => linkpath,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     debug!(
@@ -517,14 +560,20 @@ pub fn do_symlinkat(tid: ThreadIdentifier, request: SymbolicLinkAtRequest) -> Ve
     match unsafe { libc::symlinkat(target.as_ptr(), newdirfd.inner(), linkpath.as_ptr()) } {
         0 => {
             debug!("libc::symlinkat(): success");
-            vec![SymbolicLinkAtResponse::build(tid, 0)]
+            Ok(vec![SymbolicLinkAtResponse::build(tid, 0)])
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::symlinkat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }
@@ -533,7 +582,7 @@ pub fn do_symlinkat(tid: ThreadIdentifier, request: SymbolicLinkAtRequest) -> Ve
 // do_readlinkat()
 //==================================================================================================
 
-pub fn do_readlinkat(tid: ThreadIdentifier, request: ReadLinkAtRequest) -> Vec<Message> {
+pub fn do_readlinkat(tid: ThreadIdentifier, request: ReadLinkAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("readlinkat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
@@ -541,7 +590,7 @@ pub fn do_readlinkat(tid: ThreadIdentifier, request: ReadLinkAtRequest) -> Vec<M
 
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     // TODO: Have a system-wide constant for this.
@@ -562,20 +611,26 @@ pub fn do_readlinkat(tid: ThreadIdentifier, request: ReadLinkAtRequest) -> Vec<M
 
             let response: ReadLinkAtResponse = match ReadLinkAtResponse::new(buf) {
                 Ok(response) => response,
-                Err(e) => return vec![crate::build_error(tid, e.code)],
+                Err(e) => return Ok(vec![crate::build_error(tid, e.code)]),
             };
 
             match response.into_parts(tid) {
-                Ok(messages) => messages,
-                Err(e) => vec![crate::build_error(tid, e.code)],
+                Ok(messages) => Ok(messages),
+                Err(e) => Ok(vec![crate::build_error(tid, e.code)]),
             }
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::readlinkat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }
@@ -584,7 +639,7 @@ pub fn do_readlinkat(tid: ThreadIdentifier, request: ReadLinkAtRequest) -> Vec<M
 // do_mkdirat()
 //==================================================================================================
 
-pub fn do_mkdirat(tid: ThreadIdentifier, request: MakeDirectoryAtRequest) -> Vec<Message> {
+pub fn do_mkdirat(tid: ThreadIdentifier, request: MakeDirectoryAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("mkdirat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
@@ -592,12 +647,12 @@ pub fn do_mkdirat(tid: ThreadIdentifier, request: MakeDirectoryAtRequest) -> Vec
 
     let pathname: CString = match CString::new(request.pathname.as_str()) {
         Ok(pathname) => pathname,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let mode: LibcFileMode = match LibcFileMode::try_from(request.mode) {
         Ok(mode) => mode,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     debug!(
@@ -608,14 +663,20 @@ pub fn do_mkdirat(tid: ThreadIdentifier, request: MakeDirectoryAtRequest) -> Vec
     match unsafe { libc::mkdirat(dirfd.inner(), pathname.as_ptr(), mode.inner()) } {
         0 => {
             debug!("libc::mkdirat(): success");
-            vec![MakeDirectoryAtResponse::build(tid, 0)]
+            Ok(vec![MakeDirectoryAtResponse::build(tid, 0)])
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::mkdirat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }
@@ -624,7 +685,7 @@ pub fn do_mkdirat(tid: ThreadIdentifier, request: MakeDirectoryAtRequest) -> Vec
 // do_utimensat()
 //==================================================================================================
 
-pub fn do_utimensat(tid: ThreadIdentifier, request: UpdateFileAccessTimeAtRequest) -> Vec<Message> {
+pub fn do_utimensat(tid: ThreadIdentifier, request: UpdateFileAccessTimeAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("utimensat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
@@ -632,7 +693,7 @@ pub fn do_utimensat(tid: ThreadIdentifier, request: UpdateFileAccessTimeAtReques
 
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let times: [timespec; 2] = request.times;
@@ -661,14 +722,20 @@ pub fn do_utimensat(tid: ThreadIdentifier, request: UpdateFileAccessTimeAtReques
     match unsafe { libc::utimensat(dirfd.inner(), path.as_ptr(), libc_times.as_ptr(), flag) } {
         0 => {
             debug!("libc::utimensat(): success");
-            vec![UpdateFileAccessTimeAtResponse::build(tid, 0)]
+            Ok(vec![UpdateFileAccessTimeAtResponse::build(tid, 0)])
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::utimensat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }
@@ -677,7 +744,7 @@ pub fn do_utimensat(tid: ThreadIdentifier, request: UpdateFileAccessTimeAtReques
 // do_futimens()
 //==================================================================================================
 
-pub fn do_futimens(tid: ThreadIdentifier, request: UpdateFileAccessTimeRequest) -> Message {
+pub fn do_futimens(tid: ThreadIdentifier, request: UpdateFileAccessTimeRequest) -> Result<Message, WorkerThreadError> {
     trace!("futimens(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
@@ -697,14 +764,20 @@ pub fn do_futimens(tid: ThreadIdentifier, request: UpdateFileAccessTimeRequest) 
     match unsafe { libc::futimens(fd, libc_times.as_ptr()) } {
         0 => {
             debug!("libc::futimens(): success");
-            UpdateFileAccessTimeResponse::build(tid, 0)
+            Ok(UpdateFileAccessTimeResponse::build(tid, 0))
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::futimens(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
     }
 }
@@ -713,13 +786,13 @@ pub fn do_futimens(tid: ThreadIdentifier, request: UpdateFileAccessTimeRequest) 
 // do_fcntl()
 //==================================================================================================
 
-pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
+pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Result<Message, WorkerThreadError> {
     trace!("fcntl(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
     let cmd: LibcFileControlCommand = match LibcFileControlCommand::try_from(request.cmd) {
         Ok(cmd) => cmd,
-        Err(e) => return crate::build_error(tid, e.code),
+        Err(e) => return Ok(crate::build_error(tid, e.code)),
     };
 
     debug!("libc::fcntl(): fd={fd:?}, cmd={:?}, arg={:?}", cmd.inner(), { request.arg });
@@ -732,7 +805,7 @@ pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
             Ok(flags) => flags.inner(),
             Err(error) => {
                 error!("do_fcntl(): {error:?} (cmd={cmd:#x?}, arg={:?})", { request.arg });
-                return crate::build_error(tid, error.code);
+                return Ok(crate::build_error(tid, error.code));
             },
         },
         libc::F_GETFL => 0,
@@ -743,7 +816,7 @@ pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
                 Ok(flags) => flags.inner(),
                 Err(error) => {
                     error!("do_fcntl(): {error:?} (cmd={cmd:#x?}), arg={:?})", { request.arg });
-                    return crate::build_error(tid, error.code);
+                    return Ok(crate::build_error(tid, error.code));
                 },
             }
         },
@@ -753,7 +826,7 @@ pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
             if arg < 0 {
                 if arg == -1 {
                     error!("do_fcntl(): invalid owner (cmd={cmd:#x?}, arg={arg:?})");
-                    return crate::build_error(tid, ErrorCode::InvalidArgument);
+                    return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
                 } else {
                     -arg
                 }
@@ -764,17 +837,17 @@ pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
         libc::F_GETLK => {
             let reason: &str = "unsupported file lock command";
             error!("do_fcntl(): {reason:?} (cmd={cmd:#x?}, arg={:?})", { request.arg });
-            return crate::build_error(tid, ErrorCode::InvalidArgument);
+            return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
         },
         libc::F_SETLK => {
             let reason: &str = "unsupported file lock command";
             error!("do_fcntl(): {reason:?} (cmd={cmd:#x?}, arg={:?})", { request.arg });
-            return crate::build_error(tid, ErrorCode::InvalidArgument);
+            return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
         },
         libc::F_SETLKW => {
             let reason: &str = "unsupported file lock command";
             error!("do_fcntl(): {reason:?} (cmd={cmd:#x?}, arg={:?})", { request.arg });
-            return crate::build_error(tid, ErrorCode::InvalidArgument);
+            return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
         },
         unsupported_cmd => {
             // The following statement is unreachable because any unsupported commands were already
@@ -793,13 +866,19 @@ pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
         libc::F_DUPFD | libc::F_DUPFD_CLOEXEC => {
             if ret >= 0 {
                 debug!("libc::fcntl(): F_DUPFD | F_DUPFD_CLOEXEC success");
-                FileControlResponse::build(tid, ret)
+                Ok(FileControlResponse::build(tid, ret))
             } else {
                 let errno: i32 = unsafe { *libc::__errno_location() };
+
+                // Check if the thread has been interrupted.
+                if errno == libc::EINTR {
+                    return Err(WorkerThreadError::Interrupted);
+                }
+
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
                 let error: ErrorCode = ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("unknown error code {errno}"));
-                crate::build_error(tid, error)
+                Ok(crate::build_error(tid, error))
             }
         },
         libc::F_GETFD => {
@@ -808,13 +887,19 @@ pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
                 let nanvix_file_descritor_flags: c_int = LibcFileDescriptorFlags(ret)
                     .try_into_nanvix_flags()
                     .unwrap_or_else(|_| panic!("unexpected file descriptor flags: {ret:?}"));
-                FileControlResponse::build(tid, nanvix_file_descritor_flags)
+                Ok(FileControlResponse::build(tid, nanvix_file_descritor_flags))
             } else {
                 let errno: i32 = unsafe { *libc::__errno_location() };
+
+                // Check if the thread has been interrupted.
+                if errno == libc::EINTR {
+                    return Err(WorkerThreadError::Interrupted);
+                }
+
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
                 let error: ErrorCode = ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("unknown error code {errno}"));
-                crate::build_error(tid, error)
+                Ok(crate::build_error(tid, error))
             }
         },
         libc::F_GETFL => {
@@ -844,22 +929,28 @@ pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
                     "file status flags and file creation flags should not overlap"
                 );
 
-                FileControlResponse::build(
+                Ok(FileControlResponse::build(
                     tid,
                     nanvix_file_status_flags | nanvix_file_creation_flags,
-                )
+                ))
             } else {
                 let errno: i32 = unsafe { *libc::__errno_location() };
+
+                // Check if the thread has been interrupted.
+                if errno == libc::EINTR {
+                    return Err(WorkerThreadError::Interrupted);
+                }
+
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
                 let error: ErrorCode = ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("unknown error code {errno}"));
-                crate::build_error(tid, error)
+                Ok(crate::build_error(tid, error))
             }
         },
         libc::F_GETOWN => {
             if ret != -1 {
                 debug!("libc::fcntl(): F_GETOWN success");
-                FileControlResponse::build(tid, ret)
+                Ok(FileControlResponse::build(tid, ret))
             } else {
                 // The following statement is unreachable because `libc::fcntl()` should never
                 // return -1 for `F_GETOWN`.
@@ -872,13 +963,19 @@ pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
         libc::F_SETFD | libc::F_SETFL | libc::F_SETOWN => {
             if ret == 0 {
                 debug!("libc::fcntl(): libc::F_SETFD | libc::F_SETFL | libc::F_SETOWN success");
-                FileControlResponse::build(tid, ret)
+                Ok(FileControlResponse::build(tid, ret))
             } else if ret == -1 {
                 let errno: i32 = unsafe { *libc::__errno_location() };
+
+                // Check if the thread has been interrupted.
+                if errno == libc::EINTR {
+                    return Err(WorkerThreadError::Interrupted);
+                }
+
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
                 let error: ErrorCode = ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("unknown error code {errno}"));
-                crate::build_error(tid, error)
+                Ok(crate::build_error(tid, error))
             } else {
                 // The following statement is unreachable because `libc::fcntl()` should return
                 // either 0 on success or -1 on error for `F_SETFD`, `F_SETFL`, and `F_SETOWN`.
@@ -903,7 +1000,7 @@ pub fn do_fcntl(tid: ThreadIdentifier, request: FileControlRequest) -> Message {
 // do_fchownat()
 //==================================================================================================
 
-pub fn do_fchownat(tid: ThreadIdentifier, request: FileChownAtRequest) -> Vec<Message> {
+pub fn do_fchownat(tid: ThreadIdentifier, request: FileChownAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("fchownat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
@@ -911,7 +1008,7 @@ pub fn do_fchownat(tid: ThreadIdentifier, request: FileChownAtRequest) -> Vec<Me
 
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let owner: u32 = request.owner;
@@ -926,14 +1023,20 @@ pub fn do_fchownat(tid: ThreadIdentifier, request: FileChownAtRequest) -> Vec<Me
     match unsafe { libc::fchownat(dirfd.inner(), path.as_ptr(), owner, group, flag.inner()) } {
         0 => {
             debug!("libc::fchownat(): success");
-            vec![FileChownAtResponse::build(tid)]
+            Ok(vec![FileChownAtResponse::build(tid)])
         },
         _ => {
-            let errno: i32 = unsafe { *libc::__errno_location() };
+            let errno: libc::c_int = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::fchownat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }
@@ -942,7 +1045,7 @@ pub fn do_fchownat(tid: ThreadIdentifier, request: FileChownAtRequest) -> Vec<Me
 // do_fchmod
 //==================================================================================================
 
-pub fn do_fchmod(tid: ThreadIdentifier, request: FileChmodRequest) -> Message {
+pub fn do_fchmod(tid: ThreadIdentifier, request: FileChmodRequest) -> Result<Message, WorkerThreadError> {
     trace!("fchmod(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
@@ -950,14 +1053,20 @@ pub fn do_fchmod(tid: ThreadIdentifier, request: FileChmodRequest) -> Message {
 
     debug!("libc::fchmod(): fd={fd:?}, mode={mode:?}");
     match unsafe { libc::fchmod(fd, mode) } {
-        0 => FileChmodResponse::build(tid),
+        0 => Ok(FileChmodResponse::build(tid)),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
-            crate::build_error(
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
         ret => unreachable!("libc::fchmod() returned an invalid value ({ret:?})"),
     }
@@ -967,7 +1076,7 @@ pub fn do_fchmod(tid: ThreadIdentifier, request: FileChmodRequest) -> Message {
 // do_fchmodat()
 //==================================================================================================
 
-pub fn do_fchmodat(tid: ThreadIdentifier, request: FileChmodAtRequest) -> Vec<Message> {
+pub fn do_fchmodat(tid: ThreadIdentifier, request: FileChmodAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("fchmodat(): tid={tid:?}, request={request:?}");
 
     let dirfd: i32 = request.dirfd;
@@ -975,12 +1084,12 @@ pub fn do_fchmodat(tid: ThreadIdentifier, request: FileChmodAtRequest) -> Vec<Me
 
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let mode: LibcFileMode = match LibcFileMode::try_from(request.mode) {
         Ok(mode) => mode,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidMessage)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidMessage)]),
     };
 
     let flag: LibcAtFlags = LibcAtFlags::from(request.flag);
@@ -995,14 +1104,20 @@ pub fn do_fchmodat(tid: ThreadIdentifier, request: FileChmodAtRequest) -> Vec<Me
     match unsafe { libc::fchmodat(dirfd.inner(), path.as_ptr(), mode.inner(), flag.inner()) } {
         0 => {
             debug!("libc::fchmodat(): success");
-            vec![FileChmodAtResponse::build(tid)]
+            Ok(vec![FileChmodAtResponse::build(tid)])
         },
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::fchmodat(): errno={errno:?}");
             let error: ErrorCode =
                 ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-            vec![crate::build_error(tid, error)]
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }

--- a/src/daemons/linuxd/src/linuxd/assemble.rs
+++ b/src/daemons/linuxd/src/linuxd/assemble.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use crate::{
+    error::WorkerThreadError,
     fcntl,
     message::{
         RequestAssemblerTrait,
@@ -63,10 +64,10 @@ impl RequestAssemblerTrait for FileStatAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::FileStatAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::FileStatAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -84,7 +85,7 @@ impl RequestAssemblerTrait for FileStatAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         fcntl::do_fstat_at(source, request)
     }
 }
@@ -100,10 +101,10 @@ impl RequestAssemblerTrait for SymbolicLinkAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::SymbolicLinkAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::SymbolicLinkAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -121,7 +122,7 @@ impl RequestAssemblerTrait for SymbolicLinkAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         fcntl::do_symlinkat(source, request)
     }
 }
@@ -137,10 +138,10 @@ impl RequestAssemblerTrait for LinkAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::LinkAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::LinkAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -158,7 +159,7 @@ impl RequestAssemblerTrait for LinkAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         unistd::do_linkat(source, request)
     }
 }
@@ -174,10 +175,10 @@ impl RequestAssemblerTrait for ReadLinkAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::ReadLinkAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::ReadLinkAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -195,7 +196,7 @@ impl RequestAssemblerTrait for ReadLinkAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         fcntl::do_readlinkat(source, request)
     }
 }
@@ -211,10 +212,10 @@ impl RequestAssemblerTrait for MakeDirectoryAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::MakeDirectoryAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::MakeDirectoryAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -232,7 +233,7 @@ impl RequestAssemblerTrait for MakeDirectoryAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         fcntl::do_mkdirat(source, request)
     }
 }
@@ -248,12 +249,12 @@ impl RequestAssemblerTrait for UpdateFileAccessTimeAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
             RequestAssemblerType::UpdateFileAccessTimeAtRequest(assembler) => {
-                assembler.add_part(part)
+                Ok(assembler.add_part(part)?)
             },
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -275,7 +276,7 @@ impl RequestAssemblerTrait for UpdateFileAccessTimeAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         fcntl::do_utimensat(source, request)
     }
 }
@@ -291,10 +292,10 @@ impl RequestAssemblerTrait for FileChownAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::FileChownAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::FileChownAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -312,7 +313,7 @@ impl RequestAssemblerTrait for FileChownAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         fcntl::do_fchownat(source, request)
     }
 }
@@ -328,10 +329,10 @@ impl RequestAssemblerTrait for FileChmodAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::FileChmodAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::FileChmodAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -349,7 +350,7 @@ impl RequestAssemblerTrait for FileChmodAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         fcntl::do_fchmodat(source, request)
     }
 }
@@ -365,10 +366,10 @@ impl RequestAssemblerTrait for OpenAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::OpenAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::OpenAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -386,7 +387,7 @@ impl RequestAssemblerTrait for OpenAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         fcntl::do_openat(source, request)
     }
 }
@@ -402,10 +403,10 @@ impl RequestAssemblerTrait for RenameAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::RenameAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::RenameAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -423,7 +424,7 @@ impl RequestAssemblerTrait for RenameAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         fcntl::do_renameat(source, request)
     }
 }
@@ -439,10 +440,10 @@ impl RequestAssemblerTrait for UnlinkAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::UnlinkAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::UnlinkAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -460,7 +461,7 @@ impl RequestAssemblerTrait for UnlinkAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         fcntl::do_unlinkat(source, request)
     }
 }
@@ -476,10 +477,10 @@ impl RequestAssemblerTrait for ChangeDirectoryRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::ChangeDirectoryRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::ChangeDirectoryRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -497,7 +498,7 @@ impl RequestAssemblerTrait for ChangeDirectoryRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         unistd::do_chdir(source, request)
     }
 }
@@ -513,10 +514,10 @@ impl RequestAssemblerTrait for FileAccessAtRequest {
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error> {
+    ) -> Result<(), WorkerThreadError> {
         match assembler {
-            RequestAssemblerType::FileAccessAtRequest(assembler) => assembler.add_part(part),
-            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+            RequestAssemblerType::FileAccessAtRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
         }
     }
 
@@ -534,7 +535,7 @@ impl RequestAssemblerTrait for FileAccessAtRequest {
         }
     }
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message> {
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError> {
         unistd::do_faccessat(source, request)
     }
 }

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -13,7 +13,10 @@ mod assemble;
 
 use crate::{
     message::RequestAssembler,
-    venv::VirtualEnviromentDirectory,
+    venv::{
+        VenvCommand,
+        VirtualEnviromentDirectory,
+    },
     worker_thread::WorkerThreadHandle,
 };
 use ::anyhow::Result;
@@ -132,7 +135,8 @@ impl LinuxDaemon {
                                 response_buf))?;
                         }
                         Err(RecvError) => {
-                            info!("gateway STDIN channel disconnected");
+                            // This may happen during shutdown.
+                            debug!("gateway STDIN channel disconnected");
                             break Ok(());
                         }
                     }
@@ -154,9 +158,10 @@ impl LinuxDaemon {
                             // writting thread has already moved on.
                         }
                         Err(RecvError) => {
+                            // This may happen during shutdown.
                             let reason: String = "gateway STDOUT channel disconnected".to_string();
-                            error!("{}", reason);
-                            return Err(anyhow::anyhow!(reason));
+                            debug!("{}", reason);
+                            break Ok(());
                         }
                     }
                 }
@@ -184,12 +189,21 @@ impl LinuxDaemon {
                     ErrorKind::UnexpectedEof | ErrorKind::ConnectionReset => {
                         info!("connection from user VM closed");
 
+                        // Each worker thread may be in one of three states:
+                        // 1. Running
+                        // 2. Blocked on a system call
+                        // 3. Blocked waiting for a new message from the channel
+                        //
+                        // To gracefully shutdown the thread, we enqueue a shutdown message to the
+                        // message channel. In case the thread is blocked on a system call, we also
+                        // send it an interrupt signal and handle EINTR accordingly.
                         for worker_thread in worker_threads.drain(..) {
                             trace!("sending interrupt to worker thread (thread_id={:?})", worker_thread.id);
+                            worker_thread.cmd_tx.send(VenvCommand::Shutdown)
+                                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to send VenvCommand to queue"))?;
                             worker_thread.stop()?;
                             worker_thread.handle.join()
                                 .map_err(|_| Error::new(ErrorCode::IoErr, "failed to join worker thread"))?;
-                            log::warn!("done!");
                         }
 
                         break;
@@ -217,7 +231,7 @@ impl LinuxDaemon {
             };
 
             // Check if process is associated with a virtual environment.
-            let (channel_tx, channel_rx): (Sender<Message>, Option<Receiver<Message>>) = {
+            let (channel_tx, channel_rx): (Sender<VenvCommand>, Option<Receiver<VenvCommand>>) = {
                 let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
                 let env = venv.get(source);
                 if let Some(env) = env {
@@ -251,12 +265,12 @@ impl LinuxDaemon {
 
                 // Spawn an interruptible thread to handle the message.
                 let worker_thread_handle =
-                    WorkerThreadHandle::spawn(source, channel_rx, uvm_stream, gw_stdin_tx, gw_stdout_tx, venv, assembler)?;
+                    WorkerThreadHandle::spawn(source, channel_rx, channel_tx.clone(), uvm_stream, gw_stdin_tx, gw_stdout_tx, venv, assembler)?;
                 worker_threads.push_back(worker_thread_handle);
             }
 
             // Dispatch message to worker thread.
-            if let Err(error) = channel_tx.send(message) {
+            if let Err(error) = channel_tx.send(VenvCommand::Work(message)) {
                 error!(
                     "run(): failed to dispatch message to worker thread (tid={source:?}, \
                      error={error:?})"

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -159,8 +159,7 @@ impl LinuxDaemon {
                         }
                         Err(RecvError) => {
                             // This may happen during shutdown.
-                            let reason: String = "gateway STDOUT channel disconnected".to_string();
-                            debug!("{}", reason);
+                            debug!("gateway STDOUT channel disconnected");
                             break Ok(());
                         }
                     }
@@ -199,11 +198,30 @@ impl LinuxDaemon {
                         // send it an interrupt signal and handle EINTR accordingly.
                         for worker_thread in worker_threads.drain(..) {
                             trace!("sending interrupt to worker thread (thread_id={:?})", worker_thread.id);
-                            worker_thread.cmd_tx.send(VenvCommand::Shutdown)
-                                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to send VenvCommand to queue"))?;
-                            worker_thread.stop()?;
-                            worker_thread.handle.join()
-                                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to join worker thread"))?;
+
+                            // If any of the commands fail, continue trying to drain the remainnig
+                            // threads.
+                            match worker_thread.cmd_tx.send(VenvCommand::Shutdown) {
+                                Ok(_) => {},
+                                Err(e) => {
+                                    error!("error sending shutdown command to worker thread (thread_id={e:?})");
+                                    continue;
+                                }
+                            }
+                            match worker_thread.stop() {
+                                Ok(_) => {},
+                                Err(e) => {
+                                    error!("error sending interrupt to worker thread (thread_id={e:?})");
+                                    continue;
+                                }
+                            }
+                            match worker_thread.handle.join() {
+                                Ok(_) => {},
+                                Err(e) => {
+                                    error!("error joining worker thread (thread_id={e:?})");
+                                    continue;
+                                }
+                            }
                         }
 
                         break;
@@ -247,8 +265,11 @@ impl LinuxDaemon {
                                 .lock()
                                 .unwrap()
                                 .write_all(&message.to_bytes())
-                                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to write to user VM stream"))?;
-
+                                .map_err(|_| {
+                                    let reason = "failed to write to user VM stream";
+                                    error!("{reason}");
+                                    Error::new(ErrorCode::IoErr, reason)
+                                })?;
                             continue;
                         },
                     }
@@ -264,7 +285,7 @@ impl LinuxDaemon {
                 let assembler = assembler.clone();
 
                 // Spawn an interruptible thread to handle the message.
-                let worker_thread_handle =
+                let worker_thread_handle: WorkerThreadHandle =
                     WorkerThreadHandle::spawn(source, channel_rx, channel_tx.clone(), uvm_stream, gw_stdin_tx, gw_stdout_tx, venv, assembler)?;
                 worker_threads.push_back(worker_thread_handle);
             }

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -12,24 +12,13 @@ mod assemble;
 //==================================================================================================
 
 use crate::{
-    build_error,
-    dirent,
-    fcntl,
-    message::{
-        RequestAssembler,
-        RequestAssemblerTrait,
-    },
-    poll,
-    socket,
-    times,
-    unistd,
-    venv::{
-        VirtualEnviromentDirectory,
-        VirtualEnvironment,
-    },
+    message::RequestAssembler,
+    venv::VirtualEnviromentDirectory,
+    worker_thread::WorkerThreadHandle,
 };
 use ::anyhow::Result;
 use ::std::{
+    collections::VecDeque,
     io::{
         ErrorKind,
         Read,
@@ -45,97 +34,24 @@ use ::std::{
         MutexGuard,
         mpsc,
     },
-    thread::{
-        self,
-        JoinHandle,
-        ThreadId,
-    },
+    thread::JoinHandle,
 };
 use ::sys::{
     error::{
         Error,
         ErrorCode,
     },
-    ipc::{
-        Message,
-        MessageReceiver,
-        MessageSender,
-        MessageType,
-    },
+    ipc::Message,
     pm::ThreadIdentifier,
 };
-use ::sysapi::{
-    sys_types::c_ssize_t,
-    unistd::{
-        STDERR_FILENO,
-        STDIN_FILENO,
-        STDOUT_FILENO,
-    },
-};
+use ::sysapi::sys_types::c_ssize_t;
 use ::syscall::{
-    dirent::message::GetDirectoryEntriesRequest,
-    fcntl::message::{
-        FileAdvisoryInformationRequest,
-        FileControlRequest,
-        FileSpaceControlRequest,
-        OpenAtRequest,
-        RenameAtRequest,
-        UnlinkAtRequest,
-    },
-    message::LinuxDaemonMessagePart,
-    sys::{
-        socket::message::{
-            AcceptSocketRequest,
-            BindSocketRequest,
-            ConnectSocketRequest,
-            CreateSocketPairRequest,
-            CreateSocketRequest,
-            GetPeerNameRequest,
-            GetSockNameRequest,
-            ListenSocketRequest,
-            ReceiveSocketRequest,
-            SendSocketRequest,
-            ShutdownSocketRequest,
-        },
-        stat::message::{
-            FileChmodAtRequest,
-            FileChmodRequest,
-            FileStatAtRequest,
-            FileStatRequest,
-            MakeDirectoryAtRequest,
-            UpdateFileAccessTimeAtRequest,
-            UpdateFileAccessTimeRequest,
-        },
-        times::message::TimesRequest,
-    },
     unistd::message::{
-        ChangeDirectoryRequest,
-        CloseRequest,
-        CloseResponse,
-        FileAccessAtRequest,
-        FileChdirRequest,
-        FileChownAtRequest,
-        FileChownRequest,
-        FileDataSyncRequest,
-        FileSyncRequest,
-        FileTruncateRequest,
-        GetIdsRequest,
-        LinkAtRequest,
-        PartialReadRequest,
-        PartialWriteRequest,
-        PipeRequest,
-        ReadLinkAtRequest,
         ReadRequest,
         ReadResponse,
-        SeekRequest,
-        SymbolicLinkAtRequest,
         WriteRequest,
-        WriteResponse,
     },
     venv::VirtualEnvironmentIdentifier,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-    LINUXD,
 };
 use ::syscomm::SocketStream;
 
@@ -251,6 +167,9 @@ impl LinuxDaemon {
             (None, None)
         };
 
+        // Map keeping track of the worker threads associated the user VM.
+        let mut worker_threads: VecDeque<WorkerThreadHandle> = VecDeque::new();
+
         loop {
             let uvm_stream: Arc<Mutex<SocketStream>> = self.uvm_stream.clone();
             let venv: Arc<Mutex<VirtualEnviromentDirectory>> = self.venv.clone();
@@ -263,7 +182,16 @@ impl LinuxDaemon {
                 Err(error_kind) => match error_kind {
                     ErrorKind::WouldBlock => continue,
                     ErrorKind::UnexpectedEof | ErrorKind::ConnectionReset => {
-                        info!("connection closed");
+                        info!("connection from user VM closed");
+
+                        for worker_thread in worker_threads.drain(..) {
+                            trace!("sending interrupt to worker thread (thread_id={:?})", worker_thread.id);
+                            worker_thread.stop()?;
+                            worker_thread.handle.join()
+                                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to join worker thread"))?;
+                            log::warn!("done!");
+                        }
+
                         break;
                     },
                     _ => {
@@ -301,7 +229,12 @@ impl LinuxDaemon {
                         Err(error) => {
                             warn!("failed to join new virtual environment (error={error:?})");
                             let message: Message = crate::build_error(source, error.code);
-                            Self::send(uvm_stream.clone(), message).unwrap();
+                            uvm_stream
+                                .lock()
+                                .unwrap()
+                                .write_all(&message.to_bytes())
+                                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to write to user VM stream"))?;
+
                             continue;
                         },
                     }
@@ -314,9 +247,12 @@ impl LinuxDaemon {
                 let venv: Arc<Mutex<VirtualEnviromentDirectory>> = venv.clone();
                 let gw_stdin_tx = gw_stdin_tx.clone();
                 let gw_stdout_tx = gw_stdout_tx.clone();
-                let _ = std::thread::spawn(move || {
-                    Self::handle_message(channel_rx, uvm_stream, gw_stdin_tx, gw_stdout_tx, venv, assembler);
-                });
+                let assembler = assembler.clone();
+
+                // Spawn an interruptible thread to handle the message.
+                let worker_thread_handle =
+                    WorkerThreadHandle::spawn(source, channel_rx, uvm_stream, gw_stdin_tx, gw_stdout_tx, venv, assembler)?;
+                worker_threads.push_back(worker_thread_handle);
             }
 
             // Dispatch message to worker thread.
@@ -340,408 +276,7 @@ impl LinuxDaemon {
         Ok(())
     }
 
-    fn handle_message(
-        channel_rx: Receiver<Message>,
-        uvm_stream: Arc<Mutex<SocketStream>>,
-        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        gateway_stdout_tx: Option<Sender<WriteRequest>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
-        assembler: Arc<Mutex<RequestAssembler>>,
-    ) {
-        let worker_tid: ThreadId = thread::current().id();
-
-        loop {
-            let message: Message = match channel_rx.recv() {
-                Ok(message) => message,
-                Err(error) => {
-                    error!(
-                        "handle_message(): failed to receive message from channel, stopping \
-                         (worker_tid={worker_tid:?}, error={error:?})"
-                    );
-                    break;
-                },
-            };
-            let source: ThreadIdentifier = match { message.source }.as_id() {
-                Err(tid) => tid,
-                Ok(_) => {
-                    unreachable!("messages that are in this channel always address threads");
-                },
-            };
-
-            match message.message_type {
-                sys::ipc::MessageType::Empty => panic!("received empty message"),
-                sys::ipc::MessageType::Interrupt => panic!("received interrupt message"),
-                sys::ipc::MessageType::Exception => panic!("received exception message"),
-                sys::ipc::MessageType::Ipc => panic!("received IPC message"),
-                sys::ipc::MessageType::ProcessTerminationEvent => {
-                    panic!("received process termination event message")
-                },
-                sys::ipc::MessageType::Ikc => {
-                    match LinuxDaemonMessage::try_from_bytes(message.payload) {
-                        Ok(message) => {
-                            let message: Message = match message.header {
-                                // The system calls are interposed before being forwarded to the
-                                // backend provider.
-                                LinuxDaemonMessageHeader::CloseRequest
-                                | LinuxDaemonMessageHeader::ReadRequest
-                                | LinuxDaemonMessageHeader::WriteRequest => {
-                                    Self::handle_special_messages(
-                                        gateway_stdin_tx.clone(),
-                                        gateway_stdout_tx.clone(),
-                                        venv.clone(),
-                                        source,
-                                        message,
-                                    )
-                                },
-
-                                // The following system calls have their request and response
-                                // data fit in a single message. Thus, they can be immediately
-                                // forwarded to the backend provider.
-                                LinuxDaemonMessageHeader::AcceptSocketRequest
-                                | LinuxDaemonMessageHeader::BindSocketRequest
-                                | LinuxDaemonMessageHeader::ConnectSocketRequest
-                                | LinuxDaemonMessageHeader::CreateSocketPairRequest
-                                | LinuxDaemonMessageHeader::CreateSocketRequest
-                                | LinuxDaemonMessageHeader::FileAdvisoryInformationRequest
-                                | LinuxDaemonMessageHeader::FileChdirRequest
-                                | LinuxDaemonMessageHeader::FileChmodRequest
-                                | LinuxDaemonMessageHeader::FileChownRequest
-                                | LinuxDaemonMessageHeader::FileControlRequest
-                                | LinuxDaemonMessageHeader::FileDataSyncRequest
-                                | LinuxDaemonMessageHeader::FileSpaceControlRequest
-                                | LinuxDaemonMessageHeader::FileSyncRequest
-                                | LinuxDaemonMessageHeader::FileTruncateRequest
-                                | LinuxDaemonMessageHeader::GetIdsRequest
-                                | LinuxDaemonMessageHeader::GetPeerNameRequest
-                                | LinuxDaemonMessageHeader::GetSockNameRequest
-                                | LinuxDaemonMessageHeader::ListenSocketRequest
-                                | LinuxDaemonMessageHeader::PartialReadRequest
-                                | LinuxDaemonMessageHeader::PartialWriteRequest
-                                | LinuxDaemonMessageHeader::ReceiveSocketRequest
-                                | LinuxDaemonMessageHeader::SeekRequest
-                                | LinuxDaemonMessageHeader::SendSocketRequest
-                                | LinuxDaemonMessageHeader::ShutdownSocketRequest
-                                | LinuxDaemonMessageHeader::TimesRequest
-                                | LinuxDaemonMessageHeader::PipeRequest
-                                | LinuxDaemonMessageHeader::PollRequest
-                                | LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
-                                    Self::handle_short_request_messages(source, message)
-                                },
-
-                                // The following system calls have their request data fit in a
-                                // single message, but their response data is too large to fit in a
-                                // single message. Thus, their response is split into multiple
-                                // messages.
-                                LinuxDaemonMessageHeader::FileStatRequest
-                                | LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest
-                                | LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
-                                    Self::handle_long_response_messages(
-                                        uvm_stream.clone(),
-                                        source,
-                                        message,
-                                    );
-                                    continue;
-                                },
-
-                                // The following system calls have request data that is too large to
-                                // fit in a single message. Thus, their request is split into multiple
-                                // messages.
-                                LinuxDaemonMessageHeader::ChangeDirectoryRequestPart
-                                | LinuxDaemonMessageHeader::FileStatAtRequestPart
-                                | LinuxDaemonMessageHeader::FileAccessAtRequestPart
-                                | LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart
-                                | LinuxDaemonMessageHeader::LinkAtRequestPart
-                                | LinuxDaemonMessageHeader::ReadLinkAtRequestPart
-                                | LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart
-                                | LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart
-                                | LinuxDaemonMessageHeader::FileChownAtRequestPart
-                                | LinuxDaemonMessageHeader::FileChmodAtRequestPart
-                                | LinuxDaemonMessageHeader::OpenAtRequestPart
-                                | LinuxDaemonMessageHeader::RenameAtRequestPart
-                                | LinuxDaemonMessageHeader::UnlinkAtRequestPart => {
-                                    Self::handle_long_request_messages(
-                                        uvm_stream.clone(),
-                                        assembler.clone(),
-                                        source,
-                                        message,
-                                    );
-                                    continue;
-                                },
-
-                                _ => Self::do_error(source, ErrorCode::InvalidMessage),
-                            };
-                            Self::send(uvm_stream.clone(), message).unwrap();
-                        },
-                        Err(e) => {
-                            error!("failed to parse Linux daemon message (error={e:?})");
-                        },
-                    }
-                },
-            }
-        }
-    }
-
-    fn handle_special_messages(
-        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        gateway_stdout_tx: Option<Sender<WriteRequest>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
-        source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
-    ) -> Message {
-        match message.header {
-            LinuxDaemonMessageHeader::CloseRequest => {
-                let request: CloseRequest = CloseRequest::from_bytes(message.payload);
-                Self::handle_close_request(source, request)
-            },
-            LinuxDaemonMessageHeader::ReadRequest => {
-                let request: ReadRequest = ReadRequest::from_bytes(message.payload);
-                Self::handle_read_request(gateway_stdin_tx, venv, source, request)
-            },
-            LinuxDaemonMessageHeader::WriteRequest => {
-                let request: WriteRequest = WriteRequest::from_bytes(message.payload);
-                Self::handle_write_request(gateway_stdout_tx, source, request)
-            },
-            header => {
-                // The following statement is unreachable, because the matching logic in this
-                // function should match the one in the `Self::run()` function.
-                unreachable!("unexpected special message {:?}", header)
-            },
-        }
-    }
-
-    fn handle_short_request_messages(
-        source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
-    ) -> Message {
-        match message.header {
-            LinuxDaemonMessageHeader::AcceptSocketRequest => {
-                let request: AcceptSocketRequest = AcceptSocketRequest::from_bytes(message.payload);
-                socket::do_accept(source, request)
-            },
-            LinuxDaemonMessageHeader::BindSocketRequest => {
-                let request: BindSocketRequest = BindSocketRequest::from_bytes(message.payload);
-                socket::do_bind(source, request)
-            },
-            LinuxDaemonMessageHeader::ConnectSocketRequest => {
-                let request: ConnectSocketRequest =
-                    ConnectSocketRequest::from_bytes(message.payload);
-                socket::do_connect(source, request)
-            },
-            LinuxDaemonMessageHeader::CreateSocketPairRequest => {
-                let request: CreateSocketPairRequest =
-                    CreateSocketPairRequest::from_bytes(message.payload);
-                socket::do_socketpair(source, request)
-            },
-            LinuxDaemonMessageHeader::CreateSocketRequest => {
-                let request: CreateSocketRequest = CreateSocketRequest::from_bytes(message.payload);
-                socket::do_socket(source, request)
-            },
-            LinuxDaemonMessageHeader::FileAdvisoryInformationRequest => {
-                let request: FileAdvisoryInformationRequest =
-                    FileAdvisoryInformationRequest::from_bytes(message.payload);
-                fcntl::do_posix_fadvise(source, request)
-            },
-            LinuxDaemonMessageHeader::FileChdirRequest => {
-                let request: FileChdirRequest = FileChdirRequest::from_bytes(message.payload);
-                unistd::do_fchdir(source, request)
-            },
-            LinuxDaemonMessageHeader::FileChmodRequest => {
-                let request: FileChmodRequest = FileChmodRequest::from_bytes(message.payload);
-                fcntl::do_fchmod(source, request)
-            },
-            LinuxDaemonMessageHeader::FileChownRequest => {
-                let request: FileChownRequest = FileChownRequest::from_bytes(message.payload);
-                unistd::do_fchown(source, request)
-            },
-            LinuxDaemonMessageHeader::FileControlRequest => {
-                let request: FileControlRequest = FileControlRequest::from_bytes(message.payload);
-                fcntl::do_fcntl(source, request)
-            },
-            LinuxDaemonMessageHeader::FileDataSyncRequest => {
-                let request: FileDataSyncRequest = FileDataSyncRequest::from_bytes(message.payload);
-                unistd::do_fdatasync(source, request)
-            },
-            LinuxDaemonMessageHeader::FileSpaceControlRequest => {
-                let request: FileSpaceControlRequest =
-                    FileSpaceControlRequest::from_bytes(message.payload);
-                fcntl::do_posix_fallocate(source, request)
-            },
-            LinuxDaemonMessageHeader::FileSyncRequest => {
-                let request: FileSyncRequest = FileSyncRequest::from_bytes(message.payload);
-                unistd::do_fsync(source, request)
-            },
-            LinuxDaemonMessageHeader::FileTruncateRequest => {
-                let request: FileTruncateRequest = FileTruncateRequest::from_bytes(message.payload);
-                unistd::do_ftruncate(source, request)
-            },
-            LinuxDaemonMessageHeader::GetIdsRequest => {
-                let request: GetIdsRequest = GetIdsRequest::from_bytes(message.payload);
-                unistd::do_getids(source, request)
-            },
-            LinuxDaemonMessageHeader::GetPeerNameRequest => {
-                let request: GetPeerNameRequest = GetPeerNameRequest::from_bytes(message.payload);
-                socket::do_getpeername(source, request)
-            },
-            LinuxDaemonMessageHeader::GetSockNameRequest => {
-                let request: GetSockNameRequest = GetSockNameRequest::from_bytes(message.payload);
-                socket::do_getsockname(source, request)
-            },
-            LinuxDaemonMessageHeader::ListenSocketRequest => {
-                let request: ListenSocketRequest = ListenSocketRequest::from_bytes(message.payload);
-                socket::do_listen(source, request)
-            },
-            LinuxDaemonMessageHeader::PartialReadRequest => {
-                let request: PartialReadRequest = PartialReadRequest::from_bytes(message.payload);
-                unistd::do_pread(source, request)
-            },
-            LinuxDaemonMessageHeader::PartialWriteRequest => {
-                let request: PartialWriteRequest = PartialWriteRequest::from_bytes(message.payload);
-                unistd::do_pwrite(source, request)
-            },
-            LinuxDaemonMessageHeader::PollRequest => {
-                let request: syscall::poll::message::PollRequest =
-                    syscall::poll::message::PollRequest::from_bytes(message.payload);
-                poll::do_poll(source, request)
-            },
-            LinuxDaemonMessageHeader::ReceiveSocketRequest => {
-                let request: ReceiveSocketRequest =
-                    ReceiveSocketRequest::from_bytes(message.payload);
-                socket::do_recv(source, request)
-            },
-            LinuxDaemonMessageHeader::SeekRequest => {
-                let request: SeekRequest = SeekRequest::from_bytes(message.payload);
-                unistd::do_lseek(source, request)
-            },
-            LinuxDaemonMessageHeader::SendSocketRequest => {
-                let request: SendSocketRequest = SendSocketRequest::from_bytes(message.payload);
-                socket::do_send(source, request)
-            },
-            LinuxDaemonMessageHeader::ShutdownSocketRequest => {
-                let request: ShutdownSocketRequest =
-                    ShutdownSocketRequest::from_bytes(message.payload);
-                socket::do_shutdown(source, request)
-            },
-            LinuxDaemonMessageHeader::TimesRequest => {
-                let request: TimesRequest = TimesRequest::from_bytes(message.payload);
-                times::do_times(source, request)
-            },
-            LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
-                let request: UpdateFileAccessTimeRequest =
-                    UpdateFileAccessTimeRequest::from_bytes(message.payload);
-                fcntl::do_futimens(source, request)
-            },
-            LinuxDaemonMessageHeader::PipeRequest => {
-                let _request = PipeRequest::from_bytes(message.payload);
-                unistd::do_pipe(source)
-            },
-            header => {
-                // The following statement is unreachable, because the matching logic in this
-                // function should match the one in the `Self::run()` function.
-                unreachable!("unexpected short message {:?}", header)
-            },
-        }
-    }
-
-    fn handle_long_request_messages(
-        uvm_stream: Arc<Mutex<SocketStream>>,
-        assembler: Arc<Mutex<RequestAssembler>>,
-        source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
-    ) {
-        match message.header {
-            LinuxDaemonMessageHeader::ChangeDirectoryRequestPart => {
-                Self::handle_long_request::<ChangeDirectoryRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            LinuxDaemonMessageHeader::FileAccessAtRequestPart => {
-                Self::handle_long_request::<FileAccessAtRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            LinuxDaemonMessageHeader::FileStatAtRequestPart => {
-                Self::handle_long_request::<FileStatAtRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart => {
-                Self::handle_long_request::<SymbolicLinkAtRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            LinuxDaemonMessageHeader::LinkAtRequestPart => {
-                Self::handle_long_request::<LinkAtRequest>(uvm_stream, assembler, source, &message);
-            },
-            LinuxDaemonMessageHeader::ReadLinkAtRequestPart => {
-                Self::handle_long_request::<ReadLinkAtRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart => {
-                Self::handle_long_request::<MakeDirectoryAtRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart => {
-                Self::handle_long_request::<UpdateFileAccessTimeAtRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            LinuxDaemonMessageHeader::FileChownAtRequestPart => {
-                Self::handle_long_request::<FileChownAtRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            LinuxDaemonMessageHeader::FileChmodAtRequestPart => {
-                Self::handle_long_request::<FileChmodAtRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            LinuxDaemonMessageHeader::OpenAtRequestPart => {
-                Self::handle_long_request::<OpenAtRequest>(uvm_stream, assembler, source, &message);
-            },
-            LinuxDaemonMessageHeader::RenameAtRequestPart => {
-                Self::handle_long_request::<RenameAtRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            LinuxDaemonMessageHeader::UnlinkAtRequestPart => {
-                Self::handle_long_request::<UnlinkAtRequest>(
-                    uvm_stream, assembler, source, &message,
-                );
-            },
-            header => {
-                // The following statement is unreachable, because the matching logic in this
-                // function should match the one in the `Self::run()` function.
-                unreachable!("unexpected long request message {:?}", header)
-            },
-        }
-    }
-
-    fn handle_long_response_messages(
-        uvm_stream: Arc<Mutex<SocketStream>>,
-        source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
-    ) {
-        match message.header {
-            LinuxDaemonMessageHeader::FileStatRequest => {
-                Self::handle_fstat_request(uvm_stream, source, message);
-            },
-            LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest => {
-                Self::handle_getcwd_request(uvm_stream, source);
-            },
-            LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
-                Self::handle_getdents_request(uvm_stream, source, message);
-            },
-            header => {
-                // The following statement is unreachable, because the matching logic in this
-                // function should match the one in the `Self::run()` function.
-                unreachable!("unexpected long response message {:?}", header)
-            },
-        }
-    }
-
-    // Read a message from the TCP stream.
+    // Read a message from the user VM stream.
     fn recv(uvm_stream: Arc<Mutex<SocketStream>>) -> Result<Message, ErrorKind> {
         let mut buf: [u8; config::kernel::IPC_MESSAGE_SIZE] =
             [0u8; config::kernel::IPC_MESSAGE_SIZE];
@@ -761,229 +296,5 @@ impl LinuxDaemon {
         };
 
         Ok(message)
-    }
-
-    // Send a message to the TCP stream.
-    fn send(uvm_stream: Arc<Mutex<SocketStream>>, message: Message) -> Result<()> {
-        let bytes = message.to_bytes();
-
-        loop {
-            let mut locked_uvm_stream = uvm_stream.lock().unwrap();
-
-            match locked_uvm_stream.write_all(&bytes) {
-                Ok(_) => break Ok(()),
-                Err(e) => {
-                    match e.kind() {
-                        ErrorKind::WouldBlock => {
-                            // The stream is not ready to write, retry.
-                            continue;
-                        },
-                        error_kind => {
-                            unimplemented!(
-                                "handle: failed to write message (error={error_kind:?})"
-                            );
-                        },
-                    }
-                },
-            }
-        }
-    }
-
-    fn do_error(source: ThreadIdentifier, code: ErrorCode) -> Message {
-        Message::new(
-            MessageSender::from(LINUXD),
-            MessageReceiver::from(source),
-            MessageType::Ikc,
-            Some(code),
-            [0u8; Message::PAYLOAD_SIZE],
-        )
-    }
-
-    fn handle_close_request(source: ThreadIdentifier, request: CloseRequest) -> Message {
-        // Inspect file descriptor that is being closed, as we need to
-        // handle standard file descriptors specially.
-        match request.fd {
-            // Closing standard file descriptors.
-            STDIN_FILENO | STDOUT_FILENO | STDERR_FILENO => {
-                // Perform a fake close, as standard file descriptors
-                // are shared with the current process.
-                CloseResponse::build(source, 0)
-            },
-            // Closing other file descriptors.
-            _ => unistd::do_close(source, request),
-        }
-    }
-
-    fn handle_write_request(
-        gateway_stdout_tx: Option<Sender<WriteRequest>>,
-        source: ThreadIdentifier,
-        mut request: WriteRequest,
-    ) -> Message {
-        trace!("handle_write_request(): source={source:?}, request={request:?}");
-        // Check if writing to gateway.
-        if request.fd == STDOUT_FILENO || request.fd == STDERR_FILENO {
-            let gateway_stdout_tx = if let Some(gateway_stdout_tx) = gateway_stdout_tx {
-                gateway_stdout_tx
-            } else {
-                error!("handle_write_request(): trying to write to stdout without a gateway configured");
-                return build_error(source, ErrorCode::InvalidArgument);
-            };
-
-            // Check if write size is invalid.
-            if request.count == 0 {
-                // Writing zero-bytes to STDOUT is not allowed, as we used this to signal EOF.
-                error!("handle_write_request(): trying to write zero bytes to STDOUT");
-                build_error(source, ErrorCode::InvalidArgument)
-            } else {
-                profiler::timestamp_message!(&mut request.buffer, 0);
-                let count: usize = request.count as usize;
-                if let Err(error) = gateway_stdout_tx.send(request) {
-                    debug!("failed to write buffer to the gateway (error={error:?})");
-                    // TODO: Check error conversion.
-                    return build_error(source, ErrorCode::ConnectionReset);
-                }
-
-                // We don't wait for the IO thread to confirm that the write was correct, as writes
-                // are fully non-blocking.
-                debug!("wrote {count} bytes to the gateway");
-                WriteResponse::build(source, count as i32)
-            }
-        } else {
-            // Write to other file descriptor.
-            unistd::do_write(source, request)
-        }
-    }
-
-    fn handle_read_request(
-        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
-        source: ThreadIdentifier,
-        request: ReadRequest,
-    ) -> Message {
-        trace!("handle_read_request(): source={source:?}, request={request:?}");
-        // Check if reading from gateway.
-        if request.fd == STDIN_FILENO {
-            let gateway_stdin_tx = if let Some(gateway_stdin_tx) = gateway_stdin_tx {
-                gateway_stdin_tx
-            } else {
-                error!("handle_read_request(): process tried to read from stdin but no gateway found");
-                return ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]);
-            };
-
-            // Check if the process is associated with a virtual environment.
-            let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
-            let env: &mut VirtualEnvironment = if let Some(env) = venv.get_mut(source) {
-                env
-            } else {
-                warn!(
-                    "handle_read_request(): process is not associated with a virtual \
-                     environment, returning EOF"
-                );
-                return ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]);
-            };
-
-            // Send ReadRequest to gateway IO thread.
-            if let Err(error) = gateway_stdin_tx.send((request, env.get_stdin_response_tx())) {
-                error!(
-                    "handle_read_request(): error sending request to gateway STDIN IO thread, returning EOF \
-                    (error={error:?})"
-                );
-                return ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]);
-            }
-
-            // Wait for response from IO thread.
-            match env
-                .get_stdin_response_rx()
-                .recv() {
-                    Ok(mut read_response) => {
-                        // We don't have access to the source in the gateway IO thread, so we set
-                        // it here.
-                        read_response.destination = source.into();
-                        read_response
-                    },
-                    Err(e) => {
-                        error!(
-                            "handle_read_request(): error receiving request response from gateway STDIN \
-                            IO thread, returning EOF (error={e:?})"
-                        );
-                        ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE])
-                    }
-                }
-        } else {
-            // Read from other file descriptor.
-            unistd::do_read(source, request)
-        }
-    }
-
-    fn handle_fstat_request(
-        uvm_stream: Arc<Mutex<SocketStream>>,
-        source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
-    ) {
-        let request: FileStatRequest = FileStatRequest::from_bytes(message.payload);
-        let messages: Vec<Message> = fcntl::do_fstat(source, request);
-        for message in messages {
-            if let Err(e) = Self::send(uvm_stream.clone(), message) {
-                error!("failed to send message (error={e:?})");
-            }
-        }
-    }
-
-    fn handle_getcwd_request(uvm_stream: Arc<Mutex<SocketStream>>, source: ThreadIdentifier) {
-        let messages: Vec<Message> = unistd::do_getcwd(source);
-        for message in messages {
-            if let Err(e) = Self::send(uvm_stream.clone(), message) {
-                error!("failed to send message (error={e:?})");
-            }
-        }
-    }
-
-    fn handle_getdents_request(
-        uvm_stream: Arc<Mutex<SocketStream>>,
-        source: ThreadIdentifier,
-        message: LinuxDaemonMessage,
-    ) {
-        let request: GetDirectoryEntriesRequest =
-            GetDirectoryEntriesRequest::from_bytes(message.payload);
-
-        let messages: Vec<Message> = dirent::do_getdents(source, request);
-        for message in messages {
-            if let Err(e) = Self::send(uvm_stream.clone(), message) {
-                error!("failed to send message (error={e:?})");
-            }
-        }
-    }
-
-    fn handle_long_request<T>(
-        uvm_stream: Arc<Mutex<SocketStream>>,
-        assembler: Arc<Mutex<RequestAssembler>>,
-        source: ThreadIdentifier,
-        message: &LinuxDaemonMessage,
-    ) where
-        T: RequestAssemblerTrait,
-    {
-        let part: LinuxDaemonMessagePart = LinuxDaemonMessagePart::from_bytes(message.payload);
-
-        trace!("handle_long_request(): source={source:?}, part={part:?}");
-
-        let result: Result<Option<Vec<Message>>, Error> =
-            assembler.lock().unwrap().process_message::<T>(source, part);
-
-        match result {
-            Ok(Some(messages)) => {
-                for message in messages {
-                    if let Err(e) = Self::send(uvm_stream.clone(), message) {
-                        error!("failed to send message (error={e:?})");
-                    }
-                }
-            },
-            Ok(None) => {},
-            Err(e) => {
-                error!("failed to process request (error={e:?})");
-                if let Err(e) = Self::send(uvm_stream.clone(), Self::do_error(source, e.code)) {
-                    error!("failed to send error message (error={e:?})");
-                }
-            },
-        }
     }
 }

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -14,6 +14,7 @@
 
 mod args;
 mod dirent;
+mod error;
 mod fcntl;
 mod linuxd;
 mod message;
@@ -23,6 +24,7 @@ mod time;
 mod times;
 mod unistd;
 mod venv;
+mod worker_thread;
 
 //==================================================================================================
 // Imports

--- a/src/daemons/linuxd/src/message.rs
+++ b/src/daemons/linuxd/src/message.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::error::WorkerThreadError;
 use ::alloc::collections::BTreeMap;
 use ::sys::{
     error::Error,
@@ -31,12 +32,13 @@ impl RequestAssembler {
         &mut self,
         source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
-    ) -> Result<Option<Vec<Message>>, Error> {
+    ) -> Result<Option<Vec<Message>>, WorkerThreadError> {
         match self.process_message_internal::<T>(source, part) {
             Ok(messages) => Ok(messages),
-            Err(e) => {
+            Err(WorkerThreadError::Interrupted) => Err(WorkerThreadError::Interrupted),
+            Err(WorkerThreadError::Error(e)) => {
                 self.inflight.remove(&source);
-                Err(e)
+                Err(WorkerThreadError::Error(e))
             },
         }
     }
@@ -45,7 +47,7 @@ impl RequestAssembler {
         &mut self,
         source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
-    ) -> Result<Option<Vec<Message>>, Error> {
+    ) -> Result<Option<Vec<Message>>, WorkerThreadError> {
         let message_complete: bool = {
             match self.assemble_parts::<T>(source, part) {
                 Ok(message_complete) => message_complete,
@@ -69,19 +71,19 @@ impl RequestAssembler {
         &mut self,
         source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
-    ) -> Result<bool, Error> {
+    ) -> Result<bool, WorkerThreadError> {
         let assembler: &mut RequestAssemblerType = self
             .inflight
             .entry(source)
             .or_insert_with(|| T::new_assembler());
         T::add_part(assembler, part)?;
-        T::is_complete(assembler)
+        Ok(T::is_complete(assembler)?)
     }
 
     fn process_request<T: RequestAssemblerTrait>(
         &mut self,
         source: ThreadIdentifier,
-    ) -> Result<Vec<Message>, Error> {
+    ) -> Result<Vec<Message>, WorkerThreadError> {
         let assembler: RequestAssemblerType = self
             .inflight
             .remove(&source)
@@ -89,7 +91,7 @@ impl RequestAssembler {
 
         let parts: Vec<LinuxDaemonMessagePart> = T::take_parts(assembler);
         let request: T = T::from_parts(&parts)?;
-        Ok(T::process_request(source, request))
+        T::process_request(source, request)
     }
 }
 
@@ -120,11 +122,11 @@ where
     fn add_part(
         assembler: &mut RequestAssemblerType,
         part: LinuxDaemonMessagePart,
-    ) -> Result<(), Error>;
+    ) -> Result<(), WorkerThreadError>;
 
     fn is_complete(assembler: &RequestAssemblerType) -> Result<bool, Error>;
 
     fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart>;
 
-    fn process_request(source: ThreadIdentifier, request: Self) -> Vec<Message>;
+    fn process_request(source: ThreadIdentifier, request: Self) -> Result<Vec<Message>, WorkerThreadError>;
 }

--- a/src/daemons/linuxd/src/poll.rs
+++ b/src/daemons/linuxd/src/poll.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::error::WorkerThreadError;
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
@@ -36,13 +37,13 @@ use ::syscall::poll::message::{
 // do_poll()
 //==================================================================================================
 
-pub fn do_poll(tid: ThreadIdentifier, request: PollRequest) -> Message {
+pub fn do_poll(tid: ThreadIdentifier, request: PollRequest) -> Result<Message, WorkerThreadError> {
     trace!("poll(): tid={tid:?}, request={request:?}");
 
     // Check if request is not valid.
     if request.nfds == 0 || request.nfds as usize > NFDS_MAX {
         error!("poll(): invalid request ({request:?})");
-        return crate::build_error(tid, ErrorCode::InvalidArgument);
+        return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
     }
 
     // Unpack request.
@@ -78,7 +79,7 @@ pub fn do_poll(tid: ThreadIdentifier, request: PollRequest) -> Message {
 
                     // Build response.
                     match PollResponse::build(tid, nready, &ready_fds, &revents) {
-                        Ok(response) => response,
+                        Ok(response) => Ok(response),
                         Err(error) => {
                             unreachable!("poll(): failed to build response ({error:?})");
                         },
@@ -93,10 +94,16 @@ pub fn do_poll(tid: ThreadIdentifier, request: PollRequest) -> Message {
         },
         _ => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("poll(): errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
     }
 }

--- a/src/daemons/linuxd/src/socket.rs
+++ b/src/daemons/linuxd/src/socket.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::error::WorkerThreadError;
 use ::core::{
     cmp,
     mem,
@@ -72,12 +73,12 @@ use ::syscall::{
 // do_socket
 //==================================================================================================
 
-pub fn do_socket(tid: ThreadIdentifier, request: CreateSocketRequest) -> Message {
+pub fn do_socket(tid: ThreadIdentifier, request: CreateSocketRequest) -> Result<Message, WorkerThreadError> {
     trace!("socket(): tid={tid:?}, request={request:?}");
 
     let domain: LibcSocketDomain = match LibcSocketDomain::try_from(request.domain) {
         Ok(domain) => domain,
-        Err(e) => return crate::build_error(tid, e.code),
+        Err(e) => return Ok(crate::build_error(tid, e.code)),
     };
 
     let typ: LibcSocketType = LibcSocketType::from(request.typ);
@@ -92,14 +93,20 @@ pub fn do_socket(tid: ThreadIdentifier, request: CreateSocketRequest) -> Message
     match unsafe { libc::socket(domain.inner() as i32, typ.inner(), protocol.inner()) } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::socket(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
         sockfd => {
             debug!("libc::socket(): fd={sockfd:?}");
-            CreateSocketResponse::build(tid, sockfd)
+            Ok(CreateSocketResponse::build(tid, sockfd))
         },
     }
 }
@@ -108,12 +115,12 @@ pub fn do_socket(tid: ThreadIdentifier, request: CreateSocketRequest) -> Message
 // do_socketpair
 //==================================================================================================
 
-pub fn do_socketpair(tid: ThreadIdentifier, request: CreateSocketPairRequest) -> Message {
+pub fn do_socketpair(tid: ThreadIdentifier, request: CreateSocketPairRequest) -> Result<Message, WorkerThreadError> {
     trace!("socketpair(): tid={tid:?}, request={request:?}");
 
     let domain: LibcSocketDomain = match LibcSocketDomain::try_from(request.domain) {
         Ok(domain) => domain,
-        Err(e) => return crate::build_error(tid, e.code),
+        Err(e) => return Ok(crate::build_error(tid, e.code)),
     };
 
     let typ: LibcSocketType = LibcSocketType::from(request.typ);
@@ -132,14 +139,20 @@ pub fn do_socketpair(tid: ThreadIdentifier, request: CreateSocketPairRequest) ->
     } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::socketpair(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
         _ => {
             debug!("libc::socketpair(): fds={sv:?}");
-            CreateSocketPairResponse::build(tid, sv[0], sv[1])
+            Ok(CreateSocketPairResponse::build(tid, sv[0], sv[1]))
         },
     }
 }
@@ -148,13 +161,13 @@ pub fn do_socketpair(tid: ThreadIdentifier, request: CreateSocketPairRequest) ->
 // do_bind
 //==================================================================================================
 
-pub fn do_bind(tid: ThreadIdentifier, request: BindSocketRequest) -> Message {
+pub fn do_bind(tid: ThreadIdentifier, request: BindSocketRequest) -> Result<Message, WorkerThreadError> {
     trace!("bind(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
     let sockaddr: LibcSocketAddress = match LibcSocketAddress::try_from(request.sockaddr) {
         Ok(sockaddr) => sockaddr,
-        Err(e) => return crate::build_error(tid, e.code),
+        Err(e) => return Ok(crate::build_error(tid, e.code)),
     };
     let socklen: socklen_t = mem::size_of_val(&sockaddr) as socklen_t;
 
@@ -167,12 +180,18 @@ pub fn do_bind(tid: ThreadIdentifier, request: BindSocketRequest) -> Message {
     match unsafe { libc::bind(sockfd, &sockaddr.inner() as *const libc::sockaddr, socklen) } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::bind(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
-        _ => BindSocketResponse::build(tid),
+        _ => Ok(BindSocketResponse::build(tid)),
     }
 }
 
@@ -180,13 +199,13 @@ pub fn do_bind(tid: ThreadIdentifier, request: BindSocketRequest) -> Message {
 // do_connect
 //==================================================================================================
 
-pub fn do_connect(tid: ThreadIdentifier, request: ConnectSocketRequest) -> Message {
+pub fn do_connect(tid: ThreadIdentifier, request: ConnectSocketRequest) -> Result<Message, WorkerThreadError> {
     trace!("connect(): tid={tid:?}, request={request:?}");
 
     let sockfd: libc::c_int = request.sockfd;
     let sockaddr: LibcSocketAddress = match LibcSocketAddress::try_from(request.sockaddr) {
         Ok(sockaddr) => sockaddr,
-        Err(e) => return crate::build_error(tid, e.code),
+        Err(e) => return Ok(crate::build_error(tid, e.code)),
     };
     let socklen: socklen_t = request.socklen;
 
@@ -206,12 +225,18 @@ pub fn do_connect(tid: ThreadIdentifier, request: ConnectSocketRequest) -> Messa
     } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::connect(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
-        _ => ConnectSocketResponse::build(tid),
+        _ => Ok(ConnectSocketResponse::build(tid)),
     }
 }
 
@@ -219,7 +244,7 @@ pub fn do_connect(tid: ThreadIdentifier, request: ConnectSocketRequest) -> Messa
 // do_listen
 //==================================================================================================
 
-pub fn do_listen(tid: ThreadIdentifier, request: ListenSocketRequest) -> Message {
+pub fn do_listen(tid: ThreadIdentifier, request: ListenSocketRequest) -> Result<Message, WorkerThreadError> {
     trace!("listen(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
@@ -229,12 +254,18 @@ pub fn do_listen(tid: ThreadIdentifier, request: ListenSocketRequest) -> Message
     match unsafe { libc::listen(sockfd, backlog) } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::listen(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
-        _ => ListenSocketResponse::build(tid),
+        _ => Ok(ListenSocketResponse::build(tid)),
     }
 }
 
@@ -242,7 +273,7 @@ pub fn do_listen(tid: ThreadIdentifier, request: ListenSocketRequest) -> Message
 // do_getpeername
 //==================================================================================================
 
-pub fn do_getpeername(tid: ThreadIdentifier, request: GetPeerNameRequest) -> Message {
+pub fn do_getpeername(tid: ThreadIdentifier, request: GetPeerNameRequest) -> Result<Message, WorkerThreadError> {
     trace!("getpeername(): tid={tid:?}, request={request:?}");
 
     let sockfd: libc::c_int = request.sockfd;
@@ -254,10 +285,16 @@ pub fn do_getpeername(tid: ThreadIdentifier, request: GetPeerNameRequest) -> Mes
     match unsafe { libc::getpeername(sockfd, &mut address, &mut address_len) } {
         -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::getpeername(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
         _ => {
             let sockaddr: sockaddr = sockaddr {
@@ -265,7 +302,7 @@ pub fn do_getpeername(tid: ThreadIdentifier, request: GetPeerNameRequest) -> Mes
                 sa_family: address.sa_family as u8,
                 sa_data: unsafe { core::mem::transmute::<[i8; 14], [u8; 14]>(address.sa_data) },
             };
-            GetPeerNameResponse::build(tid, &sockaddr)
+            Ok(GetPeerNameResponse::build(tid, &sockaddr))
         },
     }
 }
@@ -274,7 +311,7 @@ pub fn do_getpeername(tid: ThreadIdentifier, request: GetPeerNameRequest) -> Mes
 // do_getsockname
 //==================================================================================================
 
-pub fn do_getsockname(tid: ThreadIdentifier, request: GetSockNameRequest) -> Message {
+pub fn do_getsockname(tid: ThreadIdentifier, request: GetSockNameRequest) -> Result<Message, WorkerThreadError> {
     trace!("getsockname(): tid={tid:?}, request={request:?}");
 
     let sockfd: libc::c_int = request.sockfd;
@@ -286,11 +323,17 @@ pub fn do_getsockname(tid: ThreadIdentifier, request: GetSockNameRequest) -> Mes
     match unsafe { libc::getsockname(sockfd, &mut address, &mut address_len) } {
         -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::getsockname(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
             error!("libc::getsockname(): {error:?}");
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
         _ => {
             let sockaddr: sockaddr = sockaddr {
@@ -298,7 +341,7 @@ pub fn do_getsockname(tid: ThreadIdentifier, request: GetSockNameRequest) -> Mes
                 sa_family: address.sa_family as u8,
                 sa_data: unsafe { core::mem::transmute::<[i8; 14], [u8; 14]>(address.sa_data) },
             };
-            GetSockNameResponse::build(tid, &sockaddr)
+            Ok(GetSockNameResponse::build(tid, &sockaddr))
         },
     }
 }
@@ -307,7 +350,7 @@ pub fn do_getsockname(tid: ThreadIdentifier, request: GetSockNameRequest) -> Mes
 // do_accept
 //==================================================================================================
 
-pub fn do_accept(tid: ThreadIdentifier, request: AcceptSocketRequest) -> Message {
+pub fn do_accept(tid: ThreadIdentifier, request: AcceptSocketRequest) -> Result<Message, WorkerThreadError> {
     trace!("accept(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
@@ -319,10 +362,16 @@ pub fn do_accept(tid: ThreadIdentifier, request: AcceptSocketRequest) -> Message
     match unsafe { libc::accept(sockfd, &mut address, &mut address_len) } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::accept(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
         sockfd => {
             let sockaddr: sockaddr = sockaddr {
@@ -330,7 +379,7 @@ pub fn do_accept(tid: ThreadIdentifier, request: AcceptSocketRequest) -> Message
                 sa_family: address.sa_family as u8,
                 sa_data: unsafe { core::mem::transmute::<[i8; 14], [u8; 14]>(address.sa_data) },
             };
-            AcceptSocketResponse::build(tid, sockfd, &sockaddr)
+            Ok(AcceptSocketResponse::build(tid, sockfd, &sockaddr))
         },
     }
 }
@@ -339,13 +388,13 @@ pub fn do_accept(tid: ThreadIdentifier, request: AcceptSocketRequest) -> Message
 // do_recv
 //==================================================================================================
 
-pub fn do_recv(tid: ThreadIdentifier, request: ReceiveSocketRequest) -> Message {
+pub fn do_recv(tid: ThreadIdentifier, request: ReceiveSocketRequest) -> Result<Message, WorkerThreadError> {
     trace!("recv(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
     let flags: LibcMessageFlags = match LibcMessageFlags::try_from(request.flags) {
         Ok(flags) => flags,
-        Err(e) => return crate::build_error(tid, e.code),
+        Err(e) => return Ok(crate::build_error(tid, e.code)),
     };
 
     let recv_len: usize = cmp::min(ReceiveSocketResponse::BUFFER_SIZE, request.count as usize);
@@ -359,14 +408,20 @@ pub fn do_recv(tid: ThreadIdentifier, request: ReceiveSocketRequest) -> Message 
     } {
         count if count >= 0 => {
             debug!("libc::recv(): count={count:?}");
-            ReceiveSocketResponse::build(tid, count as c_size_t, buffer)
+            Ok(ReceiveSocketResponse::build(tid, count as c_size_t, buffer))
         },
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::recv(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
         _ => unreachable!("libc::recv() returned invalid value"),
     }
@@ -376,7 +431,7 @@ pub fn do_recv(tid: ThreadIdentifier, request: ReceiveSocketRequest) -> Message 
 // do_shutdown
 //==================================================================================================
 
-pub fn do_shutdown(tid: ThreadIdentifier, request: ShutdownSocketRequest) -> Message {
+pub fn do_shutdown(tid: ThreadIdentifier, request: ShutdownSocketRequest) -> Result<Message, WorkerThreadError> {
     trace!("shutdown(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
@@ -384,13 +439,19 @@ pub fn do_shutdown(tid: ThreadIdentifier, request: ShutdownSocketRequest) -> Mes
 
     debug!("libc::shutdown(): sockfd={sockfd:?}, how={:?}", how.inner());
     match unsafe { libc::shutdown(sockfd, how.inner()) } {
-        0 => ShutdownSocketResponse::build(tid),
+        0 => Ok(ShutdownSocketResponse::build(tid)),
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::shutdown(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
         ret => unreachable!("libc::shutdown() returned invalid value {ret:?}"),
     }
@@ -400,14 +461,14 @@ pub fn do_shutdown(tid: ThreadIdentifier, request: ShutdownSocketRequest) -> Mes
 // do_send
 //==================================================================================================
 
-pub fn do_send(tid: ThreadIdentifier, request: SendSocketRequest) -> Message {
+pub fn do_send(tid: ThreadIdentifier, request: SendSocketRequest) -> Result<Message, WorkerThreadError> {
     trace!("send(): tid={tid:?}, request={request:?}");
 
     let sockfd: i32 = request.sockfd;
     let count: c_size_t = request.count;
     let flags: LibcMessageFlags = match LibcMessageFlags::try_from(request.flags) {
         Ok(flags) => flags,
-        Err(e) => return crate::build_error(tid, e.code),
+        Err(e) => return Ok(crate::build_error(tid, e.code)),
     };
     let buffer: [u8; SendSocketRequest::BUFFER_SIZE] = request.buffer;
 
@@ -420,14 +481,20 @@ pub fn do_send(tid: ThreadIdentifier, request: SendSocketRequest) -> Message {
     } {
         count if count >= 0 => {
             debug!("libc::send(): count={count:?}");
-            SendSocketResponse::build(tid, count as c_ssize_t)
+            Ok(SendSocketResponse::build(tid, count as c_ssize_t))
         },
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::send(): failed with errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
         _ => unreachable!("libc::send() returned invalid value"),
     }

--- a/src/daemons/linuxd/src/times.rs
+++ b/src/daemons/linuxd/src/times.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::error::WorkerThreadError;
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
@@ -20,7 +21,7 @@ use ::syscall::sys::times::message::{
 // do_times()
 //==================================================================================================
 
-pub fn do_times(tid: ThreadIdentifier, _request: TimesRequest) -> Message {
+pub fn do_times(tid: ThreadIdentifier, _request: TimesRequest) -> Result<Message, WorkerThreadError> {
     trace!("times(): tid={tid:?}");
 
     let mut libc_buffer: libc::tms = libc::tms {
@@ -35,9 +36,15 @@ pub fn do_times(tid: ThreadIdentifier, _request: TimesRequest) -> Message {
     match unsafe { libc::times(&mut libc_buffer as *mut libc::tms) } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             error!("libc::clock_getres(): errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno).expect("unknown error code {error}");
-            crate::build_error(tid, error)
+            Ok(crate::build_error(tid, error))
         },
         elapsed => {
             debug!(
@@ -57,7 +64,7 @@ pub fn do_times(tid: ThreadIdentifier, _request: TimesRequest) -> Message {
                 tms_cstime: libc_buffer.tms_cstime,
             };
 
-            TimesResponse::build(tid, elapsed, nanvix_buffer)
+            Ok(TimesResponse::build(tid, elapsed, nanvix_buffer))
         },
     }
 }

--- a/src/daemons/linuxd/src/unistd.rs
+++ b/src/daemons/linuxd/src/unistd.rs
@@ -80,14 +80,14 @@ use ::syscall::{
 // do_chdir
 //==================================================================================================
 
-pub fn do_chdir(tid: ThreadIdentifier, request: ChangeDirectoryRequest) -> Vec<Message> {
+pub fn do_chdir(tid: ThreadIdentifier, request: ChangeDirectoryRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("do_chdir(): tid={tid:?}, request={request:?}");
 
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
         Err(error) => {
             error!("do_chdir(): invalid path (error={error:?})");
-            return vec![crate::build_error(tid, ErrorCode::InvalidArgument)];
+            return Ok(vec![crate::build_error(tid, ErrorCode::InvalidArgument)]);
         },
     };
 
@@ -95,16 +95,22 @@ pub fn do_chdir(tid: ThreadIdentifier, request: ChangeDirectoryRequest) -> Vec<M
     match unsafe { libc::chdir(path.as_ptr()) } {
         0 => {
             debug!("do_chdir(): chdir() succeeded");
-            vec![ChangeDirectoryResponse::build(tid)]
+            Ok(vec![ChangeDirectoryResponse::build(tid)])
         },
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::chdir(): errno={errno:?}");
-            vec![crate::build_error(
+            Ok(vec![crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )]
+            )])
         },
     }
 }
@@ -122,12 +128,14 @@ pub fn do_close(tid: ThreadIdentifier, request: CloseRequest) -> Result<Message,
     match unsafe { libc::close(fd) } {
         ret if ret == 0 => Ok(CloseResponse::build(tid, ret)),
         _ => {
+            let errno: i32 = unsafe { *libc::__errno_location() };
+
             // Check if the thread has been interrupted.
-            let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(libc::EINTR) {
+            if errno == libc::EINTR {
                 return Err(WorkerThreadError::Interrupted);
             }
 
+            debug!("libc::close(): errno={errno:?}");
             Ok(crate::build_error(tid, ErrorCode::InvalidArgument))
         }
     }
@@ -137,14 +145,14 @@ pub fn do_close(tid: ThreadIdentifier, request: CloseRequest) -> Result<Message,
 // do_faccessat
 //==================================================================================================
 
-pub fn do_faccessat(tid: ThreadIdentifier, request: FileAccessAtRequest) -> Vec<Message> {
+pub fn do_faccessat(tid: ThreadIdentifier, request: FileAccessAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("faccessat(): tid={request:?}, request={tid:?}");
 
     let dirfd: c_int = request.dirfd;
     let dirfd: LibcAtFlags = LibcAtFlags::from(dirfd);
     let path: CString = match CString::new(request.path.as_str()) {
         Ok(path) => path,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidArgument)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidArgument)]),
     };
     let amode: i32 = request.mode;
     let flag: LibcAtFlags = LibcAtFlags::from(request.flag);
@@ -155,15 +163,21 @@ pub fn do_faccessat(tid: ThreadIdentifier, request: FileAccessAtRequest) -> Vec<
         flag.inner()
     );
     match unsafe { libc::faccessat(dirfd.inner(), path.as_ptr(), amode, flag.inner()) } {
-        0 => vec![FileAccessAtResponse::build(tid)],
+        0 => Ok(vec![FileAccessAtResponse::build(tid)]),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::faccessat(): errno={errno:?}");
-            vec![crate::build_error(
+            Ok(vec![crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )]
+            )])
         },
     }
 }
@@ -172,22 +186,28 @@ pub fn do_faccessat(tid: ThreadIdentifier, request: FileAccessAtRequest) -> Vec<
 // do_fdatasync
 //==================================================================================================
 
-pub fn do_fdatasync(tid: ThreadIdentifier, request: FileDataSyncRequest) -> Message {
+pub fn do_fdatasync(tid: ThreadIdentifier, request: FileDataSyncRequest) -> Result<Message, WorkerThreadError> {
     trace!("fdatasync(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
 
     debug!("libc::fdatasync(): fd={fd:?}");
     match unsafe { libc::fdatasync(fd) } {
-        ret if ret == 0 => FileDataSyncResponse::build(tid, ret),
+        ret if ret == 0 => Ok(FileDataSyncResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::fdatasync(): errno={errno:?}");
-            crate::build_error(
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
     }
 }
@@ -196,7 +216,7 @@ pub fn do_fdatasync(tid: ThreadIdentifier, request: FileDataSyncRequest) -> Mess
 // do_getids
 //==================================================================================================
 
-pub fn do_getids(tid: ThreadIdentifier, _request: GetIdsRequest) -> Message {
+pub fn do_getids(tid: ThreadIdentifier, _request: GetIdsRequest) -> Result<Message, WorkerThreadError> {
     trace!("getids(): tid={tid:?}");
 
     // Get user ID.
@@ -216,14 +236,14 @@ pub fn do_getids(tid: ThreadIdentifier, _request: GetIdsRequest) -> Message {
     debug!("libc::getegid(): egid={egid:?}");
 
     // Build response.
-    GetIdsResponse::build(tid, uid, gid, euid, egid)
+    Ok(GetIdsResponse::build(tid, uid, gid, euid, egid))
 }
 
 //==================================================================================================
 // do_getcwd
 //==================================================================================================
 
-pub fn do_getcwd(tid: ThreadIdentifier) -> Vec<Message> {
+pub fn do_getcwd(tid: ThreadIdentifier) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("getcwd(): tid={tid:?}");
 
     let mut buf: Vec<u8> = Vec::with_capacity(PATH_MAX as libc::size_t);
@@ -241,31 +261,37 @@ pub fn do_getcwd(tid: ThreadIdentifier) -> Vec<Message> {
                         Ok(response) => response,
                         Err(error) => {
                             warn!("do_getcwd(): {error:?}");
-                            return vec![crate::build_error(tid, error.code)];
+                            return Ok(vec![crate::build_error(tid, error.code)]);
                         },
                     }
                 },
                 // Failure.
                 Err(error) => {
                     error!("do_getcwd(): invalid path (error={error:?})");
-                    return vec![crate::build_error(tid, ErrorCode::InvalidArgument)];
+                    return Ok(vec![crate::build_error(tid, ErrorCode::InvalidArgument)]);
                 },
             };
 
         // Build response parts and check for errors.
         match response.into_parts(tid) {
-            Ok(messages) => messages,
+            Ok(messages) => Ok(messages),
             Err(error) => {
                 warn!("do_getcwd(): {error:?}");
-                vec![crate::build_error(tid, error.code)]
+                Ok(vec![crate::build_error(tid, error.code)])
             },
         }
     } else {
         let errno: i32 = unsafe { *libc::__errno_location() };
+
+        // Check if the thread has been interrupted.
+        if errno == libc::EINTR {
+            return Err(WorkerThreadError::Interrupted);
+        }
+
         debug!("libc::getcwd(): errno={tid:?}");
         let error: ErrorCode =
             ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-        vec![crate::build_error(tid, error)]
+        Ok(vec![crate::build_error(tid, error)])
     }
 }
 
@@ -273,22 +299,28 @@ pub fn do_getcwd(tid: ThreadIdentifier) -> Vec<Message> {
 // do_fsync
 //==================================================================================================
 
-pub fn do_fsync(tid: ThreadIdentifier, request: FileSyncRequest) -> Message {
+pub fn do_fsync(tid: ThreadIdentifier, request: FileSyncRequest) -> Result<Message, WorkerThreadError> {
     trace!("fsync(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
 
     debug!("libc::fsync(): fd={fd:?}");
     match unsafe { libc::fsync(fd) } {
-        ret if ret == 0 => FileSyncResponse::build(tid, ret),
+        ret if ret == 0 => Ok(FileSyncResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::fsync(): errno={errno:?}");
-            crate::build_error(
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
     }
 }
@@ -297,27 +329,33 @@ pub fn do_fsync(tid: ThreadIdentifier, request: FileSyncRequest) -> Message {
 // do_lseek
 //==================================================================================================
 
-pub fn do_lseek(tid: ThreadIdentifier, request: SeekRequest) -> Message {
+pub fn do_lseek(tid: ThreadIdentifier, request: SeekRequest) -> Result<Message, WorkerThreadError> {
     trace!("lseek(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
     let offset: i64 = request.offset;
     let whence: LibcSeek = match LibcSeek::try_from(request.whence) {
         Ok(whence) => whence,
-        Err(_) => return crate::build_error(tid, ErrorCode::InvalidMessage),
+        Err(_) => return Ok(crate::build_error(tid, ErrorCode::InvalidMessage)),
     };
 
     debug!("libc::lseek(): fd={:?}, offset={:?}, whence={:?}", fd, offset, whence.inner());
     match unsafe { libc::lseek(fd, offset, whence.inner()) } {
-        ret if ret >= 0 => SeekResponse::build(tid, ret),
+        ret if ret >= 0 => Ok(SeekResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::lseek(): errno={errno:?}");
-            crate::build_error(
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
     }
 }
@@ -326,7 +364,7 @@ pub fn do_lseek(tid: ThreadIdentifier, request: SeekRequest) -> Message {
 // do_ftruncate
 //==================================================================================================
 
-pub fn do_ftruncate(tid: ThreadIdentifier, request: FileTruncateRequest) -> Message {
+pub fn do_ftruncate(tid: ThreadIdentifier, request: FileTruncateRequest) -> Result<Message, WorkerThreadError> {
     trace!("ftruncate(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
@@ -334,15 +372,21 @@ pub fn do_ftruncate(tid: ThreadIdentifier, request: FileTruncateRequest) -> Mess
 
     debug!("libc::ftruncate(): fd={fd:?}, length={length:?}");
     match unsafe { libc::ftruncate(fd, length) } {
-        ret if ret == 0 => FileTruncateResponse::build(tid, ret),
+        ret if ret == 0 => Ok(FileTruncateResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::ftruncate(): errno={errno:?}");
-            crate::build_error(
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
     }
 }
@@ -425,12 +469,12 @@ pub fn do_read(tid: ThreadIdentifier, request: ReadRequest) -> Result<Message, W
 // do_pwrite
 //==================================================================================================
 
-pub fn do_pwrite(tid: ThreadIdentifier, request: PartialWriteRequest) -> Message {
+pub fn do_pwrite(tid: ThreadIdentifier, request: PartialWriteRequest) -> Result<Message, WorkerThreadError> {
     trace!("pwrite(): tid={tid:?}, request={request:?}");
 
     // Check if count is invalid.
     if request.count > PartialWriteRequest::BUFFER_SIZE as c_size_t {
-        return crate::build_error(tid, ErrorCode::InvalidArgument);
+        return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
     }
     let fd: i32 = request.fd;
     let count: usize = request.count as usize;
@@ -440,15 +484,21 @@ pub fn do_pwrite(tid: ThreadIdentifier, request: PartialWriteRequest) -> Message
 
     debug!("libc::pwrite(): fd={fd:?}, count={count:?}, offset={offset:?}, buffer={buffer:?}",);
     match unsafe { libc::pwrite(fd, buffer.as_ptr() as *const _, count, offset) } {
-        ret if ret >= 0 => PartialWriteResponse::build(tid, ret as c_ssize_t),
+        ret if ret >= 0 => Ok(PartialWriteResponse::build(tid, ret as c_ssize_t)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::pwrite(): errno={errno:?}");
-            crate::build_error(
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
     }
 }
@@ -457,12 +507,12 @@ pub fn do_pwrite(tid: ThreadIdentifier, request: PartialWriteRequest) -> Message
 // do_pread
 //==================================================================================================
 
-pub fn do_pread(tid: ThreadIdentifier, request: PartialReadRequest) -> Message {
+pub fn do_pread(tid: ThreadIdentifier, request: PartialReadRequest) -> Result<Message, WorkerThreadError> {
     trace!("pread(): tid={tid:?}, request={request:?}");
 
     // Check if count is invalid.
     if request.count > PartialReadResponse::BUFFER_SIZE as c_size_t {
-        return crate::build_error(tid, ErrorCode::InvalidArgument);
+        return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
     }
     let fd: i32 = request.fd;
     let count: usize = request.count as usize;
@@ -472,15 +522,21 @@ pub fn do_pread(tid: ThreadIdentifier, request: PartialReadRequest) -> Message {
 
     debug!("libc::pread(): fd={fd:?}, count={count:?}, offset={offset:?}, buffer={buffer:?}",);
     match unsafe { libc::pread(fd, buffer.as_mut_ptr() as *mut _, count, offset) } {
-        ret if ret >= 0 => PartialReadResponse::build(tid, ret as c_ssize_t, buffer),
+        ret if ret >= 0 => Ok(PartialReadResponse::build(tid, ret as c_ssize_t, buffer)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::pread(): errno={errno:?}");
-            crate::build_error(
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
     }
 }
@@ -489,18 +545,18 @@ pub fn do_pread(tid: ThreadIdentifier, request: PartialReadRequest) -> Message {
 // do_linkat
 //==================================================================================================
 
-pub fn do_linkat(tid: ThreadIdentifier, request: LinkAtRequest) -> Vec<Message> {
+pub fn do_linkat(tid: ThreadIdentifier, request: LinkAtRequest) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("linkat(): tid={tid:?}, request={request:?}");
 
     let olddirfd: i32 = request.olddirfd;
     let oldpath: CString = match CString::new(request.oldpath.as_str()) {
         Ok(oldpath) => oldpath,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidArgument)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidArgument)]),
     };
     let newdirfd: i32 = request.newdirfd;
     let newpath: CString = match CString::new(request.newpath.as_str()) {
         Ok(newpath) => newpath,
-        Err(_) => return vec![crate::build_error(tid, ErrorCode::InvalidArgument)],
+        Err(_) => return Ok(vec![crate::build_error(tid, ErrorCode::InvalidArgument)]),
     };
     let flags: i32 = request.flags;
 
@@ -509,15 +565,21 @@ pub fn do_linkat(tid: ThreadIdentifier, request: LinkAtRequest) -> Vec<Message> 
          newpath={newpath:?}, flags={flags:?}",
     );
     match unsafe { libc::linkat(olddirfd, oldpath.as_ptr(), newdirfd, newpath.as_ptr(), flags) } {
-        ret if ret == 0 => vec![LinkAtResponse::build(tid, ret)],
+        ret if ret == 0 => Ok(vec![LinkAtResponse::build(tid, ret)]),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::linkat(): errno={errno:?}");
-            vec![crate::build_error(
+            Ok(vec![crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )]
+            )])
         },
     }
 }
@@ -527,21 +589,27 @@ pub fn do_linkat(tid: ThreadIdentifier, request: LinkAtRequest) -> Vec<Message> 
 //==================================================================================================
 
 /// Changes the current working directory.
-pub fn do_fchdir(tid: ThreadIdentifier, request: FileChdirRequest) -> Message {
+pub fn do_fchdir(tid: ThreadIdentifier, request: FileChdirRequest) -> Result<Message, WorkerThreadError> {
     trace!("fchdir(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
 
     debug!("libc::fchdir(): fd={fd:?}");
     match unsafe { libc::fchdir(fd) } {
-        0 => FileChdirResponse::build(tid),
+        0 => Ok(FileChdirResponse::build(tid)),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
-            crate::build_error(
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
         ret => unreachable!("libc::fchdir() returned an invalid value ({:?})", ret),
     }
@@ -551,7 +619,7 @@ pub fn do_fchdir(tid: ThreadIdentifier, request: FileChdirRequest) -> Message {
 // do_fchown
 //==================================================================================================
 
-pub fn do_fchown(tid: ThreadIdentifier, request: FileChownRequest) -> Message {
+pub fn do_fchown(tid: ThreadIdentifier, request: FileChownRequest) -> Result<Message, WorkerThreadError> {
     trace!("fchown(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
@@ -560,14 +628,20 @@ pub fn do_fchown(tid: ThreadIdentifier, request: FileChownRequest) -> Message {
 
     debug!("libc::fchown(): fd={fd:?}, owner={owner:?}, group={group:?}");
     match unsafe { libc::fchown(fd, owner, group) } {
-        0 => FileChownResponse::build(tid),
+        0 => Ok(FileChownResponse::build(tid)),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
-            crate::build_error(
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
         ret => unreachable!("libc::fchown() returned an invalid value ({:?})", ret),
     }
@@ -577,7 +651,7 @@ pub fn do_fchown(tid: ThreadIdentifier, request: FileChownRequest) -> Message {
 // do_pipe
 //==================================================================================================
 
-pub fn do_pipe(tid: ThreadIdentifier) -> Message {
+pub fn do_pipe(tid: ThreadIdentifier) -> Result<Message, WorkerThreadError> {
     trace!("pipe(): tid={tid:?}");
 
     let mut fds: [i32; 2] = [0; 2];
@@ -589,16 +663,22 @@ pub fn do_pipe(tid: ThreadIdentifier) -> Message {
             let write_fd: i32 = fds[1];
 
             debug!("pipe(): read_fd={read_fd:?}, write_fd={write_fd:?}");
-            PipeResponse::build(tid, read_fd, write_fd)
+            Ok(PipeResponse::build(tid, read_fd, write_fd))
         },
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::pipe(): errno={errno:?}");
-            crate::build_error(
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
     }
 }

--- a/src/daemons/linuxd/src/unistd.rs
+++ b/src/daemons/linuxd/src/unistd.rs
@@ -5,7 +5,10 @@
 // Imports
 //==================================================================================================
 
-use crate::fcntl::LibcAtFlags;
+use crate::{
+    error::WorkerThreadError,
+    fcntl::LibcAtFlags,
+};
 use ::alloc::ffi::CString;
 use ::core::{
     ffi,
@@ -110,15 +113,23 @@ pub fn do_chdir(tid: ThreadIdentifier, request: ChangeDirectoryRequest) -> Vec<M
 // do_close
 //==================================================================================================
 
-pub fn do_close(tid: ThreadIdentifier, request: CloseRequest) -> Message {
+pub fn do_close(tid: ThreadIdentifier, request: CloseRequest) -> Result<Message, WorkerThreadError> {
     trace!("close(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
 
     debug!("libc::close(): fd={fd:?}");
     match unsafe { libc::close(fd) } {
-        ret if ret == 0 => CloseResponse::build(tid, ret),
-        _ => crate::build_error(tid, ErrorCode::InvalidArgument),
+        ret if ret == 0 => Ok(CloseResponse::build(tid, ret)),
+        _ => {
+            // Check if the thread has been interrupted.
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
+            Ok(crate::build_error(tid, ErrorCode::InvalidArgument))
+        }
     }
 }
 
@@ -340,12 +351,12 @@ pub fn do_ftruncate(tid: ThreadIdentifier, request: FileTruncateRequest) -> Mess
 // do_write
 //==================================================================================================
 
-pub fn do_write(tid: ThreadIdentifier, request: WriteRequest) -> Message {
+pub fn do_write(tid: ThreadIdentifier, request: WriteRequest) -> Result<Message, WorkerThreadError> {
     trace!("write(): tid={tid:?}, request={request:?}");
 
     // Check if count is invalid.
     if request.count > WriteRequest::BUFFER_SIZE as c_size_t {
-        return crate::build_error(tid, ErrorCode::InvalidArgument);
+        return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
     }
     let fd: i32 = request.fd;
     let count: usize = request.count as usize;
@@ -354,15 +365,21 @@ pub fn do_write(tid: ThreadIdentifier, request: WriteRequest) -> Message {
 
     debug!("libc::write(): fd={fd:?}, buffer={buffer:?}");
     match unsafe { libc::write(fd, buffer.as_ptr() as *const _, count) } {
-        ret if ret >= 0 => WriteResponse::build(tid, ret as i32),
+        ret if ret >= 0 => Ok(WriteResponse::build(tid, ret as i32)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::write(): errno={errno:?}");
-            crate::build_error(
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
     }
 }
@@ -371,12 +388,12 @@ pub fn do_write(tid: ThreadIdentifier, request: WriteRequest) -> Message {
 // do_read
 //==================================================================================================
 
-pub fn do_read(tid: ThreadIdentifier, request: ReadRequest) -> Message {
+pub fn do_read(tid: ThreadIdentifier, request: ReadRequest) -> Result<Message, WorkerThreadError> {
     trace!("read(): tid={tid:?}, request={request:?}");
 
     // Check if count is invalid.
     if request.count > ReadResponse::BUFFER_SIZE as c_size_t {
-        return crate::build_error(tid, ErrorCode::InvalidArgument);
+        return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
     }
     let fd: i32 = request.fd;
     let count: usize = request.count as usize;
@@ -385,15 +402,21 @@ pub fn do_read(tid: ThreadIdentifier, request: ReadRequest) -> Message {
 
     debug!("libc::read(): fd={fd:?}, buffer={buffer:?}");
     match unsafe { libc::read(fd, buffer.as_mut_ptr() as *mut _, count) } {
-        ret if ret >= 0 => ReadResponse::build(tid, ret as i32, buffer),
+        ret if ret >= 0 => Ok(ReadResponse::build(tid, ret as i32, buffer)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
+
+            // Check if the thread has been interrupted.
+            if errno == libc::EINTR {
+                return Err(WorkerThreadError::Interrupted);
+            }
+
             debug!("libc::read(): errno={errno:?}");
-            crate::build_error(
+            Ok(crate::build_error(
                 tid,
                 ErrorCode::try_from(errno)
                     .unwrap_or_else(|_| panic!("invalid error code: {ret:?}")),
-            )
+            ))
         },
     }
 }

--- a/src/daemons/linuxd/src/venv.rs
+++ b/src/daemons/linuxd/src/venv.rs
@@ -33,6 +33,16 @@ use ::syscall::venv::VirtualEnvironmentIdentifier;
 ///
 /// # Description
 ///
+/// Commands that we can send to a worker thread in a virtal environment.
+///
+pub enum VenvCommand {
+    Work(Message),
+    Shutdown,
+}
+
+///
+/// # Description
+///
 /// Virtual environment.
 ///
 #[derive(Debug)]
@@ -44,7 +54,7 @@ pub struct VirtualEnvironment {
     stdin_response_tx: Sender<Message>,
     stdin_response_rx: Receiver<Message>,
     /// Input channel to this virtual environment.
-    channel_tx: Sender<Message>,
+    channel_tx: Sender<VenvCommand>,
 }
 
 ///
@@ -69,7 +79,7 @@ impl VirtualEnvironment {
     ///
     /// Creates a new virtual environment.
     ///
-    fn new(id: VirtualEnvironmentIdentifier, channel_tx: Sender<Message>) -> Self {
+    fn new(id: VirtualEnvironmentIdentifier, channel_tx: Sender<VenvCommand>) -> Self {
         let (stdin_response_tx, stdin_response_rx) = mpsc::channel::<Message>();
 
         Self {
@@ -118,7 +128,7 @@ impl VirtualEnvironment {
     ///
     /// A transmitter channel for the virtual environment.
     ///
-    pub fn get_channel_tx(&self) -> Sender<Message> {
+    pub fn get_channel_tx(&self) -> Sender<VenvCommand> {
         self.channel_tx.clone()
     }
 }
@@ -158,7 +168,7 @@ impl VirtualEnviromentDirectory {
         &mut self,
         tid: ThreadIdentifier,
         mut envid: VirtualEnvironmentIdentifier,
-    ) -> Result<(VirtualEnvironmentIdentifier, Sender<Message>, Receiver<Message>), Error> {
+    ) -> Result<(VirtualEnvironmentIdentifier, Sender<VenvCommand>, Receiver<VenvCommand>), Error> {
         trace!("join(): tid={tid:?}, envid={envid:?}");
 
         // Check if the process is already in an environment.
@@ -175,7 +185,7 @@ impl VirtualEnviromentDirectory {
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
 
-        let (channel_tx, channel_rx): (Sender<Message>, Receiver<Message>) = channel::<Message>();
+        let (channel_tx, channel_rx): (Sender<VenvCommand>, Receiver<VenvCommand>) = channel::<VenvCommand>();
 
         // Thread requested to join a new environment.
         envid = self.next_env;

--- a/src/daemons/linuxd/src/venv.rs
+++ b/src/daemons/linuxd/src/venv.rs
@@ -33,7 +33,7 @@ use ::syscall::venv::VirtualEnvironmentIdentifier;
 ///
 /// # Description
 ///
-/// Commands that we can send to a worker thread in a virtal environment.
+/// Commands that we can send to a worker thread in a virtual environment.
 ///
 pub enum VenvCommand {
     Work(Message),

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -1,0 +1,872 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![deny(clippy::all)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use crate::{
+    build_error,
+    dirent,
+    error::WorkerThreadError,
+    fcntl,
+    message::{
+        RequestAssembler,
+        RequestAssemblerTrait,
+    },
+    poll,
+    socket,
+    times,
+    unistd,
+    venv::{
+        VirtualEnvironment,
+        VirtualEnviromentDirectory,
+    },
+};
+use ::nix::{
+    libc,
+    sys::{
+        pthread::{
+            pthread_self,
+            pthread_kill
+        },
+        signal::{
+            self,
+            Signal,
+            SigAction,
+            SigHandler,
+            SaFlags,
+            SigSet
+        }
+    },
+};
+use ::std::{
+    io::ErrorKind,
+    sync::{
+        atomic::{
+            AtomicUsize,
+            Ordering
+        },
+        mpsc::{
+            Receiver,
+            Sender,
+        },
+        Arc,
+        Mutex,
+        MutexGuard,
+    },
+    thread::{
+        self,
+        JoinHandle,
+        ThreadId,
+    }
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    ipc::{
+        Message,
+        MessageReceiver,
+        MessageSender,
+        MessageType,
+    },
+    pm::ThreadIdentifier,
+};
+use ::sysapi::unistd::{
+    STDERR_FILENO,
+    STDIN_FILENO,
+    STDOUT_FILENO,
+};
+use ::syscall::{
+    dirent::message::GetDirectoryEntriesRequest,
+    fcntl::message::{
+        FileAdvisoryInformationRequest,
+        FileControlRequest,
+        FileSpaceControlRequest,
+        OpenAtRequest,
+        RenameAtRequest,
+        UnlinkAtRequest,
+    },
+    message::LinuxDaemonMessagePart,
+    sys::{
+        socket::message::{
+            AcceptSocketRequest,
+            BindSocketRequest,
+            ConnectSocketRequest,
+            CreateSocketPairRequest,
+            CreateSocketRequest,
+            GetPeerNameRequest,
+            GetSockNameRequest,
+            ListenSocketRequest,
+            ReceiveSocketRequest,
+            SendSocketRequest,
+            ShutdownSocketRequest,
+        },
+        stat::message::{
+            FileChmodAtRequest,
+            FileChmodRequest,
+            FileStatAtRequest,
+            FileStatRequest,
+            MakeDirectoryAtRequest,
+            UpdateFileAccessTimeAtRequest,
+            UpdateFileAccessTimeRequest,
+        },
+        times::message::TimesRequest,
+    },
+    unistd::message::{
+        ChangeDirectoryRequest,
+        CloseRequest,
+        CloseResponse,
+        FileAccessAtRequest,
+        FileChdirRequest,
+        FileChownAtRequest,
+        FileChownRequest,
+        FileDataSyncRequest,
+        FileSyncRequest,
+        FileTruncateRequest,
+        GetIdsRequest,
+        LinkAtRequest,
+        PartialReadRequest,
+        PartialWriteRequest,
+        PipeRequest,
+        ReadLinkAtRequest,
+        ReadRequest,
+        ReadResponse,
+        SeekRequest,
+        SymbolicLinkAtRequest,
+        WriteRequest,
+        WriteResponse,
+    },
+    LinuxDaemonMessage,
+    LinuxDaemonMessageHeader,
+    LINUXD,
+};
+use ::syscomm::SocketStream;
+
+const INTERRUPT_SIGNAL: Signal = Signal::SIGUSR1;
+
+/// State associated with a worker thread in linuxd.
+pub struct WorkerThreadHandle {
+    // Internal thread identifier in linuxd.
+    pub id: ThreadIdentifier,
+    // Underlying tid returned by pthread.
+    pub pthread_id: Arc<AtomicUsize>,
+    pub handle: JoinHandle<()>,
+}
+
+/// Our signal handler is a no-op that will just interrupt any blocking system calls, and make the
+/// thread error and return EINTR.
+extern "C" fn linuxd_worker_thread_signal_handler(_: i32) {}
+
+impl WorkerThreadHandle {
+    fn install_signal_handler() {
+        let sig_action = SigAction::new(
+            SigHandler::Handler(linuxd_worker_thread_signal_handler),
+            // Empty flags to make sure the thread does not restart blocked system calls and exits
+            // with EINTR.
+            SaFlags::empty(),
+            // Do not block any other signals that may happen during signal handling.
+            SigSet::empty(),
+        );
+
+        // SAFETY: we install a signal handler that is a no-op so this is safe.
+        unsafe {
+            signal::sigaction(INTERRUPT_SIGNAL, &sig_action).expect("sigaction failed");
+        }
+    }
+
+    /// Spawn an interruptible worker thread.
+    pub fn spawn(
+        id: ThreadIdentifier,
+        channel_rx: Receiver<Message>,
+        uvm_stream: Arc<Mutex<SocketStream>>,
+        gw_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
+        gw_stdout_tx: Option<Sender<WriteRequest>>,
+        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        assembler: Arc<Mutex<RequestAssembler>>,
+    ) ->Result<Self, Error> {
+        // We use an atomic to pass the id of the created thread back to the caller context. We
+        // need this because std::thread's JoinHandle does not expose the tid.
+        let pthread_id_holder = Arc::new(AtomicUsize::new(0));
+
+        // Make copies to return as part of the thread handle.
+        let pthread_id_holder_clone = pthread_id_holder.clone();
+
+        let join_handle = thread::spawn(move || {
+            Self::install_signal_handler();
+
+            let pthread_id = pthread_self();
+            pthread_id_holder.store(pthread_id as usize, Ordering::Relaxed);
+
+            Self::handle_message(channel_rx, uvm_stream, gw_stdin_tx, gw_stdout_tx, venv, assembler);
+
+            trace!("thread shutting down after receiving interrupt (pthread_id={pthread_id})");
+        });
+
+        // TODO: pthread_id_holder used after move?
+        Ok(Self {
+            id,
+            pthread_id: pthread_id_holder_clone,
+            handle: join_handle,
+        })
+    }
+
+    /// Stop a worker-thread by setting the shutdown flag and sending an interrupt.
+    pub fn stop(&self) -> Result<(), Error> {
+        let raw_tid = self.pthread_id.load(Ordering::Relaxed);
+
+        if raw_tid == 0 {
+            let reason = "trying to stop thread with tid 0";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+
+        let pthread_id = raw_tid as libc::pthread_t;
+        pthread_kill(pthread_id, INTERRUPT_SIGNAL).expect("pthread_kill failed");
+
+        Ok(())
+    }
+
+        fn handle_message(
+        channel_rx: Receiver<Message>,
+        uvm_stream: Arc<Mutex<SocketStream>>,
+        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
+        gateway_stdout_tx: Option<Sender<WriteRequest>>,
+        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        assembler: Arc<Mutex<RequestAssembler>>,
+    ) {
+        let worker_tid: ThreadId = thread::current().id();
+
+        loop {
+            let message: Message = match channel_rx.recv() {
+                Ok(message) => message,
+                Err(error) => {
+                    error!(
+                        "handle_message(): failed to receive message from channel, stopping \
+                         (worker_tid={worker_tid:?}, error={error:?})"
+                    );
+                    break;
+                },
+            };
+            let source: ThreadIdentifier = match { message.source }.as_id() {
+                Err(tid) => tid,
+                Ok(_) => {
+                    unreachable!("messages that are in this channel always address threads");
+                },
+            };
+
+            match message.message_type {
+                sys::ipc::MessageType::Empty => panic!("received empty message"),
+                sys::ipc::MessageType::Interrupt => panic!("received interrupt message"),
+                sys::ipc::MessageType::Exception => panic!("received exception message"),
+                sys::ipc::MessageType::Ipc => panic!("received IPC message"),
+                sys::ipc::MessageType::ProcessTerminationEvent => {
+                    panic!("received process termination event message")
+                },
+                sys::ipc::MessageType::Ikc => {
+                    match LinuxDaemonMessage::try_from_bytes(message.payload) {
+                        Ok(message) => {
+                            let message: Message = match message.header {
+                                // The system calls are interposed before being forwarded to the
+                                // backend provider.
+                                LinuxDaemonMessageHeader::CloseRequest
+                                | LinuxDaemonMessageHeader::ReadRequest
+                                | LinuxDaemonMessageHeader::WriteRequest => {
+                                    match Self::handle_special_messages(
+                                        gateway_stdin_tx.clone(),
+                                        gateway_stdout_tx.clone(),
+                                        venv.clone(),
+                                        source,
+                                        message,
+                                    ) {
+                                        Ok(message) => message,
+                                        Err(WorkerThreadError::Interrupted) => break,
+                                        Err(WorkerThreadError::Error(e)) => {
+                                            // WorkerThreadErrors other than Interrupted should be
+                                            // caught by downstream functions, and converted to
+                                            // Messages with the appropriate return code.
+                                            unreachable!("fatal error in working thread (error={e:?})");
+                                        }
+                                    }
+                                },
+
+                                // The following system calls have their request and response
+                                // data fit in a single message. Thus, they can be immediately
+                                // forwarded to the backend provider.
+                                LinuxDaemonMessageHeader::AcceptSocketRequest
+                                | LinuxDaemonMessageHeader::BindSocketRequest
+                                | LinuxDaemonMessageHeader::ConnectSocketRequest
+                                | LinuxDaemonMessageHeader::CreateSocketPairRequest
+                                | LinuxDaemonMessageHeader::CreateSocketRequest
+                                | LinuxDaemonMessageHeader::FileAdvisoryInformationRequest
+                                | LinuxDaemonMessageHeader::FileChdirRequest
+                                | LinuxDaemonMessageHeader::FileChmodRequest
+                                | LinuxDaemonMessageHeader::FileChownRequest
+                                | LinuxDaemonMessageHeader::FileControlRequest
+                                | LinuxDaemonMessageHeader::FileDataSyncRequest
+                                | LinuxDaemonMessageHeader::FileSpaceControlRequest
+                                | LinuxDaemonMessageHeader::FileSyncRequest
+                                | LinuxDaemonMessageHeader::FileTruncateRequest
+                                | LinuxDaemonMessageHeader::GetIdsRequest
+                                | LinuxDaemonMessageHeader::GetPeerNameRequest
+                                | LinuxDaemonMessageHeader::GetSockNameRequest
+                                | LinuxDaemonMessageHeader::ListenSocketRequest
+                                | LinuxDaemonMessageHeader::PartialReadRequest
+                                | LinuxDaemonMessageHeader::PartialWriteRequest
+                                | LinuxDaemonMessageHeader::ReceiveSocketRequest
+                                | LinuxDaemonMessageHeader::SeekRequest
+                                | LinuxDaemonMessageHeader::SendSocketRequest
+                                | LinuxDaemonMessageHeader::ShutdownSocketRequest
+                                | LinuxDaemonMessageHeader::TimesRequest
+                                | LinuxDaemonMessageHeader::PipeRequest
+                                | LinuxDaemonMessageHeader::PollRequest
+                                | LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
+                                    Self::handle_short_request_messages(source, message)
+                                },
+
+                                // The following system calls have their request data fit in a
+                                // single message, but their response data is too large to fit in a
+                                // single message. Thus, their response is split into multiple
+                                // messages.
+                                LinuxDaemonMessageHeader::FileStatRequest
+                                | LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest
+                                | LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
+                                    Self::handle_long_response_messages(
+                                        uvm_stream.clone(),
+                                        source,
+                                        message,
+                                    );
+                                    continue;
+                                },
+
+                                // The following system calls have request data that is too large to
+                                // fit in a single message. Thus, their request is split into multiple
+                                // messages.
+                                LinuxDaemonMessageHeader::ChangeDirectoryRequestPart
+                                | LinuxDaemonMessageHeader::FileStatAtRequestPart
+                                | LinuxDaemonMessageHeader::FileAccessAtRequestPart
+                                | LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart
+                                | LinuxDaemonMessageHeader::LinkAtRequestPart
+                                | LinuxDaemonMessageHeader::ReadLinkAtRequestPart
+                                | LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart
+                                | LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart
+                                | LinuxDaemonMessageHeader::FileChownAtRequestPart
+                                | LinuxDaemonMessageHeader::FileChmodAtRequestPart
+                                | LinuxDaemonMessageHeader::OpenAtRequestPart
+                                | LinuxDaemonMessageHeader::RenameAtRequestPart
+                                | LinuxDaemonMessageHeader::UnlinkAtRequestPart => {
+                                    Self::handle_long_request_messages(
+                                        uvm_stream.clone(),
+                                        assembler.clone(),
+                                        source,
+                                        message,
+                                    );
+                                    continue;
+                                },
+
+                                _ => Self::do_error(source, ErrorCode::InvalidMessage),
+                            };
+                            Self::send(uvm_stream.clone(), message).unwrap();
+                        },
+                        Err(e) => {
+                            error!("failed to parse Linux daemon message (error={e:?})");
+                        },
+                    }
+                },
+            }
+        }
+    }
+
+    fn handle_special_messages(
+        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
+        gateway_stdout_tx: Option<Sender<WriteRequest>>,
+        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        source: ThreadIdentifier,
+        message: LinuxDaemonMessage,
+    ) -> Result<Message, WorkerThreadError> {
+        match message.header {
+            LinuxDaemonMessageHeader::CloseRequest => {
+                let request: CloseRequest = CloseRequest::from_bytes(message.payload);
+                Self::handle_close_request(source, request)
+            },
+            LinuxDaemonMessageHeader::ReadRequest => {
+                let request: ReadRequest = ReadRequest::from_bytes(message.payload);
+                Self::handle_read_request(gateway_stdin_tx, venv, source, request)
+            },
+            LinuxDaemonMessageHeader::WriteRequest => {
+                let request: WriteRequest = WriteRequest::from_bytes(message.payload);
+                Self::handle_write_request(gateway_stdout_tx, source, request)
+            },
+            header => {
+                // The following statement is unreachable, because the matching logic in this
+                // function should match the one in the `Self::run()` function.
+                unreachable!("unexpected special message {:?}", header)
+            },
+        }
+    }
+
+    fn handle_short_request_messages(
+        source: ThreadIdentifier,
+        message: LinuxDaemonMessage,
+    ) -> Message {
+        match message.header {
+            LinuxDaemonMessageHeader::AcceptSocketRequest => {
+                let request: AcceptSocketRequest = AcceptSocketRequest::from_bytes(message.payload);
+                socket::do_accept(source, request)
+            },
+            LinuxDaemonMessageHeader::BindSocketRequest => {
+                let request: BindSocketRequest = BindSocketRequest::from_bytes(message.payload);
+                socket::do_bind(source, request)
+            },
+            LinuxDaemonMessageHeader::ConnectSocketRequest => {
+                let request: ConnectSocketRequest =
+                    ConnectSocketRequest::from_bytes(message.payload);
+                socket::do_connect(source, request)
+            },
+            LinuxDaemonMessageHeader::CreateSocketPairRequest => {
+                let request: CreateSocketPairRequest =
+                    CreateSocketPairRequest::from_bytes(message.payload);
+                socket::do_socketpair(source, request)
+            },
+            LinuxDaemonMessageHeader::CreateSocketRequest => {
+                let request: CreateSocketRequest = CreateSocketRequest::from_bytes(message.payload);
+                socket::do_socket(source, request)
+            },
+            LinuxDaemonMessageHeader::FileAdvisoryInformationRequest => {
+                let request: FileAdvisoryInformationRequest =
+                    FileAdvisoryInformationRequest::from_bytes(message.payload);
+                fcntl::do_posix_fadvise(source, request)
+            },
+            LinuxDaemonMessageHeader::FileChdirRequest => {
+                let request: FileChdirRequest = FileChdirRequest::from_bytes(message.payload);
+                unistd::do_fchdir(source, request)
+            },
+            LinuxDaemonMessageHeader::FileChmodRequest => {
+                let request: FileChmodRequest = FileChmodRequest::from_bytes(message.payload);
+                fcntl::do_fchmod(source, request)
+            },
+            LinuxDaemonMessageHeader::FileChownRequest => {
+                let request: FileChownRequest = FileChownRequest::from_bytes(message.payload);
+                unistd::do_fchown(source, request)
+            },
+            LinuxDaemonMessageHeader::FileControlRequest => {
+                let request: FileControlRequest = FileControlRequest::from_bytes(message.payload);
+                fcntl::do_fcntl(source, request)
+            },
+            LinuxDaemonMessageHeader::FileDataSyncRequest => {
+                let request: FileDataSyncRequest = FileDataSyncRequest::from_bytes(message.payload);
+                unistd::do_fdatasync(source, request)
+            },
+            LinuxDaemonMessageHeader::FileSpaceControlRequest => {
+                let request: FileSpaceControlRequest =
+                    FileSpaceControlRequest::from_bytes(message.payload);
+                fcntl::do_posix_fallocate(source, request)
+            },
+            LinuxDaemonMessageHeader::FileSyncRequest => {
+                let request: FileSyncRequest = FileSyncRequest::from_bytes(message.payload);
+                unistd::do_fsync(source, request)
+            },
+            LinuxDaemonMessageHeader::FileTruncateRequest => {
+                let request: FileTruncateRequest = FileTruncateRequest::from_bytes(message.payload);
+                unistd::do_ftruncate(source, request)
+            },
+            LinuxDaemonMessageHeader::GetIdsRequest => {
+                let request: GetIdsRequest = GetIdsRequest::from_bytes(message.payload);
+                unistd::do_getids(source, request)
+            },
+            LinuxDaemonMessageHeader::GetPeerNameRequest => {
+                let request: GetPeerNameRequest = GetPeerNameRequest::from_bytes(message.payload);
+                socket::do_getpeername(source, request)
+            },
+            LinuxDaemonMessageHeader::GetSockNameRequest => {
+                let request: GetSockNameRequest = GetSockNameRequest::from_bytes(message.payload);
+                socket::do_getsockname(source, request)
+            },
+            LinuxDaemonMessageHeader::ListenSocketRequest => {
+                let request: ListenSocketRequest = ListenSocketRequest::from_bytes(message.payload);
+                socket::do_listen(source, request)
+            },
+            LinuxDaemonMessageHeader::PartialReadRequest => {
+                let request: PartialReadRequest = PartialReadRequest::from_bytes(message.payload);
+                unistd::do_pread(source, request)
+            },
+            LinuxDaemonMessageHeader::PartialWriteRequest => {
+                let request: PartialWriteRequest = PartialWriteRequest::from_bytes(message.payload);
+                unistd::do_pwrite(source, request)
+            },
+            LinuxDaemonMessageHeader::PollRequest => {
+                let request: syscall::poll::message::PollRequest =
+                    syscall::poll::message::PollRequest::from_bytes(message.payload);
+                poll::do_poll(source, request)
+            },
+            LinuxDaemonMessageHeader::ReceiveSocketRequest => {
+                let request: ReceiveSocketRequest =
+                    ReceiveSocketRequest::from_bytes(message.payload);
+                socket::do_recv(source, request)
+            },
+            LinuxDaemonMessageHeader::SeekRequest => {
+                let request: SeekRequest = SeekRequest::from_bytes(message.payload);
+                unistd::do_lseek(source, request)
+            },
+            LinuxDaemonMessageHeader::SendSocketRequest => {
+                let request: SendSocketRequest = SendSocketRequest::from_bytes(message.payload);
+                socket::do_send(source, request)
+            },
+            LinuxDaemonMessageHeader::ShutdownSocketRequest => {
+                let request: ShutdownSocketRequest =
+                    ShutdownSocketRequest::from_bytes(message.payload);
+                socket::do_shutdown(source, request)
+            },
+            LinuxDaemonMessageHeader::TimesRequest => {
+                let request: TimesRequest = TimesRequest::from_bytes(message.payload);
+                times::do_times(source, request)
+            },
+            LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
+                let request: UpdateFileAccessTimeRequest =
+                    UpdateFileAccessTimeRequest::from_bytes(message.payload);
+                fcntl::do_futimens(source, request)
+            },
+            LinuxDaemonMessageHeader::PipeRequest => {
+                let _request = PipeRequest::from_bytes(message.payload);
+                unistd::do_pipe(source)
+            },
+            header => {
+                // The following statement is unreachable, because the matching logic in this
+                // function should match the one in the `Self::run()` function.
+                unreachable!("unexpected short message {:?}", header)
+            },
+        }
+    }
+
+    fn handle_long_request_messages(
+        uvm_stream: Arc<Mutex<SocketStream>>,
+        assembler: Arc<Mutex<RequestAssembler>>,
+        source: ThreadIdentifier,
+        message: LinuxDaemonMessage,
+    ) {
+        match message.header {
+            LinuxDaemonMessageHeader::ChangeDirectoryRequestPart => {
+                Self::handle_long_request::<ChangeDirectoryRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            LinuxDaemonMessageHeader::FileAccessAtRequestPart => {
+                Self::handle_long_request::<FileAccessAtRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            LinuxDaemonMessageHeader::FileStatAtRequestPart => {
+                Self::handle_long_request::<FileStatAtRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart => {
+                Self::handle_long_request::<SymbolicLinkAtRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            LinuxDaemonMessageHeader::LinkAtRequestPart => {
+                Self::handle_long_request::<LinkAtRequest>(uvm_stream, assembler, source, &message);
+            },
+            LinuxDaemonMessageHeader::ReadLinkAtRequestPart => {
+                Self::handle_long_request::<ReadLinkAtRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart => {
+                Self::handle_long_request::<MakeDirectoryAtRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart => {
+                Self::handle_long_request::<UpdateFileAccessTimeAtRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            LinuxDaemonMessageHeader::FileChownAtRequestPart => {
+                Self::handle_long_request::<FileChownAtRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            LinuxDaemonMessageHeader::FileChmodAtRequestPart => {
+                Self::handle_long_request::<FileChmodAtRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            LinuxDaemonMessageHeader::OpenAtRequestPart => {
+                Self::handle_long_request::<OpenAtRequest>(uvm_stream, assembler, source, &message);
+            },
+            LinuxDaemonMessageHeader::RenameAtRequestPart => {
+                Self::handle_long_request::<RenameAtRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            LinuxDaemonMessageHeader::UnlinkAtRequestPart => {
+                Self::handle_long_request::<UnlinkAtRequest>(
+                    uvm_stream, assembler, source, &message,
+                );
+            },
+            header => {
+                // The following statement is unreachable, because the matching logic in this
+                // function should match the one in the `Self::run()` function.
+                unreachable!("unexpected long request message {:?}", header)
+            },
+        }
+    }
+
+    fn handle_long_response_messages(
+        uvm_stream: Arc<Mutex<SocketStream>>,
+        source: ThreadIdentifier,
+        message: LinuxDaemonMessage,
+    ) {
+        match message.header {
+            LinuxDaemonMessageHeader::FileStatRequest => {
+                Self::handle_fstat_request(uvm_stream, source, message);
+            },
+            LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest => {
+                Self::handle_getcwd_request(uvm_stream, source);
+            },
+            LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
+                Self::handle_getdents_request(uvm_stream, source, message);
+            },
+            header => {
+                // The following statement is unreachable, because the matching logic in this
+                // function should match the one in the `Self::run()` function.
+                unreachable!("unexpected long response message {:?}", header)
+            },
+        }
+    }
+
+    // Send a message to the TCP stream.
+    fn send(uvm_stream: Arc<Mutex<SocketStream>>, message: Message) -> Result<()> {
+        let bytes = message.to_bytes();
+
+        loop {
+            let mut locked_uvm_stream = uvm_stream.lock().unwrap();
+
+            match locked_uvm_stream.write_all(&bytes) {
+                Ok(_) => break Ok(()),
+                Err(e) => {
+                    match e.kind() {
+                        ErrorKind::WouldBlock => {
+                            // The stream is not ready to write, retry.
+                            continue;
+                        },
+                        error_kind => {
+                            unimplemented!(
+                                "handle: failed to write message (error={error_kind:?})"
+                            );
+                        },
+                    }
+                },
+            }
+        }
+    }
+
+    fn do_error(source: ThreadIdentifier, code: ErrorCode) -> Message {
+        Message::new(
+            MessageSender::from(LINUXD),
+            MessageReceiver::from(source),
+            MessageType::Ikc,
+            Some(code),
+            [0u8; Message::PAYLOAD_SIZE],
+        )
+    }
+
+    fn handle_close_request(source: ThreadIdentifier, request: CloseRequest) -> Result<Message, WorkerThreadError> {
+        // Inspect file descriptor that is being closed, as we need to
+        // handle standard file descriptors specially.
+        match request.fd {
+            // Closing standard file descriptors.
+            STDIN_FILENO | STDOUT_FILENO | STDERR_FILENO => {
+                // Perform a fake close, as standard file descriptors
+                // are shared with the current process.
+                Ok(CloseResponse::build(source, 0))
+            },
+            // Closing other file descriptors.
+            _ => unistd::do_close(source, request),
+        }
+    }
+
+    fn handle_write_request(
+        gateway_stdout_tx: Option<Sender<WriteRequest>>,
+        source: ThreadIdentifier,
+        mut request: WriteRequest,
+    ) -> Result<Message, WorkerThreadError> {
+        trace!("handle_write_request(): source={source:?}, request={request:?}");
+        // Check if writing to gateway.
+        if request.fd == STDOUT_FILENO || request.fd == STDERR_FILENO {
+            let gateway_stdout_tx = if let Some(gateway_stdout_tx) = gateway_stdout_tx {
+                gateway_stdout_tx
+            } else {
+                error!("handle_write_request(): trying to write to stdout without a gateway configured");
+                return Ok(build_error(source, ErrorCode::InvalidArgument));
+            };
+
+            // Check if write size is invalid.
+            if request.count == 0 {
+                // Writing zero-bytes to STDOUT is not allowed, as we used this to signal EOF.
+                error!("handle_write_request(): trying to write zero bytes to STDOUT");
+                Ok(build_error(source, ErrorCode::InvalidArgument))
+            } else {
+                profiler::timestamp_message!(&mut request.buffer, 0);
+                let count: usize = request.count as usize;
+                if let Err(error) = gateway_stdout_tx.send(request) {
+                    debug!("failed to write buffer to the gateway (error={error:?})");
+                    // TODO: Check error conversion.
+                    return Ok(build_error(source, ErrorCode::ConnectionReset));
+                }
+
+                // We don't wait for the IO thread to confirm that the write was correct, as writes
+                // are fully non-blocking.
+                debug!("wrote {count} bytes to the gateway");
+                Ok(WriteResponse::build(source, count as i32))
+            }
+        } else {
+            // Write to other file descriptor.
+            unistd::do_write(source, request)
+        }
+    }
+
+    fn handle_read_request(
+        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
+        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        source: ThreadIdentifier,
+        request: ReadRequest,
+    ) -> Result<Message, WorkerThreadError> {
+        trace!("handle_read_request(): source={source:?}, request={request:?}");
+        // Check if reading from gateway.
+        if request.fd == STDIN_FILENO {
+            let gateway_stdin_tx = if let Some(gateway_stdin_tx) = gateway_stdin_tx {
+                gateway_stdin_tx
+            } else {
+                error!("handle_read_request(): process tried to read from stdin but no gateway found");
+                return Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]));
+            };
+
+            // Check if the process is associated with a virtual environment.
+            let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
+            let env: &mut VirtualEnvironment = if let Some(env) = venv.get_mut(source) {
+                env
+            } else {
+                warn!(
+                    "handle_read_request(): process is not associated with a virtual \
+                     environment, returning EOF"
+                );
+                return Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]));
+            };
+
+            // Send ReadRequest to gateway IO thread.
+            if let Err(error) = gateway_stdin_tx.send((request, env.get_stdin_response_tx())) {
+                error!(
+                    "handle_read_request(): error sending request to gateway STDIN IO thread, returning EOF \
+                    (error={error:?})"
+                );
+                return Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]));
+            }
+
+            // Wait for response from IO thread.
+            match env
+                .get_stdin_response_rx()
+                .recv() {
+                    Ok(mut read_response) => {
+                        // We don't have access to the source in the gateway IO thread, so we set
+                        // it here.
+                        read_response.destination = source.into();
+                        Ok(read_response)
+                    },
+                    Err(e) => {
+                        error!(
+                            "handle_read_request(): error receiving request response from gateway STDIN \
+                            IO thread, returning EOF (error={e:?})"
+                        );
+                        Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]))
+                    }
+                }
+        } else {
+            // Read from other file descriptor.
+            unistd::do_read(source, request)
+        }
+    }
+
+    fn handle_fstat_request(
+        uvm_stream: Arc<Mutex<SocketStream>>,
+        source: ThreadIdentifier,
+        message: LinuxDaemonMessage,
+    ) {
+        let request: FileStatRequest = FileStatRequest::from_bytes(message.payload);
+        let messages: Vec<Message> = fcntl::do_fstat(source, request);
+        for message in messages {
+            if let Err(e) = Self::send(uvm_stream.clone(), message) {
+                error!("failed to send message (error={e:?})");
+            }
+        }
+    }
+
+    fn handle_getcwd_request(uvm_stream: Arc<Mutex<SocketStream>>, source: ThreadIdentifier) {
+        let messages: Vec<Message> = unistd::do_getcwd(source);
+        for message in messages {
+            if let Err(e) = Self::send(uvm_stream.clone(), message) {
+                error!("failed to send message (error={e:?})");
+            }
+        }
+    }
+
+    fn handle_getdents_request(
+        uvm_stream: Arc<Mutex<SocketStream>>,
+        source: ThreadIdentifier,
+        message: LinuxDaemonMessage,
+    ) {
+        let request: GetDirectoryEntriesRequest =
+            GetDirectoryEntriesRequest::from_bytes(message.payload);
+
+        let messages: Vec<Message> = dirent::do_getdents(source, request);
+        for message in messages {
+            if let Err(e) = Self::send(uvm_stream.clone(), message) {
+                error!("failed to send message (error={e:?})");
+            }
+        }
+    }
+
+    fn handle_long_request<T>(
+        uvm_stream: Arc<Mutex<SocketStream>>,
+        assembler: Arc<Mutex<RequestAssembler>>,
+        source: ThreadIdentifier,
+        message: &LinuxDaemonMessage,
+    ) where
+        T: RequestAssemblerTrait,
+    {
+        let part: LinuxDaemonMessagePart = LinuxDaemonMessagePart::from_bytes(message.payload);
+
+        trace!("handle_long_request(): source={source:?}, part={part:?}");
+
+        let result: Result<Option<Vec<Message>>, Error> =
+            assembler.lock().unwrap().process_message::<T>(source, part);
+
+        match result {
+            Ok(Some(messages)) => {
+                for message in messages {
+                    if let Err(e) = Self::send(uvm_stream.clone(), message) {
+                        error!("failed to send message (error={e:?})");
+                    }
+                }
+            },
+            Ok(None) => {},
+            Err(e) => {
+                error!("failed to process request (error={e:?})");
+                if let Err(e) = Self::send(uvm_stream.clone(), Self::do_error(source, e.code)) {
+                    error!("failed to send error message (error={e:?})");
+                }
+            },
+        }
+    }
+}

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -26,6 +26,7 @@ use crate::{
     times,
     unistd,
     venv::{
+        VenvCommand,
         VirtualEnvironment,
         VirtualEnviromentDirectory,
     },
@@ -161,6 +162,8 @@ pub struct WorkerThreadHandle {
     // Underlying tid returned by pthread.
     pub pthread_id: Arc<AtomicUsize>,
     pub handle: JoinHandle<()>,
+    // Handle to send shutdown messages to message queue.
+    pub cmd_tx: Sender<VenvCommand>,
 }
 
 /// Our signal handler is a no-op that will just interrupt any blocking system calls, and make the
@@ -187,7 +190,8 @@ impl WorkerThreadHandle {
     /// Spawn an interruptible worker thread.
     pub fn spawn(
         id: ThreadIdentifier,
-        channel_rx: Receiver<Message>,
+        channel_rx: Receiver<VenvCommand>,
+        channel_tx: Sender<VenvCommand>,
         uvm_stream: Arc<Mutex<SocketStream>>,
         gw_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
         gw_stdout_tx: Option<Sender<WriteRequest>>,
@@ -217,6 +221,7 @@ impl WorkerThreadHandle {
             id,
             pthread_id: pthread_id_holder_clone,
             handle: join_handle,
+            cmd_tx: channel_tx,
         })
     }
 
@@ -236,8 +241,8 @@ impl WorkerThreadHandle {
         Ok(())
     }
 
-        fn handle_message(
-        channel_rx: Receiver<Message>,
+    fn handle_message(
+        channel_rx: Receiver<VenvCommand>,
         uvm_stream: Arc<Mutex<SocketStream>>,
         gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
         gateway_stdout_tx: Option<Sender<WriteRequest>>,
@@ -248,7 +253,11 @@ impl WorkerThreadHandle {
 
         loop {
             let message: Message = match channel_rx.recv() {
-                Ok(message) => message,
+                Ok(VenvCommand::Work(message)) => message,
+                Ok(VenvCommand::Shutdown) => {
+                    debug!("handle_message(): thread received shutdown message (worker_tid={worker_tid:?})");
+                    break
+                },
                 Err(error) => {
                     error!(
                         "handle_message(): failed to receive message from channel, stopping \

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -31,25 +31,18 @@ use crate::{
         VirtualEnviromentDirectory,
     },
 };
-use ::nix::{
-    libc,
-    sys::{
-        pthread::{
-            pthread_self,
-            pthread_kill
-        },
-        signal::{
-            self,
-            Signal,
-            SigAction,
-            SigHandler,
-            SaFlags,
-            SigSet
-        }
-    },
+use libc::{
+    sigaction,
+    sigemptyset,
+    pthread_kill,
+    pthread_self,
+    SIGUSR1,
+    c_int,
 };
 use ::std::{
     io::ErrorKind,
+    mem,
+    ptr,
     sync::{
         atomic::{
             AtomicUsize,
@@ -153,7 +146,7 @@ use ::syscall::{
 };
 use ::syscomm::SocketStream;
 
-const INTERRUPT_SIGNAL: Signal = Signal::SIGUSR1;
+const INTERRUPT_SIGNAL: c_int = SIGUSR1;
 
 /// State associated with a worker thread in linuxd.
 pub struct WorkerThreadHandle {
@@ -172,22 +165,33 @@ extern "C" fn linuxd_worker_thread_signal_handler(_: i32) {}
 
 impl WorkerThreadHandle {
     fn install_signal_handler() {
-        let sig_action = SigAction::new(
-            SigHandler::Handler(linuxd_worker_thread_signal_handler),
-            // Empty flags to make sure the thread does not restart blocked system calls and exits
-            // with EINTR.
-            SaFlags::empty(),
-            // Do not block any other signals that may happen during signal handling.
-            SigSet::empty(),
-        );
-
         // SAFETY: we install a signal handler that is a no-op so this is safe.
-        unsafe {
-            signal::sigaction(INTERRUPT_SIGNAL, &sig_action).expect("sigaction failed");
+        let ret = unsafe {
+            let sig_action = sigaction {
+                sa_sigaction: linuxd_worker_thread_signal_handler as usize,
+                // Empty set to not block any other signals that may happen during signal handling.
+                sa_mask: {
+                    let mut set = mem::zeroed();
+                    sigemptyset(&mut set);
+                    set
+                },
+                // No SA_RESTART so that syscall will return EINTR.
+                sa_flags: 0,
+                sa_restorer: None,
+            };
+
+            sigaction(INTERRUPT_SIGNAL, &sig_action, ptr::null_mut())
+        };
+
+        if ret != 0 {
+            // Notify the error, but don't fail.
+            let errno: i32 = unsafe { *libc::__errno_location() };
+            error!("error installing signal handler (errno={errno:?})");
         }
     }
 
     /// Spawn an interruptible worker thread.
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         id: ThreadIdentifier,
         channel_rx: Receiver<VenvCommand>,
@@ -208,7 +212,7 @@ impl WorkerThreadHandle {
         let join_handle = thread::spawn(move || {
             Self::install_signal_handler();
 
-            let pthread_id = pthread_self();
+            let pthread_id = unsafe { pthread_self() };
             pthread_id_holder.store(pthread_id as usize, Ordering::Relaxed);
 
             Self::handle_message(channel_rx, uvm_stream, gw_stdin_tx, gw_stdout_tx, venv, assembler);
@@ -216,7 +220,6 @@ impl WorkerThreadHandle {
             trace!("thread shutting down after receiving interrupt (pthread_id={pthread_id})");
         });
 
-        // TODO: pthread_id_holder used after move?
         Ok(Self {
             id,
             pthread_id: pthread_id_holder_clone,
@@ -225,7 +228,7 @@ impl WorkerThreadHandle {
         })
     }
 
-    /// Stop a worker-thread by setting the shutdown flag and sending an interrupt.
+    /// Stop a worker-thread by sending an interrupt.
     pub fn stop(&self) -> Result<(), Error> {
         let raw_tid = self.pthread_id.load(Ordering::Relaxed);
 
@@ -235,8 +238,10 @@ impl WorkerThreadHandle {
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
+        // SAFETY: we call pthread_kill on a non-zero TID after we have managed to send a message
+        // to its reception queue, so the thread is alive and safe.
         let pthread_id = raw_tid as libc::pthread_t;
-        pthread_kill(pthread_id, INTERRUPT_SIGNAL).expect("pthread_kill failed");
+        unsafe { pthread_kill(pthread_id, INTERRUPT_SIGNAL) };
 
         Ok(())
     }
@@ -339,7 +344,16 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::PipeRequest
                                 | LinuxDaemonMessageHeader::PollRequest
                                 | LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
-                                    Self::handle_short_request_messages(source, message)
+                                    match Self::handle_short_request_messages(source, message) {
+                                        Ok(message) => message,
+                                        Err(WorkerThreadError::Interrupted) => break,
+                                        Err(WorkerThreadError::Error(e)) => {
+                                            // WorkerThreadErrors other than Interrupted should be
+                                            // caught by downstream functions, and converted to
+                                            // Messages with the appropriate return code.
+                                            unreachable!("fatal error in working thread (error={e:?})");
+                                        }
+                                    }
                                 },
 
                                 // The following system calls have their request data fit in a
@@ -349,11 +363,20 @@ impl WorkerThreadHandle {
                                 LinuxDaemonMessageHeader::FileStatRequest
                                 | LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest
                                 | LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
-                                    Self::handle_long_response_messages(
+                                    match Self::handle_long_response_messages(
                                         uvm_stream.clone(),
                                         source,
                                         message,
-                                    );
+                                    ) {
+                                        Ok(message) => message,
+                                        Err(WorkerThreadError::Interrupted) => break,
+                                        Err(WorkerThreadError::Error(e)) => {
+                                            // WorkerThreadErrors other than Interrupted should be
+                                            // caught by downstream functions, and converted to
+                                            // Messages with the appropriate return code.
+                                            unreachable!("fatal error in working thread (error={e:?})");
+                                        }
+                                    }
                                     continue;
                                 },
 
@@ -373,12 +396,21 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::OpenAtRequestPart
                                 | LinuxDaemonMessageHeader::RenameAtRequestPart
                                 | LinuxDaemonMessageHeader::UnlinkAtRequestPart => {
-                                    Self::handle_long_request_messages(
+                                    match Self::handle_long_request_messages(
                                         uvm_stream.clone(),
                                         assembler.clone(),
                                         source,
                                         message,
-                                    );
+                                    ) {
+                                        Ok(message) => message,
+                                        Err(WorkerThreadError::Interrupted) => break,
+                                        Err(WorkerThreadError::Error(e)) => {
+                                            // WorkerThreadErrors other than Interrupted should be
+                                            // caught by downstream functions, and converted to
+                                            // Messages with the appropriate return code.
+                                            unreachable!("fatal error in working thread (error={e:?})");
+                                        }
+                                    }
                                     continue;
                                 },
 
@@ -426,7 +458,7 @@ impl WorkerThreadHandle {
     fn handle_short_request_messages(
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
-    ) -> Message {
+    ) -> Result<Message, WorkerThreadError> {
         match message.header {
             LinuxDaemonMessageHeader::AcceptSocketRequest => {
                 let request: AcceptSocketRequest = AcceptSocketRequest::from_bytes(message.payload);
@@ -561,68 +593,68 @@ impl WorkerThreadHandle {
         assembler: Arc<Mutex<RequestAssembler>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
-    ) {
+    ) -> Result<(), WorkerThreadError> {
         match message.header {
             LinuxDaemonMessageHeader::ChangeDirectoryRequestPart => {
                 Self::handle_long_request::<ChangeDirectoryRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             LinuxDaemonMessageHeader::FileAccessAtRequestPart => {
                 Self::handle_long_request::<FileAccessAtRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             LinuxDaemonMessageHeader::FileStatAtRequestPart => {
                 Self::handle_long_request::<FileStatAtRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart => {
                 Self::handle_long_request::<SymbolicLinkAtRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             LinuxDaemonMessageHeader::LinkAtRequestPart => {
-                Self::handle_long_request::<LinkAtRequest>(uvm_stream, assembler, source, &message);
+                Self::handle_long_request::<LinkAtRequest>(uvm_stream, assembler, source, &message)
             },
             LinuxDaemonMessageHeader::ReadLinkAtRequestPart => {
                 Self::handle_long_request::<ReadLinkAtRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart => {
                 Self::handle_long_request::<MakeDirectoryAtRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart => {
                 Self::handle_long_request::<UpdateFileAccessTimeAtRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             LinuxDaemonMessageHeader::FileChownAtRequestPart => {
                 Self::handle_long_request::<FileChownAtRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             LinuxDaemonMessageHeader::FileChmodAtRequestPart => {
                 Self::handle_long_request::<FileChmodAtRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             LinuxDaemonMessageHeader::OpenAtRequestPart => {
-                Self::handle_long_request::<OpenAtRequest>(uvm_stream, assembler, source, &message);
+                Self::handle_long_request::<OpenAtRequest>(uvm_stream, assembler, source, &message)
             },
             LinuxDaemonMessageHeader::RenameAtRequestPart => {
                 Self::handle_long_request::<RenameAtRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             LinuxDaemonMessageHeader::UnlinkAtRequestPart => {
                 Self::handle_long_request::<UnlinkAtRequest>(
                     uvm_stream, assembler, source, &message,
-                );
+                )
             },
             header => {
                 // The following statement is unreachable, because the matching logic in this
@@ -636,16 +668,16 @@ impl WorkerThreadHandle {
         uvm_stream: Arc<Mutex<SocketStream>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
-    ) {
+    ) -> Result<(), WorkerThreadError> {
         match message.header {
             LinuxDaemonMessageHeader::FileStatRequest => {
-                Self::handle_fstat_request(uvm_stream, source, message);
+                Self::handle_fstat_request(uvm_stream, source, message)
             },
             LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest => {
-                Self::handle_getcwd_request(uvm_stream, source);
+                Self::handle_getcwd_request(uvm_stream, source)
             },
             LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
-                Self::handle_getdents_request(uvm_stream, source, message);
+                Self::handle_getdents_request(uvm_stream, source, message)
             },
             header => {
                 // The following statement is unreachable, because the matching logic in this
@@ -811,39 +843,45 @@ impl WorkerThreadHandle {
         uvm_stream: Arc<Mutex<SocketStream>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
-    ) {
+    ) -> Result<(), WorkerThreadError> {
         let request: FileStatRequest = FileStatRequest::from_bytes(message.payload);
-        let messages: Vec<Message> = fcntl::do_fstat(source, request);
+        let messages: Vec<Message> = fcntl::do_fstat(source, request)?;
         for message in messages {
             if let Err(e) = Self::send(uvm_stream.clone(), message) {
                 error!("failed to send message (error={e:?})");
             }
         }
+
+        Ok(())
     }
 
-    fn handle_getcwd_request(uvm_stream: Arc<Mutex<SocketStream>>, source: ThreadIdentifier) {
-        let messages: Vec<Message> = unistd::do_getcwd(source);
+    fn handle_getcwd_request(uvm_stream: Arc<Mutex<SocketStream>>, source: ThreadIdentifier) -> Result<(), WorkerThreadError> {
+        let messages: Vec<Message> = unistd::do_getcwd(source)?;
         for message in messages {
             if let Err(e) = Self::send(uvm_stream.clone(), message) {
                 error!("failed to send message (error={e:?})");
             }
         }
+
+        Ok(())
     }
 
     fn handle_getdents_request(
         uvm_stream: Arc<Mutex<SocketStream>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
-    ) {
+    ) -> Result<(), WorkerThreadError> {
         let request: GetDirectoryEntriesRequest =
             GetDirectoryEntriesRequest::from_bytes(message.payload);
 
-        let messages: Vec<Message> = dirent::do_getdents(source, request);
+        let messages: Vec<Message> = dirent::do_getdents(source, request)?;
         for message in messages {
             if let Err(e) = Self::send(uvm_stream.clone(), message) {
                 error!("failed to send message (error={e:?})");
             }
         }
+
+        Ok(())
     }
 
     fn handle_long_request<T>(
@@ -851,14 +889,15 @@ impl WorkerThreadHandle {
         assembler: Arc<Mutex<RequestAssembler>>,
         source: ThreadIdentifier,
         message: &LinuxDaemonMessage,
-    ) where
+    ) -> Result<(), WorkerThreadError>
+        where
         T: RequestAssemblerTrait,
     {
         let part: LinuxDaemonMessagePart = LinuxDaemonMessagePart::from_bytes(message.payload);
 
         trace!("handle_long_request(): source={source:?}, part={part:?}");
 
-        let result: Result<Option<Vec<Message>>, Error> =
+        let result: Result<Option<Vec<Message>>, WorkerThreadError> =
             assembler.lock().unwrap().process_message::<T>(source, part);
 
         match result {
@@ -868,13 +907,19 @@ impl WorkerThreadHandle {
                         error!("failed to send message (error={e:?})");
                     }
                 }
+
+                Ok(())
             },
-            Ok(None) => {},
-            Err(e) => {
+            Ok(None) => Ok(()),
+            Err(WorkerThreadError::Interrupted) => Err(WorkerThreadError::Interrupted),
+            Err(WorkerThreadError::Error(e)) => {
                 error!("failed to process request (error={e:?})");
-                if let Err(e) = Self::send(uvm_stream.clone(), Self::do_error(source, e.code)) {
+                // TODO: proper error code conversion.
+                if let Err(e) = Self::send(uvm_stream.clone(), Self::do_error(source, ErrorCode::IoErr)) {
                     error!("failed to send error message (error={e:?})");
                 }
+
+                Ok(())
             },
         }
     }

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -226,6 +226,11 @@ impl SocketError {
     }
 
     /// Gets the kind of the socket error.
+    pub fn raw_os_error(&self) -> Option<i32> {
+        self.error.raw_os_error()
+    }
+
+    /// Gets the kind of the socket error.
     pub fn kind(&self) -> ::std::io::ErrorKind {
         self.error.kind()
     }
@@ -234,6 +239,12 @@ impl SocketError {
 impl fmt::Display for SocketError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SocketError: {}", self.error)
+    }
+}
+
+impl From<SocketError> for io::Error {
+    fn from(err: SocketError) -> Self {
+        err.error
     }
 }
 


### PR DESCRIPTION
In this PR I implement support to gracefully shutdown the worker threads in linuxd associated to a user VM execution.

A worker thread can be in three different states:
1. Running
2. Blocked on the main `recv` loop in `handle_message` (trying to receive from a `mpsc::Channel`
3. Blocked on a system call

To address 1 and 2, I introduce a shutdown message that can be queued to the main work queue. To address 3 I install a SIGUSR1 handler in worker threads, and send them a signal when it is time to exit. Note that a signal interrupt will not wake a thread blocked on a `mpsc::Channel`.

To handle the signal interrupt and propagate it all the way up the stack such that the thread knows it needs to exit, I need to modify every system call to handle an `EINTR` return value, and propagate it encapsulated in an `Error`.

To encapsulate the logic of starting/stopping an interruptible worker thread, including the handler installation, I abstract all the logic corresponding to each worker thread from `src/daemons/linuxd/src/linuxd/mod.rs` to `src/daemons/linuxd/src/worker_thread.rs`.