### PR TITLE
[build] Upgrading `compiler_builtins`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ bitmap = { path = "src/libs/bitmap", default-features = false }
 cc = "1.2.26"
 cfg-if = "1.0.0"
 chrono = "0.4.42"
+compiler_builtins = "0.1.160"
 config = { path = "src/libs/config", default-features = false }
 control-plane-api = { path = "src/libs/control-plane-api", default-features = false }
 dirs = "6.0"

--- a/src/libs/arch/Cargo.toml
+++ b/src/libs/arch/Cargo.toml
@@ -17,7 +17,7 @@ error = { workspace = true }
 static_assert = { workspace = true }
 sys = { workspace = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 
 [build-dependencies]
 cfg-if = { workspace = true }

--- a/src/libs/config/Cargo.toml
+++ b/src/libs/config/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["lib"]
 [dependencies]
 cfg-if = { workspace = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/src/libs/error/Cargo.toml
+++ b/src/libs/error/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["lib"]
 
 [dependencies]
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 sysapi = { workspace = true }
 
 [features]

--- a/src/libs/libc_stdlib/Cargo.toml
+++ b/src/libs/libc_stdlib/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["lib"]
 [dependencies]
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 cfg-if = { workspace = true }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 flexi_logger = { workspace = true, optional = true }
 log = { workspace = true, optional = true }

--- a/src/libs/nvx/Cargo.toml
+++ b/src/libs/nvx/Cargo.toml
@@ -16,7 +16,7 @@ cfg-if = { workspace = true }
 syslog = { workspace = true, default-features = true }
 sys = { workspace = true, features = ["kcall"] }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 
 # Platform-specific dependencies.
 [target.'cfg(any(target_os = "none", target_os = "nanvix"))'.dependencies]

--- a/src/libs/static_assert/Cargo.toml
+++ b/src/libs/static_assert/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 
 [dependencies]
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/src/libs/sys/Cargo.toml
+++ b/src/libs/sys/Cargo.toml
@@ -15,7 +15,7 @@ config = { workspace = true }
 error = { workspace = true }
 static_assert = { workspace = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 
 [features]
 std = []

--- a/src/libs/sysalloc/Cargo.toml
+++ b/src/libs/sysalloc/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 arch = { workspace = true }
 cfg-if = { workspace = true }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 config = { workspace = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 spin = { workspace = true, features = ["lazy", "spin_mutex"] }
@@ -37,6 +37,8 @@ rustc-dep-of-std = [
     "sys/rustc-dep-of-std",
     "syslog/rustc-dep-of-std",
     "cfg-if/rustc-dep-of-std",
+    "spin/rustc-dep-of-std",
+    "static_assert/rustc-dep-of-std",
 ]
 
 # Logging Features

--- a/src/libs/sysapi/Cargo.toml
+++ b/src/libs/sysapi/Cargo.toml
@@ -11,7 +11,7 @@ description = "System Application Programming Interface"
 homepage.workspace = true
 
 [dependencies]
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 config = { workspace = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 static_assert = { workspace = true }

--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -36,7 +36,7 @@ sysapi = { workspace = true }
 type-safe = { workspace = true }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 
 [features]
 default = ["syscall", "dlfcn", "sbrk"]

--- a/src/libs/syslog/Cargo.toml
+++ b/src/libs/syslog/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 [dependencies]
 cfg-if = { workspace = true, optional = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 flexi_logger = { workspace = true, optional = true }
 sys = { workspace = true, features = ["kcall"], optional = true }

--- a/src/libs/type-safe/Cargo.toml
+++ b/src/libs/type-safe/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["lib"]
 [dependencies]
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1", optional = true }
+compiler_builtins = { workspace = true, optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
This pull request updates the way the `compiler_builtins` dependency is managed across multiple library crates. The main goal is to centralize and standardize the dependency versioning by referencing it from the workspace, rather than specifying a version in each crate. Additionally, a couple of new dependencies are added to the `rustc-dep-of-std` feature list in `sysalloc`.

Dependency management improvements:

* Updated all `Cargo.toml` files in the library crates to reference `compiler_builtins` from the workspace instead of specifying the version directly. This ensures consistent versioning and easier dependency management across the project. [[1]](diffhunk://#diff-40664893b2664b7295e19014fe2bada3739ede20536c914da86053c5ee98b8cdL20-R20) [[2]](diffhunk://#diff-b48d8648439a6a251064563b7d1265305252c87c425a2d4b1470a57b71cd5b6aL19-R19) [[3]](diffhunk://#diff-004e61ecf61758a7fdc6f44632918a2e4cc774e01e7d3cfb4efa45ea5a870dddL18-R18) [[4]](diffhunk://#diff-8e61161cffb6bac8040453d829da99c503f21107e2b5ff0de218a03961985c54L18-R18) [[5]](diffhunk://#diff-071735bf6ca07217473b53b4f9ed10dd182d0b98517c278630f4b86ee7237a32L19-R19) [[6]](diffhunk://#diff-3a8bd0b955a3b7e455ff5ec1be9d7a573ee8d9588d020ec4fdb421658e23350dL15-R15) [[7]](diffhunk://#diff-4a64d7761ae26bc4c0fe95a7872d57c948d3c670313291d46311d92d014f3a00L18-R18) [[8]](diffhunk://#diff-2c4acf6847e86a16536dae50fdd51ed7a2a107aeb9842cf66be174e7d08260dcL17-R17) [[9]](diffhunk://#diff-9155d525609effaa217ffb73494736bc503c66b4490f6941083c21d5f0150bc9L14-R14) [[10]](diffhunk://#diff-d97ab93cb82679f7061c73c37147ab6a197fc1f682c6b8a471b45f250a5f440aL39-R39) [[11]](diffhunk://#diff-1a87e84c478f7c48c35476cf7b8f0577e9e5f97f8919d22a32c2aaee352c488dL16-R16) [[12]](diffhunk://#diff-82e2a9e62139039a5f97af5bb7caa5b2911e900217ed980cf0ef06a41994b5a9L19-R19)

* Added `compiler_builtins` as a direct dependency in the workspace root `Cargo.toml`, specifying version `0.1.160`.

Feature enhancements:

* Added `spin/rustc-dep-of-std` and `static_assert/rustc-dep-of-std` to the `rustc-dep-of-std` feature list in `src/libs/sysalloc/Cargo.toml`. This ensures these crates are included when building for the standard library.