### PR TITLE
[scripts] Use run-nanvixd.sh in test-nanvixd.sh

### DIFF
--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -35,30 +35,6 @@ fi
 LOGS_DIR=${NANVIX_HOME}/logs/nanvixd-$(basename "${PROGRAM_NAME}")
 
 #===================================================================================================
-# Helper functions
-#===================================================================================================
-
-MAX_TRIALS=100
-SLEEP_INTERVAL=0.1
-
-wait_for_tcp_socket() {
-    local host=$1
-    local port=$2
-
-    for i in $(seq 1 $MAX_TRIALS); do
-        print_info "Waiting for TCP socket at $host:$port..."
-        sleep ${SLEEP_INTERVAL}
-
-        if nc -z "${host}" "${port}" 2>/dev/null; then
-            print_info "TCP socket ready after $(echo "${i} * ${SLEEP_INTERVAL}" | bc -l) ms."
-            return
-        fi
-    done
-
-    print_error "Timed-out waiting for TCP socket to be ready at $host:$port"
-}
-
-#===================================================================================================
 # Test execution
 #===================================================================================================
 
@@ -67,100 +43,43 @@ TENANT_ID="foo"
 APP_NAME="bar"
 
 # Temporary Directory
-TMP_DIR_PATH="/tmp/nanvixd"
-TMP_DIR=$(mktemp -d ${TMP_DIR_PATH}-XXXXXX)
-
 mkdir -p "${LOGS_DIR}"
 
