### PR TITLE
[nanvix-sandbox] Refactor Exports

### DIFF
--- a/src/libs/nanvix-sandbox/Cargo.toml
+++ b/src/libs/nanvix-sandbox/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+cfg-if = { workspace = true }
 config = { workspace = true }
 control-plane-api = { workspace = true }
 hwloc = { workspace = true }

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -124,36 +124,41 @@ mod uservm_args;
 // Public Modules
 //==================================================================================================
 
-#[cfg(not(feature = "single-process"))]
-pub mod multi_process;
-#[cfg(feature = "single-process")]
-pub mod single_process;
+::cfg_if::cfg_if! {
+    if #[cfg(feature = "single-process")] {
+        pub mod single_process;
+    } else {
+        pub mod multi_process;
+    }
+}
+
 pub mod tcp_port;
 
 //==================================================================================================
 // Exports
 //==================================================================================================
 
-#[cfg(not(feature = "single-process"))]
-pub use self::multi_process::*;
-#[cfg(feature = "single-process")]
-pub use self::single_process::*;
+::cfg_if::cfg_if! {
+    if #[cfg(feature = "single-process")] {
+        pub use self::single_process::*;
+        pub use ::linuxd::syscalls::SyscallAction;
+        pub use ::linuxd::syscalls::SyscallTable;
+    } else {
+        pub use self::multi_process::*;
+    }
+}
 
-pub use initialized::InitializedSandbox;
-pub use linuxd_args::LinuxDaemonArgs;
-pub use running::RunningSandbox;
-pub use sandbox_config::SandboxConfig;
-pub use uninitialized::UninitializedSandbox;
-pub use user_vm_api::UserVmIdentifier;
-pub use uservm_args::UserVmArgs;
-
-#[cfg(feature = "single-process")]
-pub use ::linuxd::syscalls::SyscallAction;
-#[cfg(feature = "single-process")]
-pub use ::linuxd::syscalls::SyscallTable;
-
+pub use self::{
+    initialized::InitializedSandbox,
+    linuxd_args::LinuxDaemonArgs,
+    running::RunningSandbox,
+    sandbox_config::SandboxConfig,
+    uninitialized::UninitializedSandbox,
+    uservm_args::UserVmArgs,
+};
 pub use ::hwloc::HwLoc;
 pub use ::syscomm;
+pub use ::user_vm_api::UserVmIdentifier;
 pub use config::{
     control_plane_sockaddr_builder,
     gateway_sockaddr_builder,

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -148,6 +148,8 @@ pub use user_vm_api::UserVmIdentifier;
 pub use uservm_args::UserVmArgs;
 
 #[cfg(feature = "single-process")]
+pub use ::linuxd::syscalls::SyscallAction;
+#[cfg(feature = "single-process")]
 pub use ::linuxd::syscalls::SyscallTable;
 
 pub use ::hwloc::HwLoc;


### PR DESCRIPTION
This pull request refactors how feature flags are handled for module imports and exports in the `nanvix-sandbox` library. The main improvement is the use of the `cfg-if` crate to simplify and centralize conditional compilation logic, reducing code duplication and improving maintainability.

**Feature flag handling improvements:**

* Replaced manual `#[cfg(...)]` attributes with `cfg_if!` macro to conditionally import and export either the `single_process` or `multi_process` modules and their related items, depending on the `single-process` feature flag. This reduces code repetition and makes the conditional logic clearer.
* Added the `cfg-if` crate as a dependency in `Cargo.toml` to enable the use of the `cfg_if!` macro throughout the codebase.