### PR TITLE
[libs] Adding `nanvix-registry` Crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
         "src/libs/elf",
         "src/libs/error",
         "src/libs/hwloc",
+        "src/libs/nanvix-registry",
         "src/libs/nanvix-sandbox",
         "src/libs/nanvix-sandbox-cache",
         "src/libs/nvx",
@@ -69,6 +70,7 @@ cc = "1.2.26"
 cfg-if = "1.0.0"
 config = { path = "src/libs/config", default-features = false }
 control-plane-api = { path = "src/libs/control-plane-api", default-features = false }
+dirs = "5.0"
 elf = { path = "src/libs/elf", default-features = false }
 error = { path = "src/libs/error", default-features = false }
 flexi_logger = "0.31.2"
@@ -91,6 +93,7 @@ kvm-ioctls = "0.24.0"
 libc = "0.2.172"
 linuxd = { path = "src/daemons/linuxd", default-features = false }
 log = "0.4.27"
+nanvix-registry = { path = "src/libs/nanvix-registry", default-features = false }
 nanvix-sandbox = { path = "src/libs/nanvix-sandbox", default-features = false }
 nanvix-sandbox-cache = { path = "src/libs/nanvix-sandbox-cache", default-features = false }
 nanvixd = { path = "src/utils/nanvixd", default-features = false }
