### PR TITLE
[libs] Increase Maximum Number of File Descriptors in `poll()`

### DIFF
--- a/src/daemons/linuxd/src/linuxd/assemble.rs
+++ b/src/daemons/linuxd/src/linuxd/assemble.rs
@@ -33,6 +33,7 @@ use ::syscall::{
         LinuxDaemonLongMessage,
         LinuxDaemonMessagePart,
     },
+    poll::message::PollRequest,
     sys::stat::message::{
         FileChmodAtRequest,
         FileStatAtRequest,
@@ -580,5 +581,45 @@ impl RequestAssemblerTrait for FileAccessAtRequest {
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
         unistd::do_faccessat(source, request)
+    }
+}
+
+impl RequestAssemblerTrait for PollRequest {
+    fn new_assembler() -> RequestAssemblerType {
+        let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+        RequestAssemblerType::PollRequest(
+            LinuxDaemonLongMessage::new(capacity).expect("capacity is set to a valid value"),
+        )
+    }
+
+    fn add_part(
+        assembler: &mut RequestAssemblerType,
+        part: LinuxDaemonMessagePart,
+    ) -> Result<(), WorkerThreadError> {
+        match assembler {
+            RequestAssemblerType::PollRequest(assembler) => Ok(assembler.add_part(part)?),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type").into()),
+        }
+    }
+
+    fn is_complete(assembler: &RequestAssemblerType) -> Result<bool, Error> {
+        match assembler {
+            RequestAssemblerType::PollRequest(assembler) => Ok(assembler.is_complete()),
+            _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid assembler type")),
+        }
+    }
+
+    fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart> {
+        match assembler {
+            RequestAssemblerType::PollRequest(assembler) => assembler.take_parts(),
+            _ => unreachable!("invalid assembler type"),
+        }
+    }
+
+    fn process_request(
+        source: ThreadIdentifier,
+        request: Self,
+    ) -> Result<Vec<Message>, WorkerThreadError> {
+        crate::poll::do_poll(source, request)
     }
 }

--- a/src/daemons/linuxd/src/message.rs
+++ b/src/daemons/linuxd/src/message.rs
@@ -110,6 +110,7 @@ pub enum RequestAssemblerType {
     UnlinkAtRequest(LinuxDaemonLongMessage),
     ChangeDirectoryRequest(LinuxDaemonLongMessage),
     FileAccessAtRequest(LinuxDaemonLongMessage),
+    PollRequest(LinuxDaemonLongMessage),
 }
 
 pub trait RequestAssemblerTrait

--- a/src/daemons/linuxd/src/poll.rs
+++ b/src/daemons/linuxd/src/poll.rs
@@ -11,39 +11,47 @@ use ::sys::{
     ipc::Message,
     pm::ThreadIdentifier,
 };
