### PR TITLE
[ci] Add Pre-Check Reusable Workflow 

### DIFF
--- a/.github/workflows/branch-up-to-date.yml
+++ b/.github/workflows/branch-up-to-date.yml
@@ -1,0 +1,96 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Pre-Check if Branch is Up-To-Date"
+
+# Reusable workflow that checks if the current ref branch is behind the repository's default
+# branch. The default branch is detected dynamically. If branch is up-to-date (not behind) the
+# default branch, `up_to_date` output variable is set to 'true', otherwise it is set to 'false'.
+
+on:
+  workflow_call:
+    outputs:
+      up_to_date:
+        description: "Whether the branch is up to date with the default branch (not behind)."
+        value: ${{ jobs.precheck.outputs.up_to_date }}
+
+jobs:
+  precheck:
+    name: "Compute Branch Divergence"
+    runs-on: [self-hosted, Linux, X64]
+    permissions:
+      pull-requests: write  # Needed to comment on PRs.
+    outputs:
+      up_to_date: ${{ steps.branch_status.outputs.up_to_date }}
+      # Extra metadata (not currently used by callers, but useful for diagnostics / comments).
+      behind_count: ${{ steps.branch_status.outputs.behind_count }}
+      default_branch: ${{ steps.branch_status.outputs.default_branch }}
+    steps:
+      - name: "Checkout (full history for dev)"
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: "Determine if branch is behind default branch"
+        id: branch_status
+        shell: bash
+        run: |
+          set -euo pipefail
+          CURRENT_BRANCH="${GITHUB_REF_NAME}"
+          # Discover default branch from remote metadata.
+          DEFAULT_BRANCH=$(git remote show origin | awk '/HEAD branch:/ {print $NF}')
+          if [ -z "${DEFAULT_BRANCH}" ]; then
+            echo "Failed to determine default branch; assuming up-to-date to avoid false positives." >&2
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+            echo "behind_count=0" >> "$GITHUB_OUTPUT"
+            echo "default_branch=unknown" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${CURRENT_BRANCH}" = "${DEFAULT_BRANCH}" ]; then
+            echo "On default branch (${DEFAULT_BRANCH}); marking up_to_date=true." >&2
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+            echo "behind_count=0" >> "$GITHUB_OUTPUT"
+            echo "default_branch=${DEFAULT_BRANCH}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Fetch latest default branch snapshot.
+          git fetch --no-tags origin "${DEFAULT_BRANCH}"
+          # Compute commits present in default branch but not in HEAD (behind count).
+          COUNTS=$(git rev-list --left-right --count "origin/${DEFAULT_BRANCH}...HEAD")
+          BEHIND=$(echo "$COUNTS" | awk '{print $1}')
+          if [ "${BEHIND}" -eq 0 ]; then
+            echo "Branch is not behind ${DEFAULT_BRANCH} (behind=${BEHIND})." >&2
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+            echo "behind_count=${BEHIND}" >> "$GITHUB_OUTPUT"
+            echo "default_branch=${DEFAULT_BRANCH}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Branch is behind ${DEFAULT_BRANCH} by ${BEHIND} commits." >&2
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+            echo "behind_count=${BEHIND}" >> "$GITHUB_OUTPUT"
+            echo "default_branch=${DEFAULT_BRANCH}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: "Comment on PR when branch is behind default branch"
+        if: ${{ github.event_name == 'pull_request' && steps.branch_status.outputs.up_to_date == 'false' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const number = context.payload.pull_request.number;
+            const defaultBranch = `${{ steps.branch_status.outputs.default_branch }}`;
+            const behind = `${{ steps.branch_status.outputs.behind_count }}`;
+            const body = [
+              `⚠️ This branch is behind \`${defaultBranch}\` by ${behind} commit(s).`,
+              '',
+              'Please update your branch so CI can proceed:',
+              '```bash',
+              'git fetch origin',
+              `git rebase origin/${defaultBranch}`,
+              'git push --force-with-lease',
+              '```',
+              '',
+              'After updating, re-run the workflows by pushing new commits or using the GitHub UI.'
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body
+            });

--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -27,8 +27,13 @@ env:
   SCCACHE: "/usr/local/bin/sccache"
 
 jobs:
+  precheck:
+    uses: nanvix/nanvix/.github/workflows/branch-up-to-date.yml@dev
+    secrets: inherit
+
   benchmark:
     name: "Nanvix Benchmark (self-hosted)"
+    needs: precheck
     timeout-minutes: 240
     strategy:
       matrix:
@@ -41,18 +46,16 @@ jobs:
     # - Non-draft PRs where the source branch starts with one of:
     #     'enhancement-', 'feature-', 'bugfix-', or 'copilot/' (skip dependabot PRs)
     if: |
-      github.event_name != 'pull_request' ||
-      (
+      (github.event_name != 'pull_request' || (
         !github.event.pull_request.draft &&
         !startsWith(github.head_ref, 'dependabot/') &&
-        !startsWith(github.head_ref, 'dependabot-') &&
-        (
+        !startsWith(github.head_ref, 'dependabot-') && (
           startsWith(github.head_ref, 'enhancement-') ||
           startsWith(github.head_ref, 'feature-') ||
           startsWith(github.head_ref, 'bugfix-') ||
           startsWith(github.head_ref, 'copilot/')
         )
-      )
+      )) && needs.precheck.outputs.up_to_date == 'true'
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -1,4 +1,4 @@
-# Copyright(c) 2011-2024 The Maintainers of Nanvix.
+# Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
 name: "Nanvix Benchmark (Self-Hosted)"

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -27,8 +27,14 @@ env:
   SCCACHE: "/usr/local/bin/sccache"
 
 jobs:
+  precheck:
+    uses: nanvix/nanvix/.github/workflows/branch-up-to-date.yml@dev
+    secrets: inherit
+    # No additional with: parameters needed.
+
   ci:
     name: "Nanvix CI/CD (self-hosted)"
+    needs: precheck
     timeout-minutes: 60
     strategy:
       matrix:
@@ -41,10 +47,8 @@ jobs:
     # - Non-draft PRs where the source branch starts with one of:
     #     'enhancement-', 'feature-', 'bugfix-', 'dependabot-', 'dependabot/', or 'copilot/'
     if: |
-      github.event_name != 'pull_request' ||
-      (
-        !github.event.pull_request.draft &&
-        (
+      (github.event_name != 'pull_request' || (
+        !github.event.pull_request.draft && (
           startsWith(github.head_ref, 'enhancement-') ||
           startsWith(github.head_ref, 'feature-') ||
           startsWith(github.head_ref, 'bugfix-') ||
@@ -52,7 +56,7 @@ jobs:
           startsWith(github.head_ref, 'dependabot/') ||
           startsWith(github.head_ref, 'copilot/')
         )
-      )
+      )) && needs.precheck.outputs.up_to_date == 'true'
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -1,4 +1,4 @@
-# Copyright(c) 2011-2024 The Maintainers of Nanvix.
+# Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
 name: "Nanvix CI/CD (Self-Hosted)"


### PR DESCRIPTION
This pull request introduces a new reusable GitHub Actions workflow to check if a branch is up-to-date with the default branch before running CI or benchmark jobs. It then integrates this check into both the self-hosted CI and benchmark workflows, ensuring that jobs only run when the branch is current. This helps avoid wasted CI resources on outdated branches and provides clear feedback to contributors.

Key changes include:

**New reusable workflow for branch freshness:**
* Added `.github/workflows/branch-up-to-date.yml`, a reusable workflow that determines if the current branch is behind the repository's default branch. If it is, it sets an output variable and comments on the pull request with instructions to update the branch.

**Integration into existing workflows:**
* Updated `.github/workflows/self-hosted-ci.yml` and `.github/workflows/self-hosted-benchmark.yml` to call the new `precheck` job using the reusable workflow, and made the main jobs depend on this check. [[1]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811R30-R37) [[2]](diffhunk://#diff-331a9af7ea0111e347b5a567d95dbb846cab81450473315ff4a7031a956144efR30-R36)
* Modified the job conditions in both workflows so that CI and benchmark jobs only run if the branch is up-to-date (`needs.precheck.outputs.up_to_date == 'true'`). [[1]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811L44-R59) [[2]](diffhunk://#diff-331a9af7ea0111e347b5a567d95dbb846cab81450473315ff4a7031a956144efL44-R58)

**Minor improvements:**
* Standardized copyright headers in workflow files. [[1]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811L1-R1) [[2]](diffhunk://#diff-331a9af7ea0111e347b5a567d95dbb846cab81450473315ff4a7031a956144efL1-R1)