### PR TITLE
[libs] Move Syscomm To Metal IO Sockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ kvm-ioctls = "0.23.0"
 libc = "0.2.172"
 log = "0.4.27"
 microvm = { path = "src/microvm", default-features = false }
+mio = { version = "1.0.4", default-features = false }
 nanvixd = { path = "src/utils/nanvixd", default-features = false }
 num_enum = { version = "0.7.3", default-features = false }
 nvx = { path = "src/libs/nvx", default-features = false }

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -183,10 +183,23 @@ impl LinuxDaemon {
                         Err(error) => {
                             warn!("failed to join new virtual environment (error={error:?})");
                             let message: Message = crate::build_error(source, error.code);
-                            uvm_handle
-                                .get_user_vm_stream()
-                                .lock()
-                                .unwrap()
+
+                            let uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>> =
+                                uvm_handle.get_user_vm_stream();
+                            let mut guard: MutexGuard<'_, (SocketStream, VecDeque<u8>)> =
+                                match uvm_stream.lock() {
+                                    Ok(guard) => guard,
+                                    Err(e) => {
+                                        error!(
+                                            "error acquiring lock on user VM stream (error={e:?})"
+                                        );
+                                        continue;
+                                    },
+                                };
+                            let (locked_uvm_stream, _): &mut (SocketStream, VecDeque<u8>) =
+                                &mut guard;
+
+                            locked_uvm_stream
                                 .write_all(&message.to_bytes())
                                 .map_err(|_| {
                                     let reason = "failed to write to user VM stream";
@@ -236,16 +249,52 @@ impl LinuxDaemon {
         Ok(())
     }
 
-    // Read a message from the user VM stream.
-    fn recv(uvm_stream: Arc<Mutex<SocketStream>>) -> Result<Message, ErrorKind> {
+    /// Read a message from the user VM stream. We need to handle the situation where we can only
+    /// do a partial read, so we keep a buffer alongside our socket. It is safe to have this buffer
+    /// dynamically sized, as it will always be smaller than one message size.
+    fn recv(uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>) -> Result<Message, ErrorKind> {
+        let mut guard: MutexGuard<'_, (SocketStream, VecDeque<u8>)> = match uvm_stream.lock() {
+            Ok(guard) => guard,
+            Err(e) => {
+                error!("error acquiring lock on user VM stream (error={e:?})");
+                return Err(ErrorKind::InvalidData);
+            },
+        };
+        let (locked_uvm_stream, partial_read_buffer): &mut (SocketStream, VecDeque<u8>) =
+            &mut guard;
+
         let mut buf: [u8; config::kernel::IPC_MESSAGE_SIZE] =
             [0u8; config::kernel::IPC_MESSAGE_SIZE];
 
-        let mut locked_uvm_stream: MutexGuard<'_, SocketStream> = uvm_stream.lock().unwrap();
+        let mut num_filled = 0;
+        if !partial_read_buffer.is_empty() {
+            // Prepare data in buffer for partial read.
+            partial_read_buffer.make_contiguous();
+            let partial_bytes = partial_read_buffer.as_slices().0;
 
-        if let Err(e) = locked_uvm_stream.try_read_exact(&mut buf) {
-            return Err(e.kind());
-        };
+            // We take the minimum at the end just in case, but the partial read should always be
+            // strictly smaller than the message size.
+            let num_partial_read = partial_bytes.len().min(buf.len());
+
+            buf[..num_partial_read].copy_from_slice(&partial_bytes[..num_partial_read]);
+
+            // Clear partial read buffer.
+            partial_read_buffer.clear();
+            num_filled += num_partial_read;
+        }
+        // Post-condition: partial_read_buffer is empty.
+
+        match locked_uvm_stream.try_read_exact(&mut buf[num_filled..]) {
+            Ok(n) => {
+                // Handle partial reads by copying all we have read to the partial read buffer and
+                // returning a WouldBlock indicating that we need more data.
+                if n + num_filled < buf.len() {
+                    partial_read_buffer.extend(&buf[..(n + num_filled)]);
+                    return Err(ErrorKind::WouldBlock);
+                }
+            },
+            Err(e) => return Err(e.kind()),
+        }
 
         let message: Message = match Message::try_from_bytes(buf) {
             Ok(message) => message,

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -71,12 +71,6 @@ impl LinuxDaemon {
         uvm_stream: SocketStream,
         gateway_stream: Option<SocketStream>,
     ) -> Result<Self, Error> {
-        if let Err(error) = uvm_stream.set_nonblocking(true) {
-            let reason: &str = "failed to set UVM stream to non-blocking mode";
-            error!("init(): {reason:?} (error={error:?})");
-            return Err(Error::new(ErrorCode::InvalidArgument, reason));
-        }
-
         Ok(Self {
             assembler: Arc::new(Mutex::new(RequestAssembler::default())),
             uvm_stream,
@@ -249,7 +243,7 @@ impl LinuxDaemon {
 
         let mut locked_uvm_stream: MutexGuard<'_, SocketStream> = uvm_stream.lock().unwrap();
 
-        if let Err(e) = locked_uvm_stream.read_exact(&mut buf) {
+        if let Err(e) = locked_uvm_stream.try_read_exact(&mut buf) {
             return Err(e.kind());
         };
 

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -48,6 +48,7 @@ use ::flexi_logger::{
 };
 use ::std::{
     env,
+    io::ErrorKind,
     str::FromStr,
     sync::Once,
 };
@@ -167,6 +168,7 @@ pub fn main() -> Result<()> {
                 info!("Connected to user VM in: {:?}", stream.peer_addr());
                 break stream;
             },
+            Err(e) if e.kind() == ErrorKind::WouldBlock => continue,
             Err(error) => {
                 error!("Failed to accept connection: {error:?}");
                 continue;
@@ -200,6 +202,7 @@ pub fn main() -> Result<()> {
                         info!("Connected to gateway in: {:?}", stream.peer_addr());
                         break Some(stream);
                     },
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => continue,
                     Err(error) => {
                         error!("Failed to accept connection: {error:?}");
                         continue;

--- a/src/daemons/linuxd/src/user_vm_handle.rs
+++ b/src/daemons/linuxd/src/user_vm_handle.rs
@@ -5,9 +5,12 @@
 // Imports
 //==================================================================================================
 
-use ::std::sync::{
-    Arc,
-    Mutex,
+use ::std::{
+    collections::VecDeque,
+    sync::{
+        Arc,
+        Mutex,
+    },
 };
 use ::syscomm::{
     BlockingSocketStream,
@@ -24,7 +27,9 @@ pub struct UserVmHandle {
     // FIXME: this field is relevant once we start managing more than one user VMs.
     #[allow(dead_code)]
     conn_id: usize,
-    user_vm_stream: Arc<Mutex<SocketStream>>,
+    // We keep track of a buffer to handle partial reads from the user VM socket. This buffer will
+    // never exceed the IPC message size.
+    user_vm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>,
     gw_stream: Option<Arc<Mutex<BlockingSocketStream>>>,
 }
 
@@ -49,7 +54,7 @@ impl UserVmHandle {
 
         Self {
             conn_id,
-            user_vm_stream: Arc::new(Mutex::new(user_vm_stream)),
+            user_vm_stream: Arc::new(Mutex::new((user_vm_stream, VecDeque::new()))),
             gw_stream: blocking_stream.map(|stream| Arc::new(Mutex::new(stream))),
         }
     }
@@ -60,7 +65,7 @@ impl UserVmHandle {
         self.conn_id
     }
 
-    pub fn get_user_vm_stream(&self) -> Arc<Mutex<SocketStream>> {
+    pub fn get_user_vm_stream(&self) -> Arc<Mutex<(SocketStream, VecDeque<u8>)>> {
         self.user_vm_stream.clone()
     }
 

--- a/src/daemons/linuxd/src/user_vm_handle.rs
+++ b/src/daemons/linuxd/src/user_vm_handle.rs
@@ -9,7 +9,10 @@ use ::std::sync::{
     Arc,
     Mutex,
 };
-use ::syscomm::SocketStream;
+use ::syscomm::{
+    BlockingSocketStream,
+    SocketStream,
+};
 
 //==================================================================================================
 // Structures
@@ -22,7 +25,7 @@ pub struct UserVmHandle {
     #[allow(dead_code)]
     conn_id: usize,
     user_vm_stream: Arc<Mutex<SocketStream>>,
-    gw_stream: Option<Arc<Mutex<SocketStream>>>,
+    gw_stream: Option<Arc<Mutex<BlockingSocketStream>>>,
 }
 
 impl UserVmHandle {
@@ -31,10 +34,23 @@ impl UserVmHandle {
         user_vm_stream: SocketStream,
         gw_stream: Option<SocketStream>,
     ) -> Self {
+        let blocking_stream: Option<BlockingSocketStream> = if let Some(gw_stream) = gw_stream {
+            match gw_stream.set_blocking() {
+                Ok(stream) => Some(stream),
+                // We don't panic if we can not set the stream to blocking.
+                Err(e) => {
+                    error!("error setting gateway stream as blocking (error={e:?})");
+                    None
+                },
+            }
+        } else {
+            None
+        };
+
         Self {
             conn_id,
             user_vm_stream: Arc::new(Mutex::new(user_vm_stream)),
-            gw_stream: gw_stream.map(|stream| Arc::new(Mutex::new(stream))),
+            gw_stream: blocking_stream.map(|stream| Arc::new(Mutex::new(stream))),
         }
     }
 
@@ -48,7 +64,7 @@ impl UserVmHandle {
         self.user_vm_stream.clone()
     }
 
-    pub fn get_gw_vm_stream(&self) -> Option<Arc<Mutex<SocketStream>>> {
+    pub fn get_gw_vm_stream(&self) -> Option<Arc<Mutex<BlockingSocketStream>>> {
         self.gw_stream.clone()
     }
 }

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -29,10 +29,7 @@ use crate::{
 };
 use ::anyhow::Result;
 use ::std::{
-    io::{
-        ErrorKind,
-        Read,
-    },
+    io::ErrorKind,
     mem,
     ptr,
     sync::{
@@ -140,6 +137,7 @@ use ::syscall::{
     LINUXD,
 };
 use ::syscomm::{
+    BlockingSocketStream,
     SocketError,
     SocketStream,
 };
@@ -256,7 +254,7 @@ impl WorkerThreadHandle {
     ) {
         let worker_tid: ThreadId = thread::current().id();
         let uvm_stream: Arc<Mutex<SocketStream>> = uvm_handle.get_user_vm_stream();
-        let gw_stream: Option<Arc<Mutex<SocketStream>>> = uvm_handle.get_gw_vm_stream();
+        let gw_stream: Option<Arc<Mutex<BlockingSocketStream>>> = uvm_handle.get_gw_vm_stream();
 
         loop {
             let message: Message = match channel_rx.recv() {
@@ -452,7 +450,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_special_messages(
-        gw_stream: Option<Arc<Mutex<SocketStream>>>,
+        gw_stream: Option<Arc<Mutex<BlockingSocketStream>>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<Message, WorkerThreadError> {
@@ -770,7 +768,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_write_request(
-        gw_stream: Option<Arc<Mutex<SocketStream>>>,
+        gw_stream: Option<Arc<Mutex<BlockingSocketStream>>>,
         source: ThreadIdentifier,
         mut request: WriteRequest,
     ) -> Result<Message, WorkerThreadError> {
@@ -824,7 +822,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_read_request(
-        gw_stream: Option<Arc<Mutex<SocketStream>>>,
+        gw_stream: Option<Arc<Mutex<BlockingSocketStream>>>,
         source: ThreadIdentifier,
         request: ReadRequest,
     ) -> Result<Message, WorkerThreadError> {
@@ -842,10 +840,11 @@ impl WorkerThreadHandle {
 
             let response: Result<Message, WorkerThreadError> = {
                 // Take the lock (handle poison however you prefer)
-                let mut locked_gw_stream: MutexGuard<'_, SocketStream> = match gw_stream.lock() {
-                    Ok(g) => g,
-                    Err(e) => {
-                        error!("gateway stream mutex poisoned (error={e:?})");
+                let mut locked_gw_stream: MutexGuard<'_, BlockingSocketStream> =
+                    match gw_stream.lock() {
+                        Ok(g) => g,
+                        Err(e) => {
+                            error!("gateway stream mutex poisoned (error={e:?})");
                         return Ok(ReadResponse::eof(source));
                     },
                 };
@@ -880,6 +879,33 @@ impl WorkerThreadHandle {
                             break Ok(ReadResponse::eof(source));
                         },
                     };
+
+                // Read from the gateway thread.
+                let mut response_buf: [u8; ReadResponse::BUFFER_SIZE] =
+                    [0u8; ReadResponse::BUFFER_SIZE];
+                // Blocking read from the gateway socket to make sure we can be interrupted if
+                // necessary.
+                match locked_gw_stream.read(&mut response_buf) {
+                    Ok(0) => {
+                        error!(
+                            "handle_read_request(): error receiving request response from gateway \
+                             STDIN: EOF"
+                        );
+                        Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]))
+                    },
+                    Ok(n) => {
+                        debug!("read {n} bytes from gateway: {response_buf:?}");
+                        Ok(ReadResponse::build(source, n as c_ssize_t, response_buf))
+                    },
+                    Err(e) if e.kind() == ErrorKind::Interrupted => {
+                        Err(WorkerThreadError::Interrupted)
+                    },
+                    Err(e) => {
+                        error!(
+                            "handle_read_request(): error reading data from gateway (error={e:?})"
+                        );
+                        Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]))
+                    },
                 }
             };
 

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -29,6 +29,7 @@ use crate::{
 };
 use ::anyhow::Result;
 use ::std::{
+    collections::VecDeque,
     io::ErrorKind,
     mem,
     ptr,
@@ -253,7 +254,7 @@ impl WorkerThreadHandle {
         assembler: Arc<Mutex<RequestAssembler>>,
     ) {
         let worker_tid: ThreadId = thread::current().id();
-        let uvm_stream: Arc<Mutex<SocketStream>> = uvm_handle.get_user_vm_stream();
+        let uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>> = uvm_handle.get_user_vm_stream();
         let gw_stream: Option<Arc<Mutex<BlockingSocketStream>>> = uvm_handle.get_gw_vm_stream();
 
         loop {
@@ -609,7 +610,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_long_request_messages(
-        uvm_stream: Arc<Mutex<SocketStream>>,
+        uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>,
         assembler: Arc<Mutex<RequestAssembler>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
@@ -685,7 +686,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_long_response_messages(
-        uvm_stream: Arc<Mutex<SocketStream>>,
+        uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<(), WorkerThreadError> {
@@ -708,14 +709,24 @@ impl WorkerThreadHandle {
     }
 
     // Send a message to the TCP stream.
-    fn send(uvm_stream: Arc<Mutex<SocketStream>>, message: Message) -> Result<(), SocketError> {
+    fn send(
+        uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>,
+        message: Message,
+    ) -> Result<(), SocketError> {
         let bytes = message.to_bytes();
 
         loop {
-            let mut locked_uvm_stream = uvm_stream.lock().unwrap();
+            let mut guard: MutexGuard<'_, (SocketStream, VecDeque<u8>)> = match uvm_stream.lock() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    error!("error acquiring lock on user VM stream (error={e:?})");
+                    return Err(std::io::Error::other("error acquiring lock").into());
+                },
+            };
+            let (locked_uvm_stream, _): &mut (SocketStream, VecDeque<u8>) = &mut guard;
 
             match locked_uvm_stream.write_all(&bytes) {
-                Ok(_) => break Ok(()),
+                Ok(()) => break Ok(()),
                 Err(e) => {
                     match e.kind() {
                         ErrorKind::WouldBlock => {
@@ -845,38 +856,7 @@ impl WorkerThreadHandle {
                         Ok(g) => g,
                         Err(e) => {
                             error!("gateway stream mutex poisoned (error={e:?})");
-                        return Ok(ReadResponse::eof(source));
-                    },
-                };
-
-                // Read from the gateway thread.
-                loop {
-                    let mut response_buf: [u8; ReadResponse::BUFFER_SIZE] =
-                        [0u8; ReadResponse::BUFFER_SIZE];
-                    // Blocking read from the gateway socket to make sure we can be interrupted if
-                    // necessary.
-                    match locked_gw_stream.read(&mut response_buf) {
-                        Ok(0) => {
-                            error!(
-                                "handle_read_request(): error receiving request response from \
-                                 gateway STDIN: EOF"
-                            );
-                            break Ok(ReadResponse::eof(source));
-                        },
-                        Ok(n) => {
-                            debug!("read {n} bytes from gateway: {response_buf:?}");
-                            break Ok(ReadResponse::build(source, n as c_ssize_t, response_buf));
-                        },
-                        Err(e) if e.kind() == ErrorKind::WouldBlock => continue,
-                        Err(e) if e.kind() == ErrorKind::Interrupted => {
-                            return Err(WorkerThreadError::Interrupted)
-                        },
-                        Err(e) => {
-                            error!(
-                                "handle_read_request(): error reading data from gateway \
-                                 (error={e:?})"
-                            );
-                            break Ok(ReadResponse::eof(source));
+                            return Ok(ReadResponse::eof(source));
                         },
                     };
 
@@ -891,20 +871,20 @@ impl WorkerThreadHandle {
                             "handle_read_request(): error receiving request response from gateway \
                              STDIN: EOF"
                         );
-                        Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]))
+                        Ok(ReadResponse::eof(source))
                     },
                     Ok(n) => {
                         debug!("read {n} bytes from gateway: {response_buf:?}");
                         Ok(ReadResponse::build(source, n as c_ssize_t, response_buf))
                     },
                     Err(e) if e.kind() == ErrorKind::Interrupted => {
-                        Err(WorkerThreadError::Interrupted)
+                        return Err(WorkerThreadError::Interrupted)
                     },
                     Err(e) => {
                         error!(
                             "handle_read_request(): error reading data from gateway (error={e:?})"
                         );
-                        Ok(ReadResponse::build(source, 0, [0u8; ReadResponse::BUFFER_SIZE]))
+                        Ok(ReadResponse::eof(source))
                     },
                 }
             };
@@ -917,7 +897,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_fstat_request(
-        uvm_stream: Arc<Mutex<SocketStream>>,
+        uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<(), WorkerThreadError> {
@@ -933,7 +913,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_getcwd_request(
-        uvm_stream: Arc<Mutex<SocketStream>>,
+        uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>,
         source: ThreadIdentifier,
     ) -> Result<(), WorkerThreadError> {
         let messages: Vec<Message> = unistd::do_getcwd(source)?;
@@ -947,7 +927,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_getdents_request(
-        uvm_stream: Arc<Mutex<SocketStream>>,
+        uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<(), WorkerThreadError> {
@@ -965,7 +945,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_long_request<T>(
-        uvm_stream: Arc<Mutex<SocketStream>>,
+        uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>,
         assembler: Arc<Mutex<RequestAssembler>>,
         source: ThreadIdentifier,
         message: &LinuxDaemonMessage,

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -65,6 +65,15 @@ pub mod syscomm {
     /// Provides the length of the temporary bufer we use to read messages from the gateway.
     ///
     pub const GW_READ_BUFFER_LEN: usize = 4 * 1024;
+
+    ///
+    /// # Description
+    ///
+    /// Provides the maximum number of poll events we can buffer. We set the limit to 128 as, for
+    /// the time being, it is unlikely we will have more than 128 connections being activated at
+    /// the same time.
+    ///
+    pub const MAX_NUM_POLL_EVENTS: usize = 128;
 }
 
 //==================================================================================================

--- a/src/libs/syscomm/Cargo.toml
+++ b/src/libs/syscomm/Cargo.toml
@@ -11,6 +11,7 @@ description = "System Communication Library"
 homepage.workspace = true
 
 [dependencies]
-config = { workspace = true }
 anyhow = { workspace = true }
+config = { workspace = true }
 log = { workspace = true }
+mio = { workspace = true, features = ["net", "os-poll"] }

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -9,6 +9,19 @@ extern crate alloc;
 
 use ::anyhow::Result;
 use ::log::error;
+use ::mio::{
+    net::{
+        TcpListener,
+        TcpStream,
+        UnixListener,
+        UnixStream,
+    },
+    Events,
+    Interest,
+    Poll,
+    Registry,
+    Token,
+};
 use ::std::{
     error::Error,
     fmt,
@@ -19,15 +32,14 @@ use ::std::{
         Read,
         Write,
     },
-    net::{
-        TcpListener,
-        TcpStream,
-    },
-    os::unix::net::{
-        UnixListener,
-        UnixStream,
-    },
 };
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Blocking sockets use a per-socket poll structure with only one entry with this token.
+const BLOCKING_THREAD_TOKEN: Token = Token(0);
 
 //==================================================================================================
 // Imports
@@ -48,7 +60,7 @@ pub struct Socket;
 impl Socket {
     pub fn bind(typ: SocketType, addr: String) -> Result<SocketListener> {
         match typ {
-            SocketType::Tcp => Ok(SocketListener::Tcp(TcpListener::bind(addr)?)),
+            SocketType::Tcp => Ok(SocketListener::Tcp(TcpListener::bind(addr.parse()?)?)),
             SocketType::Unix => Ok(SocketListener::Unix {
                 listener: UnixListener::bind(&addr)?,
                 path: addr.clone(),
@@ -109,6 +121,43 @@ impl Drop for SocketListener {
     }
 }
 
+impl mio::event::Source for SocketListener {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        match self {
+            SocketListener::Tcp(listener) => listener.register(registry, token, interests),
+            SocketListener::Unix { listener, path: _ } => {
+                listener.register(registry, token, interests)
+            },
+        }
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        match self {
+            SocketListener::Tcp(listener) => listener.reregister(registry, token, interests),
+            SocketListener::Unix { listener, path: _ } => {
+                listener.reregister(registry, token, interests)
+            },
+        }
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        match self {
+            SocketListener::Tcp(listener) => listener.deregister(registry),
+            SocketListener::Unix { listener, path: _ } => listener.deregister(registry),
+        }
+    }
+}
+
 /// A struct representing a socket stream.
 #[derive(Debug)]
 pub enum SocketStream {
@@ -123,7 +172,7 @@ impl SocketStream {
     pub fn connect(typ: SocketType, addr: String) -> Result<SocketStream> {
         match typ {
             SocketType::Tcp => {
-                let stream: TcpStream = TcpStream::connect(addr)?;
+                let stream: TcpStream = TcpStream::connect(addr.parse()?)?;
                 Ok(SocketStream::Tcp(stream))
             },
             SocketType::Unix => {
@@ -133,24 +182,59 @@ impl SocketStream {
         }
     }
 
-    pub fn try_clone(&self) -> Result<SocketStream, ::std::io::Error> {
+    ///
+    /// # Description
+    ///
+    /// Set the stream to blocking mode.
+    ///
+    /// We use non-blocking sockets, so to provide a blocking-like behaviour we extend each stream
+    /// with its own poll structure that can be used to wait on data.
+    ///
+    /// We return a different struct, a BlockingSocketStream, to enforce type checks.
+    ///
+    /// # Returns
+    ///
+    /// A blocking socket stream based on the same underlying stream.
+    ///
+    pub fn set_blocking(self) -> io::Result<BlockingSocketStream> {
         match self {
-            SocketStream::Tcp(stream) => {
-                let stream: TcpStream = stream.try_clone()?;
-                Ok(SocketStream::Tcp(stream))
-            },
-            SocketStream::Unix(stream) => {
-                let stream: UnixStream = stream.try_clone()?;
-                Ok(SocketStream::Unix(stream))
-            },
-        }
-    }
+            SocketStream::Tcp(mut stream) => {
+                // Initialize Poll structure if it's not already set
+                let poll_instance = Poll::new().map_err(|e| {
+                    io::Error::other(format!("failed to create Poll instance (error={e:?})"))
+                })?;
 
-    /// Sets a socket stream to non-blocking mode.
-    pub fn set_nonblocking(&self, nonblocking: bool) -> Result<(), ::std::io::Error> {
-        match self {
-            SocketStream::Tcp(stream) => stream.set_nonblocking(nonblocking),
-            SocketStream::Unix(stream) => stream.set_nonblocking(nonblocking),
+                poll_instance
+                    .registry()
+                    .register(
+                        &mut stream,
+                        BLOCKING_THREAD_TOKEN,
+                        Interest::READABLE | Interest::WRITABLE,
+                    )
+                    .map_err(|e| {
+                        io::Error::other(format!("failed to register thread to poll (error={e:?})"))
+                    })?;
+
+                Ok(BlockingSocketStream::Tcp(stream, poll_instance))
+            },
+            SocketStream::Unix(mut stream) => {
+                let poll_instance = Poll::new().map_err(|e| {
+                    io::Error::other(format!("failed to create Poll instance (error={e:?})"))
+                })?;
+
+                poll_instance
+                    .registry()
+                    .register(
+                        &mut stream,
+                        BLOCKING_THREAD_TOKEN,
+                        Interest::READABLE | Interest::WRITABLE,
+                    )
+                    .map_err(|e| {
+                        io::Error::other(format!("failed to register thread to poll (error={e:?})"))
+                    })?;
+
+                Ok(BlockingSocketStream::Unix(stream, poll_instance))
+            },
         }
     }
 
@@ -167,17 +251,59 @@ impl SocketStream {
         }
     }
 
-    /// Reads data from a socket stream.
-    pub fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), ::std::io::Error> {
-        let result = match self {
-            SocketStream::Tcp(stream) => stream.read_exact(buf),
-            SocketStream::Unix(stream) => stream.read_exact(buf),
-        };
-
-        match result {
-            Ok(_) => Ok(()),
-            Err(error) => Err(error),
+    ///
+    /// # Description
+    ///
+    /// Non-blocking read implementation.
+    ///
+    /// # Parameters
+    ///
+    /// A mutable buffer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes read into the buffer.
+    ///
+    pub fn try_read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            SocketStream::Tcp(stream) => stream.read(buf),
+            SocketStream::Unix(stream) => stream.read(buf),
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Non-blocking read exact implementation. This implementation returns partial reads and does
+    /// no buffering. Callers must handle partial reads themselves and retry.
+    ///
+    /// # Parameters
+    ///
+    /// A mutable buffer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes read into the buffer.
+    ///
+    pub fn try_read_exact(&mut self, buf: &mut [u8]) -> Result<usize, SocketError> {
+        let mut total_read = 0;
+
+        while total_read < buf.len() {
+            match self.try_read(&mut buf[total_read..]) {
+                Ok(0) => {
+                    return Err(io::Error::new(ErrorKind::UnexpectedEof, "connection closed").into())
+                },
+                Ok(n) => total_read += n,
+                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                    // Not ready yet — must wait for next Poll notification
+                    break;
+                },
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        // Return as much as we were able to read.
+        Ok(total_read)
     }
 
     /// Gets the peer address of a socket stream.
@@ -195,12 +321,132 @@ impl SocketStream {
     }
 }
 
-/// Implement Read trait for SocketStream.
-impl Read for SocketStream {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+impl mio::event::Source for SocketStream {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
         match self {
-            SocketStream::Tcp(stream) => stream.read(buf),
-            SocketStream::Unix(stream) => stream.read(buf),
+            SocketStream::Tcp(stream) => stream.register(registry, token, interests),
+            SocketStream::Unix(stream) => stream.register(registry, token, interests),
+        }
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        match self {
+            SocketStream::Tcp(stream) => stream.reregister(registry, token, interests),
+            SocketStream::Unix(stream) => stream.reregister(registry, token, interests),
+        }
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        match self {
+            SocketStream::Tcp(stream) => stream.deregister(registry),
+            SocketStream::Unix(stream) => stream.deregister(registry),
+        }
+    }
+}
+
+/// A struct representing a blocking socket stream.
+#[derive(Debug)]
+pub enum BlockingSocketStream {
+    /// TCP socket stream.
+    Tcp(TcpStream, Poll),
+    /// Unix socket stream.
+    Unix(UnixStream, Poll),
+}
+
+impl BlockingSocketStream {
+    ///
+    /// # Description
+    ///
+    /// Blocking read implementation.
+    ///
+    /// # Parameters
+    ///
+    /// A mutable buffer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes read into the buffer.
+    ///
+    pub fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            BlockingSocketStream::Tcp(stream, poll) => {
+                let mut events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+
+                // Even after a poll wake-up the socket may still return WouldBlock.
+                loop {
+                    poll.poll(&mut events, None)?;
+                    match stream.read(buf) {
+                        Ok(n) => return Ok(n),
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                        Err(e) => return Err(e),
+                    }
+                }
+            },
+            BlockingSocketStream::Unix(stream, poll) => {
+                let mut events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+
+                // Even after a poll wake-up the socket may still return WouldBlock.
+                loop {
+                    poll.poll(&mut events, None)?;
+                    match stream.read(buf) {
+                        Ok(n) => return Ok(n),
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                        Err(e) => return Err(e),
+                    }
+                }
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Blocking read exact implementation.
+    ///
+    /// # Parameters
+    ///
+    /// A mutable buffer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes read into the buffer.
+    ///
+    pub fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), SocketError> {
+        let mut num_read = 0;
+        while num_read < buf.len() {
+            match self.read(&mut buf[num_read..]) {
+                Ok(0) => {
+                    return Err(
+                        io::Error::new(io::ErrorKind::UnexpectedEof, "End of file reached").into()
+                    )
+                },
+                Ok(n) => num_read += n,
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(())
+    }
+
+    /// Writes data to a socket stream.
+    pub fn write_all(&mut self, buf: &[u8]) -> Result<(), SocketError> {
+        let result = match self {
+            BlockingSocketStream::Tcp(stream, _) => stream.write_all(buf),
+            BlockingSocketStream::Unix(stream, _) => stream.write_all(buf),
+        };
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(error) => Err(SocketError { error }),
         }
     }
 }

--- a/src/microvm/src/gateway.rs
+++ b/src/microvm/src/gateway.rs
@@ -7,6 +7,7 @@
 
 use ::anyhow::Result;
 use ::std::{
+    collections::VecDeque,
     io::{
         Error,
         ErrorKind,
@@ -25,6 +26,7 @@ use ::syscomm::{
 
 pub struct Gateway {
     stream: SocketStream,
+    partial_read_buffer: VecDeque<u8>,
 }
 
 impl Gateway {
@@ -42,7 +44,10 @@ impl Gateway {
     /// A new gateway instance.
     ///
     pub fn new(stream: SocketStream) -> Self {
-        Gateway { stream }
+        Gateway {
+            stream,
+            partial_read_buffer: VecDeque::new(),
+        }
     }
 
     ///
@@ -84,23 +89,34 @@ impl Gateway {
     /// Upon success, the received message is returned. Otherwise, an error is returned.
     ///
     pub fn try_receive(&mut self) -> Result<Message, SocketError> {
-        let mut bytes: [u8; mem::size_of::<Message>()] = [0; mem::size_of::<Message>()];
-        match self.stream.read_exact(&mut bytes) {
-            Ok(_) => {
-                let mut message: Message = match Message::try_from_bytes(bytes) {
-                    Ok(message) => message,
-                    Err(e) => {
-                        let reason: String = format!("failed to parse message ({e:?})");
-                        error!("receive(): {reason}");
-                        return Err(SocketError::new(Error::new(ErrorKind::InvalidData, reason)));
-                    },
-                };
-                profiler::timestamp_message!(
-                    &mut message.payload,
-                    mem::offset_of!(syscall::LinuxDaemonMessage, payload)
-                        + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
-                );
-                Ok(message)
+        let mut buf: [u8; mem::size_of::<Message>()] = [0; mem::size_of::<Message>()];
+
+        let mut num_filled = 0;
+        if !self.partial_read_buffer.is_empty() {
+            // Prepare data in buffer for partial read.
+            self.partial_read_buffer.make_contiguous();
+            let partial_bytes = self.partial_read_buffer.as_slices().0;
+
+            // We take the minimum at the end just in case, but the partial read should always be
+            // strictly smaller than the message size.
+            let num_partial_read = partial_bytes.len().min(buf.len());
+
+            buf[..num_partial_read].copy_from_slice(&partial_bytes[..num_partial_read]);
+
+            // Clear partial read buffer.
+            self.partial_read_buffer.clear();
+            num_filled += num_partial_read;
+        }
+        // Post-condition: partial_read_buffer is empty.
+
+        match self.stream.try_read_exact(&mut buf[num_filled..]) {
+            Ok(n) => {
+                // Handle partial reads by copying all we have read to the partial read buffer and
+                // returning a WouldBlock indicating that we need more data.
+                if n + num_filled < buf.len() {
+                    self.partial_read_buffer.extend(&buf[..(n + num_filled)]);
+                    return Err(std::io::Error::new(ErrorKind::WouldBlock, "partial read").into());
+                }
             },
             Err(e) => {
                 // Print error messages only if it is not a WouldBlock error to avoid spamming the logs.
@@ -109,8 +125,23 @@ impl Gateway {
                     error!("receive(): {reason}");
                 }
 
-                Err(SocketError::new(e))
+                return Err(SocketError::new(e.into()));
             },
-        }
+        };
+
+        let mut message: Message = match Message::try_from_bytes(buf) {
+            Ok(message) => message,
+            Err(e) => {
+                let reason: String = format!("failed to parse message ({e:?})");
+                error!("receive(): {reason}");
+                return Err(SocketError::new(Error::new(ErrorKind::InvalidData, reason)));
+            },
+        };
+        profiler::timestamp_message!(
+            &mut message.payload,
+            mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
+        );
+        Ok(message)
     }
 }

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -84,10 +84,7 @@ fn main() -> Result<ExitCode> {
 
     let gateway: Option<Gateway> = match &gateway_addr {
         Some(addr) => match SocketStream::connect(gateway_socket_type, addr.clone()) {
-            Ok(stream) => {
-                stream.set_nonblocking(true)?;
-                Some(Gateway::new(stream))
-            },
+            Ok(stream) => Some(Gateway::new(stream)),
             Err(e) => {
                 let reason: String =
                     format!("failed to connect to gateway (gateway_addr={addr:?}, error={e:?})",);

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -19,6 +19,7 @@ indicatif = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 microvm = { workspace = true }
+mio = { workspace = true, features = ["net"] }
 nanvixd = { workspace = true }
 profiler = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -47,6 +47,7 @@ use microvm::{
     Gateway,
     Vmm,
 };
+use mio::net::UnixStream;
 use nanvixd::config::DEFAULT_TMP_DIRECTORY;
 use reqwest::header::{
     CONTENT_TYPE,
@@ -54,14 +55,9 @@ use reqwest::header::{
 };
 use std::{
     fs::File,
-    io::{
-        BufReader,
-        Read,
-        Write,
-    },
+    io::BufReader,
     mem,
     net::TcpStream,
-    os::unix::net::UnixStream,
     process::{
         self,
         Child,
@@ -84,6 +80,7 @@ use syscall::{
     },
 };
 use syscomm::{
+    BlockingSocketStream,
     SocketStream,
     SocketType,
 };
@@ -205,7 +202,7 @@ impl Benchmark {
         &mut self,
         payload: nanvixd::message::New,
         headers: HeaderMap,
-    ) -> Result<(String, SocketStream)> {
+    ) -> Result<(String, BlockingSocketStream)> {
         let response: nanvixd::message::NewResponse = self
             .nanvixd_client
             .post(format!("http://{}", NANVIXD_ADDRESS))
@@ -228,7 +225,9 @@ impl Benchmark {
             };
         };
 
-        Ok((response.user_vm_id, gateway_stream))
+        let blocking_gateway_stream: BlockingSocketStream = gateway_stream.set_blocking()?;
+
+        Ok((response.user_vm_id, blocking_gateway_stream))
     }
 
     /// Kill the Nano VM via POST request to nanvixd.
@@ -483,12 +482,12 @@ impl Benchmark {
         response_buf[..payload.len()].copy_from_slice(&payload);
 
         // Initialize a UNIX pair that is directly connected to the VMM.
-        let (mut input_stream, vmm_stream) = UnixStream::pair()?;
+        let (input_stream, vmm_stream) = UnixStream::pair()?;
+        let mut input_stream = syscomm::SocketStream::Unix(input_stream);
 
         // Spawn the VMM in a separate thread.
         let program = self.flavour.get_program();
         let vmm_handle = std::thread::spawn(move || -> Result<()> {
-            vmm_stream.set_nonblocking(true)?;
             match Vmm::spawn(
                 config::kernel::MEMORY_SIZE,
                 format!("{}/bin/kernel.elf", get_proj_root()).as_str(),
@@ -513,7 +512,26 @@ impl Benchmark {
             // Before starting the timer, we need to receive the ReadRequest from the user VM.
             let mut buf: [u8; config::kernel::IPC_MESSAGE_SIZE] =
                 [0u8; config::kernel::IPC_MESSAGE_SIZE];
-            input_stream.read_exact(&mut buf)?;
+
+            // Explicitly spin-loop when receiving to isolate the overheads of the VMM.
+            let mut num_read = 0;
+            loop {
+                match input_stream.try_read_exact(&mut buf[num_read..]) {
+                    Ok(n) => {
+                        num_read += n;
+                        if num_read == buf.len() {
+                            break;
+                        }
+                    },
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                    Err(e) => {
+                        return Err(anyhow::anyhow!(
+                            "error reading from input VMM stream (error={e:?})"
+                        ));
+                    },
+                }
+            }
+
             let ipc_read_message: Message = match Message::try_from_bytes(buf) {
                 Ok(message) => message,
                 Err(_) => return Err(anyhow::anyhow!("Error parsing buffer to IPC Read message")),
@@ -538,7 +556,26 @@ impl Benchmark {
             // Now we are ready to push the ReadResponse, and wait for a WriteRequest as a reply.
             let start = Instant::now();
             input_stream.write_all(&read_response.to_bytes())?;
-            input_stream.read_exact(&mut buf)?;
+
+            // Explicitly spin-loop when receiving to isolate the overheads of the VMM.
+            let mut num_read = 0;
+            loop {
+                match input_stream.try_read_exact(&mut buf[num_read..]) {
+                    Ok(n) => {
+                        num_read += n;
+                        if num_read == buf.len() {
+                            break;
+                        }
+                    },
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                    Err(e) => {
+                        let reason: String =
+                            format!("error reading from input VMM stream (error={e:?})");
+                        return Err(anyhow::anyhow!(reason));
+                    },
+                }
+            }
+
             latencies.push(start.elapsed().as_micros());
 
             // After receiving the WriteRequest, we need to acknowledge it by sending a WriteResponse.
@@ -757,7 +794,7 @@ async fn main() -> Result<()> {
     };
     match result {
         Ok(_) => {},
-        Err(e) => error!("error running benchmark: {e:?}"),
+        Err(e) => error!("error running benchmark {}: {e:?}", args.benchmark()),
     }
 
     Ok(())

--- a/src/utils/nanvixd/src/control_plane.rs
+++ b/src/utils/nanvixd/src/control_plane.rs
@@ -14,8 +14,9 @@ use ::std::io::{
     ErrorKind,
 };
 use ::syscomm::{
+    // TODO: move back to SocketStream when linuxd polls connections.
+    BlockingSocketStream,
     SocketError,
-    SocketStream,
 };
 
 #[repr(u8)]
@@ -27,7 +28,7 @@ pub enum Command {
 // This function is actually used by linuxd, consuming nanvixd as a library. It is never used from
 // the main nanvixd binary, hence why we need to add this annotation to silent clippy.
 #[allow(dead_code)]
-pub fn read_command(stream: &mut SocketStream) -> Result<Command, SocketError> {
+pub fn read_command(stream: &mut BlockingSocketStream) -> Result<Command, SocketError> {
     let mut buf: [u8; 1] = [0u8; 1];
     stream.read_exact(&mut buf)?;
 
@@ -36,7 +37,7 @@ pub fn read_command(stream: &mut SocketStream) -> Result<Command, SocketError> {
     })
 }
 
-pub fn send_command(stream: &mut SocketStream, cmd: Command) -> Result<(), SocketError> {
+pub fn send_command(stream: &mut BlockingSocketStream, cmd: Command) -> Result<(), SocketError> {
     let byte: u8 = cmd.into();
     stream.write_all(&[byte])?;
     Ok(())

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -10,6 +10,7 @@ use ::anyhow::Result;
 use ::hwloc::HwLoc;
 use ::std::process::Stdio;
 use ::syscomm::{
+    BlockingSocketStream,
     Socket,
     SocketStream,
     SocketType,
@@ -25,7 +26,7 @@ use ::tokio::process::{
 
 pub struct LinuxDaemon {
     child: Child,
-    control_plane_stream: SocketStream,
+    control_plane_stream: BlockingSocketStream,
 }
 
 //==================================================================================================
@@ -82,7 +83,7 @@ impl LinuxDaemon {
 
         // After linuxd has started, accept the incoming connection and return the stream for
         // further use.
-        let control_plane_stream = loop {
+        let control_plane_stream: SocketStream = loop {
             match control_plane_listener.accept() {
                 Ok(stream) => {
                     debug!("nanvixd received connection from linuxd's control-plane socket");
@@ -99,9 +100,12 @@ impl LinuxDaemon {
             }
         };
 
+        let blocking_control_plane_stream: BlockingSocketStream =
+            control_plane_stream.set_blocking()?;
+
         Ok(Self {
             child,
-            control_plane_stream,
+            control_plane_stream: blocking_control_plane_stream,
         })
     }
 


### PR DESCRIPTION
In this PR I move the syscomm library to use metal IO sockets. 

These sockets are non-blocking by default, and the only way to block on them is via a `poll` structure. Given that in some places we rely on blocking reads, I implement a `BlockingSocketStream` object that wraps around the blocking logic. Thus, `SocketStream` only implements non-blocking `try_read/try_read_exact`, whereas `BlockingSocketStream` only implements blocking calls `read/read_exact`. We can get a `BlockingSocketStream` from a `SocketStream` by calling `SocketStream::set_blocking()`.