### PR TITLE
[libs] Initial Implementation for `pthread_getattr_np`

### DIFF
--- a/src/libs/sysapi/Cargo.toml
+++ b/src/libs/sysapi/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 
 [dependencies]
 compiler_builtins = { version = "0.1", optional = true }
+config = { workspace = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 static_assert = { workspace = true }
 
@@ -21,5 +22,6 @@ std = []
 rustc-dep-of-std = [
     "core",
     "compiler_builtins/rustc-dep-of-std",
+    "config/rustc-dep-of-std",
     "static_assert/rustc-dep-of-std",
 ]

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -28,6 +28,10 @@ use crate::{
     },
     sys_socket::socklen_t,
 };
+use ::config::memory_layout::{
+    USER_STACK_SIZE,
+    USER_STACK_TOP_RAW,
+};
 use ::core::mem::size_of;
 
 #[cfg(target_pointer_width = "32")]
@@ -166,8 +170,8 @@ impl Default for pthread_attr_t {
         // TODO: review this once all fields are supported
         Self {
             is_initialized: 1,
-            stackaddr: core::ptr::null_mut(),
-            stacksize: 0,
+            stackaddr: USER_STACK_TOP_RAW as *mut _,
+            stacksize: USER_STACK_SIZE as c_size_t,
             contentionscope: 0,
             inheritsched: 0,
             schedpolicy: SCHED_OTHER,

--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -51,6 +51,7 @@ rustc-dep-of-std = [
     "sbrk",
     "cfg-if/rustc-dep-of-std",
     "compiler_builtins/rustc-dep-of-std",
+    "config/rustc-dep-of-std",
     "nvx/rustc-dep-of-std",
     "sys/rustc-dep-of-std",
     "static_assert/rustc-dep-of-std",

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -15,6 +15,7 @@ pub mod pthread_cond_signal;
 pub mod pthread_cond_timedwait;
 pub mod pthread_cond_wait;
 pub mod pthread_create;
+pub mod pthread_getattr_np;
 pub mod pthread_getschedparam;
 pub mod pthread_getspecific;
 pub mod pthread_join;

--- a/src/libs/syscall/src/pthread/bindings/pthread_getattr_np.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_getattr_np.rs
@@ -1,0 +1,84 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::pthread::syscall;
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::{
+        pthread_attr_t,
+        pthread_t,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Initializes the thread attributes object with the actual values of a given thread.
+///
+/// # Parameters
+///
+/// - `thread`: Thread whose attributes will be retrieved.
+/// - `attr`: Pointer to the thread attributes object to be filled.
+///
+/// # Return Value
+///
+/// On success, this function returns zero. Otherwise, it returns an non-zero error code indicating
+/// the reason for the failure.
+///
+/// # Errors
+///
+/// The following errors can be returned by this function:
+///
+/// - [`ErrorCode::InvalidArgument`] if `attr` points to an invalid address.
+/// - [`ErrorCode::InvalidArgument`] if `attr` points to a misaligned address.
+/// - [`ErrorCode::ResourceBusy`] if `attr` references a thread attribute object that was already
+///   initialized.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+///
+/// - `attr` points to a valid `pthread_attr_t` structure.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_getattr_np(thread: pthread_t, attr: *mut pthread_attr_t) -> c_int {
+    ::syslog::trace!("pthread_getattr_np(): thread={:?}, attr={attr:p}", thread);
+
+    // Check if `attr` points to an invalid address.
+    if attr.is_null() {
+        ::syslog::error!(
+            "pthread_getattr_np(): invalid pointer to thread attributes object (attr={attr:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `attr` points to a misaligned address.
+    if (attr as usize) % core::mem::align_of::<pthread_attr_t>() != 0 {
+        ::syslog::error!(
+            "pthread_getattr_np(): misaligned pointer to thread attributes object (attr={attr:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    match syscall::pthread_getattr_np(thread, &mut *attr) {
+        Ok(()) => {
+            ::syslog::trace!("pthread_getattr_np(): success (attr={attr:p})");
+            0
+        },
+        Err(error) => {
+            ::syslog::warn!("pthread_getattr_np(): {error:?} (attr={attr:p})");
+            error.code.get()
+        },
+    }
+}

--- a/src/libs/syscall/src/pthread/mod.rs
+++ b/src/libs/syscall/src/pthread/mod.rs
@@ -13,6 +13,7 @@ cfg_if::cfg_if! {
         pub use syscall::pthread_attr_init;
         pub use syscall::pthread_create;
         pub use syscall::pthread_exit;
+        pub use syscall::pthread_getattr_np;
         pub use syscall::pthread_join;
         pub use syscall::pthread_self;
         pub use syscall::pthread_mutex_destroy;

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -20,6 +20,9 @@ mod pthread_attr_destroy;
 /// Implementation of `pthread_attr_init()` system call.
 mod pthread_attr_init;
 
+/// Implementation of `pthread_getattr_np()` system call.
+mod pthread_getattr_np;
+
 //==================================================================================================
 // Imports
 //==================================================================================================
@@ -54,6 +57,7 @@ pub use cond::*;
 pub use mutex::*;
 pub use pthread_attr_destroy::*;
 pub use pthread_attr_init::*;
+pub use pthread_getattr_np::*;
 pub use tda::*;
 
 //==================================================================================================

--- a/src/libs/syscall/src/pthread/syscall/pthread_getattr_np.rs
+++ b/src/libs/syscall/src/pthread/syscall/pthread_getattr_np.rs
@@ -40,7 +40,7 @@ use sysalloc::Address;
 ///
 /// The following errors can be returned by this function:
 ///
-/// - [`ErrorCode::InvalidArgument`] if `attr` references a thread attribute object that was already
+/// - [`ErrorCode::ResourceBusy`] if `attr` references a thread attribute object that was already
 ///   initialized.
 ///
 pub fn pthread_getattr_np(thread: pthread_t, attr: &mut pthread_attr_t) -> Result<(), Error> {
@@ -50,7 +50,7 @@ pub fn pthread_getattr_np(thread: pthread_t, attr: &mut pthread_attr_t) -> Resul
     if attr.is_initialized != 0 {
         let reason: &'static str = "thread attributes object was already initialized";
         ::syslog::error!("pthread_getattr_np(): {reason} (attr={:p})", attr as *const _);
-        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        return Err(Error::new(ErrorCode::ResourceBusy, reason));
     }
 
     *attr = pthread_attr_t::default();

--- a/src/libs/syscall/src/pthread/syscall/pthread_getattr_np.rs
+++ b/src/libs/syscall/src/pthread/syscall/pthread_getattr_np.rs
@@ -1,0 +1,67 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::pthread::syscall::STACKS;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+use ::sysapi::sys_types::{
+    c_size_t,
+    pthread_attr_t,
+    pthread_t,
+};
+use sysalloc::Address;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Initializes the thread attributes object with the actual values of a given thread.
+///
+/// # Parameters
+///
+/// * `thread` - Thread whose attributes will be retrieved.
+/// * `attr` - Place where the thread attributes will be stored.
+///
+/// # Returns
+///
+/// On success, this function returns empty. Otherwise, it returns an error indicating the cause
+/// of the failure.
+///
+/// # Errors
+///
+/// The following errors can be returned by this function:
+///
+/// - [`ErrorCode::InvalidArgument`] if `attr` references a thread attribute object that was already
+///   initialized.
+///
+pub fn pthread_getattr_np(thread: pthread_t, attr: &mut pthread_attr_t) -> Result<(), Error> {
+    ::syslog::trace!("pthread_getattr_np(): thread={:?}, attr={:p}", thread, attr as *const _);
+
+    // Check if `attr` references a thread attributes object that was already initialized.
+    if attr.is_initialized != 0 {
+        let reason: &'static str = "thread attributes object was already initialized";
+        ::syslog::error!("pthread_getattr_np(): {reason} (attr={:p})", attr as *const _);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    *attr = pthread_attr_t::default();
+
+    // Try to retrieve the thread's stack info. If no entry is found, the caller is the main thread
+    // of the current process and the previously-initialized default attributes contain the correct
+    // values for the main thread's stack.
+    if let Some(stack) = STACKS.lock().get(&thread) {
+        attr.stackaddr = stack.base().into_raw_value() as *mut _;
+        attr.stacksize = stack.size() as c_size_t;
+    }
+
+    Ok(())
+}

--- a/src/tests/thread-c/common.h
+++ b/src/tests/thread-c/common.h
@@ -42,4 +42,7 @@ extern void test_thread_local(void);
 // Tests if pthread attributes can be initialized and destroyed.
 extern void test_pthread_attr_init_destroy(void);
 
+// Tests if pthread_getattr_np() can retrieve attributes and they can be destroyed.
+extern void test_pthread_getattr_np_destroy(void);
+
 #endif

--- a/src/tests/thread-c/getattr.c
+++ b/src/tests/thread-c/getattr.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#define _GNU_SOURCE 1
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+/* FIXME: Remove the following import once it is available from NewLib headers. */
+extern int pthread_getattr_np(pthread_t thread, pthread_attr_t *attr);
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if pthread_getattr_np() can retrieve attributes and they can be destroyed.
+void test_pthread_getattr_np_destroy(void)
+{
+    fprintf(stderr, "testing pthread_getattr_np() and pthread_attr_destroy() ... ");
+
+    // Get attributes of the calling thread.
+    pthread_attr_t attr = {0};
+    int ret = pthread_getattr_np(pthread_self(), &attr);
+    assert(ret == 0);
+
+    // Sanity check a couple of fields via accessors; values are implementation-defined,
+    // so we only verify that getters succeed and return something sensible.
+    size_t stacksize = 0;
+    void *stackaddr = NULL;
+    ret = pthread_attr_getstack(&attr, &stackaddr, &stacksize);
+    assert(ret == 0);
+    assert(stacksize > 0);
+
+    int detachstate = 0;
+    ret = pthread_attr_getdetachstate(&attr, &detachstate);
+    assert(ret == 0);
+    assert(detachstate == PTHREAD_CREATE_JOINABLE || detachstate == PTHREAD_CREATE_DETACHED);
+
+    // Destroy the attributes object.
+    ret = pthread_attr_destroy(&attr);
+    assert(ret == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/thread-c/main.c
+++ b/src/tests/thread-c/main.c
@@ -104,6 +104,7 @@ int main(int argc, const char *argv[])
 
     test_pthread_self();
     test_pthread_attr_init_destroy();
+    test_pthread_getattr_np_destroy();
     test_pthread_create_join();
     test_pthread_mutex_static_init();
     test_pthread_mutex_dynamic_init();


### PR DESCRIPTION
This pull request introduces support for the non-portable `pthread_getattr_np()` function in the syscall and sysapi libraries, including its implementation, binding, and tests. It also updates thread attribute initialization to use platform stack defaults and ensures the new function is properly integrated and tested.

**Support for pthread_getattr_np():**

* Added a full implementation of `pthread_getattr_np()` in `src/libs/syscall/src/pthread/syscall/pthread_getattr_np.rs`, which retrieves thread attributes, including stack information, for a given thread.
* Introduced a C binding for `pthread_getattr_np()` in `src/libs/syscall/src/pthread/bindings/pthread_getattr_np.rs` and exposed it in the module system.

**Integration and Dependency Updates:**

* Registered the new `config` dependency in `sysapi` and `syscall` crates and included it in the `rustc-dep-of-std` feature group to ensure consistent stack configuration.
* Updated `pthread_attr_t::default()` to use `USER_STACK_TOP_RAW` and `USER_STACK_SIZE` from the `config` crate, ensuring correct stack defaults for new threads.

**Testing:**

* Added comprehensive tests for `pthread_getattr_np()` in C (`src/tests/thread-c/getattr.c`), checking attribute retrieval and destruction, and integrated the test into the main test runner.