### PR TITLE
[scripts] Util Script

### DIFF
--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#
+# Utility functions.
+#
+
+#===================================================================================================
+# Include Guard
+#===================================================================================================
+
+# Skip this file if already included.
+if [[ -n "${__UTILS_SH_INCLUDED:-}" ]]; then
+    return
+fi
+readonly __UTILS_SH_INCLUDED=1
+
+#==================================================================================================
+# Imports
+#==================================================================================================
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/logging.sh"
+
+#==================================================================================================
+# Functions
+#==================================================================================================
+
+#
+# Description
+#
+#   Gets the current version from a Cargo.toml file.
+#
+# Arguments
+#
+#   $1 - The path to the Cargo.toml file.
+#
+# Return Value
+#
+#   - On success, a string containing the current version in the format MAJOR.MINOR.PATCH.
+#   - On failure, exits with a non-zero status.
+#
+# Usage Example
+#
+#   cargo_toml_version=$(get_cargo_toml_version "path/to/Cargo.toml")
+#
+get_cargo_toml_version() {
+    local cargo_toml="$1"
+
+    # Check if the target file does not exist.
+    if [[ ! -f "$cargo_toml" ]]; then
+        print_error "$cargo_toml does not exist."
+        exit 1
+    fi
+
+    # Check if target file is not a toml file.
+    if [[ "${cargo_toml##*.}" != "toml" ]]; then
+        print_error "$cargo_toml is not a toml file."
+        exit 1
+    fi
+
+    local cargo_toml_version
+    cargo_toml_version=$(sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$cargo_toml" | head -n1)
+
+    # Check if version was not extracted successfully.
+    if [[ -z "$cargo_toml_version" ]]; then
+        print_error "Could not extract version from ${cargo_toml}."
+        exit 1
+    fi
+
+    echo "$cargo_toml_version"
+}

--- a/scripts/create-minor-release.sh
+++ b/scripts/create-minor-release.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 IMPORT_DIR="$(cd "$(dirname "$0")" && pwd)/common"
 
 source "${IMPORT_DIR}/logging.sh"
+source "${IMPORT_DIR}/utils.sh"
 
 #===================================================================================================
 # Global Variables
@@ -51,40 +52,6 @@ Options
   --help   Print the help information.
   --push   Pushes the release commit to the remote origin.
 EOF
-}
-
-#
-# DESCRIPTION
-#   Extracts the current version from the Cargo.toml file.
-#
-# ARGUMENTS
-#   $1 - The path to the Cargo.toml file.
-#
-# RETURNS
-#   The current version as a string in the format MAJOR.MINOR.PATCH.
-#
-# USAGE EXAMPLE
-#   current_version=$(extract_current_version "path/to/Cargo.toml")
-#
-extract_current_version() {
-    local cargo_toml="$1"
-
-    # Check if the Cargo.toml file does not exist.
-    if [[ ! -f "$cargo_toml" ]]; then
-        print_error "Cargo.toml not found at $cargo_toml"
-        exit 1
-    fi
-
-    local current_version
-    current_version=$(sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$cargo_toml" | head -n1)
-
-    # Check if version was not extracted successfully.
-    if [[ -z "$current_version" ]]; then
-        print_error "Could not extract version from Cargo.toml"
-        exit 1
-    fi
-
-    echo "$current_version"
 }
 
 #
@@ -149,7 +116,7 @@ update_cargo_toml() {
 
     # Check if version was not updated successfully.
     local updated_version
-    updated_version=$(extract_current_version "$cargo_toml")
+    updated_version=$(get_cargo_toml_version "$cargo_toml")
     if [[ "$updated_version" != "$new_version" ]]; then
         print_error "Failed to update version in Cargo.toml"
 
@@ -364,7 +331,7 @@ main() {
     print_info "Creating minor release..."
 
     local current_version new_version
-    current_version=$(extract_current_version "$CARGO_TOML_FILE_PATH")
+    current_version=$(get_cargo_toml_version "$CARGO_TOML_FILE_PATH")
     print_info "Current version: $current_version"
     new_version=$(increment_version "$current_version")
     print_info "Incrementing version: $current_version -> $new_version"

--- a/scripts/setup/toolchain.sh
+++ b/scripts/setup/toolchain.sh
@@ -17,70 +17,17 @@ PREFIX=${1:-$PWD/toolchain}
 IMPORT_DIR="$(cd "$(dirname "$0")" && pwd)/../common"
 
 source "${IMPORT_DIR}/logging.sh"
+source "${IMPORT_DIR}/utils.sh"
 
 #===================================================================================================
 # Environment Variables
 #===================================================================================================
 
-SCRIPTS_DIR=$(dirname "$(readlink -f "$0")")
 REPO_ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "ERROR: Not in a git repository" >&2
     exit 1
 }
 CARGO_TOML_FILE_PATH="${REPO_ROOT_DIR}/Cargo.toml"
-
-#===================================================================================================
-# Helper Functions
-#===================================================================================================
-
-#
-# Description
-#
-#   Extracts the current version from the Cargo.toml file and formats it for toolchain versioning.
-#
-# Arguments
-#
-#   $1 - The path to the Cargo.toml file.
-#
-# Return Value
-#
-#   The toolchain version as a string in the format A.B.x.
-#
-# Usage Example
-#
-#   toolchain_version=$(extract_toolchain_version "path/to/Cargo.toml")
-#
-extract_toolchain_version() {
-    local cargo_toml="$1"
-
-    # Check if the Cargo.toml file does not exist.
-    if [[ ! -f "$cargo_toml" ]]; then
-        print_error "Cargo.toml not found at ${cargo_toml}."
-        exit 1
-    fi
-
-    local current_version
-    current_version=$(sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$cargo_toml" | head -n1)
-
-    # Check if version was not extracted successfully.
-    if [[ -z "$current_version" ]]; then
-        print_error "Could not extract version from Cargo.toml."
-        exit 1
-    fi
-
-    # Extract major and minor version numbers.
-    local major minor
-    major=$(echo "$current_version" | cut -d. -f1)
-    minor=$(echo "$current_version" | cut -d. -f2)
-
-    # Validate version format.
-    if [[ ! "$major" =~ ^[0-9]+$ ]] || [[ ! "$minor" =~ ^[0-9]+$ ]]; then
-        print_error "Invalid version format '${current_version}'."
-        exit 1
-    fi
-
-    echo "${major}.${minor}.x"
-}
 
 #===================================================================================================
 # Main Script
@@ -95,7 +42,10 @@ extract_toolchain_version() {
 "${SCRIPTS_DIR}/cloud-hypervisor.sh" "${PREFIX}"
 
 # Create version file as the final step.
-toolchain_version=$(extract_toolchain_version "$CARGO_TOML_FILE_PATH")
+current_version=$(get_cargo_toml_version "$CARGO_TOML_FILE_PATH")
+major=$(echo "$current_version" | cut -d. -f1)
+minor=$(echo "$current_version" | cut -d. -f2)
+toolchain_version="${major}.${minor}.x"
 echo "nanvix-toolchain-v${toolchain_version}" > "${PREFIX}/version" || {
     print_error "Failed to create version file at ${PREFIX}/version."
     exit 1

--- a/z
+++ b/z
@@ -22,6 +22,7 @@ set -euo pipefail
 IMPORT_DIR="$(cd "$(dirname "$0")" && pwd)/scripts/common"
 
 source "${IMPORT_DIR}/logging.sh"
+source "${IMPORT_DIR}/utils.sh"
 
 #==================================================================================================
 # Global Constants
@@ -72,40 +73,6 @@ TOOLCHAIN_DIR="${DEFAULT_LOCAL_TOOLCHAIN_DIR}"  # Toolchain directory for setup.
 #==================================================================================================
 # Functions
 #==================================================================================================
-
-#
-# DESCRIPTION
-#   Extracts the current version from the Cargo.toml file.
-#
-# ARGUMENTS
-#   $1 - The path to the Cargo.toml file.
-#
-# RETURNS
-#   The current version as a string in the format MAJOR.MINOR.PATCH.
-#
-# USAGE EXAMPLE
-#   current_version=$(extract_current_version "path/to/Cargo.toml")
-#
-extract_current_version() {
-    local cargo_toml="$1"
-
-    # Check if the Cargo.toml file does not exist.
-    if [[ ! -f "$cargo_toml" ]]; then
-        print_error "Cargo.toml not found at $cargo_toml"
-        exit 1
-    fi
-
-    local current_version
-    current_version=$(sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$cargo_toml" | head -n1)
-
-    # Check if version was not extracted successfully.
-    if [[ -z "$current_version" ]]; then
-        print_error "Could not extract version from Cargo.toml"
-        exit 1
-    fi
-
-    echo "$current_version"
-}
 
 #
 # Description
@@ -218,7 +185,7 @@ build_docker_command() {
     check_docker_installed
 
     local current_version
-    current_version=$(extract_current_version "$CARGO_TOML_FILE_PATH")
+    current_version=$(get_cargo_toml_version "$CARGO_TOML_FILE_PATH")
 
     # Get the Docker image name.
     local image_name
@@ -508,7 +475,7 @@ main() {
 
                 # Get the Docker image name using the same logic as build_docker_command
                 local current_version
-                current_version=$(extract_current_version "$CARGO_TOML_FILE_PATH")
+                current_version=$(get_cargo_toml_version "$CARGO_TOML_FILE_PATH")
 
                 # Get the Docker image name.
                 local image_name


### PR DESCRIPTION
This pull request refactors the way version extraction from `Cargo.toml` is handled across multiple scripts by introducing a reusable utility function, reducing code duplication and improving maintainability. The new `get_cargo_toml_version` function is added to a shared `utils.sh` script and is now used wherever the current version needs to be extracted.

**Refactoring and code reuse:**

* Added a new `get_cargo_toml_version` utility function in `scripts/common/utils.sh` to extract the version from a `Cargo.toml` file, with input validation and error handling.
* Updated `scripts/create-minor-release.sh`, `scripts/setup/toolchain.sh`, and `z` to source `utils.sh` and replace their local version extraction functions with the shared `get_cargo_toml_version` function, removing duplicated logic.

**Simplification and cleanup:**

* Removed the now-redundant `extract_current_version` and `extract_toolchain_version` functions from the affected scripts, consolidating all version extraction logic into the shared utility.
* Updated all usages of version extraction in these scripts to call `get_cargo_toml_version` instead of the removed local functions.