### PR TITLE
[ci] Auto Releases

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -108,6 +108,52 @@ jobs:
         machine-type: '${{ matrix.machine-type }}'
         deployment-type: '${{ matrix.deployment-type }}'
 
+    - id: release-archive
+      name: "Create Release Archive"
+      if: ${{ success() && github.ref == 'refs/heads/dev' && matrix.build-type == 'release' }}
+      run: |
+        single_process="no"
+        if [[ "${{ matrix.deployment-type }}" == "single-process" ]]; then
+          single_process="yes"
+        fi
+
+        # Ensure a clean build.
+        ./z distclean
+
+        # Build the release archive.
+        ./z build -- \
+          MACHINE="${{ matrix.machine-type }}" \
+          SINGLE_PROCESS="${single_process}" \
+          RELEASE="yes" \
+          BUILD_OPT="yes" \
+          LOG_LEVEL="error" \
+          release
+
+        archive_path=$(ls -1t nanvix-*.tar.bz2 2>/dev/null | head -n 1)
+        if [[ -z "${archive_path}" ]]; then
+          echo "No release archive found." >&2
+          exit 1
+        fi
+
+        echo "archive-path=${archive_path}" >> "${GITHUB_OUTPUT}"
+      shell: bash
+
+    - name: "Update Latest Release"
+      if: ${{ success() && github.ref == 'refs/heads/dev' && matrix.build-type == 'release' }}
+      uses: ncipollo/release-action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: latest
+        name: Latest
+        draft: false
+        prerelease: false
+        allowUpdates: true
+        makeLatest: true
+        removeArtifacts: true
+        artifacts: ${{ steps.release-archive.outputs.archive-path }}
+        artifactContentType: application/x-bzip2
+        body: Automated release update for ${{ matrix.machine-type }} (${{ matrix.deployment-type }}) ${{ matrix.build-type }} build.
+
     - name: "Upload logs in case of failures"
       if: failure()
       uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ export OBJECTS_DIR   := $(ROOT_DIR)/target
 export SCCACHE       ?= $(shell which sccache 2>/dev/null)
 
 #===================================================================================================
-# Libraries and Binaries
+# Artifacts
 #===================================================================================================
 
 # File format for executables.
@@ -107,8 +107,16 @@ export EXEC_FORMAT := elf
 export LIBC := $(TOOLCHAIN_DIR)/i686-nanvix/lib/libc.a
 export LIBM := $(TOOLCHAIN_DIR)/i686-nanvix/lib/libm.a
 export LIBCXX := $(TOOLCHAIN_DIR)/i686-nanvix/lib/libstdc++.a
-export LIBNVX := $(LIBRARIES_DIR)/libnvx.a
 export LIBPOSIX := $(LIBRARIES_DIR)/libposix.a
+
+# Binaries.
+KERNEL := $(BINARIES_DIR)/kernel.$(EXEC_FORMAT)
+LINUXD := $(BINARIES_DIR)/linuxd.$(EXEC_FORMAT)
+NANVIXD := $(BINARIES_DIR)/nanvixd.$(EXEC_FORMAT)
+USERVM := $(BINARIES_DIR)/uservm.$(EXEC_FORMAT)
+
+# Scripts
+RUN_NANVIXD_SCRIPT := $(SCRIPTS_DIR)/run-nanvixd.sh
 
 #===================================================================================================
 # Nanvix Variables
@@ -346,8 +354,14 @@ install: all-nanvix
 	@mkdir -p ${SYSROOT_DIR}/bin
 	@mkdir -p ${SYSROOT_DIR}/lib
 	@mkdir -p ${SYSROOT_DIR}/etc/scripts
