### PR TITLE
[daemons] Index Venvs By Thread and User VM Id

### DIFF
--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -352,7 +352,7 @@ impl LinuxDaemon {
                                 info!("linuxd received shutdown message from control-plane");
 
                                 // Close all existing connections to user VMs.
-                                while let Some(uvm_handle) = user_vm_connections.drain().next() {
+                                for uvm_handle in user_vm_connections.drain() {
                                     let conn_id: usize = uvm_handle.get_conn_id();
                                     info!("shutting down user VM (conn_id={conn_id})");
 

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -125,6 +125,7 @@ impl LinuxDaemon {
                     let entry: VacantEntry<UserVmHandle> = user_vm_connections.vacant_entry();
                     let entry_key: usize = entry.key();
                     let token: Token = Token(start_token + entry_key);
+                    trace!("accepted connection from user VM (conn_id={entry_key})");
 
                     user_vm_poll
                         .registry()
@@ -162,6 +163,10 @@ impl LinuxDaemon {
                         None
                     };
 
+                    trace!(
+                        "registered user VM handle (conn_id={entry_key}, gw_stream={})",
+                        gateway_stream.is_some()
+                    );
                     entry.insert(UserVmHandle::new(entry_key, user_vm_stream, gateway_stream));
                 },
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -361,7 +366,11 @@ impl LinuxDaemon {
                                 // Draining the user VM connections should also drain the worker
                                 // threads. Print an error if not.
                                 if !worker_threads.is_empty() {
-                                    error!("finished shutdown with orphaned worker threads");
+                                    error!(
+                                        "finished shutdown with orphaned worker threads \
+                                         (conn_ids={:?})",
+                                        worker_threads.keys().collect::<Vec<_>>()
+                                    );
                                 }
 
                                 break 'main_loop;
@@ -420,7 +429,8 @@ impl LinuxDaemon {
                             };
 
                             trace!(
-                                "message.source={:?}, message.destination={:?}, message.type={:?}",
+                                "uservm.id={conn_id}, message.source={:?}, \
+                                 message.destination={:?}, message.type={:?}",
                                 { message.source },
                                 { message.destination },
                                 message.message_type,
@@ -442,12 +452,16 @@ impl LinuxDaemon {
                             ) = {
                                 let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> =
                                     venv.lock().unwrap();
-                                let env = venv.get(source);
+                                let env = venv.get(conn_id, source);
                                 if let Some(env) = env {
                                     (env.get_channel_tx(), None)
                                 } else {
                                     // Join a new virtual environment.
-                                    match venv.join(source, VirtualEnvironmentIdentifier::NEW) {
+                                    match venv.join(
+                                        conn_id,
+                                        source,
+                                        VirtualEnvironmentIdentifier::NEW,
+                                    ) {
                                         Ok((_, channel_tx, channel_rx)) => {
                                             (channel_tx, Some(channel_rx))
                                         },
@@ -523,10 +537,10 @@ impl LinuxDaemon {
                                 // Remove thread from the virtual environment.
                                 let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> =
                                     venv.lock().unwrap();
-                                if let Err(error) = venv.leave(source) {
+                                if let Err(error) = venv.leave(conn_id, source) {
                                     warn!(
                                         "run(): failed to remove thread from virtual environment \
-                                         (tid={source:?}, error={error:?})",
+                                         (conn_id={conn_id}, tid={source:?}, error={error:?})",
                                     );
                                 }
                             }

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -163,11 +163,19 @@ impl LinuxDaemon {
                         None
                     };
 
+                    // Convert the entry key to a u32 for portability.
+                    let conn_id: u32 = match u32::try_from(entry_key) {
+                        Ok(conn_id) => conn_id,
+                        Err(e) => {
+                            error!("error clipping connection id to u32 (error={e:})");
+                            continue;
+                        },
+                    };
                     trace!(
-                        "registered user VM handle (conn_id={entry_key}, gw_stream={})",
+                        "registered user VM handle (conn_id={conn_id}, gw_stream={})",
                         gateway_stream.is_some()
                     );
-                    entry.insert(UserVmHandle::new(entry_key, user_vm_stream, gateway_stream));
+                    entry.insert(UserVmHandle::new(conn_id, user_vm_stream, gateway_stream));
                 },
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     // No connections to be accepted, break.
@@ -189,9 +197,9 @@ impl LinuxDaemon {
     /// reference, and with the function call we ensure we return the borrow.
     fn process_connection(
         user_vm_connections: &mut Slab<UserVmHandle>,
-        conn_id: usize,
+        conn_id: u32,
     ) -> Result<UserVmHandle, Error> {
-        match user_vm_connections.get_mut(conn_id) {
+        match user_vm_connections.get_mut(conn_id as usize) {
             Some(user_vm_handle) => Ok(user_vm_handle.clone()),
             None => Err(Error::new(ErrorCode::InvalidArgument, "Invalid connection ID")),
         }
@@ -319,7 +327,7 @@ impl LinuxDaemon {
         // Map keeping track of the worker threads associated to each user VM identified by
         // connection ID. We use a HashMap and not a Slab because we need to support insert/removal
         // by key.
-        let mut worker_threads: HashMap<usize, VecDeque<WorkerThreadHandle>> = HashMap::new();
+        let mut worker_threads: HashMap<u32, VecDeque<WorkerThreadHandle>> = HashMap::new();
 
         'main_loop: loop {
             let venv: Arc<Mutex<VirtualEnviromentDirectory>> = self.venv.clone();
@@ -353,7 +361,7 @@ impl LinuxDaemon {
 
                                 // Close all existing connections to user VMs.
                                 for uvm_handle in user_vm_connections.drain() {
-                                    let conn_id: usize = uvm_handle.get_conn_id();
+                                    let conn_id: u32 = uvm_handle.get_conn_id();
                                     info!("shutting down user VM (conn_id={conn_id})");
 
                                     Self::close_connection(
@@ -391,7 +399,14 @@ impl LinuxDaemon {
 
                     // Now we process events from active connections.
                     Token(t) => {
-                        let conn_id: usize = t - FIRST_USER_VM_CONNECTION_ID;
+                        let conn_id: u32 = match u32::try_from(t - FIRST_USER_VM_CONNECTION_ID) {
+                            Ok(conn_id) => conn_id,
+                            Err(e) => {
+                                // Skip to next token.
+                                error!("error clipping connection id to u32 (error={e:})");
+                                continue;
+                            },
+                        };
 
                         let uvm_handle: UserVmHandle =
                             Self::process_connection(&mut user_vm_connections, conn_id)?;
@@ -415,7 +430,7 @@ impl LinuxDaemon {
                                             &user_vm_poll,
                                             worker_threads.remove(&conn_id),
                                         );
-                                        user_vm_connections.remove(conn_id);
+                                        user_vm_connections.remove(conn_id as usize);
 
                                         break 'drain_loop;
                                     },

--- a/src/daemons/linuxd/src/user_vm_handle.rs
+++ b/src/daemons/linuxd/src/user_vm_handle.rs
@@ -24,7 +24,7 @@ use ::syscomm::{
 /// State associated with a user VM connected to this linuxd instance.
 #[derive(Clone)]
 pub struct UserVmHandle {
-    conn_id: usize,
+    conn_id: u32,
     // We keep track of a buffer to handle partial reads from the user VM socket. This buffer will
     // never exceed the IPC message size.
     user_vm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>,
@@ -33,7 +33,7 @@ pub struct UserVmHandle {
 
 impl UserVmHandle {
     pub fn new(
-        conn_id: usize,
+        conn_id: u32,
         user_vm_stream: SocketStream,
         gw_stream: Option<SocketStream>,
     ) -> Self {
@@ -57,7 +57,7 @@ impl UserVmHandle {
         }
     }
 
-    pub fn get_conn_id(&self) -> usize {
+    pub fn get_conn_id(&self) -> u32 {
         self.conn_id
     }
 

--- a/src/daemons/linuxd/src/venv.rs
+++ b/src/daemons/linuxd/src/venv.rs
@@ -28,7 +28,7 @@ use ::syscall::venv::VirtualEnvironmentIdentifier;
 ///
 /// Unique identifier for each user VM.
 ///
-pub type UserVmIdentifier = usize;
+pub type UserVmIdentifier = u32;
 
 ///
 /// # Description
@@ -148,14 +148,6 @@ impl VirtualEnviromentDirectory {
         uvmid: UserVmIdentifier,
         tid: ThreadIdentifier,
     ) -> Result<GlobalThreadIdentifier, Error> {
-        let uvmid: u32 = match u32::try_from(uvmid) {
-            Ok(value) => value,
-            Err(_) => {
-                let reason: &str = "error clipping user VM id to u32";
-                error!("{reason}");
-                return Err(Error::new(ErrorCode::ValueOverflow, reason));
-            },
-        };
         let tid: u32 = match u32::try_from(tid) {
             Ok(val) => val,
             Err(_) => {

--- a/src/daemons/linuxd/src/venv.rs
+++ b/src/daemons/linuxd/src/venv.rs
@@ -23,6 +23,20 @@ use ::sys::{
 };
 use ::syscall::venv::VirtualEnvironmentIdentifier;
 
+///
+/// # Description
+///
+/// Unique identifier for each user VM.
+///
+pub type UserVmIdentifier = usize;
+
+///
+/// # Description
+///
+/// Unique identifier for each thread of execution. Each thread will belong to one user VM.
+///
+pub type GlobalThreadIdentifier = u64;
+
 //==================================================================================================
 // Structures
 //==================================================================================================
@@ -59,7 +73,7 @@ pub struct VirtualEnviromentDirectory {
     /// Next environment identifier.
     next_env: VirtualEnvironmentIdentifier,
     /// Virtual environments.
-    processes: BTreeMap<ThreadIdentifier, VirtualEnvironment>,
+    processes: BTreeMap<GlobalThreadIdentifier, VirtualEnvironment>,
 }
 
 //==================================================================================================
@@ -118,6 +132,46 @@ impl VirtualEnviromentDirectory {
     ///
     /// # Description
     ///
+    /// Generate a global thread identifier to index virtual environments.
+    ///
+    /// # Parameters
+    ///
+    /// - `uvmid`: User VM identifier.
+    /// - `tid`: Thread identifier.
+    ///
+    /// # Returns
+    ///
+    /// On success, a u64 where the user VM id sits in the first 32 bits, and the thread id in the
+    /// second 32 bits. On error an error is returned.
+    ///
+    fn get_gtid(
+        uvmid: UserVmIdentifier,
+        tid: ThreadIdentifier,
+    ) -> Result<GlobalThreadIdentifier, Error> {
+        let uvmid: u32 = match u32::try_from(uvmid) {
+            Ok(value) => value,
+            Err(_) => {
+                let reason: &str = "error clipping user VM id to u32";
+                error!("{reason}");
+                return Err(Error::new(ErrorCode::ValueOverflow, reason));
+            },
+        };
+        let tid: u32 = match u32::try_from(tid) {
+            Ok(val) => val,
+            Err(_) => {
+                let reason: &str = "error clipping thread id to u32";
+                error!("{reason}");
+                return Err(Error::new(ErrorCode::ValueOverflow, reason));
+            },
+        };
+
+        let key: u64 = ((uvmid as u64) << 32) | (tid as u64);
+        Ok(key)
+    }
+
+    ///
+    /// # Description
+    ///
     /// Joins a virtual environment.
     ///
     /// # Parameters
@@ -132,23 +186,25 @@ impl VirtualEnviromentDirectory {
     ///
     pub fn join(
         &mut self,
+        uvmid: UserVmIdentifier,
         tid: ThreadIdentifier,
         mut envid: VirtualEnvironmentIdentifier,
     ) -> Result<(VirtualEnvironmentIdentifier, Sender<VenvCommand>, Receiver<VenvCommand>), Error>
     {
-        trace!("join(): tid={tid:?}, envid={envid:?}");
+        trace!("join(): uvmid={uvmid}, tid={tid:?}, envid={envid:?}");
 
         // Check if the process is already in an environment.
-        if let Some(env) = self.processes.get(&tid) {
+        let gtid: GlobalThreadIdentifier = Self::get_gtid(uvmid, tid)?;
+        if let Some(env) = self.processes.get(&gtid) {
             let reason: &str = "process is already in an environment";
-            error!("join(): {reason:?} (tid={tid:?}, envid={envid:?}, env={env:?})");
+            error!("join(): {reason:?} (uvmid={uvmid}, tid={tid:?}, envid={envid:?}, env={env:?})");
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         };
 
         // Check whether the process requested to join a new environment or an existing one.
         if envid != VirtualEnvironmentIdentifier::NEW {
             let reason: &str = "joining existing environments is not supported";
-            error!("join(): {reason:?} (tid={tid:?}, envid={envid:?})");
+            error!("join(): {reason:?} (uvmid={uvmid}, tid={tid:?}, envid={envid:?})");
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
 
@@ -159,8 +215,8 @@ impl VirtualEnviromentDirectory {
         envid = self.next_env;
         self.next_env = self.next_env.next();
         let env = VirtualEnvironment::new(envid, channel_tx.clone());
-        self.processes.insert(tid, env);
-        info!("process {tid:?} joined new environment {envid:?}");
+        self.processes.insert(gtid, env);
+        info!("process {tid:?} (uvmid={uvmid}) joined new environment {envid:?}");
 
         Ok((envid, channel_tx, channel_rx))
     }
@@ -172,6 +228,7 @@ impl VirtualEnviromentDirectory {
     ///
     /// # Parameters
     ///
+    /// - `uvmid`: User VM identifier.
     /// - `tid`: Thread identifier.
     ///
     /// # Returns
@@ -179,18 +236,23 @@ impl VirtualEnviromentDirectory {
     /// On success, an identifier to the virtual environment which the process left is returned.
     /// Otherwise, an error is returned.
     ///
-    pub fn leave(&mut self, tid: ThreadIdentifier) -> Result<VirtualEnvironmentIdentifier, Error> {
-        trace!("leave(): tid={tid:?}");
+    pub fn leave(
+        &mut self,
+        uvmid: UserVmIdentifier,
+        tid: ThreadIdentifier,
+    ) -> Result<VirtualEnvironmentIdentifier, Error> {
+        trace!("leave(): uvmid={uvmid} tid={tid:?}");
 
         // Leave environment.
-        match self.processes.remove(&tid) {
+        let gtid: GlobalThreadIdentifier = Self::get_gtid(uvmid, tid)?;
+        match self.processes.remove(&gtid) {
             Some(env) => {
-                info!("process {tid:?} left environment {env:?}");
+                info!("process {tid:?} (uvm={uvmid}) left environment {env:?}");
                 Ok(env.id())
             },
             None => {
                 let reason: &str = "process has not joined an environment";
-                error!("leave(): {reason:?} (tid={tid:?})");
+                error!("leave(): {reason:?} (uvmid={uvmid}, tid={tid:?})");
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         }
@@ -203,6 +265,7 @@ impl VirtualEnviromentDirectory {
     ///
     /// # Parameters
     ///
+    /// - `uvmid`: User VM identifier.
     /// - `tid`: Thread identifier.
     ///
     /// # Returns
@@ -210,7 +273,22 @@ impl VirtualEnviromentDirectory {
     /// If there is a virtual environment associated with the process, the function returns a
     /// reference to the virtual environment. Otherwise, it returns `None`.
     ///
-    pub fn get(&self, tid: ThreadIdentifier) -> Option<&VirtualEnvironment> {
-        self.processes.get(&tid)
+    pub fn get(
+        &self,
+        uvmid: UserVmIdentifier,
+        tid: ThreadIdentifier,
+    ) -> Option<&VirtualEnvironment> {
+        let gtid: GlobalThreadIdentifier = match Self::get_gtid(uvmid, tid) {
+            Ok(gtid) => gtid,
+            Err(e) => {
+                error!(
+                    "error getting global thread identifier (uvmid={uvmid}, tid={tid:?}, \
+                     error={e:?})"
+                );
+                return None;
+            },
+        };
+
+        self.processes.get(&gtid)
     }
 }


### PR DESCRIPTION
In this commit I extend the virtual environment abstraction in linuxd to index thread virtual environments by a combination of the thread ID, unique per user VM, and the user VM ID, unique per linuxd instance.

Collectively, both things represent what I called a global thread identifier, where I put the connection ID on the top 32 bits of a u64, and the thread ID on the bottom ones.