### PR TITLE
[nanvix-sandbox] Sync Drop for TcpPort

### DIFF
--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -195,7 +195,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
             None => {
                 // Allocate a TCP port for the gateway if we are in L2 mode.
                 let gateway_l2_port: Option<TcpPort> = if self.config.l2() {
-                    match self.tcp_port_allocator.allocate().await {
+                    match self.tcp_port_allocator.allocate() {
                         Some(port) => Some(port),
                         None => {
                             let reason: String =

--- a/src/libs/nanvix-sandbox/src/tcp_port.rs
+++ b/src/libs/nanvix-sandbox/src/tcp_port.rs
@@ -14,9 +14,15 @@
 
 use ::std::{
     fmt,
-    sync::Arc,
+    sync::{
+        Arc,
+        Mutex,
+    },
 };
-use ::tokio::sync::Mutex;
+use ::syslog::{
+    error,
+    warn,
+};
 
 //==================================================================================================
 // Structures
@@ -69,12 +75,17 @@ impl fmt::Debug for TcpPort {
 }
 
 impl Drop for TcpPort {
+    ///
+    /// # Description
+    ///
+    /// Automatically releases the TCP port back to the allocator when the instance is dropped.
+    ///
+    /// NOTE: This uses synchronous operations since Drop cannot be async. If we spawn an
+    /// async task to do this, we risk the task not being executed if the runtime is shut down
+    /// before the task runs.
+    ///
     fn drop(&mut self) {
-        let allocator: TcpPortAllocatorInner = self.allocator.clone();
-        let port: RawTcpPortNum = self.port;
-        ::tokio::task::spawn(async move {
-            allocator.release(port).await;
-        });
+        self.allocator.release(self.port);
     }
 }
 
@@ -98,8 +109,14 @@ impl TcpPortAllocatorInner {
     ///
     /// A TCP port if there are any in the pool, or `None` otherwise.
     ///
-    async fn allocate(&mut self) -> Option<RawTcpPortNum> {
-        self.ports.lock().await.pop()
+    fn allocate(&mut self) -> Option<RawTcpPortNum> {
+        match self.ports.lock() {
+            Ok(mut guard) => guard.pop(),
+            Err(error) => {
+                error!("allocate(): failed to acquire lock on port pool: {error}");
+                None
+            },
+        }
     }
 
     ///
@@ -111,8 +128,13 @@ impl TcpPortAllocatorInner {
     ///
     /// - `port`: The TCP port to return.
     ///
-    async fn release(&self, port: RawTcpPortNum) {
-        self.ports.lock().await.push(port)
+    fn release(&self, port: RawTcpPortNum) {
+        match self.ports.lock() {
+            Ok(mut guard) => guard.push(port),
+            Err(error) => {
+                warn!("release(): failed to acquire lock on port pool: {error}");
+            },
+        }
     }
 }
 
@@ -160,12 +182,17 @@ impl TcpPortAllocator {
     /// Allocates a TCP port and returns a RAII guard that will automatically release the port
     /// when dropped.
     ///
+    /// This is a synchronous operation that completes in microseconds (mutex lock + Vec pop +
+    /// unlock). It does not need to be wrapped in `tokio::task::spawn_blocking()` when called
+    /// from async contexts because the mutex critical section is trivial and won't block the
+    /// async runtime scheduler.
+    ///
     /// # Returns
     ///
     /// A RAII wrapper around a raw TCP port, or `None` if no ports are available.
     ///
-    pub async fn allocate(&mut self) -> Option<TcpPort> {
-        if let Some(port) = self.inner.allocate().await {
+    pub fn allocate(&mut self) -> Option<TcpPort> {
+        if let Some(port) = self.inner.allocate() {
             Some(TcpPort::new(port, self.inner.clone()))
         } else {
             None


### PR DESCRIPTION
This pull request refactors the TCP port allocator in the `nanvix-sandbox` library to use synchronous locking instead of asynchronous locking for managing the TCP port pool. The main motivation is to simplify port allocation and release logic, making it more efficient and robust, especially in the context of the `Drop` trait where async operations are not allowed. The changes also improve error handling and clarify documentation.

**Refactor to synchronous locking and improved error handling:**

* Replaced `tokio::sync::Mutex` with the standard library's synchronous `Mutex` for managing the TCP port pool, ensuring that allocation and release are now synchronous and safe to use in `Drop` implementations.
* Updated `TcpPortAllocatorInner::allocate` and `release` methods to be synchronous, handle mutex lock errors gracefully, and log warnings when lock acquisition fails. [[1]](diffhunk://#diff-20729eb4e2699ce03afa5dfc2efb509854dc12eecdc76115ab9d4498ba069130L101-R116) [[2]](diffhunk://#diff-20729eb4e2699ce03afa5dfc2efb509854dc12eecdc76115ab9d4498ba069130L114-R134)
* Modified `TcpPortAllocator::allocate` to be synchronous, with updated documentation explaining that the mutex critical section is trivial and will not block the async runtime.
* Changed `SandboxCache` to use the new synchronous `allocate` method for TCP port allocation.

**RAII and Drop safety improvements:**

* Refactored the `Drop` implementation for `TcpPort` to synchronously release the port instead of spawning an async task, ensuring that ports are reliably returned to the pool even if the async runtime is shut down.