### PR TITLE
[utils] Interactive Mode for Nanvix Daemon

### DIFF
--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -35,8 +35,8 @@ use ::syscomm::SocketType;
 ///
 #[derive(Debug, Clone)]
 pub struct Args {
-    /// HTTP server socket address (host:port).
-    http_sockaddr: String,
+    /// Optional HTTP server socket address (host:port). If present, enables HTTP mode.
+    http_sockaddr: Option<String>,
     /// Directory path for temporary files and Unix sockets.
     tmp_directory: String,
     /// Directory path containing Nanvix binaries.
@@ -59,6 +59,10 @@ pub struct Args {
     gateway_socket_type: Option<SocketType>,
     /// Optional socket type for system VM communication (linuxd <-> uservm).
     system_vm_socket_type: Option<SocketType>,
+    /// Program name for interactive mode (first word after `--` separator).
+    program_name: Option<String>,
+    /// Program arguments for interactive mode (remaining words after `--` separator).
+    program_args: Vec<String>,
 }
 
 //==================================================================================================
@@ -92,6 +96,8 @@ impl Args {
     pub const OPT_GATEWAY_SOCKET_TYPE: &'static str = "-gateway-socket-type";
     /// Command-line option that sets the system VM socket type.
     pub const OPT_SYSTEM_VM_SOCKET_TYPE: &'static str = "-system-vm-socket-type";
+    /// Command-line separator for interactive mode program and arguments.
+    pub const OPT_SEPARATOR: &'static str = "--";
 
     ///
     /// # Description
@@ -100,6 +106,7 @@ impl Args {
     ///
     /// This function processes all supported command-line flags and options, validates them,
     /// and enforces constraints such as requiring TCP sockets for L2 deployment mode.
+    /// It also enforces mutual exclusivity between HTTP mode and interactive mode.
     ///
     /// # Parameters
     ///
@@ -111,7 +118,7 @@ impl Args {
     /// the parsing issue or validation failure.
     ///
     pub fn parse(args: Vec<String>) -> Result<Self> {
-        let mut http_sockaddr: String = String::new();
+        let mut http_sockaddr: Option<String> = None;
         let mut tmp_directory: String = config::DEFAULT_TMP_DIRECTORY.to_string();
         let mut binary_directory: String = config::DEFAULT_BIN_DIRECTORY.to_string();
         let mut toolchain_binary_directory: String =
@@ -124,9 +131,26 @@ impl Args {
         let mut control_plane_socket_type: Option<SocketType> = None;
         let mut gateway_socket_type: Option<SocketType> = None;
         let mut system_vm_socket_type: Option<SocketType> = None;
+        let mut program_name: Option<String> = None;
+        let mut program_args: Vec<String> = Vec::new();
 
         let mut i: usize = 1;
         while i < args.len() {
+            // Check for separator.
+            if args[i] == Self::OPT_SEPARATOR {
+                i += 1;
+                // The first word after separator is the program name.
+                if i < args.len() {
+                    program_name = Some(args[i].clone());
+                    i += 1;
+                    // Remaining words are program arguments.
+                    while i < args.len() {
+                        program_args.push(args[i].clone());
+                        i += 1;
+                    }
+                }
+                break;
+            }
             match args[i].as_str() {
                 Self::OPT_HELP => {
                     Self::usage(args[0].as_str());
@@ -134,7 +158,7 @@ impl Args {
                 },
                 Self::OPT_HTTP_SOCKADDR => {
                     i += 1;
-                    http_sockaddr = args[i].clone();
+                    http_sockaddr = Some(args[i].clone());
                 },
                 Self::OPT_TMP_DIRECTORY => {
                     i += 1;
@@ -214,6 +238,29 @@ impl Args {
             system_vm_socket_type = Some(SocketType::Tcp);
         }
 
+        // Determine operation mode: HTTP mode is active if -http-addr is provided,
+        // interactive mode is active if `--` separator with program name is provided.
+        let http_mode: bool = http_sockaddr.is_some();
+        let interactive_mode: bool = program_name.is_some();
+
+        // Ensure exactly one mode is active.
+        if http_mode && interactive_mode {
+            anyhow::bail!(
+                "cannot use both HTTP mode ({}) and interactive mode ({}) simultaneously",
+                Self::OPT_HTTP_SOCKADDR,
+                Self::OPT_SEPARATOR
+            );
+        }
+
+        if !http_mode && !interactive_mode {
+            anyhow::bail!(
+                "must specify either HTTP mode ({} <sockaddr>) or interactive mode ({} <program> \
+                 [<args>...])",
+                Self::OPT_HTTP_SOCKADDR,
+                Self::OPT_SEPARATOR
+            );
+        }
+
         Ok(Self {
             http_sockaddr,
             tmp_directory,
@@ -227,6 +274,8 @@ impl Args {
             control_plane_socket_type,
             gateway_socket_type,
             system_vm_socket_type,
+            program_name,
+            program_args,
         })
     }
 
@@ -241,38 +290,61 @@ impl Args {
     ///
     pub fn usage(program_name: &str) {
         println!(
-            concat!(
-                "Usage: {} {} <sockaddr> [{} <file>] [{} <tmp_dir>] [{} <bin_dir>] ",
-                "[{} <toolchain_bin_dir>] [{} <hwloc.json>] [{} [{} <log_dir>]] ",
-                "[{} <socket_type>] [{} <socket_type>] [{} <socket_type>] [{}]"
-            ),
-            program_name,
-            Self::OPT_HTTP_SOCKADDR,
-            Self::OPT_CONSOLE_FILE,
-            Self::OPT_TMP_DIRECTORY,
-            Self::OPT_BIN_DIRECTORY,
-            Self::OPT_TOOLCHAIN_BIN_DIRECTORY,
-            Self::OPT_HWLOC,
-            Self::OPT_LOG_TO_FILE,
-            Self::OPT_LOG_DIRECTORY,
-            Self::OPT_CONTROL_PLANE_SOCKET_TYPE,
-            Self::OPT_GATEWAY_SOCKET_TYPE,
-            Self::OPT_SYSTEM_VM_SOCKET_TYPE,
-            Self::OPT_L2
+            "\
+Nanvix Daemon - System-level service and VM orchestration daemon for Nanvix OS.
+
+Usage (HTTP mode):
+  {program_name} {http_addr} <sockaddr> [OPTIONS]
+
+Usage (Interactive mode):
+  {program_name} [OPTIONS] {separator} <program> [<args>...]
+
+Options:
+  {console_file} <file>                     Redirect console output to a file.
+  {tmp_dir} <tmp_dir>                       Directory for temporary files and Unix sockets.
+  {bin_dir} <bin_dir>                       Directory containing Nanvix binaries.
+  {toolchain_bin_dir} <toolchain_bin_dir>   Directory containing toolchain binaries \
+             (cloud-hypervisor, etc.).
+  {hwloc} <hwloc.json>                      Hardware locality configuration file for CPU \
+             affinity/topology.
+  {log_to_file}                             Enable logging to files instead of stdout/stderr.
+  {log_dir} <log_dir>                       Directory for log files (used with {log_to_file}).
+  {control_plane_socket_type} <socket_type> Socket type for control plane communication (nanvixd \
+             <-> linuxd).
+  {gateway_socket_type} <socket_type>       Socket type for gateway communication (client <-> \
+             linuxd).
+  {system_vm_socket_type} <socket_type>     Socket type for system VM communication (linuxd <-> \
+             uservm).
+  {l2}                                      Deploy linuxd inside an L2 VM (forces TCP sockets).
+",
+            program_name = program_name,
+            http_addr = Self::OPT_HTTP_SOCKADDR,
+            separator = Self::OPT_SEPARATOR,
+            console_file = Self::OPT_CONSOLE_FILE,
+            tmp_dir = Self::OPT_TMP_DIRECTORY,
+            bin_dir = Self::OPT_BIN_DIRECTORY,
+            toolchain_bin_dir = Self::OPT_TOOLCHAIN_BIN_DIRECTORY,
+            hwloc = Self::OPT_HWLOC,
+            log_to_file = Self::OPT_LOG_TO_FILE,
+            log_dir = Self::OPT_LOG_DIRECTORY,
+            control_plane_socket_type = Self::OPT_CONTROL_PLANE_SOCKET_TYPE,
+            gateway_socket_type = Self::OPT_GATEWAY_SOCKET_TYPE,
+            system_vm_socket_type = Self::OPT_SYSTEM_VM_SOCKET_TYPE,
+            l2 = Self::OPT_L2,
         );
     }
 
     ///
     /// # Description
     ///
-    /// Returns the HTTP socket address.
+    /// Returns the HTTP socket address if HTTP mode is enabled.
     ///
     /// # Returns
     ///
-    /// The HTTP socket address.
+    /// The HTTP socket address if present; `None` otherwise.
     ///
-    pub fn http_sockaddr(&self) -> &str {
-        &self.http_sockaddr
+    pub fn http_sockaddr(&self) -> Option<&str> {
+        self.http_sockaddr.as_deref()
     }
 
     ///
@@ -416,5 +488,57 @@ impl Args {
     ///
     pub fn system_vm_socket_type(&self) -> SocketType {
         self.system_vm_socket_type.unwrap_or(SocketType::Unix)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Indicates whether HTTP mode is enabled.
+    ///
+    /// # Returns
+    ///
+    /// `true` if HTTP mode is enabled; `false` otherwise.
+    ///
+    pub fn http_mode(&self) -> bool {
+        self.http_sockaddr.is_some()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Indicates whether interactive mode is enabled.
+    ///
+    /// # Returns
+    ///
+    /// `true` if interactive mode is enabled; `false` otherwise.
+    ///
+    pub fn interactive_mode(&self) -> bool {
+        self.program_name.is_some()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the program name for interactive mode.
+    ///
+    /// # Returns
+    ///
+    /// The program name if specified; `None` otherwise.
+    ///
+    pub fn program_name(&self) -> Option<&str> {
+        self.program_name.as_deref()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the program arguments for interactive mode.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the vector of program arguments.
+    ///
+    pub fn program_args(&self) -> &[String] {
+        &self.program_args
     }
 }

--- a/src/utils/nanvixd/src/lib.rs
+++ b/src/utils/nanvixd/src/lib.rs
@@ -15,3 +15,4 @@ pub mod args;
 pub mod config;
 pub mod http;
 pub mod message;
+pub mod terminal;

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -28,6 +28,7 @@ use ::nanvix_sandbox_cache::SandboxCacheConfig;
 use ::nanvixd::{
     args::Args,
     http::HttpServer,
+    terminal::Terminal,
 };
 use ::std::sync::Arc;
 use ::syslog::{
@@ -76,9 +77,47 @@ pub async fn main() -> Result<()> {
         args.tmp_directory(),
     );
 
-    let mut http_server: HttpServer = HttpServer::new(args.http_sockaddr(), config);
-    if let Err(error) = http_server.run().await {
-        error!("HTTP server failed: {}", error);
+    // Check for interactive mode or HTTP mode.
+    if args.interactive_mode() {
+        info!("running in interactive mode");
+        let guest_binary_path: String = match args.program_name() {
+            None => {
+                let reason: &str = "no program name specified in interactive mode";
+                error!("{}", reason);
+                anyhow::bail!(reason);
+            },
+            Some(path) => path.to_string(),
+        };
+
+        let guest_binary_args: String = if args.program_args().is_empty() {
+            String::new()
+        } else {
+            args.program_args().join(" ")
+        };
+
+        let mut terminal: Terminal = Terminal::new(config);
+        if let Err(error) = terminal.run(guest_binary_path, guest_binary_args).await {
+            error!("terminal failed: {}", error);
+        }
+    } else if args.http_mode() {
+        info!("running in HTTP mode");
+        let http_sockaddr: &str = match args.http_sockaddr() {
+            None => {
+                let reason: &str = "no HTTP socket address specified in HTTP mode";
+                error!("{}", reason);
+                anyhow::bail!(reason);
+            },
+            Some(addr) => addr,
+        };
+
+        let mut http_server: HttpServer = HttpServer::new(http_sockaddr, config);
+        if let Err(error) = http_server.run().await {
+            error!("http server failed: {}", error);
+        }
+    } else {
+        let reason: &str = "no operation mode specified";
+        error!("{}", reason);
+        anyhow::bail!(reason);
     }
 
     Ok(())

--- a/src/utils/nanvixd/src/terminal.rs
+++ b/src/utils/nanvixd/src/terminal.rs
@@ -1,0 +1,285 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Terminal interface module for interactive mode.
+//!
+//! This module provides functionality to run programs in interactive mode, allowing users
+//! to directly interact with guest binaries through a terminal interface. It handles
+//! terminal raw mode, I/O streaming, and VM lifecycle management.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::nanvix_sandbox_cache::{
+    SandboxCache,
+    SandboxCacheConfig,
+};
+use ::std::sync::Arc;
+use ::syscomm::{
+    SocketStream,
+    SocketStreamReader,
+    SocketStreamWriter,
+    SocketType,
+    UnboundSocket,
+    WriteAll,
+};
+use ::syslog::{
+    error,
+    info,
+};
+use ::tokio::{
+    io::{
+        self,
+        AsyncReadExt,
+        AsyncWriteExt,
+    },
+    sync::Mutex,
+};
+use ::user_vm_api::UserVmIdentifier;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Default application name for terminal sessions.
+const DEFAULT_APP_NAME: &str = "nanvixd-terminal";
+
+/// Size of I/O buffers for terminal communication.
+/// Set to 1 byte for character-by-character I/O to ensure responsive terminal interaction.
+const IO_BUFFER_SIZE: usize = 1;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Terminal interface for interacting with user VMs.
+///
+pub struct Terminal {
+    /// Configuration for sandbox cache management.
+    config: SandboxCacheConfig,
+}
+
+///
+/// # Description
+///
+/// RAII guard for terminal raw mode. Restores terminal to original mode on drop.
+///
+struct RawModeGuard {
+    /// Original terminal settings.
+    original_termios: ::libc::termios,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl RawModeGuard {
+    ///
+    /// # Description
+    ///
+    /// Enables raw mode for stdin.
+    ///
+    /// # Returns
+    ///
+    /// Returns a guard that will restore the original terminal mode on drop.
+    ///
+    fn new() -> Result<Self> {
+        // SAFETY: We are accessing stdin's file descriptor (STDIN_FILENO) which is always
+        // valid for the current process. The termios structure is properly zeroed before use,
+        // and tcgetattr/tcsetattr are standard POSIX calls that safely manipulate terminal
+        // attributes through the provided file descriptor.
+        unsafe {
+            let mut termios: ::libc::termios = ::std::mem::zeroed();
+            if ::libc::tcgetattr(::libc::STDIN_FILENO, &mut termios) != 0 {
+                let error: ::std::io::Error = ::std::io::Error::last_os_error();
+                error!("failed to get terminal attributes: {}", error);
+                return Err(anyhow::anyhow!(error));
+            }
+
+            let original_termios: ::libc::termios = termios;
+
+            // Disable canonical mode and echo.
+            termios.c_lflag &= !(::libc::ICANON | ::libc::ECHO);
+            // Set minimum characters to read to 0 (non-blocking).
+            termios.c_cc[::libc::VMIN] = 0;
+            // Set timeout to 1 decisecond (100ms).
+            termios.c_cc[::libc::VTIME] = 1;
+
+            if ::libc::tcsetattr(::libc::STDIN_FILENO, ::libc::TCSANOW, &termios) != 0 {
+                let error: ::std::io::Error = ::std::io::Error::last_os_error();
+                error!("failed to set terminal attributes: {}", error);
+                return Err(anyhow::anyhow!(error));
+            }
+
+            Ok(Self { original_termios })
+        }
+    }
+}
+
+impl Drop for RawModeGuard {
+    ///
+    /// # Description
+    ///
+    /// Restores the original terminal mode.
+    ///
+    fn drop(&mut self) {
+        // SAFETY: We are restoring the terminal attributes to their original state.
+        // The original_termios was obtained through a valid tcgetattr call in new().
+        unsafe {
+            ::libc::tcsetattr(::libc::STDIN_FILENO, ::libc::TCSANOW, &self.original_termios);
+        }
+    }
+}
+
+impl Terminal {
+    ///
+    /// # Description
+    ///
+    /// Creates a new Terminal instance.
+    ///
+    /// # Parameters
+    ///
+    /// - `config`: Configuration for sandbox cache management.
+    ///
+    pub fn new(config: SandboxCacheConfig) -> Self {
+        Self { config }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Runs the terminal interface.
+    ///
+    /// # Parameters
+    ///
+    /// - `guest_binary_path`: Path to the guest binary to execute.
+    /// - `guest_binary_args`: Arguments to pass to the guest binary.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an empty tuple after the terminal session ends. On
+    /// failure, it returns an object that describes the error that occurred.
+    ///
+    pub async fn run(
+        &mut self,
+        guest_binary_path: String,
+        guest_binary_args: String,
+    ) -> Result<()> {
+        let sandbox_cache: Arc<Mutex<SandboxCache>> = SandboxCache::new(self.config.clone());
+
+        let tenant_id: String = Self::get_current_user_name()?;
+        let app_name: String = DEFAULT_APP_NAME.to_string();
+        let (uservm_id, gateway_sockaddr, gateway_socket_type): (
+            UserVmIdentifier,
+            String,
+            SocketType,
+        ) = sandbox_cache
+            .lock()
+            .await
+            .get(
+                &tenant_id,
+                &guest_binary_path,
+                &app_name,
+                if guest_binary_args.is_empty() {
+                    None
+                } else {
+                    Some(guest_binary_args)
+                },
+            )
+            .await?;
+
+        let gateway_stream: SocketStream = UnboundSocket::new(gateway_socket_type)
+            .connect(&gateway_sockaddr)
+            .await?;
+
+        let (mut gateway_stream_rx, mut gateway_stream_tx): (
+            SocketStreamReader,
+            SocketStreamWriter,
+        ) = gateway_stream.split();
+
+        // Enable raw mode for terminal.
+        let _raw_mode_guard: RawModeGuard = RawModeGuard::new()?;
+
+        let mut stdin: tokio::io::Stdin = io::stdin();
+        let mut stdin_buffer: [u8; IO_BUFFER_SIZE] = [0; IO_BUFFER_SIZE];
+        let mut gateway_buffer: [u8; IO_BUFFER_SIZE] = [0; IO_BUFFER_SIZE];
+
+        let result: Result<()> = loop {
+            tokio::select! {
+                    // Handle input from gateway.
+                    result = gateway_stream_rx.read(&mut gateway_buffer) => {
+                        match result {
+                            Ok(n) => {
+                                if n == 0 {
+                                    // Connection closed.
+                                    break Ok(())
+                                } else {
+                                    // Echo character to terminal.
+                                    io::stdout().write_all(&gateway_buffer[..n]).await?;
+                                    ::tokio::io::stdout().flush().await?;
+                                }
+                            },
+                            Err(error) => {
+                                error!("failed to read from gateway: {}", error);
+                                break Err(anyhow::anyhow!(error));
+                            },
+                        }
+                    },
+                    // Handle input from terminal.
+                    result = stdin.read(&mut stdin_buffer) => {
+                        match result {
+                            Ok(n) => {
+                                if n == 0 {
+                                    // EOF reached.
+                                    break Ok(());
+                                } else {
+                                    // Send character to gateway.
+                                    if let Err(error) = gateway_stream_tx.write_all(&stdin_buffer[..n]).await {
+                                        error!("failed to write to gateway: {}", error);
+                                        break Err(anyhow::anyhow!(error));
+                                    }
+                                }
+                            },
+                            Err(error) => {
+                                error!("failed to read from terminal: {}", error);
+                                break Err(anyhow::anyhow!(error));
+                            },
+                        }
+                    },
+                    // Handle interrupt signal (Ctrl+C).
+                    _ = tokio::signal::ctrl_c() => {
+                        info!("received interrupt signal, exiting terminal");
+                        break Ok(())
+                    }
+            }
+        };
+
+        // Shutdown VM.
+        if let Err(e) = sandbox_cache.lock().await.kill(uservm_id).await {
+            error!("failed to shutdown VM: {}", e);
+        }
+
+        result
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the current user name from the operating system.
+    ///
+    /// # Returns
+    ///
+    /// Returns the current user name on success, or an error if the user name cannot be retrieved.
+    ///
+    pub fn get_current_user_name() -> Result<String> {
+        let username: String = ::std::env::var("USER")
+            .or_else(|_| ::std::env::var("USERNAME"))
+            .map_err(|error| ::anyhow::anyhow!("failed to get current user name: {}", error))?;
+        Ok(username)
+    }
+}


### PR DESCRIPTION
This pull request introduces two new Rust libraries, `nanvix-sandbox` and `nanvix-sandbox-cache`, to modularize and improve sandbox and cache management in the Nanvix system. The changes refactor and move cache-related logic from the `nanvixd` utility into these new libraries, enhance configurability, and update the build system and dependencies accordingly. Additionally, the socket address builder logic is refactored for clarity and reusability, and the cache interface is improved to provide more detailed information.

**Library introduction and modularization:**

* Added new crates: `nanvix-sandbox` and `nanvix-sandbox-cache`, with their own `Cargo.toml` files and workspace integration, to encapsulate sandbox and cache management functionality. [[1]](diffhunk://#diff-592fc5d9071b0856e8038038b9b48265e05866848fff357a771a19385dfbfabeR1-R32) [[2]](diffhunk://#diff-fa1a5365080b644e4b0283c72fcc62bfd819bd4c3894cad059b7f9de3a300afcR1-R25) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R24-R25) [[4]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R94-R95) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L304-R304)

**Refactoring and code movement:**

* Moved cache management code from `src/utils/nanvixd/src/cache/` to `src/libs/nanvix-sandbox-cache/`, renaming and updating files such as `config.rs` and `mod.rs` to reflect their new locations and purposes. [[1]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4R10-R65) [[2]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aL4-R6)

**Socket address builder improvements:**

* Refactored socket address construction into standalone functions (`control_plane_sockaddr_builder`, `user_vm_sockaddr_builder`, `gateway_sockaddr_builder`) with improved error handling and configurability; these now check for Unix socket name length and support both Unix and TCP sockets depending on deployment mode. [[1]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4R288-R421) [[2]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aR22-R39) [[3]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aR93-R105) [[4]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aR133-R135) [[5]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aL182-R218)

**API and interface enhancements:**

* Updated the `SandboxCache` API to return more detailed information, including the gateway socket type, and to use the new builder functions for constructing socket addresses. [[1]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aL135-R158) [[2]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aL151-R173) [[3]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aL163-R189) [[4]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aL226-R252) [[5]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aL272-R298)

**Minor cleanup and simplification:**

* Removed the redundant `l2_system_vm_guest_ip` function and inlined its logic where used, simplifying the configuration code. [[1]](diffhunk://#diff-c51ec44d94b19be1152760a6b473a7c7e0c9226394721b4a209a53118461c647L39-L51) [[2]](diffhunk://#diff-c51ec44d94b19be1152760a6b473a7c7e0c9226394721b4a209a53118461c647L62-R49)