### PR TITLE
[utils] Add Benchmark To Measure User VM Cold Start

### DIFF
--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -74,6 +74,7 @@ jobs:
           boot-time
           cold-start
           cold-start-l2
+          cold-start-uvm
           concurrent
           concurrent-l2
           echo-breakdown

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -32,6 +32,7 @@ L2_SUFFIX = "-l2"
 BOOT_TIME_BENCH = "boot-time"
 COLD_START_BENCH = "cold-start"
 COLD_START_L2_BENCH = COLD_START_BENCH + L2_SUFFIX
+COLD_START_UVM_BENCH = "cold-start-uvm"
 CONCURRENT_BENCH = "concurrent"
 CONCURRENT_L2_BENCH = CONCURRENT_BENCH + L2_SUFFIX
 ECHO_BREAKDOWN_BENCH = "echo-breakdown"
@@ -71,6 +72,7 @@ def filter_benchmark_stdout(benchmark, raw_stdout):
         BOOT_TIME_BENCH,
         COLD_START_BENCH,
         COLD_START_L2_BENCH,
+        COLD_START_UVM_BENCH,
         CONCURRENT_BENCH,
         CONCURRENT_L2_BENCH,
         WARM_START_BENCH,
@@ -144,6 +146,7 @@ def read_benchmark_values_from_file(benchmark, file_path, percentile=None):
         BOOT_TIME_BENCH,
         COLD_START_BENCH,
         COLD_START_L2_BENCH,
+        COLD_START_UVM_BENCH,
         CONCURRENT_BENCH,
         CONCURRENT_L2_BENCH,
         WARM_START_BENCH,
@@ -362,6 +365,7 @@ def ci_summary(args):
             BOOT_TIME_BENCH,
             COLD_START_BENCH,
             COLD_START_L2_BENCH,
+            COLD_START_UVM_BENCH,
             CONCURRENT_BENCH,
             CONCURRENT_L2_BENCH,
             WARM_START_BENCH,

--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -48,6 +48,7 @@ Benchmarks:
   boot-time              Measure raw user VM boot latency.
   cold-start             Measure start-up latency from client's perspective.
   cold-start-l2          Same as cold-start, but deploy linuxd insdie an L2 VM.
