### PR TITLE
[scripts] Install cpio In Setup Scripts

### DIFF
--- a/scripts/setup/Dockerfile
+++ b/scripts/setup/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && \
     build-essential \
     clang-format \
     codespell \
+    cpio \
     curl \
     debootstrap \
     dosfstools \

--- a/scripts/setup/ubuntu.sh
+++ b/scripts/setup/ubuntu.sh
@@ -18,6 +18,7 @@ apt-get install -y        \
     build-essential       \
     clang-format          \
     codespell             \
+    cpio                  \
     curl                  \
     debootstrap           \
     dosfstools            \


### PR DESCRIPTION
In this commit I address a bug I introduced when we merged the scripts to generate the L2 initramfs. In particular, I forgot to install the `cpio` APT package.