### PR TITLE
[libs] Check for Large Segment in mprotect()

### DIFF
--- a/src/libs/syscall/src/sys/mman/syscalls/mprotect.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/mprotect.rs
@@ -122,6 +122,13 @@ pub fn mprotect(
                 return Err(Error::new(ErrorCode::OutOfMemory, reason));
             };
 
+            // Check if the segment is large enough.
+            if segment.capacity() < len || base < segment.base() {
+                let reason: &'static str = "segment is too small or base not aligned with segment";
+                ::syslog::error!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            }
+
             // Check for partial mapping.
             if segment.capacity() != len || segment.base() != base {
                 ::syslog::warn!(


### PR DESCRIPTION
This pull request adds an important validation step to the `mprotect` syscall implementation to ensure memory safety and correctness. Specifically, it introduces a check to verify that the memory segment is large enough and that the base address is properly aligned with the segment before proceeding.

Memory safety and validation improvements:

* Added a check in `mprotect.rs` to ensure the segment's capacity is at least as large as the requested length and that the base address is not before the segment's base; if this validation fails, an error is returned and logged.