### PR TITLE
[utils] Don't Bail on Nanvix Daemon Cleanup

### DIFF
--- a/src/utils/nanvixd/src/cache.rs
+++ b/src/utils/nanvixd/src/cache.rs
@@ -285,11 +285,7 @@ impl SandboxCache {
 
         if let Some(mut user_vm) = self.user_vm_instances.remove(tag) {
             if let Some(user_vm_mut) = Arc::get_mut(&mut user_vm) {
-                if let Err(e) = user_vm_mut.shutdown().await {
-                    error!("error shutting down user VM (tag={tag:?}, error={e:?})");
-                } else {
-                    debug!("shut down user VM (tag={tag:?})");
-                }
+                user_vm_mut.shutdown().await;
             } else {
                 error!("error shutting down user VM: cannot get mut (tag={tag:?})");
             }
@@ -317,11 +313,7 @@ impl SandboxCache {
             debug!("cleaning user vm instance (tag={tag:?})");
             if let Some(user_vm_instance_mut) = Arc::get_mut(user_vm_instance) {
                 debug!("sending shutdown message to user vm (tag={tag:?})");
-                if let Err(e) = user_vm_instance_mut.shutdown().await {
-                    error!("error cleaning-up user vm instance (tag={tag:?}, error={e:?})");
-                } else {
-                    debug!("cleaned-up user vm instance (tag={tag:?})");
-                }
+                user_vm_instance_mut.shutdown().await;
             } else {
                 error!("error cleaning-up user vm instance: not found (tag={tag:?})");
             }

--- a/src/utils/nanvixd/src/cache.rs
+++ b/src/utils/nanvixd/src/cache.rs
@@ -323,13 +323,7 @@ impl SandboxCache {
         for (tenant_id, linuxd_instance) in self.linuxd_instances.iter_mut() {
             debug!("cleaning linuxd instance (tenant_id={tenant_id:?})");
             if let Some(linuxd_instance_mut) = Arc::get_mut(linuxd_instance) {
-                if let Err(e) = linuxd_instance_mut.shutdown().await {
-                    error!(
-                        "error cleaning-up linuxd instance (tenant_id={tenant_id}, error={e:?})"
-                    );
-                } else {
-                    debug!("cleaned-up linuxd instance (tenant_id={tenant_id})");
-                }
+                linuxd_instance_mut.shutdown().await;
             } else {
                 error!("error cleaning-up linuxd instance: not found (tenant_id={tenant_id})");
             }

--- a/src/utils/nanvixd/src/sandbox/multi_process/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/multi_process/linuxd.rs
@@ -20,7 +20,10 @@ use ::linuxd::{
     args,
     config::restore_gate_sockaddr_builder,
 };
-use ::std::process::Stdio;
+use ::std::{
+    mem,
+    process::Stdio,
+};
 use ::syscomm::{
     ReadExact,
     SocketListener,
@@ -33,6 +36,7 @@ use ::syslog::{
     debug,
     error,
     trace,
+    warn,
 };
 use ::tokio::{
     process::{
@@ -256,13 +260,27 @@ impl LinuxDaemon {
         })
     }
 
-    /// Send a shutdown message to linuxd so that it can clean-up its internal resources.
-    pub async fn shutdown(&mut self) -> Result<()> {
-        let msg: NanvixdControlMessage = NanvixdControlMessage::new(NanvixdCommand::Shutdown);
-        let mut msg_bytes: [u8; size_of::<NanvixdControlMessage>()] =
-            [0u8; size_of::<NanvixdControlMessage>()];
-        msg.to_bytes(&mut msg_bytes);
-        self.control_plane_stream.write_all(&msg_bytes).await?;
+    ///
+    /// # Description
+    ///
+    /// Shuts down the Linux Daemon instance.
+    ///
+    pub async fn shutdown(&mut self) {
+        trace!("shutdown()");
+
+        // Prepare shutdown message.
+        let msg_bytes: [u8; mem::size_of::<NanvixdControlMessage>()] = {
+            let msg: NanvixdControlMessage = NanvixdControlMessage::new(NanvixdCommand::Shutdown);
+            let mut msg_bytes: [u8; mem::size_of::<NanvixdControlMessage>()] =
+                [0u8; ::std::mem::size_of::<NanvixdControlMessage>()];
+            msg.to_bytes(&mut msg_bytes);
+            msg_bytes
+        };
+
+        // Send shutdown command to Linux Daemon.
+        if let Err(error) = self.control_plane_stream.write_all(&msg_bytes).await {
+            warn!("shutdown(): failed to send shutdown command to linuxd (error={error:?})");
+        }
 
         // Wait for linuxd instance to finish.
         match timeout(
@@ -273,23 +291,20 @@ impl LinuxDaemon {
         {
             Ok(Ok(exit_status)) => {
                 if !exit_status.success() {
-                    error!(
-                        "linuxd returned with non-zero exit status (status={:?})",
+                    warn!(
+                        "shutdown(): linuxd returned with non-zero exit status (status={:?})",
                         exit_status.code()
                     );
-                    Self::send_sigkill_to_child(&self.child);
                 }
             },
-            Ok(Err(e)) => {
-                error!("error waiting for linuxd: {e:?}");
+            Ok(Err(error)) => {
+                warn!("shutdown(): error waiting for linuxd (error={error:?})");
                 Self::send_sigkill_to_child(&self.child);
             },
-            Err(e) => {
-                error!("timed-out waiting for linuxd (error={e:?})");
+            Err(elapsed) => {
+                warn!("shutdown(): timed-out waiting for linuxd (error={elapsed:?})");
                 Self::send_sigkill_to_child(&self.child);
             },
         }
-
-        Ok(())
     }
 }

--- a/src/utils/nanvixd/src/sandbox/multi_process/uservm.rs
+++ b/src/utils/nanvixd/src/sandbox/multi_process/uservm.rs
@@ -17,7 +17,10 @@ use ::control_plane_api::{
     NanvixdCommand,
     NanvixdControlMessage,
 };
-use ::std::process::Stdio;
+use ::std::{
+    mem,
+    process::Stdio,
+};
 use ::syscomm::{
     SocketListener,
     SocketStream,
@@ -27,6 +30,7 @@ use ::syslog::{
     debug,
     error,
     trace,
+    warn,
 };
 use ::tokio::{
     process::{
@@ -198,40 +202,49 @@ impl UserVm {
     ///
     /// # Description
     ///
-    /// Send a shutdown message to the user VM's control-plane socket so that it can gracefully
-    /// shutdown, and wait until the process dies.
+    /// Shuts down the User VM instance.
     ///
-    pub async fn shutdown(&mut self) -> Result<()> {
-        let msg: NanvixdControlMessage = NanvixdControlMessage::new(NanvixdCommand::Shutdown);
-        let mut msg_bytes: [u8; std::mem::size_of::<NanvixdControlMessage>()] =
-            [0u8; std::mem::size_of::<NanvixdControlMessage>()];
-        msg.to_bytes(&mut msg_bytes);
-        self.control_plane_stream.write_all(&msg_bytes).await?;
+    pub async fn shutdown(&mut self) {
+        trace!("shutdown()");
+
+        // Prepare shutdown message.
+        let msg_bytes: [u8; mem::size_of::<NanvixdControlMessage>()] = {
+            let msg: NanvixdControlMessage = NanvixdControlMessage::new(NanvixdCommand::Shutdown);
+            let mut msg_bytes: [u8; mem::size_of::<NanvixdControlMessage>()] =
+                [0u8; ::std::mem::size_of::<NanvixdControlMessage>()];
+            msg.to_bytes(&mut msg_bytes);
+            msg_bytes
+        };
+
+        // Send shutdown command to User VM.
+        if let Err(e) = self.control_plane_stream.write_all(&msg_bytes).await {
+            warn!("shutdown(): failed to send shutdown command to embedded user VM (error={e:?})");
+        }
 
         // Wait for user VM instance to finish.
         if let Some(mut child) = self.child.take() {
             match timeout(CLEANUP_TIMEOUT, child.wait()).await {
                 Ok(Ok(exit_status)) => {
                     if !exit_status.success() {
-                        error!(
-                            "user VM returned with non-zero exit status (code={:?})",
+                        warn!(
+                            "shutdown(): user VM returned with non-zero exit status (code={:?})",
                             exit_status.code()
                         );
                     }
                 },
                 // If we encounter any errors while waiting for the user VM to gracefully shutdown,
                 // make sure we kill the underlying instance.
-                Ok(Err(e)) => {
-                    error!("error waiting for user VM (error={e:?})");
+                Ok(Err(error)) => {
+                    warn!("shutdown(): user VM terminated with error (error={error:?})");
                     Self::send_sigkill_to_child(child);
                 },
-                Err(e) => {
-                    error!("timed-out waiting for user VM (error={e:?})");
+                Err(elapsed) => {
+                    warn!(
+                        "shutdown(): timed-out waiting for user VM to shutdown (error={elapsed:?})"
+                    );
                     Self::send_sigkill_to_child(child);
                 },
             }
         }
-
-        Ok(())
     }
 }

--- a/src/utils/nanvixd/src/sandbox/single_process/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/single_process/linuxd.rs
@@ -179,12 +179,7 @@ impl LinuxDaemon {
     ///
     /// Shuts down the Linux Daemon instance.
     ///
-    /// # Return Value
-    ///
-    /// On success this function returns a future that, when resolved, indicates that the Linux
-    /// Daemon has been shutdown. On failure, this function returns an error object instead.
-    ///
-    pub async fn shutdown(&mut self) -> Result<()> {
+    pub async fn shutdown(&mut self) {
         trace!("shutdown()");
 
         // Prepare shutdown message.
@@ -198,14 +193,10 @@ impl LinuxDaemon {
 
         // Send shutdown command to Linux Daemon.
         if let Err(error) = self.control_plane_stream.write_all(&msg_bytes).await {
-            let reason: String =
-                format!("failed to send shutdown command to linuxd (error={error:?})");
-            error!("shutdown(): {reason}");
-            return Err(anyhow::anyhow!(reason));
+            warn!("shutdown(): failed to send shutdown command to linuxd (error={error:?})");
         }
 
         // Wait for the Linux Daemon to finish.
-        // NOTE: Don't bail out if we fail to keep same behavior as multi-process implementation.
         if let Some(linuxd_task) = self.linuxd_task.lock().await.take() {
             match timeout(
                 Duration::from_secs(::config::syscomm::SHUTDOWN_TIMEOUT_SECS),
@@ -216,21 +207,19 @@ impl LinuxDaemon {
                 Ok(join_result) => match join_result {
                     Ok(Ok(())) => {},
                     Ok(Err(error)) => {
-                        error!("shutdown(): linuxd terminated with error (error={error:?})");
+                        warn!("shutdown(): linuxd terminated with error (error={error:?})");
                     },
                     Err(join_error) => {
-                        error!("shutdown(): linuxd task panicked (error={join_error:?})");
+                        warn!("shutdown(): failed to join linuxd task (error={join_error:?})");
                     },
                 },
                 Err(elapsed) => {
-                    error!(
+                    warn!(
                         "shutdown(): timed-out waiting for linuxd to shutdown \
                          (elapsed={elapsed:?})"
                     );
                 },
             }
         }
-
-        Ok(())
     }
 }

--- a/src/utils/nanvixd/src/sandbox/single_process/uservm.rs
+++ b/src/utils/nanvixd/src/sandbox/single_process/uservm.rs
@@ -309,12 +309,7 @@ impl UserVm {
     ///
     /// Shuts down the User VM instance.
     ///
-    /// # Return Value
-    ///
-    /// On success this function returns a future that, when resolved, indicates that the User VM
-    /// has been shutdown. On failure, this function returns an error object instead.
-    ///
-    pub async fn shutdown(&mut self) -> Result<()> {
+    pub async fn shutdown(&mut self) {
         trace!("shutdown()");
 
         // Prepare shutdown message.
@@ -328,43 +323,37 @@ impl UserVm {
 
         // Send shutdown command to User VM.
         if let Err(e) = self.control_plane_stream.write_all(&msg_bytes).await {
-            let reason: String =
-                format!("failed to send shutdown command to embedded user VM (error={e:?})");
-            error!("shutdown(): {reason}");
-            return Err(anyhow::anyhow!("{reason}"));
+            warn!("shutdown(): failed to send shutdown command to embedded user VM (error={e:?})");
         }
 
         // Wait for User VM to finish.
-        // NOTE: Don't bail out if we fail to keep same behavior as multi-process implementation.
         if let Some(task) = self.task.lock().await.take() {
             match timeout(crate::config::CLEANUP_TIMEOUT, task).await {
                 Ok(join_result) => match join_result {
                     Ok(Ok(exit_status)) => {
                         if exit_status != ExitCode::SUCCESS {
-                            error!(
+                            warn!(
                                 "shutdown(): user VM returned with non-zero exit status \
                                  (code={exit_status:?})",
                             );
                         }
                     },
                     Ok(Err(error)) => {
-                        error!(
+                        warn!(
                             "shutdown(): embedded user VM terminated with error (error={error:?})"
                         );
                     },
                     Err(join_error) => {
-                        error!("shutdown(): embedded user VM task panicked (error={join_error:?})");
+                        warn!("shutdown(): embedded user VM task panicked (error={join_error:?})");
                     },
                 },
                 Err(elapsed) => {
-                    error!(
+                    warn!(
                         "shutdown(): timed-out waiting for embedded user VM to shutdown \
                          (error={elapsed:?})"
                     );
                 },
             }
         }
-
-        Ok(())
     }
 }


### PR DESCRIPTION
This pull request refactors the shutdown logic for both User VM and Linux Daemon instances across single-process and multi-process implementations. The main focus is to simplify error handling by making shutdown methods infallible (they no longer return a `Result`) and to downgrade most shutdown-related errors from `error!` to `warn!` log level for better clarity and consistency. Additionally, some minor code cleanups and import adjustments are included.

Key changes:

**Refactoring shutdown methods and error handling:**

* Changed the `shutdown` methods in `UserVm` and `LinuxDaemon` (in both single-process and multi-process modules) to be infallible (`async fn shutdown(&mut self)`) and removed all `Result` returns. All errors during shutdown are now logged as warnings instead of errors. [[1]](diffhunk://#diff-8961e3444f9a6579deb9c0826172b5dc7e8a1eecbded6b205200574cc0346a7fL259-R283) [[2]](diffhunk://#diff-24e3eb421e540c82226f820701eb4a71c7df4313c3150b12918ded47c9ee64a4L201-L235) [[3]](diffhunk://#diff-d287d257f00f04a0e291647a437f343501149699371ff6573f1ba806467ac334L182-R182) [[4]](diffhunk://#diff-d5dc02de184ac8391ebad219843972ceaedd86ad9c7f95adb7a4b22d836c6113L312-R312)

* Updated all call sites in `SandboxCache` to use the new infallible shutdown methods, removing error handling logic for shutdown calls. [[1]](diffhunk://#diff-aca9479ce2ada6213ec66b6f760b1811001decbb73a7a64a82950db282ddb6a1L288-R288) [[2]](diffhunk://#diff-aca9479ce2ada6213ec66b6f760b1811001decbb73a7a64a82950db282ddb6a1L320-R316) [[3]](diffhunk://#diff-aca9479ce2ada6213ec66b6f760b1811001decbb73a7a64a82950db282ddb6a1L334-R326)

**Logging improvements:**

* Changed most shutdown-related `error!` log messages to `warn!` to reflect that errors during shutdown are not fatal and to reduce noise in logs. [[1]](diffhunk://#diff-8961e3444f9a6579deb9c0826172b5dc7e8a1eecbded6b205200574cc0346a7fL276-L293) [[2]](diffhunk://#diff-24e3eb421e540c82226f820701eb4a71c7df4313c3150b12918ded47c9ee64a4L201-L235) [[3]](diffhunk://#diff-d287d257f00f04a0e291647a437f343501149699371ff6573f1ba806467ac334L201-L208) [[4]](diffhunk://#diff-d287d257f00f04a0e291647a437f343501149699371ff6573f1ba806467ac334L219-L234) [[5]](diffhunk://#diff-d5dc02de184ac8391ebad219843972ceaedd86ad9c7f95adb7a4b22d836c6113L331-L368)

**Code cleanup and imports:**

* Added missing imports for `mem` and `warn` where necessary, and cleaned up unused or redundant code in the affected files. [[1]](diffhunk://#diff-8961e3444f9a6579deb9c0826172b5dc7e8a1eecbded6b205200574cc0346a7fL23-R26) [[2]](diffhunk://#diff-8961e3444f9a6579deb9c0826172b5dc7e8a1eecbded6b205200574cc0346a7fR39) [[3]](diffhunk://#diff-24e3eb421e540c82226f820701eb4a71c7df4313c3150b12918ded47c9ee64a4L20-R23) [[4]](diffhunk://#diff-24e3eb421e540c82226f820701eb4a71c7df4313c3150b12918ded47c9ee64a4R33)

These changes make the shutdown process more robust and the code easier to maintain by treating shutdown as a best-effort operation and ensuring consistent logging across the codebase.