### PR TITLE
[microvm] Interrupt vCPU With Signal

### DIFF
--- a/src/microvm/src/vmm/microvm/kvm/vcpu/exit.rs
+++ b/src/microvm/src/vmm/microvm/kvm/vcpu/exit.rs
@@ -15,6 +15,8 @@ pub enum VirtualProcessorExitReason {
     PmioAccess,
     /// Halt virtual processor.
     Halt,
+    /// Interrupted.
+    Interrupted,
     /// Unknown.
     Unknown,
 }
@@ -31,6 +33,8 @@ pub enum VirtualProcessorExitContext<'a> {
     PmioOut(u16, u32, usize),
     /// Halt virtual processor.
     Halt,
+    /// Interrupt virtual processor.
+    Interrupted,
     /// Unknown.
     Unknown,
 }
@@ -58,6 +62,8 @@ impl VirtualProcessorExitContext<'_> {
             },
             // Halt virtual processor..
             VirtualProcessorExitContext::Halt => &VirtualProcessorExitReason::Halt,
+            // Interrupt virtual processor.
+            VirtualProcessorExitContext::Interrupted => &VirtualProcessorExitReason::Interrupted,
             // Unknown.
             VirtualProcessorExitContext::Unknown => &VirtualProcessorExitReason::Unknown,
         }

--- a/src/microvm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/microvm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -268,6 +268,11 @@ impl VirtualProcessor {
                 warn!("run(): internal error");
                 Ok(VirtualProcessorExitContext::Unknown)
             },
+            // Virtual processor was interrupted.
+            VcpuExit::Intr => {
+                warn!("run(): interrupted");
+                Ok(VirtualProcessorExitContext::Interrupted)
+            },
             // Unsupported exit reason.
             VcpuExit::Unsupported(reason) => {
                 // TODO: handle unsupported exit reason.

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -26,10 +26,18 @@ use crate::vmm::microvm::kvm::{
 
 use ::anyhow::Result;
 use ::arch::mem::PAGE_SIZE;
+use ::libc::{
+    SIGUSR1,
+    c_int,
+    sigaction,
+    sigemptyset,
+};
 use ::std::sync::{
     Arc,
     Mutex,
 };
+
+pub const INTERRUPT_SIGNAL: c_int = SIGUSR1;
 
 //==================================================================================================
 // Structures
@@ -67,6 +75,9 @@ pub type OutputFn = dyn FnMut(&Arc<Mutex<VirtualMemory>>, u32, usize) -> Result<
 //==================================================================================================
 // Implementations
 //==================================================================================================
+
+/// Signal handler for the vCPU thread. We install an empty handler to trigger an -EINTR.
+extern "C" fn vcpu_thread_signal_handler(_: i32) {}
 
 impl MicroVm {
     ///
@@ -230,6 +241,33 @@ impl MicroVm {
         self.vcpu.reset(rip, rax, rbx)
     }
 
+    /// Install a signal handler on the vCPU thread.
+    fn install_signal_handler() {
+        // SAFETY: we install a signal handler that is a no-op so this is safe.
+        let ret: c_int = unsafe {
+            let sig_action: sigaction = sigaction {
+                sa_sigaction: vcpu_thread_signal_handler as usize,
+                // Empty set to not block any other signals that may happen during signal handling.
+                sa_mask: {
+                    let mut set: libc::sigset_t = std::mem::zeroed();
+                    sigemptyset(&mut set);
+                    set
+                },
+                // No SA_RESTART so that we will trigger a -EINTR.
+                sa_flags: 0,
+                sa_restorer: None,
+            };
+
+            sigaction(INTERRUPT_SIGNAL, &sig_action, std::ptr::null_mut())
+        };
+
+        if ret != 0 {
+            // Notify the error, but don't fail.
+            let errno: i32 = unsafe { *libc::__errno_location() };
+            error!("error installing signal handler (errno={errno:?})");
+        }
+    }
+
     ///
     /// # Description
     ///
@@ -243,6 +281,9 @@ impl MicroVm {
     pub fn run(&mut self) -> Result<u16> {
         trace!("run()");
         crate::timer!("vm_run");
+
+        // Install a signal handler in the virtual processor's thread.
+        Self::install_signal_handler();
 
         // Run the virtual processor until it goes offline.
         while self.vcpu.is_online() {
@@ -260,6 +301,11 @@ impl MicroVm {
 
                 // The guest requested to halt the virtual processor.
                 VirtualProcessorExitReason::Halt => {
+                    self.vcpu.poweroff(0);
+                },
+
+                // The guest was interrupted, this means we need to power-off.
+                VirtualProcessorExitReason::Interrupted => {
                     self.vcpu.poweroff(0);
                 },
 

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -37,14 +37,20 @@ use crate::{
     },
 };
 use ::anyhow::Result;
+use ::libc::pthread_self;
 use ::std::{
     fs::File,
     io::Write,
     mem,
     sync::{
         Arc,
+        Barrier,
         Mutex,
         MutexGuard,
+        atomic::{
+            AtomicUsize,
+            Ordering,
+        },
         mpsc,
         mpsc::{
             Receiver,
@@ -236,13 +242,34 @@ impl Vmm {
             }
         });
 
+        // We use an atomic to pass the id of the created thread back to the caller context. We
+        // need this because std::thread's JoinHandle does not expose the tid. We synchronize the
+        // update using a barrier.
+        let pthread_id_holder: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+        let barrier: Arc<Barrier> = Arc::new(Barrier::new(2));
+
         let microvm_clone: Arc<Mutex<MicroVm>> = microvm.clone();
+        let barrier_clone: Arc<Barrier> = Arc::clone(&barrier);
+        let pthread_id_holder_clone: Arc<AtomicUsize> = pthread_id_holder.clone();
         let vcpu_thread: JoinHandle<Result<u16>> = std::thread::spawn(move || {
+            // Store the tid so that the caller can send signals to the vCPU thread.
+            // SAFETY: we are calling pthread_self() right after creating the thread so this is
+            // safe.
+            let pthread_id: libc::pthread_t = unsafe { pthread_self() };
+            pthread_id_holder_clone.store(pthread_id as usize, Ordering::Relaxed);
+
+            // Notify the outside thread that the thread id is ready.
+            barrier_clone.wait();
+
             microvm_clone
                 .lock()
                 .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
                 .run()
         });
+
+        // Wait right after spawning the vCPU thread such that we populate the pthread id holder
+        // before actually starting the vCPU.
+        barrier.wait();
 
         let mut vmm: Vmm = Self {
             _gateway_tx: gateway_tx,


### PR DESCRIPTION
In this commit I implement support to interrupt the vCPU thread by sending it a SIGUSR1 signal.

According to the KVM docs [1], sending a SIGUSR1 to the vCPU thread will cause KVM_RUN to return with -EINTR. For the time being we treat an interrupt as an outside request to halt execution, but we can extend this functionality in the future.

I have tested this functionality manually, but there is no way to trigger it programatically yet as we are lacking a connection with the control-plane socket.

[1] https://www.kernel.org/doc/html/v5.8/virt/kvm/api.html#kvm-set-signal-mask