+  cold-start-uvm         Measure start-up latency of the user VM only, excluding linuxd.
   concurrent             Measure cold-start times as we increase the number of concurrent user VMs.
   concurrent-l2          Same as concurrent, but deploy linuxd inside an L2 VM.
   echo-breakdown         Analyze the latency contributions of each step in the data path.

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -22,6 +22,7 @@ pub enum BenchmarkFlavour {
     BootTime,
     ColdStart,
     ColdStartL2,
+    ColdStartUvm,
     Concurrent,
     ConcurrentL2,
     EchoBreakdown,
@@ -36,21 +37,17 @@ impl BenchmarkFlavour {
     pub fn get_program(&self) -> String {
         match self {
             BenchmarkFlavour::BootTime => format!("{}/bin/noop-rust-nostd.elf", get_proj_root()),
-            BenchmarkFlavour::ColdStart => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
-            BenchmarkFlavour::ColdStartL2 => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
-            BenchmarkFlavour::Concurrent => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
-            BenchmarkFlavour::ConcurrentL2 => {
-                format!("{}/bin/echo-rust-nostd.elf", get_proj_root())
-            },
-            BenchmarkFlavour::EchoBreakdown | BenchmarkFlavour::EchoBreakdownL2 => {
-                format!("{}/bin/echo-rust-nostd.elf", get_proj_root())
-            },
-            BenchmarkFlavour::RoundTripLatency => {
-                format!("{}/bin/echo-rust-nostd.elf", get_proj_root())
-            },
-            BenchmarkFlavour::WarmStart => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
-            BenchmarkFlavour::WarmStartL2 => format!("{}/bin/echo-rust-nostd.elf", get_proj_root()),
-            BenchmarkFlavour::WarmStartVMM => {
+            BenchmarkFlavour::ColdStart
+            | BenchmarkFlavour::ColdStartL2
+            | BenchmarkFlavour::ColdStartUvm
+            | BenchmarkFlavour::Concurrent
+            | BenchmarkFlavour::ConcurrentL2
+            | BenchmarkFlavour::EchoBreakdown
+            | BenchmarkFlavour::EchoBreakdownL2
+            | BenchmarkFlavour::RoundTripLatency
+            | BenchmarkFlavour::WarmStart
+            | BenchmarkFlavour::WarmStartL2
+            | BenchmarkFlavour::WarmStartVMM => {
                 format!("{}/bin/echo-rust-nostd.elf", get_proj_root())
             },
         }
@@ -63,6 +60,7 @@ impl fmt::Display for BenchmarkFlavour {
             BenchmarkFlavour::BootTime => "boot-time",
             BenchmarkFlavour::ColdStart => "cold-start",
             BenchmarkFlavour::ColdStartL2 => "cold-start-l2",
+            BenchmarkFlavour::ColdStartUvm => "cold-start-uvm",
             BenchmarkFlavour::Concurrent => "concurrent",
             BenchmarkFlavour::ConcurrentL2 => "concurrent-l2",
             BenchmarkFlavour::EchoBreakdown => "echo-breakdown",
@@ -84,6 +82,7 @@ impl FromStr for BenchmarkFlavour {
             "boot-time" => Ok(BenchmarkFlavour::BootTime),
             "cold-start" => Ok(BenchmarkFlavour::ColdStart),
             "cold-start-l2" => Ok(BenchmarkFlavour::ColdStartL2),
+            "cold-start-uvm" => Ok(BenchmarkFlavour::ColdStartUvm),
             "concurrent" => Ok(BenchmarkFlavour::Concurrent),
             "concurrent-l2" => Ok(BenchmarkFlavour::ConcurrentL2),
             "echo-breakdown" => Ok(BenchmarkFlavour::EchoBreakdown),

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -366,13 +366,20 @@ impl Benchmark {
     ///
     async fn run_user_vm_echo_once(
         &mut self,
-        l2: bool,
         new_msg_headers: HeaderMap,
         new_msg: New,
+        l2: bool,
+        pre_warm: bool,
         latencies: &mut Vec<u128>,
         in_flight_uvms: &mut Option<Vec<(UserVmIdentifier, SocketStream)>>,
     ) -> Result<()> {
         let must_persist: bool = in_flight_uvms.is_some();
+
+        if must_persist & pre_warm {
+            let reason: &str = "inconsistent set of flags pre_warm AND must_persist";
+            error!("{reason}");
+            anyhow::bail!(reason);
+        }
 
         // If we don't need to persist, run the setup first. Otherwise we expect the caller to have
         // called setup already.
@@ -382,6 +389,23 @@ impl Benchmark {
 
         let payload: [u8; DEFAULT_PAYLOAD_SIZE] = [7u8; DEFAULT_PAYLOAD_SIZE];
         let mut response_payload: [u8; DEFAULT_PAYLOAD_SIZE] = [0u8; DEFAULT_PAYLOAD_SIZE];
+
+        if pre_warm {
+            let pw_new_msg_headers: HeaderMap = new_msg_headers.clone();
+            let mut pw_new_msg: New = new_msg.clone();
+
+            // Give the pre-warmed app a distinct name.
+            pw_new_msg.app_name = "prewarm-vm".to_string();
+
+            let (pw_user_vm_id, _): (UserVmIdentifier, SocketStream) =
+                self.start(pw_new_msg, pw_new_msg_headers, l2).await?;
+
+            // Kill the warm-up VM straight away.
+            self.kill(pw_user_vm_id).await?;
+
+            // Give some time to prevent interference.
+            sleep(Duration::from_millis(CLEANUP_SLEEP_DURATION)).await;
+        };
 
         let start: Instant = Instant::now();
         let (user_vm_id, mut gateway_stream): (UserVmIdentifier, SocketStream) =
@@ -533,7 +557,12 @@ impl Benchmark {
     /// This function runs the cold-start experiment, where we measure the time to start linuxd,
     /// start a VM, and send a request to the new VM.
     ///
-    pub async fn run_cold_start(&mut self, l2: bool) -> Result<()> {
+    /// # Arguments
+    ///
+    /// - `l2`: whether to deploy linuxd inside an L2 VM.
+    /// - `pre_warm`: whether to start a warm-up user VM connected to the same linuxd instance.
+    ///
+    pub async fn run_cold_start(&mut self, l2: bool, pre_warm: bool) -> Result<()> {
         // Display a progress bar
         let pb: ProgressBar = ProgressBar::new(self.iterations.try_into().unwrap());
         pb.set_style(
@@ -549,9 +578,10 @@ impl Benchmark {
         let mut latencies: Vec<u128> = Vec::with_capacity(self.iterations);
         for _ in 0..self.iterations {
             self.run_user_vm_echo_once(
-                l2,
                 new_msg_headers.clone(),
                 new_msg.clone(),
+                l2,
+                pre_warm,
                 &mut latencies,
                 &mut None,
             )
@@ -609,9 +639,10 @@ impl Benchmark {
             new_msg.app_name = format!("bar-{iter}");
 
             self.run_user_vm_echo_once(
-                l2,
                 new_msg_headers.clone(),
                 new_msg.clone(),
+                l2,
+                false,
                 &mut latencies,
                 &mut in_flight_uvms,
             )
@@ -1174,7 +1205,7 @@ async fn main() -> Result<()> {
 
             #[cfg(not(feature = "timestamp-messages"))]
             {
-                benchmark.run_cold_start(false).await
+                benchmark.run_cold_start(false, false).await
             }
         },
         BenchmarkFlavour::ColdStartL2 => {
@@ -1187,7 +1218,20 @@ async fn main() -> Result<()> {
 
             #[cfg(not(feature = "timestamp-messages"))]
             {
-                benchmark.run_cold_start(true).await
+                benchmark.run_cold_start(true, false).await
+            }
+        },
+        BenchmarkFlavour::ColdStartUvm => {
+            #[cfg(feature = "timestamp-messages")]
+            {
+                anyhow::bail!(
+                    "WARNING: this benchmark must be compiled with TIMESTAMP_MSG=no (or omit it)"
+                );
+            }
+
+            #[cfg(not(feature = "timestamp-messages"))]
+            {
+                benchmark.run_cold_start(false, true).await
             }
         },
         BenchmarkFlavour::EchoBreakdown => {


### PR DESCRIPTION
In this PR I add another benchmark to `nanvix-bench`, `cold-start-uvm`, that measures the cold start latency of a user VM _only_. In the `cold-start` benchmark we are, effectively, measuring the "true" cold-start, as it also includes the time to start linuxd (either as a process, or in an L2 VM in `cold-start-l2`). 

In this benchmark, on the other hand, we reuse the linuxd instance by spawning one user VM, killing it, and spawning another one under the same tenant name,