-use ::sysapi::poll::{
-    poll_errors::{
-        POLLERR,
-        POLLHUP,
-        POLLNVAL,
-    },
-    poll_flags::{
-        POLLIN,
-        POLLOUT,
-        POLLPRI,
-        POLLRDBAND,
-        POLLRDNORM,
-        POLLWRBAND,
-        POLLWRNORM,
+use ::sysapi::{
+    limits::OPEN_MAX,
+    poll::{
+        poll_errors::{
+            POLLERR,
+            POLLHUP,
+            POLLNVAL,
+        },
+        poll_flags::{
+            POLLIN,
+            POLLOUT,
+            POLLPRI,
+            POLLRDBAND,
+            POLLRDNORM,
+            POLLWRBAND,
+            POLLWRNORM,
+        },
     },
 };
-use ::syscall::poll::message::{
-    PollRequest,
-    PollResponse,
-    NFDS_MAX,
+use ::syscall::{
+    message::MessagePartitioner,
+    poll::message::{
+        PollRequest,
+        PollResponse,
+    },
 };
 
 //==================================================================================================
 // do_poll()
 //==================================================================================================
 
-pub fn do_poll(tid: ThreadIdentifier, request: PollRequest) -> Result<Message, WorkerThreadError> {
+pub fn do_poll(
+    tid: ThreadIdentifier,
+    request: PollRequest,
+) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("poll(): tid={tid:?}, request={request:?}");
 
     // Check if request is not valid.
-    if request.nfds == 0 || request.nfds as usize > NFDS_MAX {
+    if request.nfds == 0 || request.nfds as usize > OPEN_MAX {
         error!("poll(): invalid request ({request:?})");
-        return Ok(crate::build_error(tid, ErrorCode::InvalidArgument));
+        return Ok(vec![crate::build_error(tid, ErrorCode::InvalidArgument)]);
     }
 
     // Unpack request.
@@ -61,10 +69,10 @@ pub fn do_poll(tid: ThreadIdentifier, request: PollRequest) -> Result<Message, W
         nready if nready >= 0 => {
             debug!("poll(): nready={nready:?}");
 
-            match nready.try_into() {
+            match usize::try_from(nready) {
                 Ok(nready) => {
-                    let mut ready_fds: Vec<i32> = Vec::with_capacity(nready as usize);
-                    let mut revents: Vec<i16> = Vec::with_capacity(nready as usize);
+                    let mut ready_fds: Vec<i32> = Vec::with_capacity(nready);
+                    let mut revents: Vec<i16> = Vec::with_capacity(nready);
 
                     for (i, fd) in fds.iter_mut().enumerate() {
                         if fd.revents != 0 {
@@ -78,10 +86,15 @@ pub fn do_poll(tid: ThreadIdentifier, request: PollRequest) -> Result<Message, W
                     }
 
                     // Build response.
-                    match PollResponse::build(tid, nready, &ready_fds, &revents) {
-                        Ok(response) => Ok(response),
+                    match PollResponse::new(&ready_fds, &revents) {
+                        Ok(response) => match response.into_parts(tid) {
+                            Ok(messages) => Ok(messages),
+                            Err(error) => {
+                                unreachable!("poll(): failed to partition response ({error:?})")
+                            },
+                        },
                         Err(error) => {
-                            unreachable!("poll(): failed to build response ({error:?})");
+                            unreachable!("poll(): failed to build response ({error:?})")
                         },
                     }
                 },
@@ -103,7 +116,7 @@ pub fn do_poll(tid: ThreadIdentifier, request: PollRequest) -> Result<Message, W
             error!("poll(): errno={errno:?}");
             let error: ErrorCode = ErrorCode::try_from(errno)
                 .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
-            Ok(crate::build_error(tid, error))
+            Ok(vec![crate::build_error(tid, error)])
         },
     }
 }

--- a/src/daemons/linuxd/src/poll.rs
+++ b/src/daemons/linuxd/src/poll.rs
@@ -90,18 +90,19 @@ pub fn do_poll(
                         Ok(response) => match response.into_parts(tid) {
                             Ok(messages) => Ok(messages),
                             Err(error) => {
-                                unreachable!("poll(): failed to partition response ({error:?})")
+                                error!("poll(): failed to partition response ({error:?})");
+                                Ok(vec![crate::build_error(tid, error.code)])
                             },
                         },
                         Err(error) => {
-                            unreachable!("poll(): failed to build response ({error:?})")
+                            error!("poll(): failed to build response ({error:?})");
+                            Ok(vec![crate::build_error(tid, error.code)])
                         },
                     }
                 },
                 Err(_error) => {
-                    unreachable!(
-                        "poll(): invalid number of ready file descriptors (nread={nready:?})"
-                    );
+                    error!("poll(): invalid number of ready file descriptors (nread={nready:?})");
+                    Ok(vec![crate::build_error(tid, ErrorCode::ValueOutOfRange)])
                 },
             }
         },

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -20,7 +20,6 @@ use crate::{
         RequestAssembler,
         RequestAssemblerTrait,
     },
-    poll,
     socket,
     times,
     unistd,
@@ -84,6 +83,7 @@ use ::syscall::{
         UnlinkAtRequest,
     },
     message::LinuxDaemonMessagePart,
+    poll::message::PollRequest,
     sys::{
         socket::message::{
             AcceptSocketRequest,
@@ -346,7 +346,6 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::ShutdownSocketRequest
                                 | LinuxDaemonMessageHeader::TimesRequest
                                 | LinuxDaemonMessageHeader::PipeRequest
-                                | LinuxDaemonMessageHeader::PollRequest
                                 | LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
                                     match Self::handle_short_request_messages(source, message) {
                                         Ok(message) => message,
@@ -403,7 +402,8 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::FileChmodAtRequestPart
                                 | LinuxDaemonMessageHeader::OpenAtRequestPart
                                 | LinuxDaemonMessageHeader::RenameAtRequestPart
-                                | LinuxDaemonMessageHeader::UnlinkAtRequestPart => {
+                                | LinuxDaemonMessageHeader::UnlinkAtRequestPart
+                                | LinuxDaemonMessageHeader::PollRequestPart => {
                                     match Self::handle_long_request_messages(
                                         uvm_stream.clone(),
                                         assembler.clone(),
@@ -565,11 +565,6 @@ impl WorkerThreadHandle {
                 let request: PartialWriteRequest = PartialWriteRequest::from_bytes(message.payload);
                 unistd::do_pwrite(source, request)
             },
-            LinuxDaemonMessageHeader::PollRequest => {
-                let request: syscall::poll::message::PollRequest =
-                    syscall::poll::message::PollRequest::from_bytes(message.payload);
-                poll::do_poll(source, request)
-            },
             LinuxDaemonMessageHeader::ReceiveSocketRequest => {
                 let request: ReceiveSocketRequest =
                     ReceiveSocketRequest::from_bytes(message.payload);
@@ -676,6 +671,9 @@ impl WorkerThreadHandle {
                 Self::handle_long_request::<UnlinkAtRequest>(
                     uvm_stream, assembler, source, &message,
                 )
+            },
+            LinuxDaemonMessageHeader::PollRequestPart => {
+                Self::handle_long_request::<PollRequest>(uvm_stream, assembler, source, &message)
             },
             header => {
                 // The following statement is unreachable, because the matching logic in this

--- a/src/libs/sysapi/src/limits.rs
+++ b/src/libs/sysapi/src/limits.rs
@@ -33,6 +33,12 @@ pub const POSIX_NAME_MAX: usize = 14;
 /// Maximum number of bytes in a filename (not including the terminating null of a filename string).
 pub const XOPEN_NAME_MAX: usize = 255;
 
+/// Maximum number of files that can be opened by a process.
+pub const OPEN_MAX: usize = 64;
+
+/// POSIX-mandated minimum number of files that a process must be able to open.
+pub const POSIX_OPEN_MAX: usize = 20;
+
 /// Maximum number of bytes the implementation stores as a pathname in a user-supplied buffer of
 /// unspecified size, including the terminating null character. Minimum number the implementation
 /// shall accept as the maximum number of bytes in a pathname.

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -201,8 +201,8 @@ pub enum LinuxDaemonMessageHeader {
     FileAccessAtResponse,
     GetIdsRequest,
     GetIdsResponse,
-    PollRequest,
-    PollResponse,
+    PollRequestPart,
+    PollResponsePart,
 }
 // Manual TryFrom<u16> implementation for LinuxDaemonMessageHeader
 impl TryFrom<u16> for LinuxDaemonMessageHeader {
@@ -313,8 +313,8 @@ impl TryFrom<u16> for LinuxDaemonMessageHeader {
             x if x == FileAccessAtResponse as u16 => Ok(FileAccessAtResponse),
             x if x == GetIdsRequest as u16 => Ok(GetIdsRequest),
             x if x == GetIdsResponse as u16 => Ok(GetIdsResponse),
-            x if x == PollRequest as u16 => Ok(PollRequest),
-            x if x == PollResponse as u16 => Ok(PollResponse),
+            x if x == PollRequestPart as u16 => Ok(PollRequestPart),
+            x if x == PollResponsePart as u16 => Ok(PollResponsePart),
             _ => Err(()),
         }
     }

--- a/src/libs/syscall/src/poll/message.rs
+++ b/src/libs/syscall/src/poll/message.rs
@@ -6,169 +6,239 @@
 //==================================================================================================
 
 use crate::{
-    LinuxDaemonMessage,
+    message::{
+        LinuxDaemonMessagePart,
+        MessageDeserializer,
+        MessagePartitioner,
+        MessageSerializer,
+    },
     LinuxDaemonMessageHeader,
 };
+use ::alloc::vec::Vec;
 use ::core::mem;
 use ::sys::{
     error::{
         Error,
         ErrorCode,
     },
+    ipc::Message,
     pm::ThreadIdentifier,
 };
-use sys::ipc::{
-    Message,
-    MessageReceiver,
-    MessageSender,
-    MessageType,
-};
+use ::sysapi::limits::OPEN_MAX;
 
 //==================================================================================================
 // Constants
 //==================================================================================================
 
-/// Maximum number of file descriptors that can be polled in a single request.
-pub const NFDS_MAX: usize = 4;
-
-// Ensure that the maximum number of file descriptors can be encoded in a `PollRequest`.
-::static_assert::assert_eq!(NFDS_MAX < u8::MAX as usize);
+// Ensure that the maximum number of file descriptors can be encoded in a `u8`.
+::static_assert::assert_eq!(OPEN_MAX < u8::MAX as usize);
 
 //==================================================================================================
 // Structure
 //==================================================================================================
 
 #[derive(Debug)]
-#[repr(C, packed)]
 pub struct PollRequest {
-    /// Number of file descriptors in the `fds` array.
+    /// Number of file descriptors to poll.
     pub nfds: u8,
-    /// File descriptors to poll.
-    pub fds: [i32; NFDS_MAX],
-    /// Events to poll for on each file descriptor.
-    pub events: [i16; NFDS_MAX],
     /// Timeout for the poll operation, in milliseconds.
     pub timeout: i32,
-    /// Padding to align the structure to the size of `LinuxDaemonMessage`.
-    _padding: [u8; Self::PADDING_SIZE],
-}
-::static_assert::assert_eq_size!(PollRequest, LinuxDaemonMessage::PAYLOAD_SIZE);
-
-impl PollRequest {
-    /// Padding size to align the structure.
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
-        - mem::size_of::<[i32; NFDS_MAX]>() // fds
-        - mem::size_of::<[i16; NFDS_MAX]>() // events
-        - mem::size_of::<i32>() // timeout
-        - mem::size_of::<u8>(); // nfds
+    /// File descriptors to poll (length == nfds).
+    pub fds: Vec<i32>,
+    /// Events to poll for on each file descriptor (length == nfds).
+    pub events: Vec<i16>,
 }
 
 impl PollRequest {
-    /// Creates a new `PollRequest`.
-    fn new(nfds: i8, fds: &[i32], events: &[i16], timeout: i32) -> Self {
-        debug_assert!(nfds > 0 && nfds as usize <= NFDS_MAX, "nfds must be > 0 && <= {NFDS_MAX}");
-        debug_assert!(
-            !fds.is_empty() && fds.len() <= NFDS_MAX,
-            "fds.len() must be > 0 && <= {NFDS_MAX}"
-        );
-        debug_assert!(fds.len() == events.len(), "fds and events must have the same length");
+    /// Size of `nfds` field.
+    pub const SIZE_OF_NFDS: usize = mem::size_of::<u8>();
+    /// Size of `timeout` field.
+    pub const SIZE_OF_TIMEOUT: usize = mem::size_of::<i32>();
+    /// Offset of `nfds` field.
+    pub const OFFSET_OF_NFDS: usize = 0;
+    /// Offset of `timeout` field.
+    pub const OFFSET_OF_TIMEOUT: usize = Self::OFFSET_OF_NFDS + Self::SIZE_OF_NFDS;
+    /// Offset where the array of file descriptors starts.
+    pub const OFFSET_OF_FDS: usize = Self::OFFSET_OF_TIMEOUT + Self::SIZE_OF_TIMEOUT;
 
-        // Pack file descriptors.
-        let mut poll_fds: [i32; NFDS_MAX] = [0; NFDS_MAX];
-        for (i, &fd) in fds.iter().enumerate() {
-            if i < NFDS_MAX {
-                poll_fds[i] = fd;
-            }
+    /// Maximum size of the message.
+    pub const MAX_SIZE: usize =
+        Self::OFFSET_OF_FDS + OPEN_MAX * (mem::size_of::<i32>() + mem::size_of::<i16>());
+
+    ///
+    /// # Description
+    ///
+    /// Creates a new request for the `poll()` system call.
+    ///
+    /// # Parameters
+    ///
+    /// - `fds`: File descriptors to poll.
+    /// - `events`: Events to poll for on each file descriptor.
+    /// - `timeout`: Timeout for the poll operation, in milliseconds.
+    ///
+    /// # Return Value
+    ///
+    /// On success, this function returns the newly created request message for the `poll()` system
+    /// call. Otherwise, it returns an error object that describes the failure.
+    ///
+    pub fn new(fds: &[i32], events: &[i16], timeout: i32) -> Result<Self, Error> {
+        // Check if array of file descriptors is empty.
+        if fds.is_empty() {
+            return Err(Error::new(ErrorCode::InvalidArgument, "no file descriptors"));
         }
 
-        // Pack events.
-        let mut poll_events: [i16; NFDS_MAX] = [0; NFDS_MAX];
-        for (i, &event) in events.iter().enumerate() {
-            if i < NFDS_MAX {
-                poll_events[i] = event;
-            }
+        // Check if array of file descriptors is too large.
+        if fds.len() > OPEN_MAX {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "number of file descriptors exceeds maximum supported",
+            ));
         }
 
-        Self {
-            nfds: nfds as u8,
-            fds: poll_fds,
-            events: poll_events,
-            timeout,
-            _padding: [0; Self::PADDING_SIZE],
-        }
-    }
-
-    /// Creates a `PollRequest` from a byte array.
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
-        unsafe { mem::transmute(bytes) }
-    }
-
-    /// Converts the request into a byte array.
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
-        unsafe { mem::transmute(self) }
-    }
-
-    /// Builds a `Message` from a `PollRequest`.
-    pub fn build(
-        tid: ThreadIdentifier,
-        fds: &[i32],
-        events: &[i16],
-        timeout: i32,
-    ) -> Result<Message, Error> {
-        // Check if number of file descriptors exceeds the maximum supported.
-        if fds.len() > NFDS_MAX {
-            let reason: &str = "number of file descriptors exceeds maximum supported";
-            #[cfg(not(target_os = "linux"))]
-            ::syslog::error!(
-                "build(): {reason:?}, (max={NFDS_MAX}, fds.len()={}, events.len()={}, \
-                 timeout={timeout:?})",
-                fds.len(),
-                events.len(),
-            );
-            return Err(Error::new(ErrorCode::InvalidArgument, reason));
-        }
-
-        let nfds: i8 = match fds.len().try_into() {
-            Ok(n) => n,
-            Err(_) => {
-                let reason: &str = "number of file descriptors exceeds maximum supported";
-                #[cfg(not(target_os = "linux"))]
-                ::syslog::error!(
-                    "build(): {reason:?}, (max={NFDS_MAX}, fds.len()={}, events.len()={}, \
-                     timeout={timeout:?})",
-                    fds.len(),
-                    events.len(),
-                );
-                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        // Attempt to convert `fds.len()` as a `u8`.
+        let nfds: u8 = match fds.len().try_into() {
+            Ok(nfds) => nfds,
+            Err(_error) => {
+                return Err(Error::new(
+                    ErrorCode::ValueOutOfRange,
+                    "cannot encode number of file descriptors",
+                ));
             },
         };
 
-        // Check if number of events does not match the number of file descriptors.
-        if events.len() != fds.len() {
-            let reason: &str = "number of events does not match number of file descriptors";
-            #[cfg(not(target_os = "linux"))]
-            ::syslog::error!(
-                "build(): {reason:?}, (fds.len()={}, events.len()={}, timeout={timeout:?})",
-                fds.len(),
-                events.len(),
-            );
-            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        // Check if array of events is empty.
+        if events.is_empty() {
+            return Err(Error::new(ErrorCode::InvalidArgument, "no events"));
         }
 
-        let message: PollRequest = Self::new(nfds, fds, events, timeout);
+        // Check if array of events is too large.
+        if events.len() > OPEN_MAX {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "number of events exceeds maximum supported",
+            ));
+        }
 
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PollRequest, message.into_bytes());
+        // Check if the number of events does not match the number of file descriptors.
+        if fds.len() != events.len() {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "number of events does not match number of file descriptors",
+            ));
+        }
 
-        let message: Message = Message::new(
-            MessageSender::from(tid),
-            MessageReceiver::from(crate::LINUXD),
-            MessageType::Ikc,
-            None,
-            message.into_bytes(),
+        Ok(Self {
+            nfds,
+            timeout,
+            fds: fds.to_vec(),
+            events: events.to_vec(),
+        })
+    }
+}
+
+impl MessageSerializer for PollRequest {
+    /// Serializes a request message for the `poll()` system call.
+    fn to_bytes(&self) -> Vec<u8> {
+        // Allocate buffer.
+        let mut buffer: Vec<u8> = Vec::new();
+
+        // Serialize `nfds` field.
+        buffer.push(self.nfds);
+        // Serialize `timeout` field.
+        buffer.extend_from_slice(&self.timeout.to_le_bytes());
+        // Serialize `fds` array.
+        for fd in &self.fds {
+            buffer.extend_from_slice(&fd.to_le_bytes());
+        }
+        // Serialize `events` array.
+        for ev in &self.events {
+            buffer.extend_from_slice(&ev.to_le_bytes());
+        }
+
+        buffer
+    }
+}
+
+impl MessageDeserializer for PollRequest {
+    /// Deserializes a request message for the `poll()` system call.
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        // Check if the buffer is too short.
+        if bytes.len() < Self::OFFSET_OF_FDS {
+            return Err(Error::new(ErrorCode::InvalidMessage, "buffer is too short"));
+        }
+
+        // Check if message is too long.
+        if bytes.len() > Self::MAX_SIZE {
+            return Err(Error::new(ErrorCode::InvalidMessage, "message is too long"));
+        }
+
+        // Deserialize `nfds` field.
+        let nfds: u8 = bytes[Self::OFFSET_OF_NFDS];
+        if nfds == 0 || nfds as usize > OPEN_MAX {
+            return Err(Error::new(ErrorCode::InvalidMessage, "invalid nfds"));
+        }
+
+        // Deserialize `timeout` field.
+        let timeout: i32 = i32::from_le_bytes(
+            bytes[Self::OFFSET_OF_TIMEOUT..Self::OFFSET_OF_FDS]
+                .try_into()
+                .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid timeout"))?,
         );
 
-        Ok(message)
+        // Check if the buffer is too short to hold all fds and events.
+        let fds_size: usize = nfds as usize * mem::size_of::<i32>();
+        let events_size: usize = nfds as usize * mem::size_of::<i16>();
+        if bytes.len() < Self::OFFSET_OF_FDS + fds_size + events_size {
+            return Err(Error::new(ErrorCode::InvalidMessage, "buffer is too short"));
+        }
+
+        // Deserialize `fds` array.
+        let mut fds: Vec<i32> = Vec::with_capacity(nfds.into());
+        let mut events: Vec<i16> = Vec::with_capacity(nfds.into());
+        let fds_offset: usize = Self::OFFSET_OF_FDS;
+        for i in 0..nfds as usize {
+            let base: usize = fds_offset + i * mem::size_of::<i32>();
+            let fd: i32 = i32::from_le_bytes(
+                bytes[base..base + mem::size_of::<i32>()]
+                    .try_into()
+                    .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid fd"))?,
+            );
+            fds.push(fd);
+        }
+
+        // Deserialize `events` array.
+        let events_offset: usize = fds_offset + fds_size;
+        for i in 0..nfds as usize {
+            let base: usize = events_offset + i * mem::size_of::<i16>();
+            let ev: i16 = i16::from_le_bytes(
+                bytes[base..base + mem::size_of::<i16>()]
+                    .try_into()
+                    .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid event"))?,
+            );
+            events.push(ev);
+        }
+
+        PollRequest::new(&fds, &events, timeout)
+    }
+}
+
+impl MessagePartitioner for PollRequest {
+    /// Creates a new message request part for the `poll()` system call.
+    fn new_part(
+        tid: ThreadIdentifier,
+        total_parts: u16,
+        part_number: u16,
+        payload_size: u8,
+        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
+    ) -> Result<Message, Error> {
+        LinuxDaemonMessagePart::build_request(
+            tid,
+            LinuxDaemonMessageHeader::PollRequestPart,
+            total_parts,
+            part_number,
+            payload_size,
+            payload,
+        )
     }
 }
 
@@ -177,106 +247,172 @@ impl PollRequest {
 //==================================================================================================
 
 #[derive(Debug)]
-#[repr(C, packed)]
 pub struct PollResponse {
     /// Number of file descriptors with ready events.
     pub nready: u8,
-    /// File descriptors to poll.
-    pub fds: [i32; NFDS_MAX],
-    /// Events that occurred on each file descriptor.
-    pub revents: [i16; NFDS_MAX],
-    /// Padding to align the structure to the size of `LinuxDaemonMessage`.
-    _padding: [u8; Self::PADDING_SIZE],
+    /// File descriptors that are ready.
+    pub fds: Vec<i32>,
+    /// Events that occurred on each ready file descriptor.
+    pub revents: Vec<i16>,
 }
 
 impl PollResponse {
-    /// Padding size to align the structure.
-    pub const PADDING_SIZE: usize = LinuxDaemonMessage::PAYLOAD_SIZE
-    - mem::size_of::<u8>() // nready
-    - mem::size_of::<[i32; NFDS_MAX]>() // fds
-    - mem::size_of::<[i16; NFDS_MAX]>(); // revents
+    /// Offset of `nready`.
+    pub const OFFSET_OF_NREADY: usize = 0;
+    /// Offset of first array (fds) after nready.
+    pub const OFFSET_OF_FDS: usize = Self::OFFSET_OF_NREADY + mem::size_of::<u8>();
 
-    /// Creates a new `PollResponse`.
-    fn new(nready: u8, fds: &[i32], revents: &[i16]) -> Self {
-        debug_assert!(fds.len() == revents.len(), "fds and revents must have the same length");
+    /// Maximum size of the message.
+    pub const MAX_SIZE: usize = Self::OFFSET_OF_FDS
+        + OPEN_MAX * (core::mem::size_of::<i32>() + core::mem::size_of::<i16>());
 
-        // Pack file descriptors.
-        let mut ready_fds: [i32; NFDS_MAX] = [0; NFDS_MAX];
-        for (i, &fd) in fds.iter().enumerate() {
-            if i < NFDS_MAX {
-                ready_fds[i] = fd;
-            }
+    ///
+    /// # Description
+    ///
+    /// Creates a new response for the `poll()` system call.
+    ///
+    /// # Parameters
+    ///
+    /// - `fds`: File descriptors that are ready.
+    /// - `revents`: Events that occurred on each ready file descriptor.
+    ///
+    /// # Return Value
+    ///
+    /// On success, this function returns the newly created response message for the `poll()` system
+    /// call. Otherwise, it returns an error object that describes the failure.
+    ///
+    pub fn new(fds: &[i32], revents: &[i16]) -> Result<Self, Error> {
+        // Check if array of file descriptors is too large.
+        if fds.len() > OPEN_MAX {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "number of file descriptors exceeds maximum supported",
+            ));
         }
 
-        // Pack revents.
-        let mut ready_events: [i16; NFDS_MAX] = [0; NFDS_MAX];
-        for (i, &revent) in revents.iter().enumerate() {
-            if i < NFDS_MAX {
-                ready_events[i] = revent;
-            }
+        // Check if array of events is too large.
+        if revents.len() > OPEN_MAX {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "number of events exceeds maximum supported",
+            ));
         }
 
-        Self {
+        // Check if the number of events does not match the number of file descriptors.
+        if fds.len() != revents.len() {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "fds and revents must have the same length",
+            ));
+        }
+
+        // Attempt to convert `fds.len()` as a `u8`.
+        let nready: u8 = match fds.len().try_into() {
+            Ok(nready) => nready,
+            Err(_error) => {
+                return Err(Error::new(
+                    ErrorCode::ValueOutOfRange,
+                    "cannot encode number of ready file descriptors",
+                ));
+            },
+        };
+
+        Ok(Self {
             nready,
-            fds: ready_fds,
-            revents: ready_events,
-            _padding: [0; Self::PADDING_SIZE],
+            fds: fds.to_vec(),
+            revents: revents.to_vec(),
+        })
+    }
+}
+
+impl MessageSerializer for PollResponse {
+    /// Serializes a response message for the `poll()` system call.
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::new();
+        buffer.push(self.nready);
+        for fd in &self.fds {
+            buffer.extend_from_slice(&fd.to_le_bytes());
         }
+        for ev in &self.revents {
+            buffer.extend_from_slice(&ev.to_le_bytes());
+        }
+        buffer
     }
+}
 
-    /// Creates a `PollResponse` from a byte array.
-    pub fn from_bytes(bytes: [u8; LinuxDaemonMessage::PAYLOAD_SIZE]) -> Self {
-        unsafe { mem::transmute(bytes) }
+impl MessageDeserializer for PollResponse {
+    /// Deserializes a response message for the `poll()` system call.
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        // Check if the buffer is too short.
+        if bytes.len() < Self::OFFSET_OF_FDS {
+            // need at least nready
+            return Err(Error::new(ErrorCode::InvalidMessage, "buffer is too short"));
+        }
+
+        // Check if message is too long.
+        if bytes.len() > Self::MAX_SIZE {
+            return Err(Error::new(ErrorCode::InvalidMessage, "message is too long"));
+        }
+
+        // Deserialize `nready` field.
+        let nready: u8 = bytes[Self::OFFSET_OF_NREADY];
+        if nready as usize > OPEN_MAX {
+            return Err(Error::new(ErrorCode::InvalidMessage, "invalid nready"));
+        }
+
+        // Check if the buffer is too short to hold all fds and events.
+        let fds_size: usize = nready as usize * mem::size_of::<i32>();
+        let events_size: usize = nready as usize * mem::size_of::<i16>();
+        if bytes.len() < Self::OFFSET_OF_FDS + fds_size + events_size {
+            return Err(Error::new(ErrorCode::InvalidMessage, "buffer is too short"));
+        }
+
+        // Deserialize `fds` array.
+        let mut fds: Vec<i32> = Vec::with_capacity(nready as usize);
+        let mut revents: Vec<i16> = Vec::with_capacity(nready as usize);
+        let fds_offset: usize = Self::OFFSET_OF_FDS;
+        for i in 0..nready as usize {
+            let base: usize = fds_offset + i * mem::size_of::<i32>();
+            let fd: i32 = i32::from_le_bytes(
+                bytes[base..base + mem::size_of::<i32>()]
+                    .try_into()
+                    .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid fd"))?,
+            );
+            fds.push(fd);
+        }
+
+        // Deserialize `revents` array.
+        let events_offset: usize = fds_offset + fds_size;
+        for i in 0..nready as usize {
+            let base: usize = events_offset + i * mem::size_of::<i16>();
+            let ev: i16 = i16::from_le_bytes(
+                bytes[base..base + mem::size_of::<i16>()]
+                    .try_into()
+                    .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid event"))?,
+            );
+            revents.push(ev);
+        }
+
+        PollResponse::new(&fds, &revents)
     }
+}
 
-    /// Converts the response into a byte array.
-    fn into_bytes(self) -> [u8; LinuxDaemonMessage::PAYLOAD_SIZE] {
-        unsafe { mem::transmute(self) }
-    }
-
-    /// Builds a `Message` from a `PollResponse`.
-    pub fn build(
+impl MessagePartitioner for PollResponse {
+    /// Creates a new response message part for the `poll()` system call.
+    fn new_part(
         tid: ThreadIdentifier,
-        nready: u8,
-        fds: &[i32],
-        revents: &[i16],
+        total_parts: u16,
+        part_number: u16,
+        payload_size: u8,
+        payload: [u8; LinuxDaemonMessagePart::PAYLOAD_SIZE],
     ) -> Result<Message, Error> {
-        // Check if number of file descriptors exceeds the maximum supported.
-        if fds.len() > NFDS_MAX {
-            let reason: &str = "number of file descriptors exceeds maximum supported";
-            #[cfg(not(target_os = "linux"))]
-            ::syslog::error!(
-                "build(): {reason:?}, (max={NFDS_MAX}, fds.len()={}, revents.len()={})",
-                fds.len(),
-                revents.len(),
-            );
-            return Err(Error::new(ErrorCode::InvalidArgument, reason));
-        }
-
-        // Check if number of events does not match the number of file descriptors.
-        if revents.len() != fds.len() {
-            let reason: &str = "number of events does not match number of file descriptors";
-            #[cfg(not(target_os = "linux"))]
-            ::syslog::error!(
-                "build(): {reason:?}, (fds.len()={}, revents.len()={})",
-                fds.len(),
-                revents.len(),
-            );
-            return Err(Error::new(ErrorCode::InvalidArgument, reason));
-        }
-
-        let message: PollResponse = Self::new(nready, fds, revents);
-        let message: LinuxDaemonMessage =
-            LinuxDaemonMessage::new(LinuxDaemonMessageHeader::PollResponse, message.into_bytes());
-
-        let message: Message = Message::new(
-            MessageSender::from(crate::LINUXD),
-            MessageReceiver::from(tid),
-            MessageType::Ikc,
-            None,
-            message.into_bytes(),
-        );
-
-        Ok(message)
+        LinuxDaemonMessagePart::build_response(
+            tid,
+            LinuxDaemonMessageHeader::PollResponsePart,
+            total_parts,
+            part_number,
+            payload_size,
+            payload,
+        )
     }
 }

--- a/src/libs/syscall/src/poll/syscall.rs
+++ b/src/libs/syscall/src/poll/syscall.rs
@@ -6,6 +6,11 @@
 //==================================================================================================
 
 use crate::{
+    message::{
+        LinuxDaemonLongMessage,
+        LinuxDaemonMessagePart,
+        MessagePartitioner,
+    },
     poll::message::{
         PollRequest,
         PollResponse,
@@ -115,9 +120,10 @@ impl PollFd {
 ///
 /// # Returns
 ///
-/// Upon success, returns a tuple containing the number of file descriptors that are ready for I/O
-/// and a vector of events that occurred on each file descriptor. If `zero` is returned, the timeout
-/// expired without any file descriptor becoming ready. Upon failure, an `Error` is returned.
+/// Upon success, this function returns a tuple containing the number of file descriptors that are
+/// ready for I/O and a vector of events that occurred on each file descriptor. If `zero` is
+/// returned, the timeout expired without any file descriptor becoming ready. On failure, this
+/// function returns an error.
 ///
 /// # Safety
 ///
@@ -138,55 +144,90 @@ pub fn poll(
     let events: Vec<i16> = fds.iter().map(|fd| fd.events.0).collect();
     let poll_fds: Vec<RawFileDescriptor> = fds.iter().map(|fd| fd.fd).collect();
     let timeout: i32 = timeout.into();
-    let request: Message = PollRequest::build(tid, &poll_fds, &events, timeout)?;
-    ipc::send(&request)?;
+    let request: PollRequest = PollRequest::new(&poll_fds, &events, timeout)?;
+    let requests: Vec<Message> = request.into_parts(tid)?;
+    for request in &requests {
+        ipc::send(request)?;
+    }
 
-    // Receive response.
-    let response: Message = ipc::recv()?;
+    // Compute maximum number of parts in the response.
+    let capacity: usize = PollResponse::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+    let mut assembler: LinuxDaemonLongMessage = LinuxDaemonLongMessage::new(capacity)?;
 
-    // Check whether system call succeeded or not.
-    if response.status != 0 {
-        let reason: &str = "poll() failed";
-        ::syslog::error!("poll(): failed (fds={fds:?}, timeout={timeout:?}, status={:?})", {
-            response.status
-        });
+    loop {
+        let response: Message = ipc::recv()?;
 
-        // Parse error.
-        match ErrorCode::try_from(response.status) {
-            Ok(error_code) => Err(Error::new(error_code, reason)),
-            Err(error) => {
-                ::syslog::warn!("poll(): failed to parse error code (error={error:?})");
-                Err(Error::new(ErrorCode::TryAgain, reason))
-            },
+        // Check if system call failed.
+        if response.status != 0 {
+            let reason: &str = "poll() failed";
+            match ErrorCode::try_from(response.status) {
+                Ok(error_code) => {
+                    break Err(Error::new(error_code, reason));
+                },
+                Err(error) => {
+                    ::syslog::error!(
+                        "poll(): failed to parse error code (fds={fds:?}, timeout={timeout:?}, \
+                         error={error:?})"
+                    );
+                    break Err(Error::new(ErrorCode::TryAgain, reason));
+                },
+            }
         }
-    } else {
-        // System call succeeded, parse response.
-        let message: LinuxDaemonMessage = LinuxDaemonMessage::try_from_bytes(response.payload)?;
-        // response was successfully parsed.
-        match message.header {
-            // Response was successfully parsed.
-            LinuxDaemonMessageHeader::PollResponse => {
-                let message: PollResponse = PollResponse::from_bytes(message.payload);
-                let nready: i32 = message.nready.into();
-                let mut ready: Vec<(RawFileDescriptor, PollEvents)> =
-                    Vec::with_capacity(nready as usize);
 
-                for i in 0..nready as usize {
-                    ready.push((
-                        message.fds[i] as RawFileDescriptor,
-                        PollEvents(message.revents[i] as c_short),
-                    ));
+        // Parse system call response.
+        let message: LinuxDaemonMessage = match LinuxDaemonMessage::try_from_bytes(response.payload)
+        {
+            Ok(m) => m,
+            Err(error) => {
+                ::syslog::error!("poll(): {error:?} (fds={fds:?}, timeout={timeout:?})");
+                break Err(error);
+            },
+        };
+
+        match message.header {
+            LinuxDaemonMessageHeader::PollResponsePart => {
+                let part: LinuxDaemonMessagePart =
+                    LinuxDaemonMessagePart::from_bytes(message.payload);
+
+                // Add response part to message assembler and check for errors.
+                if let Err(e) = assembler.add_part(part) {
+                    ::syslog::error!(
+                        "poll(): failed to assemble response (fds={fds:?}, timeout={timeout:?})"
+                    );
+                    break Err(e);
                 }
 
-                Ok(ready)
+                // Check if all response parts were not yet received.
+                if !assembler.is_complete() {
+                    continue;
+                }
+
+                let parts: Vec<LinuxDaemonMessagePart> = assembler.take_parts();
+
+                // Assemble message.
+                match PollResponse::from_parts(&parts) {
+                    Ok(response) => {
+                        let nready: usize = response.nready as usize;
+                        let mut ready: Vec<(RawFileDescriptor, PollEvents)> =
+                            Vec::with_capacity(nready);
+                        for i in 0..nready {
+                            ready.push((
+                                response.fds[i] as RawFileDescriptor,
+                                PollEvents(response.revents[i] as c_short),
+                            ));
+                        }
+                        break Ok(ready);
+                    },
+                    Err(error) => {
+                        ::syslog::error!("poll(): {error:?} (fds={fds:?}, timeout={timeout:?})");
+                        break Err(error);
+                    },
+                }
             },
-            // Response was not successfully parsed.
-            header => {
-                ::syslog::error!(
-                    "poll(): invalid response (fds={fds:?}, timeout={timeout:?}, \
-                     header={header:?})"
-                );
-                Err(Error::new(ErrorCode::InvalidMessage, "poll() failed"))
+            _ => {
+                let reason: &'static str = "unexpected message header";
+                ::syslog::error!("poll(): {reason} (fds={fds:?}, timeout={timeout:?})");
+                break Err(Error::new(ErrorCode::InvalidMessage, reason));
             },
         }
     }

--- a/src/tests/file-c/common.h
+++ b/src/tests/file-c/common.h
@@ -132,4 +132,7 @@ extern void test_write_read(void);
 // Tests whether we can write to a file using vectorized I/O.
 extern void test_writev(void);
 
+// Tests whether we can poll a file descriptor for read/write readiness.
+extern void test_poll(void);
+
 #endif

--- a/src/tests/file-c/main.c
+++ b/src/tests/file-c/main.c
@@ -97,6 +97,7 @@ int main(int argc, const char *argv[])
     test_open_close();
     test_create_unlink();   // tests open() and unlink().
     test_write_read();      // tests open(), close() and unlink.
+    test_poll();            // tests open(), close(), write(), read(), poll() and unlink().
     test_posix_fadvise();   // requires open(), close() and unlink().
     test_lseek();           // requires open(), close(), read(), write() and unlink().
     test_posix_fallocate(); // requires open(), close(), lseek and unlink().

--- a/src/tests/file-c/poll.c
+++ b/src/tests/file-c/poll.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Maximum length for file content.
+#define POLL_TEST_DATA_MAX 256
+
+// Timeout for poll() system call.
+#define POLL_TIMEOUT 1000
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether we can poll a file descriptor for read/write readiness.
+void test_poll(void)
+{
+    fprintf(stderr, "testing poll() ... ");
+
+    const char *filename = "poll_testfile.tmp";
+    assert(strlen(filename) <= NAME_MAX);
+
+    const char *data = "Hello Nanvix!";
+    size_t data_len = strlen(data);
+    assert(data_len <= POLL_TEST_DATA_MAX);
+    char buffer[POLL_TEST_DATA_MAX + 1];
+
+    // Open file with O_NONBLOCK so that readiness semantics are exercised.
+    int fd = open(filename, O_CREAT | O_EXCL | O_RDWR | O_NONBLOCK, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+
+    // Prepare pollfd for write readiness (POLLOUT).
+    struct pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = POLLOUT;
+    pfd.revents = 0;
+
+    // Poll for write readiness. Should be ready immediately.
+    int ret = poll(&pfd, 1, POLL_TIMEOUT);
+    assert(ret == 1);
+    assert((pfd.revents & POLLOUT) != 0);
+
+    // Write data.
+    ssize_t bytes_written = write(fd, data, data_len);
+    assert(bytes_written == (ssize_t)data_len);
+
+    // Rewind to begin of the file.
+    assert(lseek(fd, 0, SEEK_SET) == 0);
+
+    // Reset pollfd for read readiness.
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+
+    // Poll for read readiness. Should be ready immediately.
+    ret = poll(&pfd, 1, POLL_TIMEOUT);
+    assert(ret == 1);
+    assert((pfd.revents & POLLIN) != 0);
+
+    // Read data and sanity check.
+    ssize_t bytes_read = read(fd, buffer, (size_t)bytes_written);
+    assert(bytes_read == bytes_written);
+    buffer[bytes_read] = '\0';
+    assert(strcmp(buffer, data) == 0);
+
+    // Close file descriptor.
+    assert(close(fd) == 0);
+
+    // Re-open read-only non-blocking and poll for read.
+    fd = open(filename, O_RDONLY | O_NONBLOCK);
+    assert(fd != -1);
+
+    // Seek to end so that no data is available.
+    assert(lseek(fd, 0, SEEK_END) != -1);
+    pfd.fd = fd;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+
+    // Poll for read readiness. It should either timeout, or return readiness with POLLHUP.
+    ret = poll(&pfd, 1, POLL_TIMEOUT);
+    assert(ret == 0 || ((ret == 1) && ((pfd.revents & (POLLIN | POLLHUP)) != 0)));
+
+    // Close file descriptor.
+    assert(close(fd) == 0);
+
+    // Remove test file.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
This pull request refactors the implementation of the `poll()` system call to support long (multi-part) messages, improving scalability and correctness when handling large numbers of file descriptors. It introduces new message types and updates the message assembly logic, both in the syscall and daemon layers. Additionally, it adds a test for polling file descriptors.

**Poll system call refactor and message handling improvements:**

* Refactored the `poll()` syscall to use long (multi-part) request and response messages, updating the message partitioning and assembly logic in both the syscall (`src/libs/syscall/src/poll/syscall.rs`) and daemon (`src/daemons/linuxd/src/poll.rs`) layers. This allows handling more file descriptors per request and response, and replaces single-message handling with a loop that assembles all message parts before returning a result. [[1]](diffhunk://#diff-d006cb68e6c56598cd8dca9e5b9b6130bdc603e9aa3434a75e444f20dd8a2c35R9-R13) [[2]](diffhunk://#diff-d006cb68e6c56598cd8dca9e5b9b6130bdc603e9aa3434a75e444f20dd8a2c35L141-R230) [[3]](diffhunk://#diff-15109955375d32a5a5ba031a258cc48c11e23f67a5c998f661c4da4018c748d8R31-R54) [[4]](diffhunk://#diff-15109955375d32a5a5ba031a258cc48c11e23f67a5c998f661c4da4018c748d8L81-R97)
* Changed message headers for poll requests and responses from single to part-based (`PollRequestPart`, `PollResponsePart`) and updated their handling throughout the codebase, including enum definitions and message header matching. [[1]](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79L204-R205) [[2]](diffhunk://#diff-cc147213476e34a9a259cb9dc6137825d445a94710b8dd2666fe38a8b2129e79L316-R317) [[3]](diffhunk://#diff-4c00c8aa53855f669f906dbd54dc2ea751b5867ec0268e941f9d059a1d281272L406-R406) [[4]](diffhunk://#diff-4c00c8aa53855f669f906dbd54dc2ea751b5867ec0268e941f9d059a1d281272R675-R677)
* Added a `RequestAssemblerTrait` implementation for `PollRequest` and updated the `RequestAssemblerType` enum to support assembling multi-part poll requests, ensuring correct processing of long poll requests in the daemon. [[1]](diffhunk://#diff-aea19e3a82e8be74bd1aa564239286996ed64a7400615961e81ba33d65dbbdbbR586-R625) [[2]](diffhunk://#diff-1f3bc0b586c134a7d4929859f0518c54425d8f577031ea6c756e3a5e11a1526fR113)

**Resource limits and constants:**

* Introduced `OPEN_MAX` and `POSIX_OPEN_MAX` constants in `src/libs/sysapi/src/limits.rs` to define the maximum number of open files per process, and updated the poll implementation to use `OPEN_MAX` instead of the previous `NFDS_MAX`. [[1]](diffhunk://#diff-5a797c67cff150fba1c3cd09b7c8ab92aa5365ab5be18845c9bc1e99622d7807R36-R41) [[2]](diffhunk://#diff-15109955375d32a5a5ba031a258cc48c11e23f67a5c998f661c4da4018c748d8L14-R16) [[3]](diffhunk://#diff-15109955375d32a5a5ba031a258cc48c11e23f67a5c998f661c4da4018c748d8R31-R54)

**Testing improvements:**

* Added a new test function `test_poll()` to verify poll functionality, and integrated it into the C test suite. [[1]](diffhunk://#diff-c92747d7a046e69d8647c9aa2e563dc67238ee6edcf4df7d605be28d99c2168aR135-R137) [[2]](diffhunk://#diff-9d9efb587de02c096b0621fe3d098cde33e8488e736d4e2801512cd013601c3bR100)