### PR TITLE
[lib] Dummy System Call Implementations

### DIFF
--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -16,6 +16,7 @@ pub mod pthread_cond_init;
 pub mod pthread_cond_signal;
 pub mod pthread_cond_timedwait;
 pub mod pthread_cond_wait;
+pub mod pthread_condattr_init;
 pub mod pthread_condattr_setclock;
 pub mod pthread_create;
 pub mod pthread_getattr_np;

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -16,6 +16,7 @@ pub mod pthread_cond_init;
 pub mod pthread_cond_signal;
 pub mod pthread_cond_timedwait;
 pub mod pthread_cond_wait;
+pub mod pthread_condattr_setclock;
 pub mod pthread_create;
 pub mod pthread_getattr_np;
 pub mod pthread_getschedparam;

--- a/src/libs/syscall/src/pthread/bindings/mod.rs
+++ b/src/libs/syscall/src/pthread/bindings/mod.rs
@@ -5,6 +5,7 @@
 // Modules
 //==================================================================================================
 
+pub mod pthread_atfork;
 pub mod pthread_attr_destroy;
 pub mod pthread_attr_getstack;
 pub mod pthread_attr_init;

--- a/src/libs/syscall/src/pthread/bindings/pthread_atfork.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_atfork.rs
@@ -1,0 +1,29 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::ErrorCode;
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// TODO: add description
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_atfork(
+    prepare: Option<extern "C" fn()>,
+    parent: Option<extern "C" fn()>,
+    child: Option<extern "C" fn()>,
+) -> c_int {
+    // TODO: https://github.com/nanvix/nanvix/issues/483
+    ::syslog::warn!(
+        "pthread_atfork(): not implemented (prepare={prepare:?}, parent={parent:?}, \
+         child={child:?})"
+    );
+    ErrorCode::InvalidSysCall.get()
+}

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_init.rs
@@ -1,0 +1,67 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::pthread_condattr_t,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Initializes a condition variable attributes object with default values.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the condition variable attributes object to initialize.
+///
+/// # Return Value
+///
+/// On success, returns 0. Otherwise, returns an error code.
+///
+/// # Notes
+///
+/// This is a dummy implementation. It only validates the input pointer and then returns success.
+/// A full implementation should set default values and mark the object as initialized.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers.
+/// It is safe to call this function iff `attr` points to writable memory large enough to hold a
+/// `pthread_condattr_t` structure and is properly aligned.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_condattr_init(attr: *mut pthread_condattr_t) -> c_int {
+    ::syslog::trace!("pthread_condattr_init(): attr={attr:p}");
+
+    // Check if pointer to cond attribute object is valid.
+    if attr.is_null() {
+        ::syslog::error!(
+            "pthread_condattr_init(): invalid pointer to cond attribute object (attr={attr:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Check if pointer to cond attribute object is properly aligned.
+    if (attr as usize) % ::core::mem::align_of::<pthread_condattr_t>() != 0 {
+        ::syslog::error!(
+            "pthread_condattr_init(): misaligned pointer to cond attribute object (attr={attr:p})"
+        );
+        return ErrorCode::InvalidArgument.get();
+    }
+
+    // Dummy initialization: write default structure.
+    ::core::ptr::write(attr, pthread_condattr_t::default());
+    ::syslog::warn!("pthread_condattr_init(): dummy implementation (attr={attr:p})");
+
+    0
+}

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_setclock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_setclock.rs
@@ -1,0 +1,52 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::ErrorCode;
+use ::sysapi::{
+    ffi::c_int,
+    sys_types::{
+        clockid_t,
+        pthread_condattr_t,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sets the clock attribute in a condition variable attributes object.
+///
+/// # Parameters
+///
+/// - `attr`: Pointer to the condition variable attributes object.
+/// - `clock_id`: The clock identifier to set.
+///
+/// # Returns
+///
+/// Upon successful completion, returns 0. Otherwise, returns an error number.
+///
+/// # Safety
+///
+/// This function is unsafe because it may dereference raw pointers.
+///
+/// It is safe to call this function if and only if:
+/// - `attr` is a valid pointer to a `pthread_condattr_t` object.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_condattr_setclock(
+    attr: *mut pthread_condattr_t,
+    clock_id: clockid_t,
+) -> c_int {
+    // TODO (#500): implement pthread_condattr_setclock
+    ::syslog::warn!(
+        "pthread_condattr_setclock(): not implemented (attr={attr:?}, clock_id={clock_id:?})"
+    );
+    ErrorCode::InvalidSysCall.get()
+}


### PR DESCRIPTION
# Description

This PR a dummy implementation for the following system calls:
- `pthread_condattr_setclock()`
- `pthread_atfork()`

This PR is a workaround for the following issues:
- https://github.com/nanvix/nanvix/issues/500
- https://github.com/nanvix/nanvix/issues/483