### PR TITLE
[daemons] Make Linuxd Poll Over A Single Connection + Control-Plane Socket

### DIFF
--- a/src/daemons/linuxd/Cargo.toml
+++ b/src/daemons/linuxd/Cargo.toml
@@ -16,6 +16,8 @@ config = { workspace = true }
 flexi_logger = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
+mio = { workspace = true, features = ["net", "os-poll"] }
+nanvixd = { workspace = true }
 profiler = { workspace = true }
 signal-hook = { workspace = true }
 sys = { workspace = true, features = ["std"] }

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -21,6 +21,13 @@ use crate::{
     worker_thread::WorkerThreadHandle,
 };
 use ::anyhow::Result;
+use ::mio::{
+    Events,
+    Interest,
+    Poll,
+    Token,
+};
+use ::nanvixd::control_plane;
 use ::std::{
     collections::VecDeque,
     io::ErrorKind,
@@ -49,7 +56,10 @@ use ::syscomm::SocketStream;
 // Constants
 //==================================================================================================
 
-const DEFAULT_CONNECTION_ID: usize = 0;
+/// We use ID 0 for the control-plane socket in the main poll structure.
+const CONTROL_PLANE_CONNECTION_ID: usize = 0;
+/// We use ID 1 for the user VM connection in the main poll structure.
+const DEFAULT_CONNECTION_ID: usize = 1;
 
 //==================================================================================================
 // Structures
@@ -57,6 +67,7 @@ const DEFAULT_CONNECTION_ID: usize = 0;
 
 pub struct LinuxDaemon {
     assembler: Arc<Mutex<RequestAssembler>>,
+    control_plane_stream: SocketStream,
     uvm_stream: SocketStream,
     gateway_stream: Option<SocketStream>,
     venv: Arc<Mutex<VirtualEnviromentDirectory>>,
@@ -68,18 +79,106 @@ pub struct LinuxDaemon {
 
 impl LinuxDaemon {
     pub fn init(
+        control_plane_stream: SocketStream,
         uvm_stream: SocketStream,
         gateway_stream: Option<SocketStream>,
     ) -> Result<Self, Error> {
         Ok(Self {
             assembler: Arc::new(Mutex::new(RequestAssembler::default())),
+            control_plane_stream,
             uvm_stream,
             gateway_stream,
             venv: Arc::new(Mutex::new(VirtualEnviromentDirectory::new())),
         })
     }
 
-    pub fn run(self) -> Result<(), Error> {
+    /// Helper method to close a connection to a user VM identified by the connection id. Closing
+    /// the connection also involves stopping all associated worker threads.
+    fn close_connection(
+        uvm_handle: UserVmHandle,
+        poll: &Poll,
+        worker_threads: Option<VecDeque<WorkerThreadHandle>>,
+    ) {
+        // De-register the user VM socket from the poll structure.
+        let user_vm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>> =
+            uvm_handle.get_user_vm_stream();
+        match user_vm_stream.lock() {
+            Ok(mut guard) => {
+                let (locked_uvm_stream, _): &mut (SocketStream, VecDeque<u8>) = &mut guard;
+                if let Err(e) = poll.registry().deregister(locked_uvm_stream) {
+                    error!("failed to deregister user VM from poll (error={e:?})");
+                }
+            },
+            Err(e) => {
+                error!("error acquiring lock on user VM stream (error={e:?})");
+            },
+        };
+
+        // Send a shutdown message to all worker threads associated
+        // with this user VM.
+        if let Some(mut worker_threads) = worker_threads {
+            for worker_thread in worker_threads.drain(..) {
+                trace!("sending interrupt to worker thread (thread_id={:?})", worker_thread.id);
+
+                // Each worker thread may be in one of three states:
+                // 1. Running
+                // 2. Blocked on a system call
+                // 3. Blocked waiting for a new message from the channel
+                //
+                // To gracefully shutdown the thread, we enqueue a shutdown message to the
+                // message channel. In case the thread is blocked on a system call, we also
+                // send it an interrupt signal and handle EINTR accordingly. Note that a signal
+                // interrupt will not unblock a thread waiting on a queue, so we need both
+                // mechanisms.
+                //
+                // If any of the commands fail, continue trying to drain the remaining
+                // threads.
+                if let Err(e) = worker_thread.cmd_tx.send(VenvCommand::Shutdown) {
+                    error!(
+                        "error sending shutdown command to worker thread (thread_id={:?}, \
+                         error={e:?})",
+                        worker_thread.id
+                    );
+                }
+                if let Err(e) = worker_thread.stop() {
+                    error!(
+                        "error sending interrupt to worker thread (thread_id={:?}, error={e:?})",
+                        worker_thread.id
+                    );
+                }
+                if let Err(e) = worker_thread.handle.join() {
+                    error!(
+                        "error joining worker thread (thread_id={:?}, error={e:?})",
+                        worker_thread.id
+                    );
+                }
+            }
+        }
+    }
+
+    fn log_and_error(code: ErrorCode, msg: &'static str) -> Error {
+        error!("{msg}");
+        Error::new(code, msg)
+    }
+
+    pub fn run(mut self) -> Result<(), Error> {
+        const CONTROL_PLANE_TOKEN: Token = Token(CONTROL_PLANE_CONNECTION_ID);
+        const USER_VM_TOKEN: Token = Token(DEFAULT_CONNECTION_ID);
+
+        let mut events: Events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+        let mut poll: Poll = Poll::new()
+            .map_err(|_| Self::log_and_error(ErrorCode::IoErr, "failed to create Poll"))?;
+        poll.registry()
+            .register(&mut self.control_plane_stream, CONTROL_PLANE_TOKEN, Interest::READABLE)
+            .map_err(|_| {
+                Self::log_and_error(ErrorCode::IoErr, "failed to register cotnrol-plane to poll")
+            })?;
+        poll.registry()
+            .register(&mut self.uvm_stream, USER_VM_TOKEN, Interest::READABLE)
+            .map_err(|_| {
+                Self::log_and_error(ErrorCode::IoErr, "failed to register user VM listener to poll")
+            })?;
+
         // Map keeping track of the worker threads associated the user VM.
         let mut worker_threads: VecDeque<WorkerThreadHandle> = VecDeque::new();
 
@@ -87,160 +186,183 @@ impl LinuxDaemon {
         let uvm_handle: UserVmHandle =
             UserVmHandle::new(DEFAULT_CONNECTION_ID, self.uvm_stream, self.gateway_stream);
 
-        loop {
-            let uvm_handle: UserVmHandle = uvm_handle.clone();
+        'main_loop: loop {
             let venv: Arc<Mutex<VirtualEnviromentDirectory>> = self.venv.clone();
             let assembler: Arc<Mutex<RequestAssembler>> = self.assembler.clone();
 
-            // Receive a message from the user virtual machine.
-            let message: Message = match Self::recv(uvm_handle.get_user_vm_stream()) {
-                Ok(message) => message,
+            poll.poll(&mut events, None)
+                .map_err(|_| Error::new(ErrorCode::IoErr, "failed to poll user VM events"))?;
 
-                Err(error_kind) => match error_kind {
-                    ErrorKind::WouldBlock => continue,
-                    ErrorKind::UnexpectedEof | ErrorKind::ConnectionReset => {
-                        info!("connection from user VM closed");
-
-                        // Each worker thread may be in one of three states:
-                        // 1. Running
-                        // 2. Blocked on a system call
-                        // 3. Blocked waiting for a new message from the channel
-                        //
-                        // To gracefully shutdown the thread, we enqueue a shutdown message to the
-                        // message channel. In case the thread is blocked on a system call, we also
-                        // send it an interrupt signal and handle EINTR accordingly.
-                        for worker_thread in worker_threads.drain(..) {
-                            trace!(
-                                "sending interrupt to worker thread (thread_id={:?})",
-                                worker_thread.id
-                            );
-
-                            // If any of the commands fail, continue trying to drain the remainnig
-                            // threads.
-                            match worker_thread.cmd_tx.send(VenvCommand::Shutdown) {
-                                Ok(_) => {},
+            for event in events.iter() {
+                match event.token() {
+                    // Process control-plane messages before anything else.
+                    CONTROL_PLANE_TOKEN => {
+                        let cmd: control_plane::Command =
+                            match control_plane::try_read_command(&mut self.control_plane_stream) {
+                                Ok(cmd) => cmd,
+                                Err(ref e) if e.kind() == ErrorKind::WouldBlock => continue,
                                 Err(e) => {
                                     error!(
-                                        "error sending shutdown command to worker thread \
-                                         (thread_id={e:?})"
+                                        "failed reading command from control-plane (error={e:?})"
                                     );
-                                    continue;
+                                    return Err(Error::new(
+                                        ErrorCode::IoErr,
+                                        "failed reading command from control-plane",
+                                    ));
                                 },
-                            }
-                            match worker_thread.stop() {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    error!(
-                                        "error sending interrupt to worker thread \
-                                         (thread_id={e:?})"
-                                    );
-                                    continue;
-                                },
-                            }
-                            match worker_thread.handle.join() {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    error!("error joining worker thread (thread_id={e:?})");
-                                    continue;
-                                },
-                            }
+                            };
+                        match cmd {
+                            control_plane::Command::Shutdown => {
+                                info!("linuxd received shutdown message from control-plane");
+
+                                // Close connection to user VM.
+                                let uvm_handle: UserVmHandle = uvm_handle.clone();
+                                info!("shutting down user VM");
+
+                                Self::close_connection(uvm_handle, &poll, Some(worker_threads));
+
+                                break 'main_loop;
+                            },
                         }
-
-                        break;
                     },
-                    _ => {
-                        let reason: String =
-                            format!("failed to read message (error={error_kind:?})");
-                        unimplemented!("handle: {reason}");
-                    },
-                },
-            };
 
-            trace!(
-                "message.source={:?}, message.destination={:?}, message.type={:?}",
-                { message.source },
-                { message.destination },
-                message.message_type,
-            );
+                    USER_VM_TOKEN => {
+                        // Receive a message from the user virtual machine.
+                        let uvm_handle: UserVmHandle = uvm_handle.clone();
+                        let message: Message = match Self::recv(uvm_handle.get_user_vm_stream()) {
+                            Ok(message) => message,
 
-            let source: ThreadIdentifier = match { message.source }.as_id() {
-                Err(tid) => tid,
-                Ok(pid) => {
-                    unimplemented!("received message from process {pid:?} instead of thread");
-                },
-            };
+                            Err(error_kind) => match error_kind {
+                                ErrorKind::WouldBlock => continue,
+                                ErrorKind::UnexpectedEof | ErrorKind::ConnectionReset => {
+                                    info!("connection from user VM closed");
 
-            // Check if process is associated with a virtual environment.
-            let (channel_tx, channel_rx): (Sender<VenvCommand>, Option<Receiver<VenvCommand>>) = {
-                let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
-                let env = venv.get(source);
-                if let Some(env) = env {
-                    (env.get_channel_tx(), None)
-                } else {
-                    // Join a new virtual environment.
-                    match venv.join(source, VirtualEnvironmentIdentifier::NEW) {
-                        Ok((_, channel_tx, channel_rx)) => (channel_tx, Some(channel_rx)),
-                        Err(error) => {
-                            warn!("failed to join new virtual environment (error={error:?})");
-                            let message: Message = crate::build_error(source, error.code);
+                                    Self::close_connection(uvm_handle, &poll, Some(worker_threads));
 
-                            let uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>> =
-                                uvm_handle.get_user_vm_stream();
-                            let mut guard: MutexGuard<'_, (SocketStream, VecDeque<u8>)> =
-                                match uvm_stream.lock() {
-                                    Ok(guard) => guard,
-                                    Err(e) => {
-                                        error!(
-                                            "error acquiring lock on user VM stream (error={e:?})"
+                                    break 'main_loop;
+                                },
+                                _ => {
+                                    let reason: String =
+                                        format!("failed to read message (error={error_kind:?})");
+                                    unimplemented!("handle: {reason}");
+                                },
+                            },
+                        };
+
+                        trace!(
+                            "message.source={:?}, message.destination={:?}, message.type={:?}",
+                            { message.source },
+                            { message.destination },
+                            message.message_type,
+                        );
+
+                        let source: ThreadIdentifier = match { message.source }.as_id() {
+                            Err(tid) => tid,
+                            Ok(pid) => {
+                                unimplemented!(
+                                    "received message from process {pid:?} instead of thread"
+                                );
+                            },
+                        };
+
+                        // Check if process is associated with a virtual environment.
+                        let (channel_tx, channel_rx): (
+                            Sender<VenvCommand>,
+                            Option<Receiver<VenvCommand>>,
+                        ) = {
+                            let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> =
+                                venv.lock().unwrap();
+                            let env = venv.get(source);
+                            if let Some(env) = env {
+                                (env.get_channel_tx(), None)
+                            } else {
+                                // Join a new virtual environment.
+                                match venv.join(source, VirtualEnvironmentIdentifier::NEW) {
+                                    Ok((_, channel_tx, channel_rx)) => {
+                                        (channel_tx, Some(channel_rx))
+                                    },
+                                    Err(error) => {
+                                        warn!(
+                                            "failed to join new virtual environment \
+                                             (error={error:?})"
                                         );
+                                        let message: Message =
+                                            crate::build_error(source, error.code);
+
+                                        let uvm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>> =
+                                            uvm_handle.get_user_vm_stream();
+                                        let mut guard: MutexGuard<
+                                            '_,
+                                            (SocketStream, VecDeque<u8>),
+                                        > = match uvm_stream.lock() {
+                                            Ok(guard) => guard,
+                                            Err(e) => {
+                                                error!(
+                                                    "error acquiring lock on user VM stream \
+                                                     (error={e:?})"
+                                                );
+                                                continue;
+                                            },
+                                        };
+                                        let (locked_uvm_stream, _): &mut (
+                                            SocketStream,
+                                            VecDeque<u8>,
+                                        ) = &mut guard;
+
+                                        locked_uvm_stream.write_all(&message.to_bytes()).map_err(
+                                            |_| {
+                                                let reason = "failed to write to user VM stream";
+                                                error!("{reason}");
+                                                Error::new(ErrorCode::IoErr, reason)
+                                            },
+                                        )?;
                                         continue;
                                     },
-                                };
-                            let (locked_uvm_stream, _): &mut (SocketStream, VecDeque<u8>) =
-                                &mut guard;
+                                }
+                            }
+                        };
 
-                            locked_uvm_stream
-                                .write_all(&message.to_bytes())
-                                .map_err(|_| {
-                                    let reason = "failed to write to user VM stream";
-                                    error!("{reason}");
-                                    Error::new(ErrorCode::IoErr, reason)
-                                })?;
-                            continue;
-                        },
-                    }
-                }
-            };
+                        // Spawn a new worker thread, if necessary.
+                        if let Some(channel_rx) = channel_rx {
+                            // Spawn a thread to handle the message.
+                            let assembler = assembler.clone();
 
-            // Spawn a new worker thread, if necessary.
-            if let Some(channel_rx) = channel_rx {
-                // Spawn a thread to handle the message.
-                let assembler = assembler.clone();
+                            // Spawn an interruptible thread to handle the message.
+                            let worker_thread_handle: WorkerThreadHandle =
+                                WorkerThreadHandle::spawn(
+                                    source,
+                                    channel_rx,
+                                    channel_tx.clone(),
+                                    uvm_handle,
+                                    assembler,
+                                )?;
+                            worker_threads.push_back(worker_thread_handle);
+                        }
 
-                // Spawn an interruptible thread to handle the message.
-                let worker_thread_handle: WorkerThreadHandle = WorkerThreadHandle::spawn(
-                    source,
-                    channel_rx,
-                    channel_tx.clone(),
-                    uvm_handle,
-                    assembler,
-                )?;
-                worker_threads.push_back(worker_thread_handle);
-            }
+                        // Dispatch message to worker thread.
+                        if let Err(error) = channel_tx.send(VenvCommand::Work(message)) {
+                            error!(
+                                "run(): failed to dispatch message to worker thread \
+                                 (tid={source:?}, error={error:?})"
+                            );
+                            // Remove thread from the virtual environment.
+                            let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> =
+                                venv.lock().unwrap();
+                            if let Err(error) = venv.leave(source) {
+                                warn!(
+                                    "run(): failed to remove thread from virtual environment \
+                                     (tid={source:?}, error={error:?})",
+                                );
+                            }
+                        }
+                    },
 
-            // Dispatch message to worker thread.
-            if let Err(error) = channel_tx.send(VenvCommand::Work(message)) {
-                error!(
-                    "run(): failed to dispatch message to worker thread (tid={source:?}, \
-                     error={error:?})"
-                );
-                // Remove thread from the virtual environment.
-                let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> = venv.lock().unwrap();
-                if let Err(error) = venv.leave(source) {
-                    warn!(
-                        "run(): failed to remove thread from virtual environment (tid={source:?}, \
-                         error={error:?})",
-                    );
+                    Token(t) => {
+                        // This should never happen, but if it does we should ignore the spurious
+                        // wake up and continue processing connections.
+                        error!("poll received notification from unrecognised token {t:?}");
+                        continue;
+                    },
                 }
             }
         }

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -131,7 +131,7 @@ pub fn main() -> Result<()> {
     };
 
     // Connect the control-plane socket.
-    let _control_plane_socket: SocketStream =
+    let control_plane_stream: SocketStream =
         match SocketStream::connect(control_plane_socket_type, control_plane_sockaddr.clone()) {
             Ok(socket) => {
                 info!("Connected to control plane on: {:?}", control_plane_sockaddr);
@@ -213,10 +213,11 @@ pub fn main() -> Result<()> {
         None => None,
     };
 
-    let procd: LinuxDaemon = match LinuxDaemon::init(user_vm_stream, gateway_stream) {
-        Ok(procd) => procd,
-        Err(e) => panic!("failed to initialize process manager daemon (error={e:?})"),
-    };
+    let procd: LinuxDaemon =
+        match LinuxDaemon::init(control_plane_stream, user_vm_stream, gateway_stream) {
+            Ok(procd) => procd,
+            Err(e) => panic!("failed to initialize process manager daemon (error={e:?})"),
+        };
 
     // Run main procd loop.
     let procd_ret = procd.run();

--- a/src/utils/nanvixd/src/control_plane.rs
+++ b/src/utils/nanvixd/src/control_plane.rs
@@ -14,9 +14,8 @@ use ::std::io::{
     ErrorKind,
 };
 use ::syscomm::{
-    // TODO: move back to SocketStream when linuxd polls connections.
-    BlockingSocketStream,
     SocketError,
+    SocketStream,
 };
 
 #[repr(u8)]
@@ -28,16 +27,20 @@ pub enum Command {
 // This function is actually used by linuxd, consuming nanvixd as a library. It is never used from
 // the main nanvixd binary, hence why we need to add this annotation to silent clippy.
 #[allow(dead_code)]
-pub fn read_command(stream: &mut BlockingSocketStream) -> Result<Command, SocketError> {
+pub fn try_read_command(stream: &mut SocketStream) -> Result<Command, SocketError> {
     let mut buf: [u8; 1] = [0u8; 1];
-    stream.read_exact(&mut buf)?;
+
+    // Try read exact returns the number of bytes read `n` with 0 < n <= buf.len(). In this case
+    // it is safe to ignore the return value because n can only ever be 1.
+    let num_read = stream.try_read_exact(&mut buf)?;
+    debug_assert!(num_read == 1);
 
     Command::try_from(buf[0]).map_err(|_| {
         Error::new(ErrorKind::InvalidData, "error parsing control-plane command".to_string()).into()
     })
 }
 
-pub fn send_command(stream: &mut BlockingSocketStream, cmd: Command) -> Result<(), SocketError> {
+pub fn send_command(stream: &mut SocketStream, cmd: Command) -> Result<(), SocketError> {
     let byte: u8 = cmd.into();
     stream.write_all(&[byte])?;
     Ok(())

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -10,7 +10,6 @@ use ::anyhow::Result;
 use ::hwloc::HwLoc;
 use ::std::process::Stdio;
 use ::syscomm::{
-    BlockingSocketStream,
     Socket,
     SocketStream,
     SocketType,
@@ -26,7 +25,7 @@ use ::tokio::process::{
 
 pub struct LinuxDaemon {
     child: Child,
-    control_plane_stream: BlockingSocketStream,
+    control_plane_stream: SocketStream,
 }
 
 //==================================================================================================
@@ -100,12 +99,9 @@ impl LinuxDaemon {
             }
         };
 
-        let blocking_control_plane_stream: BlockingSocketStream =
-            control_plane_stream.set_blocking()?;
-
         Ok(Self {
             child,
-            control_plane_stream: blocking_control_plane_stream,
+            control_plane_stream,
         })
     }
 
@@ -117,35 +113,9 @@ impl LinuxDaemon {
         ) {
             Ok(()) => {},
             Err(e) => {
-                // FIXME: this send_command is expected to fail until support is implemented in
-                // linuxd.
                 error!("failed to send shutdown command to linuxd (error={e:?})");
             },
         };
-
-        // FIXME: when linuxd reacts on shutdown commands, we will be able to get rid of this
-        // manual kill.
-        match self.child.id() {
-            Some(pid) => {
-                let ret_code = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
-
-                if ret_code < 0 {
-                    let reason: String = format!(
-                        "error sending SIGINT to linuxd: {}",
-                        std::io::Error::last_os_error()
-                    );
-                    error!("{reason}");
-
-                    return Err(anyhow::anyhow!(reason));
-                }
-            },
-            None => {
-                let reason: String = "linuxd process has no PID".to_string();
-                error!("{reason}");
-
-                return Err(anyhow::anyhow!(reason));
-            },
-        }
 
         // Wait for linuxd instance to finish.
         match self.child.wait().await {
@@ -155,9 +125,7 @@ impl LinuxDaemon {
                         "linuxd returned with non-zero exit status: {:?}",
                         exit_status.code()
                     );
-                    // FIXME: change this debug to error once linuxd dies gracefully after a
-                    // SIGINT.
-                    debug!("{reason}");
+                    error!("{reason}");
 
                     Err(anyhow::anyhow!(reason))
                 } else {


### PR DESCRIPTION
In this PR I move linuxd to poll instead of spin-loop when trying to receive a message from the user VM. In addition of being more resource efficient, this also makes it easy to poll, together with the user VM socket, over the control-plane socket, and process events from both in a unified manner.

The lines changed in this PR are very small. The diff is large because I had to indent a lot of the logic, and put it inside the right match arm.