### PR TITLE
[uservm] Reset Global Variables on VM Creation

### DIFF
--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -185,6 +185,12 @@ pub struct UserVm;
 impl UserVm {
     /// Launches a user virtual machine on a Tokio task and returns a handle to its completion.
     pub fn spawn(args: UserVmArgs) -> JoinHandle<Result<u16>> {
+        // Reset counters of previous runs.
+        IO_THREAD_NUM_MESSAGES_RECEIVED.store(0, Ordering::SeqCst);
+        MEM_THREAD_NUM_MESSAGES_RECEIVED.store(0, Ordering::SeqCst);
+        VMM_THREAD_NUM_MESSAGES_RECEIVED.store(0, Ordering::SeqCst);
+        VMM_THREAD_NUM_INPUT_CALLS.store(0, Ordering::SeqCst);
+
         tokio::spawn(async move { UserVm::run(args).await })
     }
 

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -191,6 +191,9 @@ impl Vmm {
     pub fn new(args: MicroVmArgs) -> Result<Self> {
         trace!("new(): args={:?}", args);
 
+        // Reset shutdown flag from any previous runs.
+        SHUTDOWN.store(false, Ordering::SeqCst);
+
         let mut kvm: Kvm = Kvm::new()?;
         let mut vm: VmFd = kvm.create_vm()?;
 


### PR DESCRIPTION
## Description

This PR fixes the User VM (`uservm`) implementation to reset global variables when a new VM is created.

This is required to correctly support multiple executions from the same host process, when the `uservm` is running in embedded mode.