### PR TITLE
[libs] Remove Memory Maps on `munmap()`

### DIFF
--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -186,7 +186,7 @@ pub mod memory_layout {
     ///
     /// - This should be aligned to page and page table boundaries.
     ///
-    pub const USER_MMAPPED_END_RAW: usize = 0xa000_0000;
+    pub const USER_MMAP_END_RAW: usize = 0xa000_0000;
 
     ///
     /// # Description
@@ -197,7 +197,7 @@ pub mod memory_layout {
     ///
     /// - This should be aligned to page and page table boundaries.
     ///
-    pub const USER_LIBS_BASE_RAW: usize = USER_MMAPPED_END_RAW;
+    pub const USER_LIBS_BASE_RAW: usize = USER_MMAP_END_RAW;
 
     ///
     /// # Description

--- a/src/libs/sys/src/sys/config.rs
+++ b/src/libs/sys/src/sys/config.rs
@@ -98,7 +98,7 @@ pub mod memory_layout {
     ///
     /// - This should be aligned to page and page table boundaries.
     ///
-    pub const USER_MMAPPED_END: VirtualAddress = VirtualAddress::new(USER_MMAPPED_END_RAW);
+    pub const USER_MMAP_END: VirtualAddress = VirtualAddress::new(USER_MMAP_END_RAW);
 
     ///
     /// # Description

--- a/src/libs/syscall/src/sys/mman/syscalls/mmap.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/mmap.rs
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 use ::arch::mem::PAGE_ALIGNMENT;
-use ::config::memory_layout::USER_MMAPPED_END_RAW;
+use ::config::memory_layout::USER_MMAP_END_RAW;
 use ::spin::MutexGuard;
 use ::sys::{
     error::Error,
@@ -70,7 +70,7 @@ pub fn mmap(length: usize, prot: MemoryMapProtectionFlags) -> Result<VirtualAddr
         match new_mmap_base_raw {
             Some(addr) => {
                 // Check if we have enough space for the new memory segment.
-                if addr >= USER_MMAPPED_END_RAW {
+                if addr >= USER_MMAP_END_RAW {
                     let reason: &str = "not enough space for new memory segment";
                     syslog::error!("mmap(): {reason} (length={length}, prot={prot:?})");
                     return Err(Error::new(ErrorCode::OutOfMemory, reason));

--- a/src/libs/syscall/src/sys/mman/syscalls/mprotect.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/mprotect.rs
@@ -14,12 +14,12 @@ use crate::{
 };
 use ::alloc::collections::BTreeMap;
 use ::arch::mem::PAGE_ALIGNMENT;
-use ::config::memory_layout::USER_MMAPPED_END_RAW;
+use ::config::memory_layout::USER_MMAP_END_RAW;
 use ::spin::MutexGuard;
 use ::sys::{
     config::memory_layout::{
-        USER_MMAPPED_END,
         USER_MMAP_BASE,
+        USER_MMAP_END,
     },
     error::{
         Error,
@@ -62,7 +62,7 @@ pub fn mprotect(
     prot: MemoryMapProtectionFlags,
 ) -> Result<(), Error> {
     // Check if base address is invalid.
-    if base < USER_MMAP_BASE || base >= USER_MMAPPED_END {
+    if base < USER_MMAP_BASE || base >= USER_MMAP_END {
         let reason: &'static str = "invalid base address";
         ::syslog::error!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
@@ -77,7 +77,7 @@ pub fn mprotect(
 
     // Check if end address is invalid.
     match base.into_raw_value().checked_add(len) {
-        Some(end) if end > USER_MMAPPED_END_RAW => {
+        Some(end) if end > USER_MMAP_END_RAW => {
             let reason: &'static str = "invalid end address";
             ::syslog::error!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
             return Err(Error::new(ErrorCode::OutOfMemory, reason));

--- a/src/libs/syscall/src/sys/mman/syscalls/munmap.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/munmap.rs
@@ -19,11 +19,11 @@ use ::sys::{
         VirtualAddress,
     },
 };
-use config::memory_layout::USER_MMAPPED_END_RAW;
+use config::memory_layout::USER_MMAP_END_RAW;
 use sys::{
     config::memory_layout::{
-        USER_MMAPPED_END,
         USER_MMAP_BASE,
+        USER_MMAP_END,
     },
     error::ErrorCode,
 };
@@ -56,7 +56,7 @@ pub fn munmap(base: VirtualAddress, length: usize) -> Result<(), Error> {
     ::syslog::trace!("munmap(): base={base:?}, length={length}");
 
     // Check if the base address is valid.
-    if base < USER_MMAP_BASE || base >= USER_MMAPPED_END {
+    if base < USER_MMAP_BASE || base >= USER_MMAP_END {
         let reason: &str = "invalid base address";
         syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
@@ -71,7 +71,7 @@ pub fn munmap(base: VirtualAddress, length: usize) -> Result<(), Error> {
 
     // Check if end address is invalid.
     let end: VirtualAddress = match base.into_raw_value().checked_add(length) {
-        Some(end) if end > USER_MMAPPED_END_RAW => {
+        Some(end) if end > USER_MMAP_END_RAW => {
             let reason: &str = "invalid end address";
             syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));

--- a/src/libs/syscall/src/sys/mman/syscalls/munmap.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/munmap.rs
@@ -14,7 +14,6 @@ use ::arch::mem::PAGE_ALIGNMENT;
 use ::spin::MutexGuard;
 use ::sys::{
     error::Error,
-    mm,
     mm::{
         Address,
         VirtualAddress,
@@ -22,7 +21,10 @@ use ::sys::{
 };
 use config::memory_layout::USER_MMAPPED_END_RAW;
 use sys::{
-    config::memory_layout::USER_MMAP_BASE,
+    config::memory_layout::{
+        USER_MMAPPED_END,
+        USER_MMAP_BASE,
+    },
     error::ErrorCode,
 };
 
@@ -53,41 +55,97 @@ use sys::{
 pub fn munmap(base: VirtualAddress, length: usize) -> Result<(), Error> {
     ::syslog::trace!("munmap(): base={base:?}, length={length}");
 
-    // Align up length to page size.
-    let length: usize = mm::align_up(length, PAGE_ALIGNMENT);
-
     // Check if the base address is valid.
-    match base.into_raw_value().checked_add(length) {
-        Some(end_addr) if base >= USER_MMAP_BASE && end_addr <= USER_MMAPPED_END_RAW => {},
-        _ => {
-            let reason: &str = "base address out of bounds";
+    if base < USER_MMAP_BASE || base >= USER_MMAPPED_END {
+        let reason: &str = "invalid base address";
+        syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    // Check if base address is page-aligned.
+    if !base.is_aligned(PAGE_ALIGNMENT) {
+        let reason: &str = "base address is not page-aligned";
+        syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    // Check if end address is invalid.
+    let end: VirtualAddress = match base.into_raw_value().checked_add(length) {
+        Some(end) if end > USER_MMAPPED_END_RAW => {
+            let reason: &str = "invalid end address";
             syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         },
+        None => {
+            let reason: &str = "end address overflow";
+            syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        },
+        Some(base_end) => VirtualAddress::from_raw_value(base_end),
+    };
+
+    // Check if length is page-aligned.
+    if length % usize::from(PAGE_ALIGNMENT) != 0 {
+        let reason: &str = "length is not page-aligned";
+        syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
     // Lock the segments map.
     let mut segments: MutexGuard<'_, BTreeMap<VirtualAddress, MemorySegment>> =
         MMAP_SEGMENTS.lock();
 
-    // Check if the segment exists.
-    if let Some(segment) = segments.get(&base) {
-        // Check if the segment is large enough.
-        if segment.capacity() < length {
-            let reason: &str = "segment is too small";
+    // Find the segment that contains the base address.
+    // Use BTreeMap's range query to efficiently find the segment containing the base address.
+    let segment_base: Option<VirtualAddress> =
+        segments
+            .range(..=base)
+            .next_back()
+            .and_then(|(seg_base, segment)| {
+                let seg_end: Option<VirtualAddress> = seg_base
+                    .into_raw_value()
+                    .checked_add(segment.capacity())
+                    .map(VirtualAddress::from_raw_value);
+                match seg_end {
+                    Some(seg_end_addr) => {
+                        if base >= *seg_base && end <= seg_end_addr {
+                            Some(*seg_base)
+                        } else {
+                            None
+                        }
+                    },
+                    // Overflow occurred, treat as not found.
+                    None => None,
+                }
+            });
+
+    match segment_base {
+        Some(segment_base) => {
+            let segment: &MemorySegment = &segments[&segment_base];
+
+            // Check for partial mapping.
+            if segment.capacity() != length || segment.base() != base {
+                syslog::warn!(
+                    "munmap(): partial unmapping is not supported (base={base:?}, \
+                     length={length}, segment_base={segment_base:?}, segment_capacity={})",
+                    segment.capacity()
+                );
+
+                // TODO (#992): split the segment and fall through instead of returning.
+                return Ok(());
+            }
+
+            // Remove the segment from the map.
+            debug_assert!(segments.remove(&segment_base).is_some());
+
+            // Segment is unmapped when this scope ends.
+
+            Ok(())
+        },
+        None => {
+            let reason: &str = "segment not found";
             syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
-            return Err(Error::new(ErrorCode::InvalidArgument, reason));
-        }
-
-        // Remove the segment from the map.
-        segments.remove(&base);
-
-        // Segment is unmapped when this scope ends.
-
-        Ok(())
-    } else {
-        let reason: &str = "segment not found";
-        syslog::error!("munmap(): {reason} (base={base:?}, length={length})");
-        Err(Error::new(ErrorCode::InvalidArgument, reason))
+            Err(Error::new(ErrorCode::InvalidArgument, reason))
+        },
     }
 }

--- a/src/tests/testd/src/mm/mod.rs
+++ b/src/tests/testd/src/mm/mod.rs
@@ -7,8 +7,8 @@
 
 use ::arch::mem::PAGE_SIZE;
 use ::config::memory_layout::{
-    USER_MMAPPED_END_RAW,
     USER_MMAP_BASE_RAW,
+    USER_MMAP_END_RAW,
 };
 use ::sys::{
     config::memory_layout::USER_MMAP_BASE,
@@ -152,7 +152,7 @@ fn test_mmap_munmap_many_times_inplace() -> bool {
         Err(_) => return false,
     };
 
-    let ntimes: usize = ((USER_MMAPPED_END_RAW - USER_MMAP_BASE_RAW) / 64) / PAGE_SIZE;
+    let ntimes: usize = ((USER_MMAP_END_RAW - USER_MMAP_BASE_RAW) / 64) / PAGE_SIZE;
 
     for _ in 0..ntimes {
         let vaddr: VirtualAddress = USER_MMAP_BASE;
@@ -200,7 +200,7 @@ fn test_mmap_munmap_many_times_rolling() -> bool {
         Err(_) => return false,
     };
 
-    let ntimes: usize = ((USER_MMAPPED_END_RAW - USER_MMAP_BASE_RAW) / 64) / PAGE_SIZE;
+    let ntimes: usize = ((USER_MMAP_END_RAW - USER_MMAP_BASE_RAW) / 64) / PAGE_SIZE;
 
     for vaddr in (0..ntimes).map(|i| USER_MMAP_BASE_RAW + i * PAGE_SIZE) {
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(vaddr);


### PR DESCRIPTION
This pull request primarily refactors the naming and validation logic for user memory-mapped address constants and improves the robustness of the `mmap`, `mprotect`, and `munmap` syscalls. The changes unify and clarify constant names, enhance address and alignment checks, and improve error handling and segment validation for memory management syscalls.

**Refactoring and Naming Consistency:**

- Renamed the memory-mapped end constants from `USER_MMAPPED_END_RAW`/`USER_MMAPPED_END` to `USER_MMAP_RAW`/`USER_MMAP` throughout the codebase for clarity and consistency. This affects all relevant modules and test code. [[1]](diffhunk://#diff-30d631c85a493fa748c248d7f923b54c1b1c1f6bc56b7e5f569cca5f0d711cedL189-R189) [[2]](diffhunk://#diff-30d631c85a493fa748c248d7f923b54c1b1c1f6bc56b7e5f569cca5f0d711cedL200-R200) [[3]](diffhunk://#diff-6839c6fd8dea16434462043a7c145c5128db9d3a81ad2ab9fe47bc1dc7ab15c4L101-R101) [[4]](diffhunk://#diff-295335b3bfec76bfc7384169bdecce909834a50b6fd9b1ce13caab1eb99cad4bL19-R19) [[5]](diffhunk://#diff-295335b3bfec76bfc7384169bdecce909834a50b6fd9b1ce13caab1eb99cad4bL73-R73) [[6]](diffhunk://#diff-d267604aef2ba6fb4c5ff253d90b7c5f61f46bd41cf8170996cda5facf78c155L17-R21) [[7]](diffhunk://#diff-d267604aef2ba6fb4c5ff253d90b7c5f61f46bd41cf8170996cda5facf78c155L65-R65) [[8]](diffhunk://#diff-d267604aef2ba6fb4c5ff253d90b7c5f61f46bd41cf8170996cda5facf78c155L80-R80) [[9]](diffhunk://#diff-49d0ad506e06b6a0202dde95875f89177db7db4f26b23c2b71261987e522ac7fL17-R27) [[10]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L10-R11) [[11]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L155-R155) [[12]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L203-R203)

**Syscall Validation and Error Handling Improvements:**

- Enhanced `mprotect` and `munmap` to include stricter checks for address range, alignment, and segment validity. Now, both syscalls ensure that the base and end addresses are within allowed bounds, are page-aligned, and that the segment is large enough and correctly aligned. [[1]](diffhunk://#diff-d267604aef2ba6fb4c5ff253d90b7c5f61f46bd41cf8170996cda5facf78c155L65-R65) [[2]](diffhunk://#diff-d267604aef2ba6fb4c5ff253d90b7c5f61f46bd41cf8170996cda5facf78c155L80-R80) [[3]](diffhunk://#diff-d267604aef2ba6fb4c5ff253d90b7c5f61f46bd41cf8170996cda5facf78c155R125-R131) [[4]](diffhunk://#diff-49d0ad506e06b6a0202dde95875f89177db7db4f26b23c2b71261987e522ac7fL56-R142)
- Improved `munmap` to check for page alignment of both base address and length, to verify that the segment fully contains the requested range, and to warn (rather than fail) on partial unmapping, leaving a TODO for future support.

**Test Updates:**

- Updated tests in `testd/src/mm/mod.rs` to use the new `USER_MMAP_RAW` constant for calculating test ranges and iterations, maintaining consistency with the main codebase. [[1]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L10-R11) [[2]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L155-R155) [[3]](diffhunk://#diff-a303df5746bcc0500c06526454a0d6326784c43ffe394cb270e9e5a30f88da99L203-R203)