### PR TITLE
[tests] Layout Tests for Read/Write Locks

### DIFF
--- a/src/tests/thread-c/main.c
+++ b/src/tests/thread-c/main.c
@@ -105,6 +105,9 @@ int main(int argc, const char *argv[])
     // Sanity check size of `pthread_rwlock_t` type.
     STATIC_ASSERT_SIZE(pthread_rwlock_t, sizeof(uint32_t));
 
+    // Sanity check size of `pthread_rwlockattr_t` type.
+    STATIC_ASSERT_SIZE(pthread_rwlockattr_t, sizeof(int));
+
     test_pthread_self();
     test_pthread_attr_init_destroy();
     test_pthread_attr_getstack();

--- a/src/tests/thread-c/main.c
+++ b/src/tests/thread-c/main.c
@@ -102,6 +102,9 @@ int main(int argc, const char *argv[])
                            sizeof(int)   // recursive
     );
 
+    // Sanity check size of `pthread_rwlock_t` type.
+    STATIC_ASSERT_SIZE(pthread_rwlock_t, sizeof(uint32_t));
+
     test_pthread_self();
     test_pthread_attr_init_destroy();
     test_pthread_attr_getstack();


### PR DESCRIPTION
This PR closes https://github.com/nanvix/nanvix/issues/982
This PR closes https://github.com/nanvix/nanvix/issues/983

This pull request adds compile-time sanity checks to ensure that the sizes of certain pthread-related types match expected values. This helps catch platform or implementation mismatches early during compilation.

Sanity check additions:

* Added a static assertion to verify that the size of `pthread_rwlock_t` is `sizeof(uint32_t)`.
* Added a static assertion to verify that the size of `pthread_rwlockattr_t` is `sizeof(int)`.