### PR TITLE
[microvm] Reduce number of steps in pause-resume protocol

### DIFF
--- a/src/microvm/src/memory_thread.rs
+++ b/src/microvm/src/memory_thread.rs
@@ -44,29 +44,23 @@ use crate::orchestrator::{
 ///
 /// - `data_rx`: Receives data messages from the I/O thread.
 /// - `data_tx`: Sends data messages to the virtual machine's stdin.
-/// - `control_rx`: Receives control commands from the VMM.
-/// - `control_tx`: Sends control responses to the VMM.
+/// - `_control_rx`: Receives control commands from the VMM.
+/// - `_control_tx`: Sends control responses to the VMM.
 /// - `add_credit`: Closure that adds a credit to the virtual machine credit pool.
-/// - `pause_microvm`: Closure that writes to the kernel's memory to pause the MicroVM.
-/// - `resume_microvm`: Closure that writes to the kernel's memory it shouldn't pause the MicroVM.
 ///
 /// # Returns
 ///
 /// A handle to the memory thread.
 ///
-pub fn spawn<F1, F2, F3>(
+pub fn spawn<F>(
     data_rx: Receiver<Message>,
     data_tx: Sender<Message>,
-    control_rx: Receiver<MemoryControlCommand>,
-    control_tx: Sender<MemoryControlResponse>,
-    mut add_credit: F1,
-    mut pause_microvm: F2,
-    mut resume_microvm: F3,
+    _control_rx: Receiver<MemoryControlCommand>,
+    _control_tx: Sender<MemoryControlResponse>,
+    mut add_credit: F,
 ) -> JoinHandle<Result<()>>
 where
-    F1: FnMut() -> Result<()> + std::marker::Send + 'static,
-    F2: FnMut() -> Result<()> + std::marker::Send + 'static,
-    F3: FnMut() -> Result<()> + std::marker::Send + 'static,
+    F: FnMut() -> Result<()> + std::marker::Send + 'static,
 {
     thread::spawn(move || {
         loop {
@@ -86,49 +80,6 @@ where
                 },
                 Err(TryRecvError::Disconnected) => {
                     // When the guest finishes , the vCPU thread will disconnect from this
-                    // thread. This situation is normal and should not create an error log.
-                    debug!("spawn(): channel has been disconnected");
-                    break Ok(());
-                },
-                Err(TryRecvError::Empty) => {
-                    // No message available.
-                },
-            }
-            match control_rx.try_recv() {
-                Ok(MemoryControlCommand::Pause) => {
-                    crate::timer!("vm_pause");
-                    if let Err(e) = pause_microvm() {
-                        let reason: String =
-                            format!("error requesting pause in the kernel's memory (error={e:?})");
-                        error!("spawn(): {reason}");
-                        if let Err(e) = control_tx.send(MemoryControlResponse::PauseError) {
-                            let reason: String =
-                                format!("error sending `PauseError` to the VMM (error={e:?})");
-                            error!("spawn(): {reason}");
-                            anyhow::bail!(reason)
-                        }
-                        anyhow::bail!(reason)
-                    }
-                },
-                Ok(MemoryControlCommand::Resume) => {
-                    crate::timer!("vm_resume");
-                    if let Err(e) = resume_microvm() {
-                        let reason: String = format!(
-                            "error overwriting pause request in the kernel's memory (error={e:?})"
-                        );
-                        error!("spawn(): {reason}");
-                        if let Err(e) = control_tx.send(MemoryControlResponse::ResumeError) {
-                            let reason: String =
-                                format!("error sending `ResumeError` to the VMM (error={e:?})");
-                            error!("spawn(): {reason}");
-                            anyhow::bail!(reason)
-                        }
-                        anyhow::bail!(reason)
-                    }
-                    control_tx.send(MemoryControlResponse::ResumeWritten)?;
-                },
-                Err(TryRecvError::Disconnected) => {
-                    // When the guest finishes, the vCPU thread will disconnect from this
                     // thread. This situation is normal and should not create an error log.
                     debug!("spawn(): channel has been disconnected");
                     break Ok(());

--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -29,17 +29,31 @@ pub const TIMEOUT_WARNING_INTERVAL_IN_MS: usize = 10;
 ///
 /// # Description
 ///
-/// Channels used for orchestrating control commands and the state in the snapshotting protocol.
+/// This structure holds the state of the VM, channels used for orchestrating control commands, and
+/// callback functions which implement specific functionality that's different between the MicroVM
+/// and Hyperlight.
 ///
 pub struct Orchestrator {
+    // The state of the VM.
     state: State,
+    // Channel that receives commands from the I/O thread.
     io_control_rx: Receiver<IoControlCommand>,
+    // Channel that sends commands to the I/O thread.
     io_control_tx: Sender<IoControlResponse>,
-    memory_control_rx: Receiver<MemoryControlResponse>,
-    memory_control_tx: Sender<MemoryControlCommand>,
+    // Channel that receives commands from the memory thread.
+    _memory_control_rx: Receiver<MemoryControlResponse>,
+    // Channel that sends commands to the memory thread.
+    _memory_control_tx: Sender<MemoryControlCommand>,
+    // Channel that receives commands from the vCPU thread.
     vcpu_control_rx: Receiver<VcpuControlResponse>,
+    // Channel that sends commands to the vCPU thread.
     vcpu_control_tx: Sender<VcpuControlCommand>,
-    create_snapshot: fn() -> Result<()>,
+    // Callback function to write to the kernel's memory a pause request.
+    pause_microvm: Box<dyn Fn() -> Result<()> + Send + 'static>,
+    // Callback function to erase a pause request from the kernel's memory.
+    resume_microvm: Box<dyn Fn() -> Result<()> + Send + 'static>,
+    // Callback function to create a snapshot.
+    create_snapshot: Box<dyn Fn() -> Result<()> + Send + 'static>,
 }
 
 //==================================================================================================
@@ -96,10 +110,7 @@ pub enum IoControlResponse {
 /// Control plane commands from the VMM to the memory thread.
 ///
 #[derive(PartialEq)]
-pub enum MemoryControlCommand {
-    Pause,
-    Resume,
-}
+pub enum MemoryControlCommand {}
 
 ///
 /// # Description
@@ -107,11 +118,7 @@ pub enum MemoryControlCommand {
 /// Control plane command responses from the memory thread to the VMM.
 ///
 #[derive(PartialEq)]
-pub enum MemoryControlResponse {
-    PauseError,
-    ResumeError,
-    ResumeWritten,
-}
+pub enum MemoryControlResponse {}
 
 ///
 /// # Description
@@ -139,6 +146,7 @@ pub enum VcpuControlResponse {
 //==================================================================================================
 
 impl Orchestrator {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         io_control_rx: Receiver<IoControlCommand>,
         io_control_tx: Sender<IoControlResponse>,
@@ -146,16 +154,20 @@ impl Orchestrator {
         memory_control_tx: Sender<MemoryControlCommand>,
         vcpu_control_rx: Receiver<VcpuControlResponse>,
         vcpu_control_tx: Sender<VcpuControlCommand>,
-        create_snapshot: fn() -> Result<()>,
+        pause_microvm: Box<dyn Fn() -> Result<()> + Send + 'static>,
+        resume_microvm: Box<dyn Fn() -> Result<()> + Send + 'static>,
+        create_snapshot: Box<dyn Fn() -> Result<()> + Send + 'static>,
     ) -> Self {
         Self {
             state: State::PreBoot,
             io_control_rx,
             io_control_tx,
-            memory_control_rx,
-            memory_control_tx,
+            _memory_control_rx: memory_control_rx,
+            _memory_control_tx: memory_control_tx,
             vcpu_control_rx,
             vcpu_control_tx,
+            pause_microvm,
+            resume_microvm,
             create_snapshot,
         }
     }
@@ -283,12 +295,7 @@ impl Orchestrator {
     ///
     fn pause_protocol(&mut self) -> Result<()> {
         // TODO: tell linuxd to flush (Running -> Flushing) https://github.com/nanvix/nanvix/issues/945
-        if let Err(e) = self.memory_control_tx.send(MemoryControlCommand::Pause) {
-            let reason: String =
-                format!("error sending `Pause` to the memory thread (error={e:?})");
-            error!("pause_protocol(): {reason}");
-            anyhow::bail!(reason)
-        }
+        (self.pause_microvm)()?;
         // Wait for the MicroVM to confirm it has paused.
         let start: Instant = Instant::now();
         let mut counter: usize = 1;
@@ -313,23 +320,6 @@ impl Orchestrator {
                     "pause_protocol(): {}ms have passed waiting for `Paused` message from vCPU",
                     TIMEOUT_WARNING_INTERVAL_IN_MS * counter
                 );
-                match self.memory_control_rx.try_recv() {
-                    Ok(MemoryControlResponse::PauseError) => todo!(), // TODO: graceful shutdown https://github.com/nanvix/nanvix/issues/949
-                    Ok(MemoryControlResponse::ResumeError) => unreachable!(
-                        "Received `ResumeError` during pause protocol: this indicates a protocol \
-                         violation, as `ResumeError` should not be sent while pausing."
-                    ),
-                    Ok(MemoryControlResponse::ResumeWritten) => unreachable!(
-                        "Received `ResumeWritten` during pause protocol: this indicates a \
-                         protocol violation, as `ResumeWritten` should not be sent while pausing."
-                    ),
-                    Err(TryRecvError::Empty) => (),
-                    Err(TryRecvError::Disconnected) => {
-                        let reason: String = "the vmm has disconnected".to_string();
-                        error!("pause_protocol(): {reason}");
-                        anyhow::bail!(reason)
-                    },
-                }
                 counter += 1;
             }
         }
@@ -394,38 +384,8 @@ impl Orchestrator {
     /// Upon success, empty is returned. Otherwise, an error is returned instead.
     ///
     fn resume_protocol(&mut self) -> Result<()> {
-        // Tell memory thread to write to the kernel
-        self.memory_control_tx.send(MemoryControlCommand::Resume)?;
-        // Wait for confirmation
-        let start: Instant = Instant::now();
-        let mut counter: usize = 1;
-        loop {
-            match self.memory_control_rx.try_recv() {
-                Ok(MemoryControlResponse::ResumeWritten) => break,
-                Ok(MemoryControlResponse::ResumeError) => todo!(), // TODO: graceful shutdown https://github.com/nanvix/nanvix/issues/949
-                Ok(MemoryControlResponse::PauseError) => {
-                    unreachable!(
-                        "Received `PauseError` during resume protocol: this indicates a protocol \
-                         violation, as `PauseError` should not be sent while resuming."
-                    )
-                },
-                Err(TryRecvError::Empty) => (),
-                Err(TryRecvError::Disconnected) => {
-                    let reason: String = "the memory thread has disconnected".to_string();
-                    error!("resume_protocol(): {reason}");
-                    anyhow::bail!(reason)
-                },
-            }
-            // Log a warning and increment the counter every TIMEOUT_WARNING_INTERVAL_IN_MS ms.
-            let elapsed_time: usize = start.elapsed().as_millis() as usize;
-            if elapsed_time > TIMEOUT_WARNING_INTERVAL_IN_MS * counter {
-                warn!(
-                    "{}ms have passed waiting for `ResumeWritten`",
-                    TIMEOUT_WARNING_INTERVAL_IN_MS * counter
-                );
-                counter += 1;
-            }
-        }
+        // Write to the kernel a pause is no longer requested.
+        (self.resume_microvm)()?;
         // Tell microvm to resume
         self.vcpu_control_tx.send(VcpuControlCommand::Resume)?;
         self.state = State::Running;

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -287,8 +287,6 @@ impl Vmm {
             memory_thread_control_rx,
             memory_thread_control_tx,
             add_credit,
-            pause_microvm,
-            resume_microvm,
         );
 
         let vcpu_thread: JoinHandle<Result<u16>> = std::thread::spawn(move || {
@@ -340,7 +338,9 @@ impl Vmm {
             memory_control_tx,
             vcpu_control_rx,
             vcpu_control_tx,
-            || Ok(()), // TODO: create_snapshot https://github.com/nanvix/nanvix/issues/947
+            Box::new(pause_microvm),
+            Box::new(resume_microvm),
+            Box::new(|| Ok(())), // TODO: create_snapshot https://github.com/nanvix/nanvix/issues/947
         );
 
         let mut vmm: Vmm = Self {

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -191,24 +191,6 @@ impl Vmm {
                     .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
                     .add_credit()
             },
-            move || {
-                vmem_pause_microvm
-                    .lock()
-                    .map_err(|e| anyhow::anyhow!("failed to acquire lock {:?}", e))?
-                    .write_bytes(
-                        ::config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
-                        &::config::microvm::PAUSE_REQUEST.to_le_bytes(),
-                    )
-            },
-            move || {
-                vmem_resume_microvm
-                    .lock()
-                    .map_err(|e| anyhow::anyhow!("failed to acquire lock {:?}", e))?
-                    .write_bytes(
-                        ::config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
-                        &::config::microvm::RUNNING.to_le_bytes(),
-                    )
-            },
         );
 
         let mut microvm_clone: MicroVm = microvm.clone();
@@ -245,7 +227,25 @@ impl Vmm {
             memory_control_tx,
             vcpu_control_rx,
             vcpu_control_tx,
-            || Ok(()), // TODO: create_snapshot https://github.com/nanvix/nanvix/issues/947
+            Box::new(move || {
+                vmem_pause_microvm
+                    .lock()
+                    .map_err(|e| anyhow::anyhow!("failed to acquire lock {:?}", e))?
+                    .write_bytes(
+                        ::config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
+                        &::config::microvm::PAUSE_REQUEST.to_le_bytes(),
+                    )
+            }),
+            Box::new(move || {
+                vmem_resume_microvm
+                    .lock()
+                    .map_err(|e| anyhow::anyhow!("failed to acquire lock {:?}", e))?
+                    .write_bytes(
+                        ::config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
+                        &::config::microvm::RUNNING.to_le_bytes(),
+                    )
+            }),
+            Box::new(|| Ok(())), // TODO: create_snapshot https://github.com/nanvix/nanvix/issues/947
         );
 
         let mut vmm: Vmm = Self {


### PR DESCRIPTION
# Overview

Now that the MicroVm has finer locks, this PR removes the previous indirection in writing to the kernel memory in the pause-resume protocol. Previously, the main thread asked the memory thread to write to the kernel memory, and now the main thread just writes to it directly.

pause:
```
from: main ->      memory     -> write to kernel -> vcpu -> main
to:   main -> write to kernel ->       vcpu      -> main
```

resume:
```
from: main ->      memory     -> write to kernel -> memory -> main -> vcpu
to:   main -> write to kernel ->       main      -> vcpu
```

Closes https://github.com/nanvix/nanvix/issues/968

# Details

`pause_microvm` and `resume_microvm` were moved from the memory thread to the orchestrator.

# Feedback

Should I use function pointers (Box) or Generics? The compiler would do monomorphization with generics and lead to better optimized code, but it would add a lot of boilerplate. 

Is my usage of `FnMut` and `Fn` adequate?