### PR TITLE
[utils] Make `nanvixd` Log to File Always

### DIFF
--- a/scripts/run-nanvixd.sh
+++ b/scripts/run-nanvixd.sh
@@ -503,7 +503,6 @@ main() {
     RUST_LOG="${LOG_LEVEL},hyperlight_host=off" setsid "${nanvixd_binary_path}" \
         -http-addr "${NANVIXD_SOCKADDR}" \
         -toolchain-bin-dir "${TOOLCHAIN_BIN_DIR}" \
-        -log-to-file \
         -log-dir "${logs_dir}" \
         -tmp-dir "${TMP_DIR}" \
         "$([ "$L2_VM" = "yes" ] && echo "-l2")" \

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -11,7 +11,10 @@
 // Imports
 //==================================================================================================
 
-use crate::config;
+use crate::config::{
+    self,
+    DEFAULT_LOG_DIRECTORY,
+};
 use ::anyhow::Result;
 use ::hwloc::HwLoc;
 use ::std::{
@@ -47,8 +50,6 @@ pub struct Args {
     console_file: Option<String>,
     /// Optional hardware locality configuration for CPU affinity and topology.
     hwloc: Option<HwLoc>,
-    /// Flag indicating whether to log to files instead of stdout/stderr.
-    log_to_file: bool,
     /// Directory path for writing log files when log_to_file is enabled.
     log_directory: String,
     /// Flag indicating whether to deploy linuxd inside an L2 VM.
@@ -84,8 +85,6 @@ impl Args {
     pub const OPT_CONSOLE_FILE: &'static str = "-console-file";
     /// Command-line option that loads the serialized CPU topology.
     pub const OPT_HWLOC: &'static str = "-hwloc";
-    /// Command-line flag that enables logging to files.
-    pub const OPT_LOG_TO_FILE: &'static str = "-log-to-file";
     /// Command-line option that sets the log directory path.
     pub const OPT_LOG_DIRECTORY: &'static str = "-log-dir";
     /// Command-line flag that enables L2 deployment mode.
@@ -125,8 +124,7 @@ impl Args {
             config::DEFAULT_TOOLCHAIN_BIN_DIRECTORY.to_string();
         let mut console_file: Option<String> = None;
         let mut hwloc: Option<HwLoc> = None;
-        let mut log_to_file: bool = false;
-        let mut log_directory: String = config::DEFAULT_LOG_DIRECTORY.to_string();
+        let mut log_directory: String = DEFAULT_LOG_DIRECTORY.to_string();
         let mut l2: bool = false;
         let mut control_plane_socket_type: Option<SocketType> = None;
         let mut gateway_socket_type: Option<SocketType> = None;
@@ -203,9 +201,6 @@ impl Args {
                     i += 1;
                     system_vm_socket_type = Some(args[i].parse()?);
                 },
-                Self::OPT_LOG_TO_FILE => {
-                    log_to_file = true;
-                },
                 Self::OPT_LOG_DIRECTORY => {
                     i += 1;
                     log_directory = args[i].clone();
@@ -268,7 +263,6 @@ impl Args {
             toolchain_binary_directory,
             console_file,
             hwloc,
-            log_to_file,
             log_directory,
             l2,
             control_plane_socket_type,
@@ -307,8 +301,8 @@ Options:
              (cloud-hypervisor, etc.).
   {hwloc} <hwloc.json>                      Hardware locality configuration file for CPU \
              affinity/topology.
-  {log_to_file}                             Enable logging to files instead of stdout/stderr.
-  {log_dir} <log_dir>                       Directory for log files (used with {log_to_file}).
+  {log_dir} <log_dir>                       Directory for log files (Default: \
+             {DEFAULT_LOG_DIRECTORY}).
   {control_plane_socket_type} <socket_type> Socket type for control plane communication (nanvixd \
              <-> linuxd).
   {gateway_socket_type} <socket_type>       Socket type for gateway communication (client <-> \
@@ -325,7 +319,6 @@ Options:
             bin_dir = Self::OPT_BIN_DIRECTORY,
             toolchain_bin_dir = Self::OPT_TOOLCHAIN_BIN_DIRECTORY,
             hwloc = Self::OPT_HWLOC,
-            log_to_file = Self::OPT_LOG_TO_FILE,
             log_dir = Self::OPT_LOG_DIRECTORY,
             control_plane_socket_type = Self::OPT_CONTROL_PLANE_SOCKET_TYPE,
             gateway_socket_type = Self::OPT_GATEWAY_SOCKET_TYPE,
@@ -423,19 +416,6 @@ Options:
     ///
     pub fn l2(&self) -> bool {
         self.l2
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Indicates whether to log to a file instead of stdout/stderr.
-    ///
-    /// # Returns
-    ///
-    /// `true` if logging to a file; `false` otherwise.
-    ///
-    pub fn log_to_file(&self) -> bool {
-        self.log_to_file
     }
 
     ///

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -57,7 +57,7 @@ pub async fn main() -> Result<()> {
     let args: Arc<Args> =
         Arc::new(Args::parse(std::env::args().filter(|s| !s.trim().is_empty()).collect())?);
 
-    ::syslog::init(args.log_to_file(), args.log_directory().to_string());
+    ::syslog::init(true, args.log_directory().to_string());
 
     #[cfg(feature = "single-process")]
     info!("nanvixd {} single-process mode", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
This pull request removes the `-log-to-file` flag and the associated logic from the `nanvixd` daemon. Now, logging to files is always enabled, and the log directory can still be specified with `-log-dir`. The code and documentation are updated to reflect this simplification.

**Removal of log-to-file flag and related logic:**

- Removed the `-log-to-file` command-line flag and the `log_to_file` field from the `Args` struct, so logging to files is now always enabled. [[1]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L50-L51) [[2]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L87-L88) [[3]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L128-R127) [[4]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L206-L208) [[5]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L271) [[6]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L428-L440)
- Updated the log initialization in `main.rs` to always enable file logging (the first argument to `syslog::init` is now always `true`).

**Documentation and help text updates:**

- Updated the help text and usage documentation to remove references to `-log-to-file` and clarify that `-log-dir` sets the log directory (with a default value). [[1]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L310-R305) [[2]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L328)
- Updated imports to include `DEFAULT_LOG_DIRECTORY` directly for clarity.

**Script update:**

- Removed the `-log-to-file` flag from the `run-nanvixd.sh` script to match the new behavior.