### PR TITLE
[microvm] Add pause and resume functionality

### DIFF
--- a/src/kernel/src/pm/clock.rs
+++ b/src/kernel/src/pm/clock.rs
@@ -105,6 +105,19 @@ impl TimerTicks {
 pub unsafe fn timer_handler(_intnum: InterruptNumber) {
     TIMER_TICKS.increment();
 
+    // Check if a pause has been requested.
+    #[cfg(feature = "microvm")]
+    if core::ptr::read_volatile(
+        ::config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as *const u32,
+    ) == ::config::microvm::PAUSE_REQUEST
+    {
+        // Cause a VM exit.
+        ::arch::io::out32(
+            ::config::microvm::DEFAULT_VMM_PORT,
+            (::config::microvm::DEFAULT_VMM_PAUSE_CMD as u32) << 16,
+        )
+    }
+
     // Determine if a context switch is required. The kernel's running state is checked first to
     // prevent reentrant calls to the scheduler, which could lead to undefined behavior.
     if !ProcessManager::is_kernel_running() {

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -248,6 +248,9 @@ pub mod microvm {
     /// Default VMM shutdown command
     pub const DEFAULT_VMM_SHUTDOWN_CMD: u16 = 0x2000;
 
+    /// Default VMM pause command. This MUST be a value that's never an exit code.
+    pub const DEFAULT_VMM_PAUSE_CMD: u16 = 0x3000;
+
     /// Default base address for MicroVM control registers.
     pub const DEFAULT_MICROVM_CTRL_BASE: usize = 0x00000000;
 
@@ -256,6 +259,15 @@ pub mod microvm {
 
     /// Default base address for MicroVM credits register (32-bit wide read-only register)
     pub const DEFAULT_MICROVM_CTRL_CREDITS: usize = 0x00000004;
+
+    /// Default base address for MicroVM pause-requested register (32-bit wide read-only register)
+    pub const DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED: usize = 0x00000008;
+
+    /// Magic value that identifies the running state in the pause-requested register.
+    pub const RUNNING: u32 = 0x00000000;
+
+    /// Magic value that flags that the VMM requested the guest OS to pause MicroVM execution.
+    pub const PAUSE_REQUEST: u32 = 0x00000001;
 }
 
 #[cfg(feature = "pc")]

--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -130,7 +130,7 @@ pub enum VcpuControlCommand {
 ///
 #[derive(PartialEq)]
 pub enum VcpuControlResponse {
-    _Paused,
+    Paused,
 }
 
 //==================================================================================================
@@ -183,6 +183,7 @@ impl Orchestrator {
                 IoControlCommand::_LoadSnapshotAndRun => {
                     if self.state == State::PreBoot {
                         // TODO: load snapshot https://github.com/nanvix/nanvix/issues/948
+                        trace!("State: PreBoot -> Paused");
 
                         // The Linux daemon should send messages to PreBoot VMMs by default,
                         // so there's no need to tell it to resume sending messages.
@@ -193,7 +194,6 @@ impl Orchestrator {
                             error!("handle_command(): {reason}");
                             anyhow::bail!(reason);
                         }
-                        trace!("State: PreBoot -> Running");
                     }
                     Ok(())
                 },
@@ -251,7 +251,6 @@ impl Orchestrator {
                             error!("handle_command(): {reason}");
                             anyhow::bail!(reason);
                         }
-                        trace!("State: Paused -> Running");
                     }
                     Ok(())
                 },
@@ -294,7 +293,7 @@ impl Orchestrator {
         let mut counter: usize = 1;
         loop {
             match self.vcpu_control_rx.try_recv() {
-                Ok(VcpuControlResponse::_Paused) => break,
+                Ok(VcpuControlResponse::Paused) => break,
                 Err(TryRecvError::Empty) => (),
                 Err(TryRecvError::Disconnected) => {
                     let reason: String = "the vmm has disconnected".to_string();

--- a/src/microvm/src/vmm/microvm/kvm/emulator.rs
+++ b/src/microvm/src/vmm/microvm/kvm/emulator.rs
@@ -120,6 +120,9 @@ impl Emulator {
                             let status: u16 = (data & 0xffff) as u16;
                             return Ok(Some(status));
                         },
+                        ::config::microvm::DEFAULT_VMM_PAUSE_CMD => {
+                            return Ok(Some(::config::microvm::DEFAULT_VMM_PAUSE_CMD));
+                        },
                         cmd => anyhow::bail!("unknown virtual machine command (cmd=:{cmd:#06x})"),
                     }
                 },

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -15,6 +15,7 @@
 #[cfg(target_os = "linux")]
 use crate::{
     orchestrator::{
+        TIMEOUT_WARNING_INTERVAL_IN_MS,
         VcpuControlCommand,
         VcpuControlResponse,
     },
@@ -38,13 +39,17 @@ use ::libc::{
     sigaction,
     sigemptyset,
 };
-use ::std::sync::{
-    Arc,
-    Mutex,
-    mpsc::{
-        Receiver,
-        Sender,
+use ::std::{
+    sync::{
+        Arc,
+        Mutex,
+        mpsc::{
+            Receiver,
+            Sender,
+            TryRecvError,
+        },
     },
+    time::Instant,
 };
 
 pub const INTERRUPT_SIGNAL: c_int = SIGUSR1;
@@ -70,9 +75,9 @@ pub struct MicroVm {
     // If present, initial RAM disk location and size.
     initrd: Option<(u64, usize)>,
     // Channel to receive commands from the VMM.
-    _control_rx: Receiver<VcpuControlCommand>,
+    control_rx: Receiver<VcpuControlCommand>,
     // Channel to send control responses to the VMM.
-    _control_tx: Sender<VcpuControlResponse>,
+    control_tx: Sender<VcpuControlResponse>,
 }
 
 unsafe impl Send for MicroVm {}
@@ -138,8 +143,8 @@ impl MicroVm {
             vcpu,
             emulator,
             initrd: None,
-            _control_rx: control_rx,
-            _control_tx: control_tx,
+            control_rx,
+            control_tx,
         })
     }
 
@@ -319,7 +324,46 @@ impl MicroVm {
                 VirtualProcessorExitReason::PmioAccess => {
                     crate::timer!("vm_run_pmio_access");
                     if let Some(exit_status) = self.emulator.handle_pmio_access(exit_context)? {
-                        self.vcpu.poweroff(exit_status);
+                        if exit_status != ::config::microvm::DEFAULT_VMM_PAUSE_CMD {
+                            self.vcpu.poweroff(exit_status);
+                        }
+                        // The Nanvix Daemon requested to pause, this means we need to suspend execution,
+                        // but possibly resume it later.
+                        else {
+                            // This message changes the state from `PAUSE_REQUESTED` to `PAUSED`.
+                            self.control_tx.send(VcpuControlResponse::Paused)?;
+
+                            let start: Instant = Instant::now();
+                            let mut counter: usize = 1;
+                            // TODO: exponential back-off timeout https://github.com/nanvix/nanvix/issues/943
+                            loop {
+                                match self.control_rx.try_recv() {
+                                    Ok(VcpuControlCommand::Resume) => break,
+                                    // NOTE: Should we add an option for shutting down? Like so:
+                                    // Ok(VcpuControlCommand::Shutdown) => self.vcpu.poweroff(0),
+                                    Err(TryRecvError::Empty) => (),
+                                    Err(TryRecvError::Disconnected) => {
+                                        let reason: String = "the vmm has disconnected".to_string();
+                                        error!("run(): {reason}");
+                                        anyhow::bail!(reason)
+                                    },
+                                }
+
+                                // NOTE: is it desirable to check for timeout in this case? If it is,
+                                // should we use a larger constant, considering snapshots might take long?
+
+                                // Log a warning and increment the counter every TIMEOUT_WARNING_INTERVAL_IN_MS ms.
+                                let elapsed_time: usize = start.elapsed().as_millis() as usize;
+                                if elapsed_time > TIMEOUT_WARNING_INTERVAL_IN_MS * counter {
+                                    warn!(
+                                        "{}ms have passed waiting for `ResumeMicroVm` message",
+                                        TIMEOUT_WARNING_INTERVAL_IN_MS * counter
+                                    );
+                                    counter += 1;
+                                }
+                            }
+                            trace!("MicroVM resumed");
+                        }
                     }
                 },
 

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -189,7 +189,8 @@ impl Vmm {
             .reset_credits()?;
 
         // Create a thread that reads from vm_rx and writes to vm_rx2.
-        let memory_thread_data_tx: Sender<Message> = memory_thread_data_tx.clone();
+        let vmem_pause_microvm = vmem.clone();
+        let vmem_resume_microvm = vmem.clone();
         let memory_thread: JoinHandle<Result<(), anyhow::Error>> = memory_thread::spawn(
             memory_thread_data_rx,
             memory_thread_data_tx,
@@ -200,8 +201,24 @@ impl Vmm {
                     .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
                     .add_credit()
             },
-            move || Ok(()), // TODO: pause https://github.com/nanvix/nanvix/issues/791
-            move || Ok(()), // TODO: resume https://github.com/nanvix/nanvix/issues/791
+            move || {
+                vmem_pause_microvm
+                    .lock()
+                    .map_err(|e| anyhow::anyhow!("failed to acquire lock {:?}", e))?
+                    .write_bytes(
+                        ::config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
+                        &::config::microvm::PAUSE_REQUEST.to_le_bytes(),
+                    )
+            },
+            move || {
+                vmem_resume_microvm
+                    .lock()
+                    .map_err(|e| anyhow::anyhow!("failed to acquire lock {:?}", e))?
+                    .write_bytes(
+                        ::config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
+                        &::config::microvm::RUNNING.to_le_bytes(),
+                    )
+            },
         );
 
         // We use an atomic to pass the id of the created thread back to the caller context. We


### PR DESCRIPTION
# Overview
This implements pausing and resuming via control-plane messages to the VMM via co-design with the kernel. The VMM writes to a kernel register. The kernel polls this register during timer interrupts, and exits the VM if flagged. It pauses execution and waits for a resume messages, which might be later sent by the VMM.

This does not implement pausing and resuming for hyperlight.

# Attention points:
- `DEFAULT_VMM_PAUSE_CMD` must not collide with other exit codes for the MicroVM;
- When pausing, the main thread sends to the memory thread, then receives from the vCPU thread. The main thread only receives from the vCPU thread after the vCPU thread has read the memory in the kernel that the memory thread wrote, so there's a total order in these events.;
- When resuming, the main thread sends to the memory thread, then receives from the memory thread, then sends to the vCPU thread. This means there's also a total order, and the vCPU thread will never resume the MicroVM with a pause request written in the kernel's memory.