### PR TITLE
[nanvix-terminal] Cleanup on Shutdown

### DIFF
--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -56,7 +56,7 @@ pub const GATEWAY_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
 ///
 /// Provides the timeout we should use when waiting for Linux Daemon to shut down.
 ///
-pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60);
+pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
 ///
 /// # Description

--- a/src/libs/nanvix-terminal/src/lib.rs
+++ b/src/libs/nanvix-terminal/src/lib.rs
@@ -44,7 +44,10 @@ use ::std::{
     ptr,
     sync::Arc,
 };
-use ::syslog::error;
+use ::syslog::{
+    error,
+    info,
+};
 use ::tokio::{
     io::{
         self,
@@ -265,6 +268,7 @@ impl<T: Sync + Send + Clone + Default + 'static> Terminal<T> {
                     // Continue reading from gateway until it closes.
                 },
                 _ = signals.recv() => {
+                    info!("received exit signal, stopping...");
                     break Ok(());
                 }
 

--- a/src/libs/nanvix-terminal/src/lib.rs
+++ b/src/libs/nanvix-terminal/src/lib.rs
@@ -156,7 +156,7 @@ impl<T: Sync + Send + Clone + Default + 'static> Terminal<T> {
         let app_name: String = app_name
             .map(|s| s.to_owned())
             .unwrap_or_else(|| DEFAULT_APP_NAME.to_owned());
-        let (uservm_id, gateway_sockaddr, gateway_socket_type): (
+        let (_uservm_id, gateway_sockaddr, gateway_socket_type): (
             UserVmIdentifier,
             String,
             SocketType,
@@ -275,10 +275,8 @@ impl<T: Sync + Send + Clone + Default + 'static> Terminal<T> {
             }
         };
 
-        // Shutdown VM.
-        if let Err(error) = sandbox_cache.lock().await.kill(uservm_id).await {
-            error!("failed to shutdown VM: {error}");
-        }
+        // Cleanup sandbox resources.
+        sandbox_cache.lock().await.cleanup().await;
 
         // Send SIGUSR1 signal to stdin thread to interrupt the blocking read operation.
         // SAFETY: The thread ID is valid and was obtained from the stdin thread itself.
@@ -337,6 +335,7 @@ impl<T: Sync + Send + Clone + Default + 'static> Terminal<T> {
                     // Check if operation was interrupted by a signal.
                     if error.kind() == ::std::io::ErrorKind::Interrupted {
                         // Signal received, exit gracefully.
+                        info!("stdin thread interrupted by signal, exiting.");
                         break;
                     }
                     error!("failed to read from stdin: {error}");


### PR DESCRIPTION
This pull request makes several improvements to the shutdown and cleanup process for the terminal and sandbox, as well as minor enhancements to logging. The most significant change is that the shutdown timeout for the Linux Daemon has been drastically reduced, and the cleanup logic has been updated to be more robust and informative.

**Shutdown and Cleanup Improvements:**

* Reduced the `SHUTDOWN_TIMEOUT` in `config.rs` from 60 seconds to 1 second, making shutdowns much faster.
* Changed the sandbox cleanup logic in `Terminal` to call `cleanup()` on the sandbox cache instead of attempting to kill a specific VM, ensuring all resources are properly released.

**Logging Enhancements:**

* Added `info` logging from `syslog` and included informative log messages when exit signals are received and when the stdin thread is interrupted, improving observability of shutdown events. [[1]](diffhunk://#diff-84513b169819ff7fce72519c9bc3f1bd7aabfe9df31c3c3b7064573f90c19af1L47-R50) [[2]](diffhunk://#diff-84513b169819ff7fce72519c9bc3f1bd7aabfe9df31c3c3b7064573f90c19af1R271-R279) [[3]](diffhunk://#diff-84513b169819ff7fce72519c9bc3f1bd7aabfe9df31c3c3b7064573f90c19af1R338)

**Code Quality:**

* Removed the unused `uservm_id` variable in the `Terminal` implementation, cleaning up the code.