### PR TITLE
[kernel] Set FS on Context Switch

### DIFF
--- a/src/kernel/src/hal/arch/x86/cpu/context.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/context.rs
@@ -106,9 +106,11 @@ impl ContextInformation {
         // Set thread data area.
         if let Some(user_tda) = user_tda {
             (*to).gs = SegmentSelector::UserThreadDataArea as u32;
+            (*to).fs = SegmentSelector::UserThreadDataArea as u32;
             Gdt::set_thread_data_area(user_tda.into());
         } else {
             (*to).gs = SegmentSelector::Null as u32;
+            (*to).fs = SegmentSelector::Null as u32;
         }
 
         let tss: *const Tss = tss::get_curr();


### PR DESCRIPTION
This pull request introduces a small but important update to the handling of segment registers in the x86 CPU context switching logic. Specifically, it ensures that both the `fs` and `gs` segment registers are set consistently based on the presence of a user thread data area.

- Segment Register Consistency:
  * In `src/kernel/src/hal/arch/x86/cpu/context.rs`, the `fs` register is now set to match the `gs` register, either to `UserThreadDataArea` or `Null`, depending on whether a user thread data area is provided.