### PR TITLE
[build] Ensure Lint Rules

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,13 +8,24 @@
 set -euo pipefail
 
 #===================================================================================================
+# Imports
+#===================================================================================================
+
+# Get the repository root directory.
+REPO_ROOT_DIR=$(git rev-parse --show-toplevel)
+
+# Directory where to find scripts to import.
+IMPORT_DIR="${REPO_ROOT_DIR}/scripts/common"
+
+source "${IMPORT_DIR}/logging.sh"
+
+#===================================================================================================
 # Global Variables
 #===================================================================================================
 
-# Colors
-RED='\033[0;31m'    # Red
-GREEN='\033[0;32m'  # Green
-NC='\033[0m'        # No Color
+# Configuration matrix matching CI (self-hosted-ci.yml).
+declare -a MACHINE_TYPES=("qemu-pc" "microvm" "hyperlight")
+declare -a DEPLOYMENT_TYPES=("single-process" "multi-process")
 
 #===================================================================================================
 # Functions
@@ -22,30 +33,90 @@ NC='\033[0m'        # No Color
 
 #
 # DESCRIPTION
-#   Prints an error message on stderr.
+#   Checks if a configuration should be excluded based on CI matrix rules.
 #
 # ARGUMENTS
-#   $1 - The error message to print.
+#   $1 - Machine type.
+#   $2 - Deployment type.
+#
+# RETURNS
+#   0 if excluded, 1 if included.
 #
 # USAGE EXAMPLE
-#   print_error "Print an error message."
+#   if is_excluded "qemu-pc" "single-process"; then
+#       echo "Configuration is excluded."
+#   fi
 #
-print_error() {
-    echo -e "${RED}[ERROR] ${1}${NC}" >&2
+is_excluded() {
+    local machine="${1}"
+    local deployment="${2}"
+
+    # Exclusion rules from self-hosted-ci.yml.
+    if [[ "${machine}" == "qemu-pc" && "${deployment}" == "single-process" ]]; then
+        return 0
+    fi
+
+    return 1
 }
 
 #
 # DESCRIPTION
-#   Prints a success message on stdout.
+#   Converts deployment type to SINGLE_PROCESS and L2_VM flags.
 #
 # ARGUMENTS
-#   $1 - The success message to print.
+#   $1 - Deployment type.
+#
+# RETURNS
+#   String with SINGLE_PROCESS and L2_VM values.
 #
 # USAGE EXAMPLE
-#   print_success "Print a success message."
+#   flags=$(get_deployment_flags "multi-process")
 #
-print_success() {
-    echo -e "${GREEN}[INFO] ${1}${NC}"
+get_deployment_flags() {
+    local deployment="${1}"
+
+    case "${deployment}" in
+        single-process)
+            echo "SINGLE_PROCESS=yes"
+            ;;
+        multi-process)
+            echo "SINGLE_PROCESS=no"
+            ;;
+        *)
+            print_error "(pre-commit) Invalid deployment type: ${deployment}"
+            exit 1
+            ;;
+    esac
+}
+
+#
+# DESCRIPTION
+#   Converts build type to RELEASE flag.
+#
+# ARGUMENTS
+#   $1 - Build type.
+#
+# RETURNS
+#   String with RELEASE value.
+#
+# USAGE EXAMPLE
+#   flag=$(get_release_flag "release")
+#
+get_release_flag() {
+    local build_type="${1}"
+
+    case "${build_type}" in
+        debug)
+            echo "RELEASE=no"
+            ;;
+        release)
+            echo "RELEASE=yes"
+            ;;
+        *)
+            print_error "(pre-commit) Invalid build type: ${build_type}"
+            exit 1
+            ;;
+    esac
 }
 
 #===================================================================================================
