### PR TITLE
[ci] Group Updates on KVM Crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,9 @@ updates:
       - dependency-name: "hyperlight-common"
       - dependency-name: "hyperlight-host"
       - dependency-name: "hyperlight-guest"
+
+    groups:
+      kvm-stack:
+        patterns:
+          - "kvm-ioctls"
+          - "kvm-bindings"


### PR DESCRIPTION
This commit fixes DependaBot to group updates on all KVM dependencies.