### PR TITLE
[tests] Tests for Terminal Mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ bincode = "2.0.1"
 bitmap = { path = "src/libs/bitmap", default-features = false }
 cc = "1.2.26"
 cfg-if = "1.0.0"
+chrono = "0.4.42"
 config = { path = "src/libs/config", default-features = false }
 control-plane-api = { path = "src/libs/control-plane-api", default-features = false }
 dirs = "6.0"

--- a/build/make/test.mk
+++ b/build/make/test.mk
@@ -1,27 +1,51 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
-run-nanvixd-tests: | \
+# Main target for running all nanvixd tests in both HTTP and terminal modes.
+run-nanvixd-tests: | run-nanvixd-http-tests run-nanvixd-terminal-tests
+
+# HTTP mode tests: These tests run programs via nanvixd's HTTP API.
+# Program arguments and input are passed as JSON payloads.
+run-nanvixd-http-tests: | \
 	init-repo \
-	test-dlfcn-c \
-	test-echo-c \
-	test-echo-cpp \
-	test-echo-rust-nostd \
-	test-echo-wasm-rust \
-	test-file-c \
-	test-file-rust \
-	test-hello-c \
-	test-hello-cpp \
-	test-hello-wasm \
-	test-linux-app \
-	test-memory-c \
-	test-misc-c \
-	test-network-c \
-	test-python3 \
-	test-qjs \
-	test-quickjs \
-	test-arch-rust \
-	test-thread-c
+	test-nanvixd-http-dlfcn-c \
+	test-nanvixd-http-echo-c \
+	test-nanvixd-http-echo-cpp \
+	test-nanvixd-http-echo-rust-nostd \
+	test-nanvixd-http-echo-wasm-rust \
+	test-nanvixd-http-file-c \
+	test-nanvixd-http-file-rust \
+	test-nanvixd-http-hello-c \
+	test-nanvixd-http-hello-cpp \
+	test-nanvixd-http-hello-wasm \
+	test-nanvixd-http-linux-app \
+	test-nanvixd-http-memory-c \
+	test-nanvixd-http-misc-c \
+	test-nanvixd-http-network-c \
+	test-nanvixd-http-python3 \
+	test-nanvixd-http-qjs \
+	test-nanvixd-http-quickjs \
+	test-nanvixd-http-arch-rust \
+	test-nanvixd-http-thread-c
+
+# Terminal mode tests: These tests run programs directly via nanvixd's terminal interface.
+# Input is provided via stdin, and WASM/QuickJS tests are not supported (requires HTTP mode).
+run-nanvixd-terminal-tests: | \
+	init-repo \
+	test-nanvixd-terminal-echo-c \
+	test-nanvixd-terminal-echo-cpp \
+	test-nanvixd-terminal-echo-rust-nostd \
+	test-nanvixd-terminal-hello-c \
+	test-nanvixd-terminal-hello-cpp \
+	test-nanvixd-terminal-linux-app \
+	test-nanvixd-terminal-dlfcn-c \
+	test-nanvixd-terminal-file-c \
+	test-nanvixd-terminal-file-rust \
+	test-nanvixd-terminal-thread-c \
+	test-nanvixd-terminal-network-c \
+	test-nanvixd-terminal-misc-c \
+	test-nanvixd-terminal-memory-c \
+	test-nanvixd-terminal-arch-rust
 
 include build/make/test/system.mk
 include build/make/test/wasm.mk

--- a/build/make/test/quickjs.mk
+++ b/build/make/test/quickjs.mk
@@ -3,35 +3,37 @@
 
 QUICKJS_BINARY := $(SYSROOT_DIR)/bin/qjs
 
-define QUICKJS_TEST_RULE
-test-quickjs-$(1): all
+# QuickJS tests: Only HTTP mode is supported for JavaScript programs.
+# Terminal mode is not available because QuickJS requires special invocation with script arguments.
+define NANVIXD_HTTP_TEST_RULE
+test-nanvixd-http-quickjs-$(1): all
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 ifeq ($(L2_VM),yes)
 	printf "\033[31mWarning: Skipping %s on L2 (not supported, see #986).\033[0m\n" "$(2)";
 else
 	@if [ -f "$(QUICKJS_BINARY)" ]; then \
 		echo "Running test $(1)..."; \
