### PR TITLE
[ci] Use Commit ID in Release Archive Name

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -142,9 +142,9 @@ jobs:
         machine="${{ matrix.machine-type }}"
         deployment="${{ matrix.deployment-type }}"
         build_type="${{ matrix.build-type }}"
-        run_id="${GITHUB_RUN_ID}"
+        commit_id="${GITHUB_SHA}"
 
-        archive_name="nanvix-${machine}-${deployment}-${build_type}-${run_id}.tar.bz2"
+        archive_name="nanvix-${machine}-${deployment}-${build_type}-${commit_id}.tar.bz2"
         mv "${archive_path}" "${archive_name}"
 
         echo "archive-path=${archive_name}" >> "${GITHUB_OUTPUT}"

--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -414,7 +414,7 @@ impl Registry {
         let artifact_cache_dir: PathBuf = cache_dir.join(&subdir_name);
 
         // Load or create the release registry.
-        let mut registry: ReleaseRegistry = if ReleaseRegistry::exists(&cache_dir).await {
+        let mut release_registry: ReleaseRegistry = if ReleaseRegistry::exists(&cache_dir).await {
             match ReleaseRegistry::load(&cache_dir).await {
                 Ok(reg) => reg,
                 Err(error) => {
@@ -431,7 +431,7 @@ impl Registry {
 
         // Check if we need to download this specific configuration.
         let needs_download: bool =
-            if let Some(cached_entry) = registry.get_release(machine, deployment) {
+            if let Some(cached_entry) = release_registry.get_release(machine, deployment) {
                 if cached_entry.commit_id() != commit_id.as_str() {
                     info!(
                         "New release detected for {}-{} (cached: {}, latest: {})",
@@ -469,8 +469,8 @@ impl Registry {
             let downloaded_url: String = release.download(&artifact_cache_dir).await?;
 
             // Update the registry with the new release.
-            registry.set_release(machine, deployment, downloaded_url, commit_id);
-            registry.save(&cache_dir).await?;
+            release_registry.set_release(machine, deployment, downloaded_url, commit_id);
+            release_registry.save(&cache_dir).await?;
         }
 
         // Now search for the artifact in the specified directory.
@@ -495,24 +495,24 @@ impl Registry {
     ///
     /// # Description
     ///
-    /// Extracts the build identifier from a GitHub release URL.
+    /// Extracts the commit ID from a GitHub release URL.
     ///
-    /// The build identifier is a numeric value (such as a workflow run ID or timestamp) encoded in
-    /// the release filename. It uniquely identifies a specific build of Nanvix artifacts.
+    /// The commit ID is encoded in the release filename and uniquely identifies a specific
+    /// build of Nanvix artifacts.
     ///
     /// Example URL format:
-    /// `https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-19417333438.tar.bz2`
+    /// `https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-abc123def456.tar.bz2`
     ///
-    /// This method parses the filename to extract the numeric identifier between "release-" and
-    /// the file extension (e.g., `19417333438` from the example above).
+    /// This method parses the filename to extract the commit ID between "release-" and
+    /// the file extension (e.g., `abc123def456` from the example above).
     ///
     /// # Parameters
     ///
-    /// - `url`: The GitHub release URL containing the build identifier.
+    /// - `url`: The GitHub release URL containing the commit ID.
     ///
     /// # Returns
     ///
-    /// An `Option<String>` containing the build identifier if found, or `None` if the URL format
+    /// An `Option<String>` containing the commit ID if found, or `None` if the URL format
     /// is invalid.
     ///
     fn extract_commit_id(url: &str) -> Option<String> {
@@ -530,7 +530,11 @@ impl Registry {
         // Extract and validate the commit ID.
         if start_idx < end_idx {
             let commit_id: &str = &filename[start_idx..end_idx];
-            Some(commit_id.to_string())
+            if !commit_id.is_empty() {
+                Some(commit_id.to_string())
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -1027,26 +1031,38 @@ mod tests {
     #[test]
     fn test_extract_commit_id() {
         // Test valid URL with commit ID.
-        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-19417333438.tar.bz2";
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-abc123def456.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
-        assert_eq!(commit_id.unwrap(), "19417333438");
+        assert_eq!(commit_id.unwrap(), "abc123def456");
 
         // Test another valid URL format.
-        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-microvm-single-process-release-12345678.tar.bz2";
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-microvm-single-process-release-1a2b3c4d5e6f.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
-        assert_eq!(commit_id.unwrap(), "12345678");
+        assert_eq!(commit_id.unwrap(), "1a2b3c4d5e6f");
+
+        // Test full 40-character commit ID (matches production GITHUB_SHA format).
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-microvm-single-process-release-a1b2c3d4e5f6789012345678901234567890abcd.tar.bz2";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_some());
+        assert_eq!(commit_id.unwrap(), "a1b2c3d4e5f6789012345678901234567890abcd");
 
         // Test URL without release prefix.
         let url: &str =
-            "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-12345678.tar.bz2";
+            "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-abc123def.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_none());
 
         // Test URL without file extension.
         let url: &str =
-            "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-release-12345678";
+            "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-release-abc123def";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_none());
+
+        // Test empty commit ID (edge case: release-.tar.bz2).
+        let url: &str =
+            "https://github.com/nanvix/nanvix/releases/download/latest/release-.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_none());
 

--- a/src/libs/nanvix-registry/src/metadata.rs
+++ b/src/libs/nanvix-registry/src/metadata.rs
@@ -358,7 +358,7 @@ mod tests {
     #[test]
     fn test_entry_new() {
         let url: String = "https://github.com/test/release.tar.bz2".to_string();
-        let commit_id: String = "12345678".to_string();
+        let commit_id: String = "abc123def456".to_string();
         let entry: ReleaseEntry = ReleaseEntry::new(url.clone(), commit_id.clone());
         assert_eq!(entry.url(), url);
         assert_eq!(entry.commit_id(), commit_id);
@@ -385,7 +385,7 @@ mod tests {
         let mut registry: ReleaseRegistry = ReleaseRegistry::new();
 
         let url: String = "https://test.com/file.tar.bz2".to_string();
-        let commit_id: String = "12345678".to_string();
+        let commit_id: String = "abc123def456".to_string();
 
         // Set a release.
         registry.set_release(
@@ -419,21 +419,21 @@ mod tests {
             Machine::Microvm,
             Deployment::SingleProcess,
             "https://test.com/microvm-sp.tar.bz2".to_string(),
-            "11111111".to_string(),
+            "abc111def".to_string(),
         );
 
         registry.set_release(
             Machine::Microvm,
             Deployment::MultiProcess,
             "https://test.com/microvm-mp.tar.bz2".to_string(),
-            "22222222".to_string(),
+            "abc222def".to_string(),
         );
 
         registry.set_release(
             Machine::Hyperlight,
             Deployment::SingleProcess,
             "https://test.com/hyperlight-sp.tar.bz2".to_string(),
-            "33333333".to_string(),
+            "abc333def".to_string(),
         );
 
         // The number of entries is checked indirectly by verifying each entry exists below.
@@ -443,17 +443,17 @@ mod tests {
         let entry: &ReleaseEntry = registry
             .get_release(Machine::Microvm, Deployment::SingleProcess)
             .unwrap();
-        assert_eq!(entry.commit_id(), "11111111");
+        assert_eq!(entry.commit_id(), "abc111def");
 
         let entry: &ReleaseEntry = registry
             .get_release(Machine::Microvm, Deployment::MultiProcess)
             .unwrap();
-        assert_eq!(entry.commit_id(), "22222222");
+        assert_eq!(entry.commit_id(), "abc222def");
 
         let entry: &ReleaseEntry = registry
             .get_release(Machine::Hyperlight, Deployment::SingleProcess)
             .unwrap();
-        assert_eq!(entry.commit_id(), "33333333");
+        assert_eq!(entry.commit_id(), "abc333def");
     }
 
     ///
@@ -470,7 +470,7 @@ mod tests {
             Machine::Microvm,
             Deployment::SingleProcess,
             "https://test.com/old.tar.bz2".to_string(),
-            "11111111".to_string(),
+            "abc111def".to_string(),
         );
 
         assert_eq!(registry.len(), 1);
@@ -480,7 +480,7 @@ mod tests {
             Machine::Microvm,
             Deployment::SingleProcess,
             "https://test.com/new.tar.bz2".to_string(),
-            "22222222".to_string(),
+            "abc222def".to_string(),
         );
 
         // Should still have one entry, but updated.
@@ -490,7 +490,7 @@ mod tests {
             .get_release(Machine::Microvm, Deployment::SingleProcess)
             .unwrap();
         assert_eq!(entry.url(), "https://test.com/new.tar.bz2");
-        assert_eq!(entry.commit_id(), "22222222");
+        assert_eq!(entry.commit_id(), "abc222def");
     }
 
     ///
@@ -505,14 +505,14 @@ mod tests {
             Machine::Microvm,
             Deployment::SingleProcess,
             "https://example.com/release.tar.bz2".to_string(),
-            "12345678".to_string(),
+            "abc123def456".to_string(),
         );
 
         let json: String = serde_json::to_string(&registry).unwrap();
         assert!(json.contains("releases"));
         assert!(json.contains("microvm-single-process"));
         assert!(json.contains("https://example.com/release.tar.bz2"));
-        assert!(json.contains("12345678"));
+        assert!(json.contains("abc123def456"));
     }
 
     ///
@@ -522,14 +522,14 @@ mod tests {
     ///
     #[test]
     fn test_deserialization() {
-        let json: &str = r#"{"releases":{"microvm-single-process":{"url":"https://example.com/release.tar.bz2","commit_id":"12345678"}}}"#;
+        let json: &str = r#"{"releases":{"microvm-single-process":{"url":"https://example.com/release.tar.bz2","commit_id":"abc123def456"}}}"#;
         let registry: ReleaseRegistry = serde_json::from_str(json).unwrap();
 
         let entry: &ReleaseEntry = registry
             .get_release(Machine::Microvm, Deployment::SingleProcess)
             .unwrap();
         assert_eq!(entry.url(), "https://example.com/release.tar.bz2");
-        assert_eq!(entry.commit_id(), "12345678");
+        assert_eq!(entry.commit_id(), "abc123def456");
     }
 
     ///
@@ -548,13 +548,13 @@ mod tests {
             Machine::Microvm,
             Deployment::SingleProcess,
             "https://test.com/file1.tar.bz2".to_string(),
-            "11111111".to_string(),
+            "abc111def".to_string(),
         );
         original.set_release(
             Machine::Hyperlight,
             Deployment::MultiProcess,
             "https://test.com/file2.tar.bz2".to_string(),
-            "22222222".to_string(),
+            "abc222def".to_string(),
         );
 
         // Save registry.
@@ -571,12 +571,12 @@ mod tests {
         let entry: &ReleaseEntry = loaded
             .get_release(Machine::Microvm, Deployment::SingleProcess)
             .unwrap();
-        assert_eq!(entry.commit_id(), "11111111");
+        assert_eq!(entry.commit_id(), "abc111def");
 
         let entry: &ReleaseEntry = loaded
             .get_release(Machine::Hyperlight, Deployment::MultiProcess)
             .unwrap();
-        assert_eq!(entry.commit_id(), "22222222");
+        assert_eq!(entry.commit_id(), "abc222def");
 
         // Cleanup.
         let _: Result<(), std::io::Error> = fs::remove_dir_all(&temp_dir).await;
@@ -612,7 +612,7 @@ mod tests {
             Machine::Microvm,
             Deployment::SingleProcess,
             "https://test.com/file.tar.bz2".to_string(),
-            "12345678".to_string(),
+            "abc123def456".to_string(),
         );
         let _: Result<()> = registry.save(&temp_dir).await;
 
@@ -639,7 +639,7 @@ mod tests {
             Machine::Microvm,
             Deployment::SingleProcess,
             "https://test.com/file.tar.bz2".to_string(),
-            "12345678".to_string(),
+            "abc123def456".to_string(),
         );
         let _: Result<()> = registry.save(&temp_dir).await;
 


### PR DESCRIPTION
This pull request significantly enhances the `nanvix-registry` library to support multiple versions of Nanvix release binaries for different machine and deployment configurations. The main improvements include a new registry system for tracking releases by commit ID, changes to the cache directory structure, and new logic for managing and retrieving artifacts. Additionally, a utility for extracting commit IDs from release URLs is introduced, along with comprehensive documentation updates.

**Registry and Metadata Management:**

* Replaced the single-metadata system with a `ReleaseRegistry` that tracks multiple machine-deployment configurations and their associated commit IDs, allowing multiple versions to coexist and enabling side-by-side deployments. The registry is stored in a `release-metadata.json` file in the cache root. [[1]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L136-R156) [[2]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L378-R479) [[3]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L535-R636)
* Updated the cache directory structure to organize binaries under `nanvix-registry/<machine>-<deployment>-<commit_id>/bin/`, ensuring artifacts for different versions and configurations are isolated.

**Artifact Download and Retrieval Logic:**

* Improved the artifact fetching logic to check the registry for existing versions, extract commit IDs from release URLs, and only download new releases when a new commit is detected for a configuration. Downloads now go into the appropriate versioned subdirectory, and the registry is updated accordingly. [[1]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L378-R479) [[2]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811L145-R147)

**Utility and Testing:**

* Added a new utility method `extract_commit_id` to reliably parse commit IDs from release URLs, with a comprehensive set of tests to ensure correct extraction and error handling for malformed URLs. [[1]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834R495-R538) [[2]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834R1021-R1062)

**Documentation Updates:**

* Expanded the crate-level documentation to describe the new registry system, cache directory layout, and metadata management, making it easier for users to understand how multiple versions are handled and how the cache is organized. [[1]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834L9-R22) [[2]](diffhunk://#diff-39070155be1ab8a72d4934fc13965effe2918c993bccf5713ef89c9916342834R77-R108)

**Build Artifact Naming:**

* Updated the CI workflow to use the commit ID instead of the GitHub run ID in the build artifact archive name, ensuring consistency with the new caching and registry scheme.