### PR TITLE
[utils] Log linuxd Output to a File

### DIFF
--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -163,6 +163,7 @@ impl LinuxDaemon {
         } else {
             vec![
                 format!("{}/linuxd.elf", binary_directory),
+                args::Args::OPT_LOGFILE.to_string(),
                 args::Args::OPT_CONTROL_PLANE_SOCKADDR.to_string(),
                 control_plane_sockaddr.to_string(),
                 args::Args::OPT_USER_VM_BIND_SOCKADDR.to_string(),


### PR DESCRIPTION
This pull request fixes nanvixd to log output of linuxd to a file.