### PR TITLE
[libs] Silent Not Implemented System Calls

### DIFF
--- a/src/libs/posix/src/arpa/inet.rs
+++ b/src/libs/posix/src/arpa/inet.rs
@@ -46,7 +46,7 @@ use ::sysapi::{
 pub unsafe extern "C" fn inet_addr(cp: *const c_char) -> in_addr_t {
     ::syslog::trace!("inet_addr(): cp={cp:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/594.
-    ::syslog::error!("inet_addr(): not implemented");
+    ::syslog::debug!("inet_addr(): not implemented");
     in_addr_t::MAX
 }
 
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn inet_addr(cp: *const c_char) -> in_addr_t {
 pub unsafe extern "C" fn inet_ntoa(in_addr: in_addr_t) -> *const c_char {
     ::syslog::trace!("inet_ntoa(): in_addr={in_addr:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/595.
-    ::syslog::error!("inet_ntoa(): not implemented");
+    ::syslog::debug!("inet_ntoa(): not implemented");
     core::ptr::null()
 }
 
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn inet_ntop(
 ) -> *const c_char {
     ::syslog::trace!("inet_ntop(): af={af:?}, src={src:?}, dst={dst:?}, size={size:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/592.
-    ::syslog::error!("inet_ntop(): not implemented");
+    ::syslog::debug!("inet_ntop(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     core::ptr::null()
 }
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn inet_ntop(
 pub unsafe extern "C" fn inet_pton(af: c_int, src: *const c_char, dst: *mut c_void) -> c_int {
     ::syslog::trace!("inet_pton(): af={af:?}, src={src:?}, dst={dst:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/593.
-    ::syslog::error!("inet_pton(): not implemented");
+    ::syslog::debug!("inet_pton(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
 }

--- a/src/libs/posix/src/dummy.rs
+++ b/src/libs/posix/src/dummy.rs
@@ -47,7 +47,7 @@ use ::sysapi::ffi::{
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn popen(command: *const c_char, mode: *const c_char) -> *mut c_void {
     ::syslog::trace!("popen(): command={command:?}, mode={mode:?}");
-    ::syslog::error!("popen(): not implemented");
+    ::syslog::debug!("popen(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     core::ptr::null_mut()
 }
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn popen(command: *const c_char, mode: *const c_char) -> *
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pclose(stream: *mut c_void) -> c_int {
     ::syslog::trace!("pclose(): stream={stream:?}");
-    ::syslog::error!("pclose(): not implemented");
+    ::syslog::debug!("pclose(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
 }
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn pclose(stream: *mut c_void) -> c_int {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tcgetattr(fd: c_int, termios_p: *mut c_void) -> c_int {
     ::syslog::trace!("tcgetattr(): fd={fd}, termios_p={termios_p:?}");
-    ::syslog::error!("tcgetattr(): not implemented");
+    ::syslog::debug!("tcgetattr(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
 }
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn tcsetattr(
     ::syslog::trace!(
         "tcsetattr(): fd={fd}, optional_actions={optional_actions}, termios_p={termios_p:?}"
     );
-    ::syslog::error!("tcsetattr(): not implemented");
+    ::syslog::debug!("tcsetattr(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
 }
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn tcsetattr(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char) -> c_int {
     ::syslog::trace!("execvp(): file={file:?}, argv={argv:?}");
-    ::syslog::error!("execvp(): not implemented");
+    ::syslog::debug!("execvp(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
 }
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char)
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn realpath(path: *const c_char, resolved_path: *mut c_char) -> *mut c_char {
     ::syslog::trace!("realpath(): path={path:?}, resolved_path={resolved_path:?}");
-    ::syslog::error!("realpath(): not implemented");
+    ::syslog::debug!("realpath(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     core::ptr::null_mut()
 }
@@ -284,7 +284,7 @@ pub unsafe extern "C" fn ftw(
     nopenfd: c_int,
 ) -> c_int {
     ::syslog::trace!("ftw(): dirpath={dirpath:?}, fn_cb={:?}, nopenfd={nopenfd}", fn_cb);
-    ::syslog::error!("ftw(): not implemented");
+    ::syslog::debug!("ftw(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
 }

--- a/src/libs/posix/src/netdb.rs
+++ b/src/libs/posix/src/netdb.rs
@@ -44,7 +44,7 @@ use ::sysapi::{
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn freeaddrinfo(res: *mut addrinfo) {
     ::syslog::trace!("freeaddrinfo(): res={res:?}");
-    ::syslog::error!("freeaddrinfo(): not implemented");
+    ::syslog::debug!("freeaddrinfo(): not implemented");
 }
 
 ///
@@ -83,7 +83,7 @@ pub unsafe extern "C" fn getaddrinfo(
     ::syslog::trace!(
         "getaddrinfo(): node={node:?}, service={service:?}, hints={hints:?}, res={res:?}"
     );
-    ::syslog::error!("getaddrinfo(): not implemented");
+    ::syslog::debug!("getaddrinfo(): not implemented");
     ErrorCode::InvalidSysCall.get()
 }
 
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn gethostbyaddr(
     type_: c_int,
 ) -> *mut c_void {
     ::syslog::trace!("gethostbyaddr(): addr={addr:?}, len={len:?}, type_={type_:?}");
-    ::syslog::error!("gethostbyaddr(): not implemented");
+    ::syslog::debug!("gethostbyaddr(): not implemented");
     ::core::ptr::null_mut()
 }
 
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn gethostbyaddr(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn gethostbyname(name: *const c_char) -> *mut c_void {
     ::syslog::trace!("gethostbyname(): name={name:?}");
-    ::syslog::error!("gethostbyname(): not implemented");
+    ::syslog::debug!("gethostbyname(): not implemented");
     ::core::ptr::null_mut()
 }
 
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn gethostbyname(name: *const c_char) -> *mut c_void {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn getprotobyname(name: *const c_char) -> *mut c_void {
     ::syslog::trace!("getprotobyname(): name={name:?}");
-    ::syslog::error!("getprotobyname(): not implemented");
+    ::syslog::debug!("getprotobyname(): not implemented");
     ::core::ptr::null_mut()
 }
 
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn getprotobyname(name: *const c_char) -> *mut c_void {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn getservbyname(name: *const c_char, proto: *const c_char) -> *mut c_void {
     ::syslog::trace!("getservbyname(): name={name:?}, proto={proto:?}");
-    ::syslog::error!("getservbyname(): not implemented");
+    ::syslog::debug!("getservbyname(): not implemented");
     ::core::ptr::null_mut()
 }
 
@@ -226,7 +226,7 @@ pub unsafe extern "C" fn getservbyname(name: *const c_char, proto: *const c_char
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn getservbyport(port: c_int, proto: *const c_char) -> *mut c_void {
     ::syslog::trace!("getservbyport(): port={port:?}, proto={proto:?}");
-    ::syslog::error!("getservbyport(): not implemented");
+    ::syslog::debug!("getservbyport(): not implemented");
     ::core::ptr::null_mut()
 }
 
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn getnameinfo(
         "getnameinfo(): sa={sa:?}, salen={salen:?}, host={host:?}, hostlen={hostlen:?}, \
          serv={serv:?}, servlen={servlen:?}, flags={flags:?}"
     );
-    ::syslog::error!("getnameinfo(): not implemented");
+    ::syslog::debug!("getnameinfo(): not implemented");
     ErrorCode::InvalidSysCall.get()
 }
 
@@ -297,7 +297,7 @@ pub unsafe extern "C" fn getnameinfo(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn gai_strerror(errcode: c_int) -> *const c_char {
     ::syslog::trace!("gai_strerror(): errcode={errcode:?}");
-    ::syslog::error!("gai_strerror(): not implemented");
+    ::syslog::debug!("gai_strerror(): not implemented");
     ::core::ptr::null()
 }
 
@@ -319,6 +319,6 @@ pub unsafe extern "C" fn gai_strerror(errcode: c_int) -> *const c_char {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __h_errno() -> *mut c_int {
     ::syslog::trace!("__h_errno()");
-    ::syslog::error!("__h_errno(): not implemented");
+    ::syslog::debug!("__h_errno(): not implemented");
     ::core::ptr::null_mut()
 }

--- a/src/libs/posix/src/pthread/mod.rs
+++ b/src/libs/posix/src/pthread/mod.rs
@@ -308,7 +308,7 @@ pub unsafe extern "C" fn pthread_attr_getstacksize(
 #[unsafe(no_mangle)]
 pub extern "C" fn pthread_detach(_thread: pthread_t) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/502
-    ::syslog::error!("pthread_detach(): not implemented");
+    ::syslog::debug!("pthread_detach(): not implemented");
     ErrorCode::OperationNotSupported.get()
 }
 
@@ -397,7 +397,7 @@ pub unsafe extern "C" fn pthread_once(
         init_routine
     );
     // TODO: https://github.com/nanvix/nanvix/issues/513
-    ::syslog::error!("pthread_once(): not implemented");
+    ::syslog::debug!("pthread_once(): not implemented");
     0
 }
 

--- a/src/libs/posix/src/pwd.rs
+++ b/src/libs/posix/src/pwd.rs
@@ -17,7 +17,7 @@ mod bindings {
     #[allow(clippy::missing_safety_doc)]
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn getpwuid(_uid: c_int) -> *mut passwd {
-        ::syslog::error!("getpwuid(): not implemented");
+        ::syslog::debug!("getpwuid(): not implemented");
         unsafe {
             *__errno_location() = ErrorCode::InvalidSysCall.get();
         }

--- a/src/libs/posix/src/sys/ioctl.rs
+++ b/src/libs/posix/src/sys/ioctl.rs
@@ -13,7 +13,7 @@ mod bindings {
     #[unsafe(no_mangle)]
     pub extern "C" fn ioctl(_fd: c_int, _request: c_int, _arg: *mut c_int) -> c_int {
         // TODO: https://github.com/nanvix/nanvix/issues/351
-        ::syslog::error!("ioctl(): not implemented, ignoring");
+        ::syslog::debug!("ioctl(): not implemented, ignoring");
         0
     }
 }

--- a/src/libs/posix/src/sys/resource.rs
+++ b/src/libs/posix/src/sys/resource.rs
@@ -20,7 +20,7 @@ use ::sysapi::{
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn getrlimit(_resource: c_int, _rlim: *mut rlimit) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/459
-    ::syslog::error!("getrlimit(): not implemented");
+    ::syslog::debug!("getrlimit(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }
@@ -31,7 +31,7 @@ pub unsafe extern "C" fn getrlimit(_resource: c_int, _rlim: *mut rlimit) -> c_in
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn setrlimit(_resource: c_int, _rlim: *const rlimit) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/469
-    ::syslog::error!("setrlimit(): not implemented");
+    ::syslog::debug!("setrlimit(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/posix/src/sys/stat/mod.rs
+++ b/src/libs/posix/src/sys/stat/mod.rs
@@ -394,7 +394,7 @@ pub unsafe extern "C" fn mkdirat(dirfd: c_int, pathname: *const c_char, mode: mo
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn truncate(_path: *const c_char, _length: u64) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/454
-    ::syslog::error!("truncate(): not implemented");
+    ::syslog::debug!("truncate(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
 }
@@ -420,7 +420,7 @@ pub unsafe extern "C" fn truncate(_path: *const c_char, _length: u64) -> c_int {
 pub unsafe extern "C" fn umask(mask: u16) -> u16 {
     ::syslog::trace!("umask(): mask={mask:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/597.
-    ::syslog::error!("umask(): not implemented");
+    ::syslog::debug!("umask(): not implemented");
     0
 }
 

--- a/src/libs/syscall/src/pthread/bindings/pthread_atfork.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_atfork.rs
@@ -21,7 +21,7 @@ pub unsafe extern "C" fn pthread_atfork(
     child: Option<extern "C" fn()>,
 ) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/483
-    ::syslog::warn!(
+    ::syslog::debug!(
         "pthread_atfork(): not implemented (prepare={prepare:?}, parent={parent:?}, \
          child={child:?})"
     );

--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_setstacksize.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_setstacksize.rs
@@ -22,6 +22,6 @@ pub unsafe extern "C" fn pthread_attr_setstacksize(
     _stacksize: usize,
 ) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/488
-    ::syslog::warn!("pthread_attr_setstacksize(): not implemented");
+    ::syslog::debug!("pthread_attr_setstacksize(): not implemented");
     0
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_setclock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_setclock.rs
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn pthread_condattr_setclock(
     clock_id: clockid_t,
 ) -> c_int {
     // TODO (#500): implement pthread_condattr_setclock
-    ::syslog::warn!(
+    ::syslog::debug!(
         "pthread_condattr_setclock(): not implemented (attr={attr:?}, clock_id={clock_id:?})"
     );
     ErrorCode::InvalidSysCall.get()

--- a/src/libs/syscall/src/pthread/bindings/pthread_getschedparam.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_getschedparam.rs
@@ -23,6 +23,6 @@ pub unsafe extern "C" fn pthread_getschedparam(
     _param: *mut sched_param,
 ) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/725
-    ::syslog::warn!("pthread_getschedparam(): not implemented");
+    ::syslog::debug!("pthread_getschedparam(): not implemented");
     0
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_kill.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_kill.rs
@@ -19,6 +19,6 @@ use ::sysapi::{
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pthread_kill(_thread: pthread_t, _sig: c_int) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/716
-    ::syslog::warn!("pthread_kill(): not implemented");
+    ::syslog::debug!("pthread_kill(): not implemented");
     0
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_setcancelstate.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_setcancelstate.rs
@@ -43,6 +43,6 @@ pub unsafe extern "C" fn pthread_setcancelstate(_state: c_int, oldstate: *mut c_
     }
 
     // TODO: implement this function.
-    ::syslog::warn!("pthread_setcancelstate(): not supported, ignoring");
+    ::syslog::debug!("pthread_setcancelstate(): not supported, ignoring");
     0
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_sigmask.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_sigmask.rs
@@ -23,6 +23,6 @@ pub unsafe extern "C" fn pthread_sigmask(
     _oldset: *mut c_void,
 ) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/717
-    ::syslog::warn!("pthread_sigmask(): not implemented");
+    ::syslog::debug!("pthread_sigmask(): not implemented");
     0
 }

--- a/src/libs/syscall/src/pthread/bindings/sem_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_destroy.rs
@@ -19,6 +19,6 @@ use ::sysapi::ffi::{
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sem_destroy(_sem: *mut c_void) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/722
-    ::syslog::warn!("sem_destroy(): not implemented");
+    ::syslog::debug!("sem_destroy(): not implemented");
     0
 }

--- a/src/libs/syscall/src/pthread/bindings/sem_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_init.rs
@@ -19,6 +19,6 @@ use ::sysapi::ffi::{
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sem_init(_sem: *mut c_void, _pshared: c_int, _value: u32) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/721
-    ::syslog::warn!("sem_init(): not implemented");
+    ::syslog::debug!("sem_init(): not implemented");
     0
 }

--- a/src/libs/syscall/src/pthread/bindings/sem_post.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_post.rs
@@ -18,6 +18,6 @@ use ::sysapi::ffi::{
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sem_post(_sem: *mut c_void) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/723
-    ::syslog::warn!("sem_post(): not implemented");
+    ::syslog::debug!("sem_post(): not implemented");
     0
 }

--- a/src/libs/syscall/src/sys/socket/bindings/getsockopt.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/getsockopt.rs
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn getsockopt(
          optval={optval:?}, optlen={optlen:?}"
     );
     // TODO: https://github.com/nanvix/nanvix/issues/591
-    ::syslog::error!("getsockopt(): not implemented");
+    ::syslog::debug!("getsockopt(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/sys/socket/bindings/recvfrom.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recvfrom.rs
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn recvfrom(
          sockaddr={sockaddr:?}, addrlen={addrlen:?}"
     );
     // TODO: https://github.com/nanvix/nanvix/issues/590
-    ::syslog::error!("recvfrom(): not implemented");
+    ::syslog::debug!("recvfrom(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/sys/socket/bindings/recvmsg.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recvmsg.rs
@@ -64,7 +64,7 @@ use ::sysapi::{
 pub unsafe extern "C" fn recvmsg(sockfd: c_int, msg: *mut msghdr, flags: c_int) -> c_ssize_t {
     ::syslog::trace!("recvmsg(): sockfd={sockfd:?}, msg={msg:?}, flags={flags:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/600
-    ::syslog::error!("recvmsg(): not implemented");
+    ::syslog::debug!("recvmsg(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
 }

--- a/src/libs/syscall/src/sys/socket/bindings/sendmsg.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/sendmsg.rs
@@ -63,7 +63,7 @@ use ::sysapi::{
 pub unsafe extern "C" fn sendmsg(sockfd: c_int, msg: *const msghdr, flags: c_int) -> c_ssize_t {
     ::syslog::trace!("sendmsg(): sockfd={sockfd:?}, msg={msg:?}, flags={flags:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/599.
-    ::syslog::error!("sendmsg(): not implemented");
+    ::syslog::debug!("sendmsg(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/sys/socket/bindings/sendto.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/sendto.rs
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn sendto(
          sockaddr={sockaddr:?}, addrlen={addrlen:?}"
     );
     // TODO: https://github.com/nanvix/nanvix/issues/589
-    ::syslog::error!("sendto(): not implemented");
+    ::syslog::debug!("sendto(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/sys/socket/bindings/setsockopt.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/setsockopt.rs
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn setsockopt(
          optval={optval:?}, optlen={optlen:?}"
     );
     // TODO: https://github.com/nanvix/nanvix/issues/471
-    ::syslog::error!("setsockopt(): not implemented");
+    ::syslog::debug!("setsockopt(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/time/bindings/gettimeofday.rs
+++ b/src/libs/syscall/src/time/bindings/gettimeofday.rs
@@ -21,6 +21,6 @@ use ::sysapi::{
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn gettimeofday(_tp: *mut timeval, _tz: *mut c_void) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/317
-    ::syslog::warn!("gettimeofday(): not implemented");
+    ::syslog::debug!("gettimeofday(): not implemented");
     0
 }

--- a/src/libs/syscall/src/time/bindings/usleep.rs
+++ b/src/libs/syscall/src/time/bindings/usleep.rs
@@ -15,6 +15,6 @@ use ::sysapi::ffi::c_int;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn usleep(_usec: u32) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/476
-    ::syslog::warn!("usleep(): not implemented");
+    ::syslog::debug!("usleep(): not implemented");
     0
 }

--- a/src/libs/syscall/src/unistd/bindings/chroot.rs
+++ b/src/libs/syscall/src/unistd/bindings/chroot.rs
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn chroot(path: *const c_char) -> c_int {
     ::syslog::trace!("chroot(): path={path:?}");
 
     // TODO: https://github.com/nanvix/nanvix/issues/517
-    ::syslog::error!("chroot(): not implemented");
+    ::syslog::debug!("chroot(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/unistd/bindings/dup.rs
+++ b/src/libs/syscall/src/unistd/bindings/dup.rs
@@ -48,7 +48,7 @@ use ::sysapi::ffi::c_int;
 pub unsafe extern "C" fn dup(fd: c_int) -> c_int {
     ::syslog::trace!("dup(): fd={fd:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/587
-    ::syslog::error!("dup(): not implemented");
+    ::syslog::debug!("dup(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/unistd/bindings/dup2.rs
+++ b/src/libs/syscall/src/unistd/bindings/dup2.rs
@@ -52,7 +52,7 @@ use ::sysapi::ffi::c_int;
 pub unsafe extern "C" fn dup2(oldfd: c_int, newfd: c_int) -> c_int {
     ::syslog::trace!("dup2(): oldfd={oldfd:?}, newfd={newfd:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/354
-    ::syslog::error!("dup2(): not implemented");
+    ::syslog::debug!("dup2(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/unistd/bindings/execv.rs
+++ b/src/libs/syscall/src/unistd/bindings/execv.rs
@@ -65,7 +65,7 @@ use ::sysapi::ffi::{
 pub unsafe extern "C" fn execv(path: *const c_char, argv: *const *const c_char) -> c_int {
     ::syslog::trace!("execv(): path={path:?}, argv={argv:?}");
     // TODO:https://github.com/nanvix/nanvix/issues/588
-    ::syslog::error!("execv(): not implemented");
+    ::syslog::debug!("execv(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/unistd/bindings/execve.rs
+++ b/src/libs/syscall/src/unistd/bindings/execve.rs
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn execve(
 ) -> c_int {
     ::syslog::trace!("execve(): path={path:?}, argv={argv:?}, envp={envp:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/320
-    ::syslog::error!("execve(): not implemented");
+    ::syslog::debug!("execve(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/unistd/bindings/fork.rs
+++ b/src/libs/syscall/src/unistd/bindings/fork.rs
@@ -16,7 +16,7 @@ use ::sysapi::sys_types::pid_t;
 #[unsafe(no_mangle)]
 pub extern "C" fn fork() -> pid_t {
     // TODO: https://github.com/nanvix/nanvix/issues/321
-    ::syslog::error!("fork(): not implemented");
+    ::syslog::debug!("fork(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/unistd/bindings/rmdir.rs
+++ b/src/libs/syscall/src/unistd/bindings/rmdir.rs
@@ -21,7 +21,7 @@ use ::sysapi::ffi::{
 pub unsafe extern "C" fn rmdir(path: *const c_char) -> c_int {
     ::syslog::trace!("rmdir(): path={path:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/348
-    ::syslog::error!("rmdir(): not implemented");
+    ::syslog::debug!("rmdir(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
 }

--- a/src/libs/syscall/src/unistd/bindings/setgroups.rs
+++ b/src/libs/syscall/src/unistd/bindings/setgroups.rs
@@ -24,7 +24,7 @@ use ::sysapi::{
 pub extern "C" fn setgroups(size: c_size_t, list: *const gid_t) -> c_int {
     ::syslog::trace!("setgroups(): size={size}, list={list:p}");
     // TODO: https://github.com/nanvix/nanvix/issues/523
-    ::syslog::error!("setgroups(): not implemented");
+    ::syslog::debug!("setgroups(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/unistd/bindings/sleep.rs
+++ b/src/libs/syscall/src/unistd/bindings/sleep.rs
@@ -18,7 +18,7 @@ pub extern "C" fn sleep(seconds: c_uint) -> c_uint {
     ::syslog::trace!("sleep(): seconds={seconds:?}");
 
     // TODO: https://github.com/nanvix/nanvix/issues/453
-    ::syslog::error!("sleep(): not implemented");
+    ::syslog::debug!("sleep(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/unistd/bindings/waitpid.rs
+++ b/src/libs/syscall/src/unistd/bindings/waitpid.rs
@@ -43,7 +43,7 @@ use ::sysapi::{
 pub unsafe extern "C" fn waitpid(pid: pid_t, status: *mut c_int, options: c_int) -> pid_t {
     ::syslog::trace!("waitpid(): pid={pid:?}, status={status:?}, options={options:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/336.
-    ::syslog::error!("waitpid(): not implemented");
+    ::syslog::debug!("waitpid(): not implemented");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }


### PR DESCRIPTION
This pull request changes the logging level for unimplemented POSIX and pthread functions from `error` or `warn` to `debug` across multiple modules. This update standardizes the logging output for not-yet-implemented functions, making logs less noisy and more appropriate for development/debugging rather than error reporting.

**Logging level changes for unimplemented functions:**

*POSIX library modules:*
- Changed `::syslog::error!` to `::syslog::debug!` for unimplemented functions in `arpa/inet.rs`, `dummy.rs`, `netdb.rs`, `pthread/mod.rs`, `pwd.rs`, `sys/ioctl.rs`, `sys/resource.rs`, and `sys/stat/mod.rs`. This affects functions like `inet_addr`, `popen`, `execvp`, `getaddrinfo`, `pthread_detach`, `getpwuid`, `ioctl`, `getrlimit`, `truncate`, and others. [[1]](diffhunk://#diff-bb62637c670e0330db54b4e01ecb13a0e58cb9fd4e2712c4ccbefc622e43f1dbL49-R49) [[2]](diffhunk://#diff-bb62637c670e0330db54b4e01ecb13a0e58cb9fd4e2712c4ccbefc622e43f1dbL75-R75) [[3]](diffhunk://#diff-bb62637c670e0330db54b4e01ecb13a0e58cb9fd4e2712c4ccbefc622e43f1dbL113-R113) [[4]](diffhunk://#diff-bb62637c670e0330db54b4e01ecb13a0e58cb9fd4e2712c4ccbefc622e43f1dbL146-R146) [[5]](diffhunk://#diff-0184944c9570d10efd2afc2f4d29e1d9519ad1a19e641723076249abd90c737fL50-R50) [[6]](diffhunk://#diff-0184944c9570d10efd2afc2f4d29e1d9519ad1a19e641723076249abd90c737fL84-R84) [[7]](diffhunk://#diff-0184944c9570d10efd2afc2f4d29e1d9519ad1a19e641723076249abd90c737fL119-R119) [[8]](diffhunk://#diff-0184944c9570d10efd2afc2f4d29e1d9519ad1a19e641723076249abd90c737fL161-R161) [[9]](diffhunk://#diff-0184944c9570d10efd2afc2f4d29e1d9519ad1a19e641723076249abd90c737fL198-R198) [[10]](diffhunk://#diff-0184944c9570d10efd2afc2f4d29e1d9519ad1a19e641723076249abd90c737fL236-R236) [[11]](diffhunk://#diff-0184944c9570d10efd2afc2f4d29e1d9519ad1a19e641723076249abd90c737fL287-R287) [[12]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL47-R47) [[13]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL86-R86) [[14]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL119-R119) [[15]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL146-R146) [[16]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL173-R173) [[17]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL201-R201) [[18]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL229-R229) [[19]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL274-R274) [[20]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL300-R300) [[21]](diffhunk://#diff-c10dcf05adcdf46cd2a348fd356a14edaff861797486472fdfcdc443dcac602eL322-R322) [[22]](diffhunk://#diff-751dc5b6cbfb79539e07621a0325556d016422ce3d6c13cc5752f76bbc4dd1ceL311-R311) [[23]](diffhunk://#diff-751dc5b6cbfb79539e07621a0325556d016422ce3d6c13cc5752f76bbc4dd1ceL400-R400) [[24]](diffhunk://#diff-42a0fdc584583cb5aea60cbf667cc9fbf17b16adbbace313529a9a92e3dd0efaL20-R20) [[25]](diffhunk://#diff-69281d1a6124712ad9c56dae22263ec19c7b330b8d737d557313355ba865c127L16-R16) [[26]](diffhunk://#diff-b78ba84edd60f79123c26caf632fd6b83761d9d2dc1565df4453505a5e29d800L23-R23) [[27]](diffhunk://#diff-b78ba84edd60f79123c26caf632fd6b83761d9d2dc1565df4453505a5e29d800L34-R34) [[28]](diffhunk://#diff-10553a2adcb7d59b61738981a72375c8e6a432a7a1ffe2c13068bf418cfc5ddcL397-R397) [[29]](diffhunk://#diff-10553a2adcb7d59b61738981a72375c8e6a432a7a1ffe2c13068bf418cfc5ddcL423-R423)

*Pthread syscall bindings:*
- Changed `::syslog::warn!` or `::syslog::error!` to `::syslog::debug!` for not implemented messages in pthread-related syscall bindings, including `pthread_atfork`, `pthread_attr_setstacksize`, `pthread_condattr_setclock`, `pthread_getschedparam`, and `pthread_kill`. [[1]](diffhunk://#diff-41e8b13273b5800d9eb33d75d54798f74e328342597005d010e36afced6e5f76L24-R24) [[2]](diffhunk://#diff-708047c7751bd2c87a32cfce18ec7e1a352034ff575df8c5dbfd4eb4aa5fc048L25-R25) [[3]](diffhunk://#diff-3bda71924e4cc3b1e1016862d1ca4a3e771e829249836677e20b98efdd367ab8L48-R48) [[4]](diffhunk://#diff-f8f6fd9598d099e1f77d5f2d3ea48ab5c4dcfcece128ce3e1049a21319d7bc86L26-R26) [[5]](diffhunk://#diff-3d21a835acb9ce4b93dd23222d3636a1e94e312b404ab8320659b9b3382ceaa2L22-R22)

These changes help ensure that missing implementations are logged at the appropriate level for development, reducing unnecessary error/warning noise in production or CI logs.