### PR TITLE
[nanvix-registry] Support Multiple Versions

### DIFF
--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -6,16 +6,20 @@
 //!
 //! The `nanvix-registry` library provides functionality for managing a local cache of Nanvix
 //! release binaries downloaded from GitHub releases. It automatically downloads, extracts, and
-//! caches binaries for different deployment types and target machines.
+//! caches binaries for different deployment types and target machines, supporting multiple
+//! versions to coexist simultaneously.
 //!
 //! # Features
 //!
 //! - Downloads latest Nanvix releases from GitHub.
 //! - Caches binaries locally in the user's cache directory.
+//! - Organizes cached artifacts by commit ID in subdirectories following the pattern `<machine>-<deployment>-<commit_id>`.
 //! - Supports multiple deployment types (`single-process`, `multi-process`).
 //! - Supports multiple target machines (`hyperlight`, `microvm`).
 //! - Automatic tarball extraction (supports `.tar.bz2` format).
 //! - Cache management (automatic reuse and manual clearing).
+//! - Tracks latest downloaded artifacts via release registry.
+//! - Allows multiple versions of each machine-deployment configuration to coexist.
 //!
 //! # Usage
 //!
@@ -70,22 +74,38 @@
 //!
 //! - `deployment`: Defines deployment types (`SingleProcess`, `MultiProcess`).
 //! - `machine`: Defines target machine types (`Hyperlight`, `microvm`).
+//! - `metadata`: Manages release registry tracking multiple machine-deployment configurations.
 //! - `release`: Handles fetching and downloading releases from GitHub API.
 //! - `tarball`: Provides tarball extraction functionality.
 //! - `tempfile`: Manages temporary files with automatic cleanup.
 //!
 //! # Cache Location
 //!
-//! By default, binaries are cached in the user's cache directory under `nanvix-registry/`.
+//! Binaries are cached in the user's cache directory under
+//! `nanvix-registry/<machine>-<deployment>-<commit_id>/bin/`.
 //! The exact location depends on the operating system:
 //!
-//! - Linux: `~/.cache/nanvix-registry/`
-//! - macOS: `~/Library/Caches/nanvix-registry/`
-//! - Windows: `%LOCALAPPDATA%\nanvix-registry\`
+//! - Linux: `~/.cache/nanvix-registry/<machine>-<deployment>-<commit_id>/bin/`
+//! - macOS: `~/Library/Caches/nanvix-registry/<machine>-<deployment>-<commit_id>/bin/`
+//! - Windows: `%LOCALAPPDATA%\nanvix-registry\<machine>-<deployment>-<commit_id>\bin\`
 //!
 //! A custom cache directory can be specified when creating a `Registry` instance by passing
 //! a `PathBuf` to `Registry::new()`. This is useful for testing or when you need to isolate
 //! the cache from the default location.
+//!
+//! # Metadata
+//!
+//! The registry maintains a `release-metadata.json` file in the cache directory root that tracks
+//! multiple machine-deployment configurations. Each entry in the registry contains:
+//! - The URL of the release tarball.
+//! - The commit ID of the downloaded artifacts.
+//!
+//! The key format is `<machine>-<deployment>` (e.g., "microvm-single-process"), and multiple
+//! versions can coexist in separate subdirectories. The registry tracks the most recent commit ID
+//! for each configuration, enabling the library to:
+//! - Detect when new releases are available for specific configurations.
+//! - Automatically download new releases while preserving older versions.
+//! - Support side-by-side deployment of different machine-deployment combinations.
 
 //==================================================================================================
 // Lint Configuration
