### PR TITLE
[ci] Updating Copilot Instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,6 +114,9 @@ scripts/test-nanvixd.sh 127.0.0.1:8181 bin/hello-c.elf '' '[]' 'Hello, world fro
 - Use `info!` log level for informational messages that are not errors or warnings.
 - Use `debug!` log level for debugging information that is for development purposes.
 - Use `trace!` log level for tracing execution flow and detailed debugging information.
+- Logs must be single-line, concise, and machine-parsable when feasible.
+  - Do not use multiline logs or explicit newlines (e.g., `\n`) in messages.
+  - Do not use pretty-printed debug formatting (e.g., `{:#?}`).
 
 ### Documentation & Comments
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -107,8 +107,8 @@ scripts/test-nanvixd.sh 127.0.0.1:8181 bin/hello-c.elf '' '[]' 'Hello, world fro
 
 - Do not use `panic!`, `unwrap()`, or `expect()`, instead return `Result<T, E>`.
 - Avoid `unsafe` unless strictly necessary. When unavoidable, narrow its scope and document pre/post conditions.
-- Always add type annotations when defining variables and constants, even if type can be inferred (ie: `let x: u32 = 42;`).
-- Prefix all import statements with `::` (ie: use `::std:fs` instead of `std::fs`).
+- Always add type annotations when defining variables and constants, even if type can be inferred (e.g., `let x: u32 = 42;`).
+- Prefix all import statements with `::` (e.g., use `::std:fs` instead of `std::fs`).
 - Always log errors with `error!` before returning an error.
 - Use `warn!` log level for non-critical warnings that do not affect functionality.
 - Use `info!` log level for informational messages that are not errors or warnings.


### PR DESCRIPTION
This pull request updates the coding guidelines in `.github/copilot-instructions.md` to clarify logging requirements and improve consistency in style examples. The most important changes are grouped below:

Logging practices:

* Added a new rule requiring all logs to be single-line, concise, and machine-parsable when feasible. Explicitly disallows multiline logs, explicit newlines in messages, and pretty-printed debug formatting (e.g., `{:#?}`).

Style and consistency improvements:

* Updated examples for type annotations and import statement prefixes to use "e.g." instead of "ie", and added a colon after "e.g." in the import statement example.