### PR TITLE
[libs] Initial Support for Read-Write Locks

### DIFF
--- a/src/libs/sysapi/src/pthread.rs
+++ b/src/libs/sysapi/src/pthread.rs
@@ -14,6 +14,7 @@
 use crate::sys_types::{
     pthread_cond_t,
     pthread_mutex_t,
+    pthread_rwlock_t,
     pthread_t,
 };
 
@@ -61,3 +62,6 @@ pub mod pthread_mutex_type {
     /// map this mutex to one of the other mutex types.
     pub const PTHREAD_MUTEX_DEFAULT: c_int = 3;
 }
+
+/// Used to initialize a read-write lock statically.
+pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = 0xffffffff;

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -26,6 +26,7 @@ pub mod pthread_mutex_destroy;
 pub mod pthread_mutex_init;
 pub mod pthread_mutex_lock;
 pub mod pthread_mutex_unlock;
+pub mod pthread_rwlock_init;
 pub mod pthread_rwlock_rdlock;
 pub mod pthread_rwlock_unlock;
 pub mod pthread_rwlock_wrlock;

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -26,6 +26,7 @@ pub mod pthread_mutex_destroy;
 pub mod pthread_mutex_init;
 pub mod pthread_mutex_lock;
 pub mod pthread_mutex_unlock;
+pub mod pthread_rwlock_destroy;
 pub mod pthread_rwlock_init;
 pub mod pthread_rwlock_rdlock;
 pub mod pthread_rwlock_unlock;

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -27,6 +27,7 @@ pub mod pthread_mutex_init;
 pub mod pthread_mutex_lock;
 pub mod pthread_mutex_unlock;
 pub mod pthread_rwlock_rdlock;
