### PR TITLE
[kernel] Handle Thread Stack Creation in User Space

### DIFF
--- a/src/kernel/src/mm/ustack.rs
+++ b/src/kernel/src/mm/ustack.rs
@@ -6,25 +6,12 @@
 //==================================================================================================
 
 use crate::hal::mem::PageAligned;
-use ::alloc::{
-    fmt,
-    rc::Rc,
+use ::alloc::fmt;
+use ::config::memory_layout::USER_STACK_SIZE;
+use ::sys::mm::{
+    Address,
+    VirtualAddress,
 };
-use ::bitmap::Bitmap;
-use ::config::memory_layout::{
-    NUM_USER_STACK_ENTRIES,
-    USER_STACK_SIZE,
-    USER_STACK_TOP_RAW,
-};
-use ::core::cell::RefCell;
-use ::sys::{
-    error::Error,
-    mm::{
-        Address,
-        VirtualAddress,
-    },
-};
-use core::cell::RefMut;
 
 //==================================================================================================
 // User Stack
@@ -38,16 +25,11 @@ use core::cell::RefMut;
 pub struct UserStack {
     /// Base address.
     base: PageAligned<VirtualAddress>,
-    /// Handle to stack allocator.
-    allocator: Rc<RefCell<UserStackAllocatorInner>>,
 }
 
 impl UserStack {
-    fn new(
-        allocator: Rc<RefCell<UserStackAllocatorInner>>,
-        base: PageAligned<VirtualAddress>,
-    ) -> Result<Self, Error> {
-        Ok(Self { base, allocator })
+    pub fn new(base: PageAligned<VirtualAddress>) -> Self {
+        Self { base }
     }
 
     ///
@@ -107,124 +89,5 @@ impl fmt::Debug for UserStack {
             self.top(),
             self.size()
         )
-    }
-}
-
-impl Drop for UserStack {
-    fn drop(&mut self) {
-        debug!("drop(): {:?}", &self);
-        let allocator = self.allocator.clone();
-        if let Err(err) = allocator.borrow_mut().free(self) {
-            error!("failed to free user stack: {:?}", err);
-        };
-    }
-}
-
-//==================================================================================================
-// User Stack Allocator
-//==================================================================================================
-
-///
-/// # Description
-///
-/// Inner state of a user stack allocator.
-///
-struct UserStackAllocatorInner {
-    /// Base address.
-    base: PageAligned<VirtualAddress>,
-    /// Bitmap.
-    bitmap: Bitmap,
-}
-
-impl UserStackAllocatorInner {
-    ///
-    /// # Description
-    ///
-    /// Allocates a user stack.
-    ///
-    /// # Returns
-    ///
-    /// On success, the newly allocated user stack. Otherwise, an error.
-    ///
-    /// # Notes
-    ///
-    /// After allocation, it is up to the caller to map the stack into the target virtual address
-    /// space.
-    ///
-    pub fn alloc(&mut self) -> Result<PageAligned<VirtualAddress>, Error> {
-        let index: usize = self.bitmap.alloc()?;
-        PageAligned::from_address(self.base.into_inner() + (index * USER_STACK_SIZE))
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Frees a user stack.
-    ///
-    /// # Parameters
-    ///
-    /// - `user_stack`: The user stack to free.
-    ///
-    /// # Returns
-    ///
-    /// On success, the user stack is freed. Otherwise, an error.
-    ///
-    /// # Notes
-    ///
-    /// After freeing, it is up to the caller to unmap the stack from the target virtual address
-    /// space.
-    ///
-    fn free(&mut self, user_stack: &mut UserStack) -> Result<(), Error> {
-        let index: usize =
-            (user_stack.base.into_raw_value() - self.base.into_raw_value()) / USER_STACK_SIZE;
-        self.bitmap.clear(index)
-    }
-}
-
-///
-/// # Description
-///
-/// A structure that represents a user stack allocator.
-///
-pub struct UserStackAllocator {
-    inner: Rc<RefCell<UserStackAllocatorInner>>,
-}
-
-impl UserStackAllocator {
-    ///
-    /// # Description
-    ///
-    /// Initializes a new user stack allocator.
-    ///
-    /// # Returns
-    ///
-    /// On success, the newly initialized user stack allocator. Otherwise, an error.
-    ///
-    pub fn new() -> Result<Self, Error> {
-        ::static_assert::assert_eq!(NUM_USER_STACK_ENTRIES % u8::BITS as usize == 0);
-
-        let bitmap: Bitmap = Bitmap::new(NUM_USER_STACK_ENTRIES)?;
-
-        Ok(Self {
-            inner: Rc::new(RefCell::new(UserStackAllocatorInner {
-                base: PageAligned::from_raw_value(USER_STACK_TOP_RAW)?,
-                bitmap,
-            })),
-        })
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Allocates a user stack.
-    ///
-    /// # Returns
-    ///
-    /// On success, the newly allocated user stack. Otherwise, an error.
-    ///
-    pub fn alloc(&self) -> Result<UserStack, Error> {
-        let mut inner: RefMut<'_, UserStackAllocatorInner> = self.inner.borrow_mut();
-        let base: PageAligned<VirtualAddress> = inner.alloc()?;
-        UserStack::new(self.inner.clone(), base)
     }
 }

--- a/src/kernel/src/pm/kcall/create_thread.rs
+++ b/src/kernel/src/pm/kcall/create_thread.rs
@@ -19,6 +19,7 @@ use crate::{
         ProcessManager,
     },
 };
+use ::config::memory_layout::USER_STACK_SIZE;
 use ::core::mem::size_of;
 use ::sys::{
     error::ErrorCode,
@@ -83,19 +84,30 @@ pub fn create_thread(
     }
 
     // Check if the user wrapper function does not lie within the user address space.
-    if !Vmem::is_user_addr(thread_create_args.user_wrapper_fn) {
-        let reason: &str = "user wrapper function does not lie within the user address space";
+    if !Vmem::is_user_addr(thread_create_args.user_fn) {
+        let reason: &str = "user function does not lie within the user address space";
+        error!("create_thread(): {reason} (user_fn={:?})", thread_create_args.user_fn);
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
+
+    // Check if the user stack does not lie within the user address space.
+    if !Vmem::is_user_region(thread_create_args.user_stack_base, thread_create_args.user_stack_size)
+    {
+        let reason: &str = "user stack does not lie within the user address space";
         error!(
-            "create_thread(): {reason} (user_wrapper_fn={:?})",
-            thread_create_args.user_wrapper_fn
+            "create_thread(): {reason} (user_stack_base={:?}, user_stack_size={})",
+            thread_create_args.user_stack_base, thread_create_args.user_stack_size
         );
         return KcallResult::Error(ErrorCode::InvalidArgument.into());
     }
 
-    // Check if the user function does not lie within the user address space.
-    if !Vmem::is_user_addr(thread_create_args.user_fn) {
-        let reason: &str = "user function does not lie within the user address space";
-        error!("create_thread(): {reason} (user_fn={:?})", thread_create_args.user_fn);
+    // Check if user stack size is too small.
+    if thread_create_args.user_stack_size < USER_STACK_SIZE {
+        let reason: &str = "user stack size is too small";
+        error!(
+            "create_thread(): {reason} (user_stack_size={})",
+            thread_create_args.user_stack_size
+        );
         return KcallResult::Error(ErrorCode::InvalidArgument.into());
     }
 

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -27,10 +27,7 @@ use crate::{
     mm::{
         elf::Elf32Fhdr,
         kstack::KernelStack,
-        ustack::{
-            UserStack,
-            UserStackAllocator,
-        },
+        ustack::UserStack,
         VirtMemoryManager,
         Vmem,
     },
@@ -71,6 +68,7 @@ use ::alloc::{
     rc::Rc,
 };
 use ::arch::mem::PAGE_SIZE;
+use ::config::memory_layout::USER_STACK_TOP_RAW;
 use ::core::cell::{
     Ref,
     RefCell,
@@ -149,8 +147,7 @@ impl ProcessManagerInner {
         root: Vmem,
         tm: ThreadManager,
     ) -> Self {
-        let kernel: RunnableProcess =
-            RunnableProcess::new(ProcessIdentifier::KERNEL, kernel, root, None);
+        let kernel: RunnableProcess = RunnableProcess::new(ProcessIdentifier::KERNEL, kernel, root);
 
         let (kernel, reason, _): (
             RunningProcess,
@@ -195,31 +192,26 @@ impl ProcessManagerInner {
     ///
     /// # Safety Notes
     ///
-    /// - `user_stack` refers to a memory region that lies within the user address space, it is
-    ///   writable and it has a size that is a multiple of `PAGE_SIZE`.
+    /// - `user_stack_base` refers to a memory region that lies within the user address space, it is
+    ///   writable.
+    /// - `user_stack_size` is a multiple of `PAGE_SIZE`.
     /// - `user_fn` lies within the user address space and points to an executable memory region.
     ///
     fn forge_user_context(
         mm: &mut VirtMemoryManager,
         vmem: &mut Vmem,
-        user_stack: &UserStack,
-        user_fn: VirtualAddress,
-        arg0: usize,
-        arg1: usize,
+        args: &ThreadCreateArgs,
         enable_interrupts: bool,
     ) -> Result<(KernelStack, ContextInformation), Error> {
-        trace!(
-            "forge_user_context(): user_stack={user_stack:?}, user_fn={user_fn:#x?}, \
-             arg0={arg0:#x?}, arg1={arg1:#x?}, enable_interrupts={enable_interrupts:?}",
-        );
+        trace!("forge_user_context(): args={args:?}, enable_interrupts={enable_interrupts:?}",);
 
         unsafe extern "C" {
             pub fn __leave_kernel_to_user_mode();
         }
 
         // Assert pre-conditions (these should have been checked by the caller).
-        debug_assert!(Vmem::is_user_region(user_stack.top().into_inner(), user_stack.size()));
-        debug_assert!(Vmem::is_user_addr(user_fn));
+        debug_assert!(Vmem::is_user_region(args.user_stack_base, args.user_stack_size));
+        debug_assert!(Vmem::is_user_addr(args.user_fn));
 
         let kernel_func: VirtualAddress =
             VirtualAddress::from_raw_value(__leave_kernel_to_user_mode as usize);
@@ -232,10 +224,10 @@ impl ProcessManagerInner {
         let esp: u32 = unsafe {
             hal::arch::forge_user_stack(
                 kernel_stack.top().into_raw_value() as *mut u8,
-                user_stack.top().into_raw_value(),
-                user_fn.into_raw_value(),
-                arg0,
-                arg1,
+                args.user_stack_base.into_raw_value() + args.user_stack_size,
+                args.user_fn.into_raw_value(),
+                args.user_fn_arg0,
+                args.user_fn_arg1,
                 kernel_func.into_raw_value(),
                 enable_interrupts,
             )
@@ -244,17 +236,6 @@ impl ProcessManagerInner {
 
         trace!("forge_context(): cr3={:#x}, esp={:#x}, ebp={:#x}", cr3, esp, esp0);
         let context: ContextInformation = ContextInformation::new(cr3, esp, esp0);
-
-        // Alloc user stack and map it.
-        mm.alloc_upages(
-            vmem,
-            user_stack.base(),
-            user_stack.size() / PAGE_SIZE,
-            AccessPermission::RDWR,
-        )?;
-
-        // NOTE: if we fail beyond this point we must unmap kernel pages from `vmem`, otherwise we
-        // will leak underlying pages.
 
         Ok((kernel_stack, context))
     }
@@ -280,6 +261,7 @@ impl ProcessManagerInner {
     /// - `thread_create_args` must have valid fields, specifically:
     ///   - `user_wrapper_fn` must point to a user memory region that is executable.
     ///   - `user_fn` must point to a user memory region that is executable.
+    ///   - `user_stack` must point to a user memory region that is writable.
     ///
     fn create_thread(
         &mut self,
@@ -290,7 +272,6 @@ impl ProcessManagerInner {
         trace!("create_thread(): pid={pid:?}, thread_create_args={thread_create_args:?}");
 
         // Assert pre-conditions (these should have been checked by the caller).
-        debug_assert!(Vmem::is_user_addr(thread_create_args.user_wrapper_fn));
         debug_assert!(Vmem::is_user_addr(thread_create_args.user_fn));
 
         let ready_thread: ReadyThread = {
@@ -322,28 +303,12 @@ impl ProcessManagerInner {
                 return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
             }
 
-            // Allocate a new user stack. If we fail beyond this point, `user_stack` gets dropped as
-            // soon as we exit this scope and underlying pages are released.
-            let user_stack: UserStack = match process.state_mut().get_user_stack_allocator_mut() {
-                Some(user_stack_allocator) => user_stack_allocator.alloc()?,
-                None => {
-                    // The user stack allocator is not available.
-                    panic!(
-                        "create_thread(): user stack allocator not found, is this the kernel \
-                         process?"
-                    );
-                },
-            };
-
             // Create a kernel context.
             let (kernel_stack, context): (KernelStack, ContextInformation) =
                 Self::forge_user_context(
                     mm,
                     process.state_mut().vmem_mut(),
-                    &user_stack,
-                    thread_create_args.user_wrapper_fn,
-                    thread_create_args.user_fn.into_raw_value(),
-                    thread_create_args.user_fn_arg,
+                    thread_create_args,
                     enable_interrupts,
                 )?;
 
@@ -352,8 +317,7 @@ impl ProcessManagerInner {
             //==============================================================
 
             // Create a new thread.
-            self.tm
-                .create_thread(Some(kernel_stack), Some(user_stack), context)
+            self.tm.create_thread(Some(kernel_stack), None, context)
         };
 
         Ok(self.try_add_thread(pid, ready_thread))
@@ -515,22 +479,32 @@ impl ProcessManagerInner {
             envp_vaddr, env
         );
 
-        // Create a stack allocator.
-        let user_stack_allocator: UserStackAllocator = UserStackAllocator::new()?;
-
         // Create a kernel context.
-        let user_stack: UserStack = user_stack_allocator.alloc()?;
+        let user_stack: UserStack =
+            UserStack::new(PageAligned::from_raw_value(USER_STACK_TOP_RAW)?);
         let user_fn: VirtualAddress = entry;
         let argp: usize = args_vaddr.into_raw_value();
         let envp: usize = envp_vaddr.into_raw_value();
-        let (kernel_stack, context): (KernelStack, ContextInformation) = Self::forge_user_context(
-            mm,
-            &mut vmem,
-            &user_stack,
+
+        let args: ThreadCreateArgs = ThreadCreateArgs {
             user_fn,
-            argp,
-            envp,
-            self.interrupt_capable,
+            user_fn_arg0: argp,
+            user_fn_arg1: envp,
+            user_stack_base: user_stack.base().into_inner(),
+            user_stack_size: user_stack.size(),
+        };
+
+        let (kernel_stack, context): (KernelStack, ContextInformation) =
+            Self::forge_user_context(mm, &mut vmem, &args, self.interrupt_capable)?;
+
+        // Alloc user stack and map it.
+        // NOTE: if we fail beyond this point we must unmap kernel pages from `vmem`, otherwise we
+        // will leak underlying pages.
+        mm.alloc_upages(
+            &mut vmem,
+            user_stack.base(),
+            user_stack.size() / PAGE_SIZE,
+            AccessPermission::RDWR,
         )?;
 
         //==============================================================
@@ -544,8 +518,7 @@ impl ProcessManagerInner {
         // Create process.
         let pid: ProcessIdentifier = self.next_pid;
         self.next_pid = ProcessIdentifier::from(i32::from(pid) + 1);
-        let process: RunnableProcess =
-            RunnableProcess::new(pid, thread, vmem, Some(user_stack_allocator));
+        let process: RunnableProcess = RunnableProcess::new(pid, thread, vmem);
 
         // Add process to the queue of ready processes.
         self.ready.push_back(process);
@@ -1369,6 +1342,7 @@ impl ProcessManager {
     /// - `thread_create_args` must have valid fields, specifically:
     ///   - `user_wrapper_fn` must point to a user memory region that is executable.
     ///   - `user_fn` must point to a user memory region that is executable.
+    ///   - `user_stack` must point to a user memory region that is writable.
     ///
     pub fn create_thread(
         &mut self,
@@ -1377,7 +1351,6 @@ impl ProcessManager {
         thread_create_args: &ThreadCreateArgs,
     ) -> Result<ThreadIdentifier, Error> {
         // Assert pre-conditions (these should have been checked by the caller).
-        debug_assert!(Vmem::is_user_addr(thread_create_args.user_wrapper_fn));
         debug_assert!(Vmem::is_user_addr(thread_create_args.user_fn));
 
         self.try_borrow_mut()?

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -36,10 +36,7 @@ use crate::{
         },
     },
     ipc::Mailbox,
-    mm::{
-        ustack::UserStackAllocator,
-        Vmem,
-    },
+    mm::Vmem,
     pm::{
         process::capability::Capabilities,
         sync::{
@@ -150,8 +147,6 @@ pub struct ProcessState {
     mmio: LinkedList<IoMemoryRegion>,
     /// I/O ports.
     pmio: LinkedList<AnyIoPort>,
-    /// User stack allocator.
-    user_stack_allocator: Option<UserStackAllocator>,
     /// Mutexes.
     mutexes: BTreeMap<MutexAddress, Mutex>,
     /// Condition variables.
@@ -159,11 +154,7 @@ pub struct ProcessState {
 }
 
 impl ProcessState {
-    pub fn new(
-        pid: ProcessIdentifier,
-        vmem: Vmem,
-        user_stack_allocator: Option<UserStackAllocator>,
-    ) -> Self {
+    pub fn new(pid: ProcessIdentifier, vmem: Vmem) -> Self {
         Self {
             pid,
             capabilities: Capabilities::default(),
@@ -172,7 +163,6 @@ impl ProcessState {
             mailbox: Mailbox::default(),
             mmio: LinkedList::new(),
             pmio: LinkedList::new(),
-            user_stack_allocator,
             mutexes: BTreeMap::new(),
             conditions: BTreeMap::new(),
         }
@@ -415,10 +405,6 @@ impl ProcessState {
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         }
-    }
-
-    pub fn get_user_stack_allocator_mut(&mut self) -> Option<&mut UserStackAllocator> {
-        self.user_stack_allocator.as_mut()
     }
 }
 

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -7,10 +7,7 @@
 
 use crate::{
     hal::arch::ContextInformation,
-    mm::{
-        ustack::UserStackAllocator,
-        Vmem,
-    },
+    mm::Vmem,
     pm::{
         clock,
         process::state::{
@@ -58,14 +55,9 @@ pub struct RunnableProcess {
 }
 
 impl RunnableProcess {
-    pub fn new(
-        pid: ProcessIdentifier,
-        ready_thread: ReadyThread,
-        vmem: Vmem,
-        user_stack_allocator: Option<UserStackAllocator>,
-    ) -> Self {
+    pub fn new(pid: ProcessIdentifier, ready_thread: ReadyThread, vmem: Vmem) -> Self {
         Self {
-            state: Box::new(ProcessState::new(pid, vmem, user_stack_allocator)),
+            state: Box::new(ProcessState::new(pid, vmem)),
             ready_threads: NonEmptyVecDeque::new(ready_thread),
             interrupted_threads: None,
             sleeping_threads: None,

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -144,24 +144,15 @@ pub extern "C" fn _start_thread(func: extern "C" fn(usize) -> usize, arg: usize)
     unreachable!("failed to exit thread");
 }
 
-pub fn create_thread(
-    user_fn: extern "C" fn(usize) -> usize,
-    arg: usize,
-) -> Result<ThreadIdentifier, Error> {
+pub fn create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Error> {
     unsafe extern "C" {
         fn _do_start_thread() -> !;
     }
 
-    let thread_create_args: ThreadCreateArgs = ThreadCreateArgs {
-        user_wrapper_fn: VirtualAddress::from_raw_value(_do_start_thread as usize),
-        user_fn: VirtualAddress::from_raw_value(user_fn as usize),
-        user_fn_arg: arg,
-    };
+    args.user_wrapper_fn = VirtualAddress::from_raw_value(_do_start_thread as usize);
 
-    let result: i64 = kcall1!(
-        KcallNumber::CreateThread.into(),
-        &thread_create_args as *const ThreadCreateArgs as usize as u32
-    );
+    let result: i64 =
+        kcall1!(KcallNumber::CreateThread.into(), args as *const ThreadCreateArgs as usize as u32);
 
     ThreadIdentifier::try_from(result)
 }

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -171,14 +171,14 @@ pub fn exit_thread(status: usize) -> Result<!, Error> {
 // Join Thread
 //==================================================================================================
 
-pub fn join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<i64, Error> {
+pub fn join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<(), Error> {
     let result: i64 =
         kcall2!(KcallNumber::JoinThread.into(), i32::from(tid) as u32, retval as *mut usize as u32);
 
     if result != 0 {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to join thread"))
     } else {
-        Ok(result)
+        Ok(())
     }
 }
 

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -149,7 +149,14 @@ pub fn create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Er
         fn _do_start_thread() -> !;
     }
 
-    args.user_wrapper_fn = VirtualAddress::from_raw_value(_do_start_thread as usize);
+    // Check if the user function is set.
+    if args.user_fn != ThreadCreateArgs::NULL_USER_FN {
+        // If the user function is already set, it means that this function has been called
+        // recursively, which is not allowed.
+        return Err(Error::new(ErrorCode::InvalidArgument, "user function is set"));
+    }
+
+    args.user_fn = VirtualAddress::from_raw_value(_do_start_thread as usize);
 
     let result: i64 =
         kcall1!(KcallNumber::CreateThread.into(), args as *const ThreadCreateArgs as usize as u32);

--- a/src/libs/sys/src/sys/pm/thread_create_args.rs
+++ b/src/libs/sys/src/sys/pm/thread_create_args.rs
@@ -15,21 +15,34 @@ use crate::mm::VirtualAddress;
 #[derive(Debug, Copy, Clone)]
 pub struct ThreadCreateArgs {
     /// User wrapper function to be executed by the thread.
-    pub user_wrapper_fn: VirtualAddress,
-
-    /// User function to be executed by the thread.
     pub user_fn: VirtualAddress,
 
-    /// Argument to be passed to the user function.
-    pub user_fn_arg: usize,
+    /// First argument to be passed to the user function.
+    pub user_fn_arg0: usize,
+
+    /// Second argument to be passed to the user function.
+    pub user_fn_arg1: usize,
+
+    /// Base address of the user stack.
+    pub user_stack_base: VirtualAddress,
+
+    /// Size of the user stack.
+    pub user_stack_size: usize,
+}
+
+impl ThreadCreateArgs {
+    /// Null user function.
+    pub const NULL_USER_FN: VirtualAddress = VirtualAddress::new(0);
 }
 
 impl Default for ThreadCreateArgs {
     fn default() -> Self {
         Self {
-            user_wrapper_fn: VirtualAddress::from_raw_value(0),
             user_fn: VirtualAddress::from_raw_value(0),
-            user_fn_arg: 0,
+            user_fn_arg0: 0,
+            user_fn_arg1: 0,
+            user_stack_base: VirtualAddress::from_raw_value(0),
+            user_stack_size: 0,
         }
     }
 }

--- a/src/libs/syscall/src/pthread/syscall/cond.rs
+++ b/src/libs/syscall/src/pthread/syscall/cond.rs
@@ -5,7 +5,7 @@
 // Imports
 //==================================================================================================
 
-use crate::pthread::syscall::MUTEXES;
+use crate::pthread::syscall::mutex::MUTEXES;
 use ::alloc::collections::btree_map::{
     BTreeMap,
     Entry,

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -80,7 +80,7 @@ pub fn pthread_create(
     create_thread(&mut args)?.try_into()
 }
 
-pub fn pthread_join(thread: pthread_t) -> Result<isize, Error> {
+pub fn pthread_join(thread: pthread_t) -> Result<usize, Error> {
     ::syslog::trace!("pthread_join(): _thread={:?}", thread);
 
     let mut retval: usize = 0;
@@ -93,7 +93,7 @@ pub fn pthread_join(thread: pthread_t) -> Result<isize, Error> {
     };
 
     match join_thread(thread, &mut retval) {
-        Ok(_) => Ok(retval as isize),
+        Ok(()) => Ok(retval),
         Err(error) => Err(error),
     }
 }

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -18,7 +18,9 @@ mod tda;
 // Imports
 //==================================================================================================
 
+use crate::safe::mem::stack::Stack;
 use ::alloc::collections::btree_map::BTreeMap;
+use ::config::memory_layout::USER_STACK_SIZE;
 use ::spin::{
     Lazy,
     Mutex,
@@ -30,7 +32,6 @@ use ::sys::{
         exit_thread,
         join_thread,
     },
-    mm::VirtualAddress,
     pm::{
         ThreadCreateArgs,
         ThreadIdentifier,
@@ -41,50 +42,82 @@ use ::sys::{
 // Exports
 //==================================================================================================
 
-use ::sysapi::sys_types::{
-    pthread_mutexattr_t,
-    pthread_t,
-};
+use ::sysapi::sys_types::pthread_t;
 pub use cond::*;
 pub use mutex::*;
 pub use tda::*;
 
 //==================================================================================================
-// Globals
+// Global Variables
 //==================================================================================================
 
-static MUTEXES: Lazy<Mutex<BTreeMap<usize, pthread_mutexattr_t>>> =
-    Lazy::new(|| Mutex::new(BTreeMap::new()));
+/// Map of stacks for threads.
+static STACKS: Lazy<Mutex<BTreeMap<pthread_t, Stack>>> = Lazy::new(|| Mutex::new(BTreeMap::new()));
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-pub fn pthread_create(
-    start_routine: extern "C" fn(usize) -> usize,
-    arg: usize,
-) -> Result<pthread_t, Error> {
-    ::syslog::trace!(
-        "pthread_create(): _start_routine={:?}, arg={:?}",
-        ::core::ptr::addr_of!(start_routine),
-        arg
-    );
+///
+/// # Description
+///
+/// Creates a new thread.
+///
+/// # Parameters
+///
+/// - `start_routine`: Function to be executed by the thread.
+/// - `arg`: Argument passed to the thread function.
+///
+/// # Return Value
+///
+/// On successful completion, this function returns an identifier for the newly created thread. On
+/// failure, this function returns an error that contains the reason for the failure.
+///
+pub fn pthread_create(func: extern "C" fn(usize) -> usize, arg: usize) -> Result<pthread_t, Error> {
+    ::syslog::trace!("pthread_create(): func={:?}, arg={arg:?}", ::core::ptr::addr_of!(func));
+
+    // Create a new stack.
+    // NOTE: The stack is automatically deallocated if this object is dropped.
+    let stack: Stack = Stack::new(USER_STACK_SIZE)?;
 
     let mut args: ThreadCreateArgs = ThreadCreateArgs {
         // Placeholder for user wrapper function, it will be overridden by the kernel call interface.
-        user_wrapper_fn: VirtualAddress::from_raw_value(0),
-        user_fn: VirtualAddress::from_raw_value(start_routine as usize),
-        user_fn_arg: arg,
+        user_fn: ThreadCreateArgs::NULL_USER_FN,
+        user_fn_arg0: func as usize,
+        user_fn_arg1: arg,
+        user_stack_base: stack.base(),
+        user_stack_size: stack.size(),
     };
 
-    create_thread(&mut args)?.try_into()
+    let thread: pthread_t = create_thread(&mut args)?.try_into()?;
+
+    // Store the stack in the global map.
+    // NOTE: The stack will be dropped either when the thread is joined or the process exits.
+    let previous_stack: Option<Stack> = STACKS.lock().insert(thread, stack);
+    debug_assert!(previous_stack.is_none(), "there should be no previous stack for this thread");
+
+    Ok(thread)
 }
 
+///
+/// # Description
+///
+/// Joins a thread.
+///
+/// # Parameters
+///
+/// - `thread`: Thread identifier.
+///
+/// # Return Value
+///
+/// On successful completion, this function returns the return value of the joined thread. On
+/// failure, this function returns an error that contains the reason for the failure.
+///
 pub fn pthread_join(thread: pthread_t) -> Result<usize, Error> {
-    ::syslog::trace!("pthread_join(): _thread={:?}", thread);
+    ::syslog::trace!("pthread_join(): thread={thread:?}");
 
-    let mut retval: usize = 0;
-    let thread: ThreadIdentifier = match thread.try_into() {
+    // Attempt to convert thread identifier.
+    let tid: ThreadIdentifier = match thread.try_into() {
         Ok(tid) => tid,
         Err(error) => {
             ::syslog::error!("pthread_join(): {error:?} (thread={thread:?})");
@@ -92,17 +125,51 @@ pub fn pthread_join(thread: pthread_t) -> Result<usize, Error> {
         },
     };
 
-    match join_thread(thread, &mut retval) {
-        Ok(()) => Ok(retval),
-        Err(error) => Err(error),
-    }
+    let mut retval: usize = 0;
+    join_thread(tid, &mut retval)?;
+
+    // Remove the stack from the global map.
+    // NOTE: The stack will be dropped when this function returns.
+    let stack: Option<Stack> = STACKS.lock().remove(&thread);
+    debug_assert!(stack.is_some(), "there should be a stack for this thread");
+
+    Ok(retval)
 }
 
+///
+/// # Description
+///
+/// Exits the calling thread.
+///
+/// # Parameters
+///
+/// - `retval`: Return value of the thread.
+///
+/// # Return Value
+///
+/// On successful completion, this function does not return. On failure, this function returns an
+/// error that contains the reason for the failure.
+///
 pub fn pthread_exit(retval: usize) -> Result<!, Error> {
     ::syslog::trace!("pthread_exit(): retval={:?}", retval);
     exit_thread(retval)
 }
 
+///
+/// # Description
+///
+/// Returns the identifier of the calling thread.
+///
+/// # Return Value
+///
+/// The identifier of the calling thread.
+///
+/// # Safety Notes
+///
+/// This function panics if:
+/// - The thread is unable to retrieve its own identifier.
+/// - The thread identifier returned by the kernel is not valid.
+///
 pub fn pthread_self() -> pthread_t {
     ::sys::kcall::pm::gettid()
         .expect("a thread must be able to get its own identifier")

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -30,7 +30,11 @@ use ::sys::{
         exit_thread,
         join_thread,
     },
-    pm::ThreadIdentifier,
+    mm::VirtualAddress,
+    pm::{
+        ThreadCreateArgs,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -65,7 +69,15 @@ pub fn pthread_create(
         ::core::ptr::addr_of!(start_routine),
         arg
     );
-    create_thread(start_routine, arg)?.try_into()
+
+    let mut args: ThreadCreateArgs = ThreadCreateArgs {
+        // Placeholder for user wrapper function, it will be overridden by the kernel call interface.
+        user_wrapper_fn: VirtualAddress::from_raw_value(0),
+        user_fn: VirtualAddress::from_raw_value(start_routine as usize),
+        user_fn_arg: arg,
+    };
+
+    create_thread(&mut args)?.try_into()
 }
 
 pub fn pthread_join(thread: pthread_t) -> Result<isize, Error> {

--- a/src/libs/syscall/src/pthread/syscall/mutex.rs
+++ b/src/libs/syscall/src/pthread/syscall/mutex.rs
@@ -5,12 +5,15 @@
 // Imports
 //==================================================================================================
 
-use crate::pthread::syscall::MUTEXES;
 use ::alloc::collections::btree_map::{
     BTreeMap,
     Entry,
 };
-use ::spin::MutexGuard;
+use ::spin::{
+    Lazy,
+    Mutex,
+    MutexGuard,
+};
 use ::sys::{
     error::{
         Error,
@@ -30,6 +33,14 @@ use ::sysapi::{
         pthread_mutexattr_t,
     },
 };
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Global map of mutexes for threads.
+pub(super) static MUTEXES: Lazy<Mutex<BTreeMap<usize, pthread_mutexattr_t>>> =
+    Lazy::new(|| Mutex::new(BTreeMap::new()));
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/safe/mem/mod.rs
+++ b/src/libs/syscall/src/safe/mem/mod.rs
@@ -7,3 +7,6 @@
 
 /// Memory segment.
 pub mod segment;
+
+/// Stack.
+pub mod stack;

--- a/src/libs/syscall/src/safe/mem/stack.rs
+++ b/src/libs/syscall/src/safe/mem/stack.rs
@@ -1,0 +1,140 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::alloc::alloc::{
+    alloc,
+    dealloc,
+};
+use ::core::{
+    alloc::Layout,
+    mem::align_of,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    mm::{
+        Address,
+        VirtualAddress,
+    },
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Represents a user stack.
+pub struct Stack {
+    /// Base address of the stack.
+    base: VirtualAddress,
+    /// Size of the stack.
+    size: usize,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Stack {
+    ///
+    /// # Description
+    ///
+    /// Creates a new user stack with the specified size. The stack is allocated in the user space
+    /// and it is aligned to the size of a pointer.
+    ///
+    /// # Parameters
+    ///
+    /// - `size`: Size of the stack to be created.
+    ///
+    /// # Return Value
+    ///
+    /// On successful completion, this function returns the newly created stack. On failure, this
+    /// function returns an error that contains the reason for the failure.
+    ///
+    /// # Errors
+    ///
+    /// This function fails with the following errors codes:
+    /// - [`ErrorCode::OutOfMemory`]: The stack cannot be allocated due to insufficient memory.
+    ///
+    pub fn new(size: usize) -> Result<Self, Error> {
+        ::syslog::trace!("new(): size={size:?}");
+
+        // Compute allocation layout.
+        // Align to pointer size to ensure the stack is properly aligned for any value stored.
+        let layout: Layout = match Layout::from_size_align(size, align_of::<usize>()) {
+            Ok(layout) => layout,
+            Err(error) => {
+                let reason: &str = "failed to create user stack layout";
+                ::syslog::error!("new(): {reason:?} (error={error:?}, size={size:?})");
+                return Err(Error::new(ErrorCode::OutOfMemory, reason));
+            },
+        };
+
+        // Allocate memory for the stack and check for errors.
+        let base: VirtualAddress = match unsafe { alloc(layout) } {
+            ptr if !ptr.is_null() => VirtualAddress::from_raw_value(ptr as usize),
+            _ => {
+                let reason: &str = "failed to allocate user stack";
+                ::syslog::error!("new(): {reason:?} (size={size:?})");
+                return Err(Error::new(ErrorCode::OutOfMemory, reason));
+            },
+        };
+
+        Ok(Self { base, size })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the base address of the stack.
+    ///
+    /// # Return Value
+    ///
+    /// The base address of the stack as a `VirtualAddress`.
+    ///
+    pub fn base(&self) -> VirtualAddress {
+        self.base
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the size of the stack.
+    ///
+    /// # Return Value
+    ///
+    /// The size of the stack in bytes as a `usize`.
+    ///
+    pub fn size(&self) -> usize {
+        self.size
+    }
+}
+
+impl Drop for Stack {
+    fn drop(&mut self) {
+        ::syslog::trace!("drop(): base={:#x}, size={:?}", self.base.into_raw_value(), self.size);
+
+        // Compute allocation layout.
+        let layout: Layout = match Layout::from_size_align(self.size, align_of::<usize>()) {
+            Ok(layout) => layout,
+            Err(error) => {
+                ::syslog::error!(
+                    "drop(): failed to create stack layout for drop (error={error:?})"
+                );
+                return;
+            },
+        };
+
+        // Deallocate memory for the stack.
+        // SAFETY: `self.base.into_raw_value()` returns the original pointer allocated by `alloc()`,
+        // and thus is safe to cast to `*mut u8` for deallocation.
+        unsafe {
+            dealloc(self.base.into_raw_value() as *mut u8, layout);
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the creation of thread stacks from kernel space to user space.

Additionally, the codebase is refactored for clarity and maintainability, especially in the handling of mutexes and stacks.