### PR TITLE
[kernel] Zero Out Regs Before Jump to User Mode

### DIFF
--- a/src/kernel/src/hal/arch/x86/hooks.S
+++ b/src/kernel/src/hal/arch/x86/hooks.S
@@ -496,8 +496,6 @@ __context_switch:
  */
 __leave_kernel_to_user_mode:
 
-    /* TODO: zero out all registers. */
-
     popl %ecx /* user function argument */
     popl %edx /* user function */
 
@@ -510,9 +508,19 @@ __leave_kernel_to_user_mode:
     movw %ax, %fs
     movw %ax, %gs
 
+    /*
+     * Clear volatile kernel registers to avoid leaking kernel state to
+     * user-mode. Preserve ECX and EDX registers because they hold the user
+     * function argument and the user function pointer respectively.
+     */
+    xorl %eax, %eax
+    xorl %ebx, %ebx
+    xorl %esi, %esi
+    xorl %edi, %edi
+    xorl %ebp, %ebp
+
 __leave_kernel:
     iret
-
 
 /*----------------------------------------------------------------------------*
  * __phys_memcpy()                                                            *


### PR DESCRIPTION
This pull request improves the `__leave_kernel_to_user_mode` assembly routine by explicitly zeroing out registers before transferring control to user mode. This change mitigates the risk of unintentionally exposing residual kernel state to user-space processes.