### PR TITLE
[microvm] Rename channels and enums

### DIFF
--- a/src/microvm/src/io_thread.rs
+++ b/src/microvm/src/io_thread.rs
@@ -35,17 +35,17 @@ pub struct IoThread {
     /// Connection to the gateway.
     gateway: Gateway,
     /// Gateway receiver.
-    microvm_rx: Receiver<Message>,
+    data_rx: Receiver<Message>,
     /// Gateway sender.
-    microvm_tx: Sender<Message>,
+    data_tx: Sender<Message>,
     /// Queue of incoming messages.
     incoming: VecDeque<Message>,
     /// Queue of outgoing messages.
     outgoing: VecDeque<Message>,
     /// Command sender to the VMM.
-    _vmm_control_tx: Sender<ControlCommand>,
+    _control_tx: Sender<IoControlCommand>,
     /// Response receiver from the VMM.
-    vmm_control_rx: Receiver<ControlCommandResponse>,
+    control_rx: Receiver<IoControlResponse>,
     // TODO: channels to an outside issuer of snapshot commands and to linuxd.
 }
 
@@ -56,10 +56,10 @@ pub struct IoThread {
 ///
 /// # Description
 ///
-/// Control plane commands.
+/// Control plane commands from the I/O thread to the VMM.
 ///
 #[derive(PartialEq)]
-pub enum ControlCommand {
+pub enum IoControlCommand {
     _StartMicroVm,
     _LoadSnapshotAndRun,
     _PauseMicroVm,
@@ -72,10 +72,10 @@ pub enum ControlCommand {
 ///
 /// # Description
 ///
-/// Control plane command responses.
+/// Control plane command responses from the VMM to the I/O thread.
 ///
 #[derive(PartialEq)]
-pub enum ControlCommandResponse {
+pub enum IoControlResponse {
     MicroVmPaused,
     SnapshotCreated,
     FlushOutput,
@@ -95,10 +95,10 @@ impl IoThread {
     /// # Parameters
     ///
     /// - `gateway`: Connection to gateway.
-    /// - `microvm_rx`: MicroVM receiver.
-    /// - `microvm_tx`: MicroVM sender.
-    /// - `vmm_control_tx`: Command sender.
-    /// - `vmm_control_rx`: Response receiver.
+    /// - `data_rx`: MicroVM receiver.
+    /// - `data_tx`: MicroVM sender.
+    /// - `control_tx`: Command sender.
+    /// - `control_rx`: Response receiver.
     ///
     /// # Returns
     ///
@@ -106,14 +106,14 @@ impl IoThread {
     ///
     pub fn spawn(
         gateway: Gateway,
-        microvm_rx: Receiver<Message>,
-        microvm_tx: Sender<Message>,
-        vmm_control_tx: Sender<ControlCommand>,
-        vmm_control_rx: Receiver<ControlCommandResponse>,
+        data_rx: Receiver<Message>,
+        data_tx: Sender<Message>,
+        control_tx: Sender<IoControlCommand>,
+        control_rx: Receiver<IoControlResponse>,
     ) -> JoinHandle<Result<()>> {
         thread::spawn(move || {
             let mut io_thread: IoThread =
-                IoThread::new(gateway, microvm_rx, microvm_tx, vmm_control_tx, vmm_control_rx)?;
+                IoThread::new(gateway, data_rx, data_tx, control_tx, control_rx)?;
             io_thread.run()?;
             Ok(())
         })
@@ -127,10 +127,10 @@ impl IoThread {
     /// # Parameters
     ///
     /// - `gateway`: Connection to gateway.
-    /// - `microvm_rx`: MicroVM receiver.
-    /// - `microvm_tx`: MicroVM sender.
-    /// - `vmm_control_tx`: Command sender.
-    /// - `vmm_control_rx`: Response receiver.
+    /// - `data_rx`: MicroVM receiver.
+    /// - `data_tx`: MicroVM sender.
+    /// - `control_tx`: Command sender.
+    /// - `control_rx`: Response receiver.
     ///
     /// # Returns
     ///
@@ -138,19 +138,19 @@ impl IoThread {
     ///
     fn new(
         gateway: Gateway,
-        microvm_rx: Receiver<Message>,
-        microvm_tx: Sender<Message>,
-        vmm_control_tx: Sender<ControlCommand>,
-        vmm_control_rx: Receiver<ControlCommandResponse>,
+        data_rx: Receiver<Message>,
+        data_tx: Sender<Message>,
+        control_tx: Sender<IoControlCommand>,
+        control_rx: Receiver<IoControlResponse>,
     ) -> Result<Self> {
         Ok(Self {
             gateway,
-            microvm_rx,
-            microvm_tx,
+            data_rx,
+            data_tx,
             incoming: VecDeque::new(),
             outgoing: VecDeque::new(),
-            _vmm_control_tx: vmm_control_tx,
-            vmm_control_rx,
+            _control_tx: control_tx,
+            control_rx,
         })
     }
 
@@ -213,7 +213,7 @@ impl IoThread {
     /// Otherwise, if the channel is empty, `false` is returned. Otherwise, an error is returned.
     ///
     fn try_receive_from_microvm(&mut self) -> Result<bool> {
-        match self.microvm_rx.try_recv() {
+        match self.data_rx.try_recv() {
             Ok(mut message) => {
                 profiler::timestamp_message!(
                     &mut message.payload,
@@ -289,7 +289,7 @@ impl IoThread {
                         + std::mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
                 );
                 // NOTE: calling `send()` on a channel does not block.
-                self.microvm_tx.send(message)?;
+                self.data_tx.send(message)?;
                 Ok(())
             },
             None => Ok(()),
@@ -306,10 +306,10 @@ impl IoThread {
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
     fn try_receive_from_vmm_control(&mut self) -> Result<()> {
-        match self.vmm_control_rx.try_recv() {
+        match self.control_rx.try_recv() {
             Ok(response) => match response {
-                ControlCommandResponse::FlushOutput => self.flush_microvm_output(),
-                ControlCommandResponse::FlushInput => self.flush_linuxd_input(),
+                IoControlResponse::FlushOutput => self.flush_microvm_output(),
+                IoControlResponse::FlushInput => self.flush_linuxd_input(),
                 _ => Ok(()), // TODO: forward to whoever is interested. This requires having control channels.
             },
             Err(TryRecvError::Empty) => Ok(()),
@@ -332,7 +332,7 @@ impl IoThread {
     ///
     fn flush_microvm_output(&mut self) -> Result<()> {
         while self.try_receive_from_microvm()? {
-            // Keep looping until `microvm_rx` is empty, which breaks the loop.
+            // Keep looping until `data_rx` is empty, which breaks the loop.
         }
         while !self.outgoing.is_empty() {
             self.try_send_to_gateway()?;

--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use crate::io_thread::{
-    ControlCommand,
-    ControlCommandResponse,
+    IoControlCommand,
+    IoControlResponse,
 };
 use ::anyhow::Result;
 use ::std::{
@@ -37,8 +37,8 @@ pub const TIMEOUT_WARNING_INTERVAL_IN_MS: usize = 10;
 ///
 pub struct Orchestrator {
     state: State,
-    io_control_rx: Receiver<ControlCommand>,
-    io_control_tx: Sender<ControlCommandResponse>,
+    io_control_rx: Receiver<IoControlCommand>,
+    io_control_tx: Sender<IoControlResponse>,
     create_snapshot: fn() -> Result<()>,
 }
 
@@ -67,8 +67,8 @@ enum State {
 
 impl Orchestrator {
     pub fn new(
-        io_control_rx: Receiver<ControlCommand>,
-        io_control_tx: Sender<ControlCommandResponse>,
+        io_control_rx: Receiver<IoControlCommand>,
+        io_control_tx: Sender<IoControlResponse>,
         create_snapshot: fn() -> Result<()>,
     ) -> Self {
         Self {
@@ -91,7 +91,7 @@ impl Orchestrator {
     pub fn handle_command(&mut self) -> Result<()> {
         match self.io_control_rx.try_recv() {
             Ok(command) => match command {
-                ControlCommand::_StartMicroVm => {
+                IoControlCommand::_StartMicroVm => {
                     if self.state == State::PreBoot {
                         // TODO: separate starting logic from `spawn()` and put it here
                         // This TODO could be done right now, but it's a major refactor.
@@ -100,7 +100,7 @@ impl Orchestrator {
                     }
                     Ok(())
                 },
-                ControlCommand::_LoadSnapshotAndRun => {
+                IoControlCommand::_LoadSnapshotAndRun => {
                     if self.state == State::PreBoot {
                         // TODO: load snapshot
                         // This TODO requires being able to create snapshots.
@@ -118,7 +118,7 @@ impl Orchestrator {
                     }
                     Ok(())
                 },
-                ControlCommand::_PauseMicroVm => {
+                IoControlCommand::_PauseMicroVm => {
                     if self.state == State::Running {
                         if let Err(e) = self.pause_protocol() {
                             let reason: String =
@@ -129,7 +129,7 @@ impl Orchestrator {
                     }
                     Ok(())
                 },
-                ControlCommand::_PauseAndCreateSnapshot => {
+                IoControlCommand::_PauseAndCreateSnapshot => {
                     if self.state == State::Running {
                         if let Err(e) = self.pause_protocol() {
                             let reason: String =
@@ -145,11 +145,11 @@ impl Orchestrator {
                         }
                         trace!("Snapshot created");
                         self.io_control_tx
-                            .send(ControlCommandResponse::SnapshotCreated)?;
+                            .send(IoControlResponse::SnapshotCreated)?;
                     }
                     Ok(())
                 },
-                ControlCommand::_CreateSnapshot => {
+                IoControlCommand::_CreateSnapshot => {
                     if self.state == State::Paused {
                         if let Err(e) = (self.create_snapshot)() {
                             let reason: String =
@@ -159,11 +159,11 @@ impl Orchestrator {
                         }
                         trace!("Snapshot created");
                         self.io_control_tx
-                            .send(ControlCommandResponse::SnapshotCreated)?;
+                            .send(IoControlResponse::SnapshotCreated)?;
                     }
                     Ok(())
                 },
-                ControlCommand::_ResumeMicroVm => {
+                IoControlCommand::_ResumeMicroVm => {
                     if self.state == State::Paused {
                         // TODO: tell linuxd it's fine to send more messages
                         // This TODO requires having a control plane connection with linuxd
@@ -177,7 +177,7 @@ impl Orchestrator {
                     }
                     Ok(())
                 },
-                ControlCommand::LinuxDaemonFlushed => {
+                IoControlCommand::LinuxDaemonFlushed => {
                     // NOTE: this will be unreachable once the communication is fully implemented
                     // `LinuxDaemonFlushed` should only be sent in the middle of `pause_protocol`.
                     // In fact, it should already be unreachable, but it cannot be tested ATM.
@@ -209,17 +209,14 @@ impl Orchestrator {
         // This TODO requires pausing the vCPU and a control plane communication with linuxd
         trace!("MicroVM paused");
         // Flush output to linuxd
-        self.io_control_tx
-            .send(ControlCommandResponse::FlushOutput)?;
+        self.io_control_tx.send(IoControlResponse::FlushOutput)?;
         // TODO: tell linuxd to stop sending messages (Flushing -> Paused)
         // TODO: get a response from linuxd
         // These TODOs require a control plane communication with linuxd
-        self.io_control_tx
-            .send(ControlCommandResponse::FlushInput)?;
+        self.io_control_tx.send(IoControlResponse::FlushInput)?;
         self.receive_linux_daemon_flushed()?;
         self.state = State::Paused;
-        self.io_control_tx
-            .send(ControlCommandResponse::MicroVmPaused)?;
+        self.io_control_tx.send(IoControlResponse::MicroVmPaused)?;
         Ok(())
     }
 
@@ -240,7 +237,7 @@ impl Orchestrator {
         // Different kinds of messages can be ignored,
         // as they wouldn't do anything while the VMM is pausing.
         while match self.io_control_rx.try_recv() {
-            Ok(command) => command != ControlCommand::LinuxDaemonFlushed,
+            Ok(command) => command != IoControlCommand::LinuxDaemonFlushed,
             Err(TryRecvError::Empty) => true,
             Err(TryRecvError::Disconnected) => {
                 let reason: String = "the vmm has disconnected".to_string();

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -13,8 +13,8 @@ extern crate kvm_ioctls;
 use crate::{
     Gateway,
     io_thread::{
-        ControlCommand,
-        ControlCommandResponse,
+        IoControlCommand,
+        IoControlResponse,
         IoThread,
     },
     memory_thread,
@@ -75,7 +75,7 @@ static VMEM: OnceLock<Arc<Mutex<SandboxMemoryManager<ExclusiveSharedMemory>>>> =
 //==================================================================================================
 
 pub struct Vmm {
-    _gateway_tx: Sender<Message>,
+    _io_thread_data_tx: Sender<Message>,
     io_thread: Option<JoinHandle<Result<()>>>,
     _memory_thread: JoinHandle<Result<()>>,
     vcpu_thread: JoinHandle<Result<u16>>,
@@ -116,20 +116,20 @@ impl Vmm {
     ) -> Result<u16> {
         crate::timer!("vmm_creation");
 
-        let (vm_tx, gateway_rx) = mpsc::channel::<Message>();
-        let (gateway_tx, memory_thread_rx) = mpsc::channel::<Message>();
-        let (memory_thread_tx, vm_rx) = mpsc::channel::<Message>();
-        let (control_input_tx, control_input_rx) = mpsc::channel::<ControlCommand>();
-        let (control_output_tx, control_output_rx) = mpsc::channel::<ControlCommandResponse>();
+        let (vcpu_thread_stdout_tx, io_thread_data_rx) = mpsc::channel::<Message>();
+        let (io_thread_data_tx, memory_thread_data_rx) = mpsc::channel::<Message>();
+        let (memory_thread_data_tx, vcpu_thread_stdin_rx) = mpsc::channel::<Message>();
+        let (io_thread_control_tx, io_control_rx) = mpsc::channel::<IoControlCommand>();
+        let (io_control_tx, io_thread_control_rx) = mpsc::channel::<IoControlResponse>();
 
         // Spawn I/O thread.
         let io_thread: Option<JoinHandle<Result<()>>> = gateway_conn.map(|conn| {
             IoThread::spawn(
                 conn,
-                gateway_rx,
-                gateway_tx.clone(),
-                control_input_tx,
-                control_output_rx,
+                io_thread_data_rx,
+                io_thread_data_tx.clone(),
+                io_thread_control_tx,
+                io_thread_control_rx,
             )
         });
 
@@ -246,7 +246,7 @@ impl Vmm {
                 },
             };
 
-            if let Err(e) = vm_tx.send(message) {
+            if let Err(e) = vcpu_thread_stdout_tx.send(message) {
                 let reason: String = format!("failed to send message: {:?}", e);
                 error!("output(): {}", reason);
                 return Err(HyperlightError::AnyhowError(anyhow::Error::msg(reason)));
@@ -256,7 +256,7 @@ impl Vmm {
         })?;
 
         sandbox.register("VmbusRead", move || -> Result<Vec<u8>, HyperlightError> {
-            match vm_rx.try_recv() {
+            match vcpu_thread_stdin_rx.try_recv() {
                 Ok(mut msg) => {
                     consume_credit()?;
                     msg.message_type = MessageType::Ikc;
@@ -278,7 +278,7 @@ impl Vmm {
 
         // Create a thread that reads from vm_rx and writes to vm_rx2.
         let memory_thread: JoinHandle<Result<(), anyhow::Error>> =
-            memory_thread::spawn(memory_thread_rx, memory_thread_tx, add_credit);
+            memory_thread::spawn(memory_thread_data_rx, memory_thread_data_tx, add_credit);
 
         // We use an atomic to pass the id of the created thread back to the caller context. We
         // need this because std::thread's JoinHandle does not expose the tid. We synchronize the
@@ -319,13 +319,13 @@ impl Vmm {
         barrier.wait();
 
         let orchestrator = Orchestrator::new(
-            control_input_rx,
-            control_output_tx,
+            io_control_rx,
+            io_control_tx,
             || Ok(()), // TODO: create_snapshot
         );
 
         let mut vmm: Vmm = Self {
-            _gateway_tx: gateway_tx,
+            _io_thread_data_tx: io_thread_data_tx,
             io_thread,
             _memory_thread: memory_thread,
             vcpu_thread,

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -27,8 +27,8 @@ extern crate kvm_ioctls;
 use crate::{
     Gateway,
     io_thread::{
-        ControlCommand,
-        ControlCommandResponse,
+        IoControlCommand,
+        IoControlResponse,
         IoThread,
     },
     memory_thread,
@@ -72,7 +72,7 @@ use ::sys::ipc::{
 //==================================================================================================
 
 pub struct Vmm {
-    _gateway_tx: Sender<Message>,
+    _io_thread_data_tx: Sender<Message>,
     io_thread: Option<JoinHandle<Result<()>>>,
     _memory_thread: JoinHandle<Result<()>>,
     vcpu_thread: JoinHandle<Result<u16>>,
@@ -114,29 +114,29 @@ impl Vmm {
     ) -> Result<u16> {
         crate::timer!("vmm_creation");
 
-        let (vm_tx, gateway_rx) = mpsc::channel::<Message>();
-        let (gateway_tx, memory_thread_rx) = mpsc::channel::<Message>();
-        let (memory_thread_tx, vm_rx) = mpsc::channel::<Message>();
-        let (control_input_tx, control_input_rx) = mpsc::channel::<ControlCommand>();
-        let (control_output_tx, control_output_rx) = mpsc::channel::<ControlCommandResponse>();
+        let (vcpu_thread_stdout_tx, io_thread_data_rx) = mpsc::channel::<Message>();
+        let (io_thread_data_tx, memory_thread_data_rx) = mpsc::channel::<Message>();
+        let (memory_thread_data_tx, vcpu_thread_stdin_rx) = mpsc::channel::<Message>();
+        let (io_thread_control_tx, io_control_rx) = mpsc::channel::<IoControlCommand>();
+        let (io_control_tx, io_thread_control_rx) = mpsc::channel::<IoControlResponse>();
 
         // Spawn I/O thread.
         let io_thread: Option<JoinHandle<Result<()>>> = gateway_conn.map(|conn| {
             IoThread::spawn(
                 conn,
-                gateway_rx,
-                gateway_tx.clone(),
-                control_input_tx,
-                control_output_rx,
+                io_thread_data_rx,
+                io_thread_data_tx.clone(),
+                io_thread_control_tx,
+                io_thread_control_rx,
             )
         });
 
         // Input function used for emulating I/O port reads.
-        let input: Box<microvm::InputFn> = Self::build_input_fn(vm_rx);
+        let input: Box<microvm::InputFn> = Self::build_input_fn(vcpu_thread_stdin_rx);
 
         // Output function used for emulating I/O port writes.
         let output: Box<microvm::OutputFn> =
-            Self::build_output_fn(Self::get_stderr_writer(stderr.clone())?, vm_tx);
+            Self::build_output_fn(Self::get_stderr_writer(stderr.clone())?, vcpu_thread_stdout_tx);
 
         let mut microvm: MicroVm = MicroVm::new(memory_size, input, output)?;
 
@@ -173,9 +173,9 @@ impl Vmm {
             .reset_credits()?;
 
         // Create a thread that reads from vm_rx and writes to vm_rx2.
-        let memory_thread_tx: Sender<Message> = memory_thread_tx.clone();
+        let memory_thread_data_tx: Sender<Message> = memory_thread_data_tx.clone();
         let memory_thread: JoinHandle<Result<(), anyhow::Error>> =
-            memory_thread::spawn(memory_thread_rx, memory_thread_tx, move || {
+            memory_thread::spawn(memory_thread_data_rx, memory_thread_data_tx, move || {
                 vmem.lock()
                     .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
                     .add_credit()
@@ -211,13 +211,13 @@ impl Vmm {
         barrier.wait();
 
         let orchestrator = Orchestrator::new(
-            control_input_rx,
-            control_output_tx,
+            io_control_rx,
+            io_control_tx,
             || Ok(()), // TODO: create_snapshot
         );
 
         let mut vmm: Vmm = Self {
-            _gateway_tx: gateway_tx,
+            _io_thread_data_tx: io_thread_data_tx,
             io_thread,
             _memory_thread: memory_thread,
             vcpu_thread,


### PR DESCRIPTION
Channels were renamed, because now we'll have multiple channels per thread, and it's important to differentiate between them. Enums were renamed, because there are multiple control channels, not just I/O ones.

The reason why there are more deletions than insertions is because shorter enum names turned 2 liners into 1 liners.