### PR TITLE
[build] Add Missing Exception Handling Frames

### DIFF
--- a/build/user/linker/x86/user.ld
+++ b/build/user/linker/x86/user.ld
@@ -54,6 +54,22 @@ SECTIONS
 		__TLS_END = .;
 	}
 
+	/* Exception handling frame header */
+	.eh_frame_hdr : ALIGN(4)
+	{
+		PROVIDE(__eh_frame_hdr_start = .);
+		KEEP(*(.eh_frame_hdr))
+		PROVIDE(__eh_frame_hdr_end = .);
+	}
+
+	/* Exception handling frames */
+	.eh_frame : ALIGN(4)
+	{
+		PROVIDE(__eh_frame_start = .);
+		KEEP(*(.eh_frame))
+		PROVIDE(__eh_frame_end = .);
+	}
+
 	/* Discarded. */
 	/DISCARD/ :
 	{


### PR DESCRIPTION
This pull request updates the linker script for the x86 user build to add support for exception handling metadata. The most important change is the inclusion of new sections to handle exception frames, which are necessary for proper stack unwinding and exception handling in C++ and some other languages.

Exception handling support:

* Added `.eh_frame_hdr` and `.eh_frame` sections to the linker script (`user.ld`) to include exception handling frame headers and frames, enabling stack unwinding and exception handling support.