### PR TITLE
[build] Drop nix Crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,10 +81,6 @@ libc = "0.2.172"
 log = "0.4.27"
 microvm = { path = "src/microvm", default-features = false }
 nanvixd = { path = "src/utils/nanvixd", default-features = false }
-nix = { version = "0.30.1", default-features = false, features = [
-        "process",
-        "signal",
-] }
 num_enum = { version = "0.7.3", default-features = false }
 nvx = { path = "src/libs/nvx", default-features = false }
 profiler = { path = "src/libs/profiler", default-features = false }

--- a/src/libs/hwloc/Cargo.toml
+++ b/src/libs/hwloc/Cargo.toml
@@ -12,6 +12,6 @@ homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+libc = { workspace = true }
 log = { workspace = true }
-nix = { workspace = true }
 serde = { workspace = true, features = ["derive", "std"] }

--- a/src/libs/hwloc/src/lib.rs
+++ b/src/libs/hwloc/src/lib.rs
@@ -7,7 +7,7 @@
 
 use anyhow::Result;
 use log::error;
-use nix::libc::{
+use libc::{
     CPU_SET,
     CPU_ZERO,
     cpu_set_t,

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -16,10 +16,10 @@ config = { workspace = true }
 flexi_logger = { workspace = true }
 hwloc = { workspace = true }
 indicatif = { workspace = true }
+libc = { workspace = true }
 log = { workspace = true }
 microvm = { workspace = true }
 nanvixd = { workspace = true }
-nix = { workspace = true }
 profiler = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -48,13 +48,6 @@ use microvm::{
     Vmm,
 };
 use nanvixd::config::DEFAULT_TMP_DIRECTORY;
-use nix::{
-    sys::signal::{
-        Signal,
-        kill,
-    },
-    unistd::Pid,
-};
 use reqwest::header::{
     CONTENT_TYPE,
     HeaderMap,
@@ -271,9 +264,10 @@ impl Benchmark {
     pub fn cleanup(&mut self) {
         if self.nanvixd.is_some() {
             debug!("Sending SIGINT to nanvixd");
-            match kill(Pid::from_raw(self.nanvixd.as_mut().unwrap().id() as i32), Signal::SIGINT) {
-                Ok(_) => {},
-                Err(e) => error!("error sending SIGINT to nano VM: {e:?}"),
+            let ret_code = unsafe { libc::kill(self.nanvixd.as_mut().unwrap().id() as libc::pid_t, libc::SIGINT) };
+
+            if ret_code < 0 {
+                error!("error sending SIGINT to nano VM: {}", std::io::Error::last_os_error());
             }
         }
     }

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -19,8 +19,8 @@ http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["full"] }
 hwloc = { workspace = true }
+libc = { workspace = true }
 log = { workspace = true }
-nix = { workspace = true, features = ["process", "signal"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sys = { workspace = true }

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -8,13 +8,6 @@
 use crate::config;
 use ::anyhow::Result;
 use ::hwloc::HwLoc;
-use ::nix::{
-    sys::signal::{
-        Signal,
-        kill,
-    },
-    unistd::Pid,
-};
 use ::std::{
     fs,
     io::ErrorKind,
@@ -111,12 +104,10 @@ impl Drop for LinuxDaemon {
     fn drop(&mut self) {
         match self.child.id() {
             Some(pid) => {
-                let pid: ::sys::pm::ProcessIdentifier = match pid.try_into() {
-                    Ok(pid) => pid,
-                    Err(e) => return error!("error converting micro VMs PID (error={e:?})"),
-                };
-                if let Err(e) = kill(Pid::from_raw(pid.into()), Signal::SIGINT) {
-                    error!("error sending SIGINT to linuxd (error={e:?})");
+                let ret_code = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
+
+                if ret_code < 0 {
+                    error!("error sending SIGINT to linuxd: {}", std::io::Error::last_os_error());
                 }
             },
             None => error!("linuxd process has no PID"),

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -8,13 +8,6 @@
 use crate::config;
 use ::anyhow::Result;
 use ::hwloc::HwLoc;
-use ::nix::{
-    sys::signal::{
-        Signal,
-        kill,
-    },
-    unistd::Pid,
-};
 use ::std::process::Stdio;
 use ::tokio::process::{
     Child,
@@ -86,12 +79,10 @@ impl Drop for Microvm {
         if let Some(mut child) = self.0.take() {
             match child.id() {
                 Some(pid) => {
-                    let pid: ::sys::pm::ProcessIdentifier = match pid.try_into() {
-                        Ok(pid) => pid,
-                        Err(e) => return error!("error converting micro VMs PID (error={e:?})"),
-                    };
-                    if let Err(e) = kill(Pid::from_raw(pid.into()), Signal::SIGINT) {
-                        error!("error sending SIGINT to user VM (error={e:?})");
+                    let ret_code = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
+
+                    if ret_code < 0 {
+                        error!("error sending SIGINT to user VM: {}", std::io::Error::last_os_error());
                     }
                 },
                 None => error!("user VM process has no PID"),


### PR DESCRIPTION
After a comment in a previous PR, I realized that I was using the `nix` crate (which I had introduced myself) in a way that could be fully covered by the `libc` crate (which we really need). In fact, I think the former is a wrapper of the latter.

In this commit I drop the `nix` crate, and use `libc` where needed.