### PR TITLE
[kernel] Fixing Logs

### DIFF
--- a/src/kernel/src/debug.rs
+++ b/src/kernel/src/debug.rs
@@ -27,7 +27,7 @@ fn do_debug(buf: &[u8]) -> Result<(), Error> {
         Ok(s) => s,
         Err(e) => {
             let reason: &str = "invalid UTF-8";
-            error!("debug(): {} (error={:?})", reason, e);
+            error!("{reason} (error={e:?})");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         },
     };
@@ -51,7 +51,7 @@ pub fn debug(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
     // Sanity check message size.
     if size > BUFFER_SIZE {
         let reason: &str = "message too large";
-        error!("debug() {}", reason);
+        error!("{reason}");
         return KcallResult::Error(ErrorCode::InvalidArgument.into());
     }
 

--- a/src/kernel/src/event/kcall/evctrl.rs
+++ b/src/kernel/src/event/kcall/evctrl.rs
@@ -39,7 +39,7 @@ fn do_evctrl(
 }
 
 pub fn evctrl(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
-    trace!("evctrl(): ev={:?}, req={:?}", args.arg0, args.arg1);
+    trace!("ev={:?}, req={:?}", args.arg0, args.arg1);
 
     let ev: Event = match Event::try_from(args.arg0) {
         Ok(ev) => ev,

--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -146,7 +146,7 @@ impl EventManagerInner {
         let idx: usize = usize::from(ev);
         if self.interrupt_ownership[idx].is_some() {
             let reason: &str = "interrupt is already owned by another process";
-            error!("do_evctrl_interrupt(): reason={:?}", reason);
+            error!("reason={:?}", reason);
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
 
@@ -158,14 +158,14 @@ impl EventManagerInner {
                     // Ensure that the process has the required capabilities.
                     if !pm.has_capability(pid, Capability::InterruptControl)? {
                         let reason: &str = "process does not have interrupt control capability";
-                        error!("do_evctrl_interrupt(): reason={:?}", reason);
+                        error!("reason={:?}", reason);
                         return Err(Error::new(ErrorCode::PermissionDenied, reason));
                     }
 
                     // Check if target interrupt is already owned by another process.
                     if self.interrupt_ownership[idx].is_some() {
                         let reason: &str = "interrupt is already owned by another process";
-                        error!("do_evctrl_interrupt(): reason={:?}", reason);
+                        error!("reason={:?}", reason);
                         return Err(Error::new(ErrorCode::ResourceBusy, reason));
                     }
 
@@ -176,7 +176,7 @@ impl EventManagerInner {
                 }
 
                 let reason: &str = "invalid process identifier";
-                error!("do_evctrl_interrupt(): reason={:?}", reason);
+                error!("reason={:?}", reason);
                 Err(Error::new(ErrorCode::InvalidArgument, reason))
             },
             EventCtrlRequest::Unregister => {
@@ -184,7 +184,7 @@ impl EventManagerInner {
                 if let Some(pid) = pid {
                     if self.interrupt_ownership[idx] != Some(pid) {
                         let reason: &str = "process does not own interrupt";
-                        error!("do_evctrl_interrupt(): reason={:?}", reason);
+                        error!("reason={:?}", reason);
                         return Err(Error::new(ErrorCode::PermissionDenied, reason));
                     }
                 }
@@ -214,14 +214,14 @@ impl EventManagerInner {
                     // Ensure that the process has the required capabilities.
                     if !pm.has_capability(pid, Capability::ExceptionControl)? {
                         let reason: &str = "process does not have exception control capability";
-                        error!("do_evctrl_exception(): reason={:?}", reason);
+                        error!("reason={:?}", reason);
                         return Err(Error::new(ErrorCode::PermissionDenied, reason));
                     }
 
                     // Check if target exception is already owned by another process.
                     if self.exception_ownership[idx].is_some() {
                         let reason: &str = "exception is already owned by another process";
-                        error!("do_evctrl_exception(): reason={:?}", reason);
+                        error!("reason={:?}", reason);
                         return Err(Error::new(ErrorCode::ResourceBusy, reason));
                     }
 
@@ -232,7 +232,7 @@ impl EventManagerInner {
                 }
 
                 let reason: &str = "invalid process identifier";
-                error!("do_evctrl_exception(): reason={:?}", reason);
+                error!("reason={:?}", reason);
                 Err(Error::new(ErrorCode::InvalidArgument, reason))
             },
             EventCtrlRequest::Unregister => {
@@ -240,7 +240,7 @@ impl EventManagerInner {
                 if let Some(pid) = pid {
                     if self.exception_ownership[idx] != Some(pid) {
                         let reason: &str = "process does not own exception";
-                        error!("do_evctrl_exception(): reason={:?}", reason);
+                        error!("reason={:?}", reason);
                         return Err(Error::new(ErrorCode::PermissionDenied, reason));
                     }
                 }
@@ -270,14 +270,14 @@ impl EventManagerInner {
                     // Ensure that the process has the required capabilities.
                     if !pm.has_capability(pid, Capability::ProcessManagement)? {
                         let reason: &str = "process does not have scheduling control capability";
-                        error!("do_evctrl_scheduling(): reason={:?}", reason);
+                        error!("reason={:?}", reason);
                         return Err(Error::new(ErrorCode::PermissionDenied, reason));
                     }
 
                     // Check if target scheduling event is already owned by another process.
                     if self.scheduling_ownership[idx].is_some() {
                         let reason: &str = "scheduling event is already owned by another process";
-                        error!("do_evctrl_scheduling(): reason={:?}", reason);
+                        error!("reason={:?}", reason);
                         return Err(Error::new(ErrorCode::ResourceBusy, reason));
                     }
 
@@ -288,7 +288,7 @@ impl EventManagerInner {
                 }
 
                 let reason: &str = "invalid process identifier";
-                error!("do_evctrl_scheduling(): reason={:?}", reason);
+                error!("reason={:?}", reason);
                 Err(Error::new(ErrorCode::InvalidArgument, reason))
             },
             EventCtrlRequest::Unregister => {
@@ -296,7 +296,7 @@ impl EventManagerInner {
                 if let Some(pid) = pid {
                     if self.scheduling_ownership[idx] != Some(pid) {
                         let reason: &str = "process does not own scheduling event";
-                        error!("do_evctrl_scheduling(): reason={:?}", reason);
+                        error!("reason={:?}", reason);
                         return Err(Error::new(ErrorCode::PermissionDenied, reason));
                     }
                 }
@@ -462,7 +462,7 @@ impl EventManagerInner {
             Some(owner) => owner,
             None => {
                 let reason: &str = "no owner for exception";
-                error!("resume_exception(): reason={:?}", reason);
+                error!("reason={:?}", reason);
                 unimplemented!("terminate process")
             },
         };
@@ -474,8 +474,8 @@ impl EventManagerInner {
         {
             let (_enventinfo, _excpinfo, resume) = self.pending_exceptions[idx].remove(entry);
 
-            if let Err(e) = resume.notify_process(pid) {
-                warn!("failed to notify all: {:?}", e);
+            if let Err(error) = resume.notify_process(pid) {
+                warn!("{error:?}");
                 unimplemented!("terminate process")
             }
         }
@@ -508,7 +508,7 @@ impl EventManagerInner {
         // Check if an spurious interrupt was received.
         if self.interrupt_capable {
             let reason: &str = "interrupt manager is not capable of handlin ginterrupts";
-            error!("wakeup_interrupt(): reason={:?}", reason);
+            error!("reason={:?}", reason);
             return Err(Error::new(ErrorCode::OperationNotSupported, reason));
         }
 
@@ -523,7 +523,7 @@ impl EventManagerInner {
             Some(owner) => owner,
             None => {
                 let reason: &str = "no owner for interrupt";
-                error!("wakeup_interrupt(): reason={:?}", reason);
+                error!("reason={:?}", reason);
                 return Err(Error::new(ErrorCode::NoSuchProcess, reason));
             },
         };
@@ -563,7 +563,7 @@ impl EventManagerInner {
         pid: ProcessIdentifier,
         info: &ExceptionInformation,
     ) -> Result<Condvar, Error> {
-        trace!("wakeup_exception(): exceptions={:#x}, pid={:?}, info={:?}", exceptions, pid, info);
+        trace!("exceptions={:#x}, pid={:?}, info={:?}", exceptions, pid, info);
         self.nevents += 1;
         let idx: usize = exceptions.trailing_zeros() as usize;
         let ev: Event = Event::from(ExceptionEvent::try_from(idx)?);
@@ -583,7 +583,7 @@ impl EventManagerInner {
             Some(owner) => owner,
             None => {
                 let reason: &str = "no owner for exception";
-                error!("wakeup_exception(): {reason}");
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::NoSuchProcess, reason));
             },
         };
@@ -653,12 +653,12 @@ impl EventManagerInner {
                 Some(owner) => owner,
                 None => {
                     let reason: &str = "no owner for scheduling event";
-                    error!("notify_process_termination(): reason={:?}", reason);
+                    error!("reason={:?}", reason);
                     return Err(Error::new(ErrorCode::NoSuchProcess, reason));
                 },
             };
 
-        trace!("notify_process_termination(): pid={:?}, info={:?}", pid, info);
+        trace!("pid={:?}, info={:?}", pid, info);
         self.get_wait().notify_process(pid)?;
 
         Ok(())
@@ -699,7 +699,7 @@ impl EventManager {
     /// - The calling process does not hold a reference to the process manager.
     ///
     pub unsafe fn resume(evdesc: EventDescriptor) -> Result<(), Error> {
-        trace!("do_resume(): evdesc={:?}", evdesc);
+        trace!("evdesc={:?}", evdesc);
         match evdesc.event() {
             Event::Interrupt(_ev) => {
                 // No further action is required for interrupts.
@@ -811,7 +811,7 @@ impl EventManager {
         ev: Event,
         req: EventCtrlRequest,
     ) -> Result<Option<EventOwnership>, Error> {
-        trace!("do_evctrl(): ev={:?}, req={:?}", ev, req);
+        trace!("ev={:?}, req={:?}", ev, req);
 
         let em: &'static mut EventManager = EventManager::get_mut()?;
 
@@ -820,7 +820,7 @@ impl EventManager {
                 // Check if the interrupt manager is capable of handling interrupts.
                 if !em.try_borrow_mut()?.interrupt_capable {
                     let reason: &str = "interrupt manager is not capable of handlin ginterrupts";
-                    error!("do_evctrl(): {:?} (reason={:?})", reason, req);
+                    error!("{:?} (reason={:?})", reason, req);
                     return Err(Error::new(ErrorCode::OperationNotSupported, reason));
                 }
                 em.try_borrow_mut()?
@@ -887,7 +887,7 @@ impl EventManager {
             Ok(em) => Ok(em),
             Err(e) => {
                 let reason: &str = "failed to borrow event manager";
-                error!("try_borrow_mut(): {:?} (error={:?})", reason, e);
+                error!("{:?} (error={:?})", reason, e);
                 Err(Error::new(ErrorCode::PermissionDenied, reason))
             },
         }
@@ -899,7 +899,7 @@ impl EventManager {
                 Some(ref em) => Ok(em),
                 None => {
                     let reason: &str = "event manager is not initialized";
-                    error!("get(): reason={:?}", reason);
+                    error!("reason={:?}", reason);
                     Err(Error::new(ErrorCode::TryAgain, reason))
                 },
             }
@@ -912,7 +912,7 @@ impl EventManager {
                 Some(ref mut em) => Ok(em),
                 None => {
                     let reason: &str = "event manager is not initialized";
-                    error!("get_mut(): reason={:?}", reason);
+                    error!("reason={:?}", reason);
                     Err(Error::new(ErrorCode::TryAgain, reason))
                 },
             }
@@ -925,7 +925,7 @@ impl EventManager {
 //==================================================================================================
 
 fn interrupt_handler(intnum: InterruptNumber) {
-    trace!("interrupt_handler(): intnum={:?}", intnum);
+    trace!("intnum={:?}", intnum);
     match EventManager::get_mut() {
         Ok(em) => match em.try_borrow_mut() {
             // SAFETY: the calling process does not hold a mutable reference to the inner state of the process manager.
@@ -949,7 +949,7 @@ fn do_exception_handler(
     info: &ExceptionInformation,
     ctx: &ContextInformation,
 ) -> Result<(), SleepError> {
-    trace!("exception_handler(): info={:?}", info);
+    trace!("info={:?}", info);
 
     // SAFETY: This is the only thread running, thus access to the memory manager is synchronized.
     let pid: ProcessIdentifier = unsafe { ProcessManager::get() }

--- a/src/kernel/src/hal/arch/x86/cpu/exception/controller.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/exception/controller.rs
@@ -76,7 +76,7 @@ impl ExceptionController {
     pub unsafe fn init() -> Result<Self, Error> {
         if SINGLETON_CONTROLLER.is_some() {
             let reason: &str = "exception controller already initialized";
-            error!("init(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
 
@@ -103,12 +103,12 @@ impl ExceptionController {
     /// This function is unsafe because it mutates global variables.
     ///
     pub unsafe fn register_handler(&mut self, handler: ExceptionHandler) -> Result<(), Error> {
-        trace!("register_handler(): handler={:?}", handler);
+        trace!("handler={:?}", handler);
 
         // Check if the handler is already set.
         if HANDLER.is_some() {
             let reason: &str = "exception handler already set";
-            error!("register_handler(): {}", reason);
+            error!("{}", reason);
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
 

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
@@ -141,7 +141,7 @@ impl InterruptController {
         }
 
         let reason: &str = "no interrupt controller found";
-        warn!("new(): {}", reason);
+        warn!("{reason}");
         Err(Error::new(ErrorCode::NoSuchDevice, reason))
     }
 
@@ -197,7 +197,7 @@ impl InterruptController {
         match self.intctrl {
             InterruptControllerType::Legacy(_) => {
                 let reason: &str = "legacy pic does not support starting cores";
-                error!("start_core(): {}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::OperationNotSupported, reason))
             },
             InterruptControllerType::Xapic(ref mut xapic, _) => {

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/ioapic.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/ioapic.rs
@@ -83,7 +83,7 @@ impl UninitIoapic {
         // Check ID mismatch.
         if ioapic::IoapicId::id(ioapic.deref_mut()) != self.id {
             let reason: &str = "id mismatch";
-            error!("init(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
@@ -129,7 +129,7 @@ pub struct Ioapic {
 impl Ioapic {
     /// Enables an interrupt line.
     pub fn enable(&mut self, irq: u8, cpunum: u8) -> Result<(), Error> {
-        info!("trace(): irq={}, cpunum={}", irq, cpunum);
+        info!("irq={}, cpunum={}", irq, cpunum);
         // When using physical destination mode, only the lower 4 bits of the
         // destination field are used. The specification is unclear about the
         // behavior of the upper bits. See 82093AA I/O ADVANCED PROGRAMMABLE
@@ -139,14 +139,14 @@ impl Ioapic {
         // Check IRQ lies in a valid range.
         if irq >= ioapic::IoapicVersion::maxredirect(self.deref_mut()) {
             let reason: &str = "invalid irq number";
-            error!("enable(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
         // Check CPU number lies in a valid range.
         if cpunum > MAXIMUM_NUMBER_CPUS {
             let reason: &str = "invalid cpu number";
-            error!("enable(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/pic.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/pic.rs
@@ -126,7 +126,7 @@ impl UninitPic {
                 None => {
                     // NOTE: This error is unexpected, as resources should be available.
                     let reason: &str = "pic already initialized";
-                    error!("init(): {}", reason);
+                    error!("{reason}");
                     return Err(Error::new(ErrorCode::TryAgain, reason));
                 },
             };

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/xapic.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/xapic.rs
@@ -68,7 +68,7 @@ impl UninitXapic {
         let apic_id: xapic::XapicId = xapic::XapicId::from_u32(xapic.read(xapic::XAPIC_ID));
         if apic_id.id() != xapic.id as u32 {
             let reason: &str = "id mismatch";
-            error!("init(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
         // Setup spurious interrupt vector.
@@ -366,7 +366,7 @@ impl Xapic {
         }
 
         let reason: &str = "maximum number of retries exceeded";
-        error!("wait(): {}", reason);
+        error!("{reason}");
         Err(Error::new(ErrorCode::TimerExpired, reason))
     }
 }

--- a/src/kernel/src/hal/arch/x86/cpu/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/mod.rs
@@ -107,7 +107,7 @@ pub fn init(
         // Check if required hardware features are supported.
         if !((cpuid::has_sse() || cpuid::has_sse2()) && cpuid::has_fxsr()) {
             let reason: &str = "cpu does not support SSE or SSE2 features with FXSR";
-            error!("init(): {reason}");
+            error!("{reason}");
             return Err(Error::new(ErrorCode::NoSuchEntry, reason));
         }
 

--- a/src/kernel/src/hal/arch/x86/mem/mmu/page_directory.rs
+++ b/src/kernel/src/hal/arch/x86/mem/mmu/page_directory.rs
@@ -103,7 +103,7 @@ impl PageDirectory {
             Some(pde) => pde,
             None => {
                 let reason: &str = "failed to read page directory entry";
-                error!("map(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::TryAgain, reason));
             },
         };
@@ -111,7 +111,7 @@ impl PageDirectory {
         // Check if page directory entry is busy.
         if pde.is_present() {
             let reason: &str = "page directory entry is busy";
-            error!("map(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
 
@@ -163,7 +163,7 @@ impl PageDirectory {
             Some(pde) => pde,
             None => {
                 let reason: &str = "failed to read page directory entry";
-                error!("unmap(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::TryAgain, reason));
             },
         };
@@ -171,7 +171,7 @@ impl PageDirectory {
         // Check if page directory entry is present.
         if !pde.is_present() {
             let reason: &str = "page directory entry is not present";
-            error!("unmap(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
 

--- a/src/kernel/src/hal/arch/x86/mem/mmu/page_table.rs
+++ b/src/kernel/src/hal/arch/x86/mem/mmu/page_table.rs
@@ -159,7 +159,7 @@ impl<T: DerefMut<Target = [u32]>> PageTable<T> {
             Some(pte) => pte,
             None => {
                 let reason: &str = "failed to read page table entry";
-                error!("unmap(): {} (page_address={:?})", reason, page_address);
+                error!("{reason} (page_address={page_address:?})");
                 return Err(Error::new(ErrorCode::TryAgain, reason));
             },
         };
@@ -167,7 +167,7 @@ impl<T: DerefMut<Target = [u32]>> PageTable<T> {
         // Check if page is not present.
         if !pte.is_present() {
             let reason: &str = "page is not present";
-            error!("unmap(): {} (page_address={:?})", reason, page_address);
+            error!("{reason} (page_address={page_address:?})");
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
 
@@ -216,7 +216,7 @@ impl<T: DerefMut<Target = [u32]>> PageTable<T> {
             Some(pte) => pte,
             None => {
                 let reason: &str = "failed to read page table entry";
-                error!("lookup(): {} (page_address={:?})", reason, page_address);
+                error!("{reason} (page_address={page_address:?})");
                 return Err(Error::new(ErrorCode::TryAgain, reason));
             },
         };
@@ -224,7 +224,7 @@ impl<T: DerefMut<Target = [u32]>> PageTable<T> {
         // Check if page is not present.
         if !pte.is_present() {
             let reason: &str = "page is not present";
-            error!("lookup(): {} (page_address={:?})", reason, page_address);
+            error!("{reason} (page_address={page_address:?})");
             return Err(Error::new(ErrorCode::NoSuchEntry, reason));
         }
 

--- a/src/kernel/src/hal/cpu/interrupt/controller.rs
+++ b/src/kernel/src/hal/cpu/interrupt/controller.rs
@@ -55,7 +55,7 @@ impl InterruptController {
         // Check if the interrupt controller was already initialized.
         if INTERRUPT_CONTROLLER.is_some() {
             let reason: &str = "interrupt controller already initialized";
-            error!("init(): reason={:?}", reason);
+            error!("reason={:?}", reason);
             return Err(Error::new(
                 ErrorCode::EntryExists,
                 "interrupt controller already initialized",

--- a/src/kernel/src/hal/cpu/interrupt/manager.rs
+++ b/src/kernel/src/hal/cpu/interrupt/manager.rs
@@ -59,15 +59,12 @@ impl InterruptManager {
         intnum: arch::InterruptNumber,
         handler: arch::InterruptHandler,
     ) -> Result<(), Error> {
-        trace!("register_handler(): intnum={:?}, handler={:?}", intnum, handler);
+        trace!("intnum={:?}, handler={:?}", intnum, handler);
 
         // Check if another handler is already registered.
         if self.controller.get_handler(intnum)?.is_some() {
             let reason: &str = "interrupt handler already registered";
-            error!(
-                "register_handler(): intnum={:?}, handler={:?}, reason={:?}",
-                intnum, handler, reason
-            );
+            error!("intnum={:?}, handler={:?}, reason={:?}", intnum, handler, reason);
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
 

--- a/src/kernel/src/hal/io/mmio/allocator.rs
+++ b/src/kernel/src/hal/io/mmio/allocator.rs
@@ -39,7 +39,7 @@ impl IoMemoryAllocator {
 
     #[allow(dead_code)] // TODO: Remove this attribute.
     pub fn register(&mut self, region: TruncatedMemoryRegion<VirtualAddress>) -> Result<(), Error> {
-        trace!("register(): region={:?}", region);
+        trace!("region={:?}", region);
 
         // TODO: Check regions overlap.
 
@@ -49,7 +49,7 @@ impl IoMemoryAllocator {
         for reg in self.regions.iter() {
             if reg.base() == region.start() {
                 let reason: &str = "address already registered";
-                error!("register(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::EntryExists, reason));
             }
         }
@@ -65,7 +65,7 @@ impl IoMemoryAllocator {
             if region.base().into_inner() == addr {
                 if region.ref_count() > 1 {
                     let reason: &str = "region already allocated";
-                    error!("allocate(): {}", reason);
+                    error!("{reason}");
                     return Err(Error::new(ErrorCode::EntryExists, reason));
                 }
 
@@ -74,7 +74,7 @@ impl IoMemoryAllocator {
         }
 
         let reason: &str = "region not registered";
-        error!("allocate(): {}", reason);
+        error!("{reason}");
         Err(Error::new(ErrorCode::NoSuchEntry, reason))
     }
 }

--- a/src/kernel/src/hal/io/pmio/allocator.rs
+++ b/src/kernel/src/hal/io/pmio/allocator.rs
@@ -161,7 +161,7 @@ impl IoPortAllocator {
         for entry in self.ports.iter() {
             if let Ok(e) = entry.try_borrow() {
                 if e.port.number() == port.number() {
-                    error!("register(): io port {:#06x} is already registered", port.number());
+                    error!("io port {:#06x} is already registered", port.number());
                     return Err(Error::new(
                         ErrorCode::AddressInUse,
                         "io port is already registered",
@@ -337,7 +337,7 @@ impl AnyIoPort {
             },
             AnyIoPort::WriteOnly(_) => {
                 let reason: &'static str = "write-only io port";
-                error!("read(): {:?}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::OperationNotSupported, reason))
             },
             AnyIoPort::ReadWrite(port) => match port_width {
@@ -352,7 +352,7 @@ impl AnyIoPort {
         match self {
             AnyIoPort::ReadOnly(_) => {
                 let reason: &'static str = "read-only io port";
-                error!("write(): {:?}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::OperationNotSupported, reason));
             },
             AnyIoPort::WriteOnly(port) => match port_width {

--- a/src/kernel/src/hal/io/pmio/typ.rs
+++ b/src/kernel/src/hal/io/pmio/typ.rs
@@ -53,7 +53,7 @@ impl TryFrom<usize> for IoPortType {
             2 => Ok(Self::ReadWrite),
             _ => {
                 let reason: &str = "invalid io port type";
-                error!("try_from(): {}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::InvalidArgument, reason))
             },
         }

--- a/src/kernel/src/hal/io/pmio/width.rs
+++ b/src/kernel/src/hal/io/pmio/width.rs
@@ -56,7 +56,7 @@ impl TryFrom<usize> for IoPortWidth {
             2 => Ok(Self::Bits32),
             _ => {
                 let reason: &str = "invalid io port width";
-                error!("try_from(): {}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::InvalidArgument, reason))
             },
         }

--- a/src/kernel/src/hal/platform/acpi.rs
+++ b/src/kernel/src/hal/platform/acpi.rs
@@ -63,7 +63,7 @@ pub unsafe fn find_table_by_sig(
             Ok(sig) => sig,
             Err(_) => {
                 let reason: &str = "invalid signature";
-                warn!("find_table_by_sig(): {}", reason);
+                warn!("{reason}");
                 continue;
             },
         };
@@ -83,6 +83,6 @@ pub unsafe fn find_table_by_sig(
 
     // Table not found.
     let reason: &str = "table not found";
-    error!("find_table_by_sig(): {}", reason);
+    error!("{reason}");
     Err(Error::new(ErrorCode::NoSuchEntry, reason))
 }

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -230,8 +230,8 @@ pub fn shutdown(_status: usize) -> ! {
 ///
 /// A new boot information structure.
 ///
-pub fn parse_bootinfo(_: u32, _: usize) -> Result<BootInfo, Error> {
-    trace!("parse_bootinfo()");
+pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
+    trace!("{magic:?}, {info:?}");
 
     extern "C" {
         static __KERNEL_END: u8;
@@ -284,8 +284,7 @@ pub fn parse_bootinfo(_: u32, _: usize) -> Result<BootInfo, Error> {
                     core::ptr::copy(src_ptr, dst_ptr, actual_initrd_size);
 
                     debug!(
-                        "parse_bootinfo(): initrd relocated from {current_initrd_start:#010x} to \
-                         {:#010x}",
+                        "initrd relocated from {current_initrd_start:#010x} to {:#010x}",
                         ::config::hyperlight::DEFAULT_INITRD_BASE
                     );
 
@@ -295,7 +294,7 @@ pub fn parse_bootinfo(_: u32, _: usize) -> Result<BootInfo, Error> {
                 }
             },
             None => {
-                error!("parse_bootinfo(): PEB not initialized");
+                error!("PEB not initialized");
                 return Err(Error::new(ErrorCode::NoSuchDevice, "PEB not initialized"));
             },
         }
@@ -305,10 +304,7 @@ pub fn parse_bootinfo(_: u32, _: usize) -> Result<BootInfo, Error> {
 
     // Register initrd as a kernel module.
     if initrd_size != 0 {
-        info!(
-            "parse_bootinfo(): initrd_base={:#010x}, initrd_size={:#010x}",
-            initrd_base, initrd_size
-        );
+        info!("initrd_base={:#010x}, initrd_size={:#010x}", initrd_base, initrd_size);
 
         // Add kernel module to the list of kernel modules.
         let module: KernelModule = KernelModule::new(

--- a/src/kernel/src/hal/platform/hyperlight/peb.rs
+++ b/src/kernel/src/hal/platform/hyperlight/peb.rs
@@ -56,7 +56,7 @@ impl ProcessEnvironmentBlock {
     pub unsafe fn init(peb_base: *mut HyperlightPEB) -> Result<(), Error> {
         if GUEST_HANDLE.peb().is_some() {
             let reason: &'static str = "init: peb already initialized";
-            error!("{}", reason);
+            error!("{reason}");
             Err(Error::new(ErrorCode::ResourceBusy, reason))
         } else {
             GUEST_HANDLE = GuestHandle::init(peb_base);
@@ -76,7 +76,7 @@ impl ProcessEnvironmentBlock {
             },
             None => {
                 let reason: &'static str = "set_guest_function_dispatch_ptr: peb not initialized";
-                error!("{}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::NoSuchDevice, reason))
             },
         }
@@ -100,7 +100,7 @@ impl ProcessEnvironmentBlock {
             Some(peb_ptr) => Ok((*peb_ptr).credits_value),
             None => {
                 let reason: &'static str = "get_credits: peb not initialized";
-                error!("{}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::NoSuchDevice, reason))
             },
         }

--- a/src/kernel/src/hal/platform/microvm.rs
+++ b/src/kernel/src/hal/platform/microvm.rs
@@ -231,11 +231,11 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
     // Check if magic number matches what we expect.
     if magic != ::config::microvm::DEFAULT_BOOT_MAGIC {
         let reason: &str = "invalid boot magic number";
-        error!("parse_bootinfo(): magic={:#010x}, info={:#010x} (error={})", magic, info, reason);
+        error!("magic={:#010x}, info={:#010x} (error={})", magic, info, reason);
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
-    trace!("parse_bootinfo(): magic={:#010x}, info={:#010x}", magic, info);
+    trace!("magic={:#010x}, info={:#010x}", magic, info);
 
     // Retrieve initrd information.
     // - Lower bits encode the size of the initrd.
@@ -258,14 +258,13 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
             Ok(s) => s,
             Err(_) => {
                 let reason: &str = "invalid UTF-8 in command line";
-                error!("parse_bootinfo(): invalid UTF-8 in command line");
+                error!("invalid UTF-8 in command line");
                 return Err(Error::new(ErrorCode::InvalidArgument, reason));
             },
         };
 
         info!(
-            "parse_bootinfo(): initrd_base={:#010x}, initrd_size={:#010x}, cmdline_len={:?}, \
-             cmdline={:?}",
+            "initrd_base={:#010x}, initrd_size={:#010x}, cmdline_len={:?}, cmdline={:?}",
             initrd_base,
             (initrd_size * mem::PAGE_SIZE),
             cmdline_len,

--- a/src/kernel/src/hal/platform/pc/mboot/basic_mem_info.rs
+++ b/src/kernel/src/hal/platform/pc/mboot/basic_mem_info.rs
@@ -69,14 +69,14 @@ impl MbootBasicMeminfo<'_> {
         // Ensure that `ptr` is not null.
         if ptr.is_null() {
             let reason: &str = "null pointer";
-            error!("from_raw(): {:?}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
         // Check if `ptr` is misaligned.
         if !ptr.is_aligned_to(core::mem::align_of::<MbootBasicMeminfo>()) {
             let reason: &str = "unaligned pointer";
-            error!("from_raw(): {:?}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
@@ -86,7 +86,7 @@ impl MbootBasicMeminfo<'_> {
         // Check if pointer arithmetic wraps around the address space.
         if ptr.wrapping_add(tag.size as usize) < ptr {
             let reason: &str = "pointer arithmetic wraps around the address space";
-            error!("from_raw(): {:?}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
@@ -98,7 +98,7 @@ impl MbootBasicMeminfo<'_> {
         // Check if pointer arithmetic wraps around the address space.
         if ptr.wrapping_add(core::mem::size_of::<u32>()) < ptr {
             let reason: &str = "pointer arithmetic wraps around the address space";
-            error!("from_raw(): {:?}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 

--- a/src/kernel/src/hal/platform/pc/mboot/mod.rs
+++ b/src/kernel/src/hal/platform/pc/mboot/mod.rs
@@ -237,7 +237,7 @@ fn parse_module(
         Ok(raw_addr) => PhysicalAddress::from_raw_value(raw_addr)?,
         Err(_) => {
             let reason: &'static str = "invalid kernel module start address";
-            error!("parse_module(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         },
     };
@@ -283,7 +283,7 @@ fn parse_mmap(
             Ok(raw_addr) => VirtualAddress::from_raw_value(raw_addr).align_down(PAGE_ALIGNMENT),
             Err(_) => {
                 let reason: &'static str = "invalid memory region address";
-                error!("parse_mmap(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::BadAddress, reason));
             },
         };
@@ -297,7 +297,7 @@ fn parse_mmap(
             },
             Err(_) => {
                 let reason: &'static str = "invalid memory region size";
-                error!("parse_mmap(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::BadAddress, reason));
             },
         };

--- a/src/kernel/src/hal/platform/pc/mod.rs
+++ b/src/kernel/src/hal/platform/pc/mod.rs
@@ -163,7 +163,7 @@ fn register_bios_data_area(
     // NOTE: This is possible because mem_lower_size start at address 0x0.
     if mem_lower_size < bios::BiosDataArea::BASE + mem::PAGE_SIZE {
         let reason: &str = "bios data memory region doesn't fit in lower memory available";
-        error!("register_bios_data_area(): {:?}", reason);
+        error!("{:?}", reason);
         return Err(Error::new(ErrorCode::OutOfMemory, reason));
     }
 
@@ -246,7 +246,7 @@ pub fn init(
         Some(mem_lower_size) => mem_lower_size,
         None => {
             let reason: &str = "availability of lower memory is not known";
-            error!("init(): {:?}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         },
     };
@@ -258,7 +258,7 @@ pub fn init(
     // NOTE: This is possible because mem_lower_size start at address 0x0.
     if mem_lower_size < platform::TRAMPOLINE_ADDRESS.into_raw_value() + mem::PAGE_SIZE {
         let reason: &str = "Trampoline memory region doesn't fit in lower memory available";
-        error!("init(): {:?}", reason);
+        error!("{reason}");
         return Err(Error::new(ErrorCode::OutOfMemory, reason));
     }
     // Trampoline.

--- a/src/kernel/src/hal/platform/pit.rs
+++ b/src/kernel/src/hal/platform/pit.rs
@@ -63,7 +63,7 @@ impl Pit {
 
         // Check if frequency is valid.
         if !(pit::PIT_MIN_FREQUENCY..=pit::PIT_MAX_FREQUENCY).contains(&freq) {
-            error!("new(): invalid frequency for pit (freq={})", freq);
+            error!("invalid frequency for pit (freq={})", freq);
             return Err(Error::new(ErrorCode::InvalidArgument, "invalid frequency"));
         }
 

--- a/src/kernel/src/io/kcall/mmio_alloc.rs
+++ b/src/kernel/src/io/kcall/mmio_alloc.rs
@@ -42,12 +42,12 @@ fn do_mmio_alloc(
     pid: ProcessIdentifier,
     addr: PageAligned<VirtualAddress>,
 ) -> Result<(), Error> {
-    trace!("do_mmio_alloc(): pid={:?}, addr={:?}", pid, addr.into_inner());
+    trace!("pid={:?}, addr={:?}", pid, addr.into_inner());
 
     // Check if process does not have I/O management capabilities.
     if !pm.has_capability(pid, Capability::IoManagement)? {
         let reason: &'static str = "process does not have I/O management capabilities";
-        error!("do_mmio_alloc(): {}", reason);
+        error!("{}", reason);
         return Err(Error::new(ErrorCode::PermissionDenied, reason));
     }
 

--- a/src/kernel/src/io/kcall/mmio_free.rs
+++ b/src/kernel/src/io/kcall/mmio_free.rs
@@ -37,12 +37,12 @@ fn do_mmio_free(
     pid: ProcessIdentifier,
     addr: PageAligned<VirtualAddress>,
 ) -> Result<(), Error> {
-    trace!("do_mmio_free(): pid={:?}, addr={:?}", pid, addr.into_inner());
+    trace!("pid={:?}, addr={:?}", pid, addr.into_inner());
 
     // Check if process does not have I/O management capabilities.
     if !pm.has_capability(pid, Capability::IoManagement)? {
         let reason: &'static str = "process does not have I/O management capabilities";
-        error!("do_mmio_free(): {}", reason);
+        error!("{reason}");
         return Err(Error::new(ErrorCode::PermissionDenied, reason));
     }
 

--- a/src/kernel/src/io/kcall/pmio_alloc.rs
+++ b/src/kernel/src/io/kcall/pmio_alloc.rs
@@ -41,17 +41,12 @@ fn do_pmio_alloc(
     port_type: IoPortType,
     port_number: u16,
 ) -> Result<(), Error> {
-    trace!(
-        "do_pmio_alloc(): pid={:?}, port_number={:?}, port_type={:?}",
-        pid,
-        port_number,
-        port_type
-    );
+    trace!("pid={:?}, port_number={:?}, port_type={:?}", pid, port_number, port_type);
 
     // Check if the process does not have I/O management capabilities.
     if !pm.has_capability(pid, Capability::IoManagement)? {
         let reason: &'static str = "process does not have io management capabilities";
-        error!("do_pmio_alloc(): {}", reason);
+        error!("{reason}");
         return Err(Error::new(ErrorCode::PermissionDenied, reason));
     }
 

--- a/src/kernel/src/io/kcall/pmio_free.rs
+++ b/src/kernel/src/io/kcall/pmio_free.rs
@@ -33,12 +33,12 @@ fn do_pmio_free(
     pid: ProcessIdentifier,
     port_number: u16,
 ) -> Result<(), Error> {
-    trace!("do_pmio_free(): pid={:?}, portnum={:?}", pid, port_number);
+    trace!("pid={:?}, portnum={:?}", pid, port_number);
 
     // Check if the process does not have I/O management capabilities.
     if !pm.has_capability(pid, Capability::IoManagement)? {
         let reason: &'static str = "process does not have io management capabilities";
-        error!("do_pmio_free(): {}", reason);
+        error!("{reason}");
         return Err(Error::new(ErrorCode::PermissionDenied, reason));
     }
 

--- a/src/kernel/src/io/kcall/pmio_read.rs
+++ b/src/kernel/src/io/kcall/pmio_read.rs
@@ -34,17 +34,12 @@ fn do_pmio_read(
     port_number: u16,
     port_width: IoPortWidth,
 ) -> Result<u32, Error> {
-    trace!(
-        "do_pmio_read(): pid={:?}, port_number={:?}, port_width={:?}",
-        pid,
-        port_number,
-        port_width
-    );
+    trace!("pid={:?}, port_number={:?}, port_width={:?}", pid, port_number, port_width);
 
     // Check if the process does not have I/O management capabilities.
     if !pm.has_capability(pid, Capability::IoManagement)? {
         let reason: &'static str = "process does not have io management capabilities";
-        error!("do_pmio_read(): {}", reason);
+        error!("{reason}");
         return Err(Error::new(ErrorCode::PermissionDenied, reason));
     }
 

--- a/src/kernel/src/io/kcall/pmio_write.rs
+++ b/src/kernel/src/io/kcall/pmio_write.rs
@@ -35,18 +35,12 @@ fn do_pmio_write(
     port_width: IoPortWidth,
     value: u32,
 ) -> Result<(), Error> {
-    trace!(
-        "do_pmio_write(): pid={:?}, port_number={:?}, port_width={:?}, value={:?}",
-        pid,
-        port_number,
-        port_width,
-        value
-    );
+    trace!("pid={pid:?}, port_number={port_number:?}, port_width={port_width:?}, value={value:?}");
 
     // Check if the process does not have I/O management capabilities.
     if !pm.has_capability(pid, Capability::IoManagement)? {
         let reason: &'static str = "process does not have io management capabilities";
-        error!("do_pmio_write(): {}", reason);
+        error!("{reason}");
         return Err(Error::new(ErrorCode::PermissionDenied, reason));
     }
 

--- a/src/kernel/src/ipc/kcall.rs
+++ b/src/kernel/src/ipc/kcall.rs
@@ -35,7 +35,7 @@ use ::sys::{
 //==================================================================================================
 
 fn do_send(pm: &mut ProcessManager, message: Message) -> Result<(), Error> {
-    trace!("do_send(): src={:?}, dst={:?}", { message.source }, { message.destination });
+    trace!("src={:?}, dst={:?}", { message.source }, { message.destination });
 
     // TODO: Check if source process has permission to send message to destination process.
 
@@ -58,7 +58,7 @@ pub fn send(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
         != MessageSender::from(src_pid)
     {
         let reason: &str = "invalid message source";
-        error!("do_send(): {reason:?} (message={:?})", message);
+        error!("{reason:?} (message={message:?})");
     }
 
     // Route message based on its type.
@@ -75,7 +75,7 @@ pub fn send(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
                     }
                 } else {
                     // Standard input/output is not available.
-                    error!("send(): stdio is not available");
+                    error!("stdio is not available");
                     KcallResult::Error(sys::error::ErrorCode::ProtocolNotSupported.into())
                 }
             }
@@ -97,7 +97,7 @@ pub unsafe fn recv(
     msg: usize,
 ) -> Result<(), SleepError> {
     if pid != ProcessIdentifier::INITD {
-        trace!("do_recv(): pid={:?}", pid);
+        trace!("pid={:?}", pid);
     }
 
     match EventManager::wait(tid, pid) {

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -24,7 +24,6 @@ use crate::{
         ProcessManager,
     },
 };
-use ::config::kernel::IKC_POLL_BATCH_SIZE;
 use ::sys::{
     error::ErrorCode,
     event::ProcessTerminationInfo,
@@ -32,6 +31,9 @@ use ::sys::{
     pm::ProcessIdentifier,
     ExitStatus,
 };
+
+#[cfg(feature = "stdio")]
+use ::config::kernel::IKC_POLL_BATCH_SIZE;
 
 //==================================================================================================
 //  Standalone Functions

--- a/src/kernel/src/kcall/mod.rs
+++ b/src/kernel/src/kcall/mod.rs
@@ -108,7 +108,7 @@ impl ScoreBoard {
                 Ok(scoreboard)
             } else {
                 let reason: &str = "uninitialized scoreboard";
-                error!("borrow(): {}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::TryAgain, reason))
             }
         }

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -125,7 +125,7 @@ mod startup {
                 Some(fence) => fence.wait(),
                 None => {
                     let reason: &str = "startup fence not initialized";
-                    error!("wait(): {:?}", reason);
+                    error!("{reason:?}");
                     return Err(Error::new(ErrorCode::NoSuchEntry, reason));
                 },
             }
@@ -140,7 +140,7 @@ mod startup {
                 Some(fence) => fence.signal(),
                 None => {
                     let reason: &str = "startup fence not initialized";
-                    error!("signal(): {:?}", reason);
+                    error!("{reason:?}");
                     return Err(Error::new(ErrorCode::NoSuchEntry, reason));
                 },
             }

--- a/src/kernel/src/mm/elf.rs
+++ b/src/kernel/src/mm/elf.rs
@@ -181,7 +181,7 @@ fn do_elf32_load(
     elf: &Elf32Fhdr,
     dry_run: bool,
 ) -> Result<(VirtualAddress, PageAligned<VirtualAddress>), Error> {
-    trace!("do_el32_load(): dry_run={}", dry_run);
+    trace!("dry_run={}", dry_run);
 
     let mut last_address: usize = 0;
 

--- a/src/kernel/src/mm/kredzone.rs
+++ b/src/kernel/src/mm/kredzone.rs
@@ -50,7 +50,7 @@ pub fn store(index: usize, value: usize) -> Result<(), Error> {
     // Check if the index is out of bounds.
     if index >= KREDZONE_SIZE / mem::size_of::<usize>() {
         let reason: &str = "index out of bounds";
-        error!("store(): index={:?}, value={:?}, (error={})", index, value, reason);
+        error!("index={:?}, value={:?}, (error={})", index, value, reason);
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
@@ -82,7 +82,7 @@ pub fn load(index: usize) -> Result<usize, Error> {
     // Check if the index is out of bounds.
     if index >= KREDZONE_SIZE / mem::size_of::<usize>() {
         let reason: &str = "index out of bounds";
-        error!("load(): index={:?}, (error={})", index, reason);
+        error!("index={:?}, (error={})", index, reason);
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 

--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -133,7 +133,7 @@ impl fmt::Debug for KernelStack {
 
 impl Drop for KernelStack {
     fn drop(&mut self) {
-        debug!("drop(): {:?}", &self);
+        debug!("{:?}", &self);
         while let Some(kpage) = self.kpages.pop() {
             drop(kpage);
         }

--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -86,7 +86,7 @@ impl FrameAllocator {
         let frame_number: usize = match self.bitmap.alloc() {
             Ok(frame_number) => frame_number,
             Err(error) => {
-                error!("alloc(): {error:?}");
+                error!("{error:?}");
                 return Err(error);
             },
         };
@@ -94,7 +94,7 @@ impl FrameAllocator {
             Some(frame_number) => frame_number,
             None => {
                 let reason: &str = "frame number is out of bounds";
-                error!("alloc(): {reason:?}");
+                error!("{reason:?}");
                 return Err(Error::new(ErrorCode::OutOfMemory, reason));
             },
         };
@@ -103,7 +103,7 @@ impl FrameAllocator {
         match FrameAddress::from_frame_number(frame_number) {
             Ok(frame_address) => Ok(frame_address),
             Err(error) => {
-                error!("alloc(): {error:?}");
+                error!("{error:?}");
                 Err(error)
             },
         }
@@ -127,7 +127,7 @@ impl FrameAllocator {
         match self.bitmap.clear(frame_number) {
             Ok(()) => Ok(()),
             Err(error) => {
-                error!("free(): {error:?} (frame={frame:?})");
+                error!("{error:?} (frame={frame:?})");
                 Err(error)
             },
         }
@@ -151,7 +151,7 @@ impl FrameAllocator {
         match self.bitmap.set(frame_number) {
             Ok(()) => Ok(()),
             Err(error) => {
-                error!("book(): {error:?} (phys_addr={phys_addr:?})");
+                error!("{error:?} (phys_addr={phys_addr:?})");
                 Err(error)
             },
         }
@@ -192,7 +192,7 @@ impl FrameAllocator {
         // Book all frames in the range.
         for index in start_frame_number..=end_frame_number {
             if let Err(error) = self.bitmap.set(index) {
-                error!("alloc_range(): {error:?} (region={region:?})");
+                error!("{error:?} (region={region:?})");
                 return Err(error);
             }
         }

--- a/src/kernel/src/mm/phys/kpool.rs
+++ b/src/kernel/src/mm/phys/kpool.rs
@@ -43,7 +43,7 @@ struct KpoolInner {
 
 impl KpoolInner {
     fn new(region: TruncatedMemoryRegion<PhysicalAddress>) -> Result<Self, Error> {
-        trace!("new(): region={region:?}");
+        trace!("region={region:?}");
         debug_assert_eq!(
             region.size() % mem::PAGE_SIZE,
             0,
@@ -57,7 +57,7 @@ impl KpoolInner {
         let index: usize = match self.bitmap.alloc() {
             Ok(index) => index,
             Err(error) => {
-                error!("alloc(): {error:?}");
+                error!("{error:?}");
                 return Err(error);
             },
         };
@@ -84,7 +84,7 @@ impl KpoolInner {
         let index: usize = match self.bitmap.alloc_range(count) {
             Ok(index) => index,
             Err(error) => {
-                error!("alloc_range(): {error:?} (count={count})");
+                error!("{error:?} (count={count})");
                 return Err(error);
             },
         };
@@ -110,7 +110,7 @@ impl KpoolInner {
         match self.bitmap.clear(index) {
             Ok(()) => Ok(()),
             Err(error) => {
-                error!("free(): {error:?} (addr={addr:?})");
+                error!("{error:?} (addr={addr:?})");
                 Err(error)
             },
         }

--- a/src/kernel/src/mm/phys/upool.rs
+++ b/src/kernel/src/mm/phys/upool.rs
@@ -205,7 +205,7 @@ impl Upool {
     }
 
     pub fn alloc_many(&mut self, nframes: usize) -> Result<Vec<UserFrame>, Error> {
-        trace!("alloc_many(): nframes={nframes:?}");
+        trace!("nframes={nframes:?}");
 
         // Attempt to allocate pages.
         let mut uframes: Vec<FrameAddress> = self.inner.borrow_mut().alloc_many(nframes)?;

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -186,7 +186,7 @@ impl VirtMemoryManager {
         let new_vmem: Vmem = Vmem::clone(vmem)?;
 
         trace!(
-            "new_vmem(): new_vmem={:?}, old_vmem={:?}",
+            "new_vmem={:?}, old_vmem={:?}",
             new_vmem.pgdir().physical_address(),
             vmem.pgdir().physical_address()
         );
@@ -205,7 +205,7 @@ impl VirtMemoryManager {
             Ok(mut physman) => physman.alloc_user_frame()?,
             Err(_) => {
                 let reason: &str = "failed to borrow physical memory manager";
-                error!("alloc_upage(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::ResourceBusy, reason));
             },
         };
@@ -216,7 +216,7 @@ impl VirtMemoryManager {
                 Ok(mut physman) => physman.alloc_kernel_frame(true)?,
                 Err(_) => {
                     let reason: &str = "failed to borrow physical memory manager";
-                    error!("alloc_upage(): {}", reason);
+                    error!("{reason}");
                     return Err(Error::new(ErrorCode::ResourceBusy, reason));
                 },
             };
@@ -267,7 +267,7 @@ impl VirtMemoryManager {
         nframes: usize,
         access: AccessPermission,
     ) -> Result<(), Error> {
-        trace!("alloc_upages(): vaddr={:?}, nframes={}", vaddr, nframes);
+        trace!("vaddr={:?}, nframes={}", vaddr, nframes);
 
         let physman: Rc<RefCell<PhysMemoryManager>> = self.physman.clone();
 
@@ -276,7 +276,7 @@ impl VirtMemoryManager {
                 Ok(mut physman) => physman.alloc_kernel_frame(true)?,
                 Err(_) => {
                     let reason: &str = "failed to borrow physical memory manager";
-                    error!("alloc_upage(): {}", reason);
+                    error!("{reason}");
                     return Err(Error::new(ErrorCode::ResourceBusy, reason));
                 },
             };
@@ -290,7 +290,7 @@ impl VirtMemoryManager {
             Ok(mut physman) => physman.alloc_many_user_frames(nframes)?,
             Err(_) => {
                 let reason: &str = "failed to borrow physical memory manager";
-                error!("alloc_upages(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::ResourceBusy, reason));
             },
         };
@@ -347,7 +347,7 @@ impl VirtMemoryManager {
             Ok(mut physman) => physman.alloc_kernel_frame(clear)?,
             Err(_) => {
                 let reason: &str = "failed to borrow physical memory manager";
-                error!("alloc_kpage(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::ResourceBusy, reason));
             },
         };
@@ -374,7 +374,7 @@ impl VirtMemoryManager {
             Ok(mut physman) => physman.alloc_many_kernel_frames(clear, count)?,
             Err(_) => {
                 let reason: &str = "failed to borrow physical memory manager";
-                error!("alloc_kpages(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::ResourceBusy, reason));
             },
         };

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -134,7 +134,7 @@ impl Vmem {
         mut kernel_pages: LinkedList<KernelPage>,
         mut kernel_page_tables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>,
     ) -> Result<Self, Error> {
-        trace!("new()");
+        trace!("kernel_pages.len()={}", kernel_pages.len());
 
         // Create a clean page directory.
         let mut pgdir: PageDirectory = PageDirectory::new(PageDirectoryStorage::new());
@@ -237,7 +237,7 @@ impl Vmem {
             Some(pde) => pde,
             None => {
                 let reason: &str = "failed to read page directory entry";
-                error!("map_kpage(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::TryAgain, reason));
             },
         };
@@ -288,7 +288,7 @@ impl Vmem {
         }
 
         let reason: &str = "page table not found";
-        error!("lookup_kernel_page_table(): {}", reason);
+        error!("{reason}");
         Err(Error::new(ErrorCode::NoSuchEntry, reason))
     }
 
@@ -303,11 +303,8 @@ impl Vmem {
         // Check if the provided address lies outside the user space.
         if !Self::is_user_addr(vaddr.into_inner()) {
             let reason: &str = "address is not in user space";
-            error!(
-                "map(): {} (uframe={:?}, vaddr={:?}, access={:?})",
-                reason, uframe, vaddr, access
-            );
-            return Err(Error::new(ErrorCode::BadAddress, "address is not in user space"));
+            error!("{reason} (uframe={uframe:?}, vaddr={vaddr:?}, access={access:?})",);
+            return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
         // Get corresponding page table.
@@ -321,7 +318,7 @@ impl Vmem {
                 Some(pde) => pde,
                 None => {
                     let reason: &str = "failed to read page directory entry";
-                    error!("map(): {}", reason);
+                    error!("{reason}");
                     return Err(Error::new(ErrorCode::TryAgain, reason));
                 },
             };
@@ -461,7 +458,7 @@ impl Vmem {
         // Check if corresponding page table does not exist.
         if !pde.is_present() {
             let reason: &str = "page table not present";
-            error!("lookup_page_table(): {reason:?} (pde={pde:?})");
+            error!("{reason:?} (pde={pde:?})");
             return Err(Error::new(ErrorCode::NoSuchEntry, reason));
         }
 
@@ -481,7 +478,7 @@ impl Vmem {
             Some(pt) => Ok(pt),
             None => {
                 let reason: &str = "page table not found";
-                error!("lookup_page_table(): {}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         }
@@ -494,7 +491,7 @@ impl Vmem {
         // Check if corresponding page table does not exist.
         if !pde.is_present() {
             let reason: &str = "page table not present";
-            error!("lookup_kernel_page_table(): {reason:?} (pde={pde:?})");
+            error!("{reason:?} (pde={pde:?})");
             return Err(Error::new(ErrorCode::NoSuchEntry, reason));
         }
 
@@ -515,7 +512,7 @@ impl Vmem {
             Some(entry) => Ok(entry),
             None => {
                 let reason: &str = "page table not found";
-                error!("lookup_kernel_page_table(): {}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         }
@@ -551,7 +548,7 @@ impl Vmem {
         }
 
         let reason: &str = "page not found";
-        error!("find_page(): {} (vaddr={:?})", reason, vaddr);
+        error!("{reason} (vaddr={vaddr:?})");
         Err(Error::new(ErrorCode::NoSuchEntry, reason))
     }
 
@@ -901,7 +898,7 @@ impl Vmem {
         // Check if the provided address lies outside the user space.
         if !Self::is_user_addr(vaddr.into_inner()) {
             let reason: &str = "address is not in user space";
-            error!("unmap(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
@@ -920,7 +917,7 @@ impl Vmem {
                     Some(pde) => pde,
                     None => {
                         let reason: &str = "failed to read page directory entry";
-                        error!("map(): {}", reason);
+                        error!("{reason}");
                         return Err(Error::new(ErrorCode::TryAgain, reason));
                     },
                 };
@@ -929,7 +926,7 @@ impl Vmem {
                 // Check if corresponding page table does not exist.
                 if !pde.is_present() {
                     let reason: &str = "page table not present";
-                    error!("unmap(): {}", reason);
+                    error!("{reason}");
                     return Err(Error::new(ErrorCode::NoSuchEntry, reason));
                 };
 
@@ -980,7 +977,7 @@ impl Vmem {
         // Check if the provided address lies outside the user space.
         if !Self::is_user_addr(vaddr.into_inner()) {
             let reason: &str = "address is not in user space";
-            error!("ctrl(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
@@ -994,7 +991,7 @@ impl Vmem {
                 Some(pde) => pde,
                 None => {
                     let reason: &str = "failed to read page directory entry";
-                    error!("ctrl(): {}", reason);
+                    error!("{reason}");
                     return Err(Error::new(ErrorCode::TryAgain, reason));
                 },
             };
@@ -1002,7 +999,7 @@ impl Vmem {
             // Check if corresponding page table does not exist.
             if !pde.is_present() {
                 let reason: &str = "page table not present";
-                error!("ctrl(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::NoSuchEntry, reason));
             };
 
@@ -1023,12 +1020,12 @@ impl Vmem {
         vaddr: PageAligned<VirtualAddress>,
         access: AccessPermission,
     ) -> Result<(), Error> {
-        trace!("kctrl(): {:?}", vaddr);
+        trace!("{vaddr:?}");
 
         // Check if the provided address lies outside the kernel space.
         if !Self::is_kernel_addr(vaddr.into_inner()) {
             let reason: &str = "address is not in kernel space";
-            error!("kctrl(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
@@ -1042,7 +1039,7 @@ impl Vmem {
                 Some(pde) => pde,
                 None => {
                     let reason: &str = "failed to read page directory entry";
-                    error!("ctrl(): {}", reason);
+                    error!("{reason}");
                     return Err(Error::new(ErrorCode::TryAgain, reason));
                 },
             };
@@ -1050,7 +1047,7 @@ impl Vmem {
             // Check if corresponding page table does not exist.
             if !pde.is_present() {
                 let reason: &str = "page table not present";
-                error!("ctrl(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::NoSuchEntry, reason));
             };
 

--- a/src/kernel/src/pm/kcall/capctl.rs
+++ b/src/kernel/src/pm/kcall/capctl.rs
@@ -30,7 +30,7 @@ fn do_capctl(
     capability: Capability,
     value: bool,
 ) -> Result<(), Error> {
-    trace!("do_capctl(): pid={:?}, capability={:?}, value={:?}", pid, capability, value);
+    trace!("pid={:?}, capability={:?}, value={:?}", pid, capability, value);
 
     //FIXME: check if process has enough privileges to change capabilities.
 

--- a/src/kernel/src/pm/kcall/create_thread.rs
+++ b/src/kernel/src/pm/kcall/create_thread.rs
@@ -66,7 +66,7 @@ pub fn create_thread(
     // Check if thread_create_args does not lie in user space.
     if !Vmem::is_user_region(unsafe_thread_create_args, size_of::<ThreadCreateArgs>()) {
         let reason: &str = "thread_create_args does not lie in user space";
-        error!("create_thread(): {reason} (thread_create_args={unsafe_thread_create_args:?})");
+        error!("{reason} (thread_create_args={unsafe_thread_create_args:?})");
         return KcallResult::Error(ErrorCode::InvalidArgument.into());
     }
 
@@ -79,14 +79,14 @@ pub fn create_thread(
         unsafe_thread_create_args.into_raw_value() as *const ThreadCreateArgs,
     ) {
         let reason: &str = "failed to copy thread_create_args from user space";
-        error!("create_thread(): {reason:?} (error={:?})", error);
+        error!("{reason:?} (error={:?})", error);
         return KcallResult::Error(error.code.into());
     }
 
     // Check if the user wrapper function does not lie within the user address space.
     if !Vmem::is_user_addr(thread_create_args.user_fn) {
         let reason: &str = "user function does not lie within the user address space";
-        error!("create_thread(): {reason} (user_fn={:?})", thread_create_args.user_fn);
+        error!("{reason} (user_fn={:?})", thread_create_args.user_fn);
         return KcallResult::Error(ErrorCode::InvalidArgument.into());
     }
 
@@ -116,7 +116,7 @@ pub fn create_thread(
         if !Vmem::is_user_addr(user_tda) {
             let reason: &str =
                 "user-space thread data area does not lie within the user address space";
-            error!("create_thread(): {reason} (user_tcb={:?})", thread_create_args.user_tda);
+            error!("{reason} (user_tcb={:?})", thread_create_args.user_tda);
             return KcallResult::Error(ErrorCode::InvalidArgument.into());
         }
     }
@@ -124,7 +124,7 @@ pub fn create_thread(
     // Handle thread creation.
     match pm.create_thread(mm, pid, &thread_create_args) {
         Ok(tid) => {
-            debug!("create_thread(): thread {tid:?} created");
+            debug!("thread {tid:?} created");
             KcallResult::Success(<i32>::from(tid).into())
         },
         Err(e) => KcallResult::Error(e.code.into()),

--- a/src/kernel/src/pm/kcall/get_thread_data_area.rs
+++ b/src/kernel/src/pm/kcall/get_thread_data_area.rs
@@ -48,7 +48,7 @@ pub fn get_thread_data_area(pm: &ProcessManager, args: &KcallArgs) -> KcallResul
     let pid: ProcessIdentifier = args.pid;
     let tid: ThreadIdentifier = args.tid;
 
-    trace!("get_thread_data_area(): pid={pid:?}, tid={tid:?}");
+    trace!("pid={pid:?}, tid={tid:?}");
 
     // Handle kernel call.
     match pm.get_thread_data_area(pid, tid) {
@@ -57,12 +57,12 @@ pub fn get_thread_data_area(pm: &ProcessManager, args: &KcallArgs) -> KcallResul
                 Some(user_tda) => u32::from(user_tda).into(),
                 None => 0,
             };
-            trace!("get_thread_data_area(): success (user_tda={user_tda_value:#x})");
+            trace!("user_tda={user_tda_value:#x}");
             KcallResult::Success(user_tda_value.into())
         },
 
         Err(error) => {
-            error!("get_thread_data_area(): failed: {error:?}");
+            error!("{error:?}");
             KcallResult::Error(error.code.into())
         },
     }

--- a/src/kernel/src/pm/kcall/gettime.rs
+++ b/src/kernel/src/pm/kcall/gettime.rs
@@ -32,7 +32,7 @@ fn do_gettime(
     pid: ProcessIdentifier,
     buffer_addr: VirtualAddress,
 ) -> Result<(), Error> {
-    trace!("do_gettime(): pid={:?}, buffer_addr={:?}", pid, buffer_addr);
+    trace!("pid={pid:?}, buffer_addr={buffer_addr:?}");
 
     // Get system time.
     let now: SystemTime = clock::now();

--- a/src/kernel/src/pm/kcall/join_thread.rs
+++ b/src/kernel/src/pm/kcall/join_thread.rs
@@ -63,7 +63,7 @@ pub unsafe fn join_thread(
     let tid: ThreadIdentifier = match ThreadIdentifier::try_from(arg0) {
         Ok(tid) => tid,
         Err(error) => {
-            error!("join_thread(): {error:?}");
+            error!("{error:?}");
             return Err(SleepError::Generic(error));
         },
     };

--- a/src/kernel/src/pm/kcall/mcopy.rs
+++ b/src/kernel/src/pm/kcall/mcopy.rs
@@ -73,7 +73,7 @@ pub fn mcopy(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
         Ok(true) => (),
         Ok(false) => {
             let reason: &str = "process does not have memory management capabilities";
-            error!("mmap(): {}", reason);
+            error!("{reason}");
             return KcallResult::Error(ErrorCode::PermissionDenied.into());
         },
         Err(e) => return KcallResult::Error(e.code.into()),
@@ -83,7 +83,7 @@ pub fn mcopy(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
     let src_pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
         Ok(pid) => pid,
         Err(error) => {
-            error!("mcopy(): {error:?}");
+            error!("{error:?}");
             return KcallResult::Error(error.code.into());
         },
     };
@@ -95,7 +95,7 @@ pub fn mcopy(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
     let dst_pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg2) {
         Ok(pid) => pid,
         Err(error) => {
-            error!("mcopy(): {error:?}");
+            error!("{error:?}");
             return KcallResult::Error(error.code.into());
         },
     };

--- a/src/kernel/src/pm/kcall/mctrl.rs
+++ b/src/kernel/src/pm/kcall/mctrl.rs
@@ -51,7 +51,7 @@ pub fn mctrl(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
         Ok(true) => (),
         Ok(false) => {
             let reason: &str = "process does not have memory management capabilities";
-            error!("mctrl(): {}", reason);
+            error!("{reason}");
             return KcallResult::Error(ErrorCode::PermissionDenied.into());
         },
         Err(e) => return KcallResult::Error(e.code.into()),
@@ -61,7 +61,7 @@ pub fn mctrl(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
     let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
         Ok(pid) => pid,
         Err(error) => {
-            error!("mctrl(): {error:?}");
+            error!("{error:?}");
             return KcallResult::Error(error.code.into());
         },
     };

--- a/src/kernel/src/pm/kcall/mmap.rs
+++ b/src/kernel/src/pm/kcall/mmap.rs
@@ -49,7 +49,7 @@ pub fn mmap(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallArg
     let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
         Ok(pid) => pid,
         Err(error) => {
-            error!("mmap(): {error:?}");
+            error!("{error:?}");
             return KcallResult::Error(error.code.into());
         },
     };
@@ -69,7 +69,7 @@ pub fn mmap(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallArg
             Ok(true) => (),
             Ok(false) => {
                 let reason: &str = "process does not have memory management capabilities";
-                error!("mmap(): {}", reason);
+                error!("{reason}");
                 return KcallResult::Error(ErrorCode::PermissionDenied.into());
             },
             Err(e) => return KcallResult::Error(e.code.into()),

--- a/src/kernel/src/pm/kcall/munmap.rs
+++ b/src/kernel/src/pm/kcall/munmap.rs
@@ -51,7 +51,7 @@ pub fn munmap(
     let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
         Ok(pid) => pid,
         Err(error) => {
-            error!("munmap(): {error:?}");
+            error!("{error:?}");
             return KcallResult::Error(error.code.into());
         },
     };
@@ -67,7 +67,7 @@ pub fn munmap(
             Ok(true) => (),
             Ok(false) => {
                 let reason: &str = "process does not have memory management capabilities";
-                error!("mmap(): {}", reason);
+                error!("{reason}");
                 return KcallResult::Error(ErrorCode::PermissionDenied.into());
             },
             Err(e) => return KcallResult::Error(e.code.into()),

--- a/src/kernel/src/pm/kcall/set_thread_data_area.rs
+++ b/src/kernel/src/pm/kcall/set_thread_data_area.rs
@@ -53,14 +53,14 @@ pub fn set_thread_data_area(pm: &mut ProcessManager, args: &KcallArgs) -> KcallR
     let tid: ThreadIdentifier = args.tid;
     let user_tda: VirtualAddress = VirtualAddress::from_raw_value(args.arg0 as usize);
 
-    trace!("set_thread_data_area(): pid={pid:?}, tid={tid:?}, user_tda={user_tda:?}");
+    trace!("pid={pid:?}, tid={tid:?}, user_tda={user_tda:?}");
 
     // Check if tread-local storage does not lie within the user space.
     let user_tda: Option<VirtualAddress> = if user_tda != VirtualAddress::from_raw_value(0) {
         if !Vmem::is_user_addr(user_tda) {
             error!(
-                "set_thread_data_area(): invalid base address for the user-space thread data area \
-                 (tid={tid:?}, pid={pid:?}, user_tda={user_tda:?})"
+                "invalid base address for the user-space thread data area (tid={tid:?}, \
+                 pid={pid:?}, user_tda={user_tda:?})"
             );
             return KcallResult::Error(ErrorCode::InvalidArgument.into());
         }
@@ -73,12 +73,12 @@ pub fn set_thread_data_area(pm: &mut ProcessManager, args: &KcallArgs) -> KcallR
     // Handle kernel call.
     match pm.set_thread_data_area(pid, tid, user_tda) {
         Ok(()) => {
-            trace!("set_thread_local_storage(): success");
+            trace!("success");
             KcallResult::ok()
         },
 
         Err(error) => {
-            error!("set_thread_local_storage(): failed: {error:?}");
+            error!("{error:?}");
             KcallResult::Error(error.code.into())
         },
     }

--- a/src/kernel/src/pm/kcall/sleep.rs
+++ b/src/kernel/src/pm/kcall/sleep.rs
@@ -44,7 +44,7 @@ use ::sys::{
 /// - It may block the calling thread.
 ///
 pub unsafe fn sleep(seconds: usize, nanoseconds: usize) -> Result<(), SleepError> {
-    trace!("sleep(): seconds={seconds:?}, nanoseconds={nanoseconds:?}");
+    trace!("seconds={seconds:?}, nanoseconds={nanoseconds:?}");
 
     // Get the current time.
     let now: SystemTime = clock::now();

--- a/src/kernel/src/pm/kcall/terminate.rs
+++ b/src/kernel/src/pm/kcall/terminate.rs
@@ -23,7 +23,7 @@ pub fn terminate(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
     let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
         Ok(pid) => pid,
         Err(error) => {
-            error!("terminate(): {error:?}");
+            error!("{error:?}");
             return KcallResult::Error(error.code.into());
         },
     };

--- a/src/kernel/src/pm/kcall/unlock_mutex.rs
+++ b/src/kernel/src/pm/kcall/unlock_mutex.rs
@@ -48,7 +48,7 @@ pub unsafe fn unlock_mutex(
     tid: ThreadIdentifier,
     mutex_addr: usize,
 ) -> Result<(), Error> {
-    trace!("unlock_mutex(): pid={pid:?}, tid={tid:?}, mutex_addr={mutex_addr:?}");
+    trace!("pid={pid:?}, tid={tid:?}, mutex_addr={mutex_addr:?}");
 
     // Unpack kernel call arguments.
     let mutex_addr: MutexAddress = MutexAddress::from(mutex_addr);

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -206,7 +206,7 @@ impl ProcessManagerInner {
         args: &ThreadCreateArgs,
         enable_interrupts: bool,
     ) -> Result<(KernelStack, ContextInformation), Error> {
-        trace!("forge_user_context(): args={args:?}, enable_interrupts={enable_interrupts:?}",);
+        trace!("args={args:?}, enable_interrupts={enable_interrupts:?}",);
 
         unsafe extern "C" {
             pub fn __leave_kernel_to_user_mode();
@@ -237,7 +237,7 @@ impl ProcessManagerInner {
         } as u32;
         let esp0: u32 = kernel_stack.top().into_raw_value() as u32;
 
-        trace!("forge_context(): cr3={:#x}, esp={:#x}, ebp={:#x}", cr3, esp, esp0);
+        trace!("cr3={:#x}, esp={:#x}, ebp={:#x}", cr3, esp, esp0);
         let context: ContextInformation = ContextInformation::new(cr3, esp, esp0);
 
         Ok((kernel_stack, context))
@@ -272,7 +272,7 @@ impl ProcessManagerInner {
         pid: ProcessIdentifier,
         thread_create_args: &ThreadCreateArgs,
     ) -> Result<ThreadIdentifier, Error> {
-        trace!("create_thread(): pid={pid:?}, thread_create_args={thread_create_args:?}");
+        trace!("pid={pid:?}, thread_create_args={thread_create_args:?}");
 
         // Assert pre-conditions (these should have been checked by the caller).
         debug_assert!(Vmem::is_user_addr(thread_create_args.user_fn));
@@ -287,22 +287,22 @@ impl ProcessManagerInner {
             if let ProcessRefMut::Running(_) = process {
                 // TODO: Re-evaluate this condition when we support multicore.
                 let reason: &str = "process is running";
-                error!("create_thread(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
             }
             if let ProcessRefMut::Interrupted(_) = process {
                 let reason: &str = "process is interrupted";
-                error!("create_thread(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
             }
             if let ProcessRefMut::Zombie(_) = process {
                 let reason: &str = "process is a zombie";
-                error!("create_thread(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
             }
             if let ProcessRefMut::Runnable(_) = process {
                 let reason: &str = "process is runnable";
-                error!("create_thread(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
             }
 
@@ -332,7 +332,7 @@ impl ProcessManagerInner {
         pid: ProcessIdentifier,
         ready_thread: ReadyThread,
     ) -> ThreadIdentifier {
-        trace!("try_add_thread(): pid={pid:?}, ready_thread={ready_thread:?}");
+        trace!("pid={pid:?}, ready_thread={ready_thread:?}");
         let tid: ThreadIdentifier = ready_thread.id();
 
         // Search process in the list of sleeping processes.
@@ -411,10 +411,7 @@ impl ProcessManagerInner {
             .find(|p| p.state().pid() == pid)
             .ok_or_else(|| {
                 let reason: &str = "process not found";
-                error!(
-                    "set_thread_data_area(): {reason} (pid={pid:?}, tid={tid:?}, \
-                     user_tda={user_tda:?})"
-                );
+                error!("{reason} (pid={pid:?}, tid={tid:?}, user_tda={user_tda:?})");
                 Error::new(ErrorCode::NoSuchEntry, reason)
             })?;
 
@@ -426,10 +423,7 @@ impl ProcessManagerInner {
             },
             _ => {
                 let reason: &str = "thread not found";
-                error!(
-                    "set_thread_data_area(): {reason} (tid={tid:?}, pid={pid:?}, \
-                     user_tda={user_tda:?})"
-                );
+                error!("{reason} (tid={tid:?}, pid={pid:?}, user_tda={user_tda:?})");
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         }
@@ -468,7 +462,7 @@ impl ProcessManagerInner {
             .find(|p| p.state().pid() == pid)
             .ok_or_else(|| {
                 let reason: &str = "process not found";
-                error!("get_thread_data_area(): {reason} (pid={pid:?}, tid={tid:?})");
+                error!("{reason} (pid={pid:?}, tid={tid:?})");
                 Error::new(ErrorCode::NoSuchEntry, reason)
             })?;
 
@@ -477,7 +471,7 @@ impl ProcessManagerInner {
             Some(ThreadRef::Sleeping(thread)) => Ok(thread.get_thread_data_area()),
             _ => {
                 let reason: &str = "thread not found";
-                error!("get_thread_data_area(): {reason} (tid={tid:?}, pid={pid:?})");
+                error!("{reason} (tid={tid:?}, pid={pid:?})");
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         }
@@ -511,7 +505,7 @@ impl ProcessManagerInner {
             pub fn __leave_kernel_to_user_mode();
         }
 
-        trace!("create_process(): args={:?}, env={:?}", args, env);
+        trace!("args={:?}, env={:?}", args, env);
 
         // Strip leading and trailing spaces from arguments.
         let args: &str = args.trim();
@@ -521,7 +515,7 @@ impl ProcessManagerInner {
             Ok(cmdline) => cmdline,
             Err(error) => {
                 let reason: &str = "failed to convert command line string";
-                error!("create_process(): {} (error={:?})", reason, error);
+                error!("{} (error={:?})", reason, error);
                 return Err(Error::new(ErrorCode::InvalidArgument, reason));
             },
         };
@@ -535,7 +529,7 @@ impl ProcessManagerInner {
             Ok(cmdline) => cmdline,
             Err(error) => {
                 let reason: &str = "failed to convert environment string";
-                error!("create_process(): {} (error={:?})", reason, error);
+                error!("{reason} (error={error:?})");
                 return Err(Error::new(ErrorCode::InvalidArgument, reason));
             },
         };
@@ -552,7 +546,7 @@ impl ProcessManagerInner {
         // Note we subtract a pointer size from PAGE_SIZE to account for the null terminator.
         if args.len() > PAGE_SIZE - ::core::mem::size_of::<*const u8>() {
             let reason: &str = "command line is too long";
-            error!("create_process(): {} (cmdline.len={:?})", reason, args.len());
+            error!("{reason} (cmdline.len={:?})", args.len());
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
         mm.alloc_upage(&mut vmem, args_vaddr, AccessPermission::RDWR, true)?;
@@ -561,16 +555,13 @@ impl ProcessManagerInner {
             VirtualAddress::new(args.as_ptr() as usize),
             args.len(),
         )?;
-        debug!(
-            "create_process(): arguments written to user space (args_vaddr={:?}, args={:?})",
-            args_vaddr, args
-        );
+        debug!("arguments written to user space (args_vaddr={:?}, args={:?})", args_vaddr, args);
 
         // Allocate another page for the environment variables and check for errors.
         // Note we subtract a pointer size from PAGE_SIZE to account for the null terminator.
         if env.len() > PAGE_SIZE - ::core::mem::size_of::<*const u8>() {
             let reason: &str = "environment variables are too long";
-            error!("create_process(): {} (env.len={:?})", reason, env.len());
+            error!("{reason} (env.len={:?})", env.len());
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
         let envp_vaddr: PageAligned<VirtualAddress> = PageAligned::<VirtualAddress>::from_address(
@@ -585,8 +576,7 @@ impl ProcessManagerInner {
             env.len(),
         )?;
         debug!(
-            "create_process(): environment variables written to user space (envp_vaddr={:?}, \
-             env={:?})",
+            "environment variables written to user space (envp_vaddr={:?}, env={:?})",
             envp_vaddr, env
         );
 
@@ -706,7 +696,7 @@ impl ProcessManagerInner {
             match process.wakeup_alarm(now) {
                 Ok(interrupted_process) => {
                     trace!(
-                        "check_alarm(): process {:?} interrupted at {now:?}",
+                        "process {:?} interrupted at {now:?}",
                         interrupted_process.state().pid(),
                     );
                     self.interrupted.push_back(interrupted_process);
@@ -751,7 +741,7 @@ impl ProcessManagerInner {
 
         // Check if kernel is trying to sleep.
         if running_process.state().pid() == ProcessIdentifier::KERNEL {
-            panic!("sleep(): kernel process cannot sleep");
+            panic!("kernel process cannot sleep");
         }
 
         // Suspend the execution of the calling thread.
@@ -810,7 +800,7 @@ impl ProcessManagerInner {
                 Err(running_process) => {
                     self.running = Some(running_process);
                     let reason: &str = "thread not found";
-                    error!("wake_up(): {reason} (tid={tid:?})");
+                    error!("{reason} (tid={tid:?})");
                     return Err(Error::new(ErrorCode::NoSuchEntry, reason));
                 },
             }
@@ -821,7 +811,7 @@ impl ProcessManagerInner {
             Some(runnable_process) => runnable_process,
             None => {
                 let reason: &str = "thread not found";
-                error!("wake_up(): {reason} (tid={tid:?})");
+                error!("{reason} (tid={tid:?})");
                 return Err(Error::new(ErrorCode::NoSuchEntry, reason));
             },
         };
@@ -919,7 +909,7 @@ impl ProcessManagerInner {
     ) {
         let running_process: RunningProcess = self.take_running();
         trace!(
-            "exit(): pid={:?}, tid={:?}, status={status:?}",
+            "pid={:?}, tid={:?}, status={status:?}",
             running_process.state().pid(),
             running_process.get_tid(),
         );
@@ -1000,7 +990,7 @@ impl ProcessManagerInner {
         let running_process: RunningProcess = self.take_running();
 
         trace!(
-            "exit_thread(): pid={:?}, tid={:?}, status={:?}",
+            "pid={:?}, tid={:?}, status={:?}",
             running_process.state().pid(),
             running_process.get_tid(),
             status
@@ -1008,7 +998,7 @@ impl ProcessManagerInner {
 
         // Check if kernel is trying to exit.
         if running_process.state().pid() == ProcessIdentifier::KERNEL {
-            panic!("exit_thread(): kernel process cannot exit (status={status:?})");
+            panic!("kernel process cannot exit (status={status:?})");
         }
 
         // Terminate the calling thread and schedule another thread to run.
@@ -1052,14 +1042,14 @@ impl ProcessManagerInner {
         // Check if terminating kernel process.
         if pid == ProcessIdentifier::KERNEL {
             let reason: &str = "cannot terminate kernel process";
-            error!("terminate(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
         // Check if target process is running.
         if self.running.is_some() && self.get_running().state().pid() == pid {
             let reason: &str = "cannot terminate running process";
-            error!("terminate(): {}", reason);
+            error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
@@ -1088,7 +1078,7 @@ impl ProcessManagerInner {
         }
 
         let reason: &str = "process not found";
-        error!("terminate(): {}", reason);
+        error!("{reason}");
         Err(Error::new(ErrorCode::NoSuchProcess, reason))
     }
 
@@ -1120,7 +1110,7 @@ impl ProcessManagerInner {
             // Check if capability is already set.
             if process.state_mut().has_capability(capability) {
                 let reason: &str = "capability already set";
-                error!("capctl(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::ResourceBusy, reason));
             }
             process.state_mut().set_capability(capability);
@@ -1128,7 +1118,7 @@ impl ProcessManagerInner {
             // Check if capability is not set.
             if !process.state_mut().has_capability(capability) {
                 let reason: &str = "capability not set";
-                error!("capctl(): {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::NoSuchEntry, reason));
             }
             process.state_mut().clear_capability(capability);
@@ -1169,7 +1159,7 @@ impl ProcessManagerInner {
                 Some(mut running) => running.thread_state_mut().fpu_state_mut(),
                 None => {
                     let reason: &str = "no running process";
-                    error!("handle_fpu_exception(): {reason} (tid={current_tid:?})");
+                    error!("{reason} (tid={current_tid:?})");
                     return Err(Error::new(ErrorCode::NoSuchEntry, reason));
                 },
             };
@@ -1232,22 +1222,22 @@ impl ProcessManagerInner {
             ProcessRefMut::Running(process) => process.try_join_thread(tid),
             ProcessRefMut::Runnable(_) => {
                 let reason: &str = "process is runnable";
-                error!("join_thread(): {} (pid={:?}, tid={:?})", reason, pid, tid);
+                error!("{reason} (pid={pid:?}, tid={tid:?})");
                 Err(Err(Error::new(ErrorCode::OperationNotPermitted, reason)))
             },
             ProcessRefMut::Sleeping(_) => {
                 let reason: &str = "process is sleeping";
-                error!("join_thread(): {} (pid={:?}, tid={:?})", reason, pid, tid);
+                error!("{reason} (pid={pid:?}, tid={tid:?})");
                 Err(Err(Error::new(ErrorCode::OperationNotPermitted, reason)))
             },
             ProcessRefMut::Interrupted(_) => {
                 let reason: &str = "process is interrupted";
-                error!("join_thread(): {} (pid={:?}, tid={:?})", reason, pid, tid);
+                error!("{reason} (pid={pid:?}, tid={tid:?})");
                 Err(Err(Error::new(ErrorCode::OperationNotPermitted, reason)))
             },
             ProcessRefMut::Zombie(_) => {
                 let reason: &str = "process is a zombie";
-                error!("join_thread(): {} (pid={:?}, tid={:?})", reason, pid, tid);
+                error!("{reason} (pid={pid:?}, tid={tid:?})");
                 Err(Err(Error::new(ErrorCode::OperationNotPermitted, reason)))
             },
         }
@@ -1354,7 +1344,7 @@ impl ProcessManagerInner {
             Some(mutex_guard) => mutex_guard,
             None => {
                 let reason: &str = "thread does not own mutex";
-                error!("take_mutex_guard(): {} (pid={:?}, tid={:?})", reason, pid, tid);
+                error!("{reason} (pid={pid:?}, tid={tid:?})");
                 return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
             },
         };
@@ -1414,7 +1404,7 @@ impl ProcessManagerInner {
             Ok(ProcessRef::Zombie(process))
         } else {
             let reason: &str = "process not found";
-            error!("find_process(): {} (pid={:?})", reason, pid);
+            error!("{reason} (pid={pid:?})");
             Err(Error::new(ErrorCode::NoSuchProcess, reason))
         }
     }
@@ -1432,7 +1422,7 @@ impl ProcessManagerInner {
             Ok(ProcessRefMut::Zombie(process))
         } else {
             let reason: &str = "process not found";
-            error!("find_process(): {} (pid={:?})", reason, pid);
+            error!("{reason} (pid={pid:?})");
             Err(Error::new(ErrorCode::NoSuchProcess, reason))
         }
     }
@@ -1476,7 +1466,7 @@ impl ProcessManagerInner {
             Ok(ProcessRefMut::Zombie(process))
         } else {
             let reason: &str = "thread not found";
-            error!("find_process(): {} (tid={:?})", reason, tid);
+            error!("{reason} (tid={tid:?})");
             Err(Error::new(ErrorCode::NoSuchEntry, reason))
         }
     }
@@ -1532,7 +1522,7 @@ impl ProcessManagerInner {
         }
 
         let reason: &str = "thread not found";
-        error!("find_thread_mut(): {} (tid={:?})", reason, tid);
+        error!("{reason} (tid={tid:?})");
         Err(Error::new(ErrorCode::NoSuchEntry, reason))
     }
 }
@@ -1784,10 +1774,7 @@ impl ProcessManager {
                     if let Err(error) = mm.unmap_upage(state.vmem_mut(), vaddr) {
                         // We failed, but this is not too bad, as we will free all pages
                         // when wiping out the address space anyways.
-                        warn!(
-                            "harvest_zombies(): failed to unmap page (vaddr={:?}, error={:?})",
-                            vaddr, error
-                        );
+                        warn!("failed to unmap page (vaddr={:?}, error={:?})", vaddr, error);
                     }
                 }
 
@@ -1981,7 +1968,7 @@ impl ProcessManager {
             Ok(pm) => Ok(pm),
             Err(_) => {
                 let reason: &str = "cannot borrow process manager";
-                error!("try_borrow(): {}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::ResourceBusy, reason))
             },
         }
@@ -1992,7 +1979,7 @@ impl ProcessManager {
             Ok(pm) => Ok(pm),
             Err(_) => {
                 let reason: &str = "cannot borrow process manager";
-                error!("try_borrow_mut(): {}", reason);
+                error!("{reason}");
                 Err(Error::new(ErrorCode::ResourceBusy, reason))
             },
         }

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -219,7 +219,7 @@ impl ProcessManager {
     /// - The processor is running in privileged mode.
     ///
     pub unsafe fn exit(status: ExitStatus) -> Result<!, Error> {
-        trace!("exit(): status={status:?}");
+        trace!("status={status:?}");
 
         // Terminate the calling process and select another process to run next.
         let (next_pid, next_tid, from, to, user_tda): (
@@ -342,7 +342,7 @@ impl ProcessManager {
         pid: ProcessIdentifier,
         tid: ThreadIdentifier,
     ) -> Result<ExitStatus, SleepError> {
-        trace!("join_thread(): pid={:?}, tid={:?}", pid, tid);
+        trace!("pid={:?}, tid={:?}", pid, tid);
 
         loop {
             let result: Result<ZombieThread, Result<Condvar, Error>> = Self::get_mut()
@@ -461,7 +461,7 @@ impl ProcessManager {
 
         // Check if the thread was interrupted.
         if let Some(reason) = interrupt_reason {
-            warn!("sleep(): interrupted (reason={:?})", reason);
+            warn!("interrupted (reason={reason:?})");
             return Err(SleepError::Interrupted(reason));
         }
 

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -244,7 +244,7 @@ impl ProcessState {
             Some(index) => Ok(self.pmio.remove(index)),
             None => {
                 let reason: &'static str = "io port not found";
-                error!("remove_pmio(): {:?}", reason);
+                error!("{:?}", reason);
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         }
@@ -256,7 +256,7 @@ impl ProcessState {
             Some(port) => Ok(port),
             None => {
                 let reason: &'static str = "io port not found";
-                error!("get_pmio(): {:?}", reason);
+                error!("{:?}", reason);
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         }
@@ -296,7 +296,7 @@ impl ProcessState {
         // Check if maximum number of mutexes has been reached.
         if self.mutexes.len() >= MUTEX_OPEN_MAX {
             let reason: &'static str = "maximum number of mutexes reached";
-            error!("get_mutex(): {:?} (addr={:#x?})", reason, mutex_addr);
+            error!("{:?} (addr={:#x?})", reason, mutex_addr);
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
         }
 
@@ -324,7 +324,7 @@ impl ProcessState {
         // Check if mutex exists.
         if !self.mutexes.contains_key(&mutex_addr) {
             let reason: &'static str = "mutex not found";
-            error!("put_mutex(): {:?} (addr={:#x?})", reason, mutex_addr);
+            error!("{:?} (addr={:#x?})", reason, mutex_addr);
             return Err(Error::new(ErrorCode::NoSuchEntry, reason));
         }
 
@@ -355,7 +355,7 @@ impl ProcessState {
         // Check if maximum number of condition variables has been reached.
         if self.conditions.len() >= COND_OPEN_MAX {
             let reason: &'static str = "maximum number of condition variables reached";
-            error!("get_condition(): {:?} (addr={:#x?})", reason, cond_addr);
+            error!("{:?} (addr={:#x?})", reason, cond_addr);
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
         }
 
@@ -383,7 +383,7 @@ impl ProcessState {
         // Check if condition variable exists.
         if !self.conditions.contains_key(&cond_addr) {
             let reason: &'static str = "condition variable not found";
-            error!("put_condition(): {:?} (addr={:#x?})", reason, cond_addr);
+            error!("{:?} (addr={:#x?})", reason, cond_addr);
             return Err(Error::new(ErrorCode::NoSuchEntry, reason));
         }
 
@@ -401,7 +401,7 @@ impl ProcessState {
             Some(port) => Ok(port),
             None => {
                 let reason: &'static str = "io port not found";
-                error!("get_pmio_mut(): {:?}", reason);
+                error!("{:?}", reason);
                 Err(Error::new(ErrorCode::NoSuchEntry, reason))
             },
         }

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -208,7 +208,7 @@ impl RunnableProcess {
     }
 
     pub fn add_thread(mut self, ready_thread: ReadyThread) -> Self {
-        trace!("add_thread(): self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
+        trace!("self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
         self.ready_threads.push_back(ready_thread);
         self
     }

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -390,7 +390,7 @@ impl RunningProcess {
         }
 
         let reason: &str = "thread not found";
-        error!("join_thread(): {:?} (state={:?})", reason, self.state());
+        error!("{:?} (state={:?})", reason, self.state());
         Err(Err(Error::new(ErrorCode::NoSuchProcess, reason)))
     }
 

--- a/src/kernel/src/pm/process/state/sleeping.rs
+++ b/src/kernel/src/pm/process/state/sleeping.rs
@@ -176,7 +176,7 @@ impl SleepingProcess {
     }
 
     pub fn add_thread(mut self, ready_thread: ReadyThread) -> RunnableProcess {
-        trace!("add_thread(): self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
+        trace!("self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
         RunnableProcess::from_state(
             self.state,
             NonEmptyVecDeque::new(ready_thread),

--- a/src/kernel/src/pm/sync/condvar.rs
+++ b/src/kernel/src/pm/sync/condvar.rs
@@ -245,7 +245,7 @@ impl Condvar {
             // Attempt to wake up thread and check for errors.
             if let Err(error) = ProcessManager::wakeup(tid) {
                 // Failed to wake up thread, log a warning, store the first error, and continue.
-                warn!("notify_all(): {error:?} (pid={pid:?}, tid={tid:?})");
+                warn!("{error:?} (pid={pid:?}, tid={tid:?})");
                 if first_error.is_none() {
                     first_error = Some(error);
                 }
@@ -345,7 +345,7 @@ impl fmt::Debug for Condvar {
 impl Drop for CondvarInner {
     fn drop(&mut self) {
         if !self.sleeping.borrow().is_empty() {
-            panic!("drop(): {self:?}");
+            panic!("{self:?}");
         }
     }
 }

--- a/src/kernel/src/pm/sync/mutex.rs
+++ b/src/kernel/src/pm/sync/mutex.rs
@@ -201,7 +201,7 @@ impl Drop for MutexGuard {
     fn drop(&mut self) {
         // Safety: The lock is ensured to be held by the caller.
         if let Err(error) = unsafe { self.mutex.unlock_unchecked() } {
-            warn!("drop(): failed to unlock mutex (self={self:?}, error={error:?})");
+            warn!("failed to unlock mutex (self={self:?}, error={error:?})");
         }
     }
 }

--- a/src/kernel/src/stdio.rs
+++ b/src/kernel/src/stdio.rs
@@ -39,7 +39,7 @@ pub fn write(message: Message) -> Result<(), Error> {
     // Checks if message type is not supported.
     if { message.message_type } != MessageType::Ikc {
         let reason: &str = "unsupported message type";
-        error!("write(): {}", reason);
+        error!("{reason}");
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
@@ -116,7 +116,7 @@ pub fn read() -> Result<Option<Message>, Error> {
         // No message available.
         Err(e) if e.code == ErrorCode::NoMessageAvailable => Ok(None),
         Err(e) => {
-            warn!("read(): {:?} ", e);
+            warn!("{e:?}");
             Err(e)
         },
     }

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -52,7 +52,6 @@ use ::std::{
         OnceLock,
         mpsc::{
             self,
-            Sender,
             TryRecvError,
         },
     },


### PR DESCRIPTION
## Description

This PR fixes all `trace!()`, `debug!()`, `info!()`, `warn!()`, `error!()` and `panic!()` macro invocations in `src/kernel/**/*.rs` to remove the function tag name from logged messages.

For instance, after this PR, a `trace!()` statement in function `foo` should not have a `"foo():"` in the message.