### PR TITLE
Update hyperlight to v0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,13 +83,13 @@ goblin = { version = "0.10.0", default-features = false }
 indicatif = "0.18.0"
 http = "1.3.1"
 http-body-util = "0.1.3"
-hyperlight-common = { git = "https://github.com/nanvix/hyperlight", rev = "122ba3639e7e18bb0be548408c3646b365f9ef78", default-features = false, package = "hyperlight-common" }
-hyperlight-host = { git = "https://github.com/nanvix/hyperlight", rev = "122ba3639e7e18bb0be548408c3646b365f9ef78", default-features = false, features = [
+hyperlight-common = { git = "https://github.com/nanvix/hyperlight", branch = "nanvix/v0.12.0", default-features = false }
+hyperlight-host = { git = "https://github.com/nanvix/hyperlight", branch = "nanvix/v0.12.0", default-features = false, features = [
         "kvm",
         "mshv3",
-        "host-interrupts",
-], package = "hyperlight-host" }
-hyperlight-guest = { git = "https://github.com/nanvix/hyperlight", rev = "122ba3639e7e18bb0be548408c3646b365f9ef78", default-features = false, package = "hyperlight-guest" }
+        "hw-interrupts",
+] }
+hyperlight-guest = { git = "https://github.com/nanvix/hyperlight", branch = "nanvix/v0.12.0", default-features = false }
 hyper = { version = "1.6.0", default-features = false }
 hyper-util = { version = "0.1.14", default-features = false }
 hwloc = { path = "src/libs/hwloc", default-features = false }

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -232,7 +232,7 @@ impl Vmm {
 
         // Creates Hyperlight sandbox.
         let mut sandbox: UninitializedSandbox = UninitializedSandbox::new(guest_env, Some(config))?;
-        let manager: SandboxMemoryManager<ExclusiveSharedMemory> = sandbox.mgr.unwrap_mgr().clone();
+        let manager: SandboxMemoryManager<ExclusiveSharedMemory> = sandbox.mgr.clone();
         let vmem: Arc<Mutex<VirtualMemory>> = Arc::new(Mutex::new(VirtualMemory {
             manager: manager.clone(),
         }));


### PR DESCRIPTION
Updates hyperlight dependencies from v0.11.0 to v0.12.0 via nanvix/v0.12.0 branch. Removes unwrap_mgr() call since mgr field is now directly accessible in the updated API.