### PR TITLE
[kernel] Improve Semantics for `signal_cond()`

### DIFF
--- a/src/kernel/src/pm/kcall/signal_cond.rs
+++ b/src/kernel/src/pm/kcall/signal_cond.rs
@@ -22,12 +22,37 @@ use ::sys::{
 // Standalone Functions
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Signals a condition variable.
+///
+/// # Parameters
+///
+/// - `pid`: Target process identifier.
+/// - `tid`: Target thread identifier.
+/// - `cond_addr`: Address of the condition variable.
+/// - `broadcast`: If `true`, wakes all waiting threads. Otherwise, wakes a single waiting thread.
+///
+/// # Returns
+///
+/// Upon successful completion, this function returns the number of threads that were awakened.
+/// Otherwise, it returns an error object that specifying the reason of failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it operates on global variables.
+///
+/// It is safe to call this function if and only if the following conditions are met:
+///
+/// - The calling process does not hold a reference to the process manager.
+///
 pub unsafe fn signal_cond(
     pid: ProcessIdentifier,
     tid: ThreadIdentifier,
     cond_addr: usize,
     broadcast: bool,
-) -> Result<usize, Error> {
+) -> Result<u32, Error> {
     trace!(
         "signal_cond(): pid={pid:?}, tid={tid:?}, cond_addr={cond_addr:x?}, broadcast={broadcast}"
     );
@@ -35,7 +60,7 @@ pub unsafe fn signal_cond(
     // Unpack kernel call arguments.
     let cond_addr: ConditionAddress = ConditionAddress::from(cond_addr);
 
-    let awakened: usize = {
+    let awakened: u32 = {
         let cond: Condvar = ProcessManager::get_cond(cond_addr)?;
         if broadcast {
             cond.notify_all()?

--- a/src/kernel/src/pm/sync/condvar.rs
+++ b/src/kernel/src/pm/sync/condvar.rs
@@ -97,25 +97,26 @@ impl Condvar {
     ///
     /// # Description
     ///
-    /// Wakes a single thread that is waiting on the target condition variable.
+    /// Wakes up a single thread that is waiting on a condition variable.
     ///
-    /// # Returns
+    /// # Return Value
     ///
-    /// Upon successful completion, the number of threads that were awakened is returned. Otherwise,
-    /// an error is returned instead.
+    /// Upon successful completion, this function returns the number of threads that were awakened.
+    /// Otherwise, it returns an error object that specifying the reason of failure.
     ///
     /// # Safety
     ///
     /// This function is unsafe because it operates on global variables.
     ///
-    /// This function is safe to use if and only if the following conditions are met:
+    /// It is safe to call this function if and only if the following conditions are met:
     ///
     /// - The calling process does not hold a reference to the process manager.
     ///
-    pub unsafe fn notify_first(&self) -> Result<usize, Error> {
-        let mut awakened: usize = 0;
+    pub unsafe fn notify_first(&self) -> Result<u32, Error> {
+        let mut awakened: u32 = 0;
 
-        if let Some((_, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
+        // Attempt to wake up the first thread in the sleeping queue.
+        if let Some((_pid, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
             ProcessManager::wakeup(tid)?;
             awakened += 1;
         }
@@ -217,24 +218,25 @@ impl Condvar {
     ///
     /// # Description
     ///
-    /// Wakes up all threads waiting on the target condition variable.
+    /// Wakes up all threads waiting on a condition variable.
     ///
-    /// # Returns
+    /// # Return Value
     ///
-    /// Upon successful completion, the number of threads that were awakened is returned. Otherwise,
-    /// an error is returned instead.
+    /// Upon successful completion, this function returns the number of threads that were awakened.
+    /// Otherwise, it returns an error object that specifying the reason of failure.
     ///
     /// # Safety
     ///
     /// This function is unsafe because it operates on global variables.
     ///
-    /// This function is safe to use if and only if the following conditions are met:
+    /// It is safe to call this function if and only if the following conditions are met:
     ///
     /// - The calling process does not hold a reference to the process manager.
     ///
-    pub unsafe fn notify_all(&self) -> Result<usize, Error> {
-        let mut awakened: usize = 0;
+    pub unsafe fn notify_all(&self) -> Result<u32, Error> {
+        let mut awakened: u32 = 0;
 
+        // Traverse the sleeping queue, attempting to waking up all threads.
         while let Some((_pid, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
             ProcessManager::wakeup(tid)?;
             awakened += 1;

--- a/src/kernel/src/pm/sync/condvar.rs
+++ b/src/kernel/src/pm/sync/condvar.rs
@@ -223,7 +223,10 @@ impl Condvar {
     /// # Return Value
     ///
     /// Upon successful completion, this function returns the number of threads that were awakened.
-    /// Otherwise, it returns an error object that specifying the reason of failure.
+    /// Otherwise, it returns an error object that specifying the reason of failure.  If an error
+    /// occurs while waking up a thread, it is logged and the function continues trying to wake up
+    /// the remaining threads. If no threads were successfully awakened and at least one error
+    /// occurred, the first encountered error is returned.
     ///
     /// # Safety
     ///
@@ -234,15 +237,27 @@ impl Condvar {
     /// - The calling process does not hold a reference to the process manager.
     ///
     pub unsafe fn notify_all(&self) -> Result<u32, Error> {
-        let mut awakened: u32 = 0;
+        let mut awakened: u32 = 0; // Number of awakened threads.
+        let mut first_error: Option<Error> = None; // First error encountered (if any).
 
-        // Traverse the sleeping queue, attempting to waking up all threads.
-        while let Some((_pid, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
-            ProcessManager::wakeup(tid)?;
-            awakened += 1;
+        // Traverse the sleeping queue, waking up all threads.
+        while let Some((pid, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
+            // Attempt to wake up thread and check for errors.
+            if let Err(error) = ProcessManager::wakeup(tid) {
+                // Failed to wake up thread, log a warning, store the first error, and continue.
+                warn!("notify_all(): {error:?} (pid={pid:?}, tid={tid:?})");
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+            } else {
+                // Only count successful wake-ups.
+                awakened += 1;
+            }
         }
-
-        Ok(awakened)
+        match first_error {
+            Some(error) if awakened == 0 => Err(error),
+            None | Some(_) => Ok(awakened),
+        }
     }
 
     ///


### PR DESCRIPTION
This pull request updates the signaling and notification logic for condition variables in the kernel, focusing on improving error handling, return types, and documentation. The changes ensure that the number of awakened threads is consistently returned as a `u32`, and that errors during broadcast notifications are handled more robustly.

**Condition variable notification improvements:**

* Changed the return type of `signal_cond`, `Condvar::notify_first`, and `Condvar::notify_all` from `usize` to `u32` for consistency and clarity.
* Improved error handling in `Condvar::notify_all` to log errors for individual threads and only return an error if no threads were successfully awakened.

**Documentation and safety:**

* Expanded and clarified documentation for `signal_cond`, `Condvar::notify_first`, and `Condvar::notify_all`, including detailed descriptions of parameters, return values, and safety requirements. 