### PR TITLE
[kernel] 64-Bit Return for Kernel Calls

### DIFF
--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -63,9 +63,9 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
 
     match KcallNumber::from(number) {
         // Handle `getpid()` locally.
-        KcallNumber::GetPid => KcallResult::Success(<i32>::from(pid).into()),
+        KcallNumber::GetPid => KcallResult::Success(<i64>::from(pid).into()),
         // Handle `gettid()` locally.
-        KcallNumber::GetTid => KcallResult::Success(<i32>::from(tid).into()),
+        KcallNumber::GetTid => KcallResult::Success(<i64>::from(tid).into()),
         KcallNumber::Exit => {
             // SAFETY: the calling process is not the kernel.
             let e: Error = unsafe { ProcessManager::exit(ExitStatus::from(arg0)).unwrap_err() };

--- a/src/kernel/src/kcall/kcall_result.rs
+++ b/src/kernel/src/kcall/kcall_result.rs
@@ -2,8 +2,29 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::expect_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::cast_sign_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+
+//==================================================================================================
 // Imports
-//========================================A==========================================================
+//==================================================================================================
 
 use crate::kcall::{
     KcallError,
@@ -23,15 +44,6 @@ pub enum KcallResult {
 //==================================================================================================
 // Implementations
 //==================================================================================================
-
-impl From<KcallResult> for i32 {
-    fn from(result: KcallResult) -> Self {
-        match result {
-            KcallResult::Success(success) => success.into(),
-            KcallResult::Error(error) => error.into(),
-        }
-    }
-}
 
 impl From<KcallResult> for i64 {
     fn from(result: KcallResult) -> Self {

--- a/src/kernel/src/kcall/kcall_success.rs
+++ b/src/kernel/src/kcall/kcall_success.rs
@@ -2,6 +2,27 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::expect_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::cast_sign_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+
+//==================================================================================================
 // Structures
 //==================================================================================================
 
@@ -11,48 +32,32 @@
 /// A structure that stores the result of a successful kernel call.
 ///
 #[derive(Default, Debug, Clone, Copy)]
-pub struct KcallSuccess(i32);
+pub struct KcallSuccess(i64);
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl From<usize> for KcallSuccess {
-    fn from(code: usize) -> Self {
-        match code.try_into() {
-            Ok(code) => KcallSuccess(code),
-            Err(error) => {
-                panic!("failed to convert usize to i32 (usize={:?}, error={:?})", code, error)
-            },
-        }
-    }
-}
-
 impl From<u32> for KcallSuccess {
     fn from(code: u32) -> Self {
-        match code.try_into() {
-            Ok(code) => KcallSuccess(code),
-            Err(error) => {
-                panic!("failed to convert u32 to i32 (u32={:?}, error={:?})", code, error)
-            },
-        }
+        KcallSuccess(code.into())
     }
 }
 
 impl From<i32> for KcallSuccess {
     fn from(code: i32) -> Self {
-        KcallSuccess(code)
+        KcallSuccess(code.into())
     }
 }
 
-impl From<KcallSuccess> for i32 {
-    fn from(result: KcallSuccess) -> Self {
-        result.0
+impl From<i64> for KcallSuccess {
+    fn from(code: i64) -> Self {
+        KcallSuccess(code)
     }
 }
 
 impl From<KcallSuccess> for i64 {
     fn from(result: KcallSuccess) -> Self {
-        result.0 as i64
+        result.0
     }
 }


### PR DESCRIPTION
This commit updates the kernel call dispatch mechanism to correctly handle and return 64-bit values. The enhancement ensures compatibility with system calls requiring wider return types, improving support for modern architectures and enabling more robust kernel-user space interactions.