### PR TITLE
Add credits to Hyperlight

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,11 +67,13 @@ goblin = { version = "0.10.0", default-features = false }
 indicatif = "0.18.0"
 http = "1.3.1"
 http-body-util = "0.1.3"
-hyperlight-common = { git = "https://github.com/nanvix/hyperlight", rev = "09d15d6c4d484de0a1e1c5f676a32a1497ee70d0", default-features = false, package = "hyperlight-common" }
-hyperlight-host = { git = "https://github.com/nanvix/hyperlight", rev = "09d15d6c4d484de0a1e1c5f676a32a1497ee70d0", default-features = false, features = [
-        "kvm", "mshv3", "host-interrupts"
+hyperlight-common = { git = "https://github.com/nanvix/hyperlight", rev = "ecb765b982d9e37e56dce697a4bfce96bf6975fe", default-features = false, package = "hyperlight-common" }
+hyperlight-host = { git = "https://github.com/nanvix/hyperlight", rev = "ecb765b982d9e37e56dce697a4bfce96bf6975fe", default-features = false, features = [
+        "kvm",
+        "mshv3",
+        "host-interrupts",
 ], package = "hyperlight-host" }
-hyperlight-guest = { git = "https://github.com/nanvix/hyperlight", rev = "09d15d6c4d484de0a1e1c5f676a32a1497ee70d0", default-features = false, package = "hyperlight-guest" }
+hyperlight-guest = { git = "https://github.com/nanvix/hyperlight", rev = "ecb765b982d9e37e56dce697a4bfce96bf6975fe", default-features = false, package = "hyperlight-guest" }
 hyper = { version = "1.6.0", default-features = false }
 hyper-util = { version = "0.1.14", default-features = false }
 hwloc = { path = "src/libs/hwloc", default-features = false }

--- a/src/kernel/src/stdio.rs
+++ b/src/kernel/src/stdio.rs
@@ -81,6 +81,17 @@ pub fn read() -> Result<Option<Message>, Error> {
                 return Ok(None);
             }
         }
+        else if #[cfg(feature = "hyperlight")] {
+            // Read credits register.
+            let credits: u64 = unsafe {
+                core::ptr::read_volatile(::config::hyperlight::DEFAULT_HYPERLIGHT_CTRL_CREDITS as *const u64)
+            };
+
+            // No message available.
+            if credits == 0 {
+                return Ok(None);
+            }
+        }
     }
 
     // Read message from the kernel's standard input.

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -20,9 +20,16 @@ use ::std::{
 //==================================================================================================
 
 fn main() {
-    // Read the TOML file
+    // Read the TOML file using the workspace root for a reliable path
+    let manifest_dir: String =
+        env::var("CARGO_MANIFEST_DIR").expect("Failed to get CARGO_MANIFEST_DIR");
+    let workspace_dir = Path::new(&manifest_dir)
+        .ancestors()
+        .nth(3)
+        .expect("Failed to find workspace root");
+    let config_path = workspace_dir.join("build/kernel_config.toml");
     let kernel_config_content =
-        fs::read_to_string("build/kernel_config.toml").expect("Failed to read kernel_config.toml");
+        fs::read_to_string(&config_path).expect("Failed to read kernel_config.toml");
 
     // Prepare the output path
     let out_dir: String = env::var("OUT_DIR").unwrap();

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -284,4 +284,6 @@ pub mod hyperlight {
     pub const INITRD_SIZE_BYTES: usize = 8;
     /// Default VMM shutdown command
     pub const DEFAULT_VMM_SHUTDOWN_CMD: u8 = 0x20;
+    /// Default base address for Hyperlight credits register
+    pub const DEFAULT_HYPERLIGHT_CTRL_CREDITS: usize = 0x003a7000;
 }

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     vmm::hyperlight::io::IoThread,
 };
 use ::anyhow::Result;
+use ::config::hyperlight::DEFAULT_HYPERLIGHT_CTRL_CREDITS;
 use ::hyperlight_host::{
     GuestBinary,
     UninitializedSandbox,
@@ -46,12 +47,23 @@ use ::sys::ipc::{
 };
 use hyperlight_host::{
     HyperlightError,
-    mem::memory_region::MemoryRegionFlags,
+    mem::{
+        memory_region::MemoryRegionFlags,
+        mgr::SandboxMemoryManager,
+        shared_mem::ExclusiveSharedMemory,
+    },
     sandbox::uninitialized::{
         GuestBlob,
         GuestEnvironment,
     },
 };
+use std::sync::OnceLock;
+
+// ==================================================================================================
+// Globals
+// ==================================================================================================
+
+static VMEM: OnceLock<Arc<Mutex<SandboxMemoryManager<ExclusiveSharedMemory>>>> = OnceLock::new();
 
 //==================================================================================================
 // Structure
@@ -60,6 +72,7 @@ use hyperlight_host::{
 pub struct Vmm {
     _gateway_tx: Sender<Message>,
     _io_thread: Option<JoinHandle<Result<()>>>,
+    _memory_thread: JoinHandle<Result<()>>,
     sandbox: Option<UninitializedSandbox>,
 }
 
@@ -91,7 +104,8 @@ impl Vmm {
         crate::timer!("vmm_creation");
 
         let (vm_tx, gateway_rx) = mpsc::channel::<Message>();
-        let (gateway_tx, vm_rx) = mpsc::channel::<Message>();
+        let (gateway_tx, memory_thread_rx) = mpsc::channel::<Message>();
+        let (memory_thread_tx, vm_rx) = mpsc::channel::<Message>();
 
         // Spawn I/O thread.
         let _io_thread: Option<JoinHandle<Result<()>>> =
@@ -191,6 +205,10 @@ impl Vmm {
 
         // Creates Hyperlight sandbox.
         let mut sandbox = UninitializedSandbox::new(guest_env, Some(config))?;
+        let manager = Arc::new(Mutex::new(sandbox.mgr.unwrap_mgr().clone()));
+        VMEM.set(manager).map_err(|_| {
+            anyhow::anyhow!("Failed to set VMEM: already initialized or not available")
+        })?;
         sandbox.register_print(writer_fn)?;
 
         sandbox.register("VmbusWrite", move |data: Vec<u8>| -> Result<i32, HyperlightError> {
@@ -218,6 +236,7 @@ impl Vmm {
         sandbox.register("VmbusRead", move || -> Result<Vec<u8>, HyperlightError> {
             match vm_rx.try_recv() {
                 Ok(mut msg) => {
+                    consume_credit()?;
                     msg.message_type = MessageType::Ikc;
                     Ok(msg.to_bytes().to_vec())
                 },
@@ -235,7 +254,32 @@ impl Vmm {
             }
         })?;
 
+        // Create a thread that reads from vm_rx and writes to vm_rx2.
+        let memory_thread: JoinHandle<Result<(), anyhow::Error>> = std::thread::spawn(move || {
+            loop {
+                match memory_thread_rx.try_recv() {
+                    Ok(msg) => {
+                        if let Err(e) = memory_thread_tx.send(msg) {
+                            let reason: String = format!("failed to send message: {:?}", e);
+                            error!("memory_thread(): {}", reason);
+                            continue;
+                        }
+
+                        add_credit()?;
+                    },
+                    Err(TryRecvError::Disconnected) => {
+                        debug!("memory_thread(): channel has been disconnected");
+                        break Ok(());
+                    },
+                    Err(TryRecvError::Empty) => {
+                        // No message available.
+                    },
+                }
+            }
+        });
+
         Ok(Self {
+            _memory_thread: memory_thread,
             _gateway_tx: gateway_tx,
             _io_thread,
             sandbox: Some(sandbox),
@@ -259,7 +303,18 @@ impl Vmm {
     fn run(&mut self) -> Result<u16> {
         crate::timer!("vmm_run");
         if let Some(sandbox) = self.sandbox.take() {
-            let _ = sandbox.evolve()?;
+            match sandbox.evolve() {
+                Ok(res) => anyhow::bail!("Expected DEFAULT_VMM_SHUTDOWN_CMD, got: {:#?}", res),
+                Err(err) => {
+                    // note: this is a bit of a hack to check for the shutdown command.
+                    if !err
+                        .to_string()
+                        .contains(&::config::hyperlight::DEFAULT_VMM_SHUTDOWN_CMD.to_string())
+                    {
+                        anyhow::bail!("Failed to run VMM: {}", err);
+                    }
+                },
+            }
         }
 
         // TODO: return the exit status code when supported.
@@ -299,4 +354,45 @@ impl Vmm {
         };
         Ok(file_writer)
     }
+}
+
+// Adds a credit to the virtual machine's credit pool.
+fn add_credit() -> Result<()> {
+    VMEM.get()
+        .and_then(|vmem| vmem.lock().ok())
+        .map(|mut vmem| -> Result<()> {
+            let mut credit = vmem
+                .get_shared_mem_mut()
+                .read::<u64>(DEFAULT_HYPERLIGHT_CTRL_CREDITS)?;
+            credit += 1;
+            vmem.get_shared_mem_mut()
+                .write::<u64>(DEFAULT_HYPERLIGHT_CTRL_CREDITS, credit)?;
+
+            log::info!("Adding credit: {}", credit);
+            Ok(())
+        })
+        .ok_or(anyhow::anyhow!("VMEM is not initialized"))?
+}
+
+// Consumes a credit from the virtual machine's credit pool.
+fn consume_credit() -> Result<()> {
+    VMEM.get()
+        .and_then(|vmem| vmem.lock().ok())
+        .map(|mut vmem| -> Result<()> {
+            let mut credit = vmem
+                .get_shared_mem_mut()
+                .read::<u64>(DEFAULT_HYPERLIGHT_CTRL_CREDITS)?;
+
+            if credit == 0 {
+                return Err(anyhow::anyhow!("No credit available to consume"));
+            }
+
+            credit -= 1;
+            vmem.get_shared_mem_mut()
+                .write::<u64>(DEFAULT_HYPERLIGHT_CTRL_CREDITS, credit)?;
+
+            log::info!("Consuming credit: {}", credit);
+            Ok(())
+        })
+        .ok_or(anyhow::anyhow!("VMEM is not initialized"))?
 }


### PR DESCRIPTION
This PR adds a credits feature to the Hyperlight VMM implementation, introducing a credit-based flow control mechanism for message passing between the host and guest environments. The changes implement credit tracking through shared memory and coordinate message flow through a dedicated memory thread.

Key changes:
- Implemented credit-based flow control with `add_credit()` and `consume_credit()` functions
- Added a memory thread to handle message forwarding and credit management
- Updated kernel `stdio` to check credits before processing messages in hyperlight mode