### PR TITLE
[build] Prefix `CXX`, `CC`, `CXXFLAGS` and `CFLAGS` with `NANVIX_`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,56 +150,58 @@ export NANVIX_MACHINE := $(MACHINE)
 #===================================================================================================
 
 # Tools
-export CC := $(TOOLCHAIN_DIR)/bin/i686-nanvix-gcc
-export CXX := $(TOOLCHAIN_DIR)/bin/i686-nanvix-g++
+export NANVIX_CC := $(TOOLCHAIN_DIR)/bin/i686-nanvix-gcc
+export NANVIX_CXX := $(TOOLCHAIN_DIR)/bin/i686-nanvix-g++
 
 # SCCACHE integration for C/C++ compilation (optional)
 ifneq ($(SCCACHE),)
 export CC := $(SCCACHE) $(CC)
 export CXX := $(SCCACHE) $(CXX)
+export NANVIX_CC := $(SCCACHE) $(NANVIX_CC)
+export NANVIX_CXX := $(SCCACHE) $(NANVIX_CXX)
 endif
 
 # C Compiler Options
-export CFLAGS := -std=c17
-export CFLAGS += -m32 -march=pentiumpro -Wa,-march=pentiumpro
-export CFLAGS += -Wall -Wextra -Werror
-export CFLAGS += -Winit-self -Wswitch-default -Wfloat-equal -Wno-pointer-arith
-export CFLAGS += -Wundef -Wshadow -Wuninitialized -Wlogical-op
-export CFLAGS += -Wvla -Wredundant-decls
-export CFLAGS += -pedantic-errors
-export CFLAGS += -Wstack-usage=4096
-export CFLAGS += -D__NANVIX_SYSNAME__="\"$(NANVIX_SYSNAME)\""
-export CFLAGS += -D__NANVIX_NODENAME__="\"$(NANVIX_NODENAME)\""
-export CFLAGS += -D__$(subst -,_,$(NANVIX_MACHINE))__
+export NANVIX_CFLAGS := -std=c17
+export NANVIX_CFLAGS += -m32 -march=pentiumpro -Wa,-march=pentiumpro
+export NANVIX_CFLAGS += -Wall -Wextra -Werror
+export NANVIX_CFLAGS += -Winit-self -Wswitch-default -Wfloat-equal -Wno-pointer-arith
+export NANVIX_CFLAGS += -Wundef -Wshadow -Wuninitialized -Wlogical-op
+export NANVIX_CFLAGS += -Wvla -Wredundant-decls
+export NANVIX_CFLAGS += -pedantic-errors
+export NANVIX_CFLAGS += -Wstack-usage=4096
+export NANVIX_CFLAGS += -D__NANVIX_SYSNAME__="\"$(NANVIX_SYSNAME)\""
+export NANVIX_CFLAGS += -D__NANVIX_NODENAME__="\"$(NANVIX_NODENAME)\""
+export NANVIX_CFLAGS += -D__$(subst -,_,$(NANVIX_MACHINE))__
 
 # C++ Compiler Options
-export CXXFLAGS := -std=c++17
-export CXXFLAGS += -m32 -march=pentiumpro -Wa,-march=pentiumpro
-export CXXFLAGS += -Wall -Wextra -Werror
-export CXXFLAGS += -Winit-self -Wswitch-default -Wfloat-equal -Wno-pointer-arith
-export CXXFLAGS += -Wundef -Wshadow -Wuninitialized -Wlogical-op
-export CXXFLAGS += -Wvla -Wredundant-decls
-export CXXFLAGS += -pedantic-errors
-export CXXFLAGS += -Wstack-usage=4096
-export CXXFLAGS += -D__NANVIX_SYSNAME__="\"$(NANVIX_SYSNAME)\""
-export CXXFLAGS += -D__NANVIX_NODENAME__="\"$(NANVIX_NODENAME)\""
-export CXXFLAGS += -D__$(subst -,_,$(NANVIX_MACHINE))__
+export NANVIX_CXXFLAGS := -std=c++17
+export NANVIX_CXXFLAGS += -m32 -march=pentiumpro -Wa,-march=pentiumpro
+export NANVIX_CXXFLAGS += -Wall -Wextra -Werror
+export NANVIX_CXXFLAGS += -Winit-self -Wswitch-default -Wfloat-equal -Wno-pointer-arith
+export NANVIX_CXXFLAGS += -Wundef -Wshadow -Wuninitialized -Wlogical-op
+export NANVIX_CXXFLAGS += -Wvla -Wredundant-decls
+export NANVIX_CXXFLAGS += -pedantic-errors
+export NANVIX_CXXFLAGS += -Wstack-usage=4096
+export NANVIX_CXXFLAGS += -D__NANVIX_SYSNAME__="\"$(NANVIX_SYSNAME)\""
+export NANVIX_CXXFLAGS += -D__NANVIX_NODENAME__="\"$(NANVIX_NODENAME)\""
+export NANVIX_CXXFLAGS += -D__$(subst -,_,$(NANVIX_MACHINE))__
 
 # Linker Options
