### PR TITLE
[microvm] Remove Spinning Cores From MicroVM

### DIFF
--- a/src/microvm/Cargo.toml
+++ b/src/microvm/Cargo.toml
@@ -25,6 +25,7 @@ cfg-if = { workspace = true }
 config = { workspace = true, features = ["microvm"] }
 control-plane-api = { workspace = true }
 hyperlight-host = { workspace = true, optional = true }
+mio = { workspace = true }
 profiler = { workspace = true, features = ["auto-calibrate"] }
 serde = { workspace = true, features = ["derive"] }
 static_assert = { workspace = true }

--- a/src/microvm/src/io_thread.rs
+++ b/src/microvm/src/io_thread.rs
@@ -11,14 +11,29 @@ use crate::orchestrator::{
 };
 use ::anyhow::Result;
 use ::control_plane_api;
+use ::mio::{
+    Events,
+    Interest,
+    Poll,
+    Token,
+    Waker,
+};
 use ::std::{
     collections::VecDeque,
     io::ErrorKind,
     mem,
-    sync::mpsc::{
-        Receiver,
-        Sender,
-        TryRecvError,
+    ops::ControlFlow::{
+        self,
+        Break,
+        Continue,
+    },
+    sync::{
+        Arc,
+        mpsc::{
+            Receiver,
+            Sender,
+            TryRecvError,
+        },
     },
     thread::{
         self,
@@ -33,6 +48,17 @@ use ::syslog::{
 };
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Token represnting an event notification from the control-plane socket.
+const CONTROL_PLANE_TOKEN: Token = Token(0);
+/// Token represnting an event notification from inbound queues from the VM.
+const WAKER_TOKEN: Token = Token(1);
+/// Token represnting an event notification from the system VM socket.
+const SYSTEM_VM_TOKEN: Token = Token(2);
+
+//==================================================================================================
 // Structure
 //==================================================================================================
 
@@ -42,12 +68,18 @@ use ::syslog::{
 /// Private data of the I/O thread.
 ///
 pub struct IoThread {
+    /// Poll structure to monitor connections and queues.
+    poll: Poll,
+    /// Waker to notify the I/O thread that it has messages to read from its connected queues.
+    waker: Arc<Waker>,
     /// Optional connection to the system VM.
     system_vm_stream: Option<SocketStream>,
     /// Buffer to handle partial reads from the system VM.
     system_vm_partial_read_buffer: VecDeque<u8>,
     /// Optional connection to the external control-plane, nanvixd.
     control_plane_stream: Option<SocketStream>,
+    /// Waker token for the memory thread.
+    memory_thread_waker: Arc<Waker>,
     /// Gateway receiver.
     data_rx: Receiver<Message>,
     /// Gateway sender.
@@ -56,6 +88,8 @@ pub struct IoThread {
     incoming: VecDeque<Message>,
     /// Queue of outgoing messages.
     outgoing: VecDeque<Message>,
+    /// Waker token for the VMM (orchestrator).
+    orchestrator_waker: Arc<Waker>,
     /// Command sender to the VMM.
     control_tx: Sender<IoControlCommand>,
     /// Response receiver from the VMM.
@@ -75,36 +109,48 @@ impl IoThread {
     ///
     /// # Parameters
     ///
-    /// - `system_vm_stream`: Connection to the system VM.
+    /// - `system_vm_stream`: Optional connection to the system VM.
+    /// - `memory_thread_waker`: Waker token to notify the memory thread when we send in data_tx.
     /// - `data_rx`: MicroVM receiver.
     /// - `data_tx`: MicroVM sender.
+    /// - `orchestrator`: Waker token to notify the orchestrator when we send in control_tx.
     /// - `control_tx`: Command sender.
     /// - `control_rx`: Response receiver.
+    /// - `control_plane_stream`: Optional connection to the control-plane.
     ///
     /// # Returns
     ///
     /// A handle to the I/O thread.
     ///
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         system_vm_stream: Option<SocketStream>,
+        memory_thread_waker: Arc<Waker>,
         data_rx: Receiver<Message>,
         data_tx: Sender<Message>,
+        orchestrator_waker: Arc<Waker>,
         control_tx: Sender<IoControlCommand>,
         control_rx: Receiver<IoControlResponse>,
         control_plane_stream: Option<SocketStream>,
-    ) -> JoinHandle<Result<()>> {
-        thread::spawn(move || {
-            let mut io_thread: IoThread = IoThread::new(
-                system_vm_stream,
-                data_rx,
-                data_tx,
-                control_tx,
-                control_rx,
-                control_plane_stream,
-            )?;
+    ) -> Result<(JoinHandle<Result<()>>, Arc<Waker>)> {
+        let mut io_thread: IoThread = IoThread::new(
+            system_vm_stream,
+            memory_thread_waker,
+            data_rx,
+            data_tx,
+            orchestrator_waker,
+            control_tx,
+            control_rx,
+            control_plane_stream,
+        )?;
+        let io_thread_waker: Arc<Waker> = io_thread.waker();
+
+        let io_thread_handle: JoinHandle<Result<()>> = thread::spawn(move || {
             io_thread.run()?;
             Ok(())
-        })
+        });
+
+        Ok((io_thread_handle, io_thread_waker))
     }
 
     ///
@@ -116,8 +162,10 @@ impl IoThread {
     /// # Parameters
     ///
     /// - `system_vm_stream`: Optional connection to the system VM.
+    /// - `memory_thread_waker`: Waker to notify the memory thread of pending messages in data_tx.
     /// - `data_rx`: MicroVM receiver.
     /// - `data_tx`: MicroVM sender.
+    /// - `memory_thread_waker`: Waker to notify the orchestrator of pending messages in control_tx.
     /// - `control_tx`: Command sender.
     /// - `control_rx`: Response receiver.
     /// - `control_plane_stream`: Optional connection to the control-plane stream.
@@ -126,21 +174,47 @@ impl IoThread {
     ///
     /// Upon success, a new I/O thread is returned. Otherwise, an error is returned.
     ///
+    #[allow(clippy::too_many_arguments)]
     fn new(
-        system_vm_stream: Option<SocketStream>,
+        mut system_vm_stream: Option<SocketStream>,
+        memory_thread_waker: Arc<Waker>,
         data_rx: Receiver<Message>,
         data_tx: Sender<Message>,
+        orchestrator_waker: Arc<Waker>,
         control_tx: Sender<IoControlCommand>,
         control_rx: Receiver<IoControlResponse>,
-        control_plane_stream: Option<SocketStream>,
+        mut control_plane_stream: Option<SocketStream>,
     ) -> Result<Self> {
+        let poll: Poll = Poll::new()?;
+
+        // Register system VM and/or control-plane streams. At least one should be present
+        // otherwise we would not have spawned the I/O thread.
+        if let Some(system_vm_stream) = system_vm_stream.as_mut() {
+            poll.registry()
+                .register(system_vm_stream, SYSTEM_VM_TOKEN, Interest::READABLE)?;
+        }
+        if let Some(control_plane_stream) = control_plane_stream.as_mut() {
+            poll.registry().register(
+                control_plane_stream,
+                CONTROL_PLANE_TOKEN,
+                Interest::READABLE,
+            )?;
+        }
+
+        // Register a waker token such that other components can notify us about pending work.
+        let waker: Arc<Waker> = Arc::new(Waker::new(poll.registry(), WAKER_TOKEN)?);
+
         Ok(Self {
+            poll,
+            waker,
             system_vm_stream,
             system_vm_partial_read_buffer: VecDeque::new(),
+            memory_thread_waker,
             data_rx,
             data_tx,
             incoming: VecDeque::new(),
             outgoing: VecDeque::new(),
+            orchestrator_waker,
             control_tx,
             control_rx,
             control_plane_stream,
@@ -157,13 +231,58 @@ impl IoThread {
     /// Upon success, empty is returned. Otherwise, an error is returned instead.
     ///
     fn run(&mut self) -> Result<()> {
+        let mut events: Events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+
         loop {
-            self.try_send_to_vmm_control()?;
-            self.try_receive_from_microvm()?;
-            self.try_send_to_system_vm()?;
-            self.try_receive_from_system_vm()?;
-            self.try_send_to_microvm()?;
-            self.try_receive_from_vmm_control()?;
+            self.poll.poll(&mut events, None)?;
+
+            // We must drain each socket/queue until they return WouldBlock in order to not miss
+            // any messages. We surface a WouldBlock or a queue being empty with a Break().
+            for event in events.iter() {
+                match event.token() {
+                    // Prioritize events from the control-plane.
+                    CONTROL_PLANE_TOKEN => {
+                        while self.try_send_to_vmm_control()? != Break(()) {}
+
+                        self.orchestrator_waker.wake()?;
+                    },
+
+                    // There are internal events we need to react to in any of our incoming queues.
+                    WAKER_TOKEN => {
+                        // Try to receive from the I/O thread's control-plane first.
+                        while self.try_receive_from_vmm_control()? != Break(()) {}
+
+                        // Try to receive from the data-plane.
+                        while self.try_receive_from_microvm()? != Break(()) {}
+
+                        // FIXME (#1025): merge try_receive_from_microvm and try_send_to_system_vm
+                        while !self.outgoing.is_empty() {
+                            self.try_send_to_system_vm()?;
+                        }
+                    },
+
+                    SYSTEM_VM_TOKEN => {
+                        while self.try_receive_from_system_vm()? != Break(()) {}
+
+                        // FIXME (#1025): merge try_receive_from_system_vm and try_send_to_microvm
+                        while !self.incoming.is_empty() {
+                            self.try_send_to_microvm()?;
+                        }
+
+                        // Notify the memory thread that it has work to do.
+                        self.memory_thread_waker.wake()?;
+                    },
+
+                    token => {
+                        // This error should not happen, but is not fatal, so we log it and
+                        // continue.
+                        error!(
+                            "run(): I/O thread received notification from unexpected token \
+                             (token={token:?})"
+                        );
+                    },
+                }
+            }
         }
     }
 
@@ -175,10 +294,10 @@ impl IoThread {
     ///
     /// # Returns
     ///
-    /// Upon success, the received message is pushed into the `incoming` queue, and `true` is returned.
-    /// Otherwise, if it would block, `false` is returned. Otherwise, an error is returned.
+    /// Upon success, the received message is pushed into the `incoming` queue, and `Continue()` is
+    /// returned. Otherwise, if it would block, `Break()` is returned.
     ///
-    fn try_receive_from_system_vm(&mut self) -> Result<bool> {
+    fn try_receive_from_system_vm(&mut self) -> Result<ControlFlow<()>> {
         if let Some(system_vm_stream) = self.system_vm_stream.as_mut() {
             let mut buf: [u8; mem::size_of::<Message>()] = [0; mem::size_of::<Message>()];
 
@@ -208,8 +327,8 @@ impl IoThread {
                         self.system_vm_partial_read_buffer
                             .extend(&buf[..(n + num_filled)]);
 
-                        // A partial read corresponds to a WouldBlock, so we return false.
-                        return Ok(false);
+                        // A partial read corresponds to a WouldBlock, so we break.
+                        return Ok(Break(()));
                     }
                 },
                 // If WouldBlock, return false.
@@ -221,7 +340,7 @@ impl IoThread {
                             .extend(&buf[..num_filled]);
                     }
 
-                    return Ok(false);
+                    return Ok(Break(()));
                 },
                 Err(e) => {
                     let reason: String =
@@ -248,9 +367,9 @@ impl IoThread {
             );
 
             self.incoming.push_back(message);
-            Ok(true)
+            Ok(Continue(()))
         } else {
-            Ok(false)
+            Ok(Break(()))
         }
     }
 
@@ -261,10 +380,10 @@ impl IoThread {
     ///
     /// # Returns
     ///
-    /// Upon success, the received message is pushed into the `outgoing` queue, and `true`is returned.
-    /// Otherwise, if the channel is empty, `false` is returned. Otherwise, an error is returned.
+    /// Upon success, the received message is pushed into the `outgoing` queue, and `Continue()` is
+    /// returned. Otherwise, if the channel is empty, `Break()` is returned.
     ///
-    fn try_receive_from_microvm(&mut self) -> Result<bool> {
+    fn try_receive_from_microvm(&mut self) -> Result<ControlFlow<()>> {
         match self.data_rx.try_recv() {
             Ok(mut message) => {
                 profiler::timestamp_message!(
@@ -273,9 +392,9 @@ impl IoThread {
                         + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
                 );
                 self.outgoing.push_back(message);
-                Ok(true)
+                Ok(Continue(()))
             },
-            Err(TryRecvError::Empty) => Ok(false),
+            Err(TryRecvError::Empty) => Ok(Break(())),
             Err(TryRecvError::Disconnected) => {
                 let reason: String = "the microvm has disconnected".to_string();
                 // When the guest finishes , the vCPU thread will disconnect from this thread. This
@@ -336,13 +455,13 @@ impl IoThread {
     ///
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
-    fn try_send_to_vmm_control(&mut self) -> Result<()> {
+    fn try_send_to_vmm_control(&mut self) -> Result<ControlFlow<()>> {
         if let Some(control_plane_stream) = self.control_plane_stream.as_mut() {
             let cmd: control_plane_api::Command =
                 match control_plane_api::try_read_command(control_plane_stream) {
                     Ok(cmd) => cmd,
                     // If we would block, return and do nothing.
-                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => return Ok(()),
+                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => return Ok(Break(())),
                     Err(e) => {
                         let reason: String = format!(
                             "try_send_to_vmm_control(): failed reading command from control-plane \
@@ -360,7 +479,7 @@ impl IoThread {
             }
         }
 
-        Ok(())
+        Ok(Continue(()))
     }
 
     ///
@@ -397,19 +516,26 @@ impl IoThread {
     ///
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
-    fn try_receive_from_vmm_control(&mut self) -> Result<()> {
+    fn try_receive_from_vmm_control(&mut self) -> Result<ControlFlow<()>> {
         match self.control_rx.try_recv() {
             Ok(response) => match response {
-                IoControlResponse::FlushOutput => self.flush_microvm_output(),
-                IoControlResponse::FlushInput => self.flush_linuxd_input(),
+                IoControlResponse::FlushOutput => {
+                    self.flush_microvm_output()?;
+                    Ok(Continue(()))
+                },
+                IoControlResponse::FlushInput => {
+                    self.flush_linuxd_input()?;
+                    Ok(Continue(()))
+                },
                 IoControlResponse::Shutdown => {
                     // TODO (#1004): Break() out of the main loop here.
                     let reason: String = "IO thread shutting down".to_string();
                     anyhow::bail!(reason)
                 },
-                _ => Ok(()), // TODO: forward to linuxd or nanvixd https://github.com/nanvix/nanvix/issues/945
+                // TODO: forward to linuxd or nanvixd https://github.com/nanvix/nanvix/issues/945
+                _ => Ok(Continue(())),
             },
-            Err(TryRecvError::Empty) => Ok(()),
+            Err(TryRecvError::Empty) => Ok(Break(())),
             Err(TryRecvError::Disconnected) => {
                 let reason: String = "the vmm has disconnected".to_string();
                 // When the guest finishes , the vCPU thread will disconnect from this thread. This
@@ -428,7 +554,7 @@ impl IoThread {
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
     fn flush_microvm_output(&mut self) -> Result<()> {
-        while self.try_receive_from_microvm()? {
+        while self.try_receive_from_microvm()? != Break(()) {
             // Keep looping until `data_rx` is empty, which breaks the loop.
         }
         while !self.outgoing.is_empty() {
@@ -446,9 +572,23 @@ impl IoThread {
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
     fn flush_linuxd_input(&mut self) -> Result<()> {
-        while self.try_receive_from_system_vm()? {
+        while self.try_receive_from_system_vm()? != Break(()) {
             // Keep looping until receiving from the system VM would block, which breaks the loop.
         }
         Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Get the waker token to notify the I/O thread that there is an event that it must react to.
+    /// An event normally means that a message has been pushed to one of its monitored queues.
+    ///
+    /// # Returns
+    ///
+    /// Return a handle to the waker object.
+    ///
+    fn waker(&self) -> Arc<Waker> {
+        self.waker.clone()
     }
 }

--- a/src/microvm/src/memory_thread.rs
+++ b/src/microvm/src/memory_thread.rs
@@ -16,6 +16,11 @@ use crate::orchestrator::{
     MemoryControlResponse,
 };
 use ::anyhow::Result;
+use ::mio::{
+    Events,
+    Poll,
+    Token,
+};
 use ::std::{
     sync::mpsc::{
         Receiver,
@@ -34,6 +39,13 @@ use ::syslog::{
 };
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Token represnting an event notification from inbound queues from the VM.
+pub const WAKER_TOKEN: Token = Token(0);
+
+//==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
@@ -45,6 +57,7 @@ use ::syslog::{
 ///
 /// # Parameters
 ///
+/// - `poll`: Poll structure to be notified when we have pending messages in data or control.
 /// - `data_rx`: Receives data messages from the I/O thread.
 /// - `data_tx`: Sends data messages to the virtual machine's stdin.
 /// - `control_rx`: Receives control commands from the VMM.
@@ -56,6 +69,7 @@ use ::syslog::{
 /// A handle to the memory thread.
 ///
 pub fn spawn<F>(
+    mut poll: Poll,
     data_rx: Receiver<Message>,
     data_tx: Sender<Message>,
     control_rx: Receiver<MemoryControlCommand>,
@@ -66,45 +80,55 @@ where
     F: FnMut() -> Result<()> + std::marker::Send + 'static,
 {
     thread::spawn(move || {
-        loop {
+        let mut events: Events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+
+        // Must drain each queue when we receive a notification.
+        'main_loop: loop {
+            poll.poll(&mut events, None)?;
+
             match control_rx.try_recv() {
                 Ok(command) => match command {
                     MemoryControlCommand::Shutdown => {
                         debug!("memory_thread(): received shutdown command");
-                        break Ok(());
+                        break 'main_loop Ok(());
                     },
                 },
                 Err(TryRecvError::Disconnected) => {
                     debug!("memory_thread(): VMM control channel has been disconnected");
-                    break Ok(());
+                    break 'main_loop Ok(());
                 },
                 Err(TryRecvError::Empty) => {
-                    // No message available.
+                    // No message available, try to receive from data-plane.
                 },
             }
-            match data_rx.try_recv() {
-                Ok(mut msg) => {
-                    profiler::timestamp_message!(
-                        &mut msg.payload,
-                        mem::offset_of!(syscall::LinuxDaemonMessage, payload)
-                            + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
-                    );
-                    if let Err(e) = data_tx.send(msg) {
-                        let reason: String = format!("failed to send message: {e:?}");
-                        error!("spawn(): {reason}");
-                        continue;
-                    }
-                    add_credit()?;
-                },
-                Err(TryRecvError::Disconnected) => {
-                    // When the guest finishes , the vCPU thread will disconnect from this
-                    // thread. This situation is normal and should not create an error log.
-                    debug!("spawn(): channel has been disconnected");
-                    break Ok(());
-                },
-                Err(TryRecvError::Empty) => {
-                    // No message available.
-                },
+            'data_recv_loop: loop {
+                match data_rx.try_recv() {
+                    Ok(mut msg) => {
+                        profiler::timestamp_message!(
+                            &mut msg.payload,
+                            mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                                + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
+                        );
+                        if let Err(e) = data_tx.send(msg) {
+                            // This situation is an error, we log it and continue trying to drain
+                            // this queue.
+                            let reason: String = format!("failed to send message: {e:?}");
+                            error!("spawn(): {reason}");
+                            continue 'data_recv_loop;
+                        }
+                        add_credit()?;
+                    },
+                    Err(TryRecvError::Disconnected) => {
+                        // When the guest finishes , the vCPU thread will disconnect from this
+                        // thread. This situation is normal and should not create an error log.
+                        debug!("spawn(): channel has been disconnected");
+                        break 'main_loop Ok(());
+                    },
+                    Err(TryRecvError::Empty) => {
+                        // No message available.
+                        break 'data_recv_loop;
+                    },
+                }
             }
         }
     })

--- a/src/microvm/src/orchestrator.rs
+++ b/src/microvm/src/orchestrator.rs
@@ -13,16 +13,25 @@ use ::libc::{
     pthread_kill,
     pthread_t,
 };
+use ::mio::{
+    Events,
+    Poll,
+    Token,
+    Waker,
+};
 use ::std::{
     ops::ControlFlow::{
         self,
         Break,
         Continue,
     },
-    sync::mpsc::{
-        Receiver,
-        Sender,
-        TryRecvError,
+    sync::{
+        Arc,
+        mpsc::{
+            Receiver,
+            Sender,
+            TryRecvError,
+        },
     },
     time::Instant,
 };
@@ -41,9 +50,24 @@ use ::syslog::{
 // This value was chosen so it catches issues without polluting the logs with too many warnings.
 pub const TIMEOUT_WARNING_INTERVAL_IN_MS: usize = 10;
 
+/// Token represnting an event notification from inbound queues from the VM.
+pub const WAKER_TOKEN: Token = Token(0);
+
 //==================================================================================================
 // Structure
 //==================================================================================================
+
+///
+/// # Description
+///
+/// Auxiliary enum to disambiguate when we are breaking out of a function because there are no more
+/// messages to read, or because we need to shutdown.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BreakReason {
+    Empty,
+    Shutdown,
+}
 
 ///
 /// # Description
@@ -55,6 +79,8 @@ pub const TIMEOUT_WARNING_INTERVAL_IN_MS: usize = 10;
 pub struct Orchestrator {
     // The state of the VM.
     state: State,
+    /// Poll structure to monitor incoming queues.
+    poll: Poll,
     // FIXME (#1009): once the I/O channels are optional, we will be able to infer if io_enabled
     // from whether the channels are None or not.
     /// Whether the I/O thread is enabled or not.
@@ -62,10 +88,14 @@ pub struct Orchestrator {
     /// Thread ID of the vCPU thread.
     #[cfg(not(feature = "hyperlight"))]
     vcpu_tid: u64,
+    /// Waker token for the I/O thread.
+    io_thread_waker: Option<Arc<Waker>>,
     // Channel that receives commands from the I/O thread.
     io_control_rx: Receiver<IoControlCommand>,
     // Channel that sends commands to the I/O thread.
     io_control_tx: Sender<IoControlResponse>,
+    /// Waker token for the memory thread.
+    memory_thread_waker: Arc<Waker>,
     // Channel that receives commands from the memory thread.
     _memory_control_rx: Receiver<MemoryControlResponse>,
     // Channel that sends commands to the memory thread.
@@ -181,10 +211,13 @@ pub enum VcpuControlResponse {
 impl Orchestrator {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        poll: Poll,
         io_enabled: bool,
         #[cfg(not(feature = "hyperlight"))] vcpu_tid: u64,
+        io_thread_waker: Option<Arc<Waker>>,
         io_control_rx: Receiver<IoControlCommand>,
         io_control_tx: Sender<IoControlResponse>,
+        memory_thread_waker: Arc<Waker>,
         memory_control_rx: Receiver<MemoryControlResponse>,
         memory_control_tx: Sender<MemoryControlCommand>,
         vcpu_control_rx: Receiver<VcpuControlResponse>,
@@ -195,11 +228,14 @@ impl Orchestrator {
     ) -> Self {
         Self {
             state: State::PreBoot,
+            poll,
             io_enabled,
             #[cfg(not(feature = "hyperlight"))]
             vcpu_tid,
+            io_thread_waker,
             io_control_rx,
             io_control_tx,
+            memory_thread_waker,
             _memory_control_rx: memory_control_rx,
             memory_control_tx,
             vcpu_control_rx,
@@ -213,19 +249,35 @@ impl Orchestrator {
     ///
     /// # Description
     ///
-    /// Attempts to handle a command from the control input.
+    /// Runs the main orchestrator loop.
     ///
     /// # Returns
     ///
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
     pub fn run(&mut self) -> Result<()> {
-        loop {
-            if self.io_enabled && (self.try_receive_from_io_thread()? == Break(())) {
-                break;
+        let mut events: Events = Events::with_capacity(config::syscomm::MAX_NUM_POLL_EVENTS);
+
+        'main_loop: loop {
+            self.poll.poll(&mut events, None)?;
+
+            // We must drain each socket/queue until they return WouldBlock in order to not miss
+            // any messages. We surface a WouldBlock or a queue being empty with a Break().
+            if self.io_enabled {
+                'io_recv_loop: loop {
+                    match self.try_receive_from_io_thread()? {
+                        Continue(()) => {},
+                        Break(BreakReason::Empty) => break 'io_recv_loop,
+                        Break(BreakReason::Shutdown) => break 'main_loop,
+                    }
+                }
             }
-            if self.try_receive_from_vcpu()? == Break(()) {
-                break;
+            'vcpu_recv_loop: loop {
+                match self.try_receive_from_vcpu()? {
+                    Continue(()) => {},
+                    Break(BreakReason::Empty) => break 'vcpu_recv_loop,
+                    Break(BreakReason::Shutdown) => break 'main_loop,
+                }
             }
         }
 
@@ -234,12 +286,17 @@ impl Orchestrator {
         debug!("run(): exited run loop, cleaning-up");
         self.memory_control_tx
             .send(MemoryControlCommand::Shutdown)?;
+        self.memory_thread_waker.wake()?;
+
         self.io_control_tx.send(IoControlResponse::Shutdown)?;
+        if let Some(io_thread_waker) = &self.io_thread_waker {
+            io_thread_waker.wake()?;
+        }
 
         Ok(())
     }
 
-    fn try_receive_from_io_thread(&mut self) -> Result<ControlFlow<()>> {
+    fn try_receive_from_io_thread(&mut self) -> Result<ControlFlow<BreakReason, ()>> {
         match self.io_control_rx.try_recv() {
             Ok(command) => match command {
                 IoControlCommand::_StartMicroVm => {
@@ -342,7 +399,7 @@ impl Orchestrator {
                         // the vCPU itself, we exit here. This may populate the logs with an error
                         // message during shutdown, but is functionally equivalent.
                         if #[cfg(feature = "hyperlight")] {
-                            Ok(Break(()))
+                            Ok(Break(BreakReason::Shutdown))
                         } else {
                             // SAFETY: we call pthread_kill on a non-zero TID that we have received from
                             // the VCPU thread after boot, so this is safe.
@@ -354,17 +411,17 @@ impl Orchestrator {
                     }
                 },
             },
-            Err(TryRecvError::Empty) => Ok(Continue(())),
+            Err(TryRecvError::Empty) => Ok(Break(BreakReason::Empty)),
             Err(TryRecvError::Disconnected) => {
                 let reason: String =
                     ("disconnected from the input control command channel").to_string();
                 error!("try_receive_from_io_thread(): {reason}");
-                Ok(Break(()))
+                Ok(Break(BreakReason::Shutdown))
             },
         }
     }
 
-    fn try_receive_from_vcpu(&mut self) -> Result<ControlFlow<()>> {
+    fn try_receive_from_vcpu(&mut self) -> Result<ControlFlow<BreakReason, ()>> {
         match self.vcpu_control_rx.try_recv() {
             Ok(VcpuControlResponse::Paused) => {
                 let reason: String =
@@ -374,7 +431,7 @@ impl Orchestrator {
             },
             Ok(VcpuControlResponse::Shutdown) => {
                 info!("try_receive_from_vcpu(): vCPU shutdown");
-                Ok(Break(()))
+                Ok(Break(BreakReason::Shutdown))
             },
             Ok(VcpuControlResponse::Tid(_)) => {
                 let reason: String = "The tid is only sent when the vCPU thread is spawned. \
@@ -384,7 +441,7 @@ impl Orchestrator {
                 error!("{reason}");
                 Err(anyhow::anyhow!(reason))
             },
-            Err(TryRecvError::Empty) => Ok(Continue(())),
+            Err(TryRecvError::Empty) => Ok(Break(BreakReason::Empty)),
             Err(TryRecvError::Disconnected) => {
                 let reason: String = "the vmm has disconnected".to_string();
                 error!("try_receive_from_io_thread(): {reason}");

--- a/src/microvm/src/vmm/hyperlight/mod.rs
+++ b/src/microvm/src/vmm/hyperlight/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     io_thread::IoThread,
     memory_thread,
     orchestrator::{
+        self,
         IoControlCommand,
         IoControlResponse,
         MemoryControlCommand,
@@ -40,6 +41,10 @@ use ::hyperlight_host::{
             GuestEnvironment,
         },
     },
+};
+use ::mio::{
+    Poll,
+    Waker,
 };
 use ::std::{
     fs::File,
@@ -138,19 +143,41 @@ impl Vmm {
         let (vcpu_control_tx, _vcpu_thread_control_rx) = mpsc::channel::<VcpuControlCommand>();
         let (vcpu_thread_control_tx, vcpu_control_rx) = mpsc::channel::<VcpuControlResponse>();
 
+        // Create a poll and a waker for the memory thread. We must do this first to break a
+        // circular dependency where:
+        // - I/O thread needs memory thread waker token.
+        // - Memory thread needs clone of micro VM VMEM.
+        // - Micro VM needs output function.
+        // - Output function needs I/O thread waker token.
+        let memory_thread_poll: Poll = Poll::new()?;
+        let memory_thread_waker: Arc<Waker> =
+            Arc::new(Waker::new(memory_thread_poll.registry(), memory_thread::WAKER_TOKEN)?);
+
+        // Similar for the orchestrator that needs to be woken up by either the I/O thread or the
+        // vCPU thread.
+        let orchestrator_poll: Poll = Poll::new()?;
+        let orchestrator_waker: Arc<Waker> =
+            Arc::new(Waker::new(orchestrator_poll.registry(), orchestrator::WAKER_TOKEN)?);
+
         // Spawn I/O thread if we have any external stream to monitor.
-        let io_thread: Option<JoinHandle<Result<()>>> = if io_enabled {
-            Some(IoThread::spawn(
-                system_vm_stream,
-                io_thread_data_rx,
-                io_thread_data_tx,
-                io_thread_control_tx,
-                io_thread_control_rx,
-                control_plane_stream,
-            ))
-        } else {
-            None
-        };
+        let (io_thread, io_thread_waker): (Option<JoinHandle<Result<()>>>, Option<Arc<Waker>>) =
+            if io_enabled {
+                let (io_thread, io_thread_waker): (JoinHandle<Result<()>>, Arc<Waker>) =
+                    IoThread::spawn(
+                        system_vm_stream,
+                        memory_thread_waker.clone(),
+                        io_thread_data_rx,
+                        io_thread_data_tx,
+                        orchestrator_waker.clone(),
+                        io_thread_control_tx,
+                        io_thread_control_rx,
+                        control_plane_stream,
+                    )?;
+                (Some(io_thread), Some(io_thread_waker))
+            } else {
+                (None, None)
+            };
+        let io_thread_waker_clone: Option<Arc<Waker>> = io_thread_waker.clone();
 
         // Required values for heap and stack sizes to be used by the kernel.
         let heap_size = 4 * 1024 * 1024;
@@ -271,6 +298,10 @@ impl Vmm {
                 return Err(HyperlightError::AnyhowError(anyhow::Error::msg(reason)));
             }
 
+            if let Some(io_thread_waker) = &io_thread_waker_clone {
+                io_thread_waker.wake()?;
+            }
+
             Ok(data.len() as i32)
         })?;
 
@@ -297,6 +328,7 @@ impl Vmm {
 
         // Create a thread that reads from vm_rx and writes to vm_rx2.
         let memory_thread: JoinHandle<Result<(), anyhow::Error>> = memory_thread::spawn(
+            memory_thread_poll,
             memory_thread_data_rx,
             memory_thread_data_tx,
             memory_thread_control_rx,
@@ -321,14 +353,20 @@ impl Vmm {
             // Send shutdown message to VMM thread.
             vcpu_thread_control_tx.send(VcpuControlResponse::Shutdown)?;
 
+            // Notify VMM thread.
+            orchestrator_waker.wake()?;
+
             // TODO: return the exit status code when supported.
             Ok(0)
         });
 
         let orchestrator = Orchestrator::new(
+            orchestrator_poll,
             io_enabled,
+            io_thread_waker.clone(),
             io_control_rx,
             io_control_tx,
+            memory_thread_waker.clone(),
             memory_control_rx,
             memory_control_tx,
             vcpu_control_rx,

--- a/src/microvm/src/vmm/microvm/microvm.rs
+++ b/src/microvm/src/vmm/microvm/microvm.rs
@@ -39,6 +39,7 @@ use ::libc::{
     sigaction,
     sigemptyset,
 };
+use ::mio::Waker;
 use ::std::{
     ffi::OsStr,
     fs::File,
@@ -101,6 +102,8 @@ pub struct MicroVm {
     vcpu: Arc<Mutex<VirtualProcessor>>,
     // Wraps fields that don't require individual `Arc<Mutex<_>>`s.
     handle: Arc<Mutex<InteriorMicroVmHandle>>,
+    /// Waker token to notify the VMM when we send commands.
+    orchestrator_waker: Arc<Waker>,
 }
 
 ///
@@ -157,6 +160,7 @@ impl MicroVm {
     /// - `memory_size`: Size of the virtual memory of the virtual machine.
     /// - `input`: Input function used for emulating I/O port reads.
     /// - `output`: Output function used for emulating I/O port writes.
+    /// - `orchestrator_waker`: Waker to notify the VMM when we send messages over control_tx.
     /// - `control_rx`: Channel to receive commands from the VMM.
     /// - `control_tx`: Channel to send control responses to the VMM.
     ///
@@ -169,6 +173,7 @@ impl MicroVm {
         memory_size: usize,
         input: Box<InputFn>,
         output: Box<OutputFn>,
+        orchestrator_waker: Arc<Waker>,
         control_rx: Receiver<VcpuControlCommand>,
         control_tx: Sender<VcpuControlResponse>,
     ) -> Result<Self> {
@@ -199,6 +204,7 @@ impl MicroVm {
             vmem,
             vcpu,
             handle: state,
+            orchestrator_waker,
         })
     }
 
@@ -385,6 +391,9 @@ impl MicroVm {
             .control_tx
             .send(VcpuControlResponse::Shutdown)?;
 
+        // Notify the VMM thread to check its message queues.
+        self.orchestrator_waker.wake()?;
+
         Ok(())
     }
 
@@ -442,6 +451,9 @@ impl MicroVm {
                             locked_state
                                 .control_tx
                                 .send(VcpuControlResponse::Shutdown)?;
+
+                            // Notify the VMM thread to check its message queues.
+                            self.orchestrator_waker.wake()?;
 
                             return Ok(exit_status);
                         }

--- a/src/microvm/src/vmm/microvm/mod.rs
+++ b/src/microvm/src/vmm/microvm/mod.rs
@@ -31,6 +31,7 @@ use crate::{
     io_thread::IoThread,
     memory_thread,
     orchestrator::{
+        self,
         IoControlCommand,
         IoControlResponse,
         MemoryControlCommand,
@@ -46,6 +47,10 @@ use crate::{
 };
 use ::anyhow::Result;
 use ::libc::pthread_self;
+use ::mio::{
+    Poll,
+    Waker,
+};
 use ::std::{
     fs::File,
     io::Write,
@@ -138,31 +143,56 @@ impl Vmm {
         let (vcpu_control_tx, vcpu_thread_control_rx) = mpsc::channel::<VcpuControlCommand>();
         let (vcpu_thread_control_tx, vcpu_control_rx) = mpsc::channel::<VcpuControlResponse>();
 
+        // Create a poll and a waker for the memory thread. We must do this first to break a
+        // circular dependency where:
+        // - I/O thread needs memory thread waker token.
+        // - Memory thread needs clone of micro VM VMEM.
+        // - Micro VM needs output function.
+        // - Output function needs I/O thread waker token.
+        let memory_thread_poll: Poll = Poll::new()?;
+        let memory_thread_waker: Arc<Waker> =
+            Arc::new(Waker::new(memory_thread_poll.registry(), memory_thread::WAKER_TOKEN)?);
+
+        // Similar for the orchestrator that needs to be woken up by either the I/O thread or the
+        // vCPU thread.
+        let orchestrator_poll: Poll = Poll::new()?;
+        let orchestrator_waker: Arc<Waker> =
+            Arc::new(Waker::new(orchestrator_poll.registry(), orchestrator::WAKER_TOKEN)?);
+
         // Spawn I/O thread if we have any external stream to monitor.
-        let io_thread: Option<JoinHandle<Result<()>>> = if io_enabled {
-            Some(IoThread::spawn(
-                system_vm_stream,
-                io_thread_data_rx,
-                io_thread_data_tx,
-                io_thread_control_tx,
-                io_thread_control_rx,
-                control_plane_stream,
-            ))
-        } else {
-            None
-        };
+        let (io_thread, io_thread_waker): (Option<JoinHandle<Result<()>>>, Option<Arc<Waker>>) =
+            if io_enabled {
+                let (io_thread, io_thread_waker): (JoinHandle<Result<()>>, Arc<Waker>) =
+                    IoThread::spawn(
+                        system_vm_stream,
+                        memory_thread_waker.clone(),
+                        io_thread_data_rx,
+                        io_thread_data_tx,
+                        orchestrator_waker.clone(),
+                        io_thread_control_tx,
+                        io_thread_control_rx,
+                        control_plane_stream,
+                    )?;
+                (Some(io_thread), Some(io_thread_waker))
+            } else {
+                (None, None)
+            };
 
         // Input function used for emulating I/O port reads.
         let input: Box<microvm::InputFn> = Self::build_input_fn(vcpu_thread_stdin_rx);
 
         // Output function used for emulating I/O port writes.
-        let output: Box<microvm::OutputFn> =
-            Self::build_output_fn(Self::get_stderr_writer(stderr.clone())?, vcpu_thread_stdout_tx);
+        let output: Box<microvm::OutputFn> = Self::build_output_fn(
+            Self::get_stderr_writer(stderr.clone())?,
+            vcpu_thread_stdout_tx,
+            io_thread_waker.clone(),
+        );
 
         let mut microvm: MicroVm = MicroVm::new(
             memory_size,
             input,
             output,
+            orchestrator_waker.clone(),
             vcpu_thread_control_rx,
             vcpu_thread_control_tx,
         )?;
@@ -197,7 +227,8 @@ impl Vmm {
         // Create a thread that reads from vm_rx and writes to vm_rx2.
         let vmem_pause_microvm: Arc<Mutex<VirtualMemory>> = vmem.clone();
         let vmem_resume_microvm: Arc<Mutex<VirtualMemory>> = vmem.clone();
-        let memory_thread: JoinHandle<Result<(), anyhow::Error>> = memory_thread::spawn(
+        let memory_thread: JoinHandle<Result<()>> = memory_thread::spawn(
+            memory_thread_poll,
             memory_thread_data_rx,
             memory_thread_data_tx,
             memory_thread_control_rx,
@@ -242,10 +273,13 @@ impl Vmm {
         let create_snapshot_clone: MicroVm = microvm.clone();
         let filename: String = initrd_filename.unwrap_or("bin/default.elf".to_string());
         let orchestrator = Orchestrator::new(
+            orchestrator_poll,
             io_enabled,
             vcpu_tid,
+            io_thread_waker.clone(),
             io_control_rx,
             io_control_tx,
+            memory_thread_waker.clone(),
             memory_control_rx,
             memory_control_tx,
             vcpu_control_rx,
@@ -382,6 +416,7 @@ impl Vmm {
     fn build_output_fn(
         mut file_writer: Box<dyn Write>,
         queue: Sender<Message>,
+        io_thread_waker: Option<Arc<Waker>>,
     ) -> Box<microvm::OutputFn> {
         // Output function used for emulating I/O port writes.
         let output = move |vm: &Arc<Mutex<VirtualMemory>>, data, size| -> Result<()> {
@@ -431,6 +466,10 @@ impl Vmm {
                     let reason: String = format!("failed to send message: {e:?}");
                     error!("output(): {reason}");
                     anyhow::bail!(reason);
+                }
+
+                if let Some(io_thread_waker) = &io_thread_waker {
+                    io_thread_waker.wake()?;
                 }
 
                 Ok(())

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -13,6 +13,7 @@ homepage.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 config = { workspace = true }
+control-plane-api = { workspace = true }
 hwloc = { workspace = true }
 indicatif = { workspace = true }
 libc = { workspace = true }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -532,6 +532,12 @@ impl Benchmark {
         let (input_stream, vmm_stream) = UnixStream::pair()?;
         let mut input_stream = syscomm::SocketStream::Unix(input_stream);
 
+        // Initialize control-plane stream.
+        let (control_plane_stream, vmm_control_plane_stream): (UnixStream, UnixStream) =
+            UnixStream::pair()?;
+        let mut control_plane_stream: SocketStream =
+            syscomm::SocketStream::Unix(control_plane_stream);
+
         // Spawn the VMM in a separate thread.
         let program = self.flavour.get_program();
         let vmm_handle = std::thread::spawn(move || -> Result<()> {
@@ -542,7 +548,7 @@ impl Benchmark {
                 None,
                 Some("/dev/null".to_string()),
                 Some(syscomm::SocketStream::Unix(vmm_stream)),
-                None,
+                Some(syscomm::SocketStream::Unix(vmm_control_plane_stream)),
             )? {
                 e if e != 0 => {
                     error!("error running VMM, exited with status: {e}");
@@ -635,11 +641,13 @@ impl Benchmark {
             pb.inc(1);
         }
 
-        // Drop the connection to send an EoF to the application code, which
-        // will then gracefully shut down.
-        drop(input_stream);
+        // Send shutdown command to the VMM.
+        control_plane_api::send_command(
+            &mut control_plane_stream,
+            control_plane_api::Command::Shutdown,
+        )?;
 
-        // Wait for the VMM to exit after we drop the connection.
+        // Wait for the VMM to exit after we send the shutdown command.
         match vmm_handle.join() {
             Ok(_) => {},
             Err(_) => return Err(anyhow::anyhow!("Error running VMM")),


### PR DESCRIPTION
In this commit I re-architect the micro VM to not spin any cores needlesly by having a thread execute a tight loop in a non-blocking fashion.

Instead, I move the three main components: I/O thread, memory thread, and orchestrator (i.e. VMM) thread to an asynchronous architecture with polling.

This means, firstly, moving the main loops of each of these components to a `poll()` loop. In addition, for the threads' monitoring queues, we need to give each component that may _write_ to those queues, a handle to a `Waker` structure, in order to notify the `poll` that a message has been pushed to the queue. It is very important to _drain_ any component monitored using `poll` before sleeping again in the `poll()` loop, as otherwise we may lose messages.