### PR TITLE
[build] Remove `sysalloc` Feature from `nvx` Crate

### DIFF
--- a/src/benchmarks/echo-rust-nostd/Cargo.toml
+++ b/src/benchmarks/echo-rust-nostd/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 name = "echo-rust-nostd"
 
 [dependencies]
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 sys = { workspace = true }
 sysapi = { workspace = true }
 syscall = { workspace = true, features = ["syscall"] }

--- a/src/benchmarks/noop-rust-nostd/Cargo.toml
+++ b/src/benchmarks/noop-rust-nostd/Cargo.toml
@@ -16,7 +16,7 @@ name = "noop-rust-nostd"
 [dependencies]
 sys = { workspace = true }
 cfg-if = { workspace = true }
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 sysalloc = { workspace = true }
 
 [build-dependencies]

--- a/src/daemons/memd/Cargo.toml
+++ b/src/daemons/memd/Cargo.toml
@@ -15,7 +15,7 @@ name = "memd"
 
 [dependencies]
 sys = { workspace = true }
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 proc = { workspace = true, features = ["syscall"] }
 syslog = { workspace = true }
 

--- a/src/daemons/procd/Cargo.toml
+++ b/src/daemons/procd/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 [dependencies]
 sys = { workspace = true }
 proc = { workspace = true, features = ["daemon"] }
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 syslog = { workspace = true }
 
 [build-dependencies]

--- a/src/daemons/wasmd/Cargo.toml
+++ b/src/daemons/wasmd/Cargo.toml
@@ -15,7 +15,7 @@ name = "wasmd"
 
 [dependencies]
 num_enum = { workspace = true }
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 static_assert = { workspace = true }
 sys = { workspace = true }
 sysapi = { workspace = true }

--- a/src/libs/nvx/Cargo.toml
+++ b/src/libs/nvx/Cargo.toml
@@ -11,18 +11,24 @@ description = "Nanvix Runtime Library"
 homepage.workspace = true
 
 [dependencies]
-sysalloc = { workspace = true, optional = true }
+alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 cfg-if = { workspace = true }
 syslog = { workspace = true }
 sys = { workspace = true, features = ["kcall"] }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1", optional = true }
 
+# Platform-specific dependencies.
+[target.'cfg(any(target_os = "none", target_os = "nanvix"))'.dependencies]
+# The sysalloc crate provides a memory allocator implementation for Nanvix.
+# For Linux the allocator is provided by the C library, so sysalloc is not required.
+sysalloc = { workspace = true }
+
 [features]
-default = ["staticlib", "sysalloc"]
+default = ["staticlib"]
 staticlib = []
