### PR TITLE
[kernel] Make GDT Global

### DIFF
--- a/src/kernel/src/hal/arch/x86/cpu/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/mod.rs
@@ -59,7 +59,7 @@ pub fn init(
     ioports: &mut IoPortAllocator,
     ioaddresses: &mut IoMemoryAllocator,
     madt: &Option<MadtInfo>,
-) -> Result<(Gdt, GdtPtr, TssRef, Option<InterruptController>), Error> {
+) -> Result<(GdtPtr, TssRef, Option<InterruptController>), Error> {
     unsafe extern "C" {
         static kstack: u8;
     }
@@ -99,7 +99,7 @@ pub fn init(
         info!("- has pbe:   {}", cpuid::has_pbe());
     }
 
-    let (gdt, gdtr, tss): (Gdt, GdtPtr, TssRef) = unsafe { Gdt::init(&kstack)? };
+    let (gdtr, tss): (GdtPtr, TssRef) = unsafe { Gdt::init(&kstack)? };
     unsafe { idt::init() };
 
     #[cfg(feature = "pic")]
@@ -114,13 +114,13 @@ pub fn init(
     #[cfg(not(feature = "pic"))]
     let controller: Option<InterruptController> = None;
 
-    Ok((gdt, gdtr, tss, controller))
+    Ok((gdtr, tss, controller))
 }
 
 #[cfg(feature = "smp")]
-pub fn initialize_application_core(kstack: *const u8) -> Result<(Gdt, GdtPtr, TssRef), Error> {
-    let (gdt, gdtr, tss): (Gdt, GdtPtr, TssRef) = unsafe { Gdt::init(kstack)? };
+pub fn initialize_application_core(kstack: *const u8) -> Result<(GdtPtr, TssRef), Error> {
+    let (gdtr, tss): (GdtPtr, TssRef) = unsafe { Gdt::init(kstack)? };
     unsafe { idt::load() };
 
-    Ok((gdt, gdtr, tss))
+    Ok((gdtr, tss))
 }

--- a/src/kernel/src/hal/arch/x86/mem/gdt.rs
+++ b/src/kernel/src/hal/arch/x86/mem/gdt.rs
@@ -37,8 +37,10 @@ use ::sys::error::Error;
 // Structures
 //==================================================================================================
 
-pub struct Gdt(Pin<Box<[Gdte; 6]>>);
+/// Global descriptor table.
+pub struct Gdt;
 
+/// Global descriptor table pointer.
 pub struct GdtPtr(Pin<Box<::arch::mem::gdtr::Gdtr>>);
 
 /// Global descriptor table entries.
@@ -63,6 +65,111 @@ pub enum SegmentSelector {
     UserData = ((GdtEntries::UserData as u8) << 3) | 3,
     Tss = (GdtEntries::Tss as u8) << 3,
 }
+
+//===================================================================================================
+// Global Variables
+//===================================================================================================
+
+/// Global descriptor table.
+static mut GDT: [Gdte; 6] = [
+    // Null entry.
+    Gdte::new(
+        0x0,
+        0x0,
+        GdteAccessByte::new(
+            AccessAccessed::NotAccessed,
+            AccessReadWrite::DataSegment(AccessWritable::Readonly),
+            AccessDirectionConforming::Direction(AccessDirection::GrowsUp),
+            AccessExecutable::Data,
+            AccessDescriptorType::System,
+            DescriptorPrivilegeLevel::Ring0,
+            AccessPresent::NotPresent,
+        ),
+        GdteFlags::new(
+            GdteGranularity::ByteGranularity,
+            GdteProtectedMode::ProtectedMode16,
+            GdteLongMode::CompatibilityMode,
+        ),
+    ),
+    // Kernel code entry.
+    Gdte::new(
+        0x0,
+        0xfffff,
+        GdteAccessByte::new(
+            AccessAccessed::NotAccessed,
+            AccessReadWrite::CodeSegment(AccessReadable::Readable),
+            AccessDirectionConforming::Conforming(AccessConforming::NonConforming),
+            AccessExecutable::Code,
+            AccessDescriptorType::CodeData,
+            DescriptorPrivilegeLevel::Ring0,
+            AccessPresent::Present,
+        ),
+        GdteFlags::new(
+            GdteGranularity::PageGranularity,
+            GdteProtectedMode::ProtectedMode32,
+            GdteLongMode::CompatibilityMode,
+        ),
+    ),
+    // Kernel data entry.
+    Gdte::new(
+        0x0,
+        0xfffff,
+        GdteAccessByte::new(
+            AccessAccessed::NotAccessed,
+            AccessReadWrite::DataSegment(AccessWritable::ReadWrite),
+            AccessDirectionConforming::Direction(AccessDirection::GrowsUp),
+            AccessExecutable::Data,
+            AccessDescriptorType::CodeData,
+            DescriptorPrivilegeLevel::Ring0,
+            AccessPresent::Present,
+        ),
+        GdteFlags::new(
+            GdteGranularity::PageGranularity,
+            GdteProtectedMode::ProtectedMode32,
+            GdteLongMode::CompatibilityMode,
+        ),
+    ),
+    // User code entry.
+    Gdte::new(
+        0x0,
+        0xfffff,
+        GdteAccessByte::new(
+            AccessAccessed::NotAccessed,
+            AccessReadWrite::CodeSegment(AccessReadable::Readable),
+            AccessDirectionConforming::Conforming(AccessConforming::NonConforming),
+            AccessExecutable::Code,
+            AccessDescriptorType::CodeData,
+            DescriptorPrivilegeLevel::Ring3,
+            AccessPresent::Present,
+        ),
+        GdteFlags::new(
+            GdteGranularity::PageGranularity,
+            GdteProtectedMode::ProtectedMode32,
+            GdteLongMode::CompatibilityMode,
+        ),
+    ),
+    // User data entry.
+    Gdte::new(
+        0x0,
+        0xfffff,
+        GdteAccessByte::new(
+            AccessAccessed::NotAccessed,
+            AccessReadWrite::DataSegment(AccessWritable::ReadWrite),
+            AccessDirectionConforming::Direction(AccessDirection::GrowsUp),
+            AccessExecutable::Data,
+            AccessDescriptorType::CodeData,
+            DescriptorPrivilegeLevel::Ring3,
+            AccessPresent::Present,
+        ),
+        GdteFlags::new(
+            GdteGranularity::PageGranularity,
+            GdteProtectedMode::ProtectedMode32,
+            GdteLongMode::CompatibilityMode,
+        ),
+    ),
+    // Task segment selector entry (overwritten at system initialization).
+    Gdte::default(),
+];
 
 //==================================================================================================
 // Implementations
@@ -90,134 +197,37 @@ impl Gdt {
         );
     }
 
-    pub unsafe fn init(kstack: *const u8) -> Result<(Gdt, GdtPtr, TssRef), Error> {
+    pub unsafe fn init(kstack: *const u8) -> Result<(GdtPtr, TssRef), Error> {
         trace!("initializing gdt...");
         let ss0: u32 = SegmentSelector::KernelData as u32;
         let esp0: u32 = kstack as u32;
         trace!("ss0={:x}, esp0={:x}", ss0, esp0);
         let tss: TssRef = TssRef::new(ss0, esp0)?;
 
-        let gdt = Gdt(Pin::new(Box::new([
-            // Null GDTE.
-            Gdte::new(
-                0x0,
-                0x0,
-                GdteAccessByte::new(
-                    AccessAccessed::NotAccessed,
-                    AccessReadWrite::DataSegment(AccessWritable::Readonly),
-                    AccessDirectionConforming::Direction(AccessDirection::GrowsUp),
-                    AccessExecutable::Data,
-                    AccessDescriptorType::System,
-                    DescriptorPrivilegeLevel::Ring0,
-                    AccessPresent::NotPresent,
-                ),
-                GdteFlags::new(
-                    GdteGranularity::ByteGranularity,
-                    GdteProtectedMode::ProtectedMode16,
-                    GdteLongMode::CompatibilityMode,
-                ),
+        // Overwrite task segment selector entry.
+        GDT[GdtEntries::Tss as usize] = Gdte::new(
+            tss.address() as u32,
+            tss.size() as u32 - 1,
+            GdteAccessByte::new(
+                AccessAccessed::Accessed,
+                AccessReadWrite::DataSegment(AccessWritable::Readonly),
+                AccessDirectionConforming::Conforming(AccessConforming::NonConforming),
+                AccessExecutable::Code,
+                AccessDescriptorType::System,
+                DescriptorPrivilegeLevel::Ring0,
+                AccessPresent::Present,
             ),
-            // Kernel code GDTE.
-            Gdte::new(
-                0x0,
-                0xfffff,
-                GdteAccessByte::new(
-                    AccessAccessed::NotAccessed,
-                    AccessReadWrite::CodeSegment(AccessReadable::Readable),
-                    AccessDirectionConforming::Conforming(AccessConforming::NonConforming),
-                    AccessExecutable::Code,
-                    AccessDescriptorType::CodeData,
-                    DescriptorPrivilegeLevel::Ring0,
-                    AccessPresent::Present,
-                ),
-                GdteFlags::new(
-                    GdteGranularity::PageGranularity,
-                    GdteProtectedMode::ProtectedMode32,
-                    GdteLongMode::CompatibilityMode,
-                ),
+            GdteFlags::new(
+                GdteGranularity::ByteGranularity,
+                GdteProtectedMode::ProtectedMode16,
+                GdteLongMode::CompatibilityMode,
             ),
-            // Kernel data GDTE.
-            Gdte::new(
-                0x0,
-                0xfffff,
-                GdteAccessByte::new(
-                    AccessAccessed::NotAccessed,
-                    AccessReadWrite::DataSegment(AccessWritable::ReadWrite),
-                    AccessDirectionConforming::Direction(AccessDirection::GrowsUp),
-                    AccessExecutable::Data,
-                    AccessDescriptorType::CodeData,
-                    DescriptorPrivilegeLevel::Ring0,
-                    AccessPresent::Present,
-                ),
-                GdteFlags::new(
-                    GdteGranularity::PageGranularity,
-                    GdteProtectedMode::ProtectedMode32,
-                    GdteLongMode::CompatibilityMode,
-                ),
-            ),
-            // User code GDTE.
-            Gdte::new(
-                0x0,
-                0xfffff,
-                GdteAccessByte::new(
-                    AccessAccessed::NotAccessed,
-                    AccessReadWrite::CodeSegment(AccessReadable::Readable),
-                    AccessDirectionConforming::Conforming(AccessConforming::NonConforming),
-                    AccessExecutable::Code,
-                    AccessDescriptorType::CodeData,
-                    DescriptorPrivilegeLevel::Ring3,
-                    AccessPresent::Present,
-                ),
-                GdteFlags::new(
-                    GdteGranularity::PageGranularity,
-                    GdteProtectedMode::ProtectedMode32,
-                    GdteLongMode::CompatibilityMode,
-                ),
-            ),
-            // User data GDTE.
-            Gdte::new(
-                0x0,
-                0xfffff,
-                GdteAccessByte::new(
-                    AccessAccessed::NotAccessed,
-                    AccessReadWrite::DataSegment(AccessWritable::ReadWrite),
-                    AccessDirectionConforming::Direction(AccessDirection::GrowsUp),
-                    AccessExecutable::Data,
-                    AccessDescriptorType::CodeData,
-                    DescriptorPrivilegeLevel::Ring3,
-                    AccessPresent::Present,
-                ),
-                GdteFlags::new(
-                    GdteGranularity::PageGranularity,
-                    GdteProtectedMode::ProtectedMode32,
-                    GdteLongMode::CompatibilityMode,
-                ),
-            ),
-            // TSS GDTE.
-            Gdte::new(
-                tss.address() as u32,
-                tss.size() as u32 - 1,
-                GdteAccessByte::new(
-                    AccessAccessed::Accessed,
-                    AccessReadWrite::DataSegment(AccessWritable::Readonly),
-                    AccessDirectionConforming::Conforming(AccessConforming::NonConforming),
-                    AccessExecutable::Code,
-                    AccessDescriptorType::System,
-                    DescriptorPrivilegeLevel::Ring0,
-                    AccessPresent::Present,
-                ),
-                GdteFlags::new(
-                    GdteGranularity::ByteGranularity,
-                    GdteProtectedMode::ProtectedMode16,
-                    GdteLongMode::CompatibilityMode,
-                ),
-            ),
-        ])));
+        );
 
         // Set the GDTPTR.
         let gdtr = GdtPtr(Pin::new(Box::new(::arch::mem::gdtr::Gdtr::new(
-            gdt.0.as_ptr() as u32,
-            (mem::size_of_val(&*gdt.0)) as u16,
+            GDT.as_ptr() as u32,
+            (mem::size_of_val(&GDT)) as u16,
         ))));
 
         info!("loading the GDT...");
@@ -226,6 +236,6 @@ impl Gdt {
         // Load the TSS.
         tss.load(SegmentSelector::Tss as u16);
 
-        Ok((gdt, gdtr, tss))
+        Ok((gdtr, tss))
     }
 }

--- a/src/kernel/src/hal/arch/x86/mod.rs
+++ b/src/kernel/src/hal/arch/x86/mod.rs
@@ -15,10 +15,7 @@ pub mod mem;
 use crate::hal::{
     arch::x86::{
         cpu::tss::TssRef,
-        mem::gdt::{
-            Gdt,
-            GdtPtr,
-        },
+        mem::gdt::GdtPtr,
     },
     io::{
         IoMemoryAllocator,
@@ -51,8 +48,6 @@ pub use cpu::{
 /// A type that describes the architecture-specific components.
 ///
 pub struct Arch {
-    /// Global Descriptor Table (GDT).
-    _gdt: Option<Gdt>,
     /// Global Descriptor Table Register (GDTR).
     pub _gdtr: Option<GdtPtr>,
     /// Task State Segment (TSS).
@@ -60,6 +55,7 @@ pub struct Arch {
     /// Interrupt controller.
     pub controller: Option<InterruptController>,
 }
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -72,10 +68,9 @@ pub fn init(
     info!("initializing architecture-specific components...");
 
     // Initialize interrupt controller.
-    let (gdt, gdtr, tss, controller) = cpu::init(ioports, ioaddresses, madt)?;
+    let (gdtr, tss, controller) = cpu::init(ioports, ioaddresses, madt)?;
 
     Ok(Arch {
-        _gdt: Some(gdt),
         _gdtr: Some(gdtr),
         _tss: Some(tss),
         controller,
@@ -84,10 +79,9 @@ pub fn init(
 
 #[cfg(feature = "smp")]
 pub fn initialize_application_core(kstack: *const u8) -> Result<Arch, Error> {
-    let (gdt, gdtr, tss): (Gdt, GdtPtr, TssRef) = cpu::initialize_application_core(kstack)?;
+    let (gdtr, tss): (GdtPtr, TssRef) = cpu::initialize_application_core(kstack)?;
 
     Ok(Arch {
-        _gdt: Some(gdt),
         _gdtr: Some(gdtr),
         _tss: Some(tss),
         controller: None,

--- a/src/libs/arch/src/x86/mem/gdt.rs
+++ b/src/libs/arch/src/x86/mem/gdt.rs
@@ -16,7 +16,6 @@ use crate::x86::cpu::ring::PrivilegeLevel;
 ///
 /// A type that represents an entry in the Global Descriptor Table (GDT).
 ///
-#[derive(Default)]
 #[repr(C, align(8))]
 pub struct Gdte {
     /// The lower 16 bits of the segment limit.
@@ -56,15 +55,35 @@ impl Gdte {
     ///
     /// This function returns a new GDT entry.
     ///
-    pub fn new(base: u32, limit: u32, access: GdteAccessByte, flags: GdteFlags) -> Self {
+    pub const fn new(base: u32, limit: u32, access: GdteAccessByte, flags: GdteFlags) -> Self {
         Self {
             base_low: Self::compute_base_low(base),
             base_high: Self::compute_base_high(base),
             base_middle: Self::compute_base_middle(base),
             limit_low: Self::compute_limit_low(limit),
-            flags_limit: (Self::compute_flags_low(flags.into()) << 4)
+            flags_limit: (Self::compute_flags_low(flags.into_u8()) << 4)
                 | (Self::compute_limit_high(limit) & 0x0f),
-            access: access.into(),
+            access: access.into_u8(),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Creates a new GDT entry with default values.
+    ///
+    /// # Return Value
+    ///
+    /// This function returns a new GDT entry with default values.
+    ///
+    pub const fn default() -> Self {
+        Self {
+            base_low: 0,
+            base_middle: 0,
+            base_high: 0,
+            limit_low: 0,
+            flags_limit: 0,
+            access: 0,
         }
     }
 
@@ -110,7 +129,7 @@ impl Gdte {
     /// This function returns the lower 16 bits of the segment base address.
     ///
     #[inline(always)]
-    fn compute_base_low(base: u32) -> u16 {
+    const fn compute_base_low(base: u32) -> u16 {
         (base & 0xffff) as u16
     }
 
@@ -128,7 +147,7 @@ impl Gdte {
     /// This function returns the middle 8 bits of the segment base address.
     ///
     #[inline(always)]
-    fn compute_base_middle(base: u32) -> u8 {
+    const fn compute_base_middle(base: u32) -> u8 {
         ((base >> 16) & 0xff) as u8
     }
 
@@ -146,7 +165,7 @@ impl Gdte {
     /// This function returns the upper 8 bits of the segment base address.
     ///
     #[inline(always)]
-    fn compute_base_high(base: u32) -> u8 {
+    const fn compute_base_high(base: u32) -> u8 {
         ((base >> 24) & 0xff) as u8
     }
 
@@ -164,7 +183,7 @@ impl Gdte {
     /// This function returns the lower 16 bits of the segment limit.
     ///
     #[inline(always)]
-    fn compute_limit_low(limit: u32) -> u16 {
+    const fn compute_limit_low(limit: u32) -> u16 {
         (limit & 0xffff) as u16
     }
 
@@ -182,7 +201,7 @@ impl Gdte {
     /// This function returns the upper 4 bits of the segment limit.
     ///
     #[inline(always)]
-    fn compute_limit_high(limit: u32) -> u8 {
+    const fn compute_limit_high(limit: u32) -> u8 {
         ((limit >> 16) & 0x0f) as u8
     }
 
@@ -200,7 +219,7 @@ impl Gdte {
     /// This function returns the lower 4 bits of the flags.
     ///
     #[inline(always)]
-    fn compute_flags_low(flags: u8) -> u8 {
+    const fn compute_flags_low(flags: u8) -> u8 {
         flags & 0x0f
     }
 }
@@ -233,7 +252,7 @@ pub struct GdteFlags {
 
 impl GdteFlags {
     /// Creates a new set of flags for a GDTE.
-    pub fn new(
+    pub const fn new(
         granularity: GdteGranularity,
         protected_mode: GdteProtectedMode,
         long_mode: GdteLongMode,
@@ -244,16 +263,23 @@ impl GdteFlags {
             long_mode,
         }
     }
-}
 
-impl From<GdteFlags> for u8 {
-    fn from(val: GdteFlags) -> Self {
-        (val.granularity as u8) | (val.protected_mode as u8) | (val.long_mode as u8)
+    ///
+    /// # Description
+    ///
+    /// Converts the flags into a `u8`.
+    ///
+    /// # Return Value
+    ///
+    /// This function returns the flags as a `u8`.
+    ///
+    const fn into_u8(&self) -> u8 {
+        (self.granularity as u8) | (self.protected_mode as u8) | (self.long_mode as u8)
     }
 }
 
 /// Granularity flag for a GDTE.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum GdteGranularity {
     ByteGranularity = (0 << 3),
@@ -261,7 +287,7 @@ pub enum GdteGranularity {
 }
 
 /// Protected mode flag for a GDTE.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum GdteProtectedMode {
     ProtectedMode16 = (0 << 2),
@@ -269,7 +295,7 @@ pub enum GdteProtectedMode {
 }
 
 /// Long mode flag for a GDTE.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum GdteLongMode {
     CompatibilityMode = (0 << 1),
@@ -277,7 +303,7 @@ pub enum GdteLongMode {
 }
 
 /// Present flag in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessAccessed {
     NotAccessed = 0,
@@ -285,7 +311,7 @@ pub enum AccessAccessed {
 }
 
 /// Read flag for code segments in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessReadable {
     NonReadable = (0 << 1),
@@ -293,7 +319,7 @@ pub enum AccessReadable {
 }
 
 /// Write flag for data segments in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessWritable {
     Readonly = (0 << 1),
@@ -301,7 +327,7 @@ pub enum AccessWritable {
 }
 
 /// Read/Write flag in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessReadWrite {
     CodeSegment(AccessReadable),
@@ -309,7 +335,7 @@ pub enum AccessReadWrite {
 }
 
 /// Direction flag in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessDirection {
     GrowsUp = (0 << 2),
@@ -317,7 +343,7 @@ pub enum AccessDirection {
 }
 
 /// Conforming flag in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessConforming {
     NonConforming = (0 << 2),
@@ -325,7 +351,7 @@ pub enum AccessConforming {
 }
 
 /// Direction/Conforming flag in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessDirectionConforming {
     Direction(AccessDirection),
@@ -333,7 +359,7 @@ pub enum AccessDirectionConforming {
 }
 
 /// Code/Data flag in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessExecutable {
     Data = (0 << 3),
@@ -341,7 +367,7 @@ pub enum AccessExecutable {
 }
 
 /// Descriptor type flag in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessDescriptorType {
     System = (0 << 4),
@@ -349,7 +375,7 @@ pub enum AccessDescriptorType {
 }
 
 /// Descriptor privilege level flag in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum DescriptorPrivilegeLevel {
     Ring0 = (PrivilegeLevel::Ring0 as u8) << 5,
@@ -359,7 +385,7 @@ pub enum DescriptorPrivilegeLevel {
 }
 
 /// Present flag in access byte.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessPresent {
     NotPresent = (0 << 7),
@@ -383,7 +409,7 @@ pub struct GdteAccessByte {
 
 impl GdteAccessByte {
     /// Creates a new access byte.
-    pub fn new(
+    pub const fn new(
         accessed: AccessAccessed,
         read_write: AccessReadWrite,
         direction_conforming: AccessDirectionConforming,
@@ -402,22 +428,29 @@ impl GdteAccessByte {
             present,
         }
     }
-}
 
-impl From<GdteAccessByte> for u8 {
-    fn from(val: GdteAccessByte) -> Self {
-        (val.accessed as u8)
-            | match val.read_write {
+    ///
+    /// # Description
+    ///
+    /// Converts the access byte into a `u8`.
+    ///
+    /// # Return Value
+    ///
+    /// This function returns the access byte as a `u8`.
+    ///
+    const fn into_u8(&self) -> u8 {
+        (self.accessed as u8)
+            | match self.read_write {
                 AccessReadWrite::CodeSegment(readable) => readable as u8,
                 AccessReadWrite::DataSegment(writable) => writable as u8,
             }
-            | match val.direction_conforming {
+            | match self.direction_conforming {
                 AccessDirectionConforming::Direction(direction) => direction as u8,
                 AccessDirectionConforming::Conforming(conforming) => conforming as u8,
             }
-            | (val.executable as u8)
-            | (val.descriptor_type as u8)
-            | (val.dpl as u8)
-            | (val.present as u8)
+            | (self.executable as u8)
+            | (self.descriptor_type as u8)
+            | (self.dpl as u8)
+            | (self.present as u8)
     }
 }


### PR DESCRIPTION
This pull request refactors the x86 GDT (Global Descriptor Table) initialization and usage in the kernel, simplifying the GDT's internal representation and improving const-correctness and clarity in the GDT entry code. The GDT is now a static global variable rather than a heap-allocated structure, and related APIs and types have been adjusted accordingly. This reduces memory allocations and clarifies ownership and usage patterns throughout the kernel and architecture initialization code.

**GDT Representation and Initialization Refactor:**

* Changed `Gdt` from a heap-allocated struct to a zero-sized struct with a static mutable global array `GDT` for the actual entries, eliminating unnecessary heap allocations. (`src/kernel/src/hal/arch/x86/mem/gdt.rs`, [[1]](diffhunk://#diff-ec47f4f1837f70c927bc3cd9b0268bab181b979d440880a7d293238de6d1b4e1L40-R43) [[2]](diffhunk://#diff-ec47f4f1837f70c927bc3cd9b0268bab181b979d440880a7d293238de6d1b4e1L67-R75) [[3]](diffhunk://#diff-ec47f4f1837f70c927bc3cd9b0268bab181b979d440880a7d293238de6d1b4e1L196-R208)
* Updated the `Gdt::init` function to only return a `GdtPtr` and `TssRef`, instead of also returning the `Gdt` itself. The GDT entries are now managed globally. (`src/kernel/src/hal/arch/x86/mem/gdt.rs`, [[1]](diffhunk://#diff-ec47f4f1837f70c927bc3cd9b0268bab181b979d440880a7d293238de6d1b4e1L229-R239) [[2]](diffhunk://#diff-28ceb635aedd52ae74955df68508c797e019ef3d9358a9037d8b5b58102d9b40L62-R62) [[3]](diffhunk://#diff-28ceb635aedd52ae74955df68508c797e019ef3d9358a9037d8b5b58102d9b40L102-R102) [[4]](diffhunk://#diff-28ceb635aedd52ae74955df68508c797e019ef3d9358a9037d8b5b58102d9b40L117-R125)
* Refactored all call sites and structures to remove `Gdt` as a field or return value, updating signatures and initialization accordingly. (`src/kernel/src/hal/arch/x86/cpu/mod.rs`, [[1]](diffhunk://#diff-28ceb635aedd52ae74955df68508c797e019ef3d9358a9037d8b5b58102d9b40L62-R62) [[2]](diffhunk://#diff-28ceb635aedd52ae74955df68508c797e019ef3d9358a9037d8b5b58102d9b40L102-R102) [[3]](diffhunk://#diff-28ceb635aedd52ae74955df68508c797e019ef3d9358a9037d8b5b58102d9b40L117-R125); `src/kernel/src/hal/arch/x86/mod.rs`, [[4]](diffhunk://#diff-3f5af654f1a9465d98169cd274d33734954002efeacc63300a38125bf7b11cc9L18-R18) [[5]](diffhunk://#diff-3f5af654f1a9465d98169cd274d33734954002efeacc63300a38125bf7b11cc9L54-R58) [[6]](diffhunk://#diff-3f5af654f1a9465d98169cd274d33734954002efeacc63300a38125bf7b11cc9L75-L78) [[7]](diffhunk://#diff-3f5af654f1a9465d98169cd274d33734954002efeacc63300a38125bf7b11cc9L87-L90)

**Const-correctness and GDT Entry Improvements:**

* Made `Gdte` and related builder methods (`new`, `default`, and internal field computations) `const`, enabling compile-time construction of GDT entries. (`src/libs/arch/src/x86/mem/gdt.rs`, [[1]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L19) [[2]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L59-R86) [[3]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L113-R132) [[4]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L131-R150) [[5]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L149-R168) [[6]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L167-R186) [[7]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L185-R204) [[8]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L236-R255) [[9]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L247-R378) [[10]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L386-R412)
* Added a `const fn default()` for `Gdte` to allow static initialization of unused entries. (`src/libs/arch/src/x86/mem/gdt.rs`, [src/libs/arch/src/x86/mem/gdt.rsL59-R86](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L59-R86))

**Type and Enum Improvements:**

* Changed all GDT-related flag and access enums to derive `Clone` and `Copy` for easier use in const contexts and improved ergonomics. (`src/libs/arch/src/x86/mem/gdt.rs`, [[1]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L247-R378) [[2]](diffhunk://#diff-b18e91c63c78e71829903022a09d91a7006eadf9e101b0164d2fb5d0767e13f6L362-R388)

These changes improve both performance and code maintainability, and they clarify the GDT's lifetime and usage throughout the kernel.