### PR TITLE
[uservm] Fix Crash on Startup

### DIFF
--- a/src/libs/nanvix-sandbox/src/initialized.rs
+++ b/src/libs/nanvix-sandbox/src/initialized.rs
@@ -98,7 +98,7 @@ impl InitializedSandbox {
             self.sandbox_config.into_gateway_socket_info();
 
         // Spawn User VM.
-        let uservm: UserVm = {
+        let mut uservm: UserVm = {
             let mut locked_control_plane_socket_and_info: MutexGuard<
                 '_,
                 (SocketListener, String, SocketType),
@@ -134,8 +134,12 @@ impl InitializedSandbox {
         };
 
         // Attempt to connect to the gateway socket.
-        wait_for_gateway_connection(UnboundSocket::new(gateway_socket_type), &gateway_sockaddr)
-            .await?;
+        wait_for_gateway_connection(
+            &mut uservm,
+            UnboundSocket::new(gateway_socket_type),
+            &gateway_sockaddr,
+        )
+        .await?;
 
         Ok(RunningSandbox {
             uservm,
@@ -183,6 +187,7 @@ impl InitializedSandbox {
 ///
 /// # Parameters
 ///
+/// - `uservm`: Reference to the User VM instance.
 /// - `unbound_gateway_socket`: The unbound socket to use for connection attempts.
 /// - `gateway_sockaddr`: The address of the gateway socket to connect to.
 ///
@@ -192,11 +197,22 @@ impl InitializedSandbox {
 /// timeout, returns an error describing the connection failure.
 ///
 async fn wait_for_gateway_connection(
+    uservm: &mut UserVm,
     unbound_gateway_socket: UnboundSocket,
     gateway_sockaddr: &str,
 ) -> Result<()> {
     let now: Instant = Instant::now();
     loop {
+        // Check if user VM finished before attempting to connect to gateway.
+        if !uservm.is_running() {
+            let reason: String = format!(
+                "user VM terminated before gateway socket became available \
+                 (address={gateway_sockaddr})"
+            );
+            error!("wait_for_gateway_connection(): {reason}");
+            return Err(anyhow::anyhow!("{reason}"));
+        }
+
         match unbound_gateway_socket
             .clone()
             .connect(gateway_sockaddr)

--- a/src/libs/nanvix-sandbox/src/initialized.rs
+++ b/src/libs/nanvix-sandbox/src/initialized.rs
@@ -98,7 +98,6 @@ impl InitializedSandbox {
             self.sandbox_config.into_gateway_socket_info();
 
         // Spawn User VM.
-
         let uservm: UserVm = {
             let mut locked_control_plane_socket_and_info: MutexGuard<
                 '_,

--- a/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
@@ -253,4 +253,28 @@ impl UserVm {
             }
         }
     }
+
+    ///
+    /// # Description
+    ///
+    /// Checks if the User VM instance is still running.
+    ///
+    /// # Returns
+    ///
+    /// This function returns true if the target User VM is still running, and false otherwise.
+    ///
+    pub fn is_running(&mut self) -> bool {
+        if let Some(child) = &mut self.child {
+            match child.try_wait() {
+                Ok(Some(_status)) => false,
+                Ok(None) => true,
+                Err(e) => {
+                    warn!("is_running(): failed to query user VM status (error={e:?})");
+                    false
+                },
+            }
+        } else {
+            false
+        }
+    }
 }

--- a/src/libs/nanvix-sandbox/src/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/uservm.rs
@@ -340,4 +340,21 @@ impl UserVm {
             }
         }
     }
+
+    ///
+    /// # Description
+    ///
+    /// Checks if the User VM instance is still running.
+    ///
+    /// # Returns
+    ///
+    /// This function returns true if the target User VM is still running, and false otherwise.
+    ///
+    pub fn is_running(&mut self) -> bool {
+        if let Some(task) = &self.task {
+            !task.is_finished()
+        } else {
+            false
+        }
+    }
 }

--- a/src/libs/nanvix-sandbox/src/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/uservm.rs
@@ -43,10 +43,7 @@ use ::syslog::{
     warn,
 };
 use ::tokio::{
-    sync::{
-        mpsc,
-        Mutex,
-    },
+    sync::mpsc,
     task::JoinHandle,
     time::timeout,
 };
@@ -75,7 +72,7 @@ use ::uservm::{
 ///
 pub struct UserVm {
     /// Underlying task.
-    task: Mutex<Option<JoinHandle<Result<ExitCode>>>>,
+    task: Option<JoinHandle<Result<ExitCode>>>,
     /// Control-plane socket stream.
     control_plane_stream: SocketStream,
 }
@@ -286,7 +283,7 @@ impl UserVm {
             };
 
         Ok(Self {
-            task: Mutex::new(Some(uservm_task)),
+            task: Some(uservm_task),
             control_plane_stream,
         })
     }
@@ -314,7 +311,7 @@ impl UserVm {
         }
 
         // Wait for User VM to finish.
-        if let Some(task) = self.task.lock().await.take() {
+        if let Some(task) = self.task.take() {
             match timeout(CLEANUP_TIMEOUT, task).await {
                 Ok(join_result) => match join_result {
                     Ok(Ok(exit_status)) => {


### PR DESCRIPTION
This pull request introduces two new libraries, `nanvix` and `nanvix-http`, refactors the build system to support the new `nanvix-bench` utility, and cleans up dependencies and code organization in the `nanvix-sandbox-cache` library. The changes improve modularity, clarify dependencies, and set up new build rules for the project.

**Build system and project organization:**

* Added `nanvix` and `nanvix-http` as workspace members in `Cargo.toml`, and included them in the build and dependency lists. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L6-R6) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R24-R25) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R99-R100)
* Refactored the `Makefile` to add build, check, lint, and format rules for the new `nanvix-bench` utility, and included a new `build/make/nanvix-bench.mk` file with appropriate build logic. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L306-R307) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R326) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R348) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R453) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R467) [[6]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R506) [[7]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R520) [[8]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R564) [[9]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R673-R678) [[10]](diffhunk://#diff-d7ae164e20fb717bd169817ea5a57a85c2f2045caceff42add6d315cf21bc577R1-R31)

**Library modularization and code movement:**

* Moved HTTP-related code from `src/utils/nanvixd` to the new `src/libs/nanvix-http` library, updated module paths, and improved constant usage for HTTP headers. [[1]](diffhunk://#diff-00074bb7dcef026adcc297dc5598a0806498b034e6a09471319de986cf56b49dR1-R44) [[2]](diffhunk://#diff-6dbbf4cc3d73d08069a16dc8ae30c7eb9b375e7ad2f2e054baa61c618d10f392L14-R17) [[3]](diffhunk://#diff-6dbbf4cc3d73d08069a16dc8ae30c7eb9b375e7ad2f2e054baa61c618d10f392L217-R221) [[4]](diffhunk://#diff-7e0f48d177bb6549f694e789fcda1e88aae90a8201af4b3871d8ed41482d91c8L4-R9) [[5]](diffhunk://#diff-b0fec35479d093905a0d0574a2315f3dfd4616733a8e5ee5a74094faf3a19e5cR16-R26) [[6]](diffhunk://#diff-d808686c00571742a9432834d38eaaad3810b52170d6003195fd7c754f3c0444L15-R15)
* Updated dependencies and features in `nanvix-sandbox-cache` to remove unused dependencies (`hwloc`, `linuxd`, `syscomm`, `user-vm-api`) and changed the `single-process` feature to depend on `nanvix-sandbox/single-process` instead of `linuxd`.

**Code cleanup and simplification:**

* Simplified the `config.rs` in `nanvix-sandbox-cache` by removing standalone functions and constants that are no longer needed after the refactor, and updated type usage to reference `nanvix_sandbox` instead of `linuxd`. [[1]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L14-R17) [[2]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L102-R54) [[3]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L154-R106) [[4]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L298-R250) [[5]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L354-L487)