### PR TITLE
[microvm] Create MicroVM memory snapshot

### DIFF
--- a/src/microvm/Cargo.toml
+++ b/src/microvm/Cargo.toml
@@ -26,13 +26,16 @@ flexi_logger = { workspace = true }
 hyperlight-host = { workspace = true, optional = true }
 log = { workspace = true }
 profiler = { workspace = true, features = ["auto-calibrate"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+static_assert = { workspace = true }
 sys = { workspace = true }
 syscall = { workspace = true }
 syscomm = { workspace = true }
 user-vm-api = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-kvm-bindings = { workspace = true }
+kvm-bindings = { workspace = true, features = ["serde"] }
 kvm-ioctls = { workspace = true }
 libc = { workspace = true }
 

--- a/src/microvm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/microvm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -13,6 +13,14 @@ mod timer;
 // Exports
 //==================================================================================================
 
+pub use exit::*;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::vmm::microvm::kvm::partition::VirtualPartition;
+use ::anyhow::Result;
 use ::arch::cpu::{
     cpuid::{
         CPUID_FEATURES,
@@ -30,22 +38,16 @@ use ::kvm_bindings::{
     CpuId,
     KVM_MAX_CPUID_ENTRIES,
     kvm_fpu,
-};
-pub use exit::*;
-
-//==================================================================================================
-// Imports
-//==================================================================================================
-
-use crate::vmm::microvm::kvm::partition::VirtualPartition;
-use ::anyhow::Result;
-use ::kvm_bindings::{
     kvm_regs,
     kvm_sregs,
 };
 use ::kvm_ioctls::{
     VcpuExit,
     VcpuFd,
+};
+use ::serde::{
+    Deserialize,
+    Serialize,
 };
 use ::std::sync::{
     Arc,
@@ -85,6 +87,16 @@ pub struct VirtualProcessor {
     online: bool,
     /// Exit status code.
     exit_status: u16,
+}
+
+///
+/// # Description
+///
+/// Virtual CPU state that can be serialized and saved to disk.
+///
+#[derive(Serialize, Deserialize)]
+pub struct VirtualProcessorState {
+    // TODO: fill struct with relevant state https://github.com/nanvix/nanvix/issues/947
 }
 
 impl VirtualProcessor {
@@ -379,6 +391,39 @@ impl VirtualProcessor {
             return Err(anyhow::anyhow!(reason));
         }
 
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Captures the current state of the virtual processor.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, returns the current processor state that can be serialized and
+    /// saved to a file. Otherwise, returns an error.
+    ///
+    pub fn get_state(&self) -> Result<VirtualProcessorState> {
+        // TODO: get virtual processor state https://github.com/nanvix/nanvix/issues/947
+        Ok(VirtualProcessorState {})
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Restores the virtual processor to a previously saved state.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: Processor state to restore.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, returns empty. Otherwise, returns an error.
+    ///
+    pub fn _set_state(&mut self, _state: VirtualProcessorState) -> Result<()> {
+        // TODO: set virtual processor state https://github.com/nanvix/nanvix/issues/948
         Ok(())
     }
 }

--- a/src/microvm/src/vmm/microvm/kvm/vmem.rs
+++ b/src/microvm/src/vmm/microvm/kvm/vmem.rs
@@ -16,10 +16,14 @@ use ::anyhow::Result;
 use ::arch::mem::PAGE_SIZE;
 use ::kvm_bindings::kvm_userspace_memory_region;
 use ::std::{
+    fs::File,
+    io::Write,
     mem,
+    path::Path,
     ptr::{
         self,
     },
+    slice,
     sync::{
         Arc,
         Mutex,
@@ -45,13 +49,46 @@ pub struct VirtualMemory {
     /// Kernel location and size.
     kernel: Option<(u64, usize)>,
     /// Initial RAM disk location and size.
-    _initrd: Option<(u64, usize)>,
+    initrd: Option<(u64, usize)>,
     /// Control register used to inform the guest about the number of messages ready to be consumed.
     credits: u32,
 }
 
+///
+/// # Description
+///
+/// A structure that represents the header in virtual memory snapshot files.
+///
+#[repr(C)]
+struct SnapshotHeader {
+    /// Memory size (8 bytes): usize
+    memory_size: usize,
+    /// Kernel base (8 bytes): u64
+    kernel_base: u64,
+    /// Kernel size (8 bytes): usize
+    kernel_size: usize,
+    /// Initrd base (8 bytes): u64
+    initrd_base: u64,
+    /// Initrd size (8 bytes): usize
+    initrd_size: usize,
+    /// Credits (4 bytes): u32
+    credits: u32,
+    /// Padding (SNAPSHOT_HEADER_PADDING bytes): zeros
+    padding: [u8; Self::SNAPSHOT_HEADER_PADDING],
+}
+
 unsafe impl Send for VirtualMemory {}
 unsafe impl Sync for VirtualMemory {}
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const SIZE_OF_HEADER: usize = mem::size_of::<SnapshotHeader>();
+// The virtual memory contents come right after the header. If the header is 64-byte aligned, then
+// the contents of the virtual memory inside the snapshot file are 64-byte aligned. Reading the
+// snapshot file leads to 64-byte aligned data.
+static_assert::assert_eq_size!(SnapshotHeader, 64);
 
 //==================================================================================================
 // Implementations
@@ -102,7 +139,7 @@ impl VirtualMemory {
             ptr,
             size: memory_size,
             kernel: None,
-            _initrd: None,
+            initrd: None,
             credits: 0,
         };
 
@@ -198,7 +235,7 @@ impl VirtualMemory {
             initrd.size()
         };
 
-        self._initrd = Some((::config::microvm::DEFAULT_INITRD_BASE as u64, initrd_size));
+        self.initrd = Some((::config::microvm::DEFAULT_INITRD_BASE as u64, initrd_size));
 
         Ok((::config::microvm::DEFAULT_INITRD_BASE as u64, initrd_size))
     }
@@ -220,7 +257,7 @@ impl VirtualMemory {
         trace!("write_args(): {args}");
         let args_bytes: &[u8] = args.as_bytes();
 
-        let initrd_end: usize = match self._initrd {
+        let initrd_end: usize = match self.initrd {
             Some((initrd_base, initrd_size)) => initrd_base as usize + initrd_size,
             None => {
                 let reason: String = "initrd not loaded".to_string();
@@ -386,6 +423,96 @@ impl VirtualMemory {
 
         Ok(())
     }
+
+    ///
+    /// # Description
+    ///
+    /// Saves the current state of the virtual memory to a snapshot file.
+    /// The snapshot includes the memory contents and metadata about the kernel and initrd.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the snapshot file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn save_snapshot(&self, path: &Path) -> Result<()> {
+        trace!("save_snapshot(): writing to {:?}", path);
+        crate::timer!("vmem_save_snapshot");
+
+        let mut file: File = match File::create(path) {
+            Ok(f) => f,
+            Err(e) => {
+                let reason: String =
+                    format!("failed creating virtual memory snapshot file (error={e:?})");
+                error!("save_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Kernel metadata (guaranteed to exist)
+        let (kernel_base, kernel_size) = match self.kernel {
+            Some((base, size)) => (base, size),
+            None => {
+                let reason: &str = "kernel not loaded";
+                error!("save_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Initrd metadata (guaranteed to exist)
+        let (initrd_base, initrd_size) = match self.initrd {
+            Some((base, size)) => (base, size),
+            None => {
+                let reason: &str = "initrd not loaded";
+                error!("save_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let header = SnapshotHeader::new(
+            self.size,
+            kernel_base,
+            kernel_size,
+            initrd_base,
+            initrd_size,
+            self.credits,
+        );
+
+        if let Err(e) = file.write_all(header.as_bytes()) {
+            let reason: String =
+                format!("failed writing the header to virtual memory snapshot file (error={e:?})");
+            error!("save_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        // Check alignment. Due to `mmap()` allocation, this should be PAGE_SIZE.
+        if self.ptr as usize % PAGE_SIZE != 0 {
+            let reason: &str = "memory pointer is not aligned to page size";
+            error!("save_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+        // SAFETY: The pointer points to the virtual memory, which is `self.size` bytes long. We've
+        // just checked alignment.
+        let memory_slice: &[u8] = unsafe { slice::from_raw_parts(self.ptr, self.size) };
+        // Write the actual memory contents.
+        if let Err(e) = file.write_all(memory_slice) {
+            let reason: String = format!("failed to write memory contents (error={e:?})");
+            error!("save_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        if let Err(e) = file.sync_all() {
+            let reason: String = format!("failed to sync snapshot file (error={e:?})");
+            error!("save_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        trace!("save_snapshot(): successfully saved snapshot to {:?}", path);
+        Ok(())
+    }
 }
 
 impl Drop for VirtualMemory {
@@ -396,5 +523,45 @@ impl Drop for VirtualMemory {
                 error!("munmap() failed (ret={ret})");
             }
         }
+    }
+}
+
+impl SnapshotHeader {
+    /// Padding for alignment. This makes the memory contents of the snapshot also aligned.
+    /// Adds up to 64 bytes.
+    const SNAPSHOT_HEADER_PADDING: usize = 20;
+
+    fn new(
+        memory_size: usize,
+        kernel_base: u64,
+        kernel_size: usize,
+        initrd_base: u64,
+        initrd_size: usize,
+        credits: u32,
+    ) -> Self {
+        SnapshotHeader {
+            memory_size,
+            kernel_base,
+            kernel_size,
+            initrd_base,
+            initrd_size,
+            credits,
+            padding: [0u8; Self::SNAPSHOT_HEADER_PADDING],
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Serializes the snapshot header (which has `repr(C)`) as a slice of bytes.
+    ///
+    /// # Returns
+    ///
+    /// A slice of bytes containing the snapshot header.
+    ///
+    fn as_bytes(&self) -> &[u8; SIZE_OF_HEADER] {
+        // SAFETY: Size and alignment are guaranteed by being a `SnapshotHeader` method.
+        // The struct has #[repr(C)].
+        unsafe { mem::transmute::<&SnapshotHeader, &[u8; SIZE_OF_HEADER]>(self) }
     }
 }

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -40,6 +40,13 @@ use ::libc::{
     sigemptyset,
 };
 use ::std::{
+    ffi::OsStr,
+    fs::File,
+    io::Write,
+    path::{
+        Path,
+        PathBuf,
+    },
     sync::{
         Arc,
         Mutex,
@@ -479,5 +486,79 @@ impl MicroVm {
             .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
             .control_tx
             .send(VcpuControlResponse::Tid(tid))?)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Strips prefixes and suffixes from the executable filepath, and concatenates it with the
+    /// appropriate directory and extensions.
+    ///
+    /// # Parameters
+    ///
+    /// - `filepath`: Path to the executable file.
+    ///
+    /// # Returns
+    ///
+    /// Returns the filepath to the virtual memory snapshot and the kvm snapshot.
+    ///
+    fn make_snapshot_paths(filepath: &str) -> (PathBuf, PathBuf) {
+        let snapshots_dir: &Path = Path::new("snapshots");
+
+        let stem: &OsStr = Path::new(filepath)
+            .file_stem()
+            .unwrap_or(OsStr::new("default"));
+
+        let vmem_filepath: PathBuf = snapshots_dir.join(stem).with_extension("vmem");
+        let kvm_filepath: PathBuf = snapshots_dir.join(stem).with_extension("kvm.json");
+        (vmem_filepath, kvm_filepath)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Saves the virtual memory and the KVM state to files.
+    ///
+    /// # Parameters
+    ///
+    /// - `filepath`: Path to the executable file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns empty. Otherwise, returns an error.
+    ///
+    pub fn create_snapshot(&self, filepath: &str) -> Result<()> {
+        let (vmem_filepath, kvm_filepath) = Self::make_snapshot_paths(filepath);
+
+        if let Err(e) = self
+            .vmem
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .save_snapshot(&vmem_filepath)
+        {
+            let reason: String = format!("failed creating virtual memory snapshot (error={e:?})");
+            error!("create_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        match self
+            .vcpu
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .get_state()
+        {
+            Ok(kvm_state) => {
+                // NOTE: json is not the ideal format for this. Perhaps use `bincode` instead?
+                let json: String = serde_json::to_string(&kvm_state)?;
+                let mut file: File = File::create(kvm_filepath)?;
+                file.write_all(json.as_bytes())?;
+                Ok(())
+            },
+            Err(e) => {
+                let reason: String = format!("failed getting vcpu state (error={e:?})");
+                error!("create_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        }
     }
 }

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -220,6 +220,8 @@ impl Vmm {
             },
         }
 
+        let create_snapshot_clone: MicroVm = microvm.clone();
+        let filename: String = initrd_filename.unwrap_or("bin/default.elf".to_string());
         let orchestrator = Orchestrator::new(
             io_control_rx,
             io_control_tx,
@@ -245,7 +247,8 @@ impl Vmm {
                         &::config::microvm::RUNNING.to_le_bytes(),
                     )
             }),
-            Box::new(|| Ok(())), // TODO: create_snapshot https://github.com/nanvix/nanvix/issues/947
+            Box::new(move || create_snapshot_clone.create_snapshot(&filename)),
+            // TODO: load_snapshot https://github.com/nanvix/nanvix/issues/948
         );
 
         let mut vmm: Vmm = Self {


### PR DESCRIPTION
# Overview

This PR's commits are sequenced in this way:
- Adds dependencies and rename variable (mostly boilerplate);
- Adds the plumbing so the main thread can call the snapshot function (a callback);
- High level abstract implementation of snapshots at the `MicroVm` struct level;
- Implementation of memory snapshots at the `VirtualMemory` struct level. TODOs for the `VirtualProcessor` and for loading snapshots. Removes dependencies for loading snapshots.

I'll squash them once they're reviewed.

# Next steps

This leaves snapshots of the `VirtualProcessor` for another PR, and loading snapshots for another one after that.