### PR TITLE
[microvm] Connect to Control Plane

### DIFF
--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -74,6 +74,15 @@ pub mod syscomm {
     /// the same time.
     ///
     pub const MAX_NUM_POLL_EVENTS: usize = 128;
+
+    ///
+    /// # Description
+    ///
+    /// Provides the timeout we should use when accepting a connection. This timeout is used when
+    /// manually accepting connections, and it is needed to account for races between both ends.
+    /// These races should be in the order of milliseconds.
+    ///
+    pub const ACCEPT_TIMEOUT_SECS: u64 = 1;
 }
 
 //==================================================================================================

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -32,6 +32,10 @@ use ::std::{
         Read,
         Write,
     },
+    time::{
+        Duration,
+        Instant,
+    },
 };
 
 //==================================================================================================
@@ -104,6 +108,52 @@ impl SocketListener {
                     listener.accept()?;
                 Ok(SocketStream::Unix(stream))
             },
+        }
+    }
+
+    /// Accepts a connection on a socket with a timeout.
+    ///
+    /// Our SocketStream abstraction is backed by mio sockets, so it is non-blocking. This method
+    /// offers a wrapper to accept a connection with a timeout by requiring the caller to provide
+    /// a poll structure.
+    ///
+    /// This is different from the BlockingSocketStream structure, that uses an internal poll to
+    /// receive in a blocking fashion.
+    pub fn accept_timeout(
+        &self,
+        poll: &mut Poll,
+        timeout: Duration,
+    ) -> Result<SocketStream, SocketError> {
+        let deadline: Instant = Instant::now() + timeout;
+        let mut events: Events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+
+        // Accept in a loop to account for spurious wake-ups in the poll.
+        loop {
+            // Try to accept first without blocking.
+            match self.accept() {
+                Ok(conn) => return Ok(conn),
+                // If it blocks, proceed to sleeping in a poll.
+                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {},
+                // If we were inerrupted, retry immediately.
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+                // If there was a transient error in the connection, retry immediately.
+                Err(ref e) if e.kind() == ErrorKind::ConnectionAborted => continue,
+                Err(e) => {
+                    error!("error accepting connection (error={e:?})");
+                    return Err(e);
+                },
+            }
+
+            let now: Instant = Instant::now();
+            if now >= deadline {
+                let reason: String = "accept timed-out waiting for connection".to_string();
+                error!("{reason}");
+                return Err(io::Error::new(ErrorKind::TimedOut, reason).into());
+            }
+
+            // Wait until the listener becomes readable or timeout expires
+            events.clear();
+            poll.poll(&mut events, Some(deadline - now))?;
         }
     }
 }

--- a/src/microvm/src/args.rs
+++ b/src/microvm/src/args.rs
@@ -16,7 +16,9 @@ use ::anyhow::Result;
 use ::std::{
     env,
     process,
+    str::FromStr,
 };
+use ::syscomm::SocketType;
 
 //==================================================================================================
 // Public Structures
@@ -42,6 +44,10 @@ pub struct Args {
     system_vm_addr: Option<String>,
     /// System VM socket type.
     system_vm_socket_type: Option<String>,
+    /// Control-plane address.
+    control_plane_addr: Option<String>,
+    /// Control-plane socket type.
+    control_plane_socket_type: Option<SocketType>,
     /// Log to file?
     log_to_file: bool,
 }