@@ -133,7 +153,7 @@ pub use crate::{
 //==================================================================================================
 
 use crate::{
-    metadata::ReleaseMetadata,
+    metadata::ReleaseRegistry,
     release::LatestRelease,
 };
 use ::anyhow::Result;
@@ -375,52 +395,88 @@ impl Registry {
         // Get the latest release URL.
         let latest_url: String = release.get_url().await?;
 
-        // Check if we have cached metadata.
-        let metadata_exists: bool = ReleaseMetadata::exists(&cache_dir).await;
+        // Extract commit ID from URL (format: .../release-<commit_id>.tar.bz2).
+        let commit_id: String = match Self::extract_commit_id(&latest_url) {
+            Some(id) => {
+                debug!("Extracted commit ID from URL: {}", id);
+                id
+            },
+            None => {
+                let reason: String =
+                    format!("Failed to extract commit ID from URL: {}", latest_url);
+                error!("{reason}");
+                anyhow::bail!(reason);
+            },
+        };
 
-        let needs_download: bool = if metadata_exists {
-            // Load cached metadata and compare URLs.
-            match ReleaseMetadata::load(&cache_dir).await {
-                Ok(cached_metadata) => {
-                    if cached_metadata.url != latest_url {
-                        info!(
-                            "New release detected (cached: {}, latest: {})",
-                            cached_metadata.url, latest_url
-                        );
-                        info!("Clearing old cache...");
-                        // Clear the cache to download the new release.
-                        self.clear_cache().await?;
-                        true
-                    } else {
-                        debug!("Using cached release: {}", cached_metadata.url);
-                        false
-                    }
-                },
-                Err(_) => {
-                    // Failed to load metadata, download fresh.
-                    info!("Failed to load metadata, downloading fresh release...");
-                    true
+        // Construct the subdirectory name: <machine>-<deployment>-<commit_id>.
+        let subdir_name: String = format!("{}-{}-{}", machine, deployment, commit_id);
+        let artifact_cache_dir: PathBuf = cache_dir.join(&subdir_name);
+
+        // Load or create the release registry.
+        let mut registry: ReleaseRegistry = if ReleaseRegistry::exists(&cache_dir).await {
+            match ReleaseRegistry::load(&cache_dir).await {
+                Ok(reg) => reg,
+                Err(error) => {
+                    let reason: String = format!("Failed to load registry: {error}");
+                    error!("{reason}");
+                    anyhow::bail!(reason)
                 },
             }
         } else {
-            // No metadata, need to download.
-            info!("Release not cached, downloading latest release...");
-            true
+            // No registry exists, create a new one.
+            info!("Creating a new registry...");
+            ReleaseRegistry::new()
         };
 
-        if needs_download {
-            // Download and extract the release.
-            let downloaded_url: String = release.download(&cache_dir).await?;
+        // Check if we need to download this specific configuration.
+        let needs_download: bool =
+            if let Some(cached_entry) = registry.get_release(machine, deployment) {
+                if cached_entry.commit_id() != commit_id.as_str() {
+                    info!(
+                        "New release detected for {}-{} (cached: {}, latest: {})",
+                        machine,
+                        deployment,
+                        cached_entry.commit_id(),
+                        commit_id
+                    );
+                    true
+                } else {
+                    debug!(
+                        "Using cached release for {}-{}: {}",
+                        machine,
+                        deployment,
+                        cached_entry.commit_id()
+                    );
+                    false
+                }
+            } else {
+                // Configuration not in registry, need to download.
+                info!("Configuration {}-{} not cached, downloading...", machine, deployment);
+                true
+            };
 
-            // Save the release metadata.
-            let metadata: ReleaseMetadata = ReleaseMetadata::new(downloaded_url);
-            metadata.save(&cache_dir).await?;
+        if needs_download {
+            // Create the artifact cache directory.
+            if let Err(error) = fs::create_dir_all(&artifact_cache_dir).await {
+                let reason: String =
+                    format!("Failed to create artifact cache directory: {}", error);
+                error!("{reason}");
+                anyhow::bail!(reason);
+            }
+
+            // Download and extract the release.
+            let downloaded_url: String = release.download(&artifact_cache_dir).await?;
+
+            // Update the registry with the new release.
+            registry.set_release(machine, deployment, downloaded_url, commit_id);
+            registry.save(&cache_dir).await?;
         }
 
         // Now search for the artifact in the specified directory.
         let search_dir: PathBuf = match dir {
-            Some(custom_dir) => cache_dir.join(custom_dir),
-            None => cache_dir.clone(),
+            Some(custom_dir) => artifact_cache_dir.join(custom_dir),
+            None => artifact_cache_dir.clone(),
         };
         match Self::search_artifact(search_dir, artifact_name.to_string()).await {
             Some(artifact_path) => {
@@ -433,6 +489,50 @@ impl Registry {
                 error!("{reason}");
                 anyhow::bail!(reason);
             },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Extracts the build identifier from a GitHub release URL.
+    ///
+    /// The build identifier is a numeric value (such as a workflow run ID or timestamp) encoded in
+    /// the release filename. It uniquely identifies a specific build of Nanvix artifacts.
+    ///
+    /// Example URL format:
+    /// `https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-19417333438.tar.bz2`
+    ///
+    /// This method parses the filename to extract the numeric identifier between "release-" and
+    /// the file extension (e.g., `19417333438` from the example above).
+    ///
+    /// # Parameters
+    ///
+    /// - `url`: The GitHub release URL containing the build identifier.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<String>` containing the build identifier if found, or `None` if the URL format
+    /// is invalid.
+    ///
+    fn extract_commit_id(url: &str) -> Option<String> {
+        // Extract the filename from the URL.
+        let filename: &str = url.rsplit('/').next()?;
+
+        // Find "release-" prefix.
+        let release_prefix: &str = "release-";
+        let start_idx: usize = filename.find(release_prefix)? + release_prefix.len();
+
+        // Find the first dot after "release-" to identify start of file extension.
+        let remaining: &str = &filename[start_idx..];
+        let end_idx: usize = start_idx + remaining.find('.')?;
+
+        // Extract and validate the commit ID.
+        if start_idx < end_idx {
+            let commit_id: &str = &filename[start_idx..end_idx];
+            Some(commit_id.to_string())
+        } else {
+            None
         }
     }
 
@@ -532,8 +632,8 @@ impl Registry {
     pub async fn clear_cache(&self) -> Result<()> {
         let cache_dir: PathBuf = self.get_cache_dir().await?;
         if fs::metadata(&cache_dir).await.is_ok() {
-            // Delete metadata first.
-            ReleaseMetadata::delete(&cache_dir).await?;
+            // Delete registry first.
+            ReleaseRegistry::delete(&cache_dir).await?;
             // Then remove the entire cache directory.
             if let Err(error) = fs::remove_dir_all(&cache_dir).await {
                 let reason: String = format!("Failed to clear cache: {error}");
@@ -917,5 +1017,47 @@ mod tests {
 
         // Clean up.
         let _ = fs::remove_dir_all(&temp_dir).await;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests commit ID extraction from GitHub release URLs.
+    ///
+    #[test]
+    fn test_extract_commit_id() {
+        // Test valid URL with commit ID.
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-19417333438.tar.bz2";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_some());
+        assert_eq!(commit_id.unwrap(), "19417333438");
+
+        // Test another valid URL format.
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-microvm-single-process-release-12345678.tar.bz2";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_some());
+        assert_eq!(commit_id.unwrap(), "12345678");
+
+        // Test URL without release prefix.
+        let url: &str =
+            "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-12345678.tar.bz2";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_none());
+
+        // Test URL without file extension.
+        let url: &str =
+            "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-release-12345678";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_none());
+
+        // Test empty string.
+        let url: &str = "";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_none());
+
+        // Test malformed URL.
+        let url: &str = "not-a-valid-url";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_none());
     }
 }

--- a/src/libs/nanvix-registry/src/metadata.rs
+++ b/src/libs/nanvix-registry/src/metadata.rs
@@ -5,14 +5,21 @@
 // Imports
 //==================================================================================================
 
+use crate::{
+    deployment::Deployment,
+    machine::Machine,
+};
 use ::anyhow::Result;
 use ::serde::{
     Deserialize,
     Serialize,
 };
-use ::std::path::{
-    Path,
-    PathBuf,
+use ::std::{
+    collections::HashMap,
+    path::{
+        Path,
+        PathBuf,
+    },
 };
 use ::syslog::{
     debug,
@@ -35,40 +42,178 @@ const METADATA_FILE_NAME: &str = "release-metadata.json";
 ///
 /// # Description
 ///
-/// Metadata about a cached release.
+/// Metadata about a cached release for a specific machine-deployment configuration.
 ///
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct ReleaseMetadata {
+pub(crate) struct ReleaseEntry {
     /// URL of the release tarball.
-    pub(crate) url: String,
+    url: String,
+    /// Commit ID extracted from the release URL.
+    commit_id: String,
+}
+
+///
+/// # Description
+///
+/// Registry metadata tracking multiple machine-deployment configurations.
+///
+/// This structure maintains a map where keys are in the format "<machine>-<deployment>"
+/// and values are `ReleaseEntry` instances containing the URL and commit ID of the
+/// most recent release for that configuration.
+///
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(crate) struct ReleaseRegistry {
+    /// Map of machine-deployment configurations to their release entries.
+    /// Key format: "<machine>-<deployment>" (e.g., "microvm-single-process").
+    releases: HashMap<String, ReleaseEntry>,
 }
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl ReleaseMetadata {
+impl ReleaseEntry {
     ///
     /// # Description
     ///
-    /// Creates a new release metadata instance.
+    /// Creates a new release entry instance.
     ///
     /// # Parameters
     ///
     /// - `url`: The URL of the release tarball.
+    /// - `commit_id`: The commit ID extracted from the release URL.
     ///
     /// # Returns
     ///
-    /// A new `ReleaseMetadata` instance.
+    /// A new `ReleaseEntry` instance.
     ///
-    pub(crate) fn new(url: String) -> Self {
-        Self { url }
+    pub(crate) fn new(url: String, commit_id: String) -> Self {
+        Self { url, commit_id }
     }
 
     ///
     /// # Description
     ///
-    /// Saves the release metadata to a file in the specified directory.
+    /// Returns the commit ID extracted from the release URL.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the commit ID string.
+    ///
+    pub(crate) fn commit_id(&self) -> &str {
+        &self.commit_id
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the URL of the release tarball.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the URL string.
+    ///
+    #[cfg(test)]
+    pub(crate) fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+impl ReleaseRegistry {
+    ///
+    /// # Description
+    ///
+    /// Creates a new empty release registry.
+    ///
+    /// # Returns
+    ///
+    /// A new `ReleaseRegistry` instance.
+    ///
+    pub(crate) fn new() -> Self {
+        Self {
+            releases: HashMap::new(),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Adds or updates a release entry for a specific machine-deployment configuration.
+    ///
+    /// # Parameters
+    ///
+    /// - `machine`: The target machine type.
+    /// - `deployment`: The deployment type.
+    /// - `url`: The URL of the release tarball.
+    /// - `commit_id`: The commit ID extracted from the release URL.
+    ///
+    pub(crate) fn set_release(
+        &mut self,
+        machine: Machine,
+        deployment: Deployment,
+        url: String,
+        commit_id: String,
+    ) {
+        let key: String = format!("{}-{}", machine, deployment);
+        let entry: ReleaseEntry = ReleaseEntry::new(url, commit_id);
+        self.releases.insert(key, entry);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets the release entry for a specific machine-deployment configuration.
+    ///
+    /// # Parameters
+    ///
+    /// - `machine`: The target machine type.
+    /// - `deployment`: The deployment type.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<&ReleaseEntry>` containing the release entry if found, or `None` otherwise.
+    ///
+    pub(crate) fn get_release(
+        &self,
+        machine: Machine,
+        deployment: Deployment,
+    ) -> Option<&ReleaseEntry> {
+        let key: String = format!("{}-{}", machine, deployment);
+        self.releases.get(&key)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the number of release entries in the registry.
+    ///
+    /// # Returns
+    ///
+    /// The number of release entries.
+    ///
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.releases.len()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks if the registry is empty.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the registry contains no entries, `false` otherwise.
+    ///
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.releases.is_empty()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Saves the release registry to a file in the specified directory.
     ///
     /// # Parameters
     ///
@@ -84,26 +229,26 @@ impl ReleaseMetadata {
         let json: String = match serde_json::to_string_pretty(self) {
             Ok(json) => json,
             Err(error) => {
-                let reason: String = format!("Failed to serialize metadata: {}", error);
+                let reason: String = format!("Failed to serialize registry: {}", error);
                 error!("{reason}");
                 anyhow::bail!(reason)
             },
         };
 
         if let Err(error) = fs::write(&metadata_path, json).await {
-            let reason: String = format!("Failed to write metadata file: {}", error);
+            let reason: String = format!("Failed to write registry file: {}", error);
             error!("{reason}");
             anyhow::bail!(reason)
         }
 
-        debug!("Saved release metadata to: {:?}", metadata_path);
+        debug!("Saved release registry to: {:?}", metadata_path);
         Ok(())
     }
 
     ///
     /// # Description
     ///
-    /// Loads release metadata from a file in the specified directory.
+    /// Loads release registry from a file in the specified directory.
     ///
     /// # Parameters
     ///
@@ -111,7 +256,7 @@ impl ReleaseMetadata {
     ///
     /// # Returns
     ///
-    /// On success, this function returns the loaded `ReleaseMetadata`. On failure, it returns an
+    /// On success, this function returns the loaded `ReleaseRegistry`. On failure, it returns an
     /// object that describes the error.
     ///
     pub(crate) async fn load(cache_dir: &Path) -> Result<Self> {
@@ -119,31 +264,33 @@ impl ReleaseMetadata {
 
         // Check if metadata file exists.
         if fs::metadata(&metadata_path).await.is_err() {
-            let reason: String = "Metadata file not found".to_string();
+            let reason: String = "Registry file not found".to_string();
             debug!("{reason}");
             anyhow::bail!(reason)
         }
 
+        // Read metadata file.
         let json: String = match fs::read_to_string(&metadata_path).await {
             Ok(content) => content,
             Err(error) => {
-                let reason: String = format!("Failed to read metadata file: {}", error);
+                let reason: String = format!("Failed to read registry file: {}", error);
                 error!("{reason}");
                 anyhow::bail!(reason)
             },
         };
 
-        let metadata: ReleaseMetadata = match serde_json::from_str(&json) {
-            Ok(metadata) => metadata,
+        // Deserialize registry.
+        let registry: ReleaseRegistry = match serde_json::from_str(&json) {
+            Ok(registry) => registry,
             Err(error) => {
-                let reason: String = format!("Failed to deserialize metadata: {}", error);
+                let reason: String = format!("Failed to deserialize registry: {}", error);
                 error!("{reason}");
                 anyhow::bail!(reason)
             },
         };
 
-        debug!("Loaded release metadata from: {:?}", metadata_path);
-        Ok(metadata)
+        debug!("Loaded release registry from: {:?}", metadata_path);
+        Ok(registry)
     }
 
     ///
@@ -206,67 +353,230 @@ mod tests {
     ///
     /// # Description
     ///
-    /// Tests metadata creation.
+    /// Tests release entry creation.
     ///
     #[test]
-    fn test_new() {
+    fn test_entry_new() {
         let url: String = "https://github.com/test/release.tar.bz2".to_string();
-        let metadata: ReleaseMetadata = ReleaseMetadata::new(url.clone());
-        assert_eq!(metadata.url, url);
+        let commit_id: String = "12345678".to_string();
+        let entry: ReleaseEntry = ReleaseEntry::new(url.clone(), commit_id.clone());
+        assert_eq!(entry.url(), url);
+        assert_eq!(entry.commit_id(), commit_id);
     }
 
     ///
     /// # Description
     ///
-    /// Tests metadata serialization to JSON.
+    /// Tests registry creation.
+    ///
+    #[test]
+    fn test_registry_new() {
+        let registry: ReleaseRegistry = ReleaseRegistry::new();
+        assert!(registry.is_empty());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests setting and getting release entries.
+    ///
+    #[test]
+    fn test_set_and_get_release() {
+        let mut registry: ReleaseRegistry = ReleaseRegistry::new();
+
+        let url: String = "https://test.com/file.tar.bz2".to_string();
+        let commit_id: String = "12345678".to_string();
+
+        // Set a release.
+        registry.set_release(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            url.clone(),
+            commit_id.clone(),
+        );
+
+        // Get the release.
+        let entry: Option<&ReleaseEntry> =
+            registry.get_release(Machine::Microvm, Deployment::SingleProcess);
+        assert!(entry.is_some());
+
+        let entry: &ReleaseEntry = entry.unwrap();
+        assert_eq!(entry.url(), url);
+        assert_eq!(entry.commit_id(), commit_id);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests multiple configurations in registry.
+    ///
+    #[test]
+    fn test_multiple_configurations() {
+        let mut registry: ReleaseRegistry = ReleaseRegistry::new();
+
+        // Add multiple configurations.
+        registry.set_release(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            "https://test.com/microvm-sp.tar.bz2".to_string(),
+            "11111111".to_string(),
+        );
+
+        registry.set_release(
+            Machine::Microvm,
+            Deployment::MultiProcess,
+            "https://test.com/microvm-mp.tar.bz2".to_string(),
+            "22222222".to_string(),
+        );
+
+        registry.set_release(
+            Machine::Hyperlight,
+            Deployment::SingleProcess,
+            "https://test.com/hyperlight-sp.tar.bz2".to_string(),
+            "33333333".to_string(),
+        );
+
+        // The number of entries is checked indirectly by verifying each entry exists below.
+        assert_eq!(registry.len(), 3);
+
+        // Verify each entry.
+        let entry: &ReleaseEntry = registry
+            .get_release(Machine::Microvm, Deployment::SingleProcess)
+            .unwrap();
+        assert_eq!(entry.commit_id(), "11111111");
+
+        let entry: &ReleaseEntry = registry
+            .get_release(Machine::Microvm, Deployment::MultiProcess)
+            .unwrap();
+        assert_eq!(entry.commit_id(), "22222222");
+
+        let entry: &ReleaseEntry = registry
+            .get_release(Machine::Hyperlight, Deployment::SingleProcess)
+            .unwrap();
+        assert_eq!(entry.commit_id(), "33333333");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests updating an existing configuration.
+    ///
+    #[test]
+    fn test_update_existing_configuration() {
+        let mut registry: ReleaseRegistry = ReleaseRegistry::new();
+
+        // Add initial release.
+        registry.set_release(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            "https://test.com/old.tar.bz2".to_string(),
+            "11111111".to_string(),
+        );
+
+        assert_eq!(registry.len(), 1);
+
+        // Update with new release.
+        registry.set_release(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            "https://test.com/new.tar.bz2".to_string(),
+            "22222222".to_string(),
+        );
+
+        // Should still have one entry, but updated.
+        assert_eq!(registry.len(), 1);
+
+        let entry: &ReleaseEntry = registry
+            .get_release(Machine::Microvm, Deployment::SingleProcess)
+            .unwrap();
+        assert_eq!(entry.url(), "https://test.com/new.tar.bz2");
+        assert_eq!(entry.commit_id(), "22222222");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests registry serialization to JSON.
     ///
     #[test]
     fn test_serialization() {
-        let metadata: ReleaseMetadata = ReleaseMetadata {
-            url: "https://example.com/release.tar.bz2".to_string(),
-        };
+        let mut registry: ReleaseRegistry = ReleaseRegistry::new();
+        registry.set_release(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            "https://example.com/release.tar.bz2".to_string(),
+            "12345678".to_string(),
+        );
 
-        let json: String = serde_json::to_string(&metadata).unwrap();
-        assert!(json.contains("url"));
+        let json: String = serde_json::to_string(&registry).unwrap();
+        assert!(json.contains("releases"));
+        assert!(json.contains("microvm-single-process"));
         assert!(json.contains("https://example.com/release.tar.bz2"));
+        assert!(json.contains("12345678"));
     }
 
     ///
     /// # Description
     ///
-    /// Tests metadata deserialization from JSON.
+    /// Tests registry deserialization from JSON.
     ///
     #[test]
     fn test_deserialization() {
-        let json: &str = r#"{"url":"https://example.com/release.tar.bz2"}"#;
-        let metadata: ReleaseMetadata = serde_json::from_str(json).unwrap();
-        assert_eq!(metadata.url, "https://example.com/release.tar.bz2");
+        let json: &str = r#"{"releases":{"microvm-single-process":{"url":"https://example.com/release.tar.bz2","commit_id":"12345678"}}}"#;
+        let registry: ReleaseRegistry = serde_json::from_str(json).unwrap();
+
+        let entry: &ReleaseEntry = registry
+            .get_release(Machine::Microvm, Deployment::SingleProcess)
+            .unwrap();
+        assert_eq!(entry.url(), "https://example.com/release.tar.bz2");
+        assert_eq!(entry.commit_id(), "12345678");
     }
 
     ///
     /// # Description
     ///
-    /// Tests metadata save and load roundtrip.
+    /// Tests registry save and load roundtrip.
     ///
     #[tokio::test]
     async fn test_save_and_load() {
-        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-metadata-save-load");
+        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-registry-save-load");
         let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
         let _: Result<(), std::io::Error> = fs::create_dir_all(&temp_dir).await;
 
-        let original: ReleaseMetadata =
-            ReleaseMetadata::new("https://test.com/file.tar.bz2".to_string());
+        let mut original: ReleaseRegistry = ReleaseRegistry::new();
+        original.set_release(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            "https://test.com/file1.tar.bz2".to_string(),
+            "11111111".to_string(),
+        );
+        original.set_release(
+            Machine::Hyperlight,
+            Deployment::MultiProcess,
+            "https://test.com/file2.tar.bz2".to_string(),
+            "22222222".to_string(),
+        );
 
-        // Save metadata.
+        // Save registry.
         let save_result: Result<()> = original.save(&temp_dir).await;
         assert!(save_result.is_ok());
 
-        // Load metadata.
-        let load_result: Result<ReleaseMetadata> = ReleaseMetadata::load(&temp_dir).await;
+        // Load registry.
+        let load_result: Result<ReleaseRegistry> = ReleaseRegistry::load(&temp_dir).await;
         assert!(load_result.is_ok());
 
-        let loaded: ReleaseMetadata = load_result.unwrap();
-        assert_eq!(original.url, loaded.url);
+        let loaded: ReleaseRegistry = load_result.unwrap();
+        assert_eq!(loaded.len(), 2);
+
+        let entry: &ReleaseEntry = loaded
+            .get_release(Machine::Microvm, Deployment::SingleProcess)
+            .unwrap();
+        assert_eq!(entry.commit_id(), "11111111");
+
+        let entry: &ReleaseEntry = loaded
+            .get_release(Machine::Hyperlight, Deployment::MultiProcess)
+            .unwrap();
+        assert_eq!(entry.commit_id(), "22222222");
 
         // Cleanup.
         let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
@@ -275,33 +585,38 @@ mod tests {
     ///
     /// # Description
     ///
-    /// Tests that exists returns false when metadata doesn't exist.
+    /// Tests that exists returns false when registry doesn't exist.
     ///
     #[tokio::test]
     async fn test_exists_false() {
-        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-metadata-nonexistent");
+        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-registry-nonexistent");
         let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
 
-        let exists: bool = ReleaseMetadata::exists(&temp_dir).await;
+        let exists: bool = ReleaseRegistry::exists(&temp_dir).await;
         assert!(!exists);
     }
 
     ///
     /// # Description
     ///
-    /// Tests that exists returns true when metadata exists.
+    /// Tests that exists returns true when registry exists.
     ///
     #[tokio::test]
     async fn test_exists_true() {
-        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-metadata-exists");
+        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-registry-exists");
         let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
         let _: Result<(), std::io::Error> = fs::create_dir_all(&temp_dir).await;
 
-        let metadata: ReleaseMetadata =
-            ReleaseMetadata::new("https://test.com/file.tar.bz2".to_string());
-        let _: Result<()> = metadata.save(&temp_dir).await;
+        let mut registry: ReleaseRegistry = ReleaseRegistry::new();
+        registry.set_release(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            "https://test.com/file.tar.bz2".to_string(),
+            "12345678".to_string(),
+        );
+        let _: Result<()> = registry.save(&temp_dir).await;
 
-        let exists: bool = ReleaseMetadata::exists(&temp_dir).await;
+        let exists: bool = ReleaseRegistry::exists(&temp_dir).await;
         assert!(exists);
 
         // Cleanup.
@@ -311,24 +626,29 @@ mod tests {
     ///
     /// # Description
     ///
-    /// Tests metadata deletion.
+    /// Tests registry deletion.
     ///
     #[tokio::test]
     async fn test_delete() {
-        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-metadata-delete");
+        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-registry-delete");
         let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
         let _: Result<(), std::io::Error> = fs::create_dir_all(&temp_dir).await;
 
-        let metadata: ReleaseMetadata =
-            ReleaseMetadata::new("https://test.com/file.tar.bz2".to_string());
-        let _: Result<()> = metadata.save(&temp_dir).await;
+        let mut registry: ReleaseRegistry = ReleaseRegistry::new();
+        registry.set_release(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            "https://test.com/file.tar.bz2".to_string(),
+            "12345678".to_string(),
+        );
+        let _: Result<()> = registry.save(&temp_dir).await;
 
-        assert!(ReleaseMetadata::exists(&temp_dir).await);
+        assert!(ReleaseRegistry::exists(&temp_dir).await);
 
-        let delete_result: Result<()> = ReleaseMetadata::delete(&temp_dir).await;
+        let delete_result: Result<()> = ReleaseRegistry::delete(&temp_dir).await;
         assert!(delete_result.is_ok());
 
-        assert!(!ReleaseMetadata::exists(&temp_dir).await);
+        assert!(!ReleaseRegistry::exists(&temp_dir).await);
 
         // Cleanup.
         let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
@@ -337,14 +657,14 @@ mod tests {
     ///
     /// # Description
     ///
-    /// Tests loading non-existent metadata returns error.
+    /// Tests loading non-existent registry returns error.
     ///
     #[tokio::test]
     async fn test_load_nonexistent() {
-        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-metadata-load-nonexistent");
+        let temp_dir: PathBuf = env::temp_dir().join("nanvix-test-registry-load-nonexistent");
         let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
 
-        let result: Result<ReleaseMetadata> = ReleaseMetadata::load(&temp_dir).await;
+        let result: Result<ReleaseRegistry> = ReleaseRegistry::load(&temp_dir).await;
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
This pull request significantly enhances the `nanvix-registry` library to support simultaneous caching and management of multiple Nanvix release versions for different machine-deployment configurations. The changes introduce a release registry system that organizes cached binaries by commit ID, improves cache management, and enables side-by-side deployment of different versions. Additionally, a utility for extracting commit IDs from release URLs is added, along with comprehensive tests for this functionality.

**Registry and Metadata Management Improvements**
* Introduced a new `ReleaseRegistry` system that tracks multiple machine-deployment configurations, allowing multiple versions to coexist and improving detection and management of new releases. This replaces the previous single-metadata approach and updates all related logic to use the new registry structure. (`src/libs/nanvix-registry/src/lib.rs`, [[1]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L136-R156) [[2]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L378-R479) [[3]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L535-R631)
* Cached binaries are now organized in subdirectories named `<machine>-<deployment>-<commit_id>/bin/`, supporting simultaneous caching of different versions for each configuration. (`src/libs/nanvix-registry/src/lib.rs`, [[1]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L9-R22) [[2]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834R77-R108)

**Commit ID Extraction Utility**
* Added the `extract_commit_id` method to reliably parse commit IDs from GitHub release URLs, which is now used throughout the registry logic to identify and organize cached releases. (`src/libs/nanvix-registry/src/lib.rs`, [src/libs/nanvix-registry/src/lib.rsR495-R533](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834R495-R533))

**Documentation Updates**
* Expanded and clarified module-level documentation to describe the new registry system, cache directory structure, and metadata management, making the library's behavior and usage clearer for developers. (`src/libs/nanvix-registry/src/lib.rs`, [[1]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L9-R22) [[2]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834R77-R108)

**Testing Enhancements**
* Added comprehensive unit tests for the `extract_commit_id` method, covering various valid and invalid URL formats to ensure robust commit ID parsing. (`src/libs/nanvix-registry/src/lib.rs`, [src/libs/nanvix-registry/src/lib.rsR1016-R1057](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834R1016-R1057))