### PR TITLE
[utils] Expose `-toolchain-bin-dir` To Nanvixd

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -35,7 +35,7 @@ runs:
 
       for bench in "${benchmarks[@]}"; do
         bench_underscore=${bench//-/_}
-        ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_MICROVM} -benchmark ${bench} -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_${bench_underscore}_microvm_${{ inputs.arch }}.txt
+        ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_MICROVM} -toolchain-bin-dir $HOME/toolchain/bin -benchmark ${bench} -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_${bench_underscore}_microvm_${{ inputs.arch }}.txt
       done
     shell: bash
   - name: Clean-up temporary directory
@@ -67,7 +67,7 @@ runs:
         fi
 
         bench_underscore=${bench//-/_}
-        ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_HL} -benchmark ${bench}  -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_${bench_underscore}_hyperlight_${{ inputs.arch }}.txt
+        ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_HL} -toolchain-bin-dir $HOME/toolchain/bin -benchmark ${bench}  -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_${bench_underscore}_hyperlight_${{ inputs.arch }}.txt
       done
     shell: bash
   - name: Clean-up temporary directory

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -34,6 +34,7 @@ CONSOLE_FILE_NAME="${LOGS_DIR}/kernel_$(date "+%Y_%m_%d_%H_%M").log"
 RUST_LOG=trace timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
     ./bin/nanvixd.elf \
         -http-addr "${NANVIXD_SOCKADDR}" \
+        -toolchain-bin-dir "${TOOLCHAIN_DIR}/bin" \
         -tmp-dir "${TMP_DIR}" \
         -console-file "${CONSOLE_FILE_NAME}" &
 NANVIXD_PID=$!

--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -22,6 +22,7 @@ pub struct Args {
     hwloc_file: Option<String>,
     iterations: usize,
     tmp_dir: String,
+    toolchain_bin_dir: String,
 }
 
 //==================================================================================================
@@ -34,16 +35,18 @@ impl Args {
     const OPT_HWLOC: &'static str = "-hwloc";
     const OPT_ITERATIONS: &'static str = "-iterations";
     const OPT_TMP_DIR: &'static str = "-tmp-dir";
+    const OPT_TOOLCHAIN_BIN_DIR: &'static str = "-toolchain-bin-dir";
 
     fn usage() -> String {
         format!(
             "usage: ./bin/nanvix-bench.elf {} \
              [boot-time,cold-start,warm-start,warm-start-vmm,echo-breakdown] [{} \
-             <path_to_hwloc.json> {} <iterations> {} <tmp_dir>]",
+             <path_to_hwloc.json> {} <iterations> {} <tmp_dir> {} <toolchain_bin_dir>]",
             Self::OPT_BENCHMARK,
             Self::OPT_HWLOC,
             Self::OPT_ITERATIONS,
             Self::OPT_TMP_DIR,
+            Self::OPT_TOOLCHAIN_BIN_DIR,
         )
     }
 
