### PR TITLE
[microvm] Refactor CLI Args

### DIFF
--- a/doc/run.md
+++ b/doc/run.md
@@ -112,7 +112,7 @@ To enable logging, consider prepending the above command with `RUST_LOG=debug` o
 Open another terminal to run the MicroVM. Use the `-initrd` option to specify which application to run, and pass it additional arguments with `-initrd-args`.
 
 ```bash
-./bin/microvm.elf -gateway /tmp/user-vm-bind.socket -kernel bin/kernel.elf -initrd bin/hello-rust-nostd.elf [-initrd-args <args>]
+./bin/microvm.elf -system-vm-addr /tmp/user-vm-bind.socket -kernel bin/kernel.elf -initrd bin/hello-rust-nostd.elf [-initrd-args <args>]
 ```
 
 If you passed a `-gateway-bind-addr` flag to `linuxd` in step 1, you will need to open a netcat session to connect to it:

--- a/src/microvm/src/args.rs
+++ b/src/microvm/src/args.rs
@@ -38,10 +38,10 @@ pub struct Args {
     memory_size: usize,
     /// Standard error.
     vm_stderr: Option<String>,
-    /// Gateway address.
-    gateway_addr: Option<String>,
-    /// Gateway socket type.
-    gateway_socket_type: Option<String>,
+    /// System VM address.
+    system_vm_addr: Option<String>,
+    /// System VM socket type.
+    system_vm_socket_type: Option<String>,
     /// Log to file?
     log_to_file: bool,
 }
@@ -61,10 +61,10 @@ impl Args {
     const OPT_MEMORY_SIZE: &'static str = "-memory";
     /// Command-line option for the standard error.
     const OPT_STDERR: &'static str = "-stderr";
-    /// Command-line option for gateway address.
-    const OPT_GATEWAY: &'static str = "-gateway";
-    /// Command-line option for the gateway socket type.
-    const OPT_GATEWAY_SOCKET_TYPE: &'static str = "-gateway-socket-type";
+    /// Command-line option for system VM address.
+    const OPT_SYSTEM_VM_SOCKADDR: &'static str = "-system-vm-addr";
+    /// Command-line option for the system VM socket type.
+    const OPT_SYSTEM_VM_SOCKET_TYPE: &'static str = "-system-vm-socket-type";
     /// Command-line option for specifying arguments to be passed to the initrd.
     const OPT_INITRD_ARGS: &'static str = "-initrd_args";
     /// Log to file.
@@ -86,8 +86,8 @@ impl Args {
         let mut initrd_args: Option<String> = None;
         let mut memory_size: usize = ::config::kernel::MEMORY_SIZE;
         let mut vm_stderr: Option<String> = None;
-        let mut gateway_addr: Option<String> = None;
-        let mut gateway_socket_type: Option<String> = None;
+        let mut system_vm_addr: Option<String> = None;
+        let mut system_vm_socket_type: Option<String> = None;
         let mut log_to_file: bool = false;
 
         // Parse command-line arguments.
@@ -148,14 +148,14 @@ impl Args {
                     vm_stderr = Some(args[i + 1].clone());
                     i += 1;
                 },
-                // Set gateway address.
-                Self::OPT_GATEWAY if i + 1 < args.len() => {
-                    gateway_addr = Some(args[i + 1].clone());
+                // Set system VM address.
+                Self::OPT_SYSTEM_VM_SOCKADDR if i + 1 < args.len() => {
+                    system_vm_addr = Some(args[i + 1].clone());
                     i += 1;
                 },
-                // Set gateway socket type.
-                Self::OPT_GATEWAY_SOCKET_TYPE if i + 1 < args.len() => {
-                    gateway_socket_type = Some(args[i + 1].clone());
+                // Set system VM socket type.
+                Self::OPT_SYSTEM_VM_SOCKET_TYPE if i + 1 < args.len() => {
+                    system_vm_socket_type = Some(args[i + 1].clone());
                     i += 1;
                 },
                 // Set log to file flag.
@@ -190,8 +190,8 @@ impl Args {
             initrd_args,
             memory_size,
             vm_stderr,
-            gateway_addr,
-            gateway_socket_type,
+            system_vm_addr,
+            system_vm_socket_type,
             log_to_file,
         })
     }
@@ -210,7 +210,7 @@ impl Args {
             Self::OPT_MEMORY_SIZE,
             Self::OPT_INITRD,
             Self::OPT_STDERR,
-            Self::OPT_GATEWAY,
+            Self::OPT_SYSTEM_VM_SOCKADDR,
             Self::OPT_LOGFILE,
             Self::OPT_INITRD_ARGS,
         );
@@ -288,29 +288,29 @@ impl Args {
     ///
     /// # Description
     ///
-    /// Returns the gateway address that was passed as a command-line argument to the program.
+    /// Returns the address of the system VM that was passed as a command-line argument to the program.
     ///
     /// # Returns
     ///
-    /// The gateway address that was passed as a command-line argument to the program.
+    /// The system VM address that was passed as a command-line argument to the program.
     ///
-    pub fn gateway_addr(&mut self) -> Option<String> {
-        self.gateway_addr.take()
+    pub fn system_vm_addr(&mut self) -> Option<String> {
+        self.system_vm_addr.take()
     }
 
     ///
     /// # Description
     ///
-    /// Returns the socket address type of the gateway socket that was passed as a command-line
+    /// Returns the socket address type of the system VM socket that was passed as a command-line
     /// argument to the program.
     ///
     /// # Returns
     ///
-    /// The socket address type of the gateway socket that was passed as a command-line argument to
+    /// The socket address type of the system VM socket that was passed as a command-line argument to
     /// the program.
     ///
-    pub fn gateway_socket_type(&mut self) -> Option<String> {
-        self.gateway_socket_type.take()
+    pub fn system_vm_socket_type(&mut self) -> Option<String> {
+        self.system_vm_socket_type.take()
     }
 
     ///

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -66,9 +66,9 @@ fn main() -> Result<ExitCode> {
     let initrd_args: Option<String> = args.initrd_args();
     let memory_size: usize = args.memory_size();
     let stderr: Option<String> = args.take_vm_stderr();
-    let gateway_addr: Option<String> = args.gateway_addr();
+    let system_vm_addr: Option<String> = args.system_vm_addr();
 
-    let gateway_socket_type: SocketType = match args.gateway_socket_type() {
+    let system_vm_socket_type: SocketType = match args.system_vm_socket_type() {
         Some(typ) => match SocketType::from_str(typ.as_str()) {
             Ok(typ) => typ,
             Err(error) => {
@@ -82,8 +82,8 @@ fn main() -> Result<ExitCode> {
     // Initialize logger. If this fails, the program will panic.
     logging::initialize(args.log_to_file());
 
-    let gateway: Option<Gateway> = match &gateway_addr {
-        Some(addr) => match SocketStream::connect(gateway_socket_type, addr.clone()) {
+    let gateway: Option<Gateway> = match &system_vm_addr {
+        Some(addr) => match SocketStream::connect(system_vm_socket_type, addr.clone()) {
             Ok(stream) => Some(Gateway::new(stream)),
             Err(e) => {
                 let reason: String =

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -39,7 +39,7 @@ impl Microvm {
             format!("{}/kernel.elf", binary_directory),
             "-initrd".to_string(),
             program.to_string(),
-            "-gateway".to_string(),
+            "-system-vm-addr".to_string(),
             addr.to_string(),
         ];
 


### PR DESCRIPTION
In this PR I refactor the overloaded `-gateway` arg in the microvm CLI to `-system-vm`.