### PR TITLE
[utils] Add -tmp-dir To Nanvix-Bench For Nanvixd

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -14,30 +14,48 @@ runs:
   using: "composite"
   steps:
   # MicroVM benchmarks
+  - name: Create temp dir
+    run: |
+      TMPDIR_MICROVM=$(mktemp -d /tmp/nanvix-bench-microvm-XXXXX)
+      echo "TMPDIR_MICROVM=$TMPDIR_MICROVM" >> "$GITHUB_ENV"
+    shell: bash
   - name: Build (MicroVM)
     run: |
       python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=panic --target-machine=microvm --release --without-opt --build
     shell: bash
   - name: Run micro-benchmarks (MicroVM)
     run: |
-      ./bin/nanvix-bench.elf -benchmark boot-time -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_boot_time_microvm_${{ inputs.arch }}.txt
-      ./bin/nanvix-bench.elf -benchmark cold-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_cold_start_microvm_${{ inputs.arch }}.txt
-      ./bin/nanvix-bench.elf -benchmark warm-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_microvm_${{ inputs.arch }}.txt
-      ./bin/nanvix-bench.elf -benchmark warm-start-vmm -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_vmm_microvm_${{ inputs.arch }}.txt
+      ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_MICROVM} -benchmark boot-time -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_boot_time_microvm_${{ inputs.arch }}.txt
+      ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_MICROVM} -benchmark cold-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_cold_start_microvm_${{ inputs.arch }}.txt
+      ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_MICROVM} -benchmark warm-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_microvm_${{ inputs.arch }}.txt
+      ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_MICROVM} -benchmark warm-start-vmm -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_vmm_microvm_${{ inputs.arch }}.txt
+    shell: bash
+  - name: Clean-up temporary directory
+    if: always()
+    run: rm -rf ${TMPDIR_MICROVM}
     shell: bash
 
   # Hyperlight benchmarks
+  - name: Create temp dir
+    run: |
+      TMPDIR_HL=$(mktemp -d /tmp/nanvix-bench-hl-XXXXX)
+      echo "TMPDIR_HL=$TMPDIR_HL" >> "$GITHUB_ENV"
+    shell: bash
   - name: Build (Hyperlight)
     run: |
       python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=panic --target-machine=hyperlight --release --without-opt --build
     shell: bash
   - name: Run micro-benchmarks (Hyperlight)
     run: |
-      ./bin/nanvix-bench.elf -benchmark boot-time -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_boot_time_hyperlight_${{ inputs.arch }}.txt
-      ./bin/nanvix-bench.elf -benchmark cold-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_cold_start_hyperlight_${{ inputs.arch }}.txt
-      ./bin/nanvix-bench.elf -benchmark warm-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_hyperlight_${{ inputs.arch }}.txt
+      ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_HL} -benchmark boot-time -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_boot_time_hyperlight_${{ inputs.arch }}.txt
+      ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_HL} -benchmark cold-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_cold_start_hyperlight_${{ inputs.arch }}.txt
+      ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_HL} -benchmark warm-start -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_hyperlight_${{ inputs.arch }}.txt
       # FIXME: warm-start-vmm is stuck on hyperlight (#709)
-      # ./bin/nanvix-bench.elf -benchmark warm-start-vmm -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_vmm_hyperlight_${{ inputs.arch }}.txt
+      # ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_HL} -benchmark warm-start-vmm -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_warm_start_vmm_hyperlight_${{ inputs.arch }}.txt
+    shell: bash
+  - name: Clean-up temporary directory
+    if: always()
+    run: rm -rf ${TMPDIR_HL}
     shell: bash
 
   # Post-process the results

--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -21,6 +21,7 @@ pub struct Args {
     benchmark: BenchmarkFlavour,
     hwloc_file: Option<String>,
     iterations: usize,
+    tmp_dir: String,
 }
 
 //==================================================================================================
