### PR TITLE
[ci] Improving Testing Matrix Strategy

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -13,21 +13,15 @@ inputs:
     description: "Log level"
     required: true
     default: "trace"
+  machine-type:
+    description: "Machine type"
+    required: true
+    default: "qemu-pc"
 
 runs:
   using: "composite"
   steps:
-  - name: "Build (qemu-pc)"
+  - name: "Build (${{ inputs.machine-type }})"
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=qemu-pc --${{ inputs.release }} --build --sccache=${SCCACHE}
-    shell: bash
-
-  - name: "Build (microvm)"
-    run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=microvm --${{ inputs.release }} --build --sccache=${SCCACHE}
-    shell: bash
-
-  - name: "Build (hyperlight)"
-    run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=hyperlight --${{ inputs.release }} --build --sccache=${SCCACHE}
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --build --sccache=${SCCACHE}
     shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -17,11 +17,19 @@ inputs:
     description: "Machine type"
     required: true
     default: "qemu-pc"
+  deployment-type:
+    description: "Deployment type"
+    required: true
+    default: "single-process"
 
 runs:
   using: "composite"
   steps:
+  - id: deployment
+    uses: ./.github/actions/deployment-features
+    with:
+      deployment-type: "${{ inputs.deployment-type }}"
   - name: "Build (${{ inputs.machine-type }})"
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --build --sccache=${SCCACHE}
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --build --sccache=${SCCACHE} ${{ steps.deployment.outputs.features-arg }}
     shell: bash

--- a/.github/actions/deployment-features/action.yml
+++ b/.github/actions/deployment-features/action.yml
@@ -1,0 +1,34 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Resolve Deployment Features"
+description: "Compute feature flags for a given deployment type"
+
+inputs:
+  deployment-type:
+    description: "Deployment type"
+    required: true
+
+outputs:
+  features-arg:
+    description: "Feature flag argument for scripts/ci.py"
+    value: ${{ steps.compute.outputs.features-arg }}
+
+runs:
+  using: "composite"
+  steps:
+  - id: compute
+    shell: bash
+    run: |
+      case "${{ inputs.deployment-type }}" in
+        single-process)
+          echo "features-arg=--features SINGLE_PROCESS=yes" >> "$GITHUB_OUTPUT"
+          ;;
+        multi-process)
+          echo "features-arg=--features SINGLE_PROCESS=no" >> "$GITHUB_OUTPUT"
+          ;;
+        *)
+          echo "invalid deployment type: ${{ inputs.deployment-type }}" >&2
+          exit 1
+          ;;
+      esac

--- a/.github/actions/format/action.yml
+++ b/.github/actions/format/action.yml
@@ -17,11 +17,19 @@ inputs:
     description: "Machine type"
     required: true
     default: "qemu-pc"
+  deployment-type:
+    description: "Deployment type"
+    required: true
+    default: "single-process"
 
 runs:
   using: "composite"
   steps:
+  - id: deployment
+    uses: ./.github/actions/deployment-features
+    with:
+      deployment-type: "${{ inputs.deployment-type }}"
   - name: "format (${{ inputs.machine-type }})"
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --format
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --format ${{ steps.deployment.outputs.features-arg }}
     shell: bash

--- a/.github/actions/format/action.yml
+++ b/.github/actions/format/action.yml
@@ -13,21 +13,15 @@ inputs:
     description: "Log level"
     required: true
     default: "trace"
+  machine-type:
+    description: "Machine type"
+    required: true
+    default: "qemu-pc"
 
 runs:
   using: "composite"
   steps:
-  - name: "format (qemu-pc)"
+  - name: "format (${{ inputs.machine-type }})"
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=qemu-pc --${{ inputs.release }} --format
-    shell: bash
-
-  - name: "format (microvm)"
-    run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=microvm --${{ inputs.release }} --format
-    shell: bash
-
-  - name: "format (hyperlight)"
-    run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=hyperlight --${{ inputs.release }} --format
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --format
     shell: bash

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -17,11 +17,19 @@ inputs:
     description: "Machine type"
     required: true
     default: "qemu-pc"
+  deployment-type:
+    description: "Deployment type"
+    required: true
+    default: "single-process"
 
 runs:
   using: "composite"
   steps:
+  - id: deployment
+    uses: ./.github/actions/deployment-features
+    with:
+      deployment-type: "${{ inputs.deployment-type }}"
   - name: "Lint (${{ inputs.machine-type }})"
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --lint
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --lint ${{ steps.deployment.outputs.features-arg }}
     shell: bash

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -13,21 +13,15 @@ inputs:
     description: "Log level"
     required: true
     default: "trace"
+  machine-type:
+    description: "Machine type"
+    required: true
+    default: "qemu-pc"
 
 runs:
   using: "composite"
   steps:
