### PR TITLE
[kernel] Remove `MessageType::Empty`

### DIFF
--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -309,7 +309,6 @@ impl WorkerThreadHandle {
             };
 
             match message.message_type {
-                sys::ipc::MessageType::Empty => panic!("received empty message"),
                 sys::ipc::MessageType::Interrupt => panic!("received interrupt message"),
                 sys::ipc::MessageType::Exception => panic!("received exception message"),
                 sys::ipc::MessageType::Ipc => panic!("received IPC message"),

--- a/src/daemons/memd/src/main.rs
+++ b/src/daemons/memd/src/main.rs
@@ -128,7 +128,6 @@ pub fn main() {
                     Ok(false) => continue,
                     Err(e) => ::syslog::error!("failed to handle ipc request (error={:?})", e),
                 },
-                MessageType::Empty => unreachable!("should not receive empty messages"),
                 MessageType::Interrupt => unreachable!("should not receive interrupts"),
                 MessageType::Ikc => unreachable!("should not receive ikc messages"),
                 MessageType::ProcessTerminationEvent => {

--- a/src/kernel/src/stdio.rs
+++ b/src/kernel/src/stdio.rs
@@ -84,24 +84,18 @@ pub fn read() -> Result<Option<Message>, Error> {
             let credits: u32 = unsafe {
                 core::ptr::read_volatile(::config::microvm::DEFAULT_MICROVM_CTRL_CREDITS as *const u32)
             };
-
-            // No message available.
-            if credits == 0 {
-                return Ok(None);
-            }
         }
         else if #[cfg(feature = "hyperlight")] {
-            use crate::hal::platform::hyperlight::peb::ProcessEnvironmentBlock;
             // Read credits register.
             let credits: u64 = unsafe {
-                ProcessEnvironmentBlock::get_credits()?
+                crate::hal::platform::hyperlight::peb::ProcessEnvironmentBlock::get_credits()?
             };
-
-            // No message available.
-            if credits == 0 {
-                return Ok(None);
-            }
         }
+    }
+
+    // No message available.
+    if credits == 0 {
+        return Ok(None);
     }
 
     // Read message from the kernel's standard input.

--- a/src/kernel/src/stdio.rs
+++ b/src/kernel/src/stdio.rs
@@ -115,15 +115,7 @@ pub fn read() -> Result<Option<Message>, Error> {
 
     // Convert message to Message struct.
     match Message::try_from_bytes(message) {
-        Ok(message) => {
-            // Check if message is empty.
-            if { message.message_type } == MessageType::Empty {
-                Ok(None)
-            } else {
-                // NOTE: trace command after reading the first byte, to avoid flooding the log.
-                Ok(Some(message))
-            }
-        },
+        Ok(message) => Ok(Some(message)),
         // No message available.
         Err(e) if e.code == ErrorCode::NoMessageAvailable => Ok(None),
         Err(e) => {

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -94,7 +94,6 @@ impl ProcessDaemon {
                                 ::syslog::error!("failed to handle IPC message (error={:?})", e);
                             }
                         },
-                        MessageType::Empty => unreachable!("should not receive empty messages"),
                         MessageType::Interrupt => unreachable!("should not receive interrupts"),
                         MessageType::Ikc => unreachable!("should not receive IKC messages"),
                         MessageType::ProcessTerminationEvent => {

--- a/src/libs/sys/src/sys/ipc/message/kernel.rs
+++ b/src/libs/sys/src/sys/ipc/message/kernel.rs
@@ -193,7 +193,7 @@ impl Message {
 impl Default for Message {
     fn default() -> Self {
         Self {
-            message_type: MessageType::Empty,
+            message_type: MessageType::Ikc,
             source: MessageSender::KERNEL,
             destination: MessageReceiver::KERNEL,
             status: 0,

--- a/src/libs/sys/src/sys/ipc/typ.rs
+++ b/src/libs/sys/src/sys/ipc/typ.rs
@@ -26,8 +26,6 @@ use ::core::{
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum MessageType {
-    /// The message is empty.
-    Empty,
     /// The message encodes information about an interrupt that occurred.
     Interrupt,
     /// The message encodes information about an exception that occurred.
@@ -60,7 +58,6 @@ impl MessageType {
     ///
     pub fn to_bytes(&self) -> [u8; Self::SIZE] {
         match self {
-            MessageType::Empty => [0],
             MessageType::Interrupt => [1],
             MessageType::Exception => [2],
             MessageType::Ipc => [3],
@@ -85,7 +82,6 @@ impl MessageType {
     ///
     pub fn try_from_bytes(bytes: [u8; Self::SIZE]) -> Result<Self, Error> {
         match bytes {
-            [0] => Ok(MessageType::Empty),
             [1] => Ok(MessageType::Interrupt),
             [2] => Ok(MessageType::Exception),
             [3] => Ok(MessageType::Ipc),
@@ -99,7 +95,6 @@ impl MessageType {
 impl fmt::Debug for MessageType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MessageType::Empty => write!(f, "empty"),
             MessageType::Interrupt => write!(f, "interrupt"),
             MessageType::Exception => write!(f, "exception"),
             MessageType::Ipc => write!(f, "inter-process communication"),


### PR DESCRIPTION
## Description

This PR removes `MessageType::Empty`, which is no longer necessary.