### PR TITLE
[build] F: Fix Docker Build with Optional Software

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -59,8 +59,9 @@ docker run \
   -it --rm -v"$(pwd):/mnt" \
   nanvix/toolchain \
   /bin/bash -l -c "\
+    set -e; \
     cd /mnt ; \
-    git config --global --add safe.directory /mnt ; \
+    git config --global --add safe.directory '*' ; \
     make TOOLCHAIN_DIR=/opt/nanvix all ; \
     chown -R $(id -u):$(id -g) . "
 ```

--- a/z
+++ b/z
@@ -204,8 +204,9 @@ build_docker_command() {
         -v \"$(pwd):/mnt\" \
         ${image_name} \
         /bin/bash -l -c '\
+            set -e ; \
             cd /mnt ; \
-            git config --global --add safe.directory /mnt ; \
+            git config --global --add safe.directory \* ; \
             make TOOLCHAIN_DIR=${DOCKER_IMAGE_TOOLCHAIN_PATH} ${build_parameters} ; \
             chown -R \"${user_id}:${group_id}\" .\
         '"
@@ -487,7 +488,11 @@ main() {
     done
 
     # Collect build parameters.
-    local build_parameters=("TOOLCHAIN_DIR=${TOOLCHAIN_DIR}")
+    local build_parameters=()
+    # Only add TOOLCHAIN_DIR for local builds, not Docker builds
+    if ! ${BUILD_WITH_DOCKER}; then
+        build_parameters+=("TOOLCHAIN_DIR=${TOOLCHAIN_DIR}")
+    fi
     while [[ $# -gt 0 ]]; do
         build_parameters+=("$1")
         shift


### PR DESCRIPTION
`./z build --with-docker -- all BUILD_OPT=yes` failed with several reasons, I fixed them:

- `/mnt` does not work for git safe.directory during build (like openblas). Use wildcard `*` instead.
- `chown` masks failures so that it exits with 0, add `set -e` to prevent chown from masking build failures
- `local build_parameters=("TOOLCHAIN_DIR=${TOOLCHAIN_DIR}")` causes the path in docker to wrongly use host local dir, remove `TOOLCHAIN_DIR` in default `build_parameters` for Docker builds

However, I did not fix `pre-commit` and `pre-push` files, they use the local build TOOLCHAIN, I did not install them. I manually ran the workflows in these scripts and they passed.