### PR TITLE
[nanvix-sandbox] Cleanup Dangling Resources form Previous Run

### DIFF
--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -178,9 +178,8 @@ pub fn control_plane_sockaddr_builder(tmp_str: &str, tenant_id: &str, l2: bool) 
         return Ok(format!("0.0.0.0:{}", config::linuxd::CONTROL_PLANE_PORT));
     }
 
-    let unix_socket_name: String = format!(
-        "{tmp_str}/{NAMED_RESOURCE_PREFIX}:control-plane:{tenant_id}:cp{UNIX_SOCKET_SUFFIX}"
-    );
+    let unix_socket_name: String =
+        format!("{tmp_str}/{NAMED_RESOURCE_PREFIX}:{tenant_id}:cp{UNIX_SOCKET_SUFFIX}");
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {

--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -73,6 +73,13 @@ const UNIX_PATH_MAX: usize = 108;
 ///
 /// # Description
 ///
+/// Prefix for all named resources.
+///
+pub const NAMED_RESOURCE_PREFIX: &str = "nvx";
+
+///
+/// # Description
+///
 /// Suffix for Unix sockets in debug builds.
 ///
 #[cfg(debug_assertions)]
@@ -171,8 +178,9 @@ pub fn control_plane_sockaddr_builder(tmp_str: &str, tenant_id: &str, l2: bool) 
         return Ok(format!("0.0.0.0:{}", config::linuxd::CONTROL_PLANE_PORT));
     }
 
-    let unix_socket_name: String =
-        format!("{tmp_str}/control-plane:{tenant_id}:cp{UNIX_SOCKET_SUFFIX}");
+    let unix_socket_name: String = format!(
+        "{tmp_str}/{NAMED_RESOURCE_PREFIX}:control-plane:{tenant_id}:cp{UNIX_SOCKET_SUFFIX}"
+    );
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {
@@ -212,7 +220,8 @@ pub fn user_vm_sockaddr_builder(tmp_str: &str, tenant_id: &str, l2: bool) -> Res
         ));
     }
 
-    let unix_socket_name: String = format!("{tmp_str}/{tenant_id}:uvm{UNIX_SOCKET_SUFFIX}");
+    let unix_socket_name: String =
+        format!("{tmp_str}/{NAMED_RESOURCE_PREFIX}:{tenant_id}:uvm{UNIX_SOCKET_SUFFIX}");
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {
@@ -256,8 +265,9 @@ pub fn gateway_sockaddr_builder(
     }
 
     let sandbox_id: u32 = sandbox_id.into();
-    let unix_socket_name: String =
-        format!("{tmp_str}/{tenant_id}:gw-{sandbox_id}{UNIX_SOCKET_SUFFIX}");
+    let unix_socket_name: String = format!(
+        "{tmp_str}/{NAMED_RESOURCE_PREFIX}:{tenant_id}:gw-{sandbox_id}{UNIX_SOCKET_SUFFIX}"
+    );
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -109,6 +109,26 @@
 //! - Utilities: [`tcp_port`] for managing TCP port allocations
 
 //==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::config::NAMED_RESOURCE_PREFIX;
+use ::anyhow::Result;
+use ::std::{
+    borrow::Cow,
+    ffi::OsString,
+    path::PathBuf,
+};
+use ::syslog::{
+    error,
+    warn,
+};
+use ::tokio::{
+    fs,
+    fs::ReadDir,
+};
+
+//==================================================================================================
 // Private Modules
 //==================================================================================================
 
@@ -164,3 +184,81 @@ pub use config::{
     gateway_sockaddr_builder,
     user_vm_sockaddr_builder,
 };
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Helper function that removes dangling resources from previous runs.
+///
+/// # Parameters
+///
+/// - `tmp_dir_path`: Path to the temporary directory.
+///
+/// # Returns
+///
+/// On success, this function returns an empty tuple. On failure, it returns an object that
+/// describes the error.
+///
+pub async fn remove_dangling_resources(tmp_dir_path: &str) -> Result<()> {
+    let mut result: Result<()> = Ok(());
+
+    // Open temporary directory, all named resources are created here.
+    let mut dir_entries: ReadDir = fs::read_dir(tmp_dir_path).await.map_err(|error| {
+        let reason: String =
+            format!("failed to read temporary directory '{tmp_dir_path}': {error}");
+        error!("remove_dangling_resources(): {reason}");
+        anyhow::anyhow!(reason)
+    })?;
+
+    // Traverse directory entries and remove all dangling resources that start with the magic prefix
+    // for named resources. If we fail, log an error message and continue, as we want to cleanup as
+    // many resources as possible. The overall result will be an error if any removal fails.
+    loop {
+        match dir_entries.next_entry().await {
+            Ok(None) => break,
+            Ok(Some(entry)) => {
+                let file_name: OsString = entry.file_name();
+                let file_name_str: Cow<'_, str> = file_name.to_string_lossy();
+
+                // Check if the file name matches the named resource prefix.
+                if file_name_str.starts_with(NAMED_RESOURCE_PREFIX) {
+                    let file_path: PathBuf = entry.path();
+
+                    // Attempt to remove dangling resource.
+                    if let Err(error) = fs::remove_file(file_path).await {
+                        let reason: String = format!(
+                            "failed to remove dangling resource '{}': {error}",
+                            file_name_str
+                        );
+                        error!("remove_dangling_resources(): {reason}");
+
+                        // Do not overwrite previous errors.
+                        if result.is_ok() {
+                            result = Err(anyhow::anyhow!(reason));
+                        }
+                    } else {
+                        warn!("removed dangling resource: {}", file_name_str);
+                    }
+                }
+            },
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to read entry in temporary directory '{}': {error}",
+                    tmp_dir_path
+                );
+                error!("remove_dangling_resources(): {reason}");
+
+                // Do not overwrite previous errors.
+                if result.is_ok() {
+                    result = Err(anyhow::anyhow!(reason));
+                }
+            },
+        };
+    }
+
+    result
+}

