### PR TITLE
[daemons] Use A Separate Gateway Address Per User VM

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -43,6 +43,8 @@ runs:
         if [[ "$bench" == "cold-start-l2" ]]; then
           continue
         fi
+
+        echo "Running benchmark: ${bench} (Microvm)"
         bench_underscore=${bench//-/_}
         ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_MICROVM} -toolchain-bin-dir $HOME/toolchain/bin -benchmark ${bench} -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_${bench_underscore}_microvm_${{ inputs.arch }}.txt
       done
@@ -85,6 +87,7 @@ runs:
           continue
         fi
 
+        echo "Running benchmark: ${bench} (Hyperlight)"
         bench_underscore=${bench//-/_}
         ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_HL} -toolchain-bin-dir $HOME/toolchain/bin -benchmark ${bench}  -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_${bench_underscore}_hyperlight_${{ inputs.arch }}.txt
       done

--- a/build/linuxd_config.toml
+++ b/build/linuxd_config.toml
@@ -13,4 +13,11 @@ snapshot_name = "l2-sysvm-snapshot"
 # Ports used for different services in linuxd.
 control_plane_port = 9000
 user_vm_port = 9001
-gateway_port = 9002
+
+# Each user VM instance gets a different gateway port, so we define the allowed port range
+# here. Note that this range limits the total number of concurrent user VMs we can have
+# at any point in time. We pick large values that are unlikely to overlap with other
+# services, and with the ephemeral port range used in Linux, readable with:
+# cat /proc/sys/net/ipv4/ip_local_port_range
+gateway_port_range_begin = 49152
+gateway_port_range_end = 65535

--- a/doc/run.md
+++ b/doc/run.md
@@ -101,10 +101,10 @@ nc -lU /tmp/control-plane.socket
 in another terminal, start linuxd:
 
 ```bash
-./bin/linuxd.elf -control-plane-addr /tmp/control-plane.socket -user-vm-bind-addr /tmp/user-vm-bind.socket -gateway-bind-addr /tmp/gw-bind.socket
+./bin/linuxd.elf -control-plane-addr /tmp/control-plane.socket -user-vm-bind-addr /tmp/user-vm-bind.socket
 ```
 
-all `-x-addr` flags have a corresponding `-x-socket-type` flag to switch between `tcp` or `unix` sockets. The default values are `unix`. The `-gateway-bind-addr` is optional, and should only be used if you want to connect to the VM's stdin/stdout.
+all `-x-addr` flags have a corresponding `-x-socket-type` flag to switch between `tcp` or `unix` sockets. The default values are `unix`.
 
 To enable logging, consider prepending the above command with `RUST_LOG=debug` or `RUST_LOG=trace`.
 
@@ -113,16 +113,16 @@ To enable logging, consider prepending the above command with `RUST_LOG=debug` o
 Open another terminal to run the MicroVM. Use the `-initrd` option to specify which application to run, and pass it additional arguments with `-initrd-args`.
 
 ```bash
-./bin/microvm.elf -user-vm-id 1 -system-vm-addr /tmp/user-vm-bind.socket -kernel bin/kernel.elf -initrd bin/hello-rust-nostd.elf [-initrd-args <args>]
+./bin/microvm.elf -user-vm-id 1 -system-vm-addr /tmp/user-vm-bind.socket -kernel bin/kernel.elf -initrd bin/hello-rust-nostd.elf [-gateway-addr /tmp/gw.sock] [-initrd-args <args>]
 ```
 
-If you passed a `-gateway-bind-addr` flag to `linuxd` in step 1, you will need to open a netcat session to connect to it:
+The `-gateway-addr` argument is optional, and should only be used if you want to connect to the VM's stdin/stdout. If you do set it, you next need to open a netcat session to connect to it:
 
 ```bash
-nc -U /tmp/gw-bind.socket
+nc -U /tmp/gw.socket
 ```
 
-For example, the `./bin/echo-c.elf` binary uses the gateway. Inside the netcat terminal, once you have written your message press `Ctrl-D` so that it is flushed to linuxd.
+For example, the `./bin/echo-c.elf` binary uses the gateway because it reads input from stdin. Inside the netcat terminal, once you have written your message press `Ctrl-D` so that it is flushed to linuxd.
 
 Alternatively to an interactive netcat session, you can use something like the following:
 

--- a/scripts/generate-l2-initramfs.sh
+++ b/scripts/generate-l2-initramfs.sh
@@ -55,11 +55,9 @@ GUEST_TAP_IP_ADDRESS=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "guest_tap_ip
 HOST_TAP_IP_ADDRESS=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "host_tap_ip_address")
 CONTROL_PLANE_PORT=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "control_plane_port")
 USER_VM_PORT=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "user_vm_port")
-GATEWAY_PORT=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "gateway_port")
 
 CONTROL_PLANE_SOCKADDR="${HOST_TAP_IP_ADDRESS}:${CONTROL_PLANE_PORT}"
 USER_VM_SOCKADDR="${GUEST_TAP_IP_ADDRESS}:${USER_VM_PORT}"
-GATEWAY_SOCKADDR="${GUEST_TAP_IP_ADDRESS}:${GATEWAY_PORT}"
 
 #===================================================================================================
 # Build initramfs
@@ -108,8 +106,6 @@ echo "[init] Nanvix L2 System VM passed init gate. Starting linuxd..."
     -control-plane-socket-type tcp \
     -user-vm-bind-addr ${USER_VM_SOCKADDR} \
     -user-vm-bind-socket-type tcp \
-    -gateway-bind-addr ${GATEWAY_SOCKADDR} \
-    -gateway-bind-socket-type tcp \
     -l2
 
 echo "[init] Nanvix L2 System VM shutting down!"

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -2,6 +2,23 @@
 
 set -euo pipefail
 
+#===================================================================================================
+# Global Variables
+#===================================================================================================
+
+NANVIX_HOME=$(git rev-parse --show-toplevel)
+
+#===================================================================================================
+# Utilities
+#===================================================================================================
+
+source "${NANVIX_HOME}/scripts/common/logging.sh"
+source "${NANVIX_HOME}/scripts/common/utils.sh"
+
+#===================================================================================================
+# Command line arguments
+#===================================================================================================
+
 NANVIXD_SOCKADDR=$1
 PROGRAM_NAME=$2
 PROGRAM_ARGS=$3
@@ -11,12 +28,55 @@ TIMEOUT=${6:-90}
 
 # Check if expected program output is empty.
 if [ -z "${PROGRAM_EXPECTED_OUTPUT}" ]; then
-    echo "Error: expected program output is empty and it cannot."
+    print_error "expected program output is empty and it cannot."
     exit 1
 fi
 
-NANVIX_HOME=$(git rev-parse --show-toplevel)
 LOGS_DIR=${NANVIX_HOME}/logs/nanvixd-$(basename "${PROGRAM_NAME}")
+
+#===================================================================================================
+# Helper functions
+#===================================================================================================
+
+MAX_TRIALS=100
+SLEEP_INTERVAL=0.1
+
+wait_for_tcp_socket() {
+    local host=$1
+    local port=$2
+
+    for i in $(seq 1 $MAX_TRIALS); do
+        print_info "Waiting for TCP socket at $host:$port..."
+        sleep ${SLEEP_INTERVAL}
+
+        if nc -z "${host}" "${port}" 2>/dev/null; then
+            print_info "TCP socket ready after $(echo "${i} * ${SLEEP_INTERVAL}" | bc -l) ms."
+            return
+        fi
+    done
+
+    print_error "Timed-out waiting for TCP socket to be ready at $host:$port"
+}
+
+wait_for_unix_socket() {
+    local path="$1"
+
+    print_info "Waiting for UNIX socket at ${path}..."
+    for i in $(seq 1 $MAX_TRIALS); do
+        if [ -S "${path}" ]; then
+            print_info "UNIX socket available after $(echo "${i} * ${SLEEP_INTERVAL}" | bc -l) ms."
+            return
+        fi
+
+        sleep ${SLEEP_INTERVAL}
+    done
+
+    print_error "Timed-out waiting for UNIX socket at ${path}"
+}
+
+#===================================================================================================
+# Test execution
+#===================================================================================================
 
 # Parameters for the requests to nanvixd.
 TENANT_ID="foo"
