### PR TITLE
[utils] Add -l2-snapshot-path To Nanvixd

### DIFF
--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -4,6 +4,7 @@
 NANVIX_BENCH_FEATURES :=
 NANVIX_BENCH_FEATURES += $(if $(filter yes,$(SINGLE_PROCESS)),single-process,)
 NANVIX_BENCH_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
+NANVIX_BENCH_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
 NANVIX_BENCH_FEATURES := $(strip $(NANVIX_BENCH_FEATURES))
 NANVIX_BENCH_CARGO_FEATURES := $(if $(NANVIX_BENCH_FEATURES),--features "$(NANVIX_BENCH_FEATURES)")
 

--- a/src/libs/nanvix-sandbox-cache/src/config.rs
+++ b/src/libs/nanvix-sandbox-cache/src/config.rs
@@ -58,6 +58,8 @@ pub struct SandboxCacheConfig {
     log_directory: String,
     /// Flag indicating whether to deploy linuxd inside an L2 VM (using cloud-hypervisor).
     l2: bool,
+    /// Path to the snapshot file in an L2 deployment.
+    l2_snapshot_path: String,
     /// Path to the temporary directory for Unix sockets and transient files.
     tmp_directory: String,
 }
@@ -86,6 +88,7 @@ impl SandboxCacheConfig {
     /// - `toolchain_binary_directory`: Path to the toolchain binary directory.
     /// - `log_directory`: Path to the log directory.
     /// - `l2`: Flag to deploy linuxd inside an L2 VM.
+    /// - `l2_snapshot_path`: Path to the L2 VM's snapshot.
     /// - `tmp_directory`: Path to the temporary directory.
     ///
     /// # Returns
@@ -108,6 +111,7 @@ impl SandboxCacheConfig {
         toolchain_binary_directory: &str,
         log_directory: &str,
         l2: bool,
+        l2_snapshot_path: &str,
         tmp_directory: &str,
     ) -> Self {
         Self {
@@ -126,6 +130,7 @@ impl SandboxCacheConfig {
             toolchain_binary_directory: toolchain_binary_directory.to_string(),
             log_directory: log_directory.to_string(),
             l2,
+            l2_snapshot_path: l2_snapshot_path.to_string(),
             tmp_directory: tmp_directory.to_string(),
         }
     }
@@ -288,6 +293,19 @@ impl SandboxCacheConfig {
     ///
     pub fn l2(&self) -> bool {
         self.l2
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the L2 snapshot path.
+    ///
+    /// # Returns
+    ///
+    /// The L2 snapshot path.
+    ///
+    pub fn l2_snapshot_path(&self) -> &str {
+        &self.l2_snapshot_path
     }
 
     ///

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -257,6 +257,7 @@ impl SandboxCache {
                     Some(self.config.toolchain_binary_directory().to_string()),
                     Some(self.config.tmp_directory().to_string()),
                     Some(self.config.l2()),
+                    Some(self.config.l2_snapshot_path().to_string()),
                 );
 
                 let uninitialized_sandbox: UninitializedSandbox =

--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -93,20 +93,6 @@ const UNIX_SOCKET_SUFFIX: &str = ".socket";
 ///
 /// # Description
 ///
-/// Gets the absolute path for the source root.
-///
-/// # Returns
-///
-/// The absolute path to the source code root.
-///
-#[cfg(not(feature = "single-process"))]
-fn get_proj_root() -> String {
-    format!("{}/../../..", env!("CARGO_MANIFEST_DIR"))
-}
-
-///
-/// # Description
-///
 /// Gets the absolute path for cloud-hypervisor's binary directory given a path (potentially
 /// sym-linked) to the toolchain binary directory.
 ///
@@ -138,8 +124,9 @@ pub(crate) fn get_clh_bin_dir(toolchain_bin_dir: &str) -> Result<String> {
 /// The absolute path to cloud-hypervisor's snapshot directory.
 ///
 #[cfg(not(feature = "single-process"))]
-pub(crate) fn get_clh_snapshot_path() -> String {
-    format!("{}/images/{}", get_proj_root(), ::config::linuxd::SNAPSHOT_NAME)
+pub(crate) fn get_clh_snapshot_path(l2_snapshot_path: &str) -> Result<String> {
+    let l2_snapshot_path: PathBuf = PathBuf::from(l2_snapshot_path);
+    Ok(format!("{}", fs::canonicalize(l2_snapshot_path)?.display()))
 }
 
 ///

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -74,6 +74,7 @@
 //!     Some("/path/to/toolchain".to_string()),  // toolchain_binary_directory
 //!     Some("/tmp".to_string()),  // tmp_directory
 //!     Some(false),  // l2
+//!     Some("/path/to/l2/snapshot".to_string()), // l2_snapshot_path
 //! );
 //!
 //! // Create and initialize sandbox.

--- a/src/libs/nanvix-sandbox/src/linuxd_args.rs
+++ b/src/libs/nanvix-sandbox/src/linuxd_args.rs
@@ -40,6 +40,8 @@ pub struct LinuxDaemonArgs {
     tmp_directory: String,
     /// Flag to deploy linuxd inside an L2 VM (using cloud-hypervisor).
     l2: bool,
+    /// Path to the L2 snapshot path.
+    l2_snapshot_path: String,
     /// Optional system call table for overriding default system call behavior.
     #[cfg(feature = "single-process")]
     syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>>,
@@ -65,6 +67,7 @@ impl LinuxDaemonArgs {
     /// - `log_directory`: Directory path for writing log files.
     /// - `tmp_directory`: Temporary directory path for Unix sockets and transient files.
     /// - `l2`: Flag to deploy linuxd inside an L2 VM (using cloud-hypervisor).
+    /// - `l2_snapshot_path`: Path to the L2 VM snapshot.
     /// - `syscall_table`: Optional system call table for overriding default system call behavior (only if in single-process mode).
     ///
     /// # Returns
@@ -81,6 +84,7 @@ impl LinuxDaemonArgs {
         log_directory: String,
         tmp_directory: String,
         l2: bool,
+        l2_snapshot_path: String,
         #[cfg(feature = "single-process")] syscall_table: Option<
             ::std::sync::Arc<::linuxd::syscalls::SyscallTable>,
         >,
@@ -95,6 +99,7 @@ impl LinuxDaemonArgs {
             log_directory,
             tmp_directory,
             l2,
+            l2_snapshot_path,
             #[cfg(feature = "single-process")]
             syscall_table,
         }
@@ -164,6 +169,19 @@ impl LinuxDaemonArgs {
     ///
     pub fn toolchain_binary_directory(&self) -> &str {
         &self.toolchain_binary_directory
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the L2 snapshot path.
+    ///
+    /// # Returns
+    ///
+    /// The L2 snapshot path.
+    ///
+    pub fn l2_snapshot_path(&self) -> &str {
+        &self.l2_snapshot_path
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
@@ -247,7 +247,7 @@ impl LinuxDaemon {
                 args::Args::OPT_CLH_API_SOCKET.to_string(),
                 clh_api_socket_path.clone(),
                 args::Args::OPT_CLH_RESTORE.to_string(),
-                format!("source_url=file://{}", get_clh_snapshot_path()),
+                format!("source_url=file://{}", get_clh_snapshot_path(args.l2_snapshot_path())?),
             ]
         } else {
             vec![

--- a/src/libs/nanvix-sandbox/src/sandbox_config.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox_config.rs
@@ -69,6 +69,9 @@ pub struct SandboxConfig {
     /// Optional flag to deploy the Linux Daemon inside an L2 VM (using cloud-hypervisor).
     /// This must be provided if a Linux Daemon instance was not provided before sandbox initialization.
     l2: Option<bool>,
+
+    /// Optional path to the snapshot used to deploy an L2 VM.
+    l2_snapshot_path: Option<String>,
 }
 
 //==================================================================================================
@@ -97,6 +100,7 @@ impl SandboxConfig {
     /// - `toolchain_binary_directory`: Optional path to the toolchain binary directory.
     /// - `tmp_directory`: Optional path to the temporary directory.
     /// - `l2`: Optional flag to deploy the Linux Daemon inside an L2 VM.
+    /// - `l2_snapshot_path`: Optional path to the L2 VM's snapshot.
     ///
     /// # Returns
     ///
@@ -120,6 +124,7 @@ impl SandboxConfig {
         toolchain_binary_directory: Option<String>,
         tmp_directory: Option<String>,
         l2: Option<bool>,
+        l2_snapshot_path: Option<String>,
     ) -> Self {
         Self {
             uservm_id,
@@ -139,6 +144,7 @@ impl SandboxConfig {
             toolchain_binary_directory,
             tmp_directory,
             l2,
+            l2_snapshot_path,
         }
     }
 
@@ -325,6 +331,19 @@ impl SandboxConfig {
     ///
     pub fn l2(&self) -> Option<bool> {
         self.l2
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the optional path pointing to the L2 snapshot directory.
+    ///
+    /// # Returns
+    ///
+    /// An optional path to the L2 snapshot directory.
+    ///
+    pub fn l2_snapshot_path(&self) -> Option<&str> {
+        self.l2_snapshot_path.as_deref()
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/uninitialized.rs
+++ b/src/libs/nanvix-sandbox/src/uninitialized.rs
@@ -250,6 +250,17 @@ impl UninitializedSandbox {
                         Some(l2) => l2,
                     };
 
+                    // Get L2 snapshot path.
+                    let l2_snapshot_path: &str = match config.l2_snapshot_path() {
+                        None => {
+                            let reason: &str =
+                                "L2 snapshot path not provided and linuxd not initialized";
+                            error!("initialize(): {reason}");
+                            anyhow::bail!(reason);
+                        },
+                        Some(l2_snapshot_path) => l2_snapshot_path,
+                    };
+
                     LinuxDaemonArgs::new(
                         (
                             locked_control_plane_socket_and_info.1.clone(),
@@ -263,6 +274,7 @@ impl UninitializedSandbox {
                         config.log_directory().to_string(),
                         tmp_directory,
                         l2,
+                        l2_snapshot_path.to_string(),
                         #[cfg(feature = "single-process")]
                         config.syscall_table(),
                     )

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -86,6 +86,9 @@ use ::nanvix::{
         },
     },
 };
+// FIXME(#1128): We need to re-export this import for the profiler macros.
+#[cfg(feature = "timestamp-messages")]
+use ::nanvix::log as syslog;
 use ::reqwest::header::{
     CONTENT_TYPE,
     HeaderMap,
@@ -1034,10 +1037,9 @@ async fn main() -> Result<()> {
         BenchmarkFlavour::BootTime => {
             #[cfg(feature = "timestamp-messages")]
             {
-                error!(
+                anyhow::bail!(
                     "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
                 );
-                return Ok(());
             }
 
             #[cfg(not(feature = "timestamp-messages"))]
@@ -1048,10 +1050,9 @@ async fn main() -> Result<()> {
         BenchmarkFlavour::ColdStart => {
             #[cfg(feature = "timestamp-messages")]
             {
-                error!(
+                anyhow::bail!(
                     "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
                 );
-                return Ok(());
             }
 
             #[cfg(not(feature = "timestamp-messages"))]
@@ -1062,10 +1063,9 @@ async fn main() -> Result<()> {
         BenchmarkFlavour::ColdStartL2 => {
             #[cfg(feature = "timestamp-messages")]
             {
-                error!(
+                anyhow::bail!(
                     "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
                 );
-                return Ok(());
             }
 
             #[cfg(not(feature = "timestamp-messages"))]
@@ -1076,11 +1076,10 @@ async fn main() -> Result<()> {
         BenchmarkFlavour::EchoBreakdown => {
             #[cfg(not(feature = "timestamp-messages"))]
             {
-                error!(
+                anyhow::bail!(
                     "WARNING: this benchmark requires Nanvix (re-) compilation with \
                      TIMESTAMP_MSG=yes"
                 );
-                return Ok(());
             }
 
             #[cfg(feature = "timestamp-messages")]
@@ -1091,11 +1090,10 @@ async fn main() -> Result<()> {
         BenchmarkFlavour::EchoBreakdownL2 => {
             #[cfg(not(feature = "timestamp-messages"))]
             {
-                error!(
+                anyhow::bail!(
                     "WARNING: this benchmark requires Nanvix (re-) compilation with \
                      TIMESTAMP_MSG=yes"
                 );
-                return Ok(());
             }
 
             #[cfg(feature = "timestamp-messages")]
@@ -1106,10 +1104,9 @@ async fn main() -> Result<()> {
         BenchmarkFlavour::RoundTripLatency => {
             #[cfg(feature = "timestamp-messages")]
             {
-                error!(
+                anyhow::bail!(
                     "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
                 );
-                return Ok(());
             }
 
             #[cfg(not(feature = "timestamp-messages"))]
@@ -1120,10 +1117,9 @@ async fn main() -> Result<()> {
         BenchmarkFlavour::WarmStart => {
             #[cfg(feature = "timestamp-messages")]
             {
-                error!(
+                anyhow::bail!(
                     "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
                 );
-                return Ok(());
             }
 
             #[cfg(not(feature = "timestamp-messages"))]
@@ -1134,10 +1130,9 @@ async fn main() -> Result<()> {
         BenchmarkFlavour::WarmStartL2 => {
             #[cfg(feature = "timestamp-messages")]
             {
-                error!(
+                anyhow::bail!(
                     "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
                 );
-                return Ok(());
             }
 
             #[cfg(not(feature = "timestamp-messages"))]
@@ -1148,10 +1143,9 @@ async fn main() -> Result<()> {
         BenchmarkFlavour::WarmStartVMM => {
             #[cfg(feature = "timestamp-messages")]
             {
-                error!(
+                anyhow::bail!(
                     "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
                 );
-                return Ok(());
             }
 
             #[cfg(not(feature = "timestamp-messages"))]
@@ -1163,7 +1157,7 @@ async fn main() -> Result<()> {
     match result {
         Ok(()) => {},
         Err(e) => {
-            error!("error running benchmark {}: {e:?}", args.benchmark());
+            anyhow::bail!("error running benchmark {}: {e:?}", args.benchmark());
 
             // In case of an error, re-run the clean up to prevent having dangling processes. Note
             // that the clean up is idempotent.

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -56,6 +56,8 @@ pub struct Args {
     log_directory: String,
     /// Flag indicating whether to deploy linuxd inside an L2 VM.
     l2: bool,
+    /// File path for the L2 snapshot.
+    l2_snapshot_path: String,
     /// Optional socket type for control plane communication (nanvixd <-> linuxd).
     control_plane_socket_type: Option<SocketType>,
     /// Optional socket type for gateway communication (client <-> linuxd stdin/stdout).
@@ -83,6 +85,8 @@ impl Args {
     pub const OPT_BIN_DIRECTORY: &'static str = "-bin-dir";
     /// Command-line option that sets the toolchain binary directory path.
     pub const OPT_TOOLCHAIN_BIN_DIRECTORY: &'static str = "-toolchain-bin-dir";
+    /// Command-line option that sets the L2 snapshot path.
+    pub const OPT_L2_SNAPSHOT_PATH: &'static str = "-l2-snapshot-path";
     /// Command-line option that redirects the console output to a file.
     pub const OPT_CONSOLE_FILE: &'static str = "-console-file";
     /// Command-line option that loads the serialized CPU topology.
@@ -128,6 +132,7 @@ impl Args {
         let mut hwloc: Option<HwLoc> = None;
         let mut log_directory: String = DEFAULT_LOG_DIRECTORY.to_string();
         let mut l2: bool = false;
+        let mut l2_snapshot_path: String = String::new();
         let mut control_plane_socket_type: Option<SocketType> = None;
         let mut gateway_socket_type: Option<SocketType> = None;
         let mut system_vm_socket_type: Option<SocketType> = None;
@@ -191,6 +196,10 @@ impl Args {
                 Self::OPT_L2 => {
                     l2 = true;
                 },
+                Self::OPT_L2_SNAPSHOT_PATH => {
+                    i += 1;
+                    l2_snapshot_path = args[i].clone();
+                },
                 Self::OPT_CONTROL_PLANE_SOCKET_TYPE => {
                     i += 1;
                     control_plane_socket_type = Some(args[i].parse()?);
@@ -215,6 +224,15 @@ impl Args {
             i += 1;
         }
 
+        // If we set the l2 snapshot path, but do not enable l2, we have an invalid configuration.
+        if !l2_snapshot_path.is_empty() && !l2 {
+            anyhow::bail!(
+                "{} must be used together with {}",
+                Self::OPT_L2_SNAPSHOT_PATH,
+                Self::OPT_L2,
+            );
+        }
+
         // If we deploy the Linux Daemon (linuxd) in an L2 VM, we need to make sure that all socket
         // types are set to TCP.
         if l2 {
@@ -233,6 +251,12 @@ impl Args {
             control_plane_socket_type = Some(SocketType::Tcp);
             gateway_socket_type = Some(SocketType::Tcp);
             system_vm_socket_type = Some(SocketType::Tcp);
+
+            // If we enable L2 deployment, and don't set a snapshot path, revert to the default
+            // path.
+            if l2_snapshot_path.is_empty() {
+                l2_snapshot_path = config::default_l2_snapshot_path();
+            }
         }
 
         // Determine operation mode: HTTP mode is active if -http-addr is provided,
@@ -263,6 +287,7 @@ impl Args {
             tmp_directory,
             binary_directory,
             toolchain_binary_directory,
+            l2_snapshot_path,
             console_file,
             hwloc,
             log_directory,
@@ -312,6 +337,7 @@ Options:
   {system_vm_socket_type} <socket_type>     Socket type for system VM communication (linuxd <-> \
              uservm).
   {l2}                                      Deploy linuxd inside an L2 VM (forces TCP sockets).
+  {l2_snapshot_path} <l2_snapshot_path>     Path to the L2 snapshot.
 ",
             program_name = program_name,
             http_addr = Self::OPT_HTTP_SOCKADDR,
@@ -326,6 +352,7 @@ Options:
             gateway_socket_type = Self::OPT_GATEWAY_SOCKET_TYPE,
             system_vm_socket_type = Self::OPT_SYSTEM_VM_SOCKET_TYPE,
             l2 = Self::OPT_L2,
+            l2_snapshot_path = Self::OPT_L2_SNAPSHOT_PATH,
         );
     }
 
@@ -379,6 +406,19 @@ Options:
     ///
     pub fn toolchain_binary_directory(&self) -> &str {
         &self.toolchain_binary_directory
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the L2 snapshot path.
+    ///
+    /// # Returns
+    ///
+    /// The L2 snapshot path.
+    ///
+    pub fn l2_snapshot_path(&self) -> &str {
+        &self.l2_snapshot_path
     }
 
     ///

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -38,3 +38,15 @@ pub const DEFAULT_LOG_DIRECTORY: &str = "./logs";
 /// Default path to the temporary directory.
 ///
 pub const DEFAULT_TMP_DIRECTORY: &str = "/tmp";
+
+///
+/// # Description
+///
+/// Default path for the L2 snapshot.
+///
+/// We cannot define this variable as a pub const &str because it depends on
+/// SNAPSHOT_NAME which is another build-time constant.
+///
+pub fn default_l2_snapshot_path() -> String {
+    format!("./images/{}", ::nanvix::config::linuxd::SNAPSHOT_NAME)
+}

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -107,6 +107,7 @@ pub async fn main() -> Result<()> {
         args.toolchain_binary_directory(),
         args.log_directory(),
         args.l2(),
+        args.l2_snapshot_path(),
         args.tmp_directory(),
     );
 


### PR DESCRIPTION
In this commit I add an optional flag to nanvixd, `-l2-snapshot-path` that can be used to overwrite the default path for the L2 VM snapshot (currently `./images/l2-sysvm-snapshot`).

This is useful in out-of-tree deployments of Nanvix, where the snapshot file may be generated, distributed, and stored independently.