### PR TITLE
[daemons] E: Allow logs directory to be specified

### DIFF
--- a/src/daemons/linuxd/src/args.rs
+++ b/src/daemons/linuxd/src/args.rs
@@ -27,6 +27,8 @@ pub struct Args {
     user_vm_bind_sockaddr_type: Option<String>,
     /// Log to file?
     log_to_file: bool,
+    /// Log file directory.
+    log_directory: String,
     /// Deployed in an L2 VM?
     l2: bool,
 }
@@ -48,6 +50,8 @@ impl Args {
     pub const OPT_USER_VM_BIND_SOCKET_TYPE: &'static str = "-user-vm-bind-socket-type";
     /// Command-line option for log redirecting.
     pub const OPT_LOGFILE: &'static str = "-log-to-file";
+    /// Command-line option for setting the log file directory.
+    pub const OPT_LOGDIR: &'static str = "-log-dir";
     /// Command-line option for signaling deployment in an L2 VM.
     pub const OPT_L2: &'static str = "-l2";
 
@@ -80,6 +84,7 @@ impl Args {
         let mut user_vm_bind_sockaddr: String = String::new();
         let mut user_vm_bind_sockaddr_type: Option<String> = None;
         let mut log_to_file: bool = false;
+        let mut log_directory: Option<String> = None;
         let mut l2: bool = false;
 
         let mut i: usize = 1;
@@ -108,6 +113,10 @@ impl Args {
                 Self::OPT_LOGFILE => {
                     log_to_file = true;
                 },
+                Self::OPT_LOGDIR => {
+                    i += 1;
+                    log_directory = Some(args[i].clone());
+                },
                 Self::OPT_L2 => {
                     l2 = true;
                 },
@@ -129,12 +138,58 @@ impl Args {
             return Err(anyhow::anyhow!("user VM bind socket address not set"));
         }
 
+        // Check if log file directory was set if logging to file is enabled. Set the default directory if not.
+        let log_directory: String = match (log_to_file, log_directory) {
+            (true, Some(path)) => path,
+            // default to log dir relative to the CWD, make the directory path absolute
+            (true, None) => {
+                let mut abs_path = std::env::current_dir().map_err(|e| {
+                    anyhow::anyhow!("failed to get current directory (error={:?})", e)
+                })?;
+                abs_path.push("log");
+                abs_path.to_str().map(|s| s.to_string()).ok_or_else(|| {
+                    anyhow::anyhow!("failed to convert log directory path to string")
+                })?
+            },
+            (false, _) => String::new(),
+        };
+
+        // Validate that the path to the log file exists if logging to file is enabled.
+        // If it does not exist, try to create it.
+        if log_to_file {
+            let path = std::path::Path::new(&log_directory);
+            if !path.exists() {
+                std::fs::create_dir_all(path).map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to create log file directory (path={}, error={:?})",
+                        path.display(),
+                        e
+                    )
+                })?;
+            }
+            // check if we can create and write a file in the directory
+            let test_file_path = path.join("test.log");
+            match std::fs::File::create(&test_file_path) {
+                Ok(_) => {
+                    std::fs::remove_file(&test_file_path).ok(); // clean up the test file
+                },
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "failed to create log file (path={}, error={:?})",
+                        test_file_path.display(),
+                        e
+                    ));
+                },
+            }
+        }
+
         Ok(Self {
             control_plane_sockaddr,
             control_plane_sockaddr_type,
             user_vm_bind_sockaddr,
             user_vm_bind_sockaddr_type,
             log_to_file,
+            log_directory,
             l2,
         })
     }