@@ -25,13 +85,12 @@ APP_NAME="bar"
 # Temporary Directory
 TMP_DIR_PATH="/tmp/nanvixd"
 TMP_DIR=$(mktemp -d ${TMP_DIR_PATH}-XXXXXX)
-trap 'rm -rf "${TMP_DIR}"' EXIT
 
 mkdir -p "${LOGS_DIR}"
 
 # Run nanvixd.
 CONSOLE_FILE_NAME="${LOGS_DIR}/kernel_$(date "+%Y_%m_%d_%H_%M").log"
-RUST_LOG=trace timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
+RUST_LOG=trace setsid timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
     ./bin/nanvixd.elf \
         -http-addr "${NANVIXD_SOCKADDR}" \
         -toolchain-bin-dir "${TOOLCHAIN_DIR}/bin" \
@@ -39,27 +98,30 @@ RUST_LOG=trace timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
         -console-file "${CONSOLE_FILE_NAME}" &
 NANVIXD_PID=$!
 
+cleanup() {
+    # Sometimes error messages in this script are hard to parse because they
+    # come from nested bash calls and we cannot color them accordingly.
+    # During clean-up, print a clear error message in red if the test has
+    # failed.
+    if kill -0 -- "-${NANVIXD_PID}" 2>/dev/null; then
+        print_error "Test failed: cleaning-up and nanvixd.elf is still alive"
+
+        # Make sure we force-clean any zombie processes, and ignore errors.
+        kill -s SIGKILL -- "-${NANVIXD_PID}" 2> /dev/null || true
+
+        wait "${NANVIXD_PID}" 2>/dev/null || true
+    fi
+
+    rm -rf "${TMP_DIR}"
+}
+trap 'cleanup' EXIT
+
 # Extract port number from nanvixd.
 NANVIXD_PORT_NUMBER=$(echo "${NANVIXD_SOCKADDR}" | cut -d: -f2)
 
 # Wait for nanvixd to start by checking if the HTTP socket is listening.
