### PR TITLE
Update Hyperlight Dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,11 +67,11 @@ goblin = { version = "0.10.0", default-features = false }
 indicatif = "0.18.0"
 http = "1.3.1"
 http-body-util = "0.1.3"
-hyperlight-common = { git = "https://github.com/nanvix/hyperlight", rev = "ec4eecf", default-features = false, package = "hyperlight-common" }
-hyperlight-host = { git = "https://github.com/nanvix/hyperlight", rev = "ec4eecf", default-features = false, features = [
+hyperlight-common = { git = "https://github.com/nanvix/hyperlight", rev = "09d15d6c4d484de0a1e1c5f676a32a1497ee70d0", default-features = false, package = "hyperlight-common" }
+hyperlight-host = { git = "https://github.com/nanvix/hyperlight", rev = "09d15d6c4d484de0a1e1c5f676a32a1497ee70d0", default-features = false, features = [
         "kvm", "mshv3", "host-interrupts"
 ], package = "hyperlight-host" }
-hyperlight-guest = { git = "https://github.com/nanvix/hyperlight", rev = "ec4eecf", default-features = false, package = "hyperlight-guest" }
+hyperlight-guest = { git = "https://github.com/nanvix/hyperlight", rev = "09d15d6c4d484de0a1e1c5f676a32a1497ee70d0", default-features = false, package = "hyperlight-guest" }
 hyper = { version = "1.6.0", default-features = false }
 hyper-util = { version = "0.1.14", default-features = false }
 hwloc = { path = "src/libs/hwloc", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,11 +67,11 @@ goblin = { version = "0.10.0", default-features = false }
 indicatif = "0.18.0"
 http = "1.3.1"
 http-body-util = "0.1.3"
-hyperlight-common = { version = "0.7.0", default-features = false }
-hyperlight-host = { version = "0.7.0", default-features = false, features = [
-        "kvm",
-] }
-hyperlight-guest = { version = "0.7.0", default-features = false }
+hyperlight-common = { git = "https://github.com/nanvix/hyperlight", rev = "ec4eecf", default-features = false, package = "hyperlight-common" }
+hyperlight-host = { git = "https://github.com/nanvix/hyperlight", rev = "ec4eecf", default-features = false, features = [
+        "kvm", "mshv3", "host-interrupts"
+], package = "hyperlight-host" }
+hyperlight-guest = { git = "https://github.com/nanvix/hyperlight", rev = "ec4eecf", default-features = false, package = "hyperlight-guest" }
 hyper = { version = "1.6.0", default-features = false }
 hyper-util = { version = "0.1.14", default-features = false }
 hwloc = { path = "src/libs/hwloc", default-features = false }

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -46,6 +46,7 @@ hyperlight = [
     "madt",
     "msr",
     "pic",
+    "pit",
     "xapic",
     "dep:hyperlight-common",
     "dep:hyperlight-guest",

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -11,6 +11,8 @@ mod peb;
 // Imports
 //==================================================================================================
 
+#[cfg(feature = "pit")]
+use crate::hal::platform::pit::Pit;
 use crate::{
     hal::{
         arch::x86::{
@@ -66,6 +68,8 @@ use peb::{
 
 pub struct Platform {
     pub arch: Arch,
+    #[cfg(feature = "pit")]
+    pub _pit: Pit,
 }
 
 //==================================================================================================
@@ -101,9 +105,7 @@ pub(super) unsafe fn disable_interrupts() {
 /// enabled.
 ///
 pub(super) unsafe fn enable_interrupts() {
-    // Hyperlight does not have an interrupt chip. Enabling interrupts in this context
-    // could lead to undefined behavior or other unintended side effects. Therefore, this
-    // function is intentionally left as a no-op.
+    ::arch::cpu::sti();
 }
 
 ///
@@ -118,9 +120,7 @@ pub(super) unsafe fn enable_interrupts() {
 /// It is safe to call this function only when the CPU is able to receive interrupts.
 ///
 pub(super) unsafe fn wait_for_interrupt() {
-    // Hyperlight does not have an interrupt chip. Waiting for interrupts (halt) in this context
-    // could lead to undefined behavior or other unintended side effects. Therefore, this function
-    // is intentionally left as a no-op.
+    ::arch::cpu::halt();
 }
 
 ///
@@ -213,12 +213,7 @@ pub unsafe fn vmbus_read(addr: *mut u8) {
 /// This function never returns.
 ///
 pub fn shutdown(_status: usize) -> ! {
-    unsafe {
-        ::arch::cpu::halt();
-    };
-    loop {
-        core::hint::spin_loop();
-    }
+    ::hyperlight_guest::exit::abort_with_code(&[::config::hyperlight::DEFAULT_VMM_SHUTDOWN_CMD]);
 }
 
 ///
@@ -327,6 +322,26 @@ pub fn parse_bootinfo(_: u32, _: usize) -> Result<BootInfo, Error> {
     Ok(BootInfo::new(None, None, LinkedList::new(), LinkedList::new(), kernel_modules))
 }
 
+#[cfg(feature = "pic")]
+fn register_pic_ioports(ioports: &mut IoPortAllocator) -> Result<(), Error> {
+    // Register I/O ports for 8259 PIC.
+    ioports.register_read_write(::arch::cpu::pic::PIC_CTRL_MASTER as u16)?;
+    ioports.register_read_write(::arch::cpu::pic::PIC_DATA_MASTER as u16)?;
+    ioports.register_read_write(::arch::cpu::pic::PIC_CTRL_SLAVE as u16)?;
+    ioports.register_read_write(::arch::cpu::pic::PIC_DATA_SLAVE as u16)?;
+    Ok(())
+}
+
+#[cfg(feature = "pit")]
+fn register_pit(ioports: &mut IoPortAllocator) -> Result<Pit, Error> {
+    // Register ports for the PIT.
+
+    ioports.register_read_write(::arch::cpu::pit::PIT_CTRL)?;
+    ioports.register_read_write(::arch::cpu::pit::PIT_DATA)?;
+
+    Pit::new(ioports, ::config::kernel::TIMER_FREQ)
+}
+
 pub fn init(
     ioports: &mut IoPortAllocator,
     ioaddresses: &mut IoMemoryAllocator,
@@ -335,6 +350,9 @@ pub fn init(
     madt: &Option<MadtInfo>,
     _mem_lower: Option<usize>,
 ) -> Result<Platform, Error> {
+    #[cfg(feature = "pic")]
+    register_pic_ioports(ioports)?;
+
     extern "C" {
         static __KERNEL_END: u8;
     }
@@ -427,5 +445,7 @@ pub fn init(
 
     Ok(Platform {
         arch: x86::init(ioports, ioaddresses, madt)?,
+        #[cfg(feature = "pit")]
+        _pit: register_pit(ioports)?,
     })
 }

--- a/src/kernel/src/pm/kcall/lock_mutex.rs
+++ b/src/kernel/src/pm/kcall/lock_mutex.rs
@@ -77,22 +77,7 @@ pub unsafe fn lock_mutex(
         None
     } else {
         match SystemTime::new(timeout_s as u64, timeout_ns as u32) {
-            Some(timeout) => {
-                // Check if operation is supported.
-                #[cfg(feature = "hyperlight")]
-                if timeout_s != 0 || timeout_ns != 0 {
-                    let reason: &str = "timeout not supported";
-                    error!(
-                        "lock_mutex(): {} (mutex_addr={:x?}, timeout_s={:?}, timeout_ns={:?})",
-                        reason, mutex_addr, timeout_s, timeout_ns
-                    );
-                    return Err(SleepError::Generic(Error::new(
-                        ErrorCode::OperationNotSupported,
-                        reason,
-                    )));
-                }
-                Some(timeout)
-            },
+            Some(timeout) => Some(timeout),
             None => {
                 let reason: &str = "invalid timeout";
                 error!(

--- a/src/kernel/src/pm/kcall/wait_cond.rs
+++ b/src/kernel/src/pm/kcall/wait_cond.rs
@@ -88,23 +88,7 @@ pub unsafe fn wait_cond(
         None
     } else {
         match SystemTime::new(timeout_s as u64, timeout_ns as u32) {
-            Some(timeout) => {
-                // Check if operation is supported.
-                #[cfg(feature = "hyperlight")]
-                if timeout_s != 0 || timeout_ns != 0 {
-                    let reason: &str = "timeout not supported";
-                    error!(
-                        "wait_cond(): {} (pid={:?}, tid={:?}, cond_addr={:x?}, mutex_addr={:x?}, \
-                         timeout_s={:?}, timeout_ns={:?})",
-                        reason, pid, tid, cond_addr, mutex_addr, timeout_s, timeout_ns
-                    );
-                    return Err(SleepError::Generic(Error::new(
-                        ErrorCode::OperationNotSupported,
-                        reason,
-                    )));
-                }
-                Some(timeout)
-            },
+            Some(timeout) => Some(timeout),
             None => {
                 let reason: &str = "invalid timeout";
                 error!(

--- a/src/libs/arch/Cargo.toml
+++ b/src/libs/arch/Cargo.toml
@@ -47,6 +47,7 @@ hyperlight = [
     "madt",
     "msr",
     "pic",
+    "pit",
     "xapic",
 ]
 microvm = [

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -282,4 +282,6 @@ pub mod hyperlight {
     pub const DEFAULT_INITRD_BASE: usize = 0x00802000;
     /// Number of bytes used to store initrd's size.
     pub const INITRD_SIZE_BYTES: usize = 8;
+    /// Default VMM shutdown command
+    pub const DEFAULT_VMM_SHUTDOWN_CMD: u8 = 0x20;
 }

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -23,13 +23,8 @@ use crate::{
 use ::anyhow::Result;
 use ::hyperlight_host::{
     GuestBinary,
-    MultiUseSandbox,
     UninitializedSandbox,
     sandbox::SandboxConfiguration,
-    sandbox_state::{
-        sandbox::EvolvableSandbox,
-        transition::Noop,
-    },
 };
 use ::std::{
     fs::File,
@@ -162,9 +157,6 @@ impl Vmm {
                     // Add the actual initrd data
                     padded_bytes.extend_from_slice(&bytes);
 
-                    // Fill the rest with padding
-                    padded_bytes.resize(8 + actual_size + padding_size, 0);
-
                     log::debug!(
                         "initrd with padding: {} bytes total (8 byte header + {} bytes data + {} \
                          bytes padding)",
@@ -267,7 +259,7 @@ impl Vmm {
     fn run(&mut self) -> Result<u16> {
         crate::timer!("vmm_run");
         if let Some(sandbox) = self.sandbox.take() {
-            let _ = sandbox.evolve(Noop::<UninitializedSandbox, MultiUseSandbox>::default())?;
+            let _ = sandbox.evolve()?;
         }
 
         // TODO: return the exit status code when supported.

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -147,9 +147,8 @@ impl Vmm {
                     let padding_size = memory_size - used_memory;
 
                     // Create a new vector with size header + original data + padding
-                    let mut padded_bytes = Vec::with_capacity(
-                        ::config::hyperlight::INITRD_SIZE_BYTES + actual_size + padding_size,
-                    );
+                    let mut padded_bytes =
+                        Vec::with_capacity(::config::hyperlight::INITRD_SIZE_BYTES + actual_size);
 
                     // Write the actual size as first INITRD_SIZE_BYTES-bytes (little-endian)
                     padded_bytes.extend_from_slice(&(actual_size as u64).to_le_bytes());
@@ -177,6 +176,7 @@ impl Vmm {
                                 | MemoryRegionFlags::WRITE
                                 | MemoryRegionFlags::EXECUTE,
                         }),
+                        extra_memory: Some(padding_size.try_into().unwrap()),
                     }
                 },
                 Err(err) => {

--- a/src/tests/thread-c/main.c
+++ b/src/tests/thread-c/main.c
@@ -107,13 +107,9 @@ int main(int argc, const char *argv[])
     test_pthread_mutex_static_init();
     test_pthread_mutex_dynamic_init();
     test_pthread_mutex_trylock();
-#ifndef __hyperlight__
     test_pthread_mutex_timedlock();
-#endif
     test_pthread_cond_static_init();
-#ifndef __hyperlight__
     test_pthread_cond_timedwait();
-#endif
     test_pthread_tda();
 
     // Must be last test.


### PR DESCRIPTION
This PR updates nanvix to use the HL fork at a commit that: (1) is updated to HL v0.8.0, and that (2) contains necessary bits for context switching and proper initrd setup.

We should notice some perf improvement here. In a follow-up PR, I'll bring in the credits feature that is currently present in the wip-rusty_v8 branch.