### PR TITLE
[nanvixd] Use Unique Temporary Directories

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -17,11 +17,6 @@ runs:
   using: "composite"
   steps:
   # MicroVM benchmarks
-  - name: Create temp dir
-    run: |
-      TMPDIR_MICROVM=$(mktemp -d /tmp/nanvix-bench-microvm-XXXXX)
-      echo "TMPDIR_MICROVM=$TMPDIR_MICROVM" >> "$GITHUB_ENV"
-    shell: bash
   - name: Build (MicroVM)
     run: |
       python3 scripts/ci.py \
@@ -58,7 +53,6 @@ runs:
           --hwloc $HOME/hwloc.json \
           --iterations 1000 \
           --toolchain-bin-dir $HOME/toolchain/bin \
-          --tmp-dir ${TMPDIR_MICROVM} \
           --output-dir $(pwd)
       done
 
@@ -95,21 +89,11 @@ runs:
             --hwloc $HOME/hwloc.json \
             --iterations 1000 \
             --toolchain-bin-dir $HOME/toolchain/bin \
-            --tmp-dir ${TMPDIR_MICROVM} \
             --output-dir $(pwd)
         fi
       done
-  - name: Clean-up temporary directory
-    if: always()
-    run: rm -rf ${TMPDIR_MICROVM}
-    shell: bash
 
   # Hyperlight benchmarks
-  - name: Create temp dir
-    run: |
-      TMPDIR_HL=$(mktemp -d /tmp/nanvix-bench-hl-XXXXX)
-      echo "TMPDIR_HL=$TMPDIR_HL" >> "$GITHUB_ENV"
-    shell: bash
   - name: Build (Hyperlight)
     run: |
       python3 scripts/ci.py \
@@ -156,7 +140,6 @@ runs:
           --hwloc $HOME/hwloc.json \
           --iterations 1000 \
           --toolchain-bin-dir $HOME/toolchain/bin \
-          --tmp-dir ${TMPDIR_HL} \
           --output-dir $(pwd)
       done
 
@@ -193,14 +176,9 @@ runs:
             --hwloc $HOME/hwloc.json \
             --iterations 1000 \
             --toolchain-bin-dir $HOME/toolchain/bin \
-            --tmp-dir ${TMPDIR_HL} \
             --output-dir $(pwd)
         fi
       done
-  - name: Clean-up temporary directory
-    if: always()
-    run: rm -rf ${TMPDIR_HL}
-    shell: bash
 
   # Post-process the results
   - name: Format benchmark results

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -414,7 +414,6 @@ def run_benchmark(args):
         f"-benchmark {args.benchmark}",
         f"-hwloc {args.hwloc}",
         f"-iterations {args.iterations}",
-        f"-tmp-dir {args.tmp_dir}" if args.tmp_dir is not None else "",
         f"-toolchain-bin-dir {args.toolchain_bin_dir}",
     ]
     nanvix_bench_cmd = " ".join(nanvix_bench_cmd)
@@ -486,10 +485,6 @@ if __name__ == "__main__":
         "--hwloc",
         required=True,
         help="Path to file with the hardware locality information",