@@ -65,6 +71,10 @@ impl Args {
     const OPT_SYSTEM_VM_SOCKADDR: &'static str = "-system-vm-addr";
     /// Command-line option for the system VM socket type.
     const OPT_SYSTEM_VM_SOCKET_TYPE: &'static str = "-system-vm-socket-type";
+    /// Command-line option for control-plane address.
+    const OPT_CONTROL_PLANE_SOCKADDR: &'static str = "-control-plane-addr";
+    /// Command-line option for the control-plane socket type.
+    const OPT_CONTROL_PLANE_SOCKET_TYPE: &'static str = "-control-plane-socket-type";
     /// Command-line option for specifying arguments to be passed to the initrd.
     const OPT_INITRD_ARGS: &'static str = "-initrd_args";
     /// Log to file.
@@ -88,6 +98,8 @@ impl Args {
         let mut vm_stderr: Option<String> = None;
         let mut system_vm_addr: Option<String> = None;
         let mut system_vm_socket_type: Option<String> = None;
+        let mut control_plane_addr: Option<String> = None;
+        let mut control_plane_socket_type: Option<SocketType> = None;
         let mut log_to_file: bool = false;
 
         // Parse command-line arguments.
@@ -158,6 +170,24 @@ impl Args {
                     system_vm_socket_type = Some(args[i + 1].clone());
                     i += 1;
                 },
+                // Set control-plane address.
+                Self::OPT_CONTROL_PLANE_SOCKADDR if i + 1 < args.len() => {
+                    control_plane_addr = Some(args[i + 1].clone());
+                    i += 1;
+                },
+                // Set control-plane socket type.
+                Self::OPT_CONTROL_PLANE_SOCKET_TYPE if i + 1 < args.len() => {
+                    match SocketType::from_str(&args[i + 1]) {
+                        Ok(typ) => control_plane_socket_type = Some(typ),
+                        Err(_) => {
+                            let reason: String =
+                                format!("unrecognised socket type: {}", args[i + 1].clone());
+                            error!("{reason}");
+                            return Err(anyhow::anyhow!("{reason}"));
+                        },
+                    }
+                    i += 1;
+                },
                 // Set log to file flag.
                 Self::OPT_LOGFILE => {
                     log_to_file = true;
@@ -192,6 +222,8 @@ impl Args {
             vm_stderr,
             system_vm_addr,
             system_vm_socket_type,
+            control_plane_addr,
+            control_plane_socket_type,
             log_to_file,
         })
     }
@@ -311,6 +343,34 @@ impl Args {
     ///
     pub fn system_vm_socket_type(&mut self) -> Option<String> {
         self.system_vm_socket_type.take()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the address of the control-plane that was passed as a command-line argument to the program.
+    ///
+    /// # Returns
+    ///
+    /// The control-plane address that was passed as a command-line argument to the program.
+    ///
+    pub fn control_plane_addr(&mut self) -> Option<String> {
+        self.control_plane_addr.take()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the socket address type of the control-plane socket that was passed as a command-line
+    /// argument to the program.
+    ///
+    /// # Returns
+    ///
+    /// The socket address type of the control-plane socket that was passed as a command-line argument to
+    /// the program.
+    ///
+    pub fn control_plane_socket_type(&mut self) -> Option<SocketType> {
+        self.control_plane_socket_type.take()
     }
 
     ///

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -57,7 +57,8 @@ use ::syscomm::{
 /// so we can tolerate a sleep, but the sleep needs to be short as it will affect boot time.
 const CONNECT_TIMEOUT_SLEEP_MS: u64 = 1;
 /// Default socket bind type.
-const DEFAULT_BIND_SOCKET_TYPE: SocketType = SocketType::Unix;
+const DEFAULT_SYSTEM_VM_SOCKET_TYPE: SocketType = SocketType::Unix;
+const DEFAULT_CONTROL_PLANE_SOCKET_TYPE: SocketType = SocketType::Unix;
 
 //==================================================================================================
 // Standalone Functions
@@ -81,7 +82,7 @@ fn main() -> Result<ExitCode> {
                 anyhow::bail!("failed to parse socket address type");
             },
         },
-        None => DEFAULT_BIND_SOCKET_TYPE,
+        None => DEFAULT_SYSTEM_VM_SOCKET_TYPE,
     };
 
     // Initialize logger. If this fails, the program will panic.
@@ -108,6 +109,27 @@ fn main() -> Result<ExitCode> {
                     );
                     error!("main(): {reason}");
                     anyhow::bail!(reason)
+                },
+            }
+        },
+        None => None,
+    };
+
+    let _control_plane_socket: Option<SocketStream> = match args.control_plane_addr() {
+        Some(addr) => {
+            let control_plane_socket_type: SocketType = match args.control_plane_socket_type() {
+                Some(socket_type) => socket_type,
+                None => DEFAULT_CONTROL_PLANE_SOCKET_TYPE,
+            };
+            match SocketStream::connect(control_plane_socket_type, addr.clone()) {
+                Ok(stream) => Some(stream),
+                Err(e) => {
+                    let reason: String = format!(
+                        "failed to connect to control-plane (control_plane_addr={addr:?}, \
+                         error={e:?})",
+                    );
+                    error!("main(): {reason}");
+                    return Err(anyhow::anyhow!("{reason}"));
                 },
             }
         },

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -13,6 +13,7 @@ homepage.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
+config = { workspace = true }
 flexi_logger = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
@@ -21,6 +22,7 @@ hyper-util = { workspace = true, features = ["full"] }
 hwloc = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
+mio = { workspace = true, features = ["net", "os-poll"] }
 num_enum = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -12,18 +12,35 @@ use crate::sandbox::{
     tag::SandboxTag,
 };
 use ::anyhow::Result;
+use ::mio::{
+    Interest,
+    Poll,
+    Token,
+};
 use ::std::{
     collections::HashMap,
     sync::Arc,
 };
+use ::syscomm::{
+    Socket,
+    SocketListener,
+    SocketType,
+};
 use ::tokio::sync::Mutex;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// This is the token we use to register the control-plane listener socket in the poll structure.
+/// Right now, we only keep this socket in the poll.
+const CONTROL_PLANE_LISTENER_TOKEN: Token = Token(0);
 
 //==================================================================================================
 // Structures
 //==================================================================================================
 
 /// A cache of sandboxes.
-#[derive(Clone)]
 pub struct SandboxCache {
     // Members holding the state of the cache.
     /// Main table of sandboxes managed by this nanvixd instance.
@@ -31,10 +48,16 @@ pub struct SandboxCache {
     /// Table containing linuxd instances. The key is the tenant id as, for the moment, we deploy
     /// only one linuxd instance per tenant.
     linuxd_instances: HashMap<String, Arc<LinuxDaemon>>,
-
     // Auxiliary index structures.
     /// Reverse index mapping a sandbox ID to a sandbox tag.
     sandbox_index: HashMap<String, SandboxTag>,
+
+    // Control-plane members.
+    /// Listener socket on the control-plane address. Right now each different linuxd and user VM
+    /// instances have their own control-plane socket.
+    control_plane_listener: Option<SocketListener>,
+    /// Poll structure to support accepting connections into the control-plane with a timeout.
+    control_plane_poll: Option<Poll>,
 }
 
 impl SandboxCache {
@@ -56,6 +79,8 @@ impl SandboxCache {
             user_vm_instances: HashMap::new(),
             linuxd_instances: HashMap::new(),
             sandbox_index: HashMap::new(),
+            control_plane_listener: None,
+            control_plane_poll: None,
         }))
     }
 