@@ -53,52 +124,80 @@ print_success() {
 #===================================================================================================
 
 main() {
-    # By default, use Docker to run the code formatting check.
-    local build_command="./z build --with-cached-options --"
-
     # Check if we are not running inside a Git repository.
     if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         print_error "(pre-commit) This script must be run inside a Git repository."
         exit 1
     fi
 
-    # No need to check for Docker installation or the correct Docker image here. This script uses
-    # cached build options, and all necessary environment checks were already performed when the
-    # build cache was created.
-
     # Create a temporary file to capture output.
     tmpfile="$(mktemp)"
     trap 'rm -f "$tmpfile"' EXIT
 
-    # Run code formatting check.
-    if ! eval "${build_command} format-check" > "${tmpfile}" 2>&1 ; then
-        # Code formatting check failed, print the output.
-        cat "${tmpfile}"
-        print_error "(pre-commit) Format check failed. Please fix formatting before committing."
-        exit 1
-    fi
+    # Track progress.
+    local total_configs=0
+    local checked_configs=0
 
-    print_success "(pre-commit) Code formatting check passed successfully."
+    # Note: We run format-check, lint-check, and spellcheck only once since they are
+    # configuration-independent (they check source code style, not runtime behavior).
+    # However, we iterate through all machine/deployment combinations to ensure the
+    # build system can be configured for each combination, matching CI behavior.
 
-    # Run code linting check.
-    if ! eval "${build_command} lint-check" > "${tmpfile}" 2>&1 ; then
-        # Code linting check failed, print the output.
-        cat "${tmpfile}"
-        print_error "(pre-commit) Lint check failed. Please fix linting issues before committing."
-        exit 1
-    fi
+    print_info "(pre-commit) Running pre-commit checks for all CI configurations..."
 
-    print_success "(pre-commit) Code linting check passed successfully."
+    # Use debug build for faster checks.
+    local build_type="debug"
+    local release_flag
+    release_flag=$(get_release_flag "${build_type}")
 
-    # Run spell check.
-    if ! eval "${build_command} spellcheck" > "${tmpfile}" 2>&1 ; then
-        # Spell check failed, print the output.
-        cat "${tmpfile}"
-        print_error "(pre-commit) Spell check failed. Please fix spelling errors before committing."
-        exit 1
-    fi
+    # Iterate through all machine/deployment combinations matching the CI matrix.
+    for machine in "${MACHINE_TYPES[@]}"; do
+        for deployment in "${DEPLOYMENT_TYPES[@]}"; do
+            total_configs=$((total_configs + 1))
 
-    print_success "(pre-commit) Spell check passed successfully."
+            # Skip excluded configurations.
+            if is_excluded "${machine}" "${deployment}"; then
+                print_info "(pre-commit) Skipping excluded configuration: ${build_type}, ${machine}, ${deployment}."
+                continue
+            fi
+
+            checked_configs=$((checked_configs + 1))
+
+            # Get configuration flags.
+            local deployment_flags
+            deployment_flags=$(get_deployment_flags "${deployment}")
+
+            print_info "(pre-commit) Checking configuration: ${build_type}, ${machine}, ${deployment}..."
+
+            # Build command with all parameters.
+            local build_command="./z build -- MACHINE=${machine} LOG_LEVEL=trace ${release_flag} ${deployment_flags}"
+
+            # Run code formatting check.
+            if ! eval "${build_command} format-check" > "${tmpfile}" 2>&1 ; then
+                cat "${tmpfile}"
+                print_error "(pre-commit) Format check failed for: ${build_type}, ${machine}, ${deployment}."
+                exit 1
+            fi
+
+            # Run code linting check.
+            if ! eval "${build_command} lint-check" > "${tmpfile}" 2>&1 ; then
+                cat "${tmpfile}"
+                print_error "(pre-commit) Lint check failed for: ${build_type}, ${machine}, ${deployment}."
+                exit 1
+            fi
+
+            # Run spell check.
+            if ! eval "${build_command} spellcheck" > "${tmpfile}" 2>&1 ; then
+                cat "${tmpfile}"
+                print_error "(pre-commit) Spell check failed for: ${build_type}, ${machine}, ${deployment}."
+                exit 1
+            fi
+
+            print_success "(pre-commit) Configuration passed: ${build_type}, ${machine}, ${deployment}."
+        done
+    done
+
+    print_success "(pre-commit) All checks passed successfully (${checked_configs}/${total_configs} configurations checked)."
 }
 
 # Run the main function.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,3 +173,14 @@ lto = true
 
 [workspace.lints.rust]
 warnings = "deny"
+
+[workspace.lints.clippy]
+all = "deny"
+# TODO (#1146): Enable restriction linting rules, once they are fixed.
+# restriction = "deny"
+# TODO (#1147): Enable pedantic linting rules, once they are fixed.
+# pedantic = "deny"
+# TODO (#1148): Enable nursery linting rules, once they are fixed.
+# nursery = "deny"
+# TODO (#1149): Enable cargo linting rules, once they are fixed.
+# cargo = "deny"

--- a/build/make/generic-guest-binaries.mk
+++ b/build/make/generic-guest-binaries.mk
@@ -27,7 +27,7 @@ rust-lint-guest-binaries-$(1):
 	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_BINARY_CARGO_FEATURES) --fix --allow-dirty
 
 rust-lint-check-guest-binaries-$(1):
-	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_BINARY_CARGO_FEATURES)
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_BINARY_CARGO_FEATURES) -- -D warnings
 endef
 
 $(foreach target,$(ALL_GUEST_BINARIES),$(eval $(call GUEST_BINARY_RULES,$(target))))

--- a/build/make/generic-guest-rlibs.mk
+++ b/build/make/generic-guest-rlibs.mk
@@ -15,7 +15,7 @@ rust-lint-guest-rlib-$(1):
 	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) --fix --allow-dirty
 
 rust-lint-check-guest-rlib-$(1):
-	$(GUEST_CARGO_CLIPPY_CMD) -p $(1)
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) -- -D warnings
 endef
 
 $(foreach target,$(ALL_GUEST_RUST_LIBS),$(eval $(call GUEST_RLIB_RULES,$(target))))

--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -28,7 +28,7 @@ rust-lint-guest-staticlib-$(1):
 	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES) --fix --allow-dirty
 
 rust-lint-check-guest-staticlib-$(1):
-	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES)
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES) -- -D warnings
 endef
 
 $(foreach target,$(ALL_GUEST_STATIC_LIBS),$(eval $(call GUEST_STATICLIB_RULES,$(target))))

--- a/build/make/generic-host-binaries.mk
+++ b/build/make/generic-host-binaries.mk
@@ -28,7 +28,7 @@ rust-lint-host-binaries-$(1):
 	$(HOST_CARGO_CLIPPY_CMD) $(HOST_CARGO_FEATURES) -p $(1) --fix --allow-dirty
 
 rust-lint-check-host-binaries-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) $(HOST_CARGO_FEATURES) -p $(1)
+	$(HOST_CARGO_CLIPPY_CMD) $(HOST_CARGO_FEATURES) -p $(1) -- -D warnings
 endef
 
 $(foreach target,$(ALL_HOST_BINARIES),$(eval $(call HOST_BINARY_RULES,$(target))))

--- a/build/make/generic-host-rlibs.mk
+++ b/build/make/generic-host-rlibs.mk
@@ -15,7 +15,7 @@ rust-lint-host-rlib-$(1):
 	$(HOST_CARGO_CLIPPY_CMD) -p $(1) --fix --allow-dirty
 
 rust-lint-check-host-rlib-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) -p $(1)
+	$(HOST_CARGO_CLIPPY_CMD) -p $(1) -- -D warnings
 
 test-host-rlib-$(1):
 	$(HOST_CARGO_TEST_CMD) -p $(1)

--- a/build/make/generic-wasm-binaries.mk
+++ b/build/make/generic-wasm-binaries.mk
@@ -23,7 +23,7 @@ rust-lint-wasm-binaries-$(1):
 	$(WASM_CARGO_CLIPPY_CMD) -p $(1) --fix --allow-dirty
 
 rust-lint-check-wasm-binaries-$(1):
-	$(WASM_CARGO_CLIPPY_CMD) -p $(1)
+	$(WASM_CARGO_CLIPPY_CMD) -p $(1) -- -D warnings
 endef
 
 $(foreach target,$(ALL_WASM_BINARIES),$(eval $(call WASM_BINARY_RULES,$(target))))

--- a/build/make/kernel.mk
+++ b/build/make/kernel.mk
@@ -26,4 +26,4 @@ rust-lint-kernel:
 	$(KERNEL_CARGO_CLIPPY_CMD) $(KERNEL_CARGO_FEATURES) -p kernel --fix --allow-dirty
 
 rust-lint-check-kernel:
