### PR TITLE
[libs] Asynchronous Wrapper of Syscomm Library

### DIFF
--- a/src/libs/syscomm/Cargo.toml
+++ b/src/libs/syscomm/Cargo.toml
@@ -10,9 +10,14 @@ authors.workspace = true
 description = "System Communication Library"
 homepage.workspace = true
 
+[features]
+default = []
+async = ["dep:tokio"]
+
 [dependencies]
 anyhow = { workspace = true }
 bincode = { workspace = true }
 config = { workspace = true }
 mio = { workspace = true, features = ["net", "os-poll"] }
 syslog = { workspace = true, features = ["std"] }
+tokio = { workspace = true, optional = true, features = ["macros", "net", "rt", "time"] }

--- a/src/libs/syscomm/src/async.rs
+++ b/src/libs/syscomm/src/async.rs
@@ -1,0 +1,97 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//!
+//! This module contains async wrappers around the methods in the syscomm library. It is meant to
+//! be used in places in the codebase where we are using asynchronous tasks.
+//!
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    SocketListener,
+    SocketStream,
+};
+use ::std::{
+    io::{
+        self,
+        ErrorKind,
+    },
+    os::fd::AsRawFd,
+};
+use ::tokio::io::unix::{
+    AsyncFd,
+    AsyncFdReadyGuard,
+};
+
+///
+/// # Description
+///
+/// Asynchronous read exact implementation.
+///
+/// # Parameters
+///
+/// - `stream`: A mutable, non-blocking, mio socket stream.
+/// - `buf`: A mutable buffer.
+///
+/// # Returns
+///
+/// The number of bytes read into the buffer.
+///
+pub async fn read_exact(stream: &mut SocketStream, mut buf: &mut [u8]) -> io::Result<()> {
+    let afd: AsyncFd<i32> = AsyncFd::new(stream.as_raw_fd())?;
+
+    while !buf.is_empty() {
+        let mut guard: AsyncFdReadyGuard<'_, i32> = afd.readable().await?;
+
+        match stream.try_read(buf) {
+            Ok(0) => return Err(io::ErrorKind::UnexpectedEof.into()),
+            Ok(n) => {
+                // Move the pointer in the mutable buffer by `n`.
+                let (_, rest): (&mut [u8], &mut [u8]) = buf.split_at_mut(n);
+                buf = rest;
+
+                // Keep the readiness for possible more bytes in buffer.
+            },
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                // Consume the readiness and wait again.
+                guard.clear_ready();
+            },
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Asynchronous version of the accept call to accept a connection on a socket listener.
+///
+/// # Parameters
+///
+/// - `listener`: A non-blocking mio socket listener.
+///
+/// # Returns
+///
+/// A new non-blocking mio socket stream, or an error.
+///
+pub async fn accept(listener: &SocketListener) -> io::Result<SocketStream> {
+    let afd: AsyncFd<i32> = AsyncFd::new(listener.as_raw_fd())?;
+
+    loop {
+        // Try accepting straight away.
+        match listener.accept() {
+            Ok(stream) => return Ok(stream),
+            Err(e) if e.kind() == ErrorKind::WouldBlock => {},
+            Err(e) => return Err(e.into()),
+        }
+
+        // Wait until readable again.
+        let mut guard: AsyncFdReadyGuard<'_, i32> = afd.readable().await?;
+        guard.clear_ready();
+    }
+}

--- a/src/libs/syscomm/src/lib.rs
+++ b/src/libs/syscomm/src/lib.rs
@@ -2,6 +2,13 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Modules
+//==================================================================================================
+
+#[cfg(feature = "async")]
+pub mod r#async;
+
+//==================================================================================================
 // Imports
 //==================================================================================================
 
@@ -34,6 +41,10 @@ use ::std::{
         ErrorKind,
         Read,
         Write,
+    },
+    os::fd::{
+        AsRawFd,
+        RawFd,
     },
     thread,
     time::{
@@ -214,6 +225,15 @@ impl mio::event::Source for SocketListener {
         match self {
             SocketListener::Tcp(listener) => listener.deregister(registry),
             SocketListener::Unix { listener, path: _ } => listener.deregister(registry),
+        }
+    }
+}
+
+impl AsRawFd for SocketListener {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            SocketListener::Tcp(listener) => listener.as_raw_fd(),
+            SocketListener::Unix { listener, path: _ } => listener.as_raw_fd(),
         }
     }
 }
@@ -574,6 +594,15 @@ impl mio::event::Source for SocketStream {
         match self {
             SocketStream::Tcp(stream) => stream.deregister(registry),
             SocketStream::Unix(stream) => stream.deregister(registry),
+        }
+    }
+}
+
+impl AsRawFd for SocketStream {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            SocketStream::Tcp(stream) => stream.as_raw_fd(),
+            SocketStream::Unix(stream) => stream.as_raw_fd(),
         }
     }
 }

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -29,7 +29,7 @@ rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sys = { workspace = true }
-syscomm = { workspace = true }
+syscomm = { workspace = true, features = ["async"] }
 syslog = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 user-vm-api = { workspace = true }

