### PR TITLE
[nanvix-sandbox] Spawn `linuxd` and `uservm` in Their Own Threads

### DIFF
--- a/src/libs/nanvix-sandbox/src/single_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/linuxd.rs
@@ -39,8 +39,12 @@ use ::syslog::{
     warn,
 };
 use ::tokio::{
+    runtime::Handle,
     sync::Mutex,
-    task::JoinHandle,
+    task::{
+        self,
+        JoinHandle,
+    },
     time::timeout,
 };
 
@@ -128,12 +132,14 @@ impl LinuxDaemon {
         })?;
 
         // Spawn a task to run the Linux Daemon.
-        let linuxd_task: JoinHandle<Result<()>> = ::tokio::spawn(async move {
-            let result = linuxd.run().await;
-            if let Err(ref err) = result {
-                error!("spawn(): linuxd terminated with error (error={err:?})");
-            }
-            result.map_err(|e| anyhow::anyhow!("linuxd run failed: {e:?}"))
+        let linuxd_task: JoinHandle<Result<()>> = task::spawn_blocking(move || {
+            Handle::current().block_on(async move {
+                let result = linuxd.run().await;
+                if let Err(ref err) = result {
+                    error!("spawn(): linuxd terminated with error (error={err:?})");
+                }
+                result.map_err(|e| anyhow::anyhow!("linuxd run failed: {e:?}"))
+            })
         });
 
         // Wait for the linuxd to connect to the control-plane socket.

--- a/src/libs/nanvix-sandbox/src/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/uservm.rs
@@ -61,6 +61,8 @@ use ::uservm::{
     },
     UserVm as EmbeddedUserVm,
     CHANNEL_CAPACITY,
+    CONTROL_PLANE_CONNECT_TIMEOUT,
+    SYSTEM_VM_CONNECT_TIMEOUT,
 };
 
 //==================================================================================================
@@ -136,72 +138,92 @@ impl UserVm {
                 mpsc::channel::<IoControlResponse>(CHANNEL_CAPACITY);
 
             // Connect to the control-plane socket.
-            let control_plane_stream: SocketStream =
-                match UnboundSocket::new(SocketType::from_str(&control_plane_sockaddr_type)?)
-                    .connect(&control_plane_addr)
-                    .await
-                {
-                    Ok(stream) => {
-                        debug!("user VM connected to control-plane (addr={control_plane_addr})");
-                        stream
-                    },
-                    Err(e) => {
-                        let reason: String = format!(
-                            "failed to connect to control plane (control_plane_addr={:?}, \
-                             error={e:?})",
-                            control_plane_addr
-                        );
-                        error!("spawn(): {reason}");
-                        anyhow::bail!("{reason}");
-                    },
-                };
+            let unbound_socket: UnboundSocket =
+                UnboundSocket::new(SocketType::from_str(&control_plane_sockaddr_type)?);
+            let control_plane_stream: SocketStream = match timeout(
+                CONTROL_PLANE_CONNECT_TIMEOUT,
+                unbound_socket.connect(&control_plane_addr),
+            )
+            .await
+            {
+                Ok(Ok(stream)) => {
+                    debug!("user VM connected to control-plane (addr={control_plane_addr})");
+                    stream
+                },
+                Ok(Err(e)) => {
+                    let reason: String = format!(
+                        "failed to connect to control plane (control_plane_addr={:?}, error={e:?})",
+                        control_plane_addr
+                    );
+                    error!("spawn(): {reason}");
+                    return Err(anyhow::anyhow!("{reason}"));
+                },
+                Err(_elapsed) => {
+                    let reason: String = format!(
+                        "timed out trying to connect to control plane (control_plane_addr={:?})",
+                        control_plane_addr
+                    );
+                    error!("spawn(): {reason}");
+                    return Err(anyhow::anyhow!("{reason}"));
+                },
+            };
 
             // Connect to the system VM socket.
-            let mut system_vm_stream: SocketStream =
-                match UnboundSocket::new(SocketType::from_str(&system_vm_sockaddr_type)?)
-                    .connect(&system_vm_addr)
+            let unbound_socket: UnboundSocket =
+                UnboundSocket::new(SocketType::from_str(&system_vm_sockaddr_type)?);
+            let system_vm_stream: SocketStream =
+                match timeout(SYSTEM_VM_CONNECT_TIMEOUT, unbound_socket.connect(&system_vm_addr))
                     .await
                 {
-                    Ok(stream) => {
+                    Ok(Ok(mut stream)) => {
                         info!(
                             "spawn(): connected to system VM (system_vm_addr={:?})",
                             system_vm_addr
                         );
+                        let new_msg: NewUserVm = match NewUserVm::new(
+                            user_vm_id,
+                            gateway_sockaddr.clone(),
+                            SocketType::from_str(&gateway_sockaddr_type)?,
+                        ) {
+                            Ok(message) => message,
+                            Err(e) => {
+                                let reason: String = format!(
+                                    "failed to construct user VM registration message \
+                                     (error={e:?})"
+                                );
+                                error!("spawn(): {reason}");
+                                return Err(anyhow::anyhow!(reason));
+                            },
+                        };
+
+                        debug!("forwarding user vm information to system vm");
+                        let new_msg_bytes: [u8; NEW_USER_VM_MESSAGE_LEN] = new_msg.to_bytes();
+                        if let Err(e) = stream.write_all(&new_msg_bytes).await {
+                            let reason: String = format!(
+                                "failed to send user VM registration message (error={e:?})"
+                            );
+                            error!("spawn(): {reason}");
+                            return Err(anyhow::anyhow!(reason));
+                        }
                         stream
                     },
-                    Err(error) => {
+                    Ok(Err(e)) => {
                         let reason: String = format!(
-                            "failed to connect to system VM (system_vm_addr={:?}, error={error:?})",
+                            "failed to connect to system VM (system_vm_addr={:?}, error={e:?})",
                             system_vm_addr
                         );
                         error!("spawn(): {reason}");
-                        anyhow::bail!("{reason}");
+                        return Err(anyhow::anyhow!("{reason}"));
+                    },
+                    Err(_) => {
+                        let reason: String = format!(
+                            "timed out trying to connect to system VM (system_vm_addr={:?})",
+                            system_vm_addr
+                        );
+                        error!("spawn(): {reason}");
+                        return Err(anyhow::anyhow!("{reason}"));
                     },
                 };
-
-            // Send NewUserVm registration to linuxd.
-            let new_msg: NewUserVm = match NewUserVm::new(
-                user_vm_id,
-                gateway_sockaddr.clone(),
-                SocketType::from_str(&gateway_sockaddr_type)?,
-            ) {
-                Ok(message) => message,
-                Err(error) => {
-                    let reason: String = format!(
-                        "failed to construct user VM registration message (error={error:?})"
-                    );
-                    error!("spawn(): {reason}");
-                    anyhow::bail!(reason);
-                },
-            };
-            debug!("forwarding user vm information to system vm");
-            let new_msg_bytes: [u8; NEW_USER_VM_MESSAGE_LEN] = new_msg.to_bytes();
-            if let Err(e) = system_vm_stream.write_all(&new_msg_bytes).await {
-                let reason: String =
-                    format!("failed to send user VM registration message (error={e:?})");
-                error!("spawn(): {reason}");
-                anyhow::bail!(reason);
-            }
 
             // Spawn I/O thread.
             let io_thread: JoinHandle<Result<()>> = IoThread::spawn(

--- a/src/libs/nanvix-sandbox/src/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/uservm.rs
@@ -39,6 +39,7 @@ use ::syscomm::{
 use ::syslog::{
     debug,
     error,
+    info,
     trace,
     warn,
 };
@@ -50,6 +51,7 @@ use ::tokio::{
 use ::user_vm_api::{
     NewUserVm,
     UserVmIdentifier,
+    NEW_USER_VM_MESSAGE_LEN,
 };
 use ::uservm::{
     io_thread::IoThread,
@@ -110,7 +112,7 @@ impl UserVm {
 
         // Clone configuration values to move to User VM task.
         let control_plane_addr: String = args.control_plane_socket_info().0.clone();
-        let user_vm_addr: String = args.system_vm_socket_info().0.clone();
+        let system_vm_addr: String = args.system_vm_socket_info().0.clone();
         let gateway_sockaddr: String = args.gateway_socket_info().0.clone();
         let kernel_filename: String = args.kernel_binary_path().to_string();
         let initrd_filename: String = args.program().to_string();
@@ -140,39 +142,40 @@ impl UserVm {
                     .await
                 {
                     Ok(stream) => {
-                        debug!(
-                            "embedded user VM connected to control-plane \
-                             (addr={control_plane_addr})"
-                        );
+                        debug!("user VM connected to control-plane (addr={control_plane_addr})");
                         stream
                     },
                     Err(e) => {
-                        let reason = format!(
-                            "failed to connect embedded user VM to control-plane \
-                             (addr={control_plane_addr}, error={e:?})"
+                        let reason: String = format!(
+                            "failed to connect to control plane (control_plane_addr={:?}, \
+                             error={e:?})",
+                            control_plane_addr
                         );
                         error!("spawn(): {reason}");
-                        anyhow::bail!(reason);
+                        anyhow::bail!("{reason}");
                     },
                 };
 
             // Connect to the system VM socket.
             let mut system_vm_stream: SocketStream =
                 match UnboundSocket::new(SocketType::from_str(&system_vm_sockaddr_type)?)
-                    .connect(&user_vm_addr)
+                    .connect(&system_vm_addr)
                     .await
                 {
                     Ok(stream) => {
-                        debug!("embedded user VM connected to linuxd (addr={user_vm_addr})");
+                        info!(
+                            "spawn(): connected to system VM (system_vm_addr={:?})",
+                            system_vm_addr
+                        );
                         stream
                     },
                     Err(error) => {
-                        let reason = format!(
-                            "failed to connect embedded user VM to linuxd (addr={user_vm_addr}, \
-                             error={error:?})"
+                        let reason: String = format!(
+                            "failed to connect to system VM (system_vm_addr={:?}, error={error:?})",
+                            system_vm_addr
                         );
                         error!("spawn(): {reason}");
-                        anyhow::bail!(reason);
+                        anyhow::bail!("{reason}");
                     },
                 };
 
@@ -185,20 +188,17 @@ impl UserVm {
                 Ok(message) => message,
                 Err(error) => {
                     let reason: String = format!(
-                        "failed to create embedded user VM registration message \
-                         (user_vm_id={user_vm_id}, gateway_sockaddr={gateway_sockaddr}, \
-                         error={error:?})"
+                        "failed to construct user VM registration message (error={error:?})"
                     );
                     error!("spawn(): {reason}");
                     anyhow::bail!(reason);
                 },
             };
-            debug!("forwarding embedded user VM registration to linuxd");
-            let new_msg_bytes: [u8; ::user_vm_api::NEW_USER_VM_MESSAGE_LEN] = new_msg.to_bytes();
+            debug!("forwarding user vm information to system vm");
+            let new_msg_bytes: [u8; NEW_USER_VM_MESSAGE_LEN] = new_msg.to_bytes();
             if let Err(e) = system_vm_stream.write_all(&new_msg_bytes).await {
-                let reason: String = format!(
-                    "failed to forward embedded user VM registration to linuxd (error={e:?})"
-                );
+                let reason: String =
+                    format!("failed to send user VM registration message (error={e:?})");
                 error!("spawn(): {reason}");
                 anyhow::bail!(reason);
             }
@@ -228,8 +228,10 @@ impl UserVm {
 
             // Wait for VMM thread to finish.
             let result: Result<ExitCode> = match vmm_handle.await? {
-                Ok(0) => Ok(ExitCode::from(0)),
-                Ok(exit_status) if exit_status != 0 => {
+                Ok(exit_status) => {
+                    if exit_status == 0 {
+                        return Ok(ExitCode::from(0));
+                    }
                     let exit_code_result: ::std::result::Result<u8, ::std::num::TryFromIntError> =
                         exit_status.try_into();
                     match exit_code_result {
@@ -238,21 +240,21 @@ impl UserVm {
                             let reason: String = format!(
                                 "failed to convert exit status (exit_status={exit_status})"
                             );
-                            error!("main(): {reason}");
+                            error!("spawn(): {reason}");
                             Err(anyhow::anyhow!(reason))
                         },
                     }
                 },
-                _ => {
-                    let reason: String = "virtual machine failed".to_string();
-                    error!("main(): {reason}");
+                Err(error) => {
+                    let reason: String = format!("virtual machine failed ({error:?})");
+                    error!("spawn(): {reason}");
                     Err(anyhow::anyhow!(reason))
                 },
             };
 
             // Wait for I/O thread to finish.
             if let Err(error) = io_thread.await? {
-                error!("main(): I/O thread failed (error={error:?})");
+                error!("spawn(): I/O thread failed (error={error:?})");
                 // Don't bail as we want to return the VM's exit code.
             }
 
@@ -274,8 +276,8 @@ impl UserVm {
                 Err(elapsed) => {
                     uservm_task.abort();
                     let reason: String = format!(
-                        "timed-out waiting for embedded user VM to connect the control-plane \
-                         stream (error={elapsed:?})"
+                        "timed-out waiting for user VM to connect the control-plane stream \
+                         (elapsed={elapsed:?})"
                     );
                     error!("spawn(): {reason}");
                     anyhow::bail!("{reason}");

--- a/src/libs/nanvix-sandbox/src/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/uservm.rs
@@ -44,8 +44,12 @@ use ::syslog::{
     warn,
 };
 use ::tokio::{
+    runtime::Handle,
     sync::mpsc,
-    task::JoinHandle,
+    task::{
+        self,
+        JoinHandle,
+    },
     time::timeout,
 };
 use ::user_vm_api::{
@@ -127,53 +131,58 @@ impl UserVm {
         let gateway_sockaddr_type: String = args.gateway_socket_info().1.to_str().to_string();
 
         // Spawn the User VM as a new task.
-        let uservm_task: JoinHandle<Result<ExitCode>> = ::tokio::spawn(async move {
-            let (vcpu_thread_stdout_tx, io_thread_data_rx) =
-                mpsc::channel::<Message>(CHANNEL_CAPACITY);
-            let (io_thread_data_tx, memory_thread_data_rx) =
-                mpsc::channel::<Message>(CHANNEL_CAPACITY);
-            let (io_thread_control_tx, io_control_rx) =
-                mpsc::channel::<IoControlCommand>(CHANNEL_CAPACITY);
-            let (io_control_tx, io_thread_control_rx) =
-                mpsc::channel::<IoControlResponse>(CHANNEL_CAPACITY);
+        let uservm_task: JoinHandle<Result<ExitCode>> = task::spawn_blocking(move || {
+            Handle::current().block_on(async move {
+                let (vcpu_thread_stdout_tx, io_thread_data_rx) =
+                    mpsc::channel::<Message>(CHANNEL_CAPACITY);
+                let (io_thread_data_tx, memory_thread_data_rx) =
+                    mpsc::channel::<Message>(CHANNEL_CAPACITY);
+                let (io_thread_control_tx, io_control_rx) =
+                    mpsc::channel::<IoControlCommand>(CHANNEL_CAPACITY);
+                let (io_control_tx, io_thread_control_rx) =
+                    mpsc::channel::<IoControlResponse>(CHANNEL_CAPACITY);
 
-            // Connect to the control-plane socket.
-            let unbound_socket: UnboundSocket =
-                UnboundSocket::new(SocketType::from_str(&control_plane_sockaddr_type)?);
-            let control_plane_stream: SocketStream = match timeout(
-                CONTROL_PLANE_CONNECT_TIMEOUT,
-                unbound_socket.connect(&control_plane_addr),
-            )
-            .await
-            {
-                Ok(Ok(stream)) => {
-                    debug!("user VM connected to control-plane (addr={control_plane_addr})");
-                    stream
-                },
-                Ok(Err(e)) => {
-                    let reason: String = format!(
-                        "failed to connect to control plane (control_plane_addr={:?}, error={e:?})",
-                        control_plane_addr
-                    );
-                    error!("spawn(): {reason}");
-                    return Err(anyhow::anyhow!("{reason}"));
-                },
-                Err(_elapsed) => {
-                    let reason: String = format!(
-                        "timed out trying to connect to control plane (control_plane_addr={:?})",
-                        control_plane_addr
-                    );
-                    error!("spawn(): {reason}");
-                    return Err(anyhow::anyhow!("{reason}"));
-                },
-            };
+                // Connect to the control-plane socket.
+                let unbound_socket: UnboundSocket =
+                    UnboundSocket::new(SocketType::from_str(&control_plane_sockaddr_type)?);
+                let control_plane_stream: SocketStream = match timeout(
+                    CONTROL_PLANE_CONNECT_TIMEOUT,
+                    unbound_socket.connect(&control_plane_addr),
+                )
+                .await
+                {
+                    Ok(Ok(stream)) => {
+                        debug!("user VM connected to control-plane (addr={control_plane_addr})");
+                        stream
+                    },
+                    Ok(Err(e)) => {
+                        let reason: String = format!(
+                            "failed to connect to control plane (control_plane_addr={:?}, \
+                             error={e:?})",
+                            control_plane_addr
+                        );
+                        error!("spawn(): {reason}");
+                        return Err(anyhow::anyhow!("{reason}"));
+                    },
+                    Err(_elapsed) => {
+                        let reason: String = format!(
+                            "timed out trying to connect to control plane \
+                             (control_plane_addr={:?})",
+                            control_plane_addr
+                        );
+                        error!("spawn(): {reason}");
+                        return Err(anyhow::anyhow!("{reason}"));
+                    },
+                };
 
-            // Connect to the system VM socket.
-            let unbound_socket: UnboundSocket =
-                UnboundSocket::new(SocketType::from_str(&system_vm_sockaddr_type)?);
-            let system_vm_stream: SocketStream =
-                match timeout(SYSTEM_VM_CONNECT_TIMEOUT, unbound_socket.connect(&system_vm_addr))
-                    .await
+                // Connect to the system VM socket.
+                let unbound_socket: UnboundSocket =
+                    UnboundSocket::new(SocketType::from_str(&system_vm_sockaddr_type)?);
+                let system_vm_stream: SocketStream = match timeout(
+                    SYSTEM_VM_CONNECT_TIMEOUT,
+                    unbound_socket.connect(&system_vm_addr),
+                )
+                .await
                 {
                     Ok(Ok(mut stream)) => {
                         info!(
@@ -225,62 +234,66 @@ impl UserVm {
                     },
                 };
 
-            // Spawn I/O thread.
-            let io_thread: JoinHandle<Result<()>> = IoThread::spawn(
-                system_vm_stream,
-                io_thread_data_rx,
-                io_thread_data_tx,
-                io_thread_control_tx,
-                io_thread_control_rx,
-                control_plane_stream,
-            )?;
+                // Spawn I/O thread.
+                let io_thread: JoinHandle<Result<()>> = IoThread::spawn(
+                    system_vm_stream,
+                    io_thread_data_rx,
+                    io_thread_data_tx,
+                    io_thread_control_tx,
+                    io_thread_control_rx,
+                    control_plane_stream,
+                )?;
 
-            // Spawn VMM thread.
-            let vmm_handle: JoinHandle<Result<u16>> = EmbeddedUserVm::spawn(::uservm::UserVmArgs {
-                memory_size: ::config::kernel::MEMORY_SIZE,
-                kernel_filename,
-                initrd_filename: Some(initrd_filename.clone()),
-                initrd_args,
-                stderr: stderr_file,
-                vcpu_thread_stdout_tx,
-                memory_thread_data_rx,
-                io_control_rx,
-                io_control_tx,
-            });
+                // Spawn VMM thread.
+                let vmm_handle: JoinHandle<Result<u16>> =
+                    EmbeddedUserVm::spawn(::uservm::UserVmArgs {
+                        memory_size: ::config::kernel::MEMORY_SIZE,
+                        kernel_filename,
+                        initrd_filename: Some(initrd_filename.clone()),
+                        initrd_args,
+                        stderr: stderr_file,
+                        vcpu_thread_stdout_tx,
+                        memory_thread_data_rx,
+                        io_control_rx,
+                        io_control_tx,
+                    });
 
-            // Wait for VMM thread to finish.
-            let result: Result<ExitCode> = match vmm_handle.await? {
-                Ok(exit_status) => {
-                    if exit_status == 0 {
-                        return Ok(ExitCode::from(0));
-                    }
-                    let exit_code_result: ::std::result::Result<u8, ::std::num::TryFromIntError> =
-                        exit_status.try_into();
-                    match exit_code_result {
-                        Ok(code) => Ok(ExitCode::from(code)),
-                        Err(_) => {
-                            let reason: String = format!(
-                                "failed to convert exit status (exit_status={exit_status})"
-                            );
-                            error!("spawn(): {reason}");
-                            Err(anyhow::anyhow!(reason))
-                        },
-                    }
-                },
-                Err(error) => {
-                    let reason: String = format!("virtual machine failed ({error:?})");
-                    error!("spawn(): {reason}");
-                    Err(anyhow::anyhow!(reason))
-                },
-            };
+                // Wait for VMM thread to finish.
+                let result: Result<ExitCode> = match vmm_handle.await? {
+                    Ok(exit_status) => {
+                        if exit_status == 0 {
+                            return Ok(ExitCode::from(0));
+                        }
+                        let exit_code_result: ::std::result::Result<
+                            u8,
+                            ::std::num::TryFromIntError,
+                        > = exit_status.try_into();
+                        match exit_code_result {
+                            Ok(code) => Ok(ExitCode::from(code)),
+                            Err(_) => {
+                                let reason: String = format!(
+                                    "failed to convert exit status (exit_status={exit_status})"
+                                );
+                                error!("spawn(): {reason}");
+                                Err(anyhow::anyhow!(reason))
+                            },
+                        }
+                    },
+                    Err(error) => {
+                        let reason: String = format!("virtual machine failed ({error:?})");
+                        error!("spawn(): {reason}");
+                        Err(anyhow::anyhow!(reason))
+                    },
+                };
 
-            // Wait for I/O thread to finish.
-            if let Err(error) = io_thread.await? {
-                error!("spawn(): I/O thread failed (error={error:?})");
-                // Don't bail as we want to return the VM's exit code.
-            }
+                // Wait for I/O thread to finish.
+                if let Err(error) = io_thread.await? {
+                    error!("spawn(): I/O thread failed (error={error:?})");
+                    // Don't bail as we want to return the VM's exit code.
+                }
 
-            result
+                result
+            })
         });
 
         // Wait for the User VM task to connect to the control-plane socket.


### PR DESCRIPTION
This pull request refactors the startup and connection logic for both the Linux daemon and user VM in the `nanvix-sandbox` single-process runtime. The most significant changes involve improving error handling, introducing connection timeouts, and making the code more robust and readable by switching to `spawn_blocking` for certain async tasks and clarifying variable names.

**Connection and Task Spawning Improvements:**

* Switched Linux daemon and user VM task spawning from `tokio::spawn` to `task::spawn_blocking` combined with `Handle::current().block_on`, ensuring that blocking operations do not interfere with the async runtime. [[1]](diffhunk://#diff-eb229fecb7aeccb7dbf94c9582c6bd2f97ee820233b52c86aa3f544a3b8bcc92R42-R47) [[2]](diffhunk://#diff-eb229fecb7aeccb7dbf94c9582c6bd2f97ee820233b52c86aa3f544a3b8bcc92L131-R142) [[3]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00R42-R58) [[4]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L126-R135)

**Connection Robustness and Timeout Handling:**

* Added timeouts for connections to the control-plane and system VM sockets using `timeout`, and introduced explicit error handling for connection failures and timeouts. This prevents indefinite hangs and provides clearer error messages. [[1]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00R68-R69) [[2]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L137-R235)

**Code Readability and Naming:**

* Renamed `user_vm_addr` to `system_vm_addr` for clarity and improved logging and error messages throughout the user VM startup sequence. [[1]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L113-R121) [[2]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L137-R235) [[3]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L277-R315)

**Error Reporting and Logging:**

* Standardized and clarified error messages and logging, especially in failure cases for socket connections, VM registration, and thread completion. [[1]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L137-R235) [[2]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L231-R296) [[3]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L217-R249) [[4]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L277-R315)

**Constants and API Usage:**

* Updated usage of constants such as `NEW_USER_VM_MESSAGE_LEN`, `CONTROL_PLANE_CONNECT_TIMEOUT`, and `SYSTEM_VM_CONNECT_TIMEOUT` for message sizing and timeout configuration. [[1]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00R42-R58) [[2]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00R68-R69) [[3]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L137-R235)

These changes collectively enhance the reliability, maintainability, and clarity of the process startup and communication code in the sandbox.