@@ -32,15 +33,17 @@ impl Args {
     const OPT_BENCHMARK: &'static str = "-benchmark";
     const OPT_HWLOC: &'static str = "-hwloc";
     const OPT_ITERATIONS: &'static str = "-iterations";
+    const OPT_TMP_DIR: &'static str = "-tmp-dir";
 
     fn usage() -> String {
         format!(
             "usage: ./bin/nanvix-bench.elf {} \
              [boot-time,cold-start,warm-start,warm-start-vmm,echo-breakdown] [{} \
-             <path_to_hwloc.json> {} <iterations>]",
+             <path_to_hwloc.json> {} <iterations> {} <tmp_dir>]",
             Self::OPT_BENCHMARK,
             Self::OPT_HWLOC,
             Self::OPT_ITERATIONS,
+            Self::OPT_TMP_DIR,
         )
     }
 
@@ -48,6 +51,7 @@ impl Args {
         let mut benchmark_str: String = String::new();
         let mut hwloc_file: Option<String> = None;
         let mut iterations: usize = 100;
+        let mut tmp_dir: String = "/tmp/".to_string();
 
         let mut i: usize = 1;
         while i < args.len() {
@@ -81,6 +85,14 @@ impl Args {
                     }
                     iterations = args[i].parse::<usize>()?;
                 },
+                Self::OPT_TMP_DIR => {
+                    i += 1;
+                    if i >= args.len() {
+                        error!("{}", Self::usage());
+                        return Err(anyhow::anyhow!("missing value for: {}", Self::OPT_TMP_DIR));
+                    }
+                    tmp_dir = args[i].clone();
+                },
                 arg => {
                     error!("{}", Self::usage());
                     return Err(anyhow::anyhow!("invalid argument: {arg}"));
@@ -95,6 +107,7 @@ impl Args {
                 benchmark,
                 hwloc_file,
                 iterations,
+                tmp_dir,
             }),
             Err(_) => {
                 error!("{}", Self::usage());
@@ -113,5 +126,9 @@ impl Args {
 
     pub fn iterations(&self) -> usize {
         self.iterations
+    }
+
+    pub fn tmp_dir(&self) -> String {
+        self.tmp_dir.clone()
     }
 }

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -77,5 +77,6 @@ pub struct Benchmark {
     pub flavour: BenchmarkFlavour,
     pub nanvixd: Option<Child>,
     pub nanvixd_client: reqwest::Client,
+    pub nanvixd_tmp_dir: String,
     pub user_vm_id: Option<String>,
 }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -48,7 +48,6 @@ use microvm::{
     Vmm,
 };
 use mio::net::UnixStream;
-use nanvixd::config::DEFAULT_TMP_DIRECTORY;
 use reqwest::header::{
     CONTENT_TYPE,
     HeaderMap,
@@ -121,7 +120,7 @@ impl Benchmark {
             "-http-addr".to_string(),
             NANVIXD_ADDRESS.to_string(),
             "-tmp-dir".to_string(),
-            DEFAULT_TMP_DIRECTORY.to_string(),
+            self.nanvixd_tmp_dir.clone(),
         ];
         if let Some(hwloc_file) = &self.hwloc_file {
             nanvixd_args.push("-hwloc".to_string());
@@ -716,6 +715,7 @@ async fn main() -> Result<()> {
         flavour: args.benchmark(),
         nanvixd: None,
         nanvixd_client: reqwest::Client::new(),
+        nanvixd_tmp_dir: args.tmp_dir(),
         user_vm_id: None,
     };
 


### PR DESCRIPTION
For a while now nanvixd supports a CLI arg, `-tmp-dir`, to provide a temporary directory where to store all the used socket files, and other execution artifacts. These should not leak across executions, but it is sometimes hard to know if a leak is because of a current bug, or something that happened in the past.

As a consequence, in this commit I surface this argument all the way to nanvixd-bench, such that we can set it there, too.