### PR TITLE
[daemons] Fix Race Condition When Connecting To Gateway

### DIFF
--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -58,22 +58,6 @@ wait_for_tcp_socket() {
     print_error "Timed-out waiting for TCP socket to be ready at $host:$port"
 }
 
-wait_for_unix_socket() {
-    local path="$1"
-
-    print_info "Waiting for UNIX socket at ${path}..."
-    for i in $(seq 1 $MAX_TRIALS); do
-        if [ -S "${path}" ]; then
-            print_info "UNIX socket available after $(echo "${i} * ${SLEEP_INTERVAL}" | bc -l) ms."
-            return
-        fi
-
-        sleep ${SLEEP_INTERVAL}
-    done
-
-    print_error "Timed-out waiting for UNIX socket at ${path}"
-}
-
 #===================================================================================================
 # Test execution
 #===================================================================================================
@@ -145,7 +129,6 @@ print_info "VM ID: ${VM_ID}"
 print_info "Gateway Socket Address: ${GATEWAY_SOCKADDR}"
 
 # Get output by writing to the gateway socket address.
-wait_for_unix_socket "${GATEWAY_SOCKADDR}"
 PROGRAM_ACTUAL_OUTPUT=$(echo "${PROGRAM_INPUT}" | nc -U -q 0 "${GATEWAY_SOCKADDR}" | tr -d '\0')
 
 # Save program output to a log file.

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -243,6 +243,10 @@ impl LinuxDaemon {
                                 return Err(Self::log_and_error(ErrorCode::IoErr, reason));
                             },
                         };
+                    trace!(
+                        "linuxd started gateway listener for user VM (vm_id={user_vm_id}, \
+                         addr={gateway_sockaddr})"
+                    );
 
                     // Accept one connection. We use an ephemeral poll, but this step will become
                     // unnecessary when we introduce support for lazily accepting a gateway
@@ -263,6 +267,25 @@ impl LinuxDaemon {
                                 "failed to register gateway listener to poll",
                             )
                         })?;
