### PR TITLE
[utils] Fix echo-breakdown Benchmark And Enable In CI

### DIFF
--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -867,6 +867,7 @@ impl WorkerThreadHandle {
                 error!("handle_write_request(): trying to write zero bytes to STDOUT");
                 Ok(build_error(source, ErrorCode::InvalidArgument))
             } else {
+                // Label: linuxd::worker_thread::handle_write_request()
                 profiler::timestamp_message!(&mut request.buffer, 0);
                 let count: usize = request.count as usize;
 
@@ -913,7 +914,13 @@ impl WorkerThreadHandle {
         trace!("handle_read_request(): source={source:?}, request={request:?}");
         // Check if reading from gateway.
         if request.fd == STDIN_FILENO {
-            let response: Result<Message, WorkerThreadError> = {
+            // We need a mutable message to be able to timestamp it during profiling of the data
+            // path. The profiler macro is designed to silence this warnings when compiled without
+            // the timestamp-messages macro. However, in this case we need to unwrap the message
+            // before timestamping, wrapping the macro itself in a #[cfg()]. This means we need to
+            // manually silence the warning.
+            #[allow(unused_mut)]
+            let mut response: Result<Message, WorkerThreadError> = {
                 // Take the lock.
                 let mut locked_gateway_reader: MutexGuard<'_, SocketStreamReader> =
                     gateway_reader.blocking_lock();
@@ -943,6 +950,16 @@ impl WorkerThreadHandle {
                     },
                 }
             };
+
+            #[cfg(feature = "timestamp-messages")]
+            if let Ok(read_response) = &mut response {
+                // Label: linuxd::worker_thread::handle_read_request()
+                profiler::timestamp_message!(
+                    &mut read_response.payload,
+                    std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                        + std::mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
+                );
+            }
 
             response
         } else {

--- a/src/libs/profiler/src/lib.rs
+++ b/src/libs/profiler/src/lib.rs
@@ -10,7 +10,7 @@
 #[cfg(feature = "timestamp-messages")]
 macro_rules! timestamp_message {
     ($buffer_expr:expr, $buffer_offset:expr) => {{
-        log::trace!(
+        syslog::trace!(
             "timestamp injected at {}:{}",
             std::panic::Location::caller().file(),
             std::panic::Location::caller().line()

--- a/src/uservm/Cargo.toml
+++ b/src/uservm/Cargo.toml
@@ -29,6 +29,7 @@ profiler = { workspace = true, features = ["auto-calibrate"] }
 serde = { workspace = true, features = ["derive"] }
 static_assert = { workspace = true }
 sys = { workspace = true }
+syscall = { workspace = true }
 syscomm = { workspace = true }
 syslog = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
@@ -43,3 +44,4 @@ libc = { workspace = true }
 [features]
 default = []
 hyperlight = ["dep:hyperlight-host", "config/hyperlight"]
+timestamp-messages = []

--- a/src/uservm/src/io_thread.rs
+++ b/src/uservm/src/io_thread.rs
@@ -148,13 +148,19 @@ impl IoThread {
 
                             if buf_len == buf.len() {
                                 // Convert bytes to message.
-                                let message: Message =
+                                let mut message: Message =
                                     Message::try_from_bytes(buf).map_err(|e| {
                                         let reason: String =
                                             format!("failed to decode message from system VM: {e:?}");
                                         error!("{reason}");
                                         anyhow::Error::msg(reason)
                                     })?;
+
+                                // Label: uservm::io_thread::system_vm::read()
+                                profiler::timestamp_message!(&mut message.payload,
+                                    std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                                        + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
+                                );
 
                                 buf.fill(0);
                                 buf_len = 0;
@@ -177,7 +183,13 @@ impl IoThread {
                 result = data_rx.recv() => {
                     trace!("forwarding message to system VM");
                     match result {
-                        Some(msg) => {
+                        Some(mut msg) => {
+                            // Label: uservm::io_thread::system_vm::write()
+                            profiler::timestamp_message!(&mut msg.payload,
+                                std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                                    + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
+                            );
+
                             let bytes: [u8; ::std::mem::size_of::<Message>()] = msg.to_bytes();
                             system_vm_tx.write_all(&bytes).await.map_err(|e| {
                                 let reason: String = format!("failed writing message to system VM socket: {e}");

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -414,6 +414,9 @@ pub fn get_stderr_writer(vm_stderr: Option<String>) -> Result<Box<dyn Write + Se
     Ok(file_writer)
 }
 
+///
+/// # Description
+///
 /// Builds an input callback that delivers messages from the Linux daemon to the virtual machine.
 ///
 /// # Parameters
@@ -424,6 +427,7 @@ pub fn get_stderr_writer(vm_stderr: Option<String>) -> Result<Box<dyn Write + Se
 /// # Returns
 ///
 /// A boxed closure compatible with the VMM's stdin handler implementation.
+///
 pub fn build_input_fn(mut input_queue: Receiver<Message>) -> Box<StdinFn> {
     // Input function used for emulating I/O port reads.
     #[cfg(not(feature = "hyperlight"))]
@@ -444,10 +448,25 @@ pub fn build_input_fn(mut input_queue: Receiver<Message>) -> Box<StdinFn> {
 
         match input_queue.blocking_recv() {
             Some(mut msg) => {
+                // Label: uservm::lib::vm_input::vm_exit()
+                profiler::timestamp_message!(
+                    &mut msg.payload,
+                    mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                        + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
+                );
+
                 on_message_received_from_memory_thread();
                 msg.message_type = MessageType::Ikc;
                 let mut locked_guest: MutexGuard<'_, Guest> = guest.blocking_lock();
                 let mut locked_vm: MutexGuard<'_, VirtualMemory> = vmem.blocking_lock();
+
+                // Label: uservm::lib::vm_input::vm_write_bytes()
+                profiler::timestamp_message!(
+                    &mut msg.payload,
+                    mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                        + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
+                );
+
                 locked_vm.write_bytes(data as u64, &msg.to_bytes())?;
                 locked_guest.consume_credit(&mut locked_vm)?;
             },
@@ -467,6 +486,13 @@ pub fn build_input_fn(mut input_queue: Receiver<Message>) -> Box<StdinFn> {
         on_input_function_called();
         match input_queue.blocking_recv() {
             Some(mut msg) => {
+                // Label: uservm::lib::vm_input::vm_exit()
+                profiler::timestamp_message!(
+                    &mut msg.payload,
+                    mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                        + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
+                );
+
                 on_message_received_from_memory_thread();
                 msg.message_type = MessageType::Ikc;
                 // Acquire lock on guest information.
@@ -488,6 +514,13 @@ pub fn build_input_fn(mut input_queue: Receiver<Message>) -> Box<StdinFn> {
                         hyperlight_host::HyperlightError::AnyhowError(anyhow::Error::msg(reason))
                     })?
                     .blocking_lock();
+
+                // Label: uservm::lib::vm_input::vm_write_bytes()
+                profiler::timestamp_message!(
+                    &mut msg.payload,
+                    mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                        + mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
+                );
 
                 locked_guest.consume_credit(&mut locked_vmem)?;
                 Ok(msg.to_bytes().to_vec())
@@ -529,7 +562,7 @@ pub fn output_fn(queue: Sender<Message>) -> Box<StdoutFn> {
         trace!("output(): reading message from user VM");
         vm.blocking_lock().read_bytes(data as u64, &mut bytes)?;
 
-        let message: Message = match Message::try_from_bytes(bytes) {
+        let mut message: Message = match Message::try_from_bytes(bytes) {
             Ok(message) => message,
             Err(err) => {
                 let reason: String = format!("failed to parse message: {err:?}");
@@ -537,6 +570,13 @@ pub fn output_fn(queue: Sender<Message>) -> Box<StdoutFn> {
                 anyhow::bail!(reason);
             },
         };
+
+        // Label: uservm::lib::vm_output::send()
+        profiler::timestamp_message!(
+            &mut message.payload,
+            std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
+        );
 
         trace!("output(): forwarding message to system VM");
         if let Err(e) = queue.blocking_send(message) {
@@ -569,7 +609,7 @@ pub fn output_fn(queue: Sender<Message>) -> Box<StdoutFn> {
             },
         };
 
-        let message: Message = match Message::try_from_bytes(payload) {
+        let mut message: Message = match Message::try_from_bytes(payload) {
             Ok(message) => message,
             Err(err) => {
                 let reason: String = format!("failed to parse message: {:?}", err);
@@ -579,6 +619,13 @@ pub fn output_fn(queue: Sender<Message>) -> Box<StdoutFn> {
                 )));
             },
         };
+
+        // Label: uservm::lib::vm_output::send()
+        profiler::timestamp_message!(
+            &mut message.payload,
+            std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
+        );
 
         if let Err(e) = queue.blocking_send(message) {
             let reason: String = format!("failed to send message: {:?}", e);

--- a/src/uservm/src/memory_thread.rs
+++ b/src/uservm/src/memory_thread.rs
@@ -130,7 +130,13 @@ impl MemoryThread {
                     }
                     msg = data_rx.recv() => {
                         match msg {
-                            Some(msg) => {
+                            Some(mut msg) => {
+                                // Label: uservm::memory_thread::data_rx::recv()
+                                profiler::timestamp_message!(&mut msg.payload,
+                                    std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                                        + std::mem::offset_of!(syscall::unistd::message::ReadResponse, buffer)
+                                );
+
                                 on_message_received_from_io_thread();
 
                                 if let Err(e) = data_tx.send(msg).await {

--- a/src/utils/echo-client/Cargo.toml
+++ b/src/utils/echo-client/Cargo.toml
@@ -11,10 +11,14 @@ homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["full"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-hyper = { workspace = true, features = ["full"] }
-tokio = { workspace = true, features = ["full"] }
-http-body-util = { workspace = true }
-hyper-util = { workspace = true, features = ["full"] }
 syslog = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["full"] }
+
+[features]
+default = []
+timestamp-messages = []

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -835,69 +835,132 @@ impl Benchmark {
     }
 
     #[cfg(feature = "timestamp-messages")]
-    pub fn run_echo_breakdown(&mut self) -> Result<()> {
+    pub async fn run_echo_breakdown(&mut self, l2: bool) -> Result<()> {
+        // First start nanvixd and the user VM.
+        let (new_msg_headers, new_msg) = self.prepare_new_message()?;
+        self.setup(l2);
+        let (user_vm_id, mut gateway_stream) = self.start(new_msg, new_msg_headers, l2).await?;
+
+        // The labels in this array are also added as comments to the line of code where the
+        // timestamp is added.
         let steps: Vec<&str> = vec![
             // In-path
-            "gateway::recv()",                          // 0
-            "linuxd::handle_read_request()",            // 1
-            "microvm::io::try_receive_from_gateway()",  // 2
-            "microvm::io::try_send_to_microvm()",       // 3
-            "microvm::mod::memory_thread::try_recv()",  // 4
-            "microvm::mod::vm_input::vmexit()",         // 5
-            "microvm::mod::vm_input::vm_write_bytes()", // 7
+            "nanvix-bench::write_all()",                    // 0
+            "linuxd::worker_thread::handle_read_request()", // 1
+            "uservm::io_thread::system_vm::read()",         // 2
+            "uservm::memory_thread::data_rx::recv()",       // 3
+            "uservm::lib::vm_input::vmexit()",              // 4
+            "uservm::lib::vm_input::vm_write_bytes()",      // 5
             // Out-path
-            "microvm::mod::vm_output::try_send()",  // 8
-            "microvm::io::try_recv_from_microvm()", // 9
-            "microvm::io::try_send_to_gateway()",   // 10
-            "linuxd::handle_write_request()",       // 11
-            "gateway::recv()",                      // 12
+            "uservm::lib::vm_output::send()",                // 6
+            "uservm::io_thread::system_vm::write()",         // 7
+            "linuxd::worker_thread::handle_write_request()", // 8
+            "linuxd::gw_stdout_thread::send()",              // 9
+            "nanvix-bench::read_exact()",                    // 10
         ];
 
         let header_size = 1;
         let data_size = header_size + profiler::MAX_NUMBER_MESSAGE_TIMESTAMPS * 2;
-        let mut data = vec![0u8; data_size];
 
-        // Before running this experiment, we need to wait for the nano VM to
+        // Before running this experiment, we need to wait for the user VM to
         // fully boot, as otherwise the boot time will tamper the hot-path
         // measurements.
-        tokio::sleep(Duration::from_millis(200));
+        sleep(Duration::from_millis(200)).await;
 
-        // Add initial timestamp
-        profiler::timestamp_message!(&mut data, 0);
+        // For each different step we measure, we record the delta for each iteration.
+        let mut latencies: Vec<Vec<u16>> = Vec::with_capacity(steps.len() + 1);
+        for _ in 0..(steps.len() + 1) {
+            latencies.push(vec![0u16; self.iterations]);
+        }
 
-        self.send_to_gateway(&data)?;
-        let mut response = self.recv_from_gateway(data.len())?;
+        // Display a progress bar.
+        let pb = ProgressBar::new(self.iterations.try_into().unwrap());
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{msg} [{bar:40.cyan/blue}] {pos}/{len} ({percent}%)")
+                .expect("error creating progress bar")
+                .progress_chars("#>-"),
+        );
+        pb.set_message("Benchmark progress:");
 
-        // Add final timestamp
-        profiler::timestamp_message!(&mut response, 0);
+        for iter in 0..self.iterations {
+            let mut data = vec![0u8; data_size];
+            let mut response = vec![0u8; data_size];
+
+            // Add initial timestamp
+            // Label: nanvix-bench::write_all()
+            profiler::timestamp_message!(&mut data, 0);
+
+            gateway_stream.write_all(&data).await?;
+            gateway_stream.read_exact(&mut response).await?;
+
+            // Add final timestamp.
+            // Label: nanvix-bench::read_exact()
+            profiler::timestamp_message!(&mut response, 0);
+
+            // Process results.
+            let mut first_timestamp: Option<u16> = None;
+            let mut last_timestamp: Option<u16> = None;
+            let num_stamps = response[0] as usize;
+            if num_stamps != steps.len() {
+                return Err(anyhow::anyhow!("have not collected enough timestamps!"));
+            }
+            for (step_idx, chunk) in (0..num_stamps).zip(response[header_size..].chunks_exact(2)) {
+                let timestamp = u16::from_le_bytes([chunk[0], chunk[1]]);
+
+                if first_timestamp.is_none() {
+                    first_timestamp = Some(timestamp);
+                }
+
+                if let Some(last) = last_timestamp {
+                    let delta = timestamp.wrapping_sub(last);
+                    latencies[step_idx][iter] = delta;
+                }
+
+                last_timestamp = Some(timestamp);
+            }
+
+            if first_timestamp.is_some() && last_timestamp.is_some() {
+                latencies[steps.len()][iter] = last_timestamp.unwrap() - first_timestamp.unwrap()
+            } else {
+                return Err(anyhow::anyhow!("have not collected enough timestamps!"));
+            }
+
+            pb.inc(1);
+        }
+
+        pb.finish();
+
+        // Clean-up.
+        self.kill(user_vm_id).await?;
+        self.cleanup();
 
         // Print results
-        let mut first_timestamp: Option<u16> = None;
-        let mut last_timestamp: Option<u16> = None;
-        let num_stamps = response[0] as usize;
-        for (step_idx, chunk) in (0..num_stamps).zip(response[header_size..].chunks_exact(2)) {
-            let timestamp = u16::from_le_bytes([chunk[0], chunk[1]]);
-
-            if first_timestamp.is_none() {
-                first_timestamp = Some(timestamp);
-            }
-
-            print!("{step_idx:<2} | {:<40} | Timestamp {timestamp:5} us", steps[step_idx]);
-
-            if let Some(last) = last_timestamp {
-                let delta = timestamp.wrapping_sub(last); // Handles wraparound
-                println!(" | Delta {delta:5} us");
+        for step_idx in 0..(steps.len() + 1) {
+            if step_idx < steps.len() {
+                print!("{step_idx:<2} | {:<40}", steps[step_idx]);
             } else {
-                println!(" | First Step");
+                print!("{step_idx:<2} | {:<40}", "Total");
             }
 
-            last_timestamp = Some(timestamp);
-        }
-        if first_timestamp.is_some() && last_timestamp.is_some() {
-            println!(
-                "Total time elapsed: {} us",
-                last_timestamp.unwrap() - first_timestamp.unwrap()
+            if step_idx == 0 {
+                println!(" | First Step");
+                continue;
+            }
+
+            latencies[step_idx].sort();
+            print!(
+                " | p50: {:5} | p95: {:5} | p99 {:5}",
+                latencies[step_idx][(self.iterations as f32 * 0.5) as usize],
+                latencies[step_idx][(self.iterations as f32 * 0.95) as usize],
+                latencies[step_idx][(self.iterations as f32 * 0.99) as usize],
             );
+
+            if step_idx < steps.len() && steps[step_idx] == "microvm::mod::vm_input::vmexit()" {
+                println!(" | Time for VM to react to IO being avail.");
+            } else {
+                println!();
+            }
         }
 
         Ok(())
@@ -973,21 +1036,6 @@ async fn main() -> Result<()> {
                 benchmark.run_boot_time().await
             }
         },
-        BenchmarkFlavour::EchoBreakdown => {
-            #[cfg(not(feature = "timestamp-messages"))]
-            {
-                error!(
-                    "WARNING: this benchmark requires Nanvix (re-) compilation with \
-                     TIMESTAMP_MSG=yes"
-                );
-                return Ok(());
-            }
-
-            #[cfg(feature = "timestamp-messages")]
-            {
-                benchmark.run_echo_breakdown()
-            }
-        },
         BenchmarkFlavour::ColdStart => {
             #[cfg(feature = "timestamp-messages")]
             {
@@ -1014,6 +1062,21 @@ async fn main() -> Result<()> {
             #[cfg(not(feature = "timestamp-messages"))]
             {
                 benchmark.run_cold_start(true).await
+            }
+        },
+        BenchmarkFlavour::EchoBreakdown => {
+            #[cfg(not(feature = "timestamp-messages"))]
+            {
+                error!(
+                    "WARNING: this benchmark requires Nanvix (re-) compilation with \
+                     TIMESTAMP_MSG=yes"
+                );
+                return Ok(());
+            }
+
+            #[cfg(feature = "timestamp-messages")]
+            {
+                benchmark.run_echo_breakdown(false).await
             }
         },
         BenchmarkFlavour::RoundTripLatency => {


### PR DESCRIPTION
In this PR I resurrect the `echo-breakdown` benchmark, and include it in our CI, and benchmark summary, together with its L2 variant `echo-breakdown-l2`. I also enhance the benchmark to report percentiles instead of just the breakdown of a single run.

When running this benchmark locally, remember to re-build with the `TIMESTAMP_MSG=yes` feature.

Closes #711 