### PR TITLE
[ci] Improve Workflow Trigger and Dispatch Logic

### DIFF
--- a/.github/workflows/post-benchmark-comment.yml
+++ b/.github/workflows/post-benchmark-comment.yml
@@ -17,10 +17,60 @@ permissions:
   actions: read
 
 jobs:
+  gate-post-benchmark-comment:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.evaluate.outputs.should_run }}
+    steps:
+    - name: Evaluate dispatcher eligibility
+      id: evaluate
+      env:
+        EVENT: ${{ github.event.workflow_run.event }}
+        CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        PULL_REQUESTS_JSON: ${{ toJson(github.event.workflow_run.pull_requests) }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        if [[ "${EVENT}" != "pull_request" ]]; then
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "${CONCLUSION}" == "cancelled" ]]; then
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ -z "${PULL_REQUESTS_JSON}" || "${PULL_REQUESTS_JSON}" == "null" || "${PULL_REQUESTS_JSON}" == "[]" ]]; then
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        pr_number=$(jq -r '.[0].number // ""' <<< "${PULL_REQUESTS_JSON}")
+        if [[ -z "${pr_number}" ]]; then
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if ! pr_payload=$(gh api \
+          --header "Accept: application/vnd.github+json" \
+          "/repos/${REPOSITORY}/pulls/${pr_number}"); then
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if jq -e '.draft == true' <<< "${pr_payload}" >/dev/null; then
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "should_run=true" >> "$GITHUB_OUTPUT"
+
   post-benchmark-comment:
-    if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion != 'cancelled'
+    needs: gate-post-benchmark-comment
+    if: needs.gate-post-benchmark-comment.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
     - name: Download benchmark comment payload

--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -49,14 +49,16 @@ jobs:
     # - Non-merge pushes to 'dev'.
     # - Non-draft PRs.
     if: |
-      (
-        github.event_name != 'push' ||
-        github.event.head_commit == null ||
-        !startsWith(github.event.head_commit.message, 'Merge ')
-      ) && (
-        github.event_name != 'pull_request' ||
-        !github.event.pull_request.draft
-      ) && needs.precheck.outputs.up_to_date == 'true'
+      github.repository == 'nanvix/nanvix' && (
+        (
+          github.event_name != 'push' ||
+          github.event.head_commit == null ||
+          !startsWith(github.event.head_commit.message, 'Merge ')
+        ) && (
+          github.event_name != 'pull_request' ||
+          !github.event.pull_request.draft
+        ) && needs.precheck.outputs.up_to_date == 'true'
+      )
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -54,14 +54,16 @@ jobs:
     # - Non-merge pushes to 'dev'.
     # - Non-draft PRs.
     if: |
-      (
-        github.event_name != 'push' ||
-        github.event.head_commit == null ||
-        !startsWith(github.event.head_commit.message, 'Merge ')
-      ) && (
-        github.event_name != 'pull_request' ||
-        !github.event.pull_request.draft
-      ) && needs.precheck.outputs.up_to_date == 'true'
+      github.repository == 'nanvix/nanvix' && (
+        (
+          github.event_name != 'push' ||
+          github.event.head_commit == null ||
+          !startsWith(github.event.head_commit.message, 'Merge ')
+        ) && (
+          github.event_name != 'pull_request' ||
+          !github.event.pull_request.draft
+        ) && needs.precheck.outputs.up_to_date == 'true'
+      )
 
     steps:
     - uses: actions/checkout@v6
@@ -241,7 +243,7 @@ jobs:
   publish-latest:
     name: "Publish Latest Release"
     needs: ci
-    if: ${{ github.ref == 'refs/heads/dev' }}
+    if: ${{ github.repository == 'nanvix/nanvix' && github.ref == 'refs/heads/dev' }}
     runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: write


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve control over when jobs are run, ensuring that certain jobs only execute for the main repository and under specific conditions (such as non-draft pull requests). The changes introduce a gating job to prevent unnecessary benchmark comments and tighten the conditions for running CI and benchmark jobs.

Workflow gating and job conditions:

* Added a new `gate-post-benchmark-comment` job in `.github/workflows/post-benchmark-comment.yml` to check if the workflow should proceed. The job ensures that benchmark comments are only posted for non-draft pull requests with successful workflow runs. The `post-benchmark-comment` job now depends on this gating job and only runs if the gating conditions are met.
* Updated the `if` conditions in both `.github/workflows/self-hosted-benchmark.yml` and `.github/workflows/self-hosted-ci.yml` so that jobs only run when the repository is `nanvix/nanvix`, and for non-draft pull requests or non-merge pushes to `dev`. This prevents jobs from running on forks or for draft PRs. [[1]](diffhunk://#diff-331a9af7ea0111e347b5a567d95dbb846cab81450473315ff4a7031a956144efR52) [[2]](diffhunk://#diff-331a9af7ea0111e347b5a567d95dbb846cab81450473315ff4a7031a956144efR61) [[3]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811R57) [[4]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811R66)

Release publishing restriction:

* The `publish-latest` job in `.github/workflows/self-hosted-ci.yml` now only runs when the repository is `nanvix/nanvix` and the branch is `dev`, avoiding accidental publishing from forks or other branches.