### PR TITLE
[kernel] Use `HostPrint` in in Hyperlight `puts()` Function

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -37,7 +37,6 @@ default = ["microvm"]
 # Machine Types
 hyperlight = [
     "arch/hyperlight",
-    "putb",
     "puts",
     "stdio",
     "acpi",

--- a/src/kernel/src/hal/platform/hyperlight/peb.rs
+++ b/src/kernel/src/hal/platform/hyperlight/peb.rs
@@ -14,7 +14,10 @@
 // Imports
 //==================================================================================================
 
-use ::alloc::vec::Vec;
+use ::alloc::{
+    string::ToString,
+    vec::Vec,
+};
 use ::hyperlight_common::{
     flatbuffer_wrappers::function_types::{
         ParameterValue,
@@ -22,21 +25,11 @@ use ::hyperlight_common::{
     },
     mem::HyperlightPEB,
 };
-use ::hyperlight_guest::{
-    exit::debug_print,
-    guest_handle::handle::GuestHandle,
-};
+use ::hyperlight_guest::guest_handle::handle::GuestHandle;
 use ::sys::error::{
     Error,
     ErrorCode,
 };
-
-//==================================================================================================
-// Structures
-//==================================================================================================
-
-#[derive(Debug)]
-pub struct ProcessEnvironmentBlock;
 
 //==================================================================================================
 // Global Variables
@@ -44,9 +37,18 @@ pub struct ProcessEnvironmentBlock;
 
 pub(crate) static mut GUEST_HANDLE: GuestHandle = GuestHandle::new();
 
+/// Buffer used to store messages before the PEB is initialized.
+static mut OUTPUT_BUFFER: Buffer = Buffer {
+    data: [0; Buffer::CAPACITY],
+    len: 0,
+};
+
 //==================================================================================================
-// Implementations
+// Process Environment Block
 //==================================================================================================
+
+#[derive(Debug)]
+pub struct ProcessEnvironmentBlock;
 
 impl ProcessEnvironmentBlock {
     /// Initializes the process environment block.
@@ -60,6 +62,7 @@ impl ProcessEnvironmentBlock {
             Err(Error::new(ErrorCode::ResourceBusy, reason))
         } else {
             GUEST_HANDLE = GuestHandle::init(peb_base);
+            OUTPUT_BUFFER.flush(&mut |s: &str| Self::host_print(s))?;
             Ok(())
         }
     }
@@ -87,7 +90,13 @@ impl ProcessEnvironmentBlock {
     /// # Safety
     /// This function is unsafe because it uses raw asm under the hood.
     pub unsafe fn puts(message: &str) -> Result<(), Error> {
-        debug_print(message);
+        // Check if PEB is not initialized to decide whether to buffer the message.
+        if GUEST_HANDLE.peb().is_none() {
+            return OUTPUT_BUFFER.append(message);
+        }
+
+        Self::host_print(message);
+
         Ok(())
     }
 
@@ -142,5 +151,109 @@ impl ProcessEnvironmentBlock {
         GUEST_HANDLE
             .call_host_function::<Vec<u8>>("VmbusRead", None, ReturnType::VecBytes)
             .map_err(|_| Error::new(ErrorCode::IoErr, failure_reason))
+    }
+
+    /// Writes a string to the host's standard output.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it uses a static mutable variable.
+    unsafe fn host_print(message: &str) {
+        let _ = GUEST_HANDLE.call_host_function::<i32>(
+            "HostPrint",
+            Some(Vec::from(&[ParameterValue::String(message.to_string())])),
+            ReturnType::Int,
+        );
+    }
+}
+
+//==================================================================================================
+// Buffer
+//==================================================================================================
+
+/// A fixed-size buffer for storing output messages.
+struct Buffer {
+    /// Underlying data.
+    data: [u8; Self::CAPACITY],
+    /// Current length.
+    len: usize,
+}
+
+impl Buffer {
+    /// Buffer capacity.
+    const CAPACITY: usize = 512;
+
+    ///
+    /// # Description
+    ///
+    /// Appends a message to the buffer.
+    ///
+    /// # Parameters
+    ///
+    /// - `message`: Message to append.
+    ///
+    /// # Return Value
+    ///
+    /// On success, this function returns an empty tuple. On failure, it returns an object that
+    /// describes the error.
+    ///
+    /// # Notes
+    ///
+    /// - This function intentionally does not write to the log to avoid recursive calls.
+    ///
+    fn append(&mut self, message: &str) -> Result<(), Error> {
+        let message_bytes: &[u8] = message.as_bytes();
+
+        // Check if the message does not fit in the buffer.
+        if message_bytes.len() > Self::CAPACITY {
+            return Err(Error::new(ErrorCode::MessageTooLong, "message too long"));
+        }
+
+        // Check if there is not enough space in the buffer.
+        if self.len + message_bytes.len() > Self::CAPACITY {
+            return Err(Error::new(ErrorCode::NoSpaceOnDevice, "buffer full"));
+        }
+
+        self.data[self.len..self.len + message_bytes.len()].copy_from_slice(message_bytes);
+        self.len += message_bytes.len();
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Flushes the buffer using the provided write function.
+    ///
+    /// # Parameters
+    ///
+    /// - `write_fn`: Function used to write the buffered data.
+    ///
+    /// # Return Value
+    ///
+    /// On success, this function returns an empty tuple. On failure, it returns an object that
+    /// describes the error.
+    ///
+    /// # Notes
+    ///
+    /// - This function intentionally does not write to the log to avoid recursive calls.
+    ///
+    fn flush(&mut self, write_fn: &mut dyn FnMut(&str)) -> Result<(), Error> {
+        // Check if there is nothing to flush.
+        if self.len == 0 {
+            return Ok(());
+        }
+
+        // Convert the buffered data to a string.
+        let buffered_message: &str =
+            ::core::str::from_utf8(&self.data[..self.len]).map_err(|_| {
+                Error::new(ErrorCode::InvalidArgument, "puts: buffered data is not valid UTF-8")
+            })?;
+
+        // Write the buffered message using the provided function.
+        write_fn(buffered_message);
+        self.len = 0;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Description

This PR changes the implementation of `puts()` for Hyperlgiht to use the `HostPrint` function, fixing the log pollution.