-# Run nanvixd.
-CONSOLE_FILE_NAME="${LOGS_DIR}/kernel_$(date "+%Y_%m_%d_%H_%M").log"
-RUST_LOG=trace,hyperlight_host=none setsid timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
-    ./bin/nanvixd.elf \
-        -http-addr "${NANVIXD_SOCKADDR}" \
-        -toolchain-bin-dir "${TOOLCHAIN_DIR}/bin" \
-        -tmp-dir "${TMP_DIR}" \
-        -console-file "${CONSOLE_FILE_NAME}" &
-NANVIXD_PID=$!
-
-cleanup() {
-    # Sometimes error messages in this script are hard to parse because they
-    # come from nested bash calls and we cannot color them accordingly.
-    # During clean-up, print a clear error message in red if the test has
-    # failed.
-    if kill -0 -- "-${NANVIXD_PID}" 2>/dev/null; then
-        print_error "Test failed: cleaning-up and nanvixd.elf is still alive"
-
-        # Make sure we force-clean any zombie processes, and ignore errors.
-        kill -s SIGKILL -- "-${NANVIXD_PID}" 2> /dev/null || true
-
-        wait "${NANVIXD_PID}" 2>/dev/null || true
-    fi
-
-    rm -rf "${TMP_DIR}"
-}
-trap 'cleanup' EXIT
-
-# Extract port number from nanvixd.
-NANVIXD_PORT_NUMBER=$(echo "${NANVIXD_SOCKADDR}" | cut -d: -f2)
-
-# Wait for nanvixd to start by checking if the HTTP socket is listening.
-print_info "Waiting for nanvixd to be ready"
-wait_for_tcp_socket "127.0.0.1" "$NANVIXD_PORT_NUMBER"
-
-# Run a client.
-NEW_JSON=$(jq -n \
-    --arg tenant_id "${TENANT_ID}" \
-    --arg app_name "${APP_NAME}" \
-    --arg program "${PROGRAM_NAME}" \
-    --arg program_args "${PROGRAM_ARGS}" \
-    '{tenant_id: $tenant_id, app_name: $app_name, program: $program, program_args: $program_args}'
+RUN_COMMAND=("${NANVIX_HOME}/scripts/run-nanvixd.sh"
+    "--tenant-id" "${TENANT_ID}"
+    "--app-name" "${APP_NAME}"
+    "--nanvixd-sockaddr" "${NANVIXD_SOCKADDR}"
+    "--toolchain-bin-dir" "${TOOLCHAIN_DIR}/bin"
+    "--"
+    "${PROGRAM_NAME}"
 )
-NEW_RESPONSE=$(curl \
-    --silent \
-    --header "Content-Type: application/json" \
-    --header "X-NVX-Message-Type: NEW" \
-    --request POST \
-    --data "${NEW_JSON}" \
-    http://localhost:"${NANVIXD_PORT_NUMBER}")
-VM_ID=$(echo "${NEW_RESPONSE}" | jq -r '.user_vm_id')
-GATEWAY_SOCKADDR=$(echo "${NEW_RESPONSE}" | jq -r '.gateway_sockaddr')
 
-print_info "VM ID: ${VM_ID}"
-print_info "Gateway Socket Address: ${GATEWAY_SOCKADDR}"
+if [ -n "${PROGRAM_ARGS}" ]; then
+    RUN_COMMAND+=("${PROGRAM_ARGS}")
+fi
 
-# Get output by writing to the gateway socket address.
-PROGRAM_ACTUAL_OUTPUT=$(echo "${PROGRAM_INPUT}" | nc -U -q 0 "${GATEWAY_SOCKADDR}" | tr -d '\0')
+RUN_STDERR_LOG="${LOGS_DIR}/runner_$(date "+%Y_%m_%d_%H_%M").log"
+
+set +e
+PROGRAM_ACTUAL_OUTPUT=$( \
+    cd "${NANVIX_HOME}" && \
+    { printf "%s" "${PROGRAM_INPUT}"; printf '\n'; } | \
+    timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
+        "${RUN_COMMAND[@]}" 2> "${RUN_STDERR_LOG}" | tr -d '\0'
+)
+RUN_STATUS=$?
+set -e
+
+if [ "${RUN_STATUS}" -ne 0 ]; then
+    print_error "Test failed: run-nanvixd.sh exited with status ${RUN_STATUS}. See ${RUN_STDERR_LOG}."
+    exit 1
+fi
 
 # Save program output to a log file.
 file_name=$(basename -- "${PROGRAM_NAME}")
 file_name_no_ext="${file_name%.*}"
 log_file="${LOGS_DIR}/${file_name_no_ext}_$(date "+%Y_%m_%d_%H_%M").log"
-echo "${PROGRAM_ACTUAL_OUTPUT}" > "${log_file}"
-
-# Kill the user VM.
-KILL_JSON=$(jq -n \
-    --argjson user_vm_id "${VM_ID}" \
-    '{user_vm_id: $user_vm_id}'
-)
-KILL_EXIT_CODE=$(curl \
-    --silent \
-    --header "Content-Type: application/json" \
-    --header "X-NVX-Message-Type: KILL" \
-    --request POST \
-    --data "${KILL_JSON}" \
-    http://localhost:"${NANVIXD_PORT_NUMBER}" | jq -r '.exit_code')
-
-if [ "${KILL_EXIT_CODE}" != "0" ]; then
-    print_error "Test failed: error killing user VM (code=${KILL_EXIT_CODE})"
-    exit 1
-fi
-
-# Move all Rust logs to the logs directory.
-# FIXME: https://github.com/nanvix/nanvix/issues/543
-find . -maxdepth 1 -name '*.log' -exec mv {} "${LOGS_DIR}"/ \; 2>/dev/null || true
-
-kill -s SIGINT "${NANVIXD_PID}" || true
-wait "${NANVIXD_PID}" 2>/dev/null || true
+printf "%s" "${PROGRAM_ACTUAL_OUTPUT}" > "${log_file}"
 
 # Check if curl.log contains the expected output.
 if grep -F -q -- "${PROGRAM_EXPECTED_OUTPUT}" <<< "${PROGRAM_ACTUAL_OUTPUT}"; then


### PR DESCRIPTION
This pull request refactors the `scripts/test-nanvixd.sh` script to simplify test execution and improve reliability by delegating process management and socket readiness to the `run-nanvixd.sh` helper script. The changes remove custom helper functions and manual process cleanup, streamline how the test runner is invoked, and improve error handling and logging.

**Refactoring test execution and process management:**

* Replaced manual process management, socket readiness checks, and cleanup logic with a call to the `run-nanvixd.sh` helper script, removing the need for custom helper functions like `wait_for_tcp_socket` and the `cleanup` trap. [[1]](diffhunk://#diff-00882a622663497c577fbf863301b9b4c552a64f67b741f908084107f12d181fL37-L60) [[2]](diffhunk://#diff-00882a622663497c577fbf863301b9b4c552a64f67b741f908084107f12d181fL70-R82)
* Simplified command construction and execution by building the `RUN_COMMAND` array and invoking it directly, passing all necessary arguments and handling optional program arguments.

**Error handling and logging improvements:**

* Added robust error checking for the test runner exit status and redirected standard error to a dedicated log file (`RUN_STDERR_LOG`), providing clearer diagnostics on test failures.
* Updated output handling to use `printf` for saving program output, ensuring consistent behavior and avoiding issues with null characters.

**Removal of legacy VM management and networking code:**

* Removed legacy code related to direct VM management via HTTP requests and manual socket communication, consolidating all such logic into the helper script for maintainability.