### PR TITLE
[build] Gate `microvm` and `hyperlight` Build Targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,13 +375,15 @@ install: all-nanvix
 	@mkdir -p ${SYSROOT_DIR}/lib
 	@mkdir -p ${SYSROOT_DIR}/etc/scripts
 	@cp ${KERNEL} ${SYSROOT_DIR}/bin/
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 	@cp ${NANVIXD} ${SYSROOT_DIR}/bin/
 ifneq ($(SINGLE_PROCESS),yes)
 	@cp ${LINUXD} ${SYSROOT_DIR}/bin/
 	@cp ${USERVM} ${SYSROOT_DIR}/bin/
 endif
-	@cp ${LIBPOSIX} ${SYSROOT_DIR}/lib/
 	@cp ${RUN_NANVIXD_SCRIPT} ${SYSROOT_DIR}/etc/scripts/
+endif
+	@cp ${LIBPOSIX} ${SYSROOT_DIR}/lib/
 	@cp -r ${SCRIPTS_DIR}/common/* ${SYSROOT_DIR}/etc/scripts/
 	@cp -r ${BUILD_DIR}/user/linker/$(TARGET)/user.ld ${SYSROOT_DIR}/lib/
 

--- a/Makefile
+++ b/Makefile
@@ -303,10 +303,17 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 ALL_HOST_RUST_LIBS := control-plane-api hwloc profiler nanvix nanvix-http nanvix-registry nanvix-sandbox nanvix-sandbox-cache nanvix-terminal syscomm user-vm-api
 ALL_HOST_UTILS := echo-client
 ALL_HOST_DAEMONS := linuxd
 ALL_HOST_BINARIES := $(ALL_HOST_UTILS) $(ALL_HOST_DAEMONS)
+else
+ALL_HOST_RUST_LIBS :=
+ALL_HOST_UTILS :=
+ALL_HOST_DAEMONS :=
+ALL_HOST_BINARIES :=
+endif
 
 #===================================================================================================
 # Top-Level Build Rules
@@ -322,12 +329,12 @@ all-nanvix: \
 	all-guest-binaries \
 	all-wasmd \
 	all-kernel \
-	all-nanvixd \
-	all-nanvix-bench \
 	all-wasm-binaries \
-	all-host-binaries \
-	all-snapshot \
-	all-uservm
+	all-snapshot
+
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+all-nanvix: all-host-binaries all-nanvixd all-uservm all-nanvix-bench
+endif
 
 # Performs local initialization.
 init: init-repo init-opt
@@ -344,14 +351,14 @@ clean: \
 	clean-guest-binaries \
 	clean-wasmd \
 	clean-kernel \
-	clean-nanvixd \
-	clean-nanvix-bench \
 	clean-wasm-binaries \
-	clean-host-binaries \
 	clean-opt \
 	clean-snapshot \
-	clean-uservm \
 	image-clean
+
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+clean: clean-host-binaries clean-nanvixd clean-uservm clean-nanvix-bench
+endif
 
 distclean: clean
 	$(FORCE_RM_CMD) Cargo.lock
@@ -449,30 +456,28 @@ lint-check: \
 # Runs clippy.
 rust-lint-check: \
 	rust-lint-check-kernel \
-	rust-lint-check-nanvixd \
-	rust-lint-check-nanvix-bench \
 	rust-lint-check-guest-binaries \
 	rust-lint-check-guest-rlibs \
 	rust-lint-check-guest-staticlibs \
 	rust-lint-check-wasmd \
-	rust-lint-check-wasm-binaries \
-	rust-lint-check-host-binaries \
-	rust-lint-check-host-rlibs \
-	rust-lint-check-uservm
+	rust-lint-check-wasm-binaries
+
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+rust-lint-check: rust-lint-check-host-binaries rust-lint-check-host-rlibs rust-lint-check-nanvixd rust-lint-check-uservm rust-lint-check-nanvix-bench
+endif
 
 # Fixes code linting issues.
 rust-lint: \
 	rust-lint-kernel \
-	rust-lint-nanvixd \
-	rust-lint-nanvix-bench \
 	rust-lint-guest-binaries \
 	rust-lint-guest-rlibs \
 	rust-lint-guest-staticlibs \
 	rust-lint-wasmd \
-	rust-lint-wasm-binaries \
-	rust-lint-host-binaries \
-	rust-lint-host-rlibs \
-	rust-lint-uservm
+	rust-lint-wasm-binaries
+
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+rust-lint: rust-lint-host-binaries rust-lint-host-rlibs rust-lint-nanvixd rust-lint-uservm rust-lint-nanvix-bench
+endif
 
 # Fixes spelling errors in source code and documentation.
 spellcheck-fix:
@@ -499,28 +504,26 @@ rust-format: \
 	format-guest-binaries \
 	format-guest-rlibs \
 	format-guest-staticlibs \
-	format-host-binaries \
-	format-host-rlibs \
 	format-kernel \
-	format-nanvixd \
-	format-nanvix-bench \
-	format-uservm \
 	format-wasmd \
 	format-wasm-binaries
+
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+rust-format: format-host-binaries format-host-rlibs format-nanvixd format-uservm format-nanvix-bench
+endif
 
 # Checks Rust code formatting.
 rust-format-check: \
 	format-check-guest-binaries \
 	format-check-guest-rlibs \
 	format-check-guest-staticlibs \
-	format-check-host-binaries \
-	format-check-host-rlibs \
 	format-check-kernel \
-	format-check-nanvixd \
-	format-check-nanvix-bench \
-	format-check-uservm \
 	format-check-wasmd \
 	format-check-wasm-binaries
+
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+rust-format-check: format-check-host-binaries format-check-host-rlibs format-check-nanvixd format-check-uservm format-check-nanvix-bench
+endif
 
 # Python lint variables
 PY_VERBOSE :=
@@ -560,16 +563,15 @@ clang-format:
 
 check: \
 	check-kernel \
-	check-nanvixd \
-	check-nanvix-bench \
 	check-guest-binaries \
 	check-guest-rlibs \
 	check-guest-staticlibs \
 	check-wasmd \
-	check-wasm-binaries \
-	check-host-binaries \
-	check-host-rlibs \
-	check-uservm
+	check-wasm-binaries
+
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+check: check-host-binaries check-host-rlibs check-nanvixd check-uservm check-nanvix-bench
+endif
 
 #===================================================================================================
 # Build Rules for Running and Debugging
@@ -610,9 +612,11 @@ endif
 # Build Rules for Running Tests
 #===================================================================================================
 
-run-unit-tests: all-nanvix \
-	test-guest-rlibs \
-	test-host-rlibs
+run-unit-tests: all-nanvix test-guest-rlibs
+
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+run-unit-tests: test-host-rlibs
+endif
 
 include build/make/test.mk
 

--- a/build/make/generic-host-rlibs.mk
+++ b/build/make/generic-host-rlibs.mk
@@ -1,9 +1,20 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
+# Host rlibs that depend on uservm and require machine-specific features.
+USERVM_DEPENDENT_RLIBS := nanvix nanvix-sandbox nanvix-http nanvix-terminal nanvix-sandbox-cache
+
+# Machine-specific feature flags for host rlibs that depend on uservm.
+MACHINE_FEATURES :=
+MACHINE_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
+MACHINE_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
+MACHINE_FEATURES := $(strip $(MACHINE_FEATURES))
+MACHINE_CARGO_FEATURES := $(if $(MACHINE_FEATURES),--features "$(MACHINE_FEATURES)",)
+HOST_RLIBS_CARGO_FEATURES = $(if $(filter $(1),$(USERVM_DEPENDENT_RLIBS)),$(MACHINE_CARGO_FEATURES),)
+
 define HOST_RLIB_RULES
 check-host-rlib-$(1):
-	$(HOST_CARGO_CHECK_CMD) -p $(1)
+	$(HOST_CARGO_CHECK_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1)
 
 format-host-rlib-$(1):
 	$(HOST_CARGO_FMT_CMD) -p $(1)
@@ -12,13 +23,13 @@ format-check-host-rlib-$(1):
 	$(HOST_CARGO_FMT_CMD) -p $(1) --check
 
 rust-lint-host-rlib-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) -p $(1) --fix --allow-dirty
+	$(HOST_CARGO_CLIPPY_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1) --fix --allow-dirty
 
 rust-lint-check-host-rlib-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) -p $(1) -- -D warnings
+	$(HOST_CARGO_CLIPPY_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1) -- -D warnings
 
 test-host-rlib-$(1):
-	$(HOST_CARGO_TEST_CMD) -p $(1)
+	$(HOST_CARGO_TEST_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1)
 endef
 
 $(foreach target,$(ALL_HOST_RUST_LIBS),$(eval $(call HOST_RLIB_RULES,$(target))))

--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -4,6 +4,7 @@
 NANVIX_BENCH_FEATURES :=
 NANVIX_BENCH_FEATURES += $(if $(filter yes,$(SINGLE_PROCESS)),single-process,)
 NANVIX_BENCH_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
+NANVIX_BENCH_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIX_BENCH_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
 NANVIX_BENCH_FEATURES := $(strip $(NANVIX_BENCH_FEATURES))
 NANVIX_BENCH_CARGO_FEATURES := $(if $(NANVIX_BENCH_FEATURES),--features "$(NANVIX_BENCH_FEATURES)")

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -4,6 +4,7 @@
 NANVIXD_FEATURES :=
 NANVIXD_FEATURES += $(if $(filter yes,$(SINGLE_PROCESS)),single-process,)
 NANVIXD_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
+NANVIXD_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIXD_FEATURES := $(strip $(NANVIXD_FEATURES))
 NANVIXD_CARGO_FEATURES := $(if $(NANVIXD_FEATURES),--features "$(NANVIXD_FEATURES)")
 

--- a/build/make/uservm.mk
+++ b/build/make/uservm.mk
@@ -5,6 +5,7 @@ USERVM_FEATURES :=
 USERVM_FEATURES += $(if $(filter yes,$(PROFILER)),profiler,)
 USERVM_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
 USERVM_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
+USERVM_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 USERVM_FEATURES := $(strip $(USERVM_FEATURES))
 USERVM_CARGO_FEATURES := $(if $(USERVM_FEATURES),--features "$(USERVM_FEATURES)")
 

--- a/src/libs/nanvix-http/Cargo.toml
+++ b/src/libs/nanvix-http/Cargo.toml
@@ -30,7 +30,7 @@ uservm = { workspace = true }
 user-vm-api = { workspace = true }
 
 [features]
-default = []
+default = ["microvm"]
 single-process = [
     "linuxd",
     "nanvix-sandbox-cache/single-process",
@@ -41,6 +41,12 @@ hyperlight = [
     "uservm/hyperlight",
     "nanvix-sandbox-cache/hyperlight",
     "nanvix-terminal/hyperlight",
+]
+microvm = [
+    "config/microvm",
+    "uservm/microvm",
+    "nanvix-sandbox-cache/microvm",
+    "nanvix-terminal/microvm",
 ]
 
 [lints]

--- a/src/libs/nanvix-sandbox-cache/Cargo.toml
+++ b/src/libs/nanvix-sandbox-cache/Cargo.toml
@@ -19,8 +19,9 @@ syslog = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = []
+default = ["microvm"]
 hyperlight = ["config/hyperlight", "nanvix-sandbox/hyperlight"]
+microvm = ["config/microvm", "nanvix-sandbox/microvm"]
 single-process = ["nanvix-sandbox/single-process"]
 
 [lints]

--- a/src/libs/nanvix-sandbox/Cargo.toml
+++ b/src/libs/nanvix-sandbox/Cargo.toml
@@ -26,11 +26,12 @@ user-vm-api = { workspace = true }
 uservm = { workspace = true }
 
 [features]
-default = []
+default = ["microvm"]
 # If enabled this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) are embedded
 # into the sandbox.
 single-process = []
 hyperlight = ["config/hyperlight", "uservm/hyperlight"]
+microvm = ["config/microvm", "uservm/microvm"]
 
 [lints]
 workspace = true

--- a/src/libs/nanvix-terminal/Cargo.toml
+++ b/src/libs/nanvix-terminal/Cargo.toml
@@ -19,8 +19,9 @@ tokio = { workspace = true, features = ["full"] }
 user-vm-api = { workspace = true }
 
 [features]
-default = []
+default = ["microvm"]
 hyperlight = ["nanvix-sandbox-cache/hyperlight"]
+microvm = ["nanvix-sandbox-cache/microvm"]
 single-process = ["nanvix-sandbox-cache/single-process"]
 
 [lints]

--- a/src/libs/nanvix/Cargo.toml
+++ b/src/libs/nanvix/Cargo.toml
@@ -27,7 +27,7 @@ syslog = { workspace = true, features = ["std"] }
 uservm = { workspace = true, optional = true }
 
 [features]
-default = []
+default = ["microvm"]
 internal-api = ["sys", "syscall", "uservm"]
 single-process = [
     "linuxd",
@@ -43,6 +43,14 @@ hyperlight = [
     "nanvix-sandbox-cache/hyperlight",
     "nanvix-terminal/hyperlight",
     "uservm/hyperlight",
+]
+microvm = [
+    "config/microvm",
+    "nanvix-http/microvm",
+    "nanvix-sandbox/microvm",
+    "nanvix-sandbox-cache/microvm",
+    "nanvix-terminal/microvm",
+    "uservm/microvm",
 ]
 
 [lints]

--- a/src/uservm/Cargo.toml
+++ b/src/uservm/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = { workspace = true }
 arch = { workspace = true, features = ["cpuid"] }
 bincode = { workspace = true, features = ["serde"] }
 cfg-if = { workspace = true }
-config = { workspace = true, features = ["microvm"] }
+config = { workspace = true }
 control-plane-api = { workspace = true }
 hyperlight-host = { workspace = true, optional = true }
 profiler = { workspace = true, features = ["auto-calibrate"] }
@@ -42,8 +42,9 @@ kvm-ioctls = { workspace = true }
 libc = { workspace = true }
 
 [features]
-default = []
+default = ["microvm"]
 hyperlight = ["dep:hyperlight-host", "config/hyperlight"]
+microvm = ["config/microvm"]
 timestamp-messages = ["profiler/timestamp-messages"]
 
 [lints]

--- a/src/uservm/src/vmm/mod.rs
+++ b/src/uservm/src/vmm/mod.rs
@@ -19,9 +19,11 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "hyperlight")] {
         mod hyperlight;
         pub use hyperlight::*;
-    } else {
+    } else if #[cfg(feature = "microvm")] {
         mod microvm;
         pub use microvm::*;
+    } else {
+        compile_error!("No machine feature enabled for uservm. Please enable either 'hyperlight' or 'microvm'");
     }
 }
 

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -23,10 +23,11 @@ serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = []
+default = ["microvm"]
 timestamp-messages = ["profiler/timestamp-messages"]
 single-process = ["nanvix/single-process"]
 hyperlight = ["nanvix/hyperlight"]
+microvm = ["nanvix/microvm"]
 
 [lints]
 workspace = true

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -19,11 +19,12 @@ serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = []
+default = ["microvm"]
 # If enabled this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) are embedded
 # into Nanvix Daemon (nanvixd).
 single-process = ["nanvix/single-process"]
 hyperlight = ["nanvix/hyperlight"]
+microvm = ["nanvix/microvm"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
This pull request introduces improved support for the `microvm` machine type across the build system and Rust crates, making `microvm` the default feature for several host-side libraries and utilities. The changes ensure that build rules, feature flags, and dependencies are correctly set when targeting either `microvm` or `hyperlight`, and that the build system only includes relevant binaries and checks for these targets.

**Build System Improvements:**

* The `Makefile` now conditionally includes host binaries, daemons, utilities, and related build, clean, lint, format, and test rules only when the `MACHINE` is set to `microvm` or `hyperlight`. This avoids unnecessary builds for other machine types. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R306-R316) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L325-R337) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L347-R362) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L452-R480) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L502-R527) [[6]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L563-R574) [[7]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L613-R619)

* The build system now passes machine-specific feature flags (`microvm`, `hyperlight`) to host Rust libraries that depend on `uservm`, ensuring correct conditional compilation. [[1]](diffhunk://#diff-56b5460ed196046bab3bc8f3036a0926f84b20ac09fe893b7e34e07ef2ff92efR4-R17) [[2]](diffhunk://#diff-56b5460ed196046bab3bc8f3036a0926f84b20ac09fe893b7e34e07ef2ff92efL15-R32)

* The `nanvix-bench.mk`, `nanvixd.mk`, and `uservm.mk` makefiles are updated to add `microvm` as a feature flag when building for the `microvm` machine. [[1]](diffhunk://#diff-d7ae164e20fb717bd169817ea5a57a85c2f2045caceff42add6d315cf21bc577R7) [[2]](diffhunk://#diff-28dbb1490ca7d99373f640c976b8adbb86085547204d62a24ad0c7463ef20194R7) [[3]](diffhunk://#diff-6c7fe4970416ffb042c5c15a7ca82378ddcf3dcf539527fead033ed66a830aabR8)

**Rust Crate Feature Management:**

* The default feature for several host-side crates (`nanvix`, `nanvix-http`, `nanvix-sandbox`, `nanvix-sandbox-cache`, `nanvix-terminal`, `uservm`, `nanvix-bench`, `nanvixd`) is now `microvm`, ensuring that builds target `microvm` by default unless overridden. New `microvm` features are also defined and propagate to dependencies as needed. [[1]](diffhunk://#diff-00074bb7dcef026adcc297dc5598a0806498b034e6a09471319de986cf56b49dL33-R33) [[2]](diffhunk://#diff-00074bb7dcef026adcc297dc5598a0806498b034e6a09471319de986cf56b49dR45-R50) [[3]](diffhunk://#diff-fa1a5365080b644e4b0283c72fcc62bfd819bd4c3894cad059b7f9de3a300afcL22-R24) [[4]](diffhunk://#diff-592fc5d9071b0856e8038038b9b48265e05866848fff357a771a19385dfbfabeL29-R34) [[5]](diffhunk://#diff-dd3fa3e0face263ec249aae728b749edaad88f29d3368958b49992b2e7025c90L22-R24) [[6]](diffhunk://#diff-94f905b3be5343adfff7b60feb98a2bb20d2d7fc05ffb4c348fe5552571c0a16L30-R30) [[7]](diffhunk://#diff-94f905b3be5343adfff7b60feb98a2bb20d2d7fc05ffb4c348fe5552571c0a16R47-R54) [[8]](diffhunk://#diff-37d251faf22dbc52d3cd585c2755b722d8cba0abc2b20b5eb39dc9793d7a68b0L25-R25) [[9]](diffhunk://#diff-37d251faf22dbc52d3cd585c2755b722d8cba0abc2b20b5eb39dc9793d7a68b0L45-R47) [[10]](diffhunk://#diff-007451d36037394710392dd3001751fc278b1664e8999248ea04f32f64c4385eL26-R30) [[11]](diffhunk://#diff-70d9f8c53230dcd2f3827254f3c813590074e072224f4fd6986ab1b61c275d1fL22-R27)

* The `uservm` crate now emits a compile error if neither the `hyperlight` nor `microvm` feature is enabled, preventing unsupported configurations.

These changes collectively improve the developer experience and correctness when building and testing for the `microvm` or `hyperlight` platforms, and ensure that feature flags are consistently applied throughout the codebase.