### PR TITLE
[nanvixd] Improving Logs

### DIFF
--- a/src/daemons/linuxd/src/lib.rs
+++ b/src/daemons/linuxd/src/lib.rs
@@ -374,10 +374,8 @@ impl LinuxDaemon {
                 result = control_plane_stream.read(&mut control_plane_buffer[control_plane_buffer_filled..]) => {
                     match result {
                         Ok(0) => {
-                            let reason: &'static str = "failed reading command from control-plane";
-                            error!("run(): {reason} (error=connection closed)");
-                            return Err(Error::new(ErrorCode::IoErr, reason));
-
+                            // Control-plane disconnected.
+                            break 'main_loop;
                         },
                         Ok(n) => {
                             control_plane_buffer_filled += n;
@@ -500,12 +498,12 @@ impl LinuxDaemon {
             partial_read_buffer.clear();
             num_filled += num_partial_read;
         }
-        // Post-condition: partial_read_buffer is empty.
 
+        // Post-condition: partial_read_buffer is empty.
         match locked_reader.read(&mut buf[num_filled..]).await {
             Ok(n) => {
                 if n == 0 {
-                    return Err(ErrorKind::UnexpectedEof);
+                    return Err(ErrorKind::ConnectionAborted);
                 }
                 if n + num_filled < buf.len() {
                     partial_read_buffer.extend(&buf[..(n + num_filled)]);
@@ -548,8 +546,14 @@ impl LinuxDaemon {
             let message: Message = match Self::recv(uvm_handle.get_user_vm_reader()).await {
                 Ok(m) => m,
                 Err(error_kind) => {
-                    let reason: String = format!("failed to read message (error={error_kind:?})");
-                    error!("{reason}");
+                    // Log error message only if error was not caused by a disconnection.
+                    if error_kind != ErrorKind::ConnectionAborted
+                        && error_kind != ErrorKind::WouldBlock
+                    {
+                        let reason: String =
+                            format!("failed to read message (error={error_kind:?})");
+                        error!("{reason}");
+                    }
                     return Err(uvm_id);
                 },
             };

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -41,6 +41,13 @@ use ::syslog::{
 };
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Default log-level (overridden by RUST_LOG environment variable if set).
+const DEFAULT_LOG_LEVEL: &str = "error";
+
+//==================================================================================================
 // Implementations
 //==================================================================================================
 
@@ -48,7 +55,7 @@ use ::syslog::{
 pub async fn main() -> Result<()> {
     // Parse and retrieve command-line arguments.
     let args: Args = args::Args::parse(env::args().collect())?;
-    ::syslog::init(args.log_to_file(), args.log_file_dir());
+    ::syslog::init(args.log_to_file(), DEFAULT_LOG_LEVEL, args.log_file_dir());
 
     // Work-out the socket addresses.
     let control_plane_sockaddr: &str = args.control_plane_sockaddr();

--- a/src/libs/nanvix-sandbox/src/initialized.rs
+++ b/src/libs/nanvix-sandbox/src/initialized.rs
@@ -30,6 +30,7 @@ use ::syscomm::{
 use ::syslog::{
     debug,
     error,
+    trace,
 };
 use ::tokio::{
     sync::{
@@ -201,6 +202,10 @@ async fn wait_for_gateway_connection(
     unbound_gateway_socket: UnboundSocket,
     gateway_sockaddr: &str,
 ) -> Result<()> {
+    trace!(
+        "wait_for_gateway_connection(): waiting for gateway socket to become available \
+         (address={gateway_sockaddr})"
+    );
     let now: Instant = Instant::now();
     loop {
         // Check if user VM finished before attempting to connect to gateway.

--- a/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
@@ -351,7 +351,9 @@ impl LinuxDaemon {
 
         // Send shutdown command to Linux Daemon.
         if let Err(error) = self.control_plane_stream.write_all(&msg_bytes).await {
-            warn!("shutdown(): failed to send shutdown command to linuxd (error={error:?})");
+            if error.kind() != ErrorKind::BrokenPipe {
+                error!("shutdown(): failed to send shutdown command to linuxd (error={error:?})");
+            }
         }
 
         // Wait for linuxd instance to finish.

--- a/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
@@ -224,7 +224,7 @@ impl UserVm {
 
         // Send shutdown command to User VM.
         if let Err(e) = self.control_plane_stream.write_all(&msg_bytes).await {
-            warn!("shutdown(): failed to send shutdown command to embedded user VM (error={e:?})");
+            warn!("shutdown(): failed to send shutdown command to user VM (error={e:?})");
         }
 
         // Wait for user VM instance to finish.

--- a/src/libs/syslog/src/hosted.rs
+++ b/src/libs/syslog/src/hosted.rs
@@ -35,17 +35,18 @@ pub use ::log::{
 /// # Parameters
 ///
 /// - `log_to_file`: Log to file?
+/// - `default_level`: Default log level (overridden by RUST_LOG environment variable if set).
 /// - `log_dir`: Directory to write log files to (if `log_to_file` is true).
 ///
 /// # Note
 ///
 /// If the logger cannot be initialized, the function will panic.
 ///
-pub fn init(log_to_file: bool, log_dir: String) {
+pub fn init(log_to_file: bool, default_level: &str, log_dir: String) {
     static INIT_LOG: Once = Once::new();
     INIT_LOG.call_once(|| {
-        let logger =
-            Logger::try_with_env_or_str("error").expect("malformed RUST_LOG environment variable");
+        let logger = Logger::try_with_env_or_str(default_level)
+            .expect("malformed RUST_LOG environment variable");
         if log_to_file {
             logger
                 .log_to_file(FileSpec::default().directory(log_dir))

--- a/src/libs/syslog/src/hosted.rs
+++ b/src/libs/syslog/src/hosted.rs
@@ -45,8 +45,9 @@ pub use ::log::{
 pub fn init(log_to_file: bool, default_level: &str, log_dir: String) {
     static INIT_LOG: Once = Once::new();
     INIT_LOG.call_once(|| {
-        let logger = Logger::try_with_env_or_str(default_level)
-            .expect("malformed RUST_LOG environment variable");
+        let logger: Logger = Logger::try_with_env_or_str(default_level)
+            .expect("malformed RUST_LOG environment variable")
+            .write_mode(::flexi_logger::WriteMode::Direct);
         if log_to_file {
             logger
                 .log_to_file(FileSpec::default().directory(log_dir))

--- a/src/uservm/src/main.rs
+++ b/src/uservm/src/main.rs
@@ -62,6 +62,15 @@ use ::uservm::{
 };
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Default log-level (overridden by RUST_LOG environment variable if set).
+const DEFAULT_LOG_LEVEL: &str = "error";
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
 
 #[tokio::main]
 pub async fn main() -> Result<ExitCode> {
@@ -74,7 +83,7 @@ pub async fn main() -> Result<ExitCode> {
     let stderr: Option<String> = args.take_vm_stderr();
 
     // Initialize logger. If this fails, the program will panic.
-    syslog::init(args.log_to_file(), args.log_directory());
+    syslog::init(args.log_to_file(), DEFAULT_LOG_LEVEL, args.log_directory());
 
     // Only the I/O thread channels are required here; the VMM creates its own internally.
     let (vcpu_thread_stdout_tx, io_thread_data_rx) = mpsc::channel::<Message>(CHANNEL_CAPACITY);

--- a/src/utils/echo-client/src/main.rs
+++ b/src/utils/echo-client/src/main.rs
@@ -53,13 +53,20 @@ use ::tokio::{
 };
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Default log-level (overridden by RUST_LOG environment variable if set).
+const DEFAULT_LOG_LEVEL: &str = "error";
+
+//==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging system.
-    ::syslog::init(false, String::new());
+    ::syslog::init(false, DEFAULT_LOG_LEVEL, String::new());
 
     // Parse and retrieve command-line arguments.
     let args: Args = Args::parse(env::args().collect())?;

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -120,6 +120,9 @@ use ::tokio::{
 // Constants
 //==================================================================================================
 
+/// Default log-level (overridden by RUST_LOG environment variable if set).
+const DEFAULT_LOG_LEVEL: &str = "error";
+
 // Name of this package, used for logging and error messages.
 const CARGO_PKG_NAME: &str = match option_env!("CARGO_PKG_NAME") {
     Some(cargo_pkg_name) => cargo_pkg_name,
@@ -981,7 +984,7 @@ impl Benchmark {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    log::init(false, String::new());
+    log::init(false, DEFAULT_LOG_LEVEL, String::new());
 
     // Check if RELEASE=yes was set at build time.
     match option_env!("RELEASE") {

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -515,19 +515,6 @@ Options:
     ///
     /// # Description
     ///
-    /// Indicates whether HTTP mode is enabled.
-    ///
-    /// # Returns
-    ///
-    /// `true` if HTTP mode is enabled; `false` otherwise.
-    ///
-    pub fn http_mode(&self) -> bool {
-        self.http_sockaddr.is_some()
-    }
-
-    ///
-    /// # Description
-    ///
     /// Indicates whether interactive mode is enabled.
     ///
     /// # Returns

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -37,6 +37,9 @@ use ::tokio::fs;
 // Constants
 //==================================================================================================
 
+/// Default log-level (overridden by RUST_LOG environment variable if set).
+const DEFAULT_LOG_LEVEL: &str = "info";
+
 /// Binary name for Kernel.
 const KERNEL_BINARY_NAME: &str = "kernel.elf";
 /// Binary name for Linux Daemon.
@@ -69,7 +72,7 @@ pub async fn main() -> Result<()> {
     let args: Arc<Args> =
         Arc::new(Args::parse(std::env::args().filter(|s| !s.trim().is_empty()).collect())?);
 
-    log::init(true, args.log_directory().to_string());
+    log::init(true, DEFAULT_LOG_LEVEL, args.log_directory().to_string());
 
     print_startup_info(&args);
 

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -30,7 +30,10 @@ use ::nanvix::{
     terminal::Terminal,
 };
 use ::nanvixd::args::Args;
-use ::std::sync::Arc;
+use ::std::sync::{
+    Arc,
+    OnceLock,
+};
 use ::tokio::fs;
 
 //==================================================================================================
@@ -48,6 +51,38 @@ const LINUXD_BINARY_NAME: &str = "linuxd.elf";
 /// Binary name for User VM.
 #[cfg(not(feature = "single-process"))]
 const USERVM_BINARY_NAME: &str = "uservm.elf";
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Global flag indicating whether the daemon is running in interactive mode. This flag is set
+/// exactly once during initialization and remains immutable thereafter.
+static INTERACTIVE_MODE: OnceLock<bool> = OnceLock::new();
+
+//==================================================================================================
+// Macros
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Logs a message using either `info!()` or `eprintln!()` depending on the mode.
+///
+/// # Parameters
+///
+/// - `fmt`: The format string.
+/// - `args`: The format arguments.
+///
+macro_rules! log_info {
+    ($fmt:expr $(, $($args:tt)*)?) => {
+        if let Some(true) = $crate::INTERACTIVE_MODE.get().copied() {
+            eprintln!($fmt $(, $($args)*)?);
+        } else {
+            ::nanvix::log::info!($fmt $(, $($args)*)?);
+        }
+    };
+}
 
 //==================================================================================================
 // Standalone Functions
@@ -73,6 +108,9 @@ pub async fn main() -> Result<()> {
         Arc::new(Args::parse(std::env::args().filter(|s| !s.trim().is_empty()).collect())?);
 
     log::init(true, DEFAULT_LOG_LEVEL, args.log_directory().to_string());
+
+    // Set the global INTERACTIVE_MODE flag.
+    let _: Result<(), bool> = INTERACTIVE_MODE.set(args.interactive_mode());
 
     print_startup_info(&args);
 
@@ -115,7 +153,7 @@ pub async fn main() -> Result<()> {
     );
 
     // Check for interactive mode or HTTP mode.
-    if args.interactive_mode() {
+    if let Some(true) = INTERACTIVE_MODE.get().copied() {
         let guest_binary_path: String = match args.program_name() {
             None => {
                 let reason: &str = "no program name specified in interactive mode";
@@ -135,7 +173,7 @@ pub async fn main() -> Result<()> {
         if let Err(error) = terminal.run(&guest_binary_path, &guest_binary_args).await {
             error!("terminal failed: {error}");
         }
-    } else if args.http_mode() {
+    } else {
         let http_sockaddr: &str = match args.http_sockaddr() {
             None => {
                 let reason: &str = "no HTTP socket address specified in HTTP mode";
@@ -149,10 +187,6 @@ pub async fn main() -> Result<()> {
         if let Err(error) = http_server.run().await {
             error!("http server failed: {error}");
         }
-    } else {
-        let reason: &str = "no operation mode specified";
-        error!("{reason}");
-        anyhow::bail!(reason);
     }
 
     Ok(())
@@ -203,12 +237,12 @@ async fn ensure_all_binaries_available(
 
     // If all binaries are available locally, use them.
     if all_available {
-        eprintln!("Using local binary {}: {}", KERNEL_BINARY_NAME, kernel_binary_path);
+        log_info!("using local binary {}: {}", KERNEL_BINARY_NAME, kernel_binary_path);
 
         #[cfg(not(feature = "single-process"))]
         {
-            eprintln!("Using local binary {}: {}", LINUXD_BINARY_NAME, linuxd_binary_path);
-            eprintln!("Using local binary {}: {}", USERVM_BINARY_NAME, uservm_binary_path);
+            log_info!("using local binary {}: {}", LINUXD_BINARY_NAME, linuxd_binary_path);
+            log_info!("using local binary {}: {}", USERVM_BINARY_NAME, uservm_binary_path);
         }
 
         #[cfg(feature = "single-process")]
@@ -218,14 +252,14 @@ async fn ensure_all_binaries_available(
         return Ok((kernel_binary_path, linuxd_binary_path, uservm_binary_path));
     }
 
-    eprintln!("Not all binaries found locally, fetching all from registry");
+    log_info!("not all binaries found locally, fetching all from registry");
 
     let registry: Registry = Registry::new();
 
     let kernel_cached_path: String = registry
         .get_cached_binary(machine, deployment, KERNEL_BINARY_NAME)
         .await?;
-    eprintln!("Using registry binary {}: {}", KERNEL_BINARY_NAME, kernel_cached_path);
+    log_info!("using registry binary {}: {}", KERNEL_BINARY_NAME, kernel_cached_path);
 
     #[cfg(feature = "single-process")]
     return Ok((kernel_cached_path, String::new(), String::new()));
@@ -235,12 +269,12 @@ async fn ensure_all_binaries_available(
         let linuxd_cached_path: String = registry
             .get_cached_binary(machine, deployment, LINUXD_BINARY_NAME)
             .await?;
-        eprintln!("Using registry binary {}: {}", LINUXD_BINARY_NAME, linuxd_cached_path);
+        log_info!("using registry binary {}: {}", LINUXD_BINARY_NAME, linuxd_cached_path);
 
         let uservm_cached_path: String = registry
             .get_cached_binary(machine, deployment, USERVM_BINARY_NAME)
             .await?;
-        eprintln!("Using registry binary {}: {}", USERVM_BINARY_NAME, uservm_cached_path);
+        log_info!("using registry binary {}: {}", USERVM_BINARY_NAME, uservm_cached_path);
 
         Ok((kernel_cached_path, linuxd_cached_path, uservm_cached_path))
     }
@@ -265,10 +299,10 @@ fn print_startup_info(args: &Args) {
     };
 
     #[cfg(feature = "single-process")]
-    eprintln!("nanvixd {}, single-process deployment, {} mode", env!("CARGO_PKG_VERSION"), mode);
+    log_info!("nanvixd {}, single-process deployment, {} mode", env!("CARGO_PKG_VERSION"), mode);
 
     #[cfg(not(feature = "single-process"))]
-    eprintln!(
+    log_info!(
         "nanvixd {}, multi-process deployment, {} mode, l2 {}",
         env!("CARGO_PKG_VERSION"),
         mode,


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the codebase, primarily focused on logging consistency, error handling, and code clarity. The most significant changes include standardizing logger initialization with a configurable default log level, refining error handling and reporting (especially for connection-related errors), and introducing a more flexible logging macro for interactive and non-interactive modes in `nanvixd`. Additionally, some code cleanup and minor messaging improvements were made.

**Logging improvements and standardization:**

* All binaries now initialize their loggers with a `DEFAULT_LOG_LEVEL` constant, which can be overridden by the `RUST_LOG` environment variable. The `init` function in `syslog`/`log` now takes a `default_level` parameter, improving configurability and consistency across components. [[1]](diffhunk://#diff-d500df32df8cd908ce7b0bae1f96322191f095d9a8fc8f048702ae2f63398c76R43-R49) [[2]](diffhunk://#diff-d500df32df8cd908ce7b0bae1f96322191f095d9a8fc8f048702ae2f63398c76L51-R58) [[3]](diffhunk://#diff-fe0565b18718b2d6670e8c40443a16f527c49dbe78e5ed02df648fd3fe12bdd3R64-R72) [[4]](diffhunk://#diff-fe0565b18718b2d6670e8c40443a16f527c49dbe78e5ed02df648fd3fe12bdd3L77-R86) [[5]](diffhunk://#diff-3831b74d46c7d7279ae73ab13a9506a82c0a0a658993c72e8aba2b64f8f7932dR55-R69) [[6]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bR123-R125) [[7]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL984-R987) [[8]](diffhunk://#diff-1aedb9bac137cab03b569c9748ee1f05f8b084badb4d04c7d8ec52f6dc1e066cR38-R50) [[9]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L33-R45) [[10]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462R55-R85) [[11]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L72-R112)
* Introduced a `log_info!` macro and a global `INTERACTIVE_MODE` flag in `nanvixd`, allowing info-level messages to be routed to either `eprintln!` or the logger depending on the mode. This ensures user-facing messages are visible in interactive sessions and properly logged otherwise. [[1]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462R55-R85) [[2]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L72-R112) [[3]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L115-R155) [[4]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L203-R244) [[5]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L218-R261) [[6]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L235-R276) [[7]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L265-R304)

**Error handling and reporting:**

* Improved handling of disconnections and EOFs in daemon communication: now treats control-plane disconnect as a normal exit instead of an error, and distinguishes between `UnexpectedEof` and `ConnectionAborted` for more accurate error reporting. [[1]](diffhunk://#diff-4c3eb00a2c249e839aa61c6a0d1b5cbfe914eb96d1cd03dda9cfebfa47291de1L377-R378) [[2]](diffhunk://#diff-4c3eb00a2c249e839aa61c6a0d1b5cbfe914eb96d1cd03dda9cfebfa47291de1L503-R506)
* Enhanced error logging for message reception: only logs errors if they are not caused by expected disconnections or non-blocking conditions, reducing noise in logs.
* Refined shutdown error reporting: only logs errors as errors (not warnings) if they are not due to broken pipes, and improved shutdown messaging for user VM. [[1]](diffhunk://#diff-6e1eac11a5dce6ae248f71047b49802fb115a76b19ff7e0371dbf5776dfaeeeeL354-R356) [[2]](diffhunk://#diff-d266815f475746e5199ac0df91c8e888014c93d3b218c2c98b0577ef68e2e7ddL227-R227)

**Code cleanup and messaging improvements:**

* Removed the now-unnecessary `http_mode` accessor in `nanvixd` args, simplifying operation mode selection logic. [[1]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L515-L527) [[2]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L135-R175) [[3]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L149-L152)
* Improved traceability by adding a `trace!` log when waiting for the gateway socket in the sandbox library. [[1]](diffhunk://#diff-8e76ade4a190796234ddb08b29ec6be0d33c65fba3181eb82c8741bdc6ef0c6aR33) [[2]](diffhunk://#diff-8e76ade4a190796234ddb08b29ec6be0d33c65fba3181eb82c8741bdc6ef0c6aR205-R208)
* Minor improvements to log message clarity and consistency, such as making info messages lowercase and updating shutdown warning text. [[1]](diffhunk://#diff-d266815f475746e5199ac0df91c8e888014c93d3b218c2c98b0577ef68e2e7ddL227-R227) [[2]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L203-R244) [[3]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L218-R261) [[4]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L235-R276) [[5]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L265-R304)