### PR TITLE
[kernel] Refactor `create_thread()` Kernel Call

### DIFF
--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -360,6 +360,31 @@ impl Vmem {
         virt_addr >= config::memory_layout::USER_BASE && virt_addr < config::memory_layout::USER_END
     }
 
+    ///
+    /// # Description
+    ///
+    /// Asserts whether a memory region lies entirely in user space.
+    ///
+    /// # Parameters
+    ///
+    /// - `start`: Starting virtual address of the region.
+    /// - `size`: Size of the region in bytes.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the entire region lies in user space, `false` otherwise.
+    pub fn is_user_region(start: VirtualAddress, size: usize) -> bool {
+        // Reject zero-length regions.
+        if size == 0 {
+            return false;
+        }
+        // Check if the start and end addresses of the region lie in user space.
+        match start.checked_add(size - 1) {
+            Some(end) => Self::is_user_addr(start) && Self::is_user_addr(end),
+            None => false,
+        }
+    }
+
     /// Asserts wether an address lies in the kernel space.
     fn is_kernel_addr(virt_addr: VirtualAddress) -> bool {
         !Self::is_user_addr(virt_addr)

--- a/src/kernel/src/pm/kcall/create_thread.rs
+++ b/src/kernel/src/pm/kcall/create_thread.rs
@@ -14,51 +14,93 @@ use crate::{
         VirtMemoryManager,
         Vmem,
     },
-    pm::ProcessManager,
+    pm::{
+        self,
+        ProcessManager,
+    },
 };