-MAX_TRIALS=100
-SLEEP_INTERVAL=0.1
-for i in $(seq 1 $MAX_TRIALS); do
-    echo "Waiting for nanvixd to start ... ($(echo "$i * $SLEEP_INTERVAL" | bc) s elapsed)"
-    sleep ${SLEEP_INTERVAL}
-
-    if ss -tln | grep -q ":${NANVIXD_PORT_NUMBER} "; then
-        echo "nanvixd started after ${i} ms."
-        break
-    fi
-done
-
-# Check again after waiting.
-if ! ss -tln | grep -q ":${NANVIXD_PORT_NUMBER} "; then
-    echo "nanvixd failed to start"
-    exit 2 # Error Code 2: No such file or directory (ENOENT)
-fi
+print_info "Waiting for nanvixd to be ready"
+wait_for_tcp_socket "127.0.0.1" "$NANVIXD_PORT_NUMBER"
 
 # Run a client.
 NEW_JSON=$(jq -n \
@@ -79,10 +141,11 @@ NEW_RESPONSE=$(curl \
 VM_ID=$(echo "${NEW_RESPONSE}" | jq -r '.user_vm_id')
 GATEWAY_SOCKADDR=$(echo "${NEW_RESPONSE}" | jq -r '.gateway_sockaddr')
 
-echo "VM ID: ${VM_ID}"
-echo "Gateway Socket Address: ${GATEWAY_SOCKADDR}"
+print_info "VM ID: ${VM_ID}"
+print_info "Gateway Socket Address: ${GATEWAY_SOCKADDR}"
 
 # Get output by writing to the gateway socket address.
+wait_for_unix_socket "${GATEWAY_SOCKADDR}"
 PROGRAM_ACTUAL_OUTPUT=$(echo "${PROGRAM_INPUT}" | nc -U -q 0 "${GATEWAY_SOCKADDR}" | tr -d '\0')
 
 # Save program output to a log file.
@@ -105,7 +168,7 @@ KILL_EXIT_CODE=$(curl \
     http://localhost:"${NANVIXD_PORT_NUMBER}" | jq -r '.exit_code')
 
 if [ "${KILL_EXIT_CODE}" != "0" ]; then
-    echo "Test failed: error killing user VM (code=${KILL_EXIT_CODE})"
+    print_error "Test failed: error killing user VM (code=${KILL_EXIT_CODE})"
     exit 1
 fi
 
@@ -114,12 +177,13 @@ fi
 find . -maxdepth 1 -name '*.log' -exec mv {} "${LOGS_DIR}"/ \; 2>/dev/null || true
 
 kill -s SIGINT "${NANVIXD_PID}" || true
+wait "${NANVIXD_PID}" 2>/dev/null || true
 
 # Check if curl.log contains the expected output.
 if grep -F -q -- "${PROGRAM_EXPECTED_OUTPUT}" <<< "${PROGRAM_ACTUAL_OUTPUT}"; then
-    echo "Test passed."
+    print_success "Test passed."
     exit 0
 else
-    echo "Test failed: expected output '${PROGRAM_EXPECTED_OUTPUT}' but got '${PROGRAM_ACTUAL_OUTPUT}'"
+    print_error "Test failed: expected output '${PROGRAM_EXPECTED_OUTPUT}' but got '${PROGRAM_ACTUAL_OUTPUT}'"
     exit 1
 fi

--- a/src/daemons/linuxd/src/args.rs
+++ b/src/daemons/linuxd/src/args.rs
@@ -25,10 +25,6 @@ pub struct Args {
     user_vm_bind_sockaddr: String,
     /// Server socket address type.
     user_vm_bind_sockaddr_type: Option<String>,
-    /// Socket address linuxd listens to for messages from the gateway.
-    gateway_bind_sockaddr: Option<String>,
-    /// Gateway socket address type.
-    gateway_bind_sockaddr_type: Option<String>,
     /// Log to file?
     log_to_file: bool,
     /// Deployed in an L2 VM?
@@ -50,10 +46,6 @@ impl Args {
     pub const OPT_USER_VM_BIND_SOCKADDR: &'static str = "-user-vm-bind-addr";
     /// Command-line option for setting the socket address type of the bind socket.
     pub const OPT_USER_VM_BIND_SOCKET_TYPE: &'static str = "-user-vm-bind-socket-type";
-    /// Command-line option for setting socket address of gateway.
-    pub const OPT_GATEWAY_BIND_SOCKADDR: &'static str = "-gateway-bind-addr";
-    /// Command-line option for setting the socket address type of the gateway socket.
-    pub const OPT_GATEWAY_BIND_SOCKET_TYPE: &'static str = "-gateway-bind-socket-type";
     /// Command-line option for log redirecting.
     pub const OPT_LOGFILE: &'static str = "-log-to-file";
     /// Command-line option for signaling deployment in an L2 VM.
@@ -87,8 +79,6 @@ impl Args {
         let mut control_plane_sockaddr_type: Option<String> = None;
         let mut user_vm_bind_sockaddr: String = String::new();
         let mut user_vm_bind_sockaddr_type: Option<String> = None;
-        let mut gateway_bind_sockaddr: Option<String> = None;
-        let mut gateway_bind_sockaddr_type: Option<String> = None;
         let mut log_to_file: bool = false;
         let mut l2: bool = false;
 
@@ -110,14 +100,6 @@ impl Args {
                 Self::OPT_USER_VM_BIND_SOCKADDR => {
                     i += 1;
                     user_vm_bind_sockaddr = args[i].clone();
-                },
-                Self::OPT_GATEWAY_BIND_SOCKADDR => {
-                    i += 1;
-                    gateway_bind_sockaddr = Some(args[i].clone());
-                },
-                Self::OPT_GATEWAY_BIND_SOCKET_TYPE => {
-                    i += 1;
-                    gateway_bind_sockaddr_type = Some(args[i].clone());
                 },
                 Self::OPT_USER_VM_BIND_SOCKET_TYPE => {
                     i += 1;
@@ -152,8 +134,6 @@ impl Args {
             control_plane_sockaddr_type,
             user_vm_bind_sockaddr,
             user_vm_bind_sockaddr_type,
-            gateway_bind_sockaddr,
-            gateway_bind_sockaddr_type,
             log_to_file,
             l2,
         })
@@ -171,15 +151,13 @@ impl Args {
     pub fn usage(program_name: &str) {
         println!(
             "Usage: {} {} {} <control-plane-sockaddr> {} <control-plane-socktype> {} \
-             <user-vm-sockaddr> {} <user-vm-socktype> {} <gateway-sockaddr> {} <gateway-socktype>",
+             <user-vm-sockaddr> {} <user-vm-socktype>",
             program_name,
             Self::OPT_LOGFILE,
             Self::OPT_CONTROL_PLANE_SOCKADDR,
             Self::OPT_CONTROL_PLANE_SOCKET_TYPE,
             Self::OPT_USER_VM_BIND_SOCKADDR,
             Self::OPT_USER_VM_BIND_SOCKET_TYPE,
-            Self::OPT_GATEWAY_BIND_SOCKADDR,
-            Self::OPT_GATEWAY_BIND_SOCKET_TYPE
         );
     }
 
@@ -233,32 +211,6 @@ impl Args {
     ///
     pub fn user_vm_bind_socket_type(&self) -> Option<String> {
         self.user_vm_bind_sockaddr_type.clone()
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Returns the gateway socket address.
-    ///
-    /// # Returns
-    ///
-    /// The socket address of the gateway.
-    ///
-    pub fn gateway_bind_sockaddr(&self) -> Option<String> {
-        self.gateway_bind_sockaddr.clone()
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Returns the socket address type of the gateway socket.
-    ///
-    /// # Returns
-    ///
-    /// The socket address type of the gateway socket.
-    ///
-    pub fn gateway_bind_socket_type(&self) -> Option<String> {
-        self.gateway_bind_sockaddr_type.clone()
     }
 
     ///

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -237,17 +237,10 @@ impl LinuxDaemon {
                         match Socket::bind(gateway_socket_type, gateway_sockaddr.clone()) {
                             Ok(listener) => listener,
                             Err(e) => {
-                                // Need to duplicate the error message becase log_and_error can
-                                // only take a &str, and we want a formatted String with the error
-                                // message.
-                                error!(
-                                    "error binding to gateway socket (addr={gateway_sockaddr}, \
-                                     error={e:?})"
-                                );
-                                return Err(Self::log_and_error(
-                                    ErrorCode::IoErr,
-                                    "failed to bind gateway socket for user VM",
-                                ));
+                                let reason: &'static str =
+                                    "failed to bind gateway socket for user VM";
+                                error!("{reason} (addr={gateway_sockaddr}, error={e:?})");
+                                return Err(Self::log_and_error(ErrorCode::IoErr, reason));
                             },
                         };
 

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -89,7 +89,6 @@ pub struct LinuxDaemon {
     control_plane_sockaddr: String,
     control_plane_socktype: SocketType,
     user_vm_listener: SocketListener,
-    gateway_listener: Option<SocketListener>,
     venv: Arc<Mutex<VirtualEnviromentDirectory>>,
     in_l2: bool,
 }
@@ -103,7 +102,6 @@ impl LinuxDaemon {
         control_plane_sockaddr: String,
         control_plane_socktype: SocketType,
         user_vm_listener: SocketListener,
-        gateway_listener: Option<SocketListener>,
         in_l2: bool,
     ) -> Result<Self, Error> {
         Ok(Self {
@@ -111,7 +109,6 @@ impl LinuxDaemon {
             control_plane_sockaddr,
             control_plane_socktype,
             user_vm_listener,
-            gateway_listener,
             venv: Arc::new(Mutex::new(VirtualEnviromentDirectory::new())),
             in_l2,
         })
@@ -189,7 +186,6 @@ impl LinuxDaemon {
         &mut self,
         user_vm_connections: &mut HashMap<RawUserVmIdentifier, UserVmHandle>,
         user_vm_poll: &Poll,
-        gateway_poll: &mut Option<Poll>,
     ) -> Result<(), Error> {
         // Accept new connection in a loop, as we have a non-blocking socket, and
         // we may have more than one connection pending to be accepted.
@@ -233,31 +229,60 @@ impl LinuxDaemon {
                             )
                         })?;
 
-                    // After accepting a connection from the user VM, accept a connection from the
-                    // gateway if necessary.
-                    let gateway_stream: Option<SocketStream> = if let Some(gateway_poll) =
-                        gateway_poll.as_mut()
-                    {
-                        if let Some(gateway_listener) = self.gateway_listener.as_mut() {
-                            Some(
-                                gateway_listener
-                                    .accept_timeout(
-                                        gateway_poll,
-                                        Duration::from_secs(config::syscomm::ACCEPT_TIMEOUT_SECS),
-                                    )
-                                    .map_err(|_| {
-                                        Self::log_and_error(
-                                            ErrorCode::IoErr,
-                                            "error accepting connection from gateway",
-                                        )
-                                    })?,
+                    // After accepting a connection from the user VM, open a listening socket for
+                    // the user VM's gateway.
+                    let gateway_sockaddr: String = new_msg.gateway_sockaddr().to_string();
+                    let gateway_socket_type: SocketType = new_msg.gateway_socket_type();
+                    let mut gateway_listener: SocketListener =
+                        match Socket::bind(gateway_socket_type, gateway_sockaddr.clone()) {
+                            Ok(listener) => listener,
+                            Err(e) => {
+                                // Need to duplicate the error message becase log_and_error can
+                                // only take a &str, and we want a formatted String with the error
+                                // message.
+                                error!(
+                                    "error binding to gateway socket (addr={gateway_sockaddr}, \
+                                     error={e:?})"
+                                );
+                                return Err(Self::log_and_error(
+                                    ErrorCode::IoErr,
+                                    "failed to bind gateway socket for user VM",
+                                ));
+                            },
+                        };
+
+                    // Accept one connection. We use an ephemeral poll, but this step will become
+                    // unnecessary when we introduce support for lazily accepting a gateway
+                    // connection.
+                    let mut gateway_poll: Poll = Poll::new().map_err(|_| {
+                        Self::log_and_error(ErrorCode::IoErr, "failed to create Poll")
+                    })?;
+                    gateway_poll
+                        .registry()
+                        .register(
+                            &mut gateway_listener,
+                            Token(GATEWAY_LISTENER_CONNECTION_ID),
+                            Interest::READABLE,
+                        )
+                        .map_err(|_| {
+                            Self::log_and_error(
+                                ErrorCode::IoErr,
+                                "failed to register gateway listener to poll",
                             )
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
+                        })?;
+                    let gateway_stream: Option<SocketStream> = Some(
+                        gateway_listener
+                            .accept_timeout(
+                                &mut gateway_poll,
+                                Duration::from_secs(config::syscomm::ACCEPT_TIMEOUT_SECS),
+                            )
+                            .map_err(|_| {
+                                Self::log_and_error(
+                                    ErrorCode::IoErr,
+                                    "error accepting connection from gateway",
+                                )
+                            })?,
+                    );
 
                     trace!(
                         "registered user VM handle (vm_id={user_vm_id}, gw_stream={})",
@@ -354,7 +379,6 @@ impl LinuxDaemon {
     pub fn run(mut self) -> Result<(), Error> {
         const CONTROL_PLANE_TOKEN: Token = Token(CONTROL_PLANE_CONNECTION_ID);
         const USER_VM_LISTENER_TOKEN: Token = Token(USER_VM_LISTENER_CONNECTION_ID);
-        const GATEWAY_LISTENER_TOKEN: Token = Token(GATEWAY_LISTENER_CONNECTION_ID);
 
         let mut events: Events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
 
@@ -367,28 +391,6 @@ impl LinuxDaemon {
             .map_err(|_| {
                 Self::log_and_error(ErrorCode::IoErr, "failed to register user VM listener to poll")
             })?;
-
-        // Poll structure used to accept connections from the gateway in a blocking fashion. For
-        // the gateway we want to give each worker thread the mutex-protected socket stream
-        // connected to the gateway.
-        let mut gateway_poll: Option<Poll> =
-            if let Some(gateway_listener) = self.gateway_listener.as_mut() {
-                let gateway_poll: Poll = Poll::new()
-                    .map_err(|_| Self::log_and_error(ErrorCode::IoErr, "failed to create Poll"))?;
-                gateway_poll
-                    .registry()
-                    .register(gateway_listener, GATEWAY_LISTENER_TOKEN, Interest::READABLE)
-                    .map_err(|_| {
-                        Self::log_and_error(
-                            ErrorCode::IoErr,
-                            "failed to register gateway listener to poll",
-                        )
-                    })?;
-
-                Some(gateway_poll)
-            } else {
-                None
-            };
 
         // Structure keeping track of the active user VM connections, indexed by their connection
         // ID. We use a slab to easily get the smallest available entry.
@@ -476,11 +478,7 @@ impl LinuxDaemon {
                     // Check if we have received any messages on the main listener socket.
                     // These indicate new user VMs connecting to linuxd.
                     USER_VM_LISTENER_TOKEN => {
-                        self.accept_connections(
-                            &mut user_vm_connections,
-                            &user_vm_poll,
-                            &mut gateway_poll,
-                        )?;
+                        self.accept_connections(&mut user_vm_connections, &user_vm_poll)?;
                     },
 
                     // Now we process events from active connections.

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -78,9 +78,6 @@ const DEFAULT_CONTROL_PLANE_SOCKET_TYPE: SocketType = SocketType::Unix;
 /// Default user VM type.
 const DEFAULT_USER_VM_SOCKET_TYPE: SocketType = SocketType::Unix;
 
-/// Default gateway socket type.
-const DEFAULT_GATEWAY_SOCKET_TYPE: SocketType = SocketType::Unix;
-
 //==================================================================================================
 // Implementations
 //==================================================================================================
@@ -93,7 +90,6 @@ pub fn main() -> Result<()> {
     // Work-out the socket addresses.
     let control_plane_sockaddr: String = args.control_plane_sockaddr();
     let user_vm_sockaddr: String = args.user_vm_bind_sockaddr();
-    let gateway_sockaddr: Option<String> = args.gateway_bind_sockaddr();
 
     // Deployed in an L2 VM?
     let in_l2: bool = args.l2();
@@ -121,17 +117,6 @@ pub fn main() -> Result<()> {
         None => DEFAULT_USER_VM_SOCKET_TYPE,
     };
 
-    let gateway_bind_socket_type: SocketType = match args.gateway_bind_socket_type() {
-        Some(typ) => match SocketType::from_str(typ.as_str()) {
-            Ok(typ) => typ,
-            Err(error) => {
-                error!("{error} (type={typ:?})");
-                anyhow::bail!("failed to parse socket address type");
-            },
-        },
-        None => DEFAULT_GATEWAY_SOCKET_TYPE,
-    };
-
     // Start listening for incoming connections from user VMs associated to this linuxd instance.
     let user_vm_listener: SocketListener =
         match Socket::bind(user_vm_bind_socket_type, user_vm_sockaddr.clone()) {
@@ -146,26 +131,10 @@ pub fn main() -> Result<()> {
         };
     info!("Listening to user VMs on: {user_vm_sockaddr:?}");
 
-    // Start listening for requests for requests to feed input to the user VM.
-    let gateway_listener: Option<SocketListener> = match gateway_sockaddr {
-        Some(ref sockaddr) => match Socket::bind(gateway_bind_socket_type, sockaddr.clone()) {
-            Ok(stream) => {
-                info!("Listening for user VM input on gateway at: {:?}", gateway_sockaddr);
-                Some(stream)
-            },
-            Err(e) => {
-                error!("failed to bind to gateway (address={}, error={e:?})", sockaddr.clone());
-                anyhow::bail!("failed to bind to gateway");
-            },
-        },
-        None => None,
-    };
-
     let procd: LinuxDaemon = match LinuxDaemon::init(
         control_plane_sockaddr,
         control_plane_socket_type,
         user_vm_listener,
-        gateway_listener,
         in_l2,
     ) {
         Ok(procd) => procd,

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -185,9 +185,14 @@ fn generate_linuxd_config(linuxd_config_toml_path: &Path, linuxd_config_output_p
             constants.push_str(&format!("pub const USER_VM_PORT: u32 = {val};\n"));
         }
     }
-    if let Some(gateway_port) = linuxd_config_toml.get("gateway_port") {
+    if let Some(gateway_port) = linuxd_config_toml.get("gateway_port_range_begin") {
         if let Ok(val) = gateway_port.parse::<u32>() {
-            constants.push_str(&format!("pub const GATEWAY_PORT: u32 = {val};\n"));
+            constants.push_str(&format!("pub const GATEWAY_PORT_RANGE_BEGIN: u16 = {val};\n"));
+        }
+    }
+    if let Some(gateway_port) = linuxd_config_toml.get("gateway_port_range_end") {
+        if let Ok(val) = gateway_port.parse::<u32>() {
+            constants.push_str(&format!("pub const GATEWAY_PORT_RANGE_END: u16 = {val};\n"));
         }
     }
     constants.push_str("}\n");

--- a/src/libs/syscomm/Cargo.toml
+++ b/src/libs/syscomm/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 config = { workspace = true }
 log = { workspace = true }
 mio = { workspace = true, features = ["net", "os-poll"] }

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -8,6 +8,10 @@
 extern crate alloc;
 
 use ::anyhow::Result;
+use ::bincode::{
+    Decode,
+    Encode,
+};
 use ::log::error;
 use ::mio::{
     net::{
@@ -50,7 +54,7 @@ const BLOCKING_THREAD_TOKEN: Token = Token(0);
 //==================================================================================================
 
 /// An enum representing the type of a socket.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Decode, Encode)]
 pub enum SocketType {
     /// TCP socket.
     Tcp,

--- a/src/libs/user-vm-api/src/lib.rs
+++ b/src/libs/user-vm-api/src/lib.rs
@@ -18,7 +18,10 @@ use ::bincode::{
 };
 use ::log::error;
 use ::std::io;
-use ::syscomm::BlockingSocketStream;
+use ::syscomm::{
+    BlockingSocketStream,
+    SocketType,
+};
 
 //==================================================================================================
 // Types
@@ -44,15 +47,52 @@ pub type RawUserVmIdentifier = u32;
 #[derive(Clone, Debug, Decode, Encode)]
 pub struct NewUserVm {
     user_vm_id: RawUserVmIdentifier,
+    /// Socket address that users can read/write to communicate with the VM's stdin/stdout.
+    gateway_sockaddr: String,
+    gateway_socket_type: SocketType,
 }
 
 impl NewUserVm {
-    pub fn new(user_vm_id: RawUserVmIdentifier) -> Self {
-        Self { user_vm_id }
+    pub fn new(
+        user_vm_id: RawUserVmIdentifier,
+        gateway_sockaddr: String,
+        gateway_socket_type: SocketType,
+    ) -> Self {
+        Self {
+            user_vm_id,
+            gateway_sockaddr,
+            gateway_socket_type,
+        }
     }
 
     pub fn id(&self) -> RawUserVmIdentifier {
         self.user_vm_id
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Get the gateway socket address.
+    ///
+    /// # Return Value
+    ///
+    /// The gateway socket address.
+    ///
+    pub fn gateway_sockaddr(&self) -> &str {
+        self.gateway_sockaddr.as_ref()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Get the gateway socket type.
+    ///
+    /// # Return Value
+    ///
+    /// The gateway socket type.
+    ///
+    pub fn gateway_socket_type(&self) -> SocketType {
+        self.gateway_socket_type.clone()
     }
 
     ///
@@ -70,8 +110,8 @@ impl NewUserVm {
     /// indicating the reason for the failure.
     ///
     pub fn send(&self, blocking_stream: &mut BlockingSocketStream) -> io::Result<()> {
-        let payload: Vec<u8> = bincode::encode_to_vec(self.user_vm_id, config::standard())
-            .map_err(|encode_error| {
+        let payload: Vec<u8> =
+            bincode::encode_to_vec(self, config::standard()).map_err(|encode_error| {
                 let reason: String =
                     format!("failed to serialize message (error={encode_error:?})");
                 error!("send(): {reason}");

--- a/src/microvm/src/args.rs
+++ b/src/microvm/src/args.rs
@@ -51,6 +51,10 @@ pub struct Args {
     control_plane_addr: Option<String>,
     /// Control-plane socket type.
     control_plane_socket_type: Option<SocketType>,
+    /// Socket address exposed in the system VM for users to connect to the user VM's stdin/stdout.
+    gateway_addr: Option<String>,
+    /// Socket type for the gateway socket.
+    gateway_socket_type: Option<SocketType>,
     /// Log to file?
     log_to_file: bool,
 }
@@ -80,6 +84,10 @@ impl Args {
     pub const OPT_CONTROL_PLANE_SOCKADDR: &'static str = "-control-plane-addr";
     /// Command-line option for the control-plane socket type.
     pub const OPT_CONTROL_PLANE_SOCKET_TYPE: &'static str = "-control-plane-socket-type";
+    /// Command-line option for setting socket address of the gateway.
+    pub const OPT_GATEWAY_SOCKADDR: &'static str = "-gateway-addr";
+    /// Command-line option for setting the socket address type of the gateway socket.
+    pub const OPT_GATEWAY_SOCKET_TYPE: &'static str = "-gateway-bind-socket-type";
     /// Command-line option for specifying arguments to be passed to the initrd.
     pub const OPT_INITRD_ARGS: &'static str = "-initrd_args";
     /// Log to file.
@@ -106,6 +114,8 @@ impl Args {
         let mut system_vm_socket_type: Option<String> = None;
         let mut control_plane_addr: Option<String> = None;
         let mut control_plane_socket_type: Option<SocketType> = None;
+        let mut gateway_addr: Option<String> = None;
+        let mut gateway_socket_type: Option<SocketType> = None;
         let mut log_to_file: bool = false;
 
         // Parse command-line arguments.
@@ -207,6 +217,24 @@ impl Args {
                     }
                     i += 1;
                 },
+                // Set gateway address.
+                Self::OPT_GATEWAY_SOCKADDR if i + 1 < args.len() => {
+                    gateway_addr = Some(args[i + 1].clone());
+                    i += 1;
+                },
+                // Set gateway socket type.
+                Self::OPT_GATEWAY_SOCKET_TYPE if i + 1 < args.len() => {
+                    match SocketType::from_str(&args[i + 1]) {
+                        Ok(typ) => gateway_socket_type = Some(typ),
+                        Err(_) => {
+                            let reason: String =
+                                format!("unrecognised socket type: {}", args[i + 1].clone());
+                            error!("{reason}");
+                            return Err(anyhow::anyhow!("{reason}"));
+                        },
+                    }
+                    i += 1;
+                },
                 // Set log to file flag.
                 Self::OPT_LOGFILE => {
                     log_to_file = true;
@@ -252,6 +280,8 @@ impl Args {
             system_vm_socket_type,
             control_plane_addr,
             control_plane_socket_type,
+            gateway_addr,
+            gateway_socket_type,
             log_to_file,
         })
     }
@@ -264,7 +294,7 @@ impl Args {
     pub fn usage() {
         eprintln!(
             "Usage: {} {} <id> {} <kernel> [{} <size>] [{} <file>] [{} <file>]  [{} \
-             <socket-address>] [{}] [{} <args>]",
+             <system-vm-addr> {} <control-plane-addr> {} <gateway-addr>] [{}] [{} <args>]",
             env::args().next().unwrap_or("microvm".to_string()),
             Self::OPT_USER_VM_ID,
             Self::OPT_KERNEL,
@@ -272,6 +302,8 @@ impl Args {
             Self::OPT_INITRD,
             Self::OPT_STDERR,
             Self::OPT_SYSTEM_VM_SOCKADDR,
+            Self::OPT_CONTROL_PLANE_SOCKADDR,
+            Self::OPT_GATEWAY_SOCKADDR,
             Self::OPT_LOGFILE,
             Self::OPT_INITRD_ARGS,
         );
@@ -413,6 +445,34 @@ impl Args {
     ///
     pub fn control_plane_socket_type(&mut self) -> Option<SocketType> {
         self.control_plane_socket_type.take()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the address of the gateway that was passed as a command-line argument to the program.
+    ///
+    /// # Returns
+    ///
+    /// The gateway address that was passed as a command-line argument to the program.
+    ///
+    pub fn gateway_addr(&mut self) -> Option<String> {
+        self.gateway_addr.take()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the socket address type of the gateway socket that was passed as a command-line
+    /// argument to the program.
+    ///
+    /// # Returns
+    ///
+    /// The socket address type of the gateway socket that was passed as a command-line argument to
+    /// the program.
+    ///
+    pub fn gateway_socket_type(&mut self) -> Option<SocketType> {
+        self.gateway_socket_type.take()
     }
 
     ///

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -61,6 +61,7 @@ const CONNECT_TIMEOUT_SLEEP_MS: u64 = 1;
 /// Default socket bind type.
 const DEFAULT_SYSTEM_VM_SOCKET_TYPE: SocketType = SocketType::Unix;
 const DEFAULT_CONTROL_PLANE_SOCKET_TYPE: SocketType = SocketType::Unix;
+const DEFAULT_GATEWAY_SOCKET_TYPE: SocketType = SocketType::Unix;
 
 //==================================================================================================
 // Standalone Functions
@@ -94,11 +95,27 @@ fn main() -> Result<ExitCode> {
         Some(addr) => loop {
             match SocketStream::connect(system_vm_socket_type, addr.clone()) {
                 Ok(stream) => {
-                    let mut blocking_stream: BlockingSocketStream = stream.set_blocking()?;
-                    let new_msg: NewUserVm = NewUserVm::new(args.user_vm_id());
-                    new_msg.send(&mut blocking_stream)?;
+                    let gateway_socket_type: SocketType = match args.gateway_socket_type() {
+                        Some(socket_type) => socket_type,
+                        None => DEFAULT_GATEWAY_SOCKET_TYPE,
+                    };
+                    if let Some(gateway_sockaddr) = args.gateway_addr() {
+                        let mut blocking_stream: BlockingSocketStream = stream.set_blocking()?;
+                        let new_msg: NewUserVm = NewUserVm::new(
+                            args.user_vm_id(),
+                            gateway_sockaddr,
+                            gateway_socket_type,
+                        );
+                        new_msg.send(&mut blocking_stream)?;
 
-                    break Some(Gateway::new(blocking_stream.set_nonblocking()?));
+                        break Some(Gateway::new(blocking_stream.set_nonblocking()?));
+                    } else {
+                        let reason: String = "configured user VM with system VM but without \
+                                              gateway address"
+                            .to_string();
+                        error!("main() {reason}");
+                        anyhow::bail!(reason);
+                    }
                 },
                 // The micro VM is trying to connect before the system VM's listener socket is
                 // responsive.

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -103,7 +103,7 @@ impl SandboxCache {
     pub async fn get(
         &mut self,
         tag: &SandboxTag,
-        config: Option<&SandboxConfig>,
+        config: Option<SandboxConfig>,
         tmp_directory: String,
     ) -> Result<Arc<Microvm>> {
         if !self.user_vm_instances.contains_key(tag) {
@@ -180,14 +180,13 @@ impl SandboxCache {
                         Arc::new(LinuxDaemon::spawn(
                             sandbox_config.control_plane_sockaddr(),
                             sandbox_config.user_vm_sockaddr(),
-                            sandbox_config.gateway_sockaddr(),
                             sandbox_config.hwloc(),
                             sandbox_config.binary_directory(),
                             sandbox_config.toolchain_binary_directory(),
                             control_plane_listener,
                             control_plane_poll,
                             sandbox_config.l2(),
-                            tmp_directory,
+                            tmp_directory.clone(),
                         )?),
                     );
                 }
@@ -195,19 +194,17 @@ impl SandboxCache {
                 // Spawn the user VM that will connect to the linuxd instance.
                 self.user_vm_instances.insert(
                     tag.clone(),
-                    Arc::new(Microvm::spawn(
-                        tag.sandbox_id(),
-                        sandbox_config.program(),
-                        sandbox_config.program_args(),
-                        sandbox_config.user_vm_sockaddr(),
-                        sandbox_config.control_plane_sockaddr(),
-                        sandbox_config.console_file(),
-                        sandbox_config.hwloc(),
-                        sandbox_config.binary_directory(),
-                        control_plane_listener,
-                        control_plane_poll,
-                        sandbox_config.l2(),
-                    )?),
+                    Arc::new(
+                        Microvm::spawn(
+                            tag.clone(),
+                            // Pass ownership of the sandbox config, including the TCP port if
+                            // allocated, to the user VM so that we bind their lifetimes.
+                            sandbox_config,
+                            control_plane_listener,
+                            control_plane_poll,
+                        )
+                        .await?,
+                    ),
                 );
                 self.sandbox_index.insert(tag.sandbox_id(), tag.clone());
             } else {
@@ -272,7 +269,7 @@ impl SandboxCache {
         if let Some(user_vm) = self.user_vm_instances.remove(tag) {
             if Arc::strong_count(&user_vm) != 1 {
                 warn!(
-                    "trying to drop user VM, but there are dangling references to itthis may \
+                    "trying to drop user VM, but there are dangling references to it this may \
                      introduce unexpected behaviour"
                 );
             }

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::sandbox::tcp_port::TcpPort;
 use ::anyhow::Result;
 use ::linuxd::config::l2_system_vm_guest_ip;
 use ::log::error;
@@ -12,6 +13,7 @@ use ::std::{
     fs,
     path::PathBuf,
 };
+use ::user_vm_api::RawUserVmIdentifier;
 
 //==================================================================================================
 // Constants
@@ -132,24 +134,32 @@ pub fn user_vm_sockaddr_builder(tmp_str: &str, tenant_id: &str, l2: bool) -> Res
 ///
 /// # Description
 ///
-/// Builds the gateway socket address for a given tenant ID.
+/// Builds the gateway Unix socket address for a given tenant and sandbox ID.
 ///
 /// # Arguments
 ///
 /// - tmp_str: Temporary directory path.
 /// - tenant_id: Tenant ID.
-/// - l2: Flag to enable deploying linuxd inside an L2 VM.
+/// - sandbox_id: Sandbox ID.
+/// - l2_port: Optional value to indicate deployment in an L2 VM. If set, it contains the TCP port
+///   for the gateway in the L2 VM.
 ///
 /// # Returns
 ///
 /// On success, returns the name of the gateway Unix socket. On failure, returns an error.
 ///
-pub fn gateway_sockaddr_builder(tmp_str: &str, tenant_id: &str, l2: bool) -> Result<String> {
-    if l2 {
-        return Ok(format!("{}:{}", l2_system_vm_guest_ip(), config::linuxd::GATEWAY_PORT));
+pub fn gateway_sockaddr_builder(
+    tmp_str: &str,
+    tenant_id: &str,
+    sandbox_id: RawUserVmIdentifier,
+    l2_port: &Option<TcpPort>,
+) -> Result<String> {
+    if let Some(l2_port) = l2_port {
+        return Ok(format!("{}:{:?}", l2_system_vm_guest_ip(), l2_port));
     }
 
-    let unix_socket_name: String = format!("{tmp_str}/{tenant_id}:gw{UNIX_SOCKET_SUFFIX}");
+    let unix_socket_name: String =
+        format!("{tmp_str}/{tenant_id}:gw-{sandbox_id}{UNIX_SOCKET_SUFFIX}");
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -16,6 +16,10 @@ use crate::{
     sandbox::{
         config::SandboxConfig,
         tag::SandboxTag,
+        tcp_port::{
+            get_tcp_port_allocator,
+            TcpPort,
+        },
     },
 };
 use ::anyhow::Result;
@@ -99,10 +103,34 @@ impl HttpClient {
 
         let control_plane_sockaddr: String =
             config::control_plane_sockaddr_builder(tmp_directory, tag.tenant_id(), in_l2)?;
-        let gateway_sockaddr: String =
-            config::gateway_sockaddr_builder(tmp_directory, tag.tenant_id(), in_l2)?;
         let user_vm_sockaddr: String =
             config::user_vm_sockaddr_builder(tmp_directory, tag.tenant_id(), in_l2)?;
+
+        // Take a lock on the sandbox cache so that we can get the next available port, and then
+        // get the sandbox from the cache.
+        let mut locked_sandbox_cache = sandbox_cache.lock().await;
+
+        // Work-out the gateway address. We use one per user VM instance.
+        let gateway_l2_port: Option<TcpPort> = if in_l2 {
+            match get_tcp_port_allocator().lock().await.allocate().await {
+                Some(port) => Some(port),
+                None => {
+                    let reason: String = "failed to allocate TCP port for gateway".to_string();
+                    error!("{reason}");
+                    return Err(::anyhow::anyhow!("{reason}"));
+                },
+            }
+        } else {
+            None
+        };
+
+        let gateway_sockaddr: String = config::gateway_sockaddr_builder(
+            tmp_directory,
+            tag.tenant_id(),
+            tag.sandbox_id(),
+            &gateway_l2_port,
+        )?;
+
         let program_args = match message.program_args.len() {
             0 => None,
             _ => Some(message.program_args.clone()),
@@ -119,12 +147,13 @@ impl HttpClient {
             args.binary_directory(),
             args.toolchain_binary_directory(),
             args.l2(),
+            // Pass ownership of the L2 gateway port, if L2 deployment enabled.
+            gateway_l2_port,
         );
 
         // This method will create a sandbox if it is not in the cache.
-        let mut locked_sandbox_cache = sandbox_cache.lock().await;
         let _ = locked_sandbox_cache
-            .get(&tag, Some(&config), args.tmp_directory().to_string())
+            .get(&tag, Some(config), args.tmp_directory().to_string())
             .await?;
 
         Ok(message::NewResponse {

--- a/src/utils/nanvixd/src/lib.rs
+++ b/src/utils/nanvixd/src/lib.rs
@@ -4,3 +4,4 @@
 pub mod args;
 pub mod config;
 pub mod message;
+pub mod sandbox;

--- a/src/utils/nanvixd/src/sandbox/config.rs
+++ b/src/utils/nanvixd/src/sandbox/config.rs
@@ -1,6 +1,7 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+use crate::sandbox::tcp_port::TcpPort;
 use hwloc::HwLoc;
 
 //==================================================================================================
@@ -8,7 +9,7 @@ use hwloc::HwLoc;
 //==================================================================================================
 
 /// Packs configuration for a sandbox.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SandboxConfig {
     /// Socket address for the control plane nanvixd <-> linuxd.
     control_plane_sockaddr: String,
@@ -30,6 +31,10 @@ pub struct SandboxConfig {
     toolchain_binary_directory: String,
     /// Flag to deploy linuxd in an L2 VM.
     l2: bool,
+    /// TCP port for the gateway in the L2 VM if L2 deployment enabled.
+    // The value is never read, but we keep it around to trigger a port
+    // release upon drop.
+    _gateway_l2_port: Option<TcpPort>,
 }
 
 //==================================================================================================
@@ -54,6 +59,7 @@ impl SandboxConfig {
     /// - `binary_directory`: Path to the binary directory.
     /// - `toolchain_binary_directory`: Path to the toolchain binary directory.
     /// - `l2`: Flag to deploy linuxd in an L2 VM.
+    /// - `gateway_l2_port`: Port for the gateway in the L2 VM.
     ///
     /// # Returns
     ///
@@ -71,6 +77,7 @@ impl SandboxConfig {
         binary_directory: &str,
         toolchain_binary_directory: &str,
         l2: bool,
+        gateway_l2_port: Option<TcpPort>,
     ) -> Self {
         Self {
             control_plane_sockaddr: control_plane_sockaddr.to_string(),
@@ -83,6 +90,7 @@ impl SandboxConfig {
             binary_directory: binary_directory.to_string(),
             toolchain_binary_directory: toolchain_binary_directory.to_string(),
             l2,
+            _gateway_l2_port: gateway_l2_port,
         }
     }
 

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -17,6 +17,10 @@ use ::linuxd::{
     args,
     config::restore_gate_sockaddr_builder,
 };
+use ::log::{
+    debug,
+    error,
+};
 use ::mio::Poll;
 use ::std::{
     process::Stdio,
@@ -127,7 +131,6 @@ impl LinuxDaemon {
     pub fn spawn(
         control_plane_sockaddr: &str,
         user_vm_sockaddr: &str,
-        gateway_sockaddr: &str,
         hwloc: Option<HwLoc>,
         binary_directory: &str,
         toolchain_binary_directory: &str,
@@ -138,7 +141,7 @@ impl LinuxDaemon {
     ) -> Result<Self> {
         debug!(
             "spawning linux daemon (control-plane={control_plane_sockaddr}, \
-             user-vm={user_vm_sockaddr}, gateway={gateway_sockaddr}, l2={l2})"
+             user-vm={user_vm_sockaddr}, l2={l2})"
         );
 
         let clh_api_socket_path: String = get_clh_api_socket_path(&tmp_directory);
@@ -168,8 +171,6 @@ impl LinuxDaemon {
                 control_plane_sockaddr.to_string(),
                 args::Args::OPT_USER_VM_BIND_SOCKADDR.to_string(),
                 user_vm_sockaddr.to_string(),
-                args::Args::OPT_GATEWAY_BIND_SOCKADDR.to_string(),
-                gateway_sockaddr.to_string(),
             ]
         };
         if let Some(hwloc) = hwloc {

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -5,8 +5,15 @@
 // Imports
 //==================================================================================================
 
+use crate::sandbox::{
+    config::SandboxConfig,
+    tag::SandboxTag,
+};
 use ::anyhow::Result;
-use ::hwloc::HwLoc;
+use ::log::{
+    debug,
+    error,
+};
 use ::mio::Poll;
 use ::std::{
     process::Stdio,
@@ -20,7 +27,6 @@ use ::tokio::process::{
     Child,
     Command,
 };
-use ::user_vm_api::RawUserVmIdentifier;
 
 //==================================================================================================
 // Structures
@@ -32,6 +38,9 @@ pub struct Microvm {
     #[allow(dead_code)]
     // FIXME: the micro VM still does not support processing messages from the control-plane.
     control_plane_stream: SocketStream,
+    /// Configuration for this sandbox instance. It includes a RAII handle around the TCP
+    /// port used for the gateway of this user VM if linuxd is deployed in an L2 VM.
+    _config: SandboxConfig,
 }
 
 //==================================================================================================
@@ -39,53 +48,49 @@ pub struct Microvm {
 //==================================================================================================
 
 impl Microvm {
-    #[allow(clippy::too_many_arguments)]
-    pub fn spawn(
-        id: RawUserVmIdentifier,
-        program: &str,
-        program_args: Option<&str>,
-        addr: &str,
-        control_plane_addr: &str,
-        stderr: Option<&str>,
-        hwloc: Option<HwLoc>,
-        binary_directory: &str,
+    pub async fn spawn(
+        sandbox_tag: SandboxTag,
+        sandbox_config: SandboxConfig,
         control_plane_listener: &mut SocketListener,
         control_plane_poll: &mut Poll,
-        l2: bool,
     ) -> Result<Self> {
         let mut user_vm_args: Vec<String> = vec![
-            format!("{}/microvm.elf", binary_directory),
+            format!("{}/microvm.elf", sandbox_config.binary_directory()),
             ::microvm::args::Args::OPT_LOGFILE.to_string(),
             ::microvm::args::Args::OPT_USER_VM_ID.to_string(),
-            id.to_string(),
+            sandbox_tag.sandbox_id().to_string(),
             ::microvm::args::Args::OPT_KERNEL.to_string(),
-            format!("{}/kernel.elf", binary_directory),
+            format!("{}/kernel.elf", sandbox_config.binary_directory()),
             ::microvm::args::Args::OPT_INITRD.to_string(),
-            program.to_string(),
+            sandbox_config.program().to_string(),
             ::microvm::args::Args::OPT_SYSTEM_VM_SOCKADDR.to_string(),
-            addr.to_string(),
+            sandbox_config.user_vm_sockaddr().to_string(),
             ::microvm::args::Args::OPT_CONTROL_PLANE_SOCKADDR.to_string(),
-            control_plane_addr.to_string(),
+            sandbox_config.control_plane_sockaddr().to_string(),
+            ::microvm::args::Args::OPT_GATEWAY_SOCKADDR.to_string(),
+            sandbox_config.gateway_sockaddr().to_string(),
         ];
 
-        if l2 {
+        if sandbox_config.l2() {
             user_vm_args.push(::microvm::args::Args::OPT_SYSTEM_VM_SOCKET_TYPE.to_string());
             user_vm_args.push("tcp".to_string());
             user_vm_args.push(::microvm::args::Args::OPT_CONTROL_PLANE_SOCKET_TYPE.to_string());
             user_vm_args.push("tcp".to_string());
+            user_vm_args.push(::microvm::args::Args::OPT_GATEWAY_SOCKET_TYPE.to_string());
+            user_vm_args.push("tcp".to_string());
         }
 
-        if let Some(program_args) = program_args {
+        if let Some(program_args) = sandbox_config.program_args() {
             user_vm_args.push(::microvm::args::Args::OPT_INITRD_ARGS.to_string());
             user_vm_args.push(program_args.to_string());
         }
 
-        if let Some(stderr_file) = stderr {
+        if let Some(stderr_file) = sandbox_config.console_file() {
             user_vm_args.push(::microvm::args::Args::OPT_STDERR.to_string());
             user_vm_args.push(stderr_file.to_string());
         }
 
-        if let Some(hwloc) = hwloc {
+        if let Some(hwloc) = sandbox_config.hwloc() {
             let taskset: Vec<String> = vec![
                 "taskset".to_string(),
                 "-ac".to_string(),
@@ -104,11 +109,11 @@ impl Microvm {
         debug!(
             "spawning microvm child.pid={:?} program={:?} args={:?} addr={:?} stderr={:?} l2={}",
             child.id(),
-            program,
-            program_args,
-            addr,
-            stderr,
-            l2
+            sandbox_config.program(),
+            sandbox_config.program_args(),
+            sandbox_config.user_vm_sockaddr(),
+            sandbox_config.console_file(),
+            sandbox_config.l2(),
         );
 
         // After the user VM has started, accept the incoming connection for the control-plane.
@@ -140,8 +145,9 @@ impl Microvm {
 
         Ok(Self {
             child: Some(child),
-            addr: addr.to_string(),
+            addr: sandbox_config.user_vm_sockaddr().to_string(),
             control_plane_stream,
+            _config: sandbox_config,
         })
     }
 }

--- a/src/utils/nanvixd/src/sandbox/mod.rs
+++ b/src/utils/nanvixd/src/sandbox/mod.rs
@@ -9,3 +9,4 @@ pub mod config;
 pub mod linuxd;
 pub mod microvm;
 pub mod tag;
+pub mod tcp_port;

--- a/src/utils/nanvixd/src/sandbox/tag.rs
+++ b/src/utils/nanvixd/src/sandbox/tag.rs
@@ -37,7 +37,7 @@ impl SandboxTag {
         &self.tenant_id
     }
 
-    pub fn sandbox_id(&self) -> u32 {
+    pub fn sandbox_id(&self) -> RawUserVmIdentifier {
         self.sandbox_id
     }
 }

--- a/src/utils/nanvixd/src/sandbox/tcp_port.rs
+++ b/src/utils/nanvixd/src/sandbox/tcp_port.rs
@@ -1,0 +1,175 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::std::{
+    fmt,
+    sync::Arc,
+};
+use ::tokio::sync::Mutex;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Raw TCP port number.
+///
+pub type RawTcpPortNum = u16;
+
+///
+/// # Description
+///
+/// A TCP port wrapper that ensures that we do not leak ports after a user VM dies.
+///
+pub struct TcpPort {
+    port: RawTcpPortNum,
+    allocator: TcpPortAllocatorInner,
+}
+
+impl TcpPort {
+    fn new(port: RawTcpPortNum, allocator: TcpPortAllocatorInner) -> Self {
+        Self { port, allocator }
+    }
+}
+
+impl fmt::Debug for TcpPort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.port)
+    }
+}
+
+impl Drop for TcpPort {
+    fn drop(&mut self) {
+        let allocator: TcpPortAllocatorInner = self.allocator.clone();
+        let port: RawTcpPortNum = self.port;
+        ::tokio::task::spawn(async move {
+            allocator.release(port).await;
+        });
+    }
+}
+
+///
+/// # Description
+///
+/// Pool of TCP ports that are ready to be used.
+///
+#[derive(Clone)]
+struct TcpPortAllocatorInner {
+    ports: Arc<Mutex<Vec<RawTcpPortNum>>>,
+}
+
+impl TcpPortAllocatorInner {
+    ///
+    /// # Description
+    ///
+    /// Allocate a free TCP port from the pool.
+    ///
+    /// # Returns
+    ///
+    /// A TCP port if there are any in the pool, None otherwise.
+    ///
+    async fn allocate(&mut self) -> Option<RawTcpPortNum> {
+        self.ports.lock().await.pop()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Return a TCP port to the pool.
+    ///
+    /// # Arguments
+    ///
+    /// The TCP port to return.
+    ///
+    async fn release(&self, port: RawTcpPortNum) {
+        self.ports.lock().await.push(port)
+    }
+}
+
+///
+/// # Description
+///
+/// Wrapper around the TCP port pool and allocator.
+///
+#[derive(Clone)]
+pub struct TcpPortAllocator {
+    inner: TcpPortAllocatorInner,
+}
+
+impl TcpPortAllocator {
+    ///
+    /// # Description
+    ///
+    /// Initialize a new TCP port pool and allocator.
+    ///
+    /// # Arguments
+    ///
+    /// - begin: the beginning of the port range we can use.
+    /// - end: the ending of the port range we can use.
+    ///
+    /// # Returns
+    ///
+    /// A wrapper around the TCP port pool allocator.
+    ///
+    fn new(begin: RawTcpPortNum, end: RawTcpPortNum) -> Self {
+        let mut ports: Vec<RawTcpPortNum> = Vec::with_capacity((end - begin + 1) as usize);
+        for port in begin..=end {
+            ports.push(port);
+        }
+
+        Self {
+            inner: TcpPortAllocatorInner {
+                ports: Arc::new(Mutex::new(ports)),
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Allocate a TCP port and return a RAII guard.
+    ///
+    /// # Returns
+    ///
+    /// A RAII wrapper around a raw TCP port.
+    ///
+    pub async fn allocate(&mut self) -> Option<TcpPort> {
+        if let Some(port) = self.inner.allocate().await {
+            Some(TcpPort::new(port, self.inner.clone()))
+        } else {
+            None
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Global static TCP port pool and allocator.
+///
+pub static TCP_PORT_ALLOCATOR: ::std::sync::OnceLock<Arc<Mutex<TcpPortAllocator>>> =
+    ::std::sync::OnceLock::new();
+
+///
+/// # Description
+///
+/// Initializes the global TCP port allocator if it hasn't been initialized yet.
+///
+/// # Returns
+///
+/// A reference to the global TCP port allocator.
+///
+pub fn get_tcp_port_allocator() -> &'static Arc<Mutex<TcpPortAllocator>> {
+    TCP_PORT_ALLOCATOR.get_or_init(|| {
+        Arc::new(Mutex::new(TcpPortAllocator::new(
+            ::config::linuxd::GATEWAY_PORT_RANGE_BEGIN,
+            ::config::linuxd::GATEWAY_PORT_RANGE_END,
+        )))
+    })
+}


### PR DESCRIPTION
In this PR I make each different user VM gateway bind to a different address.

Before deployment, `nanvixd` decides on the gateway address, as well as the socket type, and passes both as arguments to the user VM during start-up. Then the user VM passes this as part of the handshake with the system VM once they have established a connection. The user VM then blindly tries to listen to that address.

This is relatively straightforward for UNIX sockets, as we can just use the sandbox ID as part of the socket name, but becomes a bit more involved for TCP sockets, in L2 deployments, as we need to keep track of the available/used ports. For the moment I implement a very simple mechanism that takes a range as part of the build configuration, and then assigns ports from that range. Note that, for each gateway, linuxd binds to `GUEST_TAP_IP:PORT_FROM_RANGE` inside the L2 VM, so we should not need to worry about port clashes with other services in the host system.

It may now happen that the gateway socket is not immediately available after spawning the VM, so I modify `scripts/test-nanvixd.sh` to wait in a loop. In the process, I fix #892.