### PR TITLE
[nanvix-http] Structured Error Responses

### DIFF
--- a/doc/run.md
+++ b/doc/run.md
@@ -9,6 +9,7 @@ This document provides instructions on how to run Nanvix.
 - [Running Nanvix with `nanvixd` (Preferred Method)](#running-nanvix-with-nanvixd-preferred-method)
   - [Step 1: Run `nanvixd`](#step-1-run-nanvixd)
   - [Step 2: Run an Application](#step-2-run-an-application)
+  - [HTTP Error Responses](#http-error-responses)
 - [Running Nanvix Components Manually (Hyperlight and UserVM Machines Only)](#running-nanvix-components-manually-hyperlight-and-uservm-machines-only)
   - [Step 1: Run the Linux Daemon](#step-1-run-the-linux-daemon)
   - [Step 2: Run the UserVM](#step-2-run-the-uservm)
@@ -85,6 +86,24 @@ curl \
 ```
 
 To gracefully shutdown nanvixd, you can just press `Ctrl-C` in its terminal.
+
+### HTTP Error Responses
+
+`nanvixd` returns structured errors using the `ErrorResponse` schema.  Every failure path assigns a
+short `code` plus a human-readable `message`, which allows callers to branch on stable identifiers
+instead of scraping log text. The handler currently emits the following values:
+
+| code                   | HTTP status               | When it is emitted                                                           |
+| ---------------------- | ------------------------- | ---------------------------------------------------------------------------- |
+| `MISSING_MESSAGE_TYPE` | 400 Bad Request           | The `X-NVX-Message-Type` header is absent or invalid.                        |
+| `BODY_READ_FAILED`     | 500 Internal Server Error | Hyper could not stream the request body.                                     |
+| `INVALID_NEW_PAYLOAD`  | 400 Bad Request           | The body is not valid JSON for a `NEW` request.                              |
+| `NEW_REQUEST_FAILED`   | 500 Internal Server Error | Sandbox creation or cache insertion failed after successful deserialization. |
+| `INVALID_KILL_PAYLOAD` | 400 Bad Request           | The body is not valid JSON for a `KILL` request.                             |
+| `KILL_REQUEST_FAILED`  | 500 Internal Server Error | Terminating the requested sandbox failed after validation.                   |
+
+Client tooling (for example, `nanvix-test` and custom REST clients) should prefer inspecting `code`
+and then relaying the accompanying `message` for operator visibility.
 
 ## Running Nanvix Components Manually (Hyperlight and UserVM Machines Only)
 

--- a/src/libs/nanvix-http/src/client.rs
+++ b/src/libs/nanvix-http/src/client.rs
@@ -13,6 +13,8 @@
 
 use crate::message::{
     self,
+    ErrorCode,
+    ErrorResponse,
     MessageType,
     HTTP_HEADER_MESSAGE_TYPE,
 };
@@ -94,32 +96,81 @@ impl<T: Send + Sync + Default + 'static> HttpClient<T> {
     ///
     /// # Description
     ///
-    /// Helper function that creates an HTTP "Bad Request" (400) response.
+    /// Helper function that creates a JSON response with the provided payload.
+    ///
+    /// # Parameters
+    ///
+    /// - `status`: HTTP status code for the response.
+    /// - `payload`: Serializable payload to include in the response body.
     ///
     /// # Returns
     ///
-    /// An HTTP response with status code 400.
+    /// This function returns an HTTP response with a JSON body containing the serialized payload.
     ///
-    fn bad_request() -> Response<Full<Bytes>> {
-        let mut bad_request: Response<Full<Bytes>> = Response::new(Full::new(Bytes::new()));
-        *bad_request.status_mut() = hyper::StatusCode::BAD_REQUEST;
-        bad_request
+    fn json_response<R: serde::Serialize>(
+        status: StatusCode,
+        payload: &R,
+    ) -> Response<Full<Bytes>> {
+        match serde_json::to_vec(payload) {
+            Ok(body) => match Response::builder()
+                .status(status)
+                .header("Content-Type", "application/json")
+                .body(Full::new(Bytes::from(body)))
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    error!("failed to build response (error={error})");
+                    Self::empty_response(StatusCode::INTERNAL_SERVER_ERROR)
+                },
+            },
+            Err(error) => {
+                error!("failed to serialize response (error={error})");
+                Self::empty_response(StatusCode::INTERNAL_SERVER_ERROR)
+            },
+        }
     }
 
     ///
     /// # Description
     ///
-    /// Helper function that creates an HTTP "Internal Server Error" (500) response.
+    /// Helper function that returns an empty response with a given status code.
+    ///
+    /// # Parameters
+    ///
+    /// - `status`: HTTP status code for the response.
     ///
     /// # Returns
     ///
-    /// An HTTP response with status code 500.
+    /// This function returns an HTTP response with no body and the specified status code.
     ///
-    fn internal_server_error() -> Response<Full<Bytes>> {
-        let mut internal_server_error: Response<Full<Bytes>> =
-            Response::new(Full::new(Bytes::new()));
-        *internal_server_error.status_mut() = hyper::StatusCode::INTERNAL_SERVER_ERROR;
-        internal_server_error
+    fn empty_response(status: StatusCode) -> Response<Full<Bytes>> {
+        let mut response: Response<Full<Bytes>> = Response::new(Full::new(Bytes::new()));
+        *response.status_mut() = status;
+        response
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Helper that wraps an `ErrorResponse` payload.
+    ///
+    /// # Parameters
+    ///
+    /// - `status`: HTTP status code for the response.
+    /// - `code`: Short machine-readable error code.
+    /// - `message`: Human-readable error message.
+    ///
+    /// # Returns
+    ///
+    /// This function returns an HTTP response with a JSON body containing the error details.
+    ///
+    fn error_response(
+        status: StatusCode,
+        code: ErrorCode,
+        message: String,
+    ) -> Response<Full<Bytes>> {
+        let payload: ErrorResponse = ErrorResponse { code, message };
+        Self::json_response(status, &payload)
     }
 
     ///
@@ -187,21 +238,25 @@ impl<T: Send + Sync + Default + 'static> HttpClient<T> {
     ///
     /// # Returns
     ///
-    /// On success, returns a KillResponse with exit code 0. On failure, returns a response
-    /// with a non-zero exit code.
+    /// On success, returns an acknowledgement for the terminated sandbox. On failure, this function
+    /// returns an object that describes the error.
     ///
     async fn serve_kill(
         sandbox_cache: Arc<Mutex<SandboxCache<T>>>,
         message: &message::Kill,
     ) -> Result<message::KillResponse> {
         let mut locked_sandbox_cache = sandbox_cache.lock().await;
-        let exit_code = match locked_sandbox_cache.kill(message.user_vm_id).await {
-            Ok(()) => 0,
-            // TODO: more advanced error codes.
-            Err(_) => 1,
-        };
-
-        Ok(message::KillResponse { exit_code })
+        match locked_sandbox_cache.kill(message.user_vm_id).await {
+            // TODO: return UserVM exit code.
+            Ok(()) => Ok(message::KillResponse { exit_code: 0 }),
+            Err(error) => {
+                error!(
+                    "failed to terminate sandbox (user_vm_id={} error={error})",
+                    message.user_vm_id,
+                );
+                Err(error)
+            },
+        }
     }
 }
 
@@ -223,8 +278,14 @@ impl<T: Send + Sync + Default + 'static> Service<Request<Incoming>> for HttpClie
             {
                 Some(message_type) => message_type,
                 None => {
-                    error!("{} is a mandatory header", HTTP_HEADER_MESSAGE_TYPE);
-                    return Ok(Self::bad_request());
+                    let message: String =
+                        format!("{} is a mandatory header", HTTP_HEADER_MESSAGE_TYPE);
+                    error!("{message}");
+                    return Ok(Self::error_response(
+                        StatusCode::BAD_REQUEST,
+                        ErrorCode::MissingMessageType,
+                        message,
+                    ));
                 },
             };
 
@@ -233,7 +294,11 @@ impl<T: Send + Sync + Default + 'static> Service<Request<Incoming>> for HttpClie
                 Err(_) => {
                     let reason: String = "failed to read body".to_string();
                     error!("{reason}");
-                    return Ok(Self::internal_server_error());
+                    return Ok(Self::error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        ErrorCode::BodyReadFailed,
+                        reason,
+                    ));
                 },
             };
 
@@ -244,16 +309,27 @@ impl<T: Send + Sync + Default + 'static> Service<Request<Incoming>> for HttpClie
                     let msg: message::New = match serde_json::from_slice(&body) {
                         Ok(msg) => msg,
                         Err(_) => {
-                            error!("failed to deserialize NEW message: {body:?}");
-                            return Ok(Self::bad_request());
+                            let reason: String =
+                                format!("failed to deserialize NEW message: {body:?}");
+                            error!("{reason}");
+                            return Ok(Self::error_response(
+                                StatusCode::BAD_REQUEST,
+                                ErrorCode::InvalidNewPayload,
+                                reason,
+                            ));
                         },
                     };
 
                     match Self::serve_new(sandbox_cache, &msg).await {
                         Ok(response) => message::MessageResponse::New(response),
-                        Err(_) => {
-                            error!("error processing NEW request");
-                            return Ok(Self::internal_server_error());
+                        Err(error) => {
+                            let reason: String = format!("failed to process NEW request: {error}");
+                            error!("{reason}");
+                            return Ok(Self::error_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                ErrorCode::NewRequestFailed,
+                                reason,
+                            ));
                         },
                     }
                 },
@@ -261,8 +337,15 @@ impl<T: Send + Sync + Default + 'static> Service<Request<Incoming>> for HttpClie
                     let msg: message::Kill = match serde_json::from_slice(&body) {
                         Ok(msg) => msg,
                         Err(e) => {
-                            error!("failed to deserialize KILL message (error={e:?}): {body:?}");
-                            return Ok(Self::bad_request());
+                            let reason: String = format!(
+                                "failed to deserialize KILL message (error={e:?}): {body:?}"
+                            );
+                            error!("{reason}");
+                            return Ok(Self::error_response(
+                                StatusCode::BAD_REQUEST,
+                                ErrorCode::InvalidKillPayload,
+                                reason,
+                            ));
                         },
                     };
 
@@ -271,35 +354,20 @@ impl<T: Send + Sync + Default + 'static> Service<Request<Incoming>> for HttpClie
 
                     match Self::serve_kill(sandbox_cache, &msg).await {
                         Ok(response) => message::MessageResponse::Kill(response),
-                        Err(_) => {
-                            error!("error processing KILL request");
-                            return Ok(Self::internal_server_error());
+                        Err(error) => {
+                            let reason: String = format!("failed to process KILL request: {error}");
+                            error!("{reason}");
+                            return Ok(Self::error_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                ErrorCode::KillRequestFailed,
+                                reason,
+                            ));
                         },
                     }
                 },
             };
 
-            // Convert response JSON to string.
-            let response_string = match serde_json::to_string(&message_response) {
-                Ok(string) => Bytes::from(string),
-                Err(_) => {
-                    error!("failed to convert JSON response to string");
-                    return Ok(Self::internal_server_error());
-                },
-            };
-
-            match Response::builder()
-                .status(StatusCode::OK)
-                .header("Content-Type", "application/json")
-                .body(Full::new(response_string))
-            {
-                Ok(response) => Ok(response),
-                Err(_) => {
-                    let reason: String = "failed to build response".to_string();
-                    error!("{reason}");
-                    Ok(Self::internal_server_error())
-                },
-            }
+            Ok(Self::json_response(StatusCode::OK, &message_response))
         };
         Box::pin(future)
     }

--- a/src/libs/nanvix-http/src/message.rs
+++ b/src/libs/nanvix-http/src/message.rs
@@ -93,6 +93,59 @@ pub struct KillResponse {
 ///
 /// # Description
 ///
+/// Structured error payload returned by Nanvix Daemon when a request cannot be fulfilled.
+///
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ErrorResponse {
+    /// Short machine-readable code that identifies the failing subsystem.
+    pub code: ErrorCode,
+    /// Human-readable message that provides additional diagnostic context.
+    pub message: String,
+}
+
+///
+/// # Description
+///
+/// Enumerates the short machine-readable error codes exposed by the Nanvix Daemon HTTP API.
+///
+/// These codes allow clients to branch on stable identifiers while still relaying descriptive
+/// messages for operators. They serialize as SCREAMING_SNAKE_CASE strings for compatibility with
+/// existing tooling.
+///
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ErrorCode {
+    /// The `X-NVX-Message-Type` header is missing or invalid.
+    MissingMessageType,
+    /// Hyper failed to read the HTTP request body.
+    BodyReadFailed,
+    /// The provided payload cannot be parsed as a NEW message.
+    InvalidNewPayload,
+    /// The daemon failed while processing a valid NEW request.
+    NewRequestFailed,
+    /// The provided payload cannot be parsed as a KILL message.
+    InvalidKillPayload,
+    /// The daemon failed while processing a valid KILL request.
+    KillRequestFailed,
+}
+
+impl ::std::fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        let code: &str = match self {
+            Self::MissingMessageType => "MISSING_MESSAGE_TYPE",
+            Self::BodyReadFailed => "BODY_READ_FAILED",
+            Self::InvalidNewPayload => "INVALID_NEW_PAYLOAD",
+            Self::NewRequestFailed => "NEW_REQUEST_FAILED",
+            Self::InvalidKillPayload => "INVALID_KILL_PAYLOAD",
+            Self::KillRequestFailed => "KILL_REQUEST_FAILED",
+        };
+        f.write_str(code)
+    }
+}
+
+///
+/// # Description
+///
 /// Unified response type for all message types.
 ///
 /// This enum wraps the specific response types to allow returning different response


### PR DESCRIPTION
This pull request introduces structured error handling to the Nanvix HTTP API, making error responses machine-readable and easier to consume for client tooling. The main changes include the addition of a new `ErrorResponse` schema and `ErrorCode` enum, refactoring the HTTP service to return these structured errors for all failure paths, and updating documentation to describe the new error response format.

**Structured Error Handling Improvements**

* Added `ErrorResponse` struct and `ErrorCode` enum to `src/libs/nanvix-http/src/message.rs`, enabling the daemon to return consistent, machine-readable error payloads for failed requests.
* Refactored the HTTP service in `src/libs/nanvix-http/src/client.rs` to replace ad-hoc error responses with structured JSON error payloads using the new schema, covering all known failure paths (missing headers, bad payloads, internal errors, etc.). [[1]](diffhunk://#diff-6dbbf4cc3d73d08069a16dc8ae30c7eb9b375e7ad2f2e054baa61c618d10f392L97-R173) [[2]](diffhunk://#diff-6dbbf4cc3d73d08069a16dc8ae30c7eb9b375e7ad2f2e054baa61c618d10f392L226-R288) [[3]](diffhunk://#diff-6dbbf4cc3d73d08069a16dc8ae30c7eb9b375e7ad2f2e054baa61c618d10f392L236-R301) [[4]](diffhunk://#diff-6dbbf4cc3d73d08069a16dc8ae30c7eb9b375e7ad2f2e054baa61c618d10f392L247-R348) [[5]](diffhunk://#diff-6dbbf4cc3d73d08069a16dc8ae30c7eb9b375e7ad2f2e054baa61c618d10f392L274-R370)

**Documentation Updates**

* Updated `doc/run.md` to explain the new error response format, including a table of error codes, their associated HTTP status, and when they are emitted. [[1]](diffhunk://#diff-6218dc2316916814c575e9ab16b8ccb73aa943b853d5c3278c840fdfbbcce500R9-R13) [[2]](diffhunk://#diff-6218dc2316916814c575e9ab16b8ccb73aa943b853d5c3278c840fdfbbcce500R91-R108)

**Code Quality and API Consistency**

* Improved helper methods in `HttpClient` for generating JSON and error responses, ensuring all error paths use consistent formatting and status codes.
* Updated error handling in `serve_kill` to propagate errors with context rather than using numeric exit codes.

These changes make the API more robust and easier for clients to integrate with, as errors can now be programmatically distinguished and handled.