### PR TITLE
[daemons] User VM Handle

### DIFF
--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -13,6 +13,7 @@ mod assemble;
 
 use crate::{
     message::RequestAssembler,
+    user_vm_handle::UserVmHandle,
     venv::{
         VenvCommand,
         VirtualEnviromentDirectory,
@@ -22,22 +23,16 @@ use crate::{
 use ::anyhow::Result;
 use ::std::{
     collections::VecDeque,
-    io::{
-        ErrorKind,
-        Read,
-    },
+    io::ErrorKind,
     sync::{
-        mpsc,
         mpsc::{
             Receiver,
-            RecvError,
             Sender,
         },
         Arc,
         Mutex,
         MutexGuard,
     },
-    thread::JoinHandle,
 };
 use ::sys::{
     error::{
@@ -47,16 +42,14 @@ use ::sys::{
     ipc::Message,
     pm::ThreadIdentifier,
 };
-use ::sysapi::sys_types::c_ssize_t;
-use ::syscall::{
-    unistd::message::{
-        ReadRequest,
-        ReadResponse,
-        WriteRequest,
-    },
-    venv::VirtualEnvironmentIdentifier,
-};
+use ::syscall::venv::VirtualEnvironmentIdentifier;
 use ::syscomm::SocketStream;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const DEFAULT_CONNECTION_ID: usize = 0;
 
 //==================================================================================================
 // Structures
@@ -64,7 +57,7 @@ use ::syscomm::SocketStream;
 
 pub struct LinuxDaemon {
     assembler: Arc<Mutex<RequestAssembler>>,
-    uvm_stream: Arc<Mutex<SocketStream>>,
+    uvm_stream: SocketStream,
     gateway_stream: Option<SocketStream>,
     venv: Arc<Mutex<VirtualEnviromentDirectory>>,
 }
@@ -86,103 +79,27 @@ impl LinuxDaemon {
 
         Ok(Self {
             assembler: Arc::new(Mutex::new(RequestAssembler::default())),
-            uvm_stream: Arc::new(Mutex::new(uvm_stream)),
+            uvm_stream,
             gateway_stream,
             venv: Arc::new(Mutex::new(VirtualEnviromentDirectory::new())),
         })
     }
 
-    pub fn run(&mut self) -> Result<(), Error> {
-        // Start the thread that will poll input from the gateway.
-        // TODO: when one linuxd instance manages more than one input stream we should encapsulate
-        // this logic.
-        let (gw_stdin_tx, gw_stdout_tx) = if let Some(gateway_stream) = &self.gateway_stream {
-            // For the STDIN channel senders (TX) need to wait for a response from the IO thread,
-            // hence they send, together with the ReadRequest, the send endpoint of a channel where
-            // they will wait for the response. For STDOUT senders need not to wait, hence no need
-            // to also send the channel endpoint.
-            let (gw_stdin_tx, gw_stdin_rx) = mpsc::channel::<(ReadRequest, Sender<Message>)>();
-            let (gw_stdout_tx, gw_stdout_rx) = mpsc::channel::<WriteRequest>();
-
-            // Make sure that the input stream from the gateway is set to blocking, as otherwise we
-            // would not be able to differentiate between an EOF and a race between the application
-            // code and the gateway.
-            let mut gw_stdin_stream = gateway_stream
-                .try_clone()
-                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to clone stream"))?;
-            gw_stdin_stream
-                .set_nonblocking(false)
-                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to set non-blocing socket"))?;
-
-            let _gw_stdin_thread: JoinHandle<Result<()>> = std::thread::spawn(move || {
-                loop {
-                    // Block waiting for the user VM to request reading from STDIN.
-                    match gw_stdin_rx.recv() {
-                        Ok((_read_request, response_tx)) => {
-                            let mut response_buf: [u8; ReadResponse::BUFFER_SIZE] =
-                                [0u8; ReadResponse::BUFFER_SIZE];
-                            let num_read = match gw_stdin_stream.read(&mut response_buf) {
-                                Ok(n) => n,
-                                Err(e) => {
-                                    let reason: String =
-                                        format!("failed to read STDIN from gateway: {e:?}");
-                                    error!("{}", reason);
-                                    return Err(anyhow::anyhow!(reason));
-                                },
-                            };
-                            response_tx.send(ReadResponse::build(
-                                0.into(),
-                                num_read as c_ssize_t,
-                                response_buf,
-                            ))?;
-                        },
-                        Err(RecvError) => {
-                            // This may happen during shutdown.
-                            debug!("gateway STDIN channel disconnected");
-                            break Ok(());
-                        },
-                    }
-                }
-            });
-
-            let mut gw_stdout_stream = gateway_stream
-                .try_clone()
-                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to clone stream"))?;
-            let _gw_stdout_thread: JoinHandle<Result<()>> = std::thread::spawn(move || {
-                loop {
-                    // Block waiting the user VM to request writing to stdout.
-                    match gw_stdout_rx.recv() {
-                        Ok(write_request) => {
-                            gw_stdout_stream
-                                .write_all(&write_request.buffer[..write_request.count as usize])?;
-
-                            // We don't need to send anything in response of the write, as the
-                            // writting thread has already moved on.
-                        },
-                        Err(RecvError) => {
-                            // This may happen during shutdown.
-                            debug!("gateway STDOUT channel disconnected");
-                            break Ok(());
-                        },
-                    }
-                }
-            });
-
-            (Some(gw_stdin_tx), Some(gw_stdout_tx))
-        } else {
-            (None, None)
-        };
-
+    pub fn run(self) -> Result<(), Error> {
         // Map keeping track of the worker threads associated the user VM.
         let mut worker_threads: VecDeque<WorkerThreadHandle> = VecDeque::new();
 
+        // Handle around the user VM.
+        let uvm_handle: UserVmHandle =
+            UserVmHandle::new(DEFAULT_CONNECTION_ID, self.uvm_stream, self.gateway_stream);
+
         loop {
-            let uvm_stream: Arc<Mutex<SocketStream>> = self.uvm_stream.clone();
+            let uvm_handle: UserVmHandle = uvm_handle.clone();
             let venv: Arc<Mutex<VirtualEnviromentDirectory>> = self.venv.clone();
             let assembler: Arc<Mutex<RequestAssembler>> = self.assembler.clone();
 
             // Receive a message from the user virtual machine.
-            let message: Message = match Self::recv(uvm_stream.clone()) {
+            let message: Message = match Self::recv(uvm_handle.get_user_vm_stream()) {
                 Ok(message) => message,
 
                 Err(error_kind) => match error_kind {
@@ -272,7 +189,8 @@ impl LinuxDaemon {
                         Err(error) => {
                             warn!("failed to join new virtual environment (error={error:?})");
                             let message: Message = crate::build_error(source, error.code);
-                            uvm_stream
+                            uvm_handle
+                                .get_user_vm_stream()
                                 .lock()
                                 .unwrap()
                                 .write_all(&message.to_bytes())
@@ -290,9 +208,6 @@ impl LinuxDaemon {
             // Spawn a new worker thread, if necessary.
             if let Some(channel_rx) = channel_rx {
                 // Spawn a thread to handle the message.
-                let venv: Arc<Mutex<VirtualEnviromentDirectory>> = venv.clone();
-                let gw_stdin_tx = gw_stdin_tx.clone();
-                let gw_stdout_tx = gw_stdout_tx.clone();
                 let assembler = assembler.clone();
 
                 // Spawn an interruptible thread to handle the message.
@@ -300,10 +215,7 @@ impl LinuxDaemon {
                     source,
                     channel_rx,
                     channel_tx.clone(),
-                    uvm_stream,
-                    gw_stdin_tx,
-                    gw_stdout_tx,
-                    venv,
+                    uvm_handle,
                     assembler,
                 )?;
                 worker_threads.push_back(worker_thread_handle);

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -23,6 +23,7 @@ mod socket;
 mod time;
 mod times;
 mod unistd;
+mod user_vm_handle;
 mod venv;
 mod worker_thread;
 
@@ -209,7 +210,7 @@ pub fn main() -> Result<()> {
         None => None,
     };
 
-    let mut procd: LinuxDaemon = match LinuxDaemon::init(user_vm_stream, gateway_stream) {
+    let procd: LinuxDaemon = match LinuxDaemon::init(user_vm_stream, gateway_stream) {
         Ok(procd) => procd,
         Err(e) => panic!("failed to initialize process manager daemon (error={e:?})"),
     };

--- a/src/daemons/linuxd/src/user_vm_handle.rs
+++ b/src/daemons/linuxd/src/user_vm_handle.rs
@@ -1,0 +1,54 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::std::sync::{
+    Arc,
+    Mutex,
+};
+use ::syscomm::SocketStream;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// State associated with a user VM connected to this linuxd instance.
+#[derive(Clone)]
+pub struct UserVmHandle {
+    // FIXME: this field is relevant once we start managing more than one user VMs.
+    #[allow(dead_code)]
+    conn_id: usize,
+    user_vm_stream: Arc<Mutex<SocketStream>>,
+    gw_stream: Option<Arc<Mutex<SocketStream>>>,
+}
+
+impl UserVmHandle {
+    pub fn new(
+        conn_id: usize,
+        user_vm_stream: SocketStream,
+        gw_stream: Option<SocketStream>,
+    ) -> Self {
+        Self {
+            conn_id,
+            user_vm_stream: Arc::new(Mutex::new(user_vm_stream)),
+            gw_stream: gw_stream.map(|stream| Arc::new(Mutex::new(stream))),
+        }
+    }
+
+    // FIXME: this field is relevant once we start managing more than one user VMs.
+    #[allow(dead_code)]
+    pub fn get_conn_id(&self) -> usize {
+        self.conn_id
+    }
+
+    pub fn get_user_vm_stream(&self) -> Arc<Mutex<SocketStream>> {
+        self.user_vm_stream.clone()
+    }
+
+    pub fn get_gw_vm_stream(&self) -> Option<Arc<Mutex<SocketStream>>> {
+        self.gw_stream.clone()
+    }
+}

--- a/src/daemons/linuxd/src/venv.rs
+++ b/src/daemons/linuxd/src/venv.rs
@@ -7,13 +7,10 @@
 
 use ::std::{
     collections::BTreeMap,
-    sync::{
-        mpsc,
-        mpsc::{
-            channel,
-            Receiver,
-            Sender,
-        },
+    sync::mpsc::{
+        channel,
+        Receiver,
+        Sender,
     },
 };
 use ::sys::{
@@ -49,10 +46,6 @@ pub enum VenvCommand {
 pub struct VirtualEnvironment {
     /// Identifier.
     id: VirtualEnvironmentIdentifier,
-    /// Channel to receive stdin from the IO thread. For stdout we write to the IO thread and do
-    /// not wait for a reply, so we don't need an auxiliary channel.
-    stdin_response_tx: Sender<Message>,
-    stdin_response_rx: Receiver<Message>,
     /// Input channel to this virtual environment.
     channel_tx: Sender<VenvCommand>,
 }
@@ -80,14 +73,7 @@ impl VirtualEnvironment {
     /// Creates a new virtual environment.
     ///
     fn new(id: VirtualEnvironmentIdentifier, channel_tx: Sender<VenvCommand>) -> Self {
-        let (stdin_response_tx, stdin_response_rx) = mpsc::channel::<Message>();
-
-        Self {
-            id,
-            stdin_response_tx,
-            stdin_response_rx,
-            channel_tx,
-        }
+        Self { id, channel_tx }
     }
 
     ///
@@ -97,26 +83,6 @@ impl VirtualEnvironment {
     ///
     fn id(&self) -> VirtualEnvironmentIdentifier {
         self.id
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Get the sender end of the stdin channel. It can be passed to the gateway IO thread to
-    /// receive stdin input through it.
-    ///
-    pub fn get_stdin_response_tx(&self) -> Sender<Message> {
-        self.stdin_response_tx.clone()
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Get the receiving end of the stdin channel. We need a mutable reference as there can only
-    /// ever be one receiver, which should be the thread in the virtual environment.
-    ///
-    pub fn get_stdin_response_rx(&mut self) -> &mut Receiver<Message> {
-        &mut self.stdin_response_rx
     }
 
     ///
@@ -246,23 +212,5 @@ impl VirtualEnviromentDirectory {
     ///
     pub fn get(&self, tid: ThreadIdentifier) -> Option<&VirtualEnvironment> {
         self.processes.get(&tid)
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Gets a mutable reference to the virtual environment of a process.
-    ///
-    /// # Parameters
-    ///
-    /// - `tid`: Thread identifier.
-    ///
-    /// # Returns
-    ///
-    /// If there is a virtual environment associated with the process, the function returns a
-    /// mutable reference to the virtual environment. Otherwise, it returns `None`.
-    ///
-    pub fn get_mut(&mut self, tid: ThreadIdentifier) -> Option<&mut VirtualEnvironment> {
-        self.processes.get_mut(&tid)
     }
 }

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -24,15 +24,15 @@ use crate::{
     socket,
     times,
     unistd,
-    venv::{
-        VenvCommand,
-        VirtualEnviromentDirectory,
-        VirtualEnvironment,
-    },
+    user_vm_handle::UserVmHandle,
+    venv::VenvCommand,
 };
 use ::anyhow::Result;
 use ::std::{
-    io::ErrorKind,
+    io::{
+        ErrorKind,
+        Read,
+    },
     mem,
     ptr,
     sync::{
@@ -67,10 +67,13 @@ use ::sys::{
     },
     pm::ThreadIdentifier,
 };
-use ::sysapi::unistd::{
-    STDERR_FILENO,
-    STDIN_FILENO,
-    STDOUT_FILENO,
+use ::sysapi::{
+    sys_types::c_ssize_t,
+    unistd::{
+        STDERR_FILENO,
+        STDIN_FILENO,
+        STDOUT_FILENO,
+    },
 };
 use ::syscall::{
     dirent::message::GetDirectoryEntriesRequest,
@@ -199,10 +202,7 @@ impl WorkerThreadHandle {
         id: ThreadIdentifier,
         channel_rx: Receiver<VenvCommand>,
         channel_tx: Sender<VenvCommand>,
-        uvm_stream: Arc<Mutex<SocketStream>>,
-        gw_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        gw_stdout_tx: Option<Sender<WriteRequest>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        uvm_handle: UserVmHandle,
         assembler: Arc<Mutex<RequestAssembler>>,
     ) -> Result<Self, Error> {
         // We use an atomic to pass the id of the created thread back to the caller context. We
@@ -218,14 +218,7 @@ impl WorkerThreadHandle {
             let pthread_id = unsafe { pthread_self() };
             pthread_id_holder.store(pthread_id as usize, Ordering::Relaxed);
 
-            Self::handle_message(
-                channel_rx,
-                uvm_stream,
-                gw_stdin_tx,
-                gw_stdout_tx,
-                venv,
-                assembler,
-            );
+            Self::handle_message(channel_rx, uvm_handle, assembler);
 
             trace!("thread shutting down after receiving interrupt (pthread_id={pthread_id})");
         });
@@ -258,13 +251,12 @@ impl WorkerThreadHandle {
 
     fn handle_message(
         channel_rx: Receiver<VenvCommand>,
-        uvm_stream: Arc<Mutex<SocketStream>>,
-        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        gateway_stdout_tx: Option<Sender<WriteRequest>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        uvm_handle: UserVmHandle,
         assembler: Arc<Mutex<RequestAssembler>>,
     ) {
         let worker_tid: ThreadId = thread::current().id();
+        let uvm_stream: Arc<Mutex<SocketStream>> = uvm_handle.get_user_vm_stream();
+        let gw_stream: Option<Arc<Mutex<SocketStream>>> = uvm_handle.get_gw_vm_stream();
 
         loop {
             let message: Message = match channel_rx.recv() {
@@ -309,9 +301,7 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::ReadRequest
                                 | LinuxDaemonMessageHeader::WriteRequest => {
                                     match Self::handle_special_messages(
-                                        gateway_stdin_tx.clone(),
-                                        gateway_stdout_tx.clone(),
-                                        venv.clone(),
+                                        gw_stream.clone(),
                                         source,
                                         message,
                                     ) {
@@ -462,9 +452,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_special_messages(
-        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        gateway_stdout_tx: Option<Sender<WriteRequest>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        gw_stream: Option<Arc<Mutex<SocketStream>>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<Message, WorkerThreadError> {
@@ -475,11 +463,11 @@ impl WorkerThreadHandle {
             },
             LinuxDaemonMessageHeader::ReadRequest => {
                 let request: ReadRequest = ReadRequest::from_bytes(message.payload);
-                Self::handle_read_request(gateway_stdin_tx, venv, source, request)
+                Self::handle_read_request(gw_stream, source, request)
             },
             LinuxDaemonMessageHeader::WriteRequest => {
                 let request: WriteRequest = WriteRequest::from_bytes(message.payload);
-                Self::handle_write_request(gateway_stdout_tx, source, request)
+                Self::handle_write_request(gw_stream, source, request)
             },
             header => {
                 // The following statement is unreachable, because the matching logic in this
@@ -782,15 +770,15 @@ impl WorkerThreadHandle {
     }
 
     fn handle_write_request(
-        gateway_stdout_tx: Option<Sender<WriteRequest>>,
+        gw_stream: Option<Arc<Mutex<SocketStream>>>,
         source: ThreadIdentifier,
         mut request: WriteRequest,
     ) -> Result<Message, WorkerThreadError> {
         trace!("handle_write_request(): source={source:?}, request={request:?}");
         // Check if writing to gateway.
         if request.fd == STDOUT_FILENO || request.fd == STDERR_FILENO {
-            let gateway_stdout_tx = if let Some(gateway_stdout_tx) = gateway_stdout_tx {
-                gateway_stdout_tx
+            let gw_stream = if let Some(gw_stream) = gw_stream {
+                gw_stream
             } else {
                 error!(
                     "handle_write_request(): trying to write to stdout without a gateway \
@@ -807,10 +795,21 @@ impl WorkerThreadHandle {
             } else {
                 profiler::timestamp_message!(&mut request.buffer, 0);
                 let count: usize = request.count as usize;
-                if let Err(error) = gateway_stdout_tx.send(request) {
-                    debug!("failed to write buffer to the gateway (error={error:?})");
-                    // TODO: Check error conversion.
-                    return Ok(build_error(source, ErrorCode::ConnectionReset));
+
+                if let Ok(mut locked_gw_stream) = gw_stream.lock() {
+                    match locked_gw_stream.write_all(&request.buffer[..count]) {
+                        Ok(()) => {},
+                        Err(e) if e.kind() == ErrorKind::Interrupted => {
+                            return Err(WorkerThreadError::Interrupted)
+                        },
+                        Err(e) => {
+                            error!("failed to write to gateway socket (error={e:?})");
+                            return Ok(build_error(source, ErrorCode::IoErr));
+                        },
+                    }
+                } else {
+                    error!("gateway stream mutex poisoned");
+                    return Ok(build_error(source, ErrorCode::IoErr));
                 }
 
                 // We don't wait for the IO thread to confirm that the write was correct, as writes
@@ -825,16 +824,15 @@ impl WorkerThreadHandle {
     }
 
     fn handle_read_request(
-        gateway_stdin_tx: Option<Sender<(ReadRequest, Sender<Message>)>>,
-        venv: Arc<Mutex<VirtualEnviromentDirectory>>,
+        gw_stream: Option<Arc<Mutex<SocketStream>>>,
         source: ThreadIdentifier,
         request: ReadRequest,
     ) -> Result<Message, WorkerThreadError> {
         trace!("handle_read_request(): source={source:?}, request={request:?}");
         // Check if reading from gateway.
         if request.fd == STDIN_FILENO {
-            let gateway_stdin_tx = if let Some(gateway_stdin_tx) = gateway_stdin_tx {
-                gateway_stdin_tx
+            let gw_stream = if let Some(gw_stream) = gw_stream {
+                gw_stream
             } else {
                 error!(
                     "handle_read_request(): process tried to read from stdin but no gateway found"
@@ -842,43 +840,62 @@ impl WorkerThreadHandle {
                 return Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]));
             };
 
-            // Check if the process is associated with a virtual environment.
-            let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
-            let env: &mut VirtualEnvironment = if let Some(env) = venv.get_mut(source) {
-                env
-            } else {
-                warn!(
-                    "handle_read_request(): process is not associated with a virtual environment, \
-                     returning EOF"
-                );
-                return Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]));
+            let response: Result<Message, WorkerThreadError> = {
+                // Take the lock (handle poison however you prefer)
+                let mut locked_gw_stream: MutexGuard<'_, SocketStream> = match gw_stream.lock() {
+                    Ok(g) => g,
+                    Err(e) => {
+                        error!("gateway stream mutex poisoned (error={e:?})");
+                        return Ok(ReadResponse::build(
+                            source,
+                            0,
+                            [0u8; ReadResponse::BUFFER_SIZE],
+                        ));
+                    },
+                };
+
+                // Read from the gateway thread.
+                loop {
+                    let mut response_buf: [u8; ReadResponse::BUFFER_SIZE] =
+                        [0u8; ReadResponse::BUFFER_SIZE];
+                    // Blocking read from the gateway socket to make sure we can be interrupted if
+                    // necessary.
+                    match locked_gw_stream.read(&mut response_buf) {
+                        Ok(0) => {
+                            error!(
+                                "handle_read_request(): error receiving request response from \
+                                 gateway STDIN: EOF"
+                            );
+                            break Ok(ReadResponse::build(
+                                source,
+                                0,
+                                [0u8; ReadResponse::BUFFER_SIZE],
+                            ));
+                        },
+                        Ok(n) => {
+                            debug!("read {n} bytes from gateway: {response_buf:?}");
+                            break Ok(ReadResponse::build(source, n as c_ssize_t, response_buf));
+                        },
+                        Err(e) if e.kind() == ErrorKind::WouldBlock => continue,
+                        Err(e) if e.kind() == ErrorKind::Interrupted => {
+                            return Err(WorkerThreadError::Interrupted)
+                        },
+                        Err(e) => {
+                            error!(
+                                "handle_read_request(): error reading data from gateway \
+                                 (error={e:?})"
+                            );
+                            break Ok(ReadResponse::build(
+                                source,
+                                0,
+                                [0u8; ReadResponse::BUFFER_SIZE],
+                            ));
+                        },
+                    };
+                }
             };
 
-            // Send ReadRequest to gateway IO thread.
-            if let Err(error) = gateway_stdin_tx.send((request, env.get_stdin_response_tx())) {
-                error!(
-                    "handle_read_request(): error sending request to gateway STDIN IO thread, \
-                     returning EOF (error={error:?})"
-                );
-                return Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]));
-            }
-
-            // Wait for response from IO thread.
-            match env.get_stdin_response_rx().recv() {
-                Ok(mut read_response) => {
-                    // We don't have access to the source in the gateway IO thread, so we set
-                    // it here.
-                    read_response.destination = source.into();
-                    Ok(read_response)
-                },
-                Err(e) => {
-                    error!(
-                        "handle_read_request(): error receiving request response from gateway \
-                         STDIN IO thread, returning EOF (error={e:?})"
-                    );
-                    Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]))
-                },
-            }
+            response
         } else {
             // Read from other file descriptor.
             unistd::do_read(source, request)


### PR DESCRIPTION
In this PR I introduce a handle to encapsulate the state associated with a user VM that is running in linuxd. (For the moment, we only ever have one.)

I also simplify the gateway handling logic by giving each working thread a copy of the handle, and then making each worker thread use the internal socket stream for communication (protected by a mutex). This makes it possible to get rid of the gateway IO thread.