-sysalloc = ["dep:sysalloc"]
 rustc-dep-of-std = [
+    "alloc",
     "core",
     "compiler_builtins/rustc-dep-of-std",
     "sysalloc/rustc-dep-of-std",

--- a/src/libs/nvx/src/lib.rs
+++ b/src/libs/nvx/src/lib.rs
@@ -21,7 +21,8 @@ mod panic;
 // Imports
 //==================================================================================================
 
-#[cfg(feature = "staticlib")]
+// We link the `alloc` crate when building static libraries to provide heap allocation support.
+#[cfg(all(feature = "staticlib", not(feature = "rustc-dep-of-std")))]
 extern crate alloc;
 
 #[cfg(feature = "staticlib")]
@@ -209,11 +210,11 @@ fn c_trampoline(argp: *mut i8, envp: *mut i8) -> i32 {
 
 /// Initializes system runtime.
 fn init() {
-    #[cfg(feature = "sysalloc")]
+    #[cfg(any(target_os = "none", target_os = "nanvix"))]
     if let Err(e) = sysalloc::init() {
         panic!("failed to initialize memory manager: {:?}", e);
     }
-    #[cfg(feature = "sysalloc")]
+    #[cfg(any(target_os = "none", target_os = "nanvix"))]
     match sysalloc::tda::alloc() {
         core::prelude::v1::Ok(Some(tda_ptr)) => {
             if let Err(error) = ::sys::kcall::pm::set_thread_data_area(tda_ptr) {
@@ -231,11 +232,11 @@ fn init() {
 
 /// Cleans up system runtime.
 fn cleanup() {
-    #[cfg(feature = "sysalloc")]
+    #[cfg(any(target_os = "none", target_os = "nanvix"))]
     if let Err(error) = ::sysalloc::tda::cleanup() {
         panic!("failed to cleanup thread data area ({error:?})");
     }
-    #[cfg(feature = "sysalloc")]
+    #[cfg(any(target_os = "none", target_os = "nanvix"))]
     if let Err(e) = sysalloc::cleanup() {
         panic!("failed to cleanup memory manager: {:?}", e);
     }

--- a/src/libs/posix/Cargo.toml
+++ b/src/libs/posix/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 sys = { workspace = true }
 cfg-if = { workspace = true }
 num_enum = { workspace = true }

--- a/src/tests/arch-rust/Cargo.toml
+++ b/src/tests/arch-rust/Cargo.toml
@@ -18,7 +18,7 @@ arch = { workspace = true, features = ["cpuid"] }
 sys = { workspace = true }
 syscall = { workspace = true, features = ["syscall"] }
 sysapi = { workspace = true }
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 config = { workspace = true }
 syslog = { workspace = true }
 

--- a/src/tests/file-rust/Cargo.toml
+++ b/src/tests/file-rust/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 name = "file-rust"
 
 [dependencies]
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 sys = { workspace = true, features = ["kcall"] }
 sysapi = { workspace = true }
 syscall = { workspace = true, features = ["syscall"] }

--- a/src/tests/linux-app/Cargo.toml
+++ b/src/tests/linux-app/Cargo.toml
@@ -15,7 +15,7 @@ name = "linux-app"
 
 [dependencies]
 sys = { workspace = true }
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 sysapi = { workspace = true }
 syscall = { workspace = true, features = ["syscall"] }
 syslog = { workspace = true }

--- a/src/tests/testd/Cargo.toml
+++ b/src/tests/testd/Cargo.toml
@@ -16,7 +16,7 @@ name = "testd"
 [dependencies]
 arch = { workspace = true }
 sys = { workspace = true }
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 proc = { workspace = true, features = ["syscall"] }
 config = { workspace = true }
 syslog = { workspace = true }

--- a/src/tests/testd/Cargo.toml
+++ b/src/tests/testd/Cargo.toml
@@ -16,7 +16,7 @@ name = "testd"
 [dependencies]
 arch = { workspace = true }
 sys = { workspace = true }
-nvx = { workspace = true }
+nvx = { workspace = true, features = ["sysalloc"] }
 proc = { workspace = true, features = ["syscall"] }
 config = { workspace = true }
 syslog = { workspace = true }

--- a/src/tests/testd/src/main.rs
+++ b/src/tests/testd/src/main.rs
@@ -23,11 +23,7 @@ mod mm;
 
 extern crate nvx;
 
-use ::sys::{
-    config,
-    mm::Address,
-    pm::ProcessIdentifier,
-};
+use ::sys::pm::ProcessIdentifier;
 
 //==================================================================================================
 // Macros
@@ -90,7 +86,7 @@ pub fn main() {
     // Force a page fault.
     ::syslog::info!("triggering a page fault...");
     unsafe {
-        let ptr: *mut u8 = config::memory_layout::USER_HEAP_BASE.into_raw_value() as *mut u8;
+        let ptr: *mut u8 = ::config::memory_layout::USER_MMAP_BASE_RAW as *mut u8;
         *ptr = 1;
     }
 

--- a/src/tests/testd/src/mm/mod.rs
+++ b/src/tests/testd/src/mm/mod.rs
@@ -6,7 +6,12 @@
 //==================================================================================================
 
 use ::arch::mem::PAGE_SIZE;
+use ::config::memory_layout::{
+    USER_MMAPPED_END_RAW,
+    USER_MMAP_BASE_RAW,
+};
 use ::sys::{
+    config::memory_layout::USER_MMAP_BASE,
     mm::{
         AccessPermission,
         Address,
@@ -43,7 +48,7 @@ fn test_mmap_munmap() -> bool {
         Err(_) => return false,
     };
 
-    let vaddr: VirtualAddress = ::sys::config::memory_layout::USER_HEAP_BASE;
+    let vaddr: VirtualAddress = USER_MMAP_BASE;
 
     // Map a page.
     match ::sys::kcall::mm::mmap(mypid, vaddr, AccessPermission::RDONLY) {
@@ -87,7 +92,7 @@ fn test_mmap_write_munmap() -> bool {
         Err(_) => return false,
     };
 
-    let vaddr: VirtualAddress = ::sys::config::memory_layout::USER_HEAP_BASE;
+    let vaddr: VirtualAddress = USER_MMAP_BASE;
 
     // Map a page.
     match ::sys::kcall::mm::mmap(mypid, vaddr, AccessPermission::WRONLY) {
@@ -147,10 +152,10 @@ fn test_mmap_munmap_many_times_inplace() -> bool {
         Err(_) => return false,
     };
 
-    let ntimes: usize = (config::kernel::MEMORY_SIZE / 8) / PAGE_SIZE;
+    let ntimes: usize = ((USER_MMAPPED_END_RAW - USER_MMAP_BASE_RAW) / 64) / PAGE_SIZE;
 
     for _ in 0..ntimes {
-        let vaddr: VirtualAddress = ::sys::config::memory_layout::USER_HEAP_BASE;
+        let vaddr: VirtualAddress = USER_MMAP_BASE;
 
         // Map a page.
         match ::sys::kcall::mm::mmap(mypid, vaddr, AccessPermission::RDONLY) {
@@ -195,9 +200,9 @@ fn test_mmap_munmap_many_times_rolling() -> bool {
         Err(_) => return false,
     };
 
-    let ntimes: usize = (config::kernel::MEMORY_SIZE / 8) / PAGE_SIZE;
+    let ntimes: usize = ((USER_MMAPPED_END_RAW - USER_MMAP_BASE_RAW) / 64) / PAGE_SIZE;
 
-    for vaddr in (0..ntimes).map(|i| config::memory_layout::USER_HEAP_BASE_RAW + i * PAGE_SIZE) {
+    for vaddr in (0..ntimes).map(|i| USER_MMAP_BASE_RAW + i * PAGE_SIZE) {
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(vaddr);
 
         // Map a page.
@@ -242,7 +247,7 @@ fn test_mmap_munmap_return_zeros() -> bool {
         Err(_) => return false,
     };
 
-    let vaddr: VirtualAddress = ::sys::config::memory_layout::USER_HEAP_BASE;
+    let vaddr: VirtualAddress = USER_MMAP_BASE;
 
     // Map a page.
     if ::sys::kcall::mm::mmap(mypid, vaddr, AccessPermission::WRONLY).is_err() {

--- a/src/user/hello-rust-nostd/Cargo.toml
+++ b/src/user/hello-rust-nostd/Cargo.toml
@@ -15,7 +15,7 @@ name = "hello-rust-nostd"
 
 [dependencies]
 sys = { workspace = true }
-nvx = { workspace = true, features = ["sysalloc"] }
+nvx = { workspace = true }
 
 [build-dependencies]
 cc = { workspace = true }


### PR DESCRIPTION
This pull request refactors how the `nvx` crate and memory allocation features are managed across the codebase. The main changes are the removal of the `sysalloc` feature from most crates' dependencies on `nvx`, and a reorganization of how memory allocation dependencies are handled within the `nvx` crate itself. Additionally, the test code is updated to use new memory layout constants for mmap-related tests.

**Dependency and Feature Management:**

* Removed the `features = ["sysalloc"]` option from all dependencies on `nvx` in various `Cargo.toml` files, so now these crates depend on `nvx` without enabling the `sysalloc` feature by default. [[1]](diffhunk://#diff-c687c53d1301c976a9de9233e882e66463ab25efb486bda71dd1d8bf99df70afL17-R17) [[2]](diffhunk://#diff-89d861d583d4af8a2a94fffa924163f7e4cccd647a38de1dc17ef6f920a86619L19-R19) [[3]](diffhunk://#diff-f2c84c4f6c20f5b25cb915b4f1e479a80a9f08783847f55dede709eeae14d081L18-R18) [[4]](diffhunk://#diff-0dd0384094b8ae76dee17b512ee150ad7a91096f29df0c374e92be68809a7874L16-R16) [[5]](diffhunk://#diff-4e138f25f0e74b5c8d7e7e985ec82501884c71f531f59408c8f0e26f5527e351L18-R18) [[6]](diffhunk://#diff-b551b1b9fbcebd0982083721ef91ac2a2d31ebff56d257d1f8ae6f958930f338L17-R17) [[7]](diffhunk://#diff-b3a98fc82a6f0b6dcb8d982904c6268e5c4a6b8f1792c85b17176af47d041992L21-R21) [[8]](diffhunk://#diff-8fd265d0c9a0cde1f2ecfe8c3f61ebfb29abcdcd4dcb08065cb90359dc246a86L17-R17) [[9]](diffhunk://#diff-52c9720daf77e021b748d253e596a88ca264512872ba978806e1f3486d3ee7c6L18-R18) [[10]](diffhunk://#diff-11e0464cfd1b3486b671fe1ef40103cd3ef1c36dcc4f6ec49391fb7b57fd1ca1L18-R18)

* In the `nvx` crate (`src/libs/nvx/Cargo.toml`):
  - Replaced the direct dependency on `sysalloc` with an optional dependency on `alloc` (from `rustc-std-workspace-alloc`) and moved `sysalloc` to a platform-specific dependency for `target_os = "none"` or `target_os = "nanvix"`.
  - Updated the `default` feature to remove `sysalloc` and adjusted the `rustc-dep-of-std` feature to include the new optional dependencies.

* Updated conditional compilation in `nvx/src/lib.rs` to only initialize or clean up `sysalloc` when running on bare-metal or Nanvix OS targets, instead of using the `sysalloc` feature flag. Also refined the condition for importing `alloc`. [[1]](diffhunk://#diff-63f14467b325f3f78a86bc930958f9a345c17e31d120317274a1b39d178062d5L24-R24) [[2]](diffhunk://#diff-63f14467b325f3f78a86bc930958f9a345c17e31d120317274a1b39d178062d5L212-R216) [[3]](diffhunk://#diff-63f14467b325f3f78a86bc930958f9a345c17e31d120317274a1b39d178062d5L234-R238)

**Test and Example Code Updates:**

* Refactored test code in `src/tests/testd/src/main.rs` and `src/tests/testd/src/mm/mod.rs` to use the new `USER_MMAP_BASE`, `USER_MMAP_BASE_RAW`, and `USER_MMAPPED_END_RAW` constants from the `config::memory_layout` module, replacing previous usage of `USER_HEAP_BASE` and related constants. This includes updating mmap test logic to reflect the new memory layout. [[1]](diffhunk://#diff-0b1ab407b8409b55468b732a07fed6f4859e701cd7d25ee0238613903e44c05cL26-R26) [[2]](diffhunk://#diff-0b1ab407b8409b55468b732a07fed6f4859e701cd7d25ee0238613903e44c05cL93-R89) [[3]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99R9-R14) [[4]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L46-R51) [[5]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L90-R95) [[6]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L150-R158) [[7]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L198-R205) [[8]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L245-R250)