### PR TITLE
[build] Fix Cleanup Command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,7 @@ distclean: clean
 	$(FORCE_RM_CMD) $(LIBRARIES_DIR)
 	$(FORCE_RM_CMD) $(BINARIES_DIR)
 	$(FORCE_RM_CMD) $(PYTHON_VENV_DIRECTORY)
+	$(FORCE_RM_CMD) $(SYSROOT_DIR)
 
 # Installs build artifacts.
 install: all-nanvix

--- a/scripts/build-opt.sh
+++ b/scripts/build-opt.sh
@@ -20,6 +20,10 @@
 
 set -euo pipefail
 
+#===================================================================================================
+# Script Arguments
+#===================================================================================================
+
 if [[ $# -ne 6 ]]; then
     echo "Usage: $0 <rule> <toolchain_dir> <sysroot_dir> <repository_url> <commit_id> <dirname>" >&2
     exit 1
@@ -32,8 +36,20 @@ REPOSITORY=$4
 COMMIT=$5
 DIRNAME=$6
 
+#===================================================================================================
+# Global Variables
+#===================================================================================================
+
+NANVIX_HOME="$(git rev-parse --show-toplevel)"
 CONTRIB_DIR="${SYSROOT_DIR}/src"
 REPOSITORY_HOME="${CONTRIB_DIR}/${DIRNAME}"
+
+#===================================================================================================
+# Imports
+#===================================================================================================
+
+source "${NANVIX_HOME}/scripts/common/logging.sh"
+source "${NANVIX_HOME}/scripts/common/utils.sh"
 
 #===================================================================================================
 # Functions
@@ -60,7 +76,9 @@ do_build() {
 do_clean() {
     if [[ -d "${REPOSITORY_HOME}" ]]; then
         cd "${REPOSITORY_HOME}" || exit 1
-        ./z clean
+        ./z clean || {
+            print_warning "Failed to clean optional dependency in ${REPOSITORY_HOME}"
+        }
     fi
 }
 

--- a/z
+++ b/z
@@ -548,6 +548,8 @@ main() {
             ${BUILD_WITH_DOCKER} && cache_args+=("${OPT_NAME_WITH_DOCKER}")
             cache_args+=("${OPT_NAME_SEPARATOR}" "${build_parameters[@]}")
             write_cache "${cache_args[@]}"
+
+            print_success "Build complete."
             ;;
 
         "${CMD_NAME_CLEANUP}")
@@ -571,6 +573,8 @@ main() {
                 rm -f "${Z_CACHE_FILE}"
                 print_success "Cache file removed."
             fi
+
+            print_success "Cleanup complete."
             ;;
 
         "${CMD_NAME_SETUP}")
@@ -655,7 +659,7 @@ main() {
                 fi
             fi
 
-            print_success "Nanvix development environment setup completed successfully."
+            print_success "Setup complete."
             ;;
 
         "${CMD_NAME_HELP}")


### PR DESCRIPTION
This pull request introduces improvements to the build and clean scripts, focusing on better logging, error handling, and cleanup procedures. The most significant changes include enhanced script structure, improved feedback for users, and more robust error handling during clean operations.

**Build Script Enhancements:**

* Added imports for logging and utility functions in `scripts/build-opt.sh` to provide consistent logging and utility support across the script.
* Introduced a global variable `NANVIX_HOME` to reliably reference the project root directory in `scripts/build-opt.sh`.

**Error Handling and Logging:**

* Updated the `do_clean()` function in `scripts/build-opt.sh` to print a warning if cleaning an optional dependency fails, improving error visibility.
* Added success messages after build, cleanup, and setup operations in the `z` script, providing clearer feedback to users. [[1]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06R551-R552) [[2]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06R576-R577) [[3]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06L658-R662)

**Cleanup Improvements:**

* Modified the `distclean: clean` target in `Makefile` to also remove the `SYSROOT_DIR`, ensuring a more thorough cleanup of build artifacts.