### PR TITLE
[daemons] Homogeneous User VM Identifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,6 @@ serde_json = { version = "1.0.140", default-features = false, features = [
 ] }
 signal-hook = "0.3.18"
 slab = { path = "src/libs/slab", default-features = false }
-slab_external = { package = "slab", version = "0.4" }
 spin = { git = "https://github.com/nanvix/spin-rs", package = "spin", branch = "nanvix/v0.10.0", default-features = false }
 static_assert = { path = "src/libs/static_assert", default-features = false }
 sys = { path = "src/libs/sys", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
         "src/libs/syslog",
         "src/libs/sys",
         "src/libs/type-safe",
+        "src/libs/user-vm-api",
         "src/microvm",
         "src/tests/arch-rust",
         "src/tests/file-rust",
@@ -58,6 +59,7 @@ homepage = "https://github.com/nanvix"
 arch = { path = "src/libs/arch", default-features = false }
 anyhow = "1.0.98"
 base64 = "0.22.1"
+bincode = "2.0.1"
 bitmap = { path = "src/libs/bitmap", default-features = false }
 cc = "1.2.26"
 cfg-if = "1.0.0"
@@ -93,6 +95,7 @@ nvx = { path = "src/libs/nvx", default-features = false }
 profiler = { path = "src/libs/profiler", default-features = false }
 posix = { path = "src/libs/posix", default-features = false }
 proc = { path = "src/libs/proc", default-features = false }
+rand = "0.9.2"
 raw-array = { path = "src/libs/raw-array", default-features = false }
 reqwest = { version = "0.12", default-features = false }
 serde = { version = "1.0.219", default-features = false }
@@ -104,16 +107,16 @@ slab = { path = "src/libs/slab", default-features = false }
 slab_external = { package = "slab", version = "0.4" }
 spin = { git = "https://github.com/nanvix/spin-rs", package = "spin", branch = "nanvix/v0.10.0", default-features = false }
 static_assert = { path = "src/libs/static_assert", default-features = false }
+sys = { path = "src/libs/sys", default-features = false }
 sysapi = { path = "src/libs/sysapi", default-features = false }
 sysalloc = { path = "src/libs/sysalloc", default-features = false }
 syscall = { path = "src/libs/syscall", default-features = false }
-sys = { path = "src/libs/sys", default-features = false }
+syscomm = { path = "src/libs/syscomm", default-features = false }
+syslog = { path = "src/libs/syslog", default-features = false }
 talc = { git = "https://github.com/nanvix/talc", rev = "12e66643796be912933a369a2d556aaac4c68771", default-features = false, package = "talc" }
 tokio = { version = "1.45.1", default-features = false }
 type-safe = { path = "src/libs/type-safe", default-features = false }
-uuid = { version = "1.17.0", features = ["v4"] }
-syscomm = { path = "src/libs/syscomm", default-features = false }
-syslog = { path = "src/libs/syslog", default-features = false }
+user-vm-api = { path = "src/libs/user-vm-api", default-features = false }
 wasmi = { version = "0.51.0", default-features = false }
 
 [profile.dev]

--- a/Makefile
+++ b/Makefile
@@ -691,7 +691,7 @@ run: image
 ifeq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 	bash $(SCRIPTS_DIR)/run.sh $(TARGET) $(MACHINE) $(IMAGE) --no-debug $(TIMEOUT)
 else
-	sudo -E $(BINARIES_DIR)/microvm.elf -kernel $(BINARIES_DIR)/kernel.elf -initrd $(IMAGE) 2>&1
+	sudo -E $(BINARIES_DIR)/microvm.elf -user-vm-id 1 -kernel $(BINARIES_DIR)/kernel.elf -initrd $(IMAGE) 2>&1
 endif
 
 # Runs system in debug mode.

--- a/doc/run.md
+++ b/doc/run.md
@@ -72,7 +72,7 @@ Once you are done, you can kill the user VM by sending a `KILL` POST request:
 
 ```bash
 KILL_JSON=$(jq -n \
-    --arg user_vm_id "${VM_ID}" \
+    --argjson user_vm_id "${VM_ID}" \
     '{user_vm_id: $user_vm_id}'
 )
 curl \
@@ -113,7 +113,7 @@ To enable logging, consider prepending the above command with `RUST_LOG=debug` o
 Open another terminal to run the MicroVM. Use the `-initrd` option to specify which application to run, and pass it additional arguments with `-initrd-args`.
 
 ```bash
-./bin/microvm.elf -system-vm-addr /tmp/user-vm-bind.socket -kernel bin/kernel.elf -initrd bin/hello-rust-nostd.elf [-initrd-args <args>]
+./bin/microvm.elf -user-vm-id 1 -system-vm-addr /tmp/user-vm-bind.socket -kernel bin/kernel.elf -initrd bin/hello-rust-nostd.elf [-initrd-args <args>]
 ```
 
 If you passed a `-gateway-bind-addr` flag to `linuxd` in step 1, you will need to open a netcat session to connect to it:
@@ -145,7 +145,7 @@ Redirecting the standard error of the MicroVM to another terminal can be useful 
 
     ```bash
     # Assuming /dev/pts/5 is the tty of the new terminal.
-    RUST_LOG=trace ./bin/microvm.elf -kernel bin/kernel.elf -initrd bin/hello-rust-nostd.elf -stderr /dev/pts/5
+    RUST_LOG=trace ./bin/microvm.elf -user-vm-id 1 -kernel bin/kernel.elf -initrd bin/hello-rust-nostd.elf -stderr /dev/pts/5
     ```
 
 ## Running Nanvix Through the Build System

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -87,7 +87,7 @@ PROGRAM_ACTUAL_OUTPUT=$(echo "${PROGRAM_INPUT}" | nc -U -q 0 "${GATEWAY_SOCKADDR
 
 # Kill the user VM.
 KILL_JSON=$(jq -n \
-    --arg user_vm_id "${VM_ID}" \
+    --argjson user_vm_id "${VM_ID}" \
     '{user_vm_id: $user_vm_id}'
 )
 KILL_EXIT_CODE=$(curl \

--- a/src/daemons/linuxd/Cargo.toml
+++ b/src/daemons/linuxd/Cargo.toml
@@ -28,11 +28,11 @@ log = { workspace = true }
 mio = { workspace = true, features = ["net", "os-poll"] }
 profiler = { workspace = true }
 signal-hook = { workspace = true }
-slab_external = { workspace = true }
 sys = { workspace = true, features = ["std"] }
 sysapi = { workspace = true, features = ["std"] }
 syscall = { workspace = true, features = ["std"] }
 syscomm = { workspace = true }
+user-vm-api = { workspace = true }
 
 [features]
 default = []

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     venv::{
         VenvCommand,
         VirtualEnviromentDirectory,
+        VirtualEnvironment,
     },
     worker_thread::WorkerThreadHandle,
 };
@@ -27,10 +28,6 @@ use ::mio::{
     Interest,
     Poll,
     Token,
-};
-use ::slab_external::{
-    Slab,
-    VacantEntry,
 };
 use ::std::{
     collections::{
@@ -59,8 +56,13 @@ use ::sys::{
 };
 use ::syscall::venv::VirtualEnvironmentIdentifier;
 use ::syscomm::{
+    BlockingSocketStream,
     SocketListener,
     SocketStream,
+};
+use ::user_vm_api::{
+    self,
+    RawUserVmIdentifier,
 };
 
 //==================================================================================================
@@ -71,8 +73,6 @@ use ::syscomm::{
 const CONTROL_PLANE_CONNECTION_ID: usize = 0;
 /// We use ID 1 for the listener socket accepting user VM connections.
 const USER_VM_LISTENER_CONNECTION_ID: usize = 1;
-/// We use IDs 2 and onwards for all user VMs that connect to this instance.
-const FIRST_USER_VM_CONNECTION_ID: usize = 2;
 /// We use ID 0 for the gateway listener socket in the gateway poll structure. Given that this
 /// socket is monitored in a different poll, we can reuse the connection ID 0.
 const GATEWAY_LISTENER_CONNECTION_ID: usize = 0;
@@ -112,20 +112,41 @@ impl LinuxDaemon {
     /// necessary, accepts incoming connections for the gateway into this user VM.
     fn accept_connections(
         &mut self,
-        user_vm_connections: &mut Slab<UserVmHandle>,
+        user_vm_connections: &mut HashMap<RawUserVmIdentifier, UserVmHandle>,
         user_vm_poll: &Poll,
         gateway_poll: &mut Option<Poll>,
-        start_token: usize,
     ) -> Result<(), Error> {
         // Accept new connection in a loop, as we have a non-blocking socket, and
         // we may have more than one connection pending to be accepted.
         loop {
             match self.user_vm_listener.accept() {
-                Ok(mut user_vm_stream) => {
-                    let entry: VacantEntry<UserVmHandle> = user_vm_connections.vacant_entry();
-                    let entry_key: usize = entry.key();
-                    let token: Token = Token(start_token + entry_key);
-                    trace!("accepted connection from user VM (conn_id={entry_key})");
+                Ok(user_vm_stream) => {
+                    // Temporarily set the user VM stream to blocking mode in order to receive the
+                    // handshake message with metadata from the user VM.
+                    let mut blocking_user_vm_stream: BlockingSocketStream =
+                        user_vm_stream.set_blocking().map_err(|_| {
+                            Self::log_and_error(
+                                ErrorCode::IoErr,
+                                "error setting stream to blocking mode",
+                            )
+                        })?;
+                    let new_msg: user_vm_api::NewUserVm = user_vm_api::NewUserVm::recv(
+                        &mut blocking_user_vm_stream,
+                    )
+                    .map_err(|_| {
+                        Self::log_and_error(ErrorCode::IoErr, "error receiving ID from new user VM")
+                    })?;
+                    let mut user_vm_stream: SocketStream =
+                        blocking_user_vm_stream.set_nonblocking().map_err(|_| {
+                            Self::log_and_error(
+                                ErrorCode::IoErr,
+                                "error setting stream to non-blocking mode",
+                            )
+                        })?;
+                    let user_vm_id: RawUserVmIdentifier = new_msg.id();
+
+                    let token: Token = Token(user_vm_id as usize);
+                    trace!("accepted connection from user VM (vm_id={user_vm_id})");
 
                     user_vm_poll
                         .registry()
@@ -163,19 +184,12 @@ impl LinuxDaemon {
                         None
                     };
 
-                    // Convert the entry key to a u32 for portability.
-                    let conn_id: u32 = match u32::try_from(entry_key) {
-                        Ok(conn_id) => conn_id,
-                        Err(e) => {
-                            error!("error clipping connection id to u32 (error={e:})");
-                            continue;
-                        },
-                    };
                     trace!(
-                        "registered user VM handle (conn_id={conn_id}, gw_stream={})",
+                        "registered user VM handle (vm_id={user_vm_id}, gw_stream={})",
                         gateway_stream.is_some()
                     );
-                    entry.insert(UserVmHandle::new(conn_id, user_vm_stream, gateway_stream));
+                    user_vm_connections
+                        .insert(user_vm_id, UserVmHandle::new(user_vm_stream, gateway_stream));
                 },
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     // No connections to be accepted, break.
@@ -191,18 +205,6 @@ impl LinuxDaemon {
         }
 
         Ok(())
-    }
-
-    /// Wrapper around the extraction of the connection from the slab, as we need a mutable
-    /// reference, and with the function call we ensure we return the borrow.
-    fn process_connection(
-        user_vm_connections: &mut Slab<UserVmHandle>,
-        conn_id: u32,
-    ) -> Result<UserVmHandle, Error> {
-        match user_vm_connections.get_mut(conn_id as usize) {
-            Some(user_vm_handle) => Ok(user_vm_handle.clone()),
-            None => Err(Error::new(ErrorCode::InvalidArgument, "Invalid connection ID")),
-        }
     }
 
     /// Helper method to close a connection to a user VM identified by the connection id. Closing
@@ -277,7 +279,6 @@ impl LinuxDaemon {
     pub fn run(mut self) -> Result<(), Error> {
         const CONTROL_PLANE_TOKEN: Token = Token(CONTROL_PLANE_CONNECTION_ID);
         const USER_VM_LISTENER_TOKEN: Token = Token(USER_VM_LISTENER_CONNECTION_ID);
-        const FIRST_USER_VM_TOKEN: Token = Token(FIRST_USER_VM_CONNECTION_ID);
         const GATEWAY_LISTENER_TOKEN: Token = Token(GATEWAY_LISTENER_CONNECTION_ID);
 
         let mut events: Events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
@@ -322,12 +323,13 @@ impl LinuxDaemon {
 
         // Structure keeping track of the active user VM connections, indexed by their connection
         // ID. We use a slab to easily get the smallest available entry.
-        let mut user_vm_connections: Slab<UserVmHandle> = Slab::new();
+        let mut user_vm_connections: HashMap<RawUserVmIdentifier, UserVmHandle> = HashMap::new();
 
         // Map keeping track of the worker threads associated to each user VM identified by
         // connection ID. We use a HashMap and not a Slab because we need to support insert/removal
         // by key.
-        let mut worker_threads: HashMap<u32, VecDeque<WorkerThreadHandle>> = HashMap::new();
+        let mut worker_threads: HashMap<RawUserVmIdentifier, VecDeque<WorkerThreadHandle>> =
+            HashMap::new();
 
         'main_loop: loop {
             let venv: Arc<Mutex<VirtualEnviromentDirectory>> = self.venv.clone();
@@ -362,14 +364,13 @@ impl LinuxDaemon {
                                 info!("linuxd received shutdown message from control-plane");
 
                                 // Close all existing connections to user VMs.
-                                for uvm_handle in user_vm_connections.drain() {
-                                    let conn_id: u32 = uvm_handle.get_conn_id();
-                                    info!("shutting down user VM (conn_id={conn_id})");
+                                for (uvm_id, uvm_handle) in user_vm_connections.drain() {
+                                    info!("shutting down user VM (vm_id={uvm_id})");
 
                                     Self::close_connection(
                                         uvm_handle,
                                         &user_vm_poll,
-                                        worker_threads.remove(&conn_id),
+                                        worker_threads.remove(&uvm_id),
                                     );
                                 }
 
@@ -395,23 +396,27 @@ impl LinuxDaemon {
                             &mut user_vm_connections,
                             &user_vm_poll,
                             &mut gateway_poll,
-                            FIRST_USER_VM_TOKEN.into(),
                         )?;
                     },
 
                     // Now we process events from active connections.
                     Token(t) => {
-                        let conn_id: u32 = match u32::try_from(t - FIRST_USER_VM_CONNECTION_ID) {
-                            Ok(conn_id) => conn_id,
+                        let uvm_id: RawUserVmIdentifier = match RawUserVmIdentifier::try_from(t) {
+                            Ok(id) => id,
                             Err(e) => {
                                 // Skip to next token.
-                                error!("error clipping connection id to u32 (error={e:})");
+                                error!("error clipping connection id (error={e:})");
                                 continue;
                             },
                         };
 
-                        let uvm_handle: UserVmHandle =
-                            Self::process_connection(&mut user_vm_connections, conn_id)?;
+                        let uvm_handle: UserVmHandle = match user_vm_connections.get(&uvm_id) {
+                            Some(handle) => handle.clone(),
+                            None => {
+                                error!("error getting user VM handle (vm_id={uvm_id})");
+                                continue;
+                            },
+                        };
 
                         // Drain the user VM stream until we cannot read any more messages (i.e.
                         // WouldBlock). This is because messages may be buffered in the poll.
@@ -425,14 +430,14 @@ impl LinuxDaemon {
                                     // No more messages to read.
                                     ErrorKind::WouldBlock => break 'drain_loop,
                                     ErrorKind::UnexpectedEof | ErrorKind::ConnectionReset => {
-                                        info!("connection from user VM closed (conn_id={conn_id})");
+                                        info!("connection from user VM closed (conn_id={uvm_id})");
 
                                         Self::close_connection(
                                             uvm_handle,
                                             &user_vm_poll,
-                                            worker_threads.remove(&conn_id),
+                                            worker_threads.remove(&uvm_id),
                                         );
-                                        user_vm_connections.remove(conn_id as usize);
+                                        user_vm_connections.remove(&uvm_id);
 
                                         break 'drain_loop;
                                     },
@@ -446,7 +451,7 @@ impl LinuxDaemon {
                             };
 
                             trace!(
-                                "uservm.id={conn_id}, message.source={:?}, \
+                                "uservm.id={uvm_id}, message.source={:?}, \
                                  message.destination={:?}, message.type={:?}",
                                 { message.source },
                                 { message.destination },
@@ -469,13 +474,13 @@ impl LinuxDaemon {
                             ) = {
                                 let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> =
                                     venv.lock().unwrap();
-                                let env = venv.get(conn_id, source);
+                                let env: Option<&VirtualEnvironment> = venv.get(uvm_id, source);
                                 if let Some(env) = env {
                                     (env.get_channel_tx(), None)
                                 } else {
                                     // Join a new virtual environment.
                                     match venv.join(
-                                        conn_id,
+                                        uvm_id,
                                         source,
                                         VirtualEnvironmentIdentifier::NEW,
                                     ) {
@@ -540,7 +545,7 @@ impl LinuxDaemon {
                                         assembler,
                                     )?;
                                 worker_threads
-                                    .entry(conn_id)
+                                    .entry(uvm_id)
                                     .or_default()
                                     .push_back(worker_thread_handle);
                             }
@@ -554,10 +559,10 @@ impl LinuxDaemon {
                                 // Remove thread from the virtual environment.
                                 let mut venv: MutexGuard<'_, VirtualEnviromentDirectory> =
                                     venv.lock().unwrap();
-                                if let Err(error) = venv.leave(conn_id, source) {
+                                if let Err(error) = venv.leave(uvm_id, source) {
                                     warn!(
                                         "run(): failed to remove thread from virtual environment \
-                                         (conn_id={conn_id}, tid={source:?}, error={error:?})",
+                                         (uvm_id={uvm_id}, tid={source:?}, error={error:?})",
                                     );
                                 }
                             }

--- a/src/daemons/linuxd/src/user_vm_handle.rs
+++ b/src/daemons/linuxd/src/user_vm_handle.rs
@@ -24,7 +24,6 @@ use ::syscomm::{
 /// State associated with a user VM connected to this linuxd instance.
 #[derive(Clone)]
 pub struct UserVmHandle {
-    conn_id: u32,
     // We keep track of a buffer to handle partial reads from the user VM socket. This buffer will
     // never exceed the IPC message size.
     user_vm_stream: Arc<Mutex<(SocketStream, VecDeque<u8>)>>,
@@ -32,11 +31,7 @@ pub struct UserVmHandle {
 }
 
 impl UserVmHandle {
-    pub fn new(
-        conn_id: u32,
-        user_vm_stream: SocketStream,
-        gw_stream: Option<SocketStream>,
-    ) -> Self {
+    pub fn new(user_vm_stream: SocketStream, gw_stream: Option<SocketStream>) -> Self {
         let blocking_stream: Option<BlockingSocketStream> = if let Some(gw_stream) = gw_stream {
             match gw_stream.set_blocking() {
                 Ok(stream) => Some(stream),
@@ -51,14 +46,9 @@ impl UserVmHandle {
         };
 
         Self {
-            conn_id,
             user_vm_stream: Arc::new(Mutex::new((user_vm_stream, VecDeque::new()))),
             gw_stream: blocking_stream.map(|stream| Arc::new(Mutex::new(stream))),
         }
-    }
-
-    pub fn get_conn_id(&self) -> u32 {
-        self.conn_id
     }
 
     pub fn get_user_vm_stream(&self) -> Arc<Mutex<(SocketStream, VecDeque<u8>)>> {

--- a/src/daemons/linuxd/src/venv.rs
+++ b/src/daemons/linuxd/src/venv.rs
@@ -22,13 +22,7 @@ use ::sys::{
     pm::ThreadIdentifier,
 };
 use ::syscall::venv::VirtualEnvironmentIdentifier;
-
-///
-/// # Description
-///
-/// Unique identifier for each user VM.
-///
-pub type UserVmIdentifier = u32;
+use ::user_vm_api::RawUserVmIdentifier;
 
 ///
 /// # Description
@@ -145,7 +139,7 @@ impl VirtualEnviromentDirectory {
     /// second 32 bits. On error an error is returned.
     ///
     fn get_gtid(
-        uvmid: UserVmIdentifier,
+        uvmid: RawUserVmIdentifier,
         tid: ThreadIdentifier,
     ) -> Result<GlobalThreadIdentifier, Error> {
         let tid: u32 = match u32::try_from(tid) {
@@ -178,7 +172,7 @@ impl VirtualEnviromentDirectory {
     ///
     pub fn join(
         &mut self,
-        uvmid: UserVmIdentifier,
+        uvmid: RawUserVmIdentifier,
         tid: ThreadIdentifier,
         mut envid: VirtualEnvironmentIdentifier,
     ) -> Result<(VirtualEnvironmentIdentifier, Sender<VenvCommand>, Receiver<VenvCommand>), Error>
@@ -230,7 +224,7 @@ impl VirtualEnviromentDirectory {
     ///
     pub fn leave(
         &mut self,
-        uvmid: UserVmIdentifier,
+        uvmid: RawUserVmIdentifier,
         tid: ThreadIdentifier,
     ) -> Result<VirtualEnvironmentIdentifier, Error> {
         trace!("leave(): uvmid={uvmid} tid={tid:?}");
@@ -267,7 +261,7 @@ impl VirtualEnviromentDirectory {
     ///
     pub fn get(
         &self,
-        uvmid: UserVmIdentifier,
+        uvmid: RawUserVmIdentifier,
         tid: ThreadIdentifier,
     ) -> Option<&VirtualEnvironment> {
         let gtid: GlobalThreadIdentifier = match Self::get_gtid(uvmid, tid) {

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -54,17 +54,10 @@ pub mod syscomm {
     ///
     /// # Description
     ///
-    /// Provides the maximum length of a message we receive from the gateway. We set a limit to
+    /// Provides the maximum length of a message we receive in linuxd. We set a limit to
     /// prevent a malformed payload to trigger unbounded allocations in linuxd.
     ///
-    pub const MAX_GW_MESSAGE_LEN: usize = 128 * 1024 * 1024;
-
-    ///
-    /// # Description
-    ///
-    /// Provides the length of the temporary buffer we use to read messages from the gateway.
-    ///
-    pub const GW_READ_BUFFER_LEN: usize = 4 * 1024;
+    pub const MAX_LINUXD_MESSAGE_LEN: usize = 128 * 1024 * 1024;
 
     ///
     /// # Description

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -419,6 +419,30 @@ impl BlockingSocketStream {
     ///
     /// # Description
     ///
+    /// Convert a blocking socket stream to a non-blocking socket stream. It is important to
+    /// de-register the stream from the poll, as otherwise we could have issues trying to register
+    /// the non-blocking socket stream to a different poll.
+    ///
+    /// # Returns
+    ///
+    /// A non-blocking socket stream.
+    ///
+    pub fn set_nonblocking(self) -> io::Result<SocketStream> {
+        match self {
+            BlockingSocketStream::Tcp(mut stream, poll) => {
+                poll.registry().deregister(&mut stream)?;
+                Ok(SocketStream::Tcp(stream))
+            },
+            BlockingSocketStream::Unix(mut stream, poll) => {
+                poll.registry().deregister(&mut stream)?;
+                Ok(SocketStream::Unix(stream))
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
     /// Blocking read implementation.
     ///
     /// # Parameters

--- a/src/libs/user-vm-api/Cargo.toml
+++ b/src/libs/user-vm-api/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "user-vm-api"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "User VM API Library"
+homepage.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+bincode = { workspace = true }
+config = { workspace = true }
+log = { workspace = true }
+syscomm = { workspace = true }

--- a/src/libs/user-vm-api/src/lib.rs
+++ b/src/libs/user-vm-api/src/lib.rs
@@ -1,0 +1,138 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! This module provides a simple API that the user VM can use to communicate with linuxd (in the
+//! system VM) right after start-up.
+//!
+//! We use a simple wire-format where we prefix each message with a u32 containing the message
+//! length. We then use bincode to encode/decode the message struct.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::bincode::{
+    config,
+    Decode,
+    Encode,
+};
+use ::log::error;
+use ::std::io;
+use ::syscomm::BlockingSocketStream;
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Unique identifier for each user VM.
+///
+pub type RawUserVmIdentifier = u32;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// This message is sent by the user VM to the system VM right after they have established a
+/// connection so that the user VM can identify itself to the system VM.
+///
+#[derive(Clone, Debug, Decode, Encode)]
+pub struct NewUserVm {
+    user_vm_id: RawUserVmIdentifier,
+}
+
+impl NewUserVm {
+    pub fn new(user_vm_id: RawUserVmIdentifier) -> Self {
+        Self { user_vm_id }
+    }
+
+    pub fn id(&self) -> RawUserVmIdentifier {
+        self.user_vm_id
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sends a [`NewUserVm`] message through a blocking stream
+    ///
+    /// # Parameters
+    ///
+    /// - `blocking_stream`: Blocking stream to which the message should be sent.
+    ///
+    /// # Return Value
+    ///
+    /// On successful completion, this function returns empty. Otherwise, it returns an error
+    /// indicating the reason for the failure.
+    ///
+    pub fn send(&self, blocking_stream: &mut BlockingSocketStream) -> io::Result<()> {
+        let payload: Vec<u8> = bincode::encode_to_vec(self.user_vm_id, config::standard())
+            .map_err(|encode_error| {
+                let reason: String =
+                    format!("failed to serialize message (error={encode_error:?})");
+                error!("send(): {reason}");
+                io::Error::new(io::ErrorKind::InvalidData, reason)
+            })?;
+
+        // Check if serialized message is too large.
+        if payload.is_empty() || payload.len() > ::config::syscomm::MAX_LINUXD_MESSAGE_LEN {
+            let reason: String = format!("invalid message length (length={})", payload.len());
+            error!("send(): {reason}");
+            return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+        }
+
+        let len_be: [u8; size_of::<u32>()] = (payload.len() as u32).to_be_bytes();
+
+        blocking_stream.write_all(&len_be)?;
+        blocking_stream.write_all(&payload)?;
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Receive a [`NewUserVm`] message from a blocking stream.
+    ///
+    /// # Parameters
+    ///
+    /// - `blocking_stream`: Blocking stream from which the message should be received.
+    ///
+    /// # Returns
+    ///
+    /// On successful completion, this function returns the message received from the referred
+    /// blocking stream. Otherwise, it returns an error indicating the reason for the failure.
+    ///
+    pub fn recv(blocking_stream: &mut BlockingSocketStream) -> io::Result<Self> {
+        // Read the size of the message.
+        let mut len_buf: [u8; size_of::<u32>()] = [0u8; size_of::<u32>()];
+        blocking_stream.read_exact(&mut len_buf)?;
+        let len: usize = u32::from_be_bytes(len_buf) as usize;
+
+        // Check if message has an invalid size.
+        if len == 0 || len > ::config::syscomm::MAX_LINUXD_MESSAGE_LEN {
+            let reason: String = format!("invalid message length (length={len})");
+            error!("recv(): {reason}");
+            return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+        }
+
+        // Read the message body.
+        let mut buf: Vec<u8> = vec![0u8; len];
+        blocking_stream.read_exact(&mut buf)?;
+
+        let (msg, msg_len): (NewUserVm, usize) =
+            bincode::decode_from_slice(&buf, config::standard()).map_err(|decode_error| {
+                let reason: String =
+                    format!("failed to deserialize message (error={decode_error:?})");
+                error!("{reason}");
+                io::Error::new(io::ErrorKind::InvalidData, reason)
+            })?;
+        debug_assert!(msg_len == len);
+
+        Ok(msg)
+    }
+}

--- a/src/microvm/Cargo.toml
+++ b/src/microvm/Cargo.toml
@@ -20,15 +20,16 @@ path = "src/main.rs"
 [dependencies]
 arch = { workspace = true, features = ["cpuid"] }
 anyhow = { workspace = true }
+cfg-if = { workspace = true }
+config = { workspace = true, features = ["microvm"] }
 flexi_logger = { workspace = true }
 hyperlight-host = { workspace = true, optional = true }
 log = { workspace = true }
 profiler = { workspace = true, features = ["auto-calibrate"] }
 sys = { workspace = true }
 syscall = { workspace = true }
-cfg-if = { workspace = true }
-config = { workspace = true, features = ["microvm"] }
 syscomm = { workspace = true }
+user-vm-api = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { workspace = true }

--- a/src/microvm/src/args.rs
+++ b/src/microvm/src/args.rs
@@ -19,6 +19,7 @@ use ::std::{
     str::FromStr,
 };
 use ::syscomm::SocketType;
+use ::user_vm_api::RawUserVmIdentifier;
 
 //==================================================================================================
 // Public Structures
@@ -30,6 +31,8 @@ use ::syscomm::SocketType;
 /// This structure packs the command-line arguments that were passed to the program.
 ///
 pub struct Args {
+    /// Unique identifier for this VM.
+    user_vm_id: RawUserVmIdentifier,
     /// Kernel filename.
     kernel_filename: String,
     /// Initrd filename.
@@ -59,6 +62,8 @@ pub struct Args {
 impl Args {
     /// Command-line option for printing the help message.
     pub const OPT_HELP: &'static str = "-help";
+    /// Command-line option for id.
+    pub const OPT_USER_VM_ID: &'static str = "-user-vm-id";
     /// Command-line option for initrd file.
     pub const OPT_INITRD: &'static str = "-initrd";
     /// Command-line option for the kernel file.
@@ -91,6 +96,7 @@ impl Args {
     /// to the program. Otherwise, it returns an error.
     ///
     pub fn parse(args: Vec<String>) -> Result<Self> {
+        let mut user_vm_id: Option<u32> = None;
         let mut kernel_filename: String = String::new();
         let mut initrd_filename: Option<String> = None;
         let mut initrd_args: Option<String> = None;
@@ -110,6 +116,19 @@ impl Args {
                 Self::OPT_HELP => {
                     Self::usage();
                     process::exit(0);
+                },
+                // Parse user VM ID.
+                Self::OPT_USER_VM_ID if i + 1 < args.len() => {
+                    let user_vm_id_arg: &String = &args[i + 1];
+
+                    // Parse memory size.
+                    user_vm_id = match user_vm_id_arg.parse::<u32>() {
+                        Ok(id) => Some(id),
+                        Err(e) => {
+                            anyhow::bail!("invalid user vm id (arg={user_vm_id_arg}, error={e:?})");
+                        },
+                    };
+                    i += 1;
                 },
                 // Set initrd file.
                 Self::OPT_INITRD if i + 1 < args.len() => {
@@ -202,6 +221,14 @@ impl Args {
             i += 1;
         }
 
+        let user_vm_id: u32 = match user_vm_id {
+            Some(id) => id,
+            None => {
+                Self::usage();
+                anyhow::bail!("user vm id is missing");
+            },
+        };
+
         // Check if kernel file is missing.
         if kernel_filename.is_empty() {
             Self::usage();
@@ -215,6 +242,7 @@ impl Args {
         }
 
         Ok(Self {
+            user_vm_id,
             kernel_filename,
             initrd_filename,
             initrd_args,
@@ -235,9 +263,10 @@ impl Args {
     ///
     pub fn usage() {
         eprintln!(
-            "Usage: {} {} <kernel> [{} <size>] [{} <file>] [{} <file>]  [{} <socket-address>] \
-             [{}] [{} <args>]",
+            "Usage: {} {} <id> {} <kernel> [{} <size>] [{} <file>] [{} <file>]  [{} \
+             <socket-address>] [{}] [{} <args>]",
             env::args().next().unwrap_or("microvm".to_string()),
+            Self::OPT_USER_VM_ID,
             Self::OPT_KERNEL,
             Self::OPT_MEMORY_SIZE,
             Self::OPT_INITRD,
@@ -246,6 +275,19 @@ impl Args {
             Self::OPT_LOGFILE,
             Self::OPT_INITRD_ARGS,
         );
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the user VM ID that was passed as a command-line argument to the program.
+    ///
+    /// # Returns
+    ///
+    /// The ID of the user VM.
+    ///
+    pub fn user_vm_id(&self) -> u32 {
+        self.user_vm_id
     }
 
     ///

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -45,9 +45,11 @@ use ::std::{
     time::Duration,
 };
 use ::syscomm::{
+    BlockingSocketStream,
     SocketStream,
     SocketType,
 };
+use ::user_vm_api::NewUserVm;
 
 //==================================================================================================
 // Constants
@@ -91,7 +93,13 @@ fn main() -> Result<ExitCode> {
     let gateway: Option<Gateway> = match &system_vm_addr {
         Some(addr) => loop {
             match SocketStream::connect(system_vm_socket_type, addr.clone()) {
-                Ok(stream) => break Some(Gateway::new(stream)),
+                Ok(stream) => {
+                    let mut blocking_stream: BlockingSocketStream = stream.set_blocking()?;
+                    let new_msg: NewUserVm = NewUserVm::new(args.user_vm_id());
+                    new_msg.send(&mut blocking_stream)?;
+
+                    break Some(Gateway::new(blocking_stream.set_nonblocking()?));
+                },
                 // The micro VM is trying to connect before the system VM's listener socket is
                 // responsive.
                 Err(ref e) if e.kind() == ErrorKind::NotFound => {

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -29,6 +29,7 @@ sys = { workspace = true, features = ["std"] }
 syscall = { workspace = true, features = ["std"] }
 syscomm = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+user-vm-api = { workspace = true }
 
 [features]
 default = []

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -31,28 +31,28 @@ use crate::{
     },
     env::get_proj_root,
 };
-use ::sys::ipc::Message;
-use anyhow::Result;
-use flexi_logger::Logger;
-use hwloc::HwLoc;
-use indicatif::{
+use ::anyhow::Result;
+use ::flexi_logger::Logger;
+use ::hwloc::HwLoc;
+use ::indicatif::{
     ProgressBar,
     ProgressStyle,
 };
-use log::{
+use ::log::{
     debug,
     error,
 };
-use microvm::{
+use ::microvm::{
     Gateway,
     Vmm,
 };
-use mio::net::UnixStream;
-use reqwest::header::{
+use ::mio::net::UnixStream;
+use ::nanvixd::message::Kill;
+use ::reqwest::header::{
     CONTENT_TYPE,
     HeaderMap,
 };
-use std::{
+use ::std::{
     fs::File,
     io::BufReader,
     mem,
@@ -69,8 +69,11 @@ use std::{
         Instant,
     },
 };
-use sys::pm::ThreadIdentifier;
-use syscall::{
+use ::sys::{
+    ipc::Message,
+    pm::ThreadIdentifier,
+};
+use ::syscall::{
     LinuxDaemonMessage,
     unistd::message::{
         ReadRequest,
@@ -78,11 +81,12 @@ use syscall::{
         WriteResponse,
     },
 };
-use syscomm::{
+use ::syscomm::{
     BlockingSocketStream,
     SocketStream,
     SocketType,
 };
+use ::user_vm_api::RawUserVmIdentifier;
 
 //==================================================================================================
 // Constants
@@ -209,7 +213,7 @@ impl Benchmark {
         &mut self,
         payload: nanvixd::message::New,
         headers: HeaderMap,
-    ) -> Result<(String, BlockingSocketStream)> {
+    ) -> Result<(RawUserVmIdentifier, BlockingSocketStream)> {
         let response: nanvixd::message::NewResponse = self
             .nanvixd_client
             .post(format!("http://{}", NANVIXD_ADDRESS))
@@ -238,7 +242,7 @@ impl Benchmark {
     }
 
     /// Kill the Nano VM via POST request to nanvixd.
-    pub async fn kill(&mut self, user_vm_id: String) -> Result<()> {
+    pub async fn kill(&mut self, user_vm_id: RawUserVmIdentifier) -> Result<()> {
         let mut kill_msg_headers = HeaderMap::new();
         kill_msg_headers.insert(CONTENT_TYPE, "application/json".parse()?);
         kill_msg_headers.insert(
@@ -246,9 +250,7 @@ impl Benchmark {
             format!("{}", nanvixd::message::MessageType::Kill).parse()?,
         );
 
-        let kill_msg = nanvixd::message::Kill {
-            user_vm_id: user_vm_id.clone(),
-        };
+        let kill_msg: Kill = Kill { user_vm_id };
         let response: nanvixd::message::KillResponse = self
             .nanvixd_client
             .post(format!("http://{}", NANVIXD_ADDRESS))

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -27,9 +27,10 @@ microvm = { workspace = true }
 linuxd = { workspace = true }
 mio = { workspace = true, features = ["net", "os-poll"] }
 num_enum = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sys = { workspace = true }
 syscomm = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-uuid = { workspace = true }
+user-vm-api = { workspace = true }

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -27,6 +27,7 @@ use ::syscomm::{
     SocketType,
 };
 use ::tokio::sync::Mutex;
+use ::user_vm_api::UserVmIdentifier;
 
 //==================================================================================================
 // Constants
@@ -50,7 +51,7 @@ pub struct SandboxCache {
     linuxd_instances: HashMap<String, Arc<LinuxDaemon>>,
     // Auxiliary index structures.
     /// Reverse index mapping a sandbox ID to a sandbox tag.
-    sandbox_index: HashMap<String, SandboxTag>,
+    sandbox_index: HashMap<UserVmIdentifier, SandboxTag>,
 
     // Control-plane members.
     /// Listener socket on the control-plane address. Right now each different linuxd and user VM
@@ -182,6 +183,7 @@ impl SandboxCache {
                 self.user_vm_instances.insert(
                     tag.clone(),
                     Arc::new(Microvm::spawn(
+                        tag.sandbox_id(),
                         sandbox_config.program(),
                         sandbox_config.program_args(),
                         sandbox_config.user_vm_sockaddr(),
@@ -193,8 +195,7 @@ impl SandboxCache {
                         control_plane_poll,
                     )?),
                 );
-                self.sandbox_index
-                    .insert(tag.sandbox_id().to_string(), tag.clone());
+                self.sandbox_index.insert(tag.sandbox_id(), tag.clone());
             } else {
                 let reason: String =
                     format!("sandbox not cached, and no sandbox config provided (tag={tag:?})");
@@ -224,7 +225,7 @@ impl SandboxCache {
     ///
     /// A reference to the sandbox.
     ///
-    pub async fn kill(&mut self, user_vm_id: String) -> Result<()> {
+    pub async fn kill(&mut self, user_vm_id: UserVmIdentifier) -> Result<()> {
         let tag = self
             .sandbox_index
             .get(&user_vm_id)
@@ -265,7 +266,7 @@ impl SandboxCache {
             // User VM is dropped.
         }
 
-        self.sandbox_index.remove(user_vm_id);
+        self.sandbox_index.remove(&user_vm_id);
 
         Ok(())
     }

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -27,7 +27,7 @@ use ::syscomm::{
     SocketType,
 };
 use ::tokio::sync::Mutex;
-use ::user_vm_api::UserVmIdentifier;
+use ::user_vm_api::RawUserVmIdentifier;
 
 //==================================================================================================
 // Constants
@@ -51,7 +51,7 @@ pub struct SandboxCache {
     linuxd_instances: HashMap<String, Arc<LinuxDaemon>>,
     // Auxiliary index structures.
     /// Reverse index mapping a sandbox ID to a sandbox tag.
-    sandbox_index: HashMap<UserVmIdentifier, SandboxTag>,
+    sandbox_index: HashMap<RawUserVmIdentifier, SandboxTag>,
 
     // Control-plane members.
     /// Listener socket on the control-plane address. Right now each different linuxd and user VM
@@ -225,7 +225,7 @@ impl SandboxCache {
     ///
     /// A reference to the sandbox.
     ///
-    pub async fn kill(&mut self, user_vm_id: UserVmIdentifier) -> Result<()> {
+    pub async fn kill(&mut self, user_vm_id: RawUserVmIdentifier) -> Result<()> {
         let tag = self
             .sandbox_index
             .get(&user_vm_id)

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -124,7 +124,7 @@ impl HttpClient {
         let _ = locked_sandbox_cache.get(&tag, Some(&config)).await?;
 
         Ok(message::NewResponse {
-            user_vm_id: tag.sandbox_id().to_string(),
+            user_vm_id: tag.sandbox_id(),
             gateway_sockaddr: gateway_sockaddr.clone(),
         })
     }
@@ -134,7 +134,7 @@ impl HttpClient {
         message: &message::Kill,
     ) -> Result<message::KillResponse> {
         let mut locked_sandbox_cache = sandbox_cache.lock().await;
-        let exit_code = match locked_sandbox_cache.kill(message.user_vm_id.clone()).await {
+        let exit_code = match locked_sandbox_cache.kill(message.user_vm_id).await {
             Ok(()) => 0,
             // TODO: more advanced error codes.
             Err(_) => 1,

--- a/src/utils/nanvixd/src/message.rs
+++ b/src/utils/nanvixd/src/message.rs
@@ -3,10 +3,11 @@
 
 //! This file contains the messages used in the HTTP API between end-clients and nanvixd.
 
-use serde::{
+use ::serde::{
     Deserialize,
     Serialize,
 };
+use ::user_vm_api::UserVmIdentifier;
 
 /// This message can be used to create a new User VM managed by this nanvixd
 /// instance.
@@ -20,7 +21,7 @@ pub struct New {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NewResponse {
-    pub user_vm_id: String,
+    pub user_vm_id: UserVmIdentifier,
     /// UNIX socket where we can interact with the new VM's stdin/stdout.
     pub gateway_sockaddr: String,
 }
@@ -28,7 +29,7 @@ pub struct NewResponse {
 /// This message can be used to kill a running VM.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Kill {
-    pub user_vm_id: String,
+    pub user_vm_id: UserVmIdentifier,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/utils/nanvixd/src/message.rs
+++ b/src/utils/nanvixd/src/message.rs
@@ -7,7 +7,7 @@ use ::serde::{
     Deserialize,
     Serialize,
 };
-use ::user_vm_api::UserVmIdentifier;
+use ::user_vm_api::RawUserVmIdentifier;
 
 /// This message can be used to create a new User VM managed by this nanvixd
 /// instance.
@@ -21,7 +21,7 @@ pub struct New {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NewResponse {
-    pub user_vm_id: UserVmIdentifier,
+    pub user_vm_id: RawUserVmIdentifier,
     /// UNIX socket where we can interact with the new VM's stdin/stdout.
     pub gateway_sockaddr: String,
 }
@@ -29,7 +29,7 @@ pub struct NewResponse {
 /// This message can be used to kill a running VM.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Kill {
-    pub user_vm_id: UserVmIdentifier,
+    pub user_vm_id: RawUserVmIdentifier,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -20,7 +20,7 @@ use ::tokio::process::{
     Child,
     Command,
 };
-use ::user_vm_api::UserVmIdentifier;
+use ::user_vm_api::RawUserVmIdentifier;
 
 //==================================================================================================
 // Structures
@@ -41,7 +41,7 @@ pub struct Microvm {
 impl Microvm {
     #[allow(clippy::too_many_arguments)]
     pub fn spawn(
-        id: UserVmIdentifier,
+        id: RawUserVmIdentifier,
         program: &str,
         program_args: Option<&str>,
         addr: &str,
@@ -55,7 +55,7 @@ impl Microvm {
         let mut user_vm_args: Vec<String> = vec![
             format!("{}/microvm.elf", binary_directory),
             ::microvm::args::Args::OPT_LOGFILE.to_string(),
-            ::microvm::args::Args::OPT_ID.to_string(),
+            ::microvm::args::Args::OPT_USER_VM_ID.to_string(),
             id.to_string(),
             ::microvm::args::Args::OPT_KERNEL.to_string(),
             format!("{}/kernel.elf", binary_directory),

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -20,6 +20,7 @@ use ::tokio::process::{
     Child,
     Command,
 };
+use ::user_vm_api::UserVmIdentifier;
 
 //==================================================================================================
 // Structures
@@ -40,6 +41,7 @@ pub struct Microvm {
 impl Microvm {
     #[allow(clippy::too_many_arguments)]
     pub fn spawn(
+        id: UserVmIdentifier,
         program: &str,
         program_args: Option<&str>,
         addr: &str,
@@ -53,6 +55,8 @@ impl Microvm {
         let mut user_vm_args: Vec<String> = vec![
             format!("{}/microvm.elf", binary_directory),
             ::microvm::args::Args::OPT_LOGFILE.to_string(),
+            ::microvm::args::Args::OPT_ID.to_string(),
+            id.to_string(),
             ::microvm::args::Args::OPT_KERNEL.to_string(),
             format!("{}/kernel.elf", binary_directory),
             ::microvm::args::Args::OPT_INITRD.to_string(),

--- a/src/utils/nanvixd/src/sandbox/tag.rs
+++ b/src/utils/nanvixd/src/sandbox/tag.rs
@@ -10,7 +10,7 @@ use ::std::{
     self,
     hash::Hash,
 };
-use ::user_vm_api::UserVmIdentifier;
+use ::user_vm_api::RawUserVmIdentifier;
 
 //==================================================================================================
 
@@ -18,7 +18,7 @@ use ::user_vm_api::UserVmIdentifier;
 pub struct SandboxTag {
     tenant_id: String,
     app_name: String,
-    sandbox_id: UserVmIdentifier,
+    sandbox_id: RawUserVmIdentifier,
 }
 
 impl SandboxTag {

--- a/src/utils/nanvixd/src/sandbox/tag.rs
+++ b/src/utils/nanvixd/src/sandbox/tag.rs
@@ -5,11 +5,12 @@
 // Imports
 //==================================================================================================
 
+use ::rand::Rng;
 use ::std::{
     self,
     hash::Hash,
 };
-use ::uuid::Uuid;
+use ::user_vm_api::UserVmIdentifier;
 
 //==================================================================================================
 
@@ -17,15 +18,18 @@ use ::uuid::Uuid;
 pub struct SandboxTag {
     tenant_id: String,
     app_name: String,
-    sandbox_id: String,
+    sandbox_id: UserVmIdentifier,
 }
 
 impl SandboxTag {
     pub fn new(tenant_id: &str, app_name: &str) -> Self {
+        let mut rng: rand::rngs::ThreadRng = rand::rng();
+        let sandbox_id: u32 = rng.random();
+
         Self {
             tenant_id: tenant_id.to_string(),
             app_name: app_name.to_string(),
-            sandbox_id: Uuid::new_v4().to_string(),
+            sandbox_id,
         }
     }
 
@@ -33,8 +37,8 @@ impl SandboxTag {
         &self.tenant_id
     }
 
-    pub fn sandbox_id(&self) -> &str {
-        &self.sandbox_id
+    pub fn sandbox_id(&self) -> u32 {
+        self.sandbox_id
     }
 }
 


### PR DESCRIPTION
In this PR I amend the deployment flow of user VMs such that `nanvixd` and `linuxd` use the same, unique, identifier to index user VMs.

In particular, `nanvixd` assigns each new user VM a random `u32` id. We then pass this id to the `microvm` by adding a `-id` CLI flag. The `microvm` then sends this id (together with more metadata in the future) to `linuxd` right after connecting.

`linuxd` can then use this `id` internally to index different running user VMs.