### PR TITLE
[build] Run Codespell on All Tracked Files

### DIFF
--- a/.github/workflows/github-hosted-ci.yml
+++ b/.github/workflows/github-hosted-ci.yml
@@ -47,7 +47,7 @@ jobs:
           path: ./toolchain
           key: ${{ steps.extract-version.outputs.cache_key }}
 
-      - name: "Prepare build environemnt if not cached"
+      - name: "Prepare build environment if not cached"
         if: steps.cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup
 
@@ -84,7 +84,7 @@ jobs:
           key: ${{ needs.setup-toolchain.outputs.cache-key }}
           fail-on-cache-miss: 'true'
 
-      - name: "Prepare build environemnt"
+      - name: "Prepare build environment"
         uses: ./.github/actions/setup
 
       - name: "Link Rust Toolchain for Nanvix"

--- a/Makefile
+++ b/Makefile
@@ -408,11 +408,11 @@ rust-lint: \
 
 # Fixes spelling errors in source code and documentation.
 spellcheck-fix:
-	codespell --write-changes .
+	codespell --write-changes $(shell git ls-files)
 
 # Checks for spelling errors in source code and documentation.
 spellcheck:
-	codespell .
+	codespell $(shell git ls-files)
 
 # Fixes code formatting issues.
 format: \


### PR DESCRIPTION
In this commit I fix our spellcheck rule by explicitly running it on all files tracked by git. This fixes two different issues:
- First, it prevents codespell from triggering errors in files that are not tracked by git, which we should not care about. For example, the `images` directory where the L2 snapshot lives.
- Second, it actually runs codespell on tracked, invisible, directories (i.e. directories starting with '.').

In the follow-up commit I fix spelling errors caused by 2.