### PR TITLE
[uservm] CLI Arguments Support for Hyperlight

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -32,13 +32,17 @@ use crate::{
         platform::{
             bootinfo::BootInfo,
             madt::MadtInfo,
+            peb::ProcessEnvironmentBlock,
         },
     },
     kmod::KernelModule,
 };
 use ::alloc::{
     collections::linked_list::LinkedList,
-    string::ToString,
+    string::{
+        String,
+        ToString,
+    },
 };
 use ::arch::{
     mem,
@@ -56,10 +60,6 @@ use ::sys::{
         Address,
         VirtualAddress,
     },
-};
-use peb::{
-    ProcessEnvironmentBlock,
-    GUEST_HANDLE,
 };
 
 //==================================================================================================
@@ -239,81 +239,40 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
 
     let peb_base: usize =
         unsafe { ::sys::mm::align_up(&__KERNEL_END as *const u8 as usize, PAGE_ALIGNMENT) };
+    let peb_ptr: *mut HyperlightPEB = peb_base as *mut HyperlightPEB;
 
     unsafe {
-        ProcessEnvironmentBlock::init(peb_base as *mut HyperlightPEB)?;
+        ProcessEnvironmentBlock::init(peb_ptr)?;
         ProcessEnvironmentBlock::set_guest_function_dispatch_ptr(0xdeadbeef)?;
     };
 
     // Read actual size and relocate only that amount
-    let (initrd_base, initrd_size) = unsafe {
-        match GUEST_HANDLE.peb() {
-            Some(peb_ptr) => {
-                let current_data_start = (*peb_ptr).init_data.ptr as usize;
-                let total_size = (*peb_ptr).init_data.size as usize;
+    let (initrd_base, initrd_size, (cmdline_len, cmdline)) = unsafe {
+        let current_data_start = (*peb_ptr).init_data.ptr as usize;
+        let total_size = (*peb_ptr).init_data.size as usize;
 
-                // Read the actual initrd size from the first INITRD_SIZE_BYTES bytes
-                let size_bytes = core::slice::from_raw_parts(
-                    current_data_start as *const u8,
-                    ::config::hyperlight::INITRD_SIZE_BYTES,
-                );
-                let actual_initrd_size = u64::from_le_bytes([
-                    size_bytes[0],
-                    size_bytes[1],
-                    size_bytes[2],
-                    size_bytes[3],
-                    size_bytes[4],
-                    size_bytes[5],
-                    size_bytes[6],
-                    size_bytes[7],
-                ]) as usize;
+        let (initrd_base, actual_initrd_size, initrd_cmdline) =
+            parse_initrd_image(current_data_start, total_size)?;
 
-                // The actual initrd data starts after the INITRD_SIZE_BYTES-byte header
-                let current_initrd_start =
-                    current_data_start + ::config::hyperlight::INITRD_SIZE_BYTES;
-
-                debug!(
-                    "initrd: found at 0x{current_initrd_start:08x}, actual size: \
-                     {actual_initrd_size} bytes (total allocation: {total_size} bytes)"
-                );
-
-                if current_initrd_start != ::config::hyperlight::DEFAULT_INITRD_BASE {
-                    let src_ptr = current_initrd_start as *const u8;
-                    let dst_ptr = ::config::hyperlight::DEFAULT_INITRD_BASE as *mut u8;
-
-                    core::ptr::copy(src_ptr, dst_ptr, actual_initrd_size);
-
-                    debug!(
-                        "initrd relocated from {current_initrd_start:#010x} to {:#010x}",
-                        ::config::hyperlight::DEFAULT_INITRD_BASE
-                    );
-
-                    (::config::hyperlight::DEFAULT_INITRD_BASE, actual_initrd_size)
-                } else {
-                    (current_initrd_start, actual_initrd_size)
-                }
-            },
-            None => {
-                error!("PEB not initialized");
-                return Err(Error::new(ErrorCode::NoSuchDevice, "PEB not initialized"));
-            },
-        }
+        (initrd_base, actual_initrd_size, initrd_cmdline)
     };
 
     let mut kernel_modules: LinkedList<KernelModule> = LinkedList::new();
 
     // Register initrd as a kernel module.
-    if initrd_size != 0 {
-        info!("initrd_base={:#010x}, initrd_size={:#010x}", initrd_base, initrd_size);
 
-        // Add kernel module to the list of kernel modules.
-        let module: KernelModule = KernelModule::new(
-            PhysicalAddress::from_raw_value(initrd_base)?,
-            initrd_size,
-            "initrd".to_string(),
-        );
-        kernel_modules.push_back(module);
-    }
+    info!(
+        "initrd_base={:#010x}, initrd_size={:#010x}, cmdline_len={:?}, cmdline={:?}",
+        initrd_base,
+        initrd_size,
+        cmdline_len,
+        cmdline.as_str()
+    );
+
+    // Add kernel module to the list of kernel modules.
+    let module: KernelModule =
+        KernelModule::new(PhysicalAddress::from_raw_value(initrd_base)?, initrd_size, cmdline);
+    kernel_modules.push_back(module);
 
     Ok(BootInfo::new(None, None, LinkedList::new(), LinkedList::new(), kernel_modules))
 }