-	$(KERNEL_CARGO_CLIPPY_CMD) $(KERNEL_CARGO_FEATURES) -p kernel
+	$(KERNEL_CARGO_CLIPPY_CMD) $(KERNEL_CARGO_FEATURES) -p kernel -- -D warnings

--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -29,4 +29,4 @@ rust-lint-nanvix-bench:
 	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench --fix --allow-dirty
 
 rust-lint-check-nanvix-bench:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench
+	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench -- -D warnings

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -28,4 +28,4 @@ rust-lint-nanvixd:
 	$(HOST_CARGO_CLIPPY_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd --fix --allow-dirty
 
 rust-lint-check-nanvixd:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd
+	$(HOST_CARGO_CLIPPY_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd -- -D warnings

--- a/build/make/uservm.mk
+++ b/build/make/uservm.mk
@@ -29,7 +29,7 @@ rust-lint-uservm:
 	$(HOST_CARGO_CLIPPY_CMD) $(USERVM_CARGO_FEATURES) -p uservm --fix --allow-dirty
 
 rust-lint-check-uservm:
-	$(HOST_CARGO_CLIPPY_CMD) $(USERVM_CARGO_FEATURES) -p uservm
+	$(HOST_CARGO_CLIPPY_CMD) $(USERVM_CARGO_FEATURES) -p uservm -- -D warnings
 
 test-uservm:
 	$(HOST_CARGO_TEST_CMD) $(USERVM_CARGO_FEATURES) -p uservm

--- a/build/make/wasmd.mk
+++ b/build/make/wasmd.mk
@@ -32,4 +32,4 @@ rust-lint-wasmd:
 	$(GUEST_CARGO_CLIPPY_CMD) -p wasmd --fix --allow-dirty
 
 rust-lint-check-wasmd:
-	$(GUEST_CARGO_CLIPPY_CMD) -p wasmd
+	$(GUEST_CARGO_CLIPPY_CMD) -p wasmd -- -D warnings

--- a/src/benchmarks/echo-rust-nostd/Cargo.toml
+++ b/src/benchmarks/echo-rust-nostd/Cargo.toml
@@ -33,3 +33,6 @@ info = ["nvx/info"]
 warn = ["nvx/warn"]
 error = ["nvx/error"]
 panic = ["nvx/panic"]
+
+[lints]
+workspace = true

--- a/src/benchmarks/echo-wasm-rust/Cargo.toml
+++ b/src/benchmarks/echo-wasm-rust/Cargo.toml
@@ -9,3 +9,6 @@ edition.workspace = true
 authors.workspace = true
 description = "Echo Benchmark for Wasm/Rust"
 homepage.workspace = true
+
+[lints]
+workspace = true

--- a/src/benchmarks/noop-rust-nostd/Cargo.toml
+++ b/src/benchmarks/noop-rust-nostd/Cargo.toml
@@ -32,3 +32,6 @@ info = ["nvx/info"]
 warn = ["nvx/warn"]
 error = ["nvx/error"]
 panic = ["nvx/panic"]
+
+[lints]
+workspace = true

--- a/src/benchmarks/noop-wasm-rust/Cargo.toml
+++ b/src/benchmarks/noop-wasm-rust/Cargo.toml
@@ -9,3 +9,6 @@ edition.workspace = true
 authors.workspace = true
 description = "No-Operation Benchmark for Wasm/Rust"
 homepage.workspace = true
+
+[lints]
+workspace = true

--- a/src/daemons/linuxd/Cargo.toml
+++ b/src/daemons/linuxd/Cargo.toml
@@ -38,3 +38,6 @@ user-vm-api = { workspace = true }
 [features]
 default = []
 timestamp-messages = ["profiler/timestamp-messages"]
+
+[lints]
+workspace = true

--- a/src/daemons/linuxd/src/syscalls.rs
+++ b/src/daemons/linuxd/src/syscalls.rs
@@ -154,6 +154,10 @@ pub type PollFn<T> = unsafe fn(&T, *mut libc::pollfd, libc::nfds_t, libc::c_int)
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `path` is a valid pointer to a null-terminated C string.
+///
 pub unsafe fn default_chdir<T>(_state: &T, path: *const libc::c_char) -> libc::c_int {
     libc::chdir(path)
 }
@@ -171,6 +175,10 @@ pub unsafe fn default_chdir<T>(_state: &T, path: *const libc::c_char) -> libc::c
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor.
 ///
 pub unsafe fn default_close<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
     libc::close(fd)
@@ -192,6 +200,10 @@ pub unsafe fn default_close<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `pathname` is a valid pointer to a null-terminated C string.
 ///
 pub unsafe fn default_faccessat<T>(
     _state: &T,
@@ -217,6 +229,10 @@ pub unsafe fn default_faccessat<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor.
+///
 pub unsafe fn default_fdatasync<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
     libc::fdatasync(fd)
 }
@@ -233,6 +249,10 @@ pub unsafe fn default_fdatasync<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
 /// # Returns
 ///
 /// The real user ID of the calling process.
+///
+/// # Safety
+///
+/// This function is safe to call as it does not access any pointers.
 ///
 pub unsafe fn default_getuid<T>(_state: &T) -> libc::uid_t {
     libc::getuid()
@@ -251,6 +271,10 @@ pub unsafe fn default_getuid<T>(_state: &T) -> libc::uid_t {
 ///
 /// The effective user ID of the calling process.
 ///
+/// # Safety
+///
+/// This function is safe to call as it does not access any pointers.
+///
 pub unsafe fn default_geteuid<T>(_state: &T) -> libc::uid_t {
     libc::geteuid()
 }
@@ -268,6 +292,10 @@ pub unsafe fn default_geteuid<T>(_state: &T) -> libc::uid_t {
 ///
 /// The real group ID of the calling process.
 ///
+/// # Safety
+///
+/// This function is safe to call as it does not access any pointers.
+///
 pub unsafe fn default_getgid<T>(_state: &T) -> libc::gid_t {
     libc::getgid()
 }
@@ -284,6 +312,10 @@ pub unsafe fn default_getgid<T>(_state: &T) -> libc::gid_t {
 /// # Returns
 ///
 /// The effective group ID of the calling process.
+///
+/// # Safety
+///
+/// This function is safe to call as it does not access any pointers.
 ///
 pub unsafe fn default_getegid<T>(_state: &T) -> libc::gid_t {
     libc::getegid()
@@ -303,6 +335,10 @@ pub unsafe fn default_getegid<T>(_state: &T) -> libc::gid_t {
 /// # Returns
 ///
 /// Upon successful completion, a pointer to the buffer is returned. Otherwise, NULL is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `buf` is a valid pointer to a writable buffer of at least `size` bytes.
 ///
 pub unsafe fn default_getcwd<T>(
     _state: &T,
@@ -326,6 +362,10 @@ pub unsafe fn default_getcwd<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor.
+///
 pub unsafe fn default_fsync<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
     libc::fsync(fd)
 }
@@ -345,6 +385,10 @@ pub unsafe fn default_fsync<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
 /// # Returns
 ///
 /// Upon successful completion, the resulting offset is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor.
 ///
 pub unsafe fn default_lseek<T>(
     _state: &T,
@@ -370,6 +414,10 @@ pub unsafe fn default_lseek<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor.
+///
 pub unsafe fn default_ftruncate<T>(
     _state: &T,
     fd: libc::c_int,
@@ -393,6 +441,10 @@ pub unsafe fn default_ftruncate<T>(
 /// # Returns
 ///
 /// Upon successful completion, the number of bytes written is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor and `buf` is a valid pointer to readable memory of at least `count` bytes.
 ///
 pub unsafe fn default_write<T>(
     _state: &T,
@@ -418,6 +470,10 @@ pub unsafe fn default_write<T>(
 /// # Returns
 ///
 /// Upon successful completion, the number of bytes read is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor and `buf` is a valid pointer to writable memory of at least `count` bytes.
 ///
 pub unsafe fn default_read<T>(
     _state: &T,
@@ -445,6 +501,10 @@ pub unsafe fn default_read<T>(
 ///
 /// Upon successful completion, the number of bytes written is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor and `buf` is a valid pointer to readable memory of at least `count` bytes.
+///
 pub unsafe fn default_pwrite<T>(
     _state: &T,
     fd: libc::c_int,
@@ -471,6 +531,10 @@ pub unsafe fn default_pwrite<T>(
 /// # Returns
 ///
 /// Upon successful completion, the number of bytes read is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor and `buf` is a valid pointer to writable memory of at least `count` bytes.
 ///
 pub unsafe fn default_pread<T>(
     _state: &T,
@@ -500,6 +564,10 @@ pub unsafe fn default_pread<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `oldpath` and `newpath` are valid pointers to null-terminated C strings.
+///
 pub unsafe fn default_linkat<T>(
     _state: &T,
     olddirfd: libc::c_int,
@@ -525,6 +593,10 @@ pub unsafe fn default_linkat<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor.
+///
 pub unsafe fn default_fchdir<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
     libc::fchdir(fd)
 }
@@ -544,6 +616,10 @@ pub unsafe fn default_fchdir<T>(_state: &T, fd: libc::c_int) -> libc::c_int {
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor.
 ///
 pub unsafe fn default_fchown<T>(
     _state: &T,
@@ -567,6 +643,10 @@ pub unsafe fn default_fchown<T>(
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `pipefd` is a valid pointer to writable memory for at least 2 integers.
 ///
 pub unsafe fn default_pipe<T>(_state: &T, pipefd: *mut libc::c_int) -> libc::c_int {
     libc::pipe(pipefd)
@@ -673,6 +753,10 @@ pub type FchmodatFn<T> =
 ///
 /// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `pathname` is a valid pointer to a null-terminated C string.
+///
 pub unsafe fn default_openat<T>(
     _state: &T,
     dirfd: libc::c_int,
@@ -699,6 +783,10 @@ pub unsafe fn default_openat<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `pathname` is a valid pointer to a null-terminated C string.
+///
 pub unsafe fn default_unlinkat<T>(
     _state: &T,
     dirfd: libc::c_int,
@@ -724,6 +812,10 @@ pub unsafe fn default_unlinkat<T>(
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `oldpath` and `newpath` are valid pointers to null-terminated C strings.
 ///
 pub unsafe fn default_renameat<T>(
     _state: &T,
@@ -752,6 +844,10 @@ pub unsafe fn default_renameat<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `pathname` is a valid pointer to a null-terminated C string and `buf` is a valid pointer to writable memory.
+///
 pub unsafe fn default_fstatat<T>(
     _state: &T,
     dirfd: libc::c_int,
@@ -777,6 +873,10 @@ pub unsafe fn default_fstatat<T>(
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, an error number is returned.
+///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor.
 ///
 pub unsafe fn default_posix_fallocate<T>(
     _state: &T,
@@ -804,6 +904,10 @@ pub unsafe fn default_posix_fallocate<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, an error number is returned.
 ///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor.
+///
 pub unsafe fn default_posix_fadvise<T>(
     _state: &T,
     fd: libc::c_int,
@@ -829,6 +933,10 @@ pub unsafe fn default_posix_fadvise<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor and `buf` is a valid pointer to writable memory.
+///
 pub unsafe fn default_fstat<T>(_state: &T, fd: libc::c_int, buf: *mut libc::stat) -> libc::c_int {
     libc::fstat(fd, buf)
 }
@@ -848,6 +956,10 @@ pub unsafe fn default_fstat<T>(_state: &T, fd: libc::c_int, buf: *mut libc::stat
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `target` and `linkpath` are valid pointers to null-terminated C strings.
 ///
 pub unsafe fn default_symlinkat<T>(
     _state: &T,
@@ -875,6 +987,10 @@ pub unsafe fn default_symlinkat<T>(
 ///
 /// Upon successful completion, the number of bytes placed in the buffer is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `pathname` is a valid pointer to a null-terminated C string and `buf` is a valid pointer to writable memory of at least `bufsiz` bytes.
+///
 pub unsafe fn default_readlinkat<T>(
     _state: &T,
     dirfd: libc::c_int,
@@ -900,6 +1016,10 @@ pub unsafe fn default_readlinkat<T>(
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `pathname` is a valid pointer to a null-terminated C string.
 ///
 pub unsafe fn default_mkdirat<T>(
     _state: &T,
@@ -927,6 +1047,10 @@ pub unsafe fn default_mkdirat<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `pathname` is a valid pointer to a null-terminated C string and `times` is either NULL or a valid pointer to readable memory.
+///
 pub unsafe fn default_utimensat<T>(
     _state: &T,
     dirfd: libc::c_int,
@@ -952,6 +1076,10 @@ pub unsafe fn default_utimensat<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor and `times` is either NULL or a valid pointer to readable memory.
+///
 pub unsafe fn default_futimens<T>(
     _state: &T,
     fd: libc::c_int,
@@ -975,6 +1103,10 @@ pub unsafe fn default_futimens<T>(
 /// # Returns
 ///
 /// Upon successful completion, a value depends on the command. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor and `arg` is valid for the given command.
 ///
 pub unsafe fn default_fcntl<T>(
     _state: &T,
@@ -1003,6 +1135,10 @@ pub unsafe fn default_fcntl<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `pathname` is a valid pointer to a null-terminated C string.
+///
 pub unsafe fn default_fchownat<T>(
     _state: &T,
     dirfd: libc::c_int,
@@ -1029,6 +1165,10 @@ pub unsafe fn default_fchownat<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor.
+///
 pub unsafe fn default_fchmod<T>(_state: &T, fd: libc::c_int, mode: libc::mode_t) -> libc::c_int {
     libc::fchmod(fd, mode)
 }
@@ -1049,6 +1189,10 @@ pub unsafe fn default_fchmod<T>(_state: &T, fd: libc::c_int, mode: libc::mode_t)
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `pathname` is a valid pointer to a null-terminated C string.
 ///
 pub unsafe fn default_fchmodat<T>(
     _state: &T,
@@ -1080,6 +1224,10 @@ pub unsafe fn default_fchmodat<T>(
 ///
 /// Upon successful completion, the number of bytes read is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `fd` is a valid file descriptor and `dirp` is a valid pointer to writable memory of at least `count` bytes.
+///
 pub unsafe fn default_getdents<T>(
     _state: &T,
     fd: libc::c_int,
@@ -1109,6 +1257,10 @@ pub unsafe fn default_getdents<T>(
 ///
 /// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// This function is safe to call as it does not access any pointers.
+///
 pub unsafe fn default_socket<T>(
     _state: &T,
     domain: libc::c_int,
@@ -1134,6 +1286,10 @@ pub unsafe fn default_socket<T>(
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `sv` is a valid pointer to writable memory for at least 2 integers.
 ///
 pub unsafe fn default_socketpair<T>(
     _state: &T,
@@ -1161,6 +1317,10 @@ pub unsafe fn default_socketpair<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `sockfd` is a valid socket file descriptor and `addr` is a valid pointer to readable memory of at least `addrlen` bytes.
+///
 pub unsafe fn default_bind<T>(
     _state: &T,
     sockfd: libc::c_int,
@@ -1186,6 +1346,10 @@ pub unsafe fn default_bind<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `sockfd` is a valid socket file descriptor and `addr` is a valid pointer to readable memory of at least `addrlen` bytes.
+///
 pub unsafe fn default_connect<T>(
     _state: &T,
     sockfd: libc::c_int,
@@ -1210,6 +1374,10 @@ pub unsafe fn default_connect<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `sockfd` is a valid socket file descriptor.
+///
 pub unsafe fn default_listen<T>(
     _state: &T,
     sockfd: libc::c_int,
@@ -1233,6 +1401,10 @@ pub unsafe fn default_listen<T>(
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `sockfd` is a valid socket file descriptor, `addr` is a valid pointer to writable memory, and `addrlen` is a valid pointer to writable memory.
 ///
 pub unsafe fn default_getpeername<T>(
     _state: &T,
@@ -1259,6 +1431,10 @@ pub unsafe fn default_getpeername<T>(
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `sockfd` is a valid socket file descriptor, `addr` is a valid pointer to writable memory, and `addrlen` is a valid pointer to writable memory.
+///
 pub unsafe fn default_getsockname<T>(
     _state: &T,
     sockfd: libc::c_int,
@@ -1283,6 +1459,10 @@ pub unsafe fn default_getsockname<T>(
 /// # Returns
 ///
 /// Upon successful completion, a file descriptor is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `sockfd` is a valid socket file descriptor, and if `addr` is not NULL, it must be a valid pointer to writable memory and `addrlen` must be a valid pointer to writable memory.
 ///
 pub unsafe fn default_accept<T>(
     _state: &T,
@@ -1309,6 +1489,10 @@ pub unsafe fn default_accept<T>(
 /// # Returns
 ///
 /// Upon successful completion, the number of bytes received is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `sockfd` is a valid socket file descriptor and `buf` is a valid pointer to writable memory of at least `len` bytes.
 ///
 pub unsafe fn default_recv<T>(
     _state: &T,
@@ -1337,6 +1521,10 @@ pub unsafe fn default_recv<T>(
 ///
 /// Upon successful completion, the number of bytes sent is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `sockfd` is a valid socket file descriptor and `buf` is a valid pointer to readable memory of at least `len` bytes.
+///
 pub unsafe fn default_send<T>(
     _state: &T,
     sockfd: libc::c_int,
@@ -1361,6 +1549,10 @@ pub unsafe fn default_send<T>(
 /// # Returns
 ///
 /// Upon successful completion, zero is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `sockfd` is a valid socket file descriptor.
 ///
 pub unsafe fn default_shutdown<T>(
     _state: &T,
@@ -1389,6 +1581,10 @@ pub unsafe fn default_shutdown<T>(
 /// # Returns
 ///
 /// Upon successful completion, the number of file descriptors with events is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `fds` is a valid pointer to readable and writable memory for at least `nfds` elements.
 ///
 pub unsafe fn default_poll<T>(
     _state: &T,
@@ -1421,6 +1617,10 @@ pub unsafe fn default_poll<T>(
 ///
 /// Upon successful completion, the number of file descriptors with events is returned. Otherwise, -1 is returned and `errno` is set.
 ///
+/// # Safety
+///
+/// The caller must ensure that `readfds`, `writefds`, `exceptfds`, and `timeout` are either NULL or valid pointers to readable and writable memory.
+///
 pub unsafe fn default_select<T>(
     _state: &T,
     nfds: libc::c_int,
@@ -1449,6 +1649,10 @@ pub unsafe fn default_select<T>(
 /// # Returns
 ///
 /// Upon successful completion, the elapsed real time in clock ticks is returned. Otherwise, -1 is returned and `errno` is set.
+///
+/// # Safety
+///
+/// The caller must ensure that `buf` is a valid pointer to writable memory.
 ///
 pub unsafe fn default_times<T>(_state: &T, buf: *mut libc::tms) -> libc::clock_t {
     libc::times(buf)

--- a/src/daemons/memd/Cargo.toml
+++ b/src/daemons/memd/Cargo.toml
@@ -32,3 +32,6 @@ info = ["nvx/info", "syslog/info"]
 warn = ["nvx/warn", "syslog/warn"]
 error = ["nvx/error", "syslog/error"]
 panic = ["nvx/panic", "syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/daemons/procd/Cargo.toml
+++ b/src/daemons/procd/Cargo.toml
@@ -29,3 +29,6 @@ info = ["nvx/info"]
 warn = ["nvx/warn"]
 error = ["nvx/error"]
 panic = ["nvx/panic"]
+
+[lints]
+workspace = true

--- a/src/daemons/wasmd/Cargo.toml
+++ b/src/daemons/wasmd/Cargo.toml
@@ -31,3 +31,6 @@ cfg-if = { workspace = true }
 [features]
 default = []
 wasm_binary = []
+
+[lints]
+workspace = true

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -120,3 +120,6 @@ info = ["warn"]
 warn = ["error"]
 error = ["panic"]
 panic = []
+
+[lints]
+workspace = true

--- a/src/libs/arch/Cargo.toml
+++ b/src/libs/arch/Cargo.toml
@@ -99,3 +99,6 @@ pit = []
 putb = []
 puts = []
 stdio = []
+
+[lints]
+workspace = true

--- a/src/libs/bitmap/Cargo.toml
+++ b/src/libs/bitmap/Cargo.toml
@@ -19,3 +19,6 @@ sys = { workspace = true }
 [features]
 default = []
 std = ["sys/std"]
+
+[lints]
+workspace = true

--- a/src/libs/config/Cargo.toml
+++ b/src/libs/config/Cargo.toml
@@ -29,3 +29,6 @@ rustc-dep-of-std = [
     "cfg-if/rustc-dep-of-std",
     "compiler_builtins/rustc-dep-of-std",
 ]
+
+[lints]
+workspace = true

--- a/src/libs/control-plane-api/Cargo.toml
+++ b/src/libs/control-plane-api/Cargo.toml
@@ -21,3 +21,6 @@ anyhow = { workspace = true }
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/src/libs/elf/Cargo.toml
+++ b/src/libs/elf/Cargo.toml
@@ -27,3 +27,6 @@ sys = { workspace = true }
 [features]
 default = []
 std = []
+
+[lints]
+workspace = true

--- a/src/libs/error/Cargo.toml
+++ b/src/libs/error/Cargo.toml
@@ -26,3 +26,6 @@ rustc-dep-of-std = [
     "compiler_builtins/rustc-dep-of-std",
     "sysapi/rustc-dep-of-std",
 ]
+
+[lints]
+workspace = true

--- a/src/libs/hwloc/Cargo.toml
+++ b/src/libs/hwloc/Cargo.toml
@@ -15,3 +15,6 @@ anyhow = { workspace = true }
 libc = { workspace = true }
 serde = { workspace = true, features = ["derive", "std"] }
 syslog = { workspace = true, features = ["std"] }
+
+[lints]
+workspace = true

--- a/src/libs/libc_stdlib/Cargo.toml
+++ b/src/libs/libc_stdlib/Cargo.toml
@@ -46,3 +46,6 @@ info = ["syslog/info"]
 warn = ["syslog/warn"]
 error = ["syslog/error"]
 panic = ["syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/libs/libc_string/Cargo.toml
+++ b/src/libs/libc_string/Cargo.toml
@@ -19,3 +19,6 @@ sysapi = { workspace = true }
 default = []
 # Enables the use of the Rust Standard Library.
 std = []
+
+[lints]
+workspace = true

--- a/src/libs/nanvix-http/Cargo.toml
+++ b/src/libs/nanvix-http/Cargo.toml
@@ -42,3 +42,6 @@ hyperlight = [
     "nanvix-sandbox-cache/hyperlight",
     "nanvix-terminal/hyperlight",
 ]
+
+[lints]
+workspace = true

--- a/src/libs/nanvix-registry/Cargo.toml
+++ b/src/libs/nanvix-registry/Cargo.toml
@@ -25,3 +25,6 @@ uuid = { workspace = true, features = ["std", "v4"] }
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/src/libs/nanvix-sandbox-cache/Cargo.toml
+++ b/src/libs/nanvix-sandbox-cache/Cargo.toml
@@ -22,3 +22,6 @@ tokio = { workspace = true, features = ["full"] }
 default = []
 hyperlight = ["config/hyperlight", "nanvix-sandbox/hyperlight"]
 single-process = ["nanvix-sandbox/single-process"]
+
+[lints]
+workspace = true

--- a/src/libs/nanvix-sandbox/Cargo.toml
+++ b/src/libs/nanvix-sandbox/Cargo.toml
@@ -30,3 +30,6 @@ default = []
 # into the sandbox.
 single-process = []
 hyperlight = ["config/hyperlight", "uservm/hyperlight"]
+
+[lints]
+workspace = true

--- a/src/libs/nanvix-terminal/Cargo.toml
+++ b/src/libs/nanvix-terminal/Cargo.toml
@@ -22,3 +22,6 @@ user-vm-api = { workspace = true }
 default = []
 hyperlight = ["nanvix-sandbox-cache/hyperlight"]
 single-process = ["nanvix-sandbox-cache/single-process"]
+
+[lints]
+workspace = true

--- a/src/libs/nanvix/Cargo.toml
+++ b/src/libs/nanvix/Cargo.toml
@@ -44,3 +44,6 @@ hyperlight = [
     "nanvix-terminal/hyperlight",
     "uservm/hyperlight",
 ]
+
+[lints]
+workspace = true

--- a/src/libs/nvx/Cargo.toml
+++ b/src/libs/nvx/Cargo.toml
@@ -44,3 +44,6 @@ info = ["syslog/info"]
 warn = ["syslog/warn"]
 error = ["syslog/error"]
 panic = ["syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/libs/posix/Cargo.toml
+++ b/src/libs/posix/Cargo.toml
@@ -45,3 +45,6 @@ info = ["syslog/info"]
 warn = ["syslog/warn"]
 error = ["syslog/error"]
 panic = ["syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/libs/proc/Cargo.toml
+++ b/src/libs/proc/Cargo.toml
@@ -27,3 +27,6 @@ default = ["syslog"]
 std = []
 syscall = []
 daemon = ["syslog"]
+
+[lints]
+workspace = true

--- a/src/libs/profiler/Cargo.toml
+++ b/src/libs/profiler/Cargo.toml
@@ -20,3 +20,6 @@ syslog = { workspace = true, features = ["std"] }
 default = []
 auto-calibrate = []
 timestamp-messages = []
+
+[lints]
+workspace = true

--- a/src/libs/raw-array/Cargo.toml
+++ b/src/libs/raw-array/Cargo.toml
@@ -20,3 +20,6 @@ sys = { workspace = true }
 [features]
 default = []
 std = ["sys/std"]
+
+[lints]
+workspace = true

--- a/src/libs/slab/Cargo.toml
+++ b/src/libs/slab/Cargo.toml
@@ -20,3 +20,6 @@ sys = { workspace = true }
 [features]
 default = []
 std = ["sys/std", "bitmap/std", "raw-array/std"]
+
+[lints]
+workspace = true

--- a/src/libs/static_assert/Cargo.toml
+++ b/src/libs/static_assert/Cargo.toml
@@ -18,3 +18,6 @@ compiler_builtins = { version = "0.1", optional = true }
 default = []
 std = []
 rustc-dep-of-std = ["core", "compiler_builtins/rustc-dep-of-std"]
+
+[lints]
+workspace = true

--- a/src/libs/sys/Cargo.toml
+++ b/src/libs/sys/Cargo.toml
@@ -27,3 +27,6 @@ rustc-dep-of-std = [
     "static_assert/rustc-dep-of-std",
     "error/rustc-dep-of-std",
 ]
+
+[lints]
+workspace = true

--- a/src/libs/sysalloc/Cargo.toml
+++ b/src/libs/sysalloc/Cargo.toml
@@ -46,3 +46,6 @@ info = ["syslog/info"]
 warn = ["syslog/warn"]
 error = ["syslog/error"]
 panic = ["syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/libs/sysapi/Cargo.toml
+++ b/src/libs/sysapi/Cargo.toml
@@ -25,3 +25,6 @@ rustc-dep-of-std = [
     "config/rustc-dep-of-std",
     "static_assert/rustc-dep-of-std",
 ]
+
+[lints]
+workspace = true

--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -75,3 +75,6 @@ debug = ["syslog/debug"]
 info = ["syslog/info"]
 warn = ["syslog/warn"]
 panic = ["syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/libs/syscomm/Cargo.toml
+++ b/src/libs/syscomm/Cargo.toml
@@ -19,3 +19,6 @@ tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/src/libs/syslog/Cargo.toml
+++ b/src/libs/syslog/Cargo.toml
@@ -38,3 +38,6 @@ info = []
 warn = []
 error = []
 panic = []
+
+[lints]
+workspace = true

--- a/src/libs/type-safe/Cargo.toml
+++ b/src/libs/type-safe/Cargo.toml
@@ -22,3 +22,6 @@ compiler_builtins = { version = "0.1", optional = true }
 default = []
 std = []
 rustc-dep-of-std = ["alloc", "core", "compiler_builtins/rustc-dep-of-std"]
+
+[lints]
+workspace = true

--- a/src/libs/user-vm-api/Cargo.toml
+++ b/src/libs/user-vm-api/Cargo.toml
@@ -22,3 +22,6 @@ anyhow = { workspace = true }
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/src/tests/arch-rust/Cargo.toml
+++ b/src/tests/arch-rust/Cargo.toml
@@ -35,3 +35,6 @@ info = ["nvx/info", "syscall/info", "syslog/info"]
 warn = ["nvx/warn", "syscall/warn", "syslog/warn"]
 error = ["nvx/error", "syscall/error", "syslog/error"]
 panic = ["nvx/panic", "syscall/panic", "syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/tests/file-rust/Cargo.toml
+++ b/src/tests/file-rust/Cargo.toml
@@ -33,3 +33,6 @@ info = ["nvx/info", "syscall/info", "syslog/info"]
 warn = ["nvx/warn", "syscall/warn", "syslog/warn"]
 error = ["nvx/error", "syscall/error", "syslog/error"]
 panic = ["nvx/panic", "syscall/panic", "syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/tests/linux-app/Cargo.toml
+++ b/src/tests/linux-app/Cargo.toml
@@ -33,3 +33,6 @@ info = ["nvx/info"]
 warn = ["nvx/warn"]
 error = ["nvx/error"]
 panic = ["nvx/panic"]
+
+[lints]
+workspace = true

--- a/src/tests/testd/Cargo.toml
+++ b/src/tests/testd/Cargo.toml
@@ -34,3 +34,6 @@ info = ["nvx/info"]
 warn = ["nvx/warn"]
 error = ["nvx/error"]
 panic = ["nvx/panic"]
+
+[lints]
+workspace = true

--- a/src/user/hello-rust-nostd/Cargo.toml
+++ b/src/user/hello-rust-nostd/Cargo.toml
@@ -30,3 +30,6 @@ info = ["nvx/info"]
 warn = ["nvx/warn"]
 error = ["nvx/error"]
 panic = ["nvx/panic"]
+
+[lints]
+workspace = true

--- a/src/user/hello-wasm/Cargo.toml
+++ b/src/user/hello-wasm/Cargo.toml
@@ -9,3 +9,6 @@ edition.workspace = true
 authors.workspace = true
 description = "Hello World in WebAssembly"
 homepage.workspace = true
+
+[lints]
+workspace = true

--- a/src/uservm/Cargo.toml
+++ b/src/uservm/Cargo.toml
@@ -45,3 +45,6 @@ libc = { workspace = true }
 default = []
 hyperlight = ["dep:hyperlight-host", "config/hyperlight"]
 timestamp-messages = ["profiler/timestamp-messages"]
+
+[lints]
+workspace = true

--- a/src/utils/echo-client/Cargo.toml
+++ b/src/utils/echo-client/Cargo.toml
@@ -22,3 +22,6 @@ tokio = { workspace = true, features = ["full"] }
 [features]
 default = []
 timestamp-messages = []
+
+[lints]
+workspace = true

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -27,3 +27,6 @@ default = []
 timestamp-messages = ["profiler/timestamp-messages"]
 single-process = ["nanvix/single-process"]
 hyperlight = ["nanvix/hyperlight"]
+
+[lints]
+workspace = true

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -23,3 +23,6 @@ default = []
 # into Nanvix Daemon (nanvixd).
 single-process = ["nanvix/single-process"]
 hyperlight = ["nanvix/hyperlight"]
+
+[lints]
+workspace = true


### PR DESCRIPTION
This pull request strengthens linting and code quality enforcement across the workspace, and improves the safety documentation for system call wrappers. The main changes include making all Clippy warnings into hard errors by default, propagating workspace lint settings to all Rust packages, updating Makefile lint rules to enforce stricter checks, and enhancing the documentation of unsafe functions in the Linux daemon. Additionally, the pre-commit hook script is refactored to better match CI configuration coverage and provide improved feedback.

**Linting and code quality enforcement:**

* Set Clippy warnings to "deny" at the workspace level in `Cargo.toml`, with placeholders for future stricter lint groups.
* Propagate `[lints] workspace = true` to all relevant `Cargo.toml` files to ensure consistent linting policy across all Rust packages. [[1]](diffhunk://#diff-c687c53d1301c976a9de9233e882e66463ab25efb486bda71dd1d8bf99df70afR36-R38) [[2]](diffhunk://#diff-5f96836ee4ce97a329bca84e08b7df1dd944445dd74bfd4d75ddefe8bf4a6041R12-R14) [[3]](diffhunk://#diff-89d861d583d4af8a2a94fffa924163f7e4cccd647a38de1dc17ef6f920a86619R35-R37) [[4]](diffhunk://#diff-f314aa11584234c796aa2d0027001cb93725105dfd8a719184d97125c458f4f1R12-R14) [[5]](diffhunk://#diff-a1be501a7c9aeaafbec46b5f372be107ab274e053718327e12b67c3cf47ace91R41-R43)
* Update all Makefile lint-check rules to pass `-- -D warnings` to Clippy, making lint warnings fail the build for all guest/host/wasm binaries, staticlibs, rlibs, and key targets. [[1]](diffhunk://#diff-5c80f1f9d45ba99886763b815bcec0d11b99afc87b6d35dc05e81d2dd5874889L30-R30) [[2]](diffhunk://#diff-77868e5f1fa16f2d16dbd07b9417e35c89847e3950aafda6ca2c945d492f331bL18-R18) [[3]](diffhunk://#diff-09db66ae7883b17faf00aa294ed7e34efd659f25b9507bb1af6bb2f0bd10a1b4L31-R31) [[4]](diffhunk://#diff-ab2949ec19cfc4ef87eafa8b5f6b65e598d34f6a7651b6fb111a8eb629f77dabL31-R31) [[5]](diffhunk://#diff-56b5460ed196046bab3bc8f3036a0926f84b20ac09fe893b7e34e07ef2ff92efL18-R18) [[6]](diffhunk://#diff-264508c0737552a14432c4b9d6016bae36c1e4058468dd69d98d593f4a48c767L26-R26) [[7]](diffhunk://#diff-f9010d16915fa4b540afd586eda2ff2211bc05e6fe0338e0d447ff9b79c041aaL29-R29) [[8]](diffhunk://#diff-d7ae164e20fb717bd169817ea5a57a85c2f2045caceff42add6d315cf21bc577L32-R32) [[9]](diffhunk://#diff-28dbb1490ca7d99373f640c976b8adbb86085547204d62a24ad0c7463ef20194L31-R31) [[10]](diffhunk://#diff-6c7fe4970416ffb042c5c15a7ca82378ddcf3dcf539527fead033ed66a830aabL32-R32) [[11]](diffhunk://#diff-c5c1e87edd10d650cfe895d5c10926fc62459a365acc8d909a024831f2e46c76L35-R35)

**Pre-commit hook improvements:**

* Refactor `.githooks/pre-commit` to match the CI configuration matrix, run checks for all machine/deployment combinations, and provide clearer progress and error reporting.

**Documentation and safety improvements:**

* Add or clarify `# Safety` sections in the documentation of all unsafe system call wrappers in `src/daemons/linuxd/src/syscalls.rs`, specifying caller requirements and pointer validity. [[1]](diffhunk://#diff-c7c31a2b8f0ae1b24a26bf74ac1f09b68cc7608a387b26f883b27d2a503d02cbR157-R160) [[2]](diffhunk://#diff-c7c31a2b8f0ae1b24a26bf74ac1f09b68cc7608a387b26f883b27d2a503d02cbR179-R182) [[3]](diffhunk://#diff-c7c31a2b8f0ae1b24a26bf74ac1f09b68cc7608a387b26f883b27d2a503d02cbR204-R207) [[4]](diffhunk://#diff-c7c31a2b8f0ae1b24a26bf74ac1f09b68cc7608a387b26f883b27d2a503d02cbR232-R235) [[5]](diffhunk://#diff-c7c31a2b8f0ae1b24a26bf74ac1f09b68cc7608a387b26f883b27d2a503d02cbR253-R256) [[6]](diffhunk://#diff-c7c31a2b8f0ae1b24a26bf74ac1f09b68cc7608a387b26f883b27d2a503d02cbR274-R277) [[7]](diffhunk://#diff-c7c31a2b8f0ae1b24a26bf74ac1f09b68cc7608a387b26f883b27d2a503d02cbR295-R298) [[8]](diffhunk://#diff-c7c31a2b8f0ae1b24a26bf74ac1f09b68cc7608a387b26f883b27d2a503d02cbR316-R319) [[9]](diffhunk://#diff-c7c31a2b8f0ae1b24a26bf74ac1f09b68cc7608a387b26f883b27d2a503d02cbR339-R342)