### PR TITLE
[scripts] Make sure awk flavor is gawk

### DIFF
--- a/scripts/setup/ubuntu.sh
+++ b/scripts/setup/ubuntu.sh
@@ -25,6 +25,7 @@ apt-get install -y        \
     doxygen               \
     flex                  \
     g++-multilib          \
+    gawk                  \
     gcc-multilib          \
     git                   \
     graphviz              \


### PR DESCRIPTION
This PR fixes a small issue with setting up the development environment.

`.githooks/commit-msg` failed on my fresh Ubuntu 24.04 installation. The reason was that my installation had the `mawk` flavor of `awk` installed by default and the script uses `gawk` syntax ([here](https://github.com/nanvix/nanvix/blob/6b7791f542b4b1da635ec936cd869d027df2b5af/.githooks/commit-msg#L56)). Running `sudo apt install gawk` resolved the issue.

Therefore, adding `gawk` as a dependency during setup should resolve the issue (at least it does for my Ubuntu installation).