### PR TITLE
[microvm] Create and load MicroVM snapshots

### DIFF
--- a/src/microvm/Cargo.toml
+++ b/src/microvm/Cargo.toml
@@ -26,13 +26,15 @@ flexi_logger = { workspace = true }
 hyperlight-host = { workspace = true, optional = true }
 log = { workspace = true }
 profiler = { workspace = true, features = ["auto-calibrate"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 sys = { workspace = true }
 syscall = { workspace = true }
 syscomm = { workspace = true }
 user-vm-api = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-kvm-bindings = { workspace = true }
+kvm-bindings = { workspace = true, features = ["serde"] }
 kvm-ioctls = { workspace = true }
 libc = { workspace = true }
 

--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -54,6 +54,8 @@ pub struct Orchestrator {
     resume_microvm: Box<dyn Fn() -> Result<()> + Send + 'static>,
     // Callback function to create a snapshot.
     create_snapshot: Box<dyn Fn() -> Result<()> + Send + 'static>,
+    // Callback function to load a snapshot.
+    load_snapshot: Box<dyn FnMut() -> Result<()> + Send + 'static>,
 }
 
 //==================================================================================================
@@ -157,6 +159,7 @@ impl Orchestrator {
         pause_microvm: Box<dyn Fn() -> Result<()> + Send + 'static>,
         resume_microvm: Box<dyn Fn() -> Result<()> + Send + 'static>,
         create_snapshot: Box<dyn Fn() -> Result<()> + Send + 'static>,
+        load_snapshot: Box<dyn FnMut() -> Result<()> + Send + 'static>,
     ) -> Self {
         Self {
             state: State::PreBoot,
@@ -169,6 +172,7 @@ impl Orchestrator {
             pause_microvm,
             resume_microvm,
             create_snapshot,
+            load_snapshot,
         }
     }
 
@@ -195,7 +199,12 @@ impl Orchestrator {
                 },
                 IoControlCommand::_LoadSnapshotAndRun => {
                     if self.state == State::PreBoot {
-                        // TODO: load snapshot https://github.com/nanvix/nanvix/issues/948
+                        if let Err(e) = (self.load_snapshot)() {
+                            let reason: String =
+                                format!("LoadSnapshotAndRun: failed to load snapshot (e={e:?})");
+                            error!("handle_command(): {reason}");
+                            anyhow::bail!(reason);
+                        }
                         trace!("State: PreBoot -> Paused");
 
                         // The Linux daemon should send messages to PreBoot VMMs by default,

--- a/src/microvm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/microvm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -13,6 +13,14 @@ mod timer;
 // Exports
 //==================================================================================================
 
+pub use exit::*;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::vmm::microvm::kvm::partition::VirtualPartition;
+use ::anyhow::Result;
 use ::arch::cpu::{
     cpuid::{
         CPUID_FEATURES,
@@ -30,22 +38,16 @@ use ::kvm_bindings::{
     CpuId,
     KVM_MAX_CPUID_ENTRIES,
     kvm_fpu,
-};
-pub use exit::*;
-
-//==================================================================================================
-// Imports
-//==================================================================================================
-
-use crate::vmm::microvm::kvm::partition::VirtualPartition;
-use ::anyhow::Result;
-use ::kvm_bindings::{
     kvm_regs,
     kvm_sregs,
 };
 use ::kvm_ioctls::{
     VcpuExit,
     VcpuFd,
+};
+use ::serde::{
+    Deserialize,
+    Serialize,
 };
 use ::std::sync::{
     Arc,
@@ -82,6 +84,25 @@ pub struct VirtualProcessor {
     /// Handle to timer.
     _timer: Timer,
     /// Processor state.
+    online: bool,
+    /// Exit status code.
+    exit_status: u16,
+}
+
+///
+/// # Description
+///
+/// Virtual CPU state that can be serialized and saved to disk.
+///
+#[derive(Serialize, Deserialize)]
+pub struct VirtualProcessorState {
+    /// General purpose registers.
+    regs: kvm_regs,
+    /// System registers (segment registers, control registers, etc.).
+    sregs: kvm_sregs,
+    /// FPU/SIMD state.
+    fpu: Vec<u8>,
+    /// Whether the processor is online.
     online: bool,
     /// Exit status code.
     exit_status: u16,
@@ -380,5 +401,146 @@ impl VirtualProcessor {
         }
 
         Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Captures the current state of the virtual processor.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, returns the current processor state that can be serialized and
+    /// saved to a file. Otherwise, returns an error.
+    ///
+    pub fn get_state(&self) -> Result<VirtualProcessorState> {
+        Ok(VirtualProcessorState::new(
+            self.fd
+                .get_regs()
+                .map_err(|e| anyhow::anyhow!("failed to get registers: {e:?}"))?,
+            self.fd
+                .get_sregs()
+                .map_err(|e| anyhow::anyhow!("failed to get system registers: {e:?}"))?,
+            self.fd
+                .get_fpu()
+                .map_err(|e| anyhow::anyhow!("failed to get FPU state: {e:?}"))?,
+            self.is_online(),
+            self.exit_status(),
+        ))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Restores the virtual processor to a previously saved state.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: Processor state to restore.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, returns empty. Otherwise, returns an error.
+    ///
+    pub fn set_state(&mut self, state: VirtualProcessorState) -> Result<()> {
+        self.fd
+            .set_regs(&state.regs)
+            .map_err(|e| anyhow::anyhow!("failed to set registers: {e:?}"))?;
+
+        self.fd
+            .set_sregs(&state.sregs)
+            .map_err(|e| anyhow::anyhow!("failed to set system registers: {e:?}"))?;
+
+        self.fd
+            .set_fpu(&VirtualProcessorState::deserialize_fpu(&state.fpu)?)
+            .map_err(|e| anyhow::anyhow!("failed to set FPU state: {e:?}"))?;
+
+        self.online = state.online;
+        self.exit_status = state.exit_status;
+
+        Ok(())
+    }
+}
+
+impl VirtualProcessorState {
+    ///
+    /// # Description
+    ///
+    /// Converts `kvm_fpu` to serializable format.
+    ///
+    /// # Parameters
+    ///
+    /// - `fpu`: FPU state to serialize.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns the FPU state in a serializable format. Otherwise, returns an error.
+    ///
+    fn serialize_fpu(fpu: &kvm_fpu) -> Vec<u8> {
+        // SAFETY: we're reading the memory right after initializing the variable, so this is safe.
+        unsafe {
+            let data: *const u8 = fpu as *const kvm_fpu as *const u8;
+            let len: usize = ::std::mem::size_of_val(fpu);
+            ::std::slice::from_raw_parts(data, len).to_vec()
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts serialized bytes to `kvm_fpu`.
+    ///
+    /// # Parameters
+    ///
+    /// - `data`: Bytes to deserialize.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns the FPU state as `kvm_fpu`. Otherwise, returns an error.
+    ///
+    fn deserialize_fpu(data: &[u8]) -> Result<kvm_fpu> {
+        let kvm_fpu_size: usize = ::std::mem::size_of::<kvm_fpu>();
+        if data.len() != kvm_fpu_size {
+            Err(anyhow::anyhow!(
+                "Invalid kvm_fpu data size: expected {}, got {}",
+                kvm_fpu_size,
+                data.len()
+            ))
+        } else {
+            // SAFETY: we're checking the length before copying it, so this is safe.
+            unsafe {
+                let mut fpu: kvm_fpu = ::std::mem::zeroed();
+                let ptr: *mut u8 = &mut fpu as *mut kvm_fpu as *mut u8;
+                ::std::ptr::copy_nonoverlapping(data.as_ptr(), ptr, data.len());
+                Ok(fpu)
+            }
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Serializes `kvm_fpu` and creates a new `VirtualProcessorState`.
+    ///
+    /// # Parameters
+    ///
+    /// - `regs`: General purpose registers.
+    /// - `sregs`: System registers (segment registers, control registers, etc.).
+    /// - `fpu`: FPU/SIMD state.
+    /// - `onlline`: Whether the processor is online.
+    /// - `exit_status`: Exit status code.
+    ///
+    /// # Returns
+    ///
+    /// A serializable representation of the virtual processor state.
+    ///
+    fn new(regs: kvm_regs, sregs: kvm_sregs, fpu: kvm_fpu, online: bool, exit_status: u16) -> Self {
+        Self {
+            regs,
+            sregs,
+            fpu: Self::serialize_fpu(&fpu),
+            online,
+            exit_status,
+        }
     }
 }

--- a/src/microvm/src/vmm/microvm/kvm/vmem.rs
+++ b/src/microvm/src/vmm/microvm/kvm/vmem.rs
@@ -16,10 +16,17 @@ use ::anyhow::Result;
 use ::arch::mem::PAGE_SIZE;
 use ::kvm_bindings::kvm_userspace_memory_region;
 use ::std::{
+    fs::File,
+    io::{
+        Read,
+        Write,
+    },
     mem,
+    path::PathBuf,
     ptr::{
         self,
     },
+    slice,
     sync::{
         Arc,
         Mutex,
@@ -45,13 +52,42 @@ pub struct VirtualMemory {
     /// Kernel location and size.
     kernel: Option<(u64, usize)>,
     /// Initial RAM disk location and size.
-    _initrd: Option<(u64, usize)>,
+    initrd: Option<(u64, usize)>,
     /// Control register used to inform the guest about the number of messages ready to be consumed.
     credits: u32,
 }
 
+///
+/// # Description
+///
+/// A structure that represents the header in virtual memory snapshot files.
+///
+#[repr(C)]
+struct SnapshotHeader {
+    /// Memory size (8 bytes): usize
+    memory_size: usize,
+    /// Kernel base (8 bytes): u64
+    kernel_base: u64,
+    /// Kernel size (8 bytes): usize
+    kernel_size: usize,
+    /// Initrd base (8 bytes): u64
+    initrd_base: u64,
+    /// Initrd size (8 bytes): usize
+    initrd_size: usize,
+    /// Credits (4 bytes): u32
+    credits: u32,
+    /// Padding (20 bytes): zeros
+    padding: [u8; 20],
+}
+
 unsafe impl Send for VirtualMemory {}
 unsafe impl Sync for VirtualMemory {}
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const SIZE_OF_HEADER: usize = mem::size_of::<SnapshotHeader>();
 
 //==================================================================================================
 // Implementations
@@ -102,7 +138,7 @@ impl VirtualMemory {
             ptr,
             size: memory_size,
             kernel: None,
-            _initrd: None,
+            initrd: None,
             credits: 0,
         };
 
@@ -198,7 +234,7 @@ impl VirtualMemory {
             initrd.size()
         };
 
-        self._initrd = Some((::config::microvm::DEFAULT_INITRD_BASE as u64, initrd_size));
+        self.initrd = Some((::config::microvm::DEFAULT_INITRD_BASE as u64, initrd_size));
 
         Ok((::config::microvm::DEFAULT_INITRD_BASE as u64, initrd_size))
     }
@@ -220,7 +256,7 @@ impl VirtualMemory {
         trace!("write_args(): {args}");
         let args_bytes: &[u8] = args.as_bytes();
 
-        let initrd_end: usize = match self._initrd {
+        let initrd_end: usize = match self.initrd {
             Some((initrd_base, initrd_size)) => initrd_base as usize + initrd_size,
             None => {
                 let reason: String = "initrd not loaded".to_string();
@@ -386,6 +422,116 @@ impl VirtualMemory {
 
         Ok(())
     }
+
+    ///
+    /// # Description
+    ///
+    /// Saves the current state of the virtual memory to a snapshot file.
+    /// The snapshot includes the memory contents and metadata about the kernel and initrd.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the snapshot file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn save_snapshot(&self, path: &PathBuf) -> Result<()> {
+        trace!("save_snapshot(): writing to {:?}", path);
+        crate::timer!("vmem_save_snapshot");
+
+        let mut file: File = File::create(path)
+            .map_err(|e| anyhow::anyhow!("failed to create snapshot file: {}", e))?;
+
+        // Kernel metadata (guaranteed to exist)
+        let (kernel_base, kernel_size) = self
+            .kernel
+            .ok_or_else(|| anyhow::anyhow!("kernel not loaded"))?;
+
+        // Initrd metadata (guaranteed to exist)
+        let (initrd_base, initrd_size) = self
+            .initrd
+            .ok_or_else(|| anyhow::anyhow!("initrd not loaded"))?;
+
+        let header = SnapshotHeader::new(
+            self.size,
+            kernel_base,
+            kernel_size,
+            initrd_base,
+            initrd_size,
+            self.credits,
+        );
+
+        file.write_all(header.as_bytes())
+            .map_err(|e| anyhow::anyhow!("failed to write header: {}", e))?;
+
+        // Write the actual memory contents
+        let memory_slice: &[u8] = unsafe { slice::from_raw_parts(self.ptr, self.size) };
+        file.write_all(memory_slice)
+            .map_err(|e| anyhow::anyhow!("failed to write memory contents: {}", e))?;
+
+        file.sync_all()
+            .map_err(|e| anyhow::anyhow!("failed to sync snapshot file: {}", e))?;
+
+        trace!("save_snapshot(): successfully saved snapshot to {:?}", path);
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Loads a virtual memory snapshot from a snapshot file.
+    /// This restores the memory contents and metadata.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the snapshot file.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn load_snapshot(&mut self, path: &PathBuf) -> Result<()> {
+        crate::timer!("vmem_load_snapshot");
+
+        if !path.exists() {
+            return Err(anyhow::anyhow!("snapshot file '{:?}' not found", path));
+        }
+
+        trace!("load_snapshot(): loading from {:?}", path);
+
+        let mut file: File =
+            File::open(path).map_err(|e| anyhow::anyhow!("failed to open snapshot file: {}", e))?;
+
+        // Read and parse header
+        let mut header_bytes: [u8; SIZE_OF_HEADER] = [0u8; SIZE_OF_HEADER];
+        file.read_exact(&mut header_bytes)
+            .map_err(|e| anyhow::anyhow!("failed to read snapshot header: {}", e))?;
+        let header: &SnapshotHeader = SnapshotHeader::from_bytes(&header_bytes);
+
+        // Ensure the snapshot has the same memory size as the virtual memory.
+        if header.memory_size != self.size {
+            return Err(anyhow::anyhow!(
+                "memory size mismatch: snapshot has {} bytes, current VM has {} bytes",
+                header.memory_size,
+                self.size
+            ));
+        }
+
+        // Read memory contents
+        let memory_slice: &mut [u8] = unsafe { slice::from_raw_parts_mut(self.ptr, self.size) };
+        file.read_exact(memory_slice)
+            .map_err(|e| anyhow::anyhow!("failed to read memory contents: {}", e))?;
+
+        // Restore metadata
+        self.credits = header.credits;
+        self.kernel = Some((header.kernel_base, header.kernel_size));
+        self.initrd = Some((header.initrd_base, header.initrd_size));
+
+        trace!("load_snapshot(): successfully loaded snapshot from {:?}", path);
+        Ok(())
+    }
 }
 
 impl Drop for VirtualMemory {
@@ -396,5 +542,54 @@ impl Drop for VirtualMemory {
                 error!("munmap() failed (ret={ret})");
             }
         }
+    }
+}
+
+impl SnapshotHeader {
+    fn new(
+        memory_size: usize,
+        kernel_base: u64,
+        kernel_size: usize,
+        initrd_base: u64,
+        initrd_size: usize,
+        credits: u32,
+    ) -> Self {
+        SnapshotHeader {
+            memory_size,
+            kernel_base,
+            kernel_size,
+            initrd_base,
+            initrd_size,
+            credits,
+            padding: [0u8; 20],
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Serializes the snapshot header (which has `repr(C)`) as a slice of bytes.
+    ///
+    /// # Returns
+    ///
+    /// A slice of bytes containing the snapshot header.
+    ///
+    fn as_bytes(&self) -> &[u8; SIZE_OF_HEADER] {
+        // SAFETY: The size of the slice is the same of the struct.
+        unsafe { &*(self as *const SnapshotHeader as *const [u8; SIZE_OF_HEADER]) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Casts a snapshot header slice to a struct.
+    ///
+    /// # Returns
+    ///
+    /// A struct with the slice of bytes' content.
+    ///
+    pub fn from_bytes(bytes: &[u8; SIZE_OF_HEADER]) -> &Self {
+        // SAFETY: We're casting exactly the length that we just read.
+        unsafe { &*(bytes.as_ptr() as *const SnapshotHeader) }
     }
 }

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -26,6 +26,7 @@ use crate::{
             VirtualProcessor,
             VirtualProcessorExitContext,
             VirtualProcessorExitReason,
+            VirtualProcessorState,
         },
         vmem::VirtualMemory,
     },
@@ -40,6 +41,11 @@ use ::libc::{
     sigemptyset,
 };
 use ::std::{
+    fs::File,
+    io::{
+        Read,
+        Write,
+    },
     sync::{
         Arc,
         Mutex,
@@ -51,6 +57,10 @@ use ::std::{
         },
     },
     time::Instant,
+};
+use std::path::{
+    Path,
+    PathBuf,
 };
 
 pub const INTERRUPT_SIGNAL: c_int = SIGUSR1;
@@ -479,5 +489,105 @@ impl MicroVm {
             .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
             .control_tx
             .send(VcpuControlResponse::Tid(tid))?)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Strips prefixes and suffixes from the executable filepath, and concatenates it with the
+    /// appropriate directory and extensions.
+    ///
+    /// # Parameters
+    ///
+    /// - `filepath`: Path to the executable file.
+    ///
+    /// # Returns
+    ///
+    /// Returns the filepath to the virtual memory snapshot and the kvm snapshot.
+    ///
+    fn make_snapshot_paths(filepath: &str) -> (PathBuf, PathBuf) {
+        let snapshots_dir: &Path = Path::new("snapshots");
+
+        // E.g.: `bin/hello-c.elf` -> (`hello-c.vmem`, `hello-c.kvm.json`)
+        let filename: &str = filepath
+            .strip_suffix(".elf")
+            .unwrap_or(filepath)
+            .strip_prefix("bin/")
+            .unwrap_or(filepath);
+        // NOTE: if a different prefix might occur, we must either:
+        // - Remove all prefixes (use just the file name);
+        // - Create subdirectories in the snapshot directory;
+        // - Replace the `/`s from the path and concatenate them all into the snapshot filename.
+        // Otherwise we'll get errors from writing to a directory that doesn't exist.
+
+        let vmem_filepath: PathBuf = snapshots_dir.join(format!("{}.vmem", filename));
+        let kvm_filepath: PathBuf = snapshots_dir.join(format!("{}.kvm.json", filename));
+        (vmem_filepath, kvm_filepath)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Saves the virtual memory and the KVM state to files.
+    ///
+    /// # Parameters
+    ///
+    /// - `filepath`: Path to the executable file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns empty. Otherwise, returns an error.
+    ///
+    pub fn create_snapshot(&self, filepath: &str) -> Result<()> {
+        let (vmem_filepath, kvm_filepath) = Self::make_snapshot_paths(filepath);
+
+        self.vmem
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .save_snapshot(&vmem_filepath)?;
+
+        let kvm_state: VirtualProcessorState = self
+            .vcpu
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .get_state()?;
+        // NOTE: json is not the ideal format for this. Perhaps use `bincode` instead?
+        let json: String = serde_json::to_string(&kvm_state)?;
+
+        let mut file: File = File::create(kvm_filepath)?;
+        file.write_all(json.as_bytes())?;
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Loads the virtual memory and the KVM state from files.
+    ///
+    /// # Parameters
+    ///
+    /// - `filepath`: Path to the executable file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns empty. Otherwise, returns an error.
+    ///
+    pub fn load_snapshot(&mut self, filepath: &str) -> Result<()> {
+        let (vmem_filepath, kvm_filepath) = Self::make_snapshot_paths(filepath);
+
+        self.vmem
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .load_snapshot(&vmem_filepath)?;
+
+        let mut file: File = File::open(kvm_filepath)?;
+        let mut contents: String = String::new();
+        file.read_to_string(&mut contents)?;
+        let state: VirtualProcessorState = serde_json::from_str(&contents)?;
+        self.vcpu
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .set_state(state)
     }
 }

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -220,6 +220,10 @@ impl Vmm {
             },
         }
 
+        let create_snapshot_clone: MicroVm = microvm.clone();
+        let mut load_snapshot_clone: MicroVm = microvm.clone();
+        let filename: String = initrd_filename.unwrap_or("bin/default.elf".to_string());
+        let filename_clone: String = filename.clone();
         let orchestrator = Orchestrator::new(
             io_control_rx,
             io_control_tx,
@@ -245,7 +249,8 @@ impl Vmm {
                         &::config::microvm::RUNNING.to_le_bytes(),
                     )
             }),
-            Box::new(|| Ok(())), // TODO: create_snapshot https://github.com/nanvix/nanvix/issues/947
+            Box::new(move || create_snapshot_clone.create_snapshot(&filename_clone)),
+            Box::new(move || load_snapshot_clone.load_snapshot(&filename)),
         );
 
         let mut vmm: Vmm = Self {


### PR DESCRIPTION
# Overview

The `Vmm` passes callback funtions to the `Orchestrator` so it calls them to create or load snapshots when it needs to. These closures are implemented by the `MicroVm`, which uses both the `VirtualProcessor` and the `VirtualMemory` to gather state and persist it, or reads from files and writes to those fields.

# Details

- How to name the snapshots? For now, I just name them by the executable name and the `.vmem` and `.kvm.json` extensions, and put them in a `snapshots` directory in the repository's root;
- On the subject of naming, `make_snapshot_paths` might need to be changed based on that;
- `kvm_fpu` does not support serialization through `serde`, so I implemented serialization and deserialization manually;
- I created a custom header for the virtual memory snapshot file. It needs to be improved upon;
- I'm not sure whether loading a snapshot to a `MicroVm` with a larger memory size should be an error;
- I used `serde-json` for serializing the vCPU. This is fine for a PoC, but should be changed for production, I think.

Closes https://github.com/nanvix/nanvix/issues/947 and https://github.com/nanvix/nanvix/issues/948.