### PR TITLE
[daemons] Spawn One Reader Task Per User VM

### DIFF
--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -74,6 +74,8 @@ jobs:
           boot-time
           cold-start
           cold-start-l2
+          concurrent
+          concurrent-l2
           echo-breakdown
           echo-breakdown-l2
           round-trip-latency

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -32,12 +32,21 @@ L2_SUFFIX = "-l2"
 BOOT_TIME_BENCH = "boot-time"
 COLD_START_BENCH = "cold-start"
 COLD_START_L2_BENCH = COLD_START_BENCH + L2_SUFFIX
+CONCURRENT_BENCH = "concurrent"
+CONCURRENT_L2_BENCH = CONCURRENT_BENCH + L2_SUFFIX
 ECHO_BREAKDOWN_BENCH = "echo-breakdown"
 ECHO_BREAKDOWN_L2_BENCH = ECHO_BREAKDOWN_BENCH + L2_SUFFIX
 ROUND_TRIP_LATENCY_BENCH = "round-trip-latency"
 WARM_START_BENCH = "warm-start"
 WARM_START_L2_BENCH = WARM_START_BENCH + L2_SUFFIX
 WARM_START_VMM_BENCH = "warm-start-vmm"
+
+# ======================================================================
+# Benchmark Constants
+# ======================================================================
+
+# How many user VMs do we spawn in parallel in the CONCURRENT* benchmarks.
+NUM_CONCURRENT_VMS = 100
 
 # ======================================================================
 # Helper Functions
@@ -62,6 +71,8 @@ def filter_benchmark_stdout(benchmark, raw_stdout):
         BOOT_TIME_BENCH,
         COLD_START_BENCH,
         COLD_START_L2_BENCH,
+        CONCURRENT_BENCH,
+        CONCURRENT_L2_BENCH,
         WARM_START_BENCH,
         WARM_START_L2_BENCH,
         WARM_START_VMM_BENCH,
@@ -117,6 +128,10 @@ def filter_benchmark_stdout(benchmark, raw_stdout):
     elif benchmark.startswith(ECHO_BREAKDOWN_BENCH):
         filtered_stdout = raw_stdout
 
+    else:
+        print(f"ERROR: unrecognized benchmark '{benchmark}'")
+        raise ValueError("Unrecognized benchmark")
+
     return filtered_stdout
 
 
@@ -129,6 +144,8 @@ def read_benchmark_values_from_file(benchmark, file_path, percentile=None):
         BOOT_TIME_BENCH,
         COLD_START_BENCH,
         COLD_START_L2_BENCH,
+        CONCURRENT_BENCH,
+        CONCURRENT_L2_BENCH,
         WARM_START_BENCH,
         WARM_START_L2_BENCH,
         WARM_START_VMM_BENCH,
@@ -164,6 +181,9 @@ def read_benchmark_values_from_file(benchmark, file_path, percentile=None):
             result_dict = {}
             for msg_size in ROUND_TRIP_SIZES:
                 result_dict[msg_size] = NA
+    else:
+        print(f"ERROR: unrecognized benchmark '{benchmark}'")
+        raise ValueError("Unrecognized benchmark")
 
     return result_dict
 
@@ -342,6 +362,8 @@ def ci_summary(args):
             BOOT_TIME_BENCH,
             COLD_START_BENCH,
             COLD_START_L2_BENCH,
+            CONCURRENT_BENCH,
+            CONCURRENT_L2_BENCH,
             WARM_START_BENCH,
             WARM_START_L2_BENCH,
             WARM_START_VMM_BENCH,
@@ -409,11 +431,20 @@ def run_benchmark(args):
         f"Running '{args.benchmark}' benchmark (machine={args.machine_type}, arch={X86_64_ARCH})"
     )
 
+    # The concurrent benchmark takes slightly different command-line arguments than the other
+    # benchmarks. It does not take a `-hwloc` file, and instead of `-iterations` it takes
+    # a number of concurrent user VMs.
+    is_concurrent_bench = args.benchmark.startswith(CONCURRENT_BENCH)
+
     nanvix_bench_cmd = [
         os.path.join(args.bin_dir, NANVIX_BENCH_ELF),
         f"-benchmark {args.benchmark}",
-        f"-hwloc {args.hwloc}",
-        f"-iterations {args.iterations}",
+        f"-hwloc {args.hwloc}" if not is_concurrent_bench else "",
+        (
+            f"-iterations {args.iterations}"
+            if not is_concurrent_bench
+            else f"-num-concurrent-vms {NUM_CONCURRENT_VMS}"
+        ),
         f"-toolchain-bin-dir {args.toolchain_bin_dir}",
     ]
     nanvix_bench_cmd = " ".join(nanvix_bench_cmd)

--- a/src/daemons/linuxd/src/config.rs
+++ b/src/daemons/linuxd/src/config.rs
@@ -32,6 +32,13 @@ pub(crate) const DEFAULT_LOG_DIRECTORY: &str = "./logs";
 ///
 pub const CONTROL_PLANE_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
 
+///
+/// # Description
+///
+/// Timeout for joining the reader task when closing a user VM connection.
+///
+pub const READER_TASK_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================

