### PR TITLE
[scripts] Don't Wrongly Fail on Shell Lint

### DIFF
--- a/scripts/shell-lint-fix.sh
+++ b/scripts/shell-lint-fix.sh
@@ -17,28 +17,48 @@ if ! command -v git >/dev/null 2>&1; then
     exit 1
 fi
 
-# Get all shell scripts in the repository
-shell_files=$(git ls-files -- "*.sh")
+# Get all shell scripts in the repository (store in array to preserve filenames safely).
+mapfile -t shell_files < <(git ls-files -- '*.sh')
 
-if [ -z "$shell_files" ]; then
+if [ "${#shell_files[@]}" -eq 0 ]; then
     echo "No shell scripts found in the repository."
     exit 0
 fi
 
 echo "Fixing shell script linting issues..."
 
-# Generate diff from shellcheck and apply it
-diff_output=$(shellcheck -f diff -S warning $shell_files 2>/dev/null || true)
+# First pass: generate diff for auto-fixable issues.
+diff_output=$(shellcheck -f diff -S warning "${shell_files[@]}" 2>/dev/null || true)
 
 if [ -n "$diff_output" ]; then
     if echo "$diff_output" | git apply --allow-empty 2>/dev/null; then
-        echo "Shell script linting fixes applied successfully."
+        echo "Applied auto-fixable shell script linting changes."
     else
-        echo "Warning: Some fixes could not be applied automatically."
-        echo "Please review and fix remaining issues manually."
+        echo "Error: failed to apply some auto-fixable shell script changes." >&2
+        echo "Please review shellcheck output manually." >&2
         exit 1
     fi
 else
     echo "No auto-fixable shell script issues found."
+fi
+
+# Second pass: run shellcheck normally to detect any remaining issues (including non-fixable).
+if shellcheck -S warning "${shell_files[@]}" >/dev/null 2>&1; then
+    if [ -n "$diff_output" ]; then
+        echo "All shell script issues resolved after auto-fixes."
+    else
+        echo "No shell script issues found."
+    fi
+    exit 0
+else
+    if [ -n "$diff_output" ]; then
+        echo "Error: remaining shell script issues after applying fixes." >&2
+    else
+        echo "Error: shell script issues detected (none auto-fixable)." >&2
+    fi
+    # Print re-runnable command with proper quoting.
+    printf 'Run: shellcheck -S warning ' >&2
+    printf '%q ' "${shell_files[@]}" >&2
+    printf '\n' >&2
     exit 1
 fi


### PR DESCRIPTION
This pull request enhances the `scripts/shell-lint-fix.sh` script to provide clearer feedback and stricter error handling when fixing shell script linting issues. The script now distinguishes between auto-fixable and non-fixable issues, and guides the user accordingly.

**Shell linting workflow improvements:**

* The script now performs a two-pass check: first, it applies auto-fixable shellcheck suggestions, and then it runs shellcheck again to detect any remaining issues, including those that cannot be auto-fixed.
* Improved error messages and user guidance, especially when auto-fixes fail or when non-fixable issues remain, making it clearer what actions the user should take next.