-  - name: "Lint (qemu-pc)"
+  - name: "Lint (${{ inputs.machine-type }})"
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=qemu-pc --${{ inputs.release }} --lint
-    shell: bash
-
-  - name: "Lint (microvm)"
-    run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=microvm --${{ inputs.release }} --lint
-    shell: bash
-
-  - name: "Lint (hyperlight)"
-    run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=hyperlight --${{ inputs.release }} --lint
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --lint
     shell: bash

--- a/.github/actions/spellcheck/action.yml
+++ b/.github/actions/spellcheck/action.yml
@@ -17,11 +17,19 @@ inputs:
     description: "Machine type"
     required: true
     default: "qemu-pc"
+  deployment-type:
+    description: "Deployment type"
+    required: true
+    default: "single-process"
 
 runs:
   using: "composite"
   steps:
+  - id: deployment
+    uses: ./.github/actions/deployment-features
+    with:
+      deployment-type: "${{ inputs.deployment-type }}"
   - name: "Spellcheck (${{ inputs.machine-type }})"
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --spellcheck
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --spellcheck ${{ steps.deployment.outputs.features-arg }}
     shell: bash

--- a/.github/actions/spellcheck/action.yml
+++ b/.github/actions/spellcheck/action.yml
@@ -13,21 +13,15 @@ inputs:
     description: "Log level"
     required: true
     default: "trace"
+  machine-type:
+    description: "Machine type"
+    required: true
+    default: "qemu-pc"
 
 runs:
   using: "composite"
   steps:
-  - name: "Spellcheck (qemu-pc)"
+  - name: "Spellcheck (${{ inputs.machine-type }})"
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=qemu-pc --${{ inputs.release }} --spellcheck
-    shell: bash
-
-  - name: "Spellcheck (microvm)"
-    run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=microvm --${{ inputs.release }} --spellcheck
-    shell: bash
-
-  - name: "Spellcheck (hyperlight)"
-    run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=hyperlight --${{ inputs.release }} --spellcheck
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --spellcheck
     shell: bash

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -13,21 +13,15 @@ inputs:
     description: "Log level"
     required: true
     default: "trace"
+  machine-type:
+    description: "Machine type"
+    required: true
+    default: "qemu-pc"
 
 runs:
   using: "composite"
   steps:
-  - name: "Test (qemu-pc)"
+  - name: "Test (${{ inputs.machine-type }})"
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=qemu-pc --${{ inputs.release }} --test
-    shell: bash
-
-  - name: "Test (microvm)"
-    run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=microvm --${{ inputs.release }} --test
-    shell: bash
-
-  - name: "Test (hyperlight)"
-    run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=hyperlight --${{ inputs.release }} --test
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --test
     shell: bash

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -17,11 +17,19 @@ inputs:
     description: "Machine type"
     required: true
     default: "qemu-pc"
+  deployment-type:
+    description: "Deployment type"
+    required: true
+    default: "single-process"
 
 runs:
   using: "composite"
   steps:
+  - id: deployment
+    uses: ./.github/actions/deployment-features
+    with:
+      deployment-type: "${{ inputs.deployment-type }}"
   - name: "Test (${{ inputs.machine-type }})"
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --test
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=${{ inputs.log-level }} --target-machine=${{ inputs.machine-type }} --${{ inputs.release }} --test ${{ steps.deployment.outputs.features-arg }}
     shell: bash

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         build-type: [debug, release]
-        arch: [X64]
+        machine-type: [qemu-pc, microvm, hyperlight]
     runs-on: [self-hosted, Linux, X64]
 
     # Only run the CI for:
@@ -66,33 +66,38 @@ jobs:
       with:
         release: '${{ matrix.build-type }}'
         log-level: 'trace'
+        machine-type: '${{ matrix.machine-type }}'
 
     - name: "Lint"
       uses: ./.github/actions/lint
       with:
         release: '${{ matrix.build-type }}'
         log-level: 'trace'
+        machine-type: '${{ matrix.machine-type }}'
     - name: "Spellcheck"
       uses: ./.github/actions/spellcheck
       with:
         release: '${{ matrix.build-type }}'
         log-level: 'trace'
+        machine-type: '${{ matrix.machine-type }}'
     - name: "Build"
       uses: ./.github/actions/build
       with:
         release: '${{ matrix.build-type }}'
         log-level: 'trace'
+        machine-type: '${{ matrix.machine-type }}'
     - name: "Test"
       uses: ./.github/actions/test
       with:
         release: '${{ matrix.build-type }}'
         log-level: 'trace'
+        machine-type: '${{ matrix.machine-type }}'
 
     - name: "Upload logs in case of failures"
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: nanvix-ci-logs-${{ github.event.pull_request.number || github.run_number }}-${{ matrix.build-type }}-${{ matrix.arch }}
+        name: nanvix-ci-logs-${{ github.event.pull_request.number || github.run_number }}-${{ matrix.build-type }}-${{ matrix.machine-type }}
         # Overwrite to limit the amount of storage we use.
         overwrite: 'true'
         path: |

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -40,6 +40,10 @@ jobs:
       matrix:
         build-type: [debug, release]
         machine-type: [qemu-pc, microvm, hyperlight]
