### PR TITLE
[libs] Dummy System Call Implementations

### DIFF
--- a/src/libs/posix/src/dummy.rs
+++ b/src/libs/posix/src/dummy.rs
@@ -1,0 +1,290 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::errno::__errno_location;
+use ::sys::error::ErrorCode;
+use ::sysapi::ffi::{
+    c_char,
+    c_int,
+    c_void,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Opens a process by creating a pipe, forking, and invoking the shell.
+///
+/// # Parameters
+///
+/// - `command`: Null-terminated string containing the command to be executed.
+/// - `mode`: Null-terminated string that specifies the mode for the pipe (e.g., "r" or "w").
+///
+/// # Returns
+///
+/// On success, returns a non-null pointer to an opaque stream object. On failure, returns a null
+/// pointer and sets `errno` to indicate the error.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always fails with `ENOSYS` (function not implemented).
+/// A future implementation should create the appropriate pipe, fork a child process, and execute
+/// the requested command in a POSIX-compatible shell environment.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers supplied by foreign callers.
+/// It is safe to call this function if `command` and `mode` (when non-null) point to valid
+/// null-terminated C strings.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn popen(command: *const c_char, mode: *const c_char) -> *mut c_void {
+    ::syslog::trace!("popen(): command={command:?}, mode={mode:?}");
+    ::syslog::error!("popen(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    core::ptr::null_mut()
+}
+
+///
+/// # Description
+///
+/// Closes a stream opened by [`popen()`] and waits for the associated process to terminate.
+///
+/// # Parameters
+///
+/// - `stream`: Pointer previously returned by [`popen()`].
+///
+/// # Returns
+///
+/// On success, returns the termination status of the command. On failure, returns `-1` and sets
+/// `errno` to indicate the error.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always fails with `ENOSYS` (function not implemented).
+/// A future implementation should close any pipe file descriptors, reap the child process, and
+/// return its status code in a POSIX-compatible manner.
+///
+/// # Safety
+///
+/// This function is unsafe because it operates on an opaque raw pointer supplied by foreign
+/// callers. It is safe to call this function if `stream` is either null or a value previously
+/// returned by [`popen()`] in a future, fully implemented version.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pclose(stream: *mut c_void) -> c_int {
+    ::syslog::trace!("pclose(): stream={stream:?}");
+    ::syslog::error!("pclose(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
+}
+
+///
+/// # Description
+///
+/// Retrieves the parameters associated with the terminal referred to by `fd` and stores them in
+/// the structure pointed to by `termios_p`.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor referring to a terminal device.
+/// - `termios_p`: Pointer to a buffer where the terminal attributes would be stored on success.
+///
+/// # Returns
+///
+/// On success, returns `0`. On failure, returns `-1` and sets `errno` to indicate the error.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always fails with `ENOSYS` (function not implemented).
+/// A future implementation should query the underlying TTY driver and populate the termios
+/// structure accordingly.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers supplied by foreign callers. It is
+/// safe to call this function if `termios_p` is either null or a valid, writable buffer large
+/// enough to hold a termios structure in a future, fully implemented version.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tcgetattr(fd: c_int, termios_p: *mut c_void) -> c_int {
+    ::syslog::trace!("tcgetattr(): fd={fd}, termios_p={termios_p:?}");
+    ::syslog::error!("tcgetattr(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
+}
+
+///
+/// # Description
+///
+/// Sets the parameters associated with the terminal referred to by `fd` according to the values
+/// in the structure pointed to by `termios_p`.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor referring to a terminal device.
+/// - `optional_actions`: How the change is applied (e.g., `TCSANOW`, `TCSADRAIN`, `TCSAFLUSH`).
+/// - `termios_p`: Pointer to a buffer containing the desired terminal attributes.
+///
+/// # Returns
+///
+/// On success, returns `0`. On failure, returns `-1` and sets `errno` to indicate the error.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always fails with `ENOSYS` (function not implemented).
+/// A future implementation should validate the requested attributes and apply them atomically to
+/// the underlying TTY driver.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers supplied by foreign callers. It is
+/// safe to call this function if `termios_p` is either null or a valid, readable buffer containing
+/// a termios structure in a future, fully implemented version.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tcsetattr(
+    fd: c_int,
+    optional_actions: c_int,
+    termios_p: *const c_void,
+) -> c_int {
+    ::syslog::trace!(
+        "tcsetattr(): fd={fd}, optional_actions={optional_actions}, termios_p={termios_p:?}"
+    );
+    ::syslog::error!("tcsetattr(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
+}
+
+///
+/// # Description
+///
+/// Replaces the current process image with a new process image specified by `file` and argument
+/// vector `argv`, searching the `PATH` environment variable to locate the executable if necessary.
+///
+/// # Parameters
+///
+/// - `file`: Null-terminated string naming the file to execute (may be a bare program name).
+/// - `argv`: Null-terminated array of argument strings passed to the new program. The first element
+///   conventionally is the program name.
+///
+/// # Returns
+///
+/// This function only returns on failure, in which case it returns `-1` and sets `errno`.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always fails with `ENOSYS` (function not implemented).
+/// A future implementation should perform path resolution, validate executable format, load the
+/// program image into memory, set up the user stack with the argument and environment vectors, and
+/// transfer control without returning.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers supplied by foreign callers. It is
+/// safe to call this function if `file` and `argv` (when non-null) point to valid, null-terminated
+/// C strings and a null-terminated vector, respectively.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char) -> c_int {
+    ::syslog::trace!("execvp(): file={file:?}, argv={argv:?}");
+    ::syslog::error!("execvp(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
+}
+
+///
+/// # Description
+///
+/// Resolves a pathname to an absolute, canonical form, eliminating symbolic links, `.` and `..`
+/// components.
+///
+/// # Parameters
+///
+/// - `path`: Null-terminated input pathname to resolve.
+/// - `resolved_path`: Optional caller-provided buffer where the resolved path would be stored. If
+///   null, a future implementation would allocate a new buffer via the POSIX-specified allocator.
+///
+/// # Returns
+///
+/// On success, returns a pointer to the resolved path (either `resolved_path` or an allocated
+/// buffer). On failure, returns null and sets `errno` to indicate the error.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always fails with `ENOSYS` (function not implemented).
+/// A future implementation should perform path normalization, handle symbolic links (with an
+/// upper bound on link depth to avoid cycles), and ensure the result does not exceed `PATH_MAX`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers supplied by foreign callers. It is
+/// safe to call this function if `path` points to a valid, null-terminated C string and
+/// `resolved_path` is either null or points to a writable buffer large enough to hold the
+/// canonical path in a future, fully implemented version.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn realpath(path: *const c_char, resolved_path: *mut c_char) -> *mut c_char {
+    ::syslog::trace!("realpath(): path={path:?}, resolved_path={resolved_path:?}");
+    ::syslog::error!("realpath(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    core::ptr::null_mut()
+}
+
+///
+/// # Description
+///
+/// Performs a file tree walk starting at `dirpath` and calls the user-supplied callback
+/// function `fn_cb` for each encountered file or directory. The walk is performed in
+/// unspecified order and is limited by `nopenfd`, which specifies the maximum number of
+/// file descriptors that may be used simultaneously during the traversal.
+///
+/// # Parameters
+///
+/// - `dirpath`: Null-terminated path to the starting directory.
+/// - `fn_cb`: Callback invoked for each entry. Receives: the entry path, a pointer to a
+///   `stat`-like structure (platform specific) and a type flag describing the entry kind.
+/// - `nopenfd`: Maximum number of file descriptors to keep open while traversing.
+///
+/// # Returns
+///
+/// Returns `0` on success. On failure it returns `-1` and sets `errno` to indicate the
+/// error. If the callback returns a non-zero value, a future compliant implementation
+/// would stop the walk and propagate that value as the return code of `ftw()`.
+///
+/// # Notes
+///
+/// This is a dummy implementation that always fails with `ENOSYS` (function not
+/// implemented). A future implementation should:
+/// - Perform a depth-first (or specified order) traversal of the directory tree.
+/// - Invoke the callback for each file, directory, symbolic link, etc.
+/// - Enforce `nopenfd` by closing directories when descending beyond the limit.
+/// - Populate and pass a proper `stat` structure to the callback.
+/// - Map filesystem errors to appropriate `errno` values and continue or abort
+///   traversal according to specification and callback return values.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers supplied by foreign
+/// callers and invokes a function pointer. It is safe to call this function if `dirpath`
+/// is a valid, null-terminated string and `fn_cb` (when non-null) points to a callable
+/// function with the expected signature in a future, fully implemented version.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ftw(
+    dirpath: *const c_char,
+    fn_cb: Option<unsafe extern "C" fn(*const c_char, *const c_void, c_int) -> c_int>,
+    nopenfd: c_int,
+) -> c_int {
+    ::syslog::trace!("ftw(): dirpath={dirpath:?}, fn_cb={:?}, nopenfd={nopenfd}", fn_cb);
+    ::syslog::error!("ftw(): not implemented");
+    *__errno_location() = ErrorCode::InvalidSysCall.get();
+    -1
+}

--- a/src/libs/posix/src/lib.rs
+++ b/src/libs/posix/src/lib.rs
@@ -26,6 +26,9 @@ pub mod arpa;
 /// Dynamic linking.
 pub mod dlfcn;
 
+/// Dummy implementations.
+pub mod dummy;
+
 /// System error numbers.
 pub mod errno;
 


### PR DESCRIPTION
This commit adds the following dummy system call implementations to LibPOSIX:
- popen()
- pclose()
- tcgetattr()
- tcsetattr()
- execvp()
- realpath
- ftw()