### PR TITLE
[nanvix-registry] Use Timestamp as Suffix of Temporary Directories

### DIFF
--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -19,13 +19,15 @@
 //!
 //! # Usage
 //!
+//! ## Basic Usage (Default Cache Directory)
+//!
 //! ```no_run
 //! use nanvix_registry::Registry;
 //!
 //! #[tokio::main]
 //! async fn main() -> anyhow::Result<()> {
-//!     // Create a new registry instance.
-//!     let registry: Registry = Registry::new();
+//!     // Create a new registry instance with default cache directory.
+//!     let registry: Registry = Registry::new(None);
 //!
 //!     // Get a cached binary (downloads if not already cached).
 //!     let binary_path: String = registry
@@ -36,6 +38,27 @@
 //!
 //!     // Clear the cache when needed.
 //!     registry.clear_cache().await?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Custom Cache Directory
+//!
+//! ```no_run
+//! use nanvix_registry::Registry;
+//! use std::path::PathBuf;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     // Create a registry with a custom cache directory.
+//!     let cache_dir: PathBuf = PathBuf::from("/tmp/my-nanvix-cache");
+//!     let registry: Registry = Registry::new(Some(cache_dir));
+//!
+//!     // Use the registry normally - it will use the custom directory.
+//!     let binary_path: String = registry
+//!         .get_cached_binary("hyperlight", "multi-process", "kernel.elf")
+//!         .await?;
 //!
 //!     Ok(())
 //! }
@@ -53,12 +76,16 @@
 //!
 //! # Cache Location
 //!
-//! Binaries are cached in the user's cache directory under `nanvix-registry/bin/`.
+//! By default, binaries are cached in the user's cache directory under `nanvix-registry/`.
 //! The exact location depends on the operating system:
 //!
-//! - Linux: `~/.cache/nanvix-registry/bin/`
-//! - macOS: `~/Library/Caches/nanvix-registry/bin/`
-//! - Windows: `%LOCALAPPDATA%\nanvix-registry\bin\`
+//! - Linux: `~/.cache/nanvix-registry/`
+//! - macOS: `~/Library/Caches/nanvix-registry/`
+//! - Windows: `%LOCALAPPDATA%\nanvix-registry\`
+//!
+//! A custom cache directory can be specified when creating a `Registry` instance by passing
+//! a `PathBuf` to `Registry::new()`. This is useful for testing or when you need to isolate
+//! the cache from the default location.
 
 //==================================================================================================
 // Lint Configuration
@@ -149,7 +176,7 @@ const BINARY_DIRECTORY_NAME: &str = "bin";
 ///
 /// #[tokio::main]
 /// async fn main() -> anyhow::Result<()> {
-///     let registry: Registry = Registry::new();
+///     let registry: Registry = Registry::new(None);
 ///
 ///     // Get the kernel binary for microvm single-process deployment.
 ///     let kernel_path: String = registry
@@ -160,7 +187,10 @@ const BINARY_DIRECTORY_NAME: &str = "bin";
 /// }
 /// ```
 ///
-pub struct Registry;
+pub struct Registry {
+    /// Optional custom cache directory path.
+    cache_dir: Option<PathBuf>,
+}
 
 //==================================================================================================
 // Implementations
