### PR TITLE
[nanvix-terminal] Pass Tenant ID and App Name

### DIFF
--- a/src/libs/nanvix-terminal/src/lib.rs
+++ b/src/libs/nanvix-terminal/src/lib.rs
@@ -126,6 +126,8 @@ impl<T: Sync + Send + Clone + Default + 'static> Terminal<T> {
     ///
     /// # Parameters
     ///
+    /// - `tenant_id`: Optional tenant identifier. If `None`, a default tenant ID is used.
+    /// - `app_name`: Optional application name. If `None`, a default application name is used.
     /// - `guest_binary_path`: Path to the guest binary to execute.
     /// - `guest_binary_args`: Arguments to pass to the guest binary.
     ///
@@ -134,12 +136,23 @@ impl<T: Sync + Send + Clone + Default + 'static> Terminal<T> {
     /// On success, this function returns an empty tuple after the terminal session ends. On
     /// failure, it returns an object that describes the error that occurred.
     ///
-    pub async fn run(&mut self, guest_binary_path: &str, guest_binary_args: &str) -> Result<()> {
+    pub async fn run(
+        &mut self,
+        tenant_id: Option<&str>,
+        app_name: Option<&str>,
+        guest_binary_path: &str,
+        guest_binary_args: &str,
+    ) -> Result<()> {
         let sandbox_cache: Arc<Mutex<SandboxCache<T>>> = SandboxCache::new(self.config.clone());
         let mut signals: Signal = signal(SignalKind::interrupt())?;
 
-        let tenant_id: String = Self::get_current_user_name()?;
-        let app_name: String = DEFAULT_APP_NAME.to_string();
+        let tenant_id: String = match tenant_id {
+            Some(s) => s.to_owned(),
+            None => Self::get_current_user_name()?,
+        };
+        let app_name: String = app_name
+            .map(|s| s.to_owned())
+            .unwrap_or_else(|| DEFAULT_APP_NAME.to_owned());
         let (uservm_id, gateway_sockaddr, gateway_socket_type): (
             UserVmIdentifier,
             String,

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -170,7 +170,10 @@ pub async fn main() -> Result<()> {
         };
 
         let mut terminal: Terminal<()> = Terminal::new(config);
-        if let Err(error) = terminal.run(&guest_binary_path, &guest_binary_args).await {
+        if let Err(error) = terminal
+            .run(None, None, &guest_binary_path, &guest_binary_args)
+            .await
+        {
             error!("terminal failed: {error}");
         }
     } else {


### PR DESCRIPTION
This pull request updates the `Terminal` API to allow specifying an optional tenant ID and application name when running a terminal session. This provides more flexibility for users of the API and improves clarity in the documentation.

API enhancements:

* The `run` method in `Terminal` now accepts two new optional parameters: `tenant_id` and `app_name`. If these are not provided, default values are used.
* The documentation for the `run` method has been updated to describe the new parameters.

Usage updates:

* The call to `Terminal::run` in `nanvixd` has been updated to pass `None` for the new optional parameters, preserving the previous default behavior.