--- a/src/daemons/linuxd/src/lib.rs
+++ b/src/daemons/linuxd/src/lib.rs
@@ -15,9 +15,11 @@ use crate::{
     config::{
         restore_gate_sockaddr_builder,
         CONTROL_PLANE_CONNECT_TIMEOUT,
+        READER_TASK_JOIN_TIMEOUT,
     },
     message::RequestAssembler,
     syscalls::SyscallTable,
+    user_vm_event::UserVmEvent,
     user_vm_handle::UserVmHandle,
     venv::{
         VenvCommand,
@@ -34,7 +36,6 @@ use ::control_plane_api::{
     self,
     NanvixdControlMessage,
 };
-use ::rand::seq::SliceRandom;
 use ::std::{
     collections::{
         HashMap,
@@ -79,12 +80,14 @@ use ::tokio::{
     net::TcpListener,
     sync::{
         mpsc::{
+            channel,
             Receiver,
             Sender,
         },
         Mutex,
         MutexGuard,
     },
+    task::JoinHandle,
     time::timeout,
 };
 use ::user_vm_api::{
@@ -102,6 +105,7 @@ mod error;
 mod linux;
 mod message;
 mod time;
+mod user_vm_event;
 mod user_vm_handle;
 mod venv;
 mod worker_thread;
@@ -124,6 +128,14 @@ pub mod syscalls;
 /// Maximum number of messages that can be queued in a channel to a worker thread.
 ///
 pub const WORKER_THREAD_CHANNEL_CAPACITY: usize = 1024;
+
+///
+/// # Description
+///
+/// Maximum number of messages that can be queued in a channel multiplexing messages from all user
+/// VMs being served by this linuxd instance.
+///
+const USER_VM_CHANNEL_CAPACITY: usize = 1024;
 
 //==================================================================================================
 // Structures
@@ -258,6 +270,7 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
     async fn accept_connections(
         &self,
         mut user_vm_stream: SocketStream,
+        user_vm_event_tx: Sender<UserVmEvent>,
     ) -> Result<(UserVmIdentifier, UserVmHandle), Error> {
         trace!("accepted connection from user VM (addr={user_vm_stream:?})",);
 
@@ -280,20 +293,67 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
 
         trace!("registered new user VM connection (vm_id={user_vm_id}, addr={user_vm_stream:?})",);
 
+        // Spawn a background task that reads messages from this user VM and
+        // enqueues them to the main reception channel monitored in this loop.
+        let (user_vm_reader, user_vm_writer): (SocketStreamReader, SocketStreamWriter) =
+            user_vm_stream.split();
+        let user_vm_reader_handle: JoinHandle<Result<()>> =
+            tokio::spawn(Self::user_vm_reader_loop(user_vm_id, user_vm_reader, user_vm_event_tx));
+
         // Gateway listener for this user VM.
         Ok((
             user_vm_id,
             UserVmHandle::new(
-                user_vm_stream,
+                user_vm_writer,
                 new_msg.gateway_sockaddr(),
                 new_msg.gateway_socket_type(),
+                user_vm_reader_handle,
             ),
         ))
     }
 
+    ///
+    /// # Description
+    ///
     /// Helper method to close a connection to a user VM identified by the connection id. Closing
     /// the connection also involves stopping all associated worker threads.
-    async fn close_connection(worker_threads: Option<VecDeque<WorkerThreadHandle>>) {
+    ///
+    async fn close_connection(
+        user_vm_handle: Option<UserVmHandle>,
+        worker_threads: Option<VecDeque<WorkerThreadHandle>>,
+    ) {
+        // Join reader task in user VM handle.
+        if let Some(user_vm_handle) = user_vm_handle {
+            if let Some(mut user_vm_reader_handle) =
+                user_vm_handle.take_user_vm_reader_handle().await
+            {
+                match timeout(READER_TASK_JOIN_TIMEOUT, &mut user_vm_reader_handle).await {
+                    Ok(Ok(Ok(()))) => {
+                        trace!("close_connection(): successfully joined user VM reader task");
+                    },
+                    Ok(Ok(Err(e))) => {
+                        error!(
+                            "close_connection(): user VM reader task returned error (error={e:?})"
+                        );
+                    },
+                    Ok(Err(e)) => {
+                        error!(
+                            "close_connection(): error joining user VM reader task (error={e:?})"
+                        );
+                    },
+                    Err(_elapsed) => {
+                        warn!(
+                            "close_connection(): timeout waiting for user VM reader task, \
+                             aborting it"
+                        );
+                        user_vm_reader_handle.abort();
+                    },
+                }
+            }
+        } else {
+            warn!("run(): harvesting user VM without a handle");
+        }
+
         // Send a shutdown message to all worker threads associated
         // with this user VM.
         if let Some(mut worker_threads) = worker_threads {
@@ -356,6 +416,11 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
         // ID. We use a slab to easily get the smallest available entry.
         let mut user_vm_connections: HashMap<UserVmIdentifier, UserVmHandle> = HashMap::new();
 
+        // This queue is used to fan-in messages from all user VMs into a single queue that we can
+        // monitor and then fan-out to the corresponding worker threads.
+        let (user_vm_event_tx, mut user_vm_event_rx): (Sender<UserVmEvent>, Receiver<UserVmEvent>) =
+            channel::<UserVmEvent>(USER_VM_CHANNEL_CAPACITY);
+
         // Map keeping track of the worker threads associated to each user VM identified by
         // connection ID. We use a HashMap and not a Slab because we need to support insert/removal
         // by key.
@@ -399,9 +464,9 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
                                     control_plane_api::NanvixdCommand::Shutdown => {
                                         info!("linuxd received shutdown message from control-plane");
                                         let mut locked_worker_threads: MutexGuard<'_, HashMap<UserVmIdentifier, VecDeque<WorkerThreadHandle>>> = worker_threads.lock().await;
-                                        for (uvm_id, _handle) in user_vm_connections.drain() {
+                                        for (uvm_id, handle) in user_vm_connections.drain() {
                                             info!("shutting down user VM (vm_id={uvm_id})");
-                                            Self::close_connection(locked_worker_threads.remove(&uvm_id)).await;
+                                            Self::close_connection(Some(handle), locked_worker_threads.remove(&uvm_id)).await;
                                         }
                                         if !locked_worker_threads.is_empty() {
                                             error!("finished shutdown with orphaned worker threads (conn_ids={:?})", locked_worker_threads.keys().collect::<Vec<_>>());
@@ -430,8 +495,9 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
                 result = self.user_vm_listener.accept() => {
                     match result {
                         Ok(user_vm_stream) => {
-                            let (user_vm_id, user_vm_handle): (UserVmIdentifier, UserVmHandle) = self.accept_connections(user_vm_stream).await?;
-                            user_vm_connections.insert(user_vm_id, user_vm_handle);
+                            let (user_vm_id, user_vm_handle): (UserVmIdentifier, UserVmHandle) =
+                                self.accept_connections(user_vm_stream, user_vm_event_tx.clone()).await?;
+                            user_vm_connections.insert(user_vm_id, user_vm_handle.clone());
                         },
                         Err(e) => {
                             let reason: &'static str = "error accepting connection from user VM";
@@ -442,31 +508,59 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
 
                 }
 
-                // Drain messages from existing user VM connections.
-                user_vm_messages = self.get_user_vm_messages(&mut user_vm_connections) => {
-                    let user_vm_messages = match user_vm_messages {
-                        Ok(msgs) => msgs,
-                        Err(uvm_id) => {
-                            debug!("run(): harvesting connection to user VM (vm_id={uvm_id})");
-                            user_vm_connections.remove(&uvm_id);
-                            Self::close_connection(
-                                worker_threads.lock().await.remove(&uvm_id),
-                            ).await;
-                            continue 'main_loop;
-                        },
+                // Process one message from one user VM.
+                user_vm_event = user_vm_event_rx.recv() => {
+                    let Some(event) = user_vm_event else {
+                        // We are in this situation if all senders have dropped. This may happen if
+                        // all user VMs are done executing.
+                        trace!("run(): user_vm_rx closed, no more VM events");
+                        continue 'main_loop;
                     };
 
-                    if let Some ((uvm_id, uvm_handle, message)) = user_vm_messages {
-                        if let Err(e) = self.process_user_vm_message(
-                            uvm_id,
-                            uvm_handle,
-                            message,
-                            worker_threads.clone(),
-                        ).await {
-                            let reason: &'static str = "error processing message from user VM";
-                            error!("run(): {reason} (uvm_id={uvm_id}, error={e:?})");
-                            return Err(Self::log_and_error(ErrorCode::IoErr, reason));
-                        }
+                    match event {
+                        UserVmEvent::Message { uvm_id, message } => {
+                            let Some(uvm_handle) = user_vm_connections.get(&uvm_id).cloned() else {
+                                warn!(
+                                    "run(): received message for unknown VM (uvm_id={uvm_id}), ignoring"
+                                );
+                                continue 'main_loop;
+                            };
+
+                            if let Err(e) = self.forward_user_vm_msg_to_worker_thread(
+                                    uvm_id,
+                                    uvm_handle,
+                                    message,
+                                    worker_threads.clone(),
+                                )
+                                .await
+                            {
+                                let reason: &'static str = "error processing message from user VM, terminating it";
+                                error!("run(): {reason} (uvm_id={uvm_id}, error={e:?})");
+
+                                // Shutdown faulty user VM.
+                                Self::close_connection(
+                                    user_vm_connections.remove(&uvm_id),
+                                    worker_threads.lock().await.remove(&uvm_id),
+                                ).await;
+
+                                continue 'main_loop;
+                            }
+                        },
+
+                        UserVmEvent::ConnectionClosed { uvm_id }
+                        | UserVmEvent::ConnectionError { uvm_id, .. } => {
+                            let kind_str: String = match &event {
+                                UserVmEvent::ConnectionError { kind, .. } => format!("{kind:?}"),
+                                _ => "Closed".to_string(),
+                            };
+                            debug!("run(): harvesting connection to user VM (uvm_id={uvm_id}, reason={kind_str})");
+
+                            // Shutdown finished user VM.
+                            Self::close_connection(
+                                user_vm_connections.remove(&uvm_id),
+                                worker_threads.lock().await.remove(&uvm_id),
+                            ).await;
+                        },
                     }
                 },
             }
@@ -476,48 +570,17 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
         Ok(())
     }
 
-    /// Read a message from the user VM stream. We need to handle the situation where we can only
-    /// do a partial read, so we keep a buffer alongside our socket. It is safe to have this buffer
-    /// dynamically sized, as it will always be smaller than one message size.
-    async fn recv(
-        uvm_reader: Arc<Mutex<(SocketStreamReader, VecDeque<u8>)>>,
-    ) -> Result<Message, ErrorKind> {
-        let mut guard: MutexGuard<'_, (SocketStreamReader, VecDeque<u8>)> = uvm_reader.lock().await;
-        let (locked_reader, partial_read_buffer): &mut (SocketStreamReader, VecDeque<u8>) =
-            &mut guard;
-
+    ///
+    /// # Description
+    ///
+    /// Read a message from the user VM stream.
+    ///
+    async fn recv(uvm_reader: &mut SocketStreamReader) -> Result<Message, ErrorKind> {
         let mut buf: [u8; IPC_MESSAGE_SIZE] = [0u8; IPC_MESSAGE_SIZE];
-
-        let mut num_filled = 0;
-        if !partial_read_buffer.is_empty() {
-            // Prepare data in buffer for partial read.
-            partial_read_buffer.make_contiguous();
-            let partial_bytes = partial_read_buffer.as_slices().0;
-
-            // We take the minimum at the end just in case, but the partial read should always be
-            // strictly smaller than the message size.
-            let num_partial_read = partial_bytes.len().min(buf.len());
-
-            buf[..num_partial_read].copy_from_slice(&partial_bytes[..num_partial_read]);
-
-            // Clear partial read buffer.
-            partial_read_buffer.clear();
-            num_filled += num_partial_read;
-        }
-
-        // Post-condition: partial_read_buffer is empty.
-        match locked_reader.read(&mut buf[num_filled..]).await {
-            Ok(n) => {
-                if n == 0 {
-                    return Err(ErrorKind::ConnectionAborted);
-                }
-                if n + num_filled < buf.len() {
-                    partial_read_buffer.extend(&buf[..(n + num_filled)]);
-                    return Err(ErrorKind::WouldBlock);
-                }
-            },
-            Err(e) => return Err(e.kind()),
-        }
+        uvm_reader
+            .read_exact(&mut buf)
+            .await
+            .map_err(|e| e.kind())?;
 
         let message: Message = match Message::try_from_bytes(buf) {
             Ok(message) => message,
@@ -536,50 +599,77 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
 //==================================================================================================
 
 impl<T: Sync + Send + 'static> LinuxDaemon<T> {
-    async fn get_user_vm_messages(
-        &self,
-        user_vm_connections: &mut HashMap<UserVmIdentifier, UserVmHandle>,
-    ) -> Result<Option<(UserVmIdentifier, UserVmHandle, Message)>, UserVmIdentifier> {
-        let mut ids: Vec<UserVmIdentifier> = user_vm_connections.keys().cloned().collect();
+    ///
+    /// # Description
+    ///
+    /// This function implements the background asynchronous reading loop for a single user VM.
+    /// Each user VM spawns a task like this, and all messages are fanned in to a single MPSC
+    /// channel monitored by the main select!.
+    ///
+    async fn user_vm_reader_loop(
+        uvm_id: UserVmIdentifier,
+        mut uvm_reader: SocketStreamReader,
+        uvm_events_tx: Sender<UserVmEvent>,
+    ) -> Result<()> {
+        trace!("user_vm_reader_loop(): starting (uvm_id={uvm_id})");
 
-        // Shuffle the order in which we poll user VMs to avoid starvation.
-        ids.as_mut_slice().shuffle(&mut ::rand::rng());
+        loop {
+            match Self::recv(&mut uvm_reader).await {
+                Ok(message) => {
+                    trace!(
+                        "uservm.id={uvm_id}, message.source={:?}, message.destination={:?}, \
+                         message.type={:?}",
+                        { message.source },
+                        { message.destination },
+                        message.message_type,
+                    );
 
-        for uvm_id in ids {
-            let Some(uvm_handle) = user_vm_connections.get(&uvm_id).cloned() else {
-                continue;
-            };
-            let message: Message = match Self::recv(uvm_handle.get_user_vm_reader()).await {
-                Ok(m) => m,
-                Err(error_kind) => {
-                    // Log error message only if error was not caused by a disconnection.
-                    if error_kind != ErrorKind::ConnectionAborted
-                        && error_kind != ErrorKind::WouldBlock
+                    if uvm_events_tx
+                        .send(UserVmEvent::Message { uvm_id, message })
+                        .await
+                        .is_err()
                     {
-                        let reason: String =
-                            format!("failed to read message (error={error_kind:?})");
-                        error!("{reason}");
+                        // If the receiver side is gone, just exit.
+                        debug!(
+                            "user_vm_reader_loop(): dispatcher dropped receiver (uvm_id={uvm_id})"
+                        );
+                        break;
                     }
-                    return Err(uvm_id);
                 },
-            };
+                Err(ErrorKind::ConnectionAborted) => {
+                    // User VM closed connection.
+                    trace!("user_vm_reader_loop(): connection aborted by peer (uvm_id={uvm_id})");
 
-            trace!(
-                "uservm.id={uvm_id}, message.source={:?}, message.destination={:?}, \
-                 message.type={:?}",
-                { message.source },
-                { message.destination },
-                message.message_type,
-            );
-
-            return Ok(Some((uvm_id, uvm_handle, message)));
+                    // Ignore return value, as we are breaking anyway.
+                    let _ = uvm_events_tx
+                        .send(UserVmEvent::ConnectionClosed { uvm_id })
+                        .await;
+                    break;
+                },
+                Err(kind) => {
+                    error!("user_vm_reader_loop(): reader error (uvm_id={uvm_id}, error={kind:?})");
+                    // Propagate the error to the main loop so that we can clean-up this user VM's
+                    // state. Ignore send's return value as we are breaking from the loop anyway.
+                    let _ = uvm_events_tx
+                        .send(UserVmEvent::ConnectionError { uvm_id, kind })
+                        .await;
+                    break;
+                },
+            }
         }
 
-        Ok(None)
+        trace!("user_vm_reader_loop(): exiting (uvm_id={uvm_id})");
+
+        Ok(())
     }
 
-    /// Drain messages for each active user VM (best-effort, non-fatal on individual errors).
-    async fn process_user_vm_message(
+    ///
+    /// # Description
+    ///
+    /// This function forwards a new message from a user VM to its corresponding worker thread. If
+    /// no worker threads exist, a new one will be spawned.
+    ///
+    async fn forward_user_vm_msg_to_worker_thread(
         &self,
         uvm_id: UserVmIdentifier,
         uvm_handle: UserVmHandle,
@@ -614,7 +704,9 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
                         let err_bytes: [u8; IPC_MESSAGE_SIZE] = err_msg.to_bytes();
                         writer_guard.write_all(&err_bytes).await.map_err(|e| {
                             let reason: &str = "failed to send error message to user VM";
-                            error!("process_user_vm_message(): {reason} (error={e:?})");
+                            error!(
+                                "forward_user_vm_msg_to_worker_thread(): {reason} (error={e:?})"
+                            );
                             Error::new(ErrorCode::IoErr, reason)
                         })?;
 

--- a/src/daemons/linuxd/src/user_vm_event.rs
+++ b/src/daemons/linuxd/src/user_vm_event.rs
@@ -1,0 +1,34 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::std::io::ErrorKind;
+use ::sys::ipc::Message;
+use ::user_vm_api::UserVmIdentifier;
+
+//==================================================================================================
+// Enums
+//==================================================================================================
+
+///
+/// # Description
+///
+/// This enum captures the different events that can be sent from a user VM's reading task to the
+/// main linuxd thread for processing.
+///
+pub enum UserVmEvent {
+    Message {
+        uvm_id: UserVmIdentifier,
+        message: Message,
+    },
+    ConnectionClosed {
+        uvm_id: UserVmIdentifier,
+    },
+    ConnectionError {
+        uvm_id: UserVmIdentifier,
+        kind: ErrorKind,
+    },
+}

--- a/src/daemons/linuxd/src/user_vm_handle.rs
+++ b/src/daemons/linuxd/src/user_vm_handle.rs
@@ -6,10 +6,7 @@
 //==================================================================================================
 
 use ::anyhow::Result;
-use ::std::{
-    collections::VecDeque,
-    sync::Arc,
-};
+use ::std::sync::Arc;
 use ::syscomm::{
     SocketListener,
     SocketStream,
@@ -22,9 +19,12 @@ use ::syslog::{
     error,
     trace,
 };
-use ::tokio::sync::{
-    Mutex,
-    MutexGuard,
+use ::tokio::{
+    sync::{
+        Mutex,
+        MutexGuard,
+    },
+    task::JoinHandle,
 };
 
 //==================================================================================================
@@ -34,8 +34,6 @@ use ::tokio::sync::{
 /// State associated with a user VM connected to this linuxd instance.
 #[derive(Clone)]
 pub struct UserVmHandle {
-    /// Reader half + partial read buffer for assembling incoming messages.
-    user_vm_reader: Arc<Mutex<(SocketStreamReader, VecDeque<u8>)>>,
     /// Writer half used by worker threads to send responses without contending with the reader.
     user_vm_writer: Arc<Mutex<SocketStreamWriter>>,
     /// Address of the gateway socket to connect to.
@@ -48,30 +46,27 @@ pub struct UserVmHandle {
     gateway_writer: Arc<Mutex<Option<Arc<Mutex<SocketStreamWriter>>>>>,
     /// Listener for the gateway socket.
     gateway_listener: Arc<Mutex<Option<SocketListener>>>,
+    /// Join handle to the task that reads from the user VM stream.
+    user_vm_reader_handle: Arc<Mutex<Option<JoinHandle<Result<()>>>>>,
 }
 
 impl UserVmHandle {
     pub fn new(
-        user_vm_stream: SocketStream,
+        user_vm_writer: SocketStreamWriter,
         gateway_sockaddr: &str,
         gateway_socket_type: &SocketType,
+        user_vm_reader_handle: JoinHandle<Result<()>>,
     ) -> Self {
-        trace!("new(): user_vm_stream={:?}, gateway_sockaddr={}", user_vm_stream, gateway_sockaddr);
-        let (reader, writer) = user_vm_stream.split();
+        trace!("new(): gateway_sockaddr={}", gateway_sockaddr);
         Self {
-            user_vm_reader: Arc::new(Mutex::new((reader, VecDeque::new()))),
-            user_vm_writer: Arc::new(Mutex::new(writer)),
+            user_vm_writer: Arc::new(Mutex::new(user_vm_writer)),
             gateway_sockaddr: gateway_sockaddr.to_string(),
             gateway_socket_type: *gateway_socket_type,
             gateway_reader: Arc::new(Mutex::new(None)),
             gateway_writer: Arc::new(Mutex::new(None)),
             gateway_listener: Arc::new(Mutex::new(None)),
+            user_vm_reader_handle: Arc::new(Mutex::new(Some(user_vm_reader_handle))),
         }
-    }
-
-    /// Get the reader half (with partial buffer) of the user VM stream.
-    pub fn get_user_vm_reader(&self) -> Arc<Mutex<(SocketStreamReader, VecDeque<u8>)>> {
-        self.user_vm_reader.clone()
     }
 
     /// Get the writer half of the user VM stream.
@@ -157,5 +152,11 @@ impl UserVmHandle {
         *gateway_listener_slot = Some(gateway_listener);
 
         Ok((reader_arc, writer_arc))
+    }
+
+    pub async fn take_user_vm_reader_handle(&self) -> Option<JoinHandle<Result<()>>> {
+        let mut guard: MutexGuard<'_, Option<JoinHandle<Result<()>>>> =
+            self.user_vm_reader_handle.lock().await;
+        guard.take()
     }
 }

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -216,7 +216,17 @@ impl UserVm {
             Receiver<VcpuControlResponse>,
         ) = mpsc::channel::<VcpuControlResponse>(CHANNEL_CAPACITY);
 
-        let vmm_stderr_fn: Box<dyn Write + Send> = get_stderr_writer(args.stderr.clone())?;
+        let vmm_stderr_fn: Box<dyn Write + Send> = match get_stderr_writer(args.stderr.clone()) {
+            Ok(vmm_stderr_fn) => vmm_stderr_fn,
+            Err(e) => {
+                let reason: String = format!(
+                    "failed to get stderr writer (args.stderr={:?}, error={e:?})",
+                    args.stderr.clone()
+                );
+                error!("{reason}");
+                anyhow::bail!(reason);
+            },
+        };
 
         // Output function used for emulating I/O port writes.
         let vmm_stdout_fn: Box<StdoutFn> = output_fn(args.vcpu_thread_stdout_tx.clone());

--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -6,7 +6,6 @@
 //==================================================================================================
 
 use crate::benchmark::BenchmarkFlavour;
-use ::nanvix::log::error;
 use anyhow::Result;
 use std::{
     process,
@@ -21,6 +20,7 @@ pub struct Args {
     benchmark: BenchmarkFlavour,
     hwloc_file: Option<String>,
     iterations: usize,
+    num_concurrent_vms: Option<usize>,
     toolchain_bin_dir: String,
 }
 
@@ -33,37 +33,79 @@ impl Args {
     const OPT_BENCHMARK: &'static str = "-benchmark";
     const OPT_HWLOC: &'static str = "-hwloc";
     const OPT_ITERATIONS: &'static str = "-iterations";
+    const OPT_NUM_CONCURRENT_VMS: &'static str = "-num-concurrent-vms";
     const OPT_TOOLCHAIN_BIN_DIR: &'static str = "-toolchain-bin-dir";
 
-    fn usage() -> String {
-        format!(
-            "usage: ./bin/nanvix-bench.elf {} \
-             [boot-time,cold-start,cold-start-l2,warm-start,warm-start-l2,warm-start-vmm,\
-             echo-breakdown] [{} <path_to_hwloc.json> {} <iterations> {} <toolchain_bin_dir>]",
-            Self::OPT_BENCHMARK,
-            Self::OPT_HWLOC,
-            Self::OPT_ITERATIONS,
-            Self::OPT_TOOLCHAIN_BIN_DIR,
-        )
+    fn usage(program_name: &str) {
+        println!(
+            "\
+Nanvix Benchmarks - Benchmarking suite for Nanvix OS performance.
+
+Usage:
+  {program_name} {benchmark} [OPTIONS]
+
+Benchmarks:
+  boot-time              Measure raw user VM boot latency.
+  cold-start             Measure start-up latency from client's perspective.
+  cold-start-l2          Same as cold-start, but deploy linuxd insdie an L2 VM.
+  concurrent             Measure cold-start times as we increase the number of concurrent user VMs.
+  concurrent-l2          Same as concurrent, but deploy linuxd inside an L2 VM.
+  echo-breakdown         Analyze the latency contributions of each step in the data path.
+  echo-breakdown-l2      Same as echo-breakdown, but deploy linuxd inside L2 VM.
+  round-trip-latency     Measure latency (warm-start) as we increase the payload size.
+  warm-start             Measure round-trip latency from client's perspective.
+  warm-start-l2          Same as warm-start, but deploy linuxd inside an L2 VM.
+  warm-start-vmm         Measure raw round-trip latency inside the user VM.
+
+Options:
+  {benchmark} <benchmark>             Select which benchmark to run (required).
+  {hwloc} <hwloc.json>                Hardware locality configuration file for CPU \
+             affinity/topology.
+  {iterations} <num>                  Number of iterations to run (default: 100).
+  {num_concurrent_vms} <num>          Number of concurrent VMs to run (mandatory for concurrent \
+             benchmarks).
+  {toolchain_bin_dir} <toolchain_dir> Directory containing toolchain binaries (cloud-hypervisor, \
+             etc.).
+  {help}                              Show this help message and exit.
+
+Examples:
+  # Run the cold-start benchmark
+  {program_name} {benchmark} cold-start
+
+  # Run boot-time with a custom hwloc and 1000 iterations
+  {program_name} {benchmark} boot-time {hwloc} hwloc.json {iterations} 1000
+
+  # Run concurrent benchmark with 4 concurrent VMs
+  {program_name} {benchmark} concurrent {num_concurrent_vms} 4
+",
+            program_name = program_name,
+            benchmark = Self::OPT_BENCHMARK,
+            hwloc = Self::OPT_HWLOC,
+            iterations = Self::OPT_ITERATIONS,
+            num_concurrent_vms = Self::OPT_NUM_CONCURRENT_VMS,
+            toolchain_bin_dir = Self::OPT_TOOLCHAIN_BIN_DIR,
+            help = Self::OPT_HELP,
+        );
     }
 
     pub fn parse(args: Vec<String>) -> Result<Self> {
         let mut benchmark_str: String = String::new();
         let mut hwloc_file: Option<String> = None;
         let mut iterations: usize = 100;
+        let mut num_concurrent_vms: Option<usize> = None;
         let mut toolchain_bin_dir: String = "./toolchain/bin".to_string();
 
         let mut i: usize = 1;
         while i < args.len() {
             match args[i].as_str() {
                 Self::OPT_HELP => {
-                    println!("{}", Self::usage());
+                    Self::usage(args[0].as_str());
                     process::exit(0);
                 },
                 Self::OPT_BENCHMARK => {
                     i += 1;
                     if i >= args.len() {
-                        error!("{}", Self::usage());
+                        Self::usage(args[0].as_str());
                         return Err(anyhow::anyhow!("missing value for: {}", Self::OPT_BENCHMARK));
                     }
                     benchmark_str = args[i].clone();
@@ -71,7 +113,7 @@ impl Args {
                 Self::OPT_HWLOC => {
                     i += 1;
                     if i >= args.len() {
-                        error!("{}", Self::usage());
+                        Self::usage(args[0].as_str());
                         return Err(anyhow::anyhow!("missing value for: {}", Self::OPT_HWLOC));
                     }
 
@@ -80,15 +122,26 @@ impl Args {
                 Self::OPT_ITERATIONS => {
                     i += 1;
                     if i >= args.len() {
-                        error!("{}", Self::usage());
+                        Self::usage(args[0].as_str());
                         return Err(anyhow::anyhow!("missing value for: {}", Self::OPT_ITERATIONS));
                     }
                     iterations = args[i].parse::<usize>()?;
                 },
+                Self::OPT_NUM_CONCURRENT_VMS => {
+                    i += 1;
+                    if i >= args.len() {
+                        Self::usage(args[0].as_str());
+                        return Err(anyhow::anyhow!(
+                            "missing value for: {}",
+                            Self::OPT_NUM_CONCURRENT_VMS
+                        ));
+                    }
+                    num_concurrent_vms = Some(args[i].parse::<usize>()?);
+                },
                 Self::OPT_TOOLCHAIN_BIN_DIR => {
                     i += 1;
                     if i >= args.len() {
-                        error!("{}", Self::usage());
+                        Self::usage(args[0].as_str());
                         return Err(anyhow::anyhow!(
                             "missing value for: {}",
                             Self::OPT_TOOLCHAIN_BIN_DIR
@@ -97,7 +150,7 @@ impl Args {
                     toolchain_bin_dir = args[i].clone();
                 },
                 arg => {
-                    error!("{}", Self::usage());
+                    Self::usage(args[0].as_str());
                     return Err(anyhow::anyhow!("invalid argument: {arg}"));
                 },
             }
@@ -106,14 +159,49 @@ impl Args {
         }
 
         match BenchmarkFlavour::from_str(benchmark_str.as_str()) {
-            Ok(benchmark) => Ok(Self {
-                benchmark,
-                hwloc_file,
-                iterations,
-                toolchain_bin_dir,
-            }),
+            Ok(benchmark) => {
+                match benchmark {
+                    // The concurrent benchmarks take slightly different command-line arguments.
+                    BenchmarkFlavour::Concurrent | BenchmarkFlavour::ConcurrentL2 => {
+                        // Must pass -num-concurrent-vms
+                        if num_concurrent_vms.is_none() {
+                            Self::usage(args[0].as_str());
+                            return Err(anyhow::anyhow!(
+                                "missing value for: {}",
+                                Self::OPT_NUM_CONCURRENT_VMS
+                            ));
+                        }
+
+                        // Must not pass -hwloc.
+                        if hwloc_file.is_some() {
+                            Self::usage(args[0].as_str());
+                            return Err(anyhow::anyhow!(
+                                "{benchmark} benchmark does not take {} flag",
+                                Self::OPT_HWLOC,
+                            ));
+                        }
+                    },
+                    _ => {
+                        if num_concurrent_vms.is_some() {
+                            Self::usage(args[0].as_str());
+                            return Err(anyhow::anyhow!(
+                                "unsupported argument for this benchmark: {}",
+                                Self::OPT_NUM_CONCURRENT_VMS
+                            ));
+                        }
+                    },
+                }
+
+                Ok(Self {
+                    benchmark,
+                    hwloc_file,
+                    iterations,
+                    num_concurrent_vms,
+                    toolchain_bin_dir,
+                })
+            },
             Err(_) => {
-                error!("{}", Self::usage());
+                Self::usage(args[0].as_str());
                 Err(anyhow::anyhow!("invalid argument"))
             },
         }
@@ -129,6 +217,10 @@ impl Args {
 
     pub fn iterations(&self) -> usize {
         self.iterations
+    }
+
+    pub fn num_concurrent_vms(&self) -> Option<usize> {
+        self.num_concurrent_vms
     }
 
     pub fn toolchain_bin_dir(&self) -> String {

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -22,6 +22,8 @@ pub enum BenchmarkFlavour {
     BootTime,
     ColdStart,
     ColdStartL2,
+    Concurrent,
+    ConcurrentL2,
     EchoBreakdown,
     EchoBreakdownL2,
     RoundTripLatency,
@@ -36,6 +38,10 @@ impl BenchmarkFlavour {
             BenchmarkFlavour::BootTime => format!("{}/bin/noop-rust-nostd.elf", get_proj_root()),
             BenchmarkFlavour::ColdStart => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
             BenchmarkFlavour::ColdStartL2 => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
+            BenchmarkFlavour::Concurrent => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
+            BenchmarkFlavour::ConcurrentL2 => {
+                format!("{}/bin/echo-rust-nostd.elf", get_proj_root())
+            },
             BenchmarkFlavour::EchoBreakdown | BenchmarkFlavour::EchoBreakdownL2 => {
                 format!("{}/bin/echo-rust-nostd.elf", get_proj_root())
             },
@@ -57,6 +63,8 @@ impl fmt::Display for BenchmarkFlavour {
             BenchmarkFlavour::BootTime => "boot-time",
             BenchmarkFlavour::ColdStart => "cold-start",
             BenchmarkFlavour::ColdStartL2 => "cold-start-l2",
+            BenchmarkFlavour::Concurrent => "concurrent",
+            BenchmarkFlavour::ConcurrentL2 => "concurrent-l2",
             BenchmarkFlavour::EchoBreakdown => "echo-breakdown",
             BenchmarkFlavour::EchoBreakdownL2 => "echo-breakdown-l2",
             BenchmarkFlavour::RoundTripLatency => "round-trip-latency",
@@ -76,6 +84,8 @@ impl FromStr for BenchmarkFlavour {
             "boot-time" => Ok(BenchmarkFlavour::BootTime),
             "cold-start" => Ok(BenchmarkFlavour::ColdStart),
             "cold-start-l2" => Ok(BenchmarkFlavour::ColdStartL2),
+            "concurrent" => Ok(BenchmarkFlavour::Concurrent),
+            "concurrent-l2" => Ok(BenchmarkFlavour::ConcurrentL2),
             "echo-breakdown" => Ok(BenchmarkFlavour::EchoBreakdown),
             "echo-breakdown-l2" => Ok(BenchmarkFlavour::EchoBreakdownL2),
             "round-trip-latency" => Ok(BenchmarkFlavour::RoundTripLatency),

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -152,9 +152,17 @@ const CLEANUP_L2_SLEEP_DURATION: u64 = 100;
 ///
 pub const CHANNEL_CAPACITY: usize = 1024;
 
-//==================================================================================================
-
 const NANVIXD_ADDRESS: &str = "127.0.0.1:9999";
+
+///
+/// # Description
+///
+/// Default size of the message we are sending to the user VM.
+const DEFAULT_PAYLOAD_SIZE: usize = 32;
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
 
 impl Benchmark {
     fn prepare_new_message(&self) -> Result<(HeaderMap, message::New)> {
@@ -295,6 +303,7 @@ impl Benchmark {
                 Err(_) => continue,
             };
         };
+        debug!("connected to gateway socket stream");
 
         Ok((response.user_vm_id, gateway_stream))
     }
@@ -351,6 +360,67 @@ impl Benchmark {
             }
         }
     }
+
+    ///
+    /// # Description
+    ///
+    async fn run_user_vm_echo_once(
+        &mut self,
+        l2: bool,
+        new_msg_headers: HeaderMap,
+        new_msg: New,
+        latencies: &mut Vec<u128>,
+        in_flight_uvms: &mut Option<Vec<(UserVmIdentifier, SocketStream)>>,
+    ) -> Result<()> {
+        let must_persist: bool = in_flight_uvms.is_some();
+
+        // If we don't need to persist, run the setup first. Otherwise we expect the caller to have
+        // called setup already.
+        if !must_persist {
+            self.setup(l2);
+        }
+
+        let payload: [u8; DEFAULT_PAYLOAD_SIZE] = [7u8; DEFAULT_PAYLOAD_SIZE];
+        let mut response_payload: [u8; DEFAULT_PAYLOAD_SIZE] = [0u8; DEFAULT_PAYLOAD_SIZE];
+
+        let start: Instant = Instant::now();
+        let (user_vm_id, mut gateway_stream): (UserVmIdentifier, SocketStream) =
+            self.start(new_msg, new_msg_headers, l2).await?;
+        gateway_stream.write_all(&payload).await?;
+        gateway_stream.read_exact(&mut response_payload).await?;
+        latencies.push(start.elapsed().as_micros());
+
+        // Sanity-check the message to make sure is the same we sent.
+        if response_payload != payload {
+            error!("received payload does not match sent payload!");
+            error!(" - sent: {payload:?}");
+            error!(" - got: {response_payload:?}");
+        }
+
+        // If we must persist, store the user VM id and gateway stream. Otherwise clean-up.
+        if let Some(in_flight_uvms) = in_flight_uvms.as_mut() {
+            in_flight_uvms.push((user_vm_id, gateway_stream));
+        } else {
+            // Kill the user VM.
+            self.kill(user_vm_id).await?;
+
+            // Stop nanvixd.
+            self.cleanup();
+        }
+
+        // Need to give some time to clean-up (a bit longer for L2 benchmarks).
+        if l2 {
+            sleep(Duration::from_millis(CLEANUP_L2_SLEEP_DURATION)).await;
+        } else {
+            sleep(Duration::from_millis(CLEANUP_SLEEP_DURATION)).await;
+        }
+
+        Ok(())
+    }
+
+    //==============================================================================================
+    // Main entrypoint functions for each benchmark
+    //==============================================================================================
 
     /// This function runs the boot-time experiment, where we measure the time to start a user VM
     /// with a noop application and exit. To properly isolate just the time to start a user VM, we
@@ -457,11 +527,15 @@ impl Benchmark {
         Ok(())
     }
 
+    ///
+    /// # Description
+    ///
     /// This function runs the cold-start experiment, where we measure the time to start linuxd,
     /// start a VM, and send a request to the new VM.
+    ///
     pub async fn run_cold_start(&mut self, l2: bool) -> Result<()> {
         // Display a progress bar
-        let pb = ProgressBar::new(self.iterations.try_into().unwrap());
+        let pb: ProgressBar = ProgressBar::new(self.iterations.try_into().unwrap());
         pb.set_style(
             ProgressStyle::default_bar()
                 .template("{msg} [{bar:40.cyan/blue}] {pos}/{len} ({percent}%)")
@@ -471,55 +545,18 @@ impl Benchmark {
         pb.set_message("Benchmark progress:");
 
         // Payload we are sending over the wire
-        const DATA_SIZE: u32 = 10;
-        let payload = [7u8; DATA_SIZE as usize];
-        let mut response_payload = [0u8; DATA_SIZE as usize];
-
-        let (new_msg_headers, new_msg) = self.prepare_new_message()?;
-
+        let (new_msg_headers, new_msg): (HeaderMap, New) = self.prepare_new_message()?;
         let mut latencies: Vec<u128> = Vec::with_capacity(self.iterations);
         for _ in 0..self.iterations {
-            // Clone all messages we need before starting the clock.
-            let new_msg_headers = new_msg_headers.clone();
-            let new_msg = new_msg.clone();
-
-            // We need to start nanvixd in each iteration of the loop, as otherwise re-using the
-            // same nanvixd instance but with different linuxd instances can exhaust resource
-            // limits (like open file descriptors).
-            self.setup(l2);
-
-            // Start the clock.
-            let user_vm_id = {
-                let start = Instant::now();
-                let (user_vm_id, mut gateway_stream) =
-                    self.start(new_msg, new_msg_headers, l2).await?;
-                gateway_stream.write_all(&payload).await?;
-                gateway_stream.read_exact(&mut response_payload).await?;
-                latencies.push(start.elapsed().as_micros());
-                user_vm_id
-            };
-
-            // Sanity-check the message to make sure is the same we sent.
-            if response_payload != payload {
-                error!("received payload does not match sent payload!");
-                error!(" - sent: {payload:?}");
-                error!(" - got: {response_payload:?}");
-            }
-
-            // Kill the user VM.
-            self.kill(user_vm_id).await?;
-
-            // Stop nanvixd.
-            self.cleanup();
-
+            self.run_user_vm_echo_once(
+                l2,
+                new_msg_headers.clone(),
+                new_msg.clone(),
+                &mut latencies,
+                &mut None,
+            )
+            .await?;
             pb.inc(1);
-
-            // Need to give some time to clean-up (a bit longer for L2 benchmarks).
-            if l2 {
-                sleep(Duration::from_millis(CLEANUP_L2_SLEEP_DURATION)).await;
-            } else {
-                sleep(Duration::from_millis(CLEANUP_SLEEP_DURATION)).await;
-            }
         }
 
         pb.finish();
@@ -530,6 +567,79 @@ impl Benchmark {
         println!("p99: {} us", latencies[(self.iterations as f32 * 0.99) as usize]);
 
         print!("Cleaning up...");
+        println!("done!");
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// This benchmark measures the time to start N concurrent user VMs, all sharing the same
+    /// linuxd instance.
+    ///
+    /// # Arguments
+    ///
+    /// - `l2`: whether to deploy linuxd in an L2 VM or not.
+    /// - `num_concurrent_vms`: number of VMs to start concurrently.
+    ///
+    pub async fn run_concurrent(&mut self, l2: bool, num_concurrent_vms: usize) -> Result<()> {
+        // Display a progress bar
+        let pb: ProgressBar = ProgressBar::new(num_concurrent_vms.try_into().unwrap());
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{msg} [{bar:40.cyan/blue}] {pos}/{len} ({percent}%)")
+                .expect("error creating progress bar")
+                .progress_chars("#>-"),
+        );
+        pb.set_message("Benchmark progress:");
+
+        // Prepare message headers.
+        let (new_msg_headers, new_msg): (HeaderMap, New) = self.prepare_new_message()?;
+
+        // Start nanvixd once.
+        self.setup(l2);
+
+        let mut latencies: Vec<u128> = Vec::with_capacity(num_concurrent_vms);
+        let mut in_flight_uvms: Option<Vec<(UserVmIdentifier, SocketStream)>> =
+            Some(Vec::with_capacity(num_concurrent_vms));
+        for iter in 0..num_concurrent_vms {
+            // Update the function name to prevent collisions.
+            let mut new_msg: New = new_msg.clone();
+            new_msg.app_name = format!("bar-{iter}");
+
+            self.run_user_vm_echo_once(
+                l2,
+                new_msg_headers.clone(),
+                new_msg.clone(),
+                &mut latencies,
+                &mut in_flight_uvms,
+            )
+            .await?;
+            pb.inc(1);
+        }
+
+        pb.finish();
+        println!(
+            "Time to spawn {num_concurrent_vms} user VMs (in serial): {:.2} s",
+            (latencies.iter().sum::<u128>() as f64) / 1_000_000.0
+        );
+        latencies.sort();
+        println!("p50: {} us", latencies[(num_concurrent_vms as f32 * 0.5) as usize]);
+        println!("p95: {} us", latencies[(num_concurrent_vms as f32 * 0.95) as usize]);
+        println!("p99: {} us", latencies[(num_concurrent_vms as f32 * 0.99) as usize]);
+
+        print!("Cleaning up...");
+
+        if let Some(in_flight_uvms) = in_flight_uvms.as_mut() {
+            for (user_vm_id, _) in in_flight_uvms.drain(..) {
+                self.kill(user_vm_id).await?;
+            }
+        } else {
+            error!("in_flight_uvms cannot be none");
+        }
+        self.cleanup();
+
         println!("done!");
 
         Ok(())
@@ -649,8 +759,7 @@ impl Benchmark {
         pb.set_message("Benchmark progress:");
 
         // Payload we are sending over the wire
-        const DATA_SIZE: u32 = 10;
-        let payload = [7u8; DATA_SIZE as usize];
+        let payload = [7u8; DEFAULT_PAYLOAD_SIZE];
 
         let (new_msg_headers, new_msg) = self.prepare_new_message()?;
 
@@ -663,7 +772,7 @@ impl Benchmark {
             let (user_vm_id, mut gateway_stream) = self.start(new_msg, new_msg_headers, l2).await?;
 
             for _ in 0..self.iterations {
-                let mut response_payload = [0u8; DATA_SIZE as usize];
+                let mut response_payload = [0u8; DEFAULT_PAYLOAD_SIZE];
 
                 let start = Instant::now();
                 gateway_stream.write_all(&payload).await?;
@@ -714,10 +823,9 @@ impl Benchmark {
         pb.set_message("Benchmark progress:");
 
         // Payload we are sending over the wire.
-        const DATA_SIZE: u32 = 10;
-        let data = [7u8; DATA_SIZE as usize];
+        let data = [7u8; DEFAULT_PAYLOAD_SIZE];
         let mut payload: Vec<u8> = Vec::with_capacity(mem::size_of::<u32>() + data.len());
-        payload.extend_from_slice(&DATA_SIZE.to_le_bytes());
+        payload.extend_from_slice(&DEFAULT_PAYLOAD_SIZE.to_le_bytes());
         payload.extend_from_slice(&data);
         let mut response_buf: [u8; ReadResponse::BUFFER_SIZE] = [0u8; ReadResponse::BUFFER_SIZE];
         response_buf[..payload.len()].copy_from_slice(&payload);
@@ -1123,6 +1231,36 @@ async fn main() -> Result<()> {
                 benchmark.run_round_trip_latency(false).await
             }
         },
+        BenchmarkFlavour::Concurrent => {
+            #[cfg(feature = "timestamp-messages")]
+            {
+                anyhow::bail!(
+                    "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
+                );
+            }
+
+            #[cfg(not(feature = "timestamp-messages"))]
+            {
+                if let Some(num_concurrent_vms) = args.num_concurrent_vms() {
+                    benchmark.run_concurrent(false, num_concurrent_vms).await
+                } else {
+                    anyhow::bail!("this benchmark must be run with a set number of concurrent VMs");
+                }
+            }
+        },
+        BenchmarkFlavour::ConcurrentL2 => {
+            #[cfg(feature = "timestamp-messages")]
+            {
+                anyhow::bail!(
+                    "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
+                );
+            }
+
+            #[cfg(not(feature = "timestamp-messages"))]
+            {
+                benchmark.run_concurrent(true, args.iterations()).await
+            }
+        },
         BenchmarkFlavour::WarmStart => {
             #[cfg(feature = "timestamp-messages")]
             {
@@ -1166,11 +1304,11 @@ async fn main() -> Result<()> {
     match result {
         Ok(()) => {},
         Err(e) => {
-            anyhow::bail!("error running benchmark {}: {e:?}", args.benchmark());
-
             // In case of an error, re-run the clean up to prevent having dangling processes. Note
             // that the clean up is idempotent.
             benchmark.cleanup();
+
+            anyhow::bail!("error running benchmark {}: {e:?}", args.benchmark());
         },
     }
 


### PR DESCRIPTION
In this PR I re-factor linuxd to spawn one lightweight task per user VM to read from its socket, and enqueue messages to a shared, fan-in, queue. The main linuxd thread only needs to then `select!` on the queue to receive messages from _all_ user VMs.

This addresses a limitation in the current design where we were only able to poll one user VM at a time, picked at random. This was causing starvation, and deadlocking, in the `concurrent` benchmark that I also introduce in this PR.