### PR TITLE
[libs] Encapsulate Logic To Create Build-Time Constants From TOML + Add Linuxd Config TOML

### DIFF
--- a/build/linuxd_config.toml
+++ b/build/linuxd_config.toml
@@ -1,0 +1,5 @@
+# IP address of linuxd when running inside an L2 VM.
+guest_tap_ip_address = "192.168.249.2"
+
+# IP of the TAP device host processes can use to communicate with linuxd inside the L2 VM.
+host_tap_ip_address = "192.168.249.3"

--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -71,3 +71,33 @@ get_cargo_toml_version() {
 
     echo "$cargo_toml_version"
 }
+
+#
+# Description
+#
+#   Reads a value from a simple, single-level TOML file with key = value pairs.
+#
+# Arguments
+#
+#   $1 - The path to the TOML file.
+#   $2 - The key to get the value for.
+#
+# Return Value
+#
+#   - On success, a string containing the value for the given key.
+#   - On failure, exits with a non-zero status.
+#
+# Usage Example
+#
+#   kstack_size=$(get_value_from_toml "./build/kernel_config.toml" "kstack_size")
+#
+get_value_from_toml() {
+    local toml_path=$1
+    local toml_key=$2
+    local val
+    val="$(
+    sed -nE "s/^[[:space:]]*${toml_key}[[:space:]]*=[[:space:]]*(\"([^\"]*)\"|\'([^\']*)\'|([^[:space:]]+)).*/\2\3\4/p" "$toml_path" \
+    | head -n1
+    )"
+    [[ -n "$val" ]] && printf '%s' "$val" || exit 1
+}

--- a/scripts/generate-l2-initramfs.sh
+++ b/scripts/generate-l2-initramfs.sh
@@ -20,6 +20,12 @@ INITRAMFS_DIR="${IMAGES_DIR}/l2-sysvm-rootfs"
 LINUXD_ELF="${NANVIX_HOME}/bin/linuxd.elf"
 
 #===================================================================================================
+# Utilities
+#===================================================================================================
+
+source "${NANVIX_HOME}/scripts/common/utils.sh"
+
+#===================================================================================================
 # Command line arguments
 #===================================================================================================
 
@@ -43,10 +49,11 @@ fi
 # Socket address parsing
 #===================================================================================================
 
-# FIXME (#839): these values are currently hard-coded here and in src/utils/nanvixd/src/config.rs
-CONTROL_PLANE_SOCKADDR="192.168.249.3:9000"
-USER_VM_SOCKADDR="192.168.249.2:9001"
-GATEWAY_SOCKADDR="192.168.249.2:9002"
+GUEST_TAP_IP_ADDRESS=$(get_value_from_toml "${NANVIX_HOME}/build/linuxd_config.toml" "guest_tap_ip_address")
+HOST_TAP_IP_ADDRESS=$(get_value_from_toml "${NANVIX_HOME}/build/linuxd_config.toml" "host_tap_ip_address")
+CONTROL_PLANE_SOCKADDR="${HOST_TAP_IP_ADDRESS}:9000"
+USER_VM_SOCKADDR="${GUEST_TAP_IP_ADDRESS}:9001"
+GATEWAY_SOCKADDR="${GUEST_TAP_IP_ADDRESS}:9002"
 
 #===================================================================================================
 # Build initramfs

--- a/scripts/generate-l2-snapshot.sh
+++ b/scripts/generate-l2-snapshot.sh
@@ -34,6 +34,12 @@ CLOUD_HYPERVISOR_PATH="${BIN_DIR}/cloud-hypervisor"
 CLOUD_HYPERVISOR_REMOTE_PATH="${BIN_DIR}/ch-remote"
 
 #===================================================================================================
+# Utilities
+#===================================================================================================
+
+source "${NANVIX_HOME}/scripts/common/utils.sh"
+
+#===================================================================================================
 # Networking
 #===================================================================================================
 
@@ -41,8 +47,8 @@ CLOUD_HYPERVISOR_REMOTE_PATH="${BIN_DIR}/ch-remote"
 GUEST_MAC_ADDRESS="12:34:56:78:90:ab"
 GUEST_BROADCAST_ADDRESS="192.168.249.1"
 MASK="255.255.255.0"
