### PR TITLE
[daemons] Don't Panic on Unknown Error Code

### DIFF
--- a/src/daemons/linuxd/src/dirent.rs
+++ b/src/daemons/linuxd/src/dirent.rs
@@ -143,9 +143,15 @@ pub fn do_getdents(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            error!("libc::getdents(): errno={}", { errno });
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::getdents(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_getdents(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             return Ok(vec![crate::build_error(tid, error)]);
         },
         // Success.

--- a/src/daemons/linuxd/src/fcntl.rs
+++ b/src/daemons/linuxd/src/fcntl.rs
@@ -141,6 +141,7 @@ use ::syslog::{
     debug,
     error,
     trace,
+    warn,
 };
 use sysapi::fcntl::file_descriptor_flags::{
     FD_CLOEXEC,
@@ -195,9 +196,15 @@ pub fn do_openat(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::openat(): errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
+            error!("libc::openat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_openat(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }
@@ -241,8 +248,15 @@ pub fn do_unlinkat(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::unlinkat(): errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno).expect("unknown error code {error}");
+            error!("libc::unlinkat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_unlinkat(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }
@@ -299,7 +313,15 @@ pub fn do_renameat(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            let error: ErrorCode = ErrorCode::try_from(errno).expect("unknown error code {error}");
+            error!("libc::renameat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_renameat(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }
@@ -391,9 +413,15 @@ pub fn do_fstat_at(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::fstatat(): errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::fstatat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_fstat_at(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }
@@ -420,15 +448,20 @@ pub fn do_posix_fallocate(
             Ok(FileSpaceControlResponse::build(tid, 0))
         },
         errno => {
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
-
             // Check if the thread has been interrupted.
             if errno == libc::EINTR {
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::posix_fallocate(): errno={errno:?}");
+            error!("libc::posix_fallocate(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_posix_fallocate(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(crate::build_error(tid, error))
         },
     }
@@ -467,9 +500,15 @@ pub fn do_posix_fadvise(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::posix_fadvise(): errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::posix_fadvise(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_posix_fadvise(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(crate::build_error(tid, error))
         },
     }
@@ -551,9 +590,15 @@ pub fn do_fstat(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::fstatat(): errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::fstatat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_fstat(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }
@@ -599,9 +644,15 @@ pub fn do_symlinkat(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::symlinkat(): errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::symlinkat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_symlinkat(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }
@@ -659,9 +710,15 @@ pub fn do_readlinkat(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::readlinkat(): errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::readlinkat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_readlinkat(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }
@@ -708,9 +765,15 @@ pub fn do_mkdirat(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::mkdirat(): errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::mkdirat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_mkdirat(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }
@@ -770,9 +833,15 @@ pub fn do_utimensat(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::utimensat(): errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::utimensat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_utimensat(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }
@@ -815,9 +884,15 @@ pub fn do_futimens(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::futimens(): errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::futimens(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_futimens(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(crate::build_error(tid, error))
         },
     }
@@ -920,8 +995,14 @@ pub fn do_fcntl(
                 }
 
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
-                let error: ErrorCode = ErrorCode::try_from(errno)
-                    .unwrap_or_else(|_| panic!("unknown error code {errno}"));
+                let error: ErrorCode = match ErrorCode::try_from(errno) {
+                    Ok(error) => error,
+                    Err(_) => {
+                        let reason: &str = "unknown error code";
+                        warn!("do_fcntl(): {reason} (errno={errno:?})");
+                        ErrorCode::ValueOutOfRange
+                    },
+                };
                 Ok(crate::build_error(tid, error))
             }
         },
@@ -941,8 +1022,14 @@ pub fn do_fcntl(
                 }
 
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
-                let error: ErrorCode = ErrorCode::try_from(errno)
-                    .unwrap_or_else(|_| panic!("unknown error code {errno}"));
+                let error: ErrorCode = match ErrorCode::try_from(errno) {
+                    Ok(error) => error,
+                    Err(_) => {
+                        let reason: &str = "unknown error code";
+                        warn!("do_fcntl(): {reason} (errno={errno:?})");
+                        ErrorCode::ValueOutOfRange
+                    },
+                };
                 Ok(crate::build_error(tid, error))
             }
         },
@@ -986,8 +1073,14 @@ pub fn do_fcntl(
                 }
 
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
-                let error: ErrorCode = ErrorCode::try_from(errno)
-                    .unwrap_or_else(|_| panic!("unknown error code {errno}"));
+                let error: ErrorCode = match ErrorCode::try_from(errno) {
+                    Ok(error) => error,
+                    Err(_) => {
+                        let reason: &str = "unknown error code";
+                        warn!("do_fcntl(): {reason} (errno={errno:?})");
+                        ErrorCode::ValueOutOfRange
+                    },
+                };
                 Ok(crate::build_error(tid, error))
             }
         },
@@ -1017,8 +1110,14 @@ pub fn do_fcntl(
                 }
 
                 error!("libc::fcntl(): errno={errno:?} (cmd={cmd:#x?}, arg={libc_arg})");
-                let error: ErrorCode = ErrorCode::try_from(errno)
-                    .unwrap_or_else(|_| panic!("unknown error code {errno}"));
+                let error: ErrorCode = match ErrorCode::try_from(errno) {
+                    Ok(error) => error,
+                    Err(_) => {
+                        let reason: &str = "unknown error code";
+                        warn!("do_fcntl(): {reason} (errno={errno:?})");
+                        ErrorCode::ValueOutOfRange
+                    },
+                };
                 Ok(crate::build_error(tid, error))
             } else {
                 // The following statement is unreachable because `libc::fcntl()` should return
@@ -1080,9 +1179,15 @@ pub fn do_fchownat(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::fchownat(): errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::fchownat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_fchownat(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }
@@ -1167,9 +1272,15 @@ pub fn do_fchmodat(
                 return Err(WorkerThreadError::Interrupted);
             }
 
-            debug!("libc::fchmodat(): errno={errno:?}");
-            let error: ErrorCode =
-                ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+            error!("libc::fchmodat(): errno={errno:?}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_fchmodat(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }

--- a/src/daemons/linuxd/src/poll.rs
+++ b/src/daemons/linuxd/src/poll.rs
@@ -41,6 +41,7 @@ use ::syslog::{
     debug,
     error,
     trace,
+    warn,
 };
 
 //==================================================================================================
@@ -120,8 +121,14 @@ pub fn do_poll(
             }
 
             error!("poll(): errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_poll(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(vec![crate::build_error(tid, error)])
         },
     }

--- a/src/daemons/linuxd/src/socket.rs
+++ b/src/daemons/linuxd/src/socket.rs
@@ -72,6 +72,7 @@ use ::syslog::{
     debug,
     error,
     trace,
+    warn,
 };
 
 //==================================================================================================
@@ -108,8 +109,14 @@ pub fn do_socket(
             }
 
             error!("libc::socket(): failed with errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno)
-                .unwrap_or_else(|_| panic!("unknown error code {errno:?}"));
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_socket(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(crate::build_error(tid, error))
         },
         sockfd => {

--- a/src/daemons/linuxd/src/times.rs
+++ b/src/daemons/linuxd/src/times.rs
@@ -20,6 +20,7 @@ use ::syslog::{
     debug,
     error,
     trace,
+    warn,
 };
 
 //==================================================================================================
@@ -51,7 +52,14 @@ pub fn do_times(
             }
 
             error!("libc::clock_getres(): errno={errno:?}");
-            let error: ErrorCode = ErrorCode::try_from(errno).expect("unknown error code {error}");
+            let error: ErrorCode = match ErrorCode::try_from(errno) {
+                Ok(error) => error,
+                Err(_) => {
+                    let reason: &str = "unknown error code";
+                    warn!("do_times(): {reason} (errno={errno:?})");
+                    ErrorCode::ValueOutOfRange
+                },
+            };
             Ok(crate::build_error(tid, error))
         },
         elapsed => {

--- a/src/daemons/linuxd/src/unistd.rs
+++ b/src/daemons/linuxd/src/unistd.rs
@@ -309,9 +309,15 @@ pub fn do_getcwd(tid: ThreadIdentifier) -> Result<Vec<Message>, WorkerThreadErro
             return Err(WorkerThreadError::Interrupted);
         }
 
-        debug!("libc::getcwd(): errno={tid:?}");
-        let error: ErrorCode =
-            ErrorCode::try_from(errno).unwrap_or_else(|_| panic!("unknown error code {errno}"));
+        error!("libc::getcwd(): errno={errno:?}");
+        let error: ErrorCode = match ErrorCode::try_from(errno) {
+            Ok(error) => error,
+            Err(_) => {
+                let reason: &str = "unknown error code";
+                warn!("do_getcwd(): {reason} (errno={errno:?})");
+                ErrorCode::ValueOutOfRange
+            },
+        };
         Ok(vec![crate::build_error(tid, error)])
     }
 }


### PR DESCRIPTION
This pull request improves error handling in several Linux daemon modules by replacing panics and expects with graceful handling for unknown error codes. Instead of crashing when an unrecognized error code is encountered, the code now logs a warning and returns a standardized `ErrorCode::ValueOutOfRange`. Additionally, error logging is made more consistent by switching some messages from `debug!` to `error!`, and the `warn!` macro is introduced for logging unknown error codes.

**Error handling improvements:**

* Replaced all usages of `unwrap_or_else` and `expect` for error code conversion in functions like `do_openat`, `do_unlinkat`, `do_renameat`, `do_fstat_at`, and many others in `src/daemons/linuxd/src/fcntl.rs` with a match statement that logs a warning and returns `ErrorCode::ValueOutOfRange` for unknown error codes. [[1]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L198-R207) [[2]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L244-R259) [[3]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L302-R324) [[4]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L394-R424) [[5]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L423-R464) [[6]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L470-R511) [[7]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L554-R601) [[8]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L602-R655) [[9]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L662-R721) [[10]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L711-R776) [[11]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L773-R844) [[12]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L818-R895) [[13]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L923-R1005) [[14]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L944-R1032) [[15]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L989-R1083) [[16]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L1020-R1120) [[17]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L1083-R1190) [[18]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L1170-R1283)
* Applied the same error handling pattern to `do_poll` in `src/daemons/linuxd/src/poll.rs`, `do_socket` in `src/daemons/linuxd/src/socket.rs`, and `do_getdents` in `src/daemons/linuxd/src/dirent.rs`. [[1]](diffhunk://#diff-15109955375d32a5a5ba031a258cc48c11e23f67a5c998f661c4da4018c748d8L123-R131) [[2]](diffhunk://#diff-af0841366275aa69c082ed3f76cb08c46401da3f48580de9efb43c749da885e9L111-R119) [[3]](diffhunk://#diff-62ea281e709ac303b7bb76d6ccae10b185ac7a9a9fc08203c092b36648187d70L147-R154)

**Logging consistency:**

* Changed several error log levels from `debug!` to `error!` to better reflect the severity of system call failures throughout the affected modules. [[1]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L198-R207) [[2]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L244-R259) [[3]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L302-R324) [[4]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L394-R424) [[5]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L423-R464) [[6]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L470-R511) [[7]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L554-R601) [[8]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L602-R655) [[9]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L662-R721) [[10]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L711-R776) [[11]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L773-R844) [[12]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L818-R895) [[13]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L1083-R1190) [[14]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L1170-R1283)

**Macro imports:**

* Added the `warn` macro import to `src/daemons/linuxd/src/fcntl.rs`, `src/daemons/linuxd/src/poll.rs`, `src/daemons/linuxd/src/socket.rs`, and `src/daemons/linuxd/src/times.rs` to support the new warning log statements. [[1]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R144) [[2]](diffhunk://#diff-15109955375d32a5a5ba031a258cc48c11e23f67a5c998f661c4da4018c748d8R44) [[3]](diffhunk://#diff-af0841366275aa69c082ed3f76cb08c46401da3f48580de9efb43c749da885e9R75) [[4]](diffhunk://#diff-95884f838dd5189303055acf0dfc971789f11e208d6275ebc37c5b1a9ce460a2R23)

These changes make the daemon codebase more robust and maintainable by avoiding panics from unexpected error codes and providing clearer logging for system call failures.