### PR TITLE
[libs] Pass System Call Table Down

### DIFF
--- a/src/libs/nanvix-sandbox-cache/Cargo.toml
+++ b/src/libs/nanvix-sandbox-cache/Cargo.toml
@@ -14,6 +14,7 @@ homepage.workspace = true
 anyhow = { workspace = true }
 config = { workspace = true }
 hwloc = { workspace = true }
+linuxd = { workspace = true, optional = true }
 nanvix-sandbox = { workspace = true }
 rand = { workspace = true }
 syscomm = { workspace = true }
@@ -23,4 +24,4 @@ user-vm-api = { workspace = true }
 
 [features]
 default = []
-single-process = []
+single-process = ["linuxd"]

--- a/src/libs/nanvix-sandbox-cache/src/config.rs
+++ b/src/libs/nanvix-sandbox-cache/src/config.rs
@@ -77,7 +77,7 @@ const UNIX_PATH_MAX: usize = 108;
 /// by the Nanvix Daemon, including socket types, file paths, hardware topology, and deployment
 /// mode settings.
 ///
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SandboxCacheConfig {
     /// Socket type for control plane communication between nanvixd and linuxd.
     control_plane_socket_type: SocketType,
@@ -97,6 +97,9 @@ pub struct SandboxCacheConfig {
     /// Path to the User VM binary.
     #[cfg(not(feature = "single-process"))]
     uservm_binary_path: String,
+    /// System call table.
+    #[cfg(feature = "single-process")]
+    syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>>,
     /// Path to the toolchain binary directory containing cloud-hypervisor and other tools.
     toolchain_binary_directory: String,
     /// Directory path for writing log files.
@@ -127,6 +130,7 @@ impl SandboxCacheConfig {
     /// - `kernel_binary_path`: Path to kernel binary.
     /// - `linuxd_binary_path`: Path to the Linux Daemon binary (only if not in single-process mode).
     /// - `uservm_binary_path`: Path to the User VM binary (only if not in single-process mode).
+    /// - `syscall_table`: Optional system call table (only in single-process mode).
     /// - `toolchain_binary_directory`: Path to the toolchain binary directory.
     /// - `log_directory`: Path to the log directory.
     /// - `l2`: Flag to deploy linuxd inside an L2 VM.
@@ -146,6 +150,9 @@ impl SandboxCacheConfig {
         kernel_binary_path: &str,
         #[cfg(not(feature = "single-process"))] linuxd_binary_path: &str,
         #[cfg(not(feature = "single-process"))] uservm_binary_path: &str,
+        #[cfg(feature = "single-process")] syscall_table: Option<
+            ::std::sync::Arc<::linuxd::syscalls::SyscallTable>,
+        >,
         toolchain_binary_directory: &str,
         log_directory: &str,
         l2: bool,
@@ -162,6 +169,8 @@ impl SandboxCacheConfig {
             linuxd_binary_path: linuxd_binary_path.to_string(),
             #[cfg(not(feature = "single-process"))]
             uservm_binary_path: uservm_binary_path.to_string(),
+            #[cfg(feature = "single-process")]
+            syscall_table,
             toolchain_binary_directory: toolchain_binary_directory.to_string(),
             log_directory: log_directory.to_string(),
             l2,
@@ -273,6 +282,21 @@ impl SandboxCacheConfig {
     #[cfg(not(feature = "single-process"))]
     pub fn uservm_binary_path(&self) -> &str {
         &self.uservm_binary_path
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a handle to the system call table.
+    ///
+    /// # Returns
+    ///
+    /// If a system call table is set, this function returns a handle to it. Otherwise, it returns
+    /// empty.
+    ///
+    #[cfg(feature = "single-process")]
+    pub fn syscall_table(&self) -> Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>> {
+        self.syscall_table.clone()
     }
 
     ///

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -257,7 +257,8 @@ impl SandboxCache {
                     #[cfg(not(feature = "single-process"))]
                     self.config.uservm_binary_path(),
                     self.config.log_directory(),
-                    None,
+                    #[cfg(feature = "single-process")]
+                    self.config.syscall_table(),
                     Some((
                         control_plane_sockaddr.clone(),
                         self.config.control_plane_sockaddr_type(),

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -68,6 +68,7 @@
 //!     #[cfg(not(feature = "single-process"))]
 //!     "/path/to/uservm.elf",  // uservm_binary_path
 //!     "/path/to/logs",  // log_directory
+//!     #[cfg(feature = "single-process")]
 //!     None,  // syscall_table
 //!     Some(("127.0.0.1:8082".to_string(), SocketType::Tcp)),  // control_plane_socket_info
 //!     Some("/path/to/toolchain".to_string()),  // toolchain_binary_directory

--- a/src/libs/nanvix-sandbox/src/linuxd_args.rs
+++ b/src/libs/nanvix-sandbox/src/linuxd_args.rs
@@ -11,8 +11,6 @@
 // Imports
 //==================================================================================================
 
-use ::linuxd::syscalls::SyscallTable;
-use ::std::sync::Arc;
 use ::syscomm::SocketType;
 
 //==================================================================================================
@@ -43,7 +41,8 @@ pub struct LinuxDaemonArgs {
     /// Flag to deploy linuxd inside an L2 VM (using cloud-hypervisor).
     l2: bool,
     /// Optional system call table for overriding default system call behavior.
-    syscall_table: Option<Arc<SyscallTable>>,
+    #[cfg(feature = "single-process")]
+    syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>>,
 }
 
 //==================================================================================================
@@ -66,7 +65,7 @@ impl LinuxDaemonArgs {
     /// - `log_directory`: Directory path for writing log files.
     /// - `tmp_directory`: Temporary directory path for Unix sockets and transient files.
     /// - `l2`: Flag to deploy linuxd inside an L2 VM (using cloud-hypervisor).
-    /// - `syscall_table`: Optional system call table for overriding default system call behavior.
+    /// - `syscall_table`: Optional system call table for overriding default system call behavior (only if in single-process mode).
     ///
     /// # Returns
     ///
@@ -82,7 +81,9 @@ impl LinuxDaemonArgs {
         log_directory: String,
         tmp_directory: String,
         l2: bool,
-        syscall_table: Option<Arc<SyscallTable>>,
+        #[cfg(feature = "single-process")] syscall_table: Option<
+            ::std::sync::Arc<::linuxd::syscalls::SyscallTable>,
+        >,
     ) -> Self {
         Self {
             control_plane_socket_info,
@@ -94,6 +95,7 @@ impl LinuxDaemonArgs {
             log_directory,
             tmp_directory,
             l2,
+            #[cfg(feature = "single-process")]
             syscall_table,
         }
     }
@@ -212,7 +214,8 @@ impl LinuxDaemonArgs {
     ///
     /// An optional reference to the system call table.
     ///
-    pub fn syscall_table(&self) -> Option<&Arc<SyscallTable>> {
-        self.syscall_table.as_ref()
+    #[cfg(feature = "single-process")]
+    pub fn syscall_table(&self) -> Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>> {
+        self.syscall_table.clone()
     }
 }

--- a/src/libs/nanvix-sandbox/src/sandbox_config.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox_config.rs
@@ -12,8 +12,6 @@
 //==================================================================================================
 
 use crate::tcp_port::TcpPort;
-use ::linuxd::syscalls::SyscallTable;
-use ::std::sync::Arc;
 use ::syscomm::SocketType;
 use ::user_vm_api::UserVmIdentifier;
 
@@ -52,7 +50,8 @@ pub struct SandboxConfig {
     /// Directory path for writing log files.
     log_directory: String,
     /// Optional system call table for overriding default system call behavior.
-    syscall_table: Option<Arc<SyscallTable>>,
+    #[cfg(feature = "single-process")]
+    syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>>,
 
     /// Optional information on control plane socket (address, socket type).
     /// This must be provided if the control plane socket is not already initialized before
@@ -93,7 +92,7 @@ impl SandboxConfig {
     /// - `linuxd_binary_path`: Path to the Linux Daemon binary (only if not in single-process mode).
     /// - `uservm_binary_path`: Path to the User VM binary (only if not in single-process mode).
     /// - `log_directory`: Path to the log directory.
-    /// - `syscall_table`: Optional system call table for overriding default system call behavior.
+    /// - `syscall_table`: Optional system call table for overriding default system call behavior (only if in single-process mode).
     /// - `control_plane_socket_info`: Optional information on control plane socket (address, socket type).
     /// - `toolchain_binary_directory`: Optional path to the toolchain binary directory.
     /// - `tmp_directory`: Optional path to the temporary directory.
@@ -114,7 +113,9 @@ impl SandboxConfig {
         #[cfg(not(feature = "single-process"))] linuxd_binary_path: &str,
         #[cfg(not(feature = "single-process"))] uservm_binary_path: &str,
         log_directory: &str,
-        syscall_table: Option<Arc<SyscallTable>>,
+        #[cfg(feature = "single-process")] syscall_table: Option<
+            ::std::sync::Arc<::linuxd::syscalls::SyscallTable>,
+        >,
         control_plane_socket_info: Option<(String, SocketType)>,
         toolchain_binary_directory: Option<String>,
         tmp_directory: Option<String>,
@@ -132,6 +133,7 @@ impl SandboxConfig {
             #[cfg(not(feature = "single-process"))]
             uservm_binary_path: uservm_binary_path.to_string(),
             log_directory: log_directory.to_string(),
+            #[cfg(feature = "single-process")]
             syscall_table,
             control_plane_socket_info,
             toolchain_binary_directory,
@@ -268,7 +270,8 @@ impl SandboxConfig {
     ///
     /// An optional clone of the system call table.
     ///
-    pub fn syscall_table(&self) -> Option<Arc<SyscallTable>> {
+    #[cfg(feature = "single-process")]
+    pub fn syscall_table(&self) -> Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>> {
         self.syscall_table.clone()
     }
 

--- a/src/libs/nanvix-sandbox/src/single_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/linuxd.rs
@@ -116,7 +116,7 @@ impl LinuxDaemon {
 
         // Create a new Linux Daemon instance.
         let linuxd: EmbeddedLinuxd = EmbeddedLinuxd::init(
-            args.syscall_table().cloned().unwrap_or_default(),
+            args.syscall_table().unwrap_or_default(),
             &args.control_plane_socket_info().0,
             args.control_plane_socket_info().1.to_str(),
             user_vm_listener,

--- a/src/libs/nanvix-sandbox/src/uninitialized.rs
+++ b/src/libs/nanvix-sandbox/src/uninitialized.rs
@@ -263,6 +263,7 @@ impl UninitializedSandbox {
                         config.log_directory().to_string(),
                         tmp_directory,
                         l2,
+                        #[cfg(feature = "single-process")]
                         config.syscall_table(),
                     )
                 };

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -83,6 +83,8 @@ pub async fn main() -> Result<()> {
         &linuxd_binary_path,
         #[cfg(not(feature = "single-process"))]
         &uservm_binary_path,
+        #[cfg(feature = "single-process")]
+        None,
         args.toolchain_binary_directory(),
         args.log_directory(),
         args.l2(),


### PR DESCRIPTION
This pull request adds support for handling a system call table when the `single-process` feature is enabled, improving configurability and modularity for single-process deployments. It introduces conditional compilation to include or exclude system call table logic based on the feature flag, and updates constructors, struct fields, and method signatures accordingly. Additionally, it updates dependencies and feature definitions in the relevant `Cargo.toml` files.

**Feature flag–dependent system call table support:**

* Added an optional `syscall_table` field (with type `Option<Arc<linuxd::syscalls::SyscallTable>>`) to `SandboxCacheConfig`, `LinuxDaemonArgs`, and `SandboxConfig` structs, gated behind the `single-process` feature flag. Corresponding constructor parameters and getter methods were updated to support this field. [[1]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4R100-R102) [[2]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4R133) [[3]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4R153-R155) [[4]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4R172-R173) [[5]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4R287-R301) [[6]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L46-R45) [[7]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L69-R68) [[8]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L85-R86) [[9]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5R98) [[10]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L215-R219) [[11]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L55-R54) [[12]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L96-R95) [[13]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L117-R118) [[14]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611R136) [[15]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L271-R274)

* Updated code paths to pass the system call table where required, including in the initialization of the Linux Daemon in single-process mode. [[1]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aL260-R261) [[2]](diffhunk://#diff-eb229fecb7aeccb7dbf94c9582c6bd2f97ee820233b52c86aa3f544a3b8bcc92L119-R119) [[3]](diffhunk://#diff-b0a9a30490bc785933cc79b0229df63d805e391ba58ec3b974fdc900c73f51c9R266) [[4]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462R86-R87)

**Feature flag and dependency management:**

* Added `linuxd` as an optional dependency in `Cargo.toml` and made the `single-process` feature depend on `linuxd`, ensuring correct dependency resolution for feature-gated code. [[1]](diffhunk://#diff-fa1a5365080b644e4b0283c72fcc62bfd819bd4c3894cad059b7f9de3a300afcR17) [[2]](diffhunk://#diff-fa1a5365080b644e4b0283c72fcc62bfd819bd4c3894cad059b7f9de3a300afcL26-R27)

**Code cleanup and organization:**

* Removed unconditional imports of `SyscallTable` and `Arc` in favor of conditional, fully qualified paths, reducing unnecessary dependencies and improving clarity. [[1]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L14-L15) [[2]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L15-L16)

**Documentation updates:**

* Updated doc comments to clarify when the system call table is present, indicating its relevance only when the `single-process` feature is enabled. [[1]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4R133) [[2]](diffhunk://#diff-a9dcba1c388fb4ec78a1ca07f8deff43450c2fa572fcadd78d44e947640776b5L69-R68) [[3]](diffhunk://#diff-e283ce62f178403e8366a33a3529b8dd4747c707f24676dd0186d8451fad9611L96-R95)

These changes collectively improve the flexibility and maintainability of the codebase for single-process and multi-process deployment scenarios.