@@ -122,6 +125,7 @@ talc = { git = "https://github.com/nanvix/talc", rev = "12e66643796be912933a369a
 tokio = { version = "1.45.1", default-features = false }
 type-safe = { path = "src/libs/type-safe", default-features = false }
 uservm = { path = "src/uservm", default-features = false }
+uuid = { version = "1.18.1", default-features = false }
 user-vm-api = { path = "src/libs/user-vm-api", default-features = false }
 vmm-sys-util = { version = "0.15.0", default-features = false }
 wasmi = { version = "0.51.0", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 
-ALL_HOST_RUST_LIBS := control-plane-api hwloc profiler nanvix-sandbox nanvix-sandbox-cache syscomm user-vm-api
+ALL_HOST_RUST_LIBS := control-plane-api hwloc profiler nanvix-registry nanvix-sandbox nanvix-sandbox-cache syscomm user-vm-api
 ALL_HOST_UTILS := echo-client nanvix-bench
 ALL_HOST_DAEMONS := linuxd
 ALL_HOST_BINARIES := $(ALL_HOST_UTILS) $(ALL_HOST_DAEMONS)

--- a/src/libs/nanvix-registry/Cargo.toml
+++ b/src/libs/nanvix-registry/Cargo.toml
@@ -1,0 +1,27 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "nanvix-registry"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Registry Management Library for Nanvix"
+homepage.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+syslog = { workspace = true, features = ["std"] }
+dirs = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = [
+    "json",
+    "rustls-tls",
+] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+uuid = { workspace = true, features = ["std", "v4"] }
+
+[features]
+default = []

--- a/src/libs/nanvix-registry/src/deployment.rs
+++ b/src/libs/nanvix-registry/src/deployment.rs
@@ -1,0 +1,227 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::syslog::error;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Represents a deployment type for Nanvix releases.
+///
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Deployment {
+    /// Single-process deployment mode.
+    SingleProcess,
+    /// Multi-process deployment mode.
+    MultiProcess,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Deployment {
+    /// String representation of SingleProcess deployment.
+    pub const SINGLE_PROCESS_STR: &'static str = "single-process";
+    /// String representation of MultiProcess deployment.
+    pub const MULTI_PROCESS_STR: &'static str = "multi-process";
+
+    ///
+    /// # Description
+    ///
+    /// Converts the deployment type to its string representation.
+    ///
+    /// # Returns
+    ///
+    /// A string representation of the deployment type.
+    ///
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Deployment::SingleProcess => Deployment::SINGLE_PROCESS_STR,
+            Deployment::MultiProcess => Deployment::MULTI_PROCESS_STR,
+        }
+    }
+}
+
+impl ::std::fmt::Display for Deployment {
+    ///
+    /// # Description
+    ///
+    /// Converts the deployment type to its string representation.
+    ///
+    /// # Parameters
+    ///
+    /// - `f`: The formatter.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an empty tuple. On failure, it returns an object that
+    /// describes the error.
+    ///
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for Deployment {
+    type Error = anyhow::Error;
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to convert a string slice to a `Deployment` enum variant.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: The string representation of the deployment type (case-insensitive).
+    ///
+    /// # Returns
+    ///
+    /// On success, returns the corresponding `Deployment` variant. On failure, it returns an object
+    /// that describes the error.
+    ///
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let value_lower: String = value.to_lowercase();
+        match value_lower.as_str() {
+            Self::SINGLE_PROCESS_STR => Ok(Deployment::SingleProcess),
+            Self::MULTI_PROCESS_STR => Ok(Deployment::MultiProcess),
+            _ => {
+                let reason: String = format!("Unknown deployment type: {}", value);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        }
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `SingleProcess` deployment converts to correct string representation.
+    ///
+    #[test]
+    fn test_single_process_as_str() {
+        let deployment: Deployment = Deployment::SingleProcess;
+        assert_eq!(deployment.as_str(), "single-process");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `MultiProcess` deployment converts to correct string representation.
+    ///
+    #[test]
+    fn test_multi_process_as_str() {
+        let deployment: Deployment = Deployment::MultiProcess;
+        assert_eq!(deployment.as_str(), "multi-process");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `SingleProcess` display trait works correctly.
+    ///
+    #[test]
+    fn test_single_process_display() {
+        let deployment: Deployment = Deployment::SingleProcess;
+        assert_eq!(format!("{}", deployment), "single-process");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `MultiProcess` display trait works correctly.
+    ///
+    #[test]
+    fn test_multi_process_display() {
+        let deployment: Deployment = Deployment::MultiProcess;
+        assert_eq!(format!("{}", deployment), "multi-process");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that valid single-process string is converted successfully.
+    ///
+    #[test]
+    fn test_try_from_valid_single_process() {
+        let result: Result<Deployment> = Deployment::try_from("single-process");
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), Deployment::SingleProcess));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that valid multi-process string is converted successfully.
+    ///
+    #[test]
+    fn test_try_from_valid_multi_process() {
+        let result: Result<Deployment> = Deployment::try_from("multi-process");
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), Deployment::MultiProcess));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that conversion is case-insensitive.
+    ///
+    #[test]
+    fn test_try_from_case_insensitive() {
+        let test_cases: [&str; 4] = [
+            "SINGLE-PROCESS",
+            "Single-Process",
+            "MULTI-PROCESS",
+            "Multi-Process",
+        ];
+
+        for case in &test_cases {
+            let result: Result<Deployment> = Deployment::try_from(*case);
+            assert!(result.is_ok());
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that invalid deployment string returns an error.
+    ///
+    #[test]
+    fn test_try_from_invalid() {
+        let result: Result<Deployment> = Deployment::try_from("invalid-deployment");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown deployment type"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that empty string returns an error.
+    ///
+    #[test]
+    fn test_try_from_empty() {
+        let result: Result<Deployment> = Deployment::try_from("");
+        assert!(result.is_err());
+    }
+}

--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -1,0 +1,551 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//!
+//! # Overview
+//!
+//! The `nanvix-registry` library provides functionality for managing a local cache of Nanvix
+//! release binaries downloaded from GitHub releases. It automatically downloads, extracts, and
+//! caches binaries for different deployment types and target machines.
+//!
+//! # Features
+//!
+//! - Downloads latest Nanvix releases from GitHub.
+//! - Caches binaries locally in the user's cache directory.
+//! - Supports multiple deployment types (`single-process`, `multi-process`).
+//! - Supports multiple target machines (`hyperlight`, `microvm`).
+//! - Automatic tarball extraction (supports `.tar.bz2` format).
+//! - Cache management (automatic reuse and manual clearing).
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use nanvix_registry::Registry;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     // Create a new registry instance.
+//!     let registry: Registry = Registry::new();
+//!
+//!     // Get a cached binary (downloads if not already cached).
+//!     let binary_path: String = registry
+//!         .get_cached_binary("microvm", "single-process", "kernel.elf")
+//!         .await?;
+//!
+//!     println!("Binary path: {}", binary_path);
+//!
+//!     // Clear the cache when needed.
+//!     registry.clear_cache().await?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Architecture
+//!
+//! The library consists of the following internal modules:
+//!
+//! - `deployment`: Defines deployment types (`SingleProcess`, `MultiProcess`).
+//! - `machine`: Defines target machine types (`Hyperlight`, `microvm`).
+//! - `release`: Handles fetching and downloading releases from GitHub API.
+//! - `tarball`: Provides tarball extraction functionality.
+//! - `tempfile`: Manages temporary files with automatic cleanup.
+//!
+//! # Cache Location
+//!
+//! Binaries are cached in the user's cache directory under `nanvix-registry/bin/`.
+//! The exact location depends on the operating system:
+//!
+//! - Linux: `~/.cache/nanvix-registry/bin/`
+//! - macOS: `~/Library/Caches/nanvix-registry/bin/`
+//! - Windows: `%LOCALAPPDATA%\nanvix-registry\bin\`
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::expect_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::cast_sign_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+
+//==================================================================================================
+// Private Modules
+//==================================================================================================
+
+mod deployment;
+mod machine;
+mod metadata;
+mod release;
+mod tarball;
+mod tempfile;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    deployment::Deployment,
+    machine::Machine,
+    metadata::ReleaseMetadata,
+    release::LatestRelease,
+};
+use ::anyhow::Result;
+use ::std::path::PathBuf;
+use ::syslog::{
+    debug,
+    error,
+    info,
+};
+use ::tokio::fs;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Name for cache directory.
+const CACHE_DIRECTORY_NAME: &str = "nanvix-registry";
+
+/// Name for binary directory within the registry.
+const BINARY_DIRECTORY_NAME: &str = "bin";
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A registry for managing cached Nanvix release binaries.
+///
+/// This struct provides methods to download, cache, and retrieve Nanvix binaries from GitHub
+/// releases. Binaries are cached in the user's cache directory and automatically reused on
+/// subsequent requests.
+///
+/// # Examples
+///
+/// ```no_run
+/// use nanvix_registry::Registry;
+///
+/// #[tokio::main]
+/// async fn main() -> anyhow::Result<()> {
+///     let registry: Registry = Registry::new();
+///
+///     // Get the kernel binary for microvm single-process deployment.
+///     let kernel_path: String = registry
+///         .get_cached_binary("microvm", "single-process", "kernel.elf")
+///         .await?;
+///
+///     Ok(())
+/// }
+/// ```
+///
+pub struct Registry;
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Registry {
+    ///
+    /// # Description
+    ///
+    /// Creates a new registry instance for managing cached binaries.
+    ///
+    /// # Returns
+    ///
+    /// A new `Registry` instance.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nanvix_registry::Registry;
+    ///
+    /// let registry: Registry = Registry::new();
+    /// ```
+    ///
+    pub fn new() -> Self {
+        Registry
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the path to a cached binary, downloading and extracting it from GitHub releases
+    /// if not already cached.
+    ///
+    /// This method first checks if the binary exists in the local cache. If found, it returns the
+    /// path immediately. Otherwise, it downloads the latest release from GitHub, extracts the
+    /// tarball, and caches the binaries for future use.
+    ///
+    /// # Parameters
+    ///
+    /// - `machine`: Target machine type. Supported values:
+    ///   - `"hyperlight"`: Hyperlight machine type.
+    ///   - `"microvm"`: microvm machine type.
+    /// - `deployment`: Deployment type. Supported values:
+    ///   - `"single-process"`: Single-process deployment mode.
+    ///   - `"multi-process"`: Multi-process deployment mode.
+    /// - `binary_name`: Name of the binary file (e.g., `"qjs"`, `"python3"`, `"kernel.elf"`).
+    ///
+    /// # Returns
+    ///
+    /// The absolute path to the cached binary as a `String`.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if:
+    /// - The machine type is not recognized.
+    /// - The deployment type is not recognized.
+    /// - The GitHub API request fails.
+    /// - The release tarball cannot be downloaded or extracted.
+    /// - The binary is not found in the extracted release.
+    /// - File system operations fail.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use nanvix_registry::Registry;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> anyhow::Result<()> {
+    ///     let registry: Registry = Registry::new();
+    ///
+    ///     // Get the QuickJS binary for hyperlight multi-process deployment.
+    ///     let qjs_path: String = registry
+    ///         .get_cached_binary("hyperlight", "multi-process", "qjs")
+    ///         .await?;
+    ///
+    ///     println!("QuickJS binary: {}", qjs_path);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    pub async fn get_cached_binary(
+        &self,
+        machine: &str,
+        deployment: &str,
+        binary_name: &str,
+    ) -> Result<String> {
+        let cache_dir: PathBuf = Self::get_cache_dir().await?;
+        let binary_path: PathBuf = cache_dir.join(BINARY_DIRECTORY_NAME).join(binary_name);
+
+        // Convert machine from string representation.
+        let machine: Machine = Machine::try_from(machine)?;
+
+        // Convert deployment from string representation.
+        let deployment: Deployment = Deployment::try_from(deployment)?;
+
+        // Create release handle for checking latest release.
+        let release: LatestRelease = LatestRelease::new(deployment, machine);
+
+        // Get the latest release URL.
+        let latest_url: String = release.get_url().await?;
+
+        // Check if we have cached metadata.
+        let metadata_exists: bool = ReleaseMetadata::exists(&cache_dir).await;
+
+        let needs_download: bool = if metadata_exists {
+            // Load cached metadata and compare URLs.
+            match ReleaseMetadata::load(&cache_dir).await {
+                Ok(cached_metadata) => {
+                    if cached_metadata.url != latest_url {
+                        info!(
+                            "New release detected (cached: {}, latest: {})",
+                            cached_metadata.url, latest_url
+                        );
+                        info!("Clearing old cache...");
+                        // Clear the cache to download the new release.
+                        self.clear_cache().await?;
+                        true
+                    } else {
+                        // URLs match, check if binary exists.
+                        if fs::metadata(&binary_path).await.is_ok() {
+                            debug!("Using cached binary: {:?}", binary_path);
+                            false
+                        } else {
+                            // Metadata exists but binary is missing, re-download.
+                            info!("Binary missing from cache, re-downloading...");
+                            true
+                        }
+                    }
+                },
+                Err(_) => {
+                    // Failed to load metadata, download fresh.
+                    info!("Failed to load metadata, downloading fresh release...");
+                    true
+                },
+            }
+        } else {
+            // No metadata, need to download.
+            info!("Binary not cached, downloading latest release...");
+            true
+        };
+
+        if needs_download {
+            // Download and extract the release.
+            let downloaded_url: String = release.download(&cache_dir).await?;
+
+            // Save the release metadata.
+            let metadata: ReleaseMetadata = ReleaseMetadata::new(downloaded_url);
+            metadata.save(&cache_dir).await?;
+
+            // Verify binary now exists.
+            if fs::metadata(&binary_path).await.is_err() {
+                let reason: String = format!("Binary not found after download: {:?}", binary_path);
+                error!("{reason}");
+                anyhow::bail!(reason);
+            }
+        }
+
+        Ok(binary_path.to_string_lossy().to_string())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Clears the binary cache by removing the entire cache directory and all its contents.
+    ///
+    /// This method deletes the `nanvix-registry/` directory from the user's cache location,
+    /// removing all cached binaries. The next call to `get_cached_binary()` will trigger a fresh
+    /// download from GitHub.
+    ///
+    /// # Returns
+    ///
+    /// An empty tuple on success.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the cache directory cannot be removed due to file system
+    /// permission issues or I/O errors.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use nanvix_registry::Registry;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> anyhow::Result<()> {
+    ///     let registry: Registry = Registry::new();
+    ///
+    ///     // Clear all cached binaries.
+    ///     registry.clear_cache().await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    pub async fn clear_cache(&self) -> Result<()> {
+        let cache_dir: PathBuf = Self::get_cache_dir().await?;
+        if fs::metadata(&cache_dir).await.is_ok() {
+            // Delete metadata first.
+            ReleaseMetadata::delete(&cache_dir).await?;
+            // Then remove the entire cache directory.
+            if let Err(error) = fs::remove_dir_all(&cache_dir).await {
+                let reason: String = format!("Failed to clear cache: {error}");
+                error!("{reason}");
+                anyhow::bail!(reason);
+            }
+        }
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the cache directory path, creating it if it doesn't exist.
+    ///
+    /// This method determines the user's cache directory using platform-specific conventions and
+    /// appends `nanvix-registry/` as the cache subdirectory. If the directory doesn't exist, it is
+    /// created along with any necessary parent directories.
+    ///
+    /// # Returns
+    ///
+    /// The absolute path to the cache directory.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if:
+    /// - The user's cache directory cannot be determined.
+    /// - The blocking task for retrieving the cache directory fails.
+    /// - The cache directory cannot be created due to permission issues or I/O errors.
+    ///
+    async fn get_cache_dir() -> Result<PathBuf> {
+        // Get user's cache directory.
+        let cache_dir: PathBuf = match tokio::task::spawn_blocking(dirs::cache_dir).await {
+            Ok(Some(dir)) => dir.join(CACHE_DIRECTORY_NAME),
+            Ok(None) => {
+                let reason: &str = "could not get user's cache directory";
+                error!("{reason}");
+                anyhow::bail!(reason);
+            },
+            Err(error) => {
+                let reason: String = format!("failed to spawn blocking task: {error}");
+                error!("{reason}");
+                anyhow::bail!(reason);
+            },
+        };
+
+        // Create cache directory if it doesn't exist.
+        if let Err(error) = fs::create_dir_all(&cache_dir).await {
+            let reason: &str = "could not create cache directory";
+            error!("{reason}: {}", error);
+            anyhow::bail!(reason);
+        }
+
+        Ok(cache_dir)
+    }
+}
+
+impl Default for Registry {
+    ///
+    /// # Description
+    ///
+    /// Creates a default registry instance.
+    ///
+    /// # Returns
+    ///
+    /// A new `Registry` instance.
+    ///
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests Registry creation with new().
+    ///
+    #[test]
+    fn test_new() {
+        let _registry: Registry = Registry::new();
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests Registry creation with default().
+    ///
+    #[test]
+    fn test_default() {
+        let _registry: Registry = Registry::default();
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests cache directory name constant.
+    ///
+    #[test]
+    fn test_cache_directory_name() {
+        assert_eq!(CACHE_DIRECTORY_NAME, "nanvix-registry");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests binary directory name constant.
+    ///
+    #[test]
+    fn test_binary_directory_name() {
+        assert_eq!(BINARY_DIRECTORY_NAME, "bin");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that cache directory can be retrieved.
+    ///
+    #[tokio::test]
+    async fn test_get_cache_dir() {
+        let result: Result<PathBuf> = Registry::get_cache_dir().await;
+        assert!(result.is_ok());
+
+        let cache_dir: PathBuf = result.unwrap();
+        assert!(cache_dir.to_string_lossy().contains("nanvix-registry"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that clear_cache works when cache doesn't exist.
+    ///
+    #[tokio::test]
+    async fn test_clear_cache_nonexistent() {
+        let registry: Registry = Registry::new();
+        let result: Result<()> = registry.clear_cache().await;
+        assert!(result.is_ok());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that invalid machine type returns error.
+    ///
+    #[tokio::test]
+    async fn test_invalid_machine() {
+        let registry: Registry = Registry::new();
+        let result: Result<String> = registry
+            .get_cached_binary("invalid-machine", "single-process", "kernel.elf")
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown machine type"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that invalid deployment type returns error.
+    ///
+    #[tokio::test]
+    async fn test_invalid_deployment() {
+        let registry: Registry = Registry::new();
+        let result: Result<String> = registry
+            .get_cached_binary("microvm", "invalid-deployment", "kernel.elf")
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown deployment type"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests binary path construction.
+    ///
+    #[test]
+    fn test_binary_path_construction() {
+        let cache_dir: PathBuf = PathBuf::from("/tmp/cache");
+        let binary_path: PathBuf = cache_dir.join(BINARY_DIRECTORY_NAME).join("kernel.elf");
+
+        assert!(binary_path.to_string_lossy().contains("bin"));
+        assert!(binary_path.to_string_lossy().ends_with("kernel.elf"));
+    }
+}

--- a/src/libs/nanvix-registry/src/machine.rs
+++ b/src/libs/nanvix-registry/src/machine.rs
@@ -1,0 +1,222 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::syslog::error;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Represents a target machine type for Nanvix releases.
+///
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Machine {
+    /// Hyperlight machine type.
+    Hyperlight,
+    /// MicroVM machine type.
+    Microvm,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Machine {
+    /// String representation of Hyperlight machine.
+    pub const HYPERLIGHT_STR: &'static str = "hyperlight";
+    /// String representation of Microvm machine.
+    pub const MICROVM_STR: &'static str = "microvm";
+
+    ///
+    /// # Description
+    ///
+    /// Converts the machine type to its string representation.
+    ///
+    /// # Returns
+    ///
+    /// A string representation of the machine type.
+    ///
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Machine::Hyperlight => Machine::HYPERLIGHT_STR,
+            Machine::Microvm => Machine::MICROVM_STR,
+        }
+    }
+}
+
+impl ::std::fmt::Display for Machine {
+    ///
+    /// # Description
+    ///
+    /// Converts the machine type to its string representation.
+    ///
+    /// # Parameters
+    ///
+    /// - `f`: The formatter.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an empty tuple. On failure, it returns an object that
+    /// describes the error.
+    ///
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for Machine {
+    type Error = anyhow::Error;
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to convert a string slice to a `Machine` enum variant.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: The string representation of the machine type (case-insensitive).
+    ///
+    /// # Returns
+    ///
+    /// On success, returns the corresponding `Machine` variant. On failure, it returns an object
+    /// that describes the error.
+    ///
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let value_lower: String = value.to_lowercase();
+        match value_lower.as_str() {
+            Self::HYPERLIGHT_STR => Ok(Machine::Hyperlight),
+            Self::MICROVM_STR => Ok(Machine::Microvm),
+            _ => {
+                let reason: String = format!("Unknown machine type: {}", value);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        }
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `Hyperlight` machine converts to correct string representation.
+    ///
+    #[test]
+    fn test_hyperlight_as_str() {
+        let machine: Machine = Machine::Hyperlight;
+        assert_eq!(machine.as_str(), "hyperlight");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `Microvm` machine converts to correct string representation.
+    ///
+    #[test]
+    fn test_microvm_as_str() {
+        let machine: Machine = Machine::Microvm;
+        assert_eq!(machine.as_str(), "microvm");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `Hyperlight` display trait works correctly.
+    ///
+    #[test]
+    fn test_hyperlight_display() {
+        let machine: Machine = Machine::Hyperlight;
+        assert_eq!(format!("{}", machine), "hyperlight");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `Microvm` display trait works correctly.
+    ///
+    #[test]
+    fn test_microvm_display() {
+        let machine: Machine = Machine::Microvm;
+        assert_eq!(format!("{}", machine), "microvm");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that valid hyperlight string is converted successfully.
+    ///
+    #[test]
+    fn test_try_from_valid_hyperlight() {
+        let result: Result<Machine> = Machine::try_from("hyperlight");
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), Machine::Hyperlight));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that valid microvm string is converted successfully.
+    ///
+    #[test]
+    fn test_try_from_valid_microvm() {
+        let result: Result<Machine> = Machine::try_from("microvm");
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), Machine::Microvm));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that conversion is case-insensitive.
+    ///
+    #[test]
+    fn test_try_from_case_insensitive() {
+        let test_cases: [&str; 4] = ["HYPERLIGHT", "Hyperlight", "MICROVM", "MicroVM"];
+
+        for case in &test_cases {
+            let result: Result<Machine> = Machine::try_from(*case);
+            assert!(result.is_ok());
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that invalid machine string returns an error.
+    ///
+    #[test]
+    fn test_try_from_invalid() {
+        let result: Result<Machine> = Machine::try_from("invalid-machine");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown machine type"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that empty string returns an error.
+    ///
+    #[test]
+    fn test_try_from_empty() {
+        let result: Result<Machine> = Machine::try_from("");
+        assert!(result.is_err());
+    }
+}

--- a/src/libs/nanvix-registry/src/metadata.rs
+++ b/src/libs/nanvix-registry/src/metadata.rs
@@ -1,0 +1,350 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::serde::{
+    Deserialize,
+    Serialize,
+};
+use ::std::path::{
+    Path,
+    PathBuf,
+};
+use ::syslog::{
+    debug,
+    error,
+    info,
+};
+use ::tokio::fs;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Name of the metadata file.
+const METADATA_FILE_NAME: &str = "release-metadata.json";
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Metadata about a cached release.
+///
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ReleaseMetadata {
+    /// URL of the release tarball.
+    pub(crate) url: String,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl ReleaseMetadata {
+    ///
+    /// # Description
+    ///
+    /// Creates a new release metadata instance.
+    ///
+    /// # Parameters
+    ///
+    /// - `url`: The URL of the release tarball.
+    ///
+    /// # Returns
+    ///
+    /// A new `ReleaseMetadata` instance.
+    ///
+    pub(crate) fn new(url: String) -> Self {
+        Self { url }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Saves the release metadata to a file in the specified directory.
+    ///
+    /// # Parameters
+    ///
+    /// - `cache_dir`: The directory where the metadata file will be saved.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an empty tuple. On failure, it returns an object that
+    /// describes the error.
+    ///
+    pub(crate) async fn save(&self, cache_dir: &Path) -> Result<()> {
+        let metadata_path: PathBuf = cache_dir.join(METADATA_FILE_NAME);
+        let json: String = match serde_json::to_string_pretty(self) {
+            Ok(json) => json,
+            Err(error) => {
+                let reason: String = format!("Failed to serialize metadata: {}", error);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        if let Err(error) = fs::write(&metadata_path, json).await {
+            let reason: String = format!("Failed to write metadata file: {}", error);
+            error!("{reason}");
+            anyhow::bail!(reason)
+        }
+
+        debug!("Saved release metadata to: {:?}", metadata_path);
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Loads release metadata from a file in the specified directory.
+    ///
+    /// # Parameters
+    ///
+    /// - `cache_dir`: The directory where the metadata file is located.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns the loaded `ReleaseMetadata`. On failure, it returns an
+    /// object that describes the error.
+    ///
+    pub(crate) async fn load(cache_dir: &Path) -> Result<Self> {
+        let metadata_path: PathBuf = cache_dir.join(METADATA_FILE_NAME);
+
+        // Check if metadata file exists.
+        if fs::metadata(&metadata_path).await.is_err() {
+            let reason: String = "Metadata file not found".to_string();
+            debug!("{reason}");
+            anyhow::bail!(reason)
+        }
+
+        let json: String = match fs::read_to_string(&metadata_path).await {
+            Ok(content) => content,
+            Err(error) => {
+                let reason: String = format!("Failed to read metadata file: {}", error);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let metadata: ReleaseMetadata = match serde_json::from_str(&json) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                let reason: String = format!("Failed to deserialize metadata: {}", error);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        debug!("Loaded release metadata from: {:?}", metadata_path);
+        Ok(metadata)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks if metadata exists in the specified directory.
+    ///
+    /// # Parameters
+    ///
+    /// - `cache_dir`: The directory to check for metadata.
+    ///
+    /// # Returns
+    ///
+    /// `true` if metadata exists, `false` otherwise.
+    ///
+    pub(crate) async fn exists(cache_dir: &Path) -> bool {
+        let metadata_path: PathBuf = cache_dir.join(METADATA_FILE_NAME);
+        fs::metadata(&metadata_path).await.is_ok()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Deletes the metadata file from the specified directory.
+    ///
+    /// # Parameters
+    ///
+    /// - `cache_dir`: The directory where the metadata file is located.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an empty tuple. On failure, it returns an object that
+    /// describes the error.
+    ///
+    pub(crate) async fn delete(cache_dir: &Path) -> Result<()> {
+        let metadata_path: PathBuf = cache_dir.join(METADATA_FILE_NAME);
+
+        if fs::metadata(&metadata_path).await.is_ok() {
+            if let Err(error) = fs::remove_file(&metadata_path).await {
+                let reason: String = format!("Failed to delete metadata file: {}", error);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            }
+            info!("Deleted release metadata from: {:?}", metadata_path);
+        }
+
+        Ok(())
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::std::env;
+
+    ///
+    /// # Description
+    ///
+    /// Tests metadata creation.
+    ///
+    #[test]
+    fn test_new() {
+        let url: String = "https://github.com/test/release.tar.bz2".to_string();
+        let metadata: ReleaseMetadata = ReleaseMetadata::new(url.clone());
+        assert_eq!(metadata.url, url);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests metadata serialization to JSON.
+    ///
+    #[test]
+    fn test_serialization() {
+        let metadata: ReleaseMetadata = ReleaseMetadata {
+            url: "https://example.com/release.tar.bz2".to_string(),
+        };
+
+        let json: String = serde_json::to_string(&metadata).unwrap();
+        assert!(json.contains("url"));
+        assert!(json.contains("https://example.com/release.tar.bz2"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests metadata deserialization from JSON.
+    ///
+    #[test]
+    fn test_deserialization() {
+        let json: &str = r#"{"url":"https://example.com/release.tar.bz2"}"#;
+        let metadata: ReleaseMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(metadata.url, "https://example.com/release.tar.bz2");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests metadata save and load roundtrip.
+    ///
+    #[tokio::test]
+    async fn test_save_and_load() {
+        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-metadata-save-load");
+        let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
+        let _: Result<(), std::io::Error> = fs::create_dir_all(&temp_dir).await;
+
+        let original: ReleaseMetadata =
+            ReleaseMetadata::new("https://test.com/file.tar.bz2".to_string());
+
+        // Save metadata.
+        let save_result: Result<()> = original.save(&temp_dir).await;
+        assert!(save_result.is_ok());
+
+        // Load metadata.
+        let load_result: Result<ReleaseMetadata> = ReleaseMetadata::load(&temp_dir).await;
+        assert!(load_result.is_ok());
+
+        let loaded: ReleaseMetadata = load_result.unwrap();
+        assert_eq!(original.url, loaded.url);
+
+        // Cleanup.
+        let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that exists returns false when metadata doesn't exist.
+    ///
+    #[tokio::test]
+    async fn test_exists_false() {
+        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-metadata-nonexistent");
+        let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
+
+        let exists: bool = ReleaseMetadata::exists(&temp_dir).await;
+        assert!(!exists);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that exists returns true when metadata exists.
+    ///
+    #[tokio::test]
+    async fn test_exists_true() {
+        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-metadata-exists");
+        let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
+        let _: Result<(), std::io::Error> = fs::create_dir_all(&temp_dir).await;
+
+        let metadata: ReleaseMetadata =
+            ReleaseMetadata::new("https://test.com/file.tar.bz2".to_string());
+        let _: Result<()> = metadata.save(&temp_dir).await;
+
+        let exists: bool = ReleaseMetadata::exists(&temp_dir).await;
+        assert!(exists);
+
+        // Cleanup.
+        let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests metadata deletion.
+    ///
+    #[tokio::test]
+    async fn test_delete() {
+        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-metadata-delete");
+        let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
+        let _: Result<(), std::io::Error> = fs::create_dir_all(&temp_dir).await;
+
+        let metadata: ReleaseMetadata =
+            ReleaseMetadata::new("https://test.com/file.tar.bz2".to_string());
+        let _: Result<()> = metadata.save(&temp_dir).await;
+
+        assert!(ReleaseMetadata::exists(&temp_dir).await);
+
+        let delete_result: Result<()> = ReleaseMetadata::delete(&temp_dir).await;
+        assert!(delete_result.is_ok());
+
+        assert!(!ReleaseMetadata::exists(&temp_dir).await);
+
+        // Cleanup.
+        let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests loading non-existent metadata returns error.
+    ///
+    #[tokio::test]
+    async fn test_load_nonexistent() {
+        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-metadata-load-nonexistent");
+        let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
+
+        let result: Result<ReleaseMetadata> = ReleaseMetadata::load(&temp_dir).await;
+        assert!(result.is_err());
+    }
+}

--- a/src/libs/nanvix-registry/src/release.rs
+++ b/src/libs/nanvix-registry/src/release.rs
@@ -1,0 +1,261 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    deployment::Deployment,
+    machine::Machine,
+    tarball::Tarball,
+    tempfile::TemporaryFile,
+};
+use ::anyhow::Result;
+use ::reqwest::{
+    Client,
+    Response,
+};
+use ::std::{
+    env,
+    path::PathBuf,
+};
+use ::syslog::{
+    error,
+    info,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// GitHub API URL for fetching the latest release.
+const GITHUB_API_URL: &str = "https://api.github.com/repos/nanvix/nanvix/releases/latest";
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Represents the latest release from the Nanvix GitHub repository.
+///
+pub(crate) struct LatestRelease {
+    /// Deployment type for the release.
+    deployment: Deployment,
+    /// Target machine type for the release.
+    machine: Machine,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl LatestRelease {
+    ///
+    /// # Description
+    ///
+    /// Creates a new handle for a latest release for the specified deployment and machine type.
+    ///
+    /// # Parameters
+    ///
+    /// - `deployment`: The deployment type.
+    /// - `machine`: The target machine type.
+    ///
+    /// # Returns
+    ///
+    /// A new handle for a latest release for the specified deployment and machine type.
+    ///
+    pub(crate) fn new(deployment: Deployment, machine: Machine) -> Self {
+        Self {
+            deployment,
+            machine,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Downloads the latest release tarball from GitHub and extracts it to the specified directory.
+    ///
+    /// # Parameters
+    ///
+    /// - `dir`: The directory where the release will be extracted.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns the URL of the downloaded release. On failure, it returns
+    /// an object that describes the error.
+    ///
+    pub(crate) async fn download(&self, dir: &PathBuf) -> Result<String> {
+        let release_url: String = self.get_url().await?;
+
+        info!("Downloading release from: {}", release_url);
+
+        // Download the tarball.
+        let response: Response = match reqwest::get(&release_url).await {
+            Ok(response) => response,
+            Err(error) => {
+                let reason: String = format!("Failed to download release: {}", error);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let bytes = match response.bytes().await {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                let reason: String = format!("Failed to read release: {}", error);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Save to temp file.
+        let temp_path: PathBuf =
+            env::temp_dir().join(format!("nanvix-release-{}.tar.bz2", uuid::Uuid::new_v4()));
+        let temp_file: TemporaryFile = TemporaryFile::new(temp_path);
+        temp_file.write(&bytes).await?;
+
+        // Extract tarball.
+        info!("Extracting release...");
+        let tarball: Tarball = Tarball::open(temp_file.path())?;
+        tarball.extract(dir).await?;
+
+        Ok(release_url)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Fetches the download URL for the latest release from the GitHub API.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns the download URL as a string. On failure, it returns an
+    /// object that describes the error.
+    ///
+    pub(crate) async fn get_url(&self) -> Result<String> {
+        let client: Client = Client::new();
+        let response: Response = match client
+            .get(GITHUB_API_URL)
+            .header("User-Agent", "nanvix-embedded")
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                let reason: String = format!("Failed to fetch releases: {}", error);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let response: serde_json::Value = match response.json().await {
+            Ok(json) => json,
+            Err(error) => {
+                let reason: String = format!("Failed to parse releases: {}", error);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Find the release asset URL.
+        let assets: &Vec<serde_json::Value> = match response["assets"].as_array() {
+            Some(assets) => assets,
+            None => {
+                let reason: String = "No assets found in release".to_string();
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let release_pattern: String =
+            format!("nanvix-{}-{}-release", self.machine, self.deployment);
+
+        // Search for the matching asset.
+        for asset in assets {
+            if let Some(name) = asset["name"].as_str() {
+                if name.contains(&release_pattern) && Tarball::is_supported(name) {
+                    if let Some(url) = asset["browser_download_url"].as_str() {
+                        return Ok(url.to_string());
+                    }
+                }
+            }
+        }
+
+        let reason: String = "Could not find release tarball in latest release".to_string();
+        error!("{reason}");
+        anyhow::bail!(reason)
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests LatestRelease creation.
+    ///
+    #[test]
+    fn test_new() {
+        let deployment: Deployment = Deployment::SingleProcess;
+        let machine: Machine = Machine::Microvm;
+        let release: LatestRelease = LatestRelease::new(deployment, machine);
+
+        assert!(matches!(release.deployment, Deployment::SingleProcess));
+        assert!(matches!(release.machine, Machine::Microvm));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests release pattern construction.
+    ///
+    #[test]
+    fn test_release_pattern() {
+        let deployment: Deployment = Deployment::MultiProcess;
+        let machine: Machine = Machine::Hyperlight;
+
+        let pattern: String = format!("nanvix-{}-{}-release", machine, deployment);
+        assert_eq!(pattern, "nanvix-hyperlight-multi-process-release");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests GitHub API URL constant.
+    ///
+    #[test]
+    fn test_github_api_url() {
+        assert_eq!(GITHUB_API_URL, "https://api.github.com/repos/nanvix/nanvix/releases/latest");
+        assert!(GITHUB_API_URL.starts_with("https://"));
+        assert!(GITHUB_API_URL.contains("github.com"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests release pattern for all combinations.
+    ///
+    #[test]
+    fn test_all_release_patterns() {
+        let deployments: [Deployment; 2] = [Deployment::SingleProcess, Deployment::MultiProcess];
+        let machines: [Machine; 2] = [Machine::Hyperlight, Machine::Microvm];
+
+        for deployment in &deployments {
+            for machine in &machines {
+                let pattern: String = format!("nanvix-{}-{}-release", machine, deployment);
+                assert!(pattern.contains("nanvix-"));
+                assert!(pattern.contains("-release"));
+            }
+        }
+    }
+}

--- a/src/libs/nanvix-registry/src/tarball.rs
+++ b/src/libs/nanvix-registry/src/tarball.rs
@@ -1,0 +1,290 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::{
+    anyhow,
+    Result,
+};
+use ::std::{
+    path::{
+        Path,
+        PathBuf,
+    },
+    process::ExitStatus,
+};
+use ::syslog::error;
+use ::tokio::process::{
+    Child,
+    Command,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// .tar.bz2 file extension.
+const TAR_BZ2_EXT: &str = ".tar.bz2";
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Represents a tarball archive file.
+///
+#[derive(Debug)]
+pub(crate) enum Tarball {
+    /// Bzip2-compressed tarball.
+    Bzip2 {
+        /// Path to the tarball file.
+        path: PathBuf,
+    },
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Tarball {
+    ///
+    /// # Description
+    ///
+    /// Opens a tarball file and determines its compression format.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the tarball file.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns a handle to the tarball file. On failure, it returns an object that
+    /// describes the error.
+    ///
+    pub(crate) fn open(path: &Path) -> Result<Self> {
+        // Check for supported formats, failing otherwise.
+        if Tarball::is_bzip2(path) {
+            // Open bzip2-compressed tarball.
+            Ok(Tarball::Bzip2 {
+                path: path.to_path_buf(),
+            })
+        } else {
+            // Unsupported tarball format.
+            let reason: String = format!("Unsupported tarball format: {}", path.to_string_lossy());
+            error!("{reason}");
+            anyhow::bail!(reason)
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks whether the given filename corresponds to a supported tarball format.
+    ///
+    /// # Parameters
+    ///
+    /// - `filename`: Name of the file to check.
+    ///
+    /// # Returns
+    ///
+    /// This function returns `true` if the filename ends with a supported tarball extension,
+    /// otherwise it returns `false`.
+    ///
+    pub(crate) fn is_supported(filename: &str) -> bool {
+        filename.ends_with(TAR_BZ2_EXT)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Extracts the tarball contents to the specified destination directory.
+    ///
+    /// # Parameters
+    ///
+    /// - `dest_dir`: The directory where the tarball contents will be extracted.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an empty tuple. On failure, it returns an object that
+    /// describes the error.
+    ///
+    pub(crate) async fn extract(&self, dest_dir: &PathBuf) -> Result<()> {
+        match self {
+            Tarball::Bzip2 { path } => extract_bzip2(path, dest_dir).await,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks whether the given path corresponds to a bzip2-compressed tarball.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the file to check.
+    ///
+    /// # Returns
+    ///
+    /// This function returns `true` if the path ends with `.tar.bz2`, otherwise `false`.
+    ///
+    fn is_bzip2(path: &Path) -> bool {
+        path.to_string_lossy().ends_with(TAR_BZ2_EXT)
+    }
+}
+
+///
+/// # Description
+///
+/// Extracts a bzip2-compressed tarball using the `tar` command.
+///
+/// # Parameters
+///
+/// - `tarball_path`: Path to the tarball file.
+/// - `dir`: The directory where the tarball contents will be extracted.
+///
+/// # Returns
+///
+/// On success, returns an empty tuple. On failure, it returns an object that describes the error.
+///
+async fn extract_bzip2(tarball_path: &PathBuf, dir: &PathBuf) -> anyhow::Result<()> {
+    // Spawn tar command.
+    let mut child: Child = match Command::new("tar")
+        .arg("-xjf")
+        .arg(tarball_path)
+        .arg("-C")
+        .arg(dir)
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(error) => {
+            let reason: String = format!("Failed to spawn tar command: {}", error);
+            error!("{reason}");
+            anyhow::bail!(reason)
+        },
+    };
+
+    // Wait for tar command to finish.
+    let status: ExitStatus = match child.wait().await {
+        Ok(status) => status,
+        Err(error) => {
+            let reason: String = format!("Failed to wait for tar command: {}", error);
+            error!("{reason}");
+            return Err(anyhow!(reason));
+        },
+    };
+
+    if !status.success() {
+        let reason: String = "Tarball extraction failed".to_string();
+        error!("{reason}");
+        anyhow::bail!(reason)
+    }
+
+    Ok(())
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `.tar.bz2` files are recognized as supported.
+    ///
+    #[test]
+    fn test_is_supported_tar_bz2() {
+        assert!(Tarball::is_supported("file.tar.bz2"));
+        assert!(Tarball::is_supported("archive.tar.bz2"));
+        assert!(Tarball::is_supported("nanvix-release.tar.bz2"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that unsupported formats are not recognized.
+    ///
+    #[test]
+    fn test_is_supported_unsupported() {
+        assert!(!Tarball::is_supported("file.tar.gz"));
+        assert!(!Tarball::is_supported("file.zip"));
+        assert!(!Tarball::is_supported("file.tar"));
+        assert!(!Tarball::is_supported("file.bz2"));
+        assert!(!Tarball::is_supported("file.txt"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that bzip2 format is correctly identified.
+    ///
+    #[test]
+    fn test_is_bzip2() {
+        let path: PathBuf = PathBuf::from("/tmp/test.tar.bz2");
+        assert!(Tarball::is_bzip2(&path));
+
+        let path2: PathBuf = PathBuf::from("/tmp/test.tar.gz");
+        assert!(!Tarball::is_bzip2(&path2));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that opening unsupported tarball format returns an error.
+    ///
+    #[test]
+    fn test_open_unsupported() {
+        let path: PathBuf = PathBuf::from("/tmp/test.tar.gz");
+        let result: Result<Tarball> = Tarball::open(&path);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported tarball format"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that opening a bzip2 tarball succeeds.
+    ///
+    #[test]
+    fn test_open_bzip2() {
+        let path: PathBuf = PathBuf::from("/tmp/test.tar.bz2");
+        let result: Result<Tarball> = Tarball::open(&path);
+        assert!(result.is_ok());
+
+        match result.unwrap() {
+            Tarball::Bzip2 { path: p } => {
+                assert_eq!(p, path);
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests path extraction from tarball.
+    ///
+    #[test]
+    fn test_tarball_path() {
+        let expected_path: PathBuf = PathBuf::from("/tmp/archive.tar.bz2");
+        let tarball: Tarball = Tarball::Bzip2 {
+            path: expected_path.clone(),
+        };
+
+        match tarball {
+            Tarball::Bzip2 { path } => {
+                assert_eq!(path, expected_path);
+            },
+        }
+    }
+}

--- a/src/libs/nanvix-registry/src/tempfile.rs
+++ b/src/libs/nanvix-registry/src/tempfile.rs
@@ -1,0 +1,212 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::std::path::{
+    Path,
+    PathBuf,
+};
+use ::syslog::{
+    error,
+    warn,
+};
+use ::tokio::fs;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Represents a temporary file that is automatically deleted when dropped.
+///
+pub(crate) struct TemporaryFile {
+    /// Path to the temporary file.
+    path: PathBuf,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl TemporaryFile {
+    ///
+    /// # Description
+    ///
+    /// Creates a new temporary file at the specified path.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: The path where the temporary file will be created.
+    ///
+    /// # Returns
+    ///
+    /// A new `TemporaryFile` instance.
+    ///
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets the path to the temporary file.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the path of the temporary file.
+    ///
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Writes data to the temporary file.
+    ///
+    /// # Parameters
+    ///
+    /// - `contents`: The data to write to the file.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns an empty tuple. On failure, returns an object that describes the error.
+    ///
+    pub(crate) async fn write(&self, contents: &[u8]) -> Result<()> {
+        if let Err(error) = fs::write(&self.path, contents).await {
+            let reason: String = format!("Failed to write to temporary file: {}", error);
+            error!("{reason}");
+            anyhow::bail!(reason)
+        }
+        Ok(())
+    }
+}
+
+impl Drop for TemporaryFile {
+    ///
+    /// # Description
+    ///
+    /// Automatically removes the temporary file when the instance is dropped.
+    ///
+    fn drop(&mut self) {
+        let path: PathBuf = self.path.clone();
+        tokio::spawn(async move {
+            if fs::metadata(&path).await.is_ok() {
+                if let Err(error) = fs::remove_file(&path).await {
+                    warn!("Failed to remove temporary file {:?}: {}", path, error);
+                }
+            }
+        });
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::std::env;
+
+    ///
+    /// # Description
+    ///
+    /// Tests temporary file creation.
+    ///
+    #[test]
+    fn test_new() {
+        let path: PathBuf = env::temp_dir().join("test-tempfile.txt");
+        // Creating TemporaryFile doesn't require tokio runtime until drop.
+        let tempfile: TemporaryFile = TemporaryFile { path: path.clone() };
+        assert_eq!(tempfile.path(), path.as_path());
+        // Prevent drop which requires tokio runtime.
+        ::std::mem::forget(tempfile);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that path() returns correct path.
+    ///
+    #[test]
+    fn test_path() {
+        let expected_path: PathBuf = PathBuf::from("/tmp/test-file.tar.bz2");
+        let tempfile: TemporaryFile = TemporaryFile {
+            path: expected_path.clone(),
+        };
+        assert_eq!(tempfile.path(), expected_path.as_path());
+        // Prevent drop which requires tokio runtime.
+        ::std::mem::forget(tempfile);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests writing to temporary file.
+    ///
+    #[tokio::test]
+    async fn test_write() {
+        let path: PathBuf = env::temp_dir().join("nanvix-test-tempfile-write.txt");
+        let tempfile: TemporaryFile = TemporaryFile::new(path.clone());
+
+        let data: &[u8] = b"test data";
+        let result: Result<()> = tempfile.write(data).await;
+        assert!(result.is_ok());
+
+        // Verify file was written.
+        let contents: Result<Vec<u8>, std::io::Error> = fs::read(&path).await;
+        assert!(contents.is_ok());
+        assert_eq!(contents.unwrap(), data);
+
+        // Cleanup.
+        let _: Result<(), std::io::Error> = fs::remove_file(&path).await;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests writing empty data.
+    ///
+    #[tokio::test]
+    async fn test_write_empty() {
+        let path: PathBuf = env::temp_dir().join("nanvix-test-tempfile-empty.txt");
+        let tempfile: TemporaryFile = TemporaryFile::new(path.clone());
+
+        let data: &[u8] = b"";
+        let result: Result<()> = tempfile.write(data).await;
+        assert!(result.is_ok());
+
+        // Cleanup.
+        let _: Result<(), std::io::Error> = fs::remove_file(&path).await;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests writing large data.
+    ///
+    #[tokio::test]
+    async fn test_write_large() {
+        let path: PathBuf = env::temp_dir().join("nanvix-test-tempfile-large.txt");
+        let tempfile: TemporaryFile = TemporaryFile::new(path.clone());
+
+        let data: Vec<u8> = vec![0u8; 1024 * 1024]; // 1 MB.
+        let result: Result<()> = tempfile.write(&data).await;
+        assert!(result.is_ok());
+
+        // Verify file size.
+        let metadata: Result<std::fs::Metadata, std::io::Error> = fs::metadata(&path).await;
+        assert!(metadata.is_ok());
+        assert_eq!(metadata.unwrap().len(), 1024 * 1024);
+
+        // Cleanup.
+        let _: Result<(), std::io::Error> = fs::remove_file(&path).await;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Rust library, `nanvix-registry`, for managing registry-related functionality in the Nanvix project. It adds core type definitions for deployment and machine types, complete with parsing, display, and thorough unit tests. The changes also update the build system and project dependencies to integrate this new library.

Key changes include:

**New Library: `nanvix-registry`**
* Added a new library crate, `nanvix-registry`, with its own `Cargo.toml` specifying dependencies such as `anyhow`, `syslog`, `dirs`, `reqwest`, `serde`, `serde_json`, `tokio`, and `uuid`.
* Integrated `nanvix-registry` into the workspace members list in the top-level `Cargo.toml`.
* Added `nanvix-registry` as a dependency in the main `Cargo.toml` and included related dependencies (`dirs`, `uuid`). [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R96) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R73) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R128)
* Updated the `Makefile` to build the new `nanvix-registry` library as part of the host Rust libraries.

**Core Types and Functionality**
* Implemented the `Deployment` enum in `deployment.rs` to represent deployment modes (single-process and multi-process), including parsing from string (case-insensitive), string conversion, display formatting, and comprehensive unit tests for all behaviors.
* Implemented the `Machine` enum in `machine.rs` to represent machine types (hyperlight and microvm), with similar parsing, display, and unit test coverage as `Deployment`.