-export LDFLAGS := -z noexecstack -T $(BUILD_DIR)/user/linker/$(TARGET)/user.ld
+export NANVIX_LDFLAGS := -z noexecstack -T $(BUILD_DIR)/user/linker/$(TARGET)/user.ld
 
 # Optimization Flags
 ifeq ($(RELEASE), yes)
-export CFLAGS += -O3
-export CXXFLAGS += -O3
-export CFLAGS += -D__RELEASE
-export CXXFLAGS += -D__RELEASE
+export NANVIX_CFLAGS += -O3
+export NANVIX_CXXFLAGS += -O3
+export NANVIX_CFLAGS += -D__RELEASE
+export NANVIX_CXXFLAGS += -D__RELEASE
 else
-export CFLAGS += -O0
-export CFLAGS += -g
-export CXXFLAGS += -O0
-export CFLAGS += -D__DEBUG
-export CXXFLAGS += -D__DEBUG
+export NANVIX_CFLAGS += -O0
+export NANVIX_CFLAGS += -g
+export NANVIX_CXXFLAGS += -O0
+export NANVIX_CFLAGS += -D__DEBUG
+export NANVIX_CXXFLAGS += -D__DEBUG
 endif
 
 #===================================================================================================

--- a/src/benchmarks/echo-c/Makefile
+++ b/src/benchmarks/echo-c/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C source files.
 %.$(TARGET).$(MACHINE).o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/benchmarks/echo-cpp/Makefile
+++ b/src/benchmarks/echo-cpp/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CXX) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CXX) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C++ source files.
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) $< -c -o $@
+	$(NANVIX_CXX) $(NANVIX_CXXFLAGS) $< -c -o $@

--- a/src/benchmarks/noop-c/Makefile
+++ b/src/benchmarks/noop-c/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C source files.
 %.$(TARGET).$(MACHINE).o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/benchmarks/noop-cpp/Makefile
+++ b/src/benchmarks/noop-cpp/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CXX) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CXX) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C++ source files.
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) $< -c -o $@
+	$(NANVIX_CXX) $(NANVIX_CXXFLAGS) $< -c -o $@

--- a/src/tests/c-bindings/Makefile
+++ b/src/tests/c-bindings/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C source files.
 %.$(TARGET).$(MACHINE).o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/dlfcn-c/Makefile
+++ b/src/tests/dlfcn-c/Makefile
@@ -29,14 +29,14 @@ REQUIRED_TYPES = R_386_RELATIVE R_386_PC32 R_386_GLOB_DAT R_386_32 R_386_JUMP_SL
 #===============================================================================
 
 all: $(OBJECTS) libs-all
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean: libs-clean
 	rm -rf $(OBJECTS)
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 libs-all:
-	$(CC) libs/mul.c -shared -fPIC -o $(LIBRARIES_DIR)/libmul.so
+	$(NANVIX_CC) libs/mul.c -shared -fPIC -o $(LIBRARIES_DIR)/libmul.so
 	@for TYPE in $(REQUIRED_TYPES); do \
 	if ! readelf -r $(LIBRARIES_DIR)/libmul.so | grep -q $$TYPE; then \
 	echo "Error: Relocation type $$TYPE not found in $(LIBRARIES_DIR)/libmul.so"; \
@@ -49,4 +49,4 @@ libs-clean:
 
 # Builds C source files.
 %.$(TARGET).$(MACHINE).o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/file-c/Makefile
+++ b/src/tests/file-c/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C source files.
 %.$(TARGET).$(MACHINE).o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/memory-c/Makefile
+++ b/src/tests/memory-c/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C source files.
 %.$(TARGET).$(MACHINE).o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/misc-c/Makefile
+++ b/src/tests/misc-c/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C source files.
 %.$(TARGET).$(MACHINE).o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/network-c/Makefile
+++ b/src/tests/network-c/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C source files.
 %.$(TARGET).$(MACHINE).o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/thread-c/Makefile
+++ b/src/tests/thread-c/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C source files.
 %.$(TARGET).$(MACHINE).o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/user/hello-c/Makefile
+++ b/src/user/hello-c/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C source files.
 %.$(TARGET).$(MACHINE).o: %.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/user/hello-cpp/Makefile
+++ b/src/user/hello-cpp/Makefile
@@ -26,7 +26,7 @@ export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
 #===============================================================================
 
 all: $(OBJECTS)
-	$(CXX) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+	$(NANVIX_CXX) $(NANVIX_LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
 
 clean:
 	rm -rf $(OBJECTS)
@@ -34,4 +34,4 @@ clean:
 
 # Builds C++ source files.
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) $< -c -o $@
+	$(NANVIX_CXX) $(NANVIX_CXXFLAGS) $< -c -o $@


### PR DESCRIPTION
This pull request refactors the build system to use namespaced variables (`NANVIX_CC`, `NANVIX_CFLAGS`, etc.) for compiler and linker commands and flags, instead of the generic `CC`, `CFLAGS`, etc. This change improves clarity and reduces the risk of variable conflicts, especially when integrating with tools like `sccache` or when building multiple targets. All affected Makefiles in the project are updated to use these new variables.

Key changes include:

**Build system variable namespacing:**

