### PR TITLE
[tests] Enable L2 Tests

### DIFF
--- a/.github/actions/deployment-features/action.yml
+++ b/.github/actions/deployment-features/action.yml
@@ -27,6 +27,9 @@ runs:
         multi-process)
           echo "features-arg=--features SINGLE_PROCESS=no" >> "$GITHUB_OUTPUT"
           ;;
+        l2)
+          echo "features-arg=--features SINGLE_PROCESS=no,L2_VM=yes" >> "$GITHUB_OUTPUT"
+          ;;
         *)
           echo "invalid deployment type: ${{ inputs.deployment-type }}" >&2
           exit 1

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -40,10 +40,12 @@ jobs:
       matrix:
         build-type: [debug, release]
         machine-type: [qemu-pc, microvm, hyperlight]
-        deployment-type: [single-process, multi-process]
+        deployment-type: [single-process, multi-process, l2]
         exclude:
           - machine-type: qemu-pc
             deployment-type: single-process
+          - machine-type: qemu-pc
+            deployment-type: l2
     runs-on: [self-hosted, Linux, X64]
 
     # Only run the CI for:
@@ -110,7 +112,7 @@ jobs:
 
     - id: release-archive
       name: "Create Release Archive"
-      if: ${{ success() && github.ref == 'refs/heads/dev' && matrix.build-type == 'release' }}
+      if: ${{ success() && github.ref == 'refs/heads/dev' && matrix.build-type == 'release' &&  matrix.deployment-type != 'l2' }}
       run: |
         single_process="no"
         if [[ "${{ matrix.deployment-type }}" == "single-process" ]]; then
@@ -149,7 +151,7 @@ jobs:
       shell: bash
 
     - name: "Upload Release Artifact"
-      if: ${{ success() && github.ref == 'refs/heads/dev' && matrix.build-type == 'release' }}
+      if: ${{ success() && github.ref == 'refs/heads/dev' && matrix.build-type == 'release' && matrix.deployment-type != 'l2' }}
       uses: actions/upload-artifact@v4
       with:
         name: release-${{ matrix.machine-type }}-${{ matrix.deployment-type }}

--- a/build/make/test/quickjs.mk
+++ b/build/make/test/quickjs.mk
@@ -6,10 +6,14 @@ QUICKJS_BINARY := $(SYSROOT_DIR)/bin/qjs
 define QUICKJS_TEST_RULE
 test-quickjs-$(1): all
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+ifeq ($(L2_VM),yes)
+	printf "\033[31mWarning: Skipping %s on L2 (not supported, see #986).\033[0m\n" "$(2)";
+else
 	@if [ -f "$(QUICKJS_BINARY)" ]; then \
 		echo "Running test $(1)..."; \
 		$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) $(QUICKJS_BINARY) "--std $(SOURCES_DIR)/tests/quickjs/$(1).js" $(2) $(3) $(TIMEOUT); \
 	fi
+endif
 endif
 endef
 

--- a/build/make/test/system.mk
+++ b/build/make/test/system.mk
@@ -3,15 +3,31 @@
 
 comma:=,
 
+# List of supported functions in the L2 VM.
+# FIXME (#986): modify tests such that they don't rely on linuxd being invoked
+# from the root of the source tree.
+MICROVM_L2_BLOCKLIST := dlfcn-c file-c file-rust python3 qjs
+
 define TEST_RULE
 test-$(2): all
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+ifeq ($(L2_VM),yes)
 	@if [ ! -f "$(1)/$(2)$(3)" ]; then \
-		echo "\033[31mWarning: $(1)/$(2)$(3) missing, skipping test.\033[0m"; \
-		else \
-		echo "Running test $(2)..." ; \
-			$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) $(1)/$(2)$(3) $(4) $(5) $(6) $(TIMEOUT); \
+		printf "\033[31mWarning: %s missing, skipping test.\033[0m\n" "$(1)/$(2)$(3)"; \
+	elif printf '%s\n' $(MICROVM_L2_BLOCKLIST) | grep -Fxq -- "$(2)"; then \
+		printf "\033[31mWarning: Skipping %s on L2 (not supported, see #986).\033[0m\n" "$(2)"; \
+	else \
+		echo "Running test $(2)..."; \
+		$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) "$(1)/$(2)$(3)" $(4) $(5) $(6) $(TIMEOUT); \
 	fi