-	@cp -r ${BINARIES_DIR}/* ${SYSROOT_DIR}/bin/
-	@cp -r ${LIBRARIES_DIR}/* ${SYSROOT_DIR}/lib/
+	@cp ${KERNEL} ${SYSROOT_DIR}/bin/
+	@cp ${NANVIXD} ${SYSROOT_DIR}/bin/
+ifneq ($(SINGLE_PROCESS),yes)
+	@cp ${LINUXD} ${SYSROOT_DIR}/bin/
+	@cp ${USERVM} ${SYSROOT_DIR}/bin/
+endif
+	@cp ${LIBPOSIX} ${SYSROOT_DIR}/lib/
+	@cp ${RUN_NANVIXD_SCRIPT} ${SYSROOT_DIR}/etc/scripts/
 	@cp -r ${SCRIPTS_DIR}/common/* ${SYSROOT_DIR}/etc/scripts/
 	@cp -r ${BUILD_DIR}/user/linker/$(TARGET)/user.ld ${SYSROOT_DIR}/lib/
 

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,15 @@ export OBJECTS_DIR   := $(ROOT_DIR)/target
 export SCCACHE       ?= $(shell which sccache 2>/dev/null)
 
 #===================================================================================================
+# Release Artifact Configuration
+#===================================================================================================
+
+RELEASE_DEPLOYMENT_MODE := $(if $(filter yes,$(SINGLE_PROCESS)),single_process,multi_process)
+RELEASE_BUILD_MODE := $(if $(filter yes,$(RELEASE)),release,debug)
+RELEASE_VERSION := $(strip $(shell cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.packages[0].version'))
+RELEASE_ARCHIVE := nanvix-$(RELEASE_VERSION)-$(MACHINE)-$(RELEASE_DEPLOYMENT_MODE)-$(RELEASE_BUILD_MODE)-$(LOG_LEVEL).tar.bz2
+
+#===================================================================================================
 # Artifacts
 #===================================================================================================
 
@@ -365,6 +374,11 @@ endif
 	@cp -r ${SCRIPTS_DIR}/common/* ${SYSROOT_DIR}/etc/scripts/
 	@cp -r ${BUILD_DIR}/user/linker/$(TARGET)/user.ld ${SYSROOT_DIR}/lib/
 
+release: install
+	@echo "Creating release archive ${RELEASE_ARCHIVE} from ${SYSROOT_DIR}..."
+	@$(RM_CMD) ${RELEASE_ARCHIVE}
+	@tar -cjf ${RELEASE_ARCHIVE} -C ${SYSROOT_DIR} .
+
 # Shows available make targets and build parameters.
 help:
 	@echo ""
@@ -379,6 +393,7 @@ help:
 	@echo "  format          Fix code formatting issues automatically"
 	@echo "  format-check    Check code formatting without fixing"
 	@echo "  install         Install build artifacts in the sysroot directory"
+	@echo "  release         Create release archive from the sysroot directory"
 	@echo "  lint            Fix code linting issues automatically"
 	@echo "  lint-check      Check for linting issues without fixing"
 	@echo "  spellcheck      Check for spelling errors in source code and documentation"


### PR DESCRIPTION
This pull request introduces an automated release workflow for the project, focusing on generating and publishing release archives for builds on the `dev` branch. The changes enhance the build system and CI pipeline to support robust release artifact creation, versioning, and deployment.

**Release workflow automation:**

* Added a new job to the GitHub Actions workflow (`.github/workflows/self-hosted-ci.yml`) that builds a release archive for release builds on the `dev` branch and uploads it as the "Latest" release using the `ncipollo/release-action`, including proper artifact handling and metadata.

**Makefile enhancements for release artifacts:**

* Introduced variables in the `Makefile` to configure release artifact naming, versioning, and deployment mode, ensuring consistent and descriptive archive filenames.
* Defined explicit binary and script targets in the `Makefile` for inclusion in the release archive, improving artifact selection and reproducibility.
* Updated the `install` and new `release` targets in the `Makefile` to copy only the necessary files to the sysroot and package them into a versioned `.tar.bz2` archive.
* Added documentation for the new `release` target in the `Makefile` help output, making it easier for developers to discover and use the release functionality.