--- a/src/utils/nanvixd/src/cache/mod.rs
+++ b/src/utils/nanvixd/src/cache/mod.rs
@@ -12,11 +12,6 @@ use crate::sandbox::{
     tag::SandboxTag,
 };
 use ::anyhow::Result;
-use ::mio::{
-    Interest,
-    Poll,
-    Token,
-};
 use ::std::{
     collections::HashMap,
     sync::Arc,
@@ -33,14 +28,6 @@ use ::syslog::{
 };
 use ::tokio::sync::Mutex;
 use ::user_vm_api::RawUserVmIdentifier;
-
-//==================================================================================================
-// Constants
-//==================================================================================================
-
-/// This is the token we use to register the control-plane listener socket in the poll structure.
-/// Right now, we only keep this socket in the poll.
-const CONTROL_PLANE_LISTENER_TOKEN: Token = Token(0);
 
 //==================================================================================================
 // Structures
@@ -62,8 +49,6 @@ pub struct SandboxCache {
     /// Listener socket on the control-plane address. Right now each different linuxd and user VM
     /// instances have their own control-plane socket.
     control_plane_listener: Option<SocketListener>,
-    /// Poll structure to support accepting connections into the control-plane with a timeout.
-    control_plane_poll: Option<Poll>,
 }
 
 impl SandboxCache {
@@ -86,7 +71,6 @@ impl SandboxCache {
             linuxd_instances: HashMap::new(),
             sandbox_index: HashMap::new(),
             control_plane_listener: None,
-            control_plane_poll: None,
         }))
     }
 
@@ -125,7 +109,7 @@ impl SandboxCache {
                         SocketType::Unix
                     };
 
-                    let mut control_plane_listener: SocketListener = match Socket::bind(
+                    let control_plane_listener: SocketListener = match Socket::bind(
                         control_plane_socket_type,
                         control_plane_sockaddr.to_string(),
                     ) {
@@ -141,29 +125,7 @@ impl SandboxCache {
                         },
                     };
 
-                    // Add control-plane socket to a poll structure so that we can accept
-                    // connections with a timeout.
-                    let poll: Poll = Poll::new().map_err(|e| {
-                        let reason: String =
-                            format!("failed to create control-plane poll (error={e:?})");
-                        error!("{reason}");
-                        anyhow::anyhow!("{reason}")
-                    })?;
-                    poll.registry()
-                        .register(
-                            &mut control_plane_listener,
-                            CONTROL_PLANE_LISTENER_TOKEN,
-                            Interest::READABLE,
-                        )
-                        .map_err(|e| {
-                            let reason: String =
-                                format!("failed to create control-plane poll (error={e:?})");
-                            error!("{reason}");
-                            anyhow::anyhow!("{reason}")
-                        })?;
-
                     self.control_plane_listener = Some(control_plane_listener);
-                    self.control_plane_poll = Some(poll);
                 }
 
                 let control_plane_listener: &mut SocketListener = self
@@ -171,29 +133,26 @@ impl SandboxCache {
                     .as_mut()
                     .ok_or_else(|| anyhow::anyhow!("control-plane listener is none"))?;
 
-                let control_plane_poll: &mut Poll = self
-                    .control_plane_poll
-                    .as_mut()
-                    .ok_or_else(|| anyhow::anyhow!("control-plane poll is none"))?;
-
                 debug!("creating sandbox {tag:?}");
                 if !self.linuxd_instances.contains_key(tag.tenant_id()) {
                     // If this is the first user VM we deploy for this tenant, we first need to
                     // deploy an instance of linuxd.
                     self.linuxd_instances.insert(
                         tag.tenant_id().to_string(),
-                        Arc::new(LinuxDaemon::spawn(
-                            sandbox_config.control_plane_sockaddr(),
-                            sandbox_config.user_vm_sockaddr(),
-                            sandbox_config.hwloc(),
-                            sandbox_config.binary_directory(),
-                            sandbox_config.toolchain_binary_directory(),
-                            sandbox_config.log_directory(),
-                            control_plane_listener,
-                            control_plane_poll,
-                            sandbox_config.l2(),
-                            tmp_directory.clone(),
-                        )?),
+                        Arc::new(
+                            LinuxDaemon::spawn(
+                                sandbox_config.control_plane_sockaddr(),
+                                sandbox_config.user_vm_sockaddr(),
+                                sandbox_config.hwloc(),
+                                sandbox_config.binary_directory(),
+                                sandbox_config.toolchain_binary_directory(),
+                                sandbox_config.log_directory(),
+                                control_plane_listener,
+                                sandbox_config.l2(),
+                                tmp_directory.clone(),
+                            )
+                            .await?,
+                        ),
                     );
                 }
 
@@ -207,7 +166,6 @@ impl SandboxCache {
                             // allocated, to the user VM so that we bind their lifetimes.
                             sandbox_config,
                             control_plane_listener,
-                            control_plane_poll,
                         )
                         .await?,
                     ),

