### PR TITLE
[uservm] Improve Shutdown Protocol

### DIFF
--- a/src/uservm/src/orchestrator.rs
+++ b/src/uservm/src/orchestrator.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::vmm::KILL_SIGNAL;
 use ::anyhow::Result;
 use ::std::{
     ops::ControlFlow::{
@@ -41,6 +42,10 @@ use ::tokio::{
 
 // This value was chosen so it catches issues without polluting the logs with too many warnings.
 pub const TIMEOUT_WARNING_INTERVAL_IN_MS: usize = 10;
+
+/// Timeout for shutdown operations.
+/// After this timeout, the orchestrator will forcefully terminate the vCPU thread.
+pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(5000);
 
 //==================================================================================================
 // Types
@@ -108,6 +113,8 @@ enum State {
     Running,
     /// VM is not running.
     Paused,
+    /// VM is shutting down, waiting for vCPU to confirm.
+    ShuttingDown,
 }
 
 ///
@@ -229,6 +236,28 @@ impl Orchestrator {
     ///
     async fn run(&mut self) -> Result<()> {
         loop {
+            // If we're in shutting down state, add timeout to prevent indefinite hang.
+            if self.state == State::ShuttingDown {
+                match timeout(SHUTDOWN_TIMEOUT, self.wait_for_shutdown()).await {
+                    Ok(Ok(())) => break,
+                    Ok(Err(error)) => {
+                        error!("run(): error during shutdown: {error:?}");
+                        break;
+                    },
+                    Err(_) => {
+                        error!(
+                            "run(): shutdown timeout after {}ms, forcefully terminating vCPU \
+                             thread",
+                            SHUTDOWN_TIMEOUT.as_millis()
+                        );
+                        // Forcefully terminate the vCPU thread.
+                        let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
+                        unsafe { ::libc::pthread_kill(pthread_id, KILL_SIGNAL) };
+                        break;
+                    },
+                }
+            }
+
             select! {
                 // Only poll the I/O control channel when I/O is enabled; otherwise skip this branch.
                 result = self.io_control_rx.recv() => {
@@ -278,6 +307,48 @@ impl Orchestrator {
         self.io_control_tx.send(IoControlResponse::Shutdown).await?;
 
         Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Waits for the vCPU thread to send a shutdown message.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned.
+    ///
+    async fn wait_for_shutdown(&mut self) -> Result<()> {
+        loop {
+            select! {
+                result = self.io_control_rx.recv() => {
+                    // Ignore I/O commands during shutdown.
+                    if result.is_none() {
+                        let reason: String =
+                            "I/O control channel closed during shutdown".to_string();
+                        warn!("wait_for_shutdown(): {reason}");
+                    }
+                },
+
+                result = self.vcpu_control_rx.recv() => {
+                    match result {
+                        Some(VcpuControlResponse::Shutdown) => {
+                            info!("wait_for_shutdown(): vCPU shutdown confirmed");
+                            return Ok(());
+                        },
+                        Some(other) => {
+                            warn!("wait_for_shutdown(): unexpected vCPU response: {other:?}");
+                        },
+                        None => {
+                            let reason: String =
+                                "vCPU control channel closed during shutdown".to_string();
+                            error!("wait_for_shutdown(): {reason}");
+                            return Err(anyhow::anyhow!(reason));
+                        },
+                    }
+                },
+            }
+        }
     }
 
     ///
@@ -402,9 +473,9 @@ impl Orchestrator {
             IoControlCommand::_ResumeMicroVm => {
                 if self.state == State::Paused {
                     // TODO: tell linuxd it's fine to send more messages https://github.com/nanvix/nanvix/issues/945
-                    if let Err(e) = self.resume_protocol().await {
+                    if let Err(error) = self.resume_protocol().await {
                         let reason: String =
-                            format!("ResumeMicroVm: failed to resume microvm: {e:?}");
+                            format!("ResumeMicroVm: failed to resume microvm: {error:?}");
                         error!("try_receive_from_io_thread(): {reason}");
                         anyhow::bail!(reason);
                     }
@@ -428,16 +499,20 @@ impl Orchestrator {
                     // itself, we kill it here. This may populate the logs with an error message
                     // during shutdown, but is functionally equivalent.
                     if #[cfg(feature = "hyperlight")] {
-                        debug!("vcpu thread id: {}", self.vcpu_tid);
+                        debug!("try_receive_from_io_thread(): killing vcpu thread id: {}", self.vcpu_tid);
                         let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
-                        unsafe { ::libc::pthread_kill(pthread_id, libc::SIGKILL) };
+                        unsafe { ::libc::pthread_kill(pthread_id, KILL_SIGNAL) };
+                        self.state = State::ShuttingDown;
                         Ok(Continue(()))
                     } else {
                         // SAFETY: we call pthread_kill on a non-zero TID that we have received from
                         // the VCPU thread after boot, so this is safe.
                         let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
-                        unsafe { ::libc::pthread_kill(pthread_id, libc::SIGUSR1) };
+                        debug!("try_receive_from_io_thread(): signaling to vcpu thread (tid={})", self.vcpu_tid);
+                        unsafe { ::libc::pthread_kill(pthread_id, crate::vmm::INTERRUPT_SIGNAL) };
 
+                        // Transition to shutting down state.
+                        self.state = State::ShuttingDown;
                         Ok(Continue(()))
                     }
                 }

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -37,6 +37,7 @@ use ::hyperlight_host::{
 };
 use ::std::{
     io::Write,
+    os::raw::c_int,
     path::Path,
     sync::Arc,
 };
@@ -53,6 +54,16 @@ use ::tokio::{
     },
     task,
 };
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Signal used to interrupt the vCPU thread.
+pub const INTERRUPT_SIGNAL: c_int = libc::SIGUSR1;
+
+/// Signal used to kill the vCPU thread.
+pub const KILL_SIGNAL: c_int = libc::SIGKILL;
 
 //==================================================================================================
 // Types

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -95,19 +95,32 @@ use ::tokio::{
 
 pub use kvm::vmem::VirtualMemory;
 
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Signal used to interrupt the vCPU thread.
 pub const INTERRUPT_SIGNAL: c_int = SIGUSR1;
 
+/// Signal used to kill the vCPU thread.
+pub const KILL_SIGNAL: c_int = libc::SIGKILL;
+
 //==================================================================================================
-// Global variables
+// Thread-Local Variables
 //==================================================================================================
 
-///
-/// # Description
-///
-/// Global shutdown flag. Safe to read/write from any thread. Writing an AtomicBool is
-/// async-signal-safe, so a signal handler can set it.
-///
-pub static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+thread_local! {
+    ///
+    /// # Description
+    ///
+    /// Shutdown flag, set to true when the vCPU thread receives a shutdown signal.
+    /// This will prevent the vCPU from entering KVM_RUN again and blocking indefinitely.
+    ///
+    /// This variable must be thread-safe to enable multiple VMM instances to co-exist in the same
+    /// process.
+    ///
+    static SHUTDOWN: AtomicBool = const { AtomicBool::new(false) };
+}
 
 //==================================================================================================
 // Structures
@@ -170,7 +183,7 @@ pub type StderrFn = dyn Write + Send;
 
 /// Signal handler for the vCPU thread. We install an empty handler to trigger an -EINTR.
 extern "C" fn vcpu_thread_signal_handler(_: i32) {
-    SHUTDOWN.store(true, Ordering::SeqCst);
+    SHUTDOWN.with(|shutdown| shutdown.store(true, Ordering::SeqCst));
 }
 
 impl Vmm {
@@ -190,9 +203,6 @@ impl Vmm {
     ///
     pub fn new(args: MicroVmArgs) -> Result<Self> {
         trace!("new(): args={:?}", args);
-
-        // Reset shutdown flag from any previous runs.
-        SHUTDOWN.store(false, Ordering::SeqCst);
 
         let mut kvm: Kvm = Kvm::new()?;
         let mut vm: VmFd = kvm.create_vm()?;
@@ -288,10 +298,20 @@ impl Vmm {
     pub fn run(&mut self) -> Result<u16> {
         trace!("run()");
 
+        // Reset shutdown flag from any previous runs.
+        SHUTDOWN.with(|shutdown| shutdown.store(false, Ordering::SeqCst));
+
         // Install a signal handler in the virtual processor's thread.
         Self::install_signal_handler();
 
         loop {
+            // Check shutdown flag before entering KVM_RUN, and blocking indefinitely.
+            if SHUTDOWN.with(|shutdown| shutdown.load(Ordering::SeqCst)) {
+                let exit_status: u16 = 0;
+                Handle::current().block_on(self.handle_shutdown(exit_status));
+                break Ok(exit_status);
+            }
+
             let exit_context: VirtualProcessorExitContext = {
                 let mut locked_vcpu: MutexGuard<'_, VirtualProcessor> = self.vcpu.blocking_lock();
                 // Exit if the vCPU is no longer online.
@@ -334,15 +354,6 @@ impl Vmm {
                 VirtualProcessorExitReasonRef::Unknown => {
                     break Ok(ErrorCode::IllegalByteSequence.into());
                 },
-            }
-
-            // Check if we were interrupted while handling a PMIO exit. This check covers
-            // the situation where we have sent an interrupt to the vCPU, but the vCPU
-            // thread was not in KVM_RUN, thus not triggering an -EINTR that we can catch.
-            if SHUTDOWN.load(std::sync::atomic::Ordering::SeqCst) {
-                let exit_status: u16 = 0;
-                Handle::current().block_on(self.handle_shutdown(exit_status));
-                break Ok(exit_status);
             }
         }
     }
@@ -459,7 +470,8 @@ impl Vmm {
     /// # Description
     ///
     /// Helper method to poweroff the vCPU with a given exit status, and send a shutdown message to
-    /// the VMM thread.
+    /// the orchestrator thread. If the channel is closed, we still proceed with shutdown as the
+    /// orchestrator will handle this via timeout.
     ///
     /// # Arguments
     ///
@@ -469,8 +481,10 @@ impl Vmm {
         // Power-off vCPU.
         self.vcpu.lock().await.poweroff(exit_status);
 
-        // Send message to VMM thread.
-        if let Err(error) = self
+        // Send message to orchestrator thread.
+        // If the channel is closed, the orchestrator has already disconnected,
+        // but we still need to clean up our side properly.
+        match self
             .inner
             .lock()
             .await
@@ -478,8 +492,14 @@ impl Vmm {
             .send(VcpuControlResponse::Shutdown)
             .await
         {
-            warn!("handle_shutdown(): failed to notify vmm thread (error={error:?})");
-            // Don't bail as we are shutting down anyway.
+            Ok(()) => {
+                trace!("handle_shutdown(): shutdown notification sent to orchestrator");
+            },
+            Err(error) => {
+                warn!("handle_shutdown(): failed to notify orchestrator thread (error={error:?})");
+                // Don't bail as we are shutting down anyway. The orchestrator will detect
+                // this via timeout and forcefully terminate the vCPU thread if needed.
+            },
         }
     }
 


### PR DESCRIPTION
This pull request introduces improvements to the VM shutdown process, making it more robust and preventing the vCPU thread from hanging indefinitely during shutdown. The orchestrator now enforces a shutdown timeout and can forcefully terminate the vCPU thread if necessary. Additionally, signal handling and shutdown flags have been refactored for better safety and clarity.

**Shutdown process improvements:**

* Added a `SHUTDOWN_TIMEOUT` constant (5 seconds) to the orchestrator, which is used to limit how long the orchestrator waits for the vCPU thread to confirm shutdown before forcefully terminating it. (`src/uservm/src/orchestrator.rs`) [[1]](diffhunk://#diff-5638efc97e39d645e02c34b0c1ff1586f7834276a9dd9e3e2f897cdfef2e7026R49-R52) [[2]](diffhunk://#diff-5638efc97e39d645e02c34b0c1ff1586f7834276a9dd9e3e2f897cdfef2e7026R242-R263)
* Introduced a new `State::ShuttingDown` to the orchestrator state machine and updated logic to transition to this state during shutdown. (`src/uservm/src/orchestrator.rs`) [[1]](diffhunk://#diff-5638efc97e39d645e02c34b0c1ff1586f7834276a9dd9e3e2f897cdfef2e7026R119-R120) [[2]](diffhunk://#diff-5638efc97e39d645e02c34b0c1ff1586f7834276a9dd9e3e2f897cdfef2e7026L431-R518)
* Implemented a `wait_for_shutdown` async method in the orchestrator to await the vCPU's shutdown confirmation and handle errors or timeouts. (`src/uservm/src/orchestrator.rs`)

**Signal and shutdown flag handling:**

* Refactored the shutdown flag to be thread-local using Rust's `thread_local!`, improving thread safety and enabling multiple VMM instances in the same process. (`src/uservm/src/vmm/microvm/mod.rs`)
* Updated the vCPU signal handler and VM run logic to use the thread-local shutdown flag and ensure it is reset at the start of each run. (`src/uservm/src/vmm/microvm/mod.rs`) [[1]](diffhunk://#diff-2bb285216b4339bd543bcb76513e2c616471fe9be88cf670557fd8fc9b7e9624L173-R186) [[2]](diffhunk://#diff-2bb285216b4339bd543bcb76513e2c616471fe9be88cf670557fd8fc9b7e9624R301-R314)
* Removed redundant shutdown checks after PMIO exits, as the new logic checks the shutdown flag before entering KVM_RUN. (`src/uservm/src/vmm/microvm/mod.rs`)

**Shutdown notification and error handling:**

* Improved shutdown notification from the vCPU to the orchestrator, handling the case where the channel is closed and ensuring the orchestrator can still detect shutdown via timeout. (`src/uservm/src/vmm/microvm/mod.rs`) [[1]](diffhunk://#diff-2bb285216b4339bd543bcb76513e2c616471fe9be88cf670557fd8fc9b7e9624L462-R474) [[2]](diffhunk://#diff-2bb285216b4339bd543bcb76513e2c616471fe9be88cf670557fd8fc9b7e9624L472-R502)
* Enhanced error logging and trace messages for shutdown and resume operations to aid debugging. (`src/uservm/src/orchestrator.rs`, `src/uservm/src/vmm/microvm/mod.rs`) [[1]](diffhunk://#diff-5638efc97e39d645e02c34b0c1ff1586f7834276a9dd9e3e2f897cdfef2e7026L405-R481) [[2]](diffhunk://#diff-5638efc97e39d645e02c34b0c1ff1586f7834276a9dd9e3e2f897cdfef2e7026L431-R518) [[3]](diffhunk://#diff-2bb285216b4339bd543bcb76513e2c616471fe9be88cf670557fd8fc9b7e9624L472-R502)