### PR TITLE
[utils] Make Nanvixd Send Shutdown Messages To Linuxd

### DIFF
--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -78,7 +78,7 @@ impl ::std::str::FromStr for SocketType {
 
 impl SocketListener {
     /// Accepts a connection on a socket.
-    pub fn accept(&self) -> Result<SocketStream> {
+    pub fn accept(&self) -> Result<SocketStream, SocketError> {
         match self {
             SocketListener::Tcp(listener) => {
                 let (stream, _sockaddr): (TcpStream, std::net::SocketAddr) = listener.accept()?;
@@ -245,6 +245,12 @@ impl fmt::Display for SocketError {
 impl From<SocketError> for io::Error {
     fn from(err: SocketError) -> Self {
         err.error
+    }
+}
+
+impl From<std::io::Error> for SocketError {
+    fn from(error: std::io::Error) -> Self {
+        SocketError::new(error)
     }
 }
 

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -269,6 +269,17 @@ impl Benchmark {
             if ret_code < 0 {
                 error!("error sending SIGINT to nano VM: {}", std::io::Error::last_os_error());
             }
+
+            if let Some(nanvixd) = self.nanvixd.as_mut() {
+                match nanvixd.wait() {
+                    Ok(exit_status) => {
+                        if !exit_status.success() {
+                            error!("nanvixd returned with non-zero exit status: {:?}", exit_status.code());
+                        }
+                    },
+                    Err(e) => error!("error waiting for nanvixd: {e:?}"),
+                }
+            }
         }
     }
 
@@ -378,7 +389,6 @@ impl Benchmark {
         println!("p99: {} us", latencies[(self.iterations as f32 * 0.99) as usize]);
 
         print!("Cleaning up...");
-        self.cleanup();
         println!("done!");
 
         Ok(())
@@ -744,9 +754,6 @@ async fn main() -> Result<()> {
         Ok(_) => {},
         Err(e) => error!("error running benchmark: {e:?}"),
     }
-
-    // Additional clean-up in case of errors in the benchmarks.
-    benchmark.cleanup();
 
     Ok(())
 }

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -21,6 +21,7 @@ hyper-util = { workspace = true, features = ["full"] }
 hwloc = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
+num_enum = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sys = { workspace = true }

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -6,9 +6,9 @@
 //==================================================================================================
 
 use crate::sandbox::{
+    config::SandboxConfig,
     linuxd::LinuxDaemon,
     microvm::Microvm,
-    config::SandboxConfig,
     tag::SandboxTag,
 };
 use ::anyhow::Result;
@@ -180,5 +180,31 @@ impl SandboxCache{
         self.sandbox_index.remove(user_vm_id);
 
         Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Stop all instances in the cache.
+    ///
+    /// # Returns
+    ///
+    /// On success empty is returned. On failure an error is returned instead.
+    ///
+    pub async fn cleanup(&mut self) {
+        // TODO: for the time being only linuxd instances support being gracefully shutdown. User
+        // VMs are missing a control-plane socket.
+        for (tenant_id, linuxd_instance) in self.linuxd_instances.iter_mut() {
+            if let Some(linuxd_instance_mut) = Arc::get_mut(linuxd_instance) {
+                if let Err(e) = linuxd_instance_mut.shutdown().await {
+                    // FIXME: convert to error once linuxd supports a graceful shutdown.
+                    debug!("error cleaning-up linuxd instance for tenant {tenant_id}: {e:?}");
+                } else {
+                    debug!("cleaned-up linuxd instance for tenant {tenant_id}");
+                }
+            } else {
+                error!("error cleaning-up linuxd instance for tenant {tenant_id}: instance not found");
+            }
+        }
     }
 }

--- a/src/utils/nanvixd/src/control_plane.rs
+++ b/src/utils/nanvixd/src/control_plane.rs
@@ -1,0 +1,43 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// This file contains the messages used in the control-plane API between
+// nanvixd and linuxd/user VM.
+
+use ::anyhow::Result;
+use ::num_enum::{
+    IntoPrimitive,
+    TryFromPrimitive,
+};
+use ::std::io::{
+    Error,
+    ErrorKind,
+};
+use ::syscomm::{
+    SocketError,
+    SocketStream,
+};
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, IntoPrimitive, TryFromPrimitive)]
+pub enum Command {
+    Shutdown,
+}
+
+// This function is actually used by linuxd, consuming nanvixd as a library. It is never used from
+// the main nanvixd binary, hence why we need to add this annotation to silent clippy.
+#[allow(dead_code)]
+pub fn read_command(stream: &mut SocketStream) -> Result<Command, SocketError> {
+    let mut buf: [u8; 1] = [0u8; 1];
+    stream.read_exact(&mut buf)?;
+
+    Command::try_from(buf[0]).map_err(|_| {
+        Error::new(ErrorKind::InvalidData, "error parsing control-plane command".to_string()).into()
+    })
+}
+
+pub fn send_command(stream: &mut SocketStream, cmd: Command) -> Result<(), SocketError> {
+    let byte: u8 = cmd.into();
+    stream.write_all(&[byte])?;
+    Ok(())
+}

--- a/src/utils/nanvixd/src/lib.rs
+++ b/src/utils/nanvixd/src/lib.rs
@@ -2,4 +2,5 @@
 // Licensed under the MIT License.
 
 pub mod config;
+pub mod control_plane;
 pub mod message;

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -16,6 +16,7 @@
 mod args;
 mod cache;
 mod config;
+mod control_plane;
 mod http;
 mod logging;
 mod message;
@@ -90,6 +91,12 @@ pub async fn main() -> Result<()> {
             },
             _ = signals.recv() => {
                 info!("received exit signal, stopping...");
+                sandbox_cache
+                    .clone()
+                    .lock()
+                    .await
+                    .cleanup()
+                    .await;
                 break;
             },
         }

--- a/src/utils/nanvixd/src/message.rs
+++ b/src/utils/nanvixd/src/message.rs
@@ -1,6 +1,8 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+//! This file contains the messages used in the HTTP API between end-clients and nanvixd.
+
 use serde::{
     Deserialize,
     Serialize,

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -5,14 +5,13 @@
 // Imports
 //==================================================================================================
 
-use crate::config;
+use crate::{
+    config,
+    control_plane,
+};
 use ::anyhow::Result;
 use ::hwloc::HwLoc;
-use ::std::{
-    fs,
-    io::ErrorKind,
-    process::Stdio,
-};
+use ::std::process::Stdio;
 use ::syscomm::{
     Socket,
     SocketStream,
@@ -29,12 +28,7 @@ use ::tokio::process::{
 
 pub struct LinuxDaemon {
     child: Child,
-    // TODO: we currently do not send any information via the control-plane stream.
-    _control_plane_stream: SocketStream,
-    // Linuxd currently does not properly clean-up on shutdown (there is no such thing as shutdown)
-    // so we need to make sure we clean-up the linuxd socket when we drop linuxd. We thus keep
-    // track of it here.
-    linuxd_sockaddr: String,
+    control_plane_stream: SocketStream,
 }
 
 //==================================================================================================
@@ -85,6 +79,7 @@ impl LinuxDaemon {
                     debug!("nanvixd received connection from linuxd's control-plane socket");
                     break stream;
                 }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
                 Err(error) => {
                     error!("nanvixd failed to accept connection from linuxd's control-plane (error={error:?})");
                     continue;
@@ -94,30 +89,62 @@ impl LinuxDaemon {
 
         Ok(Self {
             child,
-            _control_plane_stream: control_plane_stream,
-            linuxd_sockaddr: user_vm_sockaddr.to_string(),
+            control_plane_stream,
         })
     }
-}
 
-impl Drop for LinuxDaemon {
-    fn drop(&mut self) {
+    /// Send a shutdown message to linuxd so that it can clean-up its internal resources.
+    pub async fn shutdown(&mut self) -> Result<()> {
+        match control_plane::send_command(&mut self.control_plane_stream, control_plane::Command::Shutdown) {
+            Ok(()) => {},
+            Err(e) => {
+                // FIXME: this send_command is expected to fail until support is implemented in
+                // linuxd.
+                error!("failed to send shutdown command to linuxd (error={e:?})");
+            }
+        };
+
+        // FIXME: when linuxd reacts on shutdown commands, we will be able to get rid of this
+        // manual kill.
         match self.child.id() {
             Some(pid) => {
                 let ret_code = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
 
                 if ret_code < 0 {
-                    error!("error sending SIGINT to linuxd: {}", std::io::Error::last_os_error());
+                    let reason: String = format!("error sending SIGINT to linuxd: {}", std::io::Error::last_os_error());
+                    error!("{reason}");
+
+                    return Err(anyhow::anyhow!(reason));
                 }
             },
-            None => error!("linuxd process has no PID"),
+            None => {
+                let reason: String = "linuxd process has no PID".to_string();
+                error!("{reason}");
+
+                return Err(anyhow::anyhow!(reason));
+            }
         }
 
-        // Clean-up the socket files left behind by linuxd.
-        match fs::remove_file(self.linuxd_sockaddr.clone()) {
-            Ok(_) => {},
-            Err(ref e) if e.kind() == ErrorKind::NotFound => {},
-            Err(e) => error!("error removing UNIX socket (path={}, error={e:?})", self.linuxd_sockaddr.clone()),
+        // Wait for linuxd instance to finish.
+        match self.child.wait().await {
+            Ok(exit_status) => {
+                if !exit_status.success() {
+                    let reason: String = format!("linuxd returned with non-zero exit status: {:?}", exit_status.code());
+                    // FIXME: change this debug to error once linuxd dies gracefully after a
+                    // SIGINT.
+                    debug!("{reason}");
+
+                    Err(anyhow::anyhow!(reason))
+                } else {
+                    Ok(())
+                }
+            }
+            Err(e) => {
+                let reason: String = format!("error waiting for linuxd: {e:?}");
+                error!("{reason}");
+
+                Err(anyhow::anyhow!(reason))
+            }
         }
     }
 }


### PR DESCRIPTION
In this PRI implement the Nanvixd support for graceful linuxd shutdown. When Nanvixd receives a SIGINT, it will send a `Shutdown` message over the control-plane socket that it shares with linuxd.

This PR misses the linuxd handling to be complete, which is blocked until we can poll over different sockets in linuxd. I have left FIXMEs in the bits of code that will change once this is implemented.