### PR TITLE
[nanvix-termina] Install Signal Handler for Stdin Thread

### DIFF
--- a/src/libs/nanvix-terminal/src/lib.rs
+++ b/src/libs/nanvix-terminal/src/lib.rs
@@ -20,6 +20,12 @@
 //==================================================================================================
 
 use ::anyhow::Result;
+use ::libc::{
+    c_int,
+    sigaction,
+    sigemptyset,
+    SIGUSR1,
+};
 use ::nanvix_sandbox_cache::{
     syscomm::{
         SocketStream,
@@ -34,6 +40,8 @@ use ::nanvix_sandbox_cache::{
 };
 use ::std::{
     io::Read,
+    mem,
+    ptr,
     sync::Arc,
 };
 use ::syslog::error;
@@ -70,8 +78,8 @@ const DEFAULT_APP_NAME: &str = "nanvixd-terminal";
 /// Set to 1 byte for character-by-character I/O to ensure responsive terminal interaction.
 const IO_BUFFER_SIZE: usize = 1;
 
-/// Signal used to interrupt stdin thread.
-const SIGUSR1: i32 = 10;
+/// Signal used to interrupt blocking operations in stdin thread.
+const INTERRUPT_SIGNAL: c_int = SIGUSR1;
 
 //==================================================================================================
 // Structures
@@ -242,6 +250,8 @@ impl Terminal {
     /// - `thread_id_tx`: Channel sender to send the thread ID back to the main task.
     ///
     fn stdin_thread(stdin_tx: UnboundedSender<Vec<u8>>, thread_id_tx: UnboundedSender<u64>) {
+        install_signal_handler();
+
         // Send thread ID back to the main task.
         // SAFETY: Calling pthread_self is safe as it only reads the thread ID.
         let thread_id: u64 = unsafe { libc::pthread_self() };
@@ -293,5 +303,67 @@ impl Terminal {
             .or_else(|_| ::std::env::var("USERNAME"))
             .map_err(|error| ::anyhow::anyhow!("failed to get current user name: {}", error))?;
         Ok(username)
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// No-op signal handler for SIGUSR1 used to interrupt blocking I/O operations in the stdin thread.
+///
+/// When SIGUSR1 is delivered, this handler causes any blocking system calls (such as read)
+/// to be interrupted and return EINTR, allowing the thread to exit gracefully or handle the
+/// interruption as needed. The handler itself performs no action.
+///
+extern "C" fn stdin_thread_signal_handler(_: i32) {}
+
+///
+/// # Description
+///
+/// Installs signal handler for SIGUSR1 in the stdin thread.
+///
+// SAFETY:
+// Pre-conditions:
+// - The signal handler (`stdin_thread_signal_handler`) is a no-op and only sets EINTR on blocking syscalls.
+// - SIGUSR1 is not used for any other purpose in this process while this handler is installed.
+// - The handler does not perform any non-signal-safe operations (it is an empty function).
+// - The signal mask is empty, so no other signals are blocked during handler execution.
+// - No SA_RESTART flag is set, so syscalls will return EINTR as intended.
+// Post-conditions:
+// - After installation, SIGUSR1 will interrupt blocking syscalls in the thread, causing them to return EINTR.
+// - Only this thread installs this handler for SIGUSR1; no other code should modify the handler for SIGUSR1 while this is in effect.
+// Invariants:
+// - The handler remains a no-op and signal-safe.
+// - The signal mask and flags remain as specified.
+/// EINTR. This allows graceful shutdown of the stdin thread.
+///
+///
+fn install_signal_handler() {
+    // SAFETY: We install a signal handler that is a no-op so this is safe.
+    let ret: c_int = unsafe {
+        let sig_action: sigaction = sigaction {
+            sa_sigaction: stdin_thread_signal_handler as usize,
+            // Empty set to not block any other signals that may happen during signal handling.
+            sa_mask: {
+                let mut set: libc::sigset_t = mem::zeroed();
+                sigemptyset(&mut set);
+                set
+            },
+            // No SA_RESTART so that syscall will return EINTR.
+            sa_flags: 0,
+            sa_restorer: None,
+        };
+
+        sigaction(INTERRUPT_SIGNAL, &sig_action, ptr::null_mut())
+    };
+
+    if ret != 0 {
+        // Notify the error, but don't fail.
+        let errno: libc::c_int = unsafe { *libc::__errno_location() };
+        error!("error installing signal handler (errno={errno:?})");
     }
 }


### PR DESCRIPTION
This pull request introduces the new `nanvix-http` library as a standalone crate, updates build and dependency configurations to support it, and refactors related code to improve modularity and maintainability. It also adds new build rules for `nanvix-bench` and cleans up dependencies and code in the `nanvix-sandbox-cache` crate.

**Key changes:**

### New Crates and Build System Updates

* Added the `nanvix-http` crate as a new library for HTTP interfaces, moving HTTP-related code out of `nanvixd` and into its own module, with its own `Cargo.toml` and dependencies. [[1]](diffhunk://#diff-00074bb7dcef026adcc297dc5598a0806498b034e6a09471319de986cf56b49dR1-R44) [[2]](diffhunk://#diff-6dbbf4cc3d73d08069a16dc8ae30c7eb9b375e7ad2f2e054baa61c618d10f392L14-R17) [[3]](diffhunk://#diff-7e0f48d177bb6549f694e789fcda1e88aae90a8201af4b3871d8ed41482d91c8L4-R9) [[4]](diffhunk://#diff-b0fec35479d093905a0d0574a2315f3dfd4616733a8e5ee5a74094faf3a19e5cR16-R26) [[5]](diffhunk://#diff-d808686c00571742a9432834d38eaaad3810b52170d6003195fd7c754f3c0444L15-R15)
* Updated `Cargo.toml` workspace and members to include `nanvix` and `nanvix-http` libraries, and adjusted dependencies accordingly. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L6-R6) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R24-R25) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R99-R100)
* Added new build rules, linting, formatting, and cleaning targets for `nanvix-bench` in the `Makefile`, and included a dedicated `build/make/nanvix-bench.mk` file. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L306-R307) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R326) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R348) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R453) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R467) [[6]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R506) [[7]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R520) [[8]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R564) [[9]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R673-R678) [[10]](diffhunk://#diff-d7ae164e20fb717bd169817ea5a57a85c2f2045caceff42add6d315cf21bc577R1-R31)

### Code Refactoring and Cleanup

* Refactored HTTP message header constant (`HTTP_HEADER_MESSAGE_TYPE`) into the new `nanvix-http` crate and updated all references to use the new location. [[1]](diffhunk://#diff-6dbbf4cc3d73d08069a16dc8ae30c7eb9b375e7ad2f2e054baa61c618d10f392L217-R221) [[2]](diffhunk://#diff-b0fec35479d093905a0d0574a2315f3dfd4616733a8e5ee5a74094faf3a19e5cR16-R26)
* Cleaned up and simplified the `nanvix-sandbox-cache` crate:
  - Removed unused dependencies and constants.
  - Adjusted the `single-process` feature to depend on `nanvix-sandbox` instead of `linuxd`.
  - Updated references to the syscall table to use `nanvix_sandbox::SyscallTable`. [[1]](diffhunk://#diff-fa1a5365080b644e4b0283c72fcc62bfd819bd4c3894cad059b7f9de3a300afcL16-R24) [[2]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L14-R17) [[3]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L102-R54) [[4]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L154-R106) [[5]](diffhunk://#diff-27b94aeade4ded2f32138a7701a04975605cd8a3893e3f2c57fd2ecd6bbb59e4L298-R250)
  - Removed several standalone socket address builder functions and related constants that are no longer needed.

These changes modularize the HTTP interface, improve dependency management, and streamline the build process for new and existing components.