@@ -81,6 +106,59 @@ impl SandboxCache {
         if !self.user_vm_instances.contains_key(tag) {
             // Cache miss.
             if let Some(sandbox_config) = config {
+                // Start control-plane listener socket lazily.
+                // FIXME(#764): make SocketType configurable.
+                if self.control_plane_listener.is_none() {
+                    let control_plane_sockaddr = sandbox_config.control_plane_sockaddr();
+                    let mut control_plane_listener =
+                        match Socket::bind(SocketType::Unix, control_plane_sockaddr.to_string()) {
+                            Ok(listener) => listener,
+                            Err(e) => {
+                                error!(
+                                    "failed to bind control-plane listening socket \
+                                     (address={control_plane_sockaddr}, error={e:?})"
+                                );
+                                return Err(anyhow::anyhow!(
+                                    "failed to bind control-plane listening socket"
+                                ));
+                            },
+                        };
+
+                    // Add control-plane socket to a poll structure so that we can accept
+                    // connections with a timeout.
+                    let poll: Poll = Poll::new().map_err(|e| {
+                        let reason: String =
+                            format!("failed to create control-plane poll (error={e:?})");
+                        error!("{reason}");
+                        anyhow::anyhow!("{reason}")
+                    })?;
+                    poll.registry()
+                        .register(
+                            &mut control_plane_listener,
+                            CONTROL_PLANE_LISTENER_TOKEN,
+                            Interest::READABLE,
+                        )
+                        .map_err(|e| {
+                            let reason: String =
+                                format!("failed to create control-plane poll (error={e:?})");
+                            error!("{reason}");
+                            anyhow::anyhow!("{reason}")
+                        })?;
+
+                    self.control_plane_listener = Some(control_plane_listener);
+                    self.control_plane_poll = Some(poll);
+                }
+
+                let control_plane_listener = self
+                    .control_plane_listener
+                    .as_mut()
+                    .ok_or_else(|| anyhow::anyhow!("control-plane listener is none"))?;
+
+                let control_plane_poll = self
+                    .control_plane_poll
+                    .as_mut()
+                    .ok_or_else(|| anyhow::anyhow!("control-plane poll is none"))?;
+
                 debug!("creating sandbox {tag:?}");
                 if !self.linuxd_instances.contains_key(tag.tenant_id()) {
                     // If this is the first user VM we deploy for this tenant, we first need to
@@ -93,6 +171,8 @@ impl SandboxCache {
                             sandbox_config.gateway_sockaddr(),
                             sandbox_config.hwloc(),
                             sandbox_config.binary_directory(),
+                            control_plane_listener,
+                            control_plane_poll,
                         )?),
                     );
                 }
@@ -104,9 +184,12 @@ impl SandboxCache {
                         sandbox_config.program(),
                         sandbox_config.program_args(),
                         sandbox_config.user_vm_sockaddr(),
+                        sandbox_config.control_plane_sockaddr(),
                         sandbox_config.console_file(),
                         sandbox_config.hwloc(),
                         sandbox_config.binary_directory(),
+                        control_plane_listener,
+                        control_plane_poll,
                     )?),
                 );
                 self.sandbox_index

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -8,11 +8,14 @@
 use crate::control_plane;
 use ::anyhow::Result;
 use ::hwloc::HwLoc;
