### PR TITLE
[build] Improve `z` Utility to Check Toolchain Version and Auto-Install Development Dependencies

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -11,10 +11,11 @@ This guide will help you set up your development environment to build and run Na
   - [4. Setup KVM](#4-setup-kvm)
   - [5. Setup Docker (Optional)](#5-setup-docker-optional)
   - [6. Setup SCCACHE (Optional)](#6-setup-sccache-optional)
-- [Setting Up Development Tools](#setting-up-development-tools)
+- [Setting Up Development Tools for the First Time](#setting-up-development-tools-for-the-first-time)
   - [Option 1: Build Development Tools Locally (Preferred Method)](#option-1-build-development-tools-locally-preferred-method)
   - [Option 2: Use a Pre-Built Docker Image](#option-2-use-a-pre-built-docker-image)
   - [Option 3: Build a Docker Image](#option-3-build-a-docker-image)
+- [Updating Your Development Tools](#updating-your-development-tools)
 - [Setup Your IDE (Optional)](#setup-your-ide-optional)
   - [Visual Studio Code](#visual-studio-code)
 
@@ -101,7 +102,7 @@ source ~/.bashrc
 
 ---
 
-## Setting Up Development Tools
+## Setting Up Development Tools for the First Time
 
 > ⚠️ **Note:** This process may take some time to complete.
 
@@ -169,6 +170,16 @@ To build a Docker image with the required tools:
 # Ensure you are in the project's root directory.
 docker build --no-cache -t nanvix/toolchain ./scripts/setup/
 ```
+
+## Updating Your Development Tools
+
+When a new major release of Nanvix is available, you must update your development tools to ensure
+compatibility. Follow these steps to update your environment:
+
+1. **Update system dependencies**: [Re-install dependencies for development tools](#3-install-dependencies-for-development-tools).
+2. **Rebuild development tools**: [Re-build the development tools](#option-1-build-development-tools-locally-preferred-method).
+
+> **Note:** This update process is only required for major releases, not for minor updates or patches.
 
 ## Setup Your IDE (Optional)
 

--- a/z
+++ b/z
@@ -58,6 +58,9 @@ Z_CACHE_FILE=".z.cache"
 # Default toolchain directory for setup.
 DEFAULT_LOCAL_TOOLCHAIN_DIR="${PWD}/toolchain"
 
+# Location of ubuntu setup script.
+UBUNTU_SETUP_SCRIPT="${REPO_ROOT_DIR}/scripts/setup/ubuntu.sh"
+
 #==================================================================================================
 # Global Variables
 #==================================================================================================
@@ -573,6 +576,15 @@ main() {
         "${CMD_NAME_SETUP}")
             # Setup the Nanvix development environment.
             print_info "Setting up Nanvix development environment..."
+
+            # Run ubuntu setup script if it exists.
+            if [[ -f "${UBUNTU_SETUP_SCRIPT}" ]]; then
+                print_info "Installing development dependencies..."
+                if ! sudo "${UBUNTU_SETUP_SCRIPT}"; then
+                    print_error "Failed to install development dependencies."
+                    exit 1
+                fi
+            fi
 
             # If Docker is requested, download the Docker image.
             if ${BUILD_WITH_DOCKER}; then

--- a/z
+++ b/z
@@ -56,7 +56,7 @@ DOCKER_IMAGE_TOOLCHAIN_PATH="/opt/nanvix"
 Z_CACHE_FILE=".z.cache"
 
 # Default toolchain directory for setup.
-DEFAULT_LOCAL_TOOLCHAIN_DIR="${HOME}/toolchain"
+DEFAULT_LOCAL_TOOLCHAIN_DIR="${PWD}/toolchain"
 
 #==================================================================================================
 # Global Variables

--- a/z
+++ b/z
@@ -315,6 +315,109 @@ check_filesystem_support() {
     esac
 }
 
+#
+# Description
+#
+#   Checks whether the currently selected toolchain (Docker image or local installation)
+#   matches the Nanvix version required by the workspace. The Nanvix version is read
+#   from the root `Cargo.toml` (via `get_cargo_toml_version`). The expected toolchain
+#   version string format is:
+#     - Docker image tag:   vMAJOR.MINOR.x (e.g., v1.2.x)
+#     - Local version file: nanvix-toolchain-vMAJOR.MINOR.x (single line in TOOLCHAIN_DIR/version)
+#
+#   Behavior:
+#     - When building with Docker (`BUILD_WITH_DOCKER=true`):
+#         * Verifies Docker is installed.
+#         * Verifies the expected image (derived from current Nanvix version) is present locally.
+#         * Validates the derived tag matches the MAJOR.MINOR.x pattern expected.
+#     - When building with the local toolchain:
+#         * Ensures the version file exists and is readable.
+#         * Compares its contents to the expected version string.
+#
+#   On mismatch or missing artifacts, an error is printed and the function returns non-zero.
+#   On success, returns zero.
+#
+# Usage Example
+#   if ! check_toolchain; then
+#       exit 1
+#   fi
+#
+check_toolchain() {
+    local current_version
+    current_version=$(get_cargo_toml_version "$CARGO_TOML_FILE_PATH") || {
+        print_error "Failed to determine current Nanvix version."
+        return 1
+    }
+
+    local expected_tag
+    expected_tag="${current_version%.*}.x"
+
+    if ${BUILD_WITH_DOCKER}; then
+        # Docker-based toolchain validation.
+        check_docker_installed
+
+        local image_name
+        image_name=$(get_docker_image_name "${current_version}")
+
+        # Check image availability.
+        if ! docker image inspect "${image_name}" >/dev/null 2>&1; then
+            print_error "Required Docker toolchain image '${image_name}' not found. Run './z setup --with-docker' to fetch it."
+            return 1
+        fi
+
+        # Expected image tag extracted from the computed image name.
+        local image_tag
+        image_tag="${image_name##*:v}"
+
+        # Sanity check on tag consistency (defensive; should always match expected_tag).
+        if [[ "${image_tag}" != "${expected_tag}" ]]; then
+            print_error "Docker toolchain version mismatch (found tag '${image_tag}', expected '${expected_tag}'). Run './z setup --with-docker' to update the toolchain image."
+            return 1
+        fi
+
+        print_info "Docker toolchain version '${image_tag}' matches expected '${expected_tag}'."
+    else
+        # Local toolchain validation.
+        local version_file
+        version_file="${TOOLCHAIN_DIR}/version"
+        local expected_version_string
+        expected_version_string="nanvix-toolchain-v${expected_tag}"
+
+        # Check if version file exists (follows symbolic links).
+        if [[ ! -e "${version_file}" ]]; then
+            print_error "Toolchain version file '${version_file}' not found. Run './z setup' to build the local toolchain."
+            return 1
+        fi
+
+        # Check if version file is readable (follows symbolic links).
+        if [[ ! -r "${version_file}" ]]; then
+            print_error "Toolchain version file '${version_file}' is not readable."
+            return 1
+        fi
+
+        local found_version
+        if ! read -r found_version < "${version_file}"; then
+            print_error "Failed to read toolchain version file '${version_file}'."
+            return 1
+        fi
+        found_version="$(echo "${found_version}" | tr -d '[:space:]')"
+
+        if [[ -z "${found_version}" ]]; then
+            print_error "Toolchain version file '${version_file}' is empty. Run './z setup' to (re)install the toolchain."
+            return 1
+        fi
+
+        if [[ "${found_version}" != "${expected_version_string}" ]]; then
+            print_error "Local toolchain version mismatch (found '${found_version}', expected '${expected_version_string}'). Run './z setup' to update the toolchain."
+            return 1
+        fi
+
+        print_info "Local toolchain version '${found_version}' matches expected '${expected_version_string}'."
+    fi
+
+    return 0
+}
+
 #==================================================================================================
 # Main Script
 #==================================================================================================
@@ -416,6 +519,11 @@ main() {
                 fi
             fi
 
+            # Validate toolchain compatibility before building.
+            if ! check_toolchain; then
+                print_error "Toolchain version check failed. Aborting build."
+                exit 1
+            fi
 
             # Build Nanvix.
             if ${BUILD_WITH_DOCKER}; then


### PR DESCRIPTION
This pull request introduces improvements to the developer setup process and build tooling for Nanvix. The main changes include clarifying and expanding the documentation for setting up and updating development tools, enforcing toolchain version compatibility checks before building, and improving the setup script's usability and reliability.

**Documentation improvements:**

* Updated `doc/setup.md` to clarify the distinction between initial setup and updating development tools, and added a new section describing how to update tools for major releases. [[1]](diffhunk://#diff-55ad3a91265d731555313fdee9af5e109244b0e825c4aff0b7cce3c78b07be97L14-R18) [[2]](diffhunk://#diff-55ad3a91265d731555313fdee9af5e109244b0e825c4aff0b7cce3c78b07be97L104-R105) [[3]](diffhunk://#diff-55ad3a91265d731555313fdee9af5e109244b0e825c4aff0b7cce3c78b07be97R174-R183)

**Build and setup script enhancements:**

* Changed the default local toolchain directory in the `z` script to use the current working directory (`${PWD}`) instead of the user's home directory, and defined the location of the Ubuntu setup script for dependency installation.
* Added a comprehensive `check_toolchain` function to the `z` script that verifies the selected toolchain (Docker image or local installation) matches the Nanvix version required by the workspace, aborting the build if there is a mismatch. [[1]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06R321-R423) [[2]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06R525-R529)
* Integrated the Ubuntu setup script into the `z` setup workflow to automatically install development dependencies if the script is present.