### PR TITLE
[libs] Linux mprotect

### DIFF
--- a/src/libs/syscall/src/sys/mman/syscalls/mprotect.rs
+++ b/src/libs/syscall/src/sys/mman/syscalls/mprotect.rs
@@ -63,9 +63,11 @@ pub fn mprotect(
 ) -> Result<(), Error> {
     // Check if base address is invalid.
     if base < USER_MMAP_BASE || base >= USER_MMAP_END {
-        let reason: &'static str = "invalid base address";
-        ::syslog::error!("mprotect(): {reason} (base={base:?}, len={len}, prot={prot:?})");
-        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        // POSIX specifies that calling `mprotect()` on an address range that was not previously
+        // mapped with `mmap()` has undefined behavior. However, Linux does allow such an operation
+        // to succeed. To be compatible with Linux, we simply don't change any protection flags.
+        // See: https://www.man7.org/linux/man-pages/man2/mprotect.2.html
+        return Ok(());
     }
 
     // Check if base address is page-aligned.


### PR DESCRIPTION
This pull request updates the behavior of the `mprotect` system call implementation to better match Linux's handling of invalid base addresses. Instead of returning an error when `mprotect` is called on an unmapped address range, the function now returns success without changing any protection flags, aligning with Linux's more permissive and POSIX-undefined behavior.

Behavioral compatibility improvement:

* Updated `src/libs/syscall/src/sys/mman/syscalls/mprotect.rs` so that `mprotect()` on an invalid (unmapped) base address now returns `Ok(())` instead of an error, for compatibility with Linux and POSIX's undefined behavior.