### PR TITLE
[daemons] System Call Filtering/Interposition

### DIFF
--- a/src/daemons/linuxd/src/dirent.rs
+++ b/src/daemons/linuxd/src/dirent.rs
@@ -5,13 +5,22 @@
 // Imports
 //==================================================================================================
 
-use crate::error::WorkerThreadError;
+use crate::{
+    error::WorkerThreadError,
+    syscalls::{
+        SystemCallAction,
+        SystemCallRouteTable,
+    },
+};
 use ::alloc::vec::Vec;
 use ::core::{
     cmp,
     mem,
 };
-use ::std::ffi::CStr;
+use ::std::{
+    ffi::CStr,
+    sync::Arc,
+};
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
@@ -110,6 +119,7 @@ impl linux_dirent {
 
 /// Handles a getdents() system call request.
 pub fn do_getdents(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: GetDirectoryEntriesRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -133,7 +143,7 @@ pub fn do_getdents(
     debug!("libc::getdents(): fd={}, buf={:#x?}, bufsize={}", { request.fd }, rawbuf.as_ptr(), {
         bufsize
     });
-    match unsafe { libc::syscall(libc::SYS_getdents, request.fd, rawbuf.as_mut_ptr(), bufsize) } {
+    match unsafe { handle_getdents(&syscall_table, request.fd, rawbuf.as_mut_ptr(), bufsize) } {
         // Failed.
         -1 => {
             let errno = unsafe { *libc::__errno_location() };
@@ -215,6 +225,28 @@ pub fn do_getdents(
         Err(error) => {
             warn!("do_getdents(): failed to build response (error={error:?})");
             Ok(vec![crate::build_error(tid, error.code)])
+        },
+    }
+}
+
+//==================================================================================================
+// System Call Wrappers
+//==================================================================================================
+
+/// Handler for `getdents()` system call.
+unsafe fn handle_getdents(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    dirp: *mut u8,
+    count: libc::size_t,
+) -> libc::c_long {
+    match syscall_table.syscall_getdents.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_getdents.syscall_fn)(fd, dirp, count)
         },
     }
 }

--- a/src/daemons/linuxd/src/fcntl.rs
+++ b/src/daemons/linuxd/src/fcntl.rs
@@ -7,10 +7,15 @@
 
 use crate::{
     error::WorkerThreadError,
+    syscalls::{
+        SystemCallAction,
+        SystemCallRouteTable,
+    },
     time::LibcTimeSpec,
 };
 use ::alloc::ffi::CString;
 use ::core::ffi;
+use ::std::sync::Arc;
 use ::sys::{
     error::{
         Error,
@@ -153,6 +158,7 @@ use sysapi::fcntl::file_descriptor_flags::{
 //==================================================================================================
 
 pub fn do_openat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: OpenAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -183,7 +189,9 @@ pub fn do_openat(
         flags.inner(),
         mode.inner()
     );
-    match unsafe { libc::openat(dirfd.inner(), pathname.as_ptr(), flags.inner(), mode.inner()) } {
+    match unsafe {
+        handle_openat(&syscall_table, dirfd.inner(), pathname.as_ptr(), flags.inner(), mode.inner())
+    } {
         fd if fd >= 0 => {
             debug!("libc::openat(): fd={fd:?}");
             Ok(vec![OpenAtResponse::build(tid, fd)])
@@ -216,6 +224,7 @@ pub fn do_openat(
 //==================================================================================================
 
 pub fn do_unlinkat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: UnlinkAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -237,8 +246,14 @@ pub fn do_unlinkat(
     };
 
     debug!("libc::unlinkat(): dirfd={:?}, pathname={pathname:?}, flags={flags:?}", dirfd.inner(),);
-    match unsafe { libc::unlinkat(dirfd.inner(), pathname.as_bytes().as_ptr() as *const i8, flags) }
-    {
+    match unsafe {
+        handle_unlinkat(
+            &syscall_table,
+            dirfd.inner(),
+            pathname.as_bytes().as_ptr() as *const i8,
+            flags,
+        )
+    } {
         ret if ret == 0 => {
             debug!("libc::unlinkat(): success");
             Ok(vec![UnlinkAtResponse::build(tid, ret)])
@@ -269,6 +284,7 @@ pub fn do_unlinkat(
 //==================================================================================================
 
 pub fn do_renameat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: RenameAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -296,7 +312,8 @@ pub fn do_renameat(
         newdirfd.inner(),
     );
     match unsafe {
-        libc::renameat(
+        handle_renameat(
+            &syscall_table,
             olddirfd.inner(),
             oldpath.as_bytes().as_ptr() as *const i8,
             newdirfd.inner(),
@@ -335,6 +352,7 @@ pub fn do_renameat(
 //==================================================================================================
 
 pub fn do_fstat_at(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileStatAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -355,7 +373,15 @@ pub fn do_fstat_at(
     let mut st: libc::stat = unsafe { core::mem::zeroed() };
 
     debug!("libc::fstatat(): dirfd={:?}, path={path:?}, flag={:?}", dirfd.inner(), flag);
-    match unsafe { libc::fstatat(dirfd.inner(), path.as_ptr(), &mut st as *mut libc::stat, flag) } {
+    match unsafe {
+        handle_fstatat(
+            &syscall_table,
+            dirfd.inner(),
+            path.as_ptr(),
+            &mut st as *mut libc::stat,
+            flag,
+        )
+    } {
         0 => {
             debug!("libc::fstatat(): success");
 
@@ -436,6 +462,7 @@ pub fn do_fstat_at(
 //==================================================================================================
 
 pub fn do_posix_fallocate(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileSpaceControlRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -446,7 +473,7 @@ pub fn do_posix_fallocate(
     let len: off_t = request.len;
 
     debug!("libc::posix_fallocate(): fd={fd:?}, offset={offset:?}, len={len:?}");
-    match unsafe { libc::posix_fallocate(fd, offset, len) } {
+    match unsafe { handle_posix_fallocate(&syscall_table, fd, offset, len) } {
         0 => {
             debug!("libc::posix_fallocate(): success");
             Ok(FileSpaceControlResponse::build(tid, 0))
@@ -480,6 +507,7 @@ pub fn do_posix_fallocate(
 //==================================================================================================
 
 pub fn do_posix_fadvise(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileAdvisoryInformationRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -497,7 +525,7 @@ pub fn do_posix_fadvise(
         "libc::posix_fadvise(): fd={fd:?}, offset={offset:?}, len={len:?}, advice={:?}",
         advice.inner()
     );
-    match unsafe { libc::posix_fadvise(fd, offset, len, advice.inner()) } {
+    match unsafe { handle_posix_fadvise(&syscall_table, fd, offset, len, advice.inner()) } {
         0 => {
             debug!("libc::posix_fadvise(): success");
             Ok(FileAdvisoryInformationResponse::build(tid, 0))
@@ -531,6 +559,7 @@ pub fn do_posix_fadvise(
 //==================================================================================================
 
 pub fn do_fstat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileStatRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -541,7 +570,7 @@ pub fn do_fstat(
     let mut st: libc::stat = unsafe { core::mem::zeroed() };
 
     debug!("libc::fstat(): fd={fd:?}");
-    match unsafe { libc::fstat(fd, &mut st) } {
+    match unsafe { handle_fstat(&syscall_table, fd, &mut st) } {
         0 => {
             debug!("libc::fstatat(): success");
 
@@ -622,6 +651,7 @@ pub fn do_fstat(
 //==================================================================================================
 
 pub fn do_symlinkat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: SymbolicLinkAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -644,7 +674,9 @@ pub fn do_symlinkat(
         "libc::symlinkat(): oldpath={target:?}, newdirfd={:?}, newpath={linkpath:?}",
         newdirfd.inner(),
     );
-    match unsafe { libc::symlinkat(target.as_ptr(), newdirfd.inner(), linkpath.as_ptr()) } {
+    match unsafe {
+        handle_symlinkat(&syscall_table, target.as_ptr(), newdirfd.inner(), linkpath.as_ptr())
+    } {
         0 => {
             debug!("libc::symlinkat(): success");
             Ok(vec![SymbolicLinkAtResponse::build(tid, 0)])
@@ -677,6 +709,7 @@ pub fn do_symlinkat(
 //==================================================================================================
 
 pub fn do_readlinkat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: ReadLinkAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -699,7 +732,13 @@ pub fn do_readlinkat(
         buf.capacity()
     );
     match unsafe {
-        libc::readlinkat(dirfd.inner(), path.as_ptr(), buf.as_mut_ptr() as *mut i8, buf.capacity())
+        handle_readlinkat(
+            &syscall_table,
+            dirfd.inner(),
+            path.as_ptr(),
+            buf.as_mut_ptr() as *mut i8,
+            buf.capacity(),
+        )
     } {
         len if len >= 0 => {
             debug!("libc::readlinkat(): (len={len:?})");
@@ -744,6 +783,7 @@ pub fn do_readlinkat(
 //==================================================================================================
 
 pub fn do_mkdirat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: MakeDirectoryAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -767,7 +807,8 @@ pub fn do_mkdirat(
         dirfd.inner(),
         mode.inner()
     );
-    match unsafe { libc::mkdirat(dirfd.inner(), pathname.as_ptr(), mode.inner()) } {
+    match unsafe { handle_mkdirat(&syscall_table, dirfd.inner(), pathname.as_ptr(), mode.inner()) }
+    {
         0 => {
             debug!("libc::mkdirat(): success");
             Ok(vec![MakeDirectoryAtResponse::build(tid, 0)])
@@ -800,6 +841,7 @@ pub fn do_mkdirat(
 //==================================================================================================
 
 pub fn do_utimensat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: UpdateFileAccessTimeAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -836,7 +878,9 @@ pub fn do_utimensat(
         libc_times[1].tv_sec,
         libc_times[1].tv_nsec
     );
-    match unsafe { libc::utimensat(dirfd.inner(), path.as_ptr(), libc_times.as_ptr(), flag) } {
+    match unsafe {
+        handle_utimensat(&syscall_table, dirfd.inner(), path.as_ptr(), libc_times.as_ptr(), flag)
+    } {
         0 => {
             debug!("libc::utimensat(): success");
             Ok(vec![UpdateFileAccessTimeAtResponse::build(tid, 0)])
@@ -869,6 +913,7 @@ pub fn do_utimensat(
 //==================================================================================================
 
 pub fn do_futimens(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: UpdateFileAccessTimeRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -888,7 +933,7 @@ pub fn do_futimens(
          times[1].tv_sec={:?}, times[1].tv_nsec={:?}",
         libc_times[0].tv_sec, libc_times[0].tv_nsec, libc_times[1].tv_sec, libc_times[1].tv_nsec
     );
-    match unsafe { libc::futimens(fd, libc_times.as_ptr()) } {
+    match unsafe { handle_futimens(&syscall_table, fd, libc_times.as_ptr()) } {
         0 => {
             debug!("libc::futimens(): success");
             Ok(UpdateFileAccessTimeResponse::build(tid, 0))
@@ -921,6 +966,7 @@ pub fn do_futimens(
 //==================================================================================================
 
 pub fn do_fcntl(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileControlRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -997,7 +1043,7 @@ pub fn do_fcntl(
         },
     };
 
-    let ret: i32 = unsafe { libc::fcntl(fd, cmd.inner(), libc_arg) };
+    let ret: i32 = unsafe { handle_fcntl(&syscall_table, fd, cmd.inner(), libc_arg) };
 
     match cmd.inner() {
         libc::F_DUPFD | libc::F_DUPFD_CLOEXEC => {
@@ -1166,6 +1212,7 @@ pub fn do_fcntl(
 //==================================================================================================
 
 pub fn do_fchownat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileChownAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -1188,7 +1235,9 @@ pub fn do_fchownat(
         dirfd.inner(),
         flag.inner()
     );
-    match unsafe { libc::fchownat(dirfd.inner(), path.as_ptr(), owner, group, flag.inner()) } {
+    match unsafe {
+        handle_fchownat(&syscall_table, dirfd.inner(), path.as_ptr(), owner, group, flag.inner())
+    } {
         0 => {
             debug!("libc::fchownat(): success");
             Ok(vec![FileChownAtResponse::build(tid)])
@@ -1221,6 +1270,7 @@ pub fn do_fchownat(
 //==================================================================================================
 
 pub fn do_fchmod(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileChmodRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -1230,7 +1280,7 @@ pub fn do_fchmod(
     let mode: u32 = request.mode;
 
     debug!("libc::fchmod(): fd={fd:?}, mode={mode:?}");
-    match unsafe { libc::fchmod(fd, mode) } {
+    match unsafe { handle_fchmod(&syscall_table, fd, mode) } {
         0 => Ok(FileChmodResponse::build(tid)),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
@@ -1256,6 +1306,7 @@ pub fn do_fchmod(
 //==================================================================================================
 
 pub fn do_fchmodat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileChmodAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -1283,7 +1334,9 @@ pub fn do_fchmodat(
         mode.inner(),
         flag.inner()
     );
-    match unsafe { libc::fchmodat(dirfd.inner(), path.as_ptr(), mode.inner(), flag.inner()) } {
+    match unsafe {
+        handle_fchmodat(&syscall_table, dirfd.inner(), path.as_ptr(), mode.inner(), flag.inner())
+    } {
         0 => {
             debug!("libc::fchmodat(): success");
             Ok(vec![FileChmodAtResponse::build(tid)])
@@ -1742,5 +1795,299 @@ impl LibcFileAdvice {
         };
 
         Ok(LibcFileAdvice(libc_advice))
+    }
+}
+
+//==================================================================================================
+// System Call Wrappers
+//==================================================================================================
+
+/// Handler for `libc::openat()`.
+unsafe fn handle_openat(
+    syscall_table: &SystemCallRouteTable,
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    flags: libc::c_int,
+    mode: libc::mode_t,
+) -> libc::c_int {
+    match syscall_table.syscall_openat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_openat.syscall_fn)(dirfd, pathname, flags, mode)
+        },
+    }
+}
+
+/// Handler for `libc::unlinkat()`.
+unsafe fn handle_unlinkat(
+    syscall_table: &SystemCallRouteTable,
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    flags: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_unlinkat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_unlinkat.syscall_fn)(dirfd, pathname, flags)
+        },
+    }
+}
+
+/// Handler for `libc::renameat()`.
+unsafe fn handle_renameat(
+    syscall_table: &SystemCallRouteTable,
+    olddirfd: libc::c_int,
+    oldpath: *const libc::c_char,
+    newdirfd: libc::c_int,
+    newpath: *const libc::c_char,
+) -> libc::c_int {
+    match syscall_table.syscall_renameat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_renameat.syscall_fn)(olddirfd, oldpath, newdirfd, newpath)
+        },
+    }
+}
+
+/// Handler for `libc::fstatat()`.
+unsafe fn handle_fstatat(
+    syscall_table: &SystemCallRouteTable,
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    buf: *mut libc::stat,
+    flags: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_fstatat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_fstatat.syscall_fn)(dirfd, pathname, buf, flags)
+        },
+    }
+}
+
+/// Handler for `libc::posix_fallocate()`.
+unsafe fn handle_posix_fallocate(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    offset: off_t,
+    len: off_t,
+) -> libc::c_int {
+    match syscall_table.syscall_posix_fallocate.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_posix_fallocate.syscall_fn)(fd, offset, len)
+        },
+    }
+}
+
+/// Handler for `libc::posix_fadvise()`.
+unsafe fn handle_posix_fadvise(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    offset: off_t,
+    len: off_t,
+    advice: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_posix_fadvise.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_posix_fadvise.syscall_fn)(fd, offset, len, advice)
+        },
+    }
+}
+
+/// Handler for `libc::fstat()`.
+unsafe fn handle_fstat(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    buf: *mut libc::stat,
+) -> libc::c_int {
+    match syscall_table.syscall_fstat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_fstat.syscall_fn)(fd, buf) },
+    }
+}
+
+/// Handler for `libc::symlinkat()`.
+unsafe fn handle_symlinkat(
+    syscall_table: &SystemCallRouteTable,
+    target: *const libc::c_char,
+    newdirfd: libc::c_int,
+    linkpath: *const libc::c_char,
+) -> libc::c_int {
+    match syscall_table.syscall_symlinkat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_symlinkat.syscall_fn)(target, newdirfd, linkpath)
+        },
+    }
+}
+
+/// Handler for `libc::readlinkat()`.
+unsafe fn handle_readlinkat(
+    syscall_table: &SystemCallRouteTable,
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    buf: *mut libc::c_char,
+    bufsiz: libc::size_t,
+) -> libc::ssize_t {
+    match syscall_table.syscall_readlinkat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_readlinkat.syscall_fn)(dirfd, pathname, buf, bufsiz)
+        },
+    }
+}
+
+/// Handler for `libc::mkdirat()`.
+unsafe fn handle_mkdirat(
+    syscall_table: &SystemCallRouteTable,
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    mode: libc::mode_t,
+) -> libc::c_int {
+    match syscall_table.syscall_mkdirat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_mkdirat.syscall_fn)(dirfd, pathname, mode)
+        },
+    }
+}
+
+/// Handler for `libc::utimensat()`.
+unsafe fn handle_utimensat(
+    syscall_table: &SystemCallRouteTable,
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    times: *const libc::timespec,
+    flags: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_utimensat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_utimensat.syscall_fn)(dirfd, pathname, times, flags)
+        },
+    }
+}
+
+/// Handler for `libc::futimens()`.
+unsafe fn handle_futimens(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    times: *const libc::timespec,
+) -> libc::c_int {
+    match syscall_table.syscall_futimens.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_futimens.syscall_fn)(fd, times)
+        },
+    }
+}
+
+/// Handler for `libc::fcntl()`.
+unsafe fn handle_fcntl(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    cmd: libc::c_int,
+    arg: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_fcntl.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_fcntl.syscall_fn)(fd, cmd, arg)
+        },
+    }
+}
+
+/// Handler for `libc::fchownat()`.
+unsafe fn handle_fchownat(
+    syscall_table: &SystemCallRouteTable,
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    owner: libc::uid_t,
+    group: libc::gid_t,
+    flags: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_fchownat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_fchownat.syscall_fn)(dirfd, pathname, owner, group, flags)
+        },
+    }
+}
+
+/// Handler for `libc::fchmod()`.
+unsafe fn handle_fchmod(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    mode: libc::mode_t,
+) -> libc::c_int {
+    match syscall_table.syscall_fchmod.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_fchmod.syscall_fn)(fd, mode) },
+    }
+}
+
+/// Handler for `libc::fchmodat()`.
+unsafe fn handle_fchmodat(
+    syscall_table: &SystemCallRouteTable,
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    mode: libc::mode_t,
+    flags: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_fchmodat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_fchmodat.syscall_fn)(dirfd, pathname, mode, flags)
+        },
     }
 }

--- a/src/daemons/linuxd/src/lib.rs
+++ b/src/daemons/linuxd/src/lib.rs
@@ -36,6 +36,7 @@ pub mod message;
 pub mod poll;
 pub mod socket;
 pub mod sys_select;
+pub mod syscalls;
 pub mod time;
 pub mod times;
 pub mod unistd;

--- a/src/daemons/linuxd/src/linuxd/assemble.rs
+++ b/src/daemons/linuxd/src/linuxd/assemble.rs
@@ -12,9 +12,11 @@ use crate::{
         RequestAssemblerTrait,
         RequestAssemblerType,
     },
+    syscalls::SystemCallRouteTable,
     unistd,
 };
 use ::anyhow::Result;
+use ::std::sync::Arc;
 use ::sys::{
     error::{
         Error,
@@ -87,10 +89,11 @@ impl RequestAssemblerTrait for FileStatAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        fcntl::do_fstat_at(source, request)
+        fcntl::do_fstat_at(syscall_table, source, request)
     }
 }
 
@@ -127,10 +130,11 @@ impl RequestAssemblerTrait for SymbolicLinkAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        fcntl::do_symlinkat(source, request)
+        fcntl::do_symlinkat(syscall_table, source, request)
     }
 }
 
@@ -167,10 +171,11 @@ impl RequestAssemblerTrait for LinkAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        unistd::do_linkat(source, request)
+        unistd::do_linkat(syscall_table, source, request)
     }
 }
 
@@ -207,10 +212,11 @@ impl RequestAssemblerTrait for ReadLinkAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        fcntl::do_readlinkat(source, request)
+        fcntl::do_readlinkat(syscall_table, source, request)
     }
 }
 
@@ -249,10 +255,11 @@ impl RequestAssemblerTrait for MakeDirectoryAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        fcntl::do_mkdirat(source, request)
+        fcntl::do_mkdirat(syscall_table, source, request)
     }
 }
 
@@ -295,10 +302,11 @@ impl RequestAssemblerTrait for UpdateFileAccessTimeAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        fcntl::do_utimensat(source, request)
+        fcntl::do_utimensat(syscall_table, source, request)
     }
 }
 
@@ -335,10 +343,11 @@ impl RequestAssemblerTrait for FileChownAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        fcntl::do_fchownat(source, request)
+        fcntl::do_fchownat(syscall_table, source, request)
     }
 }
 
@@ -375,10 +384,11 @@ impl RequestAssemblerTrait for FileChmodAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        fcntl::do_fchmodat(source, request)
+        fcntl::do_fchmodat(syscall_table, source, request)
     }
 }
 
@@ -415,10 +425,11 @@ impl RequestAssemblerTrait for OpenAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        fcntl::do_openat(source, request)
+        fcntl::do_openat(syscall_table, source, request)
     }
 }
 
@@ -455,10 +466,11 @@ impl RequestAssemblerTrait for RenameAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        fcntl::do_renameat(source, request)
+        fcntl::do_renameat(syscall_table, source, request)
     }
 }
 
@@ -495,10 +507,11 @@ impl RequestAssemblerTrait for UnlinkAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        fcntl::do_unlinkat(source, request)
+        fcntl::do_unlinkat(syscall_table, source, request)
     }
 }
 
@@ -537,10 +550,11 @@ impl RequestAssemblerTrait for ChangeDirectoryRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        unistd::do_chdir(source, request)
+        unistd::do_chdir(syscall_table, source, request)
     }
 }
 
@@ -577,10 +591,11 @@ impl RequestAssemblerTrait for FileAccessAtRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        unistd::do_faccessat(source, request)
+        unistd::do_faccessat(syscall_table, source, request)
     }
 }
 
