### PR TITLE
[utils] Print Help Information for Debug Builds on `nanvix-bench`

### DIFF
--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -677,6 +677,12 @@ impl Benchmark {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Initialize logger, and make sure we print error logs.
+    Logger::try_with_env_or_str("error")
+        .expect("malformed RUST_LOG environment variable")
+        .start()
+        .expect("failed to initialize logger");
+
     #[cfg(debug_assertions)]
     {
         error!(
@@ -685,12 +691,6 @@ async fn main() -> Result<()> {
         );
         return Ok(());
     }
-
-    // Initialize logger, and make sure we print error logs.
-    Logger::try_with_env_or_str("error")
-        .expect("malformed RUST_LOG environment variable")
-        .start()
-        .expect("failed to initialize logger");
 
     let args: Args = Args::parse(std::env::args().collect())?;
 

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -88,6 +88,12 @@ use syscomm::{
 // Constants
 //==================================================================================================
 
+// Name of this package, used for logging and error messages.
+const CARGO_PKG_NAME: &str = match option_env!("CARGO_PKG_NAME") {
+    Some(cargo_pkg_name) => cargo_pkg_name,
+    None => "nanvix-bench",
+};
+
 /// Sleep duration (in ms) to wait for the system to clean up after a benchmark run.
 const CLEANUP_SLEEP_DURATION: u64 = 10;
 
@@ -683,13 +689,26 @@ async fn main() -> Result<()> {
         .start()
         .expect("failed to initialize logger");
 
-    #[cfg(debug_assertions)]
-    {
-        error!(
-            "WARNING: the Nanvix benchmarks require compilation with RELEASE=yes and \
-             LOG_LEVEL=panic"
-        );
-        return Ok(());
+    // Check if RELEASE=yes was set at build time.
+    match option_env!("RELEASE") {
+        Some("yes") => {},
+        Some(_) | None => {
+            let reason: String =
+                format!("{CARGO_PKG_NAME} requires Nanvix to be compiled with RELEASE=yes");
+            error!("{reason}");
+            anyhow::bail!(reason);
+        },
+    }
+
+    // Check if LOG_LEVEL was set at build time and ensure it is "panic".
+    match option_env!("LOG_LEVEL") {
+        Some("panic") => {},
+        Some(_) | None => {
+            let reason: String =
+                format!("{CARGO_PKG_NAME} requires Nanvix to be compiled with LOG_LEVEL=panic");
+            error!("{reason}");
+            anyhow::bail!(reason);
+        },
     }
 
     let args: Args = Args::parse(std::env::args().collect())?;


### PR DESCRIPTION
This pull request improves the startup checks and error reporting for the `nanvix-bench` utility. The main change is to verify at runtime that the binary was built with the required `RELEASE=yes` and `LOG_LEVEL=panic` settings, and to provide clear error messages if not.

This PR closes https://github.com/nanvix/nanvix/issues/875.

Build-time configuration validation:

* Added runtime checks in `main.rs` to ensure the binary was built with `RELEASE=yes` and `LOG_LEVEL=panic`, logging an error and exiting early if these conditions are not met.
* Introduced a `CARGO_PKG_NAME` constant for consistent and clear error messages referencing the package name.

This helps prevent accidental misuse of the benchmarks in an incorrect build configuration and provides more user-friendly feedback.