+use ::core::mem::size_of;
 use ::sys::{
-    error::Error,
-    mm::VirtualAddress,
-    pm::ThreadIdentifier,
-};
-use sys::{
     error::ErrorCode,
-    pm::ProcessIdentifier,
+    mm::{
+        Address,
+        VirtualAddress,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadCreateArgs,
+    },
 };
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-fn do_create_thread(
-    pm: &mut ProcessManager,
-    mm: &mut VirtMemoryManager,
-    pid: ProcessIdentifier,
-    user_wrapper_fn: VirtualAddress,
-    user_fn: VirtualAddress,
-    user_fn_arg: usize,
-) -> Result<ThreadIdentifier, Error> {
-    pm.create_thread(mm, pid, user_wrapper_fn, user_fn, user_fn_arg)
-}
-
+///
+/// # Description
+///
+/// Creates a new thread in the calling process.
+///
+/// # Parameters
+///
+/// - `pm`: Handler to the process manager.
+/// - `mm`: Handler to the virtual memory manager.
+/// - `args`: Kernel call arguments containing the thread creation parameters.
+///
+/// # Returns
+///
+/// If successful, this function returns the thread identifier of the newly created thread.
+/// Otherwise, it returns an error code.
+///
 pub fn create_thread(
     pm: &mut ProcessManager,
     mm: &mut VirtMemoryManager,
     args: &KcallArgs,
 ) -> KcallResult {
     // Unpack kernel call arguments.
-    let user_wrapper_fn: VirtualAddress = VirtualAddress::from_raw_value(args.arg0 as usize);
-    let user_fn: VirtualAddress = VirtualAddress::from_raw_value(args.arg1 as usize);
-    let user_fn_arg: usize = args.arg2 as usize;
+    let pid: ProcessIdentifier = args.pid;
+    let unsafe_thread_create_args: VirtualAddress =
+        VirtualAddress::from_raw_value(args.arg0 as usize);
 
-    // Ensure that user function lies within the user address space.
-    if !Vmem::is_user_addr(user_fn) {
-        let reason: &str = "user function is not within the user address space";
-        error!("create_thread(): {} (user_func={:?})", reason, user_fn);
+    // Check if thread_create_args does not lie in user space.
+    if !Vmem::is_user_region(unsafe_thread_create_args, size_of::<ThreadCreateArgs>()) {
+        let reason: &str = "thread_create_args does not lie in user space";
+        error!("create_thread(): {reason} (thread_create_args={unsafe_thread_create_args:?})");
         return KcallResult::Error(ErrorCode::InvalidArgument.into());
     }
 
-    match do_create_thread(pm, mm, args.pid, user_wrapper_fn, user_fn, user_fn_arg) {
+    // Copy thread_create_args from user space to kernel space.
+    let mut thread_create_args: ThreadCreateArgs = ThreadCreateArgs::default();
+    if let Err(error) = pm::copy_from_user(
+        pm,
+        args.pid,
+        &mut thread_create_args,
+        unsafe_thread_create_args.into_raw_value() as *const ThreadCreateArgs,
+    ) {
+        let reason: &str = "failed to copy thread_create_args from user space";
+        error!("create_thread(): {reason:?} (error={:?})", error);
+        return KcallResult::Error(error.code.into());
+    }
+
+    // Check if the user wrapper function does not lie within the user address space.
+    if !Vmem::is_user_addr(thread_create_args.user_wrapper_fn) {
+        let reason: &str = "user wrapper function does not lie within the user address space";
+        error!(
+            "create_thread(): {reason} (user_wrapper_fn={:?})",
+            thread_create_args.user_wrapper_fn
+        );
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
+
+    // Check if the user function does not lie within the user address space.
+    if !Vmem::is_user_addr(thread_create_args.user_fn) {
+        let reason: &str = "user function does not lie within the user address space";
+        error!("create_thread(): {reason} (user_fn={:?})", thread_create_args.user_fn);
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
+
+    // Handle thread creation.
+    match pm.create_thread(mm, pid, &thread_create_args) {
         Ok(tid) => {
             debug!("create_thread(): thread {tid:?} created");
             KcallResult::Success(<i32>::from(tid).into())

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -299,7 +299,11 @@ impl ProcessManagerInner {
                 error!("create_thread(): {}", reason);
                 return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
             }
-            // TODO: include runnable process with interrupted threads.
+            if let ProcessRefMut::Runnable(_) = process {
+                let reason: &str = "process is runnable";
+                error!("create_thread(): {}", reason);
+                return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
+            }
 
             // Allocate a new user stack.
             let user_stack: UserStack = match process.state_mut().get_user_stack_allocator_mut() {

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -91,6 +91,7 @@ use ::sys::{
         ConditionAddress,
         MutexAddress,
         ProcessIdentifier,
+        ThreadCreateArgs,
         ThreadIdentifier,
     },
     time::SystemTime,
@@ -267,28 +268,30 @@ impl ProcessManagerInner {
     ///
     /// - `mm`: Memory manager to use.
     /// - `pid`: Process identifier.
-    /// - `user_func`: User function to execute.
+    /// - `thread_create_args`: Arguments for the thread creation.
     ///
     /// # Returns
     ///
     /// Upon successful completion, the thread identifier of the new thread is returned.
     /// Otherwise, an error is returned instead.
     ///
+    /// # Safety Notes
+    ///
+    /// - `thread_create_args` must have valid fields, specifically:
+    ///   - `user_wrapper_fn` must point to a user memory region that is executable.
+    ///   - `user_fn` must point to a user memory region that is executable.
+    ///
     fn create_thread(
         &mut self,
         mm: &mut VirtMemoryManager,
         pid: ProcessIdentifier,
-        user_wrapper_fn: VirtualAddress,
-        user_fn: VirtualAddress,
-        user_fn_arg: usize,
+        thread_create_args: &ThreadCreateArgs,
     ) -> Result<ThreadIdentifier, Error> {
-        trace!(
-            "create_thread(): pid={:?}, user_wrapper_fn={:#x?}, user_fn={:#x?}, user_fn_arg={:#x?}",
-            pid,
-            user_wrapper_fn,
-            user_fn,
-            user_fn_arg
-        );
+        trace!("create_thread(): pid={pid:?}, thread_create_args={thread_create_args:?}");
+
+        // Assert pre-conditions (these should have been checked by the caller).
+        debug_assert!(Vmem::is_user_addr(thread_create_args.user_wrapper_fn));
+        debug_assert!(Vmem::is_user_addr(thread_create_args.user_fn));
 
         let ready_thread: ReadyThread = {
             let enable_interrupts: bool = self.interrupt_capable;
@@ -319,7 +322,8 @@ impl ProcessManagerInner {
                 return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
             }
 
-            // Allocate a new user stack.
+            // Allocate a new user stack. If we fail beyond this point, `user_stack` gets dropped as
+            // soon as we exit this scope and underlying pages are released.
             let user_stack: UserStack = match process.state_mut().get_user_stack_allocator_mut() {
                 Some(user_stack_allocator) => user_stack_allocator.alloc()?,
                 None => {
@@ -337,9 +341,9 @@ impl ProcessManagerInner {
                     mm,
                     process.state_mut().vmem_mut(),
                     &user_stack,
-                    user_wrapper_fn,
-                    user_fn.into_raw_value(),
-                    user_fn_arg,
+                    thread_create_args.user_wrapper_fn,
+                    thread_create_args.user_fn.into_raw_value(),
+                    thread_create_args.user_fn_arg,
                     enable_interrupts,
                 )?;
 
@@ -1344,17 +1348,40 @@ impl ProcessManager {
         self.try_borrow_mut()?.create_process(mm, elf, args, env)
     }
 
-    /// Creates a new thread.
+    ///
+    /// # Description
+    ///
+    /// Creates a new thread in the running process.
+    ///
+    /// # Parameters
+    ///
+    /// - `mm`: Memory manager to use.
+    /// - `pid`: Process identifier.
+    /// - `thread_create_args`: Arguments for the thread creation.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, the thread identifier of the new thread is returned.
+    /// Otherwise, an error is returned instead.
+    ///
+    /// # Safety Notes
+    ///
+    /// - `thread_create_args` must have valid fields, specifically:
+    ///   - `user_wrapper_fn` must point to a user memory region that is executable.
+    ///   - `user_fn` must point to a user memory region that is executable.
+    ///
     pub fn create_thread(
         &mut self,
         mm: &mut VirtMemoryManager,
         pid: ProcessIdentifier,
-        user_wrapper_fn: VirtualAddress,
-        user_fn: VirtualAddress,
-        user_fn_arg: usize,
+        thread_create_args: &ThreadCreateArgs,
     ) -> Result<ThreadIdentifier, Error> {
+        // Assert pre-conditions (these should have been checked by the caller).
+        debug_assert!(Vmem::is_user_addr(thread_create_args.user_wrapper_fn));
+        debug_assert!(Vmem::is_user_addr(thread_create_args.user_fn));
+
         self.try_borrow_mut()?
-            .create_thread(mm, pid, user_wrapper_fn, user_fn, user_fn_arg)
+            .create_thread(mm, pid, thread_create_args)
     }
 
     pub fn has_capability(

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -172,6 +172,32 @@ impl ProcessManagerInner {
         }
     }
 
+    ///
+    /// # Description
+    ///
+    /// Creates a new thread in the calling process.
+    ///
+    /// # Parameters
+    ///
+    /// - `pm`: Handler to the process manager.
+    /// - `mm`: Handler to the virtual memory manager.
+    /// - `user_stack`: User stack to use for the new thread.
+    /// - `user_fn`: User function to execute in the new thread.
+    /// - `arg0`: First argument to pass to the user function.
+    /// - `arg1`: Second argument to pass to the user function.
+    /// - `enable_interrupts`: Whether to enable interrupts in the new thread.
+    ///
+    /// # Returns
+    ///
+    /// On successful completion, this function returns the thread identifier of the newly created
+    /// thread.  On failure, it returns an error object that provides details about the failure.
+    ///
+    /// # Safety Notes
+    ///
+    /// - `user_stack` refers to a memory region that lies within the user address space, it is
+    ///   writable and it has a size that is a multiple of `PAGE_SIZE`.
+    /// - `user_fn` lies within the user address space and points to an executable memory region.
+    ///
     fn forge_user_context(
         mm: &mut VirtMemoryManager,
         vmem: &mut Vmem,
@@ -182,36 +208,23 @@ impl ProcessManagerInner {
         enable_interrupts: bool,
     ) -> Result<(KernelStack, ContextInformation), Error> {
         trace!(
-            "forge_user_context(): user_stack={:?}, user_wrapper_fn={:#x?}, arg0={:#x?}, \
-             arg1={:#x?}, enable_interrupts={:?}",
-            user_stack,
-            user_fn,
-            arg0,
-            arg1,
-            enable_interrupts
+            "forge_user_context(): user_stack={user_stack:?}, user_fn={user_fn:#x?}, \
+             arg0={arg0:#x?}, arg1={arg1:#x?}, enable_interrupts={enable_interrupts:?}",
         );
 
         unsafe extern "C" {
             pub fn __leave_kernel_to_user_mode();
         }
 
-        // Ensure that user wrapper function lies within the user address space.
-        if !Vmem::is_user_addr(user_fn) {
-            let reason: &str = "user wrapper function is not within the user address space";
-            error!(
-                "forge_context(): {} (user_stack={:?}, user_func={:?})",
-                reason, user_stack, arg0
-            );
-            return Err(Error::new(ErrorCode::InvalidArgument, reason));
-        }
-
-        // NOTE: we don't check if the user function lies within the user address space, because
-        // if it is not it will self-crash.
+        // Assert pre-conditions (these should have been checked by the caller).
+        debug_assert!(Vmem::is_user_region(user_stack.top().into_inner(), user_stack.size()));
+        debug_assert!(Vmem::is_user_addr(user_fn));
 
         let kernel_func: VirtualAddress =
             VirtualAddress::from_raw_value(__leave_kernel_to_user_mode as usize);
 
-        // Alloc kernel pages for the kernel stack.
+        // Alloc kernel pages for the kernel stack. If we fail beyond this point, `kernel_stack`
+        // gets dropped as soon as we exit this scope and underlying pages are released.
         let kernel_stack: KernelStack = KernelStack::new(mm)?;
 
         let cr3: u32 = vmem.pgdir().physical_address()?.into_raw_value() as u32;
@@ -239,7 +252,8 @@ impl ProcessManagerInner {
             AccessPermission::RDWR,
         )?;
 
-        // NOTE: if we fail, beyond this point we must unmap kernel pages from `vmem`.
+        // NOTE: if we fail beyond this point we must unmap kernel pages from `vmem`, otherwise we
+        // will leak underlying pages.
 
         Ok((kernel_stack, context))
     }

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -15,12 +15,14 @@ use crate::{
     kcall2,
     kcall3,
     kcall4,
+    mm::VirtualAddress,
     number::KcallNumber,
     pm::{
         Capability,
         ConditionAddress,
         MutexAddress,
         ProcessIdentifier,
+        ThreadCreateArgs,
         ThreadIdentifier,
     },
     time::SystemTime,
@@ -150,11 +152,15 @@ pub fn create_thread(
         fn _do_start_thread() -> !;
     }
 
-    let result: i64 = kcall3!(
+    let thread_create_args: ThreadCreateArgs = ThreadCreateArgs {
+        user_wrapper_fn: VirtualAddress::from_raw_value(_do_start_thread as usize),
+        user_fn: VirtualAddress::from_raw_value(user_fn as usize),
+        user_fn_arg: arg,
+    };
+
+    let result: i64 = kcall1!(
         KcallNumber::CreateThread.into(),
-        _do_start_thread as usize as u32,
-        user_fn as usize as u32,
-        arg as u32
+        &thread_create_args as *const ThreadCreateArgs as usize as u32
     );
 
     ThreadIdentifier::try_from(result)

--- a/src/libs/sys/src/sys/mm/address/virt.rs
+++ b/src/libs/sys/src/sys/mm/address/virt.rs
@@ -101,6 +101,42 @@ impl VirtualAddress {
     pub fn is_aligned(&self, align: Alignment) -> bool {
         mm::is_aligned(self.0, align)
     }
+
+    ///
+    /// # Description
+    ///
+    /// Performs a checked addition of a [`VirtualAddress`] and a `usize`.
+    ///
+    /// # Parameters
+    ///
+    /// - `rhs`: The value to add.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the new [`VirtualAddress`] is returned. Upon failure (overflow), `None` is
+    /// returned instead.
+    ///
+    pub fn checked_add(&self, rhs: usize) -> Option<Self> {
+        self.0.checked_add(rhs).map(VirtualAddress::from_raw_value)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Performs a checked subtraction of a [`VirtualAddress`] and a `usize`.
+    ///
+    /// # Parameters
+    ///
+    /// - `rhs`: The value to subtract.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the new [`VirtualAddress`] is returned. Upon failure (underflow), `None` is
+    /// returned instead.
+    ///
+    pub fn checked_sub(&self, rhs: usize) -> Option<Self> {
+        self.0.checked_sub(rhs).map(VirtualAddress::from_raw_value)
+    }
 }
 
 impl Address for VirtualAddress {

--- a/src/libs/sys/src/sys/pm/mod.rs
+++ b/src/libs/sys/src/sys/pm/mod.rs
@@ -9,6 +9,7 @@ mod capability;
 mod gid;
 mod pid;
 mod sync;
+mod thread_create_args;
 mod tid;
 mod uid;
 
@@ -23,5 +24,6 @@ pub use sync::{
     ConditionAddress,
     MutexAddress,
 };
+pub use thread_create_args::ThreadCreateArgs;
 pub use tid::ThreadIdentifier;
 pub use uid::UserIdentifier;

--- a/src/libs/sys/src/sys/pm/thread_create_args.rs
+++ b/src/libs/sys/src/sys/pm/thread_create_args.rs
@@ -1,0 +1,35 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::mm::VirtualAddress;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Argument structure used with the `create_thread()` kernel call.
+#[derive(Debug, Copy, Clone)]
+pub struct ThreadCreateArgs {
+    /// User wrapper function to be executed by the thread.
+    pub user_wrapper_fn: VirtualAddress,
+
+    /// User function to be executed by the thread.
+    pub user_fn: VirtualAddress,
+
+    /// Argument to be passed to the user function.
+    pub user_fn_arg: usize,
+}
+
+impl Default for ThreadCreateArgs {
+    fn default() -> Self {
+        Self {
+            user_wrapper_fn: VirtualAddress::from_raw_value(0),
+            user_fn: VirtualAddress::from_raw_value(0),
+            user_fn_arg: 0,
+        }
+    }
+}


### PR DESCRIPTION
This PR refactors and strengthens the kernel thread creation API and its usage throughout the codebase.

The main focus is on improving safety and clarity by introducing a structured `ThreadCreateArgs` argument for thread creation, adding stricter validation of user-provided addresses, and enhancing documentation. The changes touch both kernel and user-space code, ensuring consistency and robustness in thread creation.