### PR TITLE
[libs] B: Set Default Log Level to Warn

### DIFF
--- a/src/libs/syslog/Cargo.toml
+++ b/src/libs/syslog/Cargo.toml
@@ -19,7 +19,7 @@ flexi_logger = { workspace = true, optional = true }
 sys = { workspace = true, features = ["kcall"], optional = true }
 
 [features]
-default = ["dep:cfg-if", "dep:sys"]
+default = ["dep:cfg-if", "dep:sys", "warn"]
 # Enables the use of the Rust standard library.
 std = ["dep:log", "dep:flexi_logger"]
 # Enables this crate to be used as a dependency of the Rust standard library.


### PR DESCRIPTION
To prevent unintended log output during compilation with the syslog feature enabled, this change sets the default log level to warn. This ensures that only critical failures are logged by default, reducing noise and improving clarity in log output.