### PR TITLE
[microvm] Load virtual memory snapshots

### DIFF
--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -110,6 +110,8 @@ pub struct Orchestrator {
     resume_microvm: Box<dyn Fn() -> Result<()> + Send + 'static>,
     // Callback function to create a snapshot.
     create_snapshot: Box<dyn Fn() -> Result<()> + Send + 'static>,
+    // Callback function to load a snapshot.
+    load_snapshot: Box<dyn Fn() -> Result<()> + Send + 'static>,
 }
 
 //==================================================================================================
@@ -225,6 +227,7 @@ impl Orchestrator {
         pause_microvm: Box<dyn Fn() -> Result<()> + Send + 'static>,
         resume_microvm: Box<dyn Fn() -> Result<()> + Send + 'static>,
         create_snapshot: Box<dyn Fn() -> Result<()> + Send + 'static>,
+        load_snapshot: Box<dyn Fn() -> Result<()> + Send + 'static>,
     ) -> Self {
         Self {
             state: State::PreBoot,
@@ -243,6 +246,7 @@ impl Orchestrator {
             pause_microvm,
             resume_microvm,
             create_snapshot,
+            load_snapshot,
         }
     }
 
@@ -310,7 +314,12 @@ impl Orchestrator {
                 },
                 IoControlCommand::_LoadSnapshotAndRun => {
                     if self.state == State::PreBoot {
-                        // TODO: load snapshot https://github.com/nanvix/nanvix/issues/948
+                        if let Err(e) = (self.load_snapshot)() {
+                            let reason: String =
+                                format!("LoadSnapshotAndRun: failed to load snapshot: {e:?}");
+                            error!("handle_command(): {reason}");
+                            anyhow::bail!(reason);
+                        }
                         trace!("State: PreBoot -> Paused");
 
                         // The Linux daemon should send messages to PreBoot VMMs by default,

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -374,6 +374,7 @@ impl Vmm {
             Box::new(pause_microvm),
             Box::new(resume_microvm),
             Box::new(|| Ok(())), // TODO: create_snapshot https://github.com/nanvix/nanvix/issues/947
+            Box::new(|| Ok(())), // TODO: load_snapshot https://github.com/nanvix/nanvix/issues/948
         );
 
         let mut vmm: Vmm = Self {

--- a/src/microvm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/microvm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -745,8 +745,15 @@ impl VirtualProcessor {
     ///
     /// Upon successful completion, returns empty. Otherwise, returns an error.
     ///
-    pub fn _set_state(&mut self, _state: VirtualProcessorState) -> Result<()> {
+    pub fn set_state(&mut self, _state: VirtualProcessorState) -> Result<()> {
         // TODO: set virtual processor state https://github.com/nanvix/nanvix/issues/948
+        Ok(())
+    }
+}
+
+impl VirtualProcessorState {
+    pub fn validate(&self) -> Result<()> {
+        // TODO: ensure state is safe to resume running.
         Ok(())
     }
 }

--- a/src/microvm/src/vmm/microvm/kvm/vmem.rs
+++ b/src/microvm/src/vmm/microvm/kvm/vmem.rs
@@ -17,7 +17,10 @@ use ::arch::mem::PAGE_SIZE;
 use ::kvm_bindings::kvm_userspace_memory_region;
 use ::std::{
     fs::File,
-    io::Write,
+    io::{
+        Read,
+        Write,
+    },
     mem,
     path::Path,
     ptr::{
@@ -518,6 +521,74 @@ impl VirtualMemory {
         trace!("save_snapshot(): successfully saved snapshot to {:?}", path);
         Ok(())
     }
+
+    ///
+    /// # Description
+    ///
+    /// Loads a virtual memory snapshot from a snapshot file.
+    /// This restores the memory contents and metadata.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the snapshot file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn load_snapshot(&mut self, path: &Path) -> Result<()> {
+        trace!("load_snapshot(): reading from {:?}", path);
+        crate::timer!("vmem_load_snapshot");
+
+        let mut file: File = match File::open(path) {
+            Ok(f) => f,
+            Err(e) => {
+                let reason: String =
+                    format!("failed opening virtual memory snapshot file (error={e:?})");
+                error!("load_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Read the header
+        let mut header_bytes: [u8; SIZE_OF_HEADER] = [0u8; SIZE_OF_HEADER];
+        let header: SnapshotHeader = match file.read_exact(&mut header_bytes) {
+            Ok(()) => SnapshotHeader::from_bytes(&header_bytes),
+            Err(e) => {
+                let reason: String = format!(
+                    "failed reading header from virtual memory snapshot file (error={e:?})"
+                );
+                error!("load_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Validate that the memory size matches
+        if header.memory_size != self.size {
+            let reason: String =
+                format!("memory size mismatch: expected {}, got {}", self.size, header.memory_size);
+            error!("load_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        // Read the memory contents
+        // SAFETY: We're making a slice of the size of the virtual memory starting at its base.
+        let memory_slice: &mut [u8] = unsafe { slice::from_raw_parts_mut(self.ptr, self.size) };
+        if let Err(e) = file.read_exact(memory_slice) {
+            let reason: String = format!("failed to read memory contents (error={e:?})");
+            error!("load_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+        // TODO: validate header checksum matches the checksum computed off of the memory slice https://github.com/nanvix/nanvix/issues/1014
+
+        // Restore metadata
+        self.kernel = Some((header.kernel_base, header.kernel_size));
+        self.initrd = Some((header.initrd_base, header.initrd_size));
+        self.credits = header.credits;
+
+        trace!("load_snapshot(): successfully loaded snapshot from {:?}", path);
+        Ok(())
+    }
 }
 
 impl Drop for VirtualMemory {
@@ -568,5 +639,26 @@ impl SnapshotHeader {
         // SAFETY: Size and alignment are guaranteed by being a `SnapshotHeader` method.
         // The struct has #[repr(C)].
         unsafe { mem::transmute::<&SnapshotHeader, &[u8; SIZE_OF_HEADER]>(self) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Deserializes a snapshot header from a slice of bytes.
+    ///
+    /// # Parameters
+    ///
+    /// - `bytes`: Slice of bytes containing the snapshot header.
+    ///
+    /// # Returns
+    ///
+    /// The type-safe form of the header.
+    ///
+    fn from_bytes(bytes: &[u8; SIZE_OF_HEADER]) -> Self {
+        // SAFETY: Size is guaranteed to match SIZE_OF_HEADER.
+        // The struct has #[repr(C)] so memory layout is guaranteed.
+        // The header is at the beginning of the file, so alignment is guaranteed.
+        unsafe { mem::transmute::<[u8; SIZE_OF_HEADER], SnapshotHeader>(*bytes) }
+        // TODO: #1014 Add a magic number to the header and check it after deserialization.
     }
 }

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -26,6 +26,7 @@ use crate::{
             VirtualProcessor,
             VirtualProcessorExitContext,
             VirtualProcessorExitReason,
+            VirtualProcessorState,
         },
         vmem::VirtualMemory,
     },
@@ -638,6 +639,76 @@ impl MicroVm {
                 error!("create_snapshot(): {reason}");
                 anyhow::bail!(reason)
             },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Loads the virtual memory and the KVM state from files.
+    ///
+    /// # Parameters
+    ///
+    /// - `filepath`: Path to the executable file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns empty. Otherwise, returns an error.
+    ///
+    pub fn load_snapshot(&self, filepath: &str) -> Result<()> {
+        let (vmem_filepath, kvm_filepath) = Self::make_snapshot_paths(filepath);
+
+        if let Err(e) = self
+            .vmem
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .load_snapshot(&vmem_filepath)
+        {
+            let reason: String = format!("failed loading virtual memory snapshot (error={e:?})");
+            error!("load_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        let mut file: File = match File::open(kvm_filepath) {
+            Ok(f) => f,
+            Err(e) => {
+                let reason: String = format!("failed opening vcpu snapshot file (error={e:?})");
+                error!("load_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+        let state: VirtualProcessorState = match bincode::serde::decode_from_std_read::<
+            VirtualProcessorState,
+            _,
+            _,
+        >(&mut file, bincode::config::standard())
+        {
+            Ok(state) => {
+                if let Err(e) = state.validate() {
+                    let reason: String = format!("decoded vcpu snapshot is invalid (error={e:?})");
+                    error!("load_snapshot(): {reason}");
+                    anyhow::bail!(reason)
+                } else {
+                    state
+                }
+            },
+            Err(e) => {
+                let reason: String = format!("failed decoding vcpu snapshot file (error={e:?})");
+                error!("load_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+        if let Err(e) = self
+            .vcpu
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to acquire lock {e:?}"))?
+            .set_state(state)
+        {
+            let reason: String = format!("failed setting vcpu state (error={e:?})");
+            error!("load_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        } else {
+            Ok(())
         }
     }
 }

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -271,7 +271,9 @@ impl Vmm {
         };
 
         let create_snapshot_clone: MicroVm = microvm.clone();
+        let load_snapshot_clone: MicroVm = microvm.clone();
         let filename: String = initrd_filename.unwrap_or("bin/default.elf".to_string());
+        let filename_clone: String = filename.clone();
         let orchestrator = Orchestrator::new(
             orchestrator_poll,
             io_enabled,
@@ -303,7 +305,7 @@ impl Vmm {
                     )
             }),
             Box::new(move || create_snapshot_clone.create_snapshot(&filename)),
-            // TODO: load_snapshot https://github.com/nanvix/nanvix/issues/948
+            Box::new(move || load_snapshot_clone.load_snapshot(&filename_clone)),
         );
 
         let mut vmm: Vmm = Self {


### PR DESCRIPTION
This PR adds a callback function to the `Orchestrator` to issue snapshot loads. This is a call to the `MicroVm`, which passes more specific calls to the `VirtualMemory` and the `VirtualProcessor`. The `VirtualProcessor` implementation has been separated from this PR, as it is more complex.