@@ -172,6 +202,11 @@ impl Registry {
     ///
     /// Creates a new registry instance for managing cached binaries.
     ///
+    /// # Parameters
+    ///
+    /// - `cache_dir`: Optional custom cache directory path. If `None`, uses the system's default
+    ///   cache directory.
+    ///
     /// # Returns
     ///
     /// A new `Registry` instance.
@@ -181,11 +216,15 @@ impl Registry {
     /// ```
     /// use nanvix_registry::Registry;
     ///
-    /// let registry: Registry = Registry::new();
+    /// // Use default cache directory.
+    /// let registry: Registry = Registry::new(None);
+    ///
+    /// // Use custom cache directory.
+    /// let registry: Registry = Registry::new(Some("/tmp/my-cache".into()));
     /// ```
     ///
-    pub fn new() -> Self {
-        Registry
+    pub fn new(cache_dir: Option<PathBuf>) -> Self {
+        Registry { cache_dir }
     }
 
     ///
@@ -229,7 +268,7 @@ impl Registry {
     ///
     /// #[tokio::main]
     /// async fn main() -> anyhow::Result<()> {
-    ///     let registry: Registry = Registry::new();
+    ///     let registry: Registry = Registry::new(None);
     ///
     ///     // Get the QuickJS binary for hyperlight multi-process deployment.
     ///     let qjs_path: String = registry
@@ -296,7 +335,7 @@ impl Registry {
     ///
     /// #[tokio::main]
     /// async fn main() -> anyhow::Result<()> {
-    ///     let registry: Registry = Registry::new();
+    ///     let registry: Registry = Registry::new(None);
     ///
     ///     // Search for a configuration file from the cache directory root.
     ///     let config_path: String = registry
@@ -322,7 +361,7 @@ impl Registry {
         artifact_name: &str,
         dir: Option<&str>,
     ) -> Result<String> {
-        let cache_dir: PathBuf = Self::get_cache_dir().await?;
+        let cache_dir: PathBuf = self.get_cache_dir().await?;
 
         // Convert machine from string representation.
         let machine: Machine = Machine::try_from(machine)?;
@@ -481,7 +520,7 @@ impl Registry {
     ///
     /// #[tokio::main]
     /// async fn main() -> anyhow::Result<()> {
-    ///     let registry: Registry = Registry::new();
+    ///     let registry: Registry = Registry::new(None);
     ///
     ///     // Clear all cached binaries.
     ///     registry.clear_cache().await?;
@@ -491,7 +530,7 @@ impl Registry {
     /// ```
     ///
     pub async fn clear_cache(&self) -> Result<()> {
-        let cache_dir: PathBuf = Self::get_cache_dir().await?;
+        let cache_dir: PathBuf = self.get_cache_dir().await?;
         if fs::metadata(&cache_dir).await.is_ok() {
             // Delete metadata first.
             ReleaseMetadata::delete(&cache_dir).await?;
@@ -511,7 +550,8 @@ impl Registry {
     /// Retrieves the cache directory path, creating it if it doesn't exist.
     ///
     /// This method determines the user's cache directory using platform-specific conventions and
-    /// appends `nanvix-registry/` as the cache subdirectory. If the directory doesn't exist, it is
+    /// appends `nanvix-registry/` as the cache subdirectory. If a custom cache directory was
+    /// provided during construction, it uses that instead. If the directory doesn't exist, it is
     /// created along with any necessary parent directories.
     ///
     /// # Returns
@@ -525,19 +565,22 @@ impl Registry {
     /// - The blocking task for retrieving the cache directory fails.
     /// - The cache directory cannot be created due to permission issues or I/O errors.
     ///
-    async fn get_cache_dir() -> Result<PathBuf> {
-        // Get user's cache directory.
-        let cache_dir: PathBuf = match tokio::task::spawn_blocking(dirs::cache_dir).await {
-            Ok(Some(dir)) => dir.join(CACHE_DIRECTORY_NAME),
-            Ok(None) => {
-                let reason: &str = "could not get user's cache directory";
-                error!("{reason}");
-                anyhow::bail!(reason);
-            },
-            Err(error) => {
-                let reason: String = format!("failed to spawn blocking task: {error}");
-                error!("{reason}");
-                anyhow::bail!(reason);
+    async fn get_cache_dir(&self) -> Result<PathBuf> {
+        // Get cache directory from custom path or user's cache directory.
+        let cache_dir: PathBuf = match &self.cache_dir {
+            Some(custom_dir) => custom_dir.clone(),
+            None => match tokio::task::spawn_blocking(dirs::cache_dir).await {
+                Ok(Some(dir)) => dir.join(CACHE_DIRECTORY_NAME),
+                Ok(None) => {
+                    let reason: &str = "could not get user's cache directory";
+                    error!("{reason}");
+                    anyhow::bail!(reason);
+                },
+                Err(error) => {
+                    let reason: String = format!("failed to spawn blocking task: {error}");
+                    error!("{reason}");
+                    anyhow::bail!(reason);
+                },
             },
         };
 
@@ -563,7 +606,7 @@ impl Default for Registry {
     /// A new `Registry` instance.
     ///
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -582,7 +625,7 @@ mod tests {
     ///
     #[test]
     fn test_new() {
-        let _registry: Registry = Registry::new();
+        let _registry: Registry = Registry::new(None);
     }
 
     ///
@@ -622,7 +665,8 @@ mod tests {
     ///
     #[tokio::test]
     async fn test_get_cache_dir() {
-        let result: Result<PathBuf> = Registry::get_cache_dir().await;
+        let registry: Registry = Registry::new(None);
+        let result: Result<PathBuf> = registry.get_cache_dir().await;
         assert!(result.is_ok());
 
         let cache_dir: PathBuf = result.unwrap();
@@ -636,9 +680,28 @@ mod tests {
     ///
     #[tokio::test]
     async fn test_clear_cache_nonexistent() {
-        let registry: Registry = Registry::new();
+        use ::tokio::fs;
+
+        // Create a unique temporary directory to avoid conflicts in NFS environments.
+        let temp_dir: PathBuf = ::std::env::temp_dir().join(format!(
+            "nanvix-registry-clear-test-{}-{}",
+            ::std::process::id(),
+            ::std::time::SystemTime::now()
+                .duration_since(::std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        // Ensure the directory doesn't exist before the test.
+        let _ = fs::remove_dir_all(&temp_dir).await;
+
+        // Create a registry with the custom cache directory.
+        let registry: Registry = Registry::new(Some(temp_dir.clone()));
         let result: Result<()> = registry.clear_cache().await;
         assert!(result.is_ok());
+
+        // Clean up.
+        let _ = fs::remove_dir_all(&temp_dir).await;
     }
 
     ///
@@ -648,7 +711,7 @@ mod tests {
     ///
     #[tokio::test]
     async fn test_invalid_machine() {
-        let registry: Registry = Registry::new();
+        let registry: Registry = Registry::new(None);
         let result = registry
             .get_cached_binary("invalid-machine", "single-process", "kernel.elf")
             .await;
@@ -667,7 +730,7 @@ mod tests {
     ///
     #[tokio::test]
     async fn test_invalid_deployment() {
-        let registry: Registry = Registry::new();
+        let registry: Registry = Registry::new(None);
         let result = registry
             .get_cached_binary("microvm", "invalid-deployment", "kernel.elf")
             .await;
@@ -700,7 +763,7 @@ mod tests {
     ///
     #[tokio::test]
     async fn test_get_cached_artifact_invalid_machine() {
-        let registry: Registry = Registry::new();
+        let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
             .get_cached_artifact("invalid-machine", "single-process", "config.json", None)
             .await;
@@ -719,7 +782,7 @@ mod tests {
     ///
     #[tokio::test]
     async fn test_get_cached_artifact_invalid_deployment() {
-        let registry: Registry = Registry::new();
+        let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
             .get_cached_artifact("microvm", "invalid-deployment", "config.json", None)
             .await;
@@ -776,7 +839,7 @@ mod tests {
     ///
     #[tokio::test]
     async fn test_get_cached_artifact_custom_directory() {
-        let registry: Registry = Registry::new();
+        let registry: Registry = Registry::new(None);
 
         // Test with None (searches from cache root) - should fail gracefully since no actual cache exists.
         let result: Result<String> = registry

--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -676,6 +676,23 @@ mod tests {
     ///
     /// # Description
     ///
+    /// Tests creating a Registry with a custom cache directory.
+    ///
+    #[tokio::test]
+    async fn test_custom_cache_directory() {
+        let custom_dir: PathBuf = ::std::env::temp_dir().join("nanvix-test-custom-cache");
+        let registry: Registry = Registry::new(Some(custom_dir.clone()));
+
+        let cache_dir: PathBuf = registry.get_cache_dir().await.unwrap();
+        assert_eq!(cache_dir, custom_dir);
+
+        // Cleanup
+        let _ = ::tokio::fs::remove_dir_all(&custom_dir).await;
+    }
+
+    ///
+    /// # Description
+    ///
     /// Tests that clear_cache works when cache doesn't exist.
     ///
     #[tokio::test]

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -109,25 +109,6 @@
 //! - Utilities: [`tcp_port`] for managing TCP port allocations
 
 //==================================================================================================
-// Imports
-//==================================================================================================
-
-use ::anyhow::Result;
-use ::std::{
-    borrow::Cow,
-    ffi::OsString,
-    path::PathBuf,
-};
-use ::syslog::{
-    error,
-    warn,
-};
-use ::tokio::{
-    fs,
-    fs::ReadDir,
-};
-
-//==================================================================================================
 // Private Modules
 //==================================================================================================
 
@@ -184,81 +165,3 @@ pub use config::{
     user_vm_sockaddr_builder,
     NAMED_RESOURCE_PREFIX,
 };
-
-//==================================================================================================
-// Standalone Functions
-//==================================================================================================
-
-///
-/// # Description
-///
-/// Helper function that removes dangling resources from previous runs.
-///
-/// # Parameters
-///
-/// - `tmp_dir_path`: Path to the temporary directory.
-///
-/// # Returns
-///
-/// On success, this function returns an empty tuple. On failure, it returns an object that
-/// describes the error.
-///
-pub async fn remove_dangling_resources(tmp_dir_path: &str) -> Result<()> {
-    let mut result: Result<()> = Ok(());
-
-    // Open temporary directory, all named resources are created here.
-    let mut dir_entries: ReadDir = fs::read_dir(tmp_dir_path).await.map_err(|error| {
-        let reason: String =
-            format!("failed to read temporary directory '{tmp_dir_path}': {error}");
-        error!("remove_dangling_resources(): {reason}");
-        anyhow::anyhow!(reason)
-    })?;
-
-    // Traverse directory entries and remove all dangling resources that start with the magic prefix
-    // for named resources. If we fail, log an error message and continue, as we want to cleanup as
-    // many resources as possible. The overall result will be an error if any removal fails.
-    loop {
-        match dir_entries.next_entry().await {
-            Ok(None) => break,
-            Ok(Some(entry)) => {
-                let file_name: OsString = entry.file_name();
-                let file_name_str: Cow<'_, str> = file_name.to_string_lossy();
-
-                // Check if the file name matches the named resource prefix.
-                if file_name_str.starts_with(NAMED_RESOURCE_PREFIX) {
-                    let file_path: PathBuf = entry.path();
-
-                    // Attempt to remove dangling resource.
-                    if let Err(error) = fs::remove_file(file_path).await {
-                        let reason: String = format!(
-                            "failed to remove dangling resource '{}': {error}",
-                            file_name_str
-                        );
-                        error!("remove_dangling_resources(): {reason}");
-
-                        // Do not overwrite previous errors.
-                        if result.is_ok() {
-                            result = Err(anyhow::anyhow!(reason));
-                        }
-                    } else {
-                        warn!("removed dangling resource: {}", file_name_str);
-                    }
-                }
-            },
-            Err(error) => {
-                let reason: String = format!(
-                    "failed to read entry in temporary directory '{}': {error}",
-                    tmp_dir_path
-                );
-                error!("remove_dangling_resources(): {reason}");
-
-                // Do not overwrite previous errors.
-                if result.is_ok() {
-                    result = Err(anyhow::anyhow!(reason));
-                }
-            },
-        };
-    }
-
-    result
-}

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -337,9 +337,10 @@ fn print_startup_info(args: &Args) {
 ///
 /// Creates a temporary directory for the sandbox cache.
 ///
-/// This function generates a unique directory name using a timestamp encoded in base64
-/// (using filename-safe characters: A-Z, a-z, 0-9, -, _) with microsecond precision.
-/// The directory will be automatically cleaned up when the returned `TemporaryDirectory` is dropped.
+/// This function generates a unique directory name using a timestamp encoded in base64url
+/// format (RFC 4648 Section 5) with filename-safe characters: A-Z, a-z, 0-9, -, _.
+/// The timestamp is based on microseconds since UNIX_EPOCH. The directory will be
+/// automatically cleaned up when the returned `TemporaryDirectory` is dropped.
 ///
 /// # Parameters
 ///
@@ -352,16 +353,16 @@ fn print_startup_info(args: &Args) {
 ///
 async fn create_tmp_dir(tmp_directory: &str) -> Result<TemporaryDirectory> {
     // Get current timestamp in microseconds.
-    let timestamp_micros: u64 = SystemTime::now()
+    let timestamp_micros: u128 = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|e| {
             let reason: String = format!("failed to get system time: {e}");
             error!("create_tmp_dir(): {reason}");
             anyhow::anyhow!(reason)
         })?
-        .as_micros() as u64;
+        .as_micros();
 
-    // Encode timestamp in base64 using filename-safe characters.
+    // Encode timestamp in base64url using RFC 4648 compliant filename-safe characters.
     let tmp_dirname: String = encode_base64_filename(timestamp_micros);
     let tmp_directory_path: PathBuf =
         PathBuf::from(tmp_directory).join(format!("{NAMED_RESOURCE_PREFIX}:{}", tmp_dirname));
@@ -382,11 +383,12 @@ async fn create_tmp_dir(tmp_directory: &str) -> Result<TemporaryDirectory> {
 ///
 /// # Description
 ///
-/// Encodes a number in base64 using filename-safe characters.
+/// Encodes a number in base64url format as defined in RFC 4648 Section 5.
 ///
-/// This function converts a 64-bit unsigned integer to a base64 string representation
-/// using the filename-safe alphabet: A-Z, a-z, 0-9, -, _. These characters are safe
-/// to use in filenames across all common operating systems.
+/// This function converts a 128-bit unsigned integer to a base64url string representation
+/// using the URL and filename-safe alphabet (RFC 4648 Table 2): A-Z (indices 0-25),
+/// a-z (indices 26-51), 0-9 (indices 52-61), - (index 62), and _ (index 63).
+/// These characters are safe to use in URLs and filenames across all common operating systems.
 ///
 /// # Parameters
 ///
@@ -394,20 +396,21 @@ async fn create_tmp_dir(tmp_directory: &str) -> Result<TemporaryDirectory> {
 ///
 /// # Returns
 ///
-/// A base64-encoded string representation of the input number using filename-safe characters.
+/// A base64url-encoded string representation of the input number using RFC 4648 compliant
+/// filename-safe characters. Zero is encoded as `"A"`.
 ///
-fn encode_base64_filename(mut num: u64) -> String {
+fn encode_base64_filename(mut num: u128) -> String {
     const BASE64_CHARS: &[char] = &[
-        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
-        'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
-        's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '-', '_',
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+        'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+        'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1',
+        '2', '3', '4', '5', '6', '7', '8', '9', '-', '_',
     ];
-    const BASE: u64 = 64;
+    const BASE: u128 = 64;
 
     // Handle the zero case.
     if num == 0 {
-        return "0".to_string();
+        return "A".to_string();
     }
 
     let mut result: Vec<char> = Vec::new();
@@ -418,4 +421,177 @@ fn encode_base64_filename(mut num: u64) -> String {
 
     result.reverse();
     result.iter().collect()
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests that encoding zero returns "A" as specified in the function documentation.
+    ///
+    #[test]
+    fn test_encode_base64_filename_zero() {
+        assert_eq!(encode_base64_filename(0), "A");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests encoding of various numbers to verify correct base64url conversion.
+    ///
+    #[test]
+    fn test_encode_base64_filename_various_numbers() {
+        // Test first 64 values map to single characters in the alphabet.
+        assert_eq!(encode_base64_filename(1), "B");
+        assert_eq!(encode_base64_filename(25), "Z");
+        assert_eq!(encode_base64_filename(26), "a");
+        assert_eq!(encode_base64_filename(51), "z");
+        assert_eq!(encode_base64_filename(52), "0");
+        assert_eq!(encode_base64_filename(61), "9");
+        assert_eq!(encode_base64_filename(62), "-");
+        assert_eq!(encode_base64_filename(63), "_");
+
+        // Test multi-character encodings.
+        assert_eq!(encode_base64_filename(64), "BA");
+        assert_eq!(encode_base64_filename(65), "BB");
+        assert_eq!(encode_base64_filename(127), "B_");
+        assert_eq!(encode_base64_filename(128), "CA");
+        assert_eq!(encode_base64_filename(4095), "__");
+        assert_eq!(encode_base64_filename(4096), "BAA");
+
+        // Test larger values.
+        assert_eq!(encode_base64_filename(1000000), "D0JA");
+        assert_eq!(encode_base64_filename(u64::MAX as u128), "P__________");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that character ordering in output follows RFC 4648 base64url alphabet ordering.
+    /// Verifies that sequential numbers produce lexicographically ordered strings when appropriate.
+    ///
+    #[test]
+    fn test_encode_base64_filename_character_ordering() {
+        // Verify RFC 4648 alphabet ordering: A-Z (0-25), a-z (26-51), 0-9 (52-61), - (62), _ (63).
+        let encodings: Vec<String> = (0..64).map(encode_base64_filename).collect();
+
+        // First 26 should be A-Z.
+        for i in 0..26 {
+            assert_eq!(encodings[i].len(), 1);
+            assert_eq!(encodings[i].chars().next().unwrap() as u8, b'A' + i as u8);
+        }
+
+        // Next 26 should be a-z.
+        for i in 26..52 {
+            assert_eq!(encodings[i].len(), 1);
+            assert_eq!(encodings[i].chars().next().unwrap() as u8, b'a' + (i - 26) as u8);
+        }
+
+        // Next 10 should be 0-9.
+        for i in 52..62 {
+            assert_eq!(encodings[i].len(), 1);
+            assert_eq!(encodings[i].chars().next().unwrap() as u8, b'0' + (i - 52) as u8);
+        }
+
+        // Last two should be - and _.
+        assert_eq!(encodings[62], "-");
+        assert_eq!(encodings[63], "_");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests uniqueness guarantees by verifying that different inputs produce different outputs.
+    /// This is critical for using the function to generate unique directory names.
+    ///
+    #[test]
+    fn test_encode_base64_filename_uniqueness() {
+        use ::std::collections::HashSet;
+
+        // Test uniqueness for a range of consecutive numbers.
+        let mut seen: HashSet<String> = HashSet::new();
+        for i in 0..10000 {
+            let encoded: String = encode_base64_filename(i);
+            assert!(seen.insert(encoded.clone()), "duplicate encoding for {}: {}", i, encoded);
+        }
+
+        // Test uniqueness for sparse large numbers.
+        let test_values: Vec<u128> = vec![
+            0,
+            1,
+            u64::MAX as u128,
+            u64::MAX as u128 + 1,
+            u128::MAX / 2,
+            u128::MAX - 1,
+            u128::MAX,
+        ];
+
+        let mut seen_large: HashSet<String> = HashSet::new();
+        for value in test_values {
+            let encoded: String = encode_base64_filename(value);
+            assert!(
+                seen_large.insert(encoded.clone()),
+                "duplicate encoding for {}: {}",
+                value,
+                encoded
+            );
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that encoded strings only contain RFC 4648 base64url filename-safe characters.
+    ///
+    #[test]
+    fn test_encode_base64_filename_valid_characters() {
+        use ::std::collections::HashSet;
+
+        let valid_chars: HashSet<char> =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+                .chars()
+                .collect();
+
+        let test_values: Vec<u128> = vec![0, 1, 63, 64, 4095, 4096, 1000000, u128::MAX];
+
+        for value in test_values {
+            let encoded: String = encode_base64_filename(value);
+            for ch in encoded.chars() {
+                assert!(
+                    valid_chars.contains(&ch),
+                    "invalid character '{}' in encoding of {}",
+                    ch,
+                    value
+                );
+            }
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests boundary conditions and edge cases.
+    ///
+    #[test]
+    fn test_encode_base64_filename_boundary_conditions() {
+        // Minimum value.
+        assert_eq!(encode_base64_filename(0), "A");
+
+        // Maximum value.
+        let max_encoding: String = encode_base64_filename(u128::MAX);
+        assert!(!max_encoding.is_empty());
+        assert!(max_encoding.len() <= 22); // log64(2^128) ≈ 21.33.
+
+        // Power of 64 values.
+        assert_eq!(encode_base64_filename(64), "BA");
+        assert_eq!(encode_base64_filename(64 * 64), "BAA");
+        assert_eq!(encode_base64_filename(64 * 64 * 64), "BAAA");
+    }
 }

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -36,15 +36,15 @@ use ::nanvixd::{
     config::DEFAULT_TMP_DIRECTORY,
     tempdir::TemporaryDirectory,
 };
-use ::rand::{
-    distr::Alphanumeric,
-    Rng,
-};
 use ::std::{
     path::PathBuf,
     sync::{
         Arc,
         OnceLock,
+    },
+    time::{
+        SystemTime,
+        UNIX_EPOCH,
     },
 };
 use ::tokio::fs;
@@ -64,9 +64,6 @@ const LINUXD_BINARY_NAME: &str = "linuxd.elf";
 /// Binary name for User VM.
 #[cfg(not(feature = "single-process"))]
 const USERVM_BINARY_NAME: &str = "uservm.elf";
-
-/// Length of temporary directory random suffix.
-const TMP_DIR_RANDOM_SUFFIX_LENGTH: usize = 4;
 
 //==================================================================================================
 // Global Variables
@@ -345,9 +342,9 @@ fn print_startup_info(args: &Args) {
 ///
 /// Creates a temporary directory for the sandbox cache.
 ///
-/// This function generates a random 4-character alphanumeric directory name under the specified
-/// tmp directory path. The directory will be automatically cleaned up when the returned
-/// `TemporaryDirectory` is dropped.
+/// This function generates a unique directory name using a timestamp encoded in base64
+/// (using filename-safe characters: A-Z, a-z, 0-9, -, _) with microsecond precision.
+/// The directory will be automatically cleaned up when the returned `TemporaryDirectory` is dropped.
 ///
 /// # Parameters
 ///
@@ -359,15 +356,22 @@ fn print_startup_info(args: &Args) {
 /// directory. On failure, returns an error describing what went wrong during directory creation.
 ///
 async fn create_tmp_dir(tmp_directory: &str) -> Result<TemporaryDirectory> {
-    let tmp_dirname: String = rand::rng()
-        .sample_iter(&Alphanumeric)
-        .take(TMP_DIR_RANDOM_SUFFIX_LENGTH)
-        .map(char::from)
-        .collect();
+    // Get current timestamp in microseconds.
+    let timestamp_micros: u64 = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| {
+            let reason: String = format!("failed to get system time: {e}");
+            error!("create_tmp_dir(): {reason}");
+            anyhow::anyhow!(reason)
+        })?
+        .as_micros() as u64;
+
+    // Encode timestamp in base64 using filename-safe characters.
+    let tmp_dirname: String = encode_base64_filename(timestamp_micros);
     let tmp_directory_path: PathBuf =
         PathBuf::from(tmp_directory).join(format!("{NAMED_RESOURCE_PREFIX}:{}", tmp_dirname));
 
-    // Check if temporary directory already exists (very unlikely).
+    // Check if temporary directory already exists (extremely unlikely with timestamp-based naming).
     if tmp_directory_path.exists() {
         let reason: String =
             format!("unique temporary directory already exists (path={tmp_directory_path:?})");
@@ -378,4 +382,45 @@ async fn create_tmp_dir(tmp_directory: &str) -> Result<TemporaryDirectory> {
     let tmp_directory: TemporaryDirectory = TemporaryDirectory::new(tmp_directory_path).await?;
 
     Ok(tmp_directory)
+}
+
+///
+/// # Description
+///
+/// Encodes a number in base64 using filename-safe characters.
+///
+/// This function converts a 64-bit unsigned integer to a base64 string representation
+/// using the filename-safe alphabet: A-Z, a-z, 0-9, -, _. These characters are safe
+/// to use in filenames across all common operating systems.
+///
+/// # Parameters
+///
+/// - `mut num`: The number to encode.
+///
+/// # Returns
+///
+/// A base64-encoded string representation of the input number using filename-safe characters.
+///
+fn encode_base64_filename(mut num: u64) -> String {
+    const BASE64_CHARS: &[char] = &[
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+        'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '-', '_',
+    ];
+    const BASE: u64 = 64;
+
+    // Handle the zero case.
+    if num == 0 {
+        return "0".to_string();
+    }
+
+    let mut result: Vec<char> = Vec::new();
+    while num > 0 {
+        result.push(BASE64_CHARS[(num % BASE) as usize]);
+        num /= BASE;
+    }
+
+    result.reverse();
+    result.iter().collect()
 }

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -281,7 +281,7 @@ async fn ensure_all_binaries_available(
 
     log_info!("not all binaries found locally, fetching all from registry");
 
-    let registry: Registry = Registry::new();
+    let registry: Registry = Registry::new(None);
 
     let kernel_cached_path: String = registry
         .get_cached_binary(machine, deployment, KERNEL_BINARY_NAME)

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -26,7 +26,6 @@ use ::nanvix::{
     log,
     log::error,
     registry::Registry,
-    sandbox,
     sandbox::NAMED_RESOURCE_PREFIX,
     sandbox_cache::SandboxCacheConfig,
     terminal::Terminal,
@@ -171,10 +170,6 @@ pub async fn main() -> Result<()> {
             anyhow::anyhow!(reason)
         })?,
     );
-
-    // Remove dangling resources from previous runs. We do not expect concurrent instances of
-    // nanvixd running in the same tmp directory, so we will not have unexpected side effects.
-    sandbox::remove_dangling_resources(config.tmp_directory()).await?;
 
     // Check for interactive mode or HTTP mode.
     if let Some(true) = INTERACTIVE_MODE.get().copied() {


### PR DESCRIPTION
This pull request introduces support for specifying a custom cache directory in the `Registry` struct of the `nanvix-registry` library, improving flexibility for users and tests. It also cleans up the `nanvix-sandbox` library by removing the unused `remove_dangling_resources` function and unused imports. Additionally, the main binary (`nanvixd`) is updated to remove unused imports. The documentation has been updated to reflect these changes.

**nanvix-registry: Custom Cache Directory Support and Documentation Updates**

* Added an optional `cache_dir` field to the `Registry` struct, allowing users to specify a custom cache directory. The `Registry::new()` constructor now takes an `Option<PathBuf>`, and all internal cache directory logic respects this setting. [[1]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L163-R193) [[2]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L184-R227) [[3]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L325-R364) [[4]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L494-R533) [[5]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L528-R572)
* Updated documentation and usage examples to demonstrate both default and custom cache directory usage, including new code examples and clarifications about cache locations. [[1]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834R22-R30) [[2]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834R46-R66) [[3]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L56-R88) [[4]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L152-R179) [[5]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834R205-R209)
* Updated tests to cover custom cache directory scenarios and ensure correct behavior, including use of temporary directories for isolation. [[1]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L585-R628) [[2]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L625-R669) [[3]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L639-R704)

**nanvix-sandbox: Code Cleanup**

* Removed the unused `remove_dangling_resources` function and related imports from `src/libs/nanvix-sandbox/src/lib.rs`, simplifying the codebase. [[1]](diffhunk://#diff-f5b055ed6c61b7998e1bb0bcc08d7aab6c496a2cd6dba4ce81bacbeb81f58c61L111-L129) [[2]](diffhunk://#diff-f5b055ed6c61b7998e1bb0bcc08d7aab6c496a2cd6dba4ce81bacbeb81f58c61L187-L264)

**nanvixd (main binary): Minor Cleanup**

* Removed unused imports from `src/utils/nanvixd/src/main.rs` for improved clarity and maintainability. [[1]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L29) [[2]](diffhunk://#diff-4bd20ad3804282240c81f8ac20af0a1ab21f9972791f21eb9fc15bead6556462L39-R47)