### PR TITLE
[ci] Skip CI On Merge Commits

### DIFF
--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -42,20 +42,26 @@ jobs:
     runs-on: [self-hosted, Linux, X64, baremetal]
 
     # Only run the benchmark for:
-    # - Pushes to 'dev' (handled by workflow triggers above)
+    # - Non-merge pushes to 'dev'.
     # - Non-draft PRs where the source branch starts with one of:
     #     'enhancement-', 'feature-', 'bugfix-', or 'copilot/' (skip dependabot PRs)
     if: |
-      (github.event_name != 'pull_request' || (
-        !github.event.pull_request.draft &&
-        !startsWith(github.head_ref, 'dependabot/') &&
-        !startsWith(github.head_ref, 'dependabot-') && (
-          startsWith(github.head_ref, 'enhancement-') ||
-          startsWith(github.head_ref, 'feature-') ||
-          startsWith(github.head_ref, 'bugfix-') ||
-          startsWith(github.head_ref, 'copilot/')
+      (
+        github.event_name != 'push' ||
+        github.event.head_commit == null ||
+        !startsWith(github.event.head_commit.message, 'Merge ')
+      ) && (
+        github.event_name != 'pull_request' || (
+          !github.event.pull_request.draft &&
+          !startsWith(github.head_ref, 'dependabot/') &&
+          !startsWith(github.head_ref, 'dependabot-') && (
+            startsWith(github.head_ref, 'enhancement-') ||
+            startsWith(github.head_ref, 'feature-') ||
+            startsWith(github.head_ref, 'bugfix-') ||
+            startsWith(github.head_ref, 'copilot/')
+          )
         )
-      )) && needs.precheck.outputs.up_to_date == 'true'
+      ) && needs.precheck.outputs.up_to_date == 'true'
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -47,20 +47,26 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
 
     # Only run the CI for:
-    # - Pushes to 'dev' (handled by workflow triggers above)
+    # - Non-merge pushes to 'dev'.
     # - Non-draft PRs where the source branch starts with one of:
     #     'enhancement-', 'feature-', 'bugfix-', 'dependabot-', 'dependabot/', or 'copilot/'
     if: |
-      (github.event_name != 'pull_request' || (
-        !github.event.pull_request.draft && (
-          startsWith(github.head_ref, 'enhancement-') ||
-          startsWith(github.head_ref, 'feature-') ||
-          startsWith(github.head_ref, 'bugfix-') ||
-          startsWith(github.head_ref, 'dependabot-') ||
-          startsWith(github.head_ref, 'dependabot/') ||
-          startsWith(github.head_ref, 'copilot/')
+      (
+        github.event_name != 'push' ||
+        github.event.head_commit == null ||
+        !startsWith(github.event.head_commit.message, 'Merge ')
+      ) && (
+        github.event_name != 'pull_request' || (
+          !github.event.pull_request.draft && (
+            startsWith(github.head_ref, 'enhancement-') ||
+            startsWith(github.head_ref, 'feature-') ||
+            startsWith(github.head_ref, 'bugfix-') ||
+            startsWith(github.head_ref, 'dependabot-') ||
+            startsWith(github.head_ref, 'dependabot/') ||
+            startsWith(github.head_ref, 'copilot/')
+          )
         )
-      )) && needs.precheck.outputs.up_to_date == 'true'
+      ) && needs.precheck.outputs.up_to_date == 'true'
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
This pull request updates the workflow conditions in both the `self-hosted-benchmark` and `self-hosted-ci` GitHub Actions workflows to improve when jobs are triggered. The main goal is to prevent unnecessary workflow runs on merge commits from push events, ensuring that jobs only run on relevant commits or pull requests.

Key changes by theme:

**Workflow trigger logic improvements:**

* Added a condition to the `precheck` job in both `.github/workflows/self-hosted-benchmark.yml` and `.github/workflows/self-hosted-ci.yml` to skip execution if the event is a push with a merge commit message, reducing redundant runs on merge commits. [[1]](diffhunk://#diff-331a9af7ea0111e347b5a567d95dbb846cab81450473315ff4a7031a956144efR31-R34) [[2]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811R31-R34)
* Updated the main job conditions in both workflow files to incorporate the new merge commit check, ensuring that jobs only proceed for relevant push and pull request events. [[1]](diffhunk://#diff-331a9af7ea0111e347b5a567d95dbb846cab81450473315ff4a7031a956144efL49-R58) [[2]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811L54-R63)
* Adjusted the logical grouping and indentation of the conditions for better readability and correctness, aligning the checks for branch prefixes and draft status with the new merge commit logic. [[1]](diffhunk://#diff-331a9af7ea0111e347b5a567d95dbb846cab81450473315ff4a7031a956144efL58-R68) [[2]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811L63-R73)