### PR TITLE
[scripts] Tolerate Missing Result Files

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -411,7 +411,8 @@ def copy_results(args):
         filename = gen_filename_for_benchmark(benchmark, machine, arch)
         cmd = f"cp {args.source_dir}/{filename} {args.target_dir}/{filename}"
         print(cmd)
-        subprocess.run(cmd, shell=True, check=True)
+        # Tolerate failures in the cp command, indicating a missing benchmark.
+        subprocess.run(cmd, shell=True, check=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In this commit I fix a bug in the benchmark.py script that does not tolerate missing files when running `copy-results`.

Not all benchmarks are supported in all machine types, so some result files will be missing. This is not a fatal error, and the script should not crash.