### PR TITLE
[build] B: Remove Unnnecessary .gitmodules File

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "opt/zlib"]
-	path = opt/zlib
-	url = https://github.com/nanvix/zlib.git
-[submodule "contrib/cloud-hypervisor"]
-	path = contrib/cloud-hypervisor
-	url = https://github.com/nanvix/cloud-hypervisor.git


### PR DESCRIPTION
This pull request removes two git submodules from the project by deleting their entries from the `.gitmodules` file.

* Removed the `opt/zlib` and `contrib/cloud-hypervisor` submodules by deleting their references from `.gitmodules`.