### PR TITLE
[utils] Add Round-Trip-Latency Benchmark

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -46,7 +46,7 @@ runs:
 
         echo "Running benchmark: ${bench} (Microvm)"
         bench_underscore=${bench//-/_}
-        ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_MICROVM} -toolchain-bin-dir $HOME/toolchain/bin -benchmark ${bench} -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_${bench_underscore}_microvm_${{ inputs.arch }}.txt
+        ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_MICROVM} -toolchain-bin-dir $HOME/toolchain/bin -benchmark ${bench} -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:|[0-9])' > bench_${bench_underscore}_microvm_${{ inputs.arch }}.txt
       done
     shell: bash
   - name: Clean-up temporary directory
@@ -94,7 +94,7 @@ runs:
 
         echo "Running benchmark: ${bench} (Hyperlight)"
         bench_underscore=${bench//-/_}
-        ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_HL} -toolchain-bin-dir $HOME/toolchain/bin -benchmark ${bench}  -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:)' > bench_${bench_underscore}_hyperlight_${{ inputs.arch }}.txt
+        ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_HL} -toolchain-bin-dir $HOME/toolchain/bin -benchmark ${bench}  -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:|[0-9])' > bench_${bench_underscore}_hyperlight_${{ inputs.arch }}.txt
       done
     shell: bash
   - name: Clean-up temporary directory

--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -68,6 +68,7 @@ jobs:
           boot-time
           cold-start
           cold-start-l2
+          round-trip-latency
           warm-start
           warm-start-l2
           warm-start-vmm

--- a/scripts/ci_bench_summary.py
+++ b/scripts/ci_bench_summary.py
@@ -10,17 +10,48 @@ import itertools
 import argparse
 
 # ======================================================================
+# Constants
+# ======================================================================
+
+PERCENTILES = ["p50", "p95", "p99"]
+ROUND_TRIP_LATENCY_BENCH = "round-trip-latency"
+
+# ======================================================================
 # Standalone Functions
 # ======================================================================
 
 
-def read_metrics(file_path):
-    try:
-        with open(file_path, "r") as f:
-            lines = f.readlines()
-            return [int(line.split(" ")[1]) for line in lines]
-    except Exception:
-        return ["NA", "NA", "NA"]
+# Helper function to decide if the benchmark is part of the round-trip-latency
+# benchmarks or not. We have multiple tables for this benchmark to capture the
+# different percentiles for all message sizes.
+def is_round_trip_latency_bench(benchmark):
+    return benchmark.startswith(ROUND_TRIP_LATENCY_BENCH)
+
+
+def read_metrics(benchmark, file_path):
+    if not is_round_trip_latency_bench(benchmark):
+        try:
+            with open(file_path, "r") as f:
+                lines = f.readlines()
+                return [int(line.split(" ")[1]) for line in lines]
+        except Exception:
+            return ["NA", "NA", "NA"]
+    else:
+        percentile = benchmark[-3:]
+        # The benchmark results are formatted like:
+        # size:\tp50\tp95\tp90
+        # so the index for each percentile is 1 + their index in PERCENTILES.
+        line_idx = PERCENTILES.index(percentile) + 1
+        try:
+            print(file_path)
+            with open(file_path, "r") as f:
+                lines = f.readlines()
+                lines = [line.strip() for line in lines]
+                print(lines[0])
+                print(lines[0].split("\t"))
+                return [int(line.split("\t")[line_idx]) for line in lines]
+        except Exception:
+            return ["NA", "NA", "NA", "NA", "NA", "NA"]
 
 
 def make_header(benchmark, table_width):
@@ -63,7 +94,7 @@ def generate_tables(dev_dir, target_dir, benchmarks, machines, archs):
         machine_header_parts = [f" {'':^{first_col_width-2}} "]
         for machine, arch in groups:
             machine_name = f"{machine} ({arch})"
-            # Each machine spans 3 sub-columns of 12 chars + 2 separators = 38 chars
+            # Each machine spans 3 sub-columns + 2 separators
             machine_span = sub_col_width * 3 + 2
             machine_header_parts.append(f"{machine_name:^{machine_span}}")
         machine_header_line = "|" + "|".join(machine_header_parts) + "|"
@@ -82,23 +113,32 @@ def generate_tables(dev_dir, target_dir, benchmarks, machines, archs):
         sub_header_line = "|" + "|".join(sub_header_parts) + "|"
         table_lines.append(sub_header_line)
 
-        # Data rows (p50, p95, p99)
-        percentiles = ["p50", "p95", "p99"]
+        print("tmp val", is_round_trip_latency_bench(benchmark))
+        if not is_round_trip_latency_bench(benchmark):
+            # Data rows (p50, p95, p99)
+            print(f"FOO: {benchmark}")
+            rows = PERCENTILES
+        else:
+            # We should consider parsing these values from the results file.
+            rows = ["32 B", "64 B", "128 B", "256 B", "512 B", "1 KiB", "4 KiB"]
 
