### PR TITLE
[ci] Improve CI Diagnostics for L2 Workflow Runs

### DIFF
--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -80,6 +80,56 @@ jobs:
           warm-start-l2
           warm-start-vmm
 
+    - name: "Collect L2 diagnostics"
+      if: failure()
+      shell: bash
+      run: |
+        set -Eeuo pipefail
+
+        snapshot_path="${GITHUB_WORKSPACE}/images/l2-sysvm-snapshot"
+        log_root="${GITHUB_WORKSPACE}/logs"
+
+        echo '::group::L2 snapshot metadata'
+        if [[ -e "${snapshot_path}" ]]; then
+          ls -al "${snapshot_path}"
+          sha256sum "${snapshot_path}" || true
+          file "${snapshot_path}" || true
+        else
+          echo "Snapshot not found at ${snapshot_path}."
+        fi
+        echo '::endgroup::'
+
+        echo '::group::Cloud Hypervisor stderr logs'
+        shopt -s nullglob
+        clh_logs=("${log_root}"/**/cloud-hypervisor-stderr.log)
+        if [[ ${#clh_logs[@]} -eq 0 ]]; then
+          echo "No cloud-hypervisor stderr logs found under ${log_root}."
+        else
+          for log_path in "${clh_logs[@]}"; do
+            echo "--- ${log_path} ---"
+            tail -n 400 "${log_path}" || true
+          done
+        fi
+        echo '::endgroup::'
+
+        echo '::group::Kernel console logs'
+        console_logs=("${log_root}"/**/kernel_*.log)
+        if [[ ${#console_logs[@]} -eq 0 ]]; then
+          echo "No kernel console logs found under ${log_root}."
+        else
+          for log_path in "${console_logs[@]}"; do
+            echo "--- ${log_path} ---"
+            tail -n 200 "${log_path}" || true
+          done
+        fi
+        echo '::endgroup::'
+
+        echo '::group::/tmp namespace overview'
+        sudo ls -al /tmp || true
+        sudo find /tmp -maxdepth 1 -name 'nvx*' -print || true
+        sudo find /tmp -maxdepth 2 -name 'nanvixd-clh.*' -print || true
+        echo '::endgroup::'
+
 
     - name: "Cleanup Dangling Resources"
       if: always()

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -103,6 +103,56 @@ jobs:
         machine-type: '${{ matrix.machine-type }}'
         deployment-type: '${{ matrix.deployment-type }}'
 
+    - name: "Collect L2 diagnostics"
+      if: ${{ failure() && matrix.deployment-type == 'l2' }}
+      shell: bash
+      run: |
+        set -Eeuo pipefail
+
+        snapshot_path="${GITHUB_WORKSPACE}/images/l2-sysvm-snapshot"
+        log_root="${GITHUB_WORKSPACE}/logs"
+
+        echo '::group::L2 snapshot metadata'
+        if [[ -e "${snapshot_path}" ]]; then
+          ls -al "${snapshot_path}"
+          sha256sum "${snapshot_path}" || true
+          file "${snapshot_path}" || true
+        else
+          echo "Snapshot not found at ${snapshot_path}."
+        fi
+        echo '::endgroup::'
+
+        echo '::group::Cloud Hypervisor stderr logs'
+        shopt -s nullglob
+        clh_logs=("${log_root}"/**/cloud-hypervisor-stderr.log)
+        if [[ ${#clh_logs[@]} -eq 0 ]]; then
+          echo "No cloud-hypervisor stderr logs found under ${log_root}."
+        else
+          for log_path in "${clh_logs[@]}"; do
+            echo "--- ${log_path} ---"
+            tail -n 400 "${log_path}" || true
+          done
+        fi
+        echo '::endgroup::'
+
+        echo '::group::Kernel console logs'
+        console_logs=("${log_root}"/**/kernel_*.log)
+        if [[ ${#console_logs[@]} -eq 0 ]]; then
+          echo "No kernel console logs found under ${log_root}."
+        else
+          for log_path in "${console_logs[@]}"; do
+            echo "--- ${log_path} ---"
+            tail -n 200 "${log_path}" || true
+          done
+        fi
+        echo '::endgroup::'
+
+        echo '::group::/tmp namespace overview'
+        sudo ls -al /tmp || true
+        sudo find /tmp -maxdepth 1 -name 'nvx*' -print || true
+        sudo find /tmp -maxdepth 2 -name 'nanvixd-clh.*' -print || true
+        echo '::endgroup::'
+
     - id: release-archive
       name: "Create Release Archive"
       if: ${{ success() && github.ref == 'refs/heads/dev' && matrix.build-type == 'release' &&  matrix.deployment-type != 'l2' }}

--- a/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
@@ -23,10 +23,7 @@ use crate::{
         NetnsHandle,
         NetnsInfo,
     },
-    netns_exec::{
-        command_in_netns,
-        spawn_in_netns,
-    },
+    netns_exec::command_in_netns,
     LinuxDaemonArgs,
 };
 use ::anyhow::Result;
@@ -39,6 +36,8 @@ use ::linuxd::{
     config::restore_gate_sockaddr_builder,
 };
 use ::std::{
+    error::Error as StdError,
+    fmt,
     fs,
     io::ErrorKind,
     mem,
@@ -66,8 +65,14 @@ use ::syslog::{
     warn,
 };
 use ::tokio::{
+    fs as tokio_fs,
+    io::{
+        AsyncReadExt,
+        AsyncWriteExt,
+    },
     process::{
         Child,
+        ChildStderr,
         Command,
     },
     time::{
@@ -83,7 +88,62 @@ use ::tokio::{
 const RESTORE_GATE_BYTES: [u8; 1] = [0];
 
 //==================================================================================================
-// Structures
+// WaitForSocketError
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Error type returned when waiting for the Cloud Hypervisor API socket to show up.
+///
+#[derive(Debug)]
+enum WaitForSocketError {
+    /// Socket path exists but is not a socket.
+    NotSocket {
+        /// Path to the unexpected file.
+        path: PathBuf,
+    },
+    /// Metadata lookup failed.
+    Metadata {
+        /// Path that triggered the error.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: ::std::io::Error,
+    },
+    /// Socket never appeared within the allowed timeout.
+    TimedOut {
+        /// Path to the awaited socket.
+        path: PathBuf,
+    },
+}
+
+impl fmt::Display for WaitForSocketError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotSocket { path } => {
+                write!(f, "file available, but not a socket (path={path:?})")
+            },
+            Self::Metadata { path, source } => {
+                write!(f, "error checking file metadata (path={path:?}, error={source:?})")
+            },
+            Self::TimedOut { path } => {
+                write!(f, "timed-out waiting for socket to be available (path={path:?})")
+            },
+        }
+    }
+}
+
+impl StdError for WaitForSocketError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Metadata { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+//==================================================================================================
+// LinuxDaemon
 //==================================================================================================
 
 ///
@@ -99,10 +159,6 @@ pub struct LinuxDaemon {
     /// RAII handle to the network namespace linuxd runs in (L2-mode only).
     netns_handle: Option<NetnsHandle>,
 }
-
-//==================================================================================================
-// Implementations
-//==================================================================================================
 
 impl LinuxDaemon {
     ///
@@ -128,7 +184,7 @@ impl LinuxDaemon {
     async fn wait_for_unix_socket<P: AsRef<Path>>(
         path: P,
         timeout_duration: Duration,
-    ) -> Result<()> {
+    ) -> ::std::result::Result<(), WaitForSocketError> {
         let path: PathBuf = path.as_ref().to_path_buf();
         let deadline: Instant = Instant::now() + timeout_duration;
         const SLEEP_DURATION: Duration = Duration::from_millis(1);
@@ -141,26 +197,34 @@ impl LinuxDaemon {
                         return Ok(());
                     } else {
                         // Exists but is not a socket, raise error.
-                        let reason: String =
-                            format!("file available, but not a socket (path={path:?})");
-                        error!("wait_for_unix_socket(): {reason}");
-                        anyhow::bail!(reason);
+                        error!(
+                            "wait_for_unix_socket(): file available, but not a socket (path={:?})",
+                            path
+                        );
+                        return Err(WaitForSocketError::NotSocket { path: path.clone() });
                     }
                 },
                 Err(e) if e.kind() == ErrorKind::NotFound => {},
                 Err(e) => {
-                    let reason: String =
-                        format!("error checking file metadata (path={path:?}, error={e:?})");
-                    error!("wait_for_unix_socket(): {reason}");
-                    anyhow::bail!(reason);
+                    error!(
+                        "wait_for_unix_socket(): error checking file metadata (path={:?}, \
+                         error={:?})",
+                        path, e
+                    );
+                    return Err(WaitForSocketError::Metadata {
+                        path: path.clone(),
+                        source: e,
+                    });
                 },
             }
 
             if Instant::now() >= deadline {
-                let reason: String =
-                    format!("timed-out waiting for socket to be available (path={path:?})");
-                error!("wait_for_unix_socket(): {reason}");
-                anyhow::bail!(reason);
+                error!(
+                    "wait_for_unix_socket(): timed-out waiting for socket to be available \
+                     (path={:?})",
+                    path
+                );
+                return Err(WaitForSocketError::TimedOut { path });
             }
 
             sleep(SLEEP_DURATION).await;
@@ -183,6 +247,7 @@ impl LinuxDaemon {
     /// - `netns_info`: Information about the L2 VM's network namespace.
     /// - `ch_remote_path`: Path to the ch-remote binary.
     /// - `clh_api_socket_path`: Path to the cloud-hypervisor API socket.
+    /// - `clh_stderr_log_path`: Destination file where CLH stderr is captured.
     ///
     /// # Returns
     ///
@@ -192,12 +257,47 @@ impl LinuxDaemon {
         netns_info: &NetnsInfo,
         ch_remote_path: &str,
         clh_api_socket_path: &str,
+        clh_stderr_log_path: &Path,
     ) -> Result<()> {
         // Timeout between the ch-remote resume operation and the API socket becoming available.
-        const CLH_RESUME_TIMEOUT: Duration = Duration::from_millis(100);
+        const CLH_RESUME_TIMEOUT: Duration = Duration::from_secs(5);
+        const CLH_SOCKET_MAX_ATTEMPTS: usize = 5;
+        const CLH_SOCKET_BACKOFF_MS: u64 = 250;
 
-        // Wait for CLH socket to be ready.
-        Self::wait_for_unix_socket(clh_api_socket_path, CLH_RESUME_TIMEOUT).await?;
+        // Wait for CLH socket to be ready with retries to mask slow boots.
+        let mut attempt: usize = 0;
+        loop {
+            match Self::wait_for_unix_socket(clh_api_socket_path, CLH_RESUME_TIMEOUT).await {
+                Ok(()) => break,
+                Err(WaitForSocketError::TimedOut { ref path }) => {
+                    attempt += 1;
+                    if attempt > CLH_SOCKET_MAX_ATTEMPTS {
+                        let reason: String = format!(
+                            "timed-out waiting for socket to be available (path={path:?}, \
+                             attempts={attempt}, stderr_log={})",
+                            clh_stderr_log_path.display()
+                        );
+                        error!("resume_l2_vm(): {reason}");
+                        anyhow::bail!(reason);
+                    }
+
+                    warn!(
+                        "resume_l2_vm(): attempt {attempt} timed out while waiting for socket \
+                         (path={path:?}), retrying..."
+                    );
+                    let backoff_ms: u64 = CLH_SOCKET_BACKOFF_MS * attempt as u64;
+                    sleep(Duration::from_millis(backoff_ms)).await;
+                },
+                Err(e) => {
+                    let reason: String = format!(
+                        "error waiting for socket readiness (error={e}, stderr_log={})",
+                        clh_stderr_log_path.display()
+                    );
+                    error!("resume_l2_vm(): {reason}");
+                    anyhow::bail!(reason);
+                },
+            }
+        }
 
         // Resume the L2 VM inside the network namespace.
         let ch_remote_args: Vec<String> = vec![
@@ -238,6 +338,64 @@ impl LinuxDaemon {
             return Err(e.into());
         }
 
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Spawns a background task that persists the stderr stream emitted by cloud-hypervisor.
+    ///
+    /// # Parameters
+    ///
+    /// - `stderr`: Pipe containing the process stderr stream.
+    /// - `destination`: Path to the log file that will receive the captured output.
+    ///
+    fn spawn_stderr_capture_task(stderr: ChildStderr, destination: PathBuf) {
+        ::tokio::spawn(async move {
+            if let Err(error) = Self::persist_child_stderr(stderr, destination.clone()).await {
+                warn!(
+                    "spawn_stderr_capture_task(): failed to persist cloud-hypervisor stderr \
+                     (path={:?}, error={error:?})",
+                    destination
+                );
+            }
+        });
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Persists stderr output emitted by cloud-hypervisor into a log file for later inspection.
+    ///
+    /// # Parameters
+    ///
+    /// - `stderr`: Pipe containing the stderr stream.
+    /// - `destination`: Log file path.
+    ///
+    /// # Returns
+    ///
+    /// Returns success when all data is written. Errors indicate an I/O failure when reading from
+    /// the process or writing to disk.
+    ///
+    async fn persist_child_stderr(stderr: ChildStderr, destination: PathBuf) -> Result<()> {
+        if let Some(parent) = destination.parent() {
+            tokio_fs::create_dir_all(parent).await?;
+        }
+
+        let mut reader: ChildStderr = stderr;
+        let mut file: tokio_fs::File = tokio_fs::File::create(&destination).await?;
+        let mut buffer: [u8; 4096] = [0; 4096];
+
+        loop {
+            let bytes_read: usize = reader.read(&mut buffer).await?;
+            if bytes_read == 0 {
+                break;
+            }
+            file.write_all(&buffer[..bytes_read]).await?;
+        }
+
+        file.flush().await?;
         Ok(())
     }
 
@@ -340,15 +498,29 @@ impl LinuxDaemon {
             // In L2 deployments, we spawn linuxd inside a network namespace.
             debug_assert!(args.l2());
 
-            let child: Child =
-                spawn_in_netns(&netns_handle.netns_info()?, &linuxd_args[0], &linuxd_args[1..])
-                    .await
-                    .map_err(|e| {
-                        let reason: String =
-                            format!("error spawning linuxd process in netns (error={e:?})");
-                        error!("spawn(): {reason}");
-                        anyhow::anyhow!(reason)
-                    })?;
+            let clh_stderr_log_path: PathBuf =
+                PathBuf::from(format!("{}/cloud-hypervisor-stderr.log", args.log_directory()));
+
+            let mut cmd: Command =
+                command_in_netns(&netns_handle.netns_info()?, &linuxd_args[0], &linuxd_args[1..]);
+            cmd.stdout(Stdio::inherit());
+            cmd.stderr(Stdio::piped());
+
+            let mut child: Child = cmd.spawn().map_err(|e| {
+                let reason: String =
+                    format!("error spawning linuxd process in netns (error={e:?})");
+                error!("spawn(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+
+            if let Some(stderr) = child.stderr.take() {
+                Self::spawn_stderr_capture_task(stderr, clh_stderr_log_path.clone());
+            } else {
+                warn!(
+                    "spawn(): failed to capture cloud-hypervisor stderr (log_path={})",
+                    clh_stderr_log_path.display()
+                );
+            }
 
             let ch_remote_path: String =
                 format!("{}/ch-remote", get_clh_bin_dir(args.toolchain_binary_directory())?);
@@ -356,6 +528,7 @@ impl LinuxDaemon {
                 &netns_handle.netns_info()?,
                 &ch_remote_path,
                 &clh_api_socket_path,
+                &clh_stderr_log_path,
             )
             .await
             {


### PR DESCRIPTION
This pull request introduces improvements to diagnostics and error handling for L2 deployments, especially around the Cloud Hypervisor (CLH) process. The main focus is on making failures more observable and easier to debug by capturing CLH stderr logs, improving socket wait logic, and surfacing richer error information in both CI and the runtime.

**Diagnostics and Observability Improvements:**

* Added a new "Collect L2 diagnostics" step to both `.github/workflows/self-hosted-benchmark.yml` and `.github/workflows/self-hosted-ci.yml` that runs on failure. This step collects snapshot metadata, recent Cloud Hypervisor stderr logs, kernel console logs, and `/tmp` namespace contents to aid debugging L2 failures. [[1]](diffhunk://#diff-331a9af7ea0111e347b5a567d95dbb846cab81450473315ff4a7031a956144efR83-R132) [[2]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811R106-R155)
* The `linuxd` process now spawns with its stderr captured and persisted to a log file (`cloud-hypervisor-stderr.log`) for each run, using new async helper functions. This enables post-mortem analysis of CLH failures. [[1]](diffhunk://#diff-6e1eac11a5dce6ae248f71047b49802fb115a76b19ff7e0371dbf5776dfaeeeeL343-R531) [[2]](diffhunk://#diff-6e1eac11a5dce6ae248f71047b49802fb115a76b19ff7e0371dbf5776dfaeeeeR344-R401)

**Error Handling and Robustness:**

* Introduced a dedicated `WaitForSocketError` type for richer error reporting when waiting for the CLH API socket, including distinguishing between timeouts, metadata errors, and non-socket files. [[1]](diffhunk://#diff-6e1eac11a5dce6ae248f71047b49802fb115a76b19ff7e0371dbf5776dfaeeeeR108-R158) [[2]](diffhunk://#diff-6e1eac11a5dce6ae248f71047b49802fb115a76b19ff7e0371dbf5776dfaeeeeL131-R187) [[3]](diffhunk://#diff-6e1eac11a5dce6ae248f71047b49802fb115a76b19ff7e0371dbf5776dfaeeeeL144-R227)
* Improved the socket wait logic in `resume_l2_vm` to use retries and exponential backoff, making the process more tolerant of slow CLH boots and surfacing the stderr log path in error messages.

**Cleanup and Refactoring:**

* Refactored imports and removed unused functions for clarity in `linuxd.rs`. [[1]](diffhunk://#diff-6e1eac11a5dce6ae248f71047b49802fb115a76b19ff7e0371dbf5776dfaeeeeL26-R26) [[2]](diffhunk://#diff-6e1eac11a5dce6ae248f71047b49802fb115a76b19ff7e0371dbf5776dfaeeeeR39-R40) [[3]](diffhunk://#diff-6e1eac11a5dce6ae248f71047b49802fb115a76b19ff7e0371dbf5776dfaeeeeR68-R75)

These changes should make L2 failures significantly easier to diagnose both locally and in CI, while also making the code more robust to transient issues with CLH startup.