--- a/src/libs/nanvix-sandbox/src/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/uservm.rs
@@ -308,9 +308,8 @@ impl UserVm {
                 Ok(Ok(stream)) => stream,
                 Ok(Err(error)) => {
                     uservm_task.abort();
-                    let reason: String = format!(
-                        "error connecting control-plane to embedded user VM (error={error:?})"
-                    );
+                    let reason: String =
+                        format!("error connecting control-plane to user VM (error={error:?})");
                     error!("spawn(): {reason}");
                     anyhow::bail!("{reason}");
                 },
@@ -350,7 +349,7 @@ impl UserVm {
 
         // Send shutdown command to User VM.
         if let Err(e) = self.control_plane_stream.write_all(&msg_bytes).await {
-            warn!("shutdown(): failed to send shutdown command to embedded user VM (error={e:?})");
+            warn!("shutdown(): failed to send shutdown command to user VM (error={e:?})");
         }
 
         // Wait for User VM to finish.
@@ -366,18 +365,15 @@ impl UserVm {
                         }
                     },
                     Ok(Err(error)) => {
-                        warn!(
-                            "shutdown(): embedded user VM terminated with error (error={error:?})"
-                        );
+                        warn!("shutdown(): user VM terminated with error (error={error:?})");
                     },
                     Err(join_error) => {
-                        warn!("shutdown(): embedded user VM task panicked (error={join_error:?})");
+                        warn!("shutdown(): user VM task panicked (error={join_error:?})");
                     },
                 },
                 Err(elapsed) => {
                     warn!(
-                        "shutdown(): timed-out waiting for embedded user VM to shutdown \
-                         (error={elapsed:?})"
+                        "shutdown(): timed-out waiting for user VM to shutdown (error={elapsed:?})"
                     );
                 },
             }

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -26,6 +26,7 @@ use ::nanvix::{
     log,
     log::error,
     registry::Registry,
+    sandbox,
     sandbox_cache::SandboxCacheConfig,
     terminal::Terminal,
 };
@@ -151,6 +152,10 @@ pub async fn main() -> Result<()> {
         args.l2_snapshot_path(),
         args.tmp_directory(),
     );
+
+    // Remove dangling resources from previous runs. We do not expect concurrent instances of
+    // nanvixd running in the same tmp directory, so we will not have unexpected side effects.
+    sandbox::remove_dangling_resources(args.tmp_directory()).await?;
 
     // Check for interactive mode or HTTP mode.
     if let Some(true) = INTERACTIVE_MODE.get().copied() {


### PR DESCRIPTION
This PR is a workaround for https://github.com/nanvix/nanvix/issues/1136.

This pull request introduces a new mechanism for cleaning up leftover resources from previous runs and standardizes the naming convention for named resources in the `nanvix-sandbox` crate. The changes help prevent resource leaks and make resource management more robust. The most important changes are grouped below:

Resource cleanup improvements:
* Added a new async function `remove_dangling_resources` to `src/libs/nanvix-sandbox/src/lib.rs`, which scans the temporary directory and removes any files with the `NAMED_RESOURCE_PREFIX` (now `"nvx"`), logging errors and warnings as appropriate. This function is now invoked during the startup of the `nanvixd` daemon to ensure a clean environment. [[1]](diffhunk://#diff-f5b055ed6c61b7998e1bb0bcc08d7aab6c496a2cd6dba4ce81bacbeb81f58c61R187-R264) [[2]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462R156-R158)
* Imported and used the new `remove_dangling_resources` function in `src/utils/nanvixd/src/main.rs`.

Resource naming standardization:
* Introduced a constant `NAMED_RESOURCE_PREFIX` in `src/libs/nanvix-sandbox/src/config.rs` and updated all socket path builders (`control_plane_sockaddr_builder`, `user_vm_sockaddr_builder`, and `gateway_sockaddr_builder`) to include this prefix in the names of created resources. This ensures all named resources are easily identifiable and consistent. [[1]](diffhunk://#diff-44ca3658a5e2d5d338f8951029d3162a16a5e0803ad5032a8179c5ba2722cbafR73-R79) [[2]](diffhunk://#diff-44ca3658a5e2d5d338f8951029d3162a16a5e0803ad5032a8179c5ba2722cbafL175-R182) [[3]](diffhunk://#diff-44ca3658a5e2d5d338f8951029d3162a16a5e0803ad5032a8179c5ba2722cbafL215-R223) [[4]](diffhunk://#diff-44ca3658a5e2d5d338f8951029d3162a16a5e0803ad5032a8179c5ba2722cbafL259-R269)

Code clarity and consistency:
* Updated log/error messages in `src/libs/nanvix-sandbox/src/single_process/uservm.rs` to refer to "user VM" instead of "embedded user VM" for consistency and clarity. [[1]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L311-R312) [[2]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L353-R352) [[3]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L369-R376)

These changes improve the reliability and maintainability of resource management in the sandbox environment.