-		$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) $(QUICKJS_BINARY) "--std $(SOURCES_DIR)/tests/quickjs/$(1).js" $(2) $(3) $(TIMEOUT); \
+		$(SCRIPTS_DIR)/test-nanvixd.sh http $(NANVIXD_SOCKADDR) $(QUICKJS_BINARY) "--std $(SOURCES_DIR)/tests/quickjs/$(1).js" $(2) $(3) $(TIMEOUT); \
 	fi
 endif
 endif
 endef
 
-$(eval $(call QUICKJS_TEST_RULE,test_bigint,'','ok'))
-$(eval $(call QUICKJS_TEST_RULE,test_builtin,'','ok'))
-$(eval $(call QUICKJS_TEST_RULE,test_closure,'','ok'))
-$(eval $(call QUICKJS_TEST_RULE,test_cyclic_import,'','ok'))
-$(eval $(call QUICKJS_TEST_RULE,test_language,'','ok'))
-$(eval $(call QUICKJS_TEST_RULE,test_loop,'','ok'))
-$(eval $(call QUICKJS_TEST_RULE,test_std,'','ok'))
-$(eval $(call QUICKJS_TEST_RULE,test_worker,'','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,test_bigint,'','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,test_builtin,'','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,test_closure,'','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,test_cyclic_import,'','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,test_language,'','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,test_loop,'','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,test_std,'','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,test_worker,'','ok'))
 
-test-quickjs: \
-	test-quickjs-test_bigint \
-	test-quickjs-test_builtin \
-	test-quickjs-test_closure \
-	test-quickjs-test_cyclic_import \
-	test-quickjs-test_language \
-	test-quickjs-test_loop \
-	test-quickjs-test_std \
-	test-quickjs-test_worker
+test-nanvixd-http-quickjs: \
+	test-nanvixd-http-quickjs-test_bigint \
+	test-nanvixd-http-quickjs-test_builtin \
+	test-nanvixd-http-quickjs-test_closure \
+	test-nanvixd-http-quickjs-test_cyclic_import \
+	test-nanvixd-http-quickjs-test_language \
+	test-nanvixd-http-quickjs-test_loop \
+	test-nanvixd-http-quickjs-test_std \
+	test-nanvixd-http-quickjs-test_worker

--- a/build/make/test/system.mk
+++ b/build/make/test/system.mk
@@ -8,8 +8,11 @@ comma:=,
 # from the root of the source tree.
 MICROVM_L2_BLOCKLIST := dlfcn-c file-c file-rust python3 qjs
 
-define TEST_RULE
-test-$(2): all
+# HTTP mode test rule: Runs tests through nanvixd's HTTP API.
+# Parameters: (binary_dir, test_name, extension, program_args, program_input, expected_output)
+# Note: program_args and program_input are passed as JSON payloads to the HTTP API.
+define NANVIXD_HTTP_TEST_RULE
+test-nanvixd-http-$(2): all
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 ifeq ($(L2_VM),yes)
 	@if [ ! -f "$(1)/$(2)$(3)" ]; then \
@@ -18,32 +21,63 @@ ifeq ($(L2_VM),yes)
 		printf "\033[31mWarning: Skipping %s on L2 (not supported, see #986).\033[0m\n" "$(2)"; \
 	else \
 		echo "Running test $(2)..."; \
-		$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) "$(1)/$(2)$(3)" $(4) $(5) $(6) $(TIMEOUT); \
+		$(SCRIPTS_DIR)/test-nanvixd.sh http $(NANVIXD_SOCKADDR) "$(1)/$(2)$(3)" $(4) $(5) $(6) $(TIMEOUT); \
 	fi
 else
 	@if [ ! -f "$(1)/$(2)$(3)" ]; then \
 		printf "\033[31mWarning: %s missing, skipping test.\033[0m\n" "$(1)/$(2)$(3)"; \
 	else \
 		echo "Running test $(2)..."; \
-		$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) "$(1)/$(2)$(3)" $(4) $(5) $(6) $(TIMEOUT); \
+		$(SCRIPTS_DIR)/test-nanvixd.sh http $(NANVIXD_SOCKADDR) "$(1)/$(2)$(3)" $(4) $(5) $(6) $(TIMEOUT); \
 	fi
 endif
 endif
 endef
 