-GUEST_TAP_IP_ADDRESS="192.168.249.2"
-HOST_TAP_IP_ADDRESS="192.168.249.3"
+GUEST_TAP_IP_ADDRESS=$(get_value_from_toml "${NANVIX_HOME}/build/linuxd_config.toml" "guest_tap_ip_address")
+HOST_TAP_IP_ADDRESS=$(get_value_from_toml "${NANVIX_HOME}/build/linuxd_config.toml" "host_tap_ip_address")
 
 CLH_API_SOCKET="/tmp/cloud-hypervisor.sock"
 CLH_CONSOLE="/tmp/clh-console"

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -1,6 +1,9 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+//! This file implements the logic to load `.toml` files in the `build/` directory so that they can
+//! be re-used as constants in rust source, and also in shell scripts.
+
 //==================================================================================================
 // Imports
 //==================================================================================================
@@ -19,25 +22,36 @@ use ::std::{
 // Standalone Functions
 //==================================================================================================
 
-fn main() {
-    // Read the TOML file using the workspace root for a reliable path
-    let manifest_dir: String =
-        env::var("CARGO_MANIFEST_DIR").expect("Failed to get CARGO_MANIFEST_DIR");
-    let workspace_dir = Path::new(&manifest_dir)
-        .ancestors()
-        .nth(3)
-        .expect("Failed to find workspace root");
-    let config_path = workspace_dir.join("build/kernel_config.toml");
-    let kernel_config_content =
-        fs::read_to_string(&config_path).expect("Failed to read kernel_config.toml");
-
-    // Prepare the output path
-    let out_dir: String = env::var("OUT_DIR").unwrap();
-    let dest_path: PathBuf = Path::new(&out_dir).join("kernel_config.rs");
+///
+/// # Description
+///
+/// Helper method to load an TOML file from a file-path, and store it in a HashMap. This is a very
+/// simple-parser that only supports single-level TOMLs (i.e. no-nesting). Concretely, this
+/// function only supports parsing files with the following format:
+///
+/// ```toml
+/// # Comment
+/// key1 = val1
+/// key2 = val2
+///
+/// # Another comment
+/// ```
+///
+/// # Arguments
+///
+/// - `toml_path`: Path to the TOML file to load.
+///
+/// # Returns
+///
+/// A hash-map with the key-values in the TOML file.
+///
+fn load_toml(toml_path: &Path) -> HashMap<String, String> {
+    let toml_content: String =
+        fs::read_to_string(toml_path).expect("Failed to read kernel_config.toml");
 
     // Parse the config into a map
-    let mut config: HashMap<String, String> = std::collections::HashMap::new();
-    for line in kernel_config_content.lines() {
+    let mut config: HashMap<String, String> = HashMap::new();
+    for line in toml_content.lines() {
         let line: &str = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -49,55 +63,61 @@ fn main() {
         }
     }
 
+    config
+}
+
+fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_path: &Path) {
+    let kernel_config_toml: HashMap<String, String> = load_toml(kernel_config_toml_path);
+
     // Generate Rust constants from config.
     let mut constants = String::new();
     constants.push_str("pub mod kernel {\n");
-    if let Some(memory_size) = config.get("memory_size") {
+    if let Some(memory_size) = kernel_config_toml.get("memory_size") {
         if let Ok(val) = memory_size.parse::<usize>() {
             constants.push_str(&format!("pub const MEMORY_SIZE: usize = {val};\n"));
         }
     }
-    if let Some(kpool_size) = config.get("kpool_size") {
+    if let Some(kpool_size) = kernel_config_toml.get("kpool_size") {
         if let Ok(val) = kpool_size.parse::<usize>() {
             constants.push_str(&format!("pub const KPOOL_SIZE: usize = {val};\n"));
         }
     }
-    if let Some(kstack_size) = config.get("kstack_size") {
+    if let Some(kstack_size) = kernel_config_toml.get("kstack_size") {
         if let Ok(val) = kstack_size.parse::<usize>() {
             constants.push_str(&format!("pub const KSTACK_SIZE: usize = {val};\n"));
         }
     }
-    if let Some(timer_freq) = config.get("timer_freq") {
+    if let Some(timer_freq) = kernel_config_toml.get("timer_freq") {
         if let Ok(val) = timer_freq.parse::<u32>() {
             constants.push_str(&format!("pub const TIMER_FREQ: u32 = {val};\n"));
         }
     }
-    if let Some(scheduler_freq) = config.get("scheduler_freq") {
+    if let Some(scheduler_freq) = kernel_config_toml.get("scheduler_freq") {
         if let Ok(val) = scheduler_freq.parse::<usize>() {
             constants.push_str(&format!("pub const SCHEDULER_FREQ: usize = {val};\n"));
         }
     }
-    if let Some(max_ikc_messages) = config.get("max_ikc_messages") {
+    if let Some(max_ikc_messages) = kernel_config_toml.get("max_ikc_messages") {
         if let Ok(val) = max_ikc_messages.parse::<usize>() {
             constants.push_str(&format!("pub const MAX_IKC_MESSAGES: usize = {val};\n"));
         }
     }
-    if let Some(ipc_message_size) = config.get("ipc_message_size") {
+    if let Some(ipc_message_size) = kernel_config_toml.get("ipc_message_size") {
         if let Ok(val) = ipc_message_size.parse::<usize>() {
             constants.push_str(&format!("pub const IPC_MESSAGE_SIZE: usize = {val};\n"));
         }
     }
-    if let Some(max_mutexes) = config.get("mutex_open_max") {
+    if let Some(max_mutexes) = kernel_config_toml.get("mutex_open_max") {
         if let Ok(val) = max_mutexes.parse::<usize>() {
             constants.push_str(&format!("pub const MUTEX_OPEN_MAX: usize = {val};\n"));
         }
     }
-    if let Some(max_conditions) = config.get("cond_open_max") {
+    if let Some(max_conditions) = kernel_config_toml.get("cond_open_max") {
         if let Ok(val) = max_conditions.parse::<usize>() {
             constants.push_str(&format!("pub const COND_OPEN_MAX: usize = {val};\n"));
         }
     }
-    if let Some(ikc_poll_batch_size) = config.get("ikc_poll_batch_size") {
+    if let Some(ikc_poll_batch_size) = kernel_config_toml.get("ikc_poll_batch_size") {
         if let Ok(val) = ikc_poll_batch_size.parse::<usize>() {
             constants.push_str(&format!("pub const IKC_POLL_BATCH_SIZE: usize = {val};\n"));
         }
@@ -105,7 +125,23 @@ fn main() {
     constants.push_str("}\n");
 
     // Write the generated file
-    fs::write(&dest_path, constants).expect("Failed to write kernel_config.rs");
+    fs::write(kernel_config_output_path, constants).expect("Failed to write kernel_config.rs");
+}
+
+fn main() {
+    // Read the TOML file using the workspace root for a reliable path
+    let manifest_dir: String =
+        env::var("CARGO_MANIFEST_DIR").expect("Failed to get CARGO_MANIFEST_DIR");
+    let workspace_dir = Path::new(&manifest_dir)
+        .ancestors()
+        .nth(3)
+        .expect("Failed to find workspace root");
+    let out_dir: String = env::var("OUT_DIR").unwrap();
+
+    // Parse kernel configuration file.
+    let kernel_config_path: PathBuf = Path::new(&workspace_dir).join("build/kernel_config.toml");
+    let kernel_dst_path: PathBuf = Path::new(&out_dir).join("kernel_config.rs");
+    generate_kernel_config(&kernel_config_path, &kernel_dst_path);
 
     // Inform Cargo to rerun the build script if the TOML changes
     println!("cargo:rerun-if-changed=build/kernel_config.toml");

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -25,8 +25,8 @@ use ::std::{
 ///
 /// # Description
 ///
-/// Helper method to load an TOML file from a file-path, and store it in a HashMap. This is a very
-/// simple-parser that only supports single-level TOMLs (i.e. no-nesting). Concretely, this
+/// Helper method to load a TOML file from a file path, and store it in a HashMap. This is a very
+/// simple parser that only supports single-level TOMLs (i.e. no-nesting). Concretely, this
 /// function only supports parsing files with the following format:
 ///
 /// ```toml
@@ -46,8 +46,7 @@ use ::std::{
 /// A hash-map with the key-values in the TOML file.
 ///
 fn load_toml(toml_path: &Path) -> HashMap<String, String> {
-    let toml_content: String =
-        fs::read_to_string(toml_path).expect("Failed to read kernel_config.toml");
+    let toml_content: String = fs::read_to_string(toml_path).expect("Failed to read TOML file");
 
     // Parse the config into a map
     let mut config: HashMap<String, String> = HashMap::new();
@@ -66,6 +65,17 @@ fn load_toml(toml_path: &Path) -> HashMap<String, String> {
     config
 }
 
+///
+/// # Description
+///
+/// This method converts a TOML file with build-time constants for the kernel into a file with rust
+/// constants that can be consumed by rust code.
+///
+/// # Arguments
+///
+/// - `kernel_config_toml_path`: Path to the TOML file to load.
+/// - `kernel_config_output_path`: Path to output the rust source file.
+///
 fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_path: &Path) {
     let kernel_config_toml: HashMap<String, String> = load_toml(kernel_config_toml_path);
 
@@ -128,14 +138,45 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     fs::write(kernel_config_output_path, constants).expect("Failed to write kernel_config.rs");
 }
 
+///
+/// # Description
+///
+/// This method converts a TOML file with build-time constants for linuxd into a file with rust
+/// constants that can be consumed by rust code.
+///
+/// # Arguments
+///
+/// - `linuxd_config_toml_path`: Path to the TOML file to load.
+/// - `linuxd_config_output_path`: Path to output the rust source file.
+///
+fn generate_linuxd_config(linuxd_config_toml_path: &Path, linuxd_config_output_path: &Path) {
+    let linuxd_config_toml: HashMap<String, String> = load_toml(linuxd_config_toml_path);
+
+    // Generate Rust constants from config.
+    let mut constants: String = String::new();
+    constants.push_str("pub mod linuxd {\n");
+    if let Some(guest_tap_ip) = linuxd_config_toml.get("guest_tap_ip_address") {
+        constants
+            .push_str(&format!("pub const GUEST_TAP_IP_ADDRESS: &str = \"{guest_tap_ip}\";\n"));
+    }
+    if let Some(host_tap_ip) = linuxd_config_toml.get("host_tap_ip_address") {
+        constants.push_str(&format!("pub const HOST_TAP_IP_ADDRESS: &str = \"{host_tap_ip}\";\n"));
+    }
+    constants.push_str("}\n");
+
+    // Write the generated file
+    fs::write(linuxd_config_output_path, constants).expect("Failed to write linuxd_config.rs");
+}
+
 fn main() {
     // Read the TOML file using the workspace root for a reliable path
     let manifest_dir: String =
         env::var("CARGO_MANIFEST_DIR").expect("Failed to get CARGO_MANIFEST_DIR");
-    let workspace_dir = Path::new(&manifest_dir)
+    let workspace_dir: PathBuf = Path::new(&manifest_dir)
         .ancestors()
         .nth(3)
-        .expect("Failed to find workspace root");
+        .expect("Failed to find workspace root")
+        .to_path_buf();
     let out_dir: String = env::var("OUT_DIR").unwrap();
 
     // Parse kernel configuration file.
@@ -143,6 +184,12 @@ fn main() {
     let kernel_dst_path: PathBuf = Path::new(&out_dir).join("kernel_config.rs");
     generate_kernel_config(&kernel_config_path, &kernel_dst_path);
 
+    // Parse linuxd configuration file.
+    let linuxd_config_path: PathBuf = Path::new(&workspace_dir).join("build/linuxd_config.toml");
+    let linuxd_dst_path: PathBuf = Path::new(&out_dir).join("linuxd_config.rs");
+    generate_linuxd_config(&linuxd_config_path, &linuxd_dst_path);
+
     // Inform Cargo to rerun the build script if the TOML changes
     println!("cargo:rerun-if-changed=build/kernel_config.toml");
+    println!("cargo:rerun-if-changed=build/linuxd_config.toml");
 }


### PR DESCRIPTION
In this PR I encapsulate the logic associated to loading and parsing a configuration TOML file, as defined in `./build/kernel_config.toml`, so that it can be re-used for a new configuration file: `./build/linuxd_config.toml`. I also add a utility method to parse the same value from a shell script.

I do not add all the variables that we need in the config file, because it is hard to know which ones we will actually need without the rust-side of things, which is implemented in #843.