### PR TITLE
[benchmarks] Fix Echo C/C++ Benchmarks

### DIFF
--- a/src/benchmarks/echo-c/main.c
+++ b/src/benchmarks/echo-c/main.c
@@ -27,7 +27,7 @@ int main(void)
     ssize_t nread = 0;
 
     while (1) {
-        nread = fread(buffer, 1, MAX_REQUEST_SIZE, stdin);
+        nread = read(STDIN_FILENO, buffer, MAX_REQUEST_SIZE);
         if (nread < 0) {
             break; // Error encountered.
         } else if (nread == 0) {
@@ -35,8 +35,7 @@ int main(void)
         }
 
         if (nread > 0) {
-            fwrite(buffer, 1, nread, stdout);
-            fflush(stdout);
+            write(STDOUT_FILENO, buffer, nread);
         }
     }
 

--- a/src/benchmarks/echo-cpp/main.cpp
+++ b/src/benchmarks/echo-cpp/main.cpp
@@ -1,8 +1,9 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
-#include <iostream>
-#include <vector>
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 //==================================================================================================
 // Constants
@@ -22,9 +23,10 @@ static char buffer[MAX_REQUEST_SIZE];
 
 int main()
 {
+    ssize_t nread = 0;
+
     while (true) {
-        std::cin.read(&buffer[0], MAX_REQUEST_SIZE);
-        std::streamsize nread = std::cin.gcount();
+        nread = read(STDIN_FILENO, buffer, MAX_REQUEST_SIZE);
         if (nread < 0) {
             break; // Error encountered.
         } else if (nread == 0) {
@@ -32,8 +34,7 @@ int main()
         }
 
         if (nread > 0) {
-            std::cout.write(buffer, nread);
-            std::cout.flush();
+            write(STDOUT_FILENO, buffer, nread);
         }
     }
 


### PR DESCRIPTION
In this PR I address a buffering issue with the C/C++ echo benchmarks.

In the C benchmark we were using `fread/fwrite` instead of `read/write` which have different semantics to the ones we were using. (Why this has worked in the past I am not sure).

In the C++ benchmark we were using `std::cin.read()` which will buffer input in a hard-to-determine way.

Instead, I move both benchmarks to use the raw `read/write` system calls to make sure there is no internal buffering happening.