### PR TITLE
[utils] Clean-Up User VM Sockets In Nanvixd

### DIFF
--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -17,7 +17,10 @@ use ::tokio::process::{
 // Structures
 //==================================================================================================
 
-pub struct Microvm(Option<Child>);
+pub struct Microvm {
+    child: Option<Child>,
+    addr: String,
+}
 
 //==================================================================================================
 // Implementations
@@ -76,13 +79,16 @@ impl Microvm {
             stderr
         );
 
-        Ok(Self(Some(child)))
+        Ok(Self {
+            child: Some(child),
+            addr: addr.to_string(),
+        })
     }
 }
 
 impl Drop for Microvm {
     fn drop(&mut self) {
-        if let Some(mut child) = self.0.take() {
+        if let Some(mut child) = self.child.take() {
             match child.id() {
                 Some(pid) => {
                     let ret_code = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
@@ -103,6 +109,17 @@ impl Drop for Microvm {
                     error!("failed to wait for user VM to shut down (error={e:?})");
                 }
             });
+
+            // Clean-up the per-micro VM socket file.
+            // FIXME: this won't be necessary once all micro VMs share a socket in one linuxd
+            // instance.
+            match std::fs::remove_file(self.addr.clone()) {
+                Ok(_) => {},
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {},
+                Err(e) => {
+                    error!("error removing micro VM socket (addr={}, error={e:?})", self.addr)
+                },
+            }
         }
     }
 }


### PR DESCRIPTION
In this commit I fix a resource leak in Nanvixd where we were not properly cleaning-up the user VM sockets. Causing crashes in the CI nodes.

In an ideal world, these patches would not be needed because the SocketListener trait should remove the file once it is dropped. This will be the case when we have a complete graceful shutdown protocol.