### PR TITLE
[microvm] E: Reusing channel instead of barrier and atomic

### DIFF
--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -128,9 +128,10 @@ pub enum VcpuControlCommand {
 ///
 /// Control plane command responses from the vCPU thread to the VMM.
 ///
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum VcpuControlResponse {
     Paused,
+    Tid(u64),
 }
 
 //==================================================================================================
@@ -294,6 +295,10 @@ impl Orchestrator {
         loop {
             match self.vcpu_control_rx.try_recv() {
                 Ok(VcpuControlResponse::Paused) => break,
+                Ok(VcpuControlResponse::Tid(tid)) => unreachable!(
+                    "The tid is only sent when the vCPU thread is spawned. Sending it in the \
+                     middle of a pause protocol is against the protocol. tid=({tid})"
+                ),
                 Err(TryRecvError::Empty) => (),
                 Err(TryRecvError::Disconnected) => {
                     let reason: String = "the vmm has disconnected".to_string();

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -48,13 +48,8 @@ use ::std::{
     io::Write,
     sync::{
         Arc,
-        Barrier,
         Mutex,
         OnceLock,
-        atomic::{
-            AtomicUsize,
-            Ordering,
-        },
         mpsc::{
             self,
             Sender,
@@ -297,23 +292,16 @@ impl Vmm {
             resume_microvm,
         );
 
-        // We use an atomic to pass the id of the created thread back to the caller context. We
-        // need this because std::thread's JoinHandle does not expose the tid. We synchronize the
-        // update using a barrier.
-        let pthread_id_holder: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-        let barrier: Arc<Barrier> = Arc::new(Barrier::new(2));
-
-        let barrier_clone: Arc<Barrier> = Arc::clone(&barrier);
-        let pthread_id_holder_clone: Arc<AtomicUsize> = pthread_id_holder.clone();
         let vcpu_thread: JoinHandle<Result<u16>> = std::thread::spawn(move || {
             // Store the tid so that the caller can send signals to the vCPU thread.
             // SAFETY: we are calling pthread_self() right after creating the thread so this is
             // safe.
             let pthread_id: libc::pthread_t = unsafe { pthread_self() };
-            pthread_id_holder_clone.store(pthread_id as usize, Ordering::Relaxed);
-
-            // Notify the outside thread that the thread id is ready.
-            barrier_clone.wait();
+            if let Err(e) = vcpu_thread_control_tx.send(VcpuControlResponse::Tid(pthread_id)) {
+                let reason: String = format!("failed to send the tid (error={e:?})");
+                error!("spawn(): {reason}");
+                anyhow::bail!(reason)
+            }
 
             match sandbox.evolve() {
                 Ok(res) => anyhow::bail!("Expected DEFAULT_VMM_SHUTDOWN_CMD, got: {:#?}", res),
@@ -333,7 +321,18 @@ impl Vmm {
         });
         // Wait right after spawning the vCPU thread such that we populate the pthread id holder
         // before actually starting the vCPU.
-        barrier.wait();
+        match vcpu_control_rx.recv() {
+            Ok(VcpuControlResponse::Tid(tid)) => trace!("Received vCPU thread tid: {tid}"),
+            Ok(response) => unreachable!(
+                "the first message sent on this channel is always a Tid response ( \
+                 response={response:?})"
+            ),
+            Err(e) => {
+                let reason: String = format!("the vCPU thread has disconnected (error={e:?})");
+                error!("spawn(): {reason}");
+                anyhow::bail!(reason)
+            },
+        }
 
         let orchestrator = Orchestrator::new(
             io_control_rx,
@@ -362,7 +361,7 @@ impl Vmm {
             Ok(exit_code) => exit_code,
             Err(e) => {
                 let reason: String = format!("failed to join vCPU thread (error={e:?})");
-                error!("run(): {reason}");
+                error!("spawn(): {reason}");
                 anyhow::bail!(reason)
             },
         }

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -45,6 +45,7 @@ use ::std::{
         Mutex,
         mpsc::{
             Receiver,
+            SendError,
             Sender,
             TryRecvError,
         },
@@ -398,5 +399,22 @@ impl MicroVm {
     ///
     pub fn vmem(&self) -> Arc<Mutex<VirtualMemory>> {
         self.vmem.clone()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sends the vCPU thread's tid to the main thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: The vCPU thread's tid.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns empty. Otherwise, returns an error.
+    ///
+    pub fn send_tid(&self, tid: u64) -> Result<(), SendError<VcpuControlResponse>> {
+        self.control_tx.send(VcpuControlResponse::Tid(tid))
     }
 }

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -50,13 +50,8 @@ use ::std::{
     mem,
     sync::{
         Arc,
-        Barrier,
         Mutex,
         MutexGuard,
-        atomic::{
-            AtomicUsize,
-            Ordering,
-        },
         mpsc,
         mpsc::{
             Receiver,
@@ -221,34 +216,35 @@ impl Vmm {
             },
         );
 
-        // We use an atomic to pass the id of the created thread back to the caller context. We
-        // need this because std::thread's JoinHandle does not expose the tid. We synchronize the
-        // update using a barrier.
-        let pthread_id_holder: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-        let barrier: Arc<Barrier> = Arc::new(Barrier::new(2));
-
         let microvm_clone: Arc<Mutex<MicroVm>> = microvm.clone();
-        let barrier_clone: Arc<Barrier> = Arc::clone(&barrier);
-        let pthread_id_holder_clone: Arc<AtomicUsize> = pthread_id_holder.clone();
         let vcpu_thread: JoinHandle<Result<u16>> = std::thread::spawn(move || {
             // Store the tid so that the caller can send signals to the vCPU thread.
             // SAFETY: we are calling pthread_self() right after creating the thread so this is
             // safe.
             let pthread_id: libc::pthread_t = unsafe { pthread_self() };
-            pthread_id_holder_clone.store(pthread_id as usize, Ordering::Relaxed);
-
-            // Notify the outside thread that the thread id is ready.
-            barrier_clone.wait();
-
-            microvm_clone
+            let mut locked_vm = microvm_clone
                 .lock()
-                .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
-                .run()
+                .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?;
+            locked_vm
+                .send_tid(pthread_id)
+                .map_err(|e| anyhow::anyhow!("failed to send tid {e:?}"))?;
+            locked_vm.run()
         });
 
         // Wait right after spawning the vCPU thread such that we populate the pthread id holder
         // before actually starting the vCPU.
-        barrier.wait();
+        match vcpu_control_rx.recv() {
+            Ok(VcpuControlResponse::Tid(tid)) => trace!("Received vCPU thread tid: {tid}"),
+            Ok(response) => unreachable!(
+                "the first message sent on this channel is always a Tid response ( \
+                 response={response:?})"
+            ),
+            Err(e) => {
+                let reason: String = format!("the vCPU thread has disconnected (error={e:?})");
+                error!("spawn(): {reason}");
+                anyhow::bail!(reason)
+            },
+        }
 
         let orchestrator = Orchestrator::new(
             io_control_rx,
@@ -278,7 +274,7 @@ impl Vmm {
             Ok(exit_code) => exit_code,
             Err(e) => {
                 let reason: String = format!("failed to join vCPU thread (error={e:?})");
-                error!("run(): {reason}");
+                error!("spawn(): {reason}");
                 anyhow::bail!(reason)
             },
         }


### PR DESCRIPTION
A `pthread_id_holder` was created when there was no channel between the main thread and the vCPU thread. Now that we have  a channel, we could use it to pass the thread id instead of creating an atomic variable and using a barrier.

Closes https://github.com/nanvix/nanvix/issues/959