### PR TITLE
[kernel] Use `__phys_memcpy32()` When Possible

### DIFF
--- a/src/kernel/src/hal/arch/x86/hooks.S
+++ b/src/kernel/src/hal/arch/x86/hooks.S
@@ -307,6 +307,7 @@
 .global __leave_kernel
 .global __leave_kernel_to_user_mode
 .global __phys_memcpy
+.global __phys_memcpy32
 .global __phys_memset
 
 /*----------------------------------------------------------------------------*
@@ -570,6 +571,58 @@ __phys_memcpy:
     popf
 
 __phys_memcpy.done:
+
+    popl %edi
+    popl %esi
+
+    ret
+
+/*----------------------------------------------------------------------------*
+ * __phys_memcpy32()                                                          *
+ *----------------------------------------------------------------------------*/
+
+/*
+ * Physical memory copy (32-bit word at a time).
+ */
+__phys_memcpy32:
+    pushl %esi
+    pushl %edi
+
+    /* Get parameters. */
+    movl 12(%esp), %edi /* dest */
+    movl 16(%esp), %esi /* src */
+    movl 20(%esp), %ecx /* size in bytes */
+
+    /* Convert size in bytes to number of 32-bit words. */
+    shrl $2, %ecx
+
+    /* If copy size is zero, skip copying. */
+    test %ecx, %ecx
+    jz __phys_memcpy32.done
+
+    /* Preserve flags before paging is disabled. */
+    pushf
+    popl %edx
+
+    /* Disable paging. */
+    movl %cr0, %eax
+    andl $0x80000000 - 1, %eax
+    movl %eax, %cr0
+
+    /* Use rep movsl while paging is temporarily disabled. */
+    cld
+    rep movsl
+
+    /* Re-enable paging. */
+    movl %cr0, %eax
+    orl $0x80000000, %eax
+    movl %eax, %cr0
+
+    /* Restore flags now that paging is enabled again. */
+    pushl %edx
+    popf
+
+__phys_memcpy32.done:
 
     popl %edi
     popl %esi

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -97,6 +97,24 @@ unsafe extern "C" {
     ///
     /// # Description
     ///
+    /// Performs a physical memory copy.
+    ///
+    /// # Parameters
+    ///
+    /// - `dst`: Destination address.
+    /// - `src`: Source address.
+    /// - `size`: Number of bytes to copy.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it performs physical memory copying and may lead to
+    /// undefined behavior if the destination or source memory regions are invalid.
+    ///
+    fn __phys_memcpy32(dst: *mut u8, src: *const u8, size: usize);
+
+    ///
+    /// # Description
+    ///
     /// This function disables paging and fills the memory region with the provided value.
     ///
     /// # Parameters
@@ -800,11 +818,15 @@ impl Vmem {
                 // - `src.into_raw_value()` is a valid kernel-space address for `copy_size` bytes.
                 // - Both regions lie in physical memory.
                 unsafe {
-                    __phys_memcpy(
-                        dst_phys_addr_raw as *mut u8,
-                        src_phys_addr_raw as *const u8,
-                        copy_size,
-                    )
+                    let dst: *mut u8 = (dst_frame.into_raw_value() + offset) as *mut u8;
+                    let src: *const u8 = src.into_raw_value() as *const u8;
+                    let phys_memcpy_fn: unsafe extern "C" fn(*mut u8, *const u8, usize) =
+                        if copy_size.is_multiple_of(::core::mem::size_of::<u32>()) {
+                            __phys_memcpy32
+                        } else {
+                            __phys_memcpy
+                        };
+                    phys_memcpy_fn(dst, src, copy_size)
                 };
             }
 


### PR DESCRIPTION
## Description

This PR introduces `__phys_memcpy32()` and uses it when possible.