@@ -617,9 +632,10 @@ impl RequestAssemblerTrait for PollRequest {
     }
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
-        crate::poll::do_poll(source, request)
+        crate::poll::do_poll(syscall_table, source, request)
     }
 }

--- a/src/daemons/linuxd/src/linuxd/mod.rs
+++ b/src/daemons/linuxd/src/linuxd/mod.rs
@@ -17,6 +17,7 @@ use crate::{
         CONTROL_PLANE_CONNECT_TIMEOUT,
     },
     message::RequestAssembler,
+    syscalls::SystemCallRouteTable,
     user_vm_handle::UserVmHandle,
     venv::{
         VenvCommand,
@@ -88,6 +89,7 @@ use ::user_vm_api::{
 //==================================================================================================
 
 pub struct LinuxDaemon {
+    syscall_table: Arc<SystemCallRouteTable>,
     assembler: Arc<Mutex<RequestAssembler>>,
     control_plane_sockaddr: String,
     control_plane_sockaddr_type: SocketType,
@@ -102,6 +104,7 @@ pub struct LinuxDaemon {
 
 impl LinuxDaemon {
     pub fn init(
+        syscall_table: Arc<SystemCallRouteTable>,
         control_plane_sockaddr: &str,
         control_plane_sockaddr_type: &str,
         user_vm_listener: SocketListener,
@@ -124,6 +127,7 @@ impl LinuxDaemon {
             };
 
         Ok(Self {
+            syscall_table,
             assembler: Arc::new(Mutex::new(RequestAssembler::default())),
             control_plane_sockaddr: control_plane_sockaddr.to_string(),
             control_plane_sockaddr_type: control_plane_sockaddr_type_parsed,
@@ -544,6 +548,7 @@ impl LinuxDaemon {
                 channel_tx.clone(),
                 uvm_handle.clone(),
                 assembler.clone(),
+                self.syscall_table.clone(),
             )?;
             worker_threads
                 .lock()

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -23,10 +23,12 @@ use ::linuxd::{
     args,
     args::Args,
     linuxd::LinuxDaemon,
+    syscalls::SystemCallRouteTable,
 };
 use ::std::{
     env,
     str::FromStr,
+    sync::Arc,
 };
 use ::syscomm::{
     SocketListener,
@@ -73,6 +75,7 @@ pub async fn main() -> Result<()> {
     info!("Listening to user VMs on: {user_vm_sockaddr:?}");
 
     let linuxd: LinuxDaemon = match LinuxDaemon::init(
+        Arc::new(SystemCallRouteTable::default()),
         control_plane_sockaddr,
         args.control_plane_socket_type(),
         user_vm_listener,

--- a/src/daemons/linuxd/src/message.rs
+++ b/src/daemons/linuxd/src/message.rs
@@ -5,8 +5,12 @@
 // Imports
 //==================================================================================================
 
-use crate::error::WorkerThreadError;
+use crate::{
+    error::WorkerThreadError,
+    syscalls::SystemCallRouteTable,
+};
 use ::alloc::collections::BTreeMap;
+use ::std::sync::Arc;
 use ::sys::{
     error::Error,
     ipc::Message,
@@ -30,10 +34,11 @@ pub struct RequestAssembler {
 impl RequestAssembler {
     pub fn process_message<T: RequestAssemblerTrait>(
         &mut self,
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
     ) -> Result<Option<Vec<Message>>, WorkerThreadError> {
-        match self.process_message_internal::<T>(source, part) {
+        match self.process_message_internal::<T>(syscall_table, source, part) {
             Ok(messages) => Ok(messages),
             Err(WorkerThreadError::Interrupted) => Err(WorkerThreadError::Interrupted),
             Err(WorkerThreadError::Error(e)) => {
@@ -45,6 +50,7 @@ impl RequestAssembler {
 
     fn process_message_internal<T: RequestAssemblerTrait>(
         &mut self,
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
     ) -> Result<Option<Vec<Message>>, WorkerThreadError> {
@@ -61,7 +67,7 @@ impl RequestAssembler {
             return Ok(None);
         }
 
-        match self.process_request::<T>(source) {
+        match self.process_request::<T>(syscall_table, source) {
             Ok(messages) => Ok(Some(messages)),
             Err(e) => Err(e),
         }
@@ -82,6 +88,7 @@ impl RequestAssembler {
 
     fn process_request<T: RequestAssemblerTrait>(
         &mut self,
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
     ) -> Result<Vec<Message>, WorkerThreadError> {
         let assembler: RequestAssemblerType = self
@@ -91,7 +98,7 @@ impl RequestAssembler {
 
         let parts: Vec<LinuxDaemonMessagePart> = T::take_parts(assembler);
         let request: T = T::from_parts(&parts)?;
-        T::process_request(source, request)
+        T::process_request(syscall_table, source, request)
     }
 }
 
@@ -130,6 +137,7 @@ where
     fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart>;
 
     fn process_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError>;

--- a/src/daemons/linuxd/src/poll.rs
+++ b/src/daemons/linuxd/src/poll.rs
@@ -5,7 +5,14 @@
 // Imports
 //==================================================================================================
 
-use crate::error::WorkerThreadError;
+use crate::{
+    error::WorkerThreadError,
+    syscalls::{
+        SystemCallAction,
+        SystemCallRouteTable,
+    },
+};
+use ::std::sync::Arc;
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
@@ -49,6 +56,7 @@ use ::syslog::{
 //==================================================================================================
 
 pub fn do_poll(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: PollRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -71,7 +79,7 @@ pub fn do_poll(
     let timeout: libc::c_int = request.timeout;
 
     debug!("libc::poll(): nfds={nfds:?}, timeout={timeout:?}");
-    match unsafe { libc::poll(fds.as_mut_ptr(), nfds, timeout) } {
+    match unsafe { handle_poll(&syscall_table, fds.as_mut_ptr(), nfds, timeout) } {
         nready if nready >= 0 => {
             debug!("poll(): nready={nready:?}");
 
@@ -190,5 +198,27 @@ impl LibcPollFd {
             events: libc_events,
             revents: 0, // revents is not used in the request
         })
+    }
+}
+
+//==================================================================================================
+// System Call Wrappers
+//==================================================================================================
+
+/// Handler for `libc::poll()`.
+unsafe fn handle_poll(
+    syscall_table: &SystemCallRouteTable,
+    fds: *mut libc::pollfd,
+    nfds: libc::nfds_t,
+    timeout: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_poll.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_poll.syscall_fn)(fds, nfds, timeout)
+        },
     }
 }

--- a/src/daemons/linuxd/src/socket.rs
+++ b/src/daemons/linuxd/src/socket.rs
@@ -5,11 +5,18 @@
 // Imports
 //==================================================================================================
 
-use crate::error::WorkerThreadError;
+use crate::{
+    error::WorkerThreadError,
+    syscalls::{
+        SystemCallAction,
+        SystemCallRouteTable,
+    },
+};
 use ::core::{
     cmp,
     mem,
 };
+use ::std::sync::Arc;
 use ::sys::{
     error::{
         Error,
@@ -80,6 +87,7 @@ use ::syslog::{
 //==================================================================================================
 
 pub fn do_socket(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: CreateSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -99,7 +107,9 @@ pub fn do_socket(
         domain.inner(),
         typ.inner(),
     );
-    match unsafe { libc::socket(domain.inner() as i32, typ.inner(), protocol.inner()) } {
+    match unsafe {
+        handle_socket(&syscall_table, domain.inner() as i32, typ.inner(), protocol.inner())
+    } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
 
@@ -132,6 +142,7 @@ pub fn do_socket(
 //==================================================================================================
 
 pub fn do_socketpair(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: CreateSocketPairRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -154,7 +165,13 @@ pub fn do_socketpair(
         typ.inner(),
     );
     match unsafe {
-        libc::socketpair(domain.inner() as i32, typ.inner(), protocol.inner(), sv.as_mut_ptr())
+        handle_socketpair(
+            &syscall_table,
+            domain.inner() as i32,
+            typ.inner(),
+            protocol.inner(),
+            sv.as_mut_ptr(),
+        )
     } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -182,6 +199,7 @@ pub fn do_socketpair(
 //==================================================================================================
 
 pub fn do_bind(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: BindSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -200,7 +218,9 @@ pub fn do_bind(
         sockaddr.inner().sa_family,
         sockaddr.inner().sa_data,
     );
-    match unsafe { libc::bind(sockfd, &sockaddr.inner() as *const libc::sockaddr, socklen) } {
+    match unsafe {
+        handle_bind(&syscall_table, sockfd, &sockaddr.inner() as *const libc::sockaddr, socklen)
+    } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
 
@@ -224,6 +244,7 @@ pub fn do_bind(
 //==================================================================================================
 
 pub fn do_connect(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: ConnectSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -244,7 +265,8 @@ pub fn do_connect(
     );
 
     match unsafe {
-        libc::connect(
+        handle_connect(
+            &syscall_table,
             sockfd,
             &sockaddr.inner() as *const libc::sockaddr,
             socklen as libc::socklen_t,
@@ -273,6 +295,7 @@ pub fn do_connect(
 //==================================================================================================
 
 pub fn do_listen(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: ListenSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -282,7 +305,7 @@ pub fn do_listen(
     let backlog: i32 = request.backlog;
 
     debug!("libc::listen(): sockfd={sockfd:?}, backlog={backlog:?}");
-    match unsafe { libc::listen(sockfd, backlog) } {
+    match unsafe { handle_listen(&syscall_table, sockfd, backlog) } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
 
@@ -306,6 +329,7 @@ pub fn do_listen(
 //==================================================================================================
 
 pub fn do_getpeername(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: GetPeerNameRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -317,7 +341,7 @@ pub fn do_getpeername(
         core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
 
     debug!("libc::getpeername(): sockfd={sockfd:?}");
-    match unsafe { libc::getpeername(sockfd, &mut address, &mut address_len) } {
+    match unsafe { handle_getpeername(&syscall_table, sockfd, &mut address, &mut address_len) } {
         -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
 
@@ -350,6 +374,7 @@ pub fn do_getpeername(
 //==================================================================================================
 
 pub fn do_getsockname(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: GetSockNameRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -361,7 +386,7 @@ pub fn do_getsockname(
         core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
 
     debug!("libc::getsockname(): sockfd={sockfd:?}");
-    match unsafe { libc::getsockname(sockfd, &mut address, &mut address_len) } {
+    match unsafe { handle_getsockname(&syscall_table, sockfd, &mut address, &mut address_len) } {
         -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
 
@@ -395,6 +420,7 @@ pub fn do_getsockname(
 //==================================================================================================
 
 pub fn do_accept(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: AcceptSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -406,9 +432,9 @@ pub fn do_accept(
         core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
 
     debug!("libc::accept(): sockfd={sockfd:?}");
-    match unsafe { libc::accept(sockfd, &mut address, &mut address_len) } {
+    match unsafe { handle_accept(&syscall_table, sockfd, &mut address, &mut address_len) } {
         -1 => {
-            let errno: i32 = unsafe { *libc::__errno_location() };
+            let errno: libc::c_int = unsafe { *libc::__errno_location() };
 
             // Check if the thread has been interrupted.
             if errno == libc::EINTR {
@@ -437,6 +463,7 @@ pub fn do_accept(
 //==================================================================================================
 
 pub fn do_recv(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: ReceiveSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -453,16 +480,22 @@ pub fn do_recv(
     let mut buffer: [u8; ReceiveSocketResponse::BUFFER_SIZE] =
         [0; ReceiveSocketResponse::BUFFER_SIZE];
 
-    debug!("libc::recv(): sockfd={sockfd:?}, flags={:?}", flags.inner());
+    debug!("libc::recv(): sockfd={sockfd:?}, len={recv_len:?}, flags={:?}", flags.inner());
     match unsafe {
-        libc::recv(sockfd, buffer.as_mut_ptr() as *mut libc::c_void, recv_len, flags.inner())
+        handle_recv(
+            &syscall_table,
+            sockfd,
+            buffer.as_mut_ptr() as *mut libc::c_void,
+            recv_len,
+            flags.inner(),
+        )
     } {
         count if count >= 0 => {
             debug!("libc::recv(): count={count:?}");
             Ok(ReceiveSocketResponse::build(tid, count as c_size_t, buffer))
         },
         -1 => {
-            let errno: i32 = unsafe { *libc::__errno_location() };
+            let errno: libc::c_int = unsafe { *libc::__errno_location() };
 
             // Check if the thread has been interrupted.
             if errno == libc::EINTR {
@@ -484,6 +517,7 @@ pub fn do_recv(
 //==================================================================================================
 
 pub fn do_shutdown(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: ShutdownSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -493,10 +527,10 @@ pub fn do_shutdown(
     let how: LibcShutdownReason = LibcShutdownReason::from(request.how);
 
     debug!("libc::shutdown(): sockfd={sockfd:?}, how={:?}", how.inner());
-    match unsafe { libc::shutdown(sockfd, how.inner()) } {
+    match unsafe { handle_shutdown(&syscall_table, sockfd, how.inner()) } {
         0 => Ok(ShutdownSocketResponse::build(tid)),
         -1 => {
-            let errno: i32 = unsafe { *libc::__errno_location() };
+            let errno: libc::c_int = unsafe { *libc::__errno_location() };
 
             // Check if the thread has been interrupted.
             if errno == libc::EINTR {
@@ -518,6 +552,7 @@ pub fn do_shutdown(
 //==================================================================================================
 
 pub fn do_send(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: SendSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -533,17 +568,23 @@ pub fn do_send(
 
     debug!(
         "libc::send(): sockfd={sockfd:?}, count={count:?}, flags={:?}, buffer={buffer:?}",
-        flags.inner(),
+        flags.inner()
     );
     match unsafe {
-        libc::send(sockfd, buffer.as_ptr() as *const libc::c_void, count as usize, flags.inner())
+        handle_send(
+            &syscall_table,
+            sockfd,
+            buffer.as_ptr() as *const libc::c_void,
+            count as usize,
+            flags.inner(),
+        )
     } {
         count if count >= 0 => {
             debug!("libc::send(): count={count:?}");
             Ok(SendSocketResponse::build(tid, count as c_ssize_t))
         },
         -1 => {
-            let errno: i32 = unsafe { *libc::__errno_location() };
+            let errno: libc::c_int = unsafe { *libc::__errno_location() };
 
             // Check if the thread has been interrupted.
             if errno == libc::EINTR {
@@ -700,5 +741,208 @@ impl LibcMessageFlags {
         }
 
         Ok(Self(libc_flags))
+    }
+}
+
+//==================================================================================================
+// System Call Wrappers
+//==================================================================================================
+
+/// Handler for `libc::socket()`.
+unsafe fn handle_socket(
+    syscall_table: &SystemCallRouteTable,
+    domain: libc::c_int,
+    type_: libc::c_int,
+    protocol: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_socket.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_socket.syscall_fn)(domain, type_, protocol)
+        },
+    }
+}
+
+/// Handler for `libc::socketpair()`.
+unsafe fn handle_socketpair(
+    syscall_table: &SystemCallRouteTable,
+    domain: libc::c_int,
+    type_: libc::c_int,
+    protocol: libc::c_int,
+    sv: *mut libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_socketpair.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_socketpair.syscall_fn)(domain, type_, protocol, sv)
+        },
+    }
+}
+
+/// Handler for `libc::bind()`.
+unsafe fn handle_bind(
+    syscall_table: &SystemCallRouteTable,
+    sockfd: libc::c_int,
+    addr: *const libc::sockaddr,
+    addrlen: libc::socklen_t,
+) -> libc::c_int {
+    match syscall_table.syscall_bind.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_bind.syscall_fn)(sockfd, addr, addrlen)
+        },
+    }
+}
+
+/// Handler for `libc::connect()`.
+unsafe fn handle_connect(
+    syscall_table: &SystemCallRouteTable,
+    sockfd: libc::c_int,
+    addr: *const libc::sockaddr,
+    addrlen: libc::socklen_t,
+) -> libc::c_int {
+    match syscall_table.syscall_connect.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_connect.syscall_fn)(sockfd, addr, addrlen)
+        },
+    }
+}
+
+/// Handler for `libc::listen()`.
+unsafe fn handle_listen(
+    syscall_table: &SystemCallRouteTable,
+    sockfd: libc::c_int,
+    backlog: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_listen.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_listen.syscall_fn)(sockfd, backlog)
+        },
+    }
+}
+
+/// Handler for `libc::getpeername()`.
+unsafe fn handle_getpeername(
+    syscall_table: &SystemCallRouteTable,
+    sockfd: libc::c_int,
+    addr: *mut libc::sockaddr,
+    addrlen: *mut libc::socklen_t,
+) -> libc::c_int {
+    match syscall_table.syscall_getpeername.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_getpeername.syscall_fn)(sockfd, addr, addrlen)
+        },
+    }
+}
+
+/// Handler for `libc::getsockname()`.
+unsafe fn handle_getsockname(
+    syscall_table: &SystemCallRouteTable,
+    sockfd: libc::c_int,
+    addr: *mut libc::sockaddr,
+    addrlen: *mut libc::socklen_t,
+) -> libc::c_int {
+    match syscall_table.syscall_getsockname.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_getsockname.syscall_fn)(sockfd, addr, addrlen)
+        },
+    }
+}
+
+/// Handler for `libc::accept()`.
+unsafe fn handle_accept(
+    syscall_table: &SystemCallRouteTable,
+    sockfd: libc::c_int,
+    addr: *mut libc::sockaddr,
+    addrlen: *mut libc::socklen_t,
+) -> libc::c_int {
+    match syscall_table.syscall_accept.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_accept.syscall_fn)(sockfd, addr, addrlen)
+        },
+    }
+}
+
+/// Handler for `libc::recv()`.
+unsafe fn handle_recv(
+    syscall_table: &SystemCallRouteTable,
+    sockfd: libc::c_int,
+    buf: *mut libc::c_void,
+    len: libc::size_t,
+    flags: libc::c_int,
+) -> libc::ssize_t {
+    match syscall_table.syscall_recv.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_recv.syscall_fn)(sockfd, buf, len, flags)
+        },
+    }
+}
+
+/// Handler for `libc::send()`.
+unsafe fn handle_send(
+    syscall_table: &SystemCallRouteTable,
+    sockfd: libc::c_int,
+    buf: *const libc::c_void,
+    len: libc::size_t,
+    flags: libc::c_int,
+) -> libc::ssize_t {
+    match syscall_table.syscall_send.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_send.syscall_fn)(sockfd, buf, len, flags)
+        },
+    }
+}
+
+/// Handler for `libc::shutdown()`.
+unsafe fn handle_shutdown(
+    syscall_table: &SystemCallRouteTable,
+    sockfd: libc::c_int,
+    how: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_shutdown.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_shutdown.syscall_fn)(sockfd, how)
+        },
     }
 }

--- a/src/daemons/linuxd/src/sys_select.rs
+++ b/src/daemons/linuxd/src/sys_select.rs
@@ -5,11 +5,18 @@
 // Imports
 //==================================================================================================
 
-use crate::error::WorkerThreadError;
+use crate::{
+    error::WorkerThreadError,
+    syscalls::{
+        SystemCallAction,
+        SystemCallRouteTable,
+    },
+};
 use ::core::{
     cmp,
     ptr,
 };
+use ::std::sync::Arc;
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
@@ -42,6 +49,7 @@ use ::syslog::{
 //==================================================================================================
 
 pub fn do_select(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: SelectRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -91,7 +99,8 @@ pub fn do_select(
 
     // SAFETY: All pointers either null or point to valid local storage; nfds validated.
     let nready: libc::c_int = unsafe {
-        libc::select(
+        handle_select(
+            &syscall_table,
             nfds_c_int,
             read_ptr
                 .as_mut()
@@ -190,5 +199,28 @@ impl TryFrom<LibcFdSet> for fd_set {
         }
 
         Ok(fd_set)
+    }
+}
+
+//==================================================================================================
+// Wrapper Functions
+//==================================================================================================
+
+unsafe fn handle_select(
+    syscall_table: &SystemCallRouteTable,
+    nfds: libc::c_int,
+    readfds: *mut libc::fd_set,
+    writefds: *mut libc::fd_set,
+    errorfds: *mut libc::fd_set,
+    timeout: *mut libc::timeval,
+) -> libc::c_int {
+    match syscall_table.syscall_select.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_select.syscall_fn)(nfds, readfds, writefds, errorfds, timeout)
+        },
     }
 }

--- a/src/daemons/linuxd/src/syscalls.rs
+++ b/src/daemons/linuxd/src/syscalls.rs
@@ -1,0 +1,1625 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::std::sync::Arc;
+
+//==================================================================================================
+// Function Type Aliases
+//==================================================================================================
+
+/// Type alias for `times()` system call function.
+pub type TimesFn = unsafe fn(*mut libc::tms) -> libc::clock_t;
+
+/// Type alias for `chdir()` system call function.
+pub type ChdirFn = unsafe fn(*const libc::c_char) -> libc::c_int;
+
+/// Type alias for `close()` system call function.
+pub type CloseFn = unsafe fn(libc::c_int) -> libc::c_int;
+
+/// Type alias for `faccessat()` system call function.
+pub type FaccessatFn =
+    unsafe fn(libc::c_int, *const libc::c_char, libc::c_int, libc::c_int) -> libc::c_int;
+
+/// Type alias for `fdatasync()` system call function.
+pub type FdatasyncFn = unsafe fn(libc::c_int) -> libc::c_int;
+
+/// Type alias for `getuid()` system call function.
+pub type GetuidFn = unsafe fn() -> libc::uid_t;
+
+/// Type alias for `geteuid()` system call function.
+pub type GeteuidFn = unsafe fn() -> libc::uid_t;
+
+/// Type alias for `getgid()` system call function.
+pub type GetgidFn = unsafe fn() -> libc::gid_t;
+
+/// Type alias for `getegid()` system call function.
+pub type GetegidFn = unsafe fn() -> libc::gid_t;
+
+/// Type alias for `getcwd()` system call function.
+pub type GetcwdFn = unsafe fn(*mut libc::c_char, libc::size_t) -> *mut libc::c_char;
+
+/// Type alias for `fsync()` system call function.
+pub type FsyncFn = unsafe fn(libc::c_int) -> libc::c_int;
+
+/// Type alias for `lseek()` system call function.
+pub type LseekFn = unsafe fn(libc::c_int, libc::off_t, libc::c_int) -> libc::off_t;
+
+/// Type alias for `ftruncate()` system call function.
+pub type FtruncateFn = unsafe fn(libc::c_int, libc::off_t) -> libc::c_int;
+
+/// Type alias for `write()` system call function.
+pub type WriteFn =
+    unsafe extern "C" fn(libc::c_int, *const libc::c_void, libc::size_t) -> libc::ssize_t;
+
+/// Type alias for `read()` system call function.
+pub type ReadFn =
+    unsafe extern "C" fn(libc::c_int, *mut libc::c_void, libc::size_t) -> libc::ssize_t;
+
+/// Type alias for `pwrite()` system call function.
+pub type PwriteFn =
+    unsafe fn(libc::c_int, *const libc::c_void, libc::size_t, libc::off_t) -> libc::ssize_t;
+
+/// Type alias for `pread()` system call function.
+pub type PreadFn =
+    unsafe fn(libc::c_int, *mut libc::c_void, libc::size_t, libc::off_t) -> libc::ssize_t;
+
+/// Type alias for `linkat()` system call function.
+pub type LinkatFn = unsafe fn(
+    libc::c_int,
+    *const libc::c_char,
+    libc::c_int,
+    *const libc::c_char,
+    libc::c_int,
+) -> libc::c_int;
+
+/// Type alias for `fchdir()` system call function.
+pub type FchdirFn = unsafe fn(libc::c_int) -> libc::c_int;
+
+/// Type alias for `fchown()` system call function.
+pub type FchownFn = unsafe fn(libc::c_int, libc::uid_t, libc::gid_t) -> libc::c_int;
+
+/// Type alias for `pipe()` system call function.
+pub type PipeFn = unsafe fn(*mut libc::c_int) -> libc::c_int;
+
+/// Type alias for `getdents()` system call function.
+pub type GetdentsFn = unsafe fn(libc::c_int, *mut u8, libc::size_t) -> libc::c_long;
+
+/// Type alias for `socket()` system call function.
+pub type SocketFn = unsafe fn(libc::c_int, libc::c_int, libc::c_int) -> libc::c_int;
+
+/// Type alias for `socketpair()` system call function.
+pub type SocketpairFn =
+    unsafe fn(libc::c_int, libc::c_int, libc::c_int, *mut libc::c_int) -> libc::c_int;
+
+/// Type alias for `bind()` system call function.
+pub type BindFn =
+    unsafe extern "C" fn(libc::c_int, *const libc::sockaddr, libc::socklen_t) -> libc::c_int;
+
+/// Type alias for `connect()` system call function.
+pub type ConnectFn =
+    unsafe extern "C" fn(libc::c_int, *const libc::sockaddr, libc::socklen_t) -> libc::c_int;
+
+/// Type alias for `listen()` system call function.
+pub type ListenFn = unsafe fn(libc::c_int, libc::c_int) -> libc::c_int;
+
+/// Type alias for `getpeername()` system call function.
+pub type GetpeernameFn =
+    unsafe fn(libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
+
+/// Type alias for `getsockname()` system call function.
+pub type GetsocknameFn =
+    unsafe fn(libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
+
+/// Type alias for `accept()` system call function.
+pub type AcceptFn =
+    unsafe fn(libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
+
+/// Type alias for `recv()` system call function.
+pub type RecvFn =
+    unsafe fn(libc::c_int, *mut libc::c_void, libc::size_t, libc::c_int) -> libc::ssize_t;
+
+/// Type alias for `send()` system call function.
+pub type SendFn =
+    unsafe fn(libc::c_int, *const libc::c_void, libc::size_t, libc::c_int) -> libc::ssize_t;
+
+/// Type alias for `shutdown()` system call function.
+pub type ShutdownFn = unsafe fn(libc::c_int, libc::c_int) -> libc::c_int;
+
+/// Type alias for `select()` system call function.
+pub type SelectFn = unsafe fn(
+    libc::c_int,
+    *mut libc::fd_set,
+    *mut libc::fd_set,
+    *mut libc::fd_set,
+    *mut libc::timeval,
+) -> libc::c_int;
+
+/// Type alias for `poll()` system call function.
+pub type PollFn = unsafe fn(*mut libc::pollfd, libc::nfds_t, libc::c_int) -> libc::c_int;
+
+//==================================================================================================
+// Default Implementations - unistd.rs
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Default implementation for `chdir()` system call.
+///
+/// # Parameters
+///
+/// - `path`: Path to change to.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_chdir(path: *const libc::c_char) -> libc::c_int {
+    libc::chdir(path)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `close()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor to close.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_close(fd: libc::c_int) -> libc::c_int {
+    libc::close(fd)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `faccessat()` system call.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor.
+/// - `pathname`: Path to check.
+/// - `mode`: Access mode.
+/// - `flags`: Flags.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_faccessat(
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    mode: libc::c_int,
+    flags: libc::c_int,
+) -> libc::c_int {
+    libc::faccessat(dirfd, pathname, mode, flags)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `fdatasync()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor to synchronize.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_fdatasync(fd: libc::c_int) -> libc::c_int {
+    libc::fdatasync(fd)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `getuid()` system call.
+///
+/// # Returns
+///
+/// The real user ID of the calling process.
+///
+pub unsafe fn default_getuid() -> libc::uid_t {
+    libc::getuid()
+}
+
+///
+/// # Description
+///
+/// Default implementation for `geteuid()` system call.
+///
+/// # Returns
+///
+/// The effective user ID of the calling process.
+///
+pub unsafe fn default_geteuid() -> libc::uid_t {
+    libc::geteuid()
+}
+
+///
+/// # Description
+///
+/// Default implementation for `getgid()` system call.
+///
+/// # Returns
+///
+/// The real group ID of the calling process.
+///
+pub unsafe fn default_getgid() -> libc::gid_t {
+    libc::getgid()
+}
+
+///
+/// # Description
+///
+/// Default implementation for `getegid()` system call.
+///
+/// # Returns
+///
+/// The effective group ID of the calling process.
+///
+pub unsafe fn default_getegid() -> libc::gid_t {
+    libc::getegid()
+}
+
+///
+/// # Description
+///
+/// Default implementation for `getcwd()` system call.
+///
+/// # Parameters
+///
+/// - `buf`: Buffer to store current working directory.
+/// - `size`: Size of buffer.
+///
+/// # Returns
+///
+/// Upon successful completion, a pointer to the buffer is returned. Otherwise, NULL is returned and `errno` is set.
+///
+pub unsafe fn default_getcwd(buf: *mut libc::c_char, size: libc::size_t) -> *mut libc::c_char {
+    libc::getcwd(buf, size)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `fsync()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor to synchronize.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_fsync(fd: libc::c_int) -> libc::c_int {
+    libc::fsync(fd)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `lseek()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `offset`: Offset.
+/// - `whence`: Whence.
+///
+/// # Returns
+///
+/// Upon successful completion, the resulting offset is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_lseek(
+    fd: libc::c_int,
+    offset: libc::off_t,
+    whence: libc::c_int,
+) -> libc::off_t {
+    libc::lseek(fd, offset, whence)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `ftruncate()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `length`: Length.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_ftruncate(fd: libc::c_int, length: libc::off_t) -> libc::c_int {
+    libc::ftruncate(fd, length)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `write()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `buf`: Buffer to write from.
+/// - `count`: Number of bytes to write.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of bytes written is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe extern "C" fn default_write(
+    fd: libc::c_int,
+    buf: *const libc::c_void,
+    count: libc::size_t,
+) -> libc::ssize_t {
+    libc::write(fd, buf, count)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `read()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `buf`: Buffer to read into.
+/// - `count`: Number of bytes to read.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of bytes read is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe extern "C" fn default_read(
+    fd: libc::c_int,
+    buf: *mut libc::c_void,
+    count: libc::size_t,
+) -> libc::ssize_t {
+    libc::read(fd, buf, count)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `pwrite()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `buf`: Buffer to write from.
+/// - `count`: Number of bytes to write.
+/// - `offset`: Offset.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of bytes written is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_pwrite(
+    fd: libc::c_int,
+    buf: *const libc::c_void,
+    count: libc::size_t,
+    offset: libc::off_t,
+) -> libc::ssize_t {
+    libc::pwrite(fd, buf, count, offset)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `pread()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `buf`: Buffer to read into.
+/// - `count`: Number of bytes to read.
+/// - `offset`: Offset.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of bytes read is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_pread(
+    fd: libc::c_int,
+    buf: *mut libc::c_void,
+    count: libc::size_t,
+    offset: libc::off_t,
+) -> libc::ssize_t {
+    libc::pread(fd, buf, count, offset)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `linkat()` system call.
+///
+/// # Parameters
+///
+/// - `olddirfd`: Old directory file descriptor.
+/// - `oldpath`: Old path.
+/// - `newdirfd`: New directory file descriptor.
+/// - `newpath`: New path.
+/// - `flags`: Flags.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_linkat(
+    olddirfd: libc::c_int,
+    oldpath: *const libc::c_char,
+    newdirfd: libc::c_int,
+    newpath: *const libc::c_char,
+    flags: libc::c_int,
+) -> libc::c_int {
+    libc::linkat(olddirfd, oldpath, newdirfd, newpath, flags)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `fchdir()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_fchdir(fd: libc::c_int) -> libc::c_int {
+    libc::fchdir(fd)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `fchown()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `owner`: Owner.
+/// - `group`: Group.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_fchown(
+    fd: libc::c_int,
+    owner: libc::uid_t,
+    group: libc::gid_t,
+) -> libc::c_int {
+    libc::fchown(fd, owner, group)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `pipe()` system call.
+///
+/// # Parameters
+///
+/// - `pipefd`: Pipe file descriptors.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_pipe(pipefd: *mut libc::c_int) -> libc::c_int {
+    libc::pipe(pipefd)
+}
+
+/// Type alias for `openat()` system call function.
+pub type OpenatFn =
+    unsafe fn(libc::c_int, *const libc::c_char, libc::c_int, libc::mode_t) -> libc::c_int;
+
+/// Type alias for `unlinkat()` system call function.
+pub type UnlinkatFn =
+    unsafe extern "C" fn(libc::c_int, *const libc::c_char, libc::c_int) -> libc::c_int;
+
+/// Type alias for `renameat()` system call function.
+pub type RenameatFn =
+    unsafe fn(libc::c_int, *const libc::c_char, libc::c_int, *const libc::c_char) -> libc::c_int;
+
+/// Type alias for `fstatat()` system call function.
+pub type FstatatFn =
+    unsafe fn(libc::c_int, *const libc::c_char, *mut libc::stat, libc::c_int) -> libc::c_int;
+
+/// Type alias for `posix_fallocate()` system call function.
+pub type PosixFallocateFn = unsafe fn(libc::c_int, libc::off_t, libc::off_t) -> libc::c_int;
+
+/// Type alias for `posix_fadvise()` system call function.
+pub type PosixFadviseFn =
+    unsafe extern "C" fn(libc::c_int, libc::off_t, libc::off_t, libc::c_int) -> libc::c_int;
+
+/// Type alias for `fstat()` system call function.
+pub type FstatFn = unsafe fn(libc::c_int, *mut libc::stat) -> libc::c_int;
+
+/// Type alias for `symlinkat()` system call function.
+pub type SymlinkatFn =
+    unsafe fn(*const libc::c_char, libc::c_int, *const libc::c_char) -> libc::c_int;
+
+/// Type alias for `readlinkat()` system call function.
+pub type ReadlinkatFn =
+    unsafe fn(libc::c_int, *const libc::c_char, *mut libc::c_char, libc::size_t) -> libc::ssize_t;
+
+/// Type alias for `mkdirat()` system call function.
+pub type MkdiratFn =
+    unsafe extern "C" fn(libc::c_int, *const libc::c_char, libc::mode_t) -> libc::c_int;
+
+/// Type alias for `utimensat()` system call function.
+pub type UtimensatFn =
+    unsafe fn(libc::c_int, *const libc::c_char, *const libc::timespec, libc::c_int) -> libc::c_int;
+
+/// Type alias for `futimens()` system call function.
+pub type FutimensFn = unsafe fn(libc::c_int, *const libc::timespec) -> libc::c_int;
+
+/// Type alias for `fcntl()` system call function.
+pub type FcntlFn = unsafe fn(libc::c_int, libc::c_int, libc::c_int) -> libc::c_int;
+
+/// Type alias for `fchownat()` system call function.
+pub type FchownatFn = unsafe fn(
+    libc::c_int,
+    *const libc::c_char,
+    libc::uid_t,
+    libc::gid_t,
+    libc::c_int,
+) -> libc::c_int;
+
+/// Type alias for `fchmod()` system call function.
+pub type FchmodFn = unsafe fn(libc::c_int, libc::mode_t) -> libc::c_int;
+
+/// Type alias for `fchmodat()` system call function.
+pub type FchmodatFn =
+    unsafe fn(libc::c_int, *const libc::c_char, libc::mode_t, libc::c_int) -> libc::c_int;
+
+//==================================================================================================
+// Default Implementations - fcntl.rs
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Default implementation for `openat()` system call.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor.
+/// - `pathname`: Path to open.
+/// - `flags`: Flags.
+/// - `mode`: Mode.
+///
+/// # Returns
+///
+/// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_openat(
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    flags: libc::c_int,
+    mode: libc::mode_t,
+) -> libc::c_int {
+    libc::openat(dirfd, pathname, flags, mode)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `unlinkat()` system call.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor.
+/// - `pathname`: Path to unlink.
+/// - `flags`: Flags.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe extern "C" fn default_unlinkat(
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    flags: libc::c_int,
+) -> libc::c_int {
+    libc::unlinkat(dirfd, pathname, flags)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `renameat()` system call.
+///
+/// # Parameters
+///
+/// - `olddirfd`: Old directory file descriptor.
+/// - `oldpath`: Old path.
+/// - `newdirfd`: New directory file descriptor.
+/// - `newpath`: New path.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_renameat(
+    olddirfd: libc::c_int,
+    oldpath: *const libc::c_char,
+    newdirfd: libc::c_int,
+    newpath: *const libc::c_char,
+) -> libc::c_int {
+    libc::renameat(olddirfd, oldpath, newdirfd, newpath)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `fstatat()` system call.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor.
+/// - `pathname`: Path to stat.
+/// - `buf`: Buffer to store stat.
+/// - `flags`: Flags.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_fstatat(
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    buf: *mut libc::stat,
+    flags: libc::c_int,
+) -> libc::c_int {
+    libc::fstatat(dirfd, pathname, buf, flags)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `posix_fallocate()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `offset`: Offset.
+/// - `len`: Length.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, an error number is returned.
+///
+pub unsafe fn default_posix_fallocate(
+    fd: libc::c_int,
+    offset: libc::off_t,
+    len: libc::off_t,
+) -> libc::c_int {
+    libc::posix_fallocate(fd, offset, len)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `posix_fadvise()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `offset`: Offset.
+/// - `len`: Length.
+/// - `advice`: Advice.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, an error number is returned.
+///
+pub unsafe extern "C" fn default_posix_fadvise(
+    fd: libc::c_int,
+    offset: libc::off_t,
+    len: libc::off_t,
+    advice: libc::c_int,
+) -> libc::c_int {
+    libc::posix_fadvise(fd, offset, len, advice)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `fstat()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `buf`: Buffer to store stat.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_fstat(fd: libc::c_int, buf: *mut libc::stat) -> libc::c_int {
+    libc::fstat(fd, buf)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `symlinkat()` system call.
+///
+/// # Parameters
+///
+/// - `target`: Target.
+/// - `newdirfd`: New directory file descriptor.
+/// - `linkpath`: Link path.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_symlinkat(
+    target: *const libc::c_char,
+    newdirfd: libc::c_int,
+    linkpath: *const libc::c_char,
+) -> libc::c_int {
+    libc::symlinkat(target, newdirfd, linkpath)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `readlinkat()` system call.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor.
+/// - `pathname`: Path to read.
+/// - `buf`: Buffer to store link.
+/// - `bufsiz`: Buffer size.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of bytes placed in the buffer is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_readlinkat(
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    buf: *mut libc::c_char,
+    bufsiz: libc::size_t,
+) -> libc::ssize_t {
+    libc::readlinkat(dirfd, pathname, buf, bufsiz)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `mkdirat()` system call.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor.
+/// - `pathname`: Path to create.
+/// - `mode`: Mode.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe extern "C" fn default_mkdirat(
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    mode: libc::mode_t,
+) -> libc::c_int {
+    libc::mkdirat(dirfd, pathname, mode)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `utimensat()` system call.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor.
+/// - `pathname`: Path to update.
+/// - `times`: Times.
+/// - `flags`: Flags.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_utimensat(
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    times: *const libc::timespec,
+    flags: libc::c_int,
+) -> libc::c_int {
+    libc::utimensat(dirfd, pathname, times, flags)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `futimens()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `times`: Times.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_futimens(fd: libc::c_int, times: *const libc::timespec) -> libc::c_int {
+    libc::futimens(fd, times)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `fcntl()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `cmd`: Command.
+/// - `arg`: Argument.
+///
+/// # Returns
+///
+/// Upon successful completion, a value depends on the command. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_fcntl(fd: libc::c_int, cmd: libc::c_int, arg: libc::c_int) -> libc::c_int {
+    libc::fcntl(fd, cmd, arg)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `fchownat()` system call.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor.
+/// - `pathname`: Path to change ownership.
+/// - `owner`: Owner.
+/// - `group`: Group.
+/// - `flags`: Flags.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_fchownat(
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    owner: libc::uid_t,
+    group: libc::gid_t,
+    flags: libc::c_int,
+) -> libc::c_int {
+    libc::fchownat(dirfd, pathname, owner, group, flags)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `fchmod()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `mode`: Mode.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_fchmod(fd: libc::c_int, mode: libc::mode_t) -> libc::c_int {
+    libc::fchmod(fd, mode)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `fchmodat()` system call.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor.
+/// - `pathname`: Path to change mode.
+/// - `mode`: Mode.
+/// - `flags`: Flags.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_fchmodat(
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    mode: libc::mode_t,
+    flags: libc::c_int,
+) -> libc::c_int {
+    libc::fchmodat(dirfd, pathname, mode, flags)
+}
+
+//==================================================================================================
+// Default Implementations - dirent.rs
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Default implementation for `getdents()` system call.
+///
+/// # Parameters
+///
+/// - `fd`: File descriptor.
+/// - `dirp`: Directory entries buffer.
+/// - `count`: Buffer size.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of bytes read is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_getdents(
+    fd: libc::c_int,
+    dirp: *mut u8,
+    count: libc::size_t,
+) -> libc::c_long {
+    libc::syscall(libc::SYS_getdents, fd, dirp, count)
+}
+
+//==================================================================================================
+// Default Implementations - socket.rs
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Default implementation for `socket()` system call.
+///
+/// # Parameters
+///
+/// - `domain`: Domain.
+/// - `type_`: Type.
+/// - `protocol`: Protocol.
+///
+/// # Returns
+///
+/// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_socket(
+    domain: libc::c_int,
+    type_: libc::c_int,
+    protocol: libc::c_int,
+) -> libc::c_int {
+    libc::socket(domain, type_, protocol)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `socketpair()` system call.
+///
+/// # Parameters
+///
+/// - `domain`: Domain.
+/// - `type_`: Type.
+/// - `protocol`: Protocol.
+/// - `sv`: Socket pair.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_socketpair(
+    domain: libc::c_int,
+    type_: libc::c_int,
+    protocol: libc::c_int,
+    sv: *mut libc::c_int,
+) -> libc::c_int {
+    libc::socketpair(domain, type_, protocol, sv)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `bind()` system call.
+///
+/// # Parameters
+///
+/// - `sockfd`: Socket file descriptor.
+/// - `addr`: Address.
+/// - `addrlen`: Address length.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe extern "C" fn default_bind(
+    sockfd: libc::c_int,
+    addr: *const libc::sockaddr,
+    addrlen: libc::socklen_t,
+) -> libc::c_int {
+    libc::bind(sockfd, addr, addrlen)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `connect()` system call.
+///
+/// # Parameters
+///
+/// - `sockfd`: Socket file descriptor.
+/// - `addr`: Address.
+/// - `addrlen`: Address length.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe extern "C" fn default_connect(
+    sockfd: libc::c_int,
+    addr: *const libc::sockaddr,
+    addrlen: libc::socklen_t,
+) -> libc::c_int {
+    libc::connect(sockfd, addr, addrlen)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `listen()` system call.
+///
+/// # Parameters
+///
+/// - `sockfd`: Socket file descriptor.
+/// - `backlog`: Backlog.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_listen(sockfd: libc::c_int, backlog: libc::c_int) -> libc::c_int {
+    libc::listen(sockfd, backlog)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `getpeername()` system call.
+///
+/// # Parameters
+///
+/// - `sockfd`: Socket file descriptor.
+/// - `addr`: Address.
+/// - `addrlen`: Address length.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_getpeername(
+    sockfd: libc::c_int,
+    addr: *mut libc::sockaddr,
+    addrlen: *mut libc::socklen_t,
+) -> libc::c_int {
+    libc::getpeername(sockfd, addr, addrlen)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `getsockname()` system call.
+///
+/// # Parameters
+///
+/// - `sockfd`: Socket file descriptor.
+/// - `addr`: Address.
+/// - `addrlen`: Address length.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_getsockname(
+    sockfd: libc::c_int,
+    addr: *mut libc::sockaddr,
+    addrlen: *mut libc::socklen_t,
+) -> libc::c_int {
+    libc::getsockname(sockfd, addr, addrlen)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `accept()` system call.
+///
+/// # Parameters
+///
+/// - `sockfd`: Socket file descriptor.
+/// - `addr`: Address.
+/// - `addrlen`: Address length.
+///
+/// # Returns
+///
+/// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_accept(
+    sockfd: libc::c_int,
+    addr: *mut libc::sockaddr,
+    addrlen: *mut libc::socklen_t,
+) -> libc::c_int {
+    libc::accept(sockfd, addr, addrlen)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `recv()` system call.
+///
+/// # Parameters
+///
+/// - `sockfd`: Socket file descriptor.
+/// - `buf`: Buffer.
+/// - `len`: Length.
+/// - `flags`: Flags.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of bytes received is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_recv(
+    sockfd: libc::c_int,
+    buf: *mut libc::c_void,
+    len: libc::size_t,
+    flags: libc::c_int,
+) -> libc::ssize_t {
+    libc::recv(sockfd, buf, len, flags)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `send()` system call.
+///
+/// # Parameters
+///
+/// - `sockfd`: Socket file descriptor.
+/// - `buf`: Buffer.
+/// - `len`: Length.
+/// - `flags`: Flags.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of bytes sent is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_send(
+    sockfd: libc::c_int,
+    buf: *const libc::c_void,
+    len: libc::size_t,
+    flags: libc::c_int,
+) -> libc::ssize_t {
+    libc::send(sockfd, buf, len, flags)
+}
+
+///
+/// # Description
+///
+/// Default implementation for `shutdown()` system call.
+///
+/// # Parameters
+///
+/// - `sockfd`: Socket file descriptor.
+/// - `how`: How.
+///
+/// # Returns
+///
+/// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_shutdown(sockfd: libc::c_int, how: libc::c_int) -> libc::c_int {
+    libc::shutdown(sockfd, how)
+}
+
+//==================================================================================================
+// Default Implementations - poll.rs
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Default implementation for `poll()` system call.
+///
+/// # Parameters
+///
+/// - `fds`: File descriptors.
+/// - `nfds`: Number of file descriptors.
+/// - `timeout`: Timeout.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of file descriptors with events is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_poll(
+    fds: *mut libc::pollfd,
+    nfds: libc::nfds_t,
+    timeout: libc::c_int,
+) -> libc::c_int {
+    libc::poll(fds, nfds, timeout)
+}
+
+//==================================================================================================
+// Default Implementations - sys_select.rs
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Default implementation for `select()` system call.
+///
+/// # Parameters
+///
+/// - `nfds`: Number of file descriptors.
+/// - `readfds`: Read file descriptors.
+/// - `writefds`: Write file descriptors.
+/// - `exceptfds`: Exception file descriptors.
+/// - `timeout`: Timeout.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of file descriptors with events is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_select(
+    nfds: libc::c_int,
+    readfds: *mut libc::fd_set,
+    writefds: *mut libc::fd_set,
+    exceptfds: *mut libc::fd_set,
+    timeout: *mut libc::timeval,
+) -> libc::c_int {
+    libc::select(nfds, readfds, writefds, exceptfds, timeout)
+}
+
+//==================================================================================================
+// Default Implementations - times.rs
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Default implementation for `times()` system call.
+///
+/// # Parameters
+///
+/// - `buf`: Buffer to store times.
+///
+/// # Returns
+///
+/// Upon successful completion, the elapsed real time in clock ticks is returned. Otherwise, -1 is returned and `errno` is set.
+///
+pub unsafe fn default_times(buf: *mut libc::tms) -> libc::clock_t {
+    libc::times(buf)
+}
+
+pub enum SystemCallAction {
+    Block,
+    Forward,
+}
+
+pub struct SystemCallRouteTableEntry<F> {
+    pub action: SystemCallAction,
+    pub syscall_fn: Arc<F>,
+}
+
+pub struct SystemCallRouteTable {
+    // unistd.rs system calls.
+    pub syscall_chdir: SystemCallRouteTableEntry<ChdirFn>,
+    pub syscall_close: SystemCallRouteTableEntry<CloseFn>,
+    pub syscall_faccessat: SystemCallRouteTableEntry<FaccessatFn>,
+    pub syscall_fdatasync: SystemCallRouteTableEntry<FdatasyncFn>,
+    pub syscall_fchdir: SystemCallRouteTableEntry<FchdirFn>,
+    pub syscall_fchown: SystemCallRouteTableEntry<FchownFn>,
+    pub syscall_fsync: SystemCallRouteTableEntry<FsyncFn>,
+    pub syscall_ftruncate: SystemCallRouteTableEntry<FtruncateFn>,
+    pub syscall_getcwd: SystemCallRouteTableEntry<GetcwdFn>,
+    pub syscall_getegid: SystemCallRouteTableEntry<GetegidFn>,
+    pub syscall_geteuid: SystemCallRouteTableEntry<GeteuidFn>,
+    pub syscall_getgid: SystemCallRouteTableEntry<GetgidFn>,
+    pub syscall_getuid: SystemCallRouteTableEntry<GetuidFn>,
+    pub syscall_linkat: SystemCallRouteTableEntry<LinkatFn>,
+    pub syscall_lseek: SystemCallRouteTableEntry<LseekFn>,
+    pub syscall_pipe: SystemCallRouteTableEntry<PipeFn>,
+    pub syscall_pread: SystemCallRouteTableEntry<PreadFn>,
+    pub syscall_pwrite: SystemCallRouteTableEntry<PwriteFn>,
+    pub syscall_read: SystemCallRouteTableEntry<ReadFn>,
+    pub syscall_write: SystemCallRouteTableEntry<WriteFn>,
+
+    // fcntl.rs system calls.
+    pub syscall_fchmod: SystemCallRouteTableEntry<FchmodFn>,
+    pub syscall_fchmodat: SystemCallRouteTableEntry<FchmodatFn>,
+    pub syscall_fchownat: SystemCallRouteTableEntry<FchownatFn>,
+    pub syscall_fcntl: SystemCallRouteTableEntry<FcntlFn>,
+    pub syscall_fstat: SystemCallRouteTableEntry<FstatFn>,
+    pub syscall_fstatat: SystemCallRouteTableEntry<FstatatFn>,
+    pub syscall_futimens: SystemCallRouteTableEntry<FutimensFn>,
+    pub syscall_mkdirat: SystemCallRouteTableEntry<MkdiratFn>,
+    pub syscall_openat: SystemCallRouteTableEntry<OpenatFn>,
+    pub syscall_posix_fadvise: SystemCallRouteTableEntry<PosixFadviseFn>,
+    pub syscall_posix_fallocate: SystemCallRouteTableEntry<PosixFallocateFn>,
+    pub syscall_readlinkat: SystemCallRouteTableEntry<ReadlinkatFn>,
+    pub syscall_renameat: SystemCallRouteTableEntry<RenameatFn>,
+    pub syscall_symlinkat: SystemCallRouteTableEntry<SymlinkatFn>,
+    pub syscall_unlinkat: SystemCallRouteTableEntry<UnlinkatFn>,
+    pub syscall_utimensat: SystemCallRouteTableEntry<UtimensatFn>,
+
+    // dirent.rs system calls.
+    pub syscall_getdents: SystemCallRouteTableEntry<GetdentsFn>,
+
+    // socket.rs system calls.
+    pub syscall_accept: SystemCallRouteTableEntry<AcceptFn>,
+    pub syscall_bind: SystemCallRouteTableEntry<BindFn>,
+    pub syscall_connect: SystemCallRouteTableEntry<ConnectFn>,
+    pub syscall_getpeername: SystemCallRouteTableEntry<GetpeernameFn>,
+    pub syscall_getsockname: SystemCallRouteTableEntry<GetsocknameFn>,
+    pub syscall_listen: SystemCallRouteTableEntry<ListenFn>,
+    pub syscall_recv: SystemCallRouteTableEntry<RecvFn>,
+    pub syscall_send: SystemCallRouteTableEntry<SendFn>,
+    pub syscall_shutdown: SystemCallRouteTableEntry<ShutdownFn>,
+    pub syscall_socket: SystemCallRouteTableEntry<SocketFn>,
+    pub syscall_socketpair: SystemCallRouteTableEntry<SocketpairFn>,
+
+    // poll.rs system calls.
+    pub syscall_poll: SystemCallRouteTableEntry<PollFn>,
+
+    // sys_select.rs system calls.
+    pub syscall_select: SystemCallRouteTableEntry<SelectFn>,
+
+    // times.rs system calls.
+    pub syscall_times: SystemCallRouteTableEntry<TimesFn>,
+}
+
+impl Default for SystemCallRouteTable {
+    fn default() -> Self {
+        Self {
+            // unistd.rs system calls.
+            syscall_chdir: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_chdir),
+            },
+            syscall_close: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_close),
+            },
+            syscall_faccessat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_faccessat),
+            },
+            syscall_fdatasync: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_fdatasync),
+            },
+            syscall_fchdir: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_fchdir),
+            },
+            syscall_fchown: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_fchown),
+            },
+            syscall_fsync: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_fsync),
+            },
+            syscall_ftruncate: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_ftruncate),
+            },
+            syscall_getcwd: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_getcwd),
+            },
+            syscall_getegid: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_getegid),
+            },
+            syscall_geteuid: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_geteuid),
+            },
+            syscall_getgid: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_getgid),
+            },
+            syscall_getuid: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_getuid),
+            },
+            syscall_linkat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_linkat),
+            },
+            syscall_lseek: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_lseek),
+            },
+            syscall_pipe: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_pipe),
+            },
+            syscall_pread: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_pread),
+            },
+            syscall_pwrite: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_pwrite),
+            },
+            syscall_read: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_read as ReadFn),
+            },
+            syscall_write: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_write as WriteFn),
+            },
+
+            // fcntl.rs system calls.
+            syscall_fchmod: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_fchmod),
+            },
+            syscall_fchmodat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_fchmodat),
+            },
+            syscall_fchownat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_fchownat),
+            },
+            syscall_fcntl: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_fcntl),
+            },
+            syscall_fstat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_fstat),
+            },
+            syscall_fstatat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_fstatat),
+            },
+            syscall_futimens: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_futimens),
+            },
+            syscall_mkdirat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_mkdirat),
+            },
+            syscall_openat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_openat),
+            },
+            syscall_posix_fadvise: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_posix_fadvise),
+            },
+            syscall_posix_fallocate: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_posix_fallocate),
+            },
+            syscall_readlinkat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_readlinkat),
+            },
+            syscall_renameat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_renameat),
+            },
+            syscall_symlinkat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_symlinkat),
+            },
+            syscall_unlinkat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_unlinkat),
+            },
+            syscall_utimensat: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_utimensat),
+            },
+
+            // dirent.rs system calls.
+            syscall_getdents: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_getdents),
+            },
+
+            // socket.rs system calls.
+            syscall_accept: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_accept),
+            },
+            syscall_bind: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_bind),
+            },
+            syscall_connect: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_connect),
+            },
+            syscall_getpeername: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_getpeername),
+            },
+            syscall_getsockname: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_getsockname),
+            },
+            syscall_listen: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_listen),
+            },
+            syscall_recv: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_recv),
+            },
+            syscall_send: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_send),
+            },
+            syscall_shutdown: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_shutdown),
+            },
+            syscall_socket: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_socket),
+            },
+            syscall_socketpair: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_socketpair),
+            },
+
+            // poll.rs system calls.
+            syscall_poll: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_poll),
+            },
+
+            // sys_select.rs system calls.
+            syscall_select: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_select),
+            },
+
+            // times.rs system calls.
+            syscall_times: SystemCallRouteTableEntry {
+                action: SystemCallAction::Forward,
+                syscall_fn: Arc::new(default_times),
+            },
+        }
+    }
+}

--- a/src/daemons/linuxd/src/times.rs
+++ b/src/daemons/linuxd/src/times.rs
@@ -5,7 +5,14 @@
 // Imports
 //==================================================================================================
 
-use crate::error::WorkerThreadError;
+use crate::{
+    error::WorkerThreadError,
+    syscalls::{
+        SystemCallAction,
+        SystemCallRouteTable,
+    },
+};
+use ::std::sync::Arc;
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
@@ -28,6 +35,7 @@ use ::syslog::{
 //==================================================================================================
 
 pub fn do_times(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     _request: TimesRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -42,7 +50,7 @@ pub fn do_times(
 
     debug!("libc::times(): buffer={:p}", &libc_buffer as *const libc::tms);
 
-    match unsafe { libc::times(&mut libc_buffer as *mut libc::tms) } {
+    match unsafe { handle_times(&syscall_table, &mut libc_buffer as *mut libc::tms) } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
 
@@ -83,5 +91,20 @@ pub fn do_times(
 
             Ok(TimesResponse::build(tid, elapsed, nanvix_buffer))
         },
+    }
+}
+
+//==================================================================================================
+// System Call Wrappers
+//==================================================================================================
+
+/// Handler for `libc::times()`.
+unsafe fn handle_times(syscall_table: &SystemCallRouteTable, buf: *mut libc::tms) -> libc::clock_t {
+    match syscall_table.syscall_times.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_times.syscall_fn)(buf) },
     }
 }

--- a/src/daemons/linuxd/src/unistd.rs
+++ b/src/daemons/linuxd/src/unistd.rs
@@ -8,12 +8,17 @@
 use crate::{
     error::WorkerThreadError,
     fcntl::LibcAtFlags,
+    syscalls::{
+        SystemCallAction,
+        SystemCallRouteTable,
+    },
 };
 use ::alloc::ffi::CString;
 use ::core::{
     ffi,
     ffi::CStr,
 };
+use ::std::sync::Arc;
 use ::sys::{
     error::{
         Error,
@@ -87,6 +92,7 @@ use ::syslog::{
 //==================================================================================================
 
 pub fn do_chdir(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: ChangeDirectoryRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -101,7 +107,7 @@ pub fn do_chdir(
     };
 
     debug!("libc::chdir(): path={path:?}");
-    match unsafe { libc::chdir(path.as_ptr()) } {
+    match unsafe { handle_chdir(&syscall_table, path.as_ptr()) } {
         0 => {
             debug!("do_chdir(): chdir() succeeded");
             Ok(vec![ChangeDirectoryResponse::build(tid)])
@@ -130,6 +136,7 @@ pub fn do_chdir(
 //==================================================================================================
 
 pub fn do_close(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: CloseRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -138,7 +145,7 @@ pub fn do_close(
     let fd: i32 = request.fd;
 
     debug!("libc::close(): fd={fd:?}");
-    match unsafe { libc::close(fd) } {
+    match unsafe { handle_close(&syscall_table, fd) } {
         ret if ret == 0 => Ok(CloseResponse::build(tid, ret)),
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -160,6 +167,7 @@ pub fn do_close(
 //==================================================================================================
 
 pub fn do_faccessat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileAccessAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -179,7 +187,9 @@ pub fn do_faccessat(
         dirfd.inner(),
         flag.inner()
     );
-    match unsafe { libc::faccessat(dirfd.inner(), path.as_ptr(), amode, flag.inner()) } {
+    match unsafe {
+        handle_faccessat(&syscall_table, dirfd.inner(), path.as_ptr(), amode, flag.inner())
+    } {
         0 => Ok(vec![FileAccessAtResponse::build(tid)]),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -205,6 +215,7 @@ pub fn do_faccessat(
 //==================================================================================================
 
 pub fn do_fdatasync(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileDataSyncRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -213,7 +224,7 @@ pub fn do_fdatasync(
     let fd: i32 = request.fd;
 
     debug!("libc::fdatasync(): fd={fd:?}");
-    match unsafe { libc::fdatasync(fd) } {
+    match unsafe { handle_fdatasync(&syscall_table, fd) } {
         ret if ret == 0 => Ok(FileDataSyncResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -239,25 +250,26 @@ pub fn do_fdatasync(
 //==================================================================================================
 
 pub fn do_getids(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     _request: GetIdsRequest,
 ) -> Result<Message, WorkerThreadError> {
     trace!("getids(): tid={tid:?}");
 
     // Get user ID.
-    let uid: libc::uid_t = unsafe { libc::getuid() };
+    let uid: libc::uid_t = unsafe { handle_getuid(&syscall_table) };
     debug!("libc::getuid(): uid={uid:?}");
 
     // Get effective user ID.
-    let euid: libc::uid_t = unsafe { libc::geteuid() };
+    let euid: libc::uid_t = unsafe { handle_geteuid(&syscall_table) };
     debug!("libc::geteuid(): euid={euid:?}");
 
     // Get group ID.
-    let gid: libc::gid_t = unsafe { libc::getgid() };
+    let gid: libc::gid_t = unsafe { handle_getgid(&syscall_table) };
     debug!("libc::getgid(): gid={gid:?}");
 
     // Get effective group ID.
-    let egid: libc::gid_t = unsafe { libc::getegid() };
+    let egid: libc::gid_t = unsafe { handle_getegid(&syscall_table) };
     debug!("libc::getegid(): egid={egid:?}");
 
     // Build response.
@@ -268,14 +280,20 @@ pub fn do_getids(
 // do_getcwd
 //==================================================================================================
 
-pub fn do_getcwd(tid: ThreadIdentifier) -> Result<Vec<Message>, WorkerThreadError> {
+pub fn do_getcwd(
+    syscall_table: Arc<SystemCallRouteTable>,
+    tid: ThreadIdentifier,
+) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("getcwd(): tid={tid:?}");
 
     let mut buf: Vec<u8> = Vec::with_capacity(PATH_MAX as libc::size_t);
 
     // Get current working directory and check for errors.
     debug!("libc::getcwd(): buf={:p}, size={:?}", buf.as_mut_ptr(), buf.capacity());
-    if unsafe { !libc::getcwd(buf.as_mut_ptr() as *mut libc::c_char, buf.capacity()).is_null() } {
+    if unsafe {
+        !handle_getcwd(&syscall_table, buf.as_mut_ptr() as *mut libc::c_char, buf.capacity())
+            .is_null()
+    } {
         // Build response and check for errors.
         let response: GetCurrentWorkingDirectoryResponse =
             match unsafe { CStr::from_ptr(buf.as_ptr() as *const libc::c_char).to_str() } {
@@ -332,6 +350,7 @@ pub fn do_getcwd(tid: ThreadIdentifier) -> Result<Vec<Message>, WorkerThreadErro
 //==================================================================================================
 
 pub fn do_fsync(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileSyncRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -340,7 +359,7 @@ pub fn do_fsync(
     let fd: i32 = request.fd;
 
     debug!("libc::fsync(): fd={fd:?}");
-    match unsafe { libc::fsync(fd) } {
+    match unsafe { handle_fsync(&syscall_table, fd) } {
         ret if ret == 0 => Ok(FileSyncResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -365,7 +384,11 @@ pub fn do_fsync(
 // do_lseek
 //==================================================================================================
 
-pub fn do_lseek(tid: ThreadIdentifier, request: SeekRequest) -> Result<Message, WorkerThreadError> {
+pub fn do_lseek(
+    syscall_table: Arc<SystemCallRouteTable>,
+    tid: ThreadIdentifier,
+    request: SeekRequest,
+) -> Result<Message, WorkerThreadError> {
     trace!("lseek(): tid={tid:?}, request={request:?}");
 
     let fd: i32 = request.fd;
@@ -376,7 +399,7 @@ pub fn do_lseek(tid: ThreadIdentifier, request: SeekRequest) -> Result<Message, 
     };
 
     debug!("libc::lseek(): fd={:?}, offset={:?}, whence={:?}", fd, offset, whence.inner());
-    match unsafe { libc::lseek(fd, offset, whence.inner()) } {
+    match unsafe { handle_lseek(&syscall_table, fd, offset, whence.inner()) } {
         ret if ret >= 0 => Ok(SeekResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -402,6 +425,7 @@ pub fn do_lseek(tid: ThreadIdentifier, request: SeekRequest) -> Result<Message, 
 //==================================================================================================
 
 pub fn do_ftruncate(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileTruncateRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -411,7 +435,7 @@ pub fn do_ftruncate(
     let length: off_t = request.length;
 
     debug!("libc::ftruncate(): fd={fd:?}, length={length:?}");
-    match unsafe { libc::ftruncate(fd, length) } {
+    match unsafe { handle_ftruncate(&syscall_table, fd, length) } {
         ret if ret == 0 => Ok(FileTruncateResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -437,6 +461,7 @@ pub fn do_ftruncate(
 //==================================================================================================
 
 pub fn do_write(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: WriteRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -452,7 +477,7 @@ pub fn do_write(
     let buffer: &[u8] = &request.buffer[..count];
 
     debug!("libc::write(): fd={fd:?}, buffer={buffer:?}");
-    match unsafe { libc::write(fd, buffer.as_ptr() as *const _, count) } {
+    match unsafe { handle_write(&syscall_table, fd, buffer.as_ptr() as *const _, count) } {
         ret if ret >= 0 => Ok(WriteResponse::build(tid, ret as i32)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -477,7 +502,11 @@ pub fn do_write(
 // do_read
 //==================================================================================================
 
-pub fn do_read(tid: ThreadIdentifier, request: ReadRequest) -> Result<Message, WorkerThreadError> {
+pub fn do_read(
+    syscall_table: Arc<SystemCallRouteTable>,
+    tid: ThreadIdentifier,
+    request: ReadRequest,
+) -> Result<Message, WorkerThreadError> {
     trace!("read(): tid={tid:?}, request={request:?}");
 
     // Check if count is invalid.
@@ -490,7 +519,7 @@ pub fn do_read(tid: ThreadIdentifier, request: ReadRequest) -> Result<Message, W
     let mut buffer: [u8; ReadResponse::BUFFER_SIZE] = [0; ReadResponse::BUFFER_SIZE];
 
     debug!("libc::read(): fd={fd:?}, buffer={buffer:?}");
-    match unsafe { libc::read(fd, buffer.as_mut_ptr() as *mut _, count) } {
+    match unsafe { handle_read(&syscall_table, fd, buffer.as_mut_ptr() as *mut _, count) } {
         ret if ret >= 0 => Ok(ReadResponse::build(tid, ret as i32, buffer)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -516,6 +545,7 @@ pub fn do_read(tid: ThreadIdentifier, request: ReadRequest) -> Result<Message, W
 //==================================================================================================
 
 pub fn do_pwrite(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: PartialWriteRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -532,7 +562,7 @@ pub fn do_pwrite(
     let buffer: &[u8] = &request.buffer[..count];
 
     debug!("libc::pwrite(): fd={fd:?}, count={count:?}, offset={offset:?}, buffer={buffer:?}",);
-    match unsafe { libc::pwrite(fd, buffer.as_ptr() as *const _, count, offset) } {
+    match unsafe { handle_pwrite(&syscall_table, fd, buffer.as_ptr() as *const _, count, offset) } {
         ret if ret >= 0 => Ok(PartialWriteResponse::build(tid, ret as c_ssize_t)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -558,6 +588,7 @@ pub fn do_pwrite(
 //==================================================================================================
 
 pub fn do_pread(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: PartialReadRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -574,7 +605,8 @@ pub fn do_pread(
     let mut buffer: [u8; PartialReadResponse::BUFFER_SIZE] = [0; PartialReadResponse::BUFFER_SIZE];
 
     debug!("libc::pread(): fd={fd:?}, count={count:?}, offset={offset:?}, buffer={buffer:?}",);
-    match unsafe { libc::pread(fd, buffer.as_mut_ptr() as *mut _, count, offset) } {
+    match unsafe { handle_pread(&syscall_table, fd, buffer.as_mut_ptr() as *mut _, count, offset) }
+    {
         ret if ret >= 0 => Ok(PartialReadResponse::build(tid, ret as c_ssize_t, buffer)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -600,6 +632,7 @@ pub fn do_pread(
 //==================================================================================================
 
 pub fn do_linkat(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: LinkAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -621,7 +654,9 @@ pub fn do_linkat(
         "libc::linkat(): olddirfd={olddirfd:?}, oldpath={oldpath:?}, newdirfd={newdirfd:?}, \
          newpath={newpath:?}, flags={flags:?}",
     );
-    match unsafe { libc::linkat(olddirfd, oldpath.as_ptr(), newdirfd, newpath.as_ptr(), flags) } {
+    match unsafe {
+        handle_linkat(&syscall_table, olddirfd, oldpath.as_ptr(), newdirfd, newpath.as_ptr(), flags)
+    } {
         ret if ret == 0 => Ok(vec![LinkAtResponse::build(tid, ret)]),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -648,6 +683,7 @@ pub fn do_linkat(
 
 /// Changes the current working directory.
 pub fn do_fchdir(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileChdirRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -656,7 +692,7 @@ pub fn do_fchdir(
     let fd: i32 = request.fd;
 
     debug!("libc::fchdir(): fd={fd:?}");
-    match unsafe { libc::fchdir(fd) } {
+    match unsafe { handle_fchdir(&syscall_table, fd) } {
         0 => Ok(FileChdirResponse::build(tid)),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
@@ -682,6 +718,7 @@ pub fn do_fchdir(
 //==================================================================================================
 
 pub fn do_fchown(
+    syscall_table: Arc<SystemCallRouteTable>,
     tid: ThreadIdentifier,
     request: FileChownRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -692,7 +729,7 @@ pub fn do_fchown(
     let group: u32 = request.group;
 
     debug!("libc::fchown(): fd={fd:?}, owner={owner:?}, group={group:?}");
-    match unsafe { libc::fchown(fd, owner, group) } {
+    match unsafe { handle_fchown(&syscall_table, fd, owner, group) } {
         0 => Ok(FileChownResponse::build(tid)),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
@@ -717,13 +754,16 @@ pub fn do_fchown(
 // do_pipe
 //==================================================================================================
 
-pub fn do_pipe(tid: ThreadIdentifier) -> Result<Message, WorkerThreadError> {
+pub fn do_pipe(
+    syscall_table: Arc<SystemCallRouteTable>,
+    tid: ThreadIdentifier,
+) -> Result<Message, WorkerThreadError> {
     trace!("pipe(): tid={tid:?}");
 
     let mut fds: [i32; 2] = [0; 2];
 
     debug!("libc::pipe(): fds={fds:?}");
-    match unsafe { libc::pipe(fds.as_mut_ptr()) } {
+    match unsafe { handle_pipe(&syscall_table, fds.as_mut_ptr()) } {
         0 => {
             let read_fd: i32 = fds[0];
             let write_fd: i32 = fds[1];
@@ -772,5 +812,296 @@ impl TryFrom<i32> for LibcSeek {
             SEEK_DATA => Ok(LibcSeek(libc::SEEK_DATA)),
             _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid whence")),
         }
+    }
+}
+
+//==================================================================================================
+// System Call Wrappers
+//==================================================================================================
+
+/// Handler for `libc::chdir()`.
+unsafe fn handle_chdir(
+    syscall_table: &SystemCallRouteTable,
+    path: *const libc::c_char,
+) -> libc::c_int {
+    match syscall_table.syscall_chdir.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_chdir.syscall_fn)(path) },
+    }
+}
+
+/// Handler for `libc::close()`.
+unsafe fn handle_close(syscall_table: &SystemCallRouteTable, fd: libc::c_int) -> libc::c_int {
+    match syscall_table.syscall_close.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_close.syscall_fn)(fd) },
+    }
+}
+
+/// Handler for `libc::faccessat()`.
+unsafe fn handle_faccessat(
+    syscall_table: &SystemCallRouteTable,
+    dirfd: libc::c_int,
+    pathname: *const libc::c_char,
+    mode: libc::c_int,
+    flags: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_faccessat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_faccessat.syscall_fn)(dirfd, pathname, mode, flags)
+        },
+    }
+}
+
+/// Handler for `libc::fdatasync()`.
+unsafe fn handle_fdatasync(syscall_table: &SystemCallRouteTable, fd: libc::c_int) -> libc::c_int {
+    match syscall_table.syscall_fdatasync.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_fdatasync.syscall_fn)(fd) },
+    }
+}
+
+/// Handler for `libc::getuid()`.
+unsafe fn handle_getuid(syscall_table: &SystemCallRouteTable) -> libc::uid_t {
+    match syscall_table.syscall_getuid.action {
+        SystemCallAction::Block => 0,
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_getuid.syscall_fn)() },
+    }
+}
+
+/// Handler for `libc::geteuid()`.
+unsafe fn handle_geteuid(syscall_table: &SystemCallRouteTable) -> libc::uid_t {
+    match syscall_table.syscall_geteuid.action {
+        SystemCallAction::Block => 0,
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_geteuid.syscall_fn)() },
+    }
+}
+
+/// Handler for `libc::getgid()`.
+unsafe fn handle_getgid(syscall_table: &SystemCallRouteTable) -> libc::gid_t {
+    match syscall_table.syscall_getgid.action {
+        SystemCallAction::Block => 0,
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_getgid.syscall_fn)() },
+    }
+}
+
+/// Handler for `libc::getegid()`.
+unsafe fn handle_getegid(syscall_table: &SystemCallRouteTable) -> libc::gid_t {
+    match syscall_table.syscall_getegid.action {
+        SystemCallAction::Block => 0,
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_getegid.syscall_fn)() },
+    }
+}
+
+/// Handler for `libc::getcwd()`.
+unsafe fn handle_getcwd(
+    syscall_table: &SystemCallRouteTable,
+    buf: *mut libc::c_char,
+    size: libc::size_t,
+) -> *mut libc::c_char {
+    match syscall_table.syscall_getcwd.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            ::core::ptr::null_mut()
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_getcwd.syscall_fn)(buf, size)
+        },
+    }
+}
+
+/// Handler for `libc::fsync()`.
+unsafe fn handle_fsync(syscall_table: &SystemCallRouteTable, fd: libc::c_int) -> libc::c_int {
+    match syscall_table.syscall_fsync.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_fsync.syscall_fn)(fd) },
+    }
+}
+
+/// Handler for `libc::lseek()`.
+unsafe fn handle_lseek(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    offset: libc::off_t,
+    whence: libc::c_int,
+) -> libc::off_t {
+    match syscall_table.syscall_lseek.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_lseek.syscall_fn)(fd, offset, whence)
+        },
+    }
+}
+
+/// Handler for `libc::ftruncate()`.
+unsafe fn handle_ftruncate(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    length: libc::off_t,
+) -> libc::c_int {
+    match syscall_table.syscall_ftruncate.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_ftruncate.syscall_fn)(fd, length)
+        },
+    }
+}
+
+/// Handler for `libc::write()`.
+unsafe fn handle_write(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    buf: *const libc::c_void,
+    count: libc::size_t,
+) -> libc::ssize_t {
+    match syscall_table.syscall_write.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_write.syscall_fn)(fd, buf, count)
+        },
+    }
+}
+
+/// Handler for `libc::read()`.
+unsafe fn handle_read(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    buf: *mut libc::c_void,
+    count: libc::size_t,
+) -> libc::ssize_t {
+    match syscall_table.syscall_read.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_read.syscall_fn)(fd, buf, count)
+        },
+    }
+}
+
+/// Handler for `libc::pwrite()`.
+unsafe fn handle_pwrite(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    buf: *const libc::c_void,
+    count: libc::size_t,
+    offset: libc::off_t,
+) -> libc::ssize_t {
+    match syscall_table.syscall_pwrite.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_pwrite.syscall_fn)(fd, buf, count, offset)
+        },
+    }
+}
+
+/// Handler for `libc::pread()`.
+unsafe fn handle_pread(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    buf: *mut libc::c_void,
+    count: libc::size_t,
+    offset: libc::off_t,
+) -> libc::ssize_t {
+    match syscall_table.syscall_pread.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_pread.syscall_fn)(fd, buf, count, offset)
+        },
+    }
+}
+
+/// Handler for `libc::linkat()`.
+unsafe fn handle_linkat(
+    syscall_table: &SystemCallRouteTable,
+    olddirfd: libc::c_int,
+    oldpath: *const libc::c_char,
+    newdirfd: libc::c_int,
+    newpath: *const libc::c_char,
+    flags: libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_linkat.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_linkat.syscall_fn)(olddirfd, oldpath, newdirfd, newpath, flags)
+        },
+    }
+}
+
+/// Handler for `libc::fchdir()`.
+unsafe fn handle_fchdir(syscall_table: &SystemCallRouteTable, fd: libc::c_int) -> libc::c_int {
+    match syscall_table.syscall_fchdir.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_fchdir.syscall_fn)(fd) },
+    }
+}
+
+/// Handler for `libc::fchown()`.
+unsafe fn handle_fchown(
+    syscall_table: &SystemCallRouteTable,
+    fd: libc::c_int,
+    owner: libc::uid_t,
+    group: libc::gid_t,
+) -> libc::c_int {
+    match syscall_table.syscall_fchown.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe {
+            (syscall_table.syscall_fchown.syscall_fn)(fd, owner, group)
+        },
+    }
+}
+
+/// Handler for `libc::pipe()`.
+unsafe fn handle_pipe(
+    syscall_table: &SystemCallRouteTable,
+    pipefd: *mut libc::c_int,
+) -> libc::c_int {
+    match syscall_table.syscall_pipe.action {
+        SystemCallAction::Block => {
+            unsafe { *libc::__errno_location() = libc::EPERM };
+            -1
+        },
+        SystemCallAction::Forward => unsafe { (syscall_table.syscall_pipe.syscall_fn)(pipefd) },
     }
 }

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     socket,
     sys_select,
+    syscalls::SystemCallRouteTable,
     times,
     unistd,
     user_vm_handle::UserVmHandle,
@@ -217,6 +218,7 @@ impl WorkerThreadHandle {
         channel_tx: Sender<VenvCommand>,
         uvm_handle: UserVmHandle,
         assembler: Arc<Mutex<RequestAssembler>>,
+        syscall_table: Arc<SystemCallRouteTable>,
     ) -> Result<Self, Error> {
         trace!("spawning workker thread (id={id:?})");
         // We use an atomic to pass the id of the created thread back to the caller context. We
@@ -232,7 +234,7 @@ impl WorkerThreadHandle {
             let pthread_id = unsafe { pthread_self() };
             pthread_id_holder.store(pthread_id as usize, Ordering::Relaxed);
 
-            Self::handle_message(channel_rx, uvm_handle, assembler);
+            Self::handle_message(channel_rx, uvm_handle, syscall_table, assembler);
 
             trace!("thread shutting down after receiving interrupt (pthread_id={pthread_id})");
         });
@@ -266,6 +268,7 @@ impl WorkerThreadHandle {
     fn handle_message(
         mut channel_rx: Receiver<VenvCommand>,
         uvm_handle: UserVmHandle,
+        syscall_table: Arc<SystemCallRouteTable>,
         assembler: Arc<Mutex<RequestAssembler>>,
     ) {
         let worker_tid: ThreadId = thread::current().id();
@@ -325,6 +328,7 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::ReadRequest
                                 | LinuxDaemonMessageHeader::WriteRequest => {
                                     match Self::handle_special_messages(
+                                        syscall_table.clone(),
                                         gateway_reader.clone(),
                                         gateway_writer.clone(),
                                         source,
@@ -374,7 +378,11 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::TimesRequest
                                 | LinuxDaemonMessageHeader::PipeRequest
                                 | LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
-                                    match Self::handle_short_request_messages(source, message) {
+                                    match Self::handle_short_request_messages(
+                                        syscall_table.clone(),
+                                        source,
+                                        message,
+                                    ) {
                                         Ok(message) => message,
                                         Err(WorkerThreadError::Interrupted) => break,
                                         Err(WorkerThreadError::Error(e)) => {
@@ -397,6 +405,7 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
                                     match Self::handle_long_response_messages(
                                         uvm_stream.clone(),
+                                        syscall_table.clone(),
                                         source,
                                         message,
                                     ) {
@@ -434,6 +443,7 @@ impl WorkerThreadHandle {
                                     match Self::handle_long_request_messages(
                                         uvm_stream.clone(),
                                         assembler.clone(),
+                                        syscall_table.clone(),
                                         source,
                                         message,
                                     ) {
@@ -480,6 +490,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_special_messages(
+        syscall_table: Arc<SystemCallRouteTable>,
         gateway_reader: Arc<Mutex<SocketStreamReader>>,
         gateway_writer: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
@@ -488,15 +499,15 @@ impl WorkerThreadHandle {
         match message.header {
             LinuxDaemonMessageHeader::CloseRequest => {
                 let request: CloseRequest = CloseRequest::from_bytes(message.payload);
-                Self::handle_close_request(source, request)
+                Self::handle_close_request(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::ReadRequest => {
                 let request: ReadRequest = ReadRequest::from_bytes(message.payload);
-                Self::handle_read_request(gateway_reader, source, request)
+                Self::handle_read_request(syscall_table, gateway_reader, source, request)
             },
             LinuxDaemonMessageHeader::WriteRequest => {
                 let request: WriteRequest = WriteRequest::from_bytes(message.payload);
-                Self::handle_write_request(gateway_writer, source, request)
+                Self::handle_write_request(syscall_table, gateway_writer, source, request)
             },
             header => {
                 // The following statement is unreachable, because the matching logic in this
@@ -507,128 +518,129 @@ impl WorkerThreadHandle {
     }
 
     fn handle_short_request_messages(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<Message, WorkerThreadError> {
         match message.header {
             LinuxDaemonMessageHeader::AcceptSocketRequest => {
                 let request: AcceptSocketRequest = AcceptSocketRequest::from_bytes(message.payload);
-                socket::do_accept(source, request)
+                socket::do_accept(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::BindSocketRequest => {
                 let request: BindSocketRequest = BindSocketRequest::from_bytes(message.payload);
-                socket::do_bind(source, request)
+                socket::do_bind(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::ConnectSocketRequest => {
                 let request: ConnectSocketRequest =
                     ConnectSocketRequest::from_bytes(message.payload);
-                socket::do_connect(source, request)
+                socket::do_connect(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::CreateSocketPairRequest => {
                 let request: CreateSocketPairRequest =
                     CreateSocketPairRequest::from_bytes(message.payload);
-                socket::do_socketpair(source, request)
+                socket::do_socketpair(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::CreateSocketRequest => {
                 let request: CreateSocketRequest = CreateSocketRequest::from_bytes(message.payload);
-                socket::do_socket(source, request)
+                socket::do_socket(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileAdvisoryInformationRequest => {
                 let request: FileAdvisoryInformationRequest =
                     FileAdvisoryInformationRequest::from_bytes(message.payload);
-                fcntl::do_posix_fadvise(source, request)
+                fcntl::do_posix_fadvise(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileChdirRequest => {
                 let request: FileChdirRequest = FileChdirRequest::from_bytes(message.payload);
-                unistd::do_fchdir(source, request)
+                unistd::do_fchdir(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileChmodRequest => {
                 let request: FileChmodRequest = FileChmodRequest::from_bytes(message.payload);
-                fcntl::do_fchmod(source, request)
+                fcntl::do_fchmod(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileChownRequest => {
                 let request: FileChownRequest = FileChownRequest::from_bytes(message.payload);
-                unistd::do_fchown(source, request)
+                unistd::do_fchown(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileControlRequest => {
                 let request: FileControlRequest = FileControlRequest::from_bytes(message.payload);
-                fcntl::do_fcntl(source, request)
+                fcntl::do_fcntl(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileDataSyncRequest => {
                 let request: FileDataSyncRequest = FileDataSyncRequest::from_bytes(message.payload);
-                unistd::do_fdatasync(source, request)
+                unistd::do_fdatasync(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileSpaceControlRequest => {
                 let request: FileSpaceControlRequest =
                     FileSpaceControlRequest::from_bytes(message.payload);
-                fcntl::do_posix_fallocate(source, request)
+                fcntl::do_posix_fallocate(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileSyncRequest => {
                 let request: FileSyncRequest = FileSyncRequest::from_bytes(message.payload);
-                unistd::do_fsync(source, request)
+                unistd::do_fsync(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileTruncateRequest => {
                 let request: FileTruncateRequest = FileTruncateRequest::from_bytes(message.payload);
-                unistd::do_ftruncate(source, request)
+                unistd::do_ftruncate(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::GetIdsRequest => {
                 let request: GetIdsRequest = GetIdsRequest::from_bytes(message.payload);
-                unistd::do_getids(source, request)
+                unistd::do_getids(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::GetPeerNameRequest => {
                 let request: GetPeerNameRequest = GetPeerNameRequest::from_bytes(message.payload);
-                socket::do_getpeername(source, request)
+                socket::do_getpeername(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::GetSockNameRequest => {
                 let request: GetSockNameRequest = GetSockNameRequest::from_bytes(message.payload);
-                socket::do_getsockname(source, request)
+                socket::do_getsockname(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::ListenSocketRequest => {
                 let request: ListenSocketRequest = ListenSocketRequest::from_bytes(message.payload);
-                socket::do_listen(source, request)
+                socket::do_listen(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::PartialReadRequest => {
                 let request: PartialReadRequest = PartialReadRequest::from_bytes(message.payload);
-                unistd::do_pread(source, request)
+                unistd::do_pread(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::PartialWriteRequest => {
                 let request: PartialWriteRequest = PartialWriteRequest::from_bytes(message.payload);
-                unistd::do_pwrite(source, request)
+                unistd::do_pwrite(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::ReceiveSocketRequest => {
                 let request: ReceiveSocketRequest =
                     ReceiveSocketRequest::from_bytes(message.payload);
-                socket::do_recv(source, request)
+                socket::do_recv(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::SeekRequest => {
                 let request: SeekRequest = SeekRequest::from_bytes(message.payload);
-                unistd::do_lseek(source, request)
+                unistd::do_lseek(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::SelectRequest => {
                 let request: SelectRequest = SelectRequest::from_bytes(message.payload);
-                sys_select::do_select(source, request)
+                sys_select::do_select(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::SendSocketRequest => {
                 let request: SendSocketRequest = SendSocketRequest::from_bytes(message.payload);
-                socket::do_send(source, request)
+                socket::do_send(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::ShutdownSocketRequest => {
                 let request: ShutdownSocketRequest =
                     ShutdownSocketRequest::from_bytes(message.payload);
-                socket::do_shutdown(source, request)
+                socket::do_shutdown(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::TimesRequest => {
                 let request: TimesRequest = TimesRequest::from_bytes(message.payload);
-                times::do_times(source, request)
+                times::do_times(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
                 let request: UpdateFileAccessTimeRequest =
                     UpdateFileAccessTimeRequest::from_bytes(message.payload);
-                fcntl::do_futimens(source, request)
+                fcntl::do_futimens(syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::PipeRequest => {
                 let _request = PipeRequest::from_bytes(message.payload);
-                unistd::do_pipe(source)
+                unistd::do_pipe(syscall_table, source)
             },
             header => {
                 // The following statement is unreachable, because the matching logic in this
@@ -641,74 +653,135 @@ impl WorkerThreadHandle {
     fn handle_long_request_messages(
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         assembler: Arc<Mutex<RequestAssembler>>,
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<(), WorkerThreadError> {
         match message.header {
             LinuxDaemonMessageHeader::ChangeDirectoryRequestPart => {
                 Self::handle_long_request::<ChangeDirectoryRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
             LinuxDaemonMessageHeader::FileAccessAtRequestPart => {
                 Self::handle_long_request::<FileAccessAtRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
             LinuxDaemonMessageHeader::FileStatAtRequestPart => {
                 Self::handle_long_request::<FileStatAtRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
             LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart => {
                 Self::handle_long_request::<SymbolicLinkAtRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
             LinuxDaemonMessageHeader::LinkAtRequestPart => {
-                Self::handle_long_request::<LinkAtRequest>(uvm_stream, assembler, source, &message)
+                Self::handle_long_request::<LinkAtRequest>(
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
+                )
             },
             LinuxDaemonMessageHeader::ReadLinkAtRequestPart => {
                 Self::handle_long_request::<ReadLinkAtRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
             LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart => {
                 Self::handle_long_request::<MakeDirectoryAtRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
             LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart => {
                 Self::handle_long_request::<UpdateFileAccessTimeAtRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
             LinuxDaemonMessageHeader::FileChownAtRequestPart => {
                 Self::handle_long_request::<FileChownAtRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
             LinuxDaemonMessageHeader::FileChmodAtRequestPart => {
                 Self::handle_long_request::<FileChmodAtRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
             LinuxDaemonMessageHeader::OpenAtRequestPart => {
-                Self::handle_long_request::<OpenAtRequest>(uvm_stream, assembler, source, &message)
+                Self::handle_long_request::<OpenAtRequest>(
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
+                )
             },
             LinuxDaemonMessageHeader::RenameAtRequestPart => {
                 Self::handle_long_request::<RenameAtRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
             LinuxDaemonMessageHeader::UnlinkAtRequestPart => {
                 Self::handle_long_request::<UnlinkAtRequest>(
-                    uvm_stream, assembler, source, &message,
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
                 )
             },
-            LinuxDaemonMessageHeader::PollRequestPart => {
-                Self::handle_long_request::<PollRequest>(uvm_stream, assembler, source, &message)
-            },
+            LinuxDaemonMessageHeader::PollRequestPart => Self::handle_long_request::<PollRequest>(
+                uvm_stream,
+                assembler,
+                syscall_table,
+                source,
+                &message,
+            ),
             header => {
                 // The following statement is unreachable, because the matching logic in this
                 // function should match the one in the `Self::run()` function.
@@ -719,18 +792,19 @@ impl WorkerThreadHandle {
 
     fn handle_long_response_messages(
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<(), WorkerThreadError> {
         match message.header {
             LinuxDaemonMessageHeader::FileStatRequest => {
-                Self::handle_fstat_request(uvm_stream, source, message)
+                Self::handle_fstat_request(syscall_table, uvm_stream, source, message)
             },
             LinuxDaemonMessageHeader::GetCurrentWorkingDirectoryRequest => {
-                Self::handle_getcwd_request(uvm_stream, source)
+                Self::handle_getcwd_request(uvm_stream, syscall_table, source)
             },
             LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
-                Self::handle_getdents_request(uvm_stream, source, message)
+                Self::handle_getdents_request(syscall_table, uvm_stream, source, message)
             },
             header => {
                 // The following statement is unreachable, because the matching logic in this
@@ -760,6 +834,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_close_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         request: CloseRequest,
     ) -> Result<Message, WorkerThreadError> {
@@ -773,11 +848,12 @@ impl WorkerThreadHandle {
                 Ok(CloseResponse::build(source, 0))
             },
             // Closing other file descriptors.
-            _ => unistd::do_close(source, request),
+            _ => unistd::do_close(syscall_table, source, request),
         }
     }
 
     fn handle_write_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         gateway_writer: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
         mut request: WriteRequest,
@@ -824,11 +900,12 @@ impl WorkerThreadHandle {
             }
         } else {
             // Write to other file descriptor.
-            unistd::do_write(source, request)
+            unistd::do_write(syscall_table, source, request)
         }
     }
 
     fn handle_read_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         gateway_reader: Arc<Mutex<SocketStreamReader>>,
         source: ThreadIdentifier,
         request: ReadRequest,
@@ -870,17 +947,18 @@ impl WorkerThreadHandle {
             response
         } else {
             // Read from other file descriptor.
-            unistd::do_read(source, request)
+            unistd::do_read(syscall_table, source, request)
         }
     }
 
     fn handle_fstat_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<(), WorkerThreadError> {
         let request: FileStatRequest = FileStatRequest::from_bytes(message.payload);
-        let messages: Vec<Message> = fcntl::do_fstat(source, request)?;
+        let messages: Vec<Message> = fcntl::do_fstat(syscall_table, source, request)?;
         trace!("handle_fstat_request(): obtained {} messages", messages.len());
         for message in messages {
             trace!("handle_fstat_request(): sending message: {message:?}");
@@ -894,9 +972,10 @@ impl WorkerThreadHandle {
 
     fn handle_getcwd_request(
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
     ) -> Result<(), WorkerThreadError> {
-        let messages: Vec<Message> = unistd::do_getcwd(source)?;
+        let messages: Vec<Message> = unistd::do_getcwd(syscall_table, source)?;
         for message in messages {
             if let Err(e) = Handle::current().block_on(Self::send(uvm_stream.clone(), message)) {
                 error!("failed to send message (error={e:?})");
@@ -907,6 +986,7 @@ impl WorkerThreadHandle {
     }
 
     fn handle_getdents_request(
+        syscall_table: Arc<SystemCallRouteTable>,
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
@@ -914,7 +994,7 @@ impl WorkerThreadHandle {
         let request: GetDirectoryEntriesRequest =
             GetDirectoryEntriesRequest::from_bytes(message.payload);
 
-        let messages: Vec<Message> = dirent::do_getdents(source, request)?;
+        let messages: Vec<Message> = dirent::do_getdents(syscall_table, source, request)?;
         for message in messages {
             if let Err(e) = Handle::current().block_on(Self::send(uvm_stream.clone(), message)) {
                 error!("failed to send message (error={e:?})");
@@ -927,6 +1007,7 @@ impl WorkerThreadHandle {
     fn handle_long_request<T>(
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         assembler: Arc<Mutex<RequestAssembler>>,
+        syscall_table: Arc<SystemCallRouteTable>,
         source: ThreadIdentifier,
         message: &LinuxDaemonMessage,
     ) -> Result<(), WorkerThreadError>
@@ -937,8 +1018,9 @@ impl WorkerThreadHandle {
 
         trace!("handle_long_request(): source={source:?}, part={part:?}");
 
-        let result: Result<Option<Vec<Message>>, WorkerThreadError> =
-            assembler.blocking_lock().process_message::<T>(source, part);
+        let result: Result<Option<Vec<Message>>, WorkerThreadError> = assembler
+            .blocking_lock()
+            .process_message::<T>(syscall_table, source, part);
 
         match result {
             Ok(Some(messages)) => {

--- a/src/utils/nanvixd/src/cache.rs
+++ b/src/utils/nanvixd/src/cache.rs
@@ -157,6 +157,8 @@ impl SandboxCache {
                         tag.tenant_id().to_string(),
                         Arc::new(
                             LinuxDaemon::spawn(
+                                #[cfg(feature = "single-process")]
+                                None,
                                 sandbox_config.control_plane_sockaddr(),
                                 sandbox_config.user_vm_sockaddr(),
                                 sandbox_config.hwloc(),

--- a/src/utils/nanvixd/src/sandbox/single_process/linuxd.rs
+++ b/src/utils/nanvixd/src/sandbox/single_process/linuxd.rs
@@ -15,8 +15,14 @@ use ::control_plane_api::{
     NanvixdControlMessage,
 };
 use ::hwloc::HwLoc;
-use ::linuxd::LinuxDaemon as EmbeddedLinuxd;
-use ::std::mem;
+use ::linuxd::{
+    syscalls::SystemCallRouteTable,
+    LinuxDaemon as EmbeddedLinuxd,
+};
+use ::std::{
+    mem,
+    sync::Arc,
+};
 use ::syscomm::{
     SocketListener,
     SocketStream,
@@ -64,6 +70,7 @@ impl LinuxDaemon {
     ///
     /// # Parameters
     ///
+    /// - `syscall_table`: Optional system call routing table.
     /// - `control_plane_sockaddr`: Control-plane socket address.
     /// - `user_vm_sockaddr`: User-VM socket address.
     /// - `hwloc`: Optional CPU affinity settings (ignored)
@@ -81,6 +88,7 @@ impl LinuxDaemon {
     ///
     #[allow(clippy::too_many_arguments)]
     pub async fn spawn(
+        syscall_table: Option<Arc<SystemCallRouteTable>>,
         control_plane_sockaddr: &str,
         user_vm_sockaddr: &str,
         hwloc: Option<HwLoc>,
@@ -122,6 +130,7 @@ impl LinuxDaemon {
 
         // Create a new Linux Daemon instance.
         let linuxd: EmbeddedLinuxd = EmbeddedLinuxd::init(
+            syscall_table.unwrap_or_default(),
             control_plane_sockaddr,
             SocketType::UNIX_STR,
             user_vm_listener,


### PR DESCRIPTION
This pull request refactors the Linux daemon's directory and file control system call handling to add a layer of abstraction for system call routing and control. Instead of invoking libc system calls directly, the affected functions now use handler functions that consult a `SystemCallRouteTable` to determine whether to block or forward each system call. This enables more flexible and granular control over system call behavior, such as blocking specific calls for security or policy reasons.

The most important changes are:

### System Call Routing Abstraction

* Added a `SystemCallRouteTable` parameter (wrapped in `Arc`) to all major directory and file control handler functions (e.g., `do_openat`, `do_unlinkat`, `do_renameat`, `do_fstat`, etc.) in `dirent.rs` and `fcntl.rs`, allowing each function to consult the system call routing table. [[1]](diffhunk://#diff-62ea281e709ac303b7bb76d6ccae10b185ac7a9a9fc08203c092b36648187d70R122) [[2]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R161) [[3]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R227) [[4]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R287) [[5]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R355) [[6]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R465) [[7]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R510) [[8]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R562) [[9]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R654) [[10]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R712) [[11]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R786) [[12]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R844) [[13]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R916) [[14]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R969) [[15]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R1215) [[16]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R1273)

* Replaced direct calls to libc system calls with new handler functions (e.g., `handle_openat`, `handle_unlinkat`, `handle_fstatat`, etc.) that use the routing table to determine whether to block or forward the call. [[1]](diffhunk://#diff-62ea281e709ac303b7bb76d6ccae10b185ac7a9a9fc08203c092b36648187d70L136-R146) [[2]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L186-R194) [[3]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L240-R256) [[4]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L299-R316) [[5]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L358-R384) [[6]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L449-R476) [[7]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L500-R528) [[8]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L544-R573) [[9]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L647-R679) [[10]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L702-R741) [[11]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L770-R811) [[12]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L839-R883) [[13]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L891-R936) [[14]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L1000-R1046) [[15]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417L1191-R1240)

### Code Structure and Imports

* Updated imports in both `dirent.rs` and `fcntl.rs` to include `SystemCallAction`, `SystemCallRouteTable`, and `Arc`, supporting the new routing logic. [[1]](diffhunk://#diff-62ea281e709ac303b7bb76d6ccae10b185ac7a9a9fc08203c092b36648187d70L8-R23) [[2]](diffhunk://#diff-63731926c55275e769bfeabfd993e3d16b05c9bb301c97ce53fbbc5257ea9417R10-R18)

### New System Call Handler Functions

* Added new handler functions (e.g., `handle_getdents`, `handle_openat`, etc.) that encapsulate the logic for checking the route table and either blocking or forwarding the system call.

These changes provide a foundation for more sophisticated system call management, such as security enforcement or syscall virtualization, by making syscall routing explicit and configurable.