@@ -150,14 +205,16 @@ impl Args {
     ///
     pub fn usage(program_name: &str) {
         println!(
-            "Usage: {} {} {} <control-plane-sockaddr> {} <control-plane-socktype> {} \
-             <user-vm-sockaddr> {} <user-vm-socktype>",
+            "Usage: {} {} <control-plane-sockaddr> {} <control-plane-socktype> {} \
+             <user-vm-sockaddr> {} <user-vm-socktype> {} {} <log-file-dir> {}",
             program_name,
-            Self::OPT_LOGFILE,
             Self::OPT_CONTROL_PLANE_SOCKADDR,
             Self::OPT_CONTROL_PLANE_SOCKET_TYPE,
             Self::OPT_USER_VM_BIND_SOCKADDR,
             Self::OPT_USER_VM_BIND_SOCKET_TYPE,
+            Self::OPT_LOGFILE,
+            Self::OPT_LOGDIR,
+            Self::OPT_L2
         );
     }
 
@@ -224,6 +281,18 @@ impl Args {
     ///
     pub fn log_to_file(&self) -> bool {
         self.log_to_file
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the log file directory.
+    /// # Returns
+    ///
+    /// The log file directory.
+    ///
+    pub fn log_file_dir(&self) -> String {
+        self.log_directory.clone()
     }
 
     ///

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -81,7 +81,7 @@ const DEFAULT_USER_VM_SOCKET_TYPE: SocketType = SocketType::Unix;
 pub fn main() -> Result<()> {
     // Parse and retrieve command-line arguments.
     let args: Args = args::Args::parse(env::args().collect())?;
-    ::syslog::init(args.log_to_file());
+    ::syslog::init(args.log_to_file(), args.log_file_dir());
 
     // Work-out the socket addresses.
     let control_plane_sockaddr: String = args.control_plane_sockaddr();

--- a/src/libs/syslog/src/hosted.rs
+++ b/src/libs/syslog/src/hosted.rs
@@ -35,19 +35,20 @@ pub use ::log::{
 /// # Parameters
 ///
 /// - `log_to_file`: Log to file?
+/// - `log_dir`: Directory to write log files to (if `log_to_file` is true).
 ///
 /// # Note
 ///
 /// If the logger cannot be initialized, the function will panic.
 ///
-pub fn init(log_to_file: bool) {
+pub fn init(log_to_file: bool, log_dir: String) {
     static INIT_LOG: Once = Once::new();
     INIT_LOG.call_once(|| {
         let logger =
             Logger::try_with_env_or_str("error").expect("malformed RUST_LOG environment variable");
         if log_to_file {
             logger
-                .log_to_file(FileSpec::default())
+                .log_to_file(FileSpec::default().directory(log_dir))
                 .start()
                 .expect("failed to initialize logger");
         } else {

--- a/src/microvm/src/args.rs
+++ b/src/microvm/src/args.rs
@@ -58,6 +58,8 @@ pub struct Args {
     gateway_socket_type: Option<SocketType>,
     /// Log to file?
     log_to_file: bool,
+    /// log_dir
+    log_directory: String,
 }
 
 //==================================================================================================
@@ -93,6 +95,8 @@ impl Args {
     pub const OPT_INITRD_ARGS: &'static str = "-initrd_args";
     /// Log to file.
     pub const OPT_LOGFILE: &'static str = "-log-to-file";
+    /// Log directory
+    pub const OPT_LOGDIR: &'static str = "-log-dir";
 
     ///
     /// # Description
@@ -118,6 +122,7 @@ impl Args {
         let mut gateway_addr: Option<String> = None;
         let mut gateway_socket_type: Option<SocketType> = None;
         let mut log_to_file: bool = false;
+        let mut log_directory: Option<String> = None;
 
         // Parse command-line arguments.
         let mut i: usize = 1;
@@ -240,6 +245,11 @@ impl Args {
                 Self::OPT_LOGFILE => {
                     log_to_file = true;
                 },
+                // Set log directory
+                Self::OPT_LOGDIR if i + 1 < args.len() => {
+                    log_directory = Some(args[i + 1].clone());
+                    i += 1;
+                },
                 // Invalid argument.
                 _ => {
                     Self::usage();
@@ -270,6 +280,51 @@ impl Args {
             anyhow::bail!("invalid memory size");
         }
 
+        // Check if log file directory was set if logging to file is enabled. Set the default directory if not.
+        let log_directory: String = match (log_to_file, log_directory) {
+            (true, Some(path)) => path,
+            // default to log dir relative to the CWD, make the directory path absolute
+            (true, None) => {
+                let mut abs_path = std::env::current_dir().map_err(|e| {
+                    anyhow::anyhow!("failed to get current directory (error={:?})", e)
+                })?;
+                abs_path.push("log");
+                abs_path.to_str().map(|s| s.to_string()).ok_or_else(|| {
+                    anyhow::anyhow!("failed to convert log directory path to string")
+                })?
+            },
+            (false, _) => String::new(),
+        };
+
+        // Validate that the path to the log file exists if logging to file is enabled.
+        // If it does not exist, try to create it.
+        if log_to_file {
+            let path = std::path::Path::new(&log_directory);
+            if !path.exists() {
+                std::fs::create_dir_all(path).map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to create log file directory (path={}, error={:?})",
+                        path.display(),
+                        e
+                    )
+                })?;
+            }
+            // check if we can create and write a file in the directory
+            let test_file_path = path.join("test.log");
+            match std::fs::File::create(&test_file_path) {
+                Ok(_) => {
+                    std::fs::remove_file(&test_file_path).ok(); // clean up the test file
+                },
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "failed to create log file (path={}, error={:?})",
+                        test_file_path.display(),
+                        e
+                    ));
+                },
+            }
+        }
+
         Ok(Self {
             user_vm_id,
             kernel_filename,
@@ -284,6 +339,7 @@ impl Args {
             gateway_addr,
             gateway_socket_type,
             log_to_file,
+            log_directory,
         })
     }
 
@@ -295,7 +351,8 @@ impl Args {
     pub fn usage() {
         eprintln!(
             "Usage: {} {} <id> {} <kernel> [{} <size>] [{} <file>] [{} <file>]  [{} \
-             <system-vm-addr> {} <control-plane-addr> {} <gateway-addr>] [{}] [{} <args>]",
+             <system-vm-addr> {} <control-plane-addr> {} <gateway-addr>] [{} [{} <dir>]] [{} \
+             <args>]",
             env::args().next().unwrap_or("microvm".to_string()),
             Self::OPT_USER_VM_ID,
             Self::OPT_KERNEL,
@@ -306,6 +363,7 @@ impl Args {
             Self::OPT_CONTROL_PLANE_SOCKADDR,
             Self::OPT_GATEWAY_SOCKADDR,
             Self::OPT_LOGFILE,
+            Self::OPT_LOGDIR,
             Self::OPT_INITRD_ARGS,
         );
     }
@@ -487,5 +545,17 @@ impl Args {
     ///
     pub fn log_to_file(&self) -> bool {
         self.log_to_file
+    }
+    ///
+    /// # Description
+    ///
+    /// Returns the log directory.
+    ///
+    /// # Returns
+    ///
+    /// The log directory.
+    ///
+    pub fn log_directory(&self) -> String {
+        self.log_directory.clone()
     }
 }

--- a/src/microvm/src/main.rs
+++ b/src/microvm/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> Result<ExitCode> {
     };
 
     // Initialize logger. If this fails, the program will panic.
-    syslog::init(args.log_to_file());
+    syslog::init(args.log_to_file(), args.log_directory());
 
     // Connect to the system VM.
     let system_vm_stream: Option<SocketStream> = match &system_vm_addr {

--- a/src/utils/echo-client/src/main.rs
+++ b/src/utils/echo-client/src/main.rs
@@ -59,7 +59,7 @@ use ::tokio::{
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging system.
-    ::syslog::init(false);
+    ::syslog::init(false, String::new());
 
     // Parse and retrieve command-line arguments.
     let args: Args = Args::parse(env::args().collect())?;

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -734,7 +734,7 @@ impl Benchmark {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    ::syslog::init(false);
+    ::syslog::init(false, String::new());
 
     // Check if RELEASE=yes was set at build time.
     match option_env!("RELEASE") {

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -25,9 +25,11 @@ pub struct Args {
     toolchain_binary_directory: String,
     console_file: Option<String>,
     hwloc: Option<HwLoc>,
-    /// Whether to log to a file instead of stdout/stderr.
+    // Whether to log to a file instead of stdout/stderr.
     log_to_file: bool,
-    /// Whether linuxd must be deployed in an L2 VM or not.
+    // If logging to file, the directory to write log files to.
+    log_directory: String,
+    // Whether linuxd must be deployed in an L2 VM or not.
     l2: bool,
 }
 
@@ -44,6 +46,7 @@ impl Args {
     pub const OPT_CONSOLE_FILE: &'static str = "-console-file";
     pub const OPT_HWLOC: &'static str = "-hwloc";
     pub const OPT_LOG_TO_FILE: &'static str = "--log-to-file";
+    pub const OPT_LOG_DIRECTORY: &'static str = "-log-dir";
     pub const OPT_L2: &'static str = "-l2";
 
     pub fn parse(args: Vec<String>) -> Result<Self> {
@@ -55,6 +58,7 @@ impl Args {
         let mut console_file: Option<String> = None;
         let mut hwloc: Option<HwLoc> = None;
         let mut log_to_file: bool = false;
+        let mut log_directory: String = config::DEFAULT_LOG_DIRECTORY.to_string();
         let mut l2: bool = false;
 
         let mut i: usize = 1;
@@ -102,6 +106,10 @@ impl Args {
                 Self::OPT_LOG_TO_FILE => {
                     log_to_file = true;
                 },
+                Self::OPT_LOG_DIRECTORY => {
+                    i += 1;
+                    log_directory = args[i].clone();
+                },
                 arg => {
                     return Err(anyhow::anyhow!("invalid argument: {arg}"));
                 },
@@ -118,6 +126,7 @@ impl Args {
             console_file,
             hwloc,
             log_to_file,
+            log_directory,
             l2,
         })
     }
@@ -125,7 +134,7 @@ impl Args {
     pub fn usage(program_name: &str) {
         println!(
             "Usage: {} {} <sockaddr> [{} <file>] [{} <tmp_dir>] [{} <bin_dir>] [{} \
-             <toolchain_bin_dir>] [{} <hwloc.json>] [{}] [{}]",
+             <toolchain_bin_dir>] [{} <hwloc.json>] [{} [{} <log_dir>]] [{}]",
             program_name,
             Self::OPT_HTTP_SOCKADDR,
             Self::OPT_CONSOLE_FILE,
@@ -134,6 +143,7 @@ impl Args {
             Self::OPT_TOOLCHAIN_BIN_DIRECTORY,
             Self::OPT_HWLOC,
             Self::OPT_LOG_TO_FILE,
+            Self::OPT_LOG_DIRECTORY,
             Self::OPT_L2
         );
     }
@@ -168,5 +178,9 @@ impl Args {
 
     pub fn log_to_file(&self) -> bool {
         self.log_to_file
+    }
+
+    pub fn log_directory(&self) -> &str {
+        &self.log_directory
     }
 }

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -188,6 +188,7 @@ impl SandboxCache {
                             sandbox_config.hwloc(),
                             sandbox_config.binary_directory(),
                             sandbox_config.toolchain_binary_directory(),
+                            sandbox_config.log_directory(),
                             control_plane_listener,
                             control_plane_poll,
                             sandbox_config.l2(),

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -33,6 +33,13 @@ pub const DEFAULT_BIN_DIRECTORY: &str = "./bin";
 ///
 pub const DEFAULT_TOOLCHAIN_BIN_DIRECTORY: &str = "./toolchain/bin";
 
+///
+/// # Description
+///
+/// Default directory for logs
+///
+pub const DEFAULT_LOG_DIRECTORY: &str = "./logs";
+
 /// Suffix for Unix sockets.
 #[cfg(debug_assertions)]
 const UNIX_SOCKET_SUFFIX: &str = ".debug.socket";

--- a/src/utils/nanvixd/src/http.rs
+++ b/src/utils/nanvixd/src/http.rs
@@ -150,6 +150,7 @@ impl HttpClient {
             args.hwloc().clone(),
             args.binary_directory(),
             args.toolchain_binary_directory(),
+            args.log_directory(),
             args.l2(),
             // Pass ownership of the L2 gateway port, if L2 deployment enabled.
             gateway_l2_port,

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -57,7 +57,7 @@ use ::tokio::{
 pub async fn main() -> Result<()> {
     let args: Args = Args::parse(std::env::args().collect())?;
 
-    ::syslog::init(args.log_to_file());
+    ::syslog::init(args.log_to_file(), args.log_directory().to_string());
 
     let mut signals: Signal = signal(SignalKind::interrupt())?;
     let http_listener: TcpListener = TcpListener::bind(args.http_sockaddr()).await?;

--- a/src/utils/nanvixd/src/sandbox/config.rs
+++ b/src/utils/nanvixd/src/sandbox/config.rs
@@ -29,6 +29,8 @@ pub struct SandboxConfig {
     binary_directory: String,
     /// Path to the toolchain binary directory.
     toolchain_binary_directory: String,
+    /// Directory for log files.
+    log_directory: String,
     /// Flag to deploy linuxd in an L2 VM.
     l2: bool,
     /// TCP port for the gateway in the L2 VM if L2 deployment enabled.
@@ -58,6 +60,7 @@ impl SandboxConfig {
     /// - `hwloc`: Hardware locality configuration.
     /// - `binary_directory`: Path to the binary directory.
     /// - `toolchain_binary_directory`: Path to the toolchain binary directory.
+    /// - `log_directory`: Path to the log directory.
     /// - `l2`: Flag to deploy linuxd in an L2 VM.
     /// - `gateway_l2_port`: Port for the gateway in the L2 VM.
     ///
@@ -76,6 +79,7 @@ impl SandboxConfig {
         hwloc: Option<HwLoc>,
         binary_directory: &str,
         toolchain_binary_directory: &str,
+        log_directory: &str,
         l2: bool,
         gateway_l2_port: Option<TcpPort>,
     ) -> Self {
@@ -89,6 +93,7 @@ impl SandboxConfig {
             hwloc,
             binary_directory: binary_directory.to_string(),
             toolchain_binary_directory: toolchain_binary_directory.to_string(),
+            log_directory: log_directory.to_string(),
             l2,
             _gateway_l2_port: gateway_l2_port,
         }
@@ -209,6 +214,16 @@ impl SandboxConfig {
     ///
     pub fn toolchain_binary_directory(&self) -> &str {
         &self.toolchain_binary_directory
+    }
+
+    /// Returns the log directory.
+    ///
+    /// # Returns
+    ///
+    /// The path to the log directory.
+    ///
+    pub fn log_directory(&self) -> &str {
+        &self.log_directory
     }
 
     ///

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -120,6 +120,7 @@ impl LinuxDaemon {
         hwloc: Option<HwLoc>,
         binary_directory: &str,
         toolchain_binary_directory: &str,
+        log_directory: &str,
         control_plane_listener: &mut SocketListener,
         control_plane_poll: &mut Poll,
         l2: bool,
@@ -153,6 +154,8 @@ impl LinuxDaemon {
             vec![
                 format!("{}/linuxd.elf", binary_directory),
                 args::Args::OPT_LOGFILE.to_string(),
+                args::Args::OPT_LOGDIR.to_string(),
+                log_directory.to_string(),
                 args::Args::OPT_CONTROL_PLANE_SOCKADDR.to_string(),
                 control_plane_sockaddr.to_string(),
                 args::Args::OPT_USER_VM_BIND_SOCKADDR.to_string(),

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -55,6 +55,8 @@ impl Microvm {
         let mut user_vm_args: Vec<String> = vec![
             format!("{}/microvm.elf", sandbox_config.binary_directory()),
             ::microvm::args::Args::OPT_LOGFILE.to_string(),
+            ::microvm::args::Args::OPT_LOGDIR.to_string(),
+            sandbox_config.log_directory().to_string(),
             ::microvm::args::Args::OPT_USER_VM_ID.to_string(),
             sandbox_tag.sandbox_id().to_string(),
             ::microvm::args::Args::OPT_KERNEL.to_string(),


### PR DESCRIPTION
Adds an argument (`--log-dir`) to nanvixd, linuxd and microvm that specifies a directory to write logs to when `--log-to-file` is specified.

If `log-to-file` is specified without `--log-dir` then the directory defaults to `./logs`