### PR TITLE
[kernel] Enable `mctrl()` for Self PID

### DIFF
--- a/src/kernel/src/pm/kcall/mctrl.rs
+++ b/src/kernel/src/pm/kcall/mctrl.rs
@@ -46,17 +46,6 @@ fn do_mctrl(
 }
 
 pub fn mctrl(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallArgs) -> KcallResult {
-    // Check if the calling process has memory management capabilities.
-    match pm.has_capability(args.pid, Capability::MemoryManagement) {
-        Ok(true) => (),
-        Ok(false) => {
-            let reason: &str = "process does not have memory management capabilities";
-            error!("{reason}");
-            return KcallResult::Error(ErrorCode::PermissionDenied.into());
-        },
-        Err(e) => return KcallResult::Error(e.code.into()),
-    }
-
     // Unpack kernel call arguments.
     let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
         Ok(pid) => pid,
@@ -65,6 +54,20 @@ pub fn mctrl(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
             return KcallResult::Error(error.code.into());
         },
     };
+
+    // Check if the calling process has memory management capabilities.
+    if pid != args.pid {
+        match pm.has_capability(args.pid, Capability::MemoryManagement) {
+            Ok(true) => (),
+            Ok(false) => {
+                let reason: &str = "process does not have memory management capabilities";
+                error!("{reason}");
+                return KcallResult::Error(ErrorCode::PermissionDenied.into());
+            },
+            Err(e) => return KcallResult::Error(e.code.into()),
+        }
+    }
+
     let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(args.arg1 as usize) {
         Ok(vaddr) => vaddr,
         Err(e) => return KcallResult::Error(e.code.into()),


### PR DESCRIPTION
This pull request updates the `mctrl` kernel call handler to ensure that only privileged processes can perform memory management operations on other processes. The main change is the addition of an explicit check: if the target process ID (`pid`) is different from the calling process, the caller must have the memory management capability.

Access control and argument handling:

* Added logic to unpack and validate the target process ID (`pid`) from the kernel call arguments, returning an error if invalid.
* Added a check so that if the calling process is trying to operate on a process other than itself, it must have the `MemoryManagement` capability; otherwise, the operation is denied.
* Refactored code to perform the capability check before unpacking the remaining arguments, improving clarity and correctness.