-use ::std::process::Stdio;
+use ::mio::Poll;
+use ::std::{
+    process::Stdio,
+    time::Duration,
+};
 use ::syscomm::{
-    Socket,
+    SocketListener,
     SocketStream,
-    SocketType,
 };
 use ::tokio::process::{
     Child,
@@ -39,20 +42,9 @@ impl LinuxDaemon {
         gateway_sockaddr: &str,
         hwloc: Option<HwLoc>,
         binary_directory: &str,
+        control_plane_listener: &mut SocketListener,
+        control_plane_poll: &mut Poll,
     ) -> Result<Self> {
-        // Start the control-plane socket in listening mode.
-        let control_plane_listener =
-            match Socket::bind(SocketType::Unix, control_plane_sockaddr.to_string()) {
-                Ok(listener) => listener,
-                Err(e) => {
-                    error!(
-                        "failed to bind control-plane listening socket \
-                         (address={control_plane_sockaddr}, error={e:?})"
-                    );
-                    return Err(anyhow::anyhow!("failed to bind control-plane listening socket"));
-                },
-            };
-
         debug!(
             "spawning linux daemon (control-plane={control_plane_sockaddr}, \
              user-vm={user_vm_sockaddr}, gateway={gateway_sockaddr})"
@@ -82,22 +74,29 @@ impl LinuxDaemon {
 
         // After linuxd has started, accept the incoming connection and return the stream for
         // further use.
-        let control_plane_stream: SocketStream = loop {
-            match control_plane_listener.accept() {
-                Ok(stream) => {
-                    debug!("nanvixd received connection from linuxd's control-plane socket");
-                    break stream;
-                },
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
-                Err(error) => {
-                    error!(
-                        "nanvixd failed to accept connection from linuxd's control-plane \
-                         (error={error:?})"
-                    );
-                    continue;
-                },
-            }
+        let control_plane_stream: SocketStream = match control_plane_listener.accept_timeout(
+            control_plane_poll,
+            Duration::from_secs(config::syscomm::ACCEPT_TIMEOUT_SECS),
+        ) {
+            Ok(stream) => stream,
+            Err(e) => {
+                // If linuxd has not accepted the control-plane connection, it means that
+                // something went wrong during start-up. We kill the process ignoring errors,
+                // and return an error.
+                let reason: String =
+                    format!("error connecting control-plane to linuxd (error={e:?})");
+                error!("{reason}");
+
+                // Use a SIGKILL because the process is already faulty.
+                if let Some(pid) = child.id() {
+                    debug!("killing linuxd instance (pid={pid:?})");
+                    let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+                }
+
+                return Err(anyhow::anyhow!("{reason}"));
+            },
         };
+        debug!("nanvixd received connection from linuxd's control-plane socket");
 
         Ok(Self {
             child,

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -7,7 +7,15 @@
 
 use ::anyhow::Result;
 use ::hwloc::HwLoc;
-use ::std::process::Stdio;
+use ::mio::Poll;
+use ::std::{
+    process::Stdio,
+    time::Duration,
+};
+use ::syscomm::{
+    SocketListener,
+    SocketStream,
+};
 use ::tokio::process::{
     Child,
     Command,
@@ -20,6 +28,9 @@ use ::tokio::process::{
 pub struct Microvm {
     child: Option<Child>,
     addr: String,
+    #[allow(dead_code)]
+    // FIXME: the micro VM still does not support processing messages from the control-plane.
+    control_plane_stream: SocketStream,
 }
 
 //==================================================================================================
@@ -27,13 +38,17 @@ pub struct Microvm {
 //==================================================================================================
 
 impl Microvm {
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         program: &str,
         program_args: Option<&str>,
         addr: &str,
+        control_plane_addr: &str,
         stderr: Option<&str>,
         hwloc: Option<HwLoc>,
         binary_directory: &str,
+        control_plane_listener: &mut SocketListener,
+        control_plane_poll: &mut Poll,
     ) -> Result<Self> {
         let mut user_vm_args: Vec<String> = vec![
             format!("{}/microvm.elf", binary_directory),
@@ -44,6 +59,8 @@ impl Microvm {
             program.to_string(),
             "-system-vm-addr".to_string(),
             addr.to_string(),
+            "-control-plane-addr".to_string(),
+            control_plane_addr.to_string(),
         ];
 
         if let Some(program_args) = program_args {
@@ -79,9 +96,37 @@ impl Microvm {
             stderr
         );
 
+        // After the user VM has started, accept the incoming connection for the control-plane.
+        // Post-condition: once the connection has been accepted, the user VM has been able to
+        // connect to the system VM (if an address is provided).
+        let control_plane_stream: SocketStream = match control_plane_listener.accept_timeout(
+            control_plane_poll,
+            Duration::from_secs(config::syscomm::ACCEPT_TIMEOUT_SECS),
+        ) {
+            Ok(stream) => stream,
+            Err(e) => {
+                // If the user VM has not accepted the control-plane connection, it means that
+                // something went wrong during start-up. We kill the process ignoring errors,
+                // and return an error.
+                let reason: String =
+                    format!("error connecting control-plane to user VM (error={e:?})");
+                error!("{reason}");
+
+                // Use a SIGKILL because the process is already faulty.
+                if let Some(pid) = child.id() {
+                    debug!("killing user VM instance (pid={pid:?})");
+                    let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+                }
+
+                return Err(anyhow::anyhow!("{reason}"));
+            },
+        };
+        debug!("nanvixd received connection from the user VM's control-plane socket");
+
         Ok(Self {
             child: Some(child),
             addr: addr.to_string(),
+            control_plane_stream,
         })
     }
 }


### PR DESCRIPTION
In this PR I connect the micro VM to the control-plane in Nanvixd by establishing a socket stream at start-up time. The mechanism is identical to the one for linuxd. For the time being, the micro VM does not support processing any control-plane commands, this is because the micro VM lacks the ability to poll over the linuxd and control-plane sockets. I will address this limitation in a follow-up PR.

Each linuxd and micro VM instance get a different socket stream, accepted from the same socket listener. I had to move the binding logic in the socket listener from linuxd's spawn method, to the caller context and persist it in the sandbox cache.

@LucasGdosR: when this set of PRs is ready we should be able to send SNAPSHOT commands to the micro VM from nanvixd. 