### PR TITLE
[libs] Improving Thread Attributes Object Initialization / Destruction

### DIFF
--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_destroy.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::pthread::syscall;
 use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::c_int,
@@ -22,11 +23,29 @@ use ::sysapi::{
 ///
 /// # Parameters
 ///
-/// - `attr`: Thread attributes object.
+/// - `attr`: Pointer to the thread attributes object to be destroyed.
 ///
-/// # Returns
+/// # Return Value
 ///
-/// If successful, zero is returned. Otherwise, an error code is returned instead.
+/// On success, this function returns zero. Otherwise, it returns an non-zero error code indicating
+/// the reason for the failure.
+///
+/// # Errors
+///
+/// The following errors can be returned by this function:
+///
+/// - [`ErrorCode::InvalidArgument`] if `attr` points to an invalid address.
+/// - [`ErrorCode::InvalidArgument`] if `attr` points to a misaligned address.
+/// - [`ErrorCode::InvalidArgument`] if `attr` references a thread attribute object that was not
+///   initialized.
+///
+/// # Notes
+///
+/// - Destroying a thread attributes object has no effect on threads that were created using that
+///   object.
+///
+/// - This function always succeed, but portable applications should nevertheless handle a possible
+///   error return.
 ///
 /// # Safety
 ///
@@ -38,15 +57,34 @@ use ::sysapi::{
 ///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pthread_attr_destroy(attr: *mut pthread_attr_t) -> c_int {
-    ::syslog::trace!("pthread_attr_destroy(): attr={:?}", attr);
+    ::syslog::trace!("pthread_attr_destroy(): attr={attr:p}");
 
-    // Check if `attr` is not valid.
+    // Check if `attr` is points to an invalid address.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_destroy(): invalid attribute pointer");
+        ::syslog::error!(
+            "pthread_attr_destroy(): invalid pointer to thread attributes object (attr={attr:p})"
+        );
         return ErrorCode::InvalidArgument.get();
     }
 
-    (*attr).is_initialized = 0;
+    // Check if `attr` points to a misaligned address.
+    if (attr as usize) % core::mem::align_of::<pthread_attr_t>() != 0 {
+        ::syslog::error!(
+            "pthread_attr_destroy(): misaligned pointer to thread attributes object \
+             (attr={attr:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
 
-    0
+    // Attempt to destroy thread attributes object and check for errors.
+    match syscall::pthread_attr_destroy(&mut *attr) {
+        Ok(()) => {
+            ::syslog::trace!("pthread_attr_destroy(): success (attr={attr:p})");
+            0
+        },
+        Err(error) => {
+            ::syslog::warn!("pthread_attr_destroy(): {error:?} (attr={attr:p})");
+            error.code.get()
+        },
+    }
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_init.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::pthread::syscall;
 use ::sys::error::ErrorCode;
 use ::sysapi::{
     ffi::c_int,
@@ -22,11 +23,32 @@ use ::sysapi::{
 ///
 /// # Parameters
 ///
-/// - `attr`: Thread attributes object.
+/// - `attr` - Pointer to the thread attributes object to be initialized.
 ///
-/// # Returns
+/// # Return Value
 ///
-/// If successful, zero is returned. Otherwise, an error code is returned instead.
+/// On success, this function returns zero. Otherwise, it returns an non-zero error code indicating
+/// the reason for the failure.
+///
+/// # Errors
+///
+/// The following errors can be returned by this function:
+///
+/// - [`ErrorCode::InvalidArgument`] if `attr` points to an invalid address.
+/// - [`ErrorCode::InvalidArgument`] if `attr` points to a misaligned address.
+/// - [`ErrorCode::InvalidArgument`] if `attr` points to a thread attribute object that was already
+///   initialized.
+///
+/// # Notes
+///
+/// - Calling this function on a thread attributes object that has already been initialized results
+///   in undefined behavior.
+///
+/// - When a thread attributes object is no longer required, it should be destroyed using the
+///   `pthread_attr_destroy()` function.
+///
+/// - This function always succeed, but portable applications should nevertheless handle a possible
+///   error return.
 ///
 /// # Safety
 ///
@@ -38,15 +60,33 @@ use ::sysapi::{
 ///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pthread_attr_init(attr: *mut pthread_attr_t) -> c_int {
-    ::syslog::trace!("pthread_attr_init(): attr={:?}", attr);
+    ::syslog::trace!("pthread_attr_init(): attr={attr:p}");
 
-    // Check if `attr` is not valid.
+    // Check if `attr` is points to an invalid address.
     if attr.is_null() {
-        ::syslog::error!("pthread_attr_init(): invalid attribute pointer");
+        ::syslog::error!(
+            "pthread_attr_init(): invalid pointer to thread attributes object (attr={attr:p})"
+        );
         return ErrorCode::InvalidArgument.get();
     }
 
-    *attr = pthread_attr_t::default();
+    // Check if `attr` points to a misaligned address.
+    if (attr as usize) % core::mem::align_of::<pthread_attr_t>() != 0 {
+        ::syslog::error!(
+            "pthread_attr_init(): misaligned pointer to thread attributes object (attr={attr:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
 
-    0
+    // Attempt to initialize thread attributes object and check for errors.
+    match syscall::pthread_attr_init(&mut *attr) {
+        Ok(()) => {
+            ::syslog::trace!("pthread_attr_init(): success (attr={attr:p})");
+            0
+        },
+        Err(error) => {
+            ::syslog::warn!("pthread_attr_init(): {error:?} (attr={attr:p})");
+            error.code.get()
+        },
+    }
 }

--- a/src/libs/syscall/src/pthread/mod.rs
+++ b/src/libs/syscall/src/pthread/mod.rs
@@ -9,6 +9,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "syscall")] {
         mod syscall;
         pub use syscall::Pointer;
+        pub use syscall::pthread_attr_init;
         pub use syscall::pthread_create;
         pub use syscall::pthread_exit;
         pub use syscall::pthread_join;

--- a/src/libs/syscall/src/pthread/mod.rs
+++ b/src/libs/syscall/src/pthread/mod.rs
@@ -9,6 +9,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "syscall")] {
         mod syscall;
         pub use syscall::Pointer;
+        pub use syscall::pthread_attr_destroy;
         pub use syscall::pthread_attr_init;
         pub use syscall::pthread_create;
         pub use syscall::pthread_exit;

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -14,6 +14,9 @@ mod mutex;
 /// Thread-specific data area.
 mod tda;
 
+/// Implementation of `pthread_attr_destroy()` system call.
+mod pthread_attr_destroy;
+
 /// Implementation of `pthread_attr_init()` system call.
 mod pthread_attr_init;
 
@@ -49,6 +52,7 @@ use ::sys::{
 use ::sysapi::sys_types::pthread_t;
 pub use cond::*;
 pub use mutex::*;
+pub use pthread_attr_destroy::*;
 pub use pthread_attr_init::*;
 pub use tda::*;
 

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -14,6 +14,9 @@ mod mutex;
 /// Thread-specific data area.
 mod tda;
 
+/// Implementation of `pthread_attr_init()` system call.
+mod pthread_attr_init;
+
 //==================================================================================================
 // Imports
 //==================================================================================================
@@ -46,6 +49,7 @@ use ::sys::{
 use ::sysapi::sys_types::pthread_t;
 pub use cond::*;
 pub use mutex::*;
+pub use pthread_attr_init::*;
 pub use tda::*;
 
 //==================================================================================================

--- a/src/libs/syscall/src/pthread/syscall/pthread_attr_destroy.rs
+++ b/src/libs/syscall/src/pthread/syscall/pthread_attr_destroy.rs
@@ -1,0 +1,60 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::sys_types::pthread_attr_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Destroys a thread attributes object.
+///
+/// # Parameters
+///
+/// - `attr` - Mutable reference to the thread attributes object to be destroyed.
+///
+/// # Return Value
+///
+/// On success, this function returns empty. Otherwise, it returns an error indicating the reason
+/// for the failure.
+///
+/// # Errors
+///
+/// The following errors can be returned by this function:
+///
+/// - [`ErrorCode::InvalidArgument`] if `attr` references a thread attribute object that was not
+///   initialized.
+///
+/// # Notes
+///
+/// - Destroying a thread attributes object has no effect on threads that were created using that
+///   object.
+///
+/// - This function always succeed, but portable applications should nevertheless handle a possible
+///   error return.
+///
+pub fn pthread_attr_destroy(attr: &mut pthread_attr_t) -> Result<(), Error> {
+    ::syslog::trace!("pthread_attr_destroy(): attr={:p}", attr as *const _);
+
+    // Check if `attr` references a thread attributes object that was not initialized.
+    if attr.is_initialized == 0 {
+        let reason: &'static str = "thread attributes object was not initialized";
+        ::syslog::error!("pthread_attr_destroy(): {reason} (attr={:p})", attr as *const _);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    attr.is_initialized = 0;
+
+    Ok(())
+}

--- a/src/libs/syscall/src/pthread/syscall/pthread_attr_init.rs
+++ b/src/libs/syscall/src/pthread/syscall/pthread_attr_init.rs
@@ -1,0 +1,63 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::sys_types::pthread_attr_t;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Initializes a thread attributes object with default values.
+///
+/// # Parameters
+///
+/// - `attr` - Mutable reference to the thread attributes object to be initialized.
+///
+/// # Return Value
+///
+/// On success, this function returns empty. Otherwise, it returns an error indicating the reason
+/// for the failure.
+///
+/// # Errors
+///
+/// The following errors can be returned by this function:
+///
+/// - [`ErrorCode::InvalidArgument`] if `attr` references a thread attribute object that was already
+///   initialized.
+///
+/// # Notes
+///
+/// - Calling this function on a thread attributes object that has already been initialized results
+///   in undefined behavior.
+///
+/// - When a thread attributes object is no longer required, it should be destroyed using the
+///   `pthread_attr_destroy()` function.
+///
+/// - This function always succeed, but portable applications should nevertheless handle a possible
+///   error return.
+///
+pub fn pthread_attr_init(attr: &mut pthread_attr_t) -> Result<(), Error> {
+    ::syslog::trace!("pthread_attr_init(): attr={:p}", attr as *const _);
+
+    // Check if `attr` references a thread attributes object that was already initialized.
+    if attr.is_initialized != 0 {
+        let reason: &'static str = "thread attributes object was already initialized";
+        ::syslog::error!("pthread_attr_init(): {reason} (attr={:p})", attr as *const _);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    *attr = pthread_attr_t::default();
+
+    Ok(())
+}

--- a/src/tests/thread-c/attr_init_destroy.c
+++ b/src/tests/thread-c/attr_init_destroy.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if pthread attributes can be initialized and destroyed.
+void test_pthread_attr_init_destroy(void)
+{
+    fprintf(stderr, "testing pthread_attr_init() and pthread_attr_destroy() ... ");
+
+    // Initialize the thread attributes object and assert operation.
+    pthread_attr_t attr = {
+        0,
+    };
+    int ret = pthread_attr_init(&attr);
+    assert(ret == 0);
+
+    // Destroy the thread attributes object and assert operation.
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/thread-c/common.h
+++ b/src/tests/thread-c/common.h
@@ -39,4 +39,7 @@ extern void test_pthread_mutex_trylock(void);
 // Tests if thread local storage works.
 extern void test_thread_local(void);
 
+// Tests if pthread attributes can be initialized and destroyed.
+extern void test_pthread_attr_init_destroy(void);
+
 #endif

--- a/src/tests/thread-c/main.c
+++ b/src/tests/thread-c/main.c
@@ -103,6 +103,7 @@ int main(int argc, const char *argv[])
     );
 
     test_pthread_self();
+    test_pthread_attr_init_destroy();
     test_pthread_create_join();
     test_pthread_mutex_static_init();
     test_pthread_mutex_dynamic_init();


### PR DESCRIPTION
This pull request adds robust implementations for `pthread_attr_init()` and `pthread_attr_destroy()` in the syscall backend, including input validation, detailed error handling, and logging. It also introduces comprehensive documentation for these APIs and adds a new test to verify their correct behavior. The most important changes are grouped below:

### Implementation and Validation Improvements

* Added syscall backend implementations for `pthread_attr_init()` and `pthread_attr_destroy` in new files (`pthread_attr_init.rs`, `pthread_attr_destroy.rs`). These implementations validate arguments, check initialization state, and provide detailed error handling and logging. [[1]](diffhunk://#diff-95d38ca79fb602034bafbc1b459359652f916b5f594522abdfe6f667f64e8bcdR1-R63) [[2]](diffhunk://#diff-ad2296602eff3e2f504f96c322e27a34fbf4a91f742082224651f18f1f4d82c6R1-R60)
* Updated the FFI bindings (`pthread_attr_init.rs`, `pthread_attr_destroy.rs`) to use the new syscall backend, with improved pointer validation (null and alignment checks), error propagation, and enhanced syslog messages. [[1]](diffhunk://#diff-12b4a48f62912815c6acbde3ecb1fb898de7f3b05af11ae0dc13493f8f10704aL41-R91) [[2]](diffhunk://#diff-125450d2861e76e80b4aacecdc768054369c4fb2520ac29cde8588afbd95ea10L41-R89)

### Documentation Updates

* Expanded and clarified documentation for both `pthread_attr_init()` and `pthread_attr_destroy()` functions, including parameter descriptions, error cases, notes, and return value details. [[1]](diffhunk://#diff-12b4a48f62912815c6acbde3ecb1fb898de7f3b05af11ae0dc13493f8f10704aL25-R51) [[2]](diffhunk://#diff-125450d2861e76e80b4aacecdc768054369c4fb2520ac29cde8588afbd95ea10L25-R48)

### Code Organization

* Registered the new syscall modules and their exports in the pthread module, ensuring they are available when the syscall feature is enabled. [[1]](diffhunk://#diff-bcc0f9c9b0ff4e720bc1a4b16d5b2bd7edd7fd295f42420fad80c18dee507743R12-R13) [[2]](diffhunk://#diff-340018d20eb8da4c8e8a6b1c481e8d61c1844cb9efae3048fadf1cac7311b314R17-R22) [[3]](diffhunk://#diff-340018d20eb8da4c8e8a6b1c481e8d61c1844cb9efae3048fadf1cac7311b314R55-R56)

### Testing

* Added a new C test (`attr_init_destroy.c`) and integrated it into the test suite to verify that `pthread_attr_init()` and `pthread_attr_destroy()` work as expected. [[1]](diffhunk://#diff-18111bd344bf8d4dd66234296d99a466297cfa1d07c34075a501abceb3a3736aR1-R35) [[2]](diffhunk://#diff-c133992a87d9a317a809390e2f758f257e1d2883bdd73a741c5f33319fba5ee2R42-R44) [[3]](diffhunk://#diff-547460b88f2f65d19763135b21d0ca67db7460b9c3982df4869f8a7c7f8478cfR106)