@@ -444,4 +403,204 @@ pub fn init(
         #[cfg(feature = "pit")]
         _pit: register_pit(ioports)?,
     })
+}
+
+///
+/// # Description
+///
+/// Parses the initrd image and relocates it to the default initrd base address if needed.
+///
+/// # Parameters
+///
+/// - `init_data_start`: Address where the init data blob begins.
+/// - `total_allocation_size`: Total allocation size for the init data blob.
+///
+/// # Return Value
+///
+/// On success, this function returns a tuple containing:
+/// - The base address of the initrd payload.
+/// - The actual size of the initrd payload.
+/// - A tuple with the length of the command line and the command line string.
+///
+/// Otherwise, it returns an error.
+///
+/// # Safety
+///
+/// This function is unsafe because it performs unchecked pointer arithmetic and dereferences raw
+/// pointers. Callers must ensure that the provided memory ranges are valid and mapped.
+///
+unsafe fn parse_initrd_image(
+    init_data_start: usize,
+    total_allocation_size: usize,
+) -> Result<(usize, usize, (u8, String)), Error> {
+    // Check if allocation is too small to hold the initrd header.
+    if total_allocation_size < ::config::hyperlight::INITRD_SIZE_BYTES {
+        let reason: &str = "insufficient initrd allocation size";
+        error!("parse_initrd_image(): {reason} (total_allocation_size={total_allocation_size})");
+        return Err(Error::new(ErrorCode::BadFile, reason));
+    }
+
+    // Read actual size and relocate only that amount
+    let initrd_header: &[u8] = core::slice::from_raw_parts(
+        init_data_start as *const u8,
+        ::config::hyperlight::INITRD_SIZE_BYTES,
+    );
+    let actual_initrd_size: usize = u64::from_le_bytes([
+        initrd_header[0],
+        initrd_header[1],
+        initrd_header[2],
+        initrd_header[3],
+        initrd_header[4],
+        initrd_header[5],
+        initrd_header[6],
+        initrd_header[7],
+    ]) as usize;
+
+    // Compute offsets and check for overflows.
+    let payload_offset: usize = ::config::hyperlight::INITRD_SIZE_BYTES;
+    let current_initrd_start: usize = match init_data_start.checked_add(payload_offset) {
+        Some(value) => value,
+        None => {
+            let reason: &str = "initrd payload address overflow";
+            error!("parse_initrd_image(): {reason}");
+            return Err(Error::new(ErrorCode::BadFile, reason));
+        },
+    };
+
+    // Check if actual size is valid.
+    let required_allocation: usize = match payload_offset.checked_add(actual_initrd_size) {
+        Some(value) => value,
+        None => {
+            let reason: &str = "initrd required allocation size overflow";
+            error!("parse_initrd_image(): {reason}");
+            return Err(Error::new(ErrorCode::BadFile, reason));
+        },
+    };
+
+    // Check if allocation is too small to hold the actual initrd payload.
+    if total_allocation_size < required_allocation {
+        let reason: &str = "initrd payload truncated";
+        error!(
+            "parse_initrd_image(): {reason} (total_allocation_size={total_allocation_size}, \
+             required_allocation={required_allocation})"
+        );
+        return Err(Error::new(ErrorCode::BadFile, reason));
+    }
+
+    debug!(
+        "parse_initrd_image(): initrd found at 0x{current_initrd_start:08x}, actual size: \
+         {actual_initrd_size} bytes (total allocation: {total_allocation_size} bytes)"
+    );
+
+    // Read initrd command line.
+    let initrd_cmdline: (u8, String) =
+        read_initrd_cmdline(current_initrd_start, actual_initrd_size, total_allocation_size)?;
+
+    // Relocate initrd to default base address if needed.
+    let initrd_base: usize = if current_initrd_start != ::config::hyperlight::DEFAULT_INITRD_BASE {
+        let src_ptr: *const u8 = current_initrd_start as *const u8;
+        let dst_ptr: *mut u8 = ::config::hyperlight::DEFAULT_INITRD_BASE as *mut u8;
+        core::ptr::copy(src_ptr, dst_ptr, actual_initrd_size);
+
+        debug!(
+            "parse_initrd_image(): initrd relocated from {current_initrd_start:#010x} to {:#010x}",
+            ::config::hyperlight::DEFAULT_INITRD_BASE
+        );
+        ::config::hyperlight::DEFAULT_INITRD_BASE
+    } else {
+        current_initrd_start
+    };
+
+    Ok((initrd_base, actual_initrd_size, initrd_cmdline))
+}
+
+///
+/// # Description
+///
+/// Reads the initrd command line from the initrd payload if present.
+///
+/// # Parameters
+///
+/// - `initrd_start`: Address where the initrd payload begins.
+/// - `initrd_size`: Size of the initrd payload.
+/// - `total_allocation_size`: Total allocation size that includes the initrd and any extra data.
+///
+/// # Returns
+///
+/// On success, this function returns a tuple containing the length of the command line and the
+/// command line string. Otherwise, it returns an error.
+///
+/// # Safety
+///
+/// This function is unsafe because it performs unchecked pointer arithmetic and dereferences raw
+/// pointers. Callers must ensure that the provided ranges are valid and mapped.
+///
+unsafe fn read_initrd_cmdline(
+    initrd_start: usize,
+    initrd_size: usize,
+    total_allocation_size: usize,
+) -> Result<(u8, String), Error> {
+    let args_section_size: usize =
+        total_allocation_size.saturating_sub(::config::hyperlight::INITRD_SIZE_BYTES + initrd_size);
+
+    // Check if initrd arguments section is missing.
+    if args_section_size == 0 {
+        let reason: &str = "initrd arguments section missing";
+        error!("read_initrd_cmdline(): {reason}");
+        return Err(Error::new(ErrorCode::BadFile, reason));
+    }
+
+    // Compute offset to arguments length byte and check for overflows.
+    let args_len_offset: usize = match initrd_start.checked_add(initrd_size) {
+        Some(offset) => offset,
+        None => {
+            let reason: &str = "initrd arguments address overflow";
+            error!("read_initrd_cmdline(): {reason}");
+            return Err(Error::new(ErrorCode::BadFile, reason));
+        },
+    };
+
+    // Compute offset to arguments payload and check for overflows.
+    let args_bytes_offset: usize = match args_len_offset.checked_add(1) {
+        Some(offset) => offset,
+        None => {
+            let reason: &str = "initrd arguments payload address overflow";
+            error!("read_initrd_cmdline(): {reason}");
+            return Err(Error::new(ErrorCode::BadFile, reason));
+        },
+    };
+
+    // Check if arguments length byte is missing>
+    if args_section_size < 1 {
+        let reason: &str = "initrd arguments length byte missing";
+        error!("read_initrd_cmdline(): {reason}");
+        return Err(Error::new(ErrorCode::BadFile, reason));
+    }
+
+    let args_len: u8 = *(args_len_offset as *const u8);
+    let args_payload_size: usize = usize::from(args_len);
+
+    if args_section_size < 1 + args_payload_size {
+        let reason: &str = "initrd arguments truncated";
+        error!(
+            "read_initrd_cmdline(): {reason} (args_section_size={args_section_size}, \
+             args_len={args_len})"
+        );
+        return Err(Error::new(ErrorCode::BadFile, reason));
+    }
+
+    let args_bytes: &[u8] =
+        core::slice::from_raw_parts(args_bytes_offset as *const u8, args_payload_size);
+
+    // Convert arguments to UTF-8 string and check for errors.
+    let args_str: &str = match core::str::from_utf8(args_bytes) {
+        Ok(value) => value,
+        Err(_) => {
+            let reason: &str = "invalid UTF-8 in initrd arguments";
+            error!("read_initrd_cmdline(): {reason}");
+            return Err(Error::new(ErrorCode::BadFile, reason));
+        },
+    };
+
+    Ok((args_len, args_str.to_string()))
 }

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -570,7 +570,7 @@ unsafe fn read_initrd_cmdline(
         },
     };
 