-$(eval $(call TEST_RULE,$(BINARIES_DIR),echo-c,.elf,'','hello world!','hello world!'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),echo-cpp,.elf,'','["hello world!"]','hello world!'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),echo-rust-nostd,.elf,'','["hello world!"]','hello world!'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),hello-c,.elf,'','[]','Hello$(comma) world from C!'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),hello-cpp,.elf,'','[]','Hello$(comma) world from C++!'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),linux-app,.elf,'','[]','ok'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),dlfcn-c,.elf,'','[]','ok'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),file-c,.elf,'','[]','ok'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),file-rust,.elf,'','[]','ok'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),thread-c,.elf,'','[]','ok'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),network-c,.elf,'','[]','ok'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),misc-c,.elf,'','[]','ok'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),memory-c,.elf,'','[]','ok'))
-$(eval $(call TEST_RULE,$(BINARIES_DIR),arch-rust,.elf,'','[]','ok'))
-$(eval $(call TEST_RULE,$(SYSROOT_DIR)/bin,python3,,'$(SOURCES_DIR)/user/hello-python/__main__.py','','Hello$(comma) from Python!'))
-$(eval $(call TEST_RULE,$(SYSROOT_DIR)/bin,qjs,,'$(SOURCES_DIR)/user/hello-js/index.js','','Hello$(comma) world from JavaScript!'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),echo-c,.elf,'','hello world!','hello world!'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),echo-cpp,.elf,'','["hello world!"]','hello world!'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),echo-rust-nostd,.elf,'','["hello world!"]','hello world!'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),hello-c,.elf,'','[]','Hello$(comma) world from C!'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),hello-cpp,.elf,'','[]','Hello$(comma) world from C++!'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),linux-app,.elf,'','[]','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),dlfcn-c,.elf,'','[]','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),file-c,.elf,'','[]','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),file-rust,.elf,'','[]','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),thread-c,.elf,'','[]','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),network-c,.elf,'','[]','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),misc-c,.elf,'','[]','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),memory-c,.elf,'','[]','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(BINARIES_DIR),arch-rust,.elf,'','[]','ok'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(SYSROOT_DIR)/bin,python3,,'$(SOURCES_DIR)/user/hello-python/__main__.py','','Hello$(comma) from Python!'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,$(SYSROOT_DIR)/bin,qjs,,'$(SOURCES_DIR)/user/hello-js/index.js','','Hello$(comma) world from JavaScript!'))
+
+# Terminal mode test rule: Runs tests through nanvixd's terminal interface.
+# Parameters: (binary_dir, test_name, extension, program_input, expected_output)
+# Note: Unlike HTTP mode, program_input is provided directly via stdin (not as JSON).
+# Terminal mode does not support L2 VM or interpreter-based tests (Python, QuickJS).
+define NANVIXD_TERMINAL_TEST_RULE
+test-nanvixd-terminal-$(2): $(1)/$(2)$(3)
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+ifneq ($(L2_VM),yes)
+	@echo "Running terminal $(2) test..."
+	@rm -f /tmp/*.socket || true
+	@$(SCRIPTS_DIR)/test-nanvixd.sh terminal '' "$(1)/$(2)$(3)" '' '$(4)' '$(5)' $(TIMEOUT)
+	@rm -f /tmp/*.socket || true
+endif
+endif
+endef
+
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),echo-c,.elf,hello world,hello world))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),echo-cpp,.elf,hello world,hello world))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),echo-rust-nostd,.elf,hello world,hello world))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),hello-c,.elf,,Hello$(comma) world from C!))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),hello-cpp,.elf,,Hello$(comma) world from C++!))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),linux-app,.elf,,ok))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),dlfcn-c,.elf,,ok))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),file-c,.elf,,ok))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),file-rust,.elf,,ok))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),thread-c,.elf,,ok))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),network-c,.elf,,ok))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),misc-c,.elf,,ok))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),memory-c,.elf,,ok))
+$(eval $(call NANVIXD_TERMINAL_TEST_RULE,$(BINARIES_DIR),arch-rust,.elf,,ok))

--- a/build/make/test/wasm.mk
+++ b/build/make/test/wasm.mk
@@ -3,15 +3,17 @@
 
 comma:=,
 
-define WASM_TEST_RULE
-test-$(1): all
+# WebAssembly tests: Only HTTP mode is supported for WASM programs.
+# Terminal mode is not available because WASM programs must run through wasmd.
+define NANVIXD_HTTP_TEST_RULE
+test-nanvixd-http-$(1): all
 ifeq ($(shell basename $(WASM_BINARY)),$(1).wasm)
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 	@echo "Running test $(1)..."
-	$(SCRIPTS_DIR)/test-nanvixd.sh $(NANVIXD_SOCKADDR) bin/wasmd.elf $(2) $(3) $(4) $(TIMEOUT);
+	$(SCRIPTS_DIR)/test-nanvixd.sh http $(NANVIXD_SOCKADDR) bin/wasmd.elf $(2) $(3) $(4) $(TIMEOUT);
 endif
 endif
 endef
 
-$(eval $(call WASM_TEST_RULE,echo-wasm-rust,'','["hello world!"]','hello world!'))
-$(eval $(call WASM_TEST_RULE,hello-wasm,'','[]','Hello$(comma) world!'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,echo-wasm-rust,'','["hello world!"]','hello world!'))
+$(eval $(call NANVIXD_HTTP_TEST_RULE,hello-wasm,'','[]','Hello$(comma) world!'))

--- a/doc/test.md
+++ b/doc/test.md
@@ -11,6 +11,9 @@ This document guides you through testing Nanvix.
 - [Running Full CI Pipeline](#running-full-ci-pipeline)
 - [Running Unit Tests](#running-unit-tests)
 - [Running System-Level Tests (MicroVM and Hyperlight Machines Only)](#running-system-level-tests-microvm-and-hyperlight-machines-only)
+  - [HTTP Mode Tests](#http-mode-tests)
+  - [Terminal Mode Tests](#terminal-mode-tests)
+  - [Understanding Test Modes](#understanding-test-modes)
 
 ## Running Full CI Pipeline
 
@@ -33,6 +36,43 @@ make run-unit-tests
 > ℹ️ This runs system-level tests with the default build parameters.  Check the
 [build.md](build.md) document for more information on how to change default
 build parameters.
+
+System-level tests for Nanvix can be run in two modes: HTTP mode and terminal mode.
+
+### HTTP Mode Tests
+
+HTTP mode tests run programs through nanvixd's HTTP API. This is the default mode and supports all test types including WASM and interpreter-based programs (Python, QuickJS).
+
+```bash
+make run-nanvixd-http-tests
+```
+
+### Terminal Mode Tests
+
+Terminal mode tests run programs directly through nanvixd's terminal interface. This mode provides a more direct execution path but does not support WASM or interpreter-based programs.
+
+```bash
+make run-nanvixd-terminal-tests
+```
+
+### Understanding Test Modes
+
+**HTTP Mode:**
+
+- Programs are invoked via HTTP requests to nanvixd
+- Program arguments and input are passed as JSON payloads
+- Supports all program types: native executables, WASM modules, and interpreter-based programs
+- Uses `run-nanvixd.sh` script to communicate with nanvixd server
+
+**Terminal Mode:**
+
+- Programs are invoked directly by nanvixd with a terminal interface
+- Input is provided directly via stdin (not as JSON)
+- Only supports native executables (ELF binaries)
+- Does not support WASM modules or interpreter-based programs (Python, QuickJS)
+- Does not support L2 VM deployment
+
+To run all tests (both HTTP and terminal modes):
 
 ```bash
 make run-nanvixd-tests

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+#
+# Test script for running Nanvix programs via nanvixd in HTTP or terminal mode.
+#
+# Usage:
+#   test-nanvixd.sh <MODE> <NANVIXD_SOCKADDR> <PROGRAM_NAME> <PROGRAM_ARGS> <PROGRAM_INPUT> <PROGRAM_EXPECTED_OUTPUT> [TIMEOUT]
+#
+# Arguments:
+#   MODE                       - Mode of operation: 'http' or 'terminal'
+#   NANVIXD_SOCKADDR           - Socket address for nanvixd (e.g., 127.0.0.1:8181). Empty string for terminal mode.
+#   PROGRAM_NAME               - Path to the program to execute
+#   PROGRAM_ARGS               - Arguments to pass to the program (use '' for none)
+#                                  HTTP mode: passed as JSON array (e.g., '["arg1", "arg2"]')
+#                                  Terminal mode: not supported (must be empty)
+#   PROGRAM_INPUT              - Input to feed to the program (use '' for none)
+#                                  HTTP mode: passed as JSON string
+#                                  Terminal mode: passed directly via stdin
+#   PROGRAM_EXPECTED_OUTPUT    - Expected output string to match
+#   TIMEOUT                    - Optional timeout in seconds (default: 90)
+#
+
 set -euo pipefail
 
 #===================================================================================================
@@ -19,12 +39,20 @@ source "${NANVIX_HOME}/scripts/common/utils.sh"
 # Command line arguments
 #===================================================================================================
 
-NANVIXD_SOCKADDR=$1
-PROGRAM_NAME=$2
-PROGRAM_ARGS=$3
-PROGRAM_INPUT=$4
-PROGRAM_EXPECTED_OUTPUT=$5
-TIMEOUT=${6:-90}
+# Mode of operation: 'http' or 'terminal'.
+MODE=${1:-http}
+NANVIXD_SOCKADDR=$2
+PROGRAM_NAME=$3
+PROGRAM_ARGS=$4
+PROGRAM_INPUT=$5
+PROGRAM_EXPECTED_OUTPUT=$6
+TIMEOUT=${7:-90}
+
+# Validate mode.
+if [ "${MODE}" != "http" ] && [ "${MODE}" != "terminal" ]; then
+    print_error "Invalid mode '${MODE}'. Expected 'http' or 'terminal'."
+    exit 1
+fi
 
 # Check if expected program output is empty.
 if [ -z "${PROGRAM_EXPECTED_OUTPUT}" ]; then
@@ -38,43 +66,100 @@ LOGS_DIR=${NANVIX_HOME}/logs/nanvixd-$(basename "${PROGRAM_NAME}")
 # Test execution
 #===================================================================================================
 
-# Parameters for the requests to nanvixd.
-TENANT_ID="foo"
-APP_NAME="bar"
-
-# Temporary Directory
+# Temporary Directory.
 mkdir -p "${LOGS_DIR}"
 
-RUN_COMMAND=("${NANVIX_HOME}/scripts/run-nanvixd.sh"
-    "--tenant-id" "${TENANT_ID}"
-    "--app-name" "${APP_NAME}"
-    "--nanvixd-sockaddr" "${NANVIXD_SOCKADDR}"
-    "--toolchain-bin-dir" "${TOOLCHAIN_DIR}/bin"
-    "--bin-dir" "${NANVIX_HOME}/bin"
-    "--log-level" "${LOG_LEVEL}"
-    "--"
-    "${PROGRAM_NAME}"
-)
+# Cleanup function to remove dangling socket files.
+cleanup_sockets() {
+    rm -f /tmp/*.socket 2>/dev/null || true
+}
 
-if [ -n "${PROGRAM_ARGS}" ]; then
-    RUN_COMMAND+=("${PROGRAM_ARGS}")
-fi
+# Clean up any existing socket files before starting.
+cleanup_sockets
 
-RUN_STDERR_LOG="${LOGS_DIR}/runner_$(date "+%Y_%m_%d_%H_%M").log"
+# Set up trap to clean up on exit.
+trap cleanup_sockets EXIT
 
-set +e
-PROGRAM_ACTUAL_OUTPUT=$( \
-    cd "${NANVIX_HOME}" && \
-    { printf "%s" "${PROGRAM_INPUT}"; printf '\n'; } | \
-    timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
-        "${RUN_COMMAND[@]}" 2> "${RUN_STDERR_LOG}" | tr -d '\0'
-)
-RUN_STATUS=$?
-set -e
+# HTTP mode: Test programs via nanvixd's HTTP API.
+# In this mode, program arguments and input are sent as JSON payloads to the HTTP endpoint.
+if [ "${MODE}" = "http" ]; then
+    # Parameters for the requests to nanvixd.
+    TENANT_ID="foo"
+    APP_NAME="bar"
 
-if [ "${RUN_STATUS}" -ne 0 ]; then
-    print_error "Test failed: run-nanvixd.sh exited with status ${RUN_STATUS}. See ${RUN_STDERR_LOG}."
-    exit 1
+    RUN_COMMAND=("${NANVIX_HOME}/scripts/run-nanvixd.sh"
+        "--tenant-id" "${TENANT_ID}"
+        "--app-name" "${APP_NAME}"
+        "--nanvixd-sockaddr" "${NANVIXD_SOCKADDR}"
+        "--toolchain-bin-dir" "${TOOLCHAIN_DIR}/bin"
+        "--bin-dir" "${NANVIX_HOME}/bin"
+        "--log-level" "${LOG_LEVEL}"
+        "--"
+        "${PROGRAM_NAME}"
+    )
+
+    if [ -n "${PROGRAM_ARGS}" ]; then
+        RUN_COMMAND+=("${PROGRAM_ARGS}")
+    fi
+
+    RUN_STDERR_LOG="${LOGS_DIR}/runner_$(date "+%Y_%m_%d_%H_%M").log"
+
+    set +e
+    if [ -n "${PROGRAM_INPUT}" ]; then
+        PROGRAM_ACTUAL_OUTPUT=$( \
+            cd "${NANVIX_HOME}" && \
+            printf "%s\n" "${PROGRAM_INPUT}" | \
+            timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
+                "${RUN_COMMAND[@]}" 2> "${RUN_STDERR_LOG}" | tr -d '\0'
+        )
+    else
+        PROGRAM_ACTUAL_OUTPUT=$( \
+            cd "${NANVIX_HOME}" && \
+            timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
+                "${RUN_COMMAND[@]}" < /dev/null 2> "${RUN_STDERR_LOG}" | tr -d '\0'
+        )
+    fi
+    RUN_STATUS=$?
+    set -e
+
+    if [ "${RUN_STATUS}" -ne 0 ]; then
+        print_error "Test failed: run-nanvixd.sh exited with status ${RUN_STATUS}. See ${RUN_STDERR_LOG}."
+        exit 1
+    fi
+# Terminal mode: Test programs via nanvixd's terminal interface.
+# In this mode, the program is invoked directly and input is provided via stdin (not JSON).
+else
+    # Terminal mode: directly invoke nanvixd.elf with -- separator.
+    RUN_COMMAND=("${NANVIX_HOME}/bin/nanvixd.elf" "--" "${PROGRAM_NAME}")
+
+    if [ -n "${PROGRAM_ARGS}" ]; then
+        RUN_COMMAND+=("${PROGRAM_ARGS}")
+    fi
+
+    RUN_STDERR_LOG="${LOGS_DIR}/runner_$(date "+%Y_%m_%d_%H_%M").log"
+
+    set +e
+    if [ -n "${PROGRAM_INPUT}" ]; then
+        PROGRAM_ACTUAL_OUTPUT=$( \
+            cd "${NANVIX_HOME}" && \
+            printf "%s\n" "${PROGRAM_INPUT}" | \
+            timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
+                "${RUN_COMMAND[@]}" 2> "${RUN_STDERR_LOG}" | tr -d '\0'
+        )
+    else
+        PROGRAM_ACTUAL_OUTPUT=$( \
+            cd "${NANVIX_HOME}" && \
+            timeout -s SIGINT --preserve-status --foreground "${TIMEOUT}" \
+                "${RUN_COMMAND[@]}" < /dev/null 2> "${RUN_STDERR_LOG}" | tr -d '\0'
+        )
+    fi
+    RUN_STATUS=$?
+    set -e
+
+    if [ "${RUN_STATUS}" -ne 0 ]; then
+        print_error "Test failed: nanvixd.elf exited with status ${RUN_STATUS}. See ${RUN_STDERR_LOG}."
+        exit 1
+    fi
 fi
 
 # Save program output to a log file.

--- a/src/libs/nanvix-terminal/src/lib.rs
+++ b/src/libs/nanvix-terminal/src/lib.rs
@@ -161,6 +161,10 @@ impl Terminal {
         let (stdin_tx, mut stdin_rx): (UnboundedSender<Vec<u8>>, UnboundedReceiver<Vec<u8>>) =
             mpsc::unbounded_channel();
 
+        // Create channel for EOF notification.
+        let (eof_tx, mut eof_rx): (UnboundedSender<()>, UnboundedReceiver<()>) =
+            mpsc::unbounded_channel();
+
         // Create channel for thread ID communication.
         let (thread_id_tx, mut thread_id_rx): (UnboundedSender<u64>, UnboundedReceiver<u64>) =
             mpsc::unbounded_channel();
@@ -170,7 +174,7 @@ impl Terminal {
         // Furthermore, we don't join this thread because it should run for the entire duration of
         // the terminal session.
         let _stdin_handle: ::std::thread::JoinHandle<()> = ::std::thread::spawn(move || {
-            Self::stdin_thread(stdin_tx, thread_id_tx);
+            Self::stdin_thread(stdin_tx, thread_id_tx, eof_tx);
         });
 
         // Wait for the thread ID to be sent.
@@ -183,10 +187,11 @@ impl Terminal {
         let mut stdout: Stdout = io::stdout();
         let mut gateway_buffer: [u8; IO_BUFFER_SIZE] = [0; IO_BUFFER_SIZE];
 
-        let (mut gateway_stream_rx, mut gateway_stream_tx): (
-            SocketStreamReader,
-            SocketStreamWriter,
-        ) = gateway_stream.split();
+        let (mut gateway_stream_rx, gateway_stream_tx): (SocketStreamReader, SocketStreamWriter) =
+            gateway_stream.split();
+
+        // Wrap the writer in an Option so we can drop it when EOF is reached.
+        let mut gateway_stream_tx: Option<SocketStreamWriter> = Some(gateway_stream_tx);
 
         let result: Result<(), ::anyhow::Error> = loop {
             tokio::select! {
@@ -211,11 +216,34 @@ impl Terminal {
                 },
                 // Handle input from stdin thread.
                 Some(data) = stdin_rx.recv() => {
-                    // Send data to gateway.
-                    if let Err(error) = gateway_stream_tx.write_all(&data).await {
-                        error!("failed to write to gateway: {}", error);
-                        break Err(anyhow::anyhow!(error));
+                    // Send data to gateway if writer is still available.
+                    if let Some(ref mut writer) = gateway_stream_tx {
+                        if let Err(error) = writer.write_all(&data).await {
+                            error!("failed to write to gateway: {}", error);
+                            break Err(anyhow::anyhow!(error));
+                        }
                     }
+                },
+                // Handle EOF from stdin.
+                Some(()) = eof_rx.recv() => {
+                    // Process any remaining buffered data before closing the writer.
+                    let mut eof_error: Option<::anyhow::Error> = None;
+                    while let Ok(data) = stdin_rx.try_recv() {
+                        if let Some(ref mut writer) = gateway_stream_tx {
+                            if let Err(error) = writer.write_all(&data).await {
+                                error!("failed to write remaining data to gateway: {}", error);
+                                eof_error = Some(anyhow::anyhow!(error));
+                                break;
+                            }
+                        }
+                    }
+                    // If an error occurred while processing buffered data, propagate it.
+                    if let Some(error) = eof_error {
+                        break Err(error);
+                    }
+                    // Drop the gateway writer to signal EOF to the guest program.
+                    gateway_stream_tx = None;
+                    // Continue reading from gateway until it closes.
                 },
                 _ = signals.recv() => {
                     break Ok(());
@@ -248,8 +276,13 @@ impl Terminal {
     ///
     /// - `stdin_tx`: Channel sender to forward stdin data to the async task.
     /// - `thread_id_tx`: Channel sender to send the thread ID back to the main task.
+    /// - `eof_tx`: Channel sender to notify when EOF is reached on stdin.
     ///
-    fn stdin_thread(stdin_tx: UnboundedSender<Vec<u8>>, thread_id_tx: UnboundedSender<u64>) {
+    fn stdin_thread(
+        stdin_tx: UnboundedSender<Vec<u8>>,
+        thread_id_tx: UnboundedSender<u64>,
+        eof_tx: UnboundedSender<()>,
+    ) {
         install_signal_handler();
 
         // Send thread ID back to the main task.
@@ -267,7 +300,8 @@ impl Terminal {
             match stdin.read(&mut buffer) {
                 Ok(n) => {
                     if n == 0 {
-                        // EOF reached.
+                        // EOF reached, notify the main task.
+                        let _ = eof_tx.send(());
                         break;
                     }
                     // Send data to async task.

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+chrono = { workspace = true, features = ["std", "clock"] }
 nanvix = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -13,9 +13,11 @@
 
 use crate::config::{
     self,
+    DEFAULT_CONSOLE_FILENAME,
     DEFAULT_LOG_DIRECTORY,
 };
 use ::anyhow::Result;
+use ::chrono::Local;
 use ::nanvix::{
     hwloc::HwLoc,
     syscomm::SocketType,
@@ -128,7 +130,12 @@ impl Args {
         let mut binary_directory: String = config::DEFAULT_BIN_DIRECTORY.to_string();
         let mut toolchain_binary_directory: String =
             config::DEFAULT_TOOLCHAIN_BIN_DIRECTORY.to_string();
-        let mut console_file: Option<String> = None;
+        let mut console_file: Option<String> = Some(format!(
+            "{}/{}_{}.log",
+            DEFAULT_LOG_DIRECTORY,
+            DEFAULT_CONSOLE_FILENAME,
+            Local::now().format("%Y_%m_%d_%H_%M")
+        ));
         let mut hwloc: Option<HwLoc> = None;
         let mut log_directory: String = DEFAULT_LOG_DIRECTORY.to_string();
         let mut l2: bool = false;

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -42,6 +42,16 @@ pub const DEFAULT_TMP_DIRECTORY: &str = "/tmp";
 ///
 /// # Description
 ///
+/// Default base filename for guest console output logs.
+///
+/// The actual log file will be named as `{DEFAULT_CONSOLE_FILENAME}_YYYY_MM_DD_HH_MM.log`
+/// where the timestamp is appended to create unique log files for each guest session.
+///
+pub const DEFAULT_CONSOLE_FILENAME: &str = "guest";
+
+///
+/// # Description
+///
 /// Default path for the L2 snapshot.
 ///
 /// We cannot define this variable as a pub const &str because it depends on


### PR DESCRIPTION
This pull request introduces significant improvements to the test infrastructure and the terminal library. The main focus is to split tests for the `nanvixd` daemon into HTTP and terminal modes, update the test runner script to support both modes, and enhance the terminal's EOF handling. Additionally, there are some dependency updates and minor refactoring for clarity and maintainability.

**Test infrastructure improvements:**

* Refactored the test makefiles to separate HTTP-based and terminal-based tests, introducing new targets (`run-nanvixd-http-tests` and `run-nanvixd-terminal-tests`) and corresponding rules for each test type in `test.mk`, `system.mk`, `quickjs.mk`, and `wasm.mk`. [[1]](diffhunk://#diff-0c3cff42eb86e77a2f7c953c7bc04af17c828d75c70faece9a92861b4052d60eL4-R43) [[2]](diffhunk://#diff-0e09793c346855261398a0be6108dbc6d1157131483ef5c94476dbdcbea9132dL11-R12) [[3]](diffhunk://#diff-0e09793c346855261398a0be6108dbc6d1157131483ef5c94476dbdcbea9132dL21-R76) [[4]](diffhunk://#diff-6053d12cf0189aaa65b2b0f177c4792f0c25c01b2abda427347adcff77076e96L6-R37) [[5]](diffhunk://#diff-084e1387557aab52e633cfceed4fa27bb761dd746bde631c08b63425169f2df5L6-R17)
* Updated the test runner script `test-nanvixd.sh` to accept a mode parameter (`http` or `terminal`), handle different execution paths for each mode, and manage socket cleanup more robustly. [[1]](diffhunk://#diff-00882a622663497c577fbf863301b9b4c552a64f67b741f908084107f12d181fR3-R18) [[2]](diffhunk://#diff-00882a622663497c577fbf863301b9b4c552a64f67b741f908084107f12d181fL22-R51) [[3]](diffhunk://#diff-00882a622663497c577fbf863301b9b4c552a64f67b741f908084107f12d181fR65-L47) [[4]](diffhunk://#diff-00882a622663497c577fbf863301b9b4c552a64f67b741f908084107f12d181fR102-R155)

**Terminal library enhancements:**

* Improved EOF handling in the `nanvix-terminal` library by introducing a dedicated channel to signal EOF from the stdin thread to the main async task, ensuring proper shutdown and resource cleanup. [[1]](diffhunk://#diff-84513b169819ff7fce72519c9bc3f1bd7aabfe9df31c3c3b7064573f90c19af1R164-R167) [[2]](diffhunk://#diff-84513b169819ff7fce72519c9bc3f1bd7aabfe9df31c3c3b7064573f90c19af1L173-R177) [[3]](diffhunk://#diff-84513b169819ff7fce72519c9bc3f1bd7aabfe9df31c3c3b7064573f90c19af1L186-R194) [[4]](diffhunk://#diff-84513b169819ff7fce72519c9bc3f1bd7aabfe9df31c3c3b7064573f90c19af1L214-R240) [[5]](diffhunk://#diff-84513b169819ff7fce72519c9bc3f1bd7aabfe9df31c3c3b7064573f90c19af1R273-R279) [[6]](diffhunk://#diff-84513b169819ff7fce72519c9bc3f1bd7aabfe9df31c3c3b7064573f90c19af1L270-R298)

**Dependency updates:**

* Added the `chrono` crate as a dependency in `Cargo.toml` and `src/utils/nanvixd/Cargo.toml` for improved time handling. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R74) [[2]](diffhunk://#diff-70d9f8c53230dcd2f3827254f3c813590074e072224f4fd6986ab1b61c275d1fR15)

**Minor codebase refactoring:**

* Cleaned up imports and improved clarity in `src/utils/nanvixd/src/args.rs` by explicitly importing `DEFAULT_CONSOLE_FILENAME`.