### PR TITLE
[microvm] Adds infrastructure for pause-resume functionality

### DIFF
--- a/src/microvm/src/io_thread.rs
+++ b/src/microvm/src/io_thread.rs
@@ -5,7 +5,13 @@
 // Imports
 //==================================================================================================
 
-use crate::Gateway;
+use crate::{
+    Gateway,
+    orchestrator::{
+        IoControlCommand,
+        IoControlResponse,
+    },
+};
 use ::anyhow::Result;
 use ::std::{
     collections::VecDeque,
@@ -47,39 +53,6 @@ pub struct IoThread {
     /// Response receiver from the VMM.
     control_rx: Receiver<IoControlResponse>,
     // TODO: channels to an outside issuer of snapshot commands and to linuxd.
-}
-
-//==================================================================================================
-// Enums
-//==================================================================================================
-
-///
-/// # Description
-///
-/// Control plane commands from the I/O thread to the VMM.
-///
-#[derive(PartialEq)]
-pub enum IoControlCommand {
-    _StartMicroVm,
-    _LoadSnapshotAndRun,
-    _PauseMicroVm,
-    _PauseAndCreateSnapshot,
-    _CreateSnapshot,
-    _ResumeMicroVm,
-    LinuxDaemonFlushed,
-}
-
-///
-/// # Description
-///
-/// Control plane command responses from the VMM to the I/O thread.
-///
-#[derive(PartialEq)]
-pub enum IoControlResponse {
-    MicroVmPaused,
-    SnapshotCreated,
-    FlushOutput,
-    FlushInput,
 }
 
 //==================================================================================================

--- a/src/microvm/src/io_thread.rs
+++ b/src/microvm/src/io_thread.rs
@@ -52,7 +52,7 @@ pub struct IoThread {
     _control_tx: Sender<IoControlCommand>,
     /// Response receiver from the VMM.
     control_rx: Receiver<IoControlResponse>,
-    // TODO: channels to an outside issuer of snapshot commands and to linuxd.
+    // TODO: channels to linuxd and nanvixd https://github.com/nanvix/nanvix/issues/945
 }
 
 //==================================================================================================
@@ -283,7 +283,7 @@ impl IoThread {
             Ok(response) => match response {
                 IoControlResponse::FlushOutput => self.flush_microvm_output(),
                 IoControlResponse::FlushInput => self.flush_linuxd_input(),
-                _ => Ok(()), // TODO: forward to whoever is interested. This requires having control channels.
+                _ => Ok(()), // TODO: forward to linuxd or nanvixd https://github.com/nanvix/nanvix/issues/945
             },
             Err(TryRecvError::Empty) => Ok(()),
             Err(TryRecvError::Disconnected) => {

--- a/src/microvm/src/memory_thread.rs
+++ b/src/microvm/src/memory_thread.rs
@@ -128,7 +128,7 @@ where
                     control_tx.send(MemoryControlResponse::ResumeWritten)?;
                 },
                 Err(TryRecvError::Disconnected) => {
-                    // When the guest finishes , the vCPU thread will disconnect from this
+                    // When the guest finishes, the vCPU thread will disconnect from this
                     // thread. This situation is normal and should not create an error log.
                     debug!("spawn(): channel has been disconnected");
                     break Ok(());

--- a/src/microvm/src/memory_thread.rs
+++ b/src/microvm/src/memory_thread.rs
@@ -25,6 +25,11 @@ use ::std::{
 };
 use ::sys::ipc::Message;
 
+use crate::orchestrator::{
+    MemoryControlCommand,
+    MemoryControlResponse,
+};
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -39,19 +44,29 @@ use ::sys::ipc::Message;
 ///
 /// - `data_rx`: Receives data messages from the I/O thread.
 /// - `data_tx`: Sends data messages to the virtual machine's stdin.
+/// - `control_rx`: Receives control commands from the VMM.
+/// - `control_tx`: Sends control responses to the VMM.
 /// - `add_credit`: Closure that adds a credit to the virtual machine credit pool.
+/// - `pause_microvm`: Closure that writes to the kernel's memory to pause the MicroVM.
+/// - `resume_microvm`: Closure that writes to the kernel's memory it shouldn't pause the MicroVM.
 ///
 /// # Returns
 ///
 /// A handle to the memory thread.
 ///
-pub fn spawn<F>(
+pub fn spawn<F1, F2, F3>(
     data_rx: Receiver<Message>,
     data_tx: Sender<Message>,
-    mut add_credit: F,
+    control_rx: Receiver<MemoryControlCommand>,
+    control_tx: Sender<MemoryControlResponse>,
+    mut add_credit: F1,
+    mut pause_microvm: F2,
+    mut resume_microvm: F3,
 ) -> JoinHandle<Result<()>>
 where
-    F: FnMut() -> Result<()> + std::marker::Send + 'static,
+    F1: FnMut() -> Result<()> + std::marker::Send + 'static,
+    F2: FnMut() -> Result<()> + std::marker::Send + 'static,
+    F3: FnMut() -> Result<()> + std::marker::Send + 'static,
 {
     thread::spawn(move || {
         loop {
@@ -64,7 +79,7 @@ where
                     );
                     if let Err(e) = data_tx.send(msg) {
                         let reason: String = format!("failed to send message: {e:?}");
-                        error!("memory_thread(): {reason}");
+                        error!("spawn(): {reason}");
                         continue;
                     }
                     add_credit()?;
@@ -72,7 +87,33 @@ where
                 Err(TryRecvError::Disconnected) => {
                     // When the guest finishes , the vCPU thread will disconnect from this
                     // thread. This situation is normal and should not create an error log.
-                    debug!("memory_thread(): channel has been disconnected");
+                    debug!("spawn(): channel has been disconnected");
+                    break Ok(());
+                },
+                Err(TryRecvError::Empty) => {
+                    // No message available.
+                },
+            }
+            match control_rx.try_recv() {
+                Ok(MemoryControlCommand::Pause) => {
+                    trace!("pause()");
+                    crate::timer!("vm_pause");
+                    if pause_microvm().is_err() {
+                        control_tx.send(MemoryControlResponse::PauseError)?;
+                    }
+                },
+                Ok(MemoryControlCommand::Resume) => {
+                    trace!("resume()");
+                    crate::timer!("vm_resume");
+                    if resume_microvm().is_err() {
+                        control_tx.send(MemoryControlResponse::ResumeError)?;
+                    }
+                    control_tx.send(MemoryControlResponse::ResumeWritten)?;
+                },
+                Err(TryRecvError::Disconnected) => {
+                    // When the guest finishes , the vCPU thread will disconnect from this
+                    // thread. This situation is normal and should not create an error log.
+                    debug!("spawn(): channel has been disconnected");
                     break Ok(());
                 },
                 Err(TryRecvError::Empty) => {

--- a/src/microvm/src/memory_thread.rs
+++ b/src/microvm/src/memory_thread.rs
@@ -96,17 +96,34 @@ where
             }
             match control_rx.try_recv() {
                 Ok(MemoryControlCommand::Pause) => {
-                    trace!("pause()");
                     crate::timer!("vm_pause");
-                    if pause_microvm().is_err() {
-                        control_tx.send(MemoryControlResponse::PauseError)?;
+                    if let Err(e) = pause_microvm() {
+                        let reason: String =
+                            format!("error requesting pause in the kernel's memory (error={e:?})");
+                        error!("spawn(): {reason}");
+                        if let Err(e) = control_tx.send(MemoryControlResponse::PauseError) {
+                            let reason: String =
+                                format!("error sending `PauseError` to the VMM (error={e:?})");
+                            error!("spawn(): {reason}");
+                            anyhow::bail!(reason)
+                        }
+                        anyhow::bail!(reason)
                     }
                 },
                 Ok(MemoryControlCommand::Resume) => {
-                    trace!("resume()");
                     crate::timer!("vm_resume");
-                    if resume_microvm().is_err() {
-                        control_tx.send(MemoryControlResponse::ResumeError)?;
+                    if let Err(e) = resume_microvm() {
+                        let reason: String = format!(
+                            "error overwriting pause request in the kernel's memory (error={e:?})"
+                        );
+                        error!("spawn(): {reason}");
+                        if let Err(e) = control_tx.send(MemoryControlResponse::ResumeError) {
+                            let reason: String =
+                                format!("error sending `ResumeError` to the VMM (error={e:?})");
+                            error!("spawn(): {reason}");
+                            anyhow::bail!(reason)
+                        }
+                        anyhow::bail!(reason)
                     }
                     control_tx.send(MemoryControlResponse::ResumeWritten)?;
                 },

--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -5,10 +5,6 @@
 // Imports
 //==================================================================================================
 
-use crate::io_thread::{
-    IoControlCommand,
-    IoControlResponse,
-};
 use ::anyhow::Result;
 use ::std::{
     sync::mpsc::{
@@ -39,6 +35,10 @@ pub struct Orchestrator {
     state: State,
     io_control_rx: Receiver<IoControlCommand>,
     io_control_tx: Sender<IoControlResponse>,
+    memory_control_rx: Receiver<MemoryControlResponse>,
+    memory_control_tx: Sender<MemoryControlCommand>,
+    vcpu_control_rx: Receiver<VcpuControlResponse>,
+    vcpu_control_tx: Sender<VcpuControlCommand>,
     create_snapshot: fn() -> Result<()>,
 }
 
@@ -61,6 +61,78 @@ enum State {
     Paused,
 }
 
+///
+/// # Description
+///
+/// Control plane commands from the I/O thread to the VMM.
+///
+#[derive(PartialEq)]
+pub enum IoControlCommand {
+    _StartMicroVm,
+    _LoadSnapshotAndRun,
+    _PauseMicroVm,
+    _PauseAndCreateSnapshot,
+    _CreateSnapshot,
+    _ResumeMicroVm,
+    LinuxDaemonFlushed,
+}
+
+///
+/// # Description
+///
+/// Control plane command responses from the VMM to the I/O thread.
+///
+#[derive(PartialEq)]
+pub enum IoControlResponse {
+    MicroVmPaused,
+    SnapshotCreated,
+    FlushOutput,
+    FlushInput,
+}
+
+///
+/// # Description
+///
+/// Control plane commands from the VMM to the memory thread.
+///
+#[derive(PartialEq)]
+pub enum MemoryControlCommand {
+    Pause,
+    Resume,
+}
+
+///
+/// # Description
+///
+/// Control plane command responses from the memory thread to the VMM.
+///
+#[derive(PartialEq)]
+pub enum MemoryControlResponse {
+    PauseError,
+    ResumeError,
+    ResumeWritten,
+}
+
+///
+/// # Description
+///
+/// Control plane commands from the VMM to the vCPU thread.
+///
+#[derive(PartialEq)]
+pub enum VcpuControlCommand {
+    Resume,
+}
+
+///
+/// # Description
+///
+/// Control plane command responses from the vCPU thread to the VMM.
+///
+#[derive(PartialEq)]
+pub enum VcpuControlResponse {
+    _Paused,
+}
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
@@ -69,12 +141,20 @@ impl Orchestrator {
     pub fn new(
         io_control_rx: Receiver<IoControlCommand>,
         io_control_tx: Sender<IoControlResponse>,
+        memory_control_rx: Receiver<MemoryControlResponse>,
+        memory_control_tx: Sender<MemoryControlCommand>,
+        vcpu_control_rx: Receiver<VcpuControlResponse>,
+        vcpu_control_tx: Sender<VcpuControlCommand>,
         create_snapshot: fn() -> Result<()>,
     ) -> Self {
         Self {
             state: State::PreBoot,
             io_control_rx,
             io_control_tx,
+            memory_control_rx,
+            memory_control_tx,
+            vcpu_control_rx,
+            vcpu_control_tx,
             create_snapshot,
         }
     }
@@ -204,9 +284,47 @@ impl Orchestrator {
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
     fn pause_protocol(&mut self) -> Result<()> {
-        // TODO: pause MicroVM (Running -> Paused)
-        // and tell linuxd to flush (Running -> Flushing)
-        // This TODO requires pausing the vCPU and a control plane communication with linuxd
+        // TODO: tell linuxd to flush (Running -> Flushing)
+        // This TODO requires control plane communication with linuxd
+        self.memory_control_tx.send(MemoryControlCommand::Pause)?;
+        // Wait for the MicroVM to confirm it has paused.
+        let start: Instant = Instant::now();
+        let mut counter: usize = 1;
+        loop {
+            match self.vcpu_control_rx.try_recv() {
+                Ok(VcpuControlResponse::_Paused) => break,
+                Err(TryRecvError::Empty) => (),
+                Err(TryRecvError::Disconnected) => {
+                    let reason: String = "the vmm has disconnected".to_string();
+                    error!("pause_protocol(): {reason}");
+                    anyhow::bail!(reason)
+                },
+            }
+            // Log a warning and increment the counter every TIMEOUT_WARNING_INTERVAL_IN_MS ms.
+            let elapsed_time: usize = start.elapsed().as_millis() as usize;
+            if elapsed_time > TIMEOUT_WARNING_INTERVAL_IN_MS * counter {
+                warn!(
+                    "pause_protocol(): {}ms have passed waiting for `ResumeMicroVm` message",
+                    TIMEOUT_WARNING_INTERVAL_IN_MS * counter
+                );
+                match self.memory_control_rx.try_recv() {
+                    Ok(MemoryControlResponse::PauseError) => todo!(), // TODO: graceful shutdown
+                    Ok(MemoryControlResponse::ResumeError) => unreachable!(
+                        "PauseError is the only message that can be sent at this point."
+                    ),
+                    Ok(MemoryControlResponse::ResumeWritten) => unreachable!(
+                        "PauseError is the only message that can be sent at this point."
+                    ),
+                    Err(TryRecvError::Empty) => (),
+                    Err(TryRecvError::Disconnected) => {
+                        let reason: String = "the vmm has disconnected".to_string();
+                        error!("pause_protocol(): {reason}");
+                        anyhow::bail!(reason)
+                    },
+                }
+                counter += 1;
+            }
+        }
         trace!("MicroVM paused");
         // Flush output to linuxd
         self.io_control_tx.send(IoControlResponse::FlushOutput)?;
@@ -216,6 +334,7 @@ impl Orchestrator {
         self.io_control_tx.send(IoControlResponse::FlushInput)?;
         self.receive_linux_daemon_flushed()?;
         self.state = State::Paused;
+        trace!("State: Running -> Paused");
         self.io_control_tx.send(IoControlResponse::MicroVmPaused)?;
         Ok(())
     }
@@ -268,6 +387,36 @@ impl Orchestrator {
     /// Upon success, empty is returned. Otherwise, an error is returned instead.
     ///
     fn resume_microvm(&mut self) -> Result<()> {
+        // Tell memory thread to write to the kernel
+        self.memory_control_tx.send(MemoryControlCommand::Resume)?;
+        // Wait for confirmation
+        let start: Instant = Instant::now();
+        let mut counter: usize = 1;
+        while match self.memory_control_rx.try_recv() {
+            Ok(MemoryControlResponse::ResumeWritten) => false,
+            Ok(MemoryControlResponse::ResumeError) => todo!(), // TODO: graceful shutdown
+            Ok(MemoryControlResponse::PauseError) => {
+                unreachable!("PauseError cannot be sent at this point.")
+            },
+            Err(TryRecvError::Empty) => true,
+            Err(TryRecvError::Disconnected) => {
+                let reason: String = "the memory thread has disconnected".to_string();
+                error!("resume_microvm(): {reason}");
+                anyhow::bail!(reason)
+            },
+        } {
+            // Log a warning and increment the counter every TIMEOUT_WARNING_INTERVAL_IN_MS ms.
+            let elapsed_time: usize = start.elapsed().as_millis() as usize;
+            if elapsed_time > TIMEOUT_WARNING_INTERVAL_IN_MS * counter {
+                warn!(
+                    "{}ms have passed waiting for `ResumeWritten`",
+                    TIMEOUT_WARNING_INTERVAL_IN_MS * counter
+                );
+                counter += 1;
+            }
+        }
+        // Tell microvm to resume
+        self.vcpu_control_tx.send(VcpuControlCommand::Resume)?;
         self.state = State::Running;
         trace!("State: Paused -> Running");
         Ok(())

--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -187,7 +187,7 @@ impl Orchestrator {
                         // The Linux daemon should send messages to PreBoot VMMs by default,
                         // so there's no need to tell it to resume sending messages.
 
-                        if let Err(e) = self.resume_microvm() {
+                        if let Err(e) = self.resume_protocol() {
                             let reason: String =
                                 format!("LoadSnapshotAndRun: failed to resume microvm: {e:?}");
                             error!("handle_command(): {reason}");
@@ -245,7 +245,7 @@ impl Orchestrator {
                 IoControlCommand::_ResumeMicroVm => {
                     if self.state == State::Paused {
                         // TODO: tell linuxd it's fine to send more messages https://github.com/nanvix/nanvix/issues/945
-                        if let Err(e) = self.resume_microvm() {
+                        if let Err(e) = self.resume_protocol() {
                             let reason: String =
                                 format!("ResumeMicroVm: failed to resume microvm: {e:?}");
                             error!("handle_command(): {reason}");
@@ -286,7 +286,7 @@ impl Orchestrator {
         if let Err(e) = self.memory_control_tx.send(MemoryControlCommand::Pause) {
             let reason: String =
                 format!("error sending `Pause` to the memory thread (error={e:?})");
-            error!("pause_protocol: {reason}");
+            error!("pause_protocol(): {reason}");
             anyhow::bail!(reason)
         }
         // Wait for the MicroVM to confirm it has paused.
@@ -312,10 +312,12 @@ impl Orchestrator {
                 match self.memory_control_rx.try_recv() {
                     Ok(MemoryControlResponse::PauseError) => todo!(), // TODO: graceful shutdown https://github.com/nanvix/nanvix/issues/949
                     Ok(MemoryControlResponse::ResumeError) => unreachable!(
-                        "PauseError is the only message that can be sent at this point."
+                        "Received `ResumeError` during pause protocol: this indicates a protocol \
+                         violation, as `ResumeError` should not be sent while pausing."
                     ),
                     Ok(MemoryControlResponse::ResumeWritten) => unreachable!(
-                        "PauseError is the only message that can be sent at this point."
+                        "Received `ResumeWritten` during pause protocol: this indicates a \
+                         protocol violation, as `ResumeWritten` should not be sent while pausing."
                     ),
                     Err(TryRecvError::Empty) => (),
                     Err(TryRecvError::Disconnected) => {
@@ -387,25 +389,29 @@ impl Orchestrator {
     ///
     /// Upon success, empty is returned. Otherwise, an error is returned instead.
     ///
-    fn resume_microvm(&mut self) -> Result<()> {
+    fn resume_protocol(&mut self) -> Result<()> {
         // Tell memory thread to write to the kernel
         self.memory_control_tx.send(MemoryControlCommand::Resume)?;
         // Wait for confirmation
         let start: Instant = Instant::now();
         let mut counter: usize = 1;
-        while match self.memory_control_rx.try_recv() {
-            Ok(MemoryControlResponse::ResumeWritten) => false,
-            Ok(MemoryControlResponse::ResumeError) => todo!(), // TODO: graceful shutdown https://github.com/nanvix/nanvix/issues/949
-            Ok(MemoryControlResponse::PauseError) => {
-                unreachable!("PauseError cannot be sent at this point.")
-            },
-            Err(TryRecvError::Empty) => true,
-            Err(TryRecvError::Disconnected) => {
-                let reason: String = "the memory thread has disconnected".to_string();
-                error!("resume_microvm(): {reason}");
-                anyhow::bail!(reason)
-            },
-        } {
+        loop {
+            match self.memory_control_rx.try_recv() {
+                Ok(MemoryControlResponse::ResumeWritten) => break,
+                Ok(MemoryControlResponse::ResumeError) => todo!(), // TODO: graceful shutdown https://github.com/nanvix/nanvix/issues/949
+                Ok(MemoryControlResponse::PauseError) => {
+                    unreachable!(
+                        "Received `PauseError` during resume protocol: this indicates a protocol \
+                         violation, as `PauseError` should not be sent while resuming."
+                    )
+                },
+                Err(TryRecvError::Empty) => (),
+                Err(TryRecvError::Disconnected) => {
+                    let reason: String = "the memory thread has disconnected".to_string();
+                    error!("resume_protocol(): {reason}");
+                    anyhow::bail!(reason)
+                },
+            }
             // Log a warning and increment the counter every TIMEOUT_WARNING_INTERVAL_IN_MS ms.
             let elapsed_time: usize = start.elapsed().as_millis() as usize;
             if elapsed_time > TIMEOUT_WARNING_INTERVAL_IN_MS * counter {

--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -183,7 +183,7 @@ impl Orchestrator {
                 IoControlCommand::_LoadSnapshotAndRun => {
                     if self.state == State::PreBoot {
                         // TODO: load snapshot https://github.com/nanvix/nanvix/issues/948
-                        
+
                         // The Linux daemon should send messages to PreBoot VMMs by default,
                         // so there's no need to tell it to resume sending messages.
 
@@ -283,7 +283,12 @@ impl Orchestrator {
     ///
     fn pause_protocol(&mut self) -> Result<()> {
         // TODO: tell linuxd to flush (Running -> Flushing) https://github.com/nanvix/nanvix/issues/945
-        self.memory_control_tx.send(MemoryControlCommand::Pause)?;
+        if let Err(e) = self.memory_control_tx.send(MemoryControlCommand::Pause) {
+            let reason: String =
+                format!("error sending `Pause` to the memory thread (error={e:?})");
+            error!("pause_protocol: {reason}");
+            anyhow::bail!(reason)
+        }
         // Wait for the MicroVM to confirm it has paused.
         let start: Instant = Instant::now();
         let mut counter: usize = 1;
@@ -301,7 +306,7 @@ impl Orchestrator {
             let elapsed_time: usize = start.elapsed().as_millis() as usize;
             if elapsed_time > TIMEOUT_WARNING_INTERVAL_IN_MS * counter {
                 warn!(
-                    "pause_protocol(): {}ms have passed waiting for `ResumeMicroVm` message",
+                    "pause_protocol(): {}ms have passed waiting for `Paused` message from vCPU",
                     TIMEOUT_WARNING_INTERVAL_IN_MS * counter
                 );
                 match self.memory_control_rx.try_recv() {

--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -174,7 +174,7 @@ impl Orchestrator {
                 IoControlCommand::_StartMicroVm => {
                     if self.state == State::PreBoot {
                         // TODO: separate starting logic from `spawn()` and put it here
-                        // This TODO could be done right now, but it's a major refactor.
+                        // This only makes sense when snapshots can already be loaded https://github.com/nanvix/nanvix/issues/948
                         self.state = State::Running;
                         trace!("State: PreBoot -> Running");
                     }
@@ -182,9 +182,8 @@ impl Orchestrator {
                 },
                 IoControlCommand::_LoadSnapshotAndRun => {
                     if self.state == State::PreBoot {
-                        // TODO: load snapshot
-                        // This TODO requires being able to create snapshots.
-
+                        // TODO: load snapshot https://github.com/nanvix/nanvix/issues/948
+                        
                         // The Linux daemon should send messages to PreBoot VMMs by default,
                         // so there's no need to tell it to resume sending messages.
 
@@ -245,8 +244,7 @@ impl Orchestrator {
                 },
                 IoControlCommand::_ResumeMicroVm => {
                     if self.state == State::Paused {
-                        // TODO: tell linuxd it's fine to send more messages
-                        // This TODO requires having a control plane connection with linuxd
+                        // TODO: tell linuxd it's fine to send more messages https://github.com/nanvix/nanvix/issues/945
                         if let Err(e) = self.resume_microvm() {
                             let reason: String =
                                 format!("ResumeMicroVm: failed to resume microvm: {e:?}");
@@ -284,8 +282,7 @@ impl Orchestrator {
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
     fn pause_protocol(&mut self) -> Result<()> {
-        // TODO: tell linuxd to flush (Running -> Flushing)
-        // This TODO requires control plane communication with linuxd
+        // TODO: tell linuxd to flush (Running -> Flushing) https://github.com/nanvix/nanvix/issues/945
         self.memory_control_tx.send(MemoryControlCommand::Pause)?;
         // Wait for the MicroVM to confirm it has paused.
         let start: Instant = Instant::now();
@@ -308,7 +305,7 @@ impl Orchestrator {
                     TIMEOUT_WARNING_INTERVAL_IN_MS * counter
                 );
                 match self.memory_control_rx.try_recv() {
-                    Ok(MemoryControlResponse::PauseError) => todo!(), // TODO: graceful shutdown
+                    Ok(MemoryControlResponse::PauseError) => todo!(), // TODO: graceful shutdown https://github.com/nanvix/nanvix/issues/949
                     Ok(MemoryControlResponse::ResumeError) => unreachable!(
                         "PauseError is the only message that can be sent at this point."
                     ),
@@ -328,9 +325,8 @@ impl Orchestrator {
         trace!("MicroVM paused");
         // Flush output to linuxd
         self.io_control_tx.send(IoControlResponse::FlushOutput)?;
-        // TODO: tell linuxd to stop sending messages (Flushing -> Paused)
-        // TODO: get a response from linuxd
-        // These TODOs require a control plane communication with linuxd
+        // TODO: tell linuxd to stop sending messages (Flushing -> Paused) https://github.com/nanvix/nanvix/issues/945
+        // TODO: get a response from linuxd https://github.com/nanvix/nanvix/issues/945
         self.io_control_tx.send(IoControlResponse::FlushInput)?;
         self.receive_linux_daemon_flushed()?;
         self.state = State::Paused;
@@ -394,7 +390,7 @@ impl Orchestrator {
         let mut counter: usize = 1;
         while match self.memory_control_rx.try_recv() {
             Ok(MemoryControlResponse::ResumeWritten) => false,
-            Ok(MemoryControlResponse::ResumeError) => todo!(), // TODO: graceful shutdown
+            Ok(MemoryControlResponse::ResumeError) => todo!(), // TODO: graceful shutdown https://github.com/nanvix/nanvix/issues/949
             Ok(MemoryControlResponse::PauseError) => {
                 unreachable!("PauseError cannot be sent at this point.")
             },

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -342,7 +342,7 @@ impl Vmm {
             memory_control_tx,
             vcpu_control_rx,
             vcpu_control_tx,
-            || Ok(()), // TODO: create_snapshot
+            || Ok(()), // TODO: create_snapshot https://github.com/nanvix/nanvix/issues/947
         );
 
         let mut vmm: Vmm = Self {
@@ -444,10 +444,10 @@ fn consume_credit() -> Result<()> {
 
 // Requests the kernel to pause the virtual machine's execution by writing to a specific register.
 fn pause_microvm() -> Result<()> {
-    Ok(()) // TODO
+    Ok(()) // TODO: https://github.com/nanvix/nanvix/issues/791
 }
 
 // Writes to a specific kernel register that execution should not be paused.
 fn resume_microvm() -> Result<()> {
-    Ok(()) // TODO
+    Ok(()) // TODO: https://github.com/nanvix/nanvix/issues/791
 }

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -12,13 +12,17 @@ extern crate kvm_ioctls;
 
 use crate::{
     Gateway,
-    io_thread::{
+    io_thread::IoThread,
+    memory_thread,
+    orchestrator::{
         IoControlCommand,
         IoControlResponse,
-        IoThread,
+        MemoryControlCommand,
+        MemoryControlResponse,
+        Orchestrator,
+        VcpuControlCommand,
+        VcpuControlResponse,
     },
-    memory_thread,
-    orchestrator::Orchestrator,
 };
 use ::anyhow::Result;
 use ::hyperlight_host::{
@@ -75,7 +79,6 @@ static VMEM: OnceLock<Arc<Mutex<SandboxMemoryManager<ExclusiveSharedMemory>>>> =
 //==================================================================================================
 
 pub struct Vmm {
-    _io_thread_data_tx: Sender<Message>,
     io_thread: Option<JoinHandle<Result<()>>>,
     _memory_thread: JoinHandle<Result<()>>,
     vcpu_thread: JoinHandle<Result<u16>>,
@@ -116,18 +119,25 @@ impl Vmm {
     ) -> Result<u16> {
         crate::timer!("vmm_creation");
 
+        // io/memory/vcpu_control_rx/tx are channels owned by the VMM and transfer control messages.
+        // *_thread_control_rx/tx are channels owned by the threads that transfer control messages.
         let (vcpu_thread_stdout_tx, io_thread_data_rx) = mpsc::channel::<Message>();
         let (io_thread_data_tx, memory_thread_data_rx) = mpsc::channel::<Message>();
         let (memory_thread_data_tx, vcpu_thread_stdin_rx) = mpsc::channel::<Message>();
         let (io_thread_control_tx, io_control_rx) = mpsc::channel::<IoControlCommand>();
         let (io_control_tx, io_thread_control_rx) = mpsc::channel::<IoControlResponse>();
+        let (memory_control_tx, memory_thread_control_rx) = mpsc::channel::<MemoryControlCommand>();
+        let (memory_thread_control_tx, memory_control_rx) =
+            mpsc::channel::<MemoryControlResponse>();
+        let (vcpu_control_tx, vcpu_thread_control_rx) = mpsc::channel::<VcpuControlCommand>();
+        let (vcpu_thread_control_tx, vcpu_control_rx) = mpsc::channel::<VcpuControlResponse>();
 
         // Spawn I/O thread.
         let io_thread: Option<JoinHandle<Result<()>>> = gateway_conn.map(|conn| {
             IoThread::spawn(
                 conn,
                 io_thread_data_rx,
-                io_thread_data_tx.clone(),
+                io_thread_data_tx,
                 io_thread_control_tx,
                 io_thread_control_rx,
             )
@@ -277,8 +287,15 @@ impl Vmm {
         })?;
 
         // Create a thread that reads from vm_rx and writes to vm_rx2.
-        let memory_thread: JoinHandle<Result<(), anyhow::Error>> =
-            memory_thread::spawn(memory_thread_data_rx, memory_thread_data_tx, add_credit);
+        let memory_thread: JoinHandle<Result<(), anyhow::Error>> = memory_thread::spawn(
+            memory_thread_data_rx,
+            memory_thread_data_tx,
+            memory_thread_control_rx,
+            memory_thread_control_tx,
+            add_credit,
+            pause_microvm,
+            resume_microvm,
+        );
 
         // We use an atomic to pass the id of the created thread back to the caller context. We
         // need this because std::thread's JoinHandle does not expose the tid. We synchronize the
@@ -321,11 +338,14 @@ impl Vmm {
         let orchestrator = Orchestrator::new(
             io_control_rx,
             io_control_tx,
+            memory_control_rx,
+            memory_control_tx,
+            vcpu_control_rx,
+            vcpu_control_tx,
             || Ok(()), // TODO: create_snapshot
         );
 
         let mut vmm: Vmm = Self {
-            _io_thread_data_tx: io_thread_data_tx,
             io_thread,
             _memory_thread: memory_thread,
             vcpu_thread,
@@ -420,4 +440,14 @@ fn consume_credit() -> Result<()> {
             Ok(())
         })
         .ok_or(anyhow::anyhow!("VMEM is not initialized"))?
+}
+
+// Requests the kernel to pause the virtual machine's execution by writing to a specific register.
+fn pause_microvm() -> Result<()> {
+    Ok(()) // TODO
+}
+
+// Writes to a specific kernel register that execution should not be paused.
+fn resume_microvm() -> Result<()> {
+    Ok(()) // TODO
 }

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -442,12 +442,28 @@ fn consume_credit() -> Result<()> {
         .ok_or(anyhow::anyhow!("VMEM is not initialized"))?
 }
 
-// Requests the kernel to pause the virtual machine's execution by writing to a specific register.
+///
+/// # Description
+///
+/// Requests the kernel to pause the virtual machine's execution by writing to a specific register.
+///
+/// # Returns
+///
+/// On success, returns empty. Otherwise, returns an error.
+///
 fn pause_microvm() -> Result<()> {
     Ok(()) // TODO: https://github.com/nanvix/nanvix/issues/791
 }
 
-// Writes to a specific kernel register that execution should not be paused.
+///
+/// # Description
+///
+/// Writes to a specific kernel register that execution should not be paused.
+///
+/// # Returns
+///
+/// On success, returns empty. Otherwise, returns an error.
+///
 fn resume_microvm() -> Result<()> {
     Ok(()) // TODO: https://github.com/nanvix/nanvix/issues/791
 }

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -13,15 +13,21 @@
 //==================================================================================================
 
 #[cfg(target_os = "linux")]
-use crate::vmm::microvm::kvm::{
-    emulator::Emulator,
-    partition::VirtualPartition,
-    vcpu::{
-        VirtualProcessor,
-        VirtualProcessorExitContext,
-        VirtualProcessorExitReason,
+use crate::{
+    orchestrator::{
+        VcpuControlCommand,
+        VcpuControlResponse,
     },
-    vmem::VirtualMemory,
+    vmm::microvm::kvm::{
+        emulator::Emulator,
+        partition::VirtualPartition,
+        vcpu::{
+            VirtualProcessor,
+            VirtualProcessorExitContext,
+            VirtualProcessorExitReason,
+        },
+        vmem::VirtualMemory,
+    },
 };
 
 use ::anyhow::Result;
@@ -35,6 +41,10 @@ use ::libc::{
 use ::std::sync::{
     Arc,
     Mutex,
+    mpsc::{
+        Receiver,
+        Sender,
+    },
 };
 
 pub const INTERRUPT_SIGNAL: c_int = SIGUSR1;
@@ -59,6 +69,10 @@ pub struct MicroVm {
     emulator: Emulator,
     // If present, initial RAM disk location and size.
     initrd: Option<(u64, usize)>,
+    // Channel to receive commands from the VMM.
+    _control_rx: Receiver<VcpuControlCommand>,
+    // Channel to send control responses to the VMM.
+    _control_tx: Sender<VcpuControlResponse>,
 }
 
 unsafe impl Send for MicroVm {}
@@ -90,13 +104,21 @@ impl MicroVm {
     /// - `memory_size`: Size of the virtual memory of the virtual machine.
     /// - `input`: Input function used for emulating I/O port reads.
     /// - `output`: Output function used for emulating I/O port writes.
+    /// - `control_rx`: Channel to receive commands from the VMM.
+    /// - `control_tx`: Channel to send control responses to the VMM.
     ///
     /// # Returns
     ///
     /// Upon successful completion, this method returns the MicroVM that was created. Otherwise, it
     /// returns an error.
     ///
-    pub fn new(memory_size: usize, input: Box<InputFn>, output: Box<OutputFn>) -> Result<Self> {
+    pub fn new(
+        memory_size: usize,
+        input: Box<InputFn>,
+        output: Box<OutputFn>,
+        control_rx: Receiver<VcpuControlCommand>,
+        control_tx: Sender<VcpuControlResponse>,
+    ) -> Result<Self> {
         trace!("new(): memory_size={memory_size}");
         crate::timer!("vm_creation");
 
@@ -116,6 +138,8 @@ impl MicroVm {
             vcpu,
             emulator,
             initrd: None,
+            _control_rx: control_rx,
+            _control_tx: control_tx,
         })
     }
 

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -26,13 +26,17 @@ extern crate kvm_ioctls;
 
 use crate::{
     Gateway,
-    io_thread::{
+    io_thread::IoThread,
+    memory_thread,
+    orchestrator::{
         IoControlCommand,
         IoControlResponse,
-        IoThread,
+        MemoryControlCommand,
+        MemoryControlResponse,
+        Orchestrator,
+        VcpuControlCommand,
+        VcpuControlResponse,
     },
-    memory_thread,
-    orchestrator::Orchestrator,
     vmm::microvm::{
         kvm::vmem::VirtualMemory,
         microvm::MicroVm,
@@ -72,7 +76,6 @@ use ::sys::ipc::{
 //==================================================================================================
 
 pub struct Vmm {
-    _io_thread_data_tx: Sender<Message>,
     io_thread: Option<JoinHandle<Result<()>>>,
     _memory_thread: JoinHandle<Result<()>>,
     vcpu_thread: JoinHandle<Result<u16>>,
@@ -114,18 +117,25 @@ impl Vmm {
     ) -> Result<u16> {
         crate::timer!("vmm_creation");
 
+        // io/memory/vcpu_control_rx/tx are channels owned by the VMM and transfer control messages.
+        // *_thread_control_rx/tx are channels owned by the threads that transfer control messages.
         let (vcpu_thread_stdout_tx, io_thread_data_rx) = mpsc::channel::<Message>();
         let (io_thread_data_tx, memory_thread_data_rx) = mpsc::channel::<Message>();
         let (memory_thread_data_tx, vcpu_thread_stdin_rx) = mpsc::channel::<Message>();
         let (io_thread_control_tx, io_control_rx) = mpsc::channel::<IoControlCommand>();
         let (io_control_tx, io_thread_control_rx) = mpsc::channel::<IoControlResponse>();
+        let (memory_control_tx, memory_thread_control_rx) = mpsc::channel::<MemoryControlCommand>();
+        let (memory_thread_control_tx, memory_control_rx) =
+            mpsc::channel::<MemoryControlResponse>();
+        let (vcpu_control_tx, vcpu_thread_control_rx) = mpsc::channel::<VcpuControlCommand>();
+        let (vcpu_thread_control_tx, vcpu_control_rx) = mpsc::channel::<VcpuControlResponse>();
 
         // Spawn I/O thread.
         let io_thread: Option<JoinHandle<Result<()>>> = gateway_conn.map(|conn| {
             IoThread::spawn(
                 conn,
                 io_thread_data_rx,
-                io_thread_data_tx.clone(),
+                io_thread_data_tx,
                 io_thread_control_tx,
                 io_thread_control_rx,
             )
@@ -138,7 +148,13 @@ impl Vmm {
         let output: Box<microvm::OutputFn> =
             Self::build_output_fn(Self::get_stderr_writer(stderr.clone())?, vcpu_thread_stdout_tx);
 
-        let mut microvm: MicroVm = MicroVm::new(memory_size, input, output)?;
+        let mut microvm: MicroVm = MicroVm::new(
+            memory_size,
+            input,
+            output,
+            vcpu_thread_control_rx,
+            vcpu_thread_control_tx,
+        )?;
 
         let rip: u64 = microvm.load_kernel(kernel_filename)?;
         if let Some(ref initrd_filename) = initrd_filename {
@@ -174,12 +190,19 @@ impl Vmm {
 
         // Create a thread that reads from vm_rx and writes to vm_rx2.
         let memory_thread_data_tx: Sender<Message> = memory_thread_data_tx.clone();
-        let memory_thread: JoinHandle<Result<(), anyhow::Error>> =
-            memory_thread::spawn(memory_thread_data_rx, memory_thread_data_tx, move || {
+        let memory_thread: JoinHandle<Result<(), anyhow::Error>> = memory_thread::spawn(
+            memory_thread_data_rx,
+            memory_thread_data_tx,
+            memory_thread_control_rx,
+            memory_thread_control_tx,
+            move || {
                 vmem.lock()
                     .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
                     .add_credit()
-            });
+            },
+            move || Ok(()), // TODO: pause
+            move || Ok(()), // TODO: resume
+        );
 
         // We use an atomic to pass the id of the created thread back to the caller context. We
         // need this because std::thread's JoinHandle does not expose the tid. We synchronize the
@@ -213,11 +236,14 @@ impl Vmm {
         let orchestrator = Orchestrator::new(
             io_control_rx,
             io_control_tx,
+            memory_control_rx,
+            memory_control_tx,
+            vcpu_control_rx,
+            vcpu_control_tx,
             || Ok(()), // TODO: create_snapshot
         );
 
         let mut vmm: Vmm = Self {
-            _io_thread_data_tx: io_thread_data_tx,
             io_thread,
             _memory_thread: memory_thread,
             vcpu_thread,

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -200,8 +200,8 @@ impl Vmm {
                     .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
                     .add_credit()
             },
-            move || Ok(()), // TODO: pause
-            move || Ok(()), // TODO: resume
+            move || Ok(()), // TODO: pause https://github.com/nanvix/nanvix/issues/791
+            move || Ok(()), // TODO: resume https://github.com/nanvix/nanvix/issues/791
         );
 
         // We use an atomic to pass the id of the created thread back to the caller context. We
@@ -240,7 +240,7 @@ impl Vmm {
             memory_control_tx,
             vcpu_control_rx,
             vcpu_control_tx,
-            || Ok(()), // TODO: create_snapshot
+            || Ok(()), // TODO: create_snapshot https://github.com/nanvix/nanvix/issues/947
         );
 
         let mut vmm: Vmm = Self {


### PR DESCRIPTION
I add types to every control channel, even though unit types would be enough for some of them. This way, they can be extended cleanly. They all have standardized enumeration names. They're all in the same file, `orchestrator.rs`.

The memory thread and the vCPU threads now have control channels to the main thread.

The `pause_protocol` now includes a step where it sends a message to the memory thread, then it waits for a response from the vCPU thread. Note the memory thread doesn't do anything yet, that's for another PR.

The `resume_microvm` (I guess I should rename it to resume_protocol) now sends a message to the memory thread and waits for a response from the memory thread, then it sends a message to the vCPU thread. Note those messages don't do anything, that's for another PR.