--- a/src/utils/nanvixd/src/sandbox/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/linuxd.rs
@@ -17,7 +17,6 @@ use ::linuxd::{
     args,
     config::restore_gate_sockaddr_builder,
 };
-use ::mio::Poll;
 use ::std::{
     process::Stdio,
     time::Duration,
@@ -117,7 +116,7 @@ impl LinuxDaemon {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn spawn(
+    pub async fn spawn(
         control_plane_sockaddr: &str,
         user_vm_sockaddr: &str,
         hwloc: Option<HwLoc>,
@@ -125,7 +124,6 @@ impl LinuxDaemon {
         toolchain_binary_directory: &str,
         log_directory: &str,
         control_plane_listener: &mut SocketListener,
-        control_plane_poll: &mut Poll,
         l2: bool,
         tmp_directory: String,
     ) -> Result<Self> {
@@ -195,12 +193,14 @@ impl LinuxDaemon {
 
         // After linuxd has started, accept the incoming connection and return the stream for
         // further use.
-        let control_plane_stream: SocketStream = match control_plane_listener.accept_timeout(
-            control_plane_poll,
+        let control_plane_stream: SocketStream = match timeout(
             Duration::from_secs(config::syscomm::ACCEPT_TIMEOUT_SECS),
-        ) {
-            Ok(stream) => stream,
-            Err(e) => {
+            ::syscomm::r#async::accept(control_plane_listener),
+        )
+        .await
+        {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) => {
                 // If linuxd has not accepted the control-plane connection, it means that
                 // something went wrong during start-up. We kill the process ignoring errors,
                 // and return an error.
@@ -211,7 +211,18 @@ impl LinuxDaemon {
                 // Use a SIGKILL because the process is already faulty.
                 Self::send_sigkill_to_child(&child);
 
-                return Err(anyhow::anyhow!("{reason}"));
+                anyhow::bail!("{reason}")
+            },
+            Err(e) => {
+                let reason: String = format!(
+                    "timed-out waiting for linuxd to connect to control-plane (error={e:?})"
+                );
+                error!("{reason}");
+
+                // Use a SIGKILL because the process is already faulty.
+                Self::send_sigkill_to_child(&child);
+
+                anyhow::bail!("{reason}")
             },
         };
         debug!("nanvixd received connection from linuxd's control-plane socket");

--- a/src/utils/nanvixd/src/sandbox/microvm.rs
+++ b/src/utils/nanvixd/src/sandbox/microvm.rs
@@ -10,7 +10,6 @@ use crate::sandbox::{
     tag::SandboxTag,
 };
 use ::anyhow::Result;
-use ::mio::Poll;
 use ::std::{
     process::Stdio,
     time::Duration,
@@ -53,7 +52,6 @@ impl Microvm {
         sandbox_tag: SandboxTag,
         sandbox_config: SandboxConfig,
         control_plane_listener: &mut SocketListener,
-        control_plane_poll: &mut Poll,
     ) -> Result<Self> {
         let mut user_vm_args: Vec<String> = vec![
             format!("{}/microvm.elf", sandbox_config.binary_directory()),
@@ -122,12 +120,14 @@ impl Microvm {
         // After the user VM has started, accept the incoming connection for the control-plane.
         // Post-condition: once the connection has been accepted, the user VM has been able to
         // connect to the system VM (if an address is provided).
-        let control_plane_stream: SocketStream = match control_plane_listener.accept_timeout(
-            control_plane_poll,
+        let control_plane_stream: SocketStream = match timeout(
             Duration::from_secs(config::syscomm::ACCEPT_TIMEOUT_SECS),
-        ) {
-            Ok(stream) => stream,
-            Err(e) => {
+            ::syscomm::r#async::accept(control_plane_listener),
+        )
+        .await
+        {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) => {
                 // If the user VM has not accepted the control-plane connection, it means that
                 // something went wrong during start-up. We kill the process ignoring errors,
                 // and return an error.
@@ -135,11 +135,18 @@ impl Microvm {
                     format!("error connecting control-plane to user VM (error={e:?})");
                 error!("{reason}");
 
-                // Use a SIGKILL because the process is already faulty.
-                if let Some(pid) = child.id() {
-                    debug!("killing user VM instance (pid={pid:?})");
-                    let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
-                }
+                Self::send_sigkill_to_child(child);
+
+                return Err(anyhow::anyhow!("{reason}"));
+            },
+            Err(e) => {
+                let reason: String = format!(
+                    "timed-out waiting for user VM to connect the control-plane stream \
+                     (error={e:?})"
+                );
+                error!("{reason}");
+
+                Self::send_sigkill_to_child(child);
 
                 return Err(anyhow::anyhow!("{reason}"));
             },


### PR DESCRIPTION
In this PR I add an optional extension to the syscomm library, gated under the `async` feature, that implements `async` versions of `read_exact` and `accept`.

We currently have blocking non-async versions of this methods, but having async versions makes it possible to integrate them better with the parts of the codebase where we use `tokio` as asynchronous runtime.

In particular, I use the new async `accept` method to replace the blocking `accept_timeout` used when spawning linuxd and the user vm fron nanvixd.