### PR TITLE
[libs] Make Control-Plane API Bi-directional

### DIFF
--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -453,8 +453,8 @@ impl LinuxDaemon {
                 match event.token() {
                     // Process control-plane messages before anything else.
                     CONTROL_PLANE_TOKEN => {
-                        let cmd: control_plane_api::Command =
-                            match control_plane_api::try_read_command(&mut control_plane_stream) {
+                        let cmd: control_plane_api::NanvixdCommand =
+                            match control_plane_api::recv_command(&mut control_plane_stream) {
                                 Ok(cmd) => cmd,
                                 Err(ref e) if e.kind() == ErrorKind::WouldBlock => continue,
                                 Err(e) => {
@@ -468,7 +468,7 @@ impl LinuxDaemon {
                                 },
                             };
                         match cmd {
-                            control_plane_api::Command::Shutdown => {
+                            control_plane_api::NanvixdCommand::Shutdown => {
                                 info!("linuxd received shutdown message from control-plane");
 
                                 // Close all existing connections to user VMs.

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -57,10 +57,18 @@ pub mod syscomm {
     ///
     /// # Description
     ///
+    /// Provides the maximum length of a message we receive. We set a limit to
+    /// prevent a malformed payload to trigger unbounded allocations in linuxd.
+    ///
+    pub const MAX_MESSAGE_LEN: usize = 128 * 1024 * 1024;
+
+    ///
+    /// # Description
+    ///
     /// Provides the maximum length of a message we receive in linuxd. We set a limit to
     /// prevent a malformed payload to trigger unbounded allocations in linuxd.
     ///
-    pub const MAX_LINUXD_MESSAGE_LEN: usize = 128 * 1024 * 1024;
+    pub const MAX_LINUXD_MESSAGE_LEN: usize = MAX_MESSAGE_LEN;
 
     ///
     /// # Description

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -65,14 +65,6 @@ pub mod syscomm {
     ///
     /// # Description
     ///
-    /// Provides the maximum length of a message we receive in linuxd. We set a limit to
-    /// prevent a malformed payload to trigger unbounded allocations in linuxd.
-    ///
-    pub const MAX_LINUXD_MESSAGE_LEN: usize = MAX_MESSAGE_LEN;
-
-    ///
-    /// # Description
-    ///
     /// Provides the maximum number of poll events we can buffer. We set the limit to 128 as, for
     /// the time being, it is unlikely we will have more than 128 connections being activated at
     /// the same time.

--- a/src/libs/control-plane-api/Cargo.toml
+++ b/src/libs/control-plane-api/Cargo.toml
@@ -12,5 +12,9 @@ homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true, features = ["serde"] }
+config = { workspace = true }
 num_enum = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 syscomm = { workspace = true }
+syslog = { workspace = true, features = ["std"] }

--- a/src/libs/control-plane-api/src/lib.rs
+++ b/src/libs/control-plane-api/src/lib.rs
@@ -1,13 +1,31 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
-//! This file contains the messages used in the control-plane API between
-//! nanvixd and linuxd/user VM.
+//!
+//! This file contains the messages used in the control-plane API between the control-plane
+//! (nanvixd), the system VM (linuxd), and the user VM. It defines a simple wire-format to allow
+//! for bi-directional communication. The specification for the wire-format is as follows:
+//! - source: u8 -> Source of the control-plane message (Nanvixd, SystemVm, or UserVm).
+//! - length: u32 LE -> Length of the message payload.
+//! - bytes: [u8; length]
+//!
+
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
 
 use ::anyhow::Result;
 use ::num_enum::{
     IntoPrimitive,
     TryFromPrimitive,
+};
+use ::serde::{
+    Deserialize,
+    Serialize,
 };
 use ::std::io::{
     Error,
@@ -17,32 +35,162 @@ use ::syscomm::{
     SocketError,
     SocketStream,
 };
+use ::syslog::error;
 
+///
+/// # Description
+///
+/// This enum indicates which entity is the source of a given control-plane message.
+///
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, IntoPrimitive, TryFromPrimitive)]
-pub enum Command {
+#[derive(Clone, Copy, Debug, IntoPrimitive, PartialEq, TryFromPrimitive)]
+pub enum Source {
+    Nanvixd,
+    SystemVm,
+    UserVm,
+}
+
+///
+/// # Description
+///
+/// Wire format for all control-plane messages, irrespective of the source.
+///
+pub trait WireCommand: Serialize + for<'de> Deserialize<'de> {
+    const SOURCE: Source;
+}
+
+///
+/// # Description
+///
+/// Default bincode options to encode/decode control-plane messages. This configuration uses
+/// fixed-size ints, and little-endian encoding.
+///
+const fn bincode_cfg() -> impl bincode::config::Config {
+    bincode::config::standard()
+        .with_fixed_int_encoding()
+        .with_little_endian()
+}
+
+
+///
+/// # Description
+///
+/// Control-plane messages from Nanvixd to the system VM and the user VM. For the moment we do not
+/// differentiate between who is the recipient.
+///
+#[derive(Debug, Serialize, Deserialize)]
+pub enum NanvixdCommand {
     Shutdown,
 }
 
-// This function is actually used by linuxd, consuming nanvixd as a library. It is never used from
-// the main nanvixd binary, hence why we need to add this annotation to silent clippy.
-#[allow(dead_code)]
-pub fn try_read_command(stream: &mut SocketStream) -> Result<Command, SocketError> {
-    let mut buf: [u8; 1] = [0u8; 1];
-
-    // Try read exact returns the number of bytes read `n` with 0 < n <= buf.len(). In this case
-    // it is safe to ignore the return value because n can only ever be 1.
-    let num_read = stream.try_read_exact(&mut buf)?;
-    debug_assert!(num_read == 1);
-
-    Command::try_from(buf[0]).map_err(|_| {
-        Error::new(ErrorKind::InvalidData, "error parsing control-plane command".to_string()).into()
-    })
+impl WireCommand for NanvixdCommand {
+    const SOURCE: Source = Source::Nanvixd;
 }
 
-#[allow(dead_code)]
-pub fn send_command(stream: &mut SocketStream, cmd: Command) -> Result<(), SocketError> {
-    let byte: u8 = cmd.into();
-    stream.write_all(&[byte])?;
+///
+/// # Description
+///
+/// Send a message following the control-plane protocol.
+///
+/// # Arguments
+///
+/// - `stream`: the control-plane stream where to send the message.
+/// - `msg`: a message that implements the WireCommand trait.
+///
+/// # Returns
+///
+/// In case of success, returns nothing. Otherwise, returns an error.
+///
+pub fn send_command<T: WireCommand>(stream: &mut SocketStream, msg: &T) -> Result<(), SocketError> {
+    let payload: Vec<u8> = bincode::serde::encode_to_vec(msg, bincode_cfg())
+        .map_err(|e| {
+            let reason: String = format!("failed to encode control-plane command (error={e:?})");
+            error!("{reason}");
+            Error::new(ErrorKind::InvalidData, reason)
+        })?;
+
+
+    if payload.len() > u32::MAX as usize {
+        let reason: String = format!("payload length exceeds maximum allowed size (length={}, max={})", payload.len(), u32::MAX);
+        error!("{reason}");
+        return Err(Error::new(ErrorKind::InvalidData, reason).into());
+    }
+    let len: [u8; 4] = u32::try_from(payload.len())
+        .map_err(|_| {
+            let reason: String = format!("error parsing payload length to u32 (len={})", payload.len());
+            error!("{reason}");
+            Error::new(ErrorKind::InvalidData, reason)
+        })?
+        .to_le_bytes();
+
+    // Send source, then payload length, then payload.
+    stream.write_all(&[T::SOURCE as u8])?;
+    stream.write_all(&len)?;
+    if !payload.is_empty() {
+        stream.write_all(&payload)?;
+    }
+
     Ok(())
+}
+
+///
+/// # Description
+///
+/// Receive a generic control-plane message following the wire-format.
+///
+/// # Arguments
+///
+/// - `stream`: the control-plane stream where to send the message.
+///
+/// # Returns
+///
+/// In case of success, a message of the indicated trait. Otherwise, an error.
+///
+pub fn recv_command<T: WireCommand>(stream: &mut SocketStream) -> Result<T, SocketError> {
+    // Read command source.
+    let mut source_bytes: [u8; 1] = [0u8; 1];
+    let num_read: usize = stream.try_read_exact(&mut source_bytes)?;
+    debug_assert_eq!(num_read, 1);
+
+    let source: Source = Source::try_from(source_bytes[0])
+        .map_err(|_| {
+            let reason: String = format!("error parsing source in control-plane command (bytes={source_bytes:?})");
+            error!("{reason}");
+            SocketError::from(Error::new(ErrorKind::InvalidData, reason))
+        })?;
+    if source != T::SOURCE {
+        let reason: String = format!("unexpected control-plane command source (got={}, expected={})", source as u8, T::SOURCE as u8);
+        error!("{reason}");
+        return Err(Error::new(ErrorKind::InvalidData, reason).into());
+    }
+
+    // Read command length.
+    let mut length_bytes: [u8; 4] = [0u8; 4];
+    let num_read: usize = stream.try_read_exact(&mut length_bytes)?;
+    debug_assert_eq!(num_read, 4);
+    let len: usize = u32::from_le_bytes(length_bytes) as usize;
+
+    // Sanity-check the received length.
+    if len > config::syscomm::MAX_MESSAGE_LEN {
+        let reason: String = format!("received control-plane message too large (len={len})");
+        error!("{reason}");
+        return Err(Error::new(ErrorKind::InvalidData, reason).into());
+    }
+
+    // Read payload.
+    let mut message_buf: Vec<u8> = vec![0u8; len];
+    if len > 0 {
+        let num_read: usize = stream.try_read_exact(&mut message_buf)?;
+        debug_assert_eq!(num_read, len);
+    }
+
+    // Decode message.
+    let (msg, _): (T, usize) = bincode::serde::decode_from_slice(&message_buf, bincode_cfg())
+        .map_err(|e| {
+            let reason: String = format!("failed to decode message (error={e:?})");
+            error!("{reason}");
+            SocketError::from(Error::new(ErrorKind::InvalidData, reason))
+        })?;
+
+    Ok(msg)
 }

--- a/src/libs/user-vm-api/src/lib.rs
+++ b/src/libs/user-vm-api/src/lib.rs
@@ -119,7 +119,7 @@ impl NewUserVm {
             })?;
 
         // Check if serialized message is too large.
-        if payload.is_empty() || payload.len() > ::config::syscomm::MAX_LINUXD_MESSAGE_LEN {
+        if payload.is_empty() || payload.len() > ::config::syscomm::MAX_MESSAGE_LEN {
             let reason: String = format!("invalid message length (length={})", payload.len());
             error!("send(): {reason}");
             return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
@@ -154,7 +154,7 @@ impl NewUserVm {
         let len: usize = u32::from_be_bytes(len_buf) as usize;
 
         // Check if message has an invalid size.
-        if len == 0 || len > ::config::syscomm::MAX_LINUXD_MESSAGE_LEN {
+        if len == 0 || len > ::config::syscomm::MAX_MESSAGE_LEN {
             let reason: String = format!("invalid message length (length={len})");
             error!("recv(): {reason}");
             return Err(io::Error::new(io::ErrorKind::InvalidData, reason));

--- a/src/microvm/src/io_thread.rs
+++ b/src/microvm/src/io_thread.rs
@@ -465,10 +465,14 @@ impl IoThread {
                     Err(e) => {
                         let reason: String = format!(
                             "try_send_to_vmm_control(): failed reading command from control-plane \
-                             (error={e:?})"
+                             will shutdown (error={e:?})"
                         );
                         error!("{reason}");
-                        return Err(anyhow::anyhow!(reason));
+
+                        // If we encounter an error, shutdown the I/O thread.
+                        // FIXME (1004): when we support graceful shutdown of the I/O thread, this
+                        // should instead be properly propagated as an error.
+                        control_plane_api::NanvixdCommand::Shutdown
                     },
                 };
             // Translate nanvixd control-plane commands to internal VMM control commands.

--- a/src/microvm/src/io_thread.rs
+++ b/src/microvm/src/io_thread.rs
@@ -457,8 +457,8 @@ impl IoThread {
     ///
     fn try_send_to_vmm_control(&mut self) -> Result<ControlFlow<()>> {
         if let Some(control_plane_stream) = self.control_plane_stream.as_mut() {
-            let cmd: control_plane_api::Command =
-                match control_plane_api::try_read_command(control_plane_stream) {
+            let cmd: control_plane_api::NanvixdCommand =
+                match control_plane_api::recv_command(control_plane_stream) {
                     Ok(cmd) => cmd,
                     // If we would block, return and do nothing.
                     Err(ref e) if e.kind() == ErrorKind::WouldBlock => return Ok(Break(())),
@@ -477,7 +477,7 @@ impl IoThread {
                 };
             // Translate nanvixd control-plane commands to internal VMM control commands.
             match cmd {
-                control_plane_api::Command::Shutdown => {
+                control_plane_api::NanvixdCommand::Shutdown => {
                     self.control_tx.send(IoControlCommand::Shutdown)?;
                 },
             }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -644,7 +644,7 @@ impl Benchmark {
         // Send shutdown command to the VMM.
         control_plane_api::send_command(
             &mut control_plane_stream,
-            control_plane_api::Command::Shutdown,
+            &control_plane_api::NanvixdCommand::Shutdown,
         )?;
 
         // Wait for the VMM to exit after we send the shutdown command.

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -299,8 +299,11 @@ impl SandboxCache {
     /// On success empty is returned. On failure an error is returned instead.
     ///
     pub async fn cleanup(&mut self) {
+        debug!("cleaning up sandbox cache");
+
         // First shutdown all user VMs.
         for (tag, user_vm_instance) in self.user_vm_instances.iter_mut() {
+            debug!("cleaning user vm instance (tag={tag:?})");
             if let Some(user_vm_instance_mut) = Arc::get_mut(user_vm_instance) {
                 debug!("sending shutdown message to user vm (tag={tag:?})");
                 if let Err(e) = user_vm_instance_mut.shutdown().await {
@@ -315,6 +318,7 @@ impl SandboxCache {
 
         // Shutdown all linuxd instances.
         for (tenant_id, linuxd_instance) in self.linuxd_instances.iter_mut() {
+            debug!("cleaning linuxd instance (tenant_id={tenant_id:?})");
             if let Some(linuxd_instance_mut) = Arc::get_mut(linuxd_instance) {
                 if let Err(e) = linuxd_instance_mut.shutdown().await {
                     error!(

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -13,6 +13,7 @@ use ::std::{
     path::PathBuf,
 };
 use ::syslog::error;
+use ::tokio::time::Duration;
 use ::user_vm_api::RawUserVmIdentifier;
 
 //==================================================================================================
@@ -56,6 +57,19 @@ pub const HTTP_HEADER_MESSAGE_TYPE: &str = "X-NVX-Message-Type";
 /// On Linux, this is defined in `<linux/un.h>`.
 /// TODO: replace this with `libc::UNIX_PATH_MAX` when it becomes available.
 const UNIX_PATH_MAX: usize = 108;
+
+///
+/// # Description
+///
+/// We use control-plane messages to synchronize the graceful shutdown of different components.
+/// However, if components are faulty or hang, nanvixd cannot block. Instead, we wait for this
+/// timeout and revert to non-graceful shutdowns if the timeout is met.
+///
+/// This constant is only used when building nanvixd as a binary, so we need to allow(dead_code)
+/// for when we build nanvixd as a library.
+///
+#[allow(dead_code)]
+const CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 //==================================================================================================
 // Standalone Functions

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -32,9 +32,12 @@ use ::syslog::{
     debug,
     error,
 };
-use ::tokio::process::{
-    Child,
-    Command,
+use ::tokio::{
+    process::{
+        Child,
+        Command,
+    },
+    time::timeout,
 };
 
 /// Single-byte that we send to unlock a linuxd instance restored from a snapshot. Anything that
@@ -106,7 +109,7 @@ impl LinuxDaemon {
         Ok(stream.write_all(&RESTORE_GATE_BYTES)?)
     }
 
-    fn send_sigkill_to_child(child: Child) {
+    fn send_sigkill_to_child(child: &Child) {
         if let Some(pid) = child.id() {
             debug!("killing linuxd instance (pid={pid:?})");
             let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
@@ -184,7 +187,7 @@ impl LinuxDaemon {
                 error!("{reason}");
 
                 // Use a SIGKILL because the process is already faulty.
-                Self::send_sigkill_to_child(child);
+                Self::send_sigkill_to_child(&child);
 
                 return Err(anyhow::anyhow!("{reason}"));
             }
@@ -206,7 +209,7 @@ impl LinuxDaemon {
                 error!("{reason}");
 
                 // Use a SIGKILL because the process is already faulty.
-                Self::send_sigkill_to_child(child);
+                Self::send_sigkill_to_child(&child);
 
                 return Err(anyhow::anyhow!("{reason}"));
             },
@@ -232,26 +235,26 @@ impl LinuxDaemon {
         };
 
         // Wait for linuxd instance to finish.
-        match self.child.wait().await {
-            Ok(exit_status) => {
+        match timeout(Duration::from_secs(5), self.child.wait()).await {
+            Ok(Ok(exit_status)) => {
                 if !exit_status.success() {
-                    let reason: String = format!(
-                        "linuxd returned with non-zero exit status: {:?}",
+                    error!(
+                        "linuxd returned with non-zero exit status (status={:?})",
                         exit_status.code()
                     );
-                    error!("{reason}");
-
-                    Err(anyhow::anyhow!(reason))
-                } else {
-                    Ok(())
+                    Self::send_sigkill_to_child(&self.child);
                 }
             },
+            Ok(Err(e)) => {
+                error!("error waiting for linuxd: {e:?}");
+                Self::send_sigkill_to_child(&self.child);
+            },
             Err(e) => {
-                let reason: String = format!("error waiting for linuxd: {e:?}");
-                error!("{reason}");
-
-                Err(anyhow::anyhow!(reason))
+                error!("timed-out waiting for linuxd (error={e:?})");
+                Self::send_sigkill_to_child(&self.child);
             },
         }
+
+        Ok(())
     }
 }

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -223,7 +223,7 @@ impl LinuxDaemon {
     pub async fn shutdown(&mut self) -> Result<()> {
         match control_plane_api::send_command(
             &mut self.control_plane_stream,
-            control_plane_api::Command::Shutdown,
+            &control_plane_api::NanvixdCommand::Shutdown,
         ) {
             Ok(()) => {},
             Err(e) => {

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -24,9 +24,12 @@ use ::syslog::{
     debug,
     error,
 };
-use ::tokio::process::{
-    Child,
-    Command,
+use ::tokio::{
+    process::{
+        Child,
+        Command,
+    },
+    time::timeout,
 };
 
 //==================================================================================================
@@ -179,6 +182,23 @@ impl Microvm {
     ///
     /// # Description
     ///
+    /// Helper method to send a SIGKILL to the user VM process in case it is faulty and we need to
+    /// clean-up.
+    ///
+    /// # Arguments
+    ///
+    /// - `child`: the user VM process handle.
+    ///
+    fn send_sigkill_to_child(child: Child) {
+        if let Some(pid) = child.id() {
+            debug!("killing linuxd instance (pid={pid:?})");
+            let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+        }
+    }
+
+    ///
+    /// # Description
+    ///
     /// Send a shutdown message to the user VM's control-plane socket so that it can gracefully
     /// shutdown, and wait until the process dies.
     ///
@@ -198,8 +218,8 @@ impl Microvm {
 
         // Wait for user VM instance to finish.
         if let Some(mut child) = self.child.take() {
-            match child.wait().await {
-                Ok(exit_status) => {
+            match timeout(Duration::from_secs(5), child.wait()).await {
+                Ok(Ok(exit_status)) => {
                     if !exit_status.success() {
                         error!(
                             "user VM returned with non-zero exit status (code={:?})",
@@ -207,8 +227,15 @@ impl Microvm {
                         );
                     }
                 },
-                Err(e) => {
+                // If we encounter any errors while waiting for the user VM to gracefully shutdown,
+                // make sure we kill the underlying instance.
+                Ok(Err(e)) => {
                     error!("error waiting for user VM (error={e:?})");
+                    Self::send_sigkill_to_child(child);
+                },
+                Err(e) => {
+                    error!("timed-out waiting for user VM (error={e:?})");
+                    Self::send_sigkill_to_child(child);
                 },
             }
         }

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -185,7 +185,7 @@ impl Microvm {
     pub async fn shutdown(&mut self) -> Result<()> {
         match control_plane_api::send_command(
             &mut self.control_plane_stream,
-            control_plane_api::Command::Shutdown,
+            &control_plane_api::NanvixdCommand::Shutdown,
         ) {
             Ok(()) => {},
             Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {


### PR DESCRIPTION
In this PR I enhance the control-plane API to support more complex messages, by moving to `bincode`-powered (de)-serialization, and supporting replies.

For the time-being, the control-plane API is bi-directional from nanvixd to the system/user VM and vice-versa. When the message is sent from nanvixd, we don't differentiate between recipients.

In follow-up PRs I will add messages from the system VM to nanvixd, to help with synchronization during system provisioning. 

We can also explore merging the user-vm API with this control-plane API. In this case, however, we should also consider having a control-plane stream between the system and the user VM. If I am not mistaken this feature is also desirable for snapshots.