-        for p_idx, percentile in enumerate(percentiles):
-            row_parts = [f" {percentile:^{first_col_width-2}} "]
+        for row_idx, row_label in enumerate(rows):
+            row_parts = [f" {row_label:^{first_col_width-2}} "]
 
             for machine, arch in groups:
                 bench_name = benchmark.replace("-", "_")
+                if is_round_trip_latency_bench(benchmark):
+                    bench_name = bench_name[:-4]
+
                 filename = f"bench_{bench_name}_{machine}_{arch}.txt"
                 dev_path = os.path.join(dev_dir, filename)
                 tgt_path = os.path.join(target_dir, filename)
 
-                dev_vals = read_metrics(dev_path)
-                tgt_vals = read_metrics(tgt_path)
+                dev_vals = read_metrics(benchmark, dev_path)
+                tgt_vals = read_metrics(benchmark, tgt_path)
 
-                dev_val = dev_vals[p_idx] if p_idx < len(dev_vals) else "NA"
-                tgt_val = tgt_vals[p_idx] if p_idx < len(tgt_vals) else "NA"
+                dev_val = dev_vals[row_idx] if row_idx < len(dev_vals) else "NA"
+                tgt_val = tgt_vals[row_idx] if row_idx < len(tgt_vals) else "NA"
 
                 # Calculate delta
                 if tgt_val == "NA" or dev_val == "NA":
@@ -169,6 +209,13 @@ if __name__ == "__main__":
     benchmarks = args.benchmarks.split(",")
     machines = args.machine_types.split(",")
     archs = args.archs.split(",")
