### PR TITLE
[uservm] Dynamic Lifetime for Global Handles

### DIFF
--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -496,24 +496,22 @@ pub fn build_input_fn(mut input_queue: Receiver<Message>) -> Box<StdinFn> {
                 on_message_received_from_memory_thread();
                 msg.message_type = MessageType::Ikc;
                 // Acquire lock on guest information.
-                let mut locked_guest: MutexGuard<'_, Guest> = crate::vmm::GUEST
-                    .get()
+                let guest_handle: Arc<Mutex<Guest>> = crate::vmm::try_get_guest_handle()
                     .ok_or_else(|| {
                         let reason: &str = "guest handle not initialized";
                         error!("input(): {reason}");
                         hyperlight_host::HyperlightError::AnyhowError(anyhow::Error::msg(reason))
-                    })?
-                    .blocking_lock();
+                    })?;
+                let mut locked_guest: MutexGuard<'_, Guest> = guest_handle.blocking_lock();
 
                 // Acquire lock on virtual memory manager.
-                let mut locked_vmem: MutexGuard<'_, VirtualMemory> = crate::vmm::VMEM
-                    .get()
+                let vmem_handle: Arc<Mutex<VirtualMemory>> = crate::vmm::try_get_vmem_handle()
                     .ok_or_else(|| {
                         let reason: &str = "vmem handle not initialized";
                         error!("input(): {reason}");
                         hyperlight_host::HyperlightError::AnyhowError(anyhow::Error::msg(reason))
-                    })?
-                    .blocking_lock();
+                    })?;
+                let mut locked_vmem: MutexGuard<'_, VirtualMemory> = vmem_handle.blocking_lock();
 
                 // Label: uservm::lib::vm_input::vm_write_bytes()
                 profiler::timestamp_message!(

--- a/src/uservm/src/vmm/hyperlight/global_handles.rs
+++ b/src/uservm/src/vmm/hyperlight/global_handles.rs
@@ -1,0 +1,162 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::vmm::{
+    VirtualMemory,
+    guest::Guest,
+};
+use ::anyhow::Result;
+use ::std::sync::{
+    Arc,
+    Mutex as StdMutex,
+    OnceLock,
+    Weak,
+};
+use ::syslog::error;
+use ::tokio::sync::Mutex;
+
+// ==================================================================================================
+// Globals
+// ==================================================================================================
+
+/// Global registry holding references to the guest and virtual memory manager.
+static GLOBAL_HANDLES: OnceLock<GlobalHandles> = OnceLock::new();
+
+//==================================================================================================
+// Structure
+//==================================================================================================
+
+pub(super) struct GlobalHandles {
+    inner: StdMutex<Handles>,
+}
+
+#[derive(Default)]
+struct Handles {
+    guest: Option<Weak<Mutex<Guest>>>,
+    vmem: Option<Weak<Mutex<VirtualMemory>>>,
+}
+
+pub(super) struct GlobalRegistration {
+    handles: &'static GlobalHandles,
+    guest: Weak<Mutex<Guest>>,
+    vmem: Weak<Mutex<VirtualMemory>>,
+}
+
+fn global_handles() -> &'static GlobalHandles {
+    GLOBAL_HANDLES.get_or_init(|| GlobalHandles {
+        inner: StdMutex::new(Handles::default()),
+    })
+}
+
+impl GlobalHandles {
+    pub(super) fn register(
+        &self,
+        guest: &Arc<Mutex<Guest>>,
+        vmem: &Arc<Mutex<VirtualMemory>>,
+    ) -> Result<()> {
+        let mut inner = match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(error) => {
+                let reason: String = format!("failed to acquire global handles lock: {error}");
+                error!("register(): {reason}");
+                return Err(anyhow::anyhow!(reason));
+            },
+        };
+
+        if inner.guest.is_some() || inner.vmem.is_some() {
+            let reason: &str = "global handles already registered";
+            error!("register(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        inner.guest = Some(Arc::downgrade(guest));
+        inner.vmem = Some(Arc::downgrade(vmem));
+        Ok(())
+    }
+
+    fn clear_if_matches(
+        &self,
+        expected_guest: &Weak<Mutex<Guest>>,
+        expected_vmem: &Weak<Mutex<VirtualMemory>>,
+    ) {
+        let mut inner = match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(error) => {
+                error!("clear_if_matches(): failed to acquire global handles lock: {error}");
+                return;
+            },
+        };
+
+        let guest_matches: bool = inner
+            .guest
+            .as_ref()
+            .map(|guest| guest.ptr_eq(expected_guest))
+            .unwrap_or(false);
+        let vmem_matches: bool = inner
+            .vmem
+            .as_ref()
+            .map(|vmem| vmem.ptr_eq(expected_vmem))
+            .unwrap_or(false);
+
+        if guest_matches && vmem_matches {
+            inner.guest = None;
+            inner.vmem = None;
+        }
+    }
+
+    fn upgrade_guest(&self) -> Option<Arc<Mutex<Guest>>> {
+        let inner = match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(error) => {
+                error!("upgrade_guest(): failed to acquire global handles lock: {error}");
+                return None;
+            },
+        };
+        inner.guest.as_ref().and_then(|guest| guest.upgrade())
+    }
+
+    fn upgrade_vmem(&self) -> Option<Arc<Mutex<VirtualMemory>>> {
+        let inner = match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(error) => {
+                error!("upgrade_vmem(): failed to acquire global handles lock: {error}");
+                return None;
+            },
+        };
+        inner.vmem.as_ref().and_then(|vmem| vmem.upgrade())
+    }
+}
+
+impl GlobalRegistration {
+    pub(super) fn register(
+        guest: Arc<Mutex<Guest>>,
+        vmem: Arc<Mutex<VirtualMemory>>,
+    ) -> Result<Arc<GlobalRegistration>> {
+        let handles: &'static GlobalHandles = global_handles();
+        handles.register(&guest, &vmem)?;
+
+        Ok(Arc::new(GlobalRegistration {
+            handles,
+            guest: Arc::downgrade(&guest),
+            vmem: Arc::downgrade(&vmem),
+        }))
+    }
+}
+
+impl Drop for GlobalRegistration {
+    fn drop(&mut self) {
+        self.handles.clear_if_matches(&self.guest, &self.vmem);
+    }
+}
+
+pub(crate) fn try_get_guest_handle() -> Option<Arc<Mutex<Guest>>> {
+    global_handles().upgrade_guest()
+}
+
+pub(crate) fn try_get_vmem_handle() -> Option<Arc<Mutex<VirtualMemory>>> {
+    global_handles().upgrade_vmem()
+}

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -1,6 +1,7 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+mod global_handles;
 pub mod guest;
 
 //==================================================================================================
