### PR TITLE
[uservm] Track Credits on Hyperlight Host

### DIFF
--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -411,8 +411,28 @@ pub fn build_input_fn(mut input_queue: Receiver<Message>) -> Box<StdinFn> {
     let input = move || -> Result<Vec<u8>, hyperlight_host::HyperlightError> {
         match input_queue.blocking_recv() {
             Some(mut msg) => {
-                Guest::consume_credit()?;
                 msg.message_type = MessageType::Ikc;
+                // Acquire lock on guest information.
+                let mut locked_guest: MutexGuard<'_, Guest> = crate::vmm::GUEST
+                    .get()
+                    .ok_or_else(|| {
+                        let reason: &str = "guest handle not initialized";
+                        error!("input(): {reason}");
+                        hyperlight_host::HyperlightError::AnyhowError(anyhow::Error::msg(reason))
+                    })?
+                    .blocking_lock();
+
+                // Acquire lock on virtual memory manager.
+                let mut locked_vmem: MutexGuard<'_, VirtualMemory> = crate::vmm::VMEM
+                    .get()
+                    .ok_or_else(|| {
+                        let reason: &str = "vmem handle not initialized";
+                        error!("input(): {reason}");
+                        hyperlight_host::HyperlightError::AnyhowError(anyhow::Error::msg(reason))
+                    })?
+                    .blocking_lock();
+
+                locked_guest.consume_credit(&mut locked_vmem)?;
                 Ok(msg.to_bytes().to_vec())
             },
 

--- a/src/uservm/src/vmm/hyperlight/guest.rs
+++ b/src/uservm/src/vmm/hyperlight/guest.rs
@@ -5,63 +5,94 @@
 // Imports
 //==================================================================================================
 
-use crate::vmm::{
-    VMEM,
-    VirtualMemory,
-};
+use crate::vmm::VirtualMemory;
 use ::anyhow::Result;
 use ::hyperlight_host::mem::{
     mgr::SandboxMemoryManager,
     shared_mem::ExclusiveSharedMemory,
 };
-use ::syslog::info;
+use ::syslog::error;
 
 //==================================================================================================
 // Structures
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Information about the guest running inside the virtual machine.
+///
 #[derive(Default)]
-pub struct Guest;
+pub struct Guest {
+    /// Credits counter, account the number of messages that the VM can consume.
+    credits: u64,
+}
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
 impl Guest {
-    // Adds a credit to the virtual machine's credit pool.
+    ///
+    /// # Description
+    ///
+    /// Increments the credit register by one.
+    ///
+    /// # Parameters
+    ///
+    /// - `vmem`: Virtual memory manager of the virtual machine.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an empty tuple. Otherwise, it returns an error.
+    ///
     pub fn add_credit(&mut self, vmem: &mut VirtualMemory) -> Result<()> {
         let manager: &mut SandboxMemoryManager<ExclusiveSharedMemory> = &mut vmem.manager;
+
+        // Increment credits, checking for overflow.
+        self.credits = self.credits.checked_add(1).ok_or_else(|| {
+            let reason: &'static str = "credit overflow";
+            error!("add_credit(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
         let credits_offset: usize = manager.get_guest_credits_offset();
-        let mut credit: u64 = manager.get_shared_mem_mut().read::<u64>(credits_offset)?;
-        credit += 1_u64;
         manager
             .get_shared_mem_mut()
-            .write::<u64>(credits_offset, credit)?;
+            .write::<u64>(credits_offset, self.credits)?;
 
-        info!("Adding credit: {}", credit);
         Ok(())
     }
 
-    // Consumes a credit from the virtual machine's credit pool.
-    pub fn consume_credit() -> Result<()> {
-        VMEM.get()
-            .map(|vmem| vmem.blocking_lock())
-            .map(|mut vmem| -> Result<()> {
-                let credits_offset: usize = vmem.get_guest_credits_offset();
-                let mut credit: u64 = vmem.get_shared_mem_mut().read::<u64>(credits_offset)?;
+    ///
+    /// # Description
+    ///
+    /// Decrements the credit register by one.
+    ///
+    /// # Parameters
+    ///
+    /// - `vmem`: Virtual memory manager of the virtual machine.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an empty tuple. Otherwise, it returns an error.
+    ///
+    pub fn consume_credit(&mut self, vmem: &mut VirtualMemory) -> Result<()> {
+        let manager: &mut SandboxMemoryManager<ExclusiveSharedMemory> = &mut vmem.manager;
 
-                if credit == 0_u64 {
-                    return Err(anyhow::anyhow!("No credit available to consume"));
-                }
+        // Decrement credits, checking for underflow.
+        self.credits = self.credits.checked_sub(1).ok_or_else(|| {
+            let reason: &'static str = "credit underflow";
+            error!("consume_credit(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
 
-                credit -= 1_u64;
-                vmem.get_shared_mem_mut()
-                    .write::<u64>(credits_offset, credit)?;
+        let credits_offset: usize = manager.get_guest_credits_offset();
+        manager
+            .get_shared_mem_mut()
+            .write::<u64>(credits_offset, self.credits)?;
 
-                info!("Consuming credit: {}", credit);
-                Ok(())
-            })
-            .ok_or(anyhow::anyhow!("VMEM is not initialized"))?
+        Ok(())
     }
 
     ///

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -61,8 +61,11 @@ use ::tokio::{
 // Globals
 // ==================================================================================================
 
-pub static VMEM: OnceLock<Arc<Mutex<SandboxMemoryManager<ExclusiveSharedMemory>>>> =
-    OnceLock::new();
+/// Global handle to the guest information, used to enable access from the input handler.
+pub static GUEST: OnceLock<Arc<Mutex<Guest>>> = OnceLock::new();
+
+/// Global handle to the virtual memory manager, used to enable access from the input handler.
+pub static VMEM: OnceLock<Arc<Mutex<VirtualMemory>>> = OnceLock::new();
 
 //==================================================================================================
 // Types
@@ -101,7 +104,7 @@ struct InnerVmm {
 
 impl Vmm {
     pub fn new(args: MicroVmArgs) -> Result<Self> {
-        let guest: Guest = Guest;
+        let guest: Guest = Guest::default();
 
         // Required values for heap and stack sizes to be used by the kernel.
         let heap_size: usize = 4 * 1024 * 1024;
@@ -235,8 +238,17 @@ impl Vmm {
         let vmem: Arc<Mutex<VirtualMemory>> = Arc::new(Mutex::new(VirtualMemory {
             manager: manager.clone(),
         }));
-        VMEM.set(Arc::new(Mutex::new(manager))).map_err(|_| {
-            anyhow::anyhow!("Failed to set VMEM: already initialized or not available")
+        VMEM.set(vmem.clone()).map_err(|_| {
+            let reason: &str = "Failed to initialize vmem handle (already initialized)";
+            error!("new(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        let guest: Arc<Mutex<Guest>> = Arc::new(Mutex::new(guest));
+        GUEST.set(guest.clone()).map_err(|_| {
+            let reason: &str = "Failed to initialize guest handle (already initialized)";
+            error!("new(): {reason}");
+            anyhow::anyhow!(reason)
         })?;
 
         // Create a closure that takes a String and writes it to stderr.
@@ -267,7 +279,7 @@ impl Vmm {
         Ok(Self {
             vmem,
             sandbox: Arc::new(Mutex::new(Some(sandbox))),
-            guest: Arc::new(Mutex::new(guest)),
+            guest,
             inner: Arc::new(Mutex::new(InnerVmm {
                 control_tx: args.control_tx,
             })),


### PR DESCRIPTION
Ensure the Hyperlight VMM host implementation maintains credit tracking on the host side.  This change prevents malicious guests from manipulating the credits register and resolves undefined memory semantics when updating it.