+        deployment-type: [single-process, multi-process]
+        exclude:
+          - machine-type: qemu-pc
+            deployment-type: single-process
     runs-on: [self-hosted, Linux, X64]
 
     # Only run the CI for:
@@ -67,6 +71,7 @@ jobs:
         release: '${{ matrix.build-type }}'
         log-level: 'trace'
         machine-type: '${{ matrix.machine-type }}'
+        deployment-type: '${{ matrix.deployment-type }}'
 
     - name: "Lint"
       uses: ./.github/actions/lint
@@ -74,24 +79,28 @@ jobs:
         release: '${{ matrix.build-type }}'
         log-level: 'trace'
         machine-type: '${{ matrix.machine-type }}'
+        deployment-type: '${{ matrix.deployment-type }}'
     - name: "Spellcheck"
       uses: ./.github/actions/spellcheck
       with:
         release: '${{ matrix.build-type }}'
         log-level: 'trace'
         machine-type: '${{ matrix.machine-type }}'
+        deployment-type: '${{ matrix.deployment-type }}'
     - name: "Build"
       uses: ./.github/actions/build
       with:
         release: '${{ matrix.build-type }}'
         log-level: 'trace'
         machine-type: '${{ matrix.machine-type }}'
+        deployment-type: '${{ matrix.deployment-type }}'
     - name: "Test"
       uses: ./.github/actions/test
       with:
         release: '${{ matrix.build-type }}'
         log-level: 'trace'
         machine-type: '${{ matrix.machine-type }}'
+        deployment-type: '${{ matrix.deployment-type }}'
 
     - name: "Upload logs in case of failures"
       if: failure()

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -74,7 +74,7 @@ mkdir -p "${LOGS_DIR}"
 
 # Run nanvixd.
 CONSOLE_FILE_NAME="${LOGS_DIR}/kernel_$(date "+%Y_%m_%d_%H_%M").log"
-RUST_LOG=trace setsid timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
+RUST_LOG=trace,hyperlight_host=none setsid timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
     ./bin/nanvixd.elf \
         -http-addr "${NANVIXD_SOCKADDR}" \
         -toolchain-bin-dir "${TOOLCHAIN_DIR}/bin" \


### PR DESCRIPTION
This pull request refactors the CI workflow to support configurable machine and deployment types, improving flexibility and maintainability. It introduces a new reusable action for deployment feature flags, consolidates repetitive steps, and updates the matrix strategy to test multiple machine and deployment combinations. The changes also propagate these new parameters through all major CI actions.

**Workflow and CI Refactoring**

* The matrix strategy in `.github/workflows/self-hosted-ci.yml` now tests all combinations of `machine-type` (`qemu-pc`, `microvm`, `hyperlight`) and `deployment-type` (`single-process`, `multi-process`), except for `qemu-pc` with `single-process`. This enables broader test coverage and simpler configuration management.
* All workflow steps now pass `machine-type` and `deployment-type` as inputs to the respective actions, ensuring consistent parameterization and easier future extensibility.

**Reusable Deployment Feature Flags**

* A new composite action `.github/actions/deployment-features/action.yml` computes feature flags for the selected deployment type, encapsulating logic that was previously duplicated across actions. This makes the workflow more maintainable and less error-prone.

**Action Simplification and Parameterization**

* The `build`, `lint`, `format`, `spellcheck`, and `test` actions now accept `machine-type` and `deployment-type` as inputs, replacing hardcoded steps for each machine type. They use the new deployment features action to set feature flags, streamlining the workflow and reducing code duplication. [[1]](diffhunk://#diff-ec444582781b87b7476f7da1be059db3757d1b8a5c33cbe8fd1e72490844cd2fR16-R34) [[2]](diffhunk://#diff-b75b025d551d3387aae641b07b3d675985802e588607716e79373d0c3adceae8R16-R34) [[3]](diffhunk://#diff-039208ff8a5a69368437b8f6cbcd9a468bb34f57d69e14d4c10b02dd6f1215a1R16-R34) [[4]](diffhunk://#diff-9d68f16100920cc1a0d76a1d7226920a86152fb20d8a2317de25709d4d824939R16-R34) [[5]](diffhunk://#diff-5974b1414e7008ac39b09a92a4292e54ea57a0c61043cf1d4f0520792733a73cR16-R34)

**Minor Logging Update**

* The `scripts/test-nanvixd.sh` script sets the `RUST_LOG` environment variable to include `hyperlight_host=none`, likely to suppress specific logs for improved clarity during CI runs.