### PR TITLE
[microvm] Graceful Shutdown

### DIFF
--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -521,10 +521,7 @@ impl SocketStream {
                     return Err(io::Error::new(ErrorKind::UnexpectedEof, "connection closed").into())
                 },
                 Ok(n) => total_read += n,
-                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
-                    // Not ready yet — must wait for next Poll notification
-                    break;
-                },
+                // Propagate error upstream for the caller to process.
                 Err(e) => return Err(e.into()),
             }
         }

--- a/src/microvm/Cargo.toml
+++ b/src/microvm/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = { workspace = true }
 bincode = { workspace = true, features = ["serde"] }
 cfg-if = { workspace = true }
 config = { workspace = true, features = ["microvm"] }
+control-plane-api = { workspace = true }
 hyperlight-host = { workspace = true, optional = true }
 profiler = { workspace = true, features = ["auto-calibrate"] }
 serde = { workspace = true, features = ["derive"] }

--- a/src/microvm/src/io_thread.rs
+++ b/src/microvm/src/io_thread.rs
@@ -10,6 +10,7 @@ use crate::orchestrator::{
     IoControlResponse,
 };
 use ::anyhow::Result;
+use ::control_plane_api;
 use ::std::{
     collections::VecDeque,
     io::ErrorKind,
@@ -41,10 +42,12 @@ use ::syslog::{
 /// Private data of the I/O thread.
 ///
 pub struct IoThread {
-    /// Connection to the system VM.
-    system_vm_stream: SocketStream,
+    /// Optional connection to the system VM.
+    system_vm_stream: Option<SocketStream>,
     /// Buffer to handle partial reads from the system VM.
     system_vm_partial_read_buffer: VecDeque<u8>,
+    /// Optional connection to the external control-plane, nanvixd.
+    control_plane_stream: Option<SocketStream>,
     /// Gateway receiver.
     data_rx: Receiver<Message>,
     /// Gateway sender.
@@ -54,7 +57,7 @@ pub struct IoThread {
     /// Queue of outgoing messages.
     outgoing: VecDeque<Message>,
     /// Command sender to the VMM.
-    _control_tx: Sender<IoControlCommand>,
+    control_tx: Sender<IoControlCommand>,
     /// Response receiver from the VMM.
     control_rx: Receiver<IoControlResponse>,
     // TODO: channels to linuxd and nanvixd https://github.com/nanvix/nanvix/issues/945
@@ -83,15 +86,22 @@ impl IoThread {
     /// A handle to the I/O thread.
     ///
     pub fn spawn(
-        system_vm_stream: SocketStream,
+        system_vm_stream: Option<SocketStream>,
         data_rx: Receiver<Message>,
         data_tx: Sender<Message>,
         control_tx: Sender<IoControlCommand>,
         control_rx: Receiver<IoControlResponse>,
+        control_plane_stream: Option<SocketStream>,
     ) -> JoinHandle<Result<()>> {
         thread::spawn(move || {
-            let mut io_thread: IoThread =
-                IoThread::new(system_vm_stream, data_rx, data_tx, control_tx, control_rx)?;
+            let mut io_thread: IoThread = IoThread::new(
+                system_vm_stream,
+                data_rx,
+                data_tx,
+                control_tx,
+                control_rx,
+                control_plane_stream,
+            )?;
             io_thread.run()?;
             Ok(())
         })
@@ -100,26 +110,29 @@ impl IoThread {
     ///
     /// # Description
     ///
-    /// Creates a new I/O thread.
+    /// Creates a new I/O thread. We start an I/O thread if we have either a connection to the
+    /// gateway, one to the control plane, or both.
     ///
     /// # Parameters
     ///
-    /// - `system_vm_stream`: Connection to the system VM.
+    /// - `system_vm_stream`: Optional connection to the system VM.
     /// - `data_rx`: MicroVM receiver.
     /// - `data_tx`: MicroVM sender.
     /// - `control_tx`: Command sender.
     /// - `control_rx`: Response receiver.
+    /// - `control_plane_stream`: Optional connection to the control-plane stream.
     ///
     /// # Returns
     ///
     /// Upon success, a new I/O thread is returned. Otherwise, an error is returned.
     ///
     fn new(
-        system_vm_stream: SocketStream,
+        system_vm_stream: Option<SocketStream>,
         data_rx: Receiver<Message>,
         data_tx: Sender<Message>,
         control_tx: Sender<IoControlCommand>,
         control_rx: Receiver<IoControlResponse>,
+        control_plane_stream: Option<SocketStream>,
     ) -> Result<Self> {
         Ok(Self {
             system_vm_stream,
@@ -128,8 +141,9 @@ impl IoThread {
             data_tx,
             incoming: VecDeque::new(),
             outgoing: VecDeque::new(),
-            _control_tx: control_tx,
+            control_tx,
             control_rx,
+            control_plane_stream,
         })
     }
 
@@ -144,6 +158,7 @@ impl IoThread {
     ///
     fn run(&mut self) -> Result<()> {
         loop {
+            self.try_send_to_vmm_control()?;
             self.try_receive_from_microvm()?;
             self.try_send_to_system_vm()?;
             self.try_receive_from_system_vm()?;
@@ -164,75 +179,79 @@ impl IoThread {
     /// Otherwise, if it would block, `false` is returned. Otherwise, an error is returned.
     ///
     fn try_receive_from_system_vm(&mut self) -> Result<bool> {
-        let mut buf: [u8; mem::size_of::<Message>()] = [0; mem::size_of::<Message>()];
+        if let Some(system_vm_stream) = self.system_vm_stream.as_mut() {
+            let mut buf: [u8; mem::size_of::<Message>()] = [0; mem::size_of::<Message>()];
 
-        let mut num_filled: usize = 0;
-        if !self.system_vm_partial_read_buffer.is_empty() {
-            // Prepare data in buffer for partial read.
-            self.system_vm_partial_read_buffer.make_contiguous();
-            let partial_bytes: &[u8] = self.system_vm_partial_read_buffer.as_slices().0;
+            let mut num_filled: usize = 0;
+            if !self.system_vm_partial_read_buffer.is_empty() {
+                // Prepare data in buffer for partial read.
+                self.system_vm_partial_read_buffer.make_contiguous();
+                let partial_bytes: &[u8] = self.system_vm_partial_read_buffer.as_slices().0;
 
-            // We take the minimum at the end just in case, but the partial read should always be
-            // strictly smaller than the message size.
-            let num_partial_read: usize = partial_bytes.len().min(buf.len());
+                // We take the minimum at the end just in case, but the partial read should always be
+                // strictly smaller than the message size.
+                let num_partial_read: usize = partial_bytes.len().min(buf.len());
 
-            buf[..num_partial_read].copy_from_slice(&partial_bytes[..num_partial_read]);
+                buf[..num_partial_read].copy_from_slice(&partial_bytes[..num_partial_read]);
 
-            // Clear partial read buffer.
-            self.system_vm_partial_read_buffer.clear();
-            num_filled += num_partial_read;
-        }
-        // Post-condition: partial_read_buffer is empty.
+                // Clear partial read buffer.
+                self.system_vm_partial_read_buffer.clear();
+                num_filled += num_partial_read;
+            }
+            // Post-condition: partial_read_buffer is empty.
 
-        match self.system_vm_stream.try_read_exact(&mut buf[num_filled..]) {
-            Ok(n) => {
-                // Handle partial reads by copying all we have read to the partial read buffer and
-                // returning a WouldBlock indicating that we need more data.
-                if n + num_filled < buf.len() {
-                    self.system_vm_partial_read_buffer
-                        .extend(&buf[..(n + num_filled)]);
+            match system_vm_stream.try_read_exact(&mut buf[num_filled..]) {
+                Ok(n) => {
+                    // Handle partial reads by copying all we have read to the partial read buffer and
+                    // returning a WouldBlock indicating that we need more data.
+                    if n + num_filled < buf.len() {
+                        self.system_vm_partial_read_buffer
+                            .extend(&buf[..(n + num_filled)]);
 
-                    // A partial read corresponds to a WouldBlock, so we return false.
+                        // A partial read corresponds to a WouldBlock, so we return false.
+                        return Ok(false);
+                    }
+                },
+                // If WouldBlock, return false.
+                Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                    // Handle the situation where we may have filled a partial read from a previous
+                    // attempt, but then error-ed out with WouldBlock.
+                    if num_filled > 0 {
+                        self.system_vm_partial_read_buffer
+                            .extend(&buf[..num_filled]);
+                    }
+
                     return Ok(false);
-                }
-            },
-            // If WouldBlock, return false.
-            Err(e) if e.kind() == ErrorKind::WouldBlock => {
-                // Handle the situation where we may have filled a partial read from a previous
-                // attempt, but then error-ed out with WouldBlock.
-                if num_filled > 0 {
-                    self.system_vm_partial_read_buffer
-                        .extend(&buf[..num_filled]);
-                }
+                },
+                Err(e) => {
+                    let reason: String =
+                        format!("failed to receive message from the system VM (error={e:?})");
+                    error!("try_receive_from_system_vm(): {reason}");
 
-                return Ok(false);
-            },
-            Err(e) => {
-                let reason: String =
-                    format!("failed to receive message from the system VM (error={e:?})");
-                error!("try_receive_from_system_vm(): {reason}");
+                    return Err(anyhow::anyhow!(reason));
+                },
+            };
 
-                return Err(anyhow::anyhow!(reason));
-            },
-        };
+            let mut message: Message = match Message::try_from_bytes(buf) {
+                Ok(message) => message,
+                Err(e) => {
+                    let reason: String =
+                        format!("failed to parse message from system VM (error={e:?})");
+                    error!("try_receive_from_system_vm(): {reason}");
+                    return Err(anyhow::anyhow!(reason));
+                },
+            };
+            profiler::timestamp_message!(
+                &mut message.payload,
+                mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                    + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
+            );
 
-        let mut message: Message = match Message::try_from_bytes(buf) {
-            Ok(message) => message,
-            Err(e) => {
-                let reason: String =
-                    format!("failed to parse message from system VM (error={e:?})");
-                error!("try_receive_from_system_vm(): {reason}");
-                return Err(anyhow::anyhow!(reason));
-            },
-        };
-        profiler::timestamp_message!(
-            &mut message.payload,
-            mem::offset_of!(syscall::LinuxDaemonMessage, payload)
-                + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
-        );
-
-        self.incoming.push_back(message);
-        Ok(true)
+            self.incoming.push_back(message);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     ///
@@ -277,30 +296,71 @@ impl IoThread {
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
     fn try_send_to_system_vm(&mut self) -> Result<()> {
-        match self.outgoing.pop_front() {
-            Some(message) => {
-                let mut message_clone: Message = message.clone();
-                profiler::timestamp_message!(
-                    &mut message_clone.payload,
-                    std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
-                        + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
-                );
-                match self.system_vm_stream.write_all(&message_clone.to_bytes()) {
-                    Ok(()) => Ok(()),
-                    Err(e) if e.kind() == ErrorKind::WouldBlock => {
-                        self.outgoing.push_front(message);
-                        Ok(())
-                    },
-                    Err(e) => {
-                        let reason: String =
-                            format!("failed to send message to the system VM (error={e:?})");
-                        error!("try_send_to_system_vm(): {reason}");
-                        Err(anyhow::anyhow!(reason))
-                    },
-                }
-            },
-            None => Ok(()),
+        if let Some(system_vm_stream) = self.system_vm_stream.as_mut() {
+            match self.outgoing.pop_front() {
+                Some(message) => {
+                    let mut message_clone: Message = message.clone();
+                    profiler::timestamp_message!(
+                        &mut message_clone.payload,
+                        std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                            + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
+                    );
+                    match system_vm_stream.write_all(&message_clone.to_bytes()) {
+                        Ok(()) => Ok(()),
+                        Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                            self.outgoing.push_front(message);
+                            Ok(())
+                        },
+                        Err(e) => {
+                            let reason: String =
+                                format!("failed to send message to the system VM (error={e:?})");
+                            error!("try_send_to_system_vm(): {reason}");
+                            Err(anyhow::anyhow!(reason))
+                        },
+                    }
+                },
+                None => Ok(()),
+            }
+        } else {
+            Ok(())
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to read a message from the external control-plane (i.e. nanvixd) and forwards it
+    /// to the VMM control-plane.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned.
+    ///
+    fn try_send_to_vmm_control(&mut self) -> Result<()> {
+        if let Some(control_plane_stream) = self.control_plane_stream.as_mut() {
+            let cmd: control_plane_api::Command =
+                match control_plane_api::try_read_command(control_plane_stream) {
+                    Ok(cmd) => cmd,
+                    // If we would block, return and do nothing.
+                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => return Ok(()),
+                    Err(e) => {
+                        let reason: String = format!(
+                            "try_send_to_vmm_control(): failed reading command from control-plane \
+                             (error={e:?})"
+                        );
+                        error!("{reason}");
+                        return Err(anyhow::anyhow!(reason));
+                    },
+                };
+            // Translate nanvixd control-plane commands to internal VMM control commands.
+            match cmd {
+                control_plane_api::Command::Shutdown => {
+                    self.control_tx.send(IoControlCommand::Shutdown)?;
+                },
+            }
+        }
+
+        Ok(())
     }
 
     ///
@@ -342,6 +402,11 @@ impl IoThread {
             Ok(response) => match response {
                 IoControlResponse::FlushOutput => self.flush_microvm_output(),
                 IoControlResponse::FlushInput => self.flush_linuxd_input(),
+                IoControlResponse::Shutdown => {
+                    // TODO (#1004): Break() out of the main loop here.
+                    let reason: String = "IO thread shutting down".to_string();
+                    anyhow::bail!(reason)
+                },
                 _ => Ok(()), // TODO: forward to linuxd or nanvixd https://github.com/nanvix/nanvix/issues/945
             },
             Err(TryRecvError::Empty) => Ok(()),

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -123,7 +123,7 @@ fn main() -> Result<ExitCode> {
         None => None,
     };
 
-    let _control_plane_socket: Option<SocketStream> = match args.control_plane_addr() {
+    let control_plane_socket: Option<SocketStream> = match args.control_plane_addr() {
         Some(addr) => {
             let control_plane_socket_type: SocketType = match args.control_plane_socket_type() {
                 Some(socket_type) => socket_type,
@@ -152,6 +152,7 @@ fn main() -> Result<ExitCode> {
         initrd_args,
         stderr,
         system_vm_stream,
+        control_plane_socket,
     )? {
         exit_status if exit_status != 0 => {
             let exit_code: u8 = match exit_status.try_into() {

--- a/src/microvm/src/memory_thread.rs
+++ b/src/microvm/src/memory_thread.rs
@@ -47,7 +47,7 @@ use ::syslog::{
 ///
 /// - `data_rx`: Receives data messages from the I/O thread.
 /// - `data_tx`: Sends data messages to the virtual machine's stdin.
-/// - `_control_rx`: Receives control commands from the VMM.
+/// - `control_rx`: Receives control commands from the VMM.
 /// - `_control_tx`: Sends control responses to the VMM.
 /// - `add_credit`: Closure that adds a credit to the virtual machine credit pool.
 ///
@@ -58,7 +58,7 @@ use ::syslog::{
 pub fn spawn<F>(
     data_rx: Receiver<Message>,
     data_tx: Sender<Message>,
-    _control_rx: Receiver<MemoryControlCommand>,
+    control_rx: Receiver<MemoryControlCommand>,
     _control_tx: Sender<MemoryControlResponse>,
     mut add_credit: F,
 ) -> JoinHandle<Result<()>>
@@ -67,6 +67,21 @@ where
 {
     thread::spawn(move || {
         loop {
+            match control_rx.try_recv() {
+                Ok(command) => match command {
+                    MemoryControlCommand::Shutdown => {
+                        debug!("memory_thread(): received shutdown command");
+                        break Ok(());
+                    },
+                },
+                Err(TryRecvError::Disconnected) => {
+                    debug!("memory_thread(): VMM control channel has been disconnected");
+                    break Ok(());
+                },
+                Err(TryRecvError::Empty) => {
+                    // No message available.
+                },
+            }
             match data_rx.try_recv() {
                 Ok(mut msg) => {
                     profiler::timestamp_message!(

--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -5,8 +5,20 @@
 // Imports
 //==================================================================================================
 
+#[cfg(not(feature = "hyperlight"))]
+use crate::vmm::INTERRUPT_SIGNAL;
 use ::anyhow::Result;
+#[cfg(not(feature = "hyperlight"))]
+use ::libc::{
+    pthread_kill,
+    pthread_t,
+};
 use ::std::{
+    ops::ControlFlow::{
+        self,
+        Break,
+        Continue,
+    },
     sync::mpsc::{
         Receiver,
         Sender,
@@ -15,7 +27,9 @@ use ::std::{
     time::Instant,
 };
 use ::syslog::{
+    debug,
     error,
+    info,
     trace,
     warn,
 };
@@ -41,6 +55,13 @@ pub const TIMEOUT_WARNING_INTERVAL_IN_MS: usize = 10;
 pub struct Orchestrator {
     // The state of the VM.
     state: State,
+    // FIXME (#1009): once the I/O channels are optional, we will be able to infer if io_enabled
+    // from whether the channels are None or not.
+    /// Whether the I/O thread is enabled or not.
+    io_enabled: bool,
+    /// Thread ID of the vCPU thread.
+    #[cfg(not(feature = "hyperlight"))]
+    vcpu_tid: u64,
     // Channel that receives commands from the I/O thread.
     io_control_rx: Receiver<IoControlCommand>,
     // Channel that sends commands to the I/O thread.
@@ -48,7 +69,7 @@ pub struct Orchestrator {
     // Channel that receives commands from the memory thread.
     _memory_control_rx: Receiver<MemoryControlResponse>,
     // Channel that sends commands to the memory thread.
-    _memory_control_tx: Sender<MemoryControlCommand>,
+    memory_control_tx: Sender<MemoryControlCommand>,
     // Channel that receives commands from the vCPU thread.
     vcpu_control_rx: Receiver<VcpuControlResponse>,
     // Channel that sends commands to the vCPU thread.
@@ -94,6 +115,7 @@ pub enum IoControlCommand {
     _CreateSnapshot,
     _ResumeMicroVm,
     LinuxDaemonFlushed,
+    Shutdown,
 }
 
 ///
@@ -107,6 +129,7 @@ pub enum IoControlResponse {
     SnapshotCreated,
     FlushOutput,
     FlushInput,
+    Shutdown,
 }
 
 ///
@@ -115,7 +138,9 @@ pub enum IoControlResponse {
 /// Control plane commands from the VMM to the memory thread.
 ///
 #[derive(PartialEq)]
-pub enum MemoryControlCommand {}
+pub enum MemoryControlCommand {
+    Shutdown,
+}
 
 ///
 /// # Description
@@ -143,6 +168,9 @@ pub enum VcpuControlCommand {
 #[derive(Debug, PartialEq)]
 pub enum VcpuControlResponse {
     Paused,
+    #[cfg_attr(feature = "hyperlight", allow(dead_code))]
+    Shutdown,
+    #[cfg_attr(feature = "hyperlight", allow(dead_code))]
     Tid(u64),
 }
 
@@ -153,6 +181,8 @@ pub enum VcpuControlResponse {
 impl Orchestrator {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        io_enabled: bool,
+        #[cfg(not(feature = "hyperlight"))] vcpu_tid: u64,
         io_control_rx: Receiver<IoControlCommand>,
         io_control_tx: Sender<IoControlResponse>,
         memory_control_rx: Receiver<MemoryControlResponse>,
@@ -165,10 +195,13 @@ impl Orchestrator {
     ) -> Self {
         Self {
             state: State::PreBoot,
+            io_enabled,
+            #[cfg(not(feature = "hyperlight"))]
+            vcpu_tid,
             io_control_rx,
             io_control_tx,
             _memory_control_rx: memory_control_rx,
-            _memory_control_tx: memory_control_tx,
+            memory_control_tx,
             vcpu_control_rx,
             vcpu_control_tx,
             pause_microvm,
@@ -186,7 +219,27 @@ impl Orchestrator {
     ///
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
-    pub fn handle_command(&mut self) -> Result<()> {
+    pub fn run(&mut self) -> Result<()> {
+        loop {
+            if self.io_enabled && (self.try_receive_from_io_thread()? == Break(())) {
+                break;
+            }
+            if self.try_receive_from_vcpu()? == Break(()) {
+                break;
+            }
+        }
+
+        // If we break out of the main loop, we need to shutdown the I/O and
+        // the memory thread.
+        debug!("run(): exited run loop, cleaning-up");
+        self.memory_control_tx
+            .send(MemoryControlCommand::Shutdown)?;
+        self.io_control_tx.send(IoControlResponse::Shutdown)?;
+
+        Ok(())
+    }
+
+    fn try_receive_from_io_thread(&mut self) -> Result<ControlFlow<()>> {
         match self.io_control_rx.try_recv() {
             Ok(command) => match command {
                 IoControlCommand::_StartMicroVm => {
@@ -196,7 +249,7 @@ impl Orchestrator {
                         self.state = State::Running;
                         trace!("State: PreBoot -> Running");
                     }
-                    Ok(())
+                    Ok(Continue(()))
                 },
                 IoControlCommand::_LoadSnapshotAndRun => {
                     if self.state == State::PreBoot {
@@ -209,56 +262,56 @@ impl Orchestrator {
                         if let Err(e) = self.resume_protocol() {
                             let reason: String =
                                 format!("LoadSnapshotAndRun: failed to resume microvm: {e:?}");
-                            error!("handle_command(): {reason}");
+                            error!("try_receive_from_io_thread(): {reason}");
                             anyhow::bail!(reason);
                         }
                     }
-                    Ok(())
+                    Ok(Continue(()))
                 },
                 IoControlCommand::_PauseMicroVm => {
                     if self.state == State::Running {
                         if let Err(e) = self.pause_protocol() {
                             let reason: String =
                                 format!("PauseMicroVm: failed to pause microvm: {e:?}");
-                            error!("handle_command(): {reason}");
+                            error!("try_receive_from_io_thread(): {reason}");
                             anyhow::bail!(reason);
                         }
                     }
-                    Ok(())
+                    Ok(Continue(()))
                 },
                 IoControlCommand::_PauseAndCreateSnapshot => {
                     if self.state == State::Running {
                         if let Err(e) = self.pause_protocol() {
                             let reason: String =
                                 format!("PauseAndCreateSnapshot: failed to pause microvm: {e:?}");
-                            error!("handle_command(): {reason}");
+                            error!("try_receive_from_io_thread(): {reason}");
                             anyhow::bail!(reason);
                         }
                         if let Err(e) = (self.create_snapshot)() {
                             let reason: String =
                                 format!("PauseAndCreateSnapshot: failed to create snapshot: {e:?}");
-                            error!("handle_command(): {reason}");
+                            error!("try_receive_from_io_thread(): {reason}");
                             anyhow::bail!(reason);
                         }
                         trace!("Snapshot created");
                         self.io_control_tx
                             .send(IoControlResponse::SnapshotCreated)?;
                     }
-                    Ok(())
+                    Ok(Continue(()))
                 },
                 IoControlCommand::_CreateSnapshot => {
                     if self.state == State::Paused {
                         if let Err(e) = (self.create_snapshot)() {
                             let reason: String =
                                 format!("CreateSnapshot: failed to create snapshot: {e:?}");
-                            error!("handle_command(): {reason}");
+                            error!("try_receive_from_io_thread(): {reason}");
                             anyhow::bail!(reason);
                         }
                         trace!("Snapshot created");
                         self.io_control_tx
                             .send(IoControlResponse::SnapshotCreated)?;
                     }
-                    Ok(())
+                    Ok(Continue(()))
                 },
                 IoControlCommand::_ResumeMicroVm => {
                     if self.state == State::Paused {
@@ -266,25 +319,76 @@ impl Orchestrator {
                         if let Err(e) = self.resume_protocol() {
                             let reason: String =
                                 format!("ResumeMicroVm: failed to resume microvm: {e:?}");
-                            error!("handle_command(): {reason}");
+                            error!("try_receive_from_io_thread(): {reason}");
                             anyhow::bail!(reason);
                         }
                     }
-                    Ok(())
+                    Ok(Continue(()))
                 },
                 IoControlCommand::LinuxDaemonFlushed => {
                     // NOTE: this will be unreachable once the communication is fully implemented
                     // `LinuxDaemonFlushed` should only be sent in the middle of `pause_protocol`.
                     // In fact, it should already be unreachable, but it cannot be tested ATM.
-                    Ok(())
+                    Ok(Continue(()))
+                },
+                IoControlCommand::Shutdown => {
+                    debug!("try_receive_from_io_thread(): received shutdown command");
+
+                    // After sending an interrupt to the vCPU thread, we continue processing
+                    // messages until we receive a shutdown message from the vCPU thread itself.
+                    cfg_if::cfg_if! {
+                        // FIXME (#1010): there is currently no way for us to actually interrupt
+                        // the hyperlight thread so, instead of waiting for a shutdown message from
+                        // the vCPU itself, we exit here. This may populate the logs with an error
+                        // message during shutdown, but is functionally equivalent.
+                        if #[cfg(feature = "hyperlight")] {
+                            Ok(Break(()))
+                        } else {
+                            // SAFETY: we call pthread_kill on a non-zero TID that we have received from
+                            // the VCPU thread after boot, so this is safe.
+                            let pthread_id: pthread_t = self.vcpu_tid as pthread_t;
+                            unsafe { pthread_kill(pthread_id, INTERRUPT_SIGNAL) };
+
+                            Ok(Continue(()))
+                        }
+                    }
                 },
             },
-            Err(TryRecvError::Empty) => Ok(()),
+            Err(TryRecvError::Empty) => Ok(Continue(())),
             Err(TryRecvError::Disconnected) => {
                 let reason: String =
                     ("disconnected from the input control command channel").to_string();
-                error!("handle_command(): {reason}");
-                anyhow::bail!(reason);
+                error!("try_receive_from_io_thread(): {reason}");
+                Ok(Break(()))
+            },
+        }
+    }
+
+    fn try_receive_from_vcpu(&mut self) -> Result<ControlFlow<()>> {
+        match self.vcpu_control_rx.try_recv() {
+            Ok(VcpuControlResponse::Paused) => {
+                let reason: String =
+                    "paused command should only be received during the pause protocol".to_string();
+                error!("{reason}");
+                Err(anyhow::anyhow!(reason))
+            },
+            Ok(VcpuControlResponse::Shutdown) => {
+                info!("try_receive_from_vcpu(): vCPU shutdown");
+                Ok(Break(()))
+            },
+            Ok(VcpuControlResponse::Tid(_)) => {
+                let reason: String = "The tid is only sent when the vCPU thread is spawned. \
+                                      Sending it in the middle of a pause protocol is against the \
+                                      protocol"
+                    .to_string();
+                error!("{reason}");
+                Err(anyhow::anyhow!(reason))
+            },
+            Err(TryRecvError::Empty) => Ok(Continue(())),
+            Err(TryRecvError::Disconnected) => {
+                let reason: String = "the vmm has disconnected".to_string();
+                error!("try_receive_from_io_thread(): {reason}");
+                Err(anyhow::anyhow!(reason))
             },
         }
     }
@@ -306,11 +410,17 @@ impl Orchestrator {
         let mut counter: usize = 1;
         loop {
             match self.vcpu_control_rx.try_recv() {
-                Ok(VcpuControlResponse::Paused) => break,
-                Ok(VcpuControlResponse::Tid(tid)) => unreachable!(
-                    "The tid is only sent when the vCPU thread is spawned. Sending it in the \
-                     middle of a pause protocol is against the protocol. tid=({tid})"
-                ),
+                Ok(command) => {
+                    if command == VcpuControlResponse::Paused {
+                        break;
+                    } else {
+                        let reason: String = "during the pause protocol we only expect a `Paused` \
+                                              command from the vCPU"
+                            .to_string();
+                        error!("pause_protocol(): {reason}");
+                        anyhow::bail!(reason)
+                    }
+                },
                 Err(TryRecvError::Empty) => (),
                 Err(TryRecvError::Disconnected) => {
                     let reason: String = "the vmm has disconnected".to_string();

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -41,7 +41,6 @@ use ::hyperlight_host::{
         },
     },
 };
-use ::libc::pthread_self;
 use ::std::{
     fs::File,
     io::Write,
@@ -65,7 +64,6 @@ use ::syslog::{
     debug,
     error,
     info,
-    trace,
 };
 
 // ==================================================================================================
@@ -80,8 +78,10 @@ static VMEM: OnceLock<Arc<Mutex<SandboxMemoryManager<ExclusiveSharedMemory>>>> =
 
 pub struct Vmm {
     io_thread: Option<JoinHandle<Result<()>>>,
-    _memory_thread: JoinHandle<Result<()>>,
-    vcpu_thread: JoinHandle<Result<u16>>,
+    memory_thread: JoinHandle<Result<()>>,
+    // FIXME (#1010): without a mechanism to interrupt a HL sandbox we cannot join() the vCPU
+    // thread handle, so we leave it temporarily unused.
+    _vcpu_thread: JoinHandle<Result<u16>>,
     orchestrator: Orchestrator,
 }
 
@@ -103,6 +103,7 @@ impl Vmm {
     /// - `initrd_args`: Optional arguments to be passed to the initrd.
     /// - `stderr`: An optional path to a file where the virtual machine's standard error output will be written.
     /// - `system_vm_stream`: An optional connection to the system VM for communication with the virtual machine.
+    /// - `control_plane_stream`: An optional connection to the nanvixd control-plane.
     ///
     /// # Returns
     ///
@@ -116,8 +117,13 @@ impl Vmm {
         _initrd_args: Option<String>,
         stderr: Option<String>,
         system_vm_stream: Option<SocketStream>,
+        control_plane_stream: Option<SocketStream>,
     ) -> Result<u16> {
         crate::timer!("vmm_creation");
+
+        // TODO (#1009): all IO-related channels should be Optional and only be initialized if
+        // io_enabled is true.
+        let io_enabled: bool = system_vm_stream.is_some() || control_plane_stream.is_some();
 
         // io/memory/vcpu_control_rx/tx are channels owned by the VMM and transfer control messages.
         // *_thread_control_rx/tx are channels owned by the threads that transfer control messages.
@@ -129,19 +135,22 @@ impl Vmm {
         let (memory_control_tx, memory_thread_control_rx) = mpsc::channel::<MemoryControlCommand>();
         let (memory_thread_control_tx, memory_control_rx) =
             mpsc::channel::<MemoryControlResponse>();
-        let (vcpu_control_tx, vcpu_thread_control_rx) = mpsc::channel::<VcpuControlCommand>();
+        let (vcpu_control_tx, _vcpu_thread_control_rx) = mpsc::channel::<VcpuControlCommand>();
         let (vcpu_thread_control_tx, vcpu_control_rx) = mpsc::channel::<VcpuControlResponse>();
 
-        // Spawn I/O thread.
-        let io_thread: Option<JoinHandle<Result<()>>> = system_vm_stream.map(|conn| {
-            IoThread::spawn(
-                conn,
+        // Spawn I/O thread if we have any external stream to monitor.
+        let io_thread: Option<JoinHandle<Result<()>>> = if io_enabled {
+            Some(IoThread::spawn(
+                system_vm_stream,
                 io_thread_data_rx,
                 io_thread_data_tx,
                 io_thread_control_tx,
                 io_thread_control_rx,
-            )
-        });
+                control_plane_stream,
+            ))
+        } else {
+            None
+        };
 
         // Required values for heap and stack sizes to be used by the kernel.
         let heap_size = 4 * 1024 * 1024;
@@ -296,16 +305,6 @@ impl Vmm {
         );
 
         let vcpu_thread: JoinHandle<Result<u16>> = std::thread::spawn(move || {
-            // Store the tid so that the caller can send signals to the vCPU thread.
-            // SAFETY: we are calling pthread_self() right after creating the thread so this is
-            // safe.
-            let pthread_id: libc::pthread_t = unsafe { pthread_self() };
-            if let Err(e) = vcpu_thread_control_tx.send(VcpuControlResponse::Tid(pthread_id)) {
-                let reason: String = format!("failed to send the tid (error={e:?})");
-                error!("spawn(): {reason}");
-                anyhow::bail!(reason)
-            }
-
             match sandbox.evolve() {
                 Ok(res) => anyhow::bail!("Expected DEFAULT_VMM_SHUTDOWN_CMD, got: {:#?}", res),
                 Err(err) => {
@@ -319,25 +318,15 @@ impl Vmm {
                 },
             }
 
+            // Send shutdown message to VMM thread.
+            vcpu_thread_control_tx.send(VcpuControlResponse::Shutdown)?;
+
             // TODO: return the exit status code when supported.
             Ok(0)
         });
-        // Wait right after spawning the vCPU thread such that we populate the pthread id holder
-        // before actually starting the vCPU.
-        match vcpu_control_rx.recv() {
-            Ok(VcpuControlResponse::Tid(tid)) => trace!("Received vCPU thread tid: {tid}"),
-            Ok(response) => unreachable!(
-                "the first message sent on this channel is always a Tid response ( \
-                 response={response:?})"
-            ),
-            Err(e) => {
-                let reason: String = format!("the vCPU thread has disconnected (error={e:?})");
-                error!("spawn(): {reason}");
-                anyhow::bail!(reason)
-            },
-        }
 
         let orchestrator = Orchestrator::new(
+            io_enabled,
             io_control_rx,
             io_control_tx,
             memory_control_rx,
@@ -351,17 +340,27 @@ impl Vmm {
 
         let mut vmm: Vmm = Self {
             io_thread,
-            _memory_thread: memory_thread,
-            vcpu_thread,
+            memory_thread,
+            _vcpu_thread: vcpu_thread,
             orchestrator,
         };
 
-        if vmm.io_thread.is_some() {
-            while !vmm.vcpu_thread.is_finished() {
-                vmm.orchestrator.handle_command()?;
-            }
+        // Main VMM loop.
+        vmm.orchestrator.run()?;
+
+        // Join all auxiliary threads once the orchestrator has finished running. Do not bail if we
+        // fail to join, as we are already shutting down.
+        if let Err(e) = vmm.memory_thread.join() {
+            error!("spawn(): error joining memory thread (error={e:?})");
+        }
+        if let Some(io_thread) = vmm.io_thread {
+            // FIXME (#1004): support graceful shutdown of the IO thread.
+            let _ = io_thread.join();
         }
 
+        /* FIXME (#1010): without a mechanism to interrupt a running hyperlight sandbox, we cannot
+         * reliably join the vCPU thread. Instead, we rely on the JoinHandle being dropped once
+         * the orchestrator has finished running.
         match vmm.vcpu_thread.join() {
             Ok(exit_code) => exit_code,
             Err(e) => {
@@ -370,6 +369,11 @@ impl Vmm {
                 anyhow::bail!(reason)
             },
         }
+        */
+
+        // FIXME (#1010): the vCPU thread already returns 0 always, but we will be able to remove
+        // this line once we can join the vCPU thread.
+        Ok(0)
     }
 
     ///

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -50,6 +50,10 @@ use ::std::{
         Arc,
         Mutex,
         MutexGuard,
+        atomic::{
+            AtomicBool,
+            Ordering,
+        },
         mpsc::{
             Receiver,
             Sender,
@@ -65,6 +69,18 @@ use ::syslog::{
 };
 
 pub const INTERRUPT_SIGNAL: c_int = SIGUSR1;
+
+//==================================================================================================
+// Global variables
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Global shutdown flag. Safe to read/write from any thread. Writing an AtomicBool is
+/// async-signal-safe, so a signal handler can set it.
+///
+pub static SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
 //==================================================================================================
 // Structures
@@ -126,7 +142,9 @@ pub type OutputFn = dyn FnMut(&Arc<Mutex<VirtualMemory>>, u32, usize) -> Result<
 //==================================================================================================
 
 /// Signal handler for the vCPU thread. We install an empty handler to trigger an -EINTR.
-extern "C" fn vcpu_thread_signal_handler(_: i32) {}
+extern "C" fn vcpu_thread_signal_handler(_: i32) {
+    SHUTDOWN.store(true, Ordering::SeqCst);
+}
 
 impl MicroVm {
     ///
@@ -346,6 +364,33 @@ impl MicroVm {
     ///
     /// # Description
     ///
+    /// Helper method to poweroff the vCPU with a given exit status, and send a shutdown message to
+    /// the VMM thread.
+    ///
+    /// # Arguments
+    ///
+    /// - `exit_status`: the exit code to set for the vCPU.
+    ///
+    fn poweroff_and_shutdown(&mut self, exit_status: u16) -> Result<()> {
+        // Power-off vCPU.
+        self.vcpu
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .poweroff(exit_status);
+
+        // Send message to VMM thread.
+        self.handle
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .control_tx
+            .send(VcpuControlResponse::Shutdown)?;
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
     /// Runs the virtual machine.
     ///
     /// # Returns
@@ -392,6 +437,13 @@ impl MicroVm {
                                 .lock()
                                 .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
                                 .poweroff(exit_status);
+
+                            // Send shutdown message to VMM.
+                            locked_state
+                                .control_tx
+                                .send(VcpuControlResponse::Shutdown)?;
+
+                            return Ok(exit_status);
                         }
                         // The Nanvix Daemon requested to pause, this means we need to suspend execution,
                         // but possibly resume it later.
@@ -433,26 +485,26 @@ impl MicroVm {
                     }
                 },
 
-                // The guest requested to halt the virtual processor.
-                VirtualProcessorExitReason::Halt => {
-                    self.vcpu
-                        .lock()
-                        .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
-                        .poweroff(0);
-                },
-
-                // The guest was interrupted, this means we need to power-off.
-                VirtualProcessorExitReason::Interrupted => {
-                    self.vcpu
-                        .lock()
-                        .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
-                        .poweroff(0);
+                // The guest was halted or interrupted, this means we need to power-off.
+                VirtualProcessorExitReason::Halt | VirtualProcessorExitReason::Interrupted => {
+                    let exit_status: u16 = 0;
+                    self.poweroff_and_shutdown(exit_status)?;
+                    return Ok(exit_status);
                 },
 
                 // Virtual machine exited due to an unknown reason.
                 VirtualProcessorExitReason::Unknown => {
                     return Err(anyhow::anyhow!("unknown exit reason"));
                 },
+            }
+
+            // Check if we were interrupted while handling a PMIO exit. This check covers
+            // the situation where we have sent an interrupt to the vCPU, but the vCPU
+            // thread was not in KVM_RUN, thus not triggering an -EINTR that we can catch.
+            if SHUTDOWN.load(std::sync::atomic::Ordering::SeqCst) {
+                let exit_status: u16 = 0;
+                self.poweroff_and_shutdown(exit_status)?;
+                return Ok(exit_status);
             }
         }
     }

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -15,6 +15,9 @@ mod kvm;
 mod microvm;
 mod pal;
 
+// We need this constant in the orchestrator.
+pub use microvm::INTERRUPT_SIGNAL;
+
 //==================================================================================================
 // Imports
 //==================================================================================================
@@ -76,7 +79,7 @@ use ::syslog::{
 
 pub struct Vmm {
     io_thread: Option<JoinHandle<Result<()>>>,
-    _memory_thread: JoinHandle<Result<()>>,
+    memory_thread: JoinHandle<Result<()>>,
     vcpu_thread: JoinHandle<Result<u16>>,
     _microvm: MicroVm,
     orchestrator: Orchestrator,
@@ -100,6 +103,7 @@ impl Vmm {
     /// - `initrd_args`: Optional arguments to be passed to the initrd.
     /// - `stderr`: An optional path to a file where the virtual machine's standard error output will be written.
     /// - `system_vm_stream`: An optional connection to the system VM for communication with the virtual machine.
+    /// - `control_plane_stream`: An optional connection to the nanvixd control-plane.
     ///
     /// # Returns
     ///
@@ -113,8 +117,13 @@ impl Vmm {
         initrd_args: Option<String>,
         stderr: Option<String>,
         system_vm_stream: Option<SocketStream>,
+        control_plane_stream: Option<SocketStream>,
     ) -> Result<u16> {
         crate::timer!("vmm_creation");
+
+        // TODO (#1009): all IO-related channels should be Optional and only be initialized if
+        // io_enabled is true.
+        let io_enabled: bool = system_vm_stream.is_some() || control_plane_stream.is_some();
 
         // io/memory/vcpu_control_rx/tx are channels owned by the VMM and transfer control messages.
         // *_thread_control_rx/tx are channels owned by the threads that transfer control messages.
@@ -129,16 +138,19 @@ impl Vmm {
         let (vcpu_control_tx, vcpu_thread_control_rx) = mpsc::channel::<VcpuControlCommand>();
         let (vcpu_thread_control_tx, vcpu_control_rx) = mpsc::channel::<VcpuControlResponse>();
 
-        // Spawn I/O thread.
-        let io_thread: Option<JoinHandle<Result<()>>> = system_vm_stream.map(|conn| {
-            IoThread::spawn(
-                conn,
+        // Spawn I/O thread if we have any external stream to monitor.
+        let io_thread: Option<JoinHandle<Result<()>>> = if io_enabled {
+            Some(IoThread::spawn(
+                system_vm_stream,
                 io_thread_data_rx,
                 io_thread_data_tx,
                 io_thread_control_tx,
                 io_thread_control_rx,
-            )
-        });
+                control_plane_stream,
+            ))
+        } else {
+            None
+        };
 
         // Input function used for emulating I/O port reads.
         let input: Box<microvm::InputFn> = Self::build_input_fn(vcpu_thread_stdin_rx);
@@ -211,8 +223,11 @@ impl Vmm {
 
         // Wait right after spawning the vCPU thread such that we populate the pthread id holder
         // before actually starting the vCPU.
-        match vcpu_control_rx.recv() {
-            Ok(VcpuControlResponse::Tid(tid)) => trace!("Received vCPU thread tid: {tid}"),
+        let vcpu_tid: u64 = match vcpu_control_rx.recv() {
+            Ok(VcpuControlResponse::Tid(tid)) => {
+                trace!("Received vCPU thread tid: {tid}");
+                tid
+            },
             Ok(response) => unreachable!(
                 "the first message sent on this channel is always a Tid response ( \
                  response={response:?})"
@@ -222,11 +237,13 @@ impl Vmm {
                 error!("spawn(): {reason}");
                 anyhow::bail!(reason)
             },
-        }
+        };
 
         let create_snapshot_clone: MicroVm = microvm.clone();
         let filename: String = initrd_filename.unwrap_or("bin/default.elf".to_string());
         let orchestrator = Orchestrator::new(
+            io_enabled,
+            vcpu_tid,
             io_control_rx,
             io_control_tx,
             memory_control_rx,
@@ -257,16 +274,23 @@ impl Vmm {
 
         let mut vmm: Vmm = Self {
             io_thread,
-            _memory_thread: memory_thread,
+            memory_thread,
             vcpu_thread,
             _microvm: microvm,
             orchestrator,
         };
 
-        if vmm.io_thread.is_some() {
-            while !vmm.vcpu_thread.is_finished() {
-                vmm.orchestrator.handle_command()?;
-            }
+        // Main VMM loop.
+        vmm.orchestrator.run()?;
+
+        // Join all auxiliary threads once the orchestrator has finished running. Do not bail if we
+        // fail to join, as we are already shutting down.
+        if let Err(e) = vmm.memory_thread.join() {
+            error!("spawn(): error joining memory thread (error={e:?})");
+        }
+        if let Some(io_thread) = vmm.io_thread {
+            // FIXME (1004): support graceful shutdown of the IO thread.
+            let _ = io_thread.join();
         }
 
         match vmm.vcpu_thread.join() {

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -528,6 +528,7 @@ impl Benchmark {
                 None,
                 Some("/dev/null".to_string()),
                 Some(syscomm::SocketStream::Unix(vmm_stream)),
+                None,
             )? {
                 e if e != 0 => {
                     error!("error running VMM, exited with status: {e}");

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -247,7 +247,7 @@ impl SandboxCache {
             .get(&user_vm_id)
             .ok_or_else(|| anyhow::anyhow!("user VM instance not found in cache"))?;
 
-        self.kill_internal(&tag.clone())
+        self.kill_internal(&tag.clone()).await
     }
 
     ///
@@ -263,23 +263,24 @@ impl SandboxCache {
     ///
     /// A reference to the sandbox.
     ///
-    fn kill_internal(&mut self, tag: &SandboxTag) -> Result<()> {
+    async fn kill_internal(&mut self, tag: &SandboxTag) -> Result<()> {
         let user_vm_id = tag.sandbox_id();
 
         if !self.user_vm_instances.contains_key(tag) {
-            warn!("trying to drop sandbox (tag={tag:?}) which is not in the cache");
+            warn!("trying to kill user VM that is not in the cache (tag={tag:?})");
             return Ok(());
         }
 
-        if let Some(user_vm) = self.user_vm_instances.remove(tag) {
-            if Arc::strong_count(&user_vm) != 1 {
-                warn!(
-                    "trying to drop user VM, but there are dangling references to it this may \
-                     introduce unexpected behaviour"
-                );
+        if let Some(mut user_vm) = self.user_vm_instances.remove(tag) {
+            if let Some(user_vm_mut) = Arc::get_mut(&mut user_vm) {
+                if let Err(e) = user_vm_mut.shutdown().await {
+                    error!("error shutting down user VM (tag={tag:?}, error={e:?})");
+                } else {
+                    debug!("shut down user VM (tag={tag:?})");
+                }
+            } else {
+                error!("error shutting down user VM: cannot get mut (tag={tag:?})");
             }
-
-            // User VM is dropped.
         }
 
         self.sandbox_index.remove(&user_vm_id);
@@ -297,20 +298,32 @@ impl SandboxCache {
     /// On success empty is returned. On failure an error is returned instead.
     ///
     pub async fn cleanup(&mut self) {
-        // TODO: for the time being only linuxd instances support being gracefully shutdown. User
-        // VMs are missing a control-plane socket.
+        // First shutdown all user VMs.
+        for (tag, user_vm_instance) in self.user_vm_instances.iter_mut() {
+            if let Some(user_vm_instance_mut) = Arc::get_mut(user_vm_instance) {
+                debug!("sending shutdown message to user vm (tag={tag:?})");
+                if let Err(e) = user_vm_instance_mut.shutdown().await {
+                    error!("error cleaning-up user vm instance (tag={tag:?}, error={e:?})");
+                } else {
+                    debug!("cleaned-up user vm instance (tag={tag:?})");
+                }
+            } else {
+                error!("error cleaning-up user vm instance: not found (tag={tag:?})");
+            }
+        }
+
+        // Shutdown all linuxd instances.
         for (tenant_id, linuxd_instance) in self.linuxd_instances.iter_mut() {
             if let Some(linuxd_instance_mut) = Arc::get_mut(linuxd_instance) {
                 if let Err(e) = linuxd_instance_mut.shutdown().await {
-                    // FIXME: convert to error once linuxd supports a graceful shutdown.
-                    debug!("error cleaning-up linuxd instance for tenant {tenant_id}: {e:?}");
+                    error!(
+                        "error cleaning-up linuxd instance (tenant_id={tenant_id}, error={e:?})"
+                    );
                 } else {
-                    debug!("cleaned-up linuxd instance for tenant {tenant_id}");
+                    debug!("cleaned-up linuxd instance (tenant_id={tenant_id})");
                 }
             } else {
-                error!(
-                    "error cleaning-up linuxd instance for tenant {tenant_id}: instance not found"
-                );
+                error!("error cleaning-up linuxd instance: not found (tenant_id={tenant_id})");
             }
         }
     }

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -35,9 +35,6 @@ use ::tokio::process::{
 
 pub struct Microvm {
     child: Option<Child>,
-    addr: String,
-    #[allow(dead_code)]
-    // FIXME: the micro VM still does not support processing messages from the control-plane.
     control_plane_stream: SocketStream,
     /// Configuration for this sandbox instance. It includes a RAII handle around the TCP
     /// port used for the gateway of this user VM if linuxd is deployed in an L2 VM.
@@ -172,47 +169,48 @@ impl Microvm {
 
         Ok(Self {
             child: Some(child),
-            addr: sandbox_config.user_vm_sockaddr().to_string(),
             control_plane_stream,
             _config: sandbox_config,
         })
     }
-}
 
-impl Drop for Microvm {
-    fn drop(&mut self) {
+    ///
+    /// # Description
+    ///
+    /// Send a shutdown message to the user VM's control-plane socket so that it can gracefully
+    /// shutdown, and wait until the process dies.
+    ///
+    pub async fn shutdown(&mut self) -> Result<()> {
+        match control_plane_api::send_command(
+            &mut self.control_plane_stream,
+            control_plane_api::Command::Shutdown,
+        ) {
+            Ok(()) => {},
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
+                debug!("user VM already shut down");
+            },
+            Err(e) => {
+                error!("failed to send shutdown command to user VM (error={e:?})");
+            },
+        };
+
+        // Wait for user VM instance to finish.
         if let Some(mut child) = self.child.take() {
-            match child.id() {
-                Some(pid) => {
-                    let ret_code = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
-
-                    if ret_code < 0 {
+            match child.wait().await {
+                Ok(exit_status) => {
+                    if !exit_status.success() {
                         error!(
-                            "error sending SIGINT to user VM: {}",
-                            std::io::Error::last_os_error()
+                            "user VM returned with non-zero exit status (code={:?})",
+                            exit_status.code()
                         );
                     }
                 },
-                None => error!("user VM process has no PID"),
-            }
-
-            // Wait for the child to finish in a separate thread to be able to `await` on it.
-            tokio::spawn(async move {
-                if let Err(e) = child.wait().await {
-                    error!("failed to wait for user VM to shut down (error={e:?})");
-                }
-            });
-
-            // Clean-up the per-micro VM socket file.
-            // FIXME: this won't be necessary once all micro VMs share a socket in one linuxd
-            // instance.
-            match std::fs::remove_file(self.addr.clone()) {
-                Ok(_) => {},
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {},
                 Err(e) => {
-                    error!("error removing micro VM socket (addr={}, error={e:?})", self.addr)
+                    error!("error waiting for user VM (error={e:?})");
                 },
             }
         }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
In this PR I implement support to gracefully shutdown the micro VM using the control-plane API from nanvixd.

This change involves a few moving pieces. First, we need to pass the `control_plane_stream` to the IO thread, so that it can monitor it. Then, we need to actually trigger the interrupt support that we introduced in #818 (guess what, there was a bug that I fix in #1007). Lastly, and this is the biggest architectural change, we need the VMM thread to actually decide when has execution finished, in order to join on all the other components.

Following-up on the last point, right now the main VMM loop (the one that calls the orchestrator) is wrapped in an while loop bound to the lifecycle of the vCPU thread (i.e. `while !self.vcpu_thread.is_finished()`). It is cleaner if we make the orchestrator `run()` in its own loop, and decide when to break out of it in its own accord. 

Right now, there are two possible exit reasons: 
1. Nanvix sends a shutdown command: I/O thread sends shutdown to orchestrator, orchestrator sends interrupt to vCPU, and waits for vCPU to send a Shutdown message via control channel.
2. vCPU runs to completion: after finishing it sends a Shutdown message to the VMM via control channel like the last step above.

Lastly, the simple interrupt approach does not work to actually interrupt hyperlight. I implement a work-around in this PR (at the cost of a few error messages during shutdown), but we should consider how to implement this properly (see #1010).