### PR TITLE
[uservm] Add Counters for Message Loss Check

### DIFF
--- a/src/uservm/src/io_thread.rs
+++ b/src/uservm/src/io_thread.rs
@@ -5,16 +5,22 @@
 // Imports
 //==================================================================================================
 
-use crate::orchestrator::{
-    IoControlCommand,
-    IoControlResponse,
+use crate::{
+    IO_THREAD_NUM_MESSAGES_RECEIVED,
+    orchestrator::{
+        IoControlCommand,
+        IoControlResponse,
+    },
 };
 use ::anyhow::Result;
 use ::control_plane_api::{
     NanvixdCommand,
     NanvixdControlMessage,
 };
-use ::std::mem;
+use ::std::{
+    mem,
+    sync::atomic::Ordering,
+};
 use ::sys::ipc::Message;
 use ::syscomm::{
     SocketStream,
@@ -153,6 +159,8 @@ impl IoThread {
                                 buf.fill(0);
                                 buf_len = 0;
 
+                                on_message_received_from_system_vm();
+
                                 // Push message to incoming queue.
                                 data_tx.send(message).await?;
                             }
@@ -253,4 +261,17 @@ impl IoThread {
             }
         }
     }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Handler to be called whenever a message is received from the system VM.
+///
+fn on_message_received_from_system_vm() {
+    IO_THREAD_NUM_MESSAGES_RECEIVED.fetch_add(1, Ordering::SeqCst);
 }

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -79,7 +79,13 @@ use ::config::syscomm::DEFAULT_CHANNEL_CAPACITY;
 use ::std::{
     fs::File,
     io::Write,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{
+            AtomicUsize,
+            Ordering,
+        },
+    },
 };
 use ::sys::ipc::{
     Message,
@@ -101,6 +107,22 @@ use ::tokio::{
     },
     task::JoinHandle,
 };
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Tracks the number of messages received by the I/O thread.
+static IO_THREAD_NUM_MESSAGES_RECEIVED: AtomicUsize = AtomicUsize::new(0);
+
+/// Tracks the number of messages received by the memory thread.
+static MEM_THREAD_NUM_MESSAGES_RECEIVED: AtomicUsize = AtomicUsize::new(0);
+
+/// Tracks the number of messages received by the VMM thread.
+static VMM_THREAD_NUM_MESSAGES_RECEIVED: AtomicUsize = AtomicUsize::new(0);
+
+/// Tracks the number of times the input function has been called.
+static VMM_THREAD_NUM_INPUT_CALLS: AtomicUsize = AtomicUsize::new(0);
 
 //==================================================================================================
 // VmmArgs
