### PR TITLE
[utils] Remove Sandbox ID From Socket Addresses

### DIFF
--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -71,25 +71,19 @@ pub fn control_plane_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<
 ///
 /// # Description
 ///
-/// Builds the user VM Unix socket address for a given tenant ID, application name, and sandbox ID.
+/// Builds the user VM Unix socket address for a given tenant ID.
 ///
 /// # Arguments
 ///
 /// - tmp_str: Temporary directory path.
 /// - tenant_id: Tenant ID.
-/// - sandbox_id: Sandbox ID.
 ///
 /// # Returns
 ///
 /// On success, returns the name of the user VM Unix socket. On failure, returns an error.
 ///
-pub fn user_vm_sockaddr_builder(
-    tmp_str: &str,
-    tenant_id: &str,
-    sandbox_id: &str,
-) -> Result<String> {
-    let unix_socket_name: String =
-        format!("{tmp_str}/{tenant_id}:{sandbox_id}:uvm{UNIX_SOCKET_SUFFIX}");
+pub fn user_vm_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<String> {
+    let unix_socket_name: String = format!("{tmp_str}/{tenant_id}:uvm{UNIX_SOCKET_SUFFIX}");
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {
@@ -108,25 +102,19 @@ pub fn user_vm_sockaddr_builder(
 ///
 /// # Description
 ///
-/// Builds the gateway Unix socket address for a given tenant ID, application name, and sandbox ID.
+/// Builds the gateway Unix socket address for a given tenant ID.
 ///
 /// # Arguments
 ///
 /// - tmp_str: Temporary directory path.
 /// - tenant_id: Tenant ID.
-/// - sandbox_id: Sandbox ID.
 ///
 /// # Returns
 ///
 /// On success, returns the name of the gateway Unix socket. On failure, returns an error.
 ///
-pub fn gateway_sockaddr_builder(
-    tmp_str: &str,
-    tenant_id: &str,
-    sandbox_id: &str,
-) -> Result<String> {
-    let unix_socket_name: String =
-        format!("{tmp_str}/{tenant_id}:{sandbox_id}:gw{UNIX_SOCKET_SUFFIX}");
+pub fn gateway_sockaddr_builder(tmp_str: &str, tenant_id: &str) -> Result<String> {
+    let unix_socket_name: String = format!("{tmp_str}/{tenant_id}:gw{UNIX_SOCKET_SUFFIX}");
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -113,9 +113,9 @@ impl HttpClient {
         let control_plane_sockaddr: String =
             config::control_plane_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
         let gateway_sockaddr: String =
-            config::gateway_sockaddr_builder(&tmp_directory, tag.tenant_id(), tag.sandbox_id())?;
+            config::gateway_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
         let user_vm_sockaddr: String =
-            config::user_vm_sockaddr_builder(&tmp_directory, tag.tenant_id(), tag.sandbox_id())?;
+            config::user_vm_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
         let program_args = match message.program_args.len() {
             0 => None,
             _ => Some(message.program_args.clone()),


### PR DESCRIPTION
In this commit I remove the sandbox ID from the socket addresses assigned by nanvixd. This is a bug because different user VMs connected to the same linuxd insntance would not share a socket address, even though they should.

Closes #817