+
+    # For the round-trip-latency benchmark we generate three tables, one for
+    # p50, one for p95, and one for p99.
+    if ROUND_TRIP_LATENCY_BENCH in benchmarks:
+        benchmarks.remove(ROUND_TRIP_LATENCY_BENCH)
+        for percentile in PERCENTILES:
+            benchmarks.append(f"{ROUND_TRIP_LATENCY_BENCH}-{percentile}")
 
     bench_summary = generate_tables(
         args.dev_dir, args.target_dir, benchmarks, machines, archs

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -22,6 +22,7 @@ pub enum BenchmarkFlavour {
     BootTime,
     ColdStart,
     ColdStartL2,
+    RoundTripLatency,
     WarmStart,
     WarmStartL2,
     WarmStartVMM,
@@ -34,6 +35,9 @@ impl BenchmarkFlavour {
             BenchmarkFlavour::BootTime => format!("{}/bin/noop-rust-nostd.elf", get_proj_root()),
             BenchmarkFlavour::ColdStart => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
             BenchmarkFlavour::ColdStartL2 => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
+            BenchmarkFlavour::RoundTripLatency => {
+                format!("{}/bin/echo-rust-nostd.elf", get_proj_root())
+            },
             BenchmarkFlavour::WarmStart => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
             BenchmarkFlavour::WarmStartL2 => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
             BenchmarkFlavour::WarmStartVMM => {
@@ -52,6 +56,7 @@ impl fmt::Display for BenchmarkFlavour {
             BenchmarkFlavour::BootTime => "boot-time",
             BenchmarkFlavour::ColdStart => "cold-start",
             BenchmarkFlavour::ColdStartL2 => "cold-start-l2",
+            BenchmarkFlavour::RoundTripLatency => "round-trip-latency",
             BenchmarkFlavour::WarmStart => "warm-start",
             BenchmarkFlavour::WarmStartL2 => "warm-start-l2",
             BenchmarkFlavour::WarmStartVMM => "warm-start-vmm",
@@ -69,6 +74,7 @@ impl FromStr for BenchmarkFlavour {
             "boot-time" => Ok(BenchmarkFlavour::BootTime),
             "cold-start" => Ok(BenchmarkFlavour::ColdStart),
             "cold-start-l2" => Ok(BenchmarkFlavour::ColdStartL2),
+            "round-trip-latency" => Ok(BenchmarkFlavour::RoundTripLatency),
             "warm-start" => Ok(BenchmarkFlavour::WarmStart),
             "warm-start-l2" => Ok(BenchmarkFlavour::WarmStartL2),
             "warm-start-vmm" => Ok(BenchmarkFlavour::WarmStartVMM),

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -44,6 +44,7 @@ use ::reqwest::header::{
     HeaderMap,
 };
 use ::std::{
+    collections::HashMap,
     fs::File,
     io::BufReader,
     mem,
@@ -81,6 +82,7 @@ use ::syscomm::{
 use ::syslog::{
     debug,
     error,
+    warn,
 };
 use ::tokio::{
     sync::mpsc,
@@ -510,6 +512,107 @@ impl Benchmark {
         Ok(())
     }
 
+    ///
+    /// # Description
+    ///
+    /// This function runs the round-trip latency benchmark, where we measure the latency of
+    /// sending one message and getting it back, as we increase the message size.
+    ///
+    /// Given that we have many message sizes (hence many rows in the result table) we default to
+    /// reporting only one percentile.
+    ///
+    /// # Arguments
+    ///
+    /// - `l2`: whether to deploy linuxd in an L2 VM or not.
+    /// - `percentile`: what percentile to report.
+    ///
+    pub async fn run_round_trip_latency(&mut self, l2: bool) -> Result<()> {
+        let message_sizes: Vec<(&str, u64)> = vec![
+            ("32 B", 32),
+            ("64 B", 64),
+            ("128 B", 128),
+            ("256 B", 256),
+            ("512 B", 512),
+            ("1 KiB", 1024),
+            ("4 KiB", 4 * 1024),
+        ];
+
+        // Display a progress bar
+        let total_num_iters: usize = self.iterations * message_sizes.len();
+        let pb: ProgressBar = ProgressBar::new(total_num_iters as u64);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{msg} [{bar:40.cyan/blue}] {pos}/{len} ({percent}%)")
+                .expect("error creating progress bar")
+                .progress_chars("#>-"),
+        );
+        pb.set_message("Benchmark progress:");
+
+        let (new_msg_headers, new_msg): (HeaderMap, nanvixd::message::New) =
+            self.prepare_new_message()?;
+
+        // Start nanvixd.
+        self.setup(l2);
+
+        let mut latencies: HashMap<&str, Vec<u128>> = HashMap::new();
+        let user_vm_id = {
+            // Start User VM.
+            let (user_vm_id, mut gateway_stream) = self.start(new_msg, new_msg_headers, l2).await?;
+
+            // Iterate over all possible message sizes.
+            for (label, message_size) in &message_sizes {
+                let payload: Vec<u8> = vec![7u8; *message_size as usize];
+
+                // For each message size send many messages to get statistically relevant results.
+                for _ in 0..self.iterations {
+                    let mut response_payload: Vec<u8> = vec![0u8; *message_size as usize];
+
+                    let start: Instant = Instant::now();
+                    gateway_stream.write_all(&payload).await?;
+                    gateway_stream.read_exact(&mut response_payload).await?;
+                    latencies
+                        .entry(label)
+                        .or_default()
+                        .push(start.elapsed().as_micros());
+
+                    // Sanity-check the message to make sure is the same we sent.
+                    if response_payload != payload {
+                        error!("received payload does not match sent payload!");
+                        error!(" - sent: {payload:?}");
+                        error!(" - got: {response_payload:?}");
+                    }
+
+                    pb.inc(1);
+                    sleep(Duration::from_millis(CLEANUP_SLEEP_DURATION)).await;
+                }
+            }
+            user_vm_id
+        };
+
+        // Kill the user VM.
+        self.kill(user_vm_id).await?;
+
+        // Stop nanvixd.
+        self.cleanup();
+
+        pb.finish();
+        println!("Size:\tp50\tp95\tp99 [us]");
+        // Iterate over the message size list to print the labels in order.
+        for (label, _) in message_sizes.iter() {
+            if let Some(latencies) = latencies.get_mut(label) {
+                latencies.sort();
+                let p50: u128 = latencies[(self.iterations as f32 * 0.5) as usize];
+                let p95: u128 = latencies[(self.iterations as f32 * 0.95) as usize];
+                let p99: u128 = latencies[(self.iterations as f32 * 0.99) as usize];
+                println!("{label}:\t{p50}\t{p95}\t{p99}");
+            } else {
+                warn!("missing latencies for message size: {label}");
+            }
+        }
+
+        Ok(())
+    }
+
     /// This function runs the warm start benchmark, where we measure the time to send a request
     /// into the VM once it has started executing.
     pub async fn run_warm_start(&mut self, l2: bool) -> Result<()> {
@@ -906,6 +1009,20 @@ async fn main() -> Result<()> {
             #[cfg(not(feature = "timestamp-messages"))]
             {
                 benchmark.run_cold_start(true).await
+            }
+        },
+        BenchmarkFlavour::RoundTripLatency => {
+            #[cfg(feature = "timestamp-messages")]
+            {
+                error!(
+                    "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
+                );
+                return Ok(());
+            }
+
+            #[cfg(not(feature = "timestamp-messages"))]
+            {
+                benchmark.run_round_trip_latency(false).await
             }
         },
         BenchmarkFlavour::WarmStart => {


### PR DESCRIPTION
In this PR I add a benchmark that measures the latency of sending an echo message as we increase the size of the message. We report the latency for each message at p50, p95, and p99 in three different tables.