### PR TITLE
[nanvix-sandbox] Improve Kill Logic

### DIFF
--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -74,6 +74,7 @@ use ::syslog::{
     debug,
     error,
     trace,
+    warn,
 };
 use ::tokio::sync::Mutex;
 
@@ -480,7 +481,27 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
 
         if let Some(sandbox) = self.running_sandboxes.remove(tag) {
             self.sandbox_index.remove(&user_vm_id);
-            sandbox.shutdown().await;
+            match sandbox.shutdown().await {
+                Some(status) => {
+                    if status.success() {
+                        debug!(
+                            "kill(): sandbox exited successfully (user_vm_id={user_vm_id}, \
+                             status={status:?})"
+                        );
+                    } else {
+                        warn!(
+                            "kill(): sandbox exited with failure (user_vm_id={user_vm_id}, \
+                             status={status:?})"
+                        );
+                    }
+                },
+                None => {
+                    warn!(
+                        "kill(): sandbox shutdown did not complete before timeout \
+                         (user_vm_id={user_vm_id})"
+                    );
+                },
+            }
 
             Ok(())
         } else {
@@ -510,8 +531,22 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
         // First shutdown all user VMs.
         for (tag, sandbox) in self.running_sandboxes.drain() {
             debug!("cleaning user vm instance (tag={tag:?})");
-            sandbox.shutdown().await;
+            match sandbox.shutdown().await {
+                Some(status) => {
+                    debug!(
+                        "cleanup(): sandbox reported exit status (tag={tag:?}, status={status:?})"
+                    );
+                },
+                None => {
+                    warn!(
+                        "cleanup(): sandbox shutdown did not complete before timeout (tag={tag:?})"
+                    );
+                },
+            }
         }
+
+        // After draining all running sandboxes, clear the index to keep it consistent.
+        self.sandbox_index.clear();
 
         // Shutdown all linuxd instances.
         for (tenant_id, linuxd_instance) in self.linuxd_instances.iter_mut() {

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -74,7 +74,6 @@ use ::syslog::{
     debug,
     error,
     trace,
-    warn,
 };
 use ::tokio::sync::Mutex;
 
@@ -473,42 +472,28 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
     /// identifier was not found in the cache.
     ///
     pub async fn kill(&mut self, user_vm_id: UserVmIdentifier) -> Result<()> {
-        let tag = self
-            .sandbox_index
-            .get(&user_vm_id)
-            .ok_or_else(|| anyhow::anyhow!("user VM instance not found in cache"))?;
-
-        self.kill_internal(&tag.clone()).await
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Internal helper to terminate and remove a sandbox by its tag.
-    ///
-    /// # Parameters
-    ///
-    /// - `tag`: Tag identifying the sandbox to terminate.
-    ///
-    /// # Returns
-    ///
-    /// On success, returns an empty tuple. On failure, returns an error.
-    ///
-    async fn kill_internal(&mut self, tag: &SandboxTag) -> Result<()> {
-        let user_vm_id: UserVmIdentifier = tag.sandbox_id();
-
-        if !self.running_sandboxes.contains_key(tag) {
-            warn!("trying to kill user VM that is not in the cache (tag={tag:?})");
-            return Ok(());
-        }
+        let tag: &SandboxTag = self.sandbox_index.get(&user_vm_id).ok_or_else(|| {
+            let reason: &str = "user VM instance not found in cache";
+            error!("kill(): {reason} (user_vm_id={user_vm_id})");
+            anyhow::anyhow!("{reason}")
+        })?;
 
         if let Some(sandbox) = self.running_sandboxes.remove(tag) {
+            self.sandbox_index.remove(&user_vm_id);
             sandbox.shutdown().await;
+
+            Ok(())
+        } else {
+            // This is unlikely to happen because every time we insert a new sandbox tag in the
+            // cache index we also insert the corresponding running sandbox in the running sandboxes
+            // map. Conversely, every time we remove a running sandbox from the running sandboxes
+            // map we also remove the corresponding tag from the cache index. Instead of panicking,
+            // we log an error message and fail to maintain backward compatibility.
+            let reason: String =
+                format!("trying to kill user VM that is not in the cache (tag={tag:?})");
+            error!("kill(): {reason}");
+            Err(anyhow::anyhow!(reason))
         }
-
-        self.sandbox_index.remove(&user_vm_id);
-
-        Ok(())
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -89,7 +89,8 @@
 //! // ... communicate with sandbox via gateway socket ...
 //!
 //! // Shutdown gracefully.
-//! running.shutdown().await;
+//! let exit_status = running.shutdown().await;
+//! // Inspect `exit_status` as needed for diagnostics.
 //! # Ok(())
 //! # }
 //! ```

--- a/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
@@ -30,7 +30,10 @@ use ::control_plane_api::{
 };
 use ::std::{
     mem,
-    process::Stdio,
+    process::{
+        ExitStatus,
+        Stdio,
+    },
 };
 use ::syscomm::{
     SocketListener,
@@ -233,7 +236,12 @@ impl UserVm {
     ///
     /// Shuts down the User VM instance.
     ///
-    pub async fn shutdown(&mut self) {
+    /// # Returns
+    ///
+    /// Returns `Some(ExitStatus)` if the child process finished before the cleanup timeout.
+    /// Returns `None` otherwise.
+    ///
+    pub async fn shutdown(&mut self) -> Option<ExitStatus> {
         trace!("shutdown()");
 
         // Prepare shutdown message.
@@ -260,6 +268,8 @@ impl UserVm {
                             exit_status.code()
                         );
                     }
+
+                    return Some(exit_status);
                 },
                 // If we encounter any errors while waiting for the user VM to gracefully shutdown,
                 // make sure we kill the underlying instance.
@@ -275,6 +285,8 @@ impl UserVm {
                 },
             }
         }
+
+        None
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/running.rs
+++ b/src/libs/nanvix-sandbox/src/running.rs
@@ -16,7 +16,10 @@ use crate::{
     tcp_port::TcpPort,
     uservm::UserVm,
 };
-use ::std::sync::Arc;
+use ::std::{
+    process::ExitStatus,
+    sync::Arc,
+};
 use ::syscomm::{
     SocketListener,
     SocketType,
@@ -73,9 +76,10 @@ impl RunningSandbox {
     ///
     /// # Returns
     ///
-    /// This method does not return a value and completes when shutdown is finished.
+    /// Returns `Some(ExitStatus)` if the User VM task or process finished gracefully, and
+    /// `None` otherwise.
     ///
-    pub async fn shutdown(mut self) {
-        self.uservm.shutdown().await;
+    pub async fn shutdown(mut self) -> Option<ExitStatus> {
+        self.uservm.shutdown().await
     }
 }

--- a/src/libs/nanvix-sandbox/src/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/uservm.rs
@@ -25,7 +25,11 @@ use ::control_plane_api::{
 };
 use ::std::{
     mem,
-    process::ExitCode,
+    os::unix::process::ExitStatusExt,
+    process::{
+        ExitCode,
+        ExitStatus,
+    },
     str::FromStr,
 };
 use ::sys::ipc::Message;
@@ -81,7 +85,7 @@ use ::uservm::{
 ///
 pub struct UserVm {
     /// Underlying task.
-    task: Option<JoinHandle<Result<ExitCode>>>,
+    task: Option<JoinHandle<Result<u8>>>,
     /// Control-plane socket stream.
     control_plane_stream: SocketStream,
 }
@@ -132,7 +136,7 @@ impl UserVm {
         let gateway_sockaddr_type: String = args.gateway_socket_info().1.to_str().to_string();
 
         // Spawn the User VM as a new task.
-        let uservm_task: JoinHandle<Result<ExitCode>> = task::spawn_blocking(move || {
+        let uservm_task: JoinHandle<Result<u8>> = task::spawn_blocking(move || {
             Handle::current().block_on(async move {
                 let (vcpu_thread_stdout_tx, io_thread_data_rx) =
                     mpsc::channel::<Message>(CHANNEL_CAPACITY);
@@ -265,17 +269,17 @@ impl UserVm {
                     });
 
                 // Wait for VMM thread to finish.
-                let result: Result<ExitCode> = match vmm_handle.await? {
+                let result: Result<u8> = match vmm_handle.await? {
                     Ok(exit_status) => {
                         if exit_status == 0 {
-                            return Ok(ExitCode::from(0));
+                            return Ok(0);
                         }
                         let exit_code_result: ::std::result::Result<
                             u8,
                             ::std::num::TryFromIntError,
                         > = exit_status.try_into();
                         match exit_code_result {
-                            Ok(code) => Ok(ExitCode::from(code)),
+                            Ok(code) => Ok(code),
                             Err(_) => {
                                 let reason: String = format!(
                                     "failed to convert exit status (exit_status={exit_status})"
@@ -335,7 +339,12 @@ impl UserVm {
     ///
     /// Shuts down the User VM instance.
     ///
-    pub async fn shutdown(&mut self) {
+    /// # Returns
+    ///
+    /// On successful shutdown, this function returns the exit status of the User VM process.
+    /// Otherwise, it returns no exit status.
+    ///
+    pub async fn shutdown(&mut self) -> Option<ExitStatus> {
         trace!("shutdown()");
 
         // Prepare shutdown message.
@@ -356,13 +365,16 @@ impl UserVm {
         if let Some(task) = self.task.take() {
             match timeout(CLEANUP_TIMEOUT, task).await {
                 Ok(join_result) => match join_result {
-                    Ok(Ok(exit_status)) => {
-                        if exit_status != ExitCode::SUCCESS {
+                    Ok(Ok(raw_code)) => {
+                        let exit_code: ExitCode = ExitCode::from(raw_code);
+                        if exit_code != ExitCode::SUCCESS {
                             warn!(
                                 "shutdown(): user VM returned with non-zero exit status \
-                                 (code={exit_status:?})",
+                                 (code={exit_code:?})",
                             );
                         }
+
+                        return Some(exit_status_from_exit_code(raw_code));
                     },
                     Ok(Err(error)) => {
                         warn!("shutdown(): user VM terminated with error (error={error:?})");
@@ -378,6 +390,8 @@ impl UserVm {
                 },
             }
         }
+
+        None
     }
 
     ///
@@ -396,4 +410,22 @@ impl UserVm {
             false
         }
     }
+}
+
+///
+/// # Description
+///
+/// Converts a raw exit code into an `ExitStatus`.
+///
+/// # Parameters
+///
+/// - `raw_code`: Raw exit code returned by the User VM.
+///
+/// # Returns
+///
+/// Returns the corresponding `ExitStatus`.
+///
+fn exit_status_from_exit_code(raw_code: u8) -> ExitStatus {
+    let code: i32 = i32::from(raw_code) & 0xff;
+    ExitStatus::from_raw(code << 8)
 }


### PR DESCRIPTION
This pull request refactors the shutdown and cleanup logic for sandboxed user VMs to consistently return and log process exit statuses. The changes unify the shutdown interface across both single-process and multi-process implementations, improve diagnostics by surfacing exit statuses, and enhance error handling and logging.

Key changes include:

**Unified Shutdown Return Values and Diagnostics**
- Changed the `shutdown` method in both `multi_process::uservm` and `single_process::uservm` to return `Option<ExitStatus>`, allowing callers to inspect whether the VM process/task exited cleanly and with what status. [[1]](diffhunk://#diff-d266815f475746e5199ac0df91c8e888014c93d3b218c2c98b0577ef68e2e7ddL236-R244) [[2]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L338-R348)
- Updated the `RunningSandbox::shutdown` method to propagate the `Option<ExitStatus>` from the underlying user VM.
- Updated documentation and example usage to reflect that shutdown now returns an exit status.

**Improved Logging and Error Handling**
- Enhanced logging in `SandboxCache::kill` and `SandboxCache::cleanup` to record exit statuses and handle potential inconsistencies between sandbox maps, returning errors instead of silently ignoring them. [[1]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aL476-R510) [[2]](diffhunk://#diff-2964b192bb09885e959d801520f71eee761b8a1ff9d6e202aae3ca91a804a96aL528-R536)
- Added warnings for non-zero exit codes and failed shutdowns, providing more context for debugging. [[1]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L359-R378) [[2]](diffhunk://#diff-d266815f475746e5199ac0df91c8e888014c93d3b218c2c98b0577ef68e2e7ddR271-R272)

**Internal Refactoring and Consistency**
- Refactored single-process user VM handling to use `u8` for exit codes internally, converting to `ExitStatus` for API consistency, and added a helper function for this conversion. [[1]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L84-R88) [[2]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L135-R139) [[3]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L268-R282) [[4]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00R415-R432)
- Updated imports and type signatures throughout to support the new shutdown return types. [[1]](diffhunk://#diff-d266815f475746e5199ac0df91c8e888014c93d3b218c2c98b0577ef68e2e7ddL33-R36) [[2]](diffhunk://#diff-128f8c58a8ea28246c02e5e698cea1a96b40d2cc553598edc1a784c0bade14c8L19-R22) [[3]](diffhunk://#diff-9bd216065a430c40d6d3fbd0527fc70255c3f7e4bccadc601dd930bf47040b00L28-R32)

These changes improve the reliability and observability of VM shutdown and cleanup operations, making it easier to track down issues related to process termination.