### PR TITLE
[build] Add cmake To Dependency List

### DIFF
--- a/scripts/setup/Dockerfile
+++ b/scripts/setup/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && \
     bridge-utils \
     build-essential \
     clang-format \
+    cmake \
     codespell \
     cpio \
     curl \

--- a/scripts/setup/ubuntu.sh
+++ b/scripts/setup/ubuntu.sh
@@ -17,6 +17,7 @@ apt-get install -y        \
     bridge-utils          \
     build-essential       \
     clang-format          \
+    cmake                 \
     codespell             \
     cpio                  \
     curl                  \


### PR DESCRIPTION
The native rust build requires cmake to be installed. In this commit I amend our setup scripts to install it.