### PR TITLE
[build] Enforce Cleanup When Switching Build Modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,7 @@ distclean: clean distclean-opt
 	$(FORCE_RM_CMD) $(OBJECTS_DIR)
 	$(FORCE_RM_CMD) $(LIBRARIES_DIR)
 	$(FORCE_RM_CMD) $(BINARIES_DIR)
+	$(FORCE_RM_CMD) $(PYTHON_VENV_DIRECTORY)
 
 # Runs clippy.
 clippy: \

--- a/z
+++ b/z
@@ -282,12 +282,21 @@ main() {
 
     case "${command}" in
         "${CMD_NAME_BUILD}")
+            # Check if we are switching build modes.
             if ${BUILD_WITH_DOCKER} && ! ${LAST_BUILD_WITH_DOCKER}; then
-                print_warning "Switching to Docker build."
-                print_warning "Consider first running './z ${CMD_NAME_CLEANUP} ${OPT_NAME_WITH_DOCKER}'."
+                print_warning "Switching to Docker build, forcing cleanup."
+                # Force a cleanup.
+                if ! eval "$(build_docker_command distclean)" ; then
+                    print_error "Cleanup failed with Docker."
+                    exit 1
+                fi
             elif ! ${BUILD_WITH_DOCKER} && ${LAST_BUILD_WITH_DOCKER}; then
-                print_warning "Switching to native toolchain build."
-                print_warning "Consider first running './z ${CMD_NAME_CLEANUP}'."
+                print_warning "Switching to native toolchain build, forcing cleanup."
+                # Force a cleanup.
+                if ! make distclean ; then
+                    print_error "Cleanup failed with native toolchain."
+                    exit 1
+                fi
             fi
 
 


### PR DESCRIPTION
## Description

This pull request improves the build process by ensuring a clean environment when switching between Docker and native toolchain builds, and enhances the cleanup process by also removing the Python virtual environment directory. 
