### PR TITLE
[microvm] F: Adding pause and resume functionality

### DIFF
--- a/src/kernel/src/pm/clock.rs
+++ b/src/kernel/src/pm/clock.rs
@@ -90,7 +90,7 @@ impl TimerTicks {
 ///
 /// # Description
 ///
-/// Handles a timer interrupt.
+/// Handles a timer interrupt. It may cause a VM exit if a pause has been requested.
 ///
 /// # Parameters
 ///
@@ -104,6 +104,19 @@ impl TimerTicks {
 ///
 pub unsafe fn timer_handler(_intnum: InterruptNumber) {
     TIMER_TICKS.increment();
+
+    // Check if a pause has been requested.
+    #[cfg(feature = "microvm")]
+    if core::ptr::read_volatile(
+        ::config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as *const u32,
+    ) == ::config::microvm::PAUSE_REQUEST
+    {
+        // Cause a VM exit.
+        ::arch::io::out32(
+            ::config::microvm::DEFAULT_VMM_PORT,
+            (::config::microvm::DEFAULT_VMM_PAUSE_CMD as u32) << 16,
+        )
+    }
 
     // Determine if a context switch is required. The kernel's running state is checked first to
     // prevent reentrant calls to the scheduler, which could lead to undefined behavior.

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -252,6 +252,9 @@ pub mod microvm {
     /// Default VMM shutdown command
     pub const DEFAULT_VMM_SHUTDOWN_CMD: u16 = 0x2000;
 
+    /// Default VMM pause command. This MUST be a value that's never an exit code.
+    pub const DEFAULT_VMM_PAUSE_CMD: u16 = 0x3000;
+
     /// Default base address for MicroVM control registers.
     pub const DEFAULT_MICROVM_CTRL_BASE: usize = 0x00000000;
 
@@ -260,6 +263,15 @@ pub mod microvm {
 
     /// Default base address for MicroVM credits register (32-bit wide read-only register)
     pub const DEFAULT_MICROVM_CTRL_CREDITS: usize = 0x00000004;
+
+    /// Default base address for MicroVM pause-requested register (32-bit wide read-only register)
+    pub const DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED: usize = 0x00000008;
+
+    /// Magic value that identifies the running state in the pause-requested register.
+    pub const RUNNING: u32 = 0x00000000;
+
+    /// Magic value that flags that the VMM requested the guest OS to pause MicroVM execution.
+    pub const PAUSE_REQUEST: u32 = 0x00000001;
 }
 
 #[cfg(feature = "pc")]

--- a/src/microvm/src/vmm/microvm/kvm/emulator.rs
+++ b/src/microvm/src/vmm/microvm/kvm/emulator.rs
@@ -120,6 +120,9 @@ impl Emulator {
                             let status: u16 = (data & 0xffff) as u16;
                             return Ok(Some(status));
                         },
+                        ::config::microvm::DEFAULT_VMM_PAUSE_CMD => {
+                            return Ok(Some(::config::microvm::DEFAULT_VMM_PAUSE_CMD));
+                        },
                         cmd => anyhow::bail!("unknown virtual machine command (cmd=:{cmd:#06x})"),
                     }
                 },

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -13,15 +13,18 @@
 //==================================================================================================
 
 #[cfg(target_os = "linux")]
-use crate::vmm::microvm::kvm::{
-    emulator::Emulator,
-    partition::VirtualPartition,
-    vcpu::{
-        VirtualProcessor,
-        VirtualProcessorExitContext,
-        VirtualProcessorExitReason,
+use crate::vmm::microvm::{
+    TIMEOUT_WARNING_INTERVAL_IN_MS,
+    kvm::{
+        emulator::Emulator,
+        partition::VirtualPartition,
+        vcpu::{
+            VirtualProcessor,
+            VirtualProcessorExitContext,
+            VirtualProcessorExitReason,
+        },
+        vmem::VirtualMemory,
     },
-    vmem::VirtualMemory,
 };
 
 use ::anyhow::Result;
@@ -32,9 +35,17 @@ use ::libc::{
     sigaction,
     sigemptyset,
 };
-use ::std::sync::{
-    Arc,
-    Mutex,
+use ::std::{
+    sync::{
+        Arc,
+        Mutex,
+        mpsc::{
+            Receiver,
+            Sender,
+            TryRecvError,
+        },
+    },
+    time::Instant,
 };
 
 pub const INTERRUPT_SIGNAL: c_int = SIGUSR1;
@@ -59,6 +70,10 @@ pub struct MicroVm {
     emulator: Emulator,
     // If present, initial RAM disk location and size.
     initrd: Option<(u64, usize)>,
+    // Channel to tell the VMM / main thread that the MicroVM has paused running.
+    paused_tx: Sender<()>,
+    // Channel to receive commands to resume a paused MicroVM.
+    resume_running_rx: Receiver<()>,
 }
 
 unsafe impl Send for MicroVm {}
@@ -90,13 +105,21 @@ impl MicroVm {
     /// - `memory_size`: Size of the virtual memory of the virtual machine.
     /// - `input`: Input function used for emulating I/O port reads.
     /// - `output`: Output function used for emulating I/O port writes.
+    /// - `paused_tx`: Channel to tell the VMM / main thread that the MicroVM has paused running.
+    /// - `resume_running_rx`: Channel to receive commands to resume a paused MicroVM.
     ///
     /// # Returns
     ///
     /// Upon successful completion, this method returns the MicroVM that was created. Otherwise, it
     /// returns an error.
     ///
-    pub fn new(memory_size: usize, input: Box<InputFn>, output: Box<OutputFn>) -> Result<Self> {
+    pub fn new(
+        memory_size: usize,
+        input: Box<InputFn>,
+        output: Box<OutputFn>,
+        paused_tx: Sender<()>,
+        resume_running_rx: Receiver<()>,
+    ) -> Result<Self> {
         trace!("new(): memory_size={memory_size}");
         crate::timer!("vm_creation");
 
@@ -116,6 +139,8 @@ impl MicroVm {
             vcpu,
             emulator,
             initrd: None,
+            resume_running_rx,
+            paused_tx,
         })
     }
 
@@ -295,7 +320,46 @@ impl MicroVm {
                 VirtualProcessorExitReason::PmioAccess => {
                     crate::timer!("vm_run_pmio_access");
                     if let Some(exit_status) = self.emulator.handle_pmio_access(exit_context)? {
-                        self.vcpu.poweroff(exit_status);
+                        if exit_status != ::config::microvm::DEFAULT_VMM_PAUSE_CMD {
+                            self.vcpu.poweroff(exit_status);
+                        }
+                        // The Nanvix Daemon requested to pause, this means we need to suspend execution,
+                        // but possibly resume it later.
+                        else {
+                            // This message changes the state from `PAUSE_REQUESTED` to `PAUSED`.
+                            self.paused_tx.send(())?;
+
+                            let start: Instant = Instant::now();
+                            let mut counter: usize = 1;
+                            loop {
+                                match self.resume_running_rx.try_recv() {
+                                    Ok(_) => break,
+                                    // NOTE: Should we add an option for shutting down (change the
+                                    // channel type)? Like so:
+                                    // Ok(Enum::Shutdown) => {self.vcpu.poweroff(0);},
+                                    Err(TryRecvError::Empty) => (),
+                                    Err(TryRecvError::Disconnected) => {
+                                        let reason: String = "the vmm has disconnected".to_string();
+                                        error!("resume_running_rx.try_recv(): {reason}");
+                                        anyhow::bail!(reason)
+                                    },
+                                }
+
+                                // NOTE: is it desirable to check for timeout in this case? If it is desirable,
+                                // should we use a larger constant, considering snapshots might take long?
+
+                                // Log a warning and increment the counter every TIMEOUT_WARNING_INTERVAL_IN_MS ms.
+                                let elapsed_time: usize = start.elapsed().as_millis() as usize;
+                                if elapsed_time > TIMEOUT_WARNING_INTERVAL_IN_MS * counter {
+                                    warn!(
+                                        "{}ms have passed waiting for `ResumeMicroVm` message",
+                                        TIMEOUT_WARNING_INTERVAL_IN_MS * counter
+                                    );
+                                    counter += 1;
+                                }
+                            }
+                            trace!("MicroVM resumed");
+                        }
                     }
                 },
 
@@ -330,5 +394,49 @@ impl MicroVm {
     ///
     pub fn vmem(&self) -> Arc<Mutex<VirtualMemory>> {
         self.vmem.clone()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Writes a pause request where the kernel checks for them.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn async_pause(&self) -> Result<()> {
+        trace!("pause()");
+        crate::timer!("vm_pause");
+        self.vmem
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {:?}", e))?
+            .write_bytes(
+                ::config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
+                &::config::microvm::PAUSE_REQUEST.to_le_bytes(),
+            )?;
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Erases a pause request where the kernel checks for them.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn resume(&self) -> Result<()> {
+        trace!("resume()");
+        crate::timer!("vm_resume");
+        self.vmem
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {:?}", e))?
+            .write_bytes(
+                ::config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
+                &::config::microvm::RUNNING.to_le_bytes(),
+            )?;
+        Ok(())
     }
 }

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -83,9 +83,11 @@ pub struct Vmm {
     io_thread: Option<JoinHandle<Result<()>>>,
     _memory_thread: JoinHandle<Result<()>>,
     vcpu_thread: JoinHandle<Result<u16>>,
-    _microvm: Arc<Mutex<MicroVm>>,
+    microvm: Arc<Mutex<MicroVm>>,
     control_input_rx: Receiver<ControlCommand>,
     control_output_tx: Sender<ControlCommandResponse>,
+    paused_microvm_rx: Receiver<()>,
+    resume_microvm_tx: Sender<()>,
     orchestrator_state: OrchestratorState,
 }
 
@@ -156,6 +158,8 @@ impl Vmm {
         let (memory_thread_tx, vm_rx) = mpsc::channel::<Message>();
         let (control_input_tx, control_input_rx) = mpsc::channel::<ControlCommand>();
         let (control_output_tx, control_output_rx) = mpsc::channel::<ControlCommandResponse>();
+        let (paused_microvm_tx, paused_microvm_rx) = mpsc::channel::<()>(); // What other uses could these channels have? Should they be more generic?
+        let (resume_microvm_tx, resume_microvm_rx) = mpsc::channel::<()>(); // What other uses could these channels have? Should they be more generic?
 
         // Spawn I/O thread.
         let io_thread: Option<JoinHandle<Result<()>>> = gateway_conn.map(|conn| {
@@ -175,7 +179,8 @@ impl Vmm {
         let output: Box<microvm::OutputFn> =
             Self::build_output_fn(Self::get_stderr_writer(stderr.clone())?, vm_tx);
 
-        let mut microvm: MicroVm = MicroVm::new(memory_size, input, output)?;
+        let mut microvm: MicroVm =
+            MicroVm::new(memory_size, input, output, paused_microvm_tx, resume_microvm_rx)?;
 
         let rip: u64 = microvm.load_kernel(kernel_filename)?;
         if let Some(ref initrd_filename) = initrd_filename {
@@ -276,9 +281,11 @@ impl Vmm {
             io_thread,
             _memory_thread: memory_thread,
             vcpu_thread,
-            _microvm: microvm,
+            microvm,
             control_input_rx,
             control_output_tx,
+            paused_microvm_rx,
+            resume_microvm_tx,
             orchestrator_state: OrchestratorState::PreBoot,
         };
 
@@ -554,9 +561,35 @@ impl Vmm {
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
     fn pause_protocol(&mut self) -> Result<()> {
-        // TODO: pause MicroVM (Running -> Paused)
-        // and tell linuxd to flush (Running -> Flushing)
-        // This TODO requires pausing the vCPU and a control plane communication with linuxd
+        // TODO: tell linuxd to flush (Running -> Flushing)
+        // This TODO requires control plane communication with linuxd
+        self.microvm
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .async_pause()?;
+        // Wait for the MicroVM to confirm it has paused.
+        let start: Instant = Instant::now();
+        let mut counter: usize = 1;
+        loop {
+            match self.paused_microvm_rx.try_recv() {
+                Ok(_) => break,
+                Err(TryRecvError::Empty) => (),
+                Err(TryRecvError::Disconnected) => {
+                    let reason: String = "the vmm has disconnected".to_string();
+                    error!("resume_running_rx.try_recv(): {reason}");
+                    anyhow::bail!(reason)
+                },
+            }
+            // Log a warning and increment the counter every TIMEOUT_WARNING_INTERVAL_IN_MS ms.
+            let elapsed_time: usize = start.elapsed().as_millis() as usize;
+            if elapsed_time > TIMEOUT_WARNING_INTERVAL_IN_MS * counter {
+                warn!(
+                    "{}ms have passed waiting for `ResumeMicroVm` message",
+                    TIMEOUT_WARNING_INTERVAL_IN_MS * counter
+                );
+                counter += 1;
+            }
+        }
         trace!("MicroVM paused");
         // Flush output to linuxd
         self.control_output_tx
@@ -619,9 +652,21 @@ impl Vmm {
         Ok(())
     }
 
+    ///
+    /// # Description
+    ///
+    /// Attempts to resume execution of a paused MicroVM.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned instead.
+    ///
     fn resume_microvm(&self) -> Result<()> {
-        // TODO: resume MicroVM
-        trace!("MicroVM resumed");
+        self.microvm
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .resume()?;
+        self.resume_microvm_tx.send(())?;
         Ok(())
     }
 }


### PR DESCRIPTION
# Feedback requested

I want feedback on the pause functionality. I'm more confident in the resume functionality, and I don't need feedback on it for now.

1. Is it ok to write a flag for pausing the MicroVM at `::config::microvm::DEFAULT_MICROVM_CTRL_BASE`, or is this address already taken? If so, where should I write?
2. I think there're 32 bits free at that address. However, I only need a single bit for this flag. Should I use a u32 or a u8 for this, or something else?
3. In the kernel, I should probably wrap the pausing functionality with a `cfg_if::cfg_if!`. What feature should I use?
4. How should I issue the VM exit and set the exit context in the kernel? I see that @csegarragonz used the KVM documentation to figure out what the exit context would be when sending a particular signal. Can I arbitrarily choose an exit context? If so, how?

# Implementation Description

This implements pausing and resuming via control-plane messages to the VMM via co-design with the kernel. Let's go through a whole pause-resume cycle to understand the implementation.

## Pause

The changes start at `mod.rs`. The VMM now has communication channels to the MicroVM, which are used for syncing the main thread and the vCPU thread. In the main thread, when the VMM receives a `ControlCommand::PauseMicroVm`, it calls `pause_protocol()` inside `handle_command()`. `pause_protocol()` now calls `MicroVm.asnc_pause()`, then waits for a confirmation from the channel to the MicroVM that the vCPU thread operates. I will add a timeout check at this point, as per the TODO.

Let's now switch to `microvm.rs`. It also has the channels to communicate between the vCPU thread and the main thread. The `async_pause()` function writes to the guest OS's kernel's memory a bit telling it to stop execution. Conceptually, we could say there's a state transition in the MicroVM from "running" to "pausing". I would like feedback on the address that's written to. Is this address already taken? If so, what address should I use?

Let's now briefly switch to `lib.rs`. It just defines the values that are supposed to be written / read in the kernel memory. I would like feedback on using an u8 vs an u32 for this.

Let's now go deep into the kernel. This runs in the vCPU thread. In `clock.rs`, the `timer_handler()` function runs whenever there's a timer interrupt. It reads the same address that was written to by `async_pause()`. If the value read corresponds to the pause request, it issues a VM exit with an exit context of `Paused`. I would like feedback on what to wrap this statement with, and how to issue the VM exit and set the exit context.

Let's now go back to `microvm.rs`. Once the VM exit is executed, the vCPU thread goes back to the body of the `MicroVm::run()` function. It's done with `self.vcpu.run()?`, and matches on the `exit_context.reason()`. A new reason was added for `Paused`. It sends a message to the VMM confirming the vCPU has stopped. That was the message it was waiting for from the beginning of this explanation. Conceptually, this changes the MicroVM state from "pausing" to "paused". To actually implement being paused, it waits for a message telling it to resume. I would like feedback on this. Should this be a blocking read? If not, what else should we do besides polling for the resume message? P.S.: I just realized that I need to poll this instead if I want to implement a timeout.

Let's briefly switch to `exit.rs`. All it does is define the new exit context and exit reason.

Now that the MicroVM is paused, we could take a consistent snapshot. However, that's for another PR. Let's turn our attention to resuming the MicroVM.

## Resume

Back at the VMM (`mod.rs`) in the main thread, we're now handling a `ControlCommand::ResumeMicroVm`. We call `resume_microvm()`, which calls `MicroVm::resume()`. It then sends a message to the channel that was expecting a message to continue the `MicroVm::run()` loop in the vCPU thread. Receiving the message conceptually changes the MicroVM state from `paused` to `running`. It's important to say that `resume_microvm()` is synchronous, so its effects will be done before the message is sent, and therefore before it is received. We'll dive deep into this soon.

Let's go to `microvm.rs` and look at `resume_microvm()`. All it does is clear the bit that requested the kernel to pause execution.

Let's focus on ordering. The VMM thread clears the bit, then it sends a message to the vCPU thread telling it to resume execution. This is an asynchronous message, to the VMM may continue handling control commands while the vCPU hasn't really resumed. Suppose the VMM receives a `ControlCommand::Pause` before the vCPU is schedulled. Then, the VMM would execute `pause_protocol()`, and write to the kernel's memory the `PAUSE_REQUESTED` value.  The VMM would eventually stop while waiting for a message from the MicroVM confirming it has paused. At this point, the vCPU thread must be schedulled. It goes back to the `MicroVm::run()` loop, and executes for a quantum. When the interrupt goes off, the kernel reads the memory with the `PAUSE_REQUESTED` value and pauses execution once more. Then, it sends the message to the main thread. Therefore, there are no race conditions in this case, and there's no need to wait for a confirmation message in `Vmm::resume_microvm()`. Just sending a message is enough.