* Replaces generic compiler and linker variables (`CC`, `CXX`, `CFLAGS`, `CXXFLAGS`, `LDFLAGS`) with namespaced equivalents (`NANVIX_CC`, `NANVIX_CXX`, `NANVIX_CFLAGS`, `NANVIX_CXXFLAGS`, `NANVIX_LDFLAGS`) in the main `Makefile` and sets up proper integration with `sccache` if enabled.

**Project-wide Makefile updates:**

* Updates all project and test Makefiles to use the new `NANVIX_*` variables for compiling and linking both C and C++ code, ensuring consistent usage throughout the codebase. [[1]](diffhunk://#diff-2e560d06633313cd532b2d4323d92af59bd7521e1d357ab20b07eb9f0f8f649dL29-R37) [[2]](diffhunk://#diff-e4e7c9d74b123eab5bd9d4291ca924de097f1084c4089056c6ed1d7bdbac502eL29-R37) [[3]](diffhunk://#diff-ec59c0f76ba6b89302ed4de655e2f2327a7297356de5e9307683229de3a095a9L29-R37) [[4]](diffhunk://#diff-467b6ab7cd435babe18d1a0be7cddd6727744a4653434a1389f1630c83ea91daL29-R37) [[5]](diffhunk://#diff-c4e4ee3654ab5152cfcdb38638f063c8860755e348fce75fb2ffc642e25249a7L29-R37) [[6]](diffhunk://#diff-7194f577a034281485117a8ab724eb5faedb9c3c4b529bfa00e104537c30abe8L32-R39) [[7]](diffhunk://#diff-7194f577a034281485117a8ab724eb5faedb9c3c4b529bfa00e104537c30abe8L52-R52) [[8]](diffhunk://#diff-7f1c4d305697759ec022c6bfa93e6b824737cb3697203725ce505904dfbf0d83L29-R37) [[9]](diffhunk://#diff-e962fb75117d56e7f5b61816992a07791a31025dbde739d0ff232287f5f9b02aL29-R37) [[10]](diffhunk://#diff-b2ea465665a62263badd3c1daec9bb11dde0cde871abeb7488ef453e752772d5L29-R37) [[11]](diffhunk://#diff-c66d7b19139763c79e952e04f5ee1ed54d9f538f5de17b894098ec2f89d35782L29-R37) [[12]](diffhunk://#diff-3f013f4117a80a5f8a71e68496f2aefd03c0760e0921e7096fbab5d702f7cde2L29-R37) [[13]](diffhunk://#diff-48574dc4129977d71b3c59ac6d2c970be32b2296a7dbfd8fd38ef363e8072e5cL29-R37) [[14]](diffhunk://#diff-4c4d60be319e3953f06334230eb94e418ae4be89b6c9a38e1847ef2a21098ea1L29-R37)

**Shared library and object build rules:**

* Ensures that building shared libraries and object files in test and benchmark Makefiles also use the new namespaced variables for consistency and maintainability. [[1]](diffhunk://#diff-7194f577a034281485117a8ab724eb5faedb9c3c4b529bfa00e104537c30abe8L32-R39) [[2]](diffhunk://#diff-7194f577a034281485117a8ab724eb5faedb9c3c4b529bfa00e104537c30abe8L52-R52) [[3]](diffhunk://#diff-2e560d06633313cd532b2d4323d92af59bd7521e1d357ab20b07eb9f0f8f649dL29-R37) [[4]](diffhunk://#diff-e4e7c9d74b123eab5bd9d4291ca924de097f1084c4089056c6ed1d7bdbac502eL29-R37) [[5]](diffhunk://#diff-ec59c0f76ba6b89302ed4de655e2f2327a7297356de5e9307683229de3a095a9L29-R37) [[6]](diffhunk://#diff-467b6ab7cd435babe18d1a0be7cddd6727744a4653434a1389f1630c83ea91daL29-R37) [[7]](diffhunk://#diff-c4e4ee3654ab5152cfcdb38638f063c8860755e348fce75fb2ffc642e25249a7L29-R37) [[8]](diffhunk://#diff-7f1c4d305697759ec022c6bfa93e6b824737cb3697203725ce505904dfbf0d83L29-R37) [[9]](diffhunk://#diff-e962fb75117d56e7f5b61816992a07791a31025dbde739d0ff232287f5f9b02aL29-R37) [[10]](diffhunk://#diff-b2ea465665a62263badd3c1daec9bb11dde0cde871abeb7488ef453e752772d5L29-R37) [[11]](diffhunk://#diff-c66d7b19139763c79e952e04f5ee1ed54d9f538f5de17b894098ec2f89d35782L29-R37) [[12]](diffhunk://#diff-3f013f4117a80a5f8a71e68496f2aefd03c0760e0921e7096fbab5d702f7cde2L29-R37) [[13]](diffhunk://#diff-48574dc4129977d71b3c59ac6d2c970be32b2296a7dbfd8fd38ef363e8072e5cL29-R37) [[14]](diffhunk://#diff-4c4d60be319e3953f06334230eb94e418ae4be89b6c9a38e1847ef2a21098ea1L29-R37)