@@ -380,6 +402,7 @@ pub fn build_input_fn(mut input_queue: Receiver<Message>) -> Box<StdinFn> {
                       size|
           -> Result<()> {
         use std::mem;
+        on_input_function_called();
 
         // Check for invalid operand size.
         if size != mem::size_of::<u32>() {
@@ -390,6 +413,7 @@ pub fn build_input_fn(mut input_queue: Receiver<Message>) -> Box<StdinFn> {
 
         match input_queue.blocking_recv() {
             Some(mut msg) => {
+                on_message_received_from_memory_thread();
                 msg.message_type = MessageType::Ikc;
                 let mut locked_guest: MutexGuard<'_, Guest> = guest.blocking_lock();
                 let mut locked_vm: MutexGuard<'_, VirtualMemory> = vmem.blocking_lock();
@@ -409,8 +433,10 @@ pub fn build_input_fn(mut input_queue: Receiver<Message>) -> Box<StdinFn> {
 
     #[cfg(feature = "hyperlight")]
     let input = move || -> Result<Vec<u8>, hyperlight_host::HyperlightError> {
+        on_input_function_called();
         match input_queue.blocking_recv() {
             Some(mut msg) => {
+                on_message_received_from_memory_thread();
                 msg.message_type = MessageType::Ikc;
                 // Acquire lock on guest information.
                 let mut locked_guest: MutexGuard<'_, Guest> = crate::vmm::GUEST
@@ -541,6 +567,69 @@ pub fn output_fn(queue: Sender<Message>) -> Box<StdoutFn> {
     };
 
     Box::new(output)
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Handler to be called whenever the input function is called.
+///
+fn on_input_function_called() {
+    VMM_THREAD_NUM_INPUT_CALLS.fetch_add(1, Ordering::SeqCst);
+
+    // Sanity check that no messages are lost.
+    #[cfg(debug_assertions)]
+    {
+        // The following check is not atomic, but since the two counters are monotonically
+        // increasing AND they are strictly updated one after another, it should be sufficient to
+        // detect message losses.
+
+        let cached_mem_thread_num_messages_received: usize =
+            MEM_THREAD_NUM_MESSAGES_RECEIVED.load(Ordering::SeqCst);
+        let cached_vmm_thread_num_input_calls: usize =
+            VMM_THREAD_NUM_INPUT_CALLS.load(Ordering::SeqCst);
+
+        debug_assert!(
+            cached_vmm_thread_num_input_calls <= cached_mem_thread_num_messages_received,
+            "vmm thread has called the input function more times than the memory thread has \
+             received messages ({} > {})",
+            cached_vmm_thread_num_input_calls,
+            cached_mem_thread_num_messages_received
+        );
+    }
+}
+
+///
+/// # Description
+///
+/// Handler to be called whenever a message is received from the memory thread.
+///
+fn on_message_received_from_memory_thread() {
+    VMM_THREAD_NUM_MESSAGES_RECEIVED.fetch_add(1, Ordering::SeqCst);
+
+    // Sanity check that no messages are lost.
+    #[cfg(debug_assertions)]
+    {
+        // The following check is not atomic, but since the two counters are monotonically
+        // increasing AND they are strictly updated one after another, it should be sufficient to
+        // detect message losses.
+
+        let cached_vmm_thread_num_input_calls: usize =
+            VMM_THREAD_NUM_INPUT_CALLS.load(Ordering::SeqCst);
+        let cached_vmm_thread_num_messages_received: usize =
+            VMM_THREAD_NUM_MESSAGES_RECEIVED.load(Ordering::SeqCst);
+
+        debug_assert!(
+            cached_vmm_thread_num_messages_received <= cached_vmm_thread_num_input_calls,
+            "vmm thread has received more messages than it has called the input function ({} > {})",
+            cached_vmm_thread_num_messages_received,
+            cached_vmm_thread_num_input_calls
+        );
+    }
 }
 
 //==================================================================================================

--- a/src/uservm/src/memory_thread.rs
+++ b/src/uservm/src/memory_thread.rs
@@ -11,9 +11,12 @@
 // Imports
 //==================================================================================================
 
-use crate::orchestrator::{
-    MemoryControlCommand,
-    MemoryControlResponse,
+use crate::{
+    MEM_THREAD_NUM_MESSAGES_RECEIVED,
+    orchestrator::{
+        MemoryControlCommand,
+        MemoryControlResponse,
+    },
 };
 use ::anyhow::{
     Error,
@@ -22,6 +25,7 @@ use ::anyhow::{
 use ::std::{
     marker::Send,
     pin::Pin,
+    sync::atomic::Ordering,
 };
 use ::sys::ipc::Message;
 use ::syslog::{
@@ -127,6 +131,8 @@ impl MemoryThread {
                     msg = data_rx.recv() => {
                         match msg {
                             Some(msg) => {
+                                on_message_received_from_io_thread();
+
                                 if let Err(e) = data_tx.send(msg).await {
                                     error!("spawn(): failed to send message: {e}");
                                     continue;
@@ -151,6 +157,41 @@ impl MemoryThread {
                 debug!("spawn(): exited normally");
             }
         })
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Handler to be called whenever a message is received from the I/O thread.
+///
+fn on_message_received_from_io_thread() {
+    MEM_THREAD_NUM_MESSAGES_RECEIVED.fetch_add(1, Ordering::SeqCst);
+
+    // Sanity check that no messages are lost.
+    #[cfg(debug_assertions)]
+    {
+        // The following check is not atomic, but since the two counters are monotonically
+        // increasing AND they are strictly updated one after another, it should be sufficient to
+        // detect message losses.
+
+        let cached_mem_thread_num_messages_received =
+            MEM_THREAD_NUM_MESSAGES_RECEIVED.load(Ordering::SeqCst);
+
+        let cached_io_thread_num_messages_received =
+            crate::IO_THREAD_NUM_MESSAGES_RECEIVED.load(Ordering::SeqCst);
+
+        debug_assert!(
+            cached_mem_thread_num_messages_received <= cached_io_thread_num_messages_received,
+            "memory thread has received more messages than the i/o thread (
+                                        {} > {})",
+            cached_mem_thread_num_messages_received,
+            cached_io_thread_num_messages_received
+        );
     }
 }
 


### PR DESCRIPTION
This pull request adds detailed message counting and sanity checks between the I/O, memory, and VMM threads in the user VM. By introducing atomic counters and handler functions, it helps track the number of messages received and input function calls in each thread, and asserts that no messages are lost or mishandled during inter-thread communication. These changes improve the reliability and debuggability of the system by catching potential synchronization or message loss issues early.

**Message Counting and Tracking**

* Added global atomic counters (`IO_THREAD_NUM_MESSAGES_RECEIVED`, `MEM_THREAD_NUM_MESSAGES_RECEIVED`, `VMM_THREAD_NUM_MESSAGES_RECEIVED`, `VMM_THREAD_NUM_INPUT_CALLS`) in `src/uservm/src/lib.rs` to track messages and input calls for each thread.
* Updated imports in `src/uservm/src/io_thread.rs` and `src/uservm/src/memory_thread.rs` to allow access to these counters from each thread module. [[1]](diffhunk://#diff-dbba3643e2968a019dd2d091ecf549b4cf004cab74c4e40771a5d7eff58524ffL8-R23) [[2]](diffhunk://#diff-96bbb1b4c82b8ffa5cbd3be7a17085e5cd58e1b0a817363a8a89336fea3ff6b0L14-R19) [[3]](diffhunk://#diff-414f997e60c026cc30febd1a963a6a6da41810de5be1739702ab1f2d1a8aaa84L82-R88) [[4]](diffhunk://#diff-96bbb1b4c82b8ffa5cbd3be7a17085e5cd58e1b0a817363a8a89336fea3ff6b0R28)

**Handler Functions and Integration**

* Added handler functions (`on_message_received_from_system_vm`, `on_message_received_from_memory_thread`, `on_message_received_from_io_thread`, `on_input_function_called`) that increment the relevant counters and are called at appropriate points in message processing and input handling. [[1]](diffhunk://#diff-dbba3643e2968a019dd2d091ecf549b4cf004cab74c4e40771a5d7eff58524ffR265-R277) [[2]](diffhunk://#diff-414f997e60c026cc30febd1a963a6a6da41810de5be1739702ab1f2d1a8aaa84R572-R634) [[3]](diffhunk://#diff-96bbb1b4c82b8ffa5cbd3be7a17085e5cd58e1b0a817363a8a89336fea3ff6b0R163-R197)
* Integrated these handler calls into the message processing logic in `src/uservm/src/io_thread.rs`, `src/uservm/src/memory_thread.rs`, and `src/uservm/src/lib.rs` (input function) to ensure counters are updated whenever a message is received or the input function is called. [[1]](diffhunk://#diff-dbba3643e2968a019dd2d091ecf549b4cf004cab74c4e40771a5d7eff58524ffR162-R163) [[2]](diffhunk://#diff-414f997e60c026cc30febd1a963a6a6da41810de5be1739702ab1f2d1a8aaa84R405) [[3]](diffhunk://#diff-414f997e60c026cc30febd1a963a6a6da41810de5be1739702ab1f2d1a8aaa84R416) [[4]](diffhunk://#diff-414f997e60c026cc30febd1a963a6a6da41810de5be1739702ab1f2d1a8aaa84R436-R439) [[5]](diffhunk://#diff-96bbb1b4c82b8ffa5cbd3be7a17085e5cd58e1b0a817363a8a89336fea3ff6b0R134-R135)

**Sanity Checks for Message Loss**

* Implemented debug-only assertions in the handler functions to check that the number of messages received and input function calls are consistent, helping to detect lost or out-of-order messages between threads. [[1]](diffhunk://#diff-414f997e60c026cc30febd1a963a6a6da41810de5be1739702ab1f2d1a8aaa84R572-R634) [[2]](diffhunk://#diff-96bbb1b4c82b8ffa5cbd3be7a17085e5cd58e1b0a817363a8a89336fea3ff6b0R163-R197)

These changes collectively enhance the observability and correctness of inter-thread message passing in the user VM.