### PR TITLE
[ci] Re-enable L2 Benchmarks

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -24,7 +24,7 @@ runs:
     shell: bash
   - name: Build (MicroVM)
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=panic --target-machine=microvm --release --without-opt --build --sccache=${SCCACHE}
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=panic --target-machine=microvm --release --without-opt --build --sccache=${SCCACHE} --features L2_VM=yes
     shell: bash
   - name: Run micro-benchmarks (MicroVM)
     run: |
@@ -34,16 +34,6 @@ runs:
       )
 
       for bench in "${benchmarks[@]}"; do
-        # FIXME (#975): warm-start-l2 is failing intermittently on MicroVM
-        if [[ "$bench" == "warm-start-l2" ]]; then
-          continue
-        fi
-
-        # FIXME (#937): cold-start-l2 is failing intermittently on MicroVM
-        if [[ "$bench" == "cold-start-l2" ]]; then
-          continue
-        fi
-
         echo "Running benchmark: ${bench} (Microvm)"
         bench_underscore=${bench//-/_}
         ./bin/nanvix-bench.elf -tmp-dir ${TMPDIR_MICROVM} -toolchain-bin-dir $HOME/toolchain/bin -benchmark ${bench} -hwloc $HOME/hwloc.json -iterations 1000 | grep -E '^(p50:|p95:|p99:|[0-9])' > bench_${bench_underscore}_microvm_${{ inputs.arch }}.txt
@@ -62,7 +52,7 @@ runs:
     shell: bash
   - name: Build (Hyperlight)
     run: |
-      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=panic --target-machine=hyperlight --release --without-opt --build --sccache=${SCCACHE}
+      python3 scripts/ci.py --toolchain-dir=$HOME/toolchain --target-arch=x86 --log-level=panic --target-machine=hyperlight --release --without-opt --build --sccache=${SCCACHE} --features L2_VM=yes
     shell: bash
   - name: Run micro-benchmarks (Hyperlight)
     run: |
@@ -79,16 +69,6 @@ runs:
 
         # FIXME (#1016): boot-time is failing on hyperlight
         if [[ "$bench" == "boot-time" ]]; then
-          continue
-        fi
-
-        # FIXME (#975): warm-start-l2 is failing intermittently on hyperlight
-        if [[ "$bench" == "warm-start-l2" ]]; then
-          continue
-        fi
-
-        # FIXME (#926): cold-start-l2 fails on hyperlight
-        if [[ "$bench" == "cold-start-l2" ]]; then
           continue
         fi
 

--- a/scripts/generate-l2-initramfs.sh
+++ b/scripts/generate-l2-initramfs.sh
@@ -41,7 +41,7 @@ done
 # Do a clean build if requested.
 if ${CLEAN}; then
     if [ -d ${INITRAMFS_DIR} ]; then
-        print_warn "removing initramfs from ${INITRAMFS_DIR}"
+        print_warning "removing initramfs from ${INITRAMFS_DIR}"
         rm -rf ${INITRAMFS_DIR}
     fi
 fi
@@ -101,7 +101,7 @@ echo "[init] Nanvix L2 System VM init wrapper started!"
 
 # We must bind to the same IP, as it is the only one available in the guest.
 echo "[init] Nanvix L2 System VM passed init gate. Starting linuxd..."
-/usr/bin/linuxd.elf \
+RUST_LOG=${LOG_LEVEL:-warn} /usr/bin/linuxd.elf \
     -control-plane-addr ${CONTROL_PLANE_SOCKADDR} \
     -control-plane-socket-type tcp \
     -user-vm-bind-addr ${USER_VM_SOCKADDR} \

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -314,7 +314,7 @@ impl Benchmark {
             };
 
             if ret_code < 0 {
-                error!("error sending SIGINT to nano VM: {}", std::io::Error::last_os_error());
+                error!("error sending SIGINT to nanvixd: {}", std::io::Error::last_os_error());
             }
 
             if let Some(nanvixd) = self.nanvixd.as_mut() {
@@ -1069,8 +1069,14 @@ async fn main() -> Result<()> {
         },
     };
     match result {
-        Ok(_) => {},
-        Err(e) => error!("error running benchmark {}: {e:?}", args.benchmark()),
+        Ok(()) => {},
+        Err(e) => {
+            error!("error running benchmark {}: {e:?}", args.benchmark());
+
+            // In case of an error, re-run the clean up to prevent having dangling processes. Note
+            // that the clean up is idempotent.
+            benchmark.cleanup();
+        },
     }
 
     Ok(())

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -13,6 +13,7 @@ use ::std::{
     fs::File,
     io::BufReader,
 };
+use ::syscomm::SocketType;
 
 //==================================================================================================
 // Structures
@@ -138,6 +139,26 @@ impl Args {
             }
 
             i += 1;
+        }
+
+        // If we deploy linuxd in an L2 VM, we need to make sure that all socket types are set to
+        // TCP.
+        if l2 {
+            if control_plane_socket_type == Some(SocketType::UNIX_STR.to_string()) {
+                anyhow::bail!("control-plane must use a tcp socket in l2 deployments");
+            }
+
+            if gateway_socket_type == Some(SocketType::UNIX_STR.to_string()) {
+                anyhow::bail!("gateway must use a tcp socket in l2 deployments");
+            }
+
+            if system_vm_socket_type == Some(SocketType::UNIX_STR.to_string()) {
+                anyhow::bail!("system vm must use a tcp socket in l2 deployments");
+            }
+
+            control_plane_socket_type = Some(SocketType::TCP_STR.to_string());
+            gateway_socket_type = Some(SocketType::TCP_STR.to_string());
+            system_vm_socket_type = Some(SocketType::TCP_STR.to_string());
         }
 
         Ok(Self {

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -265,5 +265,5 @@ pub fn get_clh_snapshot_path() -> String {
 ///
 #[cfg(not(feature = "single-process"))]
 pub fn get_clh_api_socket_path(tmp_dir: &str) -> String {
-    format!("{tmp_dir}/nanvixd-clh.{UNIX_SOCKET_SUFFIX}")
+    format!("{tmp_dir}/nanvixd-clh{UNIX_SOCKET_SUFFIX}")
 }

--- a/src/utils/nanvixd/src/sandbox/multi_process/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/multi_process/linuxd.rs
@@ -21,6 +21,7 @@ use ::linuxd::{
     config::restore_gate_sockaddr_builder,
 };
 use ::std::{
+    io::ErrorKind,
     mem,
     process::Stdio,
 };
@@ -82,27 +83,50 @@ impl LinuxDaemon {
             "\r\n",
         );
 
-        let unbound_socket: UnboundSocket = UnboundSocket::new(SocketType::Tcp);
-        let mut clh_api_socket: SocketStream = match timeout(
-            Duration::from_secs(config::syscomm::CONNECT_TIMEOUT_SECS),
-            unbound_socket.connect(clh_api_socket_path.clone()),
-        )
-        .await
-        {
-            Ok(Ok(stream)) => stream,
-            Ok(Err(e)) => {
-                let reason: String = format!(
-                    "error connecting to CLH API socket (addr={}, error={e:?})",
-                    clh_api_socket_path
-                );
-                error!("{reason}");
-                return Err(anyhow::anyhow!(reason));
-            },
-            Err(e) => {
-                let reason: String = format!("error connecting to CLH API socket (error={e:?})");
-                error!("{reason}");
-                return Err(anyhow::anyhow!(reason));
-            },
+        let unbound_clh_api_socket: UnboundSocket = UnboundSocket::new(SocketType::Unix);
+        let now: tokio::time::Instant = tokio::time::Instant::now();
+        let mut clh_api_socket: SocketStream = loop {
+            match unbound_clh_api_socket
+                .clone()
+                .connect(clh_api_socket_path.clone())
+                .await
+            {
+                Ok(stream) => {
+                    debug!(
+                        "clh API socket appeared after {:?} (path={:?})",
+                        now.elapsed(),
+                        &clh_api_socket_path
+                    );
+                    break stream;
+                },
+                Err(e) => {
+                    // Tolerate transient connection errors.
+                    if matches!(
+                        e.kind(),
+                        ErrorKind::NotFound | ErrorKind::ConnectionRefused | ErrorKind::WouldBlock
+                    ) {
+                        if now.elapsed().as_secs() > config::syscomm::CONNECT_TIMEOUT_SECS {
+                            let reason: String = format!(
+                                "error connecting to CLH API socket (addr={}, error=timed-out)",
+                                clh_api_socket_path
+                            );
+                            error!("{reason}");
+                            return Err(anyhow::anyhow!(reason));
+                        } else {
+                            tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+                            continue;
+                        }
+                    }
+
+                    // Bail on fatal errors.
+                    let reason: String = format!(
+                        "error connecting to CLH API socket (addr={}, error={e:?})",
+                        clh_api_socket_path
+                    );
+                    error!("{reason}");
+                    return Err(anyhow::anyhow!(reason));
+                },
+            }
         };
 
         // Write HTTP request.


### PR DESCRIPTION
In this PR I re-enable the L2 benchmarks for the Micro VM and Hyperlight. After the major re-factor, the race conditions that we were seeing should not no longer appear. I fix a few issues that were introduced precisely because we were not testing the L2 deployment at all.

Closes #975 
Closes #937
Closes #926