+
+                    // Accept a connection once from nanvixd, and discard it. This lets nanvixd
+                    // know, reliably, that the gateway is ready to accept connections and it can
+                    // return its address to users without risk of race conditions.
+                    gateway_listener
+                        .accept_timeout(
+                            &mut gateway_poll,
+                            Duration::from_secs(config::syscomm::ACCEPT_TIMEOUT_SECS),
+                        )
+                        .map_err(|_| {
+                            Self::log_and_error(
+                                ErrorCode::IoErr,
+                                "error accepting throw-away gateway connection from nanvixd",
+                            )
+                        })?;
+                    trace!("linuxd accepted throw-away gateway connection from nanvixd");
+
+                    // Now accept the real gateway connection. Once we move to lazily initialized
+                    // connection, the next bit of logic will be moved elsewhere.
                     let gateway_stream: Option<SocketStream> = Some(
                         gateway_listener
                             .accept_timeout(

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -79,6 +79,14 @@ pub mod syscomm {
     /// These races should be in the order of milliseconds.
     ///
     pub const ACCEPT_TIMEOUT_SECS: u64 = 1;
+
+    ///
+    /// # Description
+    ///
+    /// Provides the timeout we should use when connecting to a socket. This timeout is used
+    /// instead of manually retrying in a loop.
+    ///
+    pub const CONNECT_TIMEOUT_SECS: u64 = 2;
 }
 
 //==================================================================================================

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -36,6 +36,7 @@ use ::std::{
         Read,
         Write,
     },
+    thread,
     time::{
         Duration,
         Instant,
@@ -48,6 +49,11 @@ use ::std::{
 
 /// Blocking sockets use a per-socket poll structure with only one entry with this token.
 const BLOCKING_THREAD_TOKEN: Token = Token(0);
+
+/// When connecting to a socket stream with a timeout, we may need to sleep for a bit until the
+/// socket is in a state that we can poll on. This happens at the very beginning, and may be in the
+/// critical path, so we want to sleep for very little.
+const CONNECT_TIMEOUT_SLEEP_MICROS: u64 = 250;
 
 //==================================================================================================
 // Imports
@@ -235,6 +241,171 @@ impl SocketStream {
                 let stream: UnixStream = UnixStream::connect(addr)?;
                 Ok(SocketStream::Unix(stream))
             },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Helper method to work out if a connect error is transient (i.e. benign) or it indicates a
+    /// real issue.
+    ///
+    /// # Arguments
+    ///
+    /// - `typ`: type of socket we are using.
+    /// - `e`: error as returned by `connect`.
+    ///
+    /// # Returns
+    ///
+    /// A boolean indicating whether the error is transient or not.
+    ///
+    fn is_transient_connect_err(typ: SocketType, e: &io::Error) -> bool {
+        use io::ErrorKind::*;
+        match typ {
+            SocketType::Unix => match e.kind() {
+                NotFound                // socket path not created yet (ENOENT).
+                | ConnectionRefused     // file exists but no listener (stale/unlinked).
+                | PermissionDenied      // can be transient due to races with chmod/chown.
+                => true,
+                _ => false,
+            },
+            SocketType::Tcp => match e.kind() {
+                ConnectionRefused      // listener not up yet.
+                | AddrNotAvailable     // iface not ready yet.
+                | NetworkUnreachable   // routing/bridge not ready yet.
+                | HostUnreachable      // L2/L3 not ready yet.
+                | TimedOut             // may be reported immediately.
+                => true,
+                _ => false,
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Connect to a socket and wait for it to be writable with a timeout.
+    ///
+    /// # Arguments
+    ///
+    /// - `typ`: Type of socket.
+    /// - `addr`: Socket address.
+    /// - `timeout`: Timeout to wait for the socket to be ready.
+    ///
+    /// # Returns
+    ///
+    /// The connected, and ready, socket stream or an error if timed-out.
+    ///
+    pub fn connect_timeout(
+        typ: SocketType,
+        addr: String,
+        timeout: Duration,
+    ) -> Result<SocketStream, SocketError> {
+        let deadline: Instant = Instant::now() + timeout;
+
+        // Connect to the socket and guard against transient errors where the socket may not be
+        // ready yet. Note that a successful connect does not mean that the socket is ready to be
+        // written-to or read-from.
+        let mut stream: SocketStream = loop {
+            match SocketStream::connect(typ, addr.clone()) {
+                Ok(stream) => {
+                    break stream;
+                },
+                Err(e) => {
+                    if !Self::is_transient_connect_err(typ, &e) {
+                        let reason: String =
+                            format!("error connecting to socket (addr={addr}, error={e:?})");
+                        error!("{reason}");
+                        return Err(io::Error::other(reason).into());
+                    }
+
+                    // Transient error, wait for a short amount of time. We cannot wait on a poll
+                    // as we don't even have a socket stream.
+                    if Instant::now() >= deadline {
+                        let reason: String =
+                            format!("timed-out calling connect (addr={addr}, error={e:?})");
+                        error!("{reason}");
+                        return Err(io::Error::new(ErrorKind::TimedOut, reason).into());
+                    }
+
+                    thread::sleep(Duration::from_micros(CONNECT_TIMEOUT_SLEEP_MICROS));
+
+                    continue;
+                },
+            }
+        };
+
+        // Register the socket for WRITABLE state, which indicates that CONNECT has completed
+        // successfully.
+        let mut poll: Poll = Poll::new().map_err(|e| {
+            let reason: String = format!("failed to create new poll (error={e:?})");
+            error!("{reason}");
+            SocketError {
+                error: io::Error::other(reason),
+            }
+        })?;
+        {
+            match &mut stream {
+                SocketStream::Tcp(s) => {
+                    poll.registry()
+                        .register(s, BLOCKING_THREAD_TOKEN, Interest::WRITABLE)?
+                },
+                SocketStream::Unix(s) => {
+                    poll.registry()
+                        .register(s, BLOCKING_THREAD_TOKEN, Interest::WRITABLE)?
+                },
+            }
+        }
+
+        let mut events: Events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+        loop {
+            let now: Instant = Instant::now();
+            if now >= deadline {
+                // Timed-out. Cleanup registration before returning.
+                let _ = match &mut stream {
+                    SocketStream::Tcp(s) => poll.registry().deregister(s),
+                    SocketStream::Unix(s) => poll.registry().deregister(s),
+                };
+
+                let reason: String = "connect timed-out waiting for completion".to_string();
+                error!("{reason}");
+                return Err(io::Error::new(ErrorKind::TimedOut, reason).into());
+            }
+
+            events.clear();
+            poll.poll(&mut events, Some(deadline - now))?;
+
+            // If anything became writable, check SO_ERROR to learn the result.
+            if !events.is_empty() {
+                let res: Option<io::Error> = match &stream {
+                    SocketStream::Tcp(s) => s.take_error()?,
+                    SocketStream::Unix(s) => s.take_error()?,
+                };
+                match res {
+                    None => {
+                        // Success.
+                        match &mut stream {
+                            SocketStream::Tcp(s) => poll.registry().deregister(s)?,
+                            SocketStream::Unix(s) => poll.registry().deregister(s)?,
+                        }
+                        return Ok(stream);
+                    },
+                    Some(e) => {
+                        // Error from connect.
+                        let _ = match &mut stream {
+                            SocketStream::Tcp(s) => poll.registry().deregister(s),
+                            SocketStream::Unix(s) => poll.registry().deregister(s),
+                        };
+
+                        let reason: String =
+                            format!("error connecting to stream with timeout (error={e:?})");
+                        error!("{reason}");
+
+                        return Err(io::Error::other(reason).into());
+                    },
+                }
+            }
+            // Otherwise loop until deadline.
         }
     }
 

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -39,7 +39,6 @@ use ::microvm::{
 use ::std::{
     convert::TryInto,
     env,
-    io::ErrorKind,
     process::ExitCode,
     str::FromStr,
     time::Duration,
@@ -55,9 +54,6 @@ use ::user_vm_api::NewUserVm;
 // Constants
 //==================================================================================================
 
-/// Time-out to back-off when linuxd is not ready to accept our connection. This situation is rare
-/// so we can tolerate a sleep, but the sleep needs to be short as it will affect boot time.
-const CONNECT_TIMEOUT_SLEEP_MS: u64 = 1;
 /// Default socket bind type.
 const DEFAULT_SYSTEM_VM_SOCKET_TYPE: SocketType = SocketType::Unix;
 const DEFAULT_CONTROL_PLANE_SOCKET_TYPE: SocketType = SocketType::Unix;
@@ -92,8 +88,12 @@ fn main() -> Result<ExitCode> {
     logging::initialize(args.log_to_file());
 
     let gateway: Option<Gateway> = match &system_vm_addr {
-        Some(addr) => loop {
-            match SocketStream::connect(system_vm_socket_type, addr.clone()) {
+        Some(addr) => {
+            match SocketStream::connect_timeout(
+                system_vm_socket_type,
+                addr.clone(),
+                Duration::from_secs(config::syscomm::CONNECT_TIMEOUT_SECS),
+            ) {
                 Ok(stream) => {
                     let gateway_socket_type: SocketType = match args.gateway_socket_type() {
                         Some(socket_type) => socket_type,
@@ -108,7 +108,7 @@ fn main() -> Result<ExitCode> {
                         );
                         new_msg.send(&mut blocking_stream)?;
 
-                        break Some(Gateway::new(blocking_stream.set_nonblocking()?));
+                        Some(Gateway::new(blocking_stream.set_nonblocking()?))
                     } else {
                         let reason: String = "configured user VM with system VM but without \
                                               gateway address"
@@ -116,17 +116,6 @@ fn main() -> Result<ExitCode> {
                         error!("main() {reason}");
                         anyhow::bail!(reason);
                     }
-                },
-                // The micro VM is trying to connect before the system VM's listener socket is
-                // responsive.
-                Err(ref e) if e.kind() == ErrorKind::NotFound => {
-                    std::thread::sleep(Duration::from_millis(CONNECT_TIMEOUT_SLEEP_MS));
-                    continue;
-                },
-                // The micro VM is trying to connect to a socket that is not yet bound.
-                Err(ref e) if e.kind() == ErrorKind::ConnectionRefused => {
-                    std::thread::sleep(Duration::from_millis(CONNECT_TIMEOUT_SLEEP_MS));
-                    continue;
                 },
                 Err(e) => {
                     let reason: String = format!(

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -24,7 +24,6 @@ use ::log::{
 use ::mio::Poll;
 use ::std::{
     process::Stdio,
-    thread,
     time::Duration,
 };
 use ::syscomm::{
@@ -37,13 +36,6 @@ use ::tokio::process::{
     Child,
     Command,
 };
-
-/// When deploying linuxd from a snapshot of an L2 VM, a few operations require polling. We want to
-/// avoid nanvixd looping forever as it is a critical piece in the control-plane, so we set a
-/// maximum number of retires.
-const MAX_NUM_RETRIES: u32 = 1000;
-/// Period to sleep between retries.
-const BACKOFF_SLEEP_MS: u32 = 1;
 
 /// Single-byte that we send to unlock a linuxd instance restored from a snapshot. Anything that
 /// triggers a readable event in the receiving socket should work.
@@ -78,23 +70,17 @@ impl LinuxDaemon {
             "\r\n",
         );
 
-        let mut retries: u32 = 0;
-        let mut clh_api_socket: BlockingSocketStream = loop {
-            if retries >= MAX_NUM_RETRIES {
-                let reason: &str = "timed-out connecting to CLH API socket";
+        let mut clh_api_socket: BlockingSocketStream = match SocketStream::connect_timeout(
+            SocketType::Unix,
+            clh_api_socket_path.clone(),
+            Duration::from_secs(config::syscomm::CONNECT_TIMEOUT_SECS),
+        ) {
+            Ok(stream) => stream.set_blocking()?,
+            Err(e) => {
+                let reason: String = format!("error connecting to CLH API socket (error={e:?})");
                 error!("{reason}");
                 return Err(anyhow::anyhow!(reason));
-            }
-
-            match SocketStream::connect(SocketType::Unix, clh_api_socket_path.clone()) {
-                Ok(stream) => {
-                    break stream.set_blocking()?;
-                },
-                Err(_) => {
-                    thread::sleep(Duration::from_millis(BACKOFF_SLEEP_MS.into()));
-                    retries += 1;
-                },
-            }
+            },
         };
 
         // Write HTTP request.

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -22,6 +22,7 @@ use ::std::{
 use ::syscomm::{
     SocketListener,
     SocketStream,
+    SocketType,
 };
 use ::tokio::process::{
     Child,
@@ -142,6 +143,24 @@ impl Microvm {
             },
         };
         debug!("nanvixd received connection from the user VM's control-plane socket");
+
+        // Before returning, we must make sure that the gateway listener socket in linuxd is ready
+        // to accept connections. The way we do so, is by actually connecting once to it, and
+        // ignoring the resulting stream.
+        let socket_type: SocketType = if sandbox_config.l2() {
+            SocketType::Tcp
+        } else {
+            SocketType::Unix
+        };
+        let _ = SocketStream::connect_timeout(
+            socket_type,
+            sandbox_config.gateway_sockaddr().to_string(),
+            Duration::from_secs(config::syscomm::CONNECT_TIMEOUT_SECS),
+        )?;
+        debug!(
+            "nanvixd established throw-away gateway connection (addr={})",
+            sandbox_config.gateway_sockaddr()
+        );
 
         Ok(Self {
             child: Some(child),

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -152,11 +152,19 @@ impl Microvm {
         } else {
             SocketType::Unix
         };
-        let _ = SocketStream::connect_timeout(
+        SocketStream::connect_timeout(
             socket_type,
             sandbox_config.gateway_sockaddr().to_string(),
             Duration::from_secs(config::syscomm::CONNECT_TIMEOUT_SECS),
-        )?;
+        )
+        .map_err(|e| {
+            let reason: String = format!(
+                "error establishing throw-away connection to gateway socket (addr={}, error={e:?})",
+                sandbox_config.gateway_sockaddr()
+            );
+            error!("{reason}");
+            anyhow::anyhow!(reason)
+        })?;
         debug!(
             "nanvixd established throw-away gateway connection (addr={})",
             sandbox_config.gateway_sockaddr()


### PR DESCRIPTION
In this PR I address a race condition that happened when we tried to connect to a user VM's gateway before the gateway listener socket was ready to accept connections.

The origin of this race condition is that, in order to optimize for cold-starts, we wanted to avoid any synchronization between linuxd and nanvixd when spawning a user VM. However, it started happening more and more often, so in this PR I introduce a minimal synchronization step that should address these races altogether.

In particular, _after_ spawning a new user VM, `nanvixd` will try to connect to the gateway for that user VM. `linuxd` is aware of this, and, after starting the listener socket, will accept (and discard) a connection into the gateway. Only after this connection has been established (and discarded from both ends) will `nanvixd` return the user VM id and gateway socket address to the client.

To simplify the implementation of this fix, I also add a helper `connect_timeout` method to the syscomm library that was long overdue.

This additional synchronization step will, unfortunately, affect cold-start times, but it should not be too much.