### PR TITLE
[kernel] Initial FPU Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ export KERNEL_RUST_FLAGS := "-C relocation-model=static -C prefer-dynamic=no"
 export KERNEL_CARGO_FLAGS := -Zbuild-std=core,alloc,compiler_builtins -Zbuild-std-features=compiler-builtins-mem
 export KERNEL_CARGO_TARGET := --target $(TARGETS_DIR)/$(TARGET)-kernel.json
 export KERNEL_CARGO_FEATURES := --no-default-features --features $(MACHINE) --features $(LOG_LEVEL)
+export KERNEL_CARGO_FEATURES += $(if $(filter yes,$(SSE)),--features sse,)
 export WASMD_CARGO_FEATURES :=
 
 # Rust flags for host target.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ export TARGET ?= x86
 # Target Machine
 export MACHINE ?= microvm
 
+# Enable SSE/SSE2 Support?
+export SSE ?= no
+
 # Release Version?
 export RELEASE ?= no
 
@@ -188,6 +191,7 @@ export MICROVM_CARGO_FEATURES := --no-default-features
 export MICROVM_CARGO_FEATURES += $(if $(filter yes,$(PROFILER)),--features profiler,)
 export MICROVM_CARGO_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),--features timestamp-messages,)
 export MICROVM_CARGO_FEATURES += $(if $(filter hyperlight,$(MACHINE)),--features hyperlight,)
+export MICROVM_CARGO_FEATURES += $(if $(filter yes,$(SSE)),--features sse,)
 
 # Optimization Flags
 ifeq ($(RELEASE),yes)
@@ -361,6 +365,7 @@ help:
 	@echo "  PROFILER         Enable MicroVM profiler (default: $(PROFILER))"
 	@echo "  JAVY             Javy compiler location (default: $(JAVY)) [impacts build time]"
 	@echo "  SCCACHE          Path to ompilation cache binary (default: auto-detected from PATH) [impacts build time]"
+	@echo "  SSE              Enable SSE/SSE2 support (default: $(SSE))"
 	@echo ""
 	@echo "Parameter Values"
 	@echo "  MACHINE      hyperlight, microvm, qemu-pc, qemu-isapc, qemu-baremetal"
@@ -370,6 +375,7 @@ help:
 	@echo "  PROFILER     yes, no"
 	@echo "  BUILD_OPT    yes, no"
 	@echo "  JAVY         path to javy executable"
+	@echo "  SSE          yes, no"
 
 # Fixes code linting issues.
 lint: \

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -99,6 +99,7 @@ ioapic = []
 madt = []
 msr = []
 pic = []
+sse = []
 xapic = []
 
 # Platform Features

