### PR TITLE
[utils] E: Use `nanvix-registry` in `nanvixd`

### DIFF
--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -23,6 +23,7 @@ hwloc = { workspace = true }
 libc = { workspace = true }
 linuxd = { workspace = true }
 nanvix-sandbox = { workspace = true }
+nanvix-registry = { workspace = true }
 nanvix-sandbox-cache = { workspace = true }
 nanvix-terminal = { workspace = true }
 num_enum = { workspace = true }

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -16,14 +16,12 @@
 #![deny(clippy::expect_used)]
 
 //==================================================================================================
-// Modules
-//==================================================================================================
-
-//==================================================================================================
 // Imports
 //==================================================================================================
 
 use ::anyhow::Result;
+use ::config::system::DEFAULT_MACHINE_NAME;
+use ::nanvix_registry::Registry;
 use ::nanvix_sandbox_cache::SandboxCacheConfig;
 use ::nanvix_terminal::Terminal;
 use ::nanvixd::{
@@ -35,7 +33,23 @@ use ::syslog::{
     error,
     info,
 };
+use ::tokio::fs;
 
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Binary name for Kernel.
+const KERNEL_BINARY_NAME: &str = "kernel.elf";
+/// Binary name for Linux Daemon.
+#[cfg(not(feature = "single-process"))]
+const LINUXD_BINARY_NAME: &str = "linuxd.elf";
+/// Binary name for User VM.
+#[cfg(not(feature = "single-process"))]
+const USERVM_BINARY_NAME: &str = "uservm.elf";
+
+//==================================================================================================
+// Standalone Functions
 //==================================================================================================
 
 ///
@@ -64,13 +78,23 @@ pub async fn main() -> Result<()> {
     #[cfg(not(feature = "single-process"))]
     info!("nanvixd {} multi-process mode", env!("CARGO_PKG_VERSION"));
 
+    // Determine deployment type based on feature flag.
+    #[cfg(feature = "single-process")]
+    let deployment: &str = "single-process";
     #[cfg(not(feature = "single-process"))]
-    let linuxd_binary_path: String = format!("{}/linuxd.elf", args.binary_directory());
+    let deployment: &str = "multi-process";
 
-    let kernel_binary_path: String = format!("{}/kernel.elf", args.binary_directory());
+    // Determine target machine type from config.
+    let machine: &str = DEFAULT_MACHINE_NAME;
+
+    // Ensure all required binaries are available.
+    #[cfg(feature = "single-process")]
+    let (kernel_binary_path, _, _) =
+        ensure_all_binaries_available(&args, machine, deployment).await?;
 
     #[cfg(not(feature = "single-process"))]
-    let uservm_binary_path: String = format!("{}/uservm.elf", args.binary_directory());
+    let (kernel_binary_path, linuxd_binary_path, uservm_binary_path) =
+        ensure_all_binaries_available(&args, machine, deployment).await?;
 
     let config: SandboxCacheConfig = SandboxCacheConfig::new(
         args.control_plane_socket_type(),
@@ -135,4 +159,93 @@ pub async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+///
+/// # Description
+///
+/// Ensures all required binaries are available. Checks if all binaries exist locally first.
+/// If any binary is missing, fetches all of them from the nanvix-registry.
+///
+/// # Parameters
+///
+/// - `args`: The parsed command-line arguments.
+/// - `machine`: The target machine type (e.g., `"microvm"`, `"hyperlight"`).
+/// - `deployment`: The deployment type (e.g., `"single-process"`, `"multi-process"`).
+///
+/// # Returns
+///
+/// On success, returns a tuple containing paths to (kernel, linuxd, uservm) binaries.
+/// On failure, returns an error describing what went wrong.
+///
+async fn ensure_all_binaries_available(
+    args: &Args,
+    machine: &str,
+    deployment: &str,
+) -> Result<(String, String, String)> {
+    let kernel_binary_path: String = format!("{}/{}", args.binary_directory(), KERNEL_BINARY_NAME);
+
+    #[cfg(not(feature = "single-process"))]
+    let linuxd_binary_path: String = format!("{}/{}", args.binary_directory(), LINUXD_BINARY_NAME);
+
+    #[cfg(not(feature = "single-process"))]
+    let uservm_binary_path: String = format!("{}/{}", args.binary_directory(), USERVM_BINARY_NAME);
+
+    // Check if all binaries are available locally.
+    let kernel_available: bool = fs::metadata(&kernel_binary_path).await.is_ok();
+
+    #[cfg(feature = "single-process")]
+    let all_available: bool = kernel_available;
+
+    #[cfg(not(feature = "single-process"))]
+    let all_available: bool = {
+        let linuxd_available: bool = fs::metadata(&linuxd_binary_path).await.is_ok();
+        let uservm_available: bool = fs::metadata(&uservm_binary_path).await.is_ok();
+        kernel_available && linuxd_available && uservm_available
+    };
+
+    // If all binaries are available locally, use them.
+    if all_available {
+        info!("All required binaries found locally");
+        info!("Using local binary {}: {}", KERNEL_BINARY_NAME, kernel_binary_path);
+
+        #[cfg(not(feature = "single-process"))]
+        {
+            info!("Using local binary {}: {}", LINUXD_BINARY_NAME, linuxd_binary_path);
+            info!("Using local binary {}: {}", USERVM_BINARY_NAME, uservm_binary_path);
+        }
+
+        #[cfg(feature = "single-process")]
+        return Ok((kernel_binary_path, String::new(), String::new()));
+
+        #[cfg(not(feature = "single-process"))]
+        return Ok((kernel_binary_path, linuxd_binary_path, uservm_binary_path));
+    }
+
+    info!("Not all binaries found locally, fetching all from registry");
+
+    let registry: Registry = Registry::new();
+
+    let kernel_cached_path: String = registry
+        .get_cached_binary(machine, deployment, KERNEL_BINARY_NAME)
+        .await?;
+    info!("Using registry binary {}: {}", KERNEL_BINARY_NAME, kernel_cached_path);
+
+    #[cfg(feature = "single-process")]
+    return Ok((kernel_cached_path, String::new(), String::new()));
+
+    #[cfg(not(feature = "single-process"))]
+    {
+        let linuxd_cached_path: String = registry
+            .get_cached_binary(machine, deployment, LINUXD_BINARY_NAME)
+            .await?;
+        info!("Using registry binary {}: {}", LINUXD_BINARY_NAME, linuxd_cached_path);
+
+        let uservm_cached_path: String = registry
+            .get_cached_binary(machine, deployment, USERVM_BINARY_NAME)
+            .await?;
+        info!("Using registry binary {}: {}", USERVM_BINARY_NAME, uservm_cached_path);
+
+        Ok((kernel_cached_path, linuxd_cached_path, uservm_cached_path))
+    }
 }


### PR DESCRIPTION
This pull request enhances the binary management process in the `nanvixd` utility by introducing a mechanism to ensure that all required binaries are available before startup. If any binaries are missing locally, the system now fetches them from the `nanvix-registry`. The changes also introduce new constants for binary names and improve code organization for clarity and maintainability.

**Binary management improvements:**

* Added the `nanvix-registry` dependency to `Cargo.toml` to enable fetching binaries from a registry if they are not found locally.
* Implemented the `ensure_all_binaries_available` async function in `main.rs` to check for required binaries (`kernel.elf`, `linuxd.elf`, `uservm.elf`) and fetch them from the registry if missing. This function is now used during startup to guarantee all binaries are present. [[1]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462R80-R96) [[2]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462R162-R250)

**Code organization and clarity:**

* Introduced constants for binary names (`KERNEL_BINARY_NAME`, `LINUXD_BINARY_NAME`, `USERVM_BINARY_NAME`) to avoid hardcoding and improve maintainability.
* Cleaned up imports and removed unused module headers in `main.rs` for better readability.