### PR TITLE
[utils] Refer to ELF Binaries Directly

### DIFF
--- a/src/libs/nanvix-sandbox-cache/Cargo.toml
+++ b/src/libs/nanvix-sandbox-cache/Cargo.toml
@@ -23,3 +23,4 @@ user-vm-api = { workspace = true }
 
 [features]
 default = []
+single-process = []

--- a/src/libs/nanvix-sandbox-cache/src/config.rs
+++ b/src/libs/nanvix-sandbox-cache/src/config.rs
@@ -89,8 +89,14 @@ pub struct SandboxCacheConfig {
     console_file: Option<String>,
     /// Optional hardware locality configuration for CPU affinity and topology information.
     hwloc: Option<HwLoc>,
-    /// Path to the binary directory containing Nanvix binaries.
-    binary_directory: String,
+    /// Path to kernel binary.
+    kernel_binary_path: String,
+    /// Path to the Linux Daemon binary.
+    #[cfg(not(feature = "single-process"))]
+    linuxd_binary_path: String,
+    /// Path to the User VM binary.
+    #[cfg(not(feature = "single-process"))]
+    uservm_binary_path: String,
     /// Path to the toolchain binary directory containing cloud-hypervisor and other tools.
     toolchain_binary_directory: String,
     /// Directory path for writing log files.
@@ -118,7 +124,9 @@ impl SandboxCacheConfig {
     /// - `system_vm_socket_type`: Socket type for system VM communication.
     /// - `console_file`: Optional file path for redirecting console output.
     /// - `hwloc`: Optional hardware locality configuration.
-    /// - `binary_directory`: Path to the binary directory.
+    /// - `kernel_binary_path`: Path to kernel binary.
+    /// - `linuxd_binary_path`: Path to the Linux Daemon binary (only if not in single-process mode).
+    /// - `uservm_binary_path`: Path to the User VM binary (only if not in single-process mode).
     /// - `toolchain_binary_directory`: Path to the toolchain binary directory.
     /// - `log_directory`: Path to the log directory.
     /// - `l2`: Flag to deploy linuxd inside an L2 VM.
@@ -135,7 +143,9 @@ impl SandboxCacheConfig {
         system_vm_socket_type: SocketType,
         console_file: Option<String>,
         hwloc: Option<HwLoc>,
-        binary_directory: &str,
+        kernel_binary_path: &str,
+        #[cfg(not(feature = "single-process"))] linuxd_binary_path: &str,
+        #[cfg(not(feature = "single-process"))] uservm_binary_path: &str,
         toolchain_binary_directory: &str,
         log_directory: &str,
         l2: bool,
@@ -147,7 +157,11 @@ impl SandboxCacheConfig {
             system_vm_socket_type,
             console_file,
             hwloc,
-            binary_directory: binary_directory.to_string(),
+            kernel_binary_path: kernel_binary_path.to_string(),
+            #[cfg(not(feature = "single-process"))]
+            linuxd_binary_path: linuxd_binary_path.to_string(),
+            #[cfg(not(feature = "single-process"))]
+            uservm_binary_path: uservm_binary_path.to_string(),
             toolchain_binary_directory: toolchain_binary_directory.to_string(),
             log_directory: log_directory.to_string(),
             l2,
@@ -223,14 +237,42 @@ impl SandboxCacheConfig {
     ///
     /// # Description
     ///
-    /// Returns the path to the binary directory.
+    /// Returns the path to the kernel binary.
     ///
     /// # Returns
     ///
-    /// The path to the binary directory.
+    /// The path to the kernel binary.
     ///
-    pub fn binary_directory(&self) -> &str {
-        &self.binary_directory
+    pub fn kernel_binary_path(&self) -> &str {
+        &self.kernel_binary_path
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the path to the Linux Daemon binary.
+    ///
+    /// # Returns
+    ///
+    /// The path to the Linux Daemon binary.
+    ///
+    #[cfg(not(feature = "single-process"))]
+    pub fn linuxd_binary_path(&self) -> &str {
+        &self.linuxd_binary_path
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the path to the User VM binary.
+    ///
+    /// # Returns
+    ///
+    /// The path to the User VM binary.
+    ///
+    #[cfg(not(feature = "single-process"))]
+    pub fn uservm_binary_path(&self) -> &str {
+        &self.uservm_binary_path
     }
 
     ///

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -251,8 +251,12 @@ impl SandboxCache {
                     (user_vm_sockaddr.clone(), self.config.system_vm_sockaddr_type()),
                     self.config.console_file().map(|s| s.to_string()),
                     self.config.hwloc().clone(),
-                    self.config.binary_directory().to_string(),
-                    self.config.log_directory().to_string(),
+                    self.config.kernel_binary_path(),
+                    #[cfg(not(feature = "single-process"))]
+                    self.config.linuxd_binary_path(),
+                    #[cfg(not(feature = "single-process"))]
+                    self.config.uservm_binary_path(),
+                    self.config.log_directory(),
                     None,
                     Some((
                         control_plane_sockaddr.clone(),

--- a/src/libs/nanvix-sandbox/src/initialized.rs
+++ b/src/libs/nanvix-sandbox/src/initialized.rs
@@ -55,6 +55,8 @@ use ::tokio::{
 pub struct InitializedSandbox {
     /// Path to the guest binary file to execute.
     pub(super) guest_binary_path: String,
+    /// Path to the kernel binary file.
+    pub(super) kernel_binary_path: String,
     /// Optional command-line arguments for the program.
     pub(super) program_args: Option<String>,
     /// Shared handle to the Linux Daemon instance managing this sandbox.
@@ -86,9 +88,10 @@ impl InitializedSandbox {
         let console_file: Option<String> =
             self.sandbox_config.console_file().map(|s| s.to_string());
         let hwloc: Option<hwloc::HwLoc> = self.sandbox_config.hwloc();
-        let binary_directory: String = self.sandbox_config.binary_directory().to_string();
         let log_directory: String = self.sandbox_config.log_directory().to_string();
         let uservm_id: ::user_vm_api::UserVmIdentifier = self.sandbox_config.uservm_id();
+        #[cfg(not(feature = "single-process"))]
+        let uservm_binary_path: String = self.sandbox_config.uservm_binary_path().to_string();
 
         // Extract gateway socket info (consumes the config to get ownership of TcpPort).
         let gateway_socket_info_with_port: (String, SocketType, Option<TcpPort>) =
@@ -113,7 +116,9 @@ impl InitializedSandbox {
                     self.program_args.clone(),
                     console_file,
                     hwloc,
-                    binary_directory,
+                    self.kernel_binary_path.clone(),
+                    #[cfg(not(feature = "single-process"))]
+                    uservm_binary_path,
                     log_directory,
                     uservm_id,
                 ),

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -62,8 +62,12 @@
 //!     ("127.0.0.1:8081".to_string(), SocketType::Tcp),  // system_vm_socket_info
 //!     None,  // console_file
 //!     None,  // hwloc
-//!     "/path/to/bin".to_string(),  // binary_directory
-//!     "/path/to/logs".to_string(),  // log_directory
+//!     "/path/to/kernel.elf",  // kernel_binary_path
+//!     #[cfg(not(feature = "single-process"))]
+//!     "/path/to/linuxd.elf",  // linuxd_binary_path
+//!     #[cfg(not(feature = "single-process"))]
+//!     "/path/to/uservm.elf",  // uservm_binary_path
+//!     "/path/to/logs",  // log_directory
 //!     None,  // syscall_table
 //!     Some(("127.0.0.1:8082".to_string(), SocketType::Tcp)),  // control_plane_socket_info
 //!     Some("/path/to/toolchain".to_string()),  // toolchain_binary_directory

--- a/src/libs/nanvix-sandbox/src/linuxd_args.rs
+++ b/src/libs/nanvix-sandbox/src/linuxd_args.rs
@@ -31,8 +31,9 @@ pub struct LinuxDaemonArgs {
     system_vm_socket_info: (String, SocketType),
     /// Optional hardware locality configuration for CPU affinity and topology information.
     hwloc: Option<hwloc::HwLoc>,
-    /// Path to the binary directory containing Nanvix binaries.
-    binary_directory: String,
+    /// Path to Linux Daemon binary.
+    #[cfg(not(feature = "single-process"))]
+    linuxd_binary_path: String,
     /// Path to the toolchain binary directory containing cloud-hypervisor and other tools.
     toolchain_binary_directory: String,
     /// Directory path for writing log files.
@@ -60,7 +61,7 @@ impl LinuxDaemonArgs {
     /// - `control_plane_socket_info`: Information on control plane socket (address, socket type).
     /// - `system_vm_socket_info`: Information on System VM socket (address, socket type).
     /// - `hwloc`: Optional hardware locality configuration for CPU affinity and topology information.
-    /// - `binary_directory`: Path to the binary directory containing Nanvix binaries.
+    /// - `linuxd_binary_path`: Path to Linux Daemon binary (only if not in single-process mode).
     /// - `toolchain_binary_directory`: Path to the toolchain binary directory containing cloud-hypervisor and other tools.
     /// - `log_directory`: Directory path for writing log files.
     /// - `tmp_directory`: Temporary directory path for Unix sockets and transient files.
@@ -76,7 +77,7 @@ impl LinuxDaemonArgs {
         control_plane_socket_info: (String, SocketType),
         system_vm_socket_info: (String, SocketType),
         hwloc: Option<hwloc::HwLoc>,
-        binary_directory: String,
+        #[cfg(not(feature = "single-process"))] linuxd_binary_path: String,
         toolchain_binary_directory: String,
         log_directory: String,
         tmp_directory: String,
@@ -87,7 +88,8 @@ impl LinuxDaemonArgs {
             control_plane_socket_info,
             system_vm_socket_info,
             hwloc,
-            binary_directory,
+            #[cfg(not(feature = "single-process"))]
+            linuxd_binary_path,
             toolchain_binary_directory,
             log_directory,
             tmp_directory,
@@ -138,14 +140,15 @@ impl LinuxDaemonArgs {
     ///
     /// # Description
     ///
-    /// Returns the path to the binary directory containing Nanvix binaries.
+    /// Returns the path to the Linux Daemon binary.
     ///
     /// # Returns
     ///
-    /// The path to the binary directory.
+    /// The path to the Linux Daemon binary.
     ///
-    pub fn binary_directory(&self) -> &str {
-        &self.binary_directory
+    #[cfg(not(feature = "single-process"))]
+    pub fn linuxd_binary_path(&self) -> &str {
+        &self.linuxd_binary_path
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
@@ -251,7 +251,7 @@ impl LinuxDaemon {
             ]
         } else {
             vec![
-                format!("{}/linuxd.elf", args.binary_directory()),
+                args.linuxd_binary_path().to_string(),
                 args::Args::OPT_LOGFILE.to_string(),
                 args::Args::OPT_LOGDIR.to_string(),
                 args.log_directory().to_string(),

--- a/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
@@ -89,14 +89,14 @@ impl UserVm {
         trace!("spawn(): args={args:?}");
 
         let mut user_vm_args: Vec<String> = vec![
-            format!("{}/uservm.elf", args.binary_directory()),
+            args.uservm_binary_path().to_string(),
             ::uservm::args::Args::OPT_LOGFILE.to_string(),
             ::uservm::args::Args::OPT_LOGDIR.to_string(),
             args.log_directory().to_string(),
             ::uservm::args::Args::OPT_USER_VM_ID.to_string(),
             args.uservm_id().to_string(),
             ::uservm::args::Args::OPT_KERNEL.to_string(),
-            format!("{}/kernel.elf", args.binary_directory()),
+            args.kernel_binary_path().to_string(),
             ::uservm::args::Args::OPT_INITRD.to_string(),
             args.program().to_string(),
             ::uservm::args::Args::OPT_SYSTEM_VM_SOCKADDR.to_string(),

--- a/src/libs/nanvix-sandbox/src/sandbox_config.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox_config.rs
@@ -41,8 +41,14 @@ pub struct SandboxConfig {
     console_file: Option<String>,
     /// Optional hardware locality configuration for CPU affinity and topology information.
     hwloc: Option<hwloc::HwLoc>,
-    /// Path to the binary directory containing Nanvix binaries.
-    binary_directory: String,
+    /// Path to kernel binary.
+    kernel_binary_path: String,
+    /// Path to the Linux Daemon binary.
+    #[cfg(not(feature = "single-process"))]
+    linuxd_binary_path: String,
+    /// Path to the User VM binary.
+    #[cfg(not(feature = "single-process"))]
+    uservm_binary_path: String,
     /// Directory path for writing log files.
     log_directory: String,
     /// Optional system call table for overriding default system call behavior.
@@ -83,7 +89,9 @@ impl SandboxConfig {
     /// - `system_vm_socket_info`: Information on System VM socket (address, socket type).
     /// - `console_file`: Optional file path for redirecting console output.
     /// - `hwloc`: Optional hardware locality configuration.
-    /// - `binary_directory`: Path to the binary directory.
+    /// - `kernel_binary_path`: Path to kernel binary.
+    /// - `linuxd_binary_path`: Path to the Linux Daemon binary (only if not in single-process mode).
+    /// - `uservm_binary_path`: Path to the User VM binary (only if not in single-process mode).
     /// - `log_directory`: Path to the log directory.
     /// - `syscall_table`: Optional system call table for overriding default system call behavior.
     /// - `control_plane_socket_info`: Optional information on control plane socket (address, socket type).
@@ -102,8 +110,10 @@ impl SandboxConfig {
         system_vm_socket_info: (String, SocketType),
         console_file: Option<String>,
         hwloc: Option<hwloc::HwLoc>,
-        binary_directory: String,
-        log_directory: String,
+        kernel_binary_path: &str,
+        #[cfg(not(feature = "single-process"))] linuxd_binary_path: &str,
+        #[cfg(not(feature = "single-process"))] uservm_binary_path: &str,
+        log_directory: &str,
         syscall_table: Option<Arc<SyscallTable>>,
         control_plane_socket_info: Option<(String, SocketType)>,
         toolchain_binary_directory: Option<String>,
@@ -116,8 +126,12 @@ impl SandboxConfig {
             system_vm_socket_info,
             console_file,
             hwloc,
-            binary_directory,
-            log_directory,
+            kernel_binary_path: kernel_binary_path.to_string(),
+            #[cfg(not(feature = "single-process"))]
+            linuxd_binary_path: linuxd_binary_path.to_string(),
+            #[cfg(not(feature = "single-process"))]
+            uservm_binary_path: uservm_binary_path.to_string(),
+            log_directory: log_directory.to_string(),
             syscall_table,
             control_plane_socket_info,
             toolchain_binary_directory,
@@ -194,14 +208,42 @@ impl SandboxConfig {
     ///
     /// # Description
     ///
-    /// Returns the path to the binary directory.
+    /// Returns the path to kernel binary.
     ///
     /// # Returns
     ///
-    /// The path to the binary directory.
+    /// The path to kernel binary.
     ///
-    pub fn binary_directory(&self) -> &str {
-        &self.binary_directory
+    pub fn kernel_binary_path(&self) -> &str {
+        &self.kernel_binary_path
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the path to the Linux Daemon binary.
+    ///
+    /// # Returns
+    ///
+    /// The path to the Linux Daemon binary.
+    ///
+    #[cfg(not(feature = "single-process"))]
+    pub fn linuxd_binary_path(&self) -> &str {
+        &self.linuxd_binary_path
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the path to the User VM binary.
+    ///
+    /// # Returns
+    ///
+    /// The path to the User VM binary.
+    ///
+    #[cfg(not(feature = "single-process"))]
+    pub fn uservm_binary_path(&self) -> &str {
+        &self.uservm_binary_path
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/uservm.rs
@@ -115,7 +115,7 @@ impl UserVm {
         let control_plane_addr: String = args.control_plane_socket_info().0.clone();
         let user_vm_addr: String = args.system_vm_socket_info().0.clone();
         let gateway_sockaddr: String = args.gateway_socket_info().0.clone();
-        let kernel_filename: String = format!("{}/kernel.elf", args.binary_directory());
+        let kernel_filename: String = args.kernel_binary_path().to_string();
         let initrd_filename: String = args.program().to_string();
         let initrd_args: Option<String> = args.program_args().map(|s| s.to_string());
         let stderr_file: Option<String> = args.console_file().map(|s| s.to_string());

--- a/src/libs/nanvix-sandbox/src/uninitialized.rs
+++ b/src/libs/nanvix-sandbox/src/uninitialized.rs
@@ -257,7 +257,8 @@ impl UninitializedSandbox {
                         ),
                         config.system_vm_socket_info().clone(),
                         config.hwloc(),
-                        config.binary_directory().to_string(),
+                        #[cfg(not(feature = "single-process"))]
+                        config.linuxd_binary_path().to_string(),
                         toolchain_binary_directory,
                         config.log_directory().to_string(),
                         tmp_directory,
@@ -283,6 +284,7 @@ impl UninitializedSandbox {
 
         Ok(InitializedSandbox {
             guest_binary_path: self.guest_binary_path,
+            kernel_binary_path: config.kernel_binary_path().to_string(),
             program_args: self.program_args,
             linuxd,
             control_plane_socket_and_info,

--- a/src/libs/nanvix-sandbox/src/uservm_args.rs
+++ b/src/libs/nanvix-sandbox/src/uservm_args.rs
@@ -39,8 +39,11 @@ pub struct UserVmArgs {
     console_file: Option<String>,
     /// Optional hardware locality configuration for CPU affinity and topology information.
     hwloc: Option<hwloc::HwLoc>,
-    /// Path to the binary directory containing Nanvix binaries.
-    binary_directory: String,
+    /// Path to kernel binary.
+    kernel_binary_path: String,
+    /// Path to the User VM binary.
+    #[cfg(not(feature = "single-process"))]
+    uservm_binary_path: String,
     /// Directory path for writing log files.
     log_directory: String,
     /// Unique identifier for this User VM instance.
@@ -66,7 +69,8 @@ impl UserVmArgs {
     /// - `program_args`: Optional command-line arguments for the program.
     /// - `console_file`: Optional file path for redirecting console output.
     /// - `hwloc`: Optional hardware locality configuration.
-    /// - `binary_directory`: Path to the binary directory.
+    /// - `kernel_binary_path`: Path to kernel binary.
+    /// - `uservm_binary_path`: Path to the User VM binary (only if not in single-process mode).
     /// - `log_directory`: Path to the log directory.
     /// - `uservm_id`: Unique identifier for this User VM instance.
     ///
@@ -83,7 +87,8 @@ impl UserVmArgs {
         program_args: Option<String>,
         console_file: Option<String>,
         hwloc: Option<hwloc::HwLoc>,
-        binary_directory: String,
+        kernel_binary_path: String,
+        #[cfg(not(feature = "single-process"))] uservm_binary_path: String,
         log_directory: String,
         uservm_id: UserVmIdentifier,
     ) -> Self {
@@ -95,7 +100,9 @@ impl UserVmArgs {
             program_args,
             console_file,
             hwloc,
-            binary_directory,
+            kernel_binary_path,
+            #[cfg(not(feature = "single-process"))]
+            uservm_binary_path,
             log_directory,
             uservm_id,
         }
@@ -195,14 +202,28 @@ impl UserVmArgs {
     ///
     /// # Description
     ///
-    /// Returns the path to the binary directory.
+    /// Returns the path to the kernel binary.
     ///
     /// # Returns
     ///
-    /// The path to the binary directory.
+    /// The path to the kernel binary.
     ///
-    pub fn binary_directory(&self) -> &str {
-        &self.binary_directory
+    pub fn kernel_binary_path(&self) -> &str {
+        &self.kernel_binary_path
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the path to the User VM binary.
+    ///
+    /// # Returns
+    ///
+    /// The path to the User VM binary.
+    ///
+    #[cfg(not(feature = "single-process"))]
+    pub fn uservm_binary_path(&self) -> &str {
+        &self.uservm_binary_path
     }
 
     ///

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -39,7 +39,10 @@ uservm = { workspace = true }
 default = []
 # If enabled this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) are embedded
 # into Nanvix Daemon (nanvixd).
-single-process = ["nanvix-sandbox/single-process"]
+single-process = [
+    "nanvix-sandbox/single-process",
+    "nanvix-sandbox-cache/single-process",
+]
 hyperlight = [
     "config/hyperlight",
     "uservm/hyperlight",

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -64,13 +64,25 @@ pub async fn main() -> Result<()> {
     #[cfg(not(feature = "single-process"))]
     info!("nanvixd {} multi-process mode", env!("CARGO_PKG_VERSION"));
 
+    #[cfg(not(feature = "single-process"))]
+    let linuxd_binary_path: String = format!("{}/linuxd.elf", args.binary_directory());
+
+    let kernel_binary_path: String = format!("{}/kernel.elf", args.binary_directory());
+
+    #[cfg(not(feature = "single-process"))]
+    let uservm_binary_path: String = format!("{}/uservm.elf", args.binary_directory());
+
     let config: SandboxCacheConfig = SandboxCacheConfig::new(
         args.control_plane_socket_type(),
         args.gateway_socket_type(),
         args.system_vm_socket_type(),
         args.console_file().clone(),
         args.hwloc().clone(),
-        args.binary_directory(),
+        &kernel_binary_path,
+        #[cfg(not(feature = "single-process"))]
+        &linuxd_binary_path,
+        #[cfg(not(feature = "single-process"))]
+        &uservm_binary_path,
         args.toolchain_binary_directory(),
         args.log_directory(),
         args.l2(),


### PR DESCRIPTION
This pull request refactors how binary paths are specified and accessed throughout the sandbox codebase. Instead of passing a single binary directory and constructing paths to binaries at runtime, the code now requires explicit paths for the kernel, Linux Daemon, and User VM binaries. These changes are conditionally compiled depending on whether the `single-process` feature is enabled. This improves clarity, flexibility, and correctness when launching different components.

**Refactoring binary path handling:**

* Replaced the `binary_directory` field with explicit fields: `kernel_binary_path`, `linuxd_binary_path`, and `uservm_binary_path` in `SandboxCacheConfig`, `SandboxConfig`, `LinuxDaemonArgs`, and `UserVmArgs`. The `linuxd_binary_path` and `uservm_binary_path` fields are only included when the `single-process` feature is not enabled. [[1]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L92-R99) [[2]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L44-R51) [[3]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L34-R36) [[4]](diffhunk://#diff-2a69af6d1ee7911f6de02680cee9b62d9dc77ece2083a63c5016b8eea26cc6b4L42-R46)
* Updated constructors and methods to accept and use these explicit binary paths, including documentation and field initialization. [[1]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L121-R129) [[2]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L138-R148) [[3]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L150-R164) [[4]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L86-R94) [[5]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L105-R116) [[6]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L119-R134) [[7]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L63-R64) [[8]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L79-R80) [[9]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L90-R92)
* Added accessor methods for the new binary path fields, replacing the previous `binary_directory()` methods. [[1]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L226-R275) [[2]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L197-R246) [[3]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L141-R151)

**Adjustments to binary launching logic:**

* Updated code that launches the Linux Daemon and User VM processes to use the explicit binary paths instead of constructing them from a directory, improving reliability and configurability. [[1]](diffhunk://#diff-6e1eac11a5dce6ae248f71047b49802fb115a76b19ff7e0371dbf5776dfaeeeeL254-R254) [[2]](diffhunk://#diff-d266815f475746e5199ac0df91c8e888014c93d3b218c2c98b0577ef68e2e7ddL92-R99) [[3]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L118-R118)

**Feature flag and struct propagation:**

* Ensured that the new fields are properly propagated through all relevant structs and constructors, including `InitializedSandbox` and `UninitializedSandbox`. [[1]](diffhunk://#diff-8e76ade4a190796234ddb08b29ec6be0d33c65fba3181eb82c8741bdc6ef0c6aR58-R59) [[2]](diffhunk://#diff-8e76ade4a190796234ddb08b29ec6be0d33c65fba3181eb82c8741bdc6ef0c6aL89-R94) [[3]](diffhunk://#diff-8e76ade4a190796234ddb08b29ec6be0d33c65fba3181eb82c8741bdc6ef0c6aL116-R121) [[4]](diffhunk://#diff-b0a9a30490bc785933cc79b0229df63d805e391ba58ec3b974fdc900c73f51c9L260-R261) [[5]](diffhunk://#diff-b0a9a30490bc785933cc79b0229df63d805e391ba58ec3b974fdc900c73f51c9R287)

**Build configuration:**

* Added a new `single-process` feature flag to the `Cargo.toml` to control conditional compilation of multi-process fields and logic.

These changes make binary path management more explicit and robust, especially when supporting both single-process and multi-process modes.