+pub mod pthread_rwlock_unlock;
 pub mod pthread_rwlock_wrlock;
 pub mod pthread_self;
 pub mod pthread_setcancelstate;

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_destroy.rs
@@ -5,20 +5,57 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::{
-    c_int,
-    c_void,
+use ::core::mem::align_of;
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::pthread_rwlock_t,
 };
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-// TODO: add description
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Destroys a read-write lock.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+///
+/// # Returns
+///
+/// If successful, this function returns zero. Otherwise, if returns a non-zero error code.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+///
+/// - `rwlock` points to a valid `pthread_rwlock_t` structure.
+///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn pthread_rwlock_destroy(_rwlock: *mut c_void) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/973
-    ::syslog::warn!("pthread_rwlock_destroy(): not implemented");
+pub unsafe extern "C" fn pthread_rwlock_destroy(rwlock: *mut pthread_rwlock_t) -> c_int {
+    // Check if `rwlock` object is invalid.
+    if rwlock.is_null() {
+        ::syslog::error!("pthread_rwlock_destroy(): invalid read-write lock (rwlock={rwlock:p})");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `rwlock` is unaligned.
+    if (rwlock as usize) % align_of::<pthread_rwlock_t>() != 0 {
+        ::syslog::error!("pthread_rwlock_destroy(): unaligned read-write lock (rwlock={rwlock:p})");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Attempt to destroy the read-write lock and check for errors.
+    if let Err(error) = crate::pthread::pthread_rwlock_destroy(&mut *rwlock) {
+        ::syslog::error!("pthread_rwlock_destroy(): {error:?} (rwlock={rwlock:p})");
+        return error.code.get();
+    }
+
     0
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_destroy.rs
@@ -1,0 +1,24 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_int,
+    c_void,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// TODO: add description
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_rwlock_destroy(_rwlock: *mut c_void) -> c_int {
+    // TODO: https://github.com/nanvix/nanvix/issues/973
+    ::syslog::warn!("pthread_rwlock_destroy(): not implemented");
+    0
+}

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_init.rs
@@ -5,20 +5,85 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::{
-    c_int,
-    c_void,
+use ::core::mem::align_of;
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::{
+        pthread_rwlock_t,
+        pthread_rwlockattr_t,
+    },
 };
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-// TODO: add description
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Initializes a read-write lock.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+/// - `attr`: Read-write lock attributes (currently ignored if non-null).
+///
+/// # Return Value
+///
+/// If successful, this function returns zero. Otherwise, it returns a non-zero error code.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+///
+/// - `rwlock` points to a valid `pthread_rwlock_t` object.
+///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn pthread_rwlock_init(_rwlock: *mut c_void, _attr: *const c_void) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/972
-    ::syslog::warn!("pthread_rwlock_init(): not implemented");
+pub unsafe extern "C" fn pthread_rwlock_init(
+    rwlock: *mut pthread_rwlock_t,
+    attr: *const pthread_rwlockattr_t,
+) -> c_int {
+    // Check if `rwlock` is invalid.
+    if rwlock.is_null() {
+        ::syslog::error!(
+            "pthread_rwlock_init(): invalid read-write lock (rwlock={rwlock:p}, attr={attr:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `rwlock` is unaligned.
+    if (rwlock as usize) % align_of::<pthread_rwlock_t>() != 0 {
+        ::syslog::error!(
+            "pthread_rwlock_init(): unaligned read-write lock (rwlock={rwlock:p}, attr={attr:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if custom attributes were passed in.
+    if !attr.is_null() {
+        // Check if `attr` is unaligned.
+        if (attr as usize) % align_of::<pthread_rwlockattr_t>() != 0 {
+            ::syslog::error!(
+                "pthread_rwlock_init(): unaligned read-write lock attribute (rwlock={rwlock:p}, \
+                 attr={attr:p})"
+            );
+            return ErrorCode::InvalidArgument.get();
+        }
+
+        // TODO (#978): support custom attributes.
+        ::syslog::warn!("pthread_rwlock_init(): custom attributes not supported, ignoring");
+    }
+
+    let attr: pthread_rwlockattr_t = pthread_rwlockattr_t::default();
+
+    // Attempt to initialize read-write lock and check for errors.
+    if let Err(error) = crate::pthread::pthread_rwlock_init(&mut *rwlock, &attr) {
+        ::syslog::error!("pthread_rwlock_init(): {error:?} (rwlock={rwlock:p}, attr={attr:?})");
+        return error.code.get();
+    }
+
     0
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_init.rs
@@ -1,0 +1,24 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_int,
+    c_void,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// TODO: add description
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_rwlock_init(_rwlock: *mut c_void, _attr: *const c_void) -> c_int {
+    // TODO: https://github.com/nanvix/nanvix/issues/972
+    ::syslog::warn!("pthread_rwlock_init(): not implemented");
+    0
+}

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_rdlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_rdlock.rs
@@ -5,20 +5,58 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::{
-    c_int,
-    c_void,
+use ::core::mem::align_of;
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::pthread_rwlock_t,
 };
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-// TODO: add description
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Acquires a read lock on a read-write lock.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+///
+/// # Returns
+///
+/// If successful, this function returns zero. Otherwise, it returns a non-zero error code.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+///
+/// - `rwlock` points to a valid `pthread_rwlock_t` structure.
+///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn pthread_rwlock_rdlock(_rwlock: *mut c_void) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/720
-    ::syslog::warn!("pthread_rwlock_rdlock(): not implemented");
-    0
+pub unsafe extern "C" fn pthread_rwlock_rdlock(rwlock: *mut pthread_rwlock_t) -> c_int {
+    // Check if `rwlock` object is invalid.
+    if rwlock.is_null() {
+        ::syslog::error!("pthread_rwlock_rdlock(): invalid read-write lock (rwlock={rwlock:p})");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `rwlock` is unaligned.
+    if (rwlock as usize) % align_of::<pthread_rwlock_t>() != 0 {
+        ::syslog::error!("pthread_rwlock_rdlock(): unaligned read-write lock (rwlock={rwlock:p})");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Attempt to acquire a read lock on the read-write lock and check for errors.
+    match crate::pthread::pthread_rwlock_rdlock(&mut *rwlock) {
+        Ok(()) => 0,
+        Err(error) => {
+            ::syslog::error!("pthread_rwlock_rdlock(): {error:?} (rwlock={rwlock:p})");
+            error.code.get()
+        },
+    }
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_unlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_unlock.rs
@@ -5,20 +5,58 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::{
-    c_int,
-    c_void,
+use ::core::mem::align_of;
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::pthread_rwlock_t,
 };
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-// TODO: add description
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Unlocks (releases) a read or write lock held on a read-write lock.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+///
+/// # Returns
+///
+/// If successful, this function returns zero returned. Otherwise, if returns a non-zero error code.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+///
+/// - `rwlock` points to a valid `pthread_rwlock_t` structure.
+///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn pthread_rwlock_unlock(_rwlock: *mut c_void) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/719
-    ::syslog::warn!("pthread_rwlock_unlock(): not implemented");
-    0
+pub unsafe extern "C" fn pthread_rwlock_unlock(rwlock: *mut pthread_rwlock_t) -> c_int {
+    // Check if `rwlock` object is invalid.
+    if rwlock.is_null() {
+        ::syslog::error!("pthread_rwlock_unlock(): invalid read-write lock (rwlock={rwlock:p})");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `rwlock` is unaligned.
+    if (rwlock as usize) % align_of::<pthread_rwlock_t>() != 0 {
+        ::syslog::error!("pthread_rwlock_unlock(): unaligned read-write lock (rwlock={rwlock:p})");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Attempt to release the read-write lock and check for errors.
+    match crate::pthread::pthread_rwlock_unlock(&mut *rwlock) {
+        Ok(()) => 0,
+        Err(error) => {
+            ::syslog::error!("pthread_rwlock_unlock(): {error:?} (rwlock={rwlock:p})");
+            error.code.get()
+        },
+    }
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_unlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_unlock.rs
@@ -1,0 +1,24 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sysapi::ffi::{
+    c_int,
+    c_void,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// TODO: add description
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_rwlock_unlock(_rwlock: *mut c_void) -> c_int {
+    // TODO: https://github.com/nanvix/nanvix/issues/719
+    ::syslog::warn!("pthread_rwlock_unlock(): not implemented");
+    0
+}

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_wrlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_wrlock.rs
@@ -5,20 +5,58 @@
 // Imports
 //==================================================================================================
 
-use ::sysapi::ffi::{
-    c_int,
-    c_void,
+use ::core::mem::align_of;
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::pthread_rwlock_t,
 };
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-// TODO: add description
-#[allow(clippy::missing_safety_doc)]
+///
+/// # Description
+///
+/// Acquires a write lock on a read-write lock.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+///
+/// # Returns
+///
+/// If successful, this function returns zero. Otherwise, if returns a non-zero error code.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if the following conditions are met:
+///
+/// - `rwlock` points to a valid `pthread_rwlock_t` structure.
+///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn pthread_rwlock_wrlock(_rwlock: *mut c_void) -> c_int {
-    // TODO: https://github.com/nanvix/nanvix/issues/718
-    ::syslog::warn!("pthread_rwlock_wrlock(): not implemented");
-    0
+pub unsafe extern "C" fn pthread_rwlock_wrlock(rwlock: *mut pthread_rwlock_t) -> c_int {
+    // Check if `rwlock` object is invalid.
+    if rwlock.is_null() {
+        ::syslog::error!("pthread_rwlock_wrlock(): invalid read-write lock (rwlock={rwlock:p})");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if `rwlock` is unaligned.
+    if (rwlock as usize) % align_of::<pthread_rwlock_t>() != 0 {
+        ::syslog::error!("pthread_rwlock_wrlock(): unaligned read-write lock (rwlock={rwlock:p})");
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Attempt to acquire a write lock on the read-write lock and check for errors.
+    match crate::pthread::pthread_rwlock_wrlock(&mut *rwlock) {
+        Ok(()) => 0,
+        Err(error) => {
+            ::syslog::error!("pthread_rwlock_wrlock(): {error:?} (rwlock={rwlock:p})");
+            error.code.get()
+        },
+    }
 }

--- a/src/libs/syscall/src/pthread/mod.rs
+++ b/src/libs/syscall/src/pthread/mod.rs
@@ -22,6 +22,11 @@ cfg_if::cfg_if! {
         pub use syscall::pthread_mutex_timedlock;
         pub use syscall::pthread_mutex_trylock;
         pub use syscall::pthread_mutex_unlock;
+        pub use syscall::pthread_rwlock_init;
+        pub use syscall::pthread_rwlock_destroy;
+        pub use syscall::pthread_rwlock_rdlock;
+        pub use syscall::pthread_rwlock_wrlock;
+        pub use syscall::pthread_rwlock_unlock;
         pub use syscall::pthread_cond_broadcast;
         pub use syscall::pthread_cond_destroy;
         pub use syscall::pthread_cond_init;

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -11,6 +11,9 @@ mod cond;
 /// Mutexes.
 mod mutex;
 
+/// Read-write locks.
+mod rwlock;
+
 /// Thread-specific data area.
 mod tda;
 
@@ -62,6 +65,7 @@ pub use pthread_attr_destroy::*;
 pub use pthread_attr_getstack::*;
 pub use pthread_attr_init::*;
 pub use pthread_getattr_np::*;
+pub use rwlock::*;
 pub use tda::*;
 
 //==================================================================================================

--- a/src/libs/syscall/src/pthread/syscall/rwlock.rs
+++ b/src/libs/syscall/src/pthread/syscall/rwlock.rs
@@ -1,0 +1,421 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::alloc::{
+    boxed::Box,
+    collections::btree_map::{
+        BTreeMap,
+        Entry,
+    },
+    sync::Arc,
+};
+use ::spin::{
+    Lazy,
+    Mutex,
+    MutexGuard,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    kcall::pm::{
+        lock_mutex,
+        signal_cond,
+        unlock_mutex,
+        wait_cond,
+    },
+    pm::{
+        ConditionAddress,
+        MutexAddress,
+    },
+};
+use ::sysapi::{
+    pthread::PTHREAD_RWLOCK_INITIALIZER,
+    sys_types::{
+        pthread_rwlock_t,
+        pthread_rwlockattr_t,
+    },
+};
+
+//==================================================================================================
+// Read-Write Lock Runtime Structure
+//==================================================================================================
+
+/// Runtime state stored for each read-write lock.
+#[derive(Debug)]
+struct ReadWriteLockState {
+    /// User-provided (or default) attributes.
+    _attr: pthread_rwlockattr_t,
+    /// Number of readers currently holding the lock.
+    readers: usize,
+    /// Whether a writer currently holds the lock.
+    writer_active: bool,
+    /// Number of writers waiting. Used to give preference to writers once they arrive.
+    writers_waiting: usize,
+    /// Raw allocation backing the state mutex address.
+    state_mutex: *mut u8,
+    /// Raw allocation backing the readers condition variable address.
+    readers_cond: *mut u8,
+    /// Raw allocation backing the writers condition variable address.
+    writers_cond: *mut u8,
+}
+
+impl ReadWriteLockState {
+    ///
+    /// # Description
+    ///
+    /// Creates a new `ReadWriteLockState` with the given attributes.
+    ///
+    /// # Parameters
+    ///
+    /// - `attr`: The attributes to use for the read-write lock.
+    ///
+    /// # Return Value
+    ///
+    /// This function returns a new instance of `ReadWriteLockState`.
+    ///
+    fn new(attr: pthread_rwlockattr_t) -> Self {
+        // Allocate three distinct heap cells to serve as unique stable addresses for the underlying
+        // kernel synchronization primitives.
+        let state_mutex: *mut u8 = Box::into_raw(Box::new(0u8));
+        let readers_cond: *mut u8 = Box::into_raw(Box::new(0u8));
+        let writers_cond: *mut u8 = Box::into_raw(Box::new(0u8));
+        Self {
+            _attr: attr,
+            readers: 0,
+            writer_active: false,
+            writers_waiting: 0,
+            state_mutex,
+            readers_cond,
+            writers_cond,
+        }
+    }
+}
+
+// SAFETY: `ReadWriteLockState` only contains primitive integers and
+// `MutexAddress`/`ConditionAddress` (newtype wrappers around integers). The raw pointers were only
+// used to provide stable unique addresses; they are not dereferenced after creation. Thus it is
+// safe to share between threads.
+unsafe impl Send for ReadWriteLockState {}
+unsafe impl Sync for ReadWriteLockState {}
+
+impl Drop for ReadWriteLockState {
+    fn drop(&mut self) {
+        unsafe {
+            // SAFETY: Pointers were obtained from Box::into_raw in new() and we ensure drop
+            // occurs exactly once when the runtime structure is removed from the global map.
+            let _ = Box::from_raw(self.state_mutex);
+            let _ = Box::from_raw(self.readers_cond);
+            let _ = Box::from_raw(self.writers_cond);
+        }
+    }
+}
+
+//==================================================================================================
+// Type Aliases
+//==================================================================================================
+
+/// Read-write lock.
+type ReadWriteLock = Arc<Mutex<ReadWriteLockState>>;
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Global map of read-write locks keyed by address of the user-space object.
+static RWLOCKS: Lazy<Mutex<BTreeMap<usize, ReadWriteLock>>> =
+    Lazy::new(|| Mutex::new(BTreeMap::new()));
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Initializes a read-write lock.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+/// - `attr`: Read-write lock attributes.
+///
+/// # Return Value
+///
+/// On success, this function returns empty. On failure, it returns an error describing the reason
+/// for the failure.
+///
+pub fn pthread_rwlock_init(
+    rwlock: &mut pthread_rwlock_t,
+    attr: &pthread_rwlockattr_t,
+) -> Result<(), Error> {
+    // Register read-write lock if it is not yet registered.
+    if let Entry::Vacant(entry) = RWLOCKS
+        .lock()
+        .entry(rwlock as *const pthread_rwlock_t as usize)
+    {
+        // Register read-write lock.
+        entry.insert(Arc::new(Mutex::new(ReadWriteLockState::new(*attr))));
+        Ok(())
+    } else {
+        let reason: &str = "read-write lock is already initialized";
+        ::syslog::error!("pthread_rwlock_init(): {reason}");
+        Err(Error::new(ErrorCode::InvalidArgument, reason))
+    }
+}
+
+///
+/// # Description
+///
+/// Destroys a read-write lock.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+///
+/// # Return Value
+///
+/// On success, this function returns empty. On failure, it returns an error describing the reason
+/// for the failure.
+///
+pub fn pthread_rwlock_destroy(rwlock: &mut pthread_rwlock_t) -> Result<(), Error> {
+    let mut rwlocks: MutexGuard<'_, BTreeMap<usize, ReadWriteLock>> = RWLOCKS.lock();
+
+    // Check if read-write lock was not registered.
+    if let Some(runtime) = rwlocks.get(&(rwlock as *const pthread_rwlock_t as usize)) {
+        let locked_runtime_rwlock: MutexGuard<'_, ReadWriteLockState> = runtime.lock();
+        if locked_runtime_rwlock.readers != 0 || locked_runtime_rwlock.writer_active {
+            let reason: &str = "read-write lock is busy";
+            ::syslog::error!("pthread_rwlock_destroy(): {}", reason);
+            return Err(Error::new(ErrorCode::ResourceBusy, reason));
+        }
+    } else {
+        // Not registered; accept destroy if statically initialized.
+        if *rwlock == PTHREAD_RWLOCK_INITIALIZER {
+            return Ok(());
+        } else {
+            let reason: &str = "read-write lock is not initialized";
+            ::syslog::error!("pthread_rwlock_destroy(): {reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+    }
+
+    // Remove read-write lock from the table of read-write locks.
+    rwlocks.remove(&(rwlock as *const pthread_rwlock_t as usize));
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Acquires a read lock on a read-write lock.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+///
+/// # Return Value
+///
+/// On success, this function returns empty. On failure, it returns an error describing the reason
+/// for the failure.
+///
+pub fn pthread_rwlock_rdlock(rwlock: &mut pthread_rwlock_t) -> Result<(), Error> {
+    let runtime_rwlock: ReadWriteLock = get_runtime_rwlock(rwlock)?;
+
+    let (mutex_addr, readers_cond_addr): (MutexAddress, ConditionAddress) = {
+        let locked_runtime_rwlock: MutexGuard<'_, ReadWriteLockState> = runtime_rwlock.lock();
+        let mutex_addr: MutexAddress =
+            MutexAddress::from(locked_runtime_rwlock.state_mutex as usize);
+        let readers_cond_addr: ConditionAddress =
+            ConditionAddress::from(locked_runtime_rwlock.readers_cond as usize);
+        (mutex_addr, readers_cond_addr)
+    };
+
+    // Protect state.
+    lock_mutex(mutex_addr, None)?;
+
+    loop {
+        let should_wait: bool = {
+            let mut locked_runtime_rwlock: MutexGuard<'_, ReadWriteLockState> =
+                runtime_rwlock.lock();
+            if !locked_runtime_rwlock.writer_active && locked_runtime_rwlock.writers_waiting == 0 {
+                locked_runtime_rwlock.readers += 1;
+                false
+            } else {
+                true
+            }
+        };
+
+        if !should_wait {
+            unlock_mutex(mutex_addr)?;
+            break Ok(());
+        }
+        wait_cond(readers_cond_addr, mutex_addr, None)?;
+    }
+}
+
+///
+/// # Description
+///
+/// Acquires a write lock on a read-write lock.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+///
+/// # Return Value
+///
+/// On success, this function returns empty. On failure, it returns an error describing the reason
+/// for the failure.
+///
+pub fn pthread_rwlock_wrlock(rwlock: &mut pthread_rwlock_t) -> Result<(), Error> {
+    let runtime_rwlock: ReadWriteLock = get_runtime_rwlock(rwlock)?;
+
+    let (mutex_addr, writers_cond_addr): (MutexAddress, ConditionAddress) = {
+        let locked_runtime_rwlock: MutexGuard<'_, ReadWriteLockState> = runtime_rwlock.lock();
+        let mutex_addr: MutexAddress =
+            MutexAddress::from(locked_runtime_rwlock.state_mutex as usize);
+        let writers_cond_addr: ConditionAddress =
+            ConditionAddress::from(locked_runtime_rwlock.writers_cond as usize);
+        (mutex_addr, writers_cond_addr)
+    };
+
+    lock_mutex(mutex_addr, None)?;
+
+    {
+        let mut runtime: MutexGuard<'_, ReadWriteLockState> = runtime_rwlock.lock();
+        runtime.writers_waiting += 1;
+    }
+
+    loop {
+        let mut acquired: bool = false;
+        {
+            let mut runtime: MutexGuard<'_, ReadWriteLockState> = runtime_rwlock.lock();
+            if !runtime.writer_active && runtime.readers == 0 {
+                runtime.writer_active = true;
+                runtime.writers_waiting -= 1;
+                acquired = true;
+            }
+        }
+
+        if acquired {
+            unlock_mutex(mutex_addr)?;
+            break Ok(());
+        }
+        wait_cond(writers_cond_addr, mutex_addr, None)?;
+    }
+}
+
+///
+/// # Description
+///
+/// Releases a read or write lock held on a read-write lock.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+///
+/// # Return Value
+///
+/// On success, this function returns empty. On failure, it returns an error describing the reason
+/// for the failure.
+///
+pub fn pthread_rwlock_unlock(rwlock: &mut pthread_rwlock_t) -> Result<(), Error> {
+    let runtime_rwlock: ReadWriteLock = get_runtime_rwlock(rwlock)?;
+
+    let (mutex_addr, readers_cond_addr, writers_cond_addr): (
+        MutexAddress,
+        ConditionAddress,
+        ConditionAddress,
+    ) = {
+        let locked_runtime_rwlock: MutexGuard<'_, ReadWriteLockState> = runtime_rwlock.lock();
+        let mutex_addr: MutexAddress =
+            MutexAddress::from(locked_runtime_rwlock.state_mutex as usize);
+        let readers_cond_addr: ConditionAddress =
+            ConditionAddress::from(locked_runtime_rwlock.readers_cond as usize);
+        let writers_cond_addr: ConditionAddress =
+            ConditionAddress::from(locked_runtime_rwlock.writers_cond as usize);
+        (mutex_addr, readers_cond_addr, writers_cond_addr)
+    };
+
+    lock_mutex(mutex_addr, None)?;
+
+    let (wake_readers, wake_writer): (bool, bool) = {
+        let mut locked_runtime: MutexGuard<'_, ReadWriteLockState> = runtime_rwlock.lock();
+        if locked_runtime.writer_active {
+            locked_runtime.writer_active = false;
+            if locked_runtime.writers_waiting > 0 {
+                (false, true)
+            } else {
+                // No waiting writers; wake all readers.
+                (true, false)
+            }
+        } else {
+            // Must be a reader.
+            if locked_runtime.readers == 0 {
+                let reason: &str = "unlock on unlocked read-write lock";
+                ::syslog::error!("pthread_rwlock_unlock(): {reason}");
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            }
+            locked_runtime.readers -= 1;
+            if locked_runtime.readers == 0 && locked_runtime.writers_waiting > 0 {
+                (false, true)
+            } else {
+                (false, false)
+            }
+        }
+    };
+
+    // Wake appropriate waiters while still holding protection mutex so they observe state.
+    if wake_writer {
+        let _ = signal_cond(writers_cond_addr, false);
+    } else if wake_readers {
+        let _ = signal_cond(readers_cond_addr, true); // broadcast to all readers
+    }
+
+    unlock_mutex(mutex_addr)
+}
+
+///
+/// # Description
+///
+/// Gets the runtime structure for a read-write lock, registering the read-write lock in the table
+/// of read-write locks if necessary.
+///
+/// # Parameters
+///
+/// - `rwlock`: Read-write lock object.
+///
+/// # Return Value
+///
+/// On success, this function returns the runtime structure for the read-write lock. On failure,
+/// it returns an error describing the reason for the failure.
+///
+fn get_runtime_rwlock(rwlock: &pthread_rwlock_t) -> Result<ReadWriteLock, Error> {
+    let mut rwlocks: MutexGuard<'_, BTreeMap<usize, ReadWriteLock>> = RWLOCKS.lock();
+    let runtime_ptr: usize = rwlock as *const pthread_rwlock_t as usize;
+    if let Entry::Vacant(entry) = rwlocks.entry(runtime_ptr) {
+        if *rwlock == PTHREAD_RWLOCK_INITIALIZER {
+            entry.insert(Arc::new(Mutex::new(ReadWriteLockState::new(
+                pthread_rwlockattr_t::default(),
+            ))));
+        } else {
+            let reason: &str = "read-write lock is not initialized";
+            ::syslog::error!("lazy_register_rwlock(): {reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+    }
+
+    // Borrow runtime (need to re-lock map only when reading state). We clone needed addresses.
+    let runtime: &ReadWriteLock = rwlocks
+        .get(&runtime_ptr)
+        .ok_or_else(|| Error::new(ErrorCode::InvalidArgument, "read-write lock runtime missing"))?;
+
+    Ok(runtime.clone())
+}

--- a/src/tests/thread-c/common.h
+++ b/src/tests/thread-c/common.h
@@ -48,4 +48,10 @@ extern void test_pthread_getattr_np_destroy(void);
 // Tests if pthread_attr_getstack() can retrieve stack attributes and they can be destroyed.
 extern void test_pthread_attr_getstack(void);
 
+// Tests if statically initialized read-write locks can synchronize multiple readers.
+extern void test_pthread_rwlock_static_init(void);
+
+// Tests if dynamically initialized read-write locks work (init/destroy + exclusion semantics).
+extern void test_pthread_rwlock_dynamic_init(void);
+
 #endif

--- a/src/tests/thread-c/main.c
+++ b/src/tests/thread-c/main.c
@@ -111,6 +111,8 @@ int main(int argc, const char *argv[])
     test_pthread_mutex_dynamic_init();
     test_pthread_mutex_trylock();
     test_pthread_mutex_timedlock();
+    test_pthread_rwlock_static_init();
+    test_pthread_rwlock_dynamic_init();
     test_pthread_cond_static_init();
     test_pthread_cond_timedwait();
     test_pthread_tda();

--- a/src/tests/thread-c/rwlock_dynamic_init.c
+++ b/src/tests/thread-c/rwlock_dynamic_init.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+// Enable rwlock API in toolchain headers.
+#define _POSIX_READER_WRITER_LOCKS 1
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Flags for synchronization validation.
+static volatile int writer_inside = 0;
+static volatile int reader_inside = 0;
+static volatile int reader_started_after_writer = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Writer thread: acquires write lock, holds briefly, then releases.
+static void *writer_thread(void *arg)
+{
+    pthread_rwlock_t *rwlock = (pthread_rwlock_t *)arg;
+
+    assert(pthread_rwlock_wrlock(rwlock) == 0);
+    writer_inside = 1;
+    for (int i = 0; i < 4000; i++) {
+        sched_yield();
+    }
+    writer_inside = 0;
+    assert(pthread_rwlock_unlock(rwlock) == 0);
+    return (void *)0;
+}
+
+// Reader thread: should observe writer has left before entering.
+static void *reader_thread(void *arg)
+{
+    pthread_rwlock_t *rwlock = (pthread_rwlock_t *)arg;
+    assert(pthread_rwlock_rdlock(rwlock) == 0);
+    // By contract of scheduling in the test, writer should no longer be inside.
+    if (!writer_inside) {
+        reader_started_after_writer = 1;
+    }
+    reader_inside = 1;
+    for (int i = 0; i < 2000; i++) {
+        sched_yield();
+    }
+    reader_inside = 0;
+    assert(pthread_rwlock_unlock(rwlock) == 0);
+    return (void *)0;
+}
+
+// Tests dynamic initialization, lock exclusion between writer and reader, and destroy semantics.
+void test_pthread_rwlock_dynamic_init(void)
+{
+    fprintf(stderr, "testing pthread_rwlock_dynamic_init() ... ");
+
+    pthread_rwlock_t rwlock = 0; // Uninitialized object.
+    assert(pthread_rwlock_init(&rwlock, NULL) == 0);
+
+    // Test that destroying while locked fails.
+    assert(pthread_rwlock_wrlock(&rwlock) == 0);
+    int destroy_ret = pthread_rwlock_destroy(&rwlock);
+    assert(destroy_ret != 0); // Should fail because lock is busy.
+    assert(pthread_rwlock_unlock(&rwlock) == 0);
+
+    // Launch writer first so that reader blocks until writer releases.
+    pthread_t writer_tid = 0;
+    assert(pthread_create(&writer_tid, NULL, writer_thread, (void *)&rwlock) == 0);
+
+    // Wait until writer holds the lock.
+    while (!writer_inside) {
+        sched_yield();
+    }
+
+    // Launch reader which must block until writer releases the lock.
+    pthread_t reader_tid = 0;
+    assert(pthread_create(&reader_tid, NULL, reader_thread, (void *)&rwlock) == 0);
+
+    // While writer is inside, reader must not have entered.
+    while (writer_inside) {
+        assert(reader_inside == 0);
+        sched_yield();
+    }
+
+    // Join threads.
+    void *retval = (void *)1;
+    assert(pthread_join(writer_tid, &retval) == 0);
+    assert(retval == 0);
+    assert(pthread_join(reader_tid, &retval) == 0);
+    assert(retval == 0);
+
+    // Reader must have started only after writer exited.
+    assert(reader_started_after_writer == 1);
+
+    // Now destroy must succeed.
+    assert(pthread_rwlock_destroy(&rwlock) == 0);
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/thread-c/rwlock_static_init.c
+++ b/src/tests/thread-c/rwlock_static_init.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+// Enable rwlock API in toolchain headers.
+#define _POSIX_READER_WRITER_LOCKS 1
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+// Statically initialized read-write lock under test.
+static pthread_rwlock_t rwlock = PTHREAD_RWLOCK_INITIALIZER;
+
+// Test state machine:
+// 0 -> initial
+// 1 -> reader A acquired lock
+// 2 -> reader B acquired lock while A still holds (concurrency proven)
+// 3 -> reader A released
+// 4 -> reader B released
+static volatile int stage = 0;
+static volatile int concurrency_observed = 0;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Reader thread routine.
+static void *reader_a(void *arg)
+{
+    (void)arg;
+    assert(pthread_rwlock_rdlock(&rwlock) == 0);
+    stage = 1; // acquired
+    // Wait until reader B also acquires (stage moves to 2).
+    while (stage < 2) {
+        sched_yield();
+    }
+    assert(pthread_rwlock_unlock(&rwlock) == 0);
+    stage = 3;
+    return (void *)0;
+}
+
+static void *reader_b(void *arg)
+{
+    (void)arg;
+    // Wait until reader A has acquired (stage==1).
+    while (stage < 1) {
+        sched_yield();
+    }
+    assert(pthread_rwlock_rdlock(&rwlock) == 0);
+    if (stage == 1) {
+        // A still holds lock, so concurrency achieved.
+        concurrency_observed = 1;
+    }
+    stage = 2; // mark that B acquired
+    // Wait until A releases (stage>=3) before B releases so ordering predictable.
+    while (stage < 3) {
+        sched_yield();
+    }
+    assert(pthread_rwlock_unlock(&rwlock) == 0);
+    stage = 4;
+    return (void *)0;
+}
+
+// Tests if statically initialized read-write locks support multiple concurrent readers.
+void test_pthread_rwlock_static_init(void)
+{
+    fprintf(stderr, "testing pthread_rwlock_static_init() ... ");
+
+    pthread_t a = 0, b = 0;
+    assert(pthread_create(&a, NULL, reader_a, NULL) == 0);
+    assert(pthread_create(&b, NULL, reader_b, NULL) == 0);
+
+    void *rv = (void *)1;
+    assert(pthread_join(a, &rv) == 0 && rv == 0);
+    assert(pthread_join(b, &rv) == 0 && rv == 0);
+
+    assert(stage == 4);
+    assert(concurrency_observed == 1);
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
- This PR closes #718 
- This PR closes #719 
- This PR closes #720 
- This PR closes #972
- This PR closes #973 

This pull request adds comprehensive support for POSIX pthread read-write locks (`pthread_rwlock_t`) to the system call and system API layers, including both implementation and tests. It introduces new bindings for initialization, destruction, locking (read and write), and unlocking, along with static and dynamic initialization macros and thorough error checking. Additionally, new tests are provided to validate both static and dynamic initialization and synchronization semantics.

**POSIX pthread read-write lock support:**

- Added new system call bindings for `pthread_rwlock_init`, `pthread_rwlock_destroy`, `pthread_rwlock_rdlock`, `pthread_rwlock_wrlock`, and `pthread_rwlock_unlock`, including robust argument validation and error reporting in each function (`src/libs/syscall/src/pthread/bindings/pthread_rwlock_init.rs`, `pthread_rwlock_destroy.rs`, `pthread_rwlock_rdlock.rs`, `pthread_rwlock_wrlock.rs`, `pthread_rwlock_unlock.rs`) [[1]](diffhunk://#diff-cf566e14642b68c3828b84ecf4a1008fdb159843fda6f54fb1934c7e53f68d60R1-R89) [[2]](diffhunk://#diff-06e6882d71ef3ee49460d6e1b9372233022be63adb71a595d96fe743737521d3R1-R61) [[3]](diffhunk://#diff-61298d446ae5a13084862917b91dd6dabdbc74b47b187d9669fd2f96fa452a19L8-R61) [[4]](diffhunk://#diff-e5ad270b762332225e20a11d34f09d16478e0433859228fc64187df680d6883bL8-R61) [[5]](diffhunk://#diff-99fac6045ce852fbb0e0552c47df0cb1f3d5e394a1f08967a1d8c4388323d6ebR1-R62).
- Exposed the new read-write lock system calls in the syscall module and made them available for use in the public pthread API (`src/libs/syscall/src/pthread/mod.rs`, `src/libs/syscall/src/pthread/syscall/mod.rs`) [[1]](diffhunk://#diff-bcc0f9c9b0ff4e720bc1a4b16d5b2bd7edd7fd295f42420fad80c18dee507743R25-R29) [[2]](diffhunk://#diff-340018d20eb8da4c8e8a6b1c481e8d61c1844cb9efae3048fadf1cac7311b314R14-R16) [[3]](diffhunk://#diff-340018d20eb8da4c8e8a6b1c481e8d61c1844cb9efae3048fadf1cac7311b314R68).
- Added the `PTHREAD_RWLOCK_INITIALIZER` macro for static initialization of read-write locks in the system API (`src/libs/sysapi/src/pthread.rs`).

**Testing and validation:**

- Introduced new tests for both statically and dynamically initialized read-write locks, covering correct synchronization, exclusion semantics, and destruction behavior (`src/tests/thread-c/rwlock_dynamic_init.c`, updates to `src/tests/thread-c/common.h`, `src/tests/thread-c/main.c`) [[1]](diffhunk://#diff-5e21a2fb72ea7b93e02676ed6aac08d595d773333d05e045af336589450f1288R1-R111) [[2]](diffhunk://#diff-c133992a87d9a317a809390e2f758f257e1d2883bdd73a741c5f33319fba5ee2R51-R56) [[3]](diffhunk://#diff-547460b88f2f65d19763135b21d0ca67db7460b9c3982df4869f8a7c7f8478cfR114-R115).

**Other improvements:**

- Improved error handling and parameter validation in the new and existing pthread read-write lock functions, ensuring alignment and null-pointer checks, and logging errors appropriately [[1]](diffhunk://#diff-cf566e14642b68c3828b84ecf4a1008fdb159843fda6f54fb1934c7e53f68d60R1-R89) [[2]](diffhunk://#diff-06e6882d71ef3ee49460d6e1b9372233022be63adb71a595d96fe743737521d3R1-R61) [[3]](diffhunk://#diff-61298d446ae5a13084862917b91dd6dabdbc74b47b187d9669fd2f96fa452a19L8-R61) [[4]](diffhunk://#diff-e5ad270b762332225e20a11d34f09d16478e0433859228fc64187df680d6883bL8-R61) [[5]](diffhunk://#diff-99fac6045ce852fbb0e0552c47df0cb1f3d5e394a1f08967a1d8c4388323d6ebR1-R62).
- Cleaned up and updated imports in relevant files to support the new functionality (`src/libs/sysapi/src/pthread.rs`).

**Minor change:**

- Removed a redundant check for the runnable state in process management (`src/kernel/src/pm/process/manager/mod.rs`).