-    )
-    run_parser.add_argument(
-        "--tmp-dir",
-        help="Temporary directory to run the benchmarks in",
     )
     run_parser.add_argument(
         "--bin-dir",

--- a/scripts/run-nanvixd.sh
+++ b/scripts/run-nanvixd.sh
@@ -18,7 +18,6 @@ readonly DEFAULT_NANVIXD_SOCKADDR="${DEFAULT_NANVIXD_HOST}:${DEFAULT_NANVIXD_POR
 readonly NANVIXD_BINARY_NAME="nanvixd.elf"
 readonly MAX_TRIALS=100
 readonly SLEEP_INTERVAL=0.1
-readonly TMP_DIR_BASE_PATH="/tmp/nanvixd"
 readonly DEFAULT_TOOLCHAIN_BIN_DIR="${PWD}/toolchain/bin"
 readonly DEFAULT_BIN_DIR="${PWD}/bin"
 readonly DEFAULT_LOG_LEVEL="warn"
@@ -45,9 +44,6 @@ LOG_LEVEL="${DEFAULT_LOG_LEVEL}"
 # Derived nanvixd endpoint components.
 NANVIXD_HOST="${DEFAULT_NANVIXD_HOST}"
 NANVIXD_PORT="${DEFAULT_NANVIXD_PORT}"
-
-# Temporary directory for nanvixd.
-TMP_DIR=""
 
 # PID of the nanvixd process.
 NANVIXD_PID=""
@@ -434,8 +430,6 @@ cleanup() {
 
         wait "${NANVIXD_PID}" 2>/dev/null || true
     fi
-
-    rm -rf "${TMP_DIR}"
 }
 
 #===================================================================================================
@@ -482,12 +476,6 @@ main() {
         fi
     fi
 
-    # Create temporary directory.
-    TMP_DIR=$(mktemp -d "${TMP_DIR_BASE_PATH}-XXXXXX") || {
-        echo "Error: Unable to create temporary directory." 1>&2
-        return 1
-    }
-
     local logs_dir
     logs_dir="logs/nanvixd-$(basename "${program_name}")"
 
@@ -504,7 +492,6 @@ main() {
         -http-addr "${NANVIXD_SOCKADDR}" \
         -toolchain-bin-dir "${TOOLCHAIN_BIN_DIR}" \
         -log-dir "${logs_dir}" \
-        -tmp-dir "${TMP_DIR}" \
         "$([ "$L2_VM" = "yes" ] && echo "-l2")" \
         -console-file "${console_file_name}" &
     NANVIXD_PID=$!

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -112,7 +112,6 @@
 // Imports
 //==================================================================================================
 
-use crate::config::NAMED_RESOURCE_PREFIX;
 use ::anyhow::Result;
 use ::std::{
     borrow::Cow,
@@ -183,6 +182,7 @@ pub use config::{
     control_plane_sockaddr_builder,
     gateway_sockaddr_builder,
     user_vm_sockaddr_builder,
+    NAMED_RESOURCE_PREFIX,
 };
 
 //==================================================================================================

--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -21,7 +21,6 @@ pub struct Args {
     benchmark: BenchmarkFlavour,
     hwloc_file: Option<String>,
     iterations: usize,
-    tmp_dir: String,
     toolchain_bin_dir: String,
 }
 
@@ -34,19 +33,16 @@ impl Args {
     const OPT_BENCHMARK: &'static str = "-benchmark";
     const OPT_HWLOC: &'static str = "-hwloc";
     const OPT_ITERATIONS: &'static str = "-iterations";
-    const OPT_TMP_DIR: &'static str = "-tmp-dir";
     const OPT_TOOLCHAIN_BIN_DIR: &'static str = "-toolchain-bin-dir";
 
     fn usage() -> String {
         format!(
             "usage: ./bin/nanvix-bench.elf {} \
              [boot-time,cold-start,cold-start-l2,warm-start,warm-start-l2,warm-start-vmm,\
-             echo-breakdown] [{} <path_to_hwloc.json> {} <iterations> {} <tmp_dir> {} \
-             <toolchain_bin_dir>]",
+             echo-breakdown] [{} <path_to_hwloc.json> {} <iterations> {} <toolchain_bin_dir>]",
             Self::OPT_BENCHMARK,
             Self::OPT_HWLOC,
             Self::OPT_ITERATIONS,
-            Self::OPT_TMP_DIR,
             Self::OPT_TOOLCHAIN_BIN_DIR,
         )
     }
@@ -55,7 +51,6 @@ impl Args {
         let mut benchmark_str: String = String::new();
         let mut hwloc_file: Option<String> = None;
         let mut iterations: usize = 100;
-        let mut tmp_dir: String = "/tmp/".to_string();
         let mut toolchain_bin_dir: String = "./toolchain/bin".to_string();
 
         let mut i: usize = 1;
@@ -90,14 +85,6 @@ impl Args {
                     }
                     iterations = args[i].parse::<usize>()?;
                 },
-                Self::OPT_TMP_DIR => {
-                    i += 1;
-                    if i >= args.len() {
-                        error!("{}", Self::usage());
-                        return Err(anyhow::anyhow!("missing value for: {}", Self::OPT_TMP_DIR));
-                    }
-                    tmp_dir = args[i].clone();
-                },
                 Self::OPT_TOOLCHAIN_BIN_DIR => {
                     i += 1;
                     if i >= args.len() {
@@ -123,7 +110,6 @@ impl Args {
                 benchmark,
                 hwloc_file,
                 iterations,
-                tmp_dir,
                 toolchain_bin_dir,
             }),
             Err(_) => {
@@ -143,10 +129,6 @@ impl Args {
 
     pub fn iterations(&self) -> usize {
         self.iterations
-    }
-
-    pub fn tmp_dir(&self) -> String {
-        self.tmp_dir.clone()
     }
 
     pub fn toolchain_bin_dir(&self) -> String {

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -94,7 +94,6 @@ pub struct Benchmark {
     pub flavour: BenchmarkFlavour,
     pub nanvixd: Option<Child>,
     pub nanvixd_client: reqwest::Client,
-    pub nanvixd_tmp_dir: String,
     pub nanvixd_toolchain_bin_dir: String,
     pub user_vm_id: Option<String>,
 }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -179,8 +179,6 @@ impl Benchmark {
             format!("{}/bin/nanvixd.elf", get_proj_root()),
             ::nanvixd::args::Args::OPT_HTTP_SOCKADDR.to_string(),
             NANVIXD_ADDRESS.to_string(),
-            ::nanvixd::args::Args::OPT_TMP_DIRECTORY.to_string(),
-            self.nanvixd_tmp_dir.clone(),
             ::nanvixd::args::Args::OPT_TOOLCHAIN_BIN_DIRECTORY.to_string(),
             self.nanvixd_toolchain_bin_dir.clone(),
         ];
@@ -1040,7 +1038,6 @@ async fn main() -> Result<()> {
         flavour: args.benchmark(),
         nanvixd: None,
         nanvixd_client: reqwest::Client::new(),
-        nanvixd_tmp_dir: args.tmp_dir(),
         nanvixd_toolchain_bin_dir: args.toolchain_bin_dir(),
         user_vm_id: None,
     };

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -14,6 +14,7 @@ homepage.workspace = true
 anyhow = { workspace = true }
 chrono = { workspace = true, features = ["std", "clock"] }
 nanvix = { workspace = true }
+rand = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -44,8 +44,6 @@ use ::std::{
 pub struct Args {
     /// Optional HTTP server socket address (host:port). If present, enables HTTP mode.
     http_sockaddr: Option<String>,
-    /// Directory path for temporary files and Unix sockets.
-    tmp_directory: String,
     /// Directory path containing Nanvix binaries.
     binary_directory: String,
     /// Directory path containing toolchain binaries (cloud-hypervisor, etc.).
@@ -81,8 +79,6 @@ impl Args {
     pub const OPT_HELP: &'static str = "-help";
     /// Command-line option that sets the HTTP socket address.
     pub const OPT_HTTP_SOCKADDR: &'static str = "-http-addr";
-    /// Command-line option that sets the temporary directory path.
-    pub const OPT_TMP_DIRECTORY: &'static str = "-tmp-dir";
     /// Command-line option that sets the binary directory path.
     pub const OPT_BIN_DIRECTORY: &'static str = "-bin-dir";
     /// Command-line option that sets the toolchain binary directory path.
@@ -126,7 +122,6 @@ impl Args {
     ///
     pub fn parse(args: Vec<String>) -> Result<Self> {
         let mut http_sockaddr: Option<String> = None;
-        let mut tmp_directory: String = config::DEFAULT_TMP_DIRECTORY.to_string();
         let mut binary_directory: String = config::DEFAULT_BIN_DIRECTORY.to_string();
         let mut toolchain_binary_directory: String =
             config::DEFAULT_TOOLCHAIN_BIN_DIRECTORY.to_string();
@@ -171,10 +166,6 @@ impl Args {
                 Self::OPT_HTTP_SOCKADDR => {
                     i += 1;
                     http_sockaddr = Some(args[i].clone());
-                },
-                Self::OPT_TMP_DIRECTORY => {
-                    i += 1;
-                    tmp_directory = args[i].clone();
                 },
                 Self::OPT_BIN_DIRECTORY => {
                     i += 1;
@@ -291,7 +282,6 @@ impl Args {
 
         Ok(Self {
             http_sockaddr,
-            tmp_directory,
             binary_directory,
             toolchain_binary_directory,
             l2_snapshot_path,
@@ -329,7 +319,6 @@ Usage (Interactive mode):
 
 Options:
   {console_file} <file>                     Redirect console output to a file.
-  {tmp_dir} <tmp_dir>                       Directory for temporary files and Unix sockets.
   {bin_dir} <bin_dir>                       Directory containing Nanvix binaries.
   {toolchain_bin_dir} <toolchain_bin_dir>   Directory containing toolchain binaries \
              (cloud-hypervisor, etc.).
@@ -350,7 +339,6 @@ Options:
             http_addr = Self::OPT_HTTP_SOCKADDR,
             separator = Self::OPT_SEPARATOR,
             console_file = Self::OPT_CONSOLE_FILE,
-            tmp_dir = Self::OPT_TMP_DIRECTORY,
             bin_dir = Self::OPT_BIN_DIRECTORY,
             toolchain_bin_dir = Self::OPT_TOOLCHAIN_BIN_DIRECTORY,
             hwloc = Self::OPT_HWLOC,
@@ -374,19 +362,6 @@ Options:
     ///
     pub fn http_sockaddr(&self) -> Option<&str> {
         self.http_sockaddr.as_deref()
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Returns the temporary directory path.
-    ///
-    /// # Returns
-    ///
-    /// The temporary directory path.
-    ///
-    pub fn tmp_directory(&self) -> &str {
-        &self.tmp_directory
     }
 
     ///

--- a/src/utils/nanvixd/src/lib.rs
+++ b/src/utils/nanvixd/src/lib.rs
@@ -13,3 +13,4 @@
 
 pub mod args;
 pub mod config;
+pub mod tempdir;

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -27,13 +27,24 @@ use ::nanvix::{
     log::error,
     registry::Registry,
     sandbox,
+    sandbox::NAMED_RESOURCE_PREFIX,
     sandbox_cache::SandboxCacheConfig,
     terminal::Terminal,
 };
-use ::nanvixd::args::Args;
-use ::std::sync::{
-    Arc,
-    OnceLock,
+use ::nanvixd::{
+    args::Args,
+    tempdir::TemporaryDirectory,
+};
+use ::rand::{
+    distr::Alphanumeric,
+    Rng,
+};
+use ::std::{
+    path::PathBuf,
+    sync::{
+        Arc,
+        OnceLock,
+    },
 };
 use ::tokio::fs;
 
@@ -52,6 +63,9 @@ const LINUXD_BINARY_NAME: &str = "linuxd.elf";
 /// Binary name for User VM.
 #[cfg(not(feature = "single-process"))]
 const USERVM_BINARY_NAME: &str = "uservm.elf";
+
+/// Length of temporary directory random suffix.
+const TMP_DIR_RANDOM_SUFFIX_LENGTH: usize = 4;
 
 //==================================================================================================
 // Global Variables
@@ -133,6 +147,9 @@ pub async fn main() -> Result<()> {
     let (kernel_binary_path, linuxd_binary_path, uservm_binary_path) =
         ensure_all_binaries_available(&args, machine, deployment).await?;
 
+    // Create temporary directory that will be automatically cleaned up on drop.
+    let tmp_directory: TemporaryDirectory = create_tmp_dir(args.tmp_directory()).await?;
+
     let config: SandboxCacheConfig<()> = SandboxCacheConfig::new(
         args.control_plane_socket_type(),
         args.gateway_socket_type(),
@@ -150,12 +167,16 @@ pub async fn main() -> Result<()> {
         args.log_directory(),
         args.l2(),
         args.l2_snapshot_path(),
-        args.tmp_directory(),
+        tmp_directory.path().to_str().ok_or_else(|| {
+            let reason: &str = "temporary directory path is not valid UTF-8";
+            error!("main(): {reason}");
+            anyhow::anyhow!(reason)
+        })?,
     );
 
     // Remove dangling resources from previous runs. We do not expect concurrent instances of
     // nanvixd running in the same tmp directory, so we will not have unexpected side effects.
-    sandbox::remove_dangling_resources(args.tmp_directory()).await?;
+    sandbox::remove_dangling_resources(config.tmp_directory()).await?;
 
     // Check for interactive mode or HTTP mode.
     if let Some(true) = INTERACTIVE_MODE.get().copied() {
@@ -316,4 +337,44 @@ fn print_startup_info(args: &Args) {
         mode,
         if args.l2() { "enabled" } else { "disabled" }
     );
+}
+
+///
+/// # Description
+///
+/// Creates a temporary directory for the sandbox cache.
+///
+/// This function generates a random 4-character alphanumeric directory name under the specified
+/// tmp directory path. The directory will be automatically cleaned up when the returned
+/// `TemporaryDirectory` is dropped.
+///
+/// # Parameters
+///
+/// - `tmp_directory`: The base temporary directory path.
+///
+/// # Returns
+///
+/// On success, returns a `TemporaryDirectory` instance that manages the lifecycle of the created
+/// directory. On failure, returns an error describing what went wrong during directory creation.
+///
+async fn create_tmp_dir(tmp_directory: &str) -> Result<TemporaryDirectory> {
+    let tmp_dirname: String = rand::rng()
+        .sample_iter(&Alphanumeric)
+        .take(TMP_DIR_RANDOM_SUFFIX_LENGTH)
+        .map(char::from)
+        .collect();
+    let tmp_directory_path: PathBuf =
+        PathBuf::from(tmp_directory).join(format!("{NAMED_RESOURCE_PREFIX}:{}", tmp_dirname));
+
+    // Check if temporary directory already exists (very unlikely).
+    if tmp_directory_path.exists() {
+        let reason: String =
+            format!("unique temporary directory already exists (path={tmp_directory_path:?})");
+        error!("create_tmp_dir(): {reason}");
+        anyhow::bail!(reason);
+    }
+
+    let tmp_directory: TemporaryDirectory = TemporaryDirectory::new(tmp_directory_path).await?;
+
+    Ok(tmp_directory)
 }

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -33,6 +33,7 @@ use ::nanvix::{
 };
 use ::nanvixd::{
     args::Args,
+    config::DEFAULT_TMP_DIRECTORY,
     tempdir::TemporaryDirectory,
 };
 use ::rand::{
@@ -148,7 +149,7 @@ pub async fn main() -> Result<()> {
         ensure_all_binaries_available(&args, machine, deployment).await?;
 
     // Create temporary directory that will be automatically cleaned up on drop.
-    let tmp_directory: TemporaryDirectory = create_tmp_dir(args.tmp_directory()).await?;
+    let tmp_directory: TemporaryDirectory = create_tmp_dir(DEFAULT_TMP_DIRECTORY).await?;
 
     let config: SandboxCacheConfig<()> = SandboxCacheConfig::new(
         args.control_plane_socket_type(),

--- a/src/utils/nanvixd/src/tempdir.rs
+++ b/src/utils/nanvixd/src/tempdir.rs
@@ -1,0 +1,332 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::nanvix::log::{
+    error,
+    trace,
+    warn,
+};
+use ::std::path::{
+    Path,
+    PathBuf,
+};
+use ::tokio::fs;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Represents a temporary directory that is automatically deleted when dropped.
+///
+/// # Cleanup Behavior
+///
+/// When this structure is dropped, it attempts to remove the temporary directory and all its
+/// contents using synchronous I/O operations. If the cleanup fails (e.g., due to permission
+/// issues, the directory being in use, or filesystem errors), a warning is logged but no error is
+/// propagated. This means that in failure cases, the temporary directory may persist on the
+/// filesystem and require manual cleanup.
+///
+/// The destructor uses synchronous I/O because `Drop` cannot be async. For large directory trees,
+/// this may briefly block the current thread during cleanup.
+///
+pub struct TemporaryDirectory {
+    /// Path to the temporary directory.
+    path: PathBuf,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl TemporaryDirectory {
+    ///
+    /// # Description
+    ///
+    /// Creates a new temporary directory at the specified path.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: The path where the temporary directory will be created.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns a new `TemporaryDirectory` instance. On failure, returns an error
+    /// describing what went wrong during directory creation.
+    ///
+    pub async fn new(path: PathBuf) -> Result<Self> {
+        if let Err(error) = fs::create_dir_all(&path).await {
+            let reason: String =
+                format!("Failed to create temporary directory '{}': {}", path.display(), error);
+            error!("new(): {reason}");
+            anyhow::bail!(reason)
+        }
+        Ok(Self { path })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets the path to the temporary directory.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the path of the temporary directory.
+    ///
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TemporaryDirectory {
+    ///
+    /// # Description
+    ///
+    /// Automatically removes the temporary directory when the instance is dropped.
+    ///
+    /// NOTE: This uses synchronous I/O operations since Drop cannot be async. For large directory
+    /// trees, this may briefly block the current thread. If we spawn an async task to do this, we
+    /// risk the task not being executed if the runtime is shut down before the task runs.
+    fn drop(&mut self) {
+        trace!("drop(): self.path={:?}", self.path);
+        if ::std::fs::metadata(&self.path).is_ok() {
+            if let Err(error) = ::std::fs::remove_dir_all(&self.path) {
+                warn!("drop(): failed to remove temporary directory {:?}: {}", self.path, error);
+            }
+        }
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::std::env;
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `new()` creates a `TemporaryDirectory` instance with the correct path.
+    ///
+    #[tokio::test]
+    async fn test_new() {
+        let path: PathBuf = env::temp_dir().join("nanvix-test-tempdir-new");
+        let tempdir: TemporaryDirectory = TemporaryDirectory::new(path.clone()).await.unwrap();
+        assert_eq!(tempdir.path(), path.as_path());
+
+        // Verify directory was created.
+        assert!(
+            fs::metadata(&path).await.is_ok(),
+            "Temporary directory does not exist after creation"
+        );
+        assert!(fs::metadata(&path).await.unwrap().is_dir(), "Created path is not a directory");
+
+        // Manual cleanup: We use mem::forget to prevent automatic Drop cleanup, then manually
+        // remove the directory. This ensures tests don't interfere with each other and gives us
+        // explicit control over cleanup timing.
+        fs::remove_dir_all(&path).await.ok();
+        ::std::mem::forget(tempdir);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `path()` returns the correct path to the temporary directory.
+    ///
+    #[tokio::test]
+    async fn test_path() {
+        let expected_path: PathBuf = env::temp_dir().join("nanvix-test-tempdir-path");
+        let tempdir: TemporaryDirectory = TemporaryDirectory::new(expected_path.clone())
+            .await
+            .unwrap();
+        assert_eq!(tempdir.path(), expected_path.as_path());
+
+        // Manual cleanup: We use mem::forget to prevent automatic Drop cleanup, then manually
+        // remove the directory. This ensures tests don't interfere with each other and gives us
+        // explicit control over cleanup timing.
+        fs::remove_dir_all(&expected_path).await.ok();
+        ::std::mem::forget(tempdir);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `new()` successfully creates a temporary directory on the filesystem.
+    ///
+    #[tokio::test]
+    async fn test_create() {
+        let path: PathBuf = env::temp_dir().join("nanvix-test-tempdir-create");
+        let tempdir: TemporaryDirectory = TemporaryDirectory::new(path.clone()).await.unwrap();
+
+        // Verify directory was created.
+        assert!(
+            fs::metadata(&path).await.is_ok(),
+            "Temporary directory does not exist after creation"
+        );
+        assert!(fs::metadata(&path).await.unwrap().is_dir(), "Created path is not a directory");
+
+        // Manual cleanup: We use mem::forget to prevent automatic Drop cleanup, then manually
+        // remove the directory. This ensures tests don't interfere with each other and gives us
+        // explicit control over cleanup timing.
+        fs::remove_dir_all(&path).await.ok();
+        ::std::mem::forget(tempdir);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `new()` successfully creates nested temporary directories.
+    ///
+    #[tokio::test]
+    async fn test_create_nested() {
+        let path: PathBuf = env::temp_dir().join("nanvix-test-tempdir-nested/sub1/sub2");
+        let tempdir: TemporaryDirectory = TemporaryDirectory::new(path.clone()).await.unwrap();
+
+        // Verify directory was created.
+        assert!(
+            fs::metadata(&path).await.is_ok(),
+            "Nested temporary directory does not exist after creation"
+        );
+        assert!(
+            fs::metadata(&path).await.unwrap().is_dir(),
+            "Created nested path is not a directory"
+        );
+
+        // Manual cleanup: We use mem::forget to prevent automatic Drop cleanup, then manually
+        // remove the parent directory. This ensures tests don't interfere with each other and
+        // gives us explicit control over cleanup timing.
+        let parent: PathBuf = env::temp_dir().join("nanvix-test-tempdir-nested");
+        fs::remove_dir_all(&parent).await.ok();
+        ::std::mem::forget(tempdir);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `new()` succeeds when the directory already exists.
+    ///
+    #[tokio::test]
+    async fn test_create_existing() {
+        let path: PathBuf = env::temp_dir().join("nanvix-test-tempdir-existing");
+
+        // Pre-create directory.
+        fs::create_dir_all(&path).await.ok();
+
+        let tempdir: TemporaryDirectory = TemporaryDirectory::new(path.clone()).await.unwrap();
+
+        // Manual cleanup: We use mem::forget to prevent automatic Drop cleanup, then manually
+        // remove the directory. This ensures tests don't interfere with each other and gives us
+        // explicit control over cleanup timing.
+        fs::remove_dir_all(&path).await.ok();
+        ::std::mem::forget(tempdir);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `new()` fails gracefully when directory creation is not possible.
+    ///
+    #[tokio::test]
+    async fn test_create_failure() {
+        // Use an invalid path that cannot be created.
+        let path: PathBuf = PathBuf::from("/proc/invalid/path/that/cannot/be/created");
+        let result: Result<TemporaryDirectory> = TemporaryDirectory::new(path).await;
+
+        assert!(result.is_err(), "Expected new() to fail for invalid path");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that the temporary directory is cleaned up when dropped.
+    ///
+    #[tokio::test]
+    async fn test_drop_cleanup() {
+        let path: PathBuf = env::temp_dir().join("nanvix-test-tempdir-drop");
+
+        {
+            let _tempdir: TemporaryDirectory = TemporaryDirectory::new(path.clone()).await.unwrap();
+
+            // Verify directory exists before drop.
+            assert!(fs::metadata(&path).await.is_ok(), "Directory should exist before drop");
+        }
+
+        // Give some time for the async cleanup to complete.
+        ::tokio::time::sleep(::std::time::Duration::from_millis(100)).await;
+
+        // Verify directory was removed after drop.
+        assert!(fs::metadata(&path).await.is_err(), "Directory should not exist after drop");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that drop handles non-existent directories gracefully.
+    ///
+    #[tokio::test]
+    async fn test_drop_non_existent() {
+        let path: PathBuf = env::temp_dir().join("nanvix-test-tempdir-nonexistent");
+
+        {
+            let _tempdir: TemporaryDirectory = TemporaryDirectory::new(path.clone()).await.unwrap();
+            // Manually remove the directory before drop.
+            fs::remove_dir_all(&path).await.ok();
+        }
+
+        // Give some time for the async cleanup to complete.
+        ::tokio::time::sleep(::std::time::Duration::from_millis(100)).await;
+
+        // Should not panic or error, just no-op.
+        assert!(fs::metadata(&path).await.is_err(), "Directory should not exist");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that the destructor runs even after exiting a scoped tokio runtime.
+    ///
+    #[test]
+    fn test_drop_after_runtime_exit() {
+        let path: PathBuf = env::temp_dir().join("nanvix-test-tempdir-runtime-exit");
+
+        // Create a scoped tokio runtime.
+        {
+            let runtime: ::tokio::runtime::Runtime = ::tokio::runtime::Runtime::new().unwrap();
+            runtime.block_on(async {
+                let _tempdir: TemporaryDirectory =
+                    TemporaryDirectory::new(path.clone()).await.unwrap();
+
+                // Verify directory exists.
+                assert!(
+                    fs::metadata(&path).await.is_ok(),
+                    "Directory should exist within runtime scope"
+                );
+
+                // Drop occurs here when exiting async block.
+            });
+
+            // Runtime is still alive here but async context has exited.
+        }
+
+        // Runtime has been dropped, give time for any spawned cleanup tasks.
+        ::std::thread::sleep(::std::time::Duration::from_millis(200));
+
+        // Verify directory was removed even after runtime exit.
+        let metadata_result: ::std::io::Result<::std::fs::Metadata> = ::std::fs::metadata(&path);
+        if metadata_result.is_ok() {
+            // Clean up manually before failing.
+            ::std::fs::remove_dir_all(&path).ok();
+            panic!("Directory still exists after runtime exit, destructor did not run properly");
+        }
+    }
+}


### PR DESCRIPTION
This pull request removes the use of manually managed temporary directories for benchmark and nanvixd processes, simplifying both the CI workflow and the codebase. All logic and command-line arguments related to specifying or cleaning up temporary directories have been eliminated, and the code has been refactored to remove now-unused parameters and options.

**CI Workflow and Temporary Directory Handling:**

* Removed all steps in `.github/actions/benchmark/action.yml` that created, passed, or cleaned up temporary directories for both MicroVM and Hyperlight benchmarks. The `--tmp-dir` argument is no longer used when calling benchmark scripts. [[1]](diffhunk://#diff-c1b8f2d3cf8c180ad2941e2c4ec06bf7dc56c5faba45b3153ebf4ad7014c64c6L20-L24) [[2]](diffhunk://#diff-c1b8f2d3cf8c180ad2941e2c4ec06bf7dc56c5faba45b3153ebf4ad7014c64c6L61) [[3]](diffhunk://#diff-c1b8f2d3cf8c180ad2941e2c4ec06bf7dc56c5faba45b3153ebf4ad7014c64c6L98-L112) [[4]](diffhunk://#diff-c1b8f2d3cf8c180ad2941e2c4ec06bf7dc56c5faba45b3153ebf4ad7014c64c6L159) [[5]](diffhunk://#diff-c1b8f2d3cf8c180ad2941e2c4ec06bf7dc56c5faba45b3153ebf4ad7014c64c6L196-L203)

**Python Benchmark Script Updates:**

* Removed the `--tmp-dir` argument from `scripts/benchmark.py` and all related code, reflecting the fact that temporary directories are no longer required or passed to the benchmark. [[1]](diffhunk://#diff-60c58fe3cf845c9fb194d1c79c7dc58be1f049334e66eef6dd1212e995b403e5L417) [[2]](diffhunk://#diff-60c58fe3cf845c9fb194d1c79c7dc58be1f049334e66eef6dd1212e995b403e5L490-L493)

**Shell Script Cleanup:**

* Removed all logic related to creating and cleaning up temporary directories in `scripts/run-nanvixd.sh`, including the `TMP_DIR_BASE_PATH` variable and any code that referenced or deleted temporary directories. [[1]](diffhunk://#diff-2687c5397a4a76f47f9565fb87be8fe618ca981680c3f2a40237ed1dbdc69622L21) [[2]](diffhunk://#diff-2687c5397a4a76f47f9565fb87be8fe618ca981680c3f2a40237ed1dbdc69622L49-L51) [[3]](diffhunk://#diff-2687c5397a4a76f47f9565fb87be8fe618ca981680c3f2a40237ed1dbdc69622L437-L438) [[4]](diffhunk://#diff-2687c5397a4a76f47f9565fb87be8fe618ca981680c3f2a40237ed1dbdc69622L485-L490) [[5]](diffhunk://#diff-2687c5397a4a76f47f9565fb87be8fe618ca981680c3f2a40237ed1dbdc69622L507)

**Rust Codebase Refactoring:**

* Removed the `tmp_dir` field and all related logic from the `Args` struct and argument parsing in `src/utils/nanvix-bench` and `src/utils/nanvixd`, as well as from the `Benchmark` struct and its usage. [[1]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5L24) [[2]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5L37-L49) [[3]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5L58) [[4]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5L93-L100) [[5]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5L126) [[6]](diffhunk://#diff-02dbcc5fb1436f90aae81a221a142f35c1e93dbc2d7dd0f37af2816dd35bc5a5L148-L151) [[7]](diffhunk://#diff-6ed8757d486b1d24e0b21a9acbea66aafea26f01be0134ed027a858ff7713fa0L97) [[8]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL182-L183) [[9]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL1043) [[10]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L47-L48) [[11]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L84-L85) [[12]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L129) [[13]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L175-L178) [[14]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L294) [[15]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L332) [[16]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L353) [[17]](diffhunk://#diff-76a18b3bc0d7fef0ddb3acc0004d56b1ec90a18b6d812e9af04d0a939dc1fca9L379-L391)
* Updated imports and re-exports in `src/libs/nanvix-sandbox/src/lib.rs` to clean up unused code and maintain consistency. [[1]](diffhunk://#diff-f5b055ed6c61b7998e1bb0bcc08d7aab6c496a2cd6dba4ce81bacbeb81f58c61L115) [[2]](diffhunk://#diff-f5b055ed6c61b7998e1bb0bcc08d7aab6c496a2cd6dba4ce81bacbeb81f58c61R185)
* Added a new `tempdir` module and the `rand` dependency to `src/utils/nanvixd`, likely to support future or internal temporary directory handling in a more robust way. [[1]](diffhunk://#diff-70d9f8c53230dcd2f3827254f3c813590074e072224f4fd6986ab1b61c275d1fR17) [[2]](diffhunk://#diff-55f4d9f36de96bd9addad6a7a729b0a604a85a8a3b105f1537d3964e1e1a851fR16) [[3]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462R30-R48) [[4]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462R68-R70)

Overall, these changes streamline the workflow and code by removing manual temporary directory management, reducing complexity and potential sources of error.