--- a/src/kernel/src/hal/arch/x86/cpu/context.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/context.rs
@@ -6,7 +6,10 @@
 //==================================================================================================
 
 use crate::hal::arch::x86::{
-    cpu::tss,
+    cpu::{
+        tss,
+        FpuState,
+    },
     mem::gdt::{
         Gdt,
         SegmentSelector,
@@ -74,6 +77,8 @@ impl ContextInformation {
     ///
     /// - `from`: Execution context to switch from.
     /// - `to`: Execution context to switch to.
+    /// - `from_fpu`: FPU state to save.
+    /// - `to_fpu`: FPU state to restore.
     /// - `user_tda`: Optional base address for the user-space thread data area for the next context.
     ///
     /// # Safety
@@ -82,6 +87,7 @@ impl ContextInformation {
     ///
     /// It is safe to call this function if and only if the following conditions are met:
     /// - `from` and `to` point to valid execution contexts.
+    /// - `from_fpu` and `to_fpu` point to valid FPU state structures.
     /// - The processor is running with interrupts disabled.
     /// - The processor is running in privileged mode.
     ///
@@ -93,6 +99,8 @@ impl ContextInformation {
     pub unsafe fn switch(
         from: *mut ContextInformation,
         to: *mut ContextInformation,
+        #[cfg_attr(not(feature = "sse"), allow(unused_variables))] from_fpu: *mut FpuState,
+        #[cfg_attr(not(feature = "sse"), allow(unused_variables))] to_fpu: *mut FpuState,
         user_tda: Option<VirtualAddress>,
     ) {
         unsafe extern "C" {
@@ -112,6 +120,16 @@ impl ContextInformation {
         }
 
         let tss: *const Tss = tss::get_curr();
+
+        #[cfg(feature = "sse")]
+        {
+            // Save FPU state.
+            ::core::arch::asm!("fxsave [{}]", in(reg) from_fpu, options(nostack, preserves_flags));
+
+            // Restore FPU state.
+            ::core::arch::asm!("fxrstor [{}]", in(reg) to_fpu, options(nostack, preserves_flags));
+        }
+
         __context_switch(from, to, tss);
     }
 }

--- a/src/kernel/src/hal/arch/x86/cpu/fpu.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/fpu.rs
@@ -1,0 +1,133 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::arch::cpu::{
+    cr0::{
+        Cr0Register,
+        EmulationFlag,
+        MonitorCoprocessorFlag,
+    },
+    cr4::{
+        Cr4Register,
+        OsFxsaveFlag,
+        OsSimdExceptionFlag,
+    },
+    mxcrs::{
+        DenormalOperationMask,
+        DivideByZeroMask,
+        MxcsrRegister,
+        OverflowMask,
+        PrecisionMask,
+        UnderflowMask,
+    },
+};
+use ::core::arch::asm;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Size of the FPU state.
+const FPU_STATE_SIZE: usize = 512;
+
+/// Alignment of the FPU state.
+const _FPU_STATE_ALIGN: usize = 16;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// This structure represents the state of the FPU.
+///
+#[repr(C, align(16))]
+pub struct FpuState {
+    /// FPU state data.
+    data: [u8; FPU_STATE_SIZE],
+}
+
+::static_assert::assert_eq_size!(FpuState, FPU_STATE_SIZE);
+::static_assert::assert_eq_align!(FpuState, _FPU_STATE_ALIGN);
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Initial FPU state, overwritten during system initialization.
+static mut INITIAL_FPU_STATE: FpuState = FpuState {
+    data: [0; FPU_STATE_SIZE],
+};
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl FpuState {
+    ///
+    /// # Description
+    ///
+    /// Constructs a new FPU state.
+    ///
+    /// # Safety
+    ///
+    /// It is unsafe to call this function because it accesses global state that is not
+    /// synchronized.
+    ///
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - Calls to this function are synchronized.
+    ///
+    pub unsafe fn new() -> Self {
+        Self {
+            data: INITIAL_FPU_STATE.data,
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Enables SIMD support in the underlying processor.
+///
+/// # Safety
+///
+/// It is unsafe to call this function because it executes privileged instructions.
+///
+///
+/// It is safe to call this function if the following conditions are met:
+/// - Calls to this function are synchronized.
+/// - The caller runs on a processor that supports either SSE or SSE2 features.
+/// - The caller runs on a processor that supports FXSAVE and FXRSTOR instructions.
+/// - The caller runs at processor privilege level 0.
+///
+pub unsafe fn init() {
+    // Disable x87 emulation and enable coprocessor monitoring.
+    let mut cr0: Cr0Register = Cr0Register::read();
+    cr0.emulation = EmulationFlag::Disabled;
+    cr0.monitor_coprocessor = MonitorCoprocessorFlag::Enabled;
+    cr0.write();
+
+    // Enable support for fxsave and fxrstor instructions, as well as support for SIMD exceptions.
+    let mut cr4: Cr4Register = Cr4Register::read();
+    cr4.os_fxsave = OsFxsaveFlag::Enabled;
+    cr4.os_simd_exception = OsSimdExceptionFlag::Enabled;
+    cr4.write();
+
+    // Mask all exceptions in the MXCSR register.
+    let mut mxcrs: MxcsrRegister = MxcsrRegister::read();
+    mxcrs.precision_mask = PrecisionMask::Masked;
+    mxcrs.underflow_mask = UnderflowMask::Masked;
+    mxcrs.overflow_mask = OverflowMask::Masked;
+    mxcrs.divide_by_zero_mask = DivideByZeroMask::Masked;
+    mxcrs.denormal_operation_mask = DenormalOperationMask::Masked;
+    mxcrs.write();
+
+    // Save the initial FPU state.
+    // SAFETY: access to INITIAL_FPU_STATE is synchronized.
+    asm!("fxsave [{}]", in(reg) &mut INITIAL_FPU_STATE.data);
+}

--- a/src/kernel/src/hal/arch/x86/cpu/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/mod.rs
@@ -13,6 +13,11 @@ mod interrupt;
 #[cfg(feature = "smp")]
 mod clock;
 
+#[cfg(feature = "sse")]
+mod fpu;
+#[cfg(not(feature = "sse"))]
+mod nofpu;
+
 //==================================================================================================
 // Imports
 //==================================================================================================
@@ -50,6 +55,11 @@ pub use interrupt::{
     InterruptNumber,
 };
 pub mod tss;
+
+#[cfg(feature = "sse")]
+pub use fpu::FpuState;
+#[cfg(not(feature = "sse"))]
+pub use nofpu::FpuState;
 
 //==================================================================================================
 // Standalone Functions
@@ -97,6 +107,16 @@ pub fn init(
         info!("- has tm:    {}", cpuid::has_tm());
         info!("- has ia64:  {}", cpuid::has_ia64());
         info!("- has pbe:   {}", cpuid::has_pbe());
+
+        #[cfg(feature = "sse")]
+        if cpuid::has_sse() || cpuid::has_sse2() && (cpuid::has_fxsr()) {
+            // SAFETY: The following conditions are met:
+            // - Calls to this function are synchronized.
+            // - This function runs on a processor that supports SSE or SSE2 features.
+            // - This function runs on a processor that supports FXSAVE and FXRSTOR instructions.
+            // - This function runs at processor privilege level 0.
+            unsafe { fpu::init() };
+        }
     }
 
     let (gdtr, tss): (GdtPtr, TssRef) = unsafe { Gdt::init(&kstack)? };

--- a/src/kernel/src/hal/arch/x86/cpu/nofpu.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/nofpu.rs
@@ -1,0 +1,39 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// This structure represents a dummy FPU state for systems without FPU support.
+///
+#[derive(Clone, Copy, Debug)]
+pub struct FpuState;
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl FpuState {
+    ///
+    /// # Description
+    ///
+    /// Constructs a dummy FPU state.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a new instance of a dummy FPU state.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as unsafe to match signature with the FPU-enabled version.
+    ///
+    /// When called on a system without FPU support, this function is safe
+    ///
+    pub unsafe fn new() -> Self {
+        Self
+    }
+}

--- a/src/kernel/src/hal/arch/x86/hooks.S
+++ b/src/kernel/src/hal/arch/x86/hooks.S
@@ -444,6 +444,7 @@ _do_hwint 15
  * Saves the execution context of the calling process.
  */
 __context_switch:
+
     movl 4(%esp), %eax  /* from */
     movl 8(%esp), %edx  /* to   */
     movl 12(%esp), %ecx /* tss  */
@@ -484,7 +485,6 @@ __context_switch:
     movl CONTEXT_ESP0(%edx), %eax
     movl %eax, TSS_ESP0(%ecx)
 
-    __context_switch.out:
     ret
 
 /*----------------------------------------------------------------------------*

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -11,7 +11,10 @@ use crate::{
     event::EventOwnership,
     hal::{
         self,
-        arch::ContextInformation,
+        arch::{
+            x86::cpu::FpuState,
+            ContextInformation,
+        },
         io::{
             AnyIoPort,
             IoMemoryRegion,
@@ -150,10 +153,11 @@ impl ProcessManagerInner {
     ) -> Self {
         let kernel: RunnableProcess = RunnableProcess::new(ProcessIdentifier::KERNEL, kernel, root);
 
-        let (kernel, reason, _, _user_tda): (
+        let (kernel, reason, _, _, _user_tda): (
             RunningProcess,
             Option<InterruptReason>,
             *mut ContextInformation,
+            *mut FpuState,
             Option<VirtualAddress>,
         ) = kernel.run();
         debug_assert!(reason.is_none(), "kernel process should not be interrupted");
@@ -648,6 +652,8 @@ impl ProcessManagerInner {
     /// - The thread identifier of the next thread to run.
     /// - A pointer to the context information of the previous thread.
     /// - A pointer to the context information of the next thread.
+    /// - A pointer to the FPU state of the previous thread.
+    /// - A pointer to the FPU state of the next thread.
     /// - An optional base address for the user-space thread data area of the next thread to run.
     ///
     fn schedule(
@@ -657,12 +663,14 @@ impl ProcessManagerInner {
         ThreadIdentifier,
         *mut ContextInformation,
         *mut ContextInformation,
+        *mut FpuState,
+        *mut FpuState,
         Option<VirtualAddress>,
     ) {
         // Reschedule running process.
         let previous_process: RunningProcess = self.take_running();
 
-        let (previous_process, previous_context) = previous_process.schedule();
+        let (previous_process, previous_context, previous_fpu_state) = previous_process.schedule();
         self.ready.push_back(previous_process);
 
         self.check_alarm();
@@ -676,10 +684,11 @@ impl ProcessManagerInner {
         // Select next process to run.
         let next_process: RunnableProcess = self.take_earliest_ready();
 
-        let (next_process, reason, next_context, user_tda): (
+        let (next_process, reason, next_context, next_fpu_state, user_tda): (
             RunningProcess,
             Option<InterruptReason>,
             *mut ContextInformation,
+            *mut FpuState,
             Option<VirtualAddress>,
         ) = next_process.run();
 
@@ -687,7 +696,15 @@ impl ProcessManagerInner {
         let next_tid: ThreadIdentifier = next_process.get_tid();
         self.interrupt_reason = reason;
         self.running = Some(next_process);
-        (next_pid, next_tid, previous_context, next_context, user_tda)
+        (
+            next_pid,
+            next_tid,
+            previous_context,
+            next_context,
+            previous_fpu_state,
+            next_fpu_state,
+            user_tda,
+        )
     }
 
     // Traverses the list of sleeping processes, checking for expired alarms and moving processes
@@ -733,6 +750,8 @@ impl ProcessManagerInner {
     /// - The thread identifier of the next thread to run.
     /// - A pointer to the context information of the previous thread.
     /// - A pointer to the context information of the next thread.
+    /// - A pointer to the FPU state of the previous thread.
+    /// - A pointer to the FPU state of the next thread.
     /// - An optional base address for the user-space thread data area of the next thread to run.
     ///
     fn sleep(
@@ -743,6 +762,8 @@ impl ProcessManagerInner {
         ThreadIdentifier,
         *mut ContextInformation,
         *mut ContextInformation,
+        *mut FpuState,
+        *mut FpuState,
         Option<VirtualAddress>,
     ) {
         let running_process: RunningProcess = self.take_running();
@@ -753,26 +774,28 @@ impl ProcessManagerInner {
         }
 
         // Suspend the execution of the calling thread.
-        let previous_context: *mut ContextInformation = match running_process.sleep(alarm) {
-            // The calling process still has runnable threads, put it in the list of ready processes.
-            Ok((runnable_process, previous_context)) => {
-                self.ready.push_back(runnable_process);
-                previous_context
-            },
-            // The calling process has only sleeping threads left, put it in the list of suspended processes.
-            Err((suspended_process, previous_context)) => {
-                self.suspended.push_back(suspended_process);
-                previous_context
-            },
-        };
+        let (previous_context, previous_fpu_state): (*mut ContextInformation, *mut FpuState) =
+            match running_process.sleep(alarm) {
+                // The calling process still has runnable threads, put it in the list of ready processes.
+                Ok((runnable_process, previous_context, previous_fpu_state)) => {
+                    self.ready.push_back(runnable_process);
+                    (previous_context, previous_fpu_state)
+                },
+                // The calling process has only sleeping threads left, put it in the list of suspended processes.
+                Err((suspended_process, previous_context, previous_fpu_state)) => {
+                    self.suspended.push_back(suspended_process);
+                    (previous_context, previous_fpu_state)
+                },
+            };
 
         // Schedule another thread to run.
         let next_process: RunnableProcess = self.take_earliest_ready();
 
-        let (next_process, reason, next_context, user_tda): (
+        let (next_process, reason, next_context, next_fpu_state, user_tda): (
             RunningProcess,
             Option<InterruptReason>,
             *mut ContextInformation,
+            *mut FpuState,
             Option<VirtualAddress>,
         ) = next_process.run();
 
@@ -780,7 +803,15 @@ impl ProcessManagerInner {
         let next_tid: ThreadIdentifier = next_process.get_tid();
         self.interrupt_reason = reason;
         self.running = Some(next_process);
-        (next_pid, next_tid, previous_context, next_context, user_tda)
+        (
+            next_pid,
+            next_tid,
+            previous_context,
+            next_context,
+            previous_fpu_state,
+            next_fpu_state,
+            user_tda,
+        )
     }
 
     ///
@@ -913,6 +944,8 @@ impl ProcessManagerInner {
         ThreadIdentifier,
         *mut ContextInformation,
         *mut ContextInformation,
+        *mut FpuState,
+        *mut FpuState,
         Option<VirtualAddress>,
     ) {
         let running_process: RunningProcess = self.take_running();
@@ -928,26 +961,28 @@ impl ProcessManagerInner {
         }
 
         // Terminate the calling thread.
-        let previous_context: *mut ContextInformation = match running_process.exit(status) {
-            // The calling process still has runnable threads, put it in the list of ready processes.
-            Ok((runnable_process, previous_context)) => {
-                self.ready.push_back(runnable_process);
-                previous_context
-            },
-            // The calling process has only sleeping threads left, put it in the list of zombies processes.
-            Err((zombie_process, previous_context)) => {
-                self.zombies.push_back(zombie_process);
-                previous_context
-            },
-        };
+        let (previous_context, previous_fpu_state): (*mut ContextInformation, *mut FpuState) =
+            match running_process.exit(status) {
+                // The calling process still has runnable threads, put it in the list of ready processes.
+                Ok((runnable_process, previous_context, previous_fpu_state)) => {
+                    self.ready.push_back(runnable_process);
+                    (previous_context, previous_fpu_state)
+                },
+                // The calling process has only sleeping threads left, put it in the list of zombies processes.
+                Err((zombie_process, previous_context, previous_fpu_state)) => {
+                    self.zombies.push_back(zombie_process);
+                    (previous_context, previous_fpu_state)
+                },
+            };
 
         // Schedule another thread to run.
         let next_process: RunnableProcess = self.take_earliest_ready();
 
-        let (next_process, reason, next_context, user_tda): (
+        let (next_process, reason, next_context, next_fpu_state, user_tda): (
             RunningProcess,
             Option<InterruptReason>,
             *mut ContextInformation,
+            *mut FpuState,
             Option<VirtualAddress>,
         ) = next_process.run();
 
@@ -955,7 +990,15 @@ impl ProcessManagerInner {
         let next_tid: ThreadIdentifier = next_process.get_tid();
         self.interrupt_reason = reason;
         self.running = Some(next_process);
-        (next_pid, next_tid, previous_context, next_context, user_tda)
+        (
+            next_pid,
+            next_tid,
+            previous_context,
+            next_context,
+            previous_fpu_state,
+            next_fpu_state,
+            user_tda,
+        )
     }
 
     ///
@@ -993,6 +1036,8 @@ impl ProcessManagerInner {
         Condvar,
         *mut ContextInformation,
         *mut ContextInformation,
+        *mut FpuState,
+        *mut FpuState,
         Option<VirtualAddress>,
     ) {
         let running_process: RunningProcess = self.take_running();
@@ -1010,32 +1055,36 @@ impl ProcessManagerInner {
         }
 
         // Terminate the calling thread and schedule another thread to run.
-        let (join_cond, previous_context): (Condvar, *mut ContextInformation) =
-            match running_process.exit_thread(status) {
-                // The calling process still has runnable threads, put it in the list of ready processes.
-                Ok((join_cond, runnable_process, previous_context)) => {
-                    self.ready.push_back(runnable_process);
-                    (join_cond, previous_context)
-                },
-                // The calling process has only sleeping threads left, put it in the list of suspended processes.
-                Err(Ok((join_cond, sleeping_process, previous_context))) => {
-                    self.suspended.push_back(sleeping_process);
-                    (join_cond, previous_context)
-                },
-                // The calling process has only zombie threads left, put it in the list of zombies processes.
-                Err(Err((join_cond, zombie_process, previous_context))) => {
-                    self.zombies.push_back(zombie_process);
-                    (join_cond, previous_context)
-                },
-            };
+        let (join_cond, previous_context, previous_fpu_state): (
+            Condvar,
+            *mut ContextInformation,
+            *mut FpuState,
+        ) = match running_process.exit_thread(status) {
+            // The calling process still has runnable threads, put it in the list of ready processes.
+            Ok((join_cond, runnable_process, previous_context, previous_fpu_state)) => {
+                self.ready.push_back(runnable_process);
+                (join_cond, previous_context, previous_fpu_state)
+            },
+            // The calling process has only sleeping threads left, put it in the list of suspended processes.
+            Err(Ok((join_cond, sleeping_process, previous_context, previous_fpu_state))) => {
+                self.suspended.push_back(sleeping_process);
+                (join_cond, previous_context, previous_fpu_state)
+            },
+            // The calling process has only zombie threads left, put it in the list of zombies processes.
+            Err(Err((join_cond, zombie_process, previous_context, previous_fpu_state))) => {
+                self.zombies.push_back(zombie_process);
+                (join_cond, previous_context, previous_fpu_state)
+            },
+        };
 
         // Schedule another thread to run.
         let next_process: RunnableProcess = self.take_earliest_ready();
 
-        let (next_process, reason, next_context, user_tda): (
+        let (next_process, reason, next_context, next_fpu_state, user_tda): (
             RunningProcess,
             Option<InterruptReason>,
             *mut ContextInformation,
+            *mut FpuState,
             Option<VirtualAddress>,
         ) = next_process.run();
 
@@ -1043,7 +1092,16 @@ impl ProcessManagerInner {
         let next_tid: ThreadIdentifier = next_process.get_tid();
         self.interrupt_reason = reason;
         self.running = Some(next_process);
-        (next_pid, next_tid, join_cond, previous_context, next_context, user_tda)
+        (
+            next_pid,
+            next_tid,
+            join_cond,
+            previous_context,
+            next_context,
+            previous_fpu_state,
+            next_fpu_state,
+            user_tda,
+        )
     }
 
     pub fn terminate(&mut self, pid: ProcessIdentifier) -> Result<(), Error> {

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -7,7 +7,10 @@
 
 use crate::{
     hal::{
-        arch::ContextInformation,
+        arch::{
+            x86::cpu::FpuState,
+            ContextInformation,
+        },
         mem::{
             Address,
             PageAligned,
@@ -219,18 +222,20 @@ impl ProcessManager {
         trace!("exit(): status={status:?}");
 
         // Terminate the calling process and select another process to run next.
-        let (next_pid, next_tid, from, to, user_tda): (
+        let (next_pid, next_tid, from, to, from_fpu, to_fpu, user_tda): (
             ProcessIdentifier,
             ThreadIdentifier,
             *mut ContextInformation,
             *mut ContextInformation,
+            *mut FpuState,
+            *mut FpuState,
             Option<VirtualAddress>,
         ) = Self::get_mut().try_borrow_mut()?.exit(status);
 
         // SAFETY: `from` and `to` point to valid context information structures, and the processor
         // is running with interrupts disabled.
         PERF_SCHED_EXIT_CONTEXT_SWITCHES.fetch_add(1, ORDER);
-        Self::switch(next_pid, next_tid, from, to, user_tda);
+        Self::switch(next_pid, next_tid, from, to, from_fpu, to_fpu, user_tda);
 
         // SAFETY: Self::switch() performs a context switch and never returns. If this line is ever
         // reached, it indicates a critical bug and undefined behavior. This is considered
@@ -268,35 +273,39 @@ impl ProcessManager {
     ///
     pub unsafe fn exit_thread(status: ExitStatus) -> Result<!, Error> {
         // Terminate the calling thread and select another thread to run next.
-        let (next_pid, next_tid, from, to, user_tda): (
+        let (next_pid, next_tid, from, to, from_fpu, to_fpu, user_tda): (
             ProcessIdentifier,
             ThreadIdentifier,
             *mut ContextInformation,
             *mut ContextInformation,
+            *mut FpuState,
+            *mut FpuState,
             Option<VirtualAddress>,
         ) = {
             // Create a scope so the join condition variable is dropped before we context switch.
             // If we do not do this, the condition variable the reference count for the condition
             // variable will not be decremented, causing a memory leak.
 
-            let (next_pid, next_tid, join_cond, from, to, user_tda): (
+            let (next_pid, next_tid, join_cond, from, to, from_fpu, to_fpu, user_tda): (
                 ProcessIdentifier,
                 ThreadIdentifier,
                 Condvar,
                 *mut ContextInformation,
                 *mut ContextInformation,
+                *mut FpuState,
+                *mut FpuState,
                 Option<VirtualAddress>,
             ) = Self::get_mut().try_borrow_mut()?.exit_thread(status);
 
             join_cond.notify_all()?;
 
-            (next_pid, next_tid, from, to, user_tda)
+            (next_pid, next_tid, from, to, from_fpu, to_fpu, user_tda)
         };
 
         // SAFETY: `from` and `to` point to valid context information structures, and the processor
         // is running with interrupts disabled.
         PERF_SCHED_EXIT_THREAD_CONTEXT_SWITCHES.fetch_add(1, ORDER);
-        Self::switch(next_pid, next_tid, from, to, user_tda);
+        Self::switch(next_pid, next_tid, from, to, from_fpu, to_fpu, user_tda);
 
         // SAFETY: Self::switch() performs a context switch and never returns. If this line is ever
         // reached, it indicates a critical bug and undefined behavior. This is considered
@@ -434,11 +443,13 @@ impl ProcessManager {
     ///
     pub unsafe fn sleep(alarm: Option<SystemTime>) -> Result<(), SleepError> {
         // Suspend the execution of the calling thread and select another thread to run next.
-        let (next_pid, next_tid, from, to, user_tda): (
+        let (next_pid, next_tid, from, to, from_fpu, to_fpu, user_tda): (
             ProcessIdentifier,
             ThreadIdentifier,
             *mut ContextInformation,
             *mut ContextInformation,
+            *mut FpuState,
+            *mut FpuState,
             Option<VirtualAddress>,
         ) = Self::get_mut()
             .try_borrow_mut()
@@ -448,7 +459,7 @@ impl ProcessManager {
         // SAFETY: `from` and `to` point to valid context information structures, and the processor
         // is running with interrupts disabled.
         PERF_SCHED_SLEEP_CONTEXT_SWITCHES.fetch_add(1, ORDER);
-        Self::switch(next_pid, next_tid, from, to, user_tda);
+        Self::switch(next_pid, next_tid, from, to, from_fpu, to_fpu, user_tda);
 
         // Check the reason why the thread was woken up.
         let interrupt_reason: Option<InterruptReason> = Self::get_mut()
@@ -500,11 +511,13 @@ impl ProcessManager {
             cold_path();
 
             // Re-schedule the calling thread and select another thread to run next.
-            let (next_pid, next_tid, from, to, user_tda): (
+            let (next_pid, next_tid, from, to, from_fpu, to_fpu, user_tda): (
                 ProcessIdentifier,
                 ThreadIdentifier,
                 *mut ContextInformation,
                 *mut ContextInformation,
+                *mut FpuState,
+                *mut FpuState,
                 Option<VirtualAddress>,
             ) = Self::get_mut().try_borrow_mut()?.schedule();
 
@@ -512,7 +525,7 @@ impl ProcessManager {
             // SAFETY: `from` and `to` point to valid context information structures, and the
             // processor is running with interrupts disabled.
             PERF_SCHED_GIVEUP_CONTEXT_SWITCHES.fetch_add(1, ORDER);
-            Self::switch(next_pid, next_tid, from, to, user_tda);
+            Self::switch(next_pid, next_tid, from, to, from_fpu, to_fpu, user_tda);
         }
 
         Ok(())
@@ -735,6 +748,8 @@ impl ProcessManager {
     /// - `next_tid`: Thread identifier of the next thread to run.
     /// - `from`: Pointer to the context information of the current thread.
     /// - `to`: Pointer to the context information of the next thread.
+    /// - `from_fpu`: Pointer to the FPU state of the current thread.
+    /// - `to_fpu`: Pointer to the FPU state of the next thread.
     /// - `user_tda`: Optional base address for the user-space the thread data area of the next thread to run.
     ///
     /// # Safety
@@ -743,6 +758,7 @@ impl ProcessManager {
     ///
     /// It is safe to call this function if and only if the following conditions are met:
     /// - `from` and `to` point to valid execution contexts.
+    /// - `from_fpu` and `to_fpu` point to valid FPU state structures.
     /// - The processor is running with interrupts disabled.
     /// - The processor is running in privileged mode.
     ///
@@ -757,6 +773,8 @@ impl ProcessManager {
         next_tid: ThreadIdentifier,
         from: *mut ContextInformation,
         to: *mut ContextInformation,
+        from_fpu: *mut FpuState,
+        to_fpu: *mut FpuState,
         user_tda: Option<VirtualAddress>,
     ) {
         let previous_pid: ProcessIdentifier = ProcessIdentifier::from(CURRENT_PID.load(ORDER));
@@ -774,7 +792,7 @@ impl ProcessManager {
             }
             CURRENT_TID.store(next_tid.into(), ORDER);
 
-            ContextInformation::switch(from, to, user_tda);
+            ContextInformation::switch(from, to, from_fpu, to_fpu, user_tda);
         } else {
             // We do not need to perform a context switch, the same thread will continue running.
             PERF_SCHED_SOFT_CONTEXT_SWITCHES.fetch_add(1, ORDER);

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -6,7 +6,10 @@
 //==================================================================================================
 
 use crate::{
-    hal::arch::ContextInformation,
+    hal::arch::{
+        x86::cpu::FpuState,
+        ContextInformation,
+    },
     mm::Vmem,
     pm::{
         clock,
@@ -106,8 +109,13 @@ impl RunnableProcess {
     ///
     pub fn run(
         mut self,
-    ) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation, Option<VirtualAddress>)
-    {
+    ) -> (
+        RunningProcess,
+        Option<InterruptReason>,
+        *mut ContextInformation,
+        *mut FpuState,
+        Option<VirtualAddress>,
+    ) {
         let mut ready_threads: VecDeque<ReadyThread> = self.ready_threads.into();
 
         // Select thread with the earliest admission time.
@@ -126,10 +134,11 @@ impl RunnableProcess {
             },
         };
 
-        let (running_thread, interrupt_reason, next_context, user_tda): (
+        let (running_thread, interrupt_reason, next_context, fpu_state, user_tda): (
             RunningThread,
             Option<InterruptReason>,
             *mut ContextInformation,
+            *mut FpuState,
             Option<VirtualAddress>,
         ) = next_thread.run();
         (
@@ -143,6 +152,7 @@ impl RunnableProcess {
             ),
             interrupt_reason,
             next_context,
+            fpu_state,
             user_tda,
         )
     }

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -6,7 +6,10 @@
 //==================================================================================================
 
 use crate::{
-    hal::arch::ContextInformation,
+    hal::arch::{
+        x86::cpu::FpuState,
+        ContextInformation,
+    },
     pm::{
         process::state::{
             interrupted::interrupt,
@@ -107,9 +110,9 @@ impl RunningProcess {
         &mut self.running
     }
 
-    pub fn schedule(mut self) -> (RunnableProcess, *mut ContextInformation) {
+    pub fn schedule(mut self) -> (RunnableProcess, *mut ContextInformation, *mut FpuState) {
         let running_thread = self.running;
-        let (ready_thread, ctx) = running_thread.schedule();
+        let (ready_thread, ctx, fpu_state) = running_thread.schedule();
 
         let ready_threads = match self.ready.take() {
             Some(mut ready_threads) => {
@@ -128,6 +131,7 @@ impl RunningProcess {
                 self.zombie.take(),
             ),
             ctx,
+            fpu_state,
         )
     }
 
@@ -135,10 +139,10 @@ impl RunningProcess {
         mut self,
         alarm: Option<SystemTime>,
     ) -> Result<
-        (RunnableProcess, *mut ContextInformation),
-        (SleepingProcess, *mut ContextInformation),
+        (RunnableProcess, *mut ContextInformation, *mut FpuState),
+        (SleepingProcess, *mut ContextInformation, *mut FpuState),
     > {
-        let (sleeping_thread, ctx) = self.running.sleep(alarm);
+        let (sleeping_thread, ctx, fpu_state) = self.running.sleep(alarm);
 
         // Push sleeping thread.
         let sleeping_threads = match self.sleeping_threads.take() {
@@ -160,6 +164,7 @@ impl RunningProcess {
                     self.zombie.take(),
                 ),
                 ctx,
+                fpu_state,
             ));
         }
 
@@ -172,18 +177,24 @@ impl RunningProcess {
                 self.zombie.take(),
             );
 
-            return Ok((interrupted_process.resume(), ctx));
+            return Ok((interrupted_process.resume(), ctx, fpu_state));
         }
 
-        Err((SleepingProcess::new(self.state, sleeping_threads, self.zombie.take()), ctx))
+        Err((
+            SleepingProcess::new(self.state, sleeping_threads, self.zombie.take()),
+            ctx,
+            fpu_state,
+        ))
     }
 
     pub fn exit(
         mut self,
         status: ExitStatus,
-    ) -> Result<(RunnableProcess, *mut ContextInformation), (ZombieProcess, *mut ContextInformation)>
-    {
-        let (zombie_thread, ctx) = self.running.exit(status);
+    ) -> Result<
+        (RunnableProcess, *mut ContextInformation, *mut FpuState),
+        (ZombieProcess, *mut ContextInformation, *mut FpuState),
+    > {
+        let (zombie_thread, ctx, fpu_state) = self.running.exit(status);
         let mut zombie_threads: NonEmptyVecDeque<ZombieThread> = match self.zombie.take() {
             Some(mut zombie_threads) => {
                 zombie_threads.push_back(zombie_thread);
@@ -219,9 +230,9 @@ impl RunningProcess {
                 Some(zombie_threads),
             );
 
-            Ok((interrupted_process.resume(), ctx))
+            Ok((interrupted_process.resume(), ctx, fpu_state))
         } else {
-            Err((ZombieProcess::new(self.state, zombie_threads, status), ctx))
+            Err((ZombieProcess::new(self.state, zombie_threads, status), ctx, fpu_state))
         }
     }
 
@@ -247,15 +258,15 @@ impl RunningProcess {
         mut self,
         status: ExitStatus,
     ) -> Result<
-        (Condvar, RunnableProcess, *mut ContextInformation),
+        (Condvar, RunnableProcess, *mut ContextInformation, *mut FpuState),
         Result<
-            (Condvar, SleepingProcess, *mut ContextInformation),
-            (Condvar, ZombieProcess, *mut ContextInformation),
+            (Condvar, SleepingProcess, *mut ContextInformation, *mut FpuState),
+            (Condvar, ZombieProcess, *mut ContextInformation, *mut FpuState),
         >,
     > {
         let join_cond: Condvar = self.running.join_cond();
 
-        let (zombie_thread, ctx) = self.running.exit(status);
+        let (zombie_thread, ctx, fpu_state) = self.running.exit(status);
         let zombie_threads: NonEmptyVecDeque<ZombieThread> = match self.zombie.take() {
             Some(mut zombie_threads) => {
                 zombie_threads.push_back(zombie_thread);
@@ -275,6 +286,7 @@ impl RunningProcess {
                     Some(zombie_threads),
                 ),
                 ctx,
+                fpu_state,
             ))
         } else if let Some(interrupted_threads) = self.interrupted_threads.take() {
             let interrupted_process: InterruptedProcess = InterruptedProcess::from_sleeping(
@@ -284,15 +296,21 @@ impl RunningProcess {
                 self.zombie.take(),
             );
 
-            Ok((join_cond, interrupted_process.resume(), ctx))
+            Ok((join_cond, interrupted_process.resume(), ctx, fpu_state))
         } else if let Some(sleeping_threads) = self.sleeping_threads.take() {
             Err(Ok((
                 join_cond,
                 SleepingProcess::new(self.state, sleeping_threads, Some(zombie_threads)),
                 ctx,
+                fpu_state,
             )))
         } else {
-            Err(Err((join_cond, ZombieProcess::new(self.state, zombie_threads, status), ctx)))
+            Err(Err((
+                join_cond,
+                ZombieProcess::new(self.state, zombie_threads, status),
+                ctx,
+                fpu_state,
+            )))
         }
     }
 

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -6,7 +6,10 @@
 //==================================================================================================
 
 use crate::{
-    hal::arch::ContextInformation,
+    hal::arch::{
+        x86::cpu::FpuState,
+        ContextInformation,
+    },
     mm::{
         kstack::KernelStack,
         ustack::UserStack,
@@ -66,8 +69,17 @@ impl ThreadManager {
     /// This function returns a tuple containing the kernel thread and a new instance of a [`ThreadManager`].
     ///
     fn new() -> (ReadyThread, Self) {
-        let kernel: ReadyThread =
-            ReadyThread::new(From::<i32>::from(0), None, None, None, ContextInformation::default());
+        let kernel: ReadyThread = {
+            ReadyThread::new(
+                From::<i32>::from(0),
+                None,
+                None,
+                None,
+                ContextInformation::default(),
+                // SAFETY: calls to FpuState::new are synchronized.
+                unsafe { FpuState::new() },
+            )
+        };
         (
             kernel,
             Self {
@@ -102,7 +114,15 @@ impl ThreadManager {
         let id: ThreadIdentifier = self.next_id;
         self.next_id = ThreadIdentifier::from(<i32>::from(self.next_id) + 1);
 
-        ReadyThread::new(id, kernel_stack, user_stack, user_tda, context)
+        ReadyThread::new(
+            id,
+            kernel_stack,
+            user_stack,
+            user_tda,
+            context,
+            // SAFETY: calls to FpuState::new are synchronized.
+            unsafe { FpuState::new() },
+        )
     }
 }
 

--- a/src/kernel/src/pm/thread/ready.rs
+++ b/src/kernel/src/pm/thread/ready.rs
@@ -6,7 +6,10 @@
 //==================================================================================================
 
 use crate::{
-    hal::arch::ContextInformation,
+    hal::arch::{
+        x86::cpu::FpuState,
+        ContextInformation,
+    },
     mm::{
         kstack::KernelStack,
         ustack::UserStack,
@@ -76,9 +79,17 @@ impl ReadyThread {
         user_stack: Option<UserStack>,
         user_tda: Option<VirtualAddress>,
         context: ContextInformation,
+        fpu_state: FpuState,
     ) -> Self {
         Self {
-            state: Box::new(ThreadState::new(id, kernel_stack, user_stack, user_tda, context)),
+            state: Box::new(ThreadState::new(
+                id,
+                kernel_stack,
+                user_stack,
+                user_tda,
+                context,
+                fpu_state,
+            )),
             admission_time: clock::now(),
         }
     }
@@ -131,12 +142,18 @@ impl ReadyThread {
     ///
     pub fn run(
         mut self,
-    ) -> (RunningThread, Option<InterruptReason>, *mut ContextInformation, Option<VirtualAddress>)
-    {
+    ) -> (
+        RunningThread,
+        Option<InterruptReason>,
+        *mut ContextInformation,
+        *mut FpuState,
+        Option<VirtualAddress>,
+    ) {
         let ctx: *mut ContextInformation = self.state.context_mut();
+        let fpu_state: *mut FpuState = self.state.fpu_state_mut();
         let interrupt_reason: Option<InterruptReason> = self.state.take_interrupt_reason();
         let user_tda: Option<VirtualAddress> = self.state.get_thread_data_area();
-        (RunningThread::from_state(self.state), interrupt_reason, ctx, user_tda)
+        (RunningThread::from_state(self.state), interrupt_reason, ctx, fpu_state, user_tda)
     }
 
     ///

--- a/src/kernel/src/pm/thread/running.rs
+++ b/src/kernel/src/pm/thread/running.rs
@@ -6,7 +6,10 @@
 //==================================================================================================
 
 use crate::{
-    hal::arch::ContextInformation,
+    hal::arch::{
+        x86::cpu::FpuState,
+        ContextInformation,
+    },
     pm::{
         sync::{
             condvar::Condvar,
@@ -81,9 +84,13 @@ impl RunningThread {
     ///
     /// This function returns a tuple containing the sleeping thread and a mutable pointer to the execution context.
     ///
-    pub fn sleep(mut self, alarm: Option<SystemTime>) -> (SleepingThread, *mut ContextInformation) {
+    pub fn sleep(
+        mut self,
+        alarm: Option<SystemTime>,
+    ) -> (SleepingThread, *mut ContextInformation, *mut FpuState) {
         let ctx: *mut ContextInformation = self.state.context_mut();
-        (SleepingThread::from_state(self.state, alarm), ctx)
+        let fpu_state: *mut FpuState = self.state.fpu_state_mut();
+        (SleepingThread::from_state(self.state, alarm), ctx, fpu_state)
     }
 
     ///
@@ -95,9 +102,10 @@ impl RunningThread {
     ///
     /// This function returns a tuple containing the ready thread and a mutable pointer to the execution context.
     ///
-    pub fn schedule(mut self) -> (ReadyThread, *mut ContextInformation) {
+    pub fn schedule(mut self) -> (ReadyThread, *mut ContextInformation, *mut FpuState) {
         let ctx: *mut ContextInformation = self.state.context_mut();
-        (ReadyThread::from_state(self.state), ctx)
+        let fpu_state: *mut FpuState = self.state.fpu_state_mut();
+        (ReadyThread::from_state(self.state), ctx, fpu_state)
     }
 
     ///
@@ -140,9 +148,13 @@ impl RunningThread {
     ///
     /// This function returns a tuple containing the zombie thread and a mutable pointer to the execution context.
     ///
-    pub fn exit(mut self, status: ExitStatus) -> (ZombieThread, *mut ContextInformation) {
+    pub fn exit(
+        mut self,
+        status: ExitStatus,
+    ) -> (ZombieThread, *mut ContextInformation, *mut FpuState) {
         let ctx: *mut ContextInformation = self.state.context_mut();
-        (ZombieThread::from_state(self.state, status), ctx)
+        let fpu_state: *mut FpuState = self.state.fpu_state_mut();
+        (ZombieThread::from_state(self.state, status), ctx, fpu_state)
     }
 
     ///

--- a/src/kernel/src/pm/thread/state.rs
+++ b/src/kernel/src/pm/thread/state.rs
@@ -6,7 +6,10 @@
 //==================================================================================================
 
 use crate::{
-    hal::arch::ContextInformation,
+    hal::arch::{
+        x86::cpu::FpuState,
+        ContextInformation,
+    },
     mm::{
         kstack::KernelStack,
         ustack::UserStack,
@@ -59,6 +62,8 @@ pub struct ThreadState {
     locked_mutexes: BTreeMap<MutexAddress, MutexGuard>,
     /// Interrupt reason, if any.
     interrupt_reason: Option<InterruptReason>,
+    /// FPU state.
+    fpu_state: Pin<Box<FpuState>>,
 }
 
 //==================================================================================================
@@ -89,6 +94,7 @@ impl ThreadState {
         user_stack: Option<UserStack>,
         user_tda: Option<VirtualAddress>,
         context: ContextInformation,
+        fpu_state: FpuState,
     ) -> Self {
         Self {
             id,
@@ -99,6 +105,7 @@ impl ThreadState {
             join_cond: Condvar::new(),
             locked_mutexes: BTreeMap::new(),
             interrupt_reason: None,
+            fpu_state: Box::pin(fpu_state),
         }
     }
 
@@ -113,6 +120,19 @@ impl ThreadState {
     ///
     pub(super) fn context_mut(&mut self) -> *mut ContextInformation {
         self.context.as_mut().get_mut() as *mut ContextInformation
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a mutable pointer to the FPU state of the thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a mutable pointer to the FPU state of the thread.
+    ///
+    pub(super) fn fpu_state_mut(&mut self) -> *mut FpuState {
+        self.fpu_state.as_mut().get_mut() as *mut FpuState
     }
 
     ///

--- a/src/microvm/Cargo.toml
+++ b/src/microvm/Cargo.toml
@@ -18,7 +18,7 @@ name = "microvm"
 path = "src/main.rs"
 
 [dependencies]
-arch = { workspace = true }
+arch = { workspace = true, features = ["cpuid"] }
 anyhow = { workspace = true }
 flexi_logger = { workspace = true }
 hyperlight-host = { workspace = true, optional = true }
@@ -41,3 +41,6 @@ hyperlight = ["dep:hyperlight-host", "config/hyperlight"]
 profiler = ["profiler/auto-calibrate"]
 auto-calibrate = []
 timestamp-messages = ["profiler/timestamp-messages"]
+
+# Enables SSE/SSE2 support.
+sse = []

--- a/src/microvm/src/vmm/microvm/kvm/partition.rs
+++ b/src/microvm/src/vmm/microvm/kvm/partition.rs
@@ -22,7 +22,7 @@ use ::kvm_ioctls::{
 ///
 pub struct VirtualPartition {
     // Handle to the KVM.
-    _kvm: Kvm,
+    kvm: Kvm,
     // Handle to the virtual machine.
     vm: VmFd,
 }
@@ -67,7 +67,7 @@ impl VirtualPartition {
             anyhow::bail!(reason);
         }
 
-        Ok(Self { _kvm: kvm, vm })
+        Ok(Self { kvm, vm })
     }
 
     ///
@@ -77,5 +77,14 @@ impl VirtualPartition {
     ///
     pub fn vm(&self) -> &VmFd {
         &self.vm
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets a handle to the KVM.
+    ///
+    pub fn kvm(&self) -> &Kvm {
+        &self.kvm
     }
 }

--- a/src/microvm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/microvm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -13,7 +13,24 @@ mod timer;
 // Exports
 //==================================================================================================
 
-use ::kvm_bindings::kvm_fpu;
+use ::arch::cpu::{
+    cpuid::{
+        CPUID_FEATURES,
+        EdxFeature,
+    },
+    mxcrs::{
+        DenormalOperationMask,
+        DivideByZeroMask,
+        OverflowMask,
+        PrecisionMask,
+        UnderflowMask,
+    },
+};
+use ::kvm_bindings::{
+    CpuId,
+    KVM_MAX_CPUID_ENTRIES,
+    kvm_fpu,
+};
 pub use exit::*;
 
 //==================================================================================================
@@ -45,8 +62,6 @@ use timer::Timer;
 const FP_CONTROL_WORD_DEFAULT: u16 = 0x37f;
 // Each 8 of x87 fpu registers is empty
 const FP_TAG_WORD_DEFAULT: u8 = 0xff;
-// Mask simd fp-exceptions, clear exception flags, set rounding to nearest, disable flush-to-zero mode, disable denormals-are-zero mode
-const MXCSR_DEFAULT: u32 = 0x1f80;
 
 //==================================================================================================
 // Structures
@@ -82,17 +97,27 @@ impl VirtualProcessor {
         // Create programmable interrupt timer.
         let timer: Timer = Timer::new(&partition)?;
 
-        let fd: VcpuFd = partition
+        let mut fd: VcpuFd = partition
             .lock()
             .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
             .vm()
             .create_vcpu(id)?;
 
+        #[cfg(feature = "sse")]
+        Self::setup_sse(partition.clone(), &mut fd, true)?;
+        #[cfg(not(feature = "sse"))]
+        Self::setup_sse(partition.clone(), &mut fd, false)?;
+
         // Reset FPU state.
-        let fpu = kvm_fpu {
+        let fpu: kvm_fpu = kvm_fpu {
             fcw: FP_CONTROL_WORD_DEFAULT,
             ftwx: FP_TAG_WORD_DEFAULT,
-            mxcsr: MXCSR_DEFAULT,
+            // Mask all SIMD exceptions.
+            mxcsr: (PrecisionMask::Masked as u32)
+                | (UnderflowMask::Masked as u32)
+                | (OverflowMask::Masked as u32)
+                | (DivideByZeroMask::Masked as u32)
+                | (DenormalOperationMask::Masked as u32),
             ..Default::default() // zero out the rest
         };
         fd.set_fpu(&fpu)?;
@@ -286,5 +311,58 @@ impl VirtualProcessor {
                 Ok(VirtualProcessorExitContext::Unknown)
             },
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Enables or disables SSE support on a virtual processor.
+    ///
+    /// # Parameters
+    ///
+    /// - `partition`: Handle to the virtual partition.
+    /// - `fd`: Handle to the virtual processor.
+    /// - `enable`: If true, enables SSE support. If false, disables SSE support.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this function returns empty. Otherwise, it returns an error.
+    ///
+    fn setup_sse(
+        partition: Arc<Mutex<VirtualPartition>>,
+        fd: &mut VcpuFd,
+        enable: bool,
+    ) -> Result<()> {
+        let mut kvm_cpuid: CpuId = partition
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .kvm()
+            .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)?;
+
+        for entry in kvm_cpuid.as_mut_slice().iter_mut() {
+            match entry.function {
+                CPUID_FEATURES => {
+                    if enable {
+                        entry.edx |= (EdxFeature::Fxsr as u32)
+                            | (EdxFeature::Sse as u32)
+                            | (EdxFeature::Sse2 as u32)
+                    } else {
+                        entry.edx &= !((EdxFeature::Fxsr as u32)
+                            | (EdxFeature::Sse as u32)
+                            | (EdxFeature::Sse2 as u32))
+                    }
+                },
+                _ => continue,
+            }
+        }
+
+        // Set CPUID and check for errors.
+        if let Err(error) = fd.set_cpuid2(&kvm_cpuid) {
+            let reason: String = format!("failed to set cpuid (error={error:?})");
+            error!("setup_sse(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This pull request introduces optional SSE/SSE2 (Streaming SIMD Extensions) support for the x86 kernel, allowing the build and runtime to enable or disable SSE features as needed. The main changes include build system updates to support an `SSE` feature flag, new code for managing FPU (Floating Point Unit) state when SSE is enabled, and refactoring of context switching and process management to handle FPU state consistently. These changes enable safer and more flexible handling of SIMD instructions and FPU state across context switches.

**Build system and feature flag support:**
- Added an `SSE` option to the `Makefile`, allowing SSE/SSE2 support to be enabled or disabled at build time, and updated help documentation accordingly. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R16-R18) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R184) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R195) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R369) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R379)
- Registered the `sse` feature in the kernel's `Cargo.toml` for conditional compilation.

**FPU state management and SSE support:**
- Added a new `FpuState` struct and implementation in `fpu.rs` for systems with SSE, including initialization routines and state save/restore logic using `fxsave`/`fxrstor` instructions.
- Provided a fallback `FpuState` implementation in `nofpu.rs` for systems without SSE.
- Updated module imports and exports to use the correct `FpuState` depending on the SSE feature flag. [[1]](diffhunk://#diff-28ceb635aedd52ae74955df68508c797e019ef3d9358a9037d8b5b58102d9b40R16-R20) [[2]](diffhunk://#diff-28ceb635aedd52ae74955df68508c797e019ef3d9358a9037d8b5b58102d9b40R59-R63)

**Context switching and process management:**
- Modified context switching logic in `context.rs` to save and restore FPU state when SSE is enabled, and updated function signatures and safety documentation accordingly. [[1]](diffhunk://#diff-6a57a687f10e1abb1c56f9033619f94d29c098fd7e5d93fb767cf9037ae2a591L9-R12) [[2]](diffhunk://#diff-6a57a687f10e1abb1c56f9033619f94d29c098fd7e5d93fb767cf9037ae2a591R80-R81) [[3]](diffhunk://#diff-6a57a687f10e1abb1c56f9033619f94d29c098fd7e5d93fb767cf9037ae2a591R90) [[4]](diffhunk://#diff-6a57a687f10e1abb1c56f9033619f94d29c098fd7e5d93fb767cf9037ae2a591R102-R103) [[5]](diffhunk://#diff-6a57a687f10e1abb1c56f9033619f94d29c098fd7e5d93fb767cf9037ae2a591R123-R132)
- Refactored process manager code to track and pass FPU state pointers during scheduling and sleeping of threads, ensuring correct FPU state handling across context switches. [[1]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L14-R17) [[2]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L153-R160) [[3]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873R655-R656) [[4]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873R666-R673) [[5]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L679-R707) [[6]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873R753-R754) [[7]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873R765-R766)

**CPU initialization:**
- Updated CPU initialization to detect SSE/SSE2 and FXSR support, and to initialize the FPU state if supported and enabled.

These changes collectively provide robust and configurable SSE/FPU support, improving both performance and portability for x86 targets.