+else
+	@if [ ! -f "$(1)/$(2)$(3)" ]; then \
+		printf "\033[31mWarning: %s missing, skipping test.\033[0m\n" "$(1)/$(2)$(3)"; \
+	else \
+		echo "Running test $(2)..."; \
+		$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) "$(1)/$(2)$(3)" $(4) $(5) $(6) $(TIMEOUT); \
+	fi
+endif
 endif
 endef
 

--- a/scripts/run-nanvixd.sh
+++ b/scripts/run-nanvixd.sh
@@ -484,6 +484,7 @@ main() {
         --log-to-file \
         -log-dir "${logs_dir}" \
         -tmp-dir "${TMP_DIR}" \
+        "$([ "$L2_VM" = "yes" ] && echo "-l2")" \
         -console-file "${console_file_name}" &
     NANVIXD_PID=$!
     trap 'cleanup' EXIT
@@ -523,10 +524,20 @@ main() {
     fi
 
     # Connect to VM.
-    nc -v -U -q 0 "${gateway_sockaddr}" || {
-        echo "Error: Unable to connect VM at ${gateway_sockaddr}." 1>&2
-        return 1
-    }
+    if [[ "${L2_VM}" == "yes" ]]; then
+        gateway_host=${gateway_sockaddr%:*}
+        gateway_port=${gateway_sockaddr#*:}
+
+        nc -v -q 0 "${gateway_host}" "${gateway_port}" || {
+            echo "Error: Unable to connect VM at ${gateway_sockaddr} (L2)." 1>&2
+            return 1
+        }
+    else
+        nc -v -U -q 0 "${gateway_sockaddr}" || {
+            echo "Error: Unable to connect VM at ${gateway_sockaddr}." 1>&2
+            return 1
+        }
+    fi
 
     # Kill the user VM.
     local kill_exit_code

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -50,6 +50,7 @@ RUN_COMMAND=("${NANVIX_HOME}/scripts/run-nanvixd.sh"
     "--app-name" "${APP_NAME}"
     "--nanvixd-sockaddr" "${NANVIXD_SOCKADDR}"
     "--toolchain-bin-dir" "${TOOLCHAIN_DIR}/bin"
+    "--log-level" "${LOG_LEVEL}"
     "--"
     "${PROGRAM_NAME}"
 )

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -55,7 +55,7 @@ use ::tokio::{
 
 #[tokio::main]
 pub async fn main() -> Result<()> {
-    let args: Args = Args::parse(std::env::args().collect())?;
+    let args: Args = Args::parse(std::env::args().filter(|s| !s.trim().is_empty()).collect())?;
 
     ::syslog::init(args.log_to_file(), args.log_directory().to_string());
 


### PR DESCRIPTION
In this PR I enable running integration tests inside the L2 VM. The L2 VM can be interpreted as a new deployment type, where linuxd is deployed inside a VM itself.

This PR just turns the feature on, and blocks all the tests that are currently not passing. I make an exhaustive list, and the reasons why they do not pass in #986. The reason why there are some failing tests is two-fold:
1. The L2 VM does not ship with a "consistent" Nanvix sysroot. It only ships with `linuxd.elf`. The current `sysroot-release` is ~1.8 GiB (`sysroot-debug` is ~2.7 GiB). We need to decide whether it is acceptable to have that in the L2 VM, or we want something more minimal.
2. Some tests make further assumptions about the environment where they execute. For example, `file-c` expects a `./README.md` file.

Number 1 is a genuine thing we need to think about, but maybe not in this PR? Number 2 sounds more like an issue with the way some tests are designed.

Closes #987 