### PR TITLE
[kernel] Refactor Thread Module

### DIFF
--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -329,7 +329,7 @@ impl ProcessManagerInner {
         ready_thread: ReadyThread,
     ) -> ThreadIdentifier {
         trace!("try_add_thread(): pid={pid:?}, ready_thread={ready_thread:?}");
-        let tid: ThreadIdentifier = ready_thread.tid();
+        let tid: ThreadIdentifier = ready_thread.id();
 
         // Search process in the list of sleeping processes.
         let mut suspended: LinkedList<SleepingProcess> = LinkedList::new();

--- a/src/kernel/src/pm/process/state/interrupted.rs
+++ b/src/kernel/src/pm/process/state/interrupted.rs
@@ -96,7 +96,7 @@ impl InterruptedProcess {
         if self
             .interrupted_threads
             .iter()
-            .any(|thread| thread.tid() == tid)
+            .any(|thread| thread.id() == tid)
         {
             return true;
         }
@@ -110,7 +110,7 @@ impl InterruptedProcess {
 
         // Search in the list of zombie threads.
         if let Some(zombie_threads) = &self.zombie_threads {
-            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
+            if zombie_threads.iter().any(|thread| thread.id() == tid) {
                 return true;
             }
         }

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -189,13 +189,13 @@ impl RunnableProcess {
 
     pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {
         // Search in the list of ready threads.
-        if self.ready_threads.iter().any(|thread| thread.tid() == tid) {
+        if self.ready_threads.iter().any(|thread| thread.id() == tid) {
             return true;
         }
 
         // Search in the list of interrupted threads.
         if let Some(interrupted_threads) = &self.interrupted_threads {
-            if interrupted_threads.iter().any(|thread| thread.tid() == tid) {
+            if interrupted_threads.iter().any(|thread| thread.id() == tid) {
                 return true;
             }
         }
@@ -209,7 +209,7 @@ impl RunnableProcess {
 
         // Search in the list of zombie threads.
         if let Some(zombie_threads) = &self.zombie_threads {
-            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
+            if zombie_threads.iter().any(|thread| thread.id() == tid) {
                 return true;
             }
         }

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -346,7 +346,7 @@ impl RunningProcess {
 
         // Search for thread in zombie threads.
         if let Some(zombie_threads) = self.zombie.take() {
-            match zombie_threads.remove_if(|thread| thread.tid() == tid) {
+            match zombie_threads.remove_if(|thread| thread.id() == tid) {
                 Ok((zombie_threads, zombie_thread)) => {
                     self.zombie = NonEmptyVecDeque::from(zombie_threads);
                     return Ok(zombie_thread);
@@ -360,7 +360,7 @@ impl RunningProcess {
         // Search for thread in ready threads.
         if let Some(ready_threads) = &mut self.ready {
             for ready_thread in ready_threads.iter() {
-                if ready_thread.tid() == tid {
+                if ready_thread.id() == tid {
                     let join_cond: Condvar = ready_thread.join_cond();
                     return Err(Ok(join_cond));
                 }
@@ -380,7 +380,7 @@ impl RunningProcess {
         // Search for thread in interrupted threads.
         if let Some(interrupted_threads) = &mut self.interrupted_threads {
             for interrupted_thread in interrupted_threads.iter() {
-                if interrupted_thread.tid() == tid {
+                if interrupted_thread.id() == tid {
                     let join_cond: Condvar = interrupted_thread.join_cond();
                     return Err(Ok(join_cond));
                 }
@@ -400,14 +400,14 @@ impl RunningProcess {
 
         // Search in the list of ready threads.
         if let Some(ready_threads) = &self.ready {
-            if ready_threads.iter().any(|thread| thread.tid() == tid) {
+            if ready_threads.iter().any(|thread| thread.id() == tid) {
                 return true;
             }
         }
 
         // Search in the list of interrupted threads.
         if let Some(interrupted_threads) = &self.interrupted_threads {
-            if interrupted_threads.iter().any(|thread| thread.tid() == tid) {
+            if interrupted_threads.iter().any(|thread| thread.id() == tid) {
                 return true;
             }
         }
@@ -421,7 +421,7 @@ impl RunningProcess {
 
         // Search in the list of zombie threads.
         if let Some(zombie_threads) = &self.zombie {
-            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
+            if zombie_threads.iter().any(|thread| thread.id() == tid) {
                 return true;
             }
         }

--- a/src/kernel/src/pm/process/state/sleeping.rs
+++ b/src/kernel/src/pm/process/state/sleeping.rs
@@ -196,7 +196,7 @@ impl SleepingProcess {
 
         // Search in the list of zombie threads.
         if let Some(zombie_threads) = &self.zombie_threads {
-            if zombie_threads.iter().any(|thread| thread.tid() == tid) {
+            if zombie_threads.iter().any(|thread| thread.id() == tid) {
                 return true;
             }
         }

--- a/src/kernel/src/pm/process/state/zombie.rs
+++ b/src/kernel/src/pm/process/state/zombie.rs
@@ -59,6 +59,6 @@ impl ZombieProcess {
     }
 
     pub fn has_thread(&self, tid: ThreadIdentifier) -> bool {
-        self.zombie_threads.iter().any(|thread| thread.tid() == tid)
+        self.zombie_threads.iter().any(|thread| thread.id() == tid)
     }
 }

--- a/src/kernel/src/pm/thread/interrupted.rs
+++ b/src/kernel/src/pm/thread/interrupted.rs
@@ -1,0 +1,104 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::pm::{
+    sync::condvar::Condvar,
+    thread::{
+        state::ThreadState,
+        ReadyThread,
+    },
+};
+use ::alloc::boxed::Box;
+use ::core::fmt::Debug;
+use ::sys::pm::ThreadIdentifier;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum InterruptReason {
+    /// Process was killed.
+    Killed,
+    /// Timer expired.
+    TimedOut,
+}
+
+///
+/// # Description
+///
+/// This structure represents a thread that has been interrupted.
+///
+#[derive(Debug)]
+pub struct InterruptedThread {
+    state: Box<ThreadState>,
+    reason: InterruptReason,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl InterruptedThread {
+    ///
+    /// # Description
+    ///
+    /// Creates a new interrupted thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: The thread state.
+    /// - `reason`: The reason for the interruption.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a new instance of an [`InterruptedThread`].
+    ///
+    pub(super) fn from_state(state: Box<ThreadState>, reason: InterruptReason) -> Self {
+        Self { state, reason }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the identifier of the interrupted thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the thread identifier.
+    ///
+    pub fn id(&self) -> ThreadIdentifier {
+        self.state.id()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Resumes the interrupted thread by transitioning it to ready state.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a [`ReadyThread`] instance.
+    ///
+    pub fn resume(mut self) -> ReadyThread {
+        self.state.set_interrupt_reason(self.reason);
+        ReadyThread::from_state(self.state)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the join condition variable of the interrupted thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the join condition variable.
+    ///
+    pub fn join_cond(&self) -> Condvar {
+        self.state.join_cond()
+    }
+}

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -11,346 +11,57 @@ use crate::{
         kstack::KernelStack,
         ustack::UserStack,
     },
-    pm::{
-        clock,
-        sync::{
-            condvar::Condvar,
-            mutex::MutexGuard,
-        },
-    },
 };
-use ::alloc::{
-    boxed::Box,
-    collections::btree_map::BTreeMap,
-    fmt,
+use ::sys::pm::ThreadIdentifier;
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+mod interrupted;
+mod ready;
+mod running;
+mod sleeping;
+mod state;
+mod zombie;
+
+//==================================================================================================
+// Exports
+//==================================================================================================
+
+pub use interrupted::{
+    InterruptReason,
+    InterruptedThread,
 };
-use ::core::{
-    fmt::Debug,
-    pin::Pin,
-};
-use ::sys::{
-    error::ErrorCode,
-    pm::{
-        MutexAddress,
-        ThreadIdentifier,
-    },
-    time::SystemTime,
-    ExitStatus,
-};
-
-//==================================================================================================
-// Thread State
-//==================================================================================================
-
-struct ThreadState {
-    /// Thread identifier.
-    id: ThreadIdentifier,
-    /// Kernel stack.
-    kernel_stack: Option<KernelStack>,
-    /// User stack.
-    user_stack: Option<UserStack>,
-    /// Condition variable for join.
-    join_cond: Condvar,
-    /// Execution context.
-    context: Pin<Box<ContextInformation>>,
-    /// Lookup table of locked mutexes.
-    locked_mutexes: BTreeMap<MutexAddress, MutexGuard>,
-    /// Interrupt reason, if any.
-    interrupt_reason: Option<InterruptReason>,
-}
-
-impl ThreadState {
-    fn new(
-        id: ThreadIdentifier,
-        kernel_stack: Option<KernelStack>,
-        user_stack: Option<UserStack>,
-        context: ContextInformation,
-    ) -> Self {
-        Self {
-            id,
-            context: Box::pin(context),
-            kernel_stack,
-            user_stack,
-            join_cond: Condvar::new(),
-            locked_mutexes: BTreeMap::new(),
-            interrupt_reason: None,
-        }
-    }
-
-    fn context_mut(&mut self) -> *mut ContextInformation {
-        self.context.as_mut().get_mut() as *mut ContextInformation
-    }
-}
-
-impl fmt::Debug for ThreadState {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Thread {{ id: {:?} }}", self.id)
-    }
-}
-
-impl Drop for ThreadState {
-    fn drop(&mut self) {
-        if !self.locked_mutexes.is_empty() {
-            error!(
-                "drop(): dropping thread state with locked mutexes (self.id={:?}, \
-                 self.locked_mutexes={:?})",
-                self.id, self.locked_mutexes
-            );
-        }
-    }
-}
-
-//==================================================================================================
-// Running Thread
-//==================================================================================================
-
-#[derive(Debug)]
-pub struct RunningThread(Box<ThreadState>);
-
-impl RunningThread {
-    pub fn sleep(mut self, alarm: Option<SystemTime>) -> (SleepingThread, *mut ContextInformation) {
-        let ctx: *mut ContextInformation = self.0.context_mut();
-        (
-            SleepingThread {
-                thread: self.0,
-                alarm,
-            },
-            ctx,
-        )
-    }
-
-    pub fn schedule(mut self) -> (ReadyThread, *mut ContextInformation) {
-        let ctx: *mut ContextInformation = self.0.context_mut();
-        (ReadyThread::from_state(self.0), ctx)
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Returns the identifier of the target thread.
-    ///
-    /// # Returns
-    ///
-    /// The identifier of the target thread.
-    ///
-    pub fn id(&self) -> ThreadIdentifier {
-        self.0.id
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Wakes up all threads waiting on the join condition variable.
-    ///
-    /// # Returns
-    ///
-    /// Upon successful completion, empty is returned. Otherwise, an error is returned instead.
-    ///
-    pub fn join_cond(&self) -> Condvar {
-        // NOTE: we must wake up all, otherwise some threads can be left waiting forever.
-        self.0.join_cond.clone()
-    }
-
-    pub fn exit(mut self, status: ExitStatus) -> (ZombieThread, *mut ContextInformation) {
-        let ctx: *mut ContextInformation = self.0.context_mut();
-        (
-            ZombieThread {
-                state: self.0,
-                status,
-            },
-            ctx,
-        )
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Stores a mutex guard in the target thread.
-    ///
-    /// # Parameters
-    ///
-    /// - `mutex_addr`: Address of the mutex.
-    /// - `guard`: Mutex guard.
-    ///
-    pub fn put_mutex_guard(&mut self, mutex_addr: MutexAddress, guard: MutexGuard) {
-        self.0.locked_mutexes.insert(mutex_addr, guard);
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Returns the mutex guard associated with the target thread.
-    ///
-    /// # Parameters
-    ///
-    /// - `mutex_addr`: Address of the mutex.
-    ///
-    /// # Returns
-    ///
-    /// If the mutex guard is found, it is returned. Otherwise, `None` is returned instead.
-    ///
-    pub fn take_mutex_guard(&mut self, mutex_addr: MutexAddress) -> Option<MutexGuard> {
-        self.0.locked_mutexes.remove(&mutex_addr)
-    }
-}
-
-//==================================================================================================
-// Ready Thread
-//==================================================================================================
-
-#[derive(Debug)]
-pub struct ReadyThread {
-    state: Box<ThreadState>,
-    admission_time: SystemTime,
-}
-
-impl ReadyThread {
-    pub fn new(
-        id: ThreadIdentifier,
-        kernel_stack: Option<KernelStack>,
-        user_stack: Option<UserStack>,
-        context: ContextInformation,
-    ) -> Self {
-        Self {
-            state: Box::new(ThreadState::new(id, kernel_stack, user_stack, context)),
-            admission_time: clock::now(),
-        }
-    }
-
-    fn from_state(state: Box<ThreadState>) -> Self {
-        Self {
-            state,
-            admission_time: clock::now(),
-        }
-    }
-
-    pub fn tid(&self) -> ThreadIdentifier {
-        self.state.id
-    }
-
-    pub fn run(mut self) -> (RunningThread, Option<InterruptReason>, *mut ContextInformation) {
-        let ctx: *mut ContextInformation = self.state.context_mut();
-        let interrupt_reason: Option<InterruptReason> = self.state.interrupt_reason.take();
-        (RunningThread(self.state), interrupt_reason, ctx)
-    }
-
-    pub fn terminate(self) -> ZombieThread {
-        ZombieThread {
-            state: self.state,
-            status: ErrorCode::Interrupted.into(),
-        }
-    }
-
-    pub fn join_cond(&self) -> Condvar {
-        self.state.join_cond.clone()
-    }
-
-    pub fn admission_time(&self) -> SystemTime {
-        self.admission_time
-    }
-}
-
-//==================================================================================================
-// Sleeping Thread
-//==================================================================================================
-
-#[derive(Debug)]
-pub struct SleepingThread {
-    thread: Box<ThreadState>,
-    alarm: Option<SystemTime>,
-}
-
-impl SleepingThread {
-    pub fn wakeup(self) -> ReadyThread {
-        ReadyThread::from_state(self.thread)
-    }
-
-    pub fn interrupt(self, reason: InterruptReason) -> InterruptedThread {
-        InterruptedThread {
-            thread: self.thread,
-            reason,
-        }
-    }
-
-    pub fn id(&self) -> ThreadIdentifier {
-        self.thread.id
-    }
-
-    pub fn join_cond(&self) -> Condvar {
-        self.thread.join_cond.clone()
-    }
-
-    pub fn alarm(&self) -> Option<SystemTime> {
-        self.alarm
-    }
-}
-
-//==================================================================================================
-// Interrupted Thread
-//==================================================================================================
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum InterruptReason {
-    /// Process was killed.
-    Killed,
-    /// Timer expired.
-    TimedOut,
-}
-
-#[derive(Debug)]
-pub struct InterruptedThread {
-    thread: Box<ThreadState>,
-    reason: InterruptReason,
-}
-
-impl InterruptedThread {
-    pub fn tid(&self) -> ThreadIdentifier {
-        self.thread.id
-    }
-
-    pub fn resume(mut self) -> ReadyThread {
-        self.thread.interrupt_reason = Some(self.reason);
-        ReadyThread::from_state(self.thread)
-    }
-
-    pub fn join_cond(&self) -> Condvar {
-        self.thread.join_cond.clone()
-    }
-}
-
-//==================================================================================================
-// Zombie Thread
-//==================================================================================================
-
-#[derive(Debug)]
-pub struct ZombieThread {
-    status: ExitStatus,
-    state: Box<ThreadState>,
-}
-
-impl ZombieThread {
-    pub fn tid(&self) -> ThreadIdentifier {
-        self.state.id
-    }
-
-    pub fn harvest(mut self) -> (Option<KernelStack>, Option<UserStack>) {
-        (self.state.kernel_stack.take(), self.state.user_stack.take())
-    }
-
-    pub fn status(&self) -> ExitStatus {
-        self.status
-    }
-}
+pub use ready::ReadyThread;
+pub use running::RunningThread;
+pub use sleeping::SleepingThread;
+pub use zombie::ZombieThread;
 
 //==================================================================================================
 // Thread Manager
 //==================================================================================================
 
+///
+/// # Description
+///
+/// This structure represents a thread manager that is responsible for creating and managing threads.
+///
 pub struct ThreadManager {
+    /// Next thread identifier to be assigned.
     next_id: ThreadIdentifier,
 }
 
 impl ThreadManager {
+    ///
+    /// # Description
+    ///
+    /// Creates a new thread manager and initializes the kernel thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a tuple containing the kernel thread and a new instance of a [`ThreadManager`].
+    ///
     fn new() -> (ReadyThread, Self) {
         let kernel: ReadyThread =
             ReadyThread::new(From::<i32>::from(0), None, None, ContextInformation::default());
@@ -362,6 +73,21 @@ impl ThreadManager {
         )
     }
 
+    ///
+    /// # Description
+    ///
+    /// Creates a new thread with the specified parameters.
+    ///
+    /// # Parameters
+    ///
+    /// - `kernel_stack`: Optional kernel stack for the thread.
+    /// - `user_stack`: Optional user stack for the thread.
+    /// - `context`: Execution context for the thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a new [`ReadyThread`] instance.
+    ///
     pub fn create_thread(
         &mut self,
         kernel_stack: Option<KernelStack>,
@@ -379,7 +105,15 @@ impl ThreadManager {
 // Standalone Functions
 //==================================================================================================
 
+///
+/// # Description
+///
 /// Initializes the thread manager.
+///
+/// # Returns
+///
+/// This function returns a tuple containing the kernel thread and a new instance of a [`ThreadManager`].
+///
 pub fn init() -> (ReadyThread, ThreadManager) {
     // TODO: check for double initialization.
 

--- a/src/kernel/src/pm/thread/ready.rs
+++ b/src/kernel/src/pm/thread/ready.rs
@@ -1,0 +1,170 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    hal::arch::ContextInformation,
+    mm::{
+        kstack::KernelStack,
+        ustack::UserStack,
+    },
+    pm::{
+        clock,
+        sync::condvar::Condvar,
+        thread::{
+            state::ThreadState,
+            RunningThread,
+            ZombieThread,
+        },
+        InterruptReason,
+    },
+};
+use ::alloc::boxed::Box;
+use ::core::fmt::Debug;
+use ::sys::{
+    error::ErrorCode,
+    pm::ThreadIdentifier,
+    time::SystemTime,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// This structure represents a thread that is ready to run.
+///
+#[derive(Debug)]
+pub struct ReadyThread {
+    /// Thread state.
+    state: Box<ThreadState>,
+    /// Time when the thread was admitted to the ready queue.
+    admission_time: SystemTime,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl ReadyThread {
+    ///
+    /// # Description
+    ///
+    /// Creates a new ready thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `id`: Thread identifier.
+    /// - `kernel_stack`: Optional kernel stack.
+    /// - `user_stack`: Optional user stack.
+    /// - `context`: Execution context.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a new instance of a [`ReadyThread`].
+    ///
+    pub fn new(
+        id: ThreadIdentifier,
+        kernel_stack: Option<KernelStack>,
+        user_stack: Option<UserStack>,
+        context: ContextInformation,
+    ) -> Self {
+        Self {
+            state: Box::new(ThreadState::new(id, kernel_stack, user_stack, context)),
+            admission_time: clock::now(),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Creates a ready thread from an existing thread state.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: The thread state.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a new instance of a [`ReadyThread`].
+    ///
+    pub fn from_state(state: Box<ThreadState>) -> Self {
+        Self {
+            state,
+            admission_time: clock::now(),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the identifier of the ready thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the thread identifier.
+    ///
+    pub fn id(&self) -> ThreadIdentifier {
+        self.state.id()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Transitions the ready thread to running state.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a tuple containing the running thread, an optional interrupt reason,
+    /// and a mutable pointer to the execution context.
+    ///
+    pub fn run(mut self) -> (RunningThread, Option<InterruptReason>, *mut ContextInformation) {
+        let ctx: *mut ContextInformation = self.state.context_mut();
+        let interrupt_reason: Option<InterruptReason> = self.state.take_interrupt_reason();
+        (RunningThread::from_state(self.state), interrupt_reason, ctx)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Terminates the ready thread and transitions it to zombie state.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a [`ZombieThread`] instance.
+    ///
+    pub fn terminate(self) -> ZombieThread {
+        ZombieThread::from_state(self.state, ErrorCode::Interrupted.into())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the join condition variable of the ready thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the join condition variable.
+    ///
+    pub fn join_cond(&self) -> Condvar {
+        self.state.join_cond()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the admission time of the ready thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the time when the thread was admitted to the ready queue.
+    ///
+    pub fn admission_time(&self) -> SystemTime {
+        self.admission_time
+    }
+}

--- a/src/kernel/src/pm/thread/running.rs
+++ b/src/kernel/src/pm/thread/running.rs
@@ -1,0 +1,178 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    hal::arch::ContextInformation,
+    pm::{
+        sync::{
+            condvar::Condvar,
+            mutex::MutexGuard,
+        },
+        thread::{
+            state::ThreadState,
+            ReadyThread,
+            SleepingThread,
+            ZombieThread,
+        },
+    },
+};
+use ::alloc::boxed::Box;
+use ::core::fmt::Debug;
+use ::sys::{
+    pm::{
+        MutexAddress,
+        ThreadIdentifier,
+    },
+    time::SystemTime,
+    ExitStatus,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// This structure represents a thread that is currently running.
+///
+#[derive(Debug)]
+pub struct RunningThread {
+    /// Thread state.
+    state: Box<ThreadState>,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl RunningThread {
+    ///
+    /// # Description
+    ///
+    /// Creates a running thread from an existing thread state.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: The thread state.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a new instance of a [`RunningThread`].
+    ///
+    pub(super) fn from_state(state: Box<ThreadState>) -> Self {
+        Self { state }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Transitions the running thread to sleeping state.
+    ///
+    /// # Parameters
+    ///
+    /// - `alarm`: Optional alarm time for the sleeping thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a tuple containing the sleeping thread and a mutable pointer to the execution context.
+    ///
+    pub fn sleep(mut self, alarm: Option<SystemTime>) -> (SleepingThread, *mut ContextInformation) {
+        let ctx: *mut ContextInformation = self.state.context_mut();
+        (SleepingThread::from_state(self.state, alarm), ctx)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Schedules the running thread by transitioning it to ready state.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a tuple containing the ready thread and a mutable pointer to the execution context.
+    ///
+    pub fn schedule(mut self) -> (ReadyThread, *mut ContextInformation) {
+        let ctx: *mut ContextInformation = self.state.context_mut();
+        (ReadyThread::from_state(self.state), ctx)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the identifier of the target thread.
+    ///
+    /// # Returns
+    ///
+    /// The identifier of the target thread.
+    ///
+    pub fn id(&self) -> ThreadIdentifier {
+        self.state.id()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Wakes up all threads waiting on the join condition variable.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, empty is returned. Otherwise, an error is returned instead.
+    ///
+    pub fn join_cond(&self) -> Condvar {
+        // NOTE: we must wake up all, otherwise some threads can be left waiting forever.
+        self.state.join_cond()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Terminates the running thread with the specified exit status.
+    ///
+    /// # Parameters
+    ///
+    /// - `status`: The exit status of the thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a tuple containing the zombie thread and a mutable pointer to the execution context.
+    ///
+    pub fn exit(mut self, status: ExitStatus) -> (ZombieThread, *mut ContextInformation) {
+        let ctx: *mut ContextInformation = self.state.context_mut();
+        (ZombieThread::from_state(self.state, status), ctx)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Stores a mutex guard in the target thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `mutex_addr`: Address of the mutex.
+    /// - `guard`: Mutex guard.
+    ///
+    pub fn put_mutex_guard(&mut self, mutex_addr: MutexAddress, guard: MutexGuard) {
+        self.state.store_mutex_guard(mutex_addr, guard);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the mutex guard associated with the target thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `mutex_addr`: Address of the mutex.
+    ///
+    /// # Returns
+    ///
+    /// If the mutex guard is found, it is returned. Otherwise, `None` is returned instead.
+    ///
+    pub fn take_mutex_guard(&mut self, mutex_addr: MutexAddress) -> Option<MutexGuard> {
+        self.state.take_mutex_guard(mutex_addr)
+    }
+}

--- a/src/kernel/src/pm/thread/sleeping.rs
+++ b/src/kernel/src/pm/thread/sleeping.rs
@@ -1,0 +1,132 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::pm::{
+    sync::condvar::Condvar,
+    thread::{
+        interrupted::InterruptReason,
+        state::ThreadState,
+        InterruptedThread,
+        ReadyThread,
+    },
+};
+use ::alloc::boxed::Box;
+use ::core::fmt::Debug;
+use ::sys::{
+    pm::ThreadIdentifier,
+    time::SystemTime,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// This structure represents a thread that is sleeping.
+///
+#[derive(Debug)]
+pub struct SleepingThread {
+    /// Thread state.
+    state: Box<ThreadState>,
+    /// Optional alarm time for waking up the thread.
+    alarm: Option<SystemTime>,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl SleepingThread {
+    ///
+    /// # Description
+    ///
+    /// Creates a sleeping thread from an existing thread state and alarm time.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: The thread state.
+    /// - `alarm`: Optional alarm time for waking up the thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a new instance of a [`SleepingThread`].
+    ///
+    pub(super) fn from_state(state: Box<ThreadState>, alarm: Option<SystemTime>) -> Self {
+        Self { state, alarm }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Wakes up the sleeping thread and transitions it to ready state.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a [`ReadyThread`] instance.
+    ///
+    pub fn wakeup(self) -> ReadyThread {
+        ReadyThread::from_state(self.state)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Interrupts the sleeping thread with the specified reason.
+    ///
+    /// # Parameters
+    ///
+    /// - `reason`: The reason for the interruption.
+    ///
+    /// # Returns
+    ///
+    /// This function returns an [`InterruptedThread`] instance.
+    ///
+    pub fn interrupt(self, reason: InterruptReason) -> InterruptedThread {
+        InterruptedThread::from_state(self.state, reason)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the identifier of the sleeping thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the thread identifier.
+    ///
+    pub fn id(&self) -> ThreadIdentifier {
+        self.state.id()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the join condition variable of the sleeping thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the join condition variable.
+    ///
+    pub fn join_cond(&self) -> Condvar {
+        self.state.join_cond()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the alarm time of the sleeping thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the optional alarm time for waking up the thread.
+    ///
+    pub fn alarm(&self) -> Option<SystemTime> {
+        self.alarm
+    }
+}

--- a/src/kernel/src/pm/thread/state.rs
+++ b/src/kernel/src/pm/thread/state.rs
@@ -1,0 +1,236 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    hal::arch::ContextInformation,
+    mm::{
+        kstack::KernelStack,
+        ustack::UserStack,
+    },
+    pm::{
+        sync::{
+            condvar::Condvar,
+            mutex::MutexGuard,
+        },
+        InterruptReason,
+    },
+};
+use ::alloc::{
+    boxed::Box,
+    collections::btree_map::BTreeMap,
+    fmt,
+};
+use ::core::pin::Pin;
+use ::sys::pm::{
+    MutexAddress,
+    ThreadIdentifier,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// This structure represents the state of a thread.
+///
+pub struct ThreadState {
+    /// Thread identifier.
+    id: ThreadIdentifier,
+    /// Kernel stack.
+    kernel_stack: Option<KernelStack>,
+    /// User stack.
+    user_stack: Option<UserStack>,
+    /// Condition variable for join.
+    join_cond: Condvar,
+    /// Execution context.
+    context: Pin<Box<ContextInformation>>,
+    /// Lookup table of locked mutexes.
+    locked_mutexes: BTreeMap<MutexAddress, MutexGuard>,
+    /// Interrupt reason, if any.
+    interrupt_reason: Option<InterruptReason>,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl ThreadState {
+    ///
+    /// # Description
+    ///
+    /// Creates a new thread state.
+    ///
+    /// # Parameters
+    ///
+    /// - `id`: Thread identifier.
+    /// - `kernel_stack`: Optional kernel stack.
+    /// - `user_stack`: Optional user stack.
+    /// - `context`: Execution context.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a new instance of a [`ThreadState`].
+    ///
+    pub(super) fn new(
+        id: ThreadIdentifier,
+        kernel_stack: Option<KernelStack>,
+        user_stack: Option<UserStack>,
+        context: ContextInformation,
+    ) -> Self {
+        Self {
+            id,
+            context: Box::pin(context),
+            kernel_stack,
+            user_stack,
+            join_cond: Condvar::new(),
+            locked_mutexes: BTreeMap::new(),
+            interrupt_reason: None,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a mutable pointer to the execution context of the thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a mutable pointer to the execution context of the thread.
+    ///
+    pub(super) fn context_mut(&mut self) -> *mut ContextInformation {
+        self.context.as_mut().get_mut() as *mut ContextInformation
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the identifier of the thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the identifier of the thread.
+    ///
+    pub(super) fn id(&self) -> ThreadIdentifier {
+        self.id
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the join condition variable of the thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the join condition variable of the thread.
+    ///
+    pub(super) fn join_cond(&self) -> Condvar {
+        self.join_cond.clone()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Stores a mutex guard in the thread state.
+    ///
+    /// # Parameters
+    ///
+    /// - `address`: The address of the mutex.
+    /// - `guard`: The mutex guard to store.
+    ///
+    pub(super) fn store_mutex_guard(&mut self, address: MutexAddress, guard: MutexGuard) {
+        self.locked_mutexes.insert(address, guard);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the mutex guard associated with the thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `address`: The address of the mutex.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the mutex guard associated with the thread, if any.
+    ///
+    pub(super) fn take_mutex_guard(&mut self, address: MutexAddress) -> Option<MutexGuard> {
+        self.locked_mutexes.remove(&address)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sets reason why a thread was interrupted.
+    ///
+    /// # Parameters
+    ///
+    /// - `reason`: The reason for the interruption.
+    ///
+    pub(super) fn set_interrupt_reason(&mut self, reason: InterruptReason) {
+        self.interrupt_reason = Some(reason);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the interrupt reason, if any.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the interrupt reason, if any.
+    ///
+    pub(super) fn take_interrupt_reason(&mut self) -> Option<InterruptReason> {
+        self.interrupt_reason.take()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the kernel stack of the thread, if any.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the kernel stack of the thread, if any.
+    ///
+    pub(super) fn take_kernel_stack(&mut self) -> Option<KernelStack> {
+        self.kernel_stack.take()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the user stack of the thread, if any.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the user stack of the thread, if any.
+    ///
+    pub(super) fn take_user_stack(&mut self) -> Option<UserStack> {
+        self.user_stack.take()
+    }
+}
+
+impl fmt::Debug for ThreadState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Thread {{ id: {:?} }}", self.id)
+    }
+}
+
+impl Drop for ThreadState {
+    fn drop(&mut self) {
+        if !self.locked_mutexes.is_empty() {
+            error!(
+                "drop(): dropping thread state with locked mutexes (self.id={:?}, \
+                 self.locked_mutexes={:?})",
+                self.id, self.locked_mutexes
+            );
+        }
+    }
+}

--- a/src/kernel/src/pm/thread/zombie.rs
+++ b/src/kernel/src/pm/thread/zombie.rs
@@ -1,0 +1,100 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    mm::{
+        kstack::KernelStack,
+        ustack::UserStack,
+    },
+    pm::thread::state::ThreadState,
+};
+use ::alloc::boxed::Box;
+use ::core::fmt::Debug;
+use ::sys::{
+    pm::ThreadIdentifier,
+    ExitStatus,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// This structure represents a thread that has terminated and is waiting to be harvested.
+///
+#[derive(Debug)]
+pub struct ZombieThread {
+    /// Exit status of the terminated thread.
+    status: ExitStatus,
+    /// Thread state.
+    state: Box<ThreadState>,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl ZombieThread {
+    ///
+    /// # Description
+    ///
+    /// Creates a zombie thread from an existing thread state and exit status.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: The thread state.
+    /// - `status`: The exit status of the terminated thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a new instance of a [`ZombieThread`].
+    ///
+    pub(super) fn from_state(state: Box<ThreadState>, status: ExitStatus) -> Self {
+        Self { status, state }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the identifier of the zombie thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the thread identifier.
+    ///
+    pub fn id(&self) -> ThreadIdentifier {
+        self.state.id()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Harvests the zombie thread and reclaims its resources.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a tuple containing the optional kernel stack and user stack of the terminated thread.
+    ///
+    pub fn harvest(mut self) -> (Option<KernelStack>, Option<UserStack>) {
+        (self.state.take_kernel_stack(), self.state.take_user_stack())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the exit status of the zombie thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the exit status of the terminated thread.
+    ///
+    pub fn status(&self) -> ExitStatus {
+        self.status
+    }
+}


### PR DESCRIPTION
This pull request refactors the thread management subsystem, focusing on encapsulation and code clarity. The primary change is the extraction of thread state management into dedicated modules and types, especially introducing a new `InterruptedThread` struct. Additionally, all usages of the `tid()` method are replaced with the more general `id()` method for thread identification, aligning with the new abstractions.

Key changes include:

**Thread State Refactor and Encapsulation:**

- Extracted thread state logic into separate modules and types, notably introducing `interrupted.rs` with the new `InterruptedThread` struct and `InterruptReason` enum, which encapsulate interrupted thread behavior and state. (`src/kernel/src/pm/thread/interrupted.rs`)
- Refactored `mod.rs` in the thread module to remove the large inlined `ThreadState` struct and related logic, delegating thread state management to specialized modules and types. This results in a cleaner, more modular codebase and clearer separation of concerns. (`src/kernel/src/pm/thread/mod.rs`)

**API Consistency and Method Renaming:**

- Replaced all usages of the `tid()` method with the new `id()` method across the codebase, ensuring a consistent interface for thread identification in all process and thread state management code.

**Initialization and Construction Improvements:**

- Updated thread manager and thread creation logic to use the new abstractions and improved modularity, including a revised `init()` function for initializing the thread manager. (`src/kernel/src/pm/thread/mod.rs`)

These changes improve code maintainability, encapsulation, and make the thread management subsystem easier to extend and reason about.