### PR TITLE
[scripts] Use String Comparison for Error Code Check

### DIFF
--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -97,7 +97,7 @@ KILL_EXIT_CODE=$(curl \
     --data "${KILL_JSON}" \
     http://localhost:"${NANVIXD_PORT_NUMBER}" | jq -r '.exit_code')
 
-if [ "${KILL_EXIT_CODE}" -ne 0 ]; then
+if [ "${KILL_EXIT_CODE}" != "0" ]; then
     echo "Test failed: error killing user VM (code=${KILL_EXIT_CODE})"
     exit 1
 fi


### PR DESCRIPTION
This pull request corrects the logic used to check the error code in the user VM kill command. Previously, the comparison was performed numerically, which could lead to incorrect behavior. The updated implementation uses string comparison, ensuring accurate detection of the intended error condition. This change resolves an issue where the command could fail silently due to improper error code evaluation.