@@ -52,6 +55,7 @@ impl Args {
         let mut hwloc_file: Option<String> = None;
         let mut iterations: usize = 100;
         let mut tmp_dir: String = "/tmp/".to_string();
+        let mut toolchain_bin_dir: String = "./toolchain/bin".to_string();
 
         let mut i: usize = 1;
         while i < args.len() {
@@ -93,6 +97,17 @@ impl Args {
                     }
                     tmp_dir = args[i].clone();
                 },
+                Self::OPT_TOOLCHAIN_BIN_DIR => {
+                    i += 1;
+                    if i >= args.len() {
+                        error!("{}", Self::usage());
+                        return Err(anyhow::anyhow!(
+                            "missing value for: {}",
+                            Self::OPT_TOOLCHAIN_BIN_DIR
+                        ));
+                    }
+                    toolchain_bin_dir = args[i].clone();
+                },
                 arg => {
                     error!("{}", Self::usage());
                     return Err(anyhow::anyhow!("invalid argument: {arg}"));
@@ -108,6 +123,7 @@ impl Args {
                 hwloc_file,
                 iterations,
                 tmp_dir,
+                toolchain_bin_dir,
             }),
             Err(_) => {
                 error!("{}", Self::usage());
@@ -130,5 +146,9 @@ impl Args {
 
     pub fn tmp_dir(&self) -> String {
         self.tmp_dir.clone()
+    }
+
+    pub fn toolchain_bin_dir(&self) -> String {
+        self.toolchain_bin_dir.clone()
     }
 }

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -78,5 +78,6 @@ pub struct Benchmark {
     pub nanvixd: Option<Child>,
     pub nanvixd_client: reqwest::Client,
     pub nanvixd_tmp_dir: String,
+    pub nanvixd_toolchain_bin_dir: String,
     pub user_vm_id: Option<String>,
 }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -127,6 +127,8 @@ impl Benchmark {
             NANVIXD_ADDRESS.to_string(),
             ::nanvixd::args::Args::OPT_TMP_DIRECTORY.to_string(),
             self.nanvixd_tmp_dir.clone(),
+            ::nanvixd::args::Args::OPT_TOOLCHAIN_BIN_DIRECTORY.to_string(),
+            self.nanvixd_toolchain_bin_dir.clone(),
         ];
         if let Some(hwloc_file) = &self.hwloc_file {
             nanvixd_args.push(::nanvixd::args::Args::OPT_HWLOC.to_string());
@@ -735,6 +737,7 @@ async fn main() -> Result<()> {
         nanvixd: None,
         nanvixd_client: reqwest::Client::new(),
         nanvixd_tmp_dir: args.tmp_dir(),
+        nanvixd_toolchain_bin_dir: args.toolchain_bin_dir(),
         user_vm_id: None,
     };
 

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -17,10 +17,12 @@ use ::std::{
 // Structures
 //==================================================================================================
 
+#[derive(Clone)]
 pub struct Args {
     http_sockaddr: String,
     tmp_directory: String,
     binary_directory: String,
+    toolchain_binary_directory: String,
     console_file: Option<String>,
     hwloc: Option<HwLoc>,
 }
@@ -34,6 +36,7 @@ impl Args {
     pub const OPT_HTTP_SOCKADDR: &'static str = "-http-addr";
     pub const OPT_TMP_DIRECTORY: &'static str = "-tmp-dir";
     pub const OPT_BIN_DIRECTORY: &'static str = "-bin-dir";
+    pub const OPT_TOOLCHAIN_BIN_DIRECTORY: &'static str = "-toolchain-bin-dir";
     pub const OPT_CONSOLE_FILE: &'static str = "-console-file";
     pub const OPT_HWLOC: &'static str = "-hwloc";
 
@@ -41,6 +44,8 @@ impl Args {
         let mut http_sockaddr: String = String::new();
         let mut tmp_directory: String = config::DEFAULT_TMP_DIRECTORY.to_string();
         let mut binary_directory: String = config::DEFAULT_BIN_DIRECTORY.to_string();
+        let mut toolchain_binary_directory: String =
+            config::DEFAULT_TOOLCHAIN_BIN_DIRECTORY.to_string();
         let mut console_file: Option<String> = None;
         let mut hwloc: Option<HwLoc> = None;
 
@@ -62,6 +67,10 @@ impl Args {
                 Self::OPT_BIN_DIRECTORY => {
                     i += 1;
                     binary_directory = args[i].clone();
+                },
+                Self::OPT_TOOLCHAIN_BIN_DIRECTORY => {
+                    i += 1;
+                    toolchain_binary_directory = args[i].clone();
                 },
                 Self::OPT_CONSOLE_FILE => {
                     i += 1;
@@ -91,6 +100,7 @@ impl Args {
             http_sockaddr,
             tmp_directory,
             binary_directory,
+            toolchain_binary_directory,
             console_file,
             hwloc,
         })
@@ -98,13 +108,15 @@ impl Args {
 
     pub fn usage(program_name: &str) {
         println!(
-            "Usage: {} {} <sockaddr> [{} <file>] [{} <tmp_dir>] [{} <bin_dir>] [{} <hwloc.json>]",
+            "Usage: {} {} <sockaddr> [{} <file>] [{} <tmp_dir>] [{} <bin_dir>] [{} \
+             <toolchain_bin_dir>] [{} <hwloc.json>]",
             program_name,
             Self::OPT_HTTP_SOCKADDR,
             Self::OPT_CONSOLE_FILE,
             Self::OPT_TMP_DIRECTORY,
             Self::OPT_BIN_DIRECTORY,
-            Self::OPT_HWLOC
+            Self::OPT_TOOLCHAIN_BIN_DIRECTORY,
+            Self::OPT_HWLOC,
         );
     }
 
@@ -120,7 +132,11 @@ impl Args {
         &self.binary_directory
     }
 
-    pub fn nanvix_console(&self) -> Option<String> {
+    pub fn toolchain_binary_directory(&self) -> &str {
+        &self.toolchain_binary_directory
+    }
+
+    pub fn console_file(&self) -> Option<String> {
         self.console_file.clone()
     }
 

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -171,6 +171,7 @@ impl SandboxCache {
                             sandbox_config.gateway_sockaddr(),
                             sandbox_config.hwloc(),
                             sandbox_config.binary_directory(),
+                            sandbox_config.toolchain_binary_directory(),
                             control_plane_listener,
                             control_plane_poll,
                         )?),

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -12,8 +12,19 @@ use ::log::error;
 // Constants
 //==================================================================================================
 
-/// Default binary directory path.
+///
+/// # Description
+///
+/// Default binary directory path for Nanvix binaries.
+///
 pub const DEFAULT_BIN_DIRECTORY: &str = "./bin";
+
+///
+/// # Description
+///
+/// Default binary directory path for toolchain-related binaries.
+///
+pub const DEFAULT_TOOLCHAIN_BIN_DIRECTORY: &str = "./toolchain/bin";
 
 /// Suffix for Unix sockets.
 #[cfg(debug_assertions)]

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use crate::{
+    args::Args,
     cache::SandboxCache,
     config,
     message::{
@@ -22,7 +23,6 @@ use ::http_body_util::{
     BodyExt,
     Full,
 };
-use ::hwloc::HwLoc;
 use ::hyper::{
     body::{
         Bytes,
@@ -46,26 +46,14 @@ use ::tokio::sync::Mutex;
 
 pub struct HttpClient {
     sandbox_cache: Arc<Mutex<SandboxCache>>,
-    tmp_directory: String,
-    binary_directory: String,
-    console_file: Option<String>,
-    hwloc: Option<HwLoc>,
+    args: Arc<Args>,
 }
 
 impl HttpClient {
-    pub fn new(
-        sandbox_cache: Arc<Mutex<SandboxCache>>,
-        tmp_directory: String,
-        binary_directory: String,
-        console_file: Option<String>,
-        hwloc: Option<HwLoc>,
-    ) -> Self {
+    pub fn new(sandbox_cache: Arc<Mutex<SandboxCache>>, args: Arc<Args>) -> Self {
         Self {
             sandbox_cache,
-            tmp_directory,
-            binary_directory,
-            console_file,
-            hwloc,
+            args,
         }
     }
 
@@ -102,20 +90,18 @@ impl HttpClient {
 
     async fn serve_new(
         sandbox_cache: Arc<Mutex<SandboxCache>>,
+        args: Arc<Args>,
         message: &message::New,
-        tmp_directory: String,
-        binary_directory: String,
-        console_file: Option<String>,
-        hwloc: Option<HwLoc>,
     ) -> Result<message::NewResponse> {
         let tag: SandboxTag = SandboxTag::new(&message.tenant_id, &message.app_name);
+        let tmp_directory: &str = args.tmp_directory();
 
         let control_plane_sockaddr: String =
-            config::control_plane_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
+            config::control_plane_sockaddr_builder(tmp_directory, tag.tenant_id())?;
         let gateway_sockaddr: String =
-            config::gateway_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
+            config::gateway_sockaddr_builder(tmp_directory, tag.tenant_id())?;
         let user_vm_sockaddr: String =
-            config::user_vm_sockaddr_builder(&tmp_directory, tag.tenant_id())?;
+            config::user_vm_sockaddr_builder(tmp_directory, tag.tenant_id())?;
         let program_args = match message.program_args.len() {
             0 => None,
             _ => Some(message.program_args.clone()),
@@ -127,9 +113,10 @@ impl HttpClient {
             &user_vm_sockaddr,
             &message.program,
             program_args.clone(),
-            console_file.clone(),
-            hwloc.clone(),
-            &binary_directory,
+            args.console_file().clone(),
+            args.hwloc().clone(),
+            args.binary_directory(),
+            args.toolchain_binary_directory(),
         );
 
         // This method will create a sandbox if it is not in the cache.
@@ -148,7 +135,7 @@ impl HttpClient {
     ) -> Result<message::KillResponse> {
         let mut locked_sandbox_cache = sandbox_cache.lock().await;
         let exit_code = match locked_sandbox_cache.kill(message.user_vm_id.clone()).await {
-            Ok(_) => 0,
+            Ok(()) => 0,
             // TODO: more advanced error codes.
             Err(_) => 1,
         };
@@ -164,11 +151,8 @@ impl Service<Request<Incoming>> for HttpClient {
 
     fn call(&self, request: Request<Incoming>) -> Self::Future {
         // Clone all necessary values before moving them into the future
-        let tmp_directory: String = self.tmp_directory.clone();
-        let binary_directory: String = self.binary_directory.clone();
-        let console_file: Option<String> = self.console_file.clone();
-        let hwloc: Option<HwLoc> = self.hwloc.clone();
         let sandbox_cache: Arc<Mutex<SandboxCache>> = self.sandbox_cache.clone();
+        let args: Arc<Args> = self.args.clone();
         let future = async move {
             // Get the request headers before consuming the body.
             let message_type: MessageType = match request
@@ -211,16 +195,7 @@ impl Service<Request<Incoming>> for HttpClient {
                     debug!("- program file: {}", msg.program);
                     debug!("- program args: {}", msg.program_args);
 
-                    match Self::serve_new(
-                        sandbox_cache,
-                        &msg,
-                        tmp_directory.clone(),
-                        binary_directory.clone(),
-                        console_file.clone(),
-                        hwloc.clone(),
-                    )
-                    .await
-                    {
+                    match Self::serve_new(sandbox_cache, args, &msg).await {
                         Ok(response) => message::MessageResponse::New(response),
                         Err(_) => {
                             error!("error processing NEW request");

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -35,7 +35,6 @@ use crate::{
     http::HttpClient,
 };
 use ::anyhow::Result;
-use ::hwloc::HwLoc;
 use ::hyper::server::conn::http1;
 use ::hyper_util::rt::TokioIo;
 use ::std::sync::Arc;
@@ -70,14 +69,11 @@ pub async fn main() -> Result<()> {
                 match result {
                     Ok((stream, sockaddr)) => {
                         debug!("accepted connection from {sockaddr:?}");
-                        let tmp_directory: String = args.tmp_directory().to_string();
-                        let binary_directory: String = args.binary_directory().to_string();
-                        let console_file: Option<String> = args.nanvix_console();
-                        let hwloc: Option<HwLoc> = args.hwloc();
+                        let args: Arc<Args> = Arc::new(args.clone());
                         let sandboxe_cache: Arc<Mutex<SandboxCache>> = sandbox_cache.clone();
                         tokio::spawn(async move {
                             let client =
-                                HttpClient::new(sandboxe_cache, tmp_directory, binary_directory, console_file, hwloc);
+                                HttpClient::new(sandboxe_cache, args);
                             let io: TokioIo<TcpStream> = TokioIo::new(stream);
                             if let Err(e) = http1::Builder::new().serve_connection(io, client).await  {
                                 error!("failed to serve connection (error={e:?})");

--- a/src/utils/nanvixd/src/sandbox/config.rs
+++ b/src/utils/nanvixd/src/sandbox/config.rs
@@ -26,6 +26,8 @@ pub struct SandboxConfig {
     hwloc: Option<HwLoc>,
     /// Path to the binary directory.
     binary_directory: String,
+    /// Path to the toolchain binary directory.
+    toolchain_binary_directory: String,
 }
 
 //==================================================================================================
@@ -48,6 +50,7 @@ impl SandboxConfig {
     /// - `console_file`: File for console output.
     /// - `hwloc`: Hardware locality configuration.
     /// - `binary_directory`: Path to the binary directory.
+    /// - `toolchain_binary_directory`: Path to the toolchain binary directory.
     ///
     /// # Returns
     ///
@@ -63,6 +66,7 @@ impl SandboxConfig {
         console_file: Option<String>,
         hwloc: Option<HwLoc>,
         binary_directory: &str,
+        toolchain_binary_directory: &str,
     ) -> Self {
         Self {
             control_plane_sockaddr: control_plane_sockaddr.to_string(),
@@ -73,6 +77,7 @@ impl SandboxConfig {
             console_file,
             hwloc,
             binary_directory: binary_directory.to_string(),
+            toolchain_binary_directory: toolchain_binary_directory.to_string(),
         }
     }
 
@@ -178,5 +183,18 @@ impl SandboxConfig {
     ///
     pub fn binary_directory(&self) -> &str {
         &self.binary_directory
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the path to the toolchain binary directory.
+    ///
+    /// # Returns
+    ///
+    /// The path to the toolchain binary directory.
+    ///
+    pub fn toolchain_binary_directory(&self) -> &str {
+        &self.toolchain_binary_directory
     }
 }

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -37,12 +37,15 @@ pub struct LinuxDaemon {
 //==================================================================================================
 
 impl LinuxDaemon {
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         control_plane_sockaddr: &str,
         user_vm_sockaddr: &str,
         gateway_sockaddr: &str,
         hwloc: Option<HwLoc>,
         binary_directory: &str,
+        // The toolchain binary directory will be used once we introduce the L2 VM.
+        _toolchain_binary_directory: &str,
         control_plane_listener: &mut SocketListener,
         control_plane_poll: &mut Poll,
     ) -> Result<Self> {


### PR DESCRIPTION
In this PR I extend `nanvixd` with an additional CLI argument, `-toolchain-bin-dir` to point to the binary directory of the Nanvix toolchain. This will become necessary with the L2 VM, as we need to know where is `cloud-hypervisor` installed.

In the process I also clean-up a bit the call signatures of different functions in `nanvixd` by passing an Arc to the CLI arguments, instead of unpacking them at the beginning and passing each argument separately. I only unpack the arguments once we need to initialize the SandboxConfig, as that is, semantically, something different.

Lastly, I expose the same CLI arg to `nanvix-bench` so that it can be passed down to `nanvixd` during the benchmarks.