@@ -12,6 +13,7 @@ use crate::{
     vmm::{
         MicroVmArgs,
         guest::Guest,
+        hyperlight::global_handles::GlobalRegistration,
     },
 };
 use ::anyhow::Result;
@@ -38,10 +40,7 @@ use ::hyperlight_host::{
 use ::std::{
     io::Write,
     path::Path,
-    sync::{
-        Arc,
-        OnceLock,
-    },
+    sync::Arc,
 };
 use ::sys::error::ErrorCode;
 use ::syslog::{
@@ -57,15 +56,14 @@ use ::tokio::{
     task,
 };
 
-// ==================================================================================================
-// Globals
-// ==================================================================================================
+//==================================================================================================
+// Exports
+//==================================================================================================
 
-/// Global handle to the guest information, used to enable access from the input handler.
-pub static GUEST: OnceLock<Arc<Mutex<Guest>>> = OnceLock::new();
-
-/// Global handle to the virtual memory manager, used to enable access from the input handler.
-pub static VMEM: OnceLock<Arc<Mutex<VirtualMemory>>> = OnceLock::new();
+pub(crate) use self::global_handles::{
+    try_get_guest_handle,
+    try_get_vmem_handle,
+};
 
 //==================================================================================================
 // Types
@@ -92,6 +90,7 @@ pub struct Vmm {
     // Wrapped in Option so we can move the UninitializedSandbox out (evolve consumes self).
     sandbox: Arc<Mutex<Option<UninitializedSandbox>>>,
     vmem: Arc<Mutex<VirtualMemory>>,
+    _global_registration: Arc<GlobalRegistration>,
 }
 
 struct InnerVmm {
@@ -238,18 +237,10 @@ impl Vmm {
         let vmem: Arc<Mutex<VirtualMemory>> = Arc::new(Mutex::new(VirtualMemory {
             manager: manager.clone(),
         }));
-        VMEM.set(vmem.clone()).map_err(|_| {
-            let reason: &str = "Failed to initialize vmem handle (already initialized)";
-            error!("new(): {reason}");
-            anyhow::anyhow!(reason)
-        })?;
 
         let guest: Arc<Mutex<Guest>> = Arc::new(Mutex::new(guest));
-        GUEST.set(guest.clone()).map_err(|_| {
-            let reason: &str = "Failed to initialize guest handle (already initialized)";
-            error!("new(): {reason}");
-            anyhow::anyhow!(reason)
-        })?;
+        let global_registration: Arc<GlobalRegistration> =
+            GlobalRegistration::register(guest.clone(), vmem.clone())?;
 
         // Create a closure that takes a String and writes it to stderr.
         // NOTE: underlying writer implements `Write` and requires mutable access.
@@ -283,6 +274,7 @@ impl Vmm {
             inner: Arc::new(Mutex::new(InnerVmm {
                 control_tx: args.control_tx,
             })),
+            _global_registration: global_registration,
         })
     }
 


### PR DESCRIPTION
This pull request refactors how global handles to the `Guest` and `VirtualMemory` objects are managed in the user virtual machine (uservm) codebase. Instead of using static `OnceLock` globals, it introduces a new `global_handles` module that encapsulates registration, retrieval, and cleanup of these handles. This change improves safety, flexibility, and resource management, especially around initialization and teardown.

The most important changes are:

**Global Handle Management Refactor:**

- Introduced the `global_handles` module with a `GlobalHandles` struct and related types to manage global references to `Guest` and `VirtualMemory` using `Arc<Mutex<...>>` and `Weak` pointers, replacing the previous `OnceLock`-based statics. This module provides safe registration, retrieval, and cleanup of these handles.
- Updated the `Vmm` struct to store a `_global_registration` field, which ensures that global handles are registered on initialization and automatically cleared on drop, preventing resource leaks and double initialization. [[1]](diffhunk://#diff-2eeb0b110bec3866ba7a09cd14837a8dc2f0142ea909f4da49d666a2fad0b9c1R93) [[2]](diffhunk://#diff-2eeb0b110bec3866ba7a09cd14837a8dc2f0142ea909f4da49d666a2fad0b9c1L241-R243) [[3]](diffhunk://#diff-2eeb0b110bec3866ba7a09cd14837a8dc2f0142ea909f4da49d666a2fad0b9c1R277)

**Codebase Integration:**

- Updated imports and exports in `hyperlight/mod.rs` to use the new `global_handles` module and removed the old static globals. [[1]](diffhunk://#diff-2eeb0b110bec3866ba7a09cd14837a8dc2f0142ea909f4da49d666a2fad0b9c1R4) [[2]](diffhunk://#diff-2eeb0b110bec3866ba7a09cd14837a8dc2f0142ea909f4da49d666a2fad0b9c1R16) [[3]](diffhunk://#diff-2eeb0b110bec3866ba7a09cd14837a8dc2f0142ea909f4da49d666a2fad0b9c1L41-R43) [[4]](diffhunk://#diff-2eeb0b110bec3866ba7a09cd14837a8dc2f0142ea909f4da49d666a2fad0b9c1L61-R66)
- Refactored code in `build_input_fn` to use the new `try_get_guest_handle` and `try_get_vmem_handle` functions for acquiring handles, improving error handling and clarity.