### PR TITLE
[uservm] Handle Graceful Exits for Hyperlight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1210,32 +1210,21 @@ test-uservm:
 # Rules for Running System Level Tests Using Nanvix Daemon
 #===================================================================================================
 
-# List of supported functions in hyperlight.
-HYPERLIGHT_WHITELIST := echo-c echo-cpp echo-rust-nostd hello-c hello-cpp
-
 comma:=,
 
 define TEST_RULE
 test-$(2): all
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-	@echo "Running test $(2)..."
-ifeq ($(MACHINE),hyperlight)
-	@if echo "$(HYPERLIGHT_WHITELIST)" | grep -wq "$(2)"; then \
-		if [ `stat -c%s "$(1)/$(2)$(3)"` -gt 16777216 ]; then \
-			echo "\033[31mWarning: $(1)/$(2)$(3) exceeds 16 MB, skipping test.\033[0m"; \
+	@if [ ! -f "$(1)/$(2)$(3)" ]; then \
+		echo "\033[31mWarning: $(1)/$(2)$(3) missing, skipping test.\033[0m"; \
 		else \
+		echo "Running test $(2)..." ; \
 			$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) $(1)/$(2)$(3) $(4) $(5) $(6) $(TIMEOUT); \
-		fi; \
-	else \
-		echo "\033[31mWarning: Skipping $(2) on hyperlight (not supported).\033[0m"; \
 	fi
-else
-	$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) $(1)/$(2)$(3) $(4) $(5) $(6) $(TIMEOUT)
-endif
 endif
 endef
 
-$(eval $(call TEST_RULE,$(BINARIES_DIR),echo-c,.elf,'','["hello world!"]','hello world!'))
+$(eval $(call TEST_RULE,$(BINARIES_DIR),echo-c,.elf,'','hello world!','hello world!'))
 $(eval $(call TEST_RULE,$(BINARIES_DIR),echo-cpp,.elf,'','["hello world!"]','hello world!'))
 $(eval $(call TEST_RULE,$(BINARIES_DIR),echo-rust-nostd,.elf,'','["hello world!"]','hello world!'))
 $(eval $(call TEST_RULE,$(BINARIES_DIR),hello-c,.elf,'','[]','Hello$(comma) world from C!'))
@@ -1257,15 +1246,7 @@ test-$(1): all
 ifeq ($(shell basename $(WASM_BINARY)),$(1).wasm)
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 	@echo "Running test $(1)..."
-ifeq ($(MACHINE),hyperlight)
-	if [ `stat -c%s "bin/wasmd.elf"` -gt 16777216 ]; then \
-		echo "\033[31mWarning: bin/wasmd.elf exceeds 16 MB, skipping test!\033[0m"; \
-	else \
-		$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) bin/wasmd.elf $(2) $(3) $(4) $(TIMEOUT); \
-	fi
-else
-	$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) bin/wasmd.elf $(2) $(3) $(4) $(TIMEOUT)
-endif
+	$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) bin/wasmd.elf $(2) $(3) $(4) $(TIMEOUT);
 endif
 endif
 endef

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -17,33 +17,36 @@ use crate::{
 use ::anyhow::Result;
 use ::core::convert::TryFrom;
 use ::hyperlight_host::{
-    HyperlightError,
-    UninitializedSandbox,
-    sandbox::SandboxConfiguration,
-};
-use ::std::{
-    io::Write,
-    sync::Arc,
-};
-use hyperlight_host::{
     GuestBinary,
+    HyperlightError,
+    MultiUseSandbox,
+    UninitializedSandbox,
     mem::{
         memory_region::MemoryRegionFlags,
         mgr::SandboxMemoryManager,
         shared_mem::ExclusiveSharedMemory,
     },
-    sandbox::uninitialized::{
-        GuestBlob,
-        GuestEnvironment,
+    sandbox::{
+        SandboxConfiguration,
+        uninitialized::{
+            GuestBlob,
+            GuestEnvironment,
+        },
     },
 };
-use std::sync::OnceLock;
-use syslog::{
+use ::std::{
+    io::Write,
+    sync::{
+        Arc,
+        OnceLock,
+    },
+};
+use ::sys::error::ErrorCode;
+use ::syslog::{
     debug,
     error,
 };
-
-use tokio::{
+use ::tokio::{
     runtime::Handle,
     sync::{
         Mutex,
@@ -291,22 +294,42 @@ impl Vmm {
                 .take()
                 .ok_or_else(|| anyhow::anyhow!("sandbox already evolved"))?
         };
-        match uninit.evolve() {
-            Ok(res) => anyhow::bail!("Expected DEFAULT_VMM_SHUTDOWN_CMD, got: {:#?}", res),
-            Err(err) => {
+
+        // Run the sandbox.
+        let result: Result<MultiUseSandbox, HyperlightError> = uninit.evolve();
+
+        // Communicate shutdown to orchestrator.
+        if let Err(error) = self
+            .inner
+            .blocking_lock()
+            .control_tx
+            .blocking_send(VcpuControlResponse::Shutdown)
+        {
+            error!("run(): failed to notify vmm thread (error={error:?})");
+            // Don't bail as we are shutting down anyway.
+        }
+
+        // Parse result.
+        match result {
+            Ok(_multiuse_sandbox) => {
+                error!("run(): vmm exited");
+                Ok(ErrorCode::ConnectionAborted.into())
+            },
+            Err(error) => {
                 // note: this is a bit of a hack to check for the shutdown command.
-                if !err
+                if !error
                     .to_string()
                     .contains(&::config::hyperlight::DEFAULT_VMM_SHUTDOWN_CMD.to_string())
                 {
-                    anyhow::bail!("Failed to run VMM: {}", err);
+                    error!("run(): vmm aborted (error={error:?})");
+                    Ok(ErrorCode::ConnectionReset.into())
+                } else {
+                    // FIXME (#1010): the vCPU thread already returns 0 always, but we will be able to remove
+                    // this line once we can join the vCPU thread.
+                    Ok(0)
                 }
             },
         }
-
-        // FIXME (#1010): the vCPU thread already returns 0 always, but we will be able to remove
-        // this line once we can join the vCPU thread.
-        Ok(0)
     }
 
     ///


### PR DESCRIPTION
This pull request simplifies and unifies the logic for running system-level tests and handling sandbox execution in the Hyperlight VMM. The main focus is on removing special-case handling for the Hyperlight machine in the Makefile, improving error handling and shutdown notification in the VMM, and cleaning up imports and dependencies.

**Testing logic simplification:**

* Removed the Hyperlight-specific whitelist and associated size checks from the `Makefile`, so test rules now treat `hyperlight` and `microvm` similarly, only skipping tests if the binary is missing. This makes test execution more consistent across machine types.
* Updated WASM test rules to remove Hyperlight-specific size checks and run tests for both `microvm` and `hyperlight` in the same way, further unifying the test process.

**VMM error handling and shutdown improvements:**

* Refactored the `run` method in `src/uservm/src/vmm/hyperlight/mod.rs` to always notify the orchestrator of shutdown, handle sandbox evolution results more clearly, and return appropriate error codes (`ConnectionAborted` or `ConnectionReset`) based on the outcome.

**Code cleanup:**

* Consolidated and reorganized imports in `src/uservm/src/vmm/hyperlight/mod.rs` for clarity and maintainability, grouping related items and removing redundancies.