-    // Check if arguments length byte is missing>
+    // Check if arguments length byte is missing.
     if args_section_size < 1 {
         let reason: &str = "initrd arguments length byte missing";
         error!("read_initrd_cmdline(): {reason}");

--- a/src/tests/misc-c/main.c
+++ b/src/tests/misc-c/main.c
@@ -10,6 +10,7 @@
 #include "common.h"
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/utsname.h>
 #include <unistd.h>
 
@@ -34,7 +35,7 @@ int main(int argc, const char *argv[])
     assert(argc == 1);
     assert(argv[0] != NULL);
     assert(argv[1] == NULL);
-    // TODO: assert that argv[0] is the name of the executable.
+    assert(strcmp(argv[0], "misc-c.elf") == 0);
 
     test_getuid();
     test_getgid();

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     },
 };
 use ::anyhow::Result;
+use ::arch::mem::PAGE_SIZE;
 use ::core::convert::TryFrom;
 use ::hyperlight_host::{
     GuestBinary,
@@ -36,6 +37,7 @@ use ::hyperlight_host::{
 };
 use ::std::{
     io::Write,
+    path::Path,
     sync::{
         Arc,
         OnceLock,
@@ -106,11 +108,11 @@ impl Vmm {
         let stack_size: usize = 4 * 1024;
         let memory_size: usize = args.memory_size;
 
-        let guest_env: GuestEnvironment = if let Some(ref initrd_filename) = args.initrd_filename {
+        let guest_env: GuestEnvironment = if let Some(initrd_filename) = &args.initrd_filename {
             match std::fs::read(initrd_filename) {
                 Ok(bytes) => {
-                    let actual_size: usize = bytes.len();
-                    debug!("initrd: {} bytes", actual_size);
+                    let initrd_size: usize = bytes.len();
+                    debug!("initrd: {} bytes", initrd_size);
 
                     let kernel_metadata: ::std::fs::Metadata =
                         std::fs::metadata(&args.kernel_filename).map_err(|e| {
@@ -129,40 +131,54 @@ impl Vmm {
                             anyhow::anyhow!(reason)
                         })?;
 
-                    let initrd_bytes: Vec<u8> = std::fs::read(initrd_filename)?;
-                    let initrd_size: usize = initrd_bytes.len();
+                    let initrd_args_bytes: Vec<u8> =
+                        Self::build_args_bytes(initrd_filename, &args.initrd_args)?;
 
                     // PEB, I/O buffers, host fxn defs, guard pages, etc.
-                    let reserved_pages: usize = 11 * 4096;
+                    let reserved_pages: usize = 11 * PAGE_SIZE;
 
-                    let used_memory: usize =
-                        kernel_size + initrd_size + (heap_size + stack_size) + reserved_pages;
+                    let required_memory: usize = kernel_size
+                        + initrd_size
+                        + (heap_size + stack_size)
+                        + reserved_pages
+                        + ::config::hyperlight::INITRD_SIZE_BYTES
+                        + initrd_args_bytes.len();
 
-                    if memory_size <= used_memory {
-                        return Err(anyhow::anyhow!(
-                            "Not enough memory ({} bytes used, {} bytes total)",
-                            used_memory,
-                            memory_size
-                        ));
+                    // Check if required memory exceeds memory size.
+                    if memory_size <= required_memory {
+                        let reason: &str = "not enough memory";
+                        error!(
+                            "new(): {reason} ({required_memory} bytes required, {memory_size} \
+                             bytes total)"
+                        );
+                        return Err(anyhow::anyhow!(reason));
                     }
 
-                    let padding_size: usize = memory_size - used_memory;
+                    let padding_size: usize = memory_size - required_memory;
 
                     // Create a new vector with size header + original data + padding
-                    let mut padded_bytes: Vec<u8> =
-                        Vec::with_capacity(::config::hyperlight::INITRD_SIZE_BYTES + actual_size);
+                    let mut padded_bytes: Vec<u8> = Vec::with_capacity(
+                        ::config::hyperlight::INITRD_SIZE_BYTES
+                            + initrd_size
+                            + initrd_args_bytes.len(),
+                    );
 
                     // Write the actual size as first INITRD_SIZE_BYTES-bytes (little-endian)
-                    padded_bytes.extend_from_slice(&(actual_size as u64).to_le_bytes());
+                    padded_bytes.extend_from_slice(&(initrd_size as u64).to_le_bytes());
 
                     // Add the actual initrd data
                     padded_bytes.extend_from_slice(&bytes);
 
+                    // Append length-prefixed initrd arguments so the guest can consume them.
+                    padded_bytes.extend_from_slice(&initrd_args_bytes);
+
                     debug!(
-                        "initrd with padding: {} bytes total (8 byte header + {} bytes data + {} \
-                         bytes padding)",
+                        "initrd blob: {} bytes total ({} byte header + {} bytes data + 1 byte \
+                         args length + {} bytes args payload), extra memory: {} bytes",
                         padded_bytes.len(),
-                        actual_size,
+                        ::config::hyperlight::INITRD_SIZE_BYTES,
+                        initrd_size,
+                        initrd_args_bytes.len(),
                         padding_size
                     );
 
@@ -374,5 +390,52 @@ impl Vmm {
             format!("create_snapshot(): not implemented for filepath={}", filepath);
         error!("{}", reason);
         Err(anyhow::anyhow!(reason))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Encodes the program name and arguments into a byte vector suitable for passing to the guest.
+    /// The first byte of the vector indicates the length of the arguments, followed by the program
+    /// name and arguments as a null-terminated string.
+    ///
+    /// # Parameters
+    ///
+    /// - `program_name`: The name of the program to be executed.
+    /// - `program_args`: An optional string containing the arguments to be passed to the program.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns a vector of bytes representing the encoded arguments.
+    /// On failure, it returns an error.
+    ///
+    fn build_args_bytes(program_name: &String, program_args: &Option<String>) -> Result<Vec<u8>> {
+        // Extract filename.
+        let mut args_string: String = Path::new(program_name)
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| program_name.to_string());
+
+        // Push arguments.
+        if let Some(program_args) = program_args {
+            if !program_args.is_empty() {
+                args_string.push(' ');
+                args_string.push_str(program_args);
+            }
+        }
+
+        // Encode length-prefixed arguments.
+        let args_bytes: Vec<u8> = args_string.into_bytes();
+        let args_len: u8 = match u8::try_from(args_bytes.len()) {
+            Ok(value) => value,
+            Err(_) => {
+                let reason: String =
+                    format!("initrd arguments too long (len={})", args_bytes.len());
+                error!("build_args_bytes(): {}", reason);
+                return Err(anyhow::anyhow!(reason));
+            },
+        };
+
+        Ok([&[args_len], &args_bytes[..]].concat())
     }
 }


### PR DESCRIPTION
This pull request significantly improves the way the Hyperlight platform passes and handles initrd (initial ramdisk) arguments from the user VM host to the guest kernel. The changes introduce a robust, length-prefixed encoding for initrd command-line arguments, ensure correct relocation and validation of the initrd image, and add comprehensive error checking throughout the process. Additionally, the tests are updated to verify the correct passing of the executable name as argv[0].

**Initrd argument handling and encoding:**

* Added a new method `build_args_bytes` in `src/uservm/src/vmm/hyperlight/mod.rs` to encode the program name and arguments as a length-prefixed byte vector, ensuring the guest receives argv[0] and any arguments correctly. This method also enforces a maximum length of 255 bytes for arguments.
* The user VM now appends the encoded arguments to the initrd blob passed to the guest, and adjusts memory size calculations to account for the header and arguments.

**Initrd parsing and relocation in the guest kernel:**

* Refactored the guest kernel's `parse_bootinfo` in `src/kernel/src/hal/platform/hyperlight/mod.rs` to use a new `parse_initrd_image` function. This function reads the initrd header, validates sizes, relocates the initrd if necessary, and extracts the argument section. [[1]](diffhunk://#diff-43171bb5ac9a97f5483ae1e974f64ec7c70221d6c6c657f874cab96e16b3827eR242-L316) [[2]](diffhunk://#diff-43171bb5ac9a97f5483ae1e974f64ec7c70221d6c6c657f874cab96e16b3827eR407-R606)
* Added `read_initrd_cmdline`, which robustly reads and validates the length-prefixed command-line arguments from the initrd payload, ensuring correct UTF-8 encoding and handling edge cases.

**Testing improvements:**

* Updated the test in `src/tests/misc-c/main.c` to assert that `argv[0]` is set to the executable name, verifying the correctness of the argument passing mechanism.

**Code quality and safety:**

* Improved error handling and logging throughout the initrd parsing and argument handling code, with clear error messages for allocation, overflow, and encoding issues. [[1]](diffhunk://#diff-43171bb5ac9a97f5483ae1e974f64ec7c70221d6c6c657f874cab96e16b3827eR407-R606) [[2]](diffhunk://#diff-2eeb0b110bec3866ba7a09cd14837a8dc2f0142ea909f4da49d666a2fad0b9c1L132-R181)
* Refactored imports and removed unused code for clarity and maintainability. [[1]](diffhunk://#diff-43171bb5ac9a97f5483ae1e974f64ec7c70221d6c6c657f874cab96e16b3827eR35-R45) [[2]](diffhunk://#diff-43171bb5ac9a97f5483ae1e974f64ec7c70221d6c6c657f874cab96e16b3827eL60-L63) [[3]](diffhunk://#diff-2eeb0b110bec3866ba7a09cd14837a8dc2f0142ea909f4da49d666a2fad0b9c1R18) [[4]](diffhunk://#diff-2eeb0b110bec3866ba7a09cd14837a8dc2f0142ea909f4da49d666a2fad0b9c1R40)

These changes collectively make the initrd and argument passing mechanism more robust, secure, and easier to maintain.