### PR TITLE
[linuxd] Forward Context Structure to System Calls

### DIFF
--- a/src/daemons/linuxd/src/assemble.rs
+++ b/src/daemons/linuxd/src/assemble.rs
@@ -18,7 +18,6 @@ use crate::{
     syscalls::SyscallTable,
 };
 use ::anyhow::Result;
-use ::std::sync::Arc;
 use ::sys::{
     error::{
         Error,
@@ -58,7 +57,7 @@ use ::syscall::{
 // Implementations
 //==================================================================================================
 
-impl RequestAssemblerTrait for FileStatAtRequest {
+impl<T> RequestAssemblerTrait<T> for FileStatAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::FileStatAtRequest(
@@ -91,7 +90,7 @@ impl RequestAssemblerTrait for FileStatAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -99,7 +98,7 @@ impl RequestAssemblerTrait for FileStatAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for SymbolicLinkAtRequest {
+impl<T> RequestAssemblerTrait<T> for SymbolicLinkAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::SymbolicLinkAtRequest(
@@ -132,7 +131,7 @@ impl RequestAssemblerTrait for SymbolicLinkAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -140,7 +139,7 @@ impl RequestAssemblerTrait for SymbolicLinkAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for LinkAtRequest {
+impl<T> RequestAssemblerTrait<T> for LinkAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::LinkAtRequest(
@@ -173,7 +172,7 @@ impl RequestAssemblerTrait for LinkAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -181,7 +180,7 @@ impl RequestAssemblerTrait for LinkAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for ReadLinkAtRequest {
+impl<T> RequestAssemblerTrait<T> for ReadLinkAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::ReadLinkAtRequest(
@@ -214,7 +213,7 @@ impl RequestAssemblerTrait for ReadLinkAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -222,7 +221,7 @@ impl RequestAssemblerTrait for ReadLinkAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for MakeDirectoryAtRequest {
+impl<T> RequestAssemblerTrait<T> for MakeDirectoryAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::MakeDirectoryAtRequest(
@@ -257,7 +256,7 @@ impl RequestAssemblerTrait for MakeDirectoryAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -265,7 +264,7 @@ impl RequestAssemblerTrait for MakeDirectoryAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for UpdateFileAccessTimeAtRequest {
+impl<T> RequestAssemblerTrait<T> for UpdateFileAccessTimeAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::UpdateFileAccessTimeAtRequest(
@@ -304,7 +303,7 @@ impl RequestAssemblerTrait for UpdateFileAccessTimeAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -312,7 +311,7 @@ impl RequestAssemblerTrait for UpdateFileAccessTimeAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for FileChownAtRequest {
+impl<T> RequestAssemblerTrait<T> for FileChownAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::FileChownAtRequest(
@@ -345,7 +344,7 @@ impl RequestAssemblerTrait for FileChownAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -353,7 +352,7 @@ impl RequestAssemblerTrait for FileChownAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for FileChmodAtRequest {
+impl<T> RequestAssemblerTrait<T> for FileChmodAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::FileChmodAtRequest(
@@ -386,7 +385,7 @@ impl RequestAssemblerTrait for FileChmodAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -394,7 +393,7 @@ impl RequestAssemblerTrait for FileChmodAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for OpenAtRequest {
+impl<T> RequestAssemblerTrait<T> for OpenAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::OpenAtRequest(
@@ -427,7 +426,7 @@ impl RequestAssemblerTrait for OpenAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -435,7 +434,7 @@ impl RequestAssemblerTrait for OpenAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for RenameAtRequest {
+impl<T> RequestAssemblerTrait<T> for RenameAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::RenameAtRequest(
@@ -468,7 +467,7 @@ impl RequestAssemblerTrait for RenameAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -476,7 +475,7 @@ impl RequestAssemblerTrait for RenameAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for UnlinkAtRequest {
+impl<T> RequestAssemblerTrait<T> for UnlinkAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::UnlinkAtRequest(
@@ -509,7 +508,7 @@ impl RequestAssemblerTrait for UnlinkAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -517,7 +516,7 @@ impl RequestAssemblerTrait for UnlinkAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for ChangeDirectoryRequest {
+impl<T> RequestAssemblerTrait<T> for ChangeDirectoryRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::ChangeDirectoryRequest(
@@ -552,7 +551,7 @@ impl RequestAssemblerTrait for ChangeDirectoryRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -560,7 +559,7 @@ impl RequestAssemblerTrait for ChangeDirectoryRequest {
     }
 }
 
-impl RequestAssemblerTrait for FileAccessAtRequest {
+impl<T> RequestAssemblerTrait<T> for FileAccessAtRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::FileAccessAtRequest(
@@ -593,7 +592,7 @@ impl RequestAssemblerTrait for FileAccessAtRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -601,7 +600,7 @@ impl RequestAssemblerTrait for FileAccessAtRequest {
     }
 }
 
-impl RequestAssemblerTrait for PollRequest {
+impl<T> RequestAssemblerTrait<T> for PollRequest {
     fn new_assembler() -> RequestAssemblerType {
         let capacity: usize = Self::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
         RequestAssemblerType::PollRequest(
@@ -634,7 +633,7 @@ impl RequestAssemblerTrait for PollRequest {
     }
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError> {

--- a/src/daemons/linuxd/src/lib.rs
+++ b/src/daemons/linuxd/src/lib.rs
@@ -134,8 +134,14 @@ pub const WORKER_THREAD_CHANNEL_CAPACITY: usize = 1024;
 ///
 /// Linux daemon that manages user VMs and handles system calls.
 ///
-pub struct LinuxDaemon {
-    syscall_table: Arc<SyscallTable>,
+/// # Type Parameters
+///
+/// - `T`: Custom state type for the syscall table. This is passed to system call handlers and
+///   allows implementations to maintain context-specific information. Must implement `Sync + Send`.
+///   Use `()` if no custom state is required.
+///
+pub struct LinuxDaemon<T: Sync + Send + 'static> {
+    syscall_table: Arc<SyscallTable<T>>,
     assembler: Arc<Mutex<RequestAssembler>>,
     control_plane_sockaddr: String,
     control_plane_sockaddr_type: SocketType,
@@ -148,7 +154,7 @@ pub struct LinuxDaemon {
 // Implementations
 //==================================================================================================
 
-impl LinuxDaemon {
+impl<T: Sync + Send + 'static> LinuxDaemon<T> {
     ///
     /// # Description
     ///
@@ -168,7 +174,7 @@ impl LinuxDaemon {
     /// Upon failure, an error is returned.
     ///
     pub fn init(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: Arc<SyscallTable<T>>,
         control_plane_sockaddr: &str,
         control_plane_sockaddr_type: &str,
         user_vm_listener: SocketListener,
@@ -529,7 +535,7 @@ impl LinuxDaemon {
 // Internal Helpers (Tokio-based message processing)
 //==================================================================================================
 
-impl LinuxDaemon {
+impl<T: Sync + Send + 'static> LinuxDaemon<T> {
     async fn get_user_vm_messages(
         &self,
         user_vm_connections: &mut HashMap<UserVmIdentifier, UserVmHandle>,

--- a/src/daemons/linuxd/src/linux/dirent.rs
+++ b/src/daemons/linuxd/src/linux/dirent.rs
@@ -17,10 +17,7 @@ use ::core::{
     cmp,
     mem,
 };
-use ::std::{
-    ffi::CStr,
-    sync::Arc,
-};
+use ::std::ffi::CStr;
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
@@ -118,8 +115,8 @@ impl linux_dirent {
 //==================================================================================================
 
 /// Handles a getdents() system call request.
-pub fn do_getdents(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_getdents<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: GetDirectoryEntriesRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -143,7 +140,7 @@ pub fn do_getdents(
     debug!("libc::getdents(): fd={}, buf={:#x?}, bufsize={}", { request.fd }, rawbuf.as_ptr(), {
         bufsize
     });
-    match unsafe { handle_getdents(&syscall_table, request.fd, rawbuf.as_mut_ptr(), bufsize) } {
+    match unsafe { handle_getdents(syscall_table, request.fd, rawbuf.as_mut_ptr(), bufsize) } {
         // Failed.
         -1 => {
             let errno = unsafe { *libc::__errno_location() };
@@ -234,8 +231,8 @@ pub fn do_getdents(
 //==================================================================================================
 
 /// Handler for `getdents()` system call.
-unsafe fn handle_getdents(
-    syscall_table: &SyscallTable,
+unsafe fn handle_getdents<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     dirp: *mut u8,
     count: libc::size_t,
@@ -245,6 +242,8 @@ unsafe fn handle_getdents(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, dirp, count) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, dirp, count)
+        },
     }
 }

--- a/src/daemons/linuxd/src/linux/fcntl.rs
+++ b/src/daemons/linuxd/src/linux/fcntl.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use ::alloc::ffi::CString;
 use ::core::ffi;
-use ::std::sync::Arc;
 use ::sys::{
     error::{
         Error,
@@ -157,8 +156,8 @@ use sysapi::fcntl::file_descriptor_flags::{
 // do_openat
 //==================================================================================================
 
-pub fn do_openat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_openat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: OpenAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -190,7 +189,7 @@ pub fn do_openat(
         mode.inner()
     );
     match unsafe {
-        handle_openat(&syscall_table, dirfd.inner(), pathname.as_ptr(), flags.inner(), mode.inner())
+        handle_openat(syscall_table, dirfd.inner(), pathname.as_ptr(), flags.inner(), mode.inner())
     } {
         fd if fd >= 0 => {
             debug!("libc::openat(): fd={fd:?}");
@@ -223,8 +222,8 @@ pub fn do_openat(
 // do_unlink_at
 //==================================================================================================
 
-pub fn do_unlinkat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_unlinkat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: UnlinkAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -248,7 +247,7 @@ pub fn do_unlinkat(
     debug!("libc::unlinkat(): dirfd={:?}, pathname={pathname:?}, flags={flags:?}", dirfd.inner(),);
     match unsafe {
         handle_unlinkat(
-            &syscall_table,
+            syscall_table,
             dirfd.inner(),
             pathname.as_bytes().as_ptr() as *const i8,
             flags,
@@ -283,8 +282,8 @@ pub fn do_unlinkat(
 // do_rename_at
 //==================================================================================================
 
-pub fn do_renameat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_renameat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: RenameAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -313,7 +312,7 @@ pub fn do_renameat(
     );
     match unsafe {
         handle_renameat(
-            &syscall_table,
+            syscall_table,
             olddirfd.inner(),
             oldpath.as_bytes().as_ptr() as *const i8,
             newdirfd.inner(),
@@ -351,8 +350,8 @@ pub fn do_renameat(
 // do_fstatat
 //==================================================================================================
 
-pub fn do_fstat_at(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_fstat_at<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileStatAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -375,7 +374,7 @@ pub fn do_fstat_at(
     debug!("libc::fstatat(): dirfd={:?}, path={path:?}, flag={:?}", dirfd.inner(), flag);
     match unsafe {
         handle_fstatat(
-            &syscall_table,
+            syscall_table,
             dirfd.inner(),
             path.as_ptr(),
             &mut st as *mut libc::stat,
@@ -461,8 +460,8 @@ pub fn do_fstat_at(
 // do_posix_fallocate
 //==================================================================================================
 
-pub fn do_posix_fallocate(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_posix_fallocate<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileSpaceControlRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -473,7 +472,7 @@ pub fn do_posix_fallocate(
     let len: off_t = request.len;
 
     debug!("libc::posix_fallocate(): fd={fd:?}, offset={offset:?}, len={len:?}");
-    match unsafe { handle_posix_fallocate(&syscall_table, fd, offset, len) } {
+    match unsafe { handle_posix_fallocate(syscall_table, fd, offset, len) } {
         0 => {
             debug!("libc::posix_fallocate(): success");
             Ok(FileSpaceControlResponse::build(tid, 0))
@@ -506,8 +505,8 @@ pub fn do_posix_fallocate(
 // do_posix_fadvise
 //==================================================================================================
 
-pub fn do_posix_fadvise(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_posix_fadvise<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileAdvisoryInformationRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -525,7 +524,7 @@ pub fn do_posix_fadvise(
         "libc::posix_fadvise(): fd={fd:?}, offset={offset:?}, len={len:?}, advice={:?}",
         advice.inner()
     );
-    match unsafe { handle_posix_fadvise(&syscall_table, fd, offset, len, advice.inner()) } {
+    match unsafe { handle_posix_fadvise(syscall_table, fd, offset, len, advice.inner()) } {
         0 => {
             debug!("libc::posix_fadvise(): success");
             Ok(FileAdvisoryInformationResponse::build(tid, 0))
@@ -558,8 +557,8 @@ pub fn do_posix_fadvise(
 // do_fstat()
 //==================================================================================================
 
-pub fn do_fstat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_fstat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileStatRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -570,7 +569,7 @@ pub fn do_fstat(
     let mut st: libc::stat = unsafe { core::mem::zeroed() };
 
     debug!("libc::fstat(): fd={fd:?}");
-    match unsafe { handle_fstat(&syscall_table, fd, &mut st) } {
+    match unsafe { handle_fstat(syscall_table, fd, &mut st) } {
         0 => {
             debug!("libc::fstatat(): success");
 
@@ -650,8 +649,8 @@ pub fn do_fstat(
 // do_symlinkat()
 //==================================================================================================
 
-pub fn do_symlinkat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_symlinkat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: SymbolicLinkAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -675,7 +674,7 @@ pub fn do_symlinkat(
         newdirfd.inner(),
     );
     match unsafe {
-        handle_symlinkat(&syscall_table, target.as_ptr(), newdirfd.inner(), linkpath.as_ptr())
+        handle_symlinkat(syscall_table, target.as_ptr(), newdirfd.inner(), linkpath.as_ptr())
     } {
         0 => {
             debug!("libc::symlinkat(): success");
@@ -708,8 +707,8 @@ pub fn do_symlinkat(
 // do_readlinkat()
 //==================================================================================================
 
-pub fn do_readlinkat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_readlinkat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: ReadLinkAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -733,7 +732,7 @@ pub fn do_readlinkat(
     );
     match unsafe {
         handle_readlinkat(
-            &syscall_table,
+            syscall_table,
             dirfd.inner(),
             path.as_ptr(),
             buf.as_mut_ptr() as *mut i8,
@@ -782,8 +781,8 @@ pub fn do_readlinkat(
 // do_mkdirat()
 //==================================================================================================
 
-pub fn do_mkdirat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_mkdirat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: MakeDirectoryAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -807,8 +806,7 @@ pub fn do_mkdirat(
         dirfd.inner(),
         mode.inner()
     );
-    match unsafe { handle_mkdirat(&syscall_table, dirfd.inner(), pathname.as_ptr(), mode.inner()) }
-    {
+    match unsafe { handle_mkdirat(syscall_table, dirfd.inner(), pathname.as_ptr(), mode.inner()) } {
         0 => {
             debug!("libc::mkdirat(): success");
             Ok(vec![MakeDirectoryAtResponse::build(tid, 0)])
@@ -840,8 +838,8 @@ pub fn do_mkdirat(
 // do_utimensat()
 //==================================================================================================
 
-pub fn do_utimensat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_utimensat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: UpdateFileAccessTimeAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -879,7 +877,7 @@ pub fn do_utimensat(
         libc_times[1].tv_nsec
     );
     match unsafe {
-        handle_utimensat(&syscall_table, dirfd.inner(), path.as_ptr(), libc_times.as_ptr(), flag)
+        handle_utimensat(syscall_table, dirfd.inner(), path.as_ptr(), libc_times.as_ptr(), flag)
     } {
         0 => {
             debug!("libc::utimensat(): success");
@@ -912,8 +910,8 @@ pub fn do_utimensat(
 // do_futimens()
 //==================================================================================================
 
-pub fn do_futimens(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_futimens<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: UpdateFileAccessTimeRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -933,7 +931,7 @@ pub fn do_futimens(
          times[1].tv_sec={:?}, times[1].tv_nsec={:?}",
         libc_times[0].tv_sec, libc_times[0].tv_nsec, libc_times[1].tv_sec, libc_times[1].tv_nsec
     );
-    match unsafe { handle_futimens(&syscall_table, fd, libc_times.as_ptr()) } {
+    match unsafe { handle_futimens(syscall_table, fd, libc_times.as_ptr()) } {
         0 => {
             debug!("libc::futimens(): success");
             Ok(UpdateFileAccessTimeResponse::build(tid, 0))
@@ -965,8 +963,8 @@ pub fn do_futimens(
 // do_fcntl()
 //==================================================================================================
 
-pub fn do_fcntl(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_fcntl<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileControlRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -1043,7 +1041,7 @@ pub fn do_fcntl(
         },
     };
 
-    let ret: i32 = unsafe { handle_fcntl(&syscall_table, fd, cmd.inner(), libc_arg) };
+    let ret: i32 = unsafe { handle_fcntl(syscall_table, fd, cmd.inner(), libc_arg) };
 
     match cmd.inner() {
         libc::F_DUPFD | libc::F_DUPFD_CLOEXEC => {
@@ -1211,8 +1209,8 @@ pub fn do_fcntl(
 // do_fchownat()
 //==================================================================================================
 
-pub fn do_fchownat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_fchownat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileChownAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -1236,7 +1234,7 @@ pub fn do_fchownat(
         flag.inner()
     );
     match unsafe {
-        handle_fchownat(&syscall_table, dirfd.inner(), path.as_ptr(), owner, group, flag.inner())
+        handle_fchownat(syscall_table, dirfd.inner(), path.as_ptr(), owner, group, flag.inner())
     } {
         0 => {
             debug!("libc::fchownat(): success");
@@ -1269,8 +1267,8 @@ pub fn do_fchownat(
 // do_fchmod
 //==================================================================================================
 
-pub fn do_fchmod(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_fchmod<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileChmodRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -1280,7 +1278,7 @@ pub fn do_fchmod(
     let mode: u32 = request.mode;
 
     debug!("libc::fchmod(): fd={fd:?}, mode={mode:?}");
-    match unsafe { handle_fchmod(&syscall_table, fd, mode) } {
+    match unsafe { handle_fchmod(syscall_table, fd, mode) } {
         0 => Ok(FileChmodResponse::build(tid)),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
@@ -1305,8 +1303,8 @@ pub fn do_fchmod(
 // do_fchmodat()
 //==================================================================================================
 
-pub fn do_fchmodat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_fchmodat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileChmodAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -1335,7 +1333,7 @@ pub fn do_fchmodat(
         flag.inner()
     );
     match unsafe {
-        handle_fchmodat(&syscall_table, dirfd.inner(), path.as_ptr(), mode.inner(), flag.inner())
+        handle_fchmodat(syscall_table, dirfd.inner(), path.as_ptr(), mode.inner(), flag.inner())
     } {
         0 => {
             debug!("libc::fchmodat(): success");
@@ -1803,8 +1801,8 @@ impl LibcFileAdvice {
 //==================================================================================================
 
 /// Handler for `libc::openat()`.
-unsafe fn handle_openat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_openat<T>(
+    syscall_table: &SyscallTable<T>,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     flags: libc::c_int,
@@ -1815,13 +1813,15 @@ unsafe fn handle_openat(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(dirfd, pathname, flags, mode) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, dirfd, pathname, flags, mode)
+        },
     }
 }
 
 /// Handler for `libc::unlinkat()`.
-unsafe fn handle_unlinkat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_unlinkat<T>(
+    syscall_table: &SyscallTable<T>,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     flags: libc::c_int,
@@ -1831,13 +1831,15 @@ unsafe fn handle_unlinkat(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(dirfd, pathname, flags) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, dirfd, pathname, flags)
+        },
     }
 }
 
 /// Handler for `libc::renameat()`.
-unsafe fn handle_renameat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_renameat<T>(
+    syscall_table: &SyscallTable<T>,
     olddirfd: libc::c_int,
     oldpath: *const libc::c_char,
     newdirfd: libc::c_int,
@@ -1849,14 +1851,14 @@ unsafe fn handle_renameat(
             -1
         },
         SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(olddirfd, oldpath, newdirfd, newpath)
+            syscall_fn(&syscall_table.state, olddirfd, oldpath, newdirfd, newpath)
         },
     }
 }
 
 /// Handler for `libc::fstatat()`.
-unsafe fn handle_fstatat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_fstatat<T>(
+    syscall_table: &SyscallTable<T>,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     buf: *mut libc::stat,
@@ -1867,13 +1869,15 @@ unsafe fn handle_fstatat(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(dirfd, pathname, buf, flags) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, dirfd, pathname, buf, flags)
+        },
     }
 }
 
 /// Handler for `libc::posix_fallocate()`.
-unsafe fn handle_posix_fallocate(
-    syscall_table: &SyscallTable,
+unsafe fn handle_posix_fallocate<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     offset: off_t,
     len: off_t,
@@ -1883,13 +1887,15 @@ unsafe fn handle_posix_fallocate(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, offset, len) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, offset, len)
+        },
     }
 }
 
 /// Handler for `libc::posix_fadvise()`.
-unsafe fn handle_posix_fadvise(
-    syscall_table: &SyscallTable,
+unsafe fn handle_posix_fadvise<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     offset: off_t,
     len: off_t,
@@ -1900,13 +1906,15 @@ unsafe fn handle_posix_fadvise(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, offset, len, advice) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, offset, len, advice)
+        },
     }
 }
 
 /// Handler for `libc::fstat()`.
-unsafe fn handle_fstat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_fstat<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     buf: *mut libc::stat,
 ) -> libc::c_int {
@@ -1915,13 +1923,13 @@ unsafe fn handle_fstat(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, buf) },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state, fd, buf) },
     }
 }
 
 /// Handler for `libc::symlinkat()`.
-unsafe fn handle_symlinkat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_symlinkat<T>(
+    syscall_table: &SyscallTable<T>,
     target: *const libc::c_char,
     newdirfd: libc::c_int,
     linkpath: *const libc::c_char,
@@ -1931,13 +1939,15 @@ unsafe fn handle_symlinkat(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(target, newdirfd, linkpath) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, target, newdirfd, linkpath)
+        },
     }
 }
 
 /// Handler for `libc::readlinkat()`.
-unsafe fn handle_readlinkat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_readlinkat<T>(
+    syscall_table: &SyscallTable<T>,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     buf: *mut libc::c_char,
@@ -1948,13 +1958,15 @@ unsafe fn handle_readlinkat(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(dirfd, pathname, buf, bufsiz) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, dirfd, pathname, buf, bufsiz)
+        },
     }
 }
 
 /// Handler for `libc::mkdirat()`.
-unsafe fn handle_mkdirat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_mkdirat<T>(
+    syscall_table: &SyscallTable<T>,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     mode: libc::mode_t,
@@ -1964,13 +1976,15 @@ unsafe fn handle_mkdirat(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(dirfd, pathname, mode) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, dirfd, pathname, mode)
+        },
     }
 }
 
 /// Handler for `libc::utimensat()`.
-unsafe fn handle_utimensat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_utimensat<T>(
+    syscall_table: &SyscallTable<T>,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     times: *const libc::timespec,
@@ -1981,13 +1995,15 @@ unsafe fn handle_utimensat(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(dirfd, pathname, times, flags) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, dirfd, pathname, times, flags)
+        },
     }
 }
 
 /// Handler for `libc::futimens()`.
-unsafe fn handle_futimens(
-    syscall_table: &SyscallTable,
+unsafe fn handle_futimens<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     times: *const libc::timespec,
 ) -> libc::c_int {
@@ -1996,13 +2012,15 @@ unsafe fn handle_futimens(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, times) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, times)
+        },
     }
 }
 
 /// Handler for `libc::fcntl()`.
-unsafe fn handle_fcntl(
-    syscall_table: &SyscallTable,
+unsafe fn handle_fcntl<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     cmd: libc::c_int,
     arg: libc::c_int,
@@ -2012,13 +2030,15 @@ unsafe fn handle_fcntl(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, cmd, arg) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, cmd, arg)
+        },
     }
 }
 
 /// Handler for `libc::fchownat()`.
-unsafe fn handle_fchownat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_fchownat<T>(
+    syscall_table: &SyscallTable<T>,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     owner: libc::uid_t,
@@ -2031,14 +2051,14 @@ unsafe fn handle_fchownat(
             -1
         },
         SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(dirfd, pathname, owner, group, flags)
+            syscall_fn(&syscall_table.state, dirfd, pathname, owner, group, flags)
         },
     }
 }
 
 /// Handler for `libc::fchmod()`.
-unsafe fn handle_fchmod(
-    syscall_table: &SyscallTable,
+unsafe fn handle_fchmod<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     mode: libc::mode_t,
 ) -> libc::c_int {
@@ -2047,13 +2067,13 @@ unsafe fn handle_fchmod(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, mode) },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state, fd, mode) },
     }
 }
 
 /// Handler for `libc::fchmodat()`.
-unsafe fn handle_fchmodat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_fchmodat<T>(
+    syscall_table: &SyscallTable<T>,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     mode: libc::mode_t,
@@ -2064,6 +2084,8 @@ unsafe fn handle_fchmodat(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(dirfd, pathname, mode, flags) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, dirfd, pathname, mode, flags)
+        },
     }
 }

--- a/src/daemons/linuxd/src/linux/poll.rs
+++ b/src/daemons/linuxd/src/linux/poll.rs
@@ -12,7 +12,6 @@ use crate::{
         SyscallTable,
     },
 };
-use ::std::sync::Arc;
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
@@ -55,8 +54,8 @@ use ::syslog::{
 // do_poll()
 //==================================================================================================
 
-pub fn do_poll(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_poll<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: PollRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -79,7 +78,7 @@ pub fn do_poll(
     let timeout: libc::c_int = request.timeout;
 
     debug!("libc::poll(): nfds={nfds:?}, timeout={timeout:?}");
-    match unsafe { handle_poll(&syscall_table, fds.as_mut_ptr(), nfds, timeout) } {
+    match unsafe { handle_poll(syscall_table, fds.as_mut_ptr(), nfds, timeout) } {
         nready if nready >= 0 => {
             debug!("poll(): nready={nready:?}");
 
@@ -206,8 +205,8 @@ impl LibcPollFd {
 //==================================================================================================
 
 /// Handler for `libc::poll()`.
-unsafe fn handle_poll(
-    syscall_table: &SyscallTable,
+unsafe fn handle_poll<T>(
+    syscall_table: &SyscallTable<T>,
     fds: *mut libc::pollfd,
     nfds: libc::nfds_t,
     timeout: libc::c_int,
@@ -217,6 +216,8 @@ unsafe fn handle_poll(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fds, nfds, timeout) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fds, nfds, timeout)
+        },
     }
 }

--- a/src/daemons/linuxd/src/linux/sys_select.rs
+++ b/src/daemons/linuxd/src/linux/sys_select.rs
@@ -16,7 +16,6 @@ use ::core::{
     cmp,
     ptr,
 };
-use ::std::sync::Arc;
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
@@ -48,8 +47,8 @@ use ::syslog::{
 // do_select()
 //==================================================================================================
 
-pub fn do_select(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_select<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: SelectRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -100,7 +99,7 @@ pub fn do_select(
     // SAFETY: All pointers either null or point to valid local storage; nfds validated.
     let nready: libc::c_int = unsafe {
         handle_select(
-            &syscall_table,
+            syscall_table,
             nfds_c_int,
             read_ptr
                 .as_mut()
@@ -206,8 +205,8 @@ impl TryFrom<LibcFdSet> for fd_set {
 // Wrapper Functions
 //==================================================================================================
 
-unsafe fn handle_select(
-    syscall_table: &SyscallTable,
+unsafe fn handle_select<T>(
+    syscall_table: &SyscallTable<T>,
     nfds: libc::c_int,
     readfds: *mut libc::fd_set,
     writefds: *mut libc::fd_set,
@@ -220,7 +219,7 @@ unsafe fn handle_select(
             -1
         },
         SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(nfds, readfds, writefds, errorfds, timeout)
+            syscall_fn(&syscall_table.state, nfds, readfds, writefds, errorfds, timeout)
         },
     }
 }

--- a/src/daemons/linuxd/src/linux/sys_socket.rs
+++ b/src/daemons/linuxd/src/linux/sys_socket.rs
@@ -16,7 +16,6 @@ use ::core::{
     cmp,
     mem,
 };
-use ::std::sync::Arc;
 use ::sys::{
     error::{
         Error,
@@ -86,8 +85,8 @@ use ::syslog::{
 // do_socket
 //==================================================================================================
 
-pub fn do_socket(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_socket<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: CreateSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -108,7 +107,7 @@ pub fn do_socket(
         typ.inner(),
     );
     match unsafe {
-        handle_socket(&syscall_table, domain.inner() as i32, typ.inner(), protocol.inner())
+        handle_socket(syscall_table, domain.inner() as i32, typ.inner(), protocol.inner())
     } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -141,8 +140,8 @@ pub fn do_socket(
 // do_socketpair
 //==================================================================================================
 
-pub fn do_socketpair(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_socketpair<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: CreateSocketPairRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -166,7 +165,7 @@ pub fn do_socketpair(
     );
     match unsafe {
         handle_socketpair(
-            &syscall_table,
+            syscall_table,
             domain.inner() as i32,
             typ.inner(),
             protocol.inner(),
@@ -198,8 +197,8 @@ pub fn do_socketpair(
 // do_bind
 //==================================================================================================
 
-pub fn do_bind(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_bind<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: BindSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -219,7 +218,7 @@ pub fn do_bind(
         sockaddr.inner().sa_data,
     );
     match unsafe {
-        handle_bind(&syscall_table, sockfd, &sockaddr.inner() as *const libc::sockaddr, socklen)
+        handle_bind(syscall_table, sockfd, &sockaddr.inner() as *const libc::sockaddr, socklen)
     } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -243,8 +242,8 @@ pub fn do_bind(
 // do_connect
 //==================================================================================================
 
-pub fn do_connect(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_connect<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: ConnectSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -266,7 +265,7 @@ pub fn do_connect(
 
     match unsafe {
         handle_connect(
-            &syscall_table,
+            syscall_table,
             sockfd,
             &sockaddr.inner() as *const libc::sockaddr,
             socklen as libc::socklen_t,
@@ -294,8 +293,8 @@ pub fn do_connect(
 // do_listen
 //==================================================================================================
 
-pub fn do_listen(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_listen<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: ListenSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -305,7 +304,7 @@ pub fn do_listen(
     let backlog: i32 = request.backlog;
 
     debug!("libc::listen(): sockfd={sockfd:?}, backlog={backlog:?}");
-    match unsafe { handle_listen(&syscall_table, sockfd, backlog) } {
+    match unsafe { handle_listen(syscall_table, sockfd, backlog) } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
 
@@ -328,8 +327,8 @@ pub fn do_listen(
 // do_getpeername
 //==================================================================================================
 
-pub fn do_getpeername(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_getpeername<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: GetPeerNameRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -341,7 +340,7 @@ pub fn do_getpeername(
         core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
 
     debug!("libc::getpeername(): sockfd={sockfd:?}");
-    match unsafe { handle_getpeername(&syscall_table, sockfd, &mut address, &mut address_len) } {
+    match unsafe { handle_getpeername(syscall_table, sockfd, &mut address, &mut address_len) } {
         -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
 
@@ -373,8 +372,8 @@ pub fn do_getpeername(
 // do_getsockname
 //==================================================================================================
 
-pub fn do_getsockname(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_getsockname<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: GetSockNameRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -386,7 +385,7 @@ pub fn do_getsockname(
         core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
 
     debug!("libc::getsockname(): sockfd={sockfd:?}");
-    match unsafe { handle_getsockname(&syscall_table, sockfd, &mut address, &mut address_len) } {
+    match unsafe { handle_getsockname(syscall_table, sockfd, &mut address, &mut address_len) } {
         -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
 
@@ -419,8 +418,8 @@ pub fn do_getsockname(
 // do_accept
 //==================================================================================================
 
-pub fn do_accept(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_accept<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: AcceptSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -432,7 +431,7 @@ pub fn do_accept(
         core::mem::size_of::<libc::sockaddr>() as libc::socklen_t;
 
     debug!("libc::accept(): sockfd={sockfd:?}");
-    match unsafe { handle_accept(&syscall_table, sockfd, &mut address, &mut address_len) } {
+    match unsafe { handle_accept(syscall_table, sockfd, &mut address, &mut address_len) } {
         -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
 
@@ -462,8 +461,8 @@ pub fn do_accept(
 // do_recv
 //==================================================================================================
 
-pub fn do_recv(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_recv<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: ReceiveSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -483,7 +482,7 @@ pub fn do_recv(
     debug!("libc::recv(): sockfd={sockfd:?}, len={recv_len:?}, flags={:?}", flags.inner());
     match unsafe {
         handle_recv(
-            &syscall_table,
+            syscall_table,
             sockfd,
             buffer.as_mut_ptr() as *mut libc::c_void,
             recv_len,
@@ -516,8 +515,8 @@ pub fn do_recv(
 // do_shutdown
 //==================================================================================================
 
-pub fn do_shutdown(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_shutdown<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: ShutdownSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -527,7 +526,7 @@ pub fn do_shutdown(
     let how: LibcShutdownReason = LibcShutdownReason::from(request.how);
 
     debug!("libc::shutdown(): sockfd={sockfd:?}, how={:?}", how.inner());
-    match unsafe { handle_shutdown(&syscall_table, sockfd, how.inner()) } {
+    match unsafe { handle_shutdown(syscall_table, sockfd, how.inner()) } {
         0 => Ok(ShutdownSocketResponse::build(tid)),
         -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
@@ -551,8 +550,8 @@ pub fn do_shutdown(
 // do_send
 //==================================================================================================
 
-pub fn do_send(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_send<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: SendSocketRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -572,7 +571,7 @@ pub fn do_send(
     );
     match unsafe {
         handle_send(
-            &syscall_table,
+            syscall_table,
             sockfd,
             buffer.as_ptr() as *const libc::c_void,
             count as usize,
@@ -749,8 +748,8 @@ impl LibcMessageFlags {
 //==================================================================================================
 
 /// Handler for `libc::socket()`.
-unsafe fn handle_socket(
-    syscall_table: &SyscallTable,
+unsafe fn handle_socket<T>(
+    syscall_table: &SyscallTable<T>,
     domain: libc::c_int,
     type_: libc::c_int,
     protocol: libc::c_int,
@@ -760,13 +759,15 @@ unsafe fn handle_socket(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(domain, type_, protocol) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, domain, type_, protocol)
+        },
     }
 }
 
 /// Handler for `libc::socketpair()`.
-unsafe fn handle_socketpair(
-    syscall_table: &SyscallTable,
+unsafe fn handle_socketpair<T>(
+    syscall_table: &SyscallTable<T>,
     domain: libc::c_int,
     type_: libc::c_int,
     protocol: libc::c_int,
@@ -777,13 +778,15 @@ unsafe fn handle_socketpair(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(domain, type_, protocol, sv) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, domain, type_, protocol, sv)
+        },
     }
 }
 
 /// Handler for `libc::bind()`.
-unsafe fn handle_bind(
-    syscall_table: &SyscallTable,
+unsafe fn handle_bind<T>(
+    syscall_table: &SyscallTable<T>,
     sockfd: libc::c_int,
     addr: *const libc::sockaddr,
     addrlen: libc::socklen_t,
@@ -793,13 +796,15 @@ unsafe fn handle_bind(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(sockfd, addr, addrlen) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, sockfd, addr, addrlen)
+        },
     }
 }
 
 /// Handler for `libc::connect()`.
-unsafe fn handle_connect(
-    syscall_table: &SyscallTable,
+unsafe fn handle_connect<T>(
+    syscall_table: &SyscallTable<T>,
     sockfd: libc::c_int,
     addr: *const libc::sockaddr,
     addrlen: libc::socklen_t,
@@ -809,13 +814,15 @@ unsafe fn handle_connect(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(sockfd, addr, addrlen) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, sockfd, addr, addrlen)
+        },
     }
 }
 
 /// Handler for `libc::listen()`.
-unsafe fn handle_listen(
-    syscall_table: &SyscallTable,
+unsafe fn handle_listen<T>(
+    syscall_table: &SyscallTable<T>,
     sockfd: libc::c_int,
     backlog: libc::c_int,
 ) -> libc::c_int {
@@ -824,13 +831,15 @@ unsafe fn handle_listen(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(sockfd, backlog) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, sockfd, backlog)
+        },
     }
 }
 
 /// Handler for `libc::getpeername()`.
-unsafe fn handle_getpeername(
-    syscall_table: &SyscallTable,
+unsafe fn handle_getpeername<T>(
+    syscall_table: &SyscallTable<T>,
     sockfd: libc::c_int,
     addr: *mut libc::sockaddr,
     addrlen: *mut libc::socklen_t,
@@ -840,13 +849,15 @@ unsafe fn handle_getpeername(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(sockfd, addr, addrlen) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, sockfd, addr, addrlen)
+        },
     }
 }
 
 /// Handler for `libc::getsockname()`.
-unsafe fn handle_getsockname(
-    syscall_table: &SyscallTable,
+unsafe fn handle_getsockname<T>(
+    syscall_table: &SyscallTable<T>,
     sockfd: libc::c_int,
     addr: *mut libc::sockaddr,
     addrlen: *mut libc::socklen_t,
@@ -856,13 +867,15 @@ unsafe fn handle_getsockname(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(sockfd, addr, addrlen) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, sockfd, addr, addrlen)
+        },
     }
 }
 
 /// Handler for `libc::accept()`.
-unsafe fn handle_accept(
-    syscall_table: &SyscallTable,
+unsafe fn handle_accept<T>(
+    syscall_table: &SyscallTable<T>,
     sockfd: libc::c_int,
     addr: *mut libc::sockaddr,
     addrlen: *mut libc::socklen_t,
@@ -872,13 +885,15 @@ unsafe fn handle_accept(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(sockfd, addr, addrlen) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, sockfd, addr, addrlen)
+        },
     }
 }
 
 /// Handler for `libc::recv()`.
-unsafe fn handle_recv(
-    syscall_table: &SyscallTable,
+unsafe fn handle_recv<T>(
+    syscall_table: &SyscallTable<T>,
     sockfd: libc::c_int,
     buf: *mut libc::c_void,
     len: libc::size_t,
@@ -889,13 +904,15 @@ unsafe fn handle_recv(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(sockfd, buf, len, flags) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, sockfd, buf, len, flags)
+        },
     }
 }
 
 /// Handler for `libc::send()`.
-unsafe fn handle_send(
-    syscall_table: &SyscallTable,
+unsafe fn handle_send<T>(
+    syscall_table: &SyscallTable<T>,
     sockfd: libc::c_int,
     buf: *const libc::c_void,
     len: libc::size_t,
@@ -906,13 +923,15 @@ unsafe fn handle_send(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(sockfd, buf, len, flags) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, sockfd, buf, len, flags)
+        },
     }
 }
 
 /// Handler for `libc::shutdown()`.
-unsafe fn handle_shutdown(
-    syscall_table: &SyscallTable,
+unsafe fn handle_shutdown<T>(
+    syscall_table: &SyscallTable<T>,
     sockfd: libc::c_int,
     how: libc::c_int,
 ) -> libc::c_int {
@@ -921,6 +940,8 @@ unsafe fn handle_shutdown(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(sockfd, how) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, sockfd, how)
+        },
     }
 }

--- a/src/daemons/linuxd/src/linux/sys_times.rs
+++ b/src/daemons/linuxd/src/linux/sys_times.rs
@@ -12,7 +12,6 @@ use crate::{
         SyscallTable,
     },
 };
-use ::std::sync::Arc;
 use ::sys::{
     error::ErrorCode,
     ipc::Message,
@@ -34,8 +33,8 @@ use ::syslog::{
 // do_times()
 //==================================================================================================
 
-pub fn do_times(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_times<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     _request: TimesRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -50,7 +49,7 @@ pub fn do_times(
 
     debug!("libc::times(): buffer={:p}", &libc_buffer as *const libc::tms);
 
-    match unsafe { handle_times(&syscall_table, &mut libc_buffer as *mut libc::tms) } {
+    match unsafe { handle_times(syscall_table, &mut libc_buffer as *mut libc::tms) } {
         -1 => {
             let errno: i32 = unsafe { *libc::__errno_location() };
 
@@ -99,12 +98,12 @@ pub fn do_times(
 //==================================================================================================
 
 /// Handler for `libc::times()`.
-unsafe fn handle_times(syscall_table: &SyscallTable, buf: *mut libc::tms) -> libc::clock_t {
+unsafe fn handle_times<T>(syscall_table: &SyscallTable<T>, buf: *mut libc::tms) -> libc::clock_t {
     match &syscall_table.times {
         SyscallAction::Block => {
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(buf) },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state, buf) },
     }
 }

--- a/src/daemons/linuxd/src/linux/unistd.rs
+++ b/src/daemons/linuxd/src/linux/unistd.rs
@@ -18,7 +18,6 @@ use ::core::{
     ffi,
     ffi::CStr,
 };
-use ::std::sync::Arc;
 use ::sys::{
     error::{
         Error,
@@ -91,8 +90,8 @@ use ::syslog::{
 // do_chdir
 //==================================================================================================
 
-pub fn do_chdir(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_chdir<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: ChangeDirectoryRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -107,7 +106,7 @@ pub fn do_chdir(
     };
 
     debug!("libc::chdir(): path={path:?}");
-    match unsafe { handle_chdir(&syscall_table, path.as_ptr()) } {
+    match unsafe { handle_chdir(syscall_table, path.as_ptr()) } {
         0 => {
             debug!("do_chdir(): chdir() succeeded");
             Ok(vec![ChangeDirectoryResponse::build(tid)])
@@ -135,8 +134,8 @@ pub fn do_chdir(
 // do_close
 //==================================================================================================
 
-pub fn do_close(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_close<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: CloseRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -145,7 +144,7 @@ pub fn do_close(
     let fd: i32 = request.fd;
 
     debug!("libc::close(): fd={fd:?}");
-    match unsafe { handle_close(&syscall_table, fd) } {
+    match unsafe { handle_close(syscall_table, fd) } {
         ret if ret == 0 => Ok(CloseResponse::build(tid, ret)),
         _ => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -166,8 +165,8 @@ pub fn do_close(
 // do_faccessat
 //==================================================================================================
 
-pub fn do_faccessat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_faccessat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileAccessAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -188,7 +187,7 @@ pub fn do_faccessat(
         flag.inner()
     );
     match unsafe {
-        handle_faccessat(&syscall_table, dirfd.inner(), path.as_ptr(), amode, flag.inner())
+        handle_faccessat(syscall_table, dirfd.inner(), path.as_ptr(), amode, flag.inner())
     } {
         0 => Ok(vec![FileAccessAtResponse::build(tid)]),
         ret => {
@@ -214,8 +213,8 @@ pub fn do_faccessat(
 // do_fdatasync
 //==================================================================================================
 
-pub fn do_fdatasync(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_fdatasync<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileDataSyncRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -224,7 +223,7 @@ pub fn do_fdatasync(
     let fd: i32 = request.fd;
 
     debug!("libc::fdatasync(): fd={fd:?}");
-    match unsafe { handle_fdatasync(&syscall_table, fd) } {
+    match unsafe { handle_fdatasync(syscall_table, fd) } {
         ret if ret == 0 => Ok(FileDataSyncResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -249,27 +248,27 @@ pub fn do_fdatasync(
 // do_getids
 //==================================================================================================
 
-pub fn do_getids(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_getids<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     _request: GetIdsRequest,
 ) -> Result<Message, WorkerThreadError> {
     trace!("getids(): tid={tid:?}");
 
     // Get user ID.
-    let uid: libc::uid_t = unsafe { handle_getuid(&syscall_table) };
+    let uid: libc::uid_t = unsafe { handle_getuid(syscall_table) };
     debug!("libc::getuid(): uid={uid:?}");
 
     // Get effective user ID.
-    let euid: libc::uid_t = unsafe { handle_geteuid(&syscall_table) };
+    let euid: libc::uid_t = unsafe { handle_geteuid(syscall_table) };
     debug!("libc::geteuid(): euid={euid:?}");
 
     // Get group ID.
-    let gid: libc::gid_t = unsafe { handle_getgid(&syscall_table) };
+    let gid: libc::gid_t = unsafe { handle_getgid(syscall_table) };
     debug!("libc::getgid(): gid={gid:?}");
 
     // Get effective group ID.
-    let egid: libc::gid_t = unsafe { handle_getegid(&syscall_table) };
+    let egid: libc::gid_t = unsafe { handle_getegid(syscall_table) };
     debug!("libc::getegid(): egid={egid:?}");
 
     // Build response.
@@ -280,8 +279,8 @@ pub fn do_getids(
 // do_getcwd
 //==================================================================================================
 
-pub fn do_getcwd(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_getcwd<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
 ) -> Result<Vec<Message>, WorkerThreadError> {
     trace!("getcwd(): tid={tid:?}");
@@ -291,7 +290,7 @@ pub fn do_getcwd(
     // Get current working directory and check for errors.
     debug!("libc::getcwd(): buf={:p}, size={:?}", buf.as_mut_ptr(), buf.capacity());
     if unsafe {
-        !handle_getcwd(&syscall_table, buf.as_mut_ptr() as *mut libc::c_char, buf.capacity())
+        !handle_getcwd(syscall_table, buf.as_mut_ptr() as *mut libc::c_char, buf.capacity())
             .is_null()
     } {
         // Build response and check for errors.
@@ -349,8 +348,8 @@ pub fn do_getcwd(
 // do_fsync
 //==================================================================================================
 
-pub fn do_fsync(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_fsync<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileSyncRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -359,7 +358,7 @@ pub fn do_fsync(
     let fd: i32 = request.fd;
 
     debug!("libc::fsync(): fd={fd:?}");
-    match unsafe { handle_fsync(&syscall_table, fd) } {
+    match unsafe { handle_fsync(syscall_table, fd) } {
         ret if ret == 0 => Ok(FileSyncResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -384,8 +383,8 @@ pub fn do_fsync(
 // do_lseek
 //==================================================================================================
 
-pub fn do_lseek(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_lseek<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: SeekRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -399,7 +398,7 @@ pub fn do_lseek(
     };
 
     debug!("libc::lseek(): fd={:?}, offset={:?}, whence={:?}", fd, offset, whence.inner());
-    match unsafe { handle_lseek(&syscall_table, fd, offset, whence.inner()) } {
+    match unsafe { handle_lseek(syscall_table, fd, offset, whence.inner()) } {
         ret if ret >= 0 => Ok(SeekResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -424,8 +423,8 @@ pub fn do_lseek(
 // do_ftruncate
 //==================================================================================================
 
-pub fn do_ftruncate(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_ftruncate<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileTruncateRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -435,7 +434,7 @@ pub fn do_ftruncate(
     let length: off_t = request.length;
 
     debug!("libc::ftruncate(): fd={fd:?}, length={length:?}");
-    match unsafe { handle_ftruncate(&syscall_table, fd, length) } {
+    match unsafe { handle_ftruncate(syscall_table, fd, length) } {
         ret if ret == 0 => Ok(FileTruncateResponse::build(tid, ret)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -460,8 +459,8 @@ pub fn do_ftruncate(
 // do_write
 //==================================================================================================
 
-pub fn do_write(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_write<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: WriteRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -477,7 +476,7 @@ pub fn do_write(
     let buffer: &[u8] = &request.buffer[..count];
 
     debug!("libc::write(): fd={fd:?}, buffer={buffer:?}");
-    match unsafe { handle_write(&syscall_table, fd, buffer.as_ptr() as *const _, count) } {
+    match unsafe { handle_write(syscall_table, fd, buffer.as_ptr() as *const _, count) } {
         ret if ret >= 0 => Ok(WriteResponse::build(tid, ret as i32)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -502,8 +501,8 @@ pub fn do_write(
 // do_read
 //==================================================================================================
 
-pub fn do_read(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_read<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: ReadRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -519,7 +518,7 @@ pub fn do_read(
     let mut buffer: [u8; ReadResponse::BUFFER_SIZE] = [0; ReadResponse::BUFFER_SIZE];
 
     debug!("libc::read(): fd={fd:?}, buffer={buffer:?}");
-    match unsafe { handle_read(&syscall_table, fd, buffer.as_mut_ptr() as *mut _, count) } {
+    match unsafe { handle_read(syscall_table, fd, buffer.as_mut_ptr() as *mut _, count) } {
         ret if ret >= 0 => Ok(ReadResponse::build(tid, ret as i32, buffer)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -544,8 +543,8 @@ pub fn do_read(
 // do_pwrite
 //==================================================================================================
 
-pub fn do_pwrite(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_pwrite<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: PartialWriteRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -562,7 +561,7 @@ pub fn do_pwrite(
     let buffer: &[u8] = &request.buffer[..count];
 
     debug!("libc::pwrite(): fd={fd:?}, count={count:?}, offset={offset:?}, buffer={buffer:?}",);
-    match unsafe { handle_pwrite(&syscall_table, fd, buffer.as_ptr() as *const _, count, offset) } {
+    match unsafe { handle_pwrite(syscall_table, fd, buffer.as_ptr() as *const _, count, offset) } {
         ret if ret >= 0 => Ok(PartialWriteResponse::build(tid, ret as c_ssize_t)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -587,8 +586,8 @@ pub fn do_pwrite(
 // do_pread
 //==================================================================================================
 
-pub fn do_pread(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_pread<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: PartialReadRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -605,8 +604,7 @@ pub fn do_pread(
     let mut buffer: [u8; PartialReadResponse::BUFFER_SIZE] = [0; PartialReadResponse::BUFFER_SIZE];
 
     debug!("libc::pread(): fd={fd:?}, count={count:?}, offset={offset:?}, buffer={buffer:?}",);
-    match unsafe { handle_pread(&syscall_table, fd, buffer.as_mut_ptr() as *mut _, count, offset) }
-    {
+    match unsafe { handle_pread(syscall_table, fd, buffer.as_mut_ptr() as *mut _, count, offset) } {
         ret if ret >= 0 => Ok(PartialReadResponse::build(tid, ret as c_ssize_t, buffer)),
         ret => {
             let errno: i32 = unsafe { *libc::__errno_location() };
@@ -631,8 +629,8 @@ pub fn do_pread(
 // do_linkat
 //==================================================================================================
 
-pub fn do_linkat(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_linkat<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: LinkAtRequest,
 ) -> Result<Vec<Message>, WorkerThreadError> {
@@ -655,7 +653,7 @@ pub fn do_linkat(
          newpath={newpath:?}, flags={flags:?}",
     );
     match unsafe {
-        handle_linkat(&syscall_table, olddirfd, oldpath.as_ptr(), newdirfd, newpath.as_ptr(), flags)
+        handle_linkat(syscall_table, olddirfd, oldpath.as_ptr(), newdirfd, newpath.as_ptr(), flags)
     } {
         ret if ret == 0 => Ok(vec![LinkAtResponse::build(tid, ret)]),
         ret => {
@@ -682,8 +680,8 @@ pub fn do_linkat(
 //==================================================================================================
 
 /// Changes the current working directory.
-pub fn do_fchdir(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_fchdir<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileChdirRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -692,7 +690,7 @@ pub fn do_fchdir(
     let fd: i32 = request.fd;
 
     debug!("libc::fchdir(): fd={fd:?}");
-    match unsafe { handle_fchdir(&syscall_table, fd) } {
+    match unsafe { handle_fchdir(syscall_table, fd) } {
         0 => Ok(FileChdirResponse::build(tid)),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
@@ -717,8 +715,8 @@ pub fn do_fchdir(
 // do_fchown
 //==================================================================================================
 
-pub fn do_fchown(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_fchown<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
     request: FileChownRequest,
 ) -> Result<Message, WorkerThreadError> {
@@ -729,7 +727,7 @@ pub fn do_fchown(
     let group: u32 = request.group;
 
     debug!("libc::fchown(): fd={fd:?}, owner={owner:?}, group={group:?}");
-    match unsafe { handle_fchown(&syscall_table, fd, owner, group) } {
+    match unsafe { handle_fchown(syscall_table, fd, owner, group) } {
         0 => Ok(FileChownResponse::build(tid)),
         ret if ret == -1 => {
             let errno: libc::c_int = unsafe { *libc::__errno_location() };
@@ -754,8 +752,8 @@ pub fn do_fchown(
 // do_pipe
 //==================================================================================================
 
-pub fn do_pipe(
-    syscall_table: Arc<SyscallTable>,
+pub fn do_pipe<T>(
+    syscall_table: &SyscallTable<T>,
     tid: ThreadIdentifier,
 ) -> Result<Message, WorkerThreadError> {
     trace!("pipe(): tid={tid:?}");
@@ -763,7 +761,7 @@ pub fn do_pipe(
     let mut fds: [i32; 2] = [0; 2];
 
     debug!("libc::pipe(): fds={fds:?}");
-    match unsafe { handle_pipe(&syscall_table, fds.as_mut_ptr()) } {
+    match unsafe { handle_pipe(syscall_table, fds.as_mut_ptr()) } {
         0 => {
             let read_fd: i32 = fds[0];
             let write_fd: i32 = fds[1];
@@ -820,30 +818,33 @@ impl TryFrom<i32> for LibcSeek {
 //==================================================================================================
 
 /// Handler for `libc::chdir()`.
-unsafe fn handle_chdir(syscall_table: &SyscallTable, path: *const libc::c_char) -> libc::c_int {
+unsafe fn handle_chdir<T>(
+    syscall_table: &SyscallTable<T>,
+    path: *const libc::c_char,
+) -> libc::c_int {
     match &syscall_table.chdir {
         SyscallAction::Block => {
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(path) },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state, path) },
     }
 }
 
 /// Handler for `libc::close()`.
-unsafe fn handle_close(syscall_table: &SyscallTable, fd: libc::c_int) -> libc::c_int {
+unsafe fn handle_close<T>(syscall_table: &SyscallTable<T>, fd: libc::c_int) -> libc::c_int {
     match &syscall_table.close {
         SyscallAction::Block => {
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd) },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state, fd) },
     }
 }
 
 /// Handler for `libc::faccessat()`.
-unsafe fn handle_faccessat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_faccessat<T>(
+    syscall_table: &SyscallTable<T>,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     mode: libc::c_int,
@@ -854,56 +855,58 @@ unsafe fn handle_faccessat(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(dirfd, pathname, mode, flags) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, dirfd, pathname, mode, flags)
+        },
     }
 }
 
 /// Handler for `libc::fdatasync()`.
-unsafe fn handle_fdatasync(syscall_table: &SyscallTable, fd: libc::c_int) -> libc::c_int {
+unsafe fn handle_fdatasync<T>(syscall_table: &SyscallTable<T>, fd: libc::c_int) -> libc::c_int {
     match &syscall_table.fdatasync {
         SyscallAction::Block => {
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd) },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state, fd) },
     }
 }
 
 /// Handler for `libc::getuid()`.
-unsafe fn handle_getuid(syscall_table: &SyscallTable) -> libc::uid_t {
+unsafe fn handle_getuid<T>(syscall_table: &SyscallTable<T>) -> libc::uid_t {
     match &syscall_table.getuid {
         SyscallAction::Block => 0,
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn() },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state) },
     }
 }
 
 /// Handler for `libc::geteuid()`.
-unsafe fn handle_geteuid(syscall_table: &SyscallTable) -> libc::uid_t {
+unsafe fn handle_geteuid<T>(syscall_table: &SyscallTable<T>) -> libc::uid_t {
     match &syscall_table.geteuid {
         SyscallAction::Block => 0,
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn() },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state) },
     }
 }
 
 /// Handler for `libc::getgid()`.
-unsafe fn handle_getgid(syscall_table: &SyscallTable) -> libc::gid_t {
+unsafe fn handle_getgid<T>(syscall_table: &SyscallTable<T>) -> libc::gid_t {
     match &syscall_table.getgid {
         SyscallAction::Block => 0,
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn() },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state) },
     }
 }
 
 /// Handler for `libc::getegid()`.
-unsafe fn handle_getegid(syscall_table: &SyscallTable) -> libc::gid_t {
+unsafe fn handle_getegid<T>(syscall_table: &SyscallTable<T>) -> libc::gid_t {
     match &syscall_table.getegid {
         SyscallAction::Block => 0,
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn() },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state) },
     }
 }
 
 /// Handler for `libc::getcwd()`.
-unsafe fn handle_getcwd(
-    syscall_table: &SyscallTable,
+unsafe fn handle_getcwd<T>(
+    syscall_table: &SyscallTable<T>,
     buf: *mut libc::c_char,
     size: libc::size_t,
 ) -> *mut libc::c_char {
@@ -912,24 +915,26 @@ unsafe fn handle_getcwd(
             unsafe { *libc::__errno_location() = libc::EPERM };
             ::core::ptr::null_mut()
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(buf, size) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, buf, size)
+        },
     }
 }
 
 /// Handler for `libc::fsync()`.
-unsafe fn handle_fsync(syscall_table: &SyscallTable, fd: libc::c_int) -> libc::c_int {
+unsafe fn handle_fsync<T>(syscall_table: &SyscallTable<T>, fd: libc::c_int) -> libc::c_int {
     match &syscall_table.fsync {
         SyscallAction::Block => {
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd) },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state, fd) },
     }
 }
 
 /// Handler for `libc::lseek()`.
-unsafe fn handle_lseek(
-    syscall_table: &SyscallTable,
+unsafe fn handle_lseek<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     offset: libc::off_t,
     whence: libc::c_int,
@@ -939,13 +944,15 @@ unsafe fn handle_lseek(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, offset, whence) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, offset, whence)
+        },
     }
 }
 
 /// Handler for `libc::ftruncate()`.
-unsafe fn handle_ftruncate(
-    syscall_table: &SyscallTable,
+unsafe fn handle_ftruncate<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     length: libc::off_t,
 ) -> libc::c_int {
@@ -954,13 +961,15 @@ unsafe fn handle_ftruncate(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, length) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, length)
+        },
     }
 }
 
 /// Handler for `libc::write()`.
-unsafe fn handle_write(
-    syscall_table: &SyscallTable,
+unsafe fn handle_write<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     buf: *const libc::c_void,
     count: libc::size_t,
@@ -970,13 +979,15 @@ unsafe fn handle_write(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, buf, count) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, buf, count)
+        },
     }
 }
 
 /// Handler for `libc::read()`.
-unsafe fn handle_read(
-    syscall_table: &SyscallTable,
+unsafe fn handle_read<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     buf: *mut libc::c_void,
     count: libc::size_t,
@@ -986,13 +997,15 @@ unsafe fn handle_read(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, buf, count) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, buf, count)
+        },
     }
 }
 
 /// Handler for `libc::pwrite()`.
-unsafe fn handle_pwrite(
-    syscall_table: &SyscallTable,
+unsafe fn handle_pwrite<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     buf: *const libc::c_void,
     count: libc::size_t,
@@ -1003,13 +1016,15 @@ unsafe fn handle_pwrite(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, buf, count, offset) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, buf, count, offset)
+        },
     }
 }
 
 /// Handler for `libc::pread()`.
-unsafe fn handle_pread(
-    syscall_table: &SyscallTable,
+unsafe fn handle_pread<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     buf: *mut libc::c_void,
     count: libc::size_t,
@@ -1020,13 +1035,15 @@ unsafe fn handle_pread(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, buf, count, offset) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, buf, count, offset)
+        },
     }
 }
 
 /// Handler for `libc::linkat()`.
-unsafe fn handle_linkat(
-    syscall_table: &SyscallTable,
+unsafe fn handle_linkat<T>(
+    syscall_table: &SyscallTable<T>,
     olddirfd: libc::c_int,
     oldpath: *const libc::c_char,
     newdirfd: libc::c_int,
@@ -1039,25 +1056,25 @@ unsafe fn handle_linkat(
             -1
         },
         SyscallAction::Forward(syscall_fn) => unsafe {
-            syscall_fn(olddirfd, oldpath, newdirfd, newpath, flags)
+            syscall_fn(&syscall_table.state, olddirfd, oldpath, newdirfd, newpath, flags)
         },
     }
 }
 
 /// Handler for `libc::fchdir()`.
-unsafe fn handle_fchdir(syscall_table: &SyscallTable, fd: libc::c_int) -> libc::c_int {
+unsafe fn handle_fchdir<T>(syscall_table: &SyscallTable<T>, fd: libc::c_int) -> libc::c_int {
     match &syscall_table.fchdir {
         SyscallAction::Block => {
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd) },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state, fd) },
     }
 }
 
 /// Handler for `libc::fchown()`.
-unsafe fn handle_fchown(
-    syscall_table: &SyscallTable,
+unsafe fn handle_fchown<T>(
+    syscall_table: &SyscallTable<T>,
     fd: libc::c_int,
     owner: libc::uid_t,
     group: libc::gid_t,
@@ -1067,17 +1084,19 @@ unsafe fn handle_fchown(
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(fd, owner, group) },
+        SyscallAction::Forward(syscall_fn) => unsafe {
+            syscall_fn(&syscall_table.state, fd, owner, group)
+        },
     }
 }
 
 /// Handler for `libc::pipe()`.
-unsafe fn handle_pipe(syscall_table: &SyscallTable, pipefd: *mut libc::c_int) -> libc::c_int {
+unsafe fn handle_pipe<T>(syscall_table: &SyscallTable<T>, pipefd: *mut libc::c_int) -> libc::c_int {
     match &syscall_table.pipe {
         SyscallAction::Block => {
             unsafe { *libc::__errno_location() = libc::EPERM };
             -1
         },
-        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(pipefd) },
+        SyscallAction::Forward(syscall_fn) => unsafe { syscall_fn(&syscall_table.state, pipefd) },
     }
 }

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -80,7 +80,7 @@ pub async fn main() -> Result<()> {
     };
     info!("Listening to user VMs on: {user_vm_sockaddr:?}");
 
-    let linuxd: LinuxDaemon = match LinuxDaemon::init(
+    let linuxd: LinuxDaemon<()> = match LinuxDaemon::init(
         Arc::new(SyscallTable::default()),
         control_plane_sockaddr,
         args.control_plane_socket_type(),

--- a/src/daemons/linuxd/src/message.rs
+++ b/src/daemons/linuxd/src/message.rs
@@ -10,7 +10,6 @@ use crate::{
     syscalls::SyscallTable,
 };
 use ::alloc::collections::BTreeMap;
-use ::std::sync::Arc;
 use ::sys::{
     error::Error,
     ipc::Message,
@@ -32,13 +31,13 @@ pub struct RequestAssembler {
 }
 
 impl RequestAssembler {
-    pub fn process_message<T: RequestAssemblerTrait>(
+    pub fn process_message<S, T: RequestAssemblerTrait<S>>(
         &mut self,
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<S>,
         source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
     ) -> Result<Option<Vec<Message>>, WorkerThreadError> {
-        match self.process_message_internal::<T>(syscall_table, source, part) {
+        match self.process_message_internal::<S, T>(syscall_table, source, part) {
             Ok(messages) => Ok(messages),
             Err(WorkerThreadError::Interrupted) => Err(WorkerThreadError::Interrupted),
             Err(WorkerThreadError::Error(e)) => {
@@ -48,14 +47,14 @@ impl RequestAssembler {
         }
     }
 
-    fn process_message_internal<T: RequestAssemblerTrait>(
+    fn process_message_internal<S, T: RequestAssemblerTrait<S>>(
         &mut self,
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<S>,
         source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
     ) -> Result<Option<Vec<Message>>, WorkerThreadError> {
         let message_complete: bool = {
-            match self.assemble_parts::<T>(source, part) {
+            match self.assemble_parts::<S, T>(source, part) {
                 Ok(message_complete) => message_complete,
                 Err(e) => {
                     return Err(e);
@@ -67,13 +66,13 @@ impl RequestAssembler {
             return Ok(None);
         }
 
-        match self.process_request::<T>(syscall_table, source) {
+        match self.process_request::<S, T>(syscall_table, source) {
             Ok(messages) => Ok(Some(messages)),
             Err(e) => Err(e),
         }
     }
 
-    fn assemble_parts<T: RequestAssemblerTrait>(
+    fn assemble_parts<S, T: RequestAssemblerTrait<S>>(
         &mut self,
         source: ThreadIdentifier,
         part: LinuxDaemonMessagePart,
@@ -86,9 +85,9 @@ impl RequestAssembler {
         Ok(T::is_complete(assembler)?)
     }
 
-    fn process_request<T: RequestAssemblerTrait>(
+    fn process_request<S, T: RequestAssemblerTrait<S>>(
         &mut self,
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<S>,
         source: ThreadIdentifier,
     ) -> Result<Vec<Message>, WorkerThreadError> {
         let assembler: RequestAssemblerType = self
@@ -120,7 +119,7 @@ pub enum RequestAssemblerType {
     PollRequest(LinuxDaemonLongMessage),
 }
 
-pub trait RequestAssemblerTrait
+pub trait RequestAssemblerTrait<T>
 where
     Self: Sized,
     Self: MessagePartitioner,
@@ -137,7 +136,7 @@ where
     fn take_parts(assembler: RequestAssemblerType) -> Vec<LinuxDaemonMessagePart>;
 
     fn process_request(
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: Self,
     ) -> Result<Vec<Message>, WorkerThreadError>;

--- a/src/daemons/linuxd/src/syscalls.rs
+++ b/src/daemons/linuxd/src/syscalls.rs
@@ -6,61 +6,63 @@
 //==================================================================================================
 
 /// Type alias for `times()` system call function.
-pub type TimesFn = unsafe fn(*mut libc::tms) -> libc::clock_t;
+pub type TimesFn<T> = unsafe fn(&T, *mut libc::tms) -> libc::clock_t;
 
 /// Type alias for `chdir()` system call function.
-pub type ChdirFn = unsafe fn(*const libc::c_char) -> libc::c_int;
+pub type ChdirFn<T> = unsafe fn(&T, *const libc::c_char) -> libc::c_int;
 
 /// Type alias for `close()` system call function.
-pub type CloseFn = unsafe fn(libc::c_int) -> libc::c_int;
+pub type CloseFn<T> = unsafe fn(&T, libc::c_int) -> libc::c_int;
 
 /// Type alias for `faccessat()` system call function.
-pub type FaccessatFn =
-    unsafe fn(libc::c_int, *const libc::c_char, libc::c_int, libc::c_int) -> libc::c_int;
+pub type FaccessatFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::c_char, libc::c_int, libc::c_int) -> libc::c_int;
 
 /// Type alias for `fdatasync()` system call function.
-pub type FdatasyncFn = unsafe fn(libc::c_int) -> libc::c_int;
+pub type FdatasyncFn<T> = unsafe fn(&T, libc::c_int) -> libc::c_int;
 
 /// Type alias for `getuid()` system call function.
-pub type GetuidFn = unsafe fn() -> libc::uid_t;
+pub type GetuidFn<T> = unsafe fn(&T) -> libc::uid_t;
 
 /// Type alias for `geteuid()` system call function.
-pub type GeteuidFn = unsafe fn() -> libc::uid_t;
+pub type GeteuidFn<T> = unsafe fn(&T) -> libc::uid_t;
 
 /// Type alias for `getgid()` system call function.
-pub type GetgidFn = unsafe fn() -> libc::gid_t;
+pub type GetgidFn<T> = unsafe fn(&T) -> libc::gid_t;
 
 /// Type alias for `getegid()` system call function.
-pub type GetegidFn = unsafe fn() -> libc::gid_t;
+pub type GetegidFn<T> = unsafe fn(&T) -> libc::gid_t;
 
 /// Type alias for `getcwd()` system call function.
-pub type GetcwdFn = unsafe fn(*mut libc::c_char, libc::size_t) -> *mut libc::c_char;
+pub type GetcwdFn<T> = unsafe fn(&T, *mut libc::c_char, libc::size_t) -> *mut libc::c_char;
 
 /// Type alias for `fsync()` system call function.
-pub type FsyncFn = unsafe fn(libc::c_int) -> libc::c_int;
+pub type FsyncFn<T> = unsafe fn(&T, libc::c_int) -> libc::c_int;
 
 /// Type alias for `lseek()` system call function.
-pub type LseekFn = unsafe fn(libc::c_int, libc::off_t, libc::c_int) -> libc::off_t;
+pub type LseekFn<T> = unsafe fn(&T, libc::c_int, libc::off_t, libc::c_int) -> libc::off_t;
 
 /// Type alias for `ftruncate()` system call function.
-pub type FtruncateFn = unsafe fn(libc::c_int, libc::off_t) -> libc::c_int;
+pub type FtruncateFn<T> = unsafe fn(&T, libc::c_int, libc::off_t) -> libc::c_int;
 
 /// Type alias for `write()` system call function.
-pub type WriteFn = unsafe fn(libc::c_int, *const libc::c_void, libc::size_t) -> libc::ssize_t;
+pub type WriteFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::c_void, libc::size_t) -> libc::ssize_t;
 
 /// Type alias for `read()` system call function.
-pub type ReadFn = unsafe fn(libc::c_int, *mut libc::c_void, libc::size_t) -> libc::ssize_t;
+pub type ReadFn<T> = unsafe fn(&T, libc::c_int, *mut libc::c_void, libc::size_t) -> libc::ssize_t;
 
 /// Type alias for `pwrite()` system call function.
-pub type PwriteFn =
-    unsafe fn(libc::c_int, *const libc::c_void, libc::size_t, libc::off_t) -> libc::ssize_t;
+pub type PwriteFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::c_void, libc::size_t, libc::off_t) -> libc::ssize_t;
 
 /// Type alias for `pread()` system call function.
-pub type PreadFn =
-    unsafe fn(libc::c_int, *mut libc::c_void, libc::size_t, libc::off_t) -> libc::ssize_t;
+pub type PreadFn<T> =
+    unsafe fn(&T, libc::c_int, *mut libc::c_void, libc::size_t, libc::off_t) -> libc::ssize_t;
 
 /// Type alias for `linkat()` system call function.
-pub type LinkatFn = unsafe fn(
+pub type LinkatFn<T> = unsafe fn(
+    &T,
     libc::c_int,
     *const libc::c_char,
     libc::c_int,
@@ -69,58 +71,61 @@ pub type LinkatFn = unsafe fn(
 ) -> libc::c_int;
 
 /// Type alias for `fchdir()` system call function.
-pub type FchdirFn = unsafe fn(libc::c_int) -> libc::c_int;
+pub type FchdirFn<T> = unsafe fn(&T, libc::c_int) -> libc::c_int;
 
 /// Type alias for `fchown()` system call function.
-pub type FchownFn = unsafe fn(libc::c_int, libc::uid_t, libc::gid_t) -> libc::c_int;
+pub type FchownFn<T> = unsafe fn(&T, libc::c_int, libc::uid_t, libc::gid_t) -> libc::c_int;
 
 /// Type alias for `pipe()` system call function.
-pub type PipeFn = unsafe fn(*mut libc::c_int) -> libc::c_int;
+pub type PipeFn<T> = unsafe fn(&T, *mut libc::c_int) -> libc::c_int;
 
 /// Type alias for `getdents()` system call function.
-pub type GetdentsFn = unsafe fn(libc::c_int, *mut u8, libc::size_t) -> libc::c_long;
+pub type GetdentsFn<T> = unsafe fn(&T, libc::c_int, *mut u8, libc::size_t) -> libc::c_long;
 
 /// Type alias for `socket()` system call function.
-pub type SocketFn = unsafe fn(libc::c_int, libc::c_int, libc::c_int) -> libc::c_int;
+pub type SocketFn<T> = unsafe fn(&T, libc::c_int, libc::c_int, libc::c_int) -> libc::c_int;
 
 /// Type alias for `socketpair()` system call function.
-pub type SocketpairFn =
-    unsafe fn(libc::c_int, libc::c_int, libc::c_int, *mut libc::c_int) -> libc::c_int;
+pub type SocketpairFn<T> =
+    unsafe fn(&T, libc::c_int, libc::c_int, libc::c_int, *mut libc::c_int) -> libc::c_int;
 
 /// Type alias for `bind()` system call function.
-pub type BindFn = unsafe fn(libc::c_int, *const libc::sockaddr, libc::socklen_t) -> libc::c_int;
+pub type BindFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::sockaddr, libc::socklen_t) -> libc::c_int;
 
 /// Type alias for `connect()` system call function.
-pub type ConnectFn = unsafe fn(libc::c_int, *const libc::sockaddr, libc::socklen_t) -> libc::c_int;
+pub type ConnectFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::sockaddr, libc::socklen_t) -> libc::c_int;
 
 /// Type alias for `listen()` system call function.
-pub type ListenFn = unsafe fn(libc::c_int, libc::c_int) -> libc::c_int;
+pub type ListenFn<T> = unsafe fn(&T, libc::c_int, libc::c_int) -> libc::c_int;
 
 /// Type alias for `getpeername()` system call function.
-pub type GetpeernameFn =
-    unsafe fn(libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
+pub type GetpeernameFn<T> =
+    unsafe fn(&T, libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
 
 /// Type alias for `getsockname()` system call function.
-pub type GetsocknameFn =
-    unsafe fn(libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
+pub type GetsocknameFn<T> =
+    unsafe fn(&T, libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
 
 /// Type alias for `accept()` system call function.
-pub type AcceptFn =
-    unsafe fn(libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
+pub type AcceptFn<T> =
+    unsafe fn(&T, libc::c_int, *mut libc::sockaddr, *mut libc::socklen_t) -> libc::c_int;
 
 /// Type alias for `recv()` system call function.
-pub type RecvFn =
-    unsafe fn(libc::c_int, *mut libc::c_void, libc::size_t, libc::c_int) -> libc::ssize_t;
+pub type RecvFn<T> =
+    unsafe fn(&T, libc::c_int, *mut libc::c_void, libc::size_t, libc::c_int) -> libc::ssize_t;
 
 /// Type alias for `send()` system call function.
-pub type SendFn =
-    unsafe fn(libc::c_int, *const libc::c_void, libc::size_t, libc::c_int) -> libc::ssize_t;
+pub type SendFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::c_void, libc::size_t, libc::c_int) -> libc::ssize_t;
 
 /// Type alias for `shutdown()` system call function.
-pub type ShutdownFn = unsafe fn(libc::c_int, libc::c_int) -> libc::c_int;
+pub type ShutdownFn<T> = unsafe fn(&T, libc::c_int, libc::c_int) -> libc::c_int;
 
 /// Type alias for `select()` system call function.
-pub type SelectFn = unsafe fn(
+pub type SelectFn<T> = unsafe fn(
+    &T,
     libc::c_int,
     *mut libc::fd_set,
     *mut libc::fd_set,
@@ -129,7 +134,7 @@ pub type SelectFn = unsafe fn(
 ) -> libc::c_int;
 
 /// Type alias for `poll()` system call function.
-pub type PollFn = unsafe fn(*mut libc::pollfd, libc::nfds_t, libc::c_int) -> libc::c_int;
+pub type PollFn<T> = unsafe fn(&T, *mut libc::pollfd, libc::nfds_t, libc::c_int) -> libc::c_int;
 
 //==================================================================================================
 // Default Implementations - unistd.rs
@@ -142,13 +147,14 @@ pub type PollFn = unsafe fn(*mut libc::pollfd, libc::nfds_t, libc::c_int) -> lib
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `path`: Path to change to.
 ///
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_chdir(path: *const libc::c_char) -> libc::c_int {
+pub unsafe fn default_chdir<T>(_state: &T, path: *const libc::c_char) -> libc::c_int {
     libc::chdir(path)
 }
 
@@ -159,13 +165,14 @@ pub unsafe fn default_chdir(path: *const libc::c_char) -> libc::c_int {
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor to close.
 ///
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_close(fd: libc::c_int) -> libc::c_int {
+pub unsafe fn default_close<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
     libc::close(fd)
 }
 
@@ -176,6 +183,7 @@ pub unsafe fn default_close(fd: libc::c_int) -> libc::c_int {
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `dirfd`: Directory file descriptor.
 /// - `pathname`: Path to check.
 /// - `mode`: Access mode.
@@ -185,7 +193,8 @@ pub unsafe fn default_close(fd: libc::c_int) -> libc::c_int {
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_faccessat(
+pub unsafe fn default_faccessat<T>(
+    _state: &T,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     mode: libc::c_int,
@@ -201,13 +210,14 @@ pub unsafe fn default_faccessat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor to synchronize.
 ///
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_fdatasync(fd: libc::c_int) -> libc::c_int {
+pub unsafe fn default_fdatasync<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
     libc::fdatasync(fd)
 }
 
@@ -216,11 +226,15 @@ pub unsafe fn default_fdatasync(fd: libc::c_int) -> libc::c_int {
 ///
 /// Default implementation for `getuid()` system call.
 ///
+/// # Parameters
+///
+/// - `_state`: Immutable reference to state (unused in default implementation).
+///
 /// # Returns
 ///
 /// The real user ID of the calling process.
 ///
-pub unsafe fn default_getuid() -> libc::uid_t {
+pub unsafe fn default_getuid<T>(_state: &T) -> libc::uid_t {
     libc::getuid()
 }
 
@@ -229,11 +243,15 @@ pub unsafe fn default_getuid() -> libc::uid_t {
 ///
 /// Default implementation for `geteuid()` system call.
 ///
+/// # Parameters
+///
+/// - `_state`: Immutable reference to state (unused in default implementation).
+///
 /// # Returns
 ///
 /// The effective user ID of the calling process.
 ///
-pub unsafe fn default_geteuid() -> libc::uid_t {
+pub unsafe fn default_geteuid<T>(_state: &T) -> libc::uid_t {
     libc::geteuid()
 }
 
@@ -242,11 +260,15 @@ pub unsafe fn default_geteuid() -> libc::uid_t {
 ///
 /// Default implementation for `getgid()` system call.
 ///
+/// # Parameters
+///
+/// - `_state`: Immutable reference to state (unused in default implementation).
+///
 /// # Returns
 ///
 /// The real group ID of the calling process.
 ///
-pub unsafe fn default_getgid() -> libc::gid_t {
+pub unsafe fn default_getgid<T>(_state: &T) -> libc::gid_t {
     libc::getgid()
 }
 
@@ -255,11 +277,15 @@ pub unsafe fn default_getgid() -> libc::gid_t {
 ///
 /// Default implementation for `getegid()` system call.
 ///
+/// # Parameters
+///
+/// - `_state`: Immutable reference to state (unused in default implementation).
+///
 /// # Returns
 ///
 /// The effective group ID of the calling process.
 ///
-pub unsafe fn default_getegid() -> libc::gid_t {
+pub unsafe fn default_getegid<T>(_state: &T) -> libc::gid_t {
     libc::getegid()
 }
 
@@ -270,6 +296,7 @@ pub unsafe fn default_getegid() -> libc::gid_t {
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `buf`: Buffer to store current working directory.
 /// - `size`: Size of buffer.
 ///
@@ -277,7 +304,11 @@ pub unsafe fn default_getegid() -> libc::gid_t {
 ///
 /// Upon successful completion, a pointer to the buffer is returned. Otherwise, NULL is returned and `errno` is set.
 ///
-pub unsafe fn default_getcwd(buf: *mut libc::c_char, size: libc::size_t) -> *mut libc::c_char {
+pub unsafe fn default_getcwd<T>(
+    _state: &T,
+    buf: *mut libc::c_char,
+    size: libc::size_t,
+) -> *mut libc::c_char {
     libc::getcwd(buf, size)
 }
 
@@ -288,13 +319,14 @@ pub unsafe fn default_getcwd(buf: *mut libc::c_char, size: libc::size_t) -> *mut
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor to synchronize.
 ///
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_fsync(fd: libc::c_int) -> libc::c_int {
+pub unsafe fn default_fsync<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
     libc::fsync(fd)
 }
 
@@ -305,6 +337,7 @@ pub unsafe fn default_fsync(fd: libc::c_int) -> libc::c_int {
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `offset`: Offset.
 /// - `whence`: Whence.
@@ -313,7 +346,8 @@ pub unsafe fn default_fsync(fd: libc::c_int) -> libc::c_int {
 ///
 /// Upon successful completion, the resulting offset is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_lseek(
+pub unsafe fn default_lseek<T>(
+    _state: &T,
     fd: libc::c_int,
     offset: libc::off_t,
     whence: libc::c_int,
@@ -328,6 +362,7 @@ pub unsafe fn default_lseek(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `length`: Length.
 ///
@@ -335,7 +370,11 @@ pub unsafe fn default_lseek(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_ftruncate(fd: libc::c_int, length: libc::off_t) -> libc::c_int {
+pub unsafe fn default_ftruncate<T>(
+    _state: &T,
+    fd: libc::c_int,
+    length: libc::off_t,
+) -> libc::c_int {
     libc::ftruncate(fd, length)
 }
 
@@ -346,6 +385,7 @@ pub unsafe fn default_ftruncate(fd: libc::c_int, length: libc::off_t) -> libc::c
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `buf`: Buffer to write from.
 /// - `count`: Number of bytes to write.
@@ -354,7 +394,8 @@ pub unsafe fn default_ftruncate(fd: libc::c_int, length: libc::off_t) -> libc::c
 ///
 /// Upon successful completion, the number of bytes written is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_write(
+pub unsafe fn default_write<T>(
+    _state: &T,
     fd: libc::c_int,
     buf: *const libc::c_void,
     count: libc::size_t,
@@ -369,6 +410,7 @@ pub unsafe fn default_write(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `buf`: Buffer to read into.
 /// - `count`: Number of bytes to read.
@@ -377,7 +419,8 @@ pub unsafe fn default_write(
 ///
 /// Upon successful completion, the number of bytes read is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_read(
+pub unsafe fn default_read<T>(
+    _state: &T,
     fd: libc::c_int,
     buf: *mut libc::c_void,
     count: libc::size_t,
@@ -392,6 +435,7 @@ pub unsafe fn default_read(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `buf`: Buffer to write from.
 /// - `count`: Number of bytes to write.
@@ -401,7 +445,8 @@ pub unsafe fn default_read(
 ///
 /// Upon successful completion, the number of bytes written is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_pwrite(
+pub unsafe fn default_pwrite<T>(
+    _state: &T,
     fd: libc::c_int,
     buf: *const libc::c_void,
     count: libc::size_t,
@@ -417,6 +462,7 @@ pub unsafe fn default_pwrite(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `buf`: Buffer to read into.
 /// - `count`: Number of bytes to read.
@@ -426,7 +472,8 @@ pub unsafe fn default_pwrite(
 ///
 /// Upon successful completion, the number of bytes read is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_pread(
+pub unsafe fn default_pread<T>(
+    _state: &T,
     fd: libc::c_int,
     buf: *mut libc::c_void,
     count: libc::size_t,
@@ -442,6 +489,7 @@ pub unsafe fn default_pread(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `olddirfd`: Old directory file descriptor.
 /// - `oldpath`: Old path.
 /// - `newdirfd`: New directory file descriptor.
@@ -452,7 +500,8 @@ pub unsafe fn default_pread(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_linkat(
+pub unsafe fn default_linkat<T>(
+    _state: &T,
     olddirfd: libc::c_int,
     oldpath: *const libc::c_char,
     newdirfd: libc::c_int,
@@ -469,13 +518,14 @@ pub unsafe fn default_linkat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 ///
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_fchdir(fd: libc::c_int) -> libc::c_int {
+pub unsafe fn default_fchdir<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
     libc::fchdir(fd)
 }
 
@@ -486,6 +536,7 @@ pub unsafe fn default_fchdir(fd: libc::c_int) -> libc::c_int {
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `owner`: Owner.
 /// - `group`: Group.
@@ -494,7 +545,8 @@ pub unsafe fn default_fchdir(fd: libc::c_int) -> libc::c_int {
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_fchown(
+pub unsafe fn default_fchown<T>(
+    _state: &T,
     fd: libc::c_int,
     owner: libc::uid_t,
     group: libc::gid_t,
@@ -509,64 +561,83 @@ pub unsafe fn default_fchown(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `pipefd`: Pipe file descriptors.
 ///
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_pipe(pipefd: *mut libc::c_int) -> libc::c_int {
+pub unsafe fn default_pipe<T>(_state: &T, pipefd: *mut libc::c_int) -> libc::c_int {
     libc::pipe(pipefd)
 }
 
 /// Type alias for `openat()` system call function.
-pub type OpenatFn =
-    unsafe fn(libc::c_int, *const libc::c_char, libc::c_int, libc::mode_t) -> libc::c_int;
+pub type OpenatFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::c_char, libc::c_int, libc::mode_t) -> libc::c_int;
 
 /// Type alias for `unlinkat()` system call function.
-pub type UnlinkatFn = unsafe fn(libc::c_int, *const libc::c_char, libc::c_int) -> libc::c_int;
+pub type UnlinkatFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::c_char, libc::c_int) -> libc::c_int;
 
 /// Type alias for `renameat()` system call function.
-pub type RenameatFn =
-    unsafe fn(libc::c_int, *const libc::c_char, libc::c_int, *const libc::c_char) -> libc::c_int;
+pub type RenameatFn<T> = unsafe fn(
+    &T,
+    libc::c_int,
+    *const libc::c_char,
+    libc::c_int,
+    *const libc::c_char,
+) -> libc::c_int;
 
 /// Type alias for `fstatat()` system call function.
-pub type FstatatFn =
-    unsafe fn(libc::c_int, *const libc::c_char, *mut libc::stat, libc::c_int) -> libc::c_int;
+pub type FstatatFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::c_char, *mut libc::stat, libc::c_int) -> libc::c_int;
 
 /// Type alias for `posix_fallocate()` system call function.
-pub type PosixFallocateFn = unsafe fn(libc::c_int, libc::off_t, libc::off_t) -> libc::c_int;
+pub type PosixFallocateFn<T> = unsafe fn(&T, libc::c_int, libc::off_t, libc::off_t) -> libc::c_int;
 
 /// Type alias for `posix_fadvise()` system call function.
-pub type PosixFadviseFn =
-    unsafe fn(libc::c_int, libc::off_t, libc::off_t, libc::c_int) -> libc::c_int;
+pub type PosixFadviseFn<T> =
+    unsafe fn(&T, libc::c_int, libc::off_t, libc::off_t, libc::c_int) -> libc::c_int;
 
 /// Type alias for `fstat()` system call function.
-pub type FstatFn = unsafe fn(libc::c_int, *mut libc::stat) -> libc::c_int;
+pub type FstatFn<T> = unsafe fn(&T, libc::c_int, *mut libc::stat) -> libc::c_int;
 
 /// Type alias for `symlinkat()` system call function.
-pub type SymlinkatFn =
-    unsafe fn(*const libc::c_char, libc::c_int, *const libc::c_char) -> libc::c_int;
+pub type SymlinkatFn<T> =
+    unsafe fn(&T, *const libc::c_char, libc::c_int, *const libc::c_char) -> libc::c_int;
 
 /// Type alias for `readlinkat()` system call function.
-pub type ReadlinkatFn =
-    unsafe fn(libc::c_int, *const libc::c_char, *mut libc::c_char, libc::size_t) -> libc::ssize_t;
+pub type ReadlinkatFn<T> = unsafe fn(
+    &T,
+    libc::c_int,
+    *const libc::c_char,
+    *mut libc::c_char,
+    libc::size_t,
+) -> libc::ssize_t;
 
 /// Type alias for `mkdirat()` system call function.
-pub type MkdiratFn = unsafe fn(libc::c_int, *const libc::c_char, libc::mode_t) -> libc::c_int;
+pub type MkdiratFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::c_char, libc::mode_t) -> libc::c_int;
 
 /// Type alias for `utimensat()` system call function.
-pub type UtimensatFn =
-    unsafe fn(libc::c_int, *const libc::c_char, *const libc::timespec, libc::c_int) -> libc::c_int;
+pub type UtimensatFn<T> = unsafe fn(
+    &T,
+    libc::c_int,
+    *const libc::c_char,
+    *const libc::timespec,
+    libc::c_int,
+) -> libc::c_int;
 
 /// Type alias for `futimens()` system call function.
-pub type FutimensFn = unsafe fn(libc::c_int, *const libc::timespec) -> libc::c_int;
+pub type FutimensFn<T> = unsafe fn(&T, libc::c_int, *const libc::timespec) -> libc::c_int;
 
 /// Type alias for `fcntl()` system call function.
-pub type FcntlFn = unsafe fn(libc::c_int, libc::c_int, libc::c_int) -> libc::c_int;
+pub type FcntlFn<T> = unsafe fn(&T, libc::c_int, libc::c_int, libc::c_int) -> libc::c_int;
 
 /// Type alias for `fchownat()` system call function.
-pub type FchownatFn = unsafe fn(
+pub type FchownatFn<T> = unsafe fn(
+    &T,
     libc::c_int,
     *const libc::c_char,
     libc::uid_t,
@@ -575,11 +646,11 @@ pub type FchownatFn = unsafe fn(
 ) -> libc::c_int;
 
 /// Type alias for `fchmod()` system call function.
-pub type FchmodFn = unsafe fn(libc::c_int, libc::mode_t) -> libc::c_int;
+pub type FchmodFn<T> = unsafe fn(&T, libc::c_int, libc::mode_t) -> libc::c_int;
 
 /// Type alias for `fchmodat()` system call function.
-pub type FchmodatFn =
-    unsafe fn(libc::c_int, *const libc::c_char, libc::mode_t, libc::c_int) -> libc::c_int;
+pub type FchmodatFn<T> =
+    unsafe fn(&T, libc::c_int, *const libc::c_char, libc::mode_t, libc::c_int) -> libc::c_int;
 
 //==================================================================================================
 // Default Implementations - fcntl.rs
@@ -592,6 +663,7 @@ pub type FchmodatFn =
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `dirfd`: Directory file descriptor.
 /// - `pathname`: Path to open.
 /// - `flags`: Flags.
@@ -601,7 +673,8 @@ pub type FchmodatFn =
 ///
 /// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_openat(
+pub unsafe fn default_openat<T>(
+    _state: &T,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     flags: libc::c_int,
@@ -617,6 +690,7 @@ pub unsafe fn default_openat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `dirfd`: Directory file descriptor.
 /// - `pathname`: Path to unlink.
 /// - `flags`: Flags.
@@ -625,7 +699,8 @@ pub unsafe fn default_openat(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_unlinkat(
+pub unsafe fn default_unlinkat<T>(
+    _state: &T,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     flags: libc::c_int,
@@ -640,6 +715,7 @@ pub unsafe fn default_unlinkat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `olddirfd`: Old directory file descriptor.
 /// - `oldpath`: Old path.
 /// - `newdirfd`: New directory file descriptor.
@@ -649,7 +725,8 @@ pub unsafe fn default_unlinkat(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_renameat(
+pub unsafe fn default_renameat<T>(
+    _state: &T,
     olddirfd: libc::c_int,
     oldpath: *const libc::c_char,
     newdirfd: libc::c_int,
@@ -665,6 +742,7 @@ pub unsafe fn default_renameat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `dirfd`: Directory file descriptor.
 /// - `pathname`: Path to stat.
 /// - `buf`: Buffer to store stat.
@@ -674,7 +752,8 @@ pub unsafe fn default_renameat(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_fstatat(
+pub unsafe fn default_fstatat<T>(
+    _state: &T,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     buf: *mut libc::stat,
@@ -690,6 +769,7 @@ pub unsafe fn default_fstatat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `offset`: Offset.
 /// - `len`: Length.
@@ -698,7 +778,8 @@ pub unsafe fn default_fstatat(
 ///
 /// Upon successful completion, zero is returned. Otherwise, an error number is returned.
 ///
-pub unsafe fn default_posix_fallocate(
+pub unsafe fn default_posix_fallocate<T>(
+    _state: &T,
     fd: libc::c_int,
     offset: libc::off_t,
     len: libc::off_t,
@@ -713,6 +794,7 @@ pub unsafe fn default_posix_fallocate(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `offset`: Offset.
 /// - `len`: Length.
@@ -722,7 +804,8 @@ pub unsafe fn default_posix_fallocate(
 ///
 /// Upon successful completion, zero is returned. Otherwise, an error number is returned.
 ///
-pub unsafe fn default_posix_fadvise(
+pub unsafe fn default_posix_fadvise<T>(
+    _state: &T,
     fd: libc::c_int,
     offset: libc::off_t,
     len: libc::off_t,
@@ -738,6 +821,7 @@ pub unsafe fn default_posix_fadvise(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `buf`: Buffer to store stat.
 ///
@@ -745,7 +829,7 @@ pub unsafe fn default_posix_fadvise(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_fstat(fd: libc::c_int, buf: *mut libc::stat) -> libc::c_int {
+pub unsafe fn default_fstat<T>(_state: &T, fd: libc::c_int, buf: *mut libc::stat) -> libc::c_int {
     libc::fstat(fd, buf)
 }
 
@@ -756,6 +840,7 @@ pub unsafe fn default_fstat(fd: libc::c_int, buf: *mut libc::stat) -> libc::c_in
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `target`: Target.
 /// - `newdirfd`: New directory file descriptor.
 /// - `linkpath`: Link path.
@@ -764,7 +849,8 @@ pub unsafe fn default_fstat(fd: libc::c_int, buf: *mut libc::stat) -> libc::c_in
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_symlinkat(
+pub unsafe fn default_symlinkat<T>(
+    _state: &T,
     target: *const libc::c_char,
     newdirfd: libc::c_int,
     linkpath: *const libc::c_char,
@@ -779,6 +865,7 @@ pub unsafe fn default_symlinkat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `dirfd`: Directory file descriptor.
 /// - `pathname`: Path to read.
 /// - `buf`: Buffer to store link.
@@ -788,7 +875,8 @@ pub unsafe fn default_symlinkat(
 ///
 /// Upon successful completion, the number of bytes placed in the buffer is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_readlinkat(
+pub unsafe fn default_readlinkat<T>(
+    _state: &T,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     buf: *mut libc::c_char,
@@ -804,6 +892,7 @@ pub unsafe fn default_readlinkat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `dirfd`: Directory file descriptor.
 /// - `pathname`: Path to create.
 /// - `mode`: Mode.
@@ -812,7 +901,8 @@ pub unsafe fn default_readlinkat(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_mkdirat(
+pub unsafe fn default_mkdirat<T>(
+    _state: &T,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     mode: libc::mode_t,
@@ -827,6 +917,7 @@ pub unsafe fn default_mkdirat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `dirfd`: Directory file descriptor.
 /// - `pathname`: Path to update.
 /// - `times`: Times.
@@ -836,7 +927,8 @@ pub unsafe fn default_mkdirat(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_utimensat(
+pub unsafe fn default_utimensat<T>(
+    _state: &T,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     times: *const libc::timespec,
@@ -852,6 +944,7 @@ pub unsafe fn default_utimensat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `times`: Times.
 ///
@@ -859,7 +952,11 @@ pub unsafe fn default_utimensat(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_futimens(fd: libc::c_int, times: *const libc::timespec) -> libc::c_int {
+pub unsafe fn default_futimens<T>(
+    _state: &T,
+    fd: libc::c_int,
+    times: *const libc::timespec,
+) -> libc::c_int {
     libc::futimens(fd, times)
 }
 
@@ -870,6 +967,7 @@ pub unsafe fn default_futimens(fd: libc::c_int, times: *const libc::timespec) ->
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `cmd`: Command.
 /// - `arg`: Argument.
@@ -878,7 +976,12 @@ pub unsafe fn default_futimens(fd: libc::c_int, times: *const libc::timespec) ->
 ///
 /// Upon successful completion, a value depends on the command. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_fcntl(fd: libc::c_int, cmd: libc::c_int, arg: libc::c_int) -> libc::c_int {
+pub unsafe fn default_fcntl<T>(
+    _state: &T,
+    fd: libc::c_int,
+    cmd: libc::c_int,
+    arg: libc::c_int,
+) -> libc::c_int {
     libc::fcntl(fd, cmd, arg)
 }
 
@@ -889,6 +992,7 @@ pub unsafe fn default_fcntl(fd: libc::c_int, cmd: libc::c_int, arg: libc::c_int)
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `dirfd`: Directory file descriptor.
 /// - `pathname`: Path to change ownership.
 /// - `owner`: Owner.
@@ -899,7 +1003,8 @@ pub unsafe fn default_fcntl(fd: libc::c_int, cmd: libc::c_int, arg: libc::c_int)
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_fchownat(
+pub unsafe fn default_fchownat<T>(
+    _state: &T,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     owner: libc::uid_t,
@@ -916,6 +1021,7 @@ pub unsafe fn default_fchownat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `mode`: Mode.
 ///
@@ -923,7 +1029,7 @@ pub unsafe fn default_fchownat(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_fchmod(fd: libc::c_int, mode: libc::mode_t) -> libc::c_int {
+pub unsafe fn default_fchmod<T>(_state: &T, fd: libc::c_int, mode: libc::mode_t) -> libc::c_int {
     libc::fchmod(fd, mode)
 }
 
@@ -934,6 +1040,7 @@ pub unsafe fn default_fchmod(fd: libc::c_int, mode: libc::mode_t) -> libc::c_int
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `dirfd`: Directory file descriptor.
 /// - `pathname`: Path to change mode.
 /// - `mode`: Mode.
@@ -943,7 +1050,8 @@ pub unsafe fn default_fchmod(fd: libc::c_int, mode: libc::mode_t) -> libc::c_int
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_fchmodat(
+pub unsafe fn default_fchmodat<T>(
+    _state: &T,
     dirfd: libc::c_int,
     pathname: *const libc::c_char,
     mode: libc::mode_t,
@@ -963,6 +1071,7 @@ pub unsafe fn default_fchmodat(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fd`: File descriptor.
 /// - `dirp`: Directory entries buffer.
 /// - `count`: Buffer size.
@@ -971,7 +1080,8 @@ pub unsafe fn default_fchmodat(
 ///
 /// Upon successful completion, the number of bytes read is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_getdents(
+pub unsafe fn default_getdents<T>(
+    _state: &T,
     fd: libc::c_int,
     dirp: *mut u8,
     count: libc::size_t,
@@ -990,6 +1100,7 @@ pub unsafe fn default_getdents(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `domain`: Domain.
 /// - `type_`: Type.
 /// - `protocol`: Protocol.
@@ -998,7 +1109,8 @@ pub unsafe fn default_getdents(
 ///
 /// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_socket(
+pub unsafe fn default_socket<T>(
+    _state: &T,
     domain: libc::c_int,
     type_: libc::c_int,
     protocol: libc::c_int,
@@ -1013,6 +1125,7 @@ pub unsafe fn default_socket(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `domain`: Domain.
 /// - `type_`: Type.
 /// - `protocol`: Protocol.
@@ -1022,7 +1135,8 @@ pub unsafe fn default_socket(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_socketpair(
+pub unsafe fn default_socketpair<T>(
+    _state: &T,
     domain: libc::c_int,
     type_: libc::c_int,
     protocol: libc::c_int,
@@ -1038,6 +1152,7 @@ pub unsafe fn default_socketpair(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `sockfd`: Socket file descriptor.
 /// - `addr`: Address.
 /// - `addrlen`: Address length.
@@ -1046,7 +1161,8 @@ pub unsafe fn default_socketpair(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_bind(
+pub unsafe fn default_bind<T>(
+    _state: &T,
     sockfd: libc::c_int,
     addr: *const libc::sockaddr,
     addrlen: libc::socklen_t,
@@ -1061,6 +1177,7 @@ pub unsafe fn default_bind(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `sockfd`: Socket file descriptor.
 /// - `addr`: Address.
 /// - `addrlen`: Address length.
@@ -1069,7 +1186,8 @@ pub unsafe fn default_bind(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_connect(
+pub unsafe fn default_connect<T>(
+    _state: &T,
     sockfd: libc::c_int,
     addr: *const libc::sockaddr,
     addrlen: libc::socklen_t,
@@ -1084,6 +1202,7 @@ pub unsafe fn default_connect(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `sockfd`: Socket file descriptor.
 /// - `backlog`: Backlog.
 ///
@@ -1091,7 +1210,11 @@ pub unsafe fn default_connect(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_listen(sockfd: libc::c_int, backlog: libc::c_int) -> libc::c_int {
+pub unsafe fn default_listen<T>(
+    _state: &T,
+    sockfd: libc::c_int,
+    backlog: libc::c_int,
+) -> libc::c_int {
     libc::listen(sockfd, backlog)
 }
 
@@ -1102,6 +1225,7 @@ pub unsafe fn default_listen(sockfd: libc::c_int, backlog: libc::c_int) -> libc:
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `sockfd`: Socket file descriptor.
 /// - `addr`: Address.
 /// - `addrlen`: Address length.
@@ -1110,7 +1234,8 @@ pub unsafe fn default_listen(sockfd: libc::c_int, backlog: libc::c_int) -> libc:
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_getpeername(
+pub unsafe fn default_getpeername<T>(
+    _state: &T,
     sockfd: libc::c_int,
     addr: *mut libc::sockaddr,
     addrlen: *mut libc::socklen_t,
@@ -1125,6 +1250,7 @@ pub unsafe fn default_getpeername(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `sockfd`: Socket file descriptor.
 /// - `addr`: Address.
 /// - `addrlen`: Address length.
@@ -1133,7 +1259,8 @@ pub unsafe fn default_getpeername(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_getsockname(
+pub unsafe fn default_getsockname<T>(
+    _state: &T,
     sockfd: libc::c_int,
     addr: *mut libc::sockaddr,
     addrlen: *mut libc::socklen_t,
@@ -1148,6 +1275,7 @@ pub unsafe fn default_getsockname(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `sockfd`: Socket file descriptor.
 /// - `addr`: Address.
 /// - `addrlen`: Address length.
@@ -1156,7 +1284,8 @@ pub unsafe fn default_getsockname(
 ///
 /// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_accept(
+pub unsafe fn default_accept<T>(
+    _state: &T,
     sockfd: libc::c_int,
     addr: *mut libc::sockaddr,
     addrlen: *mut libc::socklen_t,
@@ -1171,6 +1300,7 @@ pub unsafe fn default_accept(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `sockfd`: Socket file descriptor.
 /// - `buf`: Buffer.
 /// - `len`: Length.
@@ -1180,7 +1310,8 @@ pub unsafe fn default_accept(
 ///
 /// Upon successful completion, the number of bytes received is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_recv(
+pub unsafe fn default_recv<T>(
+    _state: &T,
     sockfd: libc::c_int,
     buf: *mut libc::c_void,
     len: libc::size_t,
@@ -1196,6 +1327,7 @@ pub unsafe fn default_recv(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `sockfd`: Socket file descriptor.
 /// - `buf`: Buffer.
 /// - `len`: Length.
@@ -1205,7 +1337,8 @@ pub unsafe fn default_recv(
 ///
 /// Upon successful completion, the number of bytes sent is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_send(
+pub unsafe fn default_send<T>(
+    _state: &T,
     sockfd: libc::c_int,
     buf: *const libc::c_void,
     len: libc::size_t,
@@ -1221,6 +1354,7 @@ pub unsafe fn default_send(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `sockfd`: Socket file descriptor.
 /// - `how`: How.
 ///
@@ -1228,7 +1362,11 @@ pub unsafe fn default_send(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_shutdown(sockfd: libc::c_int, how: libc::c_int) -> libc::c_int {
+pub unsafe fn default_shutdown<T>(
+    _state: &T,
+    sockfd: libc::c_int,
+    how: libc::c_int,
+) -> libc::c_int {
     libc::shutdown(sockfd, how)
 }
 
@@ -1243,6 +1381,7 @@ pub unsafe fn default_shutdown(sockfd: libc::c_int, how: libc::c_int) -> libc::c
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `fds`: File descriptors.
 /// - `nfds`: Number of file descriptors.
 /// - `timeout`: Timeout.
@@ -1251,7 +1390,8 @@ pub unsafe fn default_shutdown(sockfd: libc::c_int, how: libc::c_int) -> libc::c
 ///
 /// Upon successful completion, the number of file descriptors with events is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_poll(
+pub unsafe fn default_poll<T>(
+    _state: &T,
     fds: *mut libc::pollfd,
     nfds: libc::nfds_t,
     timeout: libc::c_int,
@@ -1270,6 +1410,7 @@ pub unsafe fn default_poll(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `nfds`: Number of file descriptors.
 /// - `readfds`: Read file descriptors.
 /// - `writefds`: Write file descriptors.
@@ -1280,7 +1421,8 @@ pub unsafe fn default_poll(
 ///
 /// Upon successful completion, the number of file descriptors with events is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_select(
+pub unsafe fn default_select<T>(
+    _state: &T,
     nfds: libc::c_int,
     readfds: *mut libc::fd_set,
     writefds: *mut libc::fd_set,
@@ -1301,13 +1443,14 @@ pub unsafe fn default_select(
 ///
 /// # Parameters
 ///
+/// - `_state`: Immutable reference to state (unused in default implementation).
 /// - `buf`: Buffer to store times.
 ///
 /// # Returns
 ///
 /// Upon successful completion, the elapsed real time in clock ticks is returned. Otherwise, -1 is returned and `errno` is set.
 ///
-pub unsafe fn default_times(buf: *mut libc::tms) -> libc::clock_t {
+pub unsafe fn default_times<T>(_state: &T, buf: *mut libc::tms) -> libc::clock_t {
     libc::times(buf)
 }
 
@@ -1327,76 +1470,105 @@ pub enum SyscallAction<F> {
 ///
 /// System call routing table.
 ///
-pub struct SyscallTable {
+/// This structure holds the configuration for how system calls should be handled. Each system
+/// call can be either blocked or forwarded to a handler function. The generic type parameter `T`
+/// represents custom state that is passed as a reference to each system call handler, allowing
+/// implementations to maintain context-specific information (e.g., file descriptor tables,
+/// process state, or other runtime data).
+///
+/// # Type Parameters
+///
+/// - `T`: Custom state type that is passed to all system call handler functions. Use `()` if no
+///   state is required.
+///
+pub struct SyscallTable<T> {
+    /// State that is passed to each system call action function.
+    pub state: T,
+
     // unistd.rs system calls.
-    pub chdir: SyscallAction<ChdirFn>,
-    pub close: SyscallAction<CloseFn>,
-    pub faccessat: SyscallAction<FaccessatFn>,
-    pub fdatasync: SyscallAction<FdatasyncFn>,
-    pub fchdir: SyscallAction<FchdirFn>,
-    pub fchown: SyscallAction<FchownFn>,
-    pub fsync: SyscallAction<FsyncFn>,
-    pub ftruncate: SyscallAction<FtruncateFn>,
-    pub getcwd: SyscallAction<GetcwdFn>,
-    pub getegid: SyscallAction<GetegidFn>,
-    pub geteuid: SyscallAction<GeteuidFn>,
-    pub getgid: SyscallAction<GetgidFn>,
-    pub getuid: SyscallAction<GetuidFn>,
-    pub linkat: SyscallAction<LinkatFn>,
-    pub lseek: SyscallAction<LseekFn>,
-    pub pipe: SyscallAction<PipeFn>,
-    pub pread: SyscallAction<PreadFn>,
-    pub pwrite: SyscallAction<PwriteFn>,
-    pub read: SyscallAction<ReadFn>,
-    pub write: SyscallAction<WriteFn>,
+    pub chdir: SyscallAction<ChdirFn<T>>,
+    pub close: SyscallAction<CloseFn<T>>,
+    pub faccessat: SyscallAction<FaccessatFn<T>>,
+    pub fdatasync: SyscallAction<FdatasyncFn<T>>,
+    pub fchdir: SyscallAction<FchdirFn<T>>,
+    pub fchown: SyscallAction<FchownFn<T>>,
+    pub fsync: SyscallAction<FsyncFn<T>>,
+    pub ftruncate: SyscallAction<FtruncateFn<T>>,
+    pub getcwd: SyscallAction<GetcwdFn<T>>,
+    pub getegid: SyscallAction<GetegidFn<T>>,
+    pub geteuid: SyscallAction<GeteuidFn<T>>,
+    pub getgid: SyscallAction<GetgidFn<T>>,
+    pub getuid: SyscallAction<GetuidFn<T>>,
+    pub linkat: SyscallAction<LinkatFn<T>>,
+    pub lseek: SyscallAction<LseekFn<T>>,
+    pub pipe: SyscallAction<PipeFn<T>>,
+    pub pread: SyscallAction<PreadFn<T>>,
+    pub pwrite: SyscallAction<PwriteFn<T>>,
+    pub read: SyscallAction<ReadFn<T>>,
+    pub write: SyscallAction<WriteFn<T>>,
 
     // fcntl.rs system calls.
-    pub fchmod: SyscallAction<FchmodFn>,
-    pub fchmodat: SyscallAction<FchmodatFn>,
-    pub fchownat: SyscallAction<FchownatFn>,
-    pub fcntl: SyscallAction<FcntlFn>,
-    pub fstat: SyscallAction<FstatFn>,
-    pub fstatat: SyscallAction<FstatatFn>,
-    pub futimens: SyscallAction<FutimensFn>,
-    pub mkdirat: SyscallAction<MkdiratFn>,
-    pub openat: SyscallAction<OpenatFn>,
-    pub posix_fadvise: SyscallAction<PosixFadviseFn>,
-    pub posix_fallocate: SyscallAction<PosixFallocateFn>,
-    pub readlinkat: SyscallAction<ReadlinkatFn>,
-    pub renameat: SyscallAction<RenameatFn>,
-    pub symlinkat: SyscallAction<SymlinkatFn>,
-    pub unlinkat: SyscallAction<UnlinkatFn>,
-    pub utimensat: SyscallAction<UtimensatFn>,
+    pub fchmod: SyscallAction<FchmodFn<T>>,
+    pub fchmodat: SyscallAction<FchmodatFn<T>>,
+    pub fchownat: SyscallAction<FchownatFn<T>>,
+    pub fcntl: SyscallAction<FcntlFn<T>>,
+    pub fstat: SyscallAction<FstatFn<T>>,
+    pub fstatat: SyscallAction<FstatatFn<T>>,
+    pub futimens: SyscallAction<FutimensFn<T>>,
+    pub mkdirat: SyscallAction<MkdiratFn<T>>,
+    pub openat: SyscallAction<OpenatFn<T>>,
+    pub posix_fadvise: SyscallAction<PosixFadviseFn<T>>,
+    pub posix_fallocate: SyscallAction<PosixFallocateFn<T>>,
+    pub readlinkat: SyscallAction<ReadlinkatFn<T>>,
+    pub renameat: SyscallAction<RenameatFn<T>>,
+    pub symlinkat: SyscallAction<SymlinkatFn<T>>,
+    pub unlinkat: SyscallAction<UnlinkatFn<T>>,
+    pub utimensat: SyscallAction<UtimensatFn<T>>,
 
     // dirent.rs system calls.
-    pub getdents: SyscallAction<GetdentsFn>,
+    pub getdents: SyscallAction<GetdentsFn<T>>,
 
     // socket.rs system calls.
-    pub accept: SyscallAction<AcceptFn>,
-    pub bind: SyscallAction<BindFn>,
-    pub connect: SyscallAction<ConnectFn>,
-    pub getpeername: SyscallAction<GetpeernameFn>,
-    pub getsockname: SyscallAction<GetsocknameFn>,
-    pub listen: SyscallAction<ListenFn>,
-    pub recv: SyscallAction<RecvFn>,
-    pub send: SyscallAction<SendFn>,
-    pub shutdown: SyscallAction<ShutdownFn>,
-    pub socket: SyscallAction<SocketFn>,
-    pub socketpair: SyscallAction<SocketpairFn>,
+    pub accept: SyscallAction<AcceptFn<T>>,
+    pub bind: SyscallAction<BindFn<T>>,
+    pub connect: SyscallAction<ConnectFn<T>>,
+    pub getpeername: SyscallAction<GetpeernameFn<T>>,
+    pub getsockname: SyscallAction<GetsocknameFn<T>>,
+    pub listen: SyscallAction<ListenFn<T>>,
+    pub recv: SyscallAction<RecvFn<T>>,
+    pub send: SyscallAction<SendFn<T>>,
+    pub shutdown: SyscallAction<ShutdownFn<T>>,
+    pub socket: SyscallAction<SocketFn<T>>,
+    pub socketpair: SyscallAction<SocketpairFn<T>>,
 
     // poll.rs system calls.
-    pub poll: SyscallAction<PollFn>,
+    pub poll: SyscallAction<PollFn<T>>,
 
     // sys_select.rs system calls.
-    pub select: SyscallAction<SelectFn>,
+    pub select: SyscallAction<SelectFn<T>>,
 
     // times.rs system calls.
-    pub times: SyscallAction<TimesFn>,
+    pub times: SyscallAction<TimesFn<T>>,
 }
 
-impl Default for SyscallTable {
-    fn default() -> Self {
+impl<T> SyscallTable<T> {
+    ///
+    /// # Description
+    ///
+    /// Creates a new syscall table with the given state.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: State that is passed to each system call action function.
+    ///
+    /// # Returns
+    ///
+    /// A new syscall table.
+    ///
+    pub fn new(state: T) -> Self {
         Self {
+            state,
+
             // unistd.rs system calls.
             chdir: SyscallAction::Forward(default_chdir),
             close: SyscallAction::Forward(default_close),
@@ -1462,5 +1634,11 @@ impl Default for SyscallTable {
             // times.rs system calls.
             times: SyscallAction::Forward(default_times),
         }
+    }
+}
+
+impl Default for SyscallTable<()> {
+    fn default() -> Self {
+        Self::new(())
     }
 }

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -214,13 +214,13 @@ impl WorkerThreadHandle {
 
     /// Spawn an interruptible worker thread.
     #[allow(clippy::too_many_arguments)]
-    pub fn spawn_worker_thread(
+    pub fn spawn_worker_thread<T: Sync + Send + 'static>(
         id: ThreadIdentifier,
         channel_rx: Receiver<VenvCommand>,
         channel_tx: Sender<VenvCommand>,
         uvm_handle: UserVmHandle,
         assembler: Arc<Mutex<RequestAssembler>>,
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: Arc<SyscallTable<T>>,
     ) -> Result<Self, Error> {
         trace!("spawning worker thread (id={id:?})");
         // We use an atomic to pass the id of the created thread back to the caller context. We
@@ -267,10 +267,10 @@ impl WorkerThreadHandle {
         Ok(())
     }
 
-    fn handle_message(
+    fn handle_message<T>(
         mut channel_rx: Receiver<VenvCommand>,
         uvm_handle: UserVmHandle,
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: Arc<SyscallTable<T>>,
         assembler: Arc<Mutex<RequestAssembler>>,
     ) {
         let worker_tid: ThreadId = thread::current().id();
@@ -330,7 +330,7 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::ReadRequest
                                 | LinuxDaemonMessageHeader::WriteRequest => {
                                     match Self::handle_special_messages(
-                                        syscall_table.clone(),
+                                        &syscall_table,
                                         gateway_reader.clone(),
                                         gateway_writer.clone(),
                                         source,
@@ -407,7 +407,7 @@ impl WorkerThreadHandle {
                                 | LinuxDaemonMessageHeader::GetDirectoryEntriesRequest => {
                                     match Self::handle_long_response_messages(
                                         uvm_stream.clone(),
-                                        syscall_table.clone(),
+                                        &syscall_table,
                                         source,
                                         message,
                                     ) {
@@ -445,7 +445,7 @@ impl WorkerThreadHandle {
                                     match Self::handle_long_request_messages(
                                         uvm_stream.clone(),
                                         assembler.clone(),
-                                        syscall_table.clone(),
+                                        &syscall_table,
                                         source,
                                         message,
                                     ) {
@@ -491,8 +491,8 @@ impl WorkerThreadHandle {
         }
     }
 
-    fn handle_special_messages(
-        syscall_table: Arc<SyscallTable>,
+    fn handle_special_messages<T>(
+        syscall_table: &SyscallTable<T>,
         gateway_reader: Arc<Mutex<SocketStreamReader>>,
         gateway_writer: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
@@ -519,130 +519,130 @@ impl WorkerThreadHandle {
         }
     }
 
-    fn handle_short_request_messages(
-        syscall_table: Arc<SyscallTable>,
+    fn handle_short_request_messages<T>(
+        syscall_table: Arc<SyscallTable<T>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<Message, WorkerThreadError> {
         match message.header {
             LinuxDaemonMessageHeader::AcceptSocketRequest => {
                 let request: AcceptSocketRequest = AcceptSocketRequest::from_bytes(message.payload);
-                sys_socket::do_accept(syscall_table, source, request)
+                sys_socket::do_accept(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::BindSocketRequest => {
                 let request: BindSocketRequest = BindSocketRequest::from_bytes(message.payload);
-                sys_socket::do_bind(syscall_table, source, request)
+                sys_socket::do_bind(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::ConnectSocketRequest => {
                 let request: ConnectSocketRequest =
                     ConnectSocketRequest::from_bytes(message.payload);
-                sys_socket::do_connect(syscall_table, source, request)
+                sys_socket::do_connect(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::CreateSocketPairRequest => {
                 let request: CreateSocketPairRequest =
                     CreateSocketPairRequest::from_bytes(message.payload);
-                sys_socket::do_socketpair(syscall_table, source, request)
+                sys_socket::do_socketpair(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::CreateSocketRequest => {
                 let request: CreateSocketRequest = CreateSocketRequest::from_bytes(message.payload);
-                sys_socket::do_socket(syscall_table, source, request)
+                sys_socket::do_socket(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileAdvisoryInformationRequest => {
                 let request: FileAdvisoryInformationRequest =
                     FileAdvisoryInformationRequest::from_bytes(message.payload);
-                fcntl::do_posix_fadvise(syscall_table, source, request)
+                fcntl::do_posix_fadvise(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileChdirRequest => {
                 let request: FileChdirRequest = FileChdirRequest::from_bytes(message.payload);
-                unistd::do_fchdir(syscall_table, source, request)
+                unistd::do_fchdir(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileChmodRequest => {
                 let request: FileChmodRequest = FileChmodRequest::from_bytes(message.payload);
-                fcntl::do_fchmod(syscall_table, source, request)
+                fcntl::do_fchmod(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileChownRequest => {
                 let request: FileChownRequest = FileChownRequest::from_bytes(message.payload);
-                unistd::do_fchown(syscall_table, source, request)
+                unistd::do_fchown(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileControlRequest => {
                 let request: FileControlRequest = FileControlRequest::from_bytes(message.payload);
-                fcntl::do_fcntl(syscall_table, source, request)
+                fcntl::do_fcntl(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileDataSyncRequest => {
                 let request: FileDataSyncRequest = FileDataSyncRequest::from_bytes(message.payload);
-                unistd::do_fdatasync(syscall_table, source, request)
+                unistd::do_fdatasync(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileSpaceControlRequest => {
                 let request: FileSpaceControlRequest =
                     FileSpaceControlRequest::from_bytes(message.payload);
-                fcntl::do_posix_fallocate(syscall_table, source, request)
+                fcntl::do_posix_fallocate(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileSyncRequest => {
                 let request: FileSyncRequest = FileSyncRequest::from_bytes(message.payload);
-                unistd::do_fsync(syscall_table, source, request)
+                unistd::do_fsync(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::FileTruncateRequest => {
                 let request: FileTruncateRequest = FileTruncateRequest::from_bytes(message.payload);
-                unistd::do_ftruncate(syscall_table, source, request)
+                unistd::do_ftruncate(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::GetIdsRequest => {
                 let request: GetIdsRequest = GetIdsRequest::from_bytes(message.payload);
-                unistd::do_getids(syscall_table, source, request)
+                unistd::do_getids(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::GetPeerNameRequest => {
                 let request: GetPeerNameRequest = GetPeerNameRequest::from_bytes(message.payload);
-                sys_socket::do_getpeername(syscall_table, source, request)
+                sys_socket::do_getpeername(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::GetSockNameRequest => {
                 let request: GetSockNameRequest = GetSockNameRequest::from_bytes(message.payload);
-                sys_socket::do_getsockname(syscall_table, source, request)
+                sys_socket::do_getsockname(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::ListenSocketRequest => {
                 let request: ListenSocketRequest = ListenSocketRequest::from_bytes(message.payload);
-                sys_socket::do_listen(syscall_table, source, request)
+                sys_socket::do_listen(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::PartialReadRequest => {
                 let request: PartialReadRequest = PartialReadRequest::from_bytes(message.payload);
-                unistd::do_pread(syscall_table, source, request)
+                unistd::do_pread(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::PartialWriteRequest => {
                 let request: PartialWriteRequest = PartialWriteRequest::from_bytes(message.payload);
-                unistd::do_pwrite(syscall_table, source, request)
+                unistd::do_pwrite(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::ReceiveSocketRequest => {
                 let request: ReceiveSocketRequest =
                     ReceiveSocketRequest::from_bytes(message.payload);
-                sys_socket::do_recv(syscall_table, source, request)
+                sys_socket::do_recv(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::SeekRequest => {
                 let request: SeekRequest = SeekRequest::from_bytes(message.payload);
-                unistd::do_lseek(syscall_table, source, request)
+                unistd::do_lseek(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::SelectRequest => {
                 let request: SelectRequest = SelectRequest::from_bytes(message.payload);
-                sys_select::do_select(syscall_table, source, request)
+                sys_select::do_select(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::SendSocketRequest => {
                 let request: SendSocketRequest = SendSocketRequest::from_bytes(message.payload);
-                sys_socket::do_send(syscall_table, source, request)
+                sys_socket::do_send(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::ShutdownSocketRequest => {
                 let request: ShutdownSocketRequest =
                     ShutdownSocketRequest::from_bytes(message.payload);
-                sys_socket::do_shutdown(syscall_table, source, request)
+                sys_socket::do_shutdown(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::TimesRequest => {
                 let request: TimesRequest = TimesRequest::from_bytes(message.payload);
-                sys_times::do_times(syscall_table, source, request)
+                sys_times::do_times(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::UpdateFileAccessTimeRequest => {
                 let request: UpdateFileAccessTimeRequest =
                     UpdateFileAccessTimeRequest::from_bytes(message.payload);
-                fcntl::do_futimens(syscall_table, source, request)
+                fcntl::do_futimens(&syscall_table, source, request)
             },
             LinuxDaemonMessageHeader::PipeRequest => {
                 let _request = PipeRequest::from_bytes(message.payload);
-                unistd::do_pipe(syscall_table, source)
+                unistd::do_pipe(&syscall_table, source)
             },
             header => {
                 // The following statement is unreachable, because the matching logic in this
@@ -652,16 +652,16 @@ impl WorkerThreadHandle {
         }
     }
 
-    fn handle_long_request_messages(
+    fn handle_long_request_messages<T>(
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         assembler: Arc<Mutex<RequestAssembler>>,
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<(), WorkerThreadError> {
         match message.header {
             LinuxDaemonMessageHeader::ChangeDirectoryRequestPart => {
-                Self::handle_long_request::<ChangeDirectoryRequest>(
+                Self::handle_long_request::<T, ChangeDirectoryRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -670,7 +670,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::FileAccessAtRequestPart => {
-                Self::handle_long_request::<FileAccessAtRequest>(
+                Self::handle_long_request::<T, FileAccessAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -679,7 +679,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::FileStatAtRequestPart => {
-                Self::handle_long_request::<FileStatAtRequest>(
+                Self::handle_long_request::<T, FileStatAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -688,7 +688,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::SymbolicLinkAtRequestPart => {
-                Self::handle_long_request::<SymbolicLinkAtRequest>(
+                Self::handle_long_request::<T, SymbolicLinkAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -697,7 +697,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::LinkAtRequestPart => {
-                Self::handle_long_request::<LinkAtRequest>(
+                Self::handle_long_request::<T, LinkAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -706,7 +706,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::ReadLinkAtRequestPart => {
-                Self::handle_long_request::<ReadLinkAtRequest>(
+                Self::handle_long_request::<T, ReadLinkAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -715,7 +715,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::MakeDirectoryAtRequestPart => {
-                Self::handle_long_request::<MakeDirectoryAtRequest>(
+                Self::handle_long_request::<T, MakeDirectoryAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -724,7 +724,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::UpdateFileAccessTimeAtRequestPart => {
-                Self::handle_long_request::<UpdateFileAccessTimeAtRequest>(
+                Self::handle_long_request::<T, UpdateFileAccessTimeAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -733,7 +733,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::FileChownAtRequestPart => {
-                Self::handle_long_request::<FileChownAtRequest>(
+                Self::handle_long_request::<T, FileChownAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -742,7 +742,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::FileChmodAtRequestPart => {
-                Self::handle_long_request::<FileChmodAtRequest>(
+                Self::handle_long_request::<T, FileChmodAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -751,7 +751,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::OpenAtRequestPart => {
-                Self::handle_long_request::<OpenAtRequest>(
+                Self::handle_long_request::<T, OpenAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -760,7 +760,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::RenameAtRequestPart => {
-                Self::handle_long_request::<RenameAtRequest>(
+                Self::handle_long_request::<T, RenameAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -769,7 +769,7 @@ impl WorkerThreadHandle {
                 )
             },
             LinuxDaemonMessageHeader::UnlinkAtRequestPart => {
-                Self::handle_long_request::<UnlinkAtRequest>(
+                Self::handle_long_request::<T, UnlinkAtRequest>(
                     uvm_stream,
                     assembler,
                     syscall_table,
@@ -777,13 +777,15 @@ impl WorkerThreadHandle {
                     &message,
                 )
             },
-            LinuxDaemonMessageHeader::PollRequestPart => Self::handle_long_request::<PollRequest>(
-                uvm_stream,
-                assembler,
-                syscall_table,
-                source,
-                &message,
-            ),
+            LinuxDaemonMessageHeader::PollRequestPart => {
+                Self::handle_long_request::<T, PollRequest>(
+                    uvm_stream,
+                    assembler,
+                    syscall_table,
+                    source,
+                    &message,
+                )
+            },
             header => {
                 // The following statement is unreachable, because the matching logic in this
                 // function should match the one in the `Self::run()` function.
@@ -792,9 +794,9 @@ impl WorkerThreadHandle {
         }
     }
 
-    fn handle_long_response_messages(
+    fn handle_long_response_messages<T>(
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
     ) -> Result<(), WorkerThreadError> {
@@ -835,8 +837,8 @@ impl WorkerThreadHandle {
         )
     }
 
-    fn handle_close_request(
-        syscall_table: Arc<SyscallTable>,
+    fn handle_close_request<T>(
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
         request: CloseRequest,
     ) -> Result<Message, WorkerThreadError> {
@@ -854,8 +856,8 @@ impl WorkerThreadHandle {
         }
     }
 
-    fn handle_write_request(
-        syscall_table: Arc<SyscallTable>,
+    fn handle_write_request<T>(
+        syscall_table: &SyscallTable<T>,
         gateway_writer: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
         mut request: WriteRequest,
@@ -899,8 +901,8 @@ impl WorkerThreadHandle {
         }
     }
 
-    fn handle_read_request(
-        syscall_table: Arc<SyscallTable>,
+    fn handle_read_request<T>(
+        syscall_table: &SyscallTable<T>,
         gateway_reader: Arc<Mutex<SocketStreamReader>>,
         source: ThreadIdentifier,
         request: ReadRequest,
@@ -962,8 +964,8 @@ impl WorkerThreadHandle {
         }
     }
 
-    fn handle_fstat_request(
-        syscall_table: Arc<SyscallTable>,
+    fn handle_fstat_request<T>(
+        syscall_table: &SyscallTable<T>,
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
@@ -981,9 +983,9 @@ impl WorkerThreadHandle {
         Ok(())
     }
 
-    fn handle_getcwd_request(
+    fn handle_getcwd_request<T>(
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<T>,
         source: ThreadIdentifier,
     ) -> Result<(), WorkerThreadError> {
         let messages: Vec<Message> = unistd::do_getcwd(syscall_table, source)?;
@@ -996,8 +998,8 @@ impl WorkerThreadHandle {
         Ok(())
     }
 
-    fn handle_getdents_request(
-        syscall_table: Arc<SyscallTable>,
+    fn handle_getdents_request<T>(
+        syscall_table: &SyscallTable<T>,
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         source: ThreadIdentifier,
         message: LinuxDaemonMessage,
@@ -1015,15 +1017,15 @@ impl WorkerThreadHandle {
         Ok(())
     }
 
-    fn handle_long_request<T>(
+    fn handle_long_request<S, T>(
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         assembler: Arc<Mutex<RequestAssembler>>,
-        syscall_table: Arc<SyscallTable>,
+        syscall_table: &SyscallTable<S>,
         source: ThreadIdentifier,
         message: &LinuxDaemonMessage,
     ) -> Result<(), WorkerThreadError>
     where
-        T: RequestAssemblerTrait,
+        T: RequestAssemblerTrait<S>,
     {
         let part: LinuxDaemonMessagePart = LinuxDaemonMessagePart::from_bytes(message.payload);
 
@@ -1031,7 +1033,7 @@ impl WorkerThreadHandle {
 
         let result: Result<Option<Vec<Message>>, WorkerThreadError> = assembler
             .blocking_lock()
-            .process_message::<T>(syscall_table, source, part);
+            .process_message::<S, T>(syscall_table, source, part);
 
         match result {
             Ok(Some(messages)) => {

--- a/src/libs/nanvix-http/src/client.rs
+++ b/src/libs/nanvix-http/src/client.rs
@@ -59,16 +59,21 @@ use ::user_vm_api::UserVmIdentifier;
 /// It deserializes request bodies, routes them to appropriate handlers based on message
 /// type headers, and constructs JSON responses.
 ///
-pub(crate) struct HttpClient {
+/// # Type Parameters
+///
+/// - `T`: Custom state type for the syscall table. This is passed to system call handlers in
+///   single-process mode. Must implement `Send + Sync + Default`. Use `()` if no custom state is required.
+///
+pub(crate) struct HttpClient<T> {
     /// Shared handle to the sandbox cache for managing sandboxes.
-    sandbox_cache: Arc<Mutex<SandboxCache>>,
+    sandbox_cache: Arc<Mutex<SandboxCache<T>>>,
 }
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl HttpClient {
+impl<T: Send + Sync + Default + 'static> HttpClient<T> {
     ///
     /// # Description
     ///
@@ -82,7 +87,7 @@ impl HttpClient {
     ///
     /// A new HTTP client handler ready to process requests.
     ///
-    pub(crate) fn new(sandbox_cache: Arc<Mutex<SandboxCache>>) -> Self {
+    pub(crate) fn new(sandbox_cache: Arc<Mutex<SandboxCache<T>>>) -> Self {
         Self { sandbox_cache }
     }
 
@@ -136,7 +141,7 @@ impl HttpClient {
     /// On failure, returns an error describing what went wrong.
     ///
     async fn serve_new(
-        sandbox_cache: Arc<Mutex<SandboxCache>>,
+        sandbox_cache: Arc<Mutex<SandboxCache<T>>>,
         message: &message::New,
     ) -> Result<message::NewResponse> {
         trace!("serve_new(): {message:?}");
@@ -186,7 +191,7 @@ impl HttpClient {
     /// with a non-zero exit code.
     ///
     async fn serve_kill(
-        sandbox_cache: Arc<Mutex<SandboxCache>>,
+        sandbox_cache: Arc<Mutex<SandboxCache<T>>>,
         message: &message::Kill,
     ) -> Result<message::KillResponse> {
         let mut locked_sandbox_cache = sandbox_cache.lock().await;
@@ -200,14 +205,14 @@ impl HttpClient {
     }
 }
 
-impl Service<Request<Incoming>> for HttpClient {
+impl<T: Send + Sync + Default + 'static> Service<Request<Incoming>> for HttpClient<T> {
     type Response = Response<Full<Bytes>>;
     type Error = hyper::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn call(&self, request: Request<Incoming>) -> Self::Future {
         // Clone all necessary values before moving them into the future
-        let sandbox_cache: Arc<Mutex<SandboxCache>> = self.sandbox_cache.clone();
+        let sandbox_cache: Arc<Mutex<SandboxCache<T>>> = self.sandbox_cache.clone();
         let future = async move {
             // Get the request headers before consuming the body.
             let message_type: MessageType = match request

--- a/src/libs/nanvix-http/src/server.rs
+++ b/src/libs/nanvix-http/src/server.rs
@@ -52,18 +52,24 @@ use ::tokio::{
 /// handles interrupt signals for graceful shutdown, and maintains the sandbox cache for
 /// all active instances. It provides the main event loop for the daemon.
 ///
-pub struct HttpServer {
+/// # Type Parameters
+///
+/// - `T`: Custom state type for the syscall table. This is passed to system call handlers in
+///   single-process mode. Must implement `Send + Sync + Default + Clone`. Use `()` if no custom
+///   state is required.
+///
+pub struct HttpServer<T> {
     /// Socket address to bind the HTTP server to.
     sockaddr: String,
     /// Configuration for sandbox cache management.
-    config: SandboxCacheConfig,
+    config: SandboxCacheConfig<T>,
 }
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl HttpServer {
+impl<T: Send + Sync + Default + Clone + 'static> HttpServer<T> {
     ///
     /// # Description
     ///
@@ -78,7 +84,7 @@ impl HttpServer {
     ///
     /// A new HTTP server instance ready to be started.
     ///
-    pub fn new(sockaddr: &str, config: SandboxCacheConfig) -> Self {
+    pub fn new(sockaddr: &str, config: SandboxCacheConfig<T>) -> Self {
         Self {
             sockaddr: sockaddr.to_string(),
             config,
@@ -105,7 +111,7 @@ impl HttpServer {
     pub async fn run(&mut self) -> Result<()> {
         let mut signals: Signal = signal(SignalKind::interrupt())?;
         let http_listener: TcpListener = TcpListener::bind(&self.sockaddr).await?;
-        let sandbox_cache: Arc<Mutex<SandboxCache>> = SandboxCache::new(self.config.clone());
+        let sandbox_cache: Arc<Mutex<SandboxCache<T>>> = SandboxCache::new(self.config.clone());
 
         loop {
             tokio::select! {
@@ -113,11 +119,11 @@ impl HttpServer {
                     match result {
                         Ok((stream, sockaddr)) => {
                             debug!("accepted connection from {sockaddr:?}");
-                            let sandbox_cache_clone: Arc<Mutex<SandboxCache>> = sandbox_cache.clone();
+                            let sandbox_cache_clone: Arc<Mutex<SandboxCache<T>>> = sandbox_cache.clone();
                             // In single-process mode, handle connections sequentially.
                             #[cfg(feature = "single-process")]
                             {
-                                let client: HttpClient = HttpClient::new(sandbox_cache_clone);
+                                let client: HttpClient<T> = HttpClient::new(sandbox_cache_clone);
                                 let io: TokioIo<TcpStream> = TokioIo::new(stream);
                                 if let Err(e) = http1::Builder::new().serve_connection(io, client).await  {
                                     error!("failed to serve connection (error={e:?})");
@@ -126,7 +132,7 @@ impl HttpServer {
                             #[cfg(not(feature = "single-process"))]
                             {
                                 tokio::spawn(async move {
-                                    let client: HttpClient = HttpClient::new(sandbox_cache_clone);
+                                    let client: HttpClient<T> = HttpClient::new(sandbox_cache_clone);
                                     let io: TokioIo<TcpStream> = TokioIo::new(stream);
                                     if let Err(e) = http1::Builder::new().serve_connection(io, client).await  {
                                         error!("failed to serve connection (error={e:?})");

--- a/src/libs/nanvix-sandbox-cache/src/config.rs
+++ b/src/libs/nanvix-sandbox-cache/src/config.rs
@@ -15,6 +15,8 @@ use ::nanvix_sandbox::{
     syscomm::SocketType,
     HwLoc,
 };
+#[cfg(not(feature = "single-process"))]
+use ::std::marker::PhantomData;
 
 //==================================================================================================
 // Structures
@@ -29,8 +31,13 @@ use ::nanvix_sandbox::{
 /// by the Nanvix Daemon, including socket types, file paths, hardware topology, and deployment
 /// mode settings.
 ///
+/// # Type Parameters
+///
+/// - `T`: Custom state type for the syscall table. This is passed to system call handlers in
+///   single-process mode. Use `()` if no custom state is required.
+///
 #[derive(Clone)]
-pub struct SandboxCacheConfig {
+pub struct SandboxCacheConfig<T> {
     /// Socket type for control plane communication between nanvixd and linuxd.
     control_plane_socket_type: SocketType,
     /// Socket type for gateway communication between external clients and linuxd for stdin/stdout.
@@ -51,7 +58,7 @@ pub struct SandboxCacheConfig {
     uservm_binary_path: String,
     /// System call table.
     #[cfg(feature = "single-process")]
-    syscall_table: Option<::std::sync::Arc<::nanvix_sandbox::SyscallTable>>,
+    syscall_table: Option<::std::sync::Arc<::nanvix_sandbox::SyscallTable<T>>>,
     /// Path to the toolchain binary directory containing cloud-hypervisor and other tools.
     toolchain_binary_directory: String,
     /// Directory path for writing log files.
@@ -62,13 +69,17 @@ pub struct SandboxCacheConfig {
     l2_snapshot_path: String,
     /// Path to the temporary directory for Unix sockets and transient files.
     tmp_directory: String,
+    /// Phantom data to maintain the generic type parameter `T` in the structure.
+    /// This is required because `T` is only used in single-process mode for the syscall table.
+    #[cfg(not(feature = "single-process"))]
+    _phantom: PhantomData<T>,
 }
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl SandboxCacheConfig {
+impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
     ///
     /// # Description
     ///
@@ -106,7 +117,7 @@ impl SandboxCacheConfig {
         #[cfg(not(feature = "single-process"))] linuxd_binary_path: &str,
         #[cfg(not(feature = "single-process"))] uservm_binary_path: &str,
         #[cfg(feature = "single-process")] syscall_table: Option<
-            ::std::sync::Arc<::nanvix_sandbox::SyscallTable>,
+            ::std::sync::Arc<::nanvix_sandbox::SyscallTable<T>>,
         >,
         toolchain_binary_directory: &str,
         log_directory: &str,
@@ -132,6 +143,8 @@ impl SandboxCacheConfig {
             l2,
             l2_snapshot_path: l2_snapshot_path.to_string(),
             tmp_directory: tmp_directory.to_string(),
+            #[cfg(not(feature = "single-process"))]
+            _phantom: PhantomData,
         }
     }
 
@@ -252,7 +265,7 @@ impl SandboxCacheConfig {
     /// empty.
     ///
     #[cfg(feature = "single-process")]
-    pub fn syscall_table(&self) -> Option<::std::sync::Arc<::nanvix_sandbox::SyscallTable>> {
+    pub fn syscall_table(&self) -> Option<::std::sync::Arc<::nanvix_sandbox::SyscallTable<T>>> {
         self.syscall_table.clone()
     }
 

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -59,6 +59,8 @@ use ::nanvix_sandbox::{
     UninitializedSandbox,
     UserVmIdentifier,
 };
+#[cfg(not(feature = "single-process"))]
+use ::std::marker::PhantomData;
 use ::std::{
     collections::HashMap,
     sync::Arc,
@@ -84,9 +86,14 @@ use ::tokio::sync::Mutex;
 /// and their control plane connections. It handles sandbox creation, lifecycle management,
 /// and resource cleanup for the Nanvix Daemon.
 ///
-pub struct SandboxCache {
+/// # Type Parameters
+///
+/// - `T`: Custom state type for the syscall table. This is passed to system call handlers in
+///   single-process mode. Use `()` if no custom state is required.
+///
+pub struct SandboxCache<T> {
     /// Configuration parameters for all sandboxes.
-    config: SandboxCacheConfig,
+    config: SandboxCacheConfig<T>,
     /// Registry of all currently running sandboxes indexed by their unique tag.
     running_sandboxes: HashMap<SandboxTag, RunningSandbox>,
     /// Registry of Linux Daemon instances indexed by tenant ID (one per tenant).
@@ -97,9 +104,13 @@ pub struct SandboxCache {
     control_plane_socket: Option<Arc<Mutex<(SocketListener, String, SocketType)>>>,
     /// TCP port allocator for gateway ports in L2 deployment mode.
     tcp_port_allocator: TcpPortAllocator,
+    /// Phantom data to maintain the generic type parameter `T` in the structure.
+    /// This is required because `T` is only used in single-process mode for the syscall table.
+    #[cfg(not(feature = "single-process"))]
+    _phantom: PhantomData<T>,
 }
 
-impl SandboxCache {
+impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
     ///
     /// # Description
     ///
@@ -113,7 +124,7 @@ impl SandboxCache {
     ///
     /// A shared, mutex-protected sandbox cache ready for concurrent access.
     ///
-    pub fn new(config: SandboxCacheConfig) -> Arc<Mutex<Self>> {
+    pub fn new(config: SandboxCacheConfig<T>) -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(Self {
             config,
             running_sandboxes: HashMap::new(),
@@ -124,6 +135,8 @@ impl SandboxCache {
                 ::config::linuxd::GATEWAY_PORT_RANGE_BEGIN,
                 ::config::linuxd::GATEWAY_PORT_RANGE_END,
             ),
+            #[cfg(not(feature = "single-process"))]
+            _phantom: PhantomData,
         }))
     }
 
@@ -213,11 +226,11 @@ impl SandboxCache {
                     &gateway_l2_port,
                 )?;
 
-                let uninitialized_sandbox: UninitializedSandbox =
+                let uninitialized_sandbox: UninitializedSandbox<T> =
                     UninitializedSandbox::new(tag.program(), tag.program_args().cloned());
 
                 // Add Linux Daemon instance to sandbox if one exists for the tenant.
-                let uninitialized_sandbox: UninitializedSandbox =
+                let uninitialized_sandbox: UninitializedSandbox<T> =
                     if let Some(linuxd) = self.linuxd_instances.get(tag.tenant_id()) {
                         uninitialized_sandbox.with_linuxd(linuxd.clone())
                     } else {
@@ -225,7 +238,7 @@ impl SandboxCache {
                     };
 
                 // Add control-plane socket if one exists.
-                let uninitialized_sandbox: UninitializedSandbox =
+                let uninitialized_sandbox: UninitializedSandbox<T> =
                     if let Some(control_plane_socket) = &self.control_plane_socket {
                         uninitialized_sandbox
                             .with_control_plane_socket(control_plane_socket.clone())
@@ -236,7 +249,7 @@ impl SandboxCache {
                 let gateway_socket_address: String = gateway_sockaddr.clone();
                 let gateway_socket_type: SocketType = self.config.gateway_sockaddr_type();
 
-                let config: SandboxConfig = SandboxConfig::new(
+                let config: SandboxConfig<T> = SandboxConfig::new(
                     tag.sandbox_id(),
                     (gateway_socket_address.clone(), gateway_socket_type, gateway_l2_port),
                     (user_vm_sockaddr.clone(), self.config.system_vm_sockaddr_type()),
@@ -260,10 +273,10 @@ impl SandboxCache {
                     Some(self.config.l2_snapshot_path().to_string()),
                 );
 
-                let uninitialized_sandbox: UninitializedSandbox =
+                let uninitialized_sandbox: UninitializedSandbox<T> =
                     uninitialized_sandbox.with_config(config);
 
-                let initialized_sandbox: InitializedSandbox =
+                let initialized_sandbox: InitializedSandbox<T> =
                     match uninitialized_sandbox.initialize().await {
                         Ok(sandbox) => sandbox,
                         Err(error) => {

--- a/src/libs/nanvix-sandbox/src/initialized.rs
+++ b/src/libs/nanvix-sandbox/src/initialized.rs
@@ -21,6 +21,8 @@ use crate::{
     UserVmArgs,
 };
 use ::anyhow::Result;
+#[cfg(not(feature = "single-process"))]
+use ::std::marker::PhantomData;
 use ::std::sync::Arc;
 use ::syscomm::{
     SocketListener,
@@ -53,10 +55,15 @@ use ::tokio::{
 /// plane socket and a spawned Linux Daemon instance, but has not yet started executing the
 /// guest program. It holds all necessary resources to transition to a running state.
 ///
-pub struct InitializedSandbox {
+/// # Type Parameters
+///
+/// - `T`: Custom state type for the syscall table. This is passed to system call handlers in
+///   single-process mode. Must implement `Send + Sync + Default`. Use `()` if no custom state is required.
+///
+pub struct InitializedSandbox<T: Send + Sync + Default + 'static> {
     /// Path to the guest binary file to execute.
     pub(super) guest_binary_path: String,
-    /// Path to the kernel binary file.
+    /// Path to the kernel binary.
     pub(super) kernel_binary_path: String,
     /// Optional command-line arguments for the program.
     pub(super) program_args: Option<String>,
@@ -65,10 +72,14 @@ pub struct InitializedSandbox {
     /// Control plane listener socket, address, and socket type.
     pub(super) control_plane_socket_and_info: Arc<Mutex<(SocketListener, String, SocketType)>>,
     /// Complete configuration for the sandbox execution environment.
-    pub(super) sandbox_config: SandboxConfig,
+    pub(super) sandbox_config: SandboxConfig<T>,
+    /// Phantom data to maintain the generic type parameter `T` in the structure.
+    /// This is required because `T` is only used in single-process mode for the syscall table.
+    #[cfg(not(feature = "single-process"))]
+    pub(super) _phantom: PhantomData<T>,
 }
 
-impl InitializedSandbox {
+impl<T: Send + Sync + Default + 'static> InitializedSandbox<T> {
     ///
     /// # Description
     ///

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! # async fn example() -> anyhow::Result<()> {
 //! // Create configuration.
-//! let config: SandboxConfig = SandboxConfig::new(
+//! let config: SandboxConfig<()> = SandboxConfig::new(
 //!     UserVmIdentifier::new(0),  // uservm_id
 //!     ("127.0.0.1:8080".to_string(), SocketType::Tcp, None),  // gateway_socket_info
 //!     ("127.0.0.1:8081".to_string(), SocketType::Tcp),  // system_vm_socket_info

--- a/src/libs/nanvix-sandbox/src/linuxd_args.rs
+++ b/src/libs/nanvix-sandbox/src/linuxd_args.rs
@@ -11,6 +11,8 @@
 // Imports
 //==================================================================================================
 
+#[cfg(not(feature = "single-process"))]
+use ::std::marker::PhantomData;
 use ::syscomm::SocketType;
 
 //==================================================================================================
@@ -22,7 +24,12 @@ use ::syscomm::SocketType;
 ///
 /// Arguments for spawning a Linux Daemon instance.
 ///
-pub struct LinuxDaemonArgs {
+/// # Type Parameters
+///
+/// - `T`: Custom state type for the syscall table. This is passed to system call handlers in
+///   single-process mode. Use `()` if no custom state is required.
+///
+pub struct LinuxDaemonArgs<T> {
     /// Information on control plane socket (address, socket type).
     control_plane_socket_info: (String, SocketType),
     /// Information on System VM socket (address, socket type).
@@ -44,14 +51,18 @@ pub struct LinuxDaemonArgs {
     l2_snapshot_path: String,
     /// Optional system call table for overriding default system call behavior.
     #[cfg(feature = "single-process")]
-    syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>>,
+    syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>>,
+    /// Phantom data to maintain the generic type parameter `T` in the structure.
+    /// This is required because `T` is only used in single-process mode for the syscall table.
+    #[cfg(not(feature = "single-process"))]
+    _phantom: PhantomData<T>,
 }
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl LinuxDaemonArgs {
+impl<T> LinuxDaemonArgs<T> {
     ///
     /// # Description
     ///
@@ -86,7 +97,7 @@ impl LinuxDaemonArgs {
         l2: bool,
         l2_snapshot_path: String,
         #[cfg(feature = "single-process")] syscall_table: Option<
-            ::std::sync::Arc<::linuxd::syscalls::SyscallTable>,
+            ::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>,
         >,
     ) -> Self {
         Self {
@@ -102,6 +113,8 @@ impl LinuxDaemonArgs {
             l2_snapshot_path,
             #[cfg(feature = "single-process")]
             syscall_table,
+            #[cfg(not(feature = "single-process"))]
+            _phantom: PhantomData,
         }
     }
 
@@ -233,7 +246,7 @@ impl LinuxDaemonArgs {
     /// An optional reference to the system call table.
     ///
     #[cfg(feature = "single-process")]
-    pub fn syscall_table(&self) -> Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>> {
+    pub fn syscall_table(&self) -> Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>> {
         self.syscall_table.clone()
     }
 }

--- a/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
@@ -219,8 +219,8 @@ impl LinuxDaemon {
     /// On success, this function returns a handle to the spawned Linux Daemon instance. On failure,
     /// this function returns an error object instead.
     ///
-    pub async fn spawn(
-        args: &LinuxDaemonArgs,
+    pub async fn spawn<T: Sync + Send + 'static>(
+        args: &LinuxDaemonArgs<T>,
         control_plane_listener: &mut SocketListener,
     ) -> Result<Self> {
         debug!(

--- a/src/libs/nanvix-sandbox/src/sandbox_config.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox_config.rs
@@ -12,6 +12,8 @@
 //==================================================================================================
 
 use crate::tcp_port::TcpPort;
+#[cfg(not(feature = "single-process"))]
+use ::std::marker::PhantomData;
 use ::syscomm::SocketType;
 use ::user_vm_api::UserVmIdentifier;
 
@@ -28,7 +30,12 @@ use ::user_vm_api::UserVmIdentifier;
 /// execution environment, including socket information, file paths, hardware topology,
 /// and optional control plane configuration for when components are initialized separately.
 ///
-pub struct SandboxConfig {
+/// # Type Parameters
+///
+/// - `T`: Custom state type for the syscall table. This is passed to system call handlers in
+///   single-process mode. Use `()` if no custom state is required.
+///
+pub struct SandboxConfig<T> {
     /// Unique identifier for the User VM.
     uservm_id: UserVmIdentifier,
     /// Information on gateway socket (address, socket type, optional L2 TCP port).
@@ -51,7 +58,7 @@ pub struct SandboxConfig {
     log_directory: String,
     /// Optional system call table for overriding default system call behavior.
     #[cfg(feature = "single-process")]
-    syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>>,
+    syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>>,
 
     /// Optional information on control plane socket (address, socket type).
     /// This must be provided if the control plane socket is not already initialized before
@@ -72,13 +79,18 @@ pub struct SandboxConfig {
 
     /// Optional path to the snapshot used to deploy an L2 VM.
     l2_snapshot_path: Option<String>,
+
+    /// Phantom data to maintain the generic type parameter `T` in the structure.
+    /// This is required because `T` is only used in single-process mode for the syscall table.
+    #[cfg(not(feature = "single-process"))]
+    _phantom: PhantomData<T>,
 }
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl SandboxConfig {
+impl<T> SandboxConfig<T> {
     ///
     /// # Description
     ///
@@ -118,7 +130,7 @@ impl SandboxConfig {
         #[cfg(not(feature = "single-process"))] uservm_binary_path: &str,
         log_directory: &str,
         #[cfg(feature = "single-process")] syscall_table: Option<
-            ::std::sync::Arc<::linuxd::syscalls::SyscallTable>,
+            ::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>,
         >,
         control_plane_socket_info: Option<(String, SocketType)>,
         toolchain_binary_directory: Option<String>,
@@ -145,6 +157,8 @@ impl SandboxConfig {
             tmp_directory,
             l2,
             l2_snapshot_path,
+            #[cfg(not(feature = "single-process"))]
+            _phantom: PhantomData,
         }
     }
 
@@ -277,7 +291,7 @@ impl SandboxConfig {
     /// An optional clone of the system call table.
     ///
     #[cfg(feature = "single-process")]
-    pub fn syscall_table(&self) -> Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable>> {
+    pub fn syscall_table(&self) -> Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>> {
         self.syscall_table.clone()
     }
 

--- a/src/libs/nanvix-sandbox/src/single_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/linuxd.rs
@@ -84,8 +84,8 @@ impl LinuxDaemon {
     /// On success, this function returns a handle to the spawned Linux Daemon instance. On failure,
     /// this function returns an error object instead.
     ///
-    pub async fn spawn(
-        args: &LinuxDaemonArgs,
+    pub async fn spawn<T: Sync + Send + Default + 'static>(
+        args: &LinuxDaemonArgs<T>,
         control_plane_listener: &mut SocketListener,
     ) -> Result<Self> {
         trace!(
@@ -119,8 +119,13 @@ impl LinuxDaemon {
             })?;
 
         // Create a new Linux Daemon instance.
-        let linuxd: EmbeddedLinuxd = EmbeddedLinuxd::init(
-            args.syscall_table().unwrap_or_default(),
+        let syscall_table: ::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>> =
+            args.syscall_table().unwrap_or_else(|| {
+                ::std::sync::Arc::new(::linuxd::syscalls::SyscallTable::new(T::default()))
+            });
+
+        let linuxd: EmbeddedLinuxd<T> = EmbeddedLinuxd::init(
+            syscall_table,
             &args.control_plane_socket_info().0,
             args.control_plane_socket_info().1.to_str(),
             user_vm_listener,

--- a/src/libs/nanvix-sandbox/src/uninitialized.rs
+++ b/src/libs/nanvix-sandbox/src/uninitialized.rs
@@ -18,6 +18,8 @@ use crate::{
     SandboxConfig,
 };
 use ::anyhow::Result;
+#[cfg(not(feature = "single-process"))]
+use ::std::marker::PhantomData;
 use ::std::sync::Arc;
 use ::syscomm::{
     SocketListener,
@@ -43,7 +45,12 @@ use ::tokio::sync::{
 /// a builder pattern to accumulate configuration and resources (Linux Daemon, control plane
 /// socket, configuration) before transitioning to an initialized state.
 ///
-pub struct UninitializedSandbox {
+/// # Type Parameters
+///
+/// - `T`: Custom state type for the syscall table. This is passed to system call handlers in
+///   single-process mode. Use `()` if no custom state is required.
+///
+pub struct UninitializedSandbox<T> {
     /// Path to the guest binary file to execute.
     guest_binary_path: String,
     /// Optional command-line arguments for the program.
@@ -53,14 +60,18 @@ pub struct UninitializedSandbox {
     /// Optional control plane listener socket, address, and socket type.
     control_plane_socket_and_info: Option<Arc<Mutex<(SocketListener, String, SocketType)>>>,
     /// Optional sandbox configuration parameters.
-    config: Option<SandboxConfig>,
+    config: Option<SandboxConfig<T>>,
+    /// Phantom data to maintain the generic type parameter `T` in the structure.
+    /// This is required because `T` is only used in single-process mode for the syscall table.
+    #[cfg(not(feature = "single-process"))]
+    _phantom: PhantomData<T>,
 }
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl UninitializedSandbox {
+impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
     ///
     /// # Description
     ///
@@ -82,6 +93,8 @@ impl UninitializedSandbox {
             linuxd: None,
             control_plane_socket_and_info: None,
             config: None,
+            #[cfg(not(feature = "single-process"))]
+            _phantom: PhantomData,
         }
     }
 
@@ -98,7 +111,7 @@ impl UninitializedSandbox {
     ///
     /// This function returns the modified uninitialized sandbox.
     ///
-    pub fn with_config(mut self, config: SandboxConfig) -> Self {
+    pub fn with_config(mut self, config: SandboxConfig<T>) -> Self {
         self.config = Some(config);
         self
     }
@@ -153,9 +166,9 @@ impl UninitializedSandbox {
     /// On success, returns an initialized sandbox ready to be started. On failure, returns
     /// an error describing what went wrong during initialization.
     ///
-    pub async fn initialize(mut self) -> Result<InitializedSandbox> {
+    pub async fn initialize(mut self) -> Result<InitializedSandbox<T>> {
         // Get sandbox configuration.
-        let config: SandboxConfig = match self.config.take() {
+        let config: SandboxConfig<T> = match self.config.take() {
             None => {
                 let reason: &str = "sandbox configuration not provided";
                 error!("initialize(): {reason}");
@@ -216,7 +229,7 @@ impl UninitializedSandbox {
                 > = control_plane_socket_and_info.lock().await;
 
                 // Build Linux Daemon arguments.
-                let linuxd_args: LinuxDaemonArgs = {
+                let linuxd_args: LinuxDaemonArgs<T> = {
                     // Get toolchain binary directory.
                     let toolchain_binary_directory: String =
                         match config.toolchain_binary_directory() {
@@ -302,6 +315,8 @@ impl UninitializedSandbox {
             linuxd,
             control_plane_socket_and_info,
             sandbox_config: config,
+            #[cfg(not(feature = "single-process"))]
+            _phantom: PhantomData,
         })
     }
 }

--- a/src/libs/nanvix-terminal/src/lib.rs
+++ b/src/libs/nanvix-terminal/src/lib.rs
@@ -90,16 +90,22 @@ const INTERRUPT_SIGNAL: c_int = SIGUSR1;
 ///
 /// Terminal interface for interacting with user VMs.
 ///
-pub struct Terminal {
+/// # Type Parameters
+///
+/// - `T`: Custom state type for the syscall table. This is passed to system call handlers in
+///   single-process mode. Must implement `Sync + Send + Clone + Default`. Use `()` if no custom
+///   state is required.
+///
+pub struct Terminal<T> {
     /// Configuration for sandbox cache management.
-    config: SandboxCacheConfig,
+    config: SandboxCacheConfig<T>,
 }
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl Terminal {
+impl<T: Sync + Send + Clone + Default + 'static> Terminal<T> {
     ///
     /// # Description
     ///
@@ -109,7 +115,7 @@ impl Terminal {
     ///
     /// - `config`: Configuration for sandbox cache management.
     ///
-    pub fn new(config: SandboxCacheConfig) -> Self {
+    pub fn new(config: SandboxCacheConfig<T>) -> Self {
         Self { config }
     }
 
@@ -129,7 +135,7 @@ impl Terminal {
     /// failure, it returns an object that describes the error that occurred.
     ///
     pub async fn run(&mut self, guest_binary_path: &str, guest_binary_args: &str) -> Result<()> {
-        let sandbox_cache: Arc<Mutex<SandboxCache>> = SandboxCache::new(self.config.clone());
+        let sandbox_cache: Arc<Mutex<SandboxCache<T>>> = SandboxCache::new(self.config.clone());
         let mut signals: Signal = signal(SignalKind::interrupt())?;
 
         let tenant_id: String = Self::get_current_user_name()?;

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -132,7 +132,7 @@ pub async fn main() -> Result<()> {
     let (kernel_binary_path, linuxd_binary_path, uservm_binary_path) =
         ensure_all_binaries_available(&args, machine, deployment).await?;
 
-    let config: SandboxCacheConfig = SandboxCacheConfig::new(
+    let config: SandboxCacheConfig<()> = SandboxCacheConfig::new(
         args.control_plane_socket_type(),
         args.gateway_socket_type(),
         args.system_vm_socket_type(),
@@ -169,7 +169,7 @@ pub async fn main() -> Result<()> {
             args.program_args().join(" ")
         };
 
-        let mut terminal: Terminal = Terminal::new(config);
+        let mut terminal: Terminal<()> = Terminal::new(config);
         if let Err(error) = terminal.run(&guest_binary_path, &guest_binary_args).await {
             error!("terminal failed: {error}");
         }
@@ -183,7 +183,7 @@ pub async fn main() -> Result<()> {
             Some(addr) => addr,
         };
 
-        let mut http_server: HttpServer = HttpServer::new(http_sockaddr, config);
+        let mut http_server: HttpServer<()> = HttpServer::new(http_sockaddr, config);
         if let Err(error) = http_server.run().await {
             error!("http server failed: {error}");
         }


### PR DESCRIPTION
This pull request updates the `LinuxDaemon` and related system call handling code to make the `SyscallTable` generic, allowing it to be parameterized over an additional type. The changes are mostly mechanical but affect many files and system call handler implementations, improving flexibility and type safety for future extensions.

Key changes include:

**Generalization of SyscallTable and Daemon:**
- Made `SyscallTable` and `LinuxDaemon` generic over a new type parameter `T`, which must implement `Sync + Send + 'static`. This affects the structure definition and all related implementations. [[1]](diffhunk://#diff-4c3eb00a2c249e839aa61c6a0d1b5cbfe914eb96d1cd03dda9cfebfa47291de1L137-R138) [[2]](diffhunk://#diff-4c3eb00a2c249e839aa61c6a0d1b5cbfe914eb96d1cd03dda9cfebfa47291de1L151-R151) [[3]](diffhunk://#diff-4c3eb00a2c249e839aa61c6a0d1b5cbfe914eb96d1cd03dda9cfebfa47291de1L171-R171) [[4]](diffhunk://#diff-4c3eb00a2c249e839aa61c6a0d1b5cbfe914eb96d1cd03dda9cfebfa47291de1L532-R532)

**System Call Handler Updates:**
- Updated all implementations of `RequestAssemblerTrait` for various request types (e.g., `FileStatAtRequest`, `SymbolicLinkAtRequest`, etc.) to be generic over `T` and to accept `&SyscallTable<T>` instead of `Arc<SyscallTable>`. This change is reflected in both trait implementations and calls to system call handler functions. [[1]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L61-R60) [[2]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L94-R101) [[3]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L135-R142) [[4]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L176-R183) [[5]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L217-R224) [[6]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L260-R267) [[7]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L307-R314) [[8]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L348-R355) [[9]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L389-R396) [[10]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L430-R437) [[11]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L471-R478) [[12]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L512-R519) [[13]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L555-R562) [[14]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L596-R603) [[15]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L637-R636)

**System Call Function Signatures:**
- Updated the signatures of system call handler functions like `do_getdents`, `do_openat`, and `do_unlinkat` to be generic over `T` and to accept a reference to `SyscallTable<T>`. [[1]](diffhunk://#diff-cacf58d9d0db3f5850812c9f6d97786720957aa2ddb35aa799bbc3086cf7e7dfL121-R119) [[2]](diffhunk://#diff-2458c0b6cf0e4cb9e1384eeec6be4e997db6d23c1c71b841036ad5c46db75473L160-R160) [[3]](diffhunk://#diff-2458c0b6cf0e4cb9e1384eeec6be4e997db6d23c1c71b841036ad5c46db75473L226-R226)

**Internal Handler Adjustments:**
- Updated internal helper functions (e.g., `handle_getdents`, `handle_openat`, `handle_unlinkat`) to accept the generic `SyscallTable<T>` and to pass the correct state to forwarded system call functions. [[1]](diffhunk://#diff-cacf58d9d0db3f5850812c9f6d97786720957aa2ddb35aa799bbc3086cf7e7dfL237-R235) [[2]](diffhunk://#diff-cacf58d9d0db3f5850812c9f6d97786720957aa2ddb35aa799bbc3086cf7e7dfL248-R247) [[3]](diffhunk://#diff-2458c0b6cf0e4cb9e1384eeec6be4e997db6d23c1c71b841036ad5c46db75473L193-R192) [[4]](diffhunk://#diff-2458c0b6cf0e4cb9e1384eeec6be4e997db6d23c1c71b841036ad5c46db75473L251-R250)

**Cleanup:**
- Removed unnecessary imports of `Arc` where the reference is now passed instead of an owned pointer. [[1]](diffhunk://#diff-7176a68e6adb28751277255ab6f01c304e193ee369c15fe05e9635c2d54e0de4L21) [[2]](diffhunk://#diff-cacf58d9d0db3f5850812c9f6d97786720957aa2ddb35aa799bbc3086cf7e7dfL20-R20) [[3]](diffhunk://#diff-2458c0b6cf0e4cb9e1384eeec6be4e997db6d23c1c71b841036ad5c46db75473L18)

These changes lay the groundwork for more flexible and extensible system call handling in the Linux daemon, enabling future features that may require additional state or context in the syscall table.