### PR TITLE
[kernel] Performance Counters for Inter-Kernel Communication Messages

### DIFF
--- a/src/kernel/src/ipc/mbx/mailbox.rs
+++ b/src/kernel/src/ipc/mbx/mailbox.rs
@@ -15,8 +15,14 @@ use ::sys::{
 //  Structures
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Mailbox.
+///
 #[derive(Default)]
 pub struct Mailbox {
+    /// Buffered messages.
     buffer: LinkedList<Message>,
 }
 
@@ -25,12 +31,35 @@ pub struct Mailbox {
 //==================================================================================================
 
 impl Mailbox {
+    ///
+    /// # Description
+    ///
+    /// Posts a message into the mailbox.
+    ///
+    /// # Parameters
+    ///
+    /// - `message`: Message to be sent.
+    ///
     pub fn send(&mut self, message: Message) {
         self.buffer.push_back(message);
     }
 
+    ///
+    /// # Description
+    ///
+    /// Attempts to consume a message addressed to the given thread or its process.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Target thread identifier.
+    ///
+    /// # Returns
+    ///
+    /// If a message that was addressed to the given thread or its process was found,
+    /// it is returned. Otherwise, no message is returned instead.
+    ///
     pub fn receive(&mut self, tid: ThreadIdentifier) -> Option<Message> {
-        // Locate the first message that the given thread received.
+        // Search for a message that is addressed to the thread.
         let message_index = self
             .buffer
             .iter()
@@ -41,7 +70,7 @@ impl Mailbox {
             return Some(self.buffer.remove(index));
         }
 
-        // Locate the first message that the current thread received.
+        // Locate the first message that is addressed to the process.
         let message_index = self
             .buffer
             .iter()

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -153,34 +153,34 @@ mod startup {
 static mut CORES_ONLINE: AtomicUsize = AtomicUsize::new(1);
 
 /// Performance counter for the number of times the kernel was idle.
-pub static PERF_SCHED_KERNEL_IDLE: AtomicUsize = AtomicUsize::new(0);
+static PERF_SCHED_KERNEL_IDLE: AtomicUsize = AtomicUsize::new(0);
 
 /// Performance counter for the number of soft context switches that occurred.
-pub static PERF_SCHED_SOFT_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+static PERF_SCHED_SOFT_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
 
 /// Performance counter for the number of involuntary context switches that occurred.
-pub static PERF_SCHED_HARD_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+static PERF_SCHED_HARD_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
 
 /// Performance counter for the number of context switches that  were triggered by `exit`.
-pub static PERF_SCHED_EXIT_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+static PERF_SCHED_EXIT_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
 
 /// Performance counter for the number of context switches that were triggered by `exit_thread`.
-pub static PERF_SCHED_EXIT_THREAD_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+static PERF_SCHED_EXIT_THREAD_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
 
 /// Performance counter for the number of context switches that were triggered by `sleep`.
-pub static PERF_SCHED_SLEEP_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+static PERF_SCHED_SLEEP_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
 
 /// Performance counter for the number of context switches that were triggered by `giveup`.
-pub static PERF_SCHED_GIVEUP_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
+static PERF_SCHED_GIVEUP_CONTEXT_SWITCHES: AtomicUsize = AtomicUsize::new(0);
 
 /// Performance counter for the number of times `wakeup` was called.
-pub static PERF_SCHED_WAKEUP: AtomicUsize = AtomicUsize::new(0);
+static PERF_SCHED_WAKEUP: AtomicUsize = AtomicUsize::new(0);
 
 /// Number of times that `vmbus_read` was called.
-pub static PERF_VMBUS_READ: AtomicUsize = AtomicUsize::new(0);
+static PERF_VMBUS_READ: AtomicUsize = AtomicUsize::new(0);
 
 /// Number of times that `vmbus_write` was called.
-pub static PERF_VMBUS_WRITE: AtomicUsize = AtomicUsize::new(0);
+static PERF_VMBUS_WRITE: AtomicUsize = AtomicUsize::new(0);
 
 //==================================================================================================
 // Standalone Functions

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -182,6 +182,12 @@ static PERF_VMBUS_READ: AtomicUsize = AtomicUsize::new(0);
 /// Number of times that `vmbus_write` was called.
 static PERF_VMBUS_WRITE: AtomicUsize = AtomicUsize::new(0);
 
+/// Number of IKC messages sent.
+static PERF_IKC_MESSAGES_SENT: AtomicUsize = AtomicUsize::new(0);
+
+/// Number of IKC messages received.
+static PERF_IKC_MESSAGES_RECEIVED: AtomicUsize = AtomicUsize::new(0);
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -457,6 +463,8 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     info!("- Ticks: {:?}", pm::ticks());
     info!("- No. Times VMBus Read Was Called: {:?}", PERF_VMBUS_READ.load(Ordering::Relaxed));
     info!("- No. Times VMBus Write Was Called: {:?}", PERF_VMBUS_WRITE.load(Ordering::Relaxed));
+    info!("- No. IKC Messages Sent: {:?}", PERF_IKC_MESSAGES_SENT.load(Ordering::Relaxed));
+    info!("- No. IKC Messages Received: {:?}", PERF_IKC_MESSAGES_RECEIVED.load(Ordering::Relaxed));
 
     trace!("the system will shutdown now!");
     kernel_magic_string(status);

--- a/src/kernel/src/stdio.rs
+++ b/src/kernel/src/stdio.rs
@@ -5,8 +5,15 @@
 // Imports
 //==================================================================================================
 
-use crate::hal::platform;
-use ::core::mem;
+use crate::{
+    hal::platform,
+    PERF_IKC_MESSAGES_RECEIVED,
+    PERF_IKC_MESSAGES_SENT,
+};
+use ::core::{
+    mem,
+    sync::atomic::Ordering,
+};
 use ::sys::{
     error::{
         Error,
@@ -51,6 +58,8 @@ pub fn write(message: Message) -> Result<(), Error> {
         // NOTE: we assume that page is tagged as writethrough-enabled and cache-disabled.
         platform::vmbus_write(&bytes as *const u8);
     }
+
+    PERF_IKC_MESSAGES_SENT.fetch_add(1, Ordering::Relaxed);
 
     Ok(())
 }
@@ -101,6 +110,8 @@ pub fn read() -> Result<Option<Message>, Error> {
         // NOTE: we assume that page is tagged as writethrough-enabled and cache-disabled.
         platform::vmbus_read(&mut message as *mut u8);
     };
+
+    PERF_IKC_MESSAGES_RECEIVED.fetch_add(1, Ordering::Relaxed);
 
     // Convert message to Message struct.
     match Message::try_from_bytes(message) {


### PR DESCRIPTION
This pull request introduces improvements to the kernel's inter-kernel communication (IKC) performance tracking and enhances documentation in the mailbox subsystem. The main changes include adding new counters for IKC messages sent and received, updating the code to increment these counters appropriately, and adding detailed documentation to the `Mailbox` struct and its methods.

Performance monitoring enhancements:

* Added two new static counters, `PERF_IKC_MESSAGES_SENT` and `PERF_IKC_MESSAGES_RECEIVED`, to track the number of IKC messages sent and received (`src/kernel/src/kmain.rs`). These counters are now included in the kernel's shutdown summary output. [[1]](diffhunk://#diff-0442d6e6e7d7a183acb7c03c2b9b0da2fb4cda4a74b7f6588143d76b2d2bae9cL156-R189) [[2]](diffhunk://#diff-0442d6e6e7d7a183acb7c03c2b9b0da2fb4cda4a74b7f6588143d76b2d2bae9cR466-R467)
* Updated the `stdio` module to increment `PERF_IKC_MESSAGES_SENT` and `PERF_IKC_MESSAGES_RECEIVED` each time an IKC message is written or read, respectively (`src/kernel/src/stdio.rs`). [[1]](diffhunk://#diff-ab4d5fcbd4a3390b01706c41c77702e1660052423cd81cc56dfab3e1754eacebL8-R16) [[2]](diffhunk://#diff-ab4d5fcbd4a3390b01706c41c77702e1660052423cd81cc56dfab3e1754eacebR62-R63) [[3]](diffhunk://#diff-ab4d5fcbd4a3390b01706c41c77702e1660052423cd81cc56dfab3e1754eacebR114-R115)

Documentation improvements:

* Added and expanded doc comments for the `Mailbox` struct and its `send` and `receive` methods, clarifying their behavior and parameters (`src/kernel/src/ipc/mbx/mailbox.rs`). [[1]](diffhunk://#diff-0bb867f5577a981e58184a9bb5af870e3fca724822d6d1b754968e0649f8b19fR18-R25) [[2]](diffhunk://#diff-0bb867f5577a981e58184a9bb5af870e3fca724822d6d1b754968e0649f8b19fR34-R62) [[3]](diffhunk://#diff-0bb867f5577a981e58184a9bb5af870e3fca724822d6d1b754968e0649f8b19fL44-R73)