### PR TITLE
[nanvix-test] Nanvix Test Utility

### DIFF
--- a/.github/actions/nanvix-test/action.yml
+++ b/.github/actions/nanvix-test/action.yml
@@ -1,0 +1,66 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Nanvix Test"
+description: "Run nanvix-test with the appropriate configuration file"
+
+inputs:
+  deployment-type:
+    description: "Deployment mode that determines which test config to run"
+    required: true
+  machine-type:
+    description: "Machine type that is allowed to run nanvix-test"
+    required: true
+  nanvix-test-path:
+    description: "Path to the nanvix-test binary"
+    required: false
+    default: "./bin/nanvix-test.elf"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Run nanvix-test"
+      shell: bash
+      run: |
+        set -Eeuo pipefail
+
+        deployment_type="${{ inputs.deployment-type }}"
+        case "${deployment_type}" in
+          single-process)
+            config_path="test/test-single_process.toml"
+            ;;
+          multi-process)
+            config_path="test/test-multi_process.toml"
+            ;;
+          l2)
+            config_path="test/test-l2.toml"
+            ;;
+          *)
+            echo "Unsupported deployment type: ${deployment_type}" >&2
+            exit 1
+            ;;
+        esac
+
+        machine_type="${{ inputs.machine-type }}"
+        case "${machine_type}" in
+          microvm|hyperlight)
+            ;;
+          *)
+            echo "Skipping nanvix-test for unsupported machine type: ${machine_type}" >&2
+            exit 0
+            ;;
+        esac
+
+        binary_path="${{ inputs.nanvix-test-path }}"
+        if [[ ! -x "${binary_path}" ]]; then
+          echo "nanvix-test binary is missing or not executable (path=${binary_path})" >&2
+          exit 1
+        fi
+
+        if [[ ! -f "${config_path}" ]]; then
+          echo "nanvix-test configuration file missing (path=${config_path})" >&2
+          exit 1
+        fi
+
+        echo "Running nanvix-test (${deployment_type}, ${machine_type}) with ${config_path}"
+        RUST_LOG=trace "${binary_path}" "${config_path}"

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -66,6 +66,14 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    # Create a link to the toolchain directory, as tests files assume the toolchain is at
+    # ${GITHUB_WORKSPACE}/toolchain.
+    - name: "Link Toolchain Directory"
+      shell: bash
+      run: |
+        set -Eeuo pipefail
+        ln -sfn "${HOME}/toolchain" toolchain
+
     - name: "Check Code Format"
       uses: ./.github/actions/format
       with:
@@ -95,6 +103,11 @@ jobs:
         log-level: 'trace'
         machine-type: '${{ matrix.machine-type }}'
         deployment-type: '${{ matrix.deployment-type }}'
+    - name: "Test (New) (${{ matrix.deployment-type }})"
+      uses: ./.github/actions/nanvix-test
+      with:
+        deployment-type: '${{ matrix.deployment-type }}'
+        machine-type: '${{ matrix.machine-type }}'
     - name: "Test"
       uses: ./.github/actions/test
       with:
@@ -165,9 +178,12 @@ jobs:
         # Ensure a clean build.
         git clean -fdx
 
+        # Recreate toolchain symlink removed by git clean.
+        ln -sfn "${HOME}/toolchain" toolchain
+
         # Build the release archive.
         ./z build \
-          --toolchain-dir $HOME/toolchain \
+          --toolchain-dir "${GITHUB_WORKSPACE}/toolchain" \
           -- \
           MACHINE="${{ matrix.machine-type }}" \
           SINGLE_PROCESS="${single_process}" \

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ target/
 venv/
 /sysroot-debug/
 /sysroot-release/
+sysroot
 *.a
 *.elf
 *.exe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
         "src/user/hello-wasm",
         "src/utils/echo-client",
         "src/utils/nanvix-bench",
+        "src/utils/nanvix-test",
         "src/utils/nanvixd",
 ]
 
@@ -122,6 +123,7 @@ serde_cbor = { version = "0.11.2", default-features = false, features = [
 serde_json = { version = "1.0.140", default-features = false, features = [
         "alloc",
 ] }
+shell-words = "1.1"
 signal-hook = "0.4.1"
 slab = { path = "src/libs/slab", default-features = false }
 spin = { git = "https://github.com/nanvix/spin-rs", package = "spin", branch = "nanvix/v0.10.0", default-features = false }
@@ -136,6 +138,7 @@ syscomm = { path = "src/libs/syscomm", default-features = false }
 syslog = { path = "src/libs/syslog", default-features = false }
 talc = { git = "https://github.com/nanvix/talc", rev = "12e66643796be912933a369a2d556aaac4c68771", default-features = false, package = "talc" }
 tokio = { version = "1.45.1", default-features = false }
+toml = { version = "0.8.19", default-features = false, features = ["parse"] }
 type-safe = { path = "src/libs/type-safe", default-features = false }
 uservm = { path = "src/uservm", default-features = false }
 uuid = { version = "1.18.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
         "src/libs/nanvix-sandbox",
         "src/libs/nanvix-sandbox-cache",
         "src/libs/nanvix-terminal",
+        "src/libs/no_fail",
         "src/libs/nvx",
         "src/libs/posix",
         "src/libs/proc",
@@ -104,6 +105,7 @@ nanvix-sandbox = { path = "src/libs/nanvix-sandbox", default-features = false }
 nanvix-sandbox-cache = { path = "src/libs/nanvix-sandbox-cache", default-features = false }
 nanvix-terminal = { path = "src/libs/nanvix-terminal", default-features = false }
 nanvixd = { path = "src/utils/nanvixd", default-features = false }
+no_fail = { path = "src/libs/no_fail", default-features = false }
 num_enum = { version = "0.7.3", default-features = false }
 nvx = { path = "src/libs/nvx", default-features = false }
 profiler = { path = "src/libs/profiler", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ export SCRIPTS_DIR   := $(ROOT_DIR)/scripts
 export SOURCES_DIR   := $(ROOT_DIR)/src
 export TOOLCHAIN_DIR ?= $(ROOT_DIR)/toolchain
 export SYSROOT_DIR   ?= $(ROOT_DIR)/sysroot$(if $(filter yes,$(RELEASE)),-release,-debug)
+export SYSROOT_LINK  := $(ROOT_DIR)/sysroot
 export TARGETS_DIR   := $(BUILD_DIR)/targets
 export OBJECTS_DIR   := $(ROOT_DIR)/target
 export SCCACHE       ?= $(shell which sccache 2>/dev/null)
@@ -316,11 +317,25 @@ ALL_HOST_BINARIES :=
 endif
 
 #===================================================================================================
+# Sysroot Symlink Management
+#===================================================================================================
+
+.PHONY: update-sysroot-link
+update-sysroot-link:
+	@if [ -d "$(SYSROOT_DIR)" ]; then \
+		ln -sfn "$(SYSROOT_DIR)" "$(SYSROOT_LINK)"; \
+		echo "Linked sysroot -> $(notdir $(SYSROOT_DIR))"; \
+	else \
+		echo "Warning: Sysroot directory '$(SYSROOT_DIR)' not found; skipping symlink update."; \
+	fi
+
+#===================================================================================================
 # Top-Level Build Rules
 #===================================================================================================
 
 # Builds everything.
 all: all-nanvix all-opt
+	@$(MAKE) update-sysroot-link
 
 # Builds all Nanvix components.
 all-nanvix: \
@@ -386,6 +401,7 @@ endif
 	@cp ${LIBPOSIX} ${SYSROOT_DIR}/lib/
 	@cp -r ${SCRIPTS_DIR}/common/* ${SYSROOT_DIR}/etc/scripts/
 	@cp -r ${BUILD_DIR}/user/linker/$(TARGET)/user.ld ${SYSROOT_DIR}/lib/
+	@$(MAKE) update-sysroot-link
 
 release: all install
 	@echo "Creating release archive ${RELEASE_ARCHIVE} from ${SYSROOT_DIR}..."

--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ all-nanvix: \
 	all-snapshot
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-all-nanvix: all-host-binaries all-nanvixd all-uservm all-nanvix-bench
+all-nanvix: all-host-binaries all-nanvixd all-uservm all-nanvix-bench all-nanvix-test
 endif
 
 # Performs local initialization.
@@ -372,7 +372,7 @@ clean: \
 	image-clean
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-clean: clean-host-binaries clean-nanvixd clean-uservm clean-nanvix-bench
+clean: clean-host-binaries clean-nanvixd clean-uservm clean-nanvix-bench clean-nanvix-test
 endif
 
 distclean: clean
@@ -481,7 +481,7 @@ rust-lint-check: \
 	rust-lint-check-wasm-binaries
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-rust-lint-check: rust-lint-check-host-binaries rust-lint-check-host-rlibs rust-lint-check-nanvixd rust-lint-check-uservm rust-lint-check-nanvix-bench
+rust-lint-check: rust-lint-check-host-binaries rust-lint-check-host-rlibs rust-lint-check-nanvixd rust-lint-check-uservm rust-lint-check-nanvix-bench rust-lint-check-nanvix-test
 endif
 
 # Fixes code linting issues.
@@ -494,7 +494,7 @@ rust-lint: \
 	rust-lint-wasm-binaries
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-rust-lint: rust-lint-host-binaries rust-lint-host-rlibs rust-lint-nanvixd rust-lint-uservm rust-lint-nanvix-bench
+rust-lint: rust-lint-host-binaries rust-lint-host-rlibs rust-lint-nanvixd rust-lint-uservm rust-lint-nanvix-bench rust-lint-nanvix-test
 endif
 
 # Fixes spelling errors in source code and documentation.
@@ -527,7 +527,7 @@ rust-format: \
 	format-wasm-binaries
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-rust-format: format-host-binaries format-host-rlibs format-nanvixd format-uservm format-nanvix-bench
+rust-format: format-host-binaries format-host-rlibs format-nanvixd format-uservm format-nanvix-bench format-nanvix-test
 endif
 
 # Checks Rust code formatting.
@@ -540,7 +540,7 @@ rust-format-check: \
 	format-check-wasm-binaries
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-rust-format-check: format-check-host-binaries format-check-host-rlibs format-check-nanvixd format-check-uservm format-check-nanvix-bench
+rust-format-check: format-check-host-binaries format-check-host-rlibs format-check-nanvixd format-check-uservm format-check-nanvix-bench format-check-nanvix-test
 endif
 
 # Python lint variables
@@ -588,7 +588,7 @@ check: \
 	check-wasm-binaries
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-check: check-host-binaries check-host-rlibs check-nanvixd check-uservm check-nanvix-bench
+check: check-host-binaries check-host-rlibs check-nanvixd check-uservm check-nanvix-bench check-nanvix-test
 endif
 
 #===================================================================================================
@@ -697,6 +697,12 @@ include build/make/generic-host-rlibs.mk
 #===================================================================================================
 
 include build/make/nanvix-bench.mk
+
+#===================================================================================================
+# Build Rules for Nanvix Test
+#===================================================================================================
+
+include build/make/nanvix-test.mk
 
 #===================================================================================================
 # Build Rules for Nanvix Daemon

--- a/build/make/nanvix-test.mk
+++ b/build/make/nanvix-test.mk
@@ -1,0 +1,32 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+NANVIX_TEST_FEATURES :=
+NANVIX_TEST_FEATURES += $(if $(filter yes,$(SINGLE_PROCESS)),single-process,)
+NANVIX_TEST_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
+NANVIX_TEST_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
+NANVIX_TEST_FEATURES := $(strip $(NANVIX_TEST_FEATURES))
+NANVIX_TEST_CARGO_FEATURES := $(if $(NANVIX_TEST_FEATURES),--features "$(NANVIX_TEST_FEATURES)")
+
+all-nanvix-test: init
+	$(HOST_CARGO_BUILD_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test
+	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/nanvix-test $(BINARIES_DIR)/nanvix-test.elf
+
+check-nanvix-test:
+	$(HOST_CARGO_CHECK_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test
+
+format-nanvix-test:
+	$(HOST_CARGO_FMT_CMD) -p nanvix-test
+
+format-check-nanvix-test:
+	$(HOST_CARGO_FMT_CMD) -p nanvix-test --check
+
+clean-nanvix-test:
+	$(HOST_CARGO_CLEAN_CMD) -p nanvix-test
+	$(RM_CMD) $(BINARIES_DIR)/nanvix-test.elf
+
+rust-lint-nanvix-test:
+	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test --fix --allow-dirty
+
+rust-lint-check-nanvix-test:
+	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test -- -D warnings

--- a/src/libs/nanvix-http/src/server.rs
+++ b/src/libs/nanvix-http/src/server.rs
@@ -19,6 +19,7 @@ use ::hyper_util::rt::TokioIo;
 use ::nanvix_sandbox_cache::{
     SandboxCache,
     SandboxCacheConfig,
+    SandboxCacheStateSummary,
 };
 use ::std::sync::Arc;
 use ::syslog::{
@@ -147,12 +148,19 @@ impl<T: Send + Sync + Default + Clone + 'static> HttpServer<T> {
                 },
                 _ = signals.recv() => {
                     info!("received exit signal, stopping...");
-                    sandbox_cache
-                        .clone()
-                        .lock()
-                        .await
-                        .cleanup()
-                        .await;
+                    let sandbox_cache_clone: Arc<Mutex<SandboxCache<T>>> = sandbox_cache.clone();
+                    let mut cache_guard = sandbox_cache_clone.lock().await;
+                    let summary: SandboxCacheStateSummary = cache_guard.state_summary();
+                    info!(
+                        "shutdown snapshot: running_sandboxes={}, linuxd_instances={}, sandbox_index_entries={}, \
+                         control_plane_socket={}, l2_enabled={}",
+                        summary.running_sandboxes(),
+                        summary.linuxd_instances(),
+                        summary.sandbox_index_entries(),
+                        summary.has_control_plane_socket(),
+                        summary.l2_enabled()
+                    );
+                    cache_guard.cleanup().await;
                     break Ok(());
                 },
             }

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -78,10 +78,6 @@ use ::syslog::{
 };
 use ::tokio::sync::Mutex;
 
-//==================================================================================================
-// Structures
-//==================================================================================================
-
 ///
 /// # Description
 ///
@@ -114,6 +110,74 @@ pub struct SandboxCache<T> {
     /// This is required because `T` is only used in single-process mode for the syscall table.
     #[cfg(not(feature = "single-process"))]
     _phantom: PhantomData<T>,
+}
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Snapshot of the sandbox cache state captured before shutdown.
+///
+/// This structure records high-level counters that help diagnose why the daemon is
+/// still running when the test harness expects it to exit. The data is lightweight
+/// enough to log on every shutdown sequence without impacting performance.
+///
+pub struct SandboxCacheStateSummary {
+    running_sandboxes: usize,
+    linuxd_instances: usize,
+    sandbox_index_entries: usize,
+    has_control_plane_socket: bool,
+    l2_enabled: bool,
+}
+
+impl SandboxCacheStateSummary {
+    ///
+    /// # Description
+    ///
+    /// Returns the number of active sandboxes tracked in the cache.
+    ///
+    pub fn running_sandboxes(&self) -> usize {
+        self.running_sandboxes
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the number of cached linuxd instances.
+    ///
+    pub fn linuxd_instances(&self) -> usize {
+        self.linuxd_instances
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the number of sandbox index entries.
+    ///
+    pub fn sandbox_index_entries(&self) -> usize {
+        self.sandbox_index_entries
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns `true` when a control-plane socket listener is cached.
+    ///
+    pub fn has_control_plane_socket(&self) -> bool {
+        self.has_control_plane_socket
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns whether the daemon is running with L2 mode enabled.
+    ///
+    pub fn l2_enabled(&self) -> bool {
+        self.l2_enabled
+    }
 }
 
 impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
@@ -152,6 +216,25 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
             #[cfg(not(feature = "single-process"))]
             _phantom: PhantomData,
         })))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Produces a snapshot summarizing the cache state for logging purposes.
+    ///
+    /// # Returns
+    ///
+    /// A `SandboxCacheStateSummary` instance describing key counters.
+    ///
+    pub fn state_summary(&self) -> SandboxCacheStateSummary {
+        SandboxCacheStateSummary {
+            running_sandboxes: self.running_sandboxes.len(),
+            linuxd_instances: self.linuxd_instances.len(),
+            sandbox_index_entries: self.sandbox_index.len(),
+            has_control_plane_socket: self.control_plane_socket.is_some(),
+            l2_enabled: self.config.l2(),
+        }
     }
 
     ///
@@ -557,6 +640,17 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                 error!("error cleaning-up linuxd instance: not found (tenant_id={tenant_id})");
             }
         }
+
+        let summary: SandboxCacheStateSummary = self.state_summary();
+        debug!(
+            "cleanup summary: running_sandboxes={}, linuxd_instances={}, \
+             sandbox_index_entries={}, control_plane_socket={}, l2_enabled={}",
+            summary.running_sandboxes(),
+            summary.linuxd_instances(),
+            summary.sandbox_index_entries(),
+            summary.has_control_plane_socket(),
+            summary.l2_enabled()
+        );
     }
 }
 

--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -107,7 +107,7 @@ pub const VETH_NS_PREFIX: &str = "nvxgw-n-";
 /// Suffix for Unix sockets in debug builds.
 ///
 #[cfg(debug_assertions)]
-const UNIX_SOCKET_SUFFIX: &str = ".debug.socket";
+pub const UNIX_SOCKET_SUFFIX: &str = ".debug.socket";
 
 ///
 /// # Description
@@ -115,7 +115,7 @@ const UNIX_SOCKET_SUFFIX: &str = ".debug.socket";
 /// Suffix for Unix sockets in release builds.
 ///
 #[cfg(not(debug_assertions))]
-const UNIX_SOCKET_SUFFIX: &str = ".socket";
+pub const UNIX_SOCKET_SUFFIX: &str = ".socket";
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -167,6 +167,7 @@ pub use config::{
     user_vm_sockaddr_builder,
     NAMED_RESOURCE_PREFIX,
     NETNS_NAME_PREFIX,
+    UNIX_SOCKET_SUFFIX,
     VETH_HOST_PREFIX,
     VETH_NS_PREFIX,
 };

--- a/src/libs/no_fail/Cargo.toml
+++ b/src/libs/no_fail/Cargo.toml
@@ -1,0 +1,20 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "no_fail"
+version.workspace = true
+license-file.workspace = true
+edition = "2024"
+authors.workspace = true
+description = "Compile-time helper macro for infallible constructions"
+homepage.workspace = true
+
+[dependencies]
+
+[features]
+default = ["std"]
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/no_fail/src/lib.rs
+++ b/src/libs/no_fail/src/lib.rs
@@ -1,0 +1,34 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//==================================================================================================
+// Macros
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Executes the provided block, ensures it evaluates to `Result<$T, Infallible>`, and returns the
+/// contained value, turning any fallible construction into a compile-time error.
+///
+/// # Parameters
+///
+/// - `$T`: Type expected from the fallible-free computation.
+/// - `$body`: Block that must evaluate to `Result<$T, Infallible>`.
+///
+/// # Returns
+///
+/// Returns the inner `$T` value produced by the block.
+///
+#[macro_export]
+macro_rules! no_fail {
+    ($T:ty, $body:block) => {{
+        let result: ::core::result::Result<$T, ::core::convert::Infallible> = { $body };
+        match result {
+            ::core::result::Result::Ok(value) => value,
+            ::core::result::Result::Err(err) => match err {},
+        }
+    }};
+}

--- a/src/libs/syscomm/src/socket_stream.rs
+++ b/src/libs/syscomm/src/socket_stream.rs
@@ -161,6 +161,32 @@ impl SocketStream {
     ///
     /// # Description
     ///
+    /// Shuts down the write half of the socket stream so that peers observe an EOF.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `Ok(())` when the shutdown succeeds; returns an error if the underlying
+    /// transport refuses the request.
+    ///
+    pub async fn shutdown_write(&mut self) -> Result<()> {
+        let result: Result<()> = match self {
+            SocketStream::Tcp(stream) => stream.shutdown().await,
+            SocketStream::Unix(stream) => stream.shutdown().await,
+        };
+
+        match result {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                let reason: String = format!("shutdown_write(): {error}");
+                error!("shutdown_write(): {reason}");
+                Err(error)
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
     /// Gets the peer address of a socket stream.
     ///
     /// # Returns

--- a/src/utils/nanvix-test/Cargo.toml
+++ b/src/utils/nanvix-test/Cargo.toml
@@ -1,0 +1,33 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "nanvix-test"
+version.workspace = true
+license-file.workspace = true
+edition = "2024"
+authors.workspace = true
+description = "Test Utility for Nanvix"
+homepage.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+nanvixd = { workspace = true }
+nanvix = { workspace = true, features = ["internal-api"] }
+no_fail = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["full"] }
+libc = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+toml = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+shell-words = { workspace = true }
+
+[features]
+default = ["microvm"]
+single-process = ["nanvix/single-process"]
+hyperlight = ["nanvix/hyperlight"]
+microvm = ["nanvix/microvm"]
+
+[lints]
+workspace = true

--- a/src/utils/nanvix-test/src/args.rs
+++ b/src/utils/nanvix-test/src/args.rs
@@ -1,0 +1,130 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::std::process;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// CLI arguments resolved for the Nanvix test utility entrypoint.
+pub struct Args {
+    /// Path to the Nanvix test configuration file supplied on the command line.
+    config_file_path: String,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Args {
+    const OPT_HELP: &'static str = "-help";
+
+    ///
+    /// # Description
+    ///
+    /// Displays the command-line usage information for the Nanvix test utility.
+    ///
+    /// # Parameters
+    ///
+    /// - `program_name`: Executable name printed in the usage banner.
+    ///
+    /// # Return Value
+    ///
+    /// Returns immediately after printing the usage banner; does not fail.
+    ///
+    fn usage(program_name: &str) {
+        println!(
+            "\
+Nanvix Test Utility - Helper tool for testing Nanvix.
+
+Usage:
+    {program_name} [OPTIONS] <config-file>
+
+Options:
+    {help}                   Show this help message and exit.
+
+Required positional arguments:
+    config-file             Path to the TOML configuration that describes the runner and test case.
+",
+            program_name = program_name,
+            help = Self::OPT_HELP,
+        );
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Parses the CLI arguments and produces the resolved configuration options.
+    ///
+    /// # Parameters
+    ///
+    /// - `args`: Vector containing the raw arguments provided to the program.
+    ///
+    /// # Return Value
+    ///
+    /// Returns an `Args` instance when the CLI input is valid; returns an error when the
+    /// configuration file argument is missing, misordered, or an unexpected flag appears.
+    ///
+    pub fn parse(args: Vec<String>) -> Result<Self> {
+        let mut config_file_path: Option<String> = None;
+
+        let mut i: usize = 1;
+        while i < args.len() {
+            match args[i].as_str() {
+                Self::OPT_HELP => {
+                    Self::usage(args[0].as_str());
+                    process::exit(0);
+                },
+                argument => {
+                    if i == args.len() - 1 {
+                        config_file_path = Some(argument.to_string());
+                    } else {
+                        let reason: String = format!(
+                            "invalid argument order: configuration file must be the last argument \
+                             (found '{argument}')"
+                        );
+                        Self::usage(args[0].as_str());
+                        eprintln!("parse(): {reason}");
+                        return Err(::anyhow::anyhow!(reason));
+                    }
+                },
+            }
+            i += 1;
+        }
+
+        let config_file_path: String = match config_file_path {
+            Some(path) => path,
+            None => {
+                let reason: String =
+                    "missing required positional argument: <config-file>".to_string();
+                Self::usage(args[0].as_str());
+                eprintln!("parse(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+        };
+
+        Ok(Self { config_file_path })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the path to the TOML configuration file supplied via the CLI.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the configuration file path.
+    ///
+    pub fn config_file_path(&self) -> &str {
+        self.config_file_path.as_str()
+    }
+}

--- a/src/utils/nanvix-test/src/config.rs
+++ b/src/utils/nanvix-test/src/config.rs
@@ -1,0 +1,1376 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::nanvixd::config::DEFAULT_TMP_DIRECTORY;
+use ::std::{
+    fs,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+use ::toml::{
+    Value,
+    value::Table,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+///
+/// Default number of Nanvix Daemon shutdown attempts when omitted in the TOML file.
+///
+const DEFAULT_NANVIXD_SHUTDOWN_ATTEMPTS_MAX: usize = 10;
+/// Default Nanvix Daemon shutdown retry interval (in milliseconds) when omitted in the TOML file.
+const DEFAULT_NANVIXD_SHUTDOWN_RETRY_INTERVAL_MS: u64 = 100;
+/// Default iteration count for the requested test case when not specified.
+const DEFAULT_TEST_ITERATIONS: usize = 1;
+/// Default number of readiness probes issued before giving up on the Nanvix Daemon HTTP endpoint.
+const DEFAULT_NANVIXD_READY_ATTEMPTS_MAX: usize = 50;
+/// Default interval (in milliseconds) between Nanvix Daemon readiness probes.
+const DEFAULT_NANVIXD_READY_RETRY_INTERVAL_MS: u64 = 100;
+/// Default delay (in milliseconds) before launching another User VM.
+const DEFAULT_CLEANUP_USERVM_SLEEP_DURATION_MS: u64 = 10;
+/// Default delay (in milliseconds) before launching another User VM when L2 mode is enabled.
+const DEFAULT_CLEANUP_L2_USERVM_SLEEP_DURATION_MS: u64 = 100;
+/// Default timeout (in milliseconds) applied when collecting interactive stdout/stderr streams.
+const DEFAULT_STREAM_COLLECTION_TIMEOUT_MS: u64 = 300_000;
+/// Default maximum duration (in seconds) spent waiting for lingering TCP TIME_WAIT sockets.
+const DEFAULT_TCP_CLEANUP_MAX_WAIT_SECONDS: u64 = 70;
+/// Default polling interval (in seconds) used while monitoring TIME_WAIT sockets.
+const DEFAULT_TCP_CLEANUP_POLL_INTERVAL_SECONDS: u64 = 2;
+/// Default maximum number of gateway connection attempts before failing a spawn.
+const DEFAULT_GATEWAY_CONNECT_MAX_ATTEMPTS: usize = 100;
+/// Default initial backoff (in milliseconds) between gateway connection retries.
+const DEFAULT_GATEWAY_CONNECT_INITIAL_BACKOFF_MS: u64 = 10;
+/// Default maximum backoff (in milliseconds) between gateway connection retries.
+const DEFAULT_GATEWAY_CONNECT_MAX_BACKOFF_MS: u64 = 500;
+/// Default timeout (in milliseconds) applied to the gateway connection loop.
+const DEFAULT_GATEWAY_CONNECT_TIMEOUT_MS: u64 = 15_000;
+/// Placeholder token replaced with the configured sysroot path inside test definitions.
+const SYSROOT_PATH_PLACEHOLDER: &str = "${sysroot_path}";
+
+//==================================================================================================
+// Nanvix Test Configuration
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Complete Nanvix test configuration loaded from a TOML definition.
+///
+pub struct NanvixTestConfig {
+    /// Runner configuration applied when spawning the Nanvix Daemon.
+    pub runner: RunnerConfig,
+    /// List of test cases to execute sequentially.
+    pub tests: Vec<TestCaseConfig>,
+}
+
+impl NanvixTestConfig {
+    ///
+    /// # Description
+    ///
+    /// Loads the Nanvix test configuration from a TOML file.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the TOML configuration file.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the parsed configuration when the file is readable and valid; returns an error
+    /// when file I/O, TOML parsing, or validation fails.
+    ///
+    pub fn from_path(path: &Path) -> Result<Self> {
+        let contents: String = match fs::read_to_string(path) {
+            Ok(data) => data,
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to read nanvix-test config (path={}, error={error})",
+                    path.display()
+                );
+                return Err(::anyhow::anyhow!(reason));
+            },
+        };
+
+        let parsed_value: Value = match ::toml::from_str(contents.as_str()) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to parse nanvix-test config (path={}, error={error})",
+                    path.display()
+                );
+                return Err(::anyhow::anyhow!(reason));
+            },
+        };
+
+        let mut config: NanvixTestConfig = NanvixTestConfig::from_toml_value(parsed_value)?;
+
+        let base_dir: &Path = match path.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => parent,
+            _ => Path::new("."),
+        };
+        config.runner.resolve_paths(base_dir)?;
+
+        for (index, test_config) in config.tests.iter_mut().enumerate() {
+            test_config.apply_runner_placeholders(&config.runner);
+            test_config.resolve_paths(base_dir, index)?;
+            test_config.validate(index)?;
+        }
+
+        Ok(config)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Builds a `NanvixTestConfig` structure from the parsed TOML root value.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: Parsed TOML representation of the configuration file.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the fully populated configuration tree when the TOML schema matches the expected
+    /// layout; returns an error when the `runner` or `tests` tables are malformed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the root value is not a table or nested entries use unexpected
+    /// types.
+    ///
+    fn from_toml_value(value: Value) -> Result<Self> {
+        let root_table: Table = match value {
+            Value::Table(table) => table,
+            other => {
+                let reason: String = format!(
+                    "nanvix-test config must be a TOML table (found={})",
+                    describe_toml_type(&other)
+                );
+                return Err(::anyhow::anyhow!(reason));
+            },
+        };
+
+        let runner_table: &Table = get_required_table(&root_table, "runner", "runner")?;
+        let runner: RunnerConfig = RunnerConfig::from_table(runner_table)?;
+
+        let test_entries: &Vec<Value> = get_required_array(&root_table, "tests", "tests")?;
+        if test_entries.is_empty() {
+            let reason: String =
+                "at least one test entry must be provided under '[[tests]]'".to_string();
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        let mut tests: Vec<TestCaseConfig> = Vec::with_capacity(test_entries.len());
+        for (index, entry) in test_entries.iter().enumerate() {
+            let field_name: String = format!("tests[{index}]");
+            let entry_table: &Table = match entry {
+                Value::Table(table) => table,
+                other => {
+                    let reason: String = format!(
+                        "{field_name} must be a table (found={})",
+                        describe_toml_type(other)
+                    );
+                    return Err(::anyhow::anyhow!(reason));
+                },
+            };
+            tests.push(TestCaseConfig::from_table(entry_table, index)?);
+        }
+
+        Ok(Self { runner, tests })
+    }
+}
+
+//==================================================================================================
+// Runner Configuration
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Configuration required to spawn a Nanvix Daemon instance.
+pub struct RunnerConfig {
+    /// Path to the Nanvix Daemon executable that should be launched.
+    pub nanvixd_binary_path: String,
+    /// Directory used as the current working directory for the Nanvix Daemon.
+    pub working_directory: String,
+    /// Directory where Nanvix Daemon stdout/stderr logs are written.
+    pub log_directory: String,
+    /// Directory scanned for temporary artifacts created during Nanvix test runs.
+    pub tmp_directory: String,
+    /// IPv4 address where the Nanvix Daemon should listen for HTTP requests.
+    pub ipv4_addr: String,
+    /// TCP port where the Nanvix Daemon exposes its HTTP endpoint.
+    pub port_num: u16,
+    /// Optional hwloc topology description forwarded to the Nanvix Daemon. Empty strings are
+    /// treated as unset values.
+    pub hwloc_file_path: Option<String>,
+    /// Flag indicating whether the Nanvix Daemon should run with L2 mode enabled.
+    pub l2_enabled: bool,
+    /// Flag enabling fatal mode, causing warnings to fail tests when set to `true`.
+    pub fatal: bool,
+    /// Path to the toolchain root; its `bin/` directory is forwarded to the Nanvix Daemon.
+    pub toolchain_path: String,
+    /// Path to the sysroot that hosts interpreter runtimes and shared assets.
+    pub sysroot_path: String,
+    /// Maximum number of Nanvix Daemon shutdown polling attempts before giving up.
+    pub nanvixd_shutdown_attempts_max: usize,
+    /// Milliseconds to wait between Nanvix Daemon shutdown polling attempts.
+    pub nanvixd_shutdown_retry_interval_ms: u64,
+    /// Maximum number of readiness probes issued before giving up on the Nanvix Daemon HTTP endpoint.
+    pub nanvixd_ready_attempts_max: usize,
+    /// Interval (in milliseconds) between readiness probes for the Nanvix Daemon HTTP endpoint.
+    pub nanvixd_ready_retry_interval_ms: u64,
+    /// Milliseconds to wait after tearing down a User VM before spawning the next workload.
+    pub cleanup_uservm_sleep_duration_ms: u64,
+    /// Milliseconds to wait after tearing down a User VM when L2 mode is enabled.
+    pub cleanup_l2_uservm_sleep_duration_ms: u64,
+    /// Maximum time (in milliseconds) allowed for collecting interactive stdout/stderr streams.
+    pub stream_collection_timeout_ms: u64,
+    /// Maximum duration (in seconds) spent waiting for lingering TIME_WAIT sockets during
+    /// cleanup.
+    pub tcp_cleanup_max_wait_seconds: u64,
+    /// Polling interval (in seconds) used between TIME_WAIT socket inspections.
+    pub tcp_cleanup_poll_interval_seconds: u64,
+    /// Maximum number of attempts performed while connecting to a uservm gateway.
+    pub gateway_connect_max_attempts: usize,
+    /// Initial backoff (in milliseconds) between uservm gateway connection retries.
+    pub gateway_connect_initial_backoff_ms: u64,
+    /// Maximum backoff (in milliseconds) between uservm gateway connection retries.
+    pub gateway_connect_max_backoff_ms: u64,
+    /// Maximum time (in milliseconds) spent attempting to connect to the uservm gateway.
+    pub gateway_connect_timeout_ms: u64,
+}
+
+impl RunnerConfig {
+    ///
+    /// # Description
+    ///
+    /// Parses the `[runner]` table from the TOML configuration and produces a `RunnerConfig`
+    /// instance.
+    ///
+    /// # Parameters
+    ///
+    /// - `table`: Key/value map containing the runner configuration fields.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the parsed `RunnerConfig` when every required field is present and valid; returns
+    /// an error when parsing fails or a field uses an unexpected type.
+    ///
+    fn from_table(table: &Table) -> Result<Self> {
+        Ok(Self {
+            nanvixd_binary_path: read_required_string(
+                table,
+                "nanvixd_binary_path",
+                "runner.nanvixd_binary_path",
+            )?,
+            working_directory: read_required_string(
+                table,
+                "working_directory",
+                "runner.working_directory",
+            )?,
+            log_directory: read_required_string(table, "log_directory", "runner.log_directory")?,
+            tmp_directory: read_string_with_default(
+                table,
+                "tmp_directory",
+                "runner.tmp_directory",
+                default_tmp_directory,
+            )?,
+            ipv4_addr: read_required_string(table, "ipv4_addr", "runner.ipv4_addr")?,
+            port_num: read_u16_required(table, "port_num", "runner.port_num")?,
+            hwloc_file_path: read_hwloc_file_path(table)?,
+            l2_enabled: read_bool_with_default(table, "l2_enabled", "runner.l2_enabled", false)?,
+            fatal: read_bool_with_default(table, "fatal", "runner.fatal", false)?,
+            toolchain_path: read_required_string(table, "toolchain_path", "runner.toolchain_path")?,
+            sysroot_path: read_required_non_empty_string(
+                table,
+                "sysroot_path",
+                "runner.sysroot_path",
+            )?,
+            nanvixd_shutdown_attempts_max: read_usize_with_default(
+                table,
+                "nanvixd_shutdown_attempts_max",
+                "runner.nanvixd_shutdown_attempts_max",
+                default_nanvixd_shutdown_attempts_max(),
+            )?,
+            nanvixd_shutdown_retry_interval_ms: read_u64_with_default(
+                table,
+                "nanvixd_shutdown_retry_interval_ms",
+                "runner.nanvixd_shutdown_retry_interval_ms",
+                default_nanvixd_shutdown_retry_interval_ms(),
+            )?,
+            nanvixd_ready_attempts_max: read_usize_with_default(
+                table,
+                "nanvixd_ready_attempts_max",
+                "runner.nanvixd_ready_attempts_max",
+                default_nanvixd_ready_attempts_max(),
+            )?,
+            nanvixd_ready_retry_interval_ms: read_u64_with_default(
+                table,
+                "nanvixd_ready_retry_interval_ms",
+                "runner.nanvixd_ready_retry_interval_ms",
+                default_nanvixd_ready_retry_interval_ms(),
+            )?,
+            cleanup_uservm_sleep_duration_ms: read_u64_with_default(
+                table,
+                "cleanup_uservm_sleep_duration_ms",
+                "runner.cleanup_uservm_sleep_duration_ms",
+                default_cleanup_uservm_sleep_duration_ms(),
+            )?,
+            cleanup_l2_uservm_sleep_duration_ms: read_u64_with_default(
+                table,
+                "cleanup_l2_uservm_sleep_duration_ms",
+                "runner.cleanup_l2_uservm_sleep_duration_ms",
+                default_cleanup_l2_uservm_sleep_duration_ms(),
+            )?,
+            stream_collection_timeout_ms: read_u64_with_default(
+                table,
+                "stream_collection_timeout_ms",
+                "runner.stream_collection_timeout_ms",
+                default_stream_collection_timeout_ms(),
+            )?,
+            tcp_cleanup_max_wait_seconds: read_u64_with_default(
+                table,
+                "tcp_cleanup_max_wait_seconds",
+                "runner.tcp_cleanup_max_wait_seconds",
+                default_tcp_cleanup_max_wait_seconds(),
+            )?,
+            tcp_cleanup_poll_interval_seconds: read_u64_with_default(
+                table,
+                "tcp_cleanup_poll_interval_seconds",
+                "runner.tcp_cleanup_poll_interval_seconds",
+                default_tcp_cleanup_poll_interval_seconds(),
+            )?,
+            gateway_connect_max_attempts: read_usize_with_default(
+                table,
+                "gateway_connect_max_attempts",
+                "runner.gateway_connect_max_attempts",
+                default_gateway_connect_max_attempts(),
+            )?,
+            gateway_connect_initial_backoff_ms: read_u64_with_default(
+                table,
+                "gateway_connect_initial_backoff_ms",
+                "runner.gateway_connect_initial_backoff_ms",
+                default_gateway_connect_initial_backoff_ms(),
+            )?,
+            gateway_connect_max_backoff_ms: read_u64_with_default(
+                table,
+                "gateway_connect_max_backoff_ms",
+                "runner.gateway_connect_max_backoff_ms",
+                default_gateway_connect_max_backoff_ms(),
+            )?,
+            gateway_connect_timeout_ms: read_u64_with_default(
+                table,
+                "gateway_connect_timeout_ms",
+                "runner.gateway_connect_timeout_ms",
+                default_gateway_connect_timeout_ms(),
+            )?,
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Resolves relative paths using the directory that contains the TOML file.
+    ///
+    /// # Parameters
+    ///
+    /// - `base_dir`: Directory used to resolve relative paths.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `Ok(())` once all relative paths are resolved successfully; returns an error when
+    /// any resolved path cannot be represented as UTF-8.
+    ///
+    pub fn resolve_paths(&mut self, base_dir: &Path) -> Result<()> {
+        let invocation_dir: PathBuf = current_working_directory()?;
+
+        self.nanvixd_binary_path = resolve_with_invocation_dirs(
+            base_dir,
+            invocation_dir.as_path(),
+            self.nanvixd_binary_path.as_str(),
+            "runner.nanvixd_binary_path",
+        )?;
+        self.working_directory = resolve_with_invocation_dirs(
+            base_dir,
+            invocation_dir.as_path(),
+            self.working_directory.as_str(),
+            "runner.working_directory",
+        )?;
+        self.log_directory = resolve_with_invocation_dirs(
+            base_dir,
+            invocation_dir.as_path(),
+            self.log_directory.as_str(),
+            "runner.log_directory",
+        )?;
+        self.tmp_directory = resolve_with_invocation_dirs(
+            base_dir,
+            invocation_dir.as_path(),
+            self.tmp_directory.as_str(),
+            "runner.tmp_directory",
+        )?;
+        self.toolchain_path = resolve_with_invocation_dirs(
+            base_dir,
+            invocation_dir.as_path(),
+            self.toolchain_path.as_str(),
+            "runner.toolchain_path",
+        )?;
+        self.sysroot_path = resolve_with_invocation_dirs(
+            base_dir,
+            invocation_dir.as_path(),
+            self.sysroot_path.as_str(),
+            "runner.sysroot_path",
+        )?;
+
+        if let Some(path) = self.hwloc_file_path.clone() {
+            self.hwloc_file_path = Some(resolve_with_invocation_dirs(
+                base_dir,
+                invocation_dir.as_path(),
+                path.as_str(),
+                "runner.hwloc_file_path",
+            )?);
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Builds the IPv4:port socket string used to reach the Nanvix Daemon HTTP endpoint.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a socket address string formatted as `addr:port`.
+    ///
+    pub fn http_endpoint(&self) -> String {
+        format!("{}:{}", self.ipv4_addr, self.port_num)
+    }
+}
+
+//==================================================================================================
+// Test Case Configuration
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Description of the test case that should be executed.
+///
+pub struct TestCaseConfig {
+    /// Executor identifier requested for the test case (e.g., `empty`, `http`, `terminal`).
+    pub executor: String,
+    /// Number of times the test case should run.
+    pub iterations: usize,
+    /// Optional program path required by some test cases.
+    pub program: Option<String>,
+    /// Optional command-line arguments forwarded to the workload under test.
+    pub program_args: Option<String>,
+    /// Optional input payload forwarded to the workload under test.
+    pub input: Option<String>,
+    /// Optional output payload used when validating the workload response.
+    pub expected_output: Option<String>,
+}
+
+impl TestCaseConfig {
+    ///
+    /// # Description
+    ///
+    /// Parses a single `[[tests]]` entry from the TOML configuration and populates a
+    /// `TestCaseConfig` structure.
+    ///
+    /// # Parameters
+    ///
+    /// - `table`: TOML table that stores the test case fields.
+    /// - `index`: Position of the entry within the `tests` array (used for error reporting).
+    ///
+    /// # Return Value
+    ///
+    /// Returns the parsed test case configuration when all fields are valid; returns an error
+    /// when a required key is missing or of the wrong type.
+    ///
+    fn from_table(table: &Table, index: usize) -> Result<Self> {
+        let entry_prefix: String = format!("tests[{index}]");
+        let executor_field: String = format!("{entry_prefix}.executor");
+        let iterations_field: String = format!("{entry_prefix}.iterations");
+        let program_field: String = format!("{entry_prefix}.program");
+        let program_args_field: String = format!("{entry_prefix}.program_args");
+        let input_field: String = format!("{entry_prefix}.input");
+        let expected_output_field: String = format!("{entry_prefix}.expected_output");
+
+        Ok(Self {
+            executor: read_required_string(table, "executor", executor_field.as_str())?,
+            iterations: read_usize_with_default(
+                table,
+                "iterations",
+                iterations_field.as_str(),
+                default_test_iterations(),
+            )?,
+            program: read_optional_string(table, "program", program_field.as_str())?,
+            program_args: read_optional_string(table, "program_args", program_args_field.as_str())?,
+            input: read_optional_string(table, "input", input_field.as_str())?,
+            expected_output: read_optional_string(
+                table,
+                "expected_output",
+                expected_output_field.as_str(),
+            )?,
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Validates the parsed test case configuration.
+    ///
+    /// # Parameters
+    ///
+    /// - `index`: Position of the test case in the configuration (used for error reporting).
+    ///
+    /// # Return Value
+    ///
+    /// Returns `Ok(())` when the test case definition is valid; returns an error if iterations are
+    /// zero or required fields are missing for the selected executor name.
+    ///
+    pub fn validate(&self, index: usize) -> Result<()> {
+        if self.iterations == 0 {
+            let reason: String = format!(
+                "tests[{index}] iterations must be greater than zero (executor={})",
+                self.executor
+            );
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        if (self.executor == "http" || self.executor == "terminal") && self.program.is_none() {
+            let reason: String = format!(
+                "tests[{index}] requires the 'program' field when executor is '{}'",
+                self.executor
+            );
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Applies runner-provided placeholders to optional program paths.
+    ///
+    /// # Parameters
+    ///
+    /// - `runner`: Runner configuration that exposes placeholder values.
+    ///
+    pub fn apply_runner_placeholders(&mut self, runner: &RunnerConfig) {
+        if let Some(program_path) = self.program.as_mut()
+            && program_path.contains(SYSROOT_PATH_PLACEHOLDER)
+        {
+            let substituted: String =
+                program_path.replace(SYSROOT_PATH_PLACEHOLDER, runner.sysroot_path.as_str());
+            *program_path = substituted;
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Resolves optional relative paths present in the test case definition.
+    ///
+    /// # Parameters
+    ///
+    /// - `base_dir`: Directory used to resolve relative paths.
+    /// - `index`: Index of this test entry (used for error reporting).
+    ///
+    /// # Return Value
+    ///
+    /// Returns `Ok(())` when optional paths resolve successfully; returns an error if the resolved
+    /// path cannot be represented as UTF-8.
+    ///
+    pub fn resolve_paths(&mut self, base_dir: &Path, index: usize) -> Result<()> {
+        if let Some(program_path) = self.program.clone() {
+            let field_name: String = format!("tests[{index}].program");
+            let invocation_dir: PathBuf = current_working_directory()?;
+            let resolved_path: String = resolve_with_invocation_dirs(
+                base_dir,
+                invocation_dir.as_path(),
+                program_path.as_str(),
+                field_name.as_str(),
+            )?;
+            self.program = Some(resolved_path);
+        }
+
+        Ok(())
+    }
+}
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns the default number of shutdown attempts used when the value is omitted in the
+/// configuration file.
+///
+/// # Return Value
+///
+/// Returns the maximum number of shutdown attempts applied to Nanvix Daemon teardown.
+///
+fn default_nanvixd_shutdown_attempts_max() -> usize {
+    DEFAULT_NANVIXD_SHUTDOWN_ATTEMPTS_MAX
+}
+
+///
+/// # Description
+///
+/// Returns the default delay between shutdown attempts when the field is not specified.
+///
+/// # Return Value
+///
+/// Returns the milliseconds to wait between Nanvix Daemon shutdown polling attempts.
+///
+fn default_nanvixd_shutdown_retry_interval_ms() -> u64 {
+    DEFAULT_NANVIXD_SHUTDOWN_RETRY_INTERVAL_MS
+}
+
+///
+/// # Description
+///
+/// Returns the default number of readiness probes for the Nanvix Daemon HTTP endpoint.
+///
+/// # Return Value
+///
+/// Returns the maximum number of Nanvix Daemon readiness probes.
+///
+fn default_nanvixd_ready_attempts_max() -> usize {
+    DEFAULT_NANVIXD_READY_ATTEMPTS_MAX
+}
+
+///
+/// # Description
+///
+/// Returns the default interval between Nanvix Daemon readiness probes.
+///
+/// # Return Value
+///
+/// Returns the milliseconds to wait between readiness attempts.
+///
+fn default_nanvixd_ready_retry_interval_ms() -> u64 {
+    DEFAULT_NANVIXD_READY_RETRY_INTERVAL_MS
+}
+
+///
+/// # Description
+///
+/// Returns the default temporary directory path applied when the configuration omits the field.
+///
+/// # Return Value
+///
+/// Returns the temporary directory path scanned for Nanvix test artifacts.
+///
+fn default_tmp_directory() -> String {
+    DEFAULT_TMP_DIRECTORY.to_string()
+}
+
+///
+/// # Description
+///
+/// Reports the default number of iterations each test case should run when unspecified.
+///
+/// # Return Value
+///
+/// Returns the number of repetitions applied to a test case.
+///
+fn default_test_iterations() -> usize {
+    DEFAULT_TEST_ITERATIONS
+}
+
+///
+/// # Description
+///
+/// Provides the default delay between User VM launches during cleanup.
+///
+/// # Return Value
+///
+/// Returns the milliseconds spent waiting before launching the next User VM.
+///
+fn default_cleanup_uservm_sleep_duration_ms() -> u64 {
+    DEFAULT_CLEANUP_USERVM_SLEEP_DURATION_MS
+}
+
+///
+/// # Description
+///
+/// Provides the default cleanup delay between User VMs when L2 mode is enabled.
+///
+/// # Return Value
+///
+/// Returns the milliseconds spent waiting before launching the next User VM under L2 mode.
+///
+fn default_cleanup_l2_uservm_sleep_duration_ms() -> u64 {
+    DEFAULT_CLEANUP_L2_USERVM_SLEEP_DURATION_MS
+}
+
+///
+/// # Description
+///
+/// Provides the default timeout applied when collecting interactive stdout/stderr streams.
+///
+/// # Return Value
+///
+/// Returns the milliseconds spent waiting for interactive stream collection.
+///
+fn default_stream_collection_timeout_ms() -> u64 {
+    DEFAULT_STREAM_COLLECTION_TIMEOUT_MS
+}
+
+///
+/// # Description
+///
+/// Provides the default timeout applied when waiting for lingering TCP TIME_WAIT sockets.
+///
+/// # Return Value
+///
+/// Returns the maximum number of seconds spent waiting for TCP cleanup.
+///
+fn default_tcp_cleanup_max_wait_seconds() -> u64 {
+    DEFAULT_TCP_CLEANUP_MAX_WAIT_SECONDS
+}
+
+///
+/// # Description
+///
+/// Provides the default polling interval applied when monitoring TCP TIME_WAIT sockets.
+///
+/// # Return Value
+///
+/// Returns the number of seconds spent between TCP cleanup polls.
+///
+fn default_tcp_cleanup_poll_interval_seconds() -> u64 {
+    DEFAULT_TCP_CLEANUP_POLL_INTERVAL_SECONDS
+}
+
+///
+/// # Description
+///
+/// Provides the default maximum number of gateway connection attempts.
+///
+/// # Return Value
+///
+/// Returns the retry budget applied while connecting to uservm gateways.
+///
+fn default_gateway_connect_max_attempts() -> usize {
+    DEFAULT_GATEWAY_CONNECT_MAX_ATTEMPTS
+}
+
+///
+/// # Description
+///
+/// Provides the default initial gateway connection backoff.
+///
+/// # Return Value
+///
+/// Returns the milliseconds spent waiting before the first retry.
+///
+fn default_gateway_connect_initial_backoff_ms() -> u64 {
+    DEFAULT_GATEWAY_CONNECT_INITIAL_BACKOFF_MS
+}
+
+///
+/// # Description
+///
+/// Provides the default maximum gateway connection backoff.
+///
+/// # Return Value
+///
+/// Returns the upper bound on the milliseconds spent between retries.
+///
+fn default_gateway_connect_max_backoff_ms() -> u64 {
+    DEFAULT_GATEWAY_CONNECT_MAX_BACKOFF_MS
+}
+
+///
+/// # Description
+///
+/// Provides the default timeout applied to gateway connection attempts.
+///
+/// # Return Value
+///
+/// Returns the milliseconds spent trying to connect to the gateway before failing.
+///
+fn default_gateway_connect_timeout_ms() -> u64 {
+    DEFAULT_GATEWAY_CONNECT_TIMEOUT_MS
+}
+
+///
+/// # Description
+///
+/// Retrieves the working directory used when `nanvix-test` was invoked.
+///
+/// # Return Value
+///
+/// Returns the invocation directory when it can be queried successfully.
+///
+/// # Errors
+///
+/// Returns an error when the filesystem query for the current directory fails.
+///
+fn current_working_directory() -> Result<PathBuf> {
+    match ::std::env::current_dir() {
+        Ok(directory) => Ok(directory),
+        Err(error) => {
+            let reason: String =
+                format!("failed to read current working directory (error={error})");
+            Err(::anyhow::anyhow!(reason))
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Resolves a configuration-provided path by first interpreting it relative to the invocation
+/// directory and then falling back to the configuration directory when there is no matching entry.
+///
+/// # Parameters
+///
+/// - `config_dir`: Directory where the configuration file resides.
+/// - `invocation_dir`: Directory where `nanvix-test` was launched.
+/// - `provided`: Path string supplied in the configuration file.
+/// - `field_name`: Fully qualified configuration key used for error reporting.
+///
+/// # Return Value
+///
+/// Returns the normalized path string.
+///
+fn resolve_with_invocation_dirs(
+    config_dir: &Path,
+    invocation_dir: &Path,
+    provided: &str,
+    field_name: &str,
+) -> Result<String> {
+    let provided_path: &Path = Path::new(provided);
+
+    if provided_path.is_absolute() {
+        return path_to_utf8_string(provided_path, field_name);
+    }
+
+    let invocation_candidate: PathBuf = invocation_dir.join(provided_path);
+    if invocation_candidate.exists() {
+        return path_to_utf8_string(invocation_candidate.as_path(), field_name);
+    }
+
+    let config_candidate: PathBuf = config_dir.join(provided_path);
+    if config_candidate.exists() {
+        return path_to_utf8_string(config_candidate.as_path(), field_name);
+    }
+
+    path_to_utf8_string(invocation_candidate.as_path(), field_name)
+}
+
+///
+/// # Description
+///
+/// Converts a resolved filesystem path into a UTF-8 string or reports an error when conversion is
+/// not possible.
+///
+/// # Parameters
+///
+/// - `resolved_path`: Path inspected for UTF-8 compatibility.
+/// - `field_name`: Fully qualified configuration key used for error reporting.
+///
+/// # Return Value
+///
+/// Returns the path as a UTF-8 string when the conversion succeeds; returns an error when the
+/// path contains non-UTF-8 data.
+///
+fn path_to_utf8_string(resolved_path: &Path, field_name: &str) -> Result<String> {
+    match resolved_path.to_str() {
+        Some(value) => Ok(value.to_string()),
+        None => {
+            let reason: String =
+                format!("{field_name} resolves to a non-UTF-8 path (path={resolved_path:?})");
+            Err(::anyhow::anyhow!(reason))
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Describes the TOML data type of the provided value for diagnostics.
+///
+/// # Parameters
+///
+/// - `value`: TOML value inspected for its variant name.
+///
+/// # Return Value
+///
+/// Returns a static string that mirrors the TOML variant name.
+///
+fn describe_toml_type(value: &Value) -> &'static str {
+    match value {
+        Value::String(_) => "string",
+        Value::Integer(_) => "integer",
+        Value::Float(_) => "float",
+        Value::Boolean(_) => "boolean",
+        Value::Datetime(_) => "datetime",
+        Value::Array(_) => "array",
+        Value::Table(_) => "table",
+    }
+}
+
+///
+/// # Description
+///
+/// Retrieves a required nested table from the provided TOML table.
+///
+/// # Parameters
+///
+/// - `table`: Parent table searched for the nested table.
+/// - `key`: Key used to locate the nested table.
+/// - `field_name`: Fully qualified field name used in error messages.
+///
+/// # Return Value
+///
+/// Returns a reference to the nested table when present.
+///
+/// # Errors
+///
+/// Returns an error when the key is missing or the associated value is not a table.
+///
+fn get_required_table<'a>(table: &'a Table, key: &str, field_name: &str) -> Result<&'a Table> {
+    match table.get(key) {
+        Some(Value::Table(value)) => Ok(value),
+        Some(other) => {
+            let reason: String =
+                format!("{field_name} must be a table (found={})", describe_toml_type(other));
+            Err(::anyhow::anyhow!(reason))
+        },
+        None => {
+            let reason: String = format!("missing required table '{field_name}'");
+            Err(::anyhow::anyhow!(reason))
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Retrieves a required array from the provided TOML table.
+///
+/// # Parameters
+///
+/// - `table`: Parent table searched for the array.
+/// - `key`: Key used to locate the array within the table.
+/// - `field_name`: Fully qualified field name used in error messages.
+///
+/// # Return Value
+///
+/// Returns a reference to the TOML array when present.
+///
+/// # Errors
+///
+/// Returns an error when the key is missing or the value is not an array.
+///
+fn get_required_array<'a>(table: &'a Table, key: &str, field_name: &str) -> Result<&'a Vec<Value>> {
+    match table.get(key) {
+        Some(Value::Array(value)) => Ok(value),
+        Some(other) => {
+            let reason: String =
+                format!("{field_name} must be an array (found={})", describe_toml_type(other));
+            Err(::anyhow::anyhow!(reason))
+        },
+        None => {
+            let reason: String = format!("missing required array '{field_name}'");
+            Err(::anyhow::anyhow!(reason))
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Reads a required string field from the TOML table.
+///
+/// # Parameters
+///
+/// - `table`: Table that stores the target field.
+/// - `key`: Key used to retrieve the string.
+/// - `field_name`: Fully qualified field name used in error messages.
+///
+/// # Return Value
+///
+/// Returns the string value when the field exists and is a string.
+///
+/// # Errors
+///
+/// Returns an error when the field is missing or not a string.
+///
+fn read_required_string(table: &Table, key: &str, field_name: &str) -> Result<String> {
+    match table.get(key) {
+        Some(Value::String(value)) => Ok(value.clone()),
+        Some(other) => {
+            let reason: String =
+                format!("{field_name} must be a string (found={})", describe_toml_type(other));
+            Err(::anyhow::anyhow!(reason))
+        },
+        None => {
+            let reason: String = format!("missing required field '{field_name}'");
+            Err(::anyhow::anyhow!(reason))
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Reads a required string field and ensures it is not empty or whitespace-only.
+///
+/// # Parameters
+///
+/// - `table`: Table that stores the target field.
+/// - `key`: Key used to retrieve the string.
+/// - `field_name`: Fully qualified field name used in error messages.
+///
+/// # Return Value
+///
+/// Returns the non-empty string when the field exists and contains characters beyond whitespace.
+///
+/// # Errors
+///
+/// Returns an error when the field is missing, not a string, or empty.
+///
+fn read_required_non_empty_string(table: &Table, key: &str, field_name: &str) -> Result<String> {
+    let value: String = read_required_string(table, key, field_name)?;
+    if value.trim().is_empty() {
+        let reason: String = format!("{field_name} must not be empty");
+        return Err(::anyhow::anyhow!(reason));
+    }
+    Ok(value)
+}
+
+///
+/// # Description
+///
+/// Reads a string field that supports a caller-provided default when absent.
+///
+/// # Parameters
+///
+/// - `table`: Table that stores the target field.
+/// - `key`: Key used to retrieve the string.
+/// - `field_name`: Fully qualified field name used in error messages.
+/// - `default_provider`: Closure that supplies the fallback value when the key is missing.
+///
+/// # Return Value
+///
+/// Returns the parsed string or the fallback value when the field is absent.
+///
+/// # Errors
+///
+/// Returns an error when the field exists but is not a string.
+///
+fn read_string_with_default<F>(
+    table: &Table,
+    key: &str,
+    field_name: &str,
+    default_provider: F,
+) -> Result<String>
+where
+    F: FnOnce() -> String,
+{
+    match table.get(key) {
+        Some(Value::String(value)) => Ok(value.clone()),
+        Some(other) => {
+            let reason: String =
+                format!("{field_name} must be a string (found={})", describe_toml_type(other));
+            Err(::anyhow::anyhow!(reason))
+        },
+        None => Ok(default_provider()),
+    }
+}
+
+///
+/// # Description
+///
+/// Reads an optional string field from the TOML table.
+///
+/// # Parameters
+///
+/// - `table`: Table that stores the target field.
+/// - `key`: Key used to retrieve the string.
+/// - `field_name`: Fully qualified field name used in error messages.
+///
+/// # Return Value
+///
+/// Returns `Some(String)` when the field exists and is a string; otherwise returns `None` when
+/// the field is absent.
+///
+/// # Errors
+///
+/// Returns an error when the field exists but is not a string.
+///
+fn read_optional_string(table: &Table, key: &str, field_name: &str) -> Result<Option<String>> {
+    match table.get(key) {
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(other) => {
+            let reason: String =
+                format!("{field_name} must be a string (found={})", describe_toml_type(other));
+            Err(::anyhow::anyhow!(reason))
+        },
+        None => Ok(None),
+    }
+}
+
+///
+/// # Description
+///
+/// Reads an optional string and filters out whitespace-only values.
+///
+/// # Parameters
+///
+/// - `table`: Table that stores the target field.
+/// - `key`: Key used to retrieve the string.
+/// - `field_name`: Fully qualified field name used in error messages.
+///
+/// # Return Value
+///
+/// Returns `Some(String)` when the field exists and is non-empty; otherwise returns `None`.
+///
+/// # Errors
+///
+/// Returns an error when the field exists but is not a string.
+///
+fn read_optional_non_empty_string(
+    table: &Table,
+    key: &str,
+    field_name: &str,
+) -> Result<Option<String>> {
+    Ok(read_optional_string(table, key, field_name)?.and_then(|value| {
+        if value.trim().is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    }))
+}
+
+///
+/// # Description
+///
+/// Reads a boolean field from the TOML table, applying a default when the field is absent.
+///
+/// # Parameters
+///
+/// - `table`: Table that stores the target field.
+/// - `key`: Key used to retrieve the boolean.
+/// - `field_name`: Fully qualified field name used in error messages.
+/// - `default_value`: Value returned when the key is missing.
+///
+/// # Return Value
+///
+/// Returns the parsed boolean or the provided default when the field is absent.
+///
+/// # Errors
+///
+/// Returns an error when the field exists but is not a boolean.
+///
+fn read_bool_with_default(
+    table: &Table,
+    key: &str,
+    field_name: &str,
+    default_value: bool,
+) -> Result<bool> {
+    match table.get(key) {
+        Some(Value::Boolean(value)) => Ok(*value),
+        Some(other) => {
+            let reason: String =
+                format!("{field_name} must be a boolean (found={})", describe_toml_type(other));
+            Err(::anyhow::anyhow!(reason))
+        },
+        None => Ok(default_value),
+    }
+}
+
+///
+/// # Description
+///
+/// Reads an unsigned 64-bit integer field from the TOML table, applying a default when absent.
+///
+/// # Parameters
+///
+/// - `table`: Table that stores the target field.
+/// - `key`: Key used to retrieve the integer.
+/// - `field_name`: Fully qualified field name used in error messages.
+/// - `default_value`: Value returned when the key is missing.
+///
+/// # Return Value
+///
+/// Returns the parsed `u64` or the default value when the field is absent.
+///
+/// # Errors
+///
+/// Returns an error when the field exists but cannot be parsed as a non-negative integer.
+///
+fn read_u64_with_default(
+    table: &Table,
+    key: &str,
+    field_name: &str,
+    default_value: u64,
+) -> Result<u64> {
+    match table.get(key) {
+        Some(value) => {
+            let parsed: u64 = parse_non_negative_integer(value, field_name)?;
+            Ok(parsed)
+        },
+        None => Ok(default_value),
+    }
+}
+
+///
+/// # Description
+///
+/// Reads an unsigned `usize` field from the TOML table, applying a default when absent.
+///
+/// # Parameters
+///
+/// - `table`: Table that stores the target field.
+/// - `key`: Key used to retrieve the integer.
+/// - `field_name`: Fully qualified field name used in error messages.
+/// - `default_value`: Value returned when the key is missing.
+///
+/// # Return Value
+///
+/// Returns the parsed `usize` or the default value when the field is absent.
+///
+/// # Errors
+///
+/// Returns an error when the field exists but cannot be converted to `usize`.
+///
+fn read_usize_with_default(
+    table: &Table,
+    key: &str,
+    field_name: &str,
+    default_value: usize,
+) -> Result<usize> {
+    let raw_value: u64 = read_u64_with_default(table, key, field_name, default_value as u64)?;
+    match usize::try_from(raw_value) {
+        Ok(value) => Ok(value),
+        Err(_) => {
+            let reason: String = format!("{field_name} exceeds usize range (value={raw_value})");
+            Err(::anyhow::anyhow!(reason))
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Reads a required `u16` field from the TOML table.
+///
+/// # Parameters
+///
+/// - `table`: Table that stores the target field.
+/// - `key`: Key used to retrieve the integer.
+/// - `field_name`: Fully qualified field name used in error messages.
+///
+/// # Return Value
+///
+/// Returns the parsed `u16` value when the field exists and can be converted.
+///
+/// # Errors
+///
+/// Returns an error when the field is missing, negative, or outside the `u16` range.
+///
+fn read_u16_required(table: &Table, key: &str, field_name: &str) -> Result<u16> {
+    match table.get(key) {
+        Some(value) => {
+            let parsed_value: u64 = parse_non_negative_integer(value, field_name)?;
+            match u16::try_from(parsed_value) {
+                Ok(port) => Ok(port),
+                Err(_) => {
+                    let reason: String =
+                        format!("{field_name} exceeds u16 range (value={parsed_value})");
+                    Err(::anyhow::anyhow!(reason))
+                },
+            }
+        },
+        None => {
+            let reason: String = format!("missing required field '{field_name}'");
+            Err(::anyhow::anyhow!(reason))
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Parses a TOML integer value into a non-negative `u64`.
+///
+/// # Parameters
+///
+/// - `value`: TOML value inspected for its integer content.
+/// - `field_name`: Fully qualified field name used in error messages.
+///
+/// # Return Value
+///
+/// Returns the parsed `u64` when the value is a non-negative integer.
+///
+/// # Errors
+///
+/// Returns an error when the value is not an integer, is negative, or cannot be represented as
+/// `u64`.
+///
+fn parse_non_negative_integer(value: &Value, field_name: &str) -> Result<u64> {
+    match value {
+        Value::Integer(raw) => {
+            if *raw < 0 {
+                let reason: String = format!("{field_name} must be non-negative (value={raw})");
+                Err(::anyhow::anyhow!(reason))
+            } else {
+                match u64::try_from(*raw) {
+                    Ok(value) => Ok(value),
+                    Err(_) => {
+                        let reason: String =
+                            format!("{field_name} exceeds u64 range (value={raw})");
+                        Err(::anyhow::anyhow!(reason))
+                    },
+                }
+            }
+        },
+        other => {
+            let reason: String =
+                format!("{field_name} must be an integer (found={})", describe_toml_type(other));
+            Err(::anyhow::anyhow!(reason))
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Reads the optional `hwloc_file_path` field from the runner table, ignoring empty strings.
+///
+/// # Parameters
+///
+/// - `table`: Table that stores the optional hwloc path.
+///
+/// # Return Value
+///
+/// Returns `Some(String)` when the field exists and is non-empty; otherwise returns `None`.
+///
+/// # Errors
+///
+/// Returns an error when the field exists but is not a string.
+///
+fn read_hwloc_file_path(table: &Table) -> Result<Option<String>> {
+    read_optional_non_empty_string(table, "hwloc_file_path", "runner.hwloc_file_path")
+}

--- a/src/utils/nanvix-test/src/environment.rs
+++ b/src/utils/nanvix-test/src/environment.rs
@@ -1,0 +1,637 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::warn_with_policy;
+use ::anyhow::Result;
+use ::nanvix::{
+    config::linuxd::SNAPSHOT_NAME,
+    log::{
+        debug,
+        info,
+    },
+    sandbox::{
+        NAMED_RESOURCE_PREFIX,
+        NETNS_NAME_PREFIX,
+        UNIX_SOCKET_SUFFIX,
+        VETH_HOST_PREFIX,
+    },
+};
+use ::nanvixd::config::{
+    DEFAULT_L2_SNAPSHOT_DIRECTORY,
+    DEFAULT_SNAPSHOT_FILE_NAME,
+};
+use ::std::{
+    fs,
+    path::{
+        Path,
+        PathBuf,
+    },
+    process::Command,
+    thread::sleep,
+    time::{
+        Duration,
+        Instant,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Sanitizes the host before launching Nanvix Daemon runs by deleting stale sockets, stale network
+/// namespaces, and waiting for TCP TIME_WAIT sockets (when L2 mode is enabled).
+///
+/// # Parameters
+///
+/// - `l2_enabled`: Indicates whether the upcoming run requires L2 deployment.
+/// - `port_num`: TCP port exposed by the Nanvix Daemon HTTP endpoint.
+/// - `tmp_directory`: Directory inspected for stale Nanvix artifacts.
+/// - `tcp_cleanup_max_wait_seconds`: Maximum seconds spent waiting for lingering TIME_WAIT
+///   sockets.
+/// - `tcp_cleanup_poll_interval_seconds`: Seconds between TIME_WAIT socket inspections.
+///
+pub(crate) fn prepare_runner_environment(
+    l2_enabled: bool,
+    port_num: u16,
+    tmp_directory: &Path,
+    tcp_cleanup_max_wait_seconds: u64,
+    tcp_cleanup_poll_interval_seconds: u64,
+) {
+    cleanup_stale_sockets(tmp_directory);
+    cleanup_stale_files(tmp_directory);
+    cleanup_stale_netns();
+
+    if l2_enabled {
+        wait_for_tcp_cleanup(
+            port_num,
+            tcp_cleanup_max_wait_seconds,
+            tcp_cleanup_poll_interval_seconds,
+        );
+    }
+}
+
+///
+/// # Description
+///
+/// Guarantees the artifacts required for L2 deployments (initramfs and snapshot) are available by
+/// invoking the same helper scripts used by the Makefile targets.
+///
+/// # Parameters
+///
+/// - `toolchain_path`: Absolute path to the Nanvix toolchain directory.
+/// - `working_directory`: Root of the Nanvix repository (used to locate scripts and images).
+///
+/// # Return Value
+///
+/// Returns `Ok(())` when the artifacts exist (either prior to or after script execution);
+/// otherwise returns an error that surfaces the failing script or missing artifact.
+///
+/// # Errors
+///
+/// Returns an error when the helper scripts are missing, fail to execute, or the artifacts remain
+/// absent after generation attempts.
+///
+pub(crate) fn prepare_l2_artifacts(toolchain_path: &str, working_directory: &Path) -> Result<()> {
+    let images_dir: PathBuf = working_directory.join(DEFAULT_L2_SNAPSHOT_DIRECTORY);
+    if let Err(error) = fs::create_dir_all(&images_dir) {
+        let reason: String = format!(
+            "failed to create images directory (path={}, error={error})",
+            images_dir.display()
+        );
+        warn_with_policy!("prepare_l2_artifacts(): {reason}");
+        return Err(::anyhow::anyhow!(reason));
+    }
+
+    let snapshot_path: PathBuf = images_dir.join(SNAPSHOT_NAME);
+    let initramfs_path: PathBuf = images_dir.join(DEFAULT_SNAPSHOT_FILE_NAME);
+
+    if snapshot_path.exists() && initramfs_path.exists() {
+        debug!(
+            "prepare_l2_artifacts(): reusing existing L2 artifacts (snapshot={}, initramfs={})",
+            snapshot_path.display(),
+            initramfs_path.display()
+        );
+        return Ok(());
+    }
+
+    let scripts_dir: PathBuf = working_directory.join("scripts");
+    let initramfs_script: PathBuf = scripts_dir.join("generate-l2-initramfs.sh");
+    let snapshot_script: PathBuf = scripts_dir.join("generate-l2-snapshot.sh");
+
+    info!(
+        "prepare_l2_artifacts(): generating L2 initramfs (script={}, output={})",
+        initramfs_script.display(),
+        initramfs_path.display()
+    );
+    run_script(&initramfs_script, working_directory, &[])?;
+
+    info!(
+        "prepare_l2_artifacts(): generating L2 snapshot (script={}, output={}, toolchain={})",
+        snapshot_script.display(),
+        snapshot_path.display(),
+        toolchain_path
+    );
+    run_script(&snapshot_script, working_directory, &[toolchain_path])?;
+
+    if snapshot_path.exists() && initramfs_path.exists() {
+        info!(
+            "prepare_l2_artifacts(): generated L2 artifacts (snapshot={}, initramfs={})",
+            snapshot_path.display(),
+            initramfs_path.display()
+        );
+        Ok(())
+    } else {
+        let reason: String = format!(
+            "L2 artifacts missing after generation attempt (snapshot={}, initramfs={})",
+            snapshot_path.display(),
+            initramfs_path.display()
+        );
+        warn_with_policy!("prepare_l2_artifacts(): {reason}");
+        Err(::anyhow::anyhow!(reason))
+    }
+}
+
+///
+/// # Description
+///
+/// Cleans stale artifacts left after a Nanvix Daemon run, mirroring the teardown logic from the
+/// reference shell runner. Always removes Nanvix network namespaces and optionally waits for TCP
+/// TIME_WAIT sockets to clear when L2 is enabled.
+///
+/// # Parameters
+///
+/// - `l2_enabled`: Indicates whether the finished run was deployed with L2 networking.
+/// - `http_port`: Optional TCP port exposed by the Nanvix Daemon HTTP endpoint.
+/// - `tmp_directory`: Directory inspected for stale Nanvix artifacts.
+/// - `tcp_cleanup_max_wait_seconds`: Maximum seconds spent waiting for lingering TIME_WAIT
+///   sockets.
+/// - `tcp_cleanup_poll_interval_seconds`: Seconds between TIME_WAIT socket inspections.
+///
+pub(crate) fn cleanup_after_run(
+    l2_enabled: bool,
+    http_port: Option<u16>,
+    tmp_directory: &Path,
+    tcp_cleanup_max_wait_seconds: u64,
+    tcp_cleanup_poll_interval_seconds: u64,
+) {
+    cleanup_stale_sockets(tmp_directory);
+    cleanup_stale_netns();
+    cleanup_stale_files(tmp_directory);
+
+    if l2_enabled {
+        match http_port {
+            Some(port) => {
+                wait_for_tcp_cleanup(
+                    port,
+                    tcp_cleanup_max_wait_seconds,
+                    tcp_cleanup_poll_interval_seconds,
+                );
+            },
+            None => warn_with_policy!(
+                "cleanup_after_run(): skipping TCP cleanup because HTTP port is unknown"
+            ),
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Executes a helper script within the Nanvix workspace, surfacing failures as `Result` errors.
+///
+/// # Parameters
+///
+/// - `script_path`: Absolute path to the script that should be executed.
+/// - `working_directory`: Directory set as the script's current working directory.
+/// - `args`: Additional arguments forwarded to the script.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` when the script exists and exits successfully; otherwise returns an error
+/// describing the missing file, spawn failure, or non-zero exit status.
+///
+/// # Errors
+///
+/// Returns an error when the script does not exist, cannot be executed, or exits with a
+/// non-zero status code.
+///
+fn run_script(script_path: &Path, working_directory: &Path, args: &[&str]) -> Result<()> {
+    if !script_path.exists() {
+        let reason: String = format!(
+            "script not found (script={}, cwd={})",
+            script_path.display(),
+            working_directory.display()
+        );
+        warn_with_policy!("run_script(): {reason}");
+        return Err(::anyhow::anyhow!(reason));
+    }
+
+    let status: ::std::process::ExitStatus = ::std::process::Command::new(script_path)
+        .current_dir(working_directory)
+        .args(args)
+        .status()
+        .map_err(|error| {
+            let reason: String = format!(
+                "failed to execute script (script={}, error={error})",
+                script_path.display()
+            );
+            warn_with_policy!("run_script(): {reason}");
+            ::anyhow::anyhow!(reason)
+        })?;
+
+    if !status.success() {
+        let reason: String = format!(
+            "script exited unsuccessfully (script={}, status={status})",
+            script_path.display()
+        );
+        warn_with_policy!("run_script(): {reason}");
+        return Err(::anyhow::anyhow!(reason));
+    }
+
+    Ok(())
+}
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Removes stale Unix domain socket files left under the configured temporary directory.
+///
+/// # Parameters
+///
+/// - `tmp_directory`: Directory inspected for stale socket files.
+///
+fn cleanup_stale_sockets(tmp_directory: &Path) {
+    let entries = match fs::read_dir(tmp_directory) {
+        Ok(entries) => entries,
+        Err(error) => {
+            warn_with_policy!(
+                "cleanup_stale_sockets(): failed to list {} (error={})",
+                tmp_directory.display(),
+                error
+            );
+            return;
+        },
+    };
+
+    for entry_result in entries {
+        let entry = match entry_result {
+            Ok(entry) => entry,
+            Err(error) => {
+                warn_with_policy!(
+                    "cleanup_stale_sockets(): failed to read tmp entry (error={})",
+                    error
+                );
+                continue;
+            },
+        };
+
+        let file_name = entry.file_name();
+        let file_name_str: String = file_name.to_string_lossy().to_string();
+        if !file_name_str.ends_with(UNIX_SOCKET_SUFFIX) {
+            continue;
+        }
+
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        if let Err(error) = fs::remove_file(&path) {
+            warn_with_policy!(
+                "cleanup_stale_sockets(): failed to remove socket {} (error={})",
+                path.display(),
+                error
+            );
+        } else {
+            debug!("cleanup_stale_sockets(): removed stale socket {}", path.display());
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Removes stale files and directories under the configured temporary directory that follow the
+/// `NAMED_RESOURCE_PREFIX` convention used by sandboxes.
+///
+/// # Parameters
+///
+/// - `tmp_directory`: Directory inspected for stale Nanvix artifacts.
+///
+fn cleanup_stale_files(tmp_directory: &Path) {
+    let entries = match fs::read_dir(tmp_directory) {
+        Ok(entries) => entries,
+        Err(error) => {
+            warn_with_policy!(
+                "cleanup_stale_named_resources(): failed to list {} (error={})",
+                tmp_directory.display(),
+                error
+            );
+            return;
+        },
+    };
+
+    for entry_result in entries {
+        let entry = match entry_result {
+            Ok(entry) => entry,
+            Err(error) => {
+                warn_with_policy!(
+                    "cleanup_stale_named_resources(): failed to read tmp entry (error={})",
+                    error
+                );
+                continue;
+            },
+        };
+
+        let file_name: String = entry.file_name().to_string_lossy().to_string();
+        if !file_name.starts_with(NAMED_RESOURCE_PREFIX) {
+            continue;
+        }
+
+        let path = entry.path();
+        let removal_result: Result<(), ::std::io::Error> = if path.is_dir() {
+            fs::remove_dir_all(&path)
+        } else {
+            fs::remove_file(&path)
+        };
+
+        match removal_result {
+            Ok(()) => {
+                debug!(
+                    "cleanup_stale_named_resources(): removed stale resource {}",
+                    path.display()
+                );
+            },
+            Err(error) => {
+                warn_with_policy!(
+                    "cleanup_stale_named_resources(): failed to remove {} (error={})",
+                    path.display(),
+                    error
+                );
+            },
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Removes Nanvix network namespaces and associated host veth pairs left behind by previous runs.
+///
+fn cleanup_stale_netns() {
+    let output = match Command::new("sudo")
+        .arg("ip")
+        .arg("netns")
+        .arg("list")
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) => {
+            warn_with_policy!(
+                "cleanup_stale_netns(): failed to list namespaces via sudo (error={})",
+                error
+            );
+            return;
+        },
+    };
+
+    if !output.status.success() {
+        warn_with_policy!("cleanup_stale_netns(): ip netns list returned status {}", output.status);
+        return;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut namespaces: Vec<String> = stdout
+        .split_whitespace()
+        .filter(|token| token.starts_with(NETNS_NAME_PREFIX))
+        .map(|token| token.trim().to_string())
+        .collect();
+
+    namespaces.sort();
+    namespaces.dedup();
+
+    if namespaces.is_empty() {
+        debug!("cleanup_stale_netns(): no stale namespaces found");
+        return;
+    }
+
+    info!("cleanup_stale_netns(): removing {} stale namespace(s)", namespaces.len());
+    for namespace in namespaces {
+        let ns_id: &str = match namespace.strip_prefix(NETNS_NAME_PREFIX) {
+            Some(id) => id,
+            None => continue,
+        };
+        let veth_name: String = format!("{VETH_HOST_PREFIX}{ns_id}");
+
+        match Command::new("sudo")
+            .arg("ip")
+            .arg("link")
+            .arg("del")
+            .arg(&veth_name)
+            .status()
+        {
+            Err(error) => warn_with_policy!(
+                "cleanup_stale_netns(): failed to delete veth {} (error={})",
+                veth_name,
+                error
+            ),
+            Ok(status) if !status.success() => warn_with_policy!(
+                "cleanup_stale_netns(): ip link del {} exited with status {}",
+                veth_name,
+                status
+            ),
+            Ok(_) => {},
+        }
+
+        match Command::new("sudo")
+            .arg("ip")
+            .arg("netns")
+            .arg("del")
+            .arg(&namespace)
+            .status()
+        {
+            Err(error) => warn_with_policy!(
+                "cleanup_stale_netns(): failed to delete namespace {} (error={})",
+                namespace,
+                error
+            ),
+            Ok(status) if !status.success() => warn_with_policy!(
+                "cleanup_stale_netns(): ip netns del {} exited with status {}",
+                namespace,
+                status
+            ),
+            Ok(_) => {},
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Waits until lingering TCP TIME_WAIT connections bound to the provided port disappear or the
+/// timeout expires.
+///
+/// # Parameters
+///
+/// - `port`: TCP port under observation.
+/// - `tcp_cleanup_max_wait_seconds`: Maximum seconds spent waiting for TIME_WAIT sockets.
+/// - `tcp_cleanup_poll_interval_seconds`: Seconds between TIME_WAIT socket inspections.
+///
+fn wait_for_tcp_cleanup(
+    port: u16,
+    tcp_cleanup_max_wait_seconds: u64,
+    tcp_cleanup_poll_interval_seconds: u64,
+) {
+    let max_wait: Duration = Duration::from_secs(tcp_cleanup_max_wait_seconds);
+    let poll_interval: Duration = Duration::from_secs(tcp_cleanup_poll_interval_seconds);
+    let start: Instant = Instant::now();
+
+    info!(
+        "wait_for_tcp_cleanup(): waiting for TIME_WAIT sockets on port {} (timeout={}s)",
+        port, tcp_cleanup_max_wait_seconds
+    );
+
+    loop {
+        match count_time_wait_connections(port) {
+            Some(0) => {
+                info!("wait_for_tcp_cleanup(): TIME_WAIT sockets cleared for port {}", port);
+                return;
+            },
+            Some(count) => {
+                debug!(
+                    "wait_for_tcp_cleanup(): {} TIME_WAIT sockets still present on port {}",
+                    count, port
+                );
+            },
+            None => {
+                warn_with_policy!(
+                    "wait_for_tcp_cleanup(): unable to inspect TIME_WAIT sockets, skipping wait"
+                );
+                return;
+            },
+        }
+
+        if start.elapsed() >= max_wait {
+            warn_with_policy!(
+                "wait_for_tcp_cleanup(): timeout reached while waiting for TIME_WAIT sockets on \
+                 port {}",
+                port
+            );
+            return;
+        }
+
+        sleep(poll_interval);
+    }
+}
+
+///
+/// # Description
+///
+/// Counts TIME_WAIT sockets using the `ss` utility when available.
+///
+/// # Parameters
+///
+/// - `port`: TCP port under observation.
+///
+/// # Return Value
+///
+/// Returns the number of TIME_WAIT sockets bound to the port when `ss` succeeds; otherwise
+/// returns `None` when the command fails.
+///
+fn count_time_wait_with_ss(port: u16) -> Option<usize> {
+    let port_arg: String = port.to_string();
+    let output = match Command::new("ss")
+        .args(["-tan", "state", "time-wait", "sport", port_arg.as_str()])
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) => {
+            debug!("count_time_wait_with_ss(): failed to execute ss (error={})", error);
+            return None;
+        },
+    };
+
+    if !output.status.success() {
+        debug!("count_time_wait_with_ss(): ss returned status {}", output.status);
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let count: usize = stdout
+        .lines()
+        .skip(1)
+        .filter(|line| !line.trim().is_empty())
+        .count();
+
+    Some(count)
+}
+
+///
+/// # Description
+///
+/// Counts TIME_WAIT sockets using the `netstat` utility when `ss` is not available.
+///
+/// # Parameters
+///
+/// - `port`: TCP port under observation.
+///
+/// # Return Value
+///
+/// Returns the number of TIME_WAIT sockets bound to the port when `netstat` succeeds; otherwise
+/// returns `None` when the utility fails.
+///
+fn count_time_wait_with_netstat(port: u16) -> Option<usize> {
+    let output = match Command::new("netstat").args(["-tan"]).output() {
+        Ok(output) => output,
+        Err(error) => {
+            debug!("count_time_wait_with_netstat(): failed to execute netstat (error={})", error);
+            return None;
+        },
+    };
+    if !output.status.success() {
+        debug!("count_time_wait_with_netstat(): netstat returned status {}", output.status);
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let needle: String = format!(":{port}");
+    let count: usize = stdout
+        .lines()
+        .filter(|line| line.contains(needle.as_str()) && line.contains("TIME_WAIT"))
+        .count();
+
+    Some(count)
+}
+
+///
+/// # Description
+///
+/// Attempts to count TIME_WAIT sockets using the available host tooling.
+///
+/// # Parameters
+///
+/// - `port`: TCP port under observation.
+///
+/// # Return Value
+///
+/// Returns the TIME_WAIT count reported by either `ss` or `netstat`; returns `None` when both
+/// probes fail.
+///
+fn count_time_wait_connections(port: u16) -> Option<usize> {
+    if let Some(count) = count_time_wait_with_ss(port) {
+        return Some(count);
+    }
+
+    count_time_wait_with_netstat(port)
+}

--- a/src/utils/nanvix-test/src/executor/empty.rs
+++ b/src/utils/nanvix-test/src/executor/empty.rs
@@ -1,0 +1,86 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    config::RunnerConfig,
+    log_layout::{
+        GuestLogTracker,
+        RunnerLogPaths,
+        TestLogLayout,
+    },
+    nanvixd::{
+        NanvixdHttp,
+        NanvixdHttpArgs,
+    },
+};
+use ::anyhow::Result;
+use ::std::path::Path;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Runs the Empty Executor, which spawns the Nanvix Daemon with the supplied configuration and
+/// immediately shuts it down, for a specified number of iterations.
+///
+/// # Parameters
+///
+/// - `runner_config`: Configuration required to spawn the Nanvix Daemon.
+/// - `iterations`: Number of Empty Executor cycles to execute.
+/// - `log_layout`: Layout that controls where stdout/stderr artifacts for each iteration land.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` after the requested iterations succeed; returns an error if log creation,
+/// timestamp computation, or daemon spawning fails.
+///
+pub(crate) async fn empty(
+    runner_config: &RunnerConfig,
+    iterations: usize,
+    log_layout: &TestLogLayout,
+) -> Result<()> {
+    let l2_enabled: bool = runner_config.l2_enabled;
+    let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
+    let log_root: &Path = Path::new(runner_config.log_directory.as_str());
+    let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
+
+    for iteration in 0..iterations {
+        let RunnerLogPaths {
+            stdout: stdout_file_path,
+            stderr: stderr_file_path,
+        } = log_layout.allocate_runner_logs(Some(iteration));
+
+        let nanvixd_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
+            stdout_file_path.as_path(),
+            stderr_file_path.as_path(),
+            runner_config.ipv4_addr.as_str(),
+            runner_config.port_num,
+            hwloc_file_path.clone(),
+            l2_enabled,
+            log_layout.test_directory(),
+        )?;
+
+        {
+            let _nanvixd_handle: NanvixdHttp =
+                NanvixdHttp::spawn(runner_config, &nanvixd_args).await?;
+        }
+
+        guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+        log_layout.normalize_component_logs(iteration)?;
+    }
+
+    guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+    if iterations > 0 {
+        let last_iteration: usize = iterations - 1;
+        log_layout.normalize_component_logs(last_iteration)?;
+    }
+
+    Ok(())
+}

--- a/src/utils/nanvix-test/src/executor/http.rs
+++ b/src/utils/nanvix-test/src/executor/http.rs
@@ -1,0 +1,313 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    DEFAULT_TENANT_ID,
+    config::RunnerConfig,
+    log_layout::{
+        GuestLogTracker,
+        RunnerLogPaths,
+        TestLogLayout,
+    },
+    nanvixd::{
+        NanvixdHttp,
+        NanvixdHttpArgs,
+    },
+    uservm::{
+        UserVm,
+        UserVmArgs,
+    },
+};
+use ::anyhow::Result;
+use ::nanvix::{
+    log::{
+        error,
+        trace,
+    },
+    syscomm::{
+        ReadExact,
+        WriteAll,
+    },
+};
+use ::std::{
+    io::ErrorKind,
+    path::Path,
+    time::{
+        Duration,
+        SystemTime,
+        UNIX_EPOCH,
+    },
+};
+use ::tokio::time::timeout;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests a program in Nanvix using the HTTP executor.
+///
+/// # Parameters
+///
+/// - `runner_config`: Configuration required to spawn the Nanvix Daemon and User VMs.
+/// - `iterations`: Number of times the start/run/stop cycle should execute.
+/// - `program_path`: Absolute path to the executable launched inside the User VM.
+/// - `program_args`: Optional command-line arguments forwarded to the workload.
+/// - `input`: Optional payload forwarded to the workload.
+/// - `expected_output`: Optional payload that should be received back from the workload.
+/// - `log_layout`: Layout that controls how runner/program logs are timestamped and stored.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` after each iteration successfully spawns the Nanvix Daemon, launches the User
+/// VM, optionally injects the custom payload, validates the received bytes, and persists the
+/// sanitized stdout capture; returns an error when any lifecycle step fails.
+///
+pub(crate) async fn test_with_http_executor(
+    runner_config: &RunnerConfig,
+    iterations: usize,
+    program_path: &str,
+    program_args: Option<&str>,
+    input: Option<&str>,
+    expected_output: Option<&str>,
+    log_layout: &TestLogLayout,
+) -> Result<()> {
+    let l2_enabled: bool = runner_config.l2_enabled;
+    let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
+    let program_path: String = program_path.to_string();
+    let request_payload: Option<Vec<u8>> = input.map(|value| value.as_bytes().to_vec());
+    let response_timeout: Duration =
+        Duration::from_millis(runner_config.stream_collection_timeout_ms);
+    let log_root: &Path = Path::new(runner_config.log_directory.as_str());
+    let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
+    let execution_epoch_ms: u128 = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis(),
+        Err(error) => {
+            let reason: String = format!(
+                "failed to compute execution timestamp (program_path={}, error={error})",
+                program_path
+            );
+            error!("test_with_http_executor(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        },
+    };
+
+    let RunnerLogPaths {
+        stdout: stdout_file_path,
+        stderr: stderr_file_path,
+    } = log_layout.allocate_runner_logs(None);
+
+    let nanvixd_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
+        stdout_file_path.as_path(),
+        stderr_file_path.as_path(),
+        runner_config.ipv4_addr.as_str(),
+        runner_config.port_num,
+        hwloc_file_path.clone(),
+        l2_enabled,
+        log_layout.test_directory(),
+    )?;
+
+    // Run tests within a scoped block to ensure logs are captured before moving them.
+    {
+        let _nanvixd_handle: NanvixdHttp = NanvixdHttp::spawn(runner_config, &nanvixd_args).await?;
+
+        for iteration in 0..iterations {
+            let app_name: String = format!("{execution_epoch_ms}-{iteration}");
+            let uservm_args: UserVmArgs = UserVmArgs::new(
+                DEFAULT_TENANT_ID,
+                app_name.as_str(),
+                program_path.as_str(),
+                program_args,
+                l2_enabled,
+            )?;
+
+            let mut user_vm: UserVm = UserVm::spawn(runner_config, &uservm_args).await?;
+
+            if let Some(payload) = request_payload.as_ref() {
+                send_payload(&mut user_vm, payload.as_slice()).await?;
+            }
+
+            close_gateway_input(&mut user_vm).await?;
+
+            let expected_pattern: Option<&[u8]> = expected_output.and_then(|value| {
+                if value.is_empty() {
+                    None
+                } else {
+                    Some(value.as_bytes())
+                }
+            });
+
+            let payload: Vec<u8> =
+                receive_payload(&mut user_vm, expected_pattern, response_timeout).await?;
+            log_layout.persist_program_output(iteration, payload.as_slice())?;
+        }
+    }
+
+    let last_iteration: usize = iterations.saturating_sub(1);
+    guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+    log_layout.normalize_component_logs(last_iteration)?;
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Writes the provided payload to the User VM gateway stream.
+///
+/// # Parameters
+///
+/// - `user_vm`: Handle to the running User VM gateway stream.
+/// - `payload`: Bytes forwarded to the workload over the gateway stream.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` after the bytes are written successfully; returns an error on socket write
+/// failures.
+///
+async fn send_payload(user_vm: &mut UserVm, payload: &[u8]) -> Result<()> {
+    trace!("send_payload(): payload_len={}, payload={:?}", payload.len(), payload);
+    if let Err(error) = user_vm.gateway_stream().write_all(payload).await {
+        error!("send_payload(): failed to send payload (error={error})");
+        return Err(error.into());
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Signals end-of-input to the running User VM by shutting down the gateway write half.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` when the shutdown succeeds; returns an error if the gateway cannot be closed.
+///
+async fn close_gateway_input(user_vm: &mut UserVm) -> Result<()> {
+    if let Err(error) = user_vm.gateway_stream().shutdown_write().await {
+        let reason: String =
+            format!("failed to shutdown uservm gateway write half (error={error})");
+        error!("close_gateway_input(): {reason}");
+        return Err(::anyhow::anyhow!(reason));
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Reads a payload from the User VM gateway stream and returns the captured bytes.
+///
+/// # Parameters
+///
+/// - `user_vm`: Handle to the running User VM gateway stream.
+/// - `expected_pattern`: Byte pattern that must appear in the payload.
+/// - `timeout_duration`: Maximum time allowed while waiting for the expected payload.
+///
+/// # Return Value
+///
+/// Returns the captured bytes when the read succeeds; returns an error on socket read failures,
+/// pattern mismatches, or timeout expiration.
+///
+async fn receive_payload(
+    user_vm: &mut UserVm,
+    expected_pattern: Option<&[u8]>,
+    timeout_duration: Duration,
+) -> Result<Vec<u8>> {
+    match timeout(timeout_duration, collect_uservm_payload(user_vm, expected_pattern)).await {
+        Ok(result) => result,
+        Err(_elapsed) => {
+            let reason: String = match expected_pattern {
+                Some(pattern) => format!(
+                    "uservm payload timed out (timeout_ms={}, expected_pattern={:?})",
+                    timeout_duration.as_millis(),
+                    pattern
+                ),
+                None => format!(
+                    "uservm payload timed out (timeout_ms={}, expectation=none)",
+                    timeout_duration.as_millis()
+                ),
+            };
+            error!("receive_payload(): {reason}");
+            Err(::anyhow::anyhow!(reason))
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Collects bytes from the User VM gateway stream until the expected pattern is observed.
+///
+/// # Parameters
+///
+/// - `user_vm`: Handle to the running User VM gateway stream.
+/// - `expected_pattern`: Byte sequence that must appear in the collected payload.
+///
+/// # Return Value
+///
+/// Returns the captured bytes when the expected pattern is found or the stream closes; returns an
+/// error on socket failures or when the pattern never appears.
+///
+async fn collect_uservm_payload(
+    user_vm: &mut UserVm,
+    expected_pattern: Option<&[u8]>,
+) -> Result<Vec<u8>> {
+    trace!(
+        "collect_uservm_payload(): expected_len={}, expected_pattern={:?}",
+        expected_pattern.map_or(0, |pattern| pattern.len()),
+        expected_pattern
+    );
+    let mut response_payload: Vec<u8> = Vec::new();
+    let mut pattern_found: bool = expected_pattern.is_none();
+
+    loop {
+        let mut byte: [u8; 1] = [0u8; 1];
+        match user_vm.gateway_stream().read_exact(&mut byte).await {
+            Ok(_) => {
+                response_payload.push(byte[0]);
+            },
+            Err(error) => {
+                if error.kind() == ErrorKind::UnexpectedEof {
+                    break;
+                }
+                error!("collect_uservm_payload(): failed to read payload (error={error})");
+                return Err(error.into());
+            },
+        }
+
+        if let Some(pattern) = expected_pattern
+            && response_payload.ends_with(pattern)
+        {
+            pattern_found = true;
+            break;
+        }
+    }
+
+    if let Some(pattern) = expected_pattern
+        && !pattern_found
+    {
+        let reason: String = format!(
+            "echo payload mismatch (expected_pattern={:?}, received={:?})",
+            pattern, response_payload
+        );
+        error!("collect_uservm_payload(): {reason}");
+        return Err(::anyhow::anyhow!(reason));
+    }
+
+    trace!(
+        "collect_uservm_payload(): response_len={}, response={:?}",
+        response_payload.len(),
+        response_payload
+    );
+
+    Ok(response_payload)
+}

--- a/src/utils/nanvix-test/src/executor/mod.rs
+++ b/src/utils/nanvix-test/src/executor/mod.rs
@@ -1,0 +1,68 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod empty;
+pub mod http;
+pub mod terminal;
+
+use ::anyhow::Result;
+
+//==================================================================================================
+// Enumerations
+//==================================================================================================
+
+/// Executor variants supported by the Nanvix test runner.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExecutorName {
+    /// Empty executor.
+    Empty,
+    /// HTTP executor.
+    Http,
+    /// Terminal executor.
+    Terminal,
+}
+
+impl ExecutorName {
+    ///
+    /// # Description
+    ///
+    /// Parses a textual identifier into the corresponding executor.
+    ///
+    /// # Parameters
+    ///
+    /// - `identifier`: Executor label read from the configuration file.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the matching executor variant when the identifier is supported; returns an error
+    /// when the identifier is invalid.
+    pub fn from_str(identifier: &str) -> Result<Self> {
+        match identifier {
+            "empty" => Ok(Self::Empty),
+            "http" => Ok(Self::Http),
+            "terminal" => Ok(Self::Terminal),
+            _ => Err(::anyhow::anyhow!(format!("invalid executor name '{identifier}'"))),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the canonical directory label associated with the executor variant.
+    ///
+    /// # Return Value
+    ///
+    /// Returns one of `empty`, `http`, or `terminal` for use when organizing logs.
+    ///
+    pub const fn to_str(self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::Http => "http",
+            Self::Terminal => "terminal",
+        }
+    }
+}

--- a/src/utils/nanvix-test/src/executor/terminal.rs
+++ b/src/utils/nanvix-test/src/executor/terminal.rs
@@ -1,0 +1,436 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    config::RunnerConfig,
+    log_layout::{
+        GuestLogTracker,
+        RunnerLogPaths,
+        TestLogLayout,
+    },
+    nanvixd::{
+        NanvixdTerminal,
+        NanvixdTerminalArgs,
+    },
+};
+use ::anyhow::Result;
+use ::nanvix::log::error;
+use ::std::{
+    fs::write,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{
+            AtomicBool,
+            Ordering,
+        },
+    },
+    time::Duration,
+};
+use ::tokio::{
+    io::{
+        AsyncRead,
+        AsyncReadExt,
+        AsyncWriteExt,
+    },
+    process::{
+        ChildStderr,
+        ChildStdin,
+    },
+    sync::{
+        Mutex as AsyncMutex,
+        Notify,
+    },
+    task::JoinHandle,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Governs the size of the intermediate buffer used while collecting stream output.
+///
+const CHUNK_SIZE: usize = 4096;
+
+//==================================================================================================
+// Type Definitions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Bundles the async handles and buffers that collect Nanvix Daemon stdout and stderr streams.
+///
+type StreamCollectors = (
+    JoinHandle<::std::io::Result<()>>,
+    Arc<AsyncMutex<Vec<u8>>>,
+    JoinHandle<::std::io::Result<()>>,
+    Arc<AsyncMutex<Vec<u8>>>,
+);
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tests a program in Nanvix using the terminal executor.
+///
+/// # Parameters
+///
+/// - `runner_config`: Configuration required to spawn the Nanvix Daemon.
+/// - `iterations`: Number of times to run the workflow.
+/// - `program_path`: Path to the program executed by the daemon.
+/// - `program_args`: Optional argument string passed to the workload.
+/// - `input`: Optional payload sent over stdin.
+/// - `expected_output`: Optional substring expected in stdout.
+/// - `log_layout`: Layout that defines the target directory for stdout/stderr/program logs.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` after all iterations succeed; returns an error if spawning the Nanvix Daemon,
+/// wiring stdio pipes, sending input, collecting output, validating stdout, or persisting logs
+/// fails.
+///
+pub async fn test_with_terminal_executor(
+    runner_config: &RunnerConfig,
+    iterations: usize,
+    program_path: &str,
+    program_args: Option<&str>,
+    input: Option<&str>,
+    expected_output: Option<&str>,
+    log_layout: &TestLogLayout,
+) -> Result<()> {
+    if runner_config.l2_enabled {
+        let reason: String = "terminal executor does not support L2 deployment".to_string();
+        error!("test_with_terminal_executor(): {reason}");
+        return Err(::anyhow::anyhow!(reason));
+    }
+
+    let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
+    let parsed_program_args: Vec<String> = match program_args {
+        Some(args) => match shell_words::split(args) {
+            Ok(values) => values,
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to parse terminal executor program_args (args='{}', error={error})",
+                    args
+                );
+                error!("test_with_terminal_executor(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+        },
+        None => Vec::new(),
+    };
+    let log_root: &Path = Path::new(runner_config.log_directory.as_str());
+    let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
+
+    for iteration in 0..iterations {
+        let RunnerLogPaths {
+            stdout: stdout_file_path,
+            stderr: stderr_file_path,
+        } = log_layout.allocate_runner_logs(Some(iteration));
+
+        let nanvixd_args: NanvixdTerminalArgs = NanvixdTerminalArgs::new(
+            hwloc_file_path.clone(),
+            program_path,
+            parsed_program_args.as_slice(),
+            log_layout.test_directory(),
+        )?;
+
+        let collection_timeout: Duration =
+            Duration::from_millis(runner_config.stream_collection_timeout_ms);
+
+        let (_nanvixd, stream_collectors) = {
+            let mut nanvixd: NanvixdTerminal =
+                NanvixdTerminal::spawn(runner_config, &nanvixd_args).await?;
+
+            let stdout_pipe = nanvixd.take_stdout().ok_or_else(|| {
+                let reason: String =
+                    "interactive mode requires capturing nanvixd stdout".to_string();
+                error!("test_with_terminal_executor(): {reason}");
+                ::anyhow::anyhow!(reason)
+            })?;
+
+            let stdout_buffer: Arc<AsyncMutex<Vec<u8>>> = Arc::new(AsyncMutex::new(Vec::new()));
+            let stdout_handle: JoinHandle<::std::io::Result<()>> = ::tokio::spawn(
+                collect_stream_to_buffer(stdout_pipe, Arc::clone(&stdout_buffer), None, None),
+            );
+
+            let stderr_pipe: ChildStderr = nanvixd.take_stderr().ok_or_else(|| {
+                let reason: String =
+                    "interactive mode requires capturing nanvixd stderr".to_string();
+                error!("test_with_terminal_executor(): {reason}");
+                ::anyhow::anyhow!(reason)
+            })?;
+
+            let stderr_buffer: Arc<AsyncMutex<Vec<u8>>> = Arc::new(AsyncMutex::new(Vec::new()));
+            let stderr_handle: JoinHandle<::std::io::Result<()>> = ::tokio::spawn(
+                collect_stream_to_buffer(stderr_pipe, Arc::clone(&stderr_buffer), None, None),
+            );
+
+            let stdin_pipe: ChildStdin = nanvixd.take_stdin().ok_or_else(|| {
+                let reason: String = "interactive mode does not expose stdin pipe".to_string();
+                error!("test_with_terminal_executor(): {reason}");
+                ::anyhow::anyhow!(reason)
+            })?;
+
+            send_interactive_input(stdin_pipe, input).await?;
+
+            (nanvixd, (stdout_handle, stdout_buffer, stderr_handle, stderr_buffer))
+        };
+
+        let (stdout_handle, stdout_buffer, stderr_handle, stderr_buffer): StreamCollectors =
+            stream_collectors;
+
+        let stdout_bytes: Vec<u8> = wait_stream_collector(
+            stdout_handle,
+            Arc::clone(&stdout_buffer),
+            collection_timeout,
+            "stdout",
+            iteration,
+        )
+        .await?;
+        let stderr_bytes: Vec<u8> = wait_stream_collector(
+            stderr_handle,
+            Arc::clone(&stderr_buffer),
+            collection_timeout,
+            "stderr",
+            iteration,
+        )
+        .await?;
+
+        if let Err(error) = write(&stdout_file_path, &stdout_bytes) {
+            let reason: String = format!(
+                "failed to write interactive stdout log (path={}, error={error})",
+                stdout_file_path.display()
+            );
+            error!("test_with_terminal_executor(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        if let Err(error) = write(&stderr_file_path, &stderr_bytes) {
+            let reason: String = format!(
+                "failed to write interactive stderr log (path={}, error={error})",
+                stderr_file_path.display()
+            );
+            error!("test_with_terminal_executor(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        log_layout.persist_program_output(iteration, stdout_bytes.as_slice())?;
+
+        if let Some(expected) = expected_output
+            && !buffer_contains_pattern(stdout_bytes.as_slice(), expected.as_bytes())
+        {
+            let reason: String = format!(
+                "interactive output mismatch (expected='{}', log={}, iteration={iteration})",
+                expected,
+                stdout_file_path.display()
+            );
+            error!("test_with_terminal_executor(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+        log_layout.normalize_component_logs(iteration)?;
+    }
+    guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+    if iterations > 0 {
+        let last_iteration: usize = iterations - 1;
+        log_layout.normalize_component_logs(last_iteration)?;
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Consumes the Nanvix Daemon stdin handle, sends the provided payload, and shuts down the pipe.
+///
+/// # Parameters
+///
+/// - `stdin`: Writable handle to Nanvix Daemon stdin that is consumed by this function.
+/// - `payload`: Optional string sent to the workload over stdin.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` after stdin is written, flushed, and closed successfully; returns an error on
+/// write, flush, or shutdown failures.
+///
+async fn send_interactive_input(mut stdin: ChildStdin, payload: Option<&str>) -> Result<()> {
+    if let Some(data) = payload {
+        let mut bytes: Vec<u8> = data.as_bytes().to_vec();
+        if bytes.last().copied() != Some(b'\n') {
+            bytes.push(b'\n');
+        }
+
+        if let Err(error) = stdin.write_all(bytes.as_slice()).await {
+            error!("send_interactive_input(): failed to write payload (error={error})");
+            return Err(error.into());
+        }
+
+        if let Err(error) = stdin.flush().await {
+            error!("send_interactive_input(): failed to flush stdin (error={error})");
+            return Err(error.into());
+        }
+    }
+
+    if let Err(error) = stdin.shutdown().await {
+        error!("send_interactive_input(): failed to shutdown stdin (error={error})");
+        return Err(error.into());
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Reads bytes from a Nanvix Daemon stream, stores them in a shared buffer, and notifies consumers when
+/// new data arrives or the stream closes.
+///
+/// # Parameters
+///
+/// - `reader`: Async stream reader (stdout or stderr).
+/// - `buffer`: Shared buffer that accumulates the captured bytes.
+/// - `notify`: Optional notifier used to wake tasks waiting for new data.
+/// - `closed_flag`: Optional flag set when the stream reaches EOF.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` after the stream closes; returns an error if any I/O operation fails during
+/// collection.
+///
+async fn collect_stream_to_buffer<R>(
+    mut reader: R,
+    buffer: Arc<AsyncMutex<Vec<u8>>>,
+    notify: Option<Arc<Notify>>,
+    closed_flag: Option<Arc<AtomicBool>>,
+) -> ::std::io::Result<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let mut chunk: [u8; CHUNK_SIZE] = [0u8; CHUNK_SIZE];
+    loop {
+        let bytes_read: usize = reader.read(&mut chunk).await?;
+        if bytes_read == 0 {
+            if let Some(flag) = &closed_flag {
+                flag.store(true, Ordering::SeqCst);
+            }
+            if let Some(notifier) = &notify {
+                notifier.notify_waiters();
+            }
+            break;
+        }
+
+        {
+            let mut guard = buffer.lock().await;
+            guard.extend_from_slice(&chunk[..bytes_read]);
+        }
+
+        if let Some(notifier) = &notify {
+            notifier.notify_waiters();
+        }
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Waits for a stream collector to finish, returning the accumulated bytes or surfacing errors.
+///
+/// # Parameters
+///
+/// - `handle`: Join handle for the collector task.
+/// - `buffer`: Shared buffer populated by the collector.
+/// - `timeout`: Maximum time allowed while waiting for stream shutdown.
+/// - `label`: Textual label (stdout/stderr) used in error messages.
+/// - `iteration`: Iteration index for logging context.
+///
+/// # Return Value
+///
+/// Returns the buffered bytes when the collector finishes successfully; returns an error on join
+/// failures, I/O errors, or timeouts.
+///
+async fn wait_stream_collector(
+    handle: JoinHandle<::std::io::Result<()>>,
+    buffer: Arc<AsyncMutex<Vec<u8>>>,
+    timeout: Duration,
+    label: &str,
+    iteration: usize,
+) -> Result<Vec<u8>> {
+    let join_result = match ::tokio::time::timeout(timeout, handle).await {
+        Ok(result) => result,
+        Err(_elapsed) => {
+            let reason: String = format!(
+                "timed out while waiting for interactive {label} (iteration={}, timeout_ms={})",
+                iteration,
+                timeout.as_millis()
+            );
+            error!("test_with_terminal_executor(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        },
+    };
+
+    match join_result {
+        Err(join_error) => {
+            let reason: String = format!(
+                "failed to join {label} collector task (iteration={}, error={join_error})",
+                iteration
+            );
+            error!("wait_stream_collector(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        },
+        Ok(Err(io_error)) => {
+            let reason: String = format!(
+                "failed to read {label} stream from nanvixd (iteration={}, error={io_error})",
+                iteration
+            );
+            error!("wait_stream_collector(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        },
+        Ok(Ok(())) => {},
+    }
+
+    let bytes: Vec<u8> = buffer.lock().await.clone();
+    Ok(bytes)
+}
+
+///
+/// # Description
+///
+/// Checks whether a byte buffer contains the desired pattern.
+///
+/// # Parameters
+///
+/// - `buffer`: Captured byte sequence examined for the desired pattern.
+/// - `pattern`: Target byte sequence that must appear in `buffer`.
+///
+/// # Return Value
+///
+/// Returns `true` when the pattern is found or when the expected pattern is empty. Returns
+/// `false` when the pattern is non-empty but the buffer is empty.
+///
+fn buffer_contains_pattern(buffer: &[u8], pattern: &[u8]) -> bool {
+    if pattern.is_empty() && buffer.is_empty() {
+        true
+    } else if pattern.is_empty() ^ buffer.is_empty() {
+        false
+    } else {
+        buffer
+            .windows(pattern.len())
+            .any(|window| window == pattern)
+    }
+}

--- a/src/utils/nanvix-test/src/log_layout.rs
+++ b/src/utils/nanvix-test/src/log_layout.rs
@@ -1,0 +1,874 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::chrono::Local;
+use ::nanvix::log::error;
+use ::std::{
+    collections::HashSet,
+    fs::{
+        create_dir_all,
+        read_dir,
+        rename,
+        write,
+    },
+    path::{
+        Path,
+        PathBuf,
+    },
+    sync::OnceLock,
+    time::{
+        SystemTime,
+        UNIX_EPOCH,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Component label used for Nanvix Daemon logs.
+const RUNNER_COMPONENT: &str = "runner";
+/// File prefix applied to guest logs emitted by the sandbox runtime.
+const GUEST_LOG_PREFIX: &str = "guest_";
+/// File prefix applied to legacy Linux Daemon logs.
+const LINUXD_LEGACY_PREFIX: &str = "linuxd_";
+/// File prefix applied to legacy Nanvix Daemon logs.
+const NANVIXD_LEGACY_PREFIX: &str = "nanvixd_";
+/// File prefix applied to legacy User VM logs.
+const USERVM_LEGACY_PREFIX: &str = "uservm_";
+
+/// Component normalization rules indexed by legacy on-disk prefix.
+const COMPONENT_NORMALIZATION_RULES: [LegacyComponentRule; 4] = [
+    LegacyComponentRule {
+        component: "linuxd",
+        legacy_prefix: LINUXD_LEGACY_PREFIX,
+    },
+    LegacyComponentRule {
+        component: "nanvixd",
+        legacy_prefix: NANVIXD_LEGACY_PREFIX,
+    },
+    LegacyComponentRule {
+        component: "uservm",
+        legacy_prefix: USERVM_LEGACY_PREFIX,
+    },
+    LegacyComponentRule {
+        component: "guest",
+        legacy_prefix: GUEST_LOG_PREFIX,
+    },
+];
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Stores the timestamp captured when `nanvix-test` starts running.
+static RUN_START_TIMESTAMP: OnceLock<String> = OnceLock::new();
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Captures the filesystem layout used while persisting Nanvix Daemon logs for an individual
+/// test case. Each test stores its artifacts under
+/// `logs/<timestamp>/<runner-name>/<program-name>/`.
+///
+pub(crate) struct TestLogLayout {
+    /// Directory where all artifacts for the current test case are stored.
+    test_dir: PathBuf,
+    /// Friendly label used when naming program output logs.
+    program_stem: String,
+}
+
+///
+/// # Description
+///
+/// Convenience container returned when allocating stdout/stderr files for a Nanvix Daemon run.
+///
+pub(crate) struct RunnerLogPaths {
+    /// Path where Nanvix Daemon stdout is stored.
+    pub stdout: PathBuf,
+    /// Path where Nanvix Daemon stderr is stored.
+    pub stderr: PathBuf,
+}
+
+///
+/// # Description
+///
+/// Tracks guest logs created under the shared log root, enabling the runner to relocate new
+/// entries into the per-test directory once execution completes.
+///
+pub(crate) struct GuestLogTracker {
+    /// Path to the shared log directory monitored for guest logs.
+    log_root: PathBuf,
+    /// Set of guest log paths that existed before the tracker was initialized.
+    existing_paths: HashSet<PathBuf>,
+}
+
+///
+/// # Description
+///
+/// Defines the association between a canonical component name and the historical on-disk prefix
+/// produced by existing daemons.
+///
+struct LegacyComponentRule {
+    /// Component label used when emitting normalized filenames.
+    component: &'static str,
+    /// Legacy on-disk prefix used to detect files that require normalization.
+    legacy_prefix: &'static str,
+}
+
+///
+/// # Description
+///
+/// Tracks metadata for a legacy log file so entries can be processed in chronological order.
+///
+struct LegacyLogEntry {
+    /// Absolute path to the legacy log file within the test directory.
+    path: PathBuf,
+    /// Filesystem timestamp used to keep rename operations deterministic.
+    modified_at: SystemTime,
+}
+
+///
+/// # Description
+///
+/// Wraps the timestamp string inserted into the run-scoped directory hierarchy, allowing
+/// consistent formatting across helper functions.
+///
+struct LogTimestamp {
+    formatted: String,
+}
+
+impl LogTimestamp {
+    ///
+    /// # Description
+    ///
+    /// Generates a timestamp string used when naming the run-scoped directory.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a `LogTimestamp` populated with the current local time.
+    ///
+    fn now() -> Self {
+        let formatted: String = Local::now().format("%Y_%m_%d_%H_%M_%S").to_string();
+        Self { formatted }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Consumes the timestamp helper and returns the owned string representation.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the formatted timestamp captured at construction time.
+    ///
+    fn into_string(self) -> String {
+        self.formatted
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Captures the timestamp used to name the run-scoped directory that stores all log artifacts.
+/// This function should be called once, immediately after `nanvix-test` starts running, so all
+/// subsequent tests share the same `<timestamp>` component.
+///
+/// # Return Value
+///
+/// Returns the cached timestamp string after ensuring it has been initialized.
+///
+pub(crate) fn initialize_run_timestamp() -> &'static str {
+    RUN_START_TIMESTAMP.get_or_init(|| LogTimestamp::now().into_string())
+}
+
+///
+/// # Description
+///
+/// Retrieves the cached timestamp component used when building run-scoped directories. This is a
+/// thin wrapper around `initialize_run_timestamp()` to emphasize the directory-friendly semantics.
+///
+/// # Return Value
+///
+/// Returns the run-scoped timestamp string captured when `nanvix-test` started.
+///
+fn run_timestamp_component() -> &'static str {
+    initialize_run_timestamp()
+}
+
+///
+/// # Description
+///
+/// Computes the directory path used to store all logs for the current `nanvix-test` invocation.
+/// The run directory lives under the configured base path using the cached timestamp component.
+///
+/// # Parameters
+///
+/// - `base_dir`: Root directory configured for storing log artifacts.
+///
+/// # Return Value
+///
+/// Returns the absolute path to `base_dir/<timestamp>`.
+///
+fn run_directory(base_dir: &Path) -> PathBuf {
+    base_dir.join(run_timestamp_component())
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl TestLogLayout {
+    ///
+    /// # Description
+    ///
+    /// Configures a log layout for workloads that provide a concrete program path.
+    /// Artifacts are stored under `<base>/<runner-name>/<program-name>` with sanitized path
+    /// components to avoid filesystem conflicts.
+    ///
+    /// # Parameters
+    ///
+    /// - `base_dir`: Root directory configured by the runner.
+    /// - `runner_name`: Logical runner label (e.g., `empty`, `http`, `terminal`).
+    /// - `program_path`: Absolute or relative path to the workload under test.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a layout rooted at `logs/<timestamp>/<runner-name>/<program-name>` whose files are
+    /// named with the sanitized program stem.
+    ///
+    pub(crate) fn for_program(
+        base_dir: &Path,
+        runner_name: &str,
+        program_path: &str,
+    ) -> Result<Self> {
+        let program_component_raw: String = match Path::new(program_path).file_name() {
+            Some(name) => name.to_string_lossy().into_owned(),
+            None => program_path.to_string(),
+        };
+        let program_component: String = sanitize_component(program_component_raw.as_str());
+        let program_stem: String = match Path::new(program_component.as_str()).file_stem() {
+            Some(stem) => stem.to_string_lossy().into_owned(),
+            None => program_component.clone(),
+        };
+        let runner_component: String = sanitize_runner_component(runner_name);
+
+        Self::new(
+            base_dir,
+            runner_component.as_str(),
+            program_component.as_str(),
+            program_stem.as_str(),
+        )
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Configures a log layout for workloads that do not expose a concrete binary (e.g., empty
+    /// executor sweeps). The sanitized label populates the `logs/<runner-name>/<label>` directory
+    /// and program stems.
+    ///
+    /// # Parameters
+    ///
+    /// - `base_dir`: Root directory configured by the runner.
+    /// - `runner_name`: Logical runner label (e.g., `empty`, `http`, `terminal`).
+    /// - `label`: Identifier used when naming the directory and program logs.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the configured layout stored under `logs/<timestamp>/<runner-name>/<label>`.
+    ///
+    pub(crate) fn for_label(base_dir: &Path, runner_name: &str, label: &str) -> Result<Self> {
+        let sanitized_label: String = sanitize_component(label);
+        let runner_component: String = sanitize_runner_component(runner_name);
+        Self::new(
+            base_dir,
+            runner_component.as_str(),
+            sanitized_label.as_str(),
+            sanitized_label.as_str(),
+        )
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Allocates fresh stdout/stderr paths for Nanvix Daemon logs, embedding the run iteration
+    /// label to ensure the generated log files remain unique per run.
+    ///
+    /// # Parameters
+    ///
+    /// - `iteration`: Optional iteration index (appended to the file name when provided).
+    ///
+    /// # Return Value
+    ///
+    /// Returns a `RunnerLogPaths` container with unique stdout/stderr paths.
+    ///
+    pub(crate) fn allocate_runner_logs(&self, iteration: Option<usize>) -> RunnerLogPaths {
+        RunnerLogPaths {
+            stdout: self.runner_stdout_path(iteration),
+            stderr: self.runner_stderr_path(iteration),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Persists the actual program output captured during the test run, stripping embedded nul
+    /// bytes and naming the file with the sanitized program stem plus the iteration label.
+    ///
+    /// # Parameters
+    ///
+    /// - `iteration`: Iteration index used to disambiguate file names.
+    /// - `payload`: Bytes collected from the workload stdout.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the path where the payload was written; returns an error when writing fails.
+    ///
+    pub(crate) fn persist_program_output(
+        &self,
+        iteration: usize,
+        payload: &[u8],
+    ) -> Result<PathBuf> {
+        let output_path: PathBuf = self.program_output_path(Some(iteration));
+        let sanitized_payload: Vec<u8> =
+            payload.iter().copied().filter(|byte| *byte != 0).collect();
+
+        if let Err(error) = write(&output_path, sanitized_payload.as_slice()) {
+            let reason: String = format!(
+                "failed to write program output log (path={}, error={error})",
+                output_path.display()
+            );
+            error!("persist_program_output(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        Ok(output_path)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Creates a new per-test directory and associates it with the layout metadata.
+    ///
+    /// # Parameters
+    ///
+    /// - `base_dir`: Root directory where all test-specific logs reside.
+    /// - `runner_component`: Sanitized directory component derived from the runner name.
+    /// - `program_component`: Sanitized directory component derived from the workload name.
+    /// - `program_stem`: Sanitized stem used when naming program output files.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the initialized log layout on success; returns an error if the directory creation
+    /// fails.
+    ///
+    fn new(
+        base_dir: &Path,
+        runner_component: &str,
+        program_component: &str,
+        program_stem: &str,
+    ) -> Result<Self> {
+        let run_dir: PathBuf = run_directory(base_dir);
+        let runner_dir: PathBuf = run_dir.join(runner_component);
+        let test_dir: PathBuf = runner_dir.join(program_component);
+
+        if let Err(error) = create_dir_all(&test_dir) {
+            let reason: String = format!(
+                "failed to create log directory (path={}, error={error})",
+                test_dir.display()
+            );
+            error!("new(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        Ok(Self {
+            test_dir,
+            program_stem: program_stem.to_string(),
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Computes the path where Nanvix Daemon stdout logs should be written.
+    ///
+    /// # Parameters
+    ///
+    /// - `iteration`: Optional iteration index appended to the filename.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the stdout log path scoped to the current test directory.
+    ///
+    fn runner_stdout_path(&self, iteration: Option<usize>) -> PathBuf {
+        let filename: String = component_log_filename(RUNNER_COMPONENT, iteration, "stdout");
+        self.test_dir.join(filename)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Computes the path where Nanvix Daemon stderr logs should be written.
+    ///
+    /// # Parameters
+    ///
+    /// - `iteration`: Optional iteration index appended to the filename.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the stderr log path scoped to the current test directory.
+    ///
+    fn runner_stderr_path(&self, iteration: Option<usize>) -> PathBuf {
+        let filename: String = component_log_filename(RUNNER_COMPONENT, iteration, "stderr");
+        self.test_dir.join(filename)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Computes the path where captured program stdout should be persisted.
+    ///
+    /// # Parameters
+    ///
+    /// - `iteration`: Optional iteration index appended to the filename.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the program output log path scoped to the current test directory.
+    ///
+    fn program_output_path(&self, iteration: Option<usize>) -> PathBuf {
+        let filename: String =
+            component_log_filename(self.program_stem.as_str(), iteration, "stdout");
+        self.test_dir.join(filename)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the directory that stores all artifacts for the associated test case.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the path to `logs/<timestamp>/<runner-name>/<program-name>` managed by this layout
+    /// instance.
+    ///
+    pub(crate) fn test_directory(&self) -> &Path {
+        self.test_dir.as_path()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Renames legacy component logs (linuxd, nanvixd, uservm) so they follow the
+    /// `<component>-<stream>-<iter>.log` convention.
+    ///
+    /// # Parameters
+    ///
+    /// - `iteration`: Iteration index used when computing the normalized filename.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `Ok(())` after all matching files have been renamed; returns an error if any
+    /// rename operation fails.
+    ///
+    pub(crate) fn normalize_component_logs(&self, iteration: usize) -> Result<()> {
+        for rule in COMPONENT_NORMALIZATION_RULES.iter() {
+            rename_component_logs(
+                self.test_directory(),
+                rule.component,
+                iteration,
+                rule.legacy_prefix,
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Formats an optional iteration index so filenames remain unique across repeated runs.
+///
+/// # Parameters
+///
+/// - `iteration`: Optional iteration number associated with the current run.
+///
+/// # Return Value
+///
+/// Returns the iteration identifier inserted into filenames, defaulting to `iter000` when
+/// unspecified.
+///
+fn iteration_token(iteration: Option<usize>) -> String {
+    let value: usize = iteration.unwrap_or(0);
+    format!("iter{value:03}")
+}
+
+///
+/// # Description
+///
+/// Normalizes filename segments so hyphens and dots are reserved for separating the component,
+/// stream, and iteration tokens or for the `.log` extension.
+///
+/// # Parameters
+///
+/// - `segment`: Candidate text inserted into a filename.
+///
+/// # Return Value
+///
+/// Returns the sanitized segment where any hyphen or dot is replaced by an underscore.
+///
+fn normalize_filename_segment(segment: &str) -> String {
+    segment
+        .chars()
+        .map(|ch| match ch {
+            '-' | '.' => '_',
+            _ => ch,
+        })
+        .collect()
+}
+
+///
+/// # Description
+///
+/// Builds the log filename following the `<component>-<stream>-<iter>.log` convention.
+///
+/// # Parameters
+///
+/// - `component`: Sanitized component name (runner, linuxd, uservm, etc.).
+/// - `iteration`: Optional iteration index associated with the artifact.
+/// - `stream`: Log stream label (`stdout` or `stderr`).
+///
+/// # Return Value
+///
+/// Returns the fully formatted filename.
+///
+fn component_log_filename(component: &str, iteration: Option<usize>, stream: &str) -> String {
+    let component_token: String = normalize_filename_segment(component);
+    let stream_token: String = normalize_filename_segment(stream);
+    let iteration_raw: String = iteration_token(iteration);
+    let iteration_token: String = normalize_filename_segment(iteration_raw.as_str());
+    format!("{component_token}-{stream_token}-{iteration_token}.log")
+}
+
+///
+/// # Description
+///
+/// Converts arbitrary strings into filesystem-friendly components by replacing unsupported
+/// characters with dashes.
+///
+/// # Parameters
+///
+/// - `component`: Candidate string that needs sanitization.
+///
+/// # Return Value
+///
+/// Returns the sanitized component containing only alphanumeric characters, hyphens, underscores,
+/// or dots.
+///
+fn sanitize_component(component: &str) -> String {
+    component
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => ch,
+            _ => '-',
+        })
+        .collect()
+}
+
+///
+/// # Description
+///
+/// Sanitizes the runner identifier so it can be used safely as a directory component for log
+/// storage.
+///
+/// # Parameters
+///
+/// - `runner_identifier`: Text describing the runner type or binary path.
+///
+/// # Return Value
+///
+/// Returns a filesystem-safe representation derived from the runner identifier.
+///
+fn sanitize_runner_component(runner_identifier: &str) -> String {
+    match Path::new(runner_identifier).file_stem() {
+        Some(stem) => sanitize_component(stem.to_string_lossy().as_ref()),
+        None => sanitize_component(runner_identifier),
+    }
+}
+
+impl GuestLogTracker {
+    ///
+    /// # Description
+    ///
+    /// Captures the current set of guest logs so the runner can detect which files were created
+    /// during a test case.
+    ///
+    /// # Parameters
+    ///
+    /// - `log_root`: Shared log directory scanned for guest log files.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a tracker populated with the guest logs present before the test starts.
+    ///
+    pub(crate) fn capture(log_root: &Path) -> Result<Self> {
+        let mut existing_paths: HashSet<PathBuf> = HashSet::new();
+
+        match read_dir(log_root) {
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to scan guest log directory (path={}, error={error})",
+                    log_root.display()
+                );
+                error!("GuestLogTracker::capture(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            Ok(entries) => {
+                for entry in entries.flatten() {
+                    let path: PathBuf = entry.path();
+                    if !path.is_file() || !is_guest_log(path.as_path()) {
+                        continue;
+                    }
+                    existing_paths.insert(path);
+                }
+            },
+        }
+
+        Ok(Self {
+            log_root: log_root.to_path_buf(),
+            existing_paths,
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Moves any guest logs created after the tracker was initialized into the provided
+    /// destination directory.
+    ///
+    /// # Parameters
+    ///
+    /// - `destination_dir`: Per-test directory where the guest logs should reside.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the list of destination paths populated with guest logs.
+    ///
+    pub(crate) fn move_new_logs(&self, destination_dir: &Path) -> Result<Vec<PathBuf>> {
+        let mut moved_paths: Vec<PathBuf> = Vec::new();
+
+        let entries = match read_dir(self.log_root.as_path()) {
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to scan guest log directory (path={}, error={error})",
+                    self.log_root.display()
+                );
+                error!("GuestLogTracker::move_new_logs(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            Ok(entries) => entries,
+        };
+
+        for entry in entries.flatten() {
+            let source_path: PathBuf = entry.path();
+            if !source_path.is_file() || !is_guest_log(source_path.as_path()) {
+                continue;
+            }
+            if self.existing_paths.contains(&source_path) {
+                continue;
+            }
+            let Some(file_name) = source_path.file_name() else {
+                continue;
+            };
+            let destination_path: PathBuf = destination_dir.join(file_name);
+            if let Err(error) = rename(source_path.as_path(), destination_path.as_path()) {
+                let reason: String = format!(
+                    "failed to move guest log (source={}, destination={}, error={error})",
+                    source_path.display(),
+                    destination_path.display()
+                );
+                error!("GuestLogTracker::move_new_logs(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            }
+            moved_paths.push(destination_path);
+        }
+
+        Ok(moved_paths)
+    }
+}
+
+///
+/// # Description
+///
+/// Determines whether the provided path points to a guest log file.
+///
+/// # Parameters
+///
+/// - `path`: Filesystem path inspected for the guest log prefix.
+///
+/// # Return Value
+///
+/// Returns `true` when the filename begins with the guest log prefix; otherwise returns `false`.
+///
+fn is_guest_log(path: &Path) -> bool {
+    let Some(file_name) = path.file_name() else {
+        return false;
+    };
+    let Some(file_str) = file_name.to_str() else {
+        return false;
+    };
+
+    file_str.starts_with(GUEST_LOG_PREFIX)
+}
+
+///
+/// # Description
+///
+/// Renames legacy component logs so they adhere to the standardized log naming convention.
+///
+/// # Parameters
+///
+/// - `test_dir`: Directory that stores the artifacts for the current test case.
+/// - `component`: Canonical component name (e.g., `linuxd`).
+/// - `iteration`: Iteration index recorded in the final filename.
+/// - `legacy_prefix`: On-disk prefix used by the legacy component logs.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` if all detected files were normalized successfully; otherwise returns an
+/// error describing the failure.
+///
+fn rename_component_logs(
+    test_dir: &Path,
+    component: &str,
+    iteration: usize,
+    legacy_prefix: &str,
+) -> Result<()> {
+    let mut legacy_entries: Vec<LegacyLogEntry> = Vec::new();
+
+    let entries = match read_dir(test_dir) {
+        Err(error) => {
+            let reason: String = format!(
+                "failed to scan test directory (path={}, error={error})",
+                test_dir.display()
+            );
+            error!("rename_component_logs(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        },
+        Ok(entries) => entries,
+    };
+
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let file_name_raw = entry.file_name();
+        let Some(file_name) = file_name_raw.to_str() else {
+            continue;
+        };
+        if !file_name.starts_with(legacy_prefix) || !file_name.ends_with(".log") {
+            continue;
+        }
+
+        let modified_at: SystemTime = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(UNIX_EPOCH);
+
+        legacy_entries.push(LegacyLogEntry {
+            path: entry.path(),
+            modified_at,
+        });
+    }
+
+    if legacy_entries.is_empty() {
+        return Ok(());
+    }
+
+    legacy_entries.sort_by(|left, right| {
+        left.modified_at
+            .cmp(&right.modified_at)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+
+    for (index, entry) in legacy_entries.into_iter().enumerate() {
+        let stream_label: &str = entry
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(stream_label_from_legacy_filename)
+            .unwrap_or("stdout");
+        let base_filename: String =
+            component_log_filename(component, Some(iteration), stream_label);
+        let candidate_name: String = if index == 0 {
+            base_filename
+        } else {
+            format!("{base_filename}.{index}")
+        };
+        let mut destination_path: PathBuf = test_dir.join(candidate_name.clone());
+        let mut collision_suffix: usize = 1;
+        while destination_path.exists() {
+            let duplicate_name: String = format!("{candidate_name}.{collision_suffix}");
+            destination_path = test_dir.join(duplicate_name);
+            collision_suffix += 1;
+        }
+
+        if let Err(error) = rename(entry.path.as_path(), destination_path.as_path()) {
+            let reason: String = format!(
+                "failed to rename component log (source={}, destination={}, error={error})",
+                entry.path.display(),
+                destination_path.display()
+            );
+            error!("rename_component_logs(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        }
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Infers whether a legacy component log captured stdout or stderr based on its filename.
+///
+/// # Parameters
+///
+/// - `file_name`: Filename that still uses the legacy prefix-based convention.
+///
+/// # Return Value
+///
+/// Returns `stderr` when the filename contains the substring `stderr` (case-insensitive);
+/// otherwise defaults to `stdout`.
+///
+fn stream_label_from_legacy_filename(file_name: &str) -> &'static str {
+    let lowercase: String = file_name.to_ascii_lowercase();
+    if lowercase.contains("stderr") {
+        "stderr"
+    } else {
+        "stdout"
+    }
+}

--- a/src/utils/nanvix-test/src/main.rs
+++ b/src/utils/nanvix-test/src/main.rs
@@ -1,0 +1,287 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![forbid(clippy::all)]
+#![forbid(clippy::unwrap_used)]
+#![forbid(clippy::expect_used)]
+#![forbid(clippy::cast_possible_truncation)]
+#![forbid(clippy::cast_possible_wrap)]
+#![forbid(clippy::cast_precision_loss)]
+#![forbid(clippy::cast_sign_loss)]
+#![forbid(clippy::char_lit_as_u8)]
+#![forbid(clippy::fn_to_numeric_cast)]
+#![forbid(clippy::fn_to_numeric_cast_with_truncation)]
+#![forbid(clippy::ptr_as_ptr)]
+#![forbid(clippy::unnecessary_cast)]
+#![forbid(invalid_reference_casting)]
+#![forbid(clippy::panic)]
+#![forbid(clippy::unimplemented)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unreachable)]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+mod args;
+mod config;
+mod environment;
+mod executor;
+mod log_layout;
+mod nanvixd;
+mod uservm;
+mod warning;
+
+#[macro_export]
+macro_rules! warn_with_policy {
+    ($($arg:tt)+) => {{
+        let formatted_message: String = format!($($arg)+);
+        ::nanvix::log::warn!("{}", formatted_message);
+        $crate::warning::record_warning(formatted_message);
+    }};
+}
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    config::{
+        NanvixTestConfig,
+        TestCaseConfig,
+    },
+    environment::{
+        prepare_l2_artifacts,
+        prepare_runner_environment,
+    },
+    executor::{
+        ExecutorName,
+        empty::empty,
+        http::test_with_http_executor,
+        terminal::test_with_terminal_executor,
+    },
+    log_layout::{
+        TestLogLayout,
+        initialize_run_timestamp,
+    },
+};
+use ::anyhow::Result;
+use ::nanvix::log::{
+    self,
+    debug,
+    error,
+};
+use ::std::{
+    fs::create_dir_all,
+    path::Path,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Default log-level (overridden by RUST_LOG environment variable if set).
+const DEFAULT_LOG_LEVEL: &str = "error";
+/// Default tenant identifier used when creating test sandboxes.
+pub(crate) const DEFAULT_TENANT_ID: &str = "nanvix-test";
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Initializes logging, builds a Tokio runtime, and dispatches the asynchronous test harness.
+///
+/// # Return Value
+///
+/// Returns the status produced by `run()`.
+///
+fn main() -> Result<()> {
+    log::init(false, DEFAULT_LOG_LEVEL, String::new(), None);
+
+    let runtime: ::tokio::runtime::Runtime = ::tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| {
+            let reason: String = format!("failed to build tokio runtime (error={error})");
+            error!("main(): {reason}");
+            ::anyhow::anyhow!(reason)
+        })?;
+
+    runtime.block_on(run())
+}
+
+///
+/// # Description
+///
+/// Parses CLI arguments, loads the configuration file, and runs the selected Nanvix Daemon
+/// integration tests.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` once all requested tests finish successfully; returns an error if CLI parsing,
+/// configuration loading, log directory creation, or test execution fails.
+///
+async fn run() -> Result<()> {
+    initialize_run_timestamp();
+
+    let parsed_args: args::Args =
+        args::Args::parse(::std::env::args().collect::<::std::vec::Vec<String>>())?;
+    let NanvixTestConfig {
+        runner: runner_config,
+        tests,
+    } = NanvixTestConfig::from_path(Path::new(parsed_args.config_file_path()))?;
+    warning::configure(runner_config.fatal);
+
+    let log_directory: &str = runner_config.log_directory.as_str();
+    if let Err(error) = create_dir_all(log_directory) {
+        let reason: String =
+            format!("failed to create nanvixd log directory (path={log_directory}, error={error})");
+        error!("main(): {reason}");
+        return Err(::anyhow::anyhow!(reason));
+    }
+    let log_root: &Path = Path::new(log_directory);
+
+    if runner_config.l2_enabled
+        && let Err(error) = prepare_l2_artifacts(
+            runner_config.toolchain_path.as_str(),
+            Path::new(runner_config.working_directory.as_str()),
+        )
+    {
+        let reason: String = format!(
+            "failed to prepare L2 artifacts (working_directory={}, toolchain={}, error={error})",
+            runner_config.working_directory, runner_config.toolchain_path
+        );
+        error!("main(): {reason}");
+        return Err(::anyhow::anyhow!(reason));
+    }
+
+    prepare_runner_environment(
+        runner_config.l2_enabled,
+        runner_config.port_num,
+        Path::new(runner_config.tmp_directory.as_str()),
+        runner_config.tcp_cleanup_max_wait_seconds,
+        runner_config.tcp_cleanup_poll_interval_seconds,
+    );
+    warning::fail_if_triggered("prepare_runner_environment")?;
+
+    for test_config in tests {
+        let TestCaseConfig {
+            executor,
+            iterations,
+            program,
+            program_args,
+            input,
+            expected_output,
+        } = test_config;
+
+        debug!(
+            "main(): running test (executor={}, iterations={}, program={:?}, program_args={:?})",
+            executor, iterations, program, program_args,
+        );
+
+        let executor_name: ExecutorName = ExecutorName::from_str(executor.as_str())?;
+
+        match (executor_name, program, program_args, input, expected_output) {
+            (ExecutorName::Empty, _, _, _, _) => {
+                let log_layout: TestLogLayout = TestLogLayout::for_label(
+                    log_root,
+                    ExecutorName::Empty.to_str(),
+                    executor.as_str(),
+                )?;
+                empty(&runner_config, iterations, &log_layout).await?;
+                let context: String = format!("empty executor completed (label={})", executor);
+                warning::fail_if_triggered(context.as_str())?;
+            },
+            (ExecutorName::Http, Some(program_path), program_args, input, expected_output) => {
+                if !Path::new(program_path.as_str()).exists() {
+                    warn_with_policy!(
+                        "main(): skipping tests with http executor because program path is \
+                         missing (path={})",
+                        program_path
+                    );
+                    warning::fail_if_triggered("http executor missing program")?;
+                    continue;
+                }
+
+                let log_layout: TestLogLayout = TestLogLayout::for_program(
+                    log_root,
+                    ExecutorName::Http.to_str(),
+                    program_path.as_str(),
+                )?;
+
+                test_with_http_executor(
+                    &runner_config,
+                    iterations,
+                    program_path.as_str(),
+                    program_args.as_deref(),
+                    input.as_deref(),
+                    expected_output.as_deref(),
+                    &log_layout,
+                )
+                .await?;
+                let context: String = format!(
+                    "http executor completed (program={}, test={})",
+                    program_path, executor
+                );
+                warning::fail_if_triggered(context.as_str())?;
+            },
+            (ExecutorName::Http, None, _, _, _) => {
+                let reason: String =
+                    "tests entries with http executor must define the 'program' field".to_string();
+                error!("main(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            (ExecutorName::Terminal, Some(program_path), program_args, input, expected_output) => {
+                if !Path::new(program_path.as_str()).exists() {
+                    warn_with_policy!(
+                        "main(): skipping tests with terminal executor because program path is \
+                         missing (path={})",
+                        program_path
+                    );
+                    warning::fail_if_triggered("terminal executor missing program")?;
+                    continue;
+                }
+
+                let log_layout: TestLogLayout = TestLogLayout::for_program(
+                    log_root,
+                    ExecutorName::Terminal.to_str(),
+                    program_path.as_str(),
+                )?;
+
+                test_with_terminal_executor(
+                    &runner_config,
+                    iterations,
+                    program_path.as_str(),
+                    program_args.as_deref(),
+                    input.as_deref(),
+                    expected_output.as_deref(),
+                    &log_layout,
+                )
+                .await?;
+                let context: String = format!(
+                    "terminal executor completed (program={}, test={})",
+                    program_path, executor
+                );
+                warning::fail_if_triggered(context.as_str())?;
+            },
+            (ExecutorName::Terminal, None, _, _, _) => {
+                let reason: String = "test entries with terminal executor must define the \
+                                      'program' field"
+                    .to_string();
+                error!("main(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+        }
+    }
+
+    warning::fail_if_triggered("nanvix-test completion")?;
+
+    Ok(())
+}

--- a/src/utils/nanvix-test/src/nanvixd/http.rs
+++ b/src/utils/nanvix-test/src/nanvixd/http.rs
@@ -1,0 +1,410 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::{
+    EnvironmentCleanupGuard,
+    Nanvixd,
+};
+use crate::config::RunnerConfig;
+use ::anyhow::Result;
+use ::nanvix::log::{
+    debug,
+    error,
+    trace,
+};
+use ::no_fail::no_fail;
+use ::std::{
+    fs::{
+        File,
+        OpenOptions,
+    },
+    path::{
+        Path,
+        PathBuf,
+    },
+    process::Stdio,
+};
+use ::tokio::{
+    net::TcpStream,
+    process::Command,
+    time::sleep,
+};
+
+//==================================================================================================
+// Nanvix Daemon HTTP Handle
+//==================================================================================================
+
+///
+/// Handle to a Nanvix Daemon instance exposing the HTTP control interface.
+///
+pub struct NanvixdHttp {
+    /// Shared process management state.
+    inner: Nanvixd,
+    /// IPv4 address exposed by the running daemon.
+    ipv4_addr: String,
+    /// TCP port exposed by the running daemon.
+    port_num: u16,
+    /// Maximum number of readiness checks before giving up on the HTTP endpoint.
+    nanvixd_ready_attempts_max: usize,
+    /// Interval (in milliseconds) between readiness probes.
+    nanvixd_ready_retry_interval_ms: u64,
+}
+
+impl NanvixdHttp {
+    ///
+    /// # Description
+    ///
+    /// Spawns a new Nanvix Daemon instance configured for HTTP coordination.
+    ///
+    /// # Parameters
+    ///
+    /// - `config`: Configuration object describing how the Nanvix Daemon should be spawned.
+    /// - `nanvixd_args`: File handles and runtime arguments used when spawning the Nanvix Daemon.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a handle to the HTTP-enabled Nanvix Daemon on success; returns an error when the
+    /// child process cannot be spawned or the readiness checks fail.
+    ///
+    pub async fn spawn(config: &RunnerConfig, nanvixd_args: &NanvixdHttpArgs) -> Result<Self> {
+        let hwloc_file_path: Option<&str> = nanvixd_args.hwloc_file_path();
+        let l2_enabled: bool = nanvixd_args.l2();
+        let log_directory: &Path = nanvixd_args.log_directory();
+        trace!(
+            "spawn(): nanvixd_binary_path={}, working_directory={}, toolchain_path={}, mode=http, \
+             hwloc_file_path={:?}, l2={}",
+            config.nanvixd_binary_path,
+            config.working_directory,
+            config.toolchain_path,
+            hwloc_file_path,
+            l2_enabled,
+        );
+
+        let port_num: u16 = nanvixd_args.port_num();
+        let http_address: String = format!("{}:{}", nanvixd_args.ipv4_addr(), port_num);
+
+        let mut command: Command =
+            Nanvixd::build_base_command(config, hwloc_file_path, l2_enabled, log_directory);
+
+        let stdout_file: File = nanvixd_args
+            .stdout_file_handle()
+            .try_clone()
+            .map_err(|error| {
+                let reason: String =
+                    format!("failed to clone nanvixd stdout log file (error={error})");
+                error!("spawn(): {reason}");
+                ::anyhow::anyhow!(reason)
+            })?;
+
+        let stderr_file: File = nanvixd_args
+            .stderr_file_handle()
+            .try_clone()
+            .map_err(|error| {
+                let reason: String =
+                    format!("failed to clone nanvixd stderr log file (error={error})");
+                error!("spawn(): {reason}");
+                ::anyhow::anyhow!(reason)
+            })?;
+
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::from(stdout_file));
+        command.stderr(Stdio::from(stderr_file));
+        command.arg(::nanvixd::args::Args::OPT_HTTP_SOCKADDR);
+        command.arg(http_address.as_str());
+
+        let mode_label: String = format!("http_address={http_address}");
+
+        // Spawn the Nanvix Daemon process.
+        let nanvixd: Self = match command.spawn() {
+            Err(error) => {
+                let reason: String = error.to_string();
+                error!("spawn(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            Ok(child) => {
+                // We cannot fail here; otherwise, `child` would linger.
+                no_fail!(Self, {
+                    debug!("spawn(): nanvixd spawned with pid {}", child.id().unwrap_or(0));
+                    let ipv4_addr: String = nanvixd_args.ipv4_addr().to_string();
+                    let cleanup_guard: EnvironmentCleanupGuard = EnvironmentCleanupGuard::new(
+                        l2_enabled,
+                        Some(port_num),
+                        PathBuf::from(config.tmp_directory.as_str()),
+                        config.tcp_cleanup_max_wait_seconds,
+                        config.tcp_cleanup_poll_interval_seconds,
+                    );
+
+                    Ok(Self {
+                        inner: Nanvixd::new(
+                            child,
+                            config.nanvixd_shutdown_attempts_max,
+                            config.nanvixd_shutdown_retry_interval_ms,
+                            mode_label.as_str(),
+                            cleanup_guard,
+                        ),
+                        ipv4_addr,
+                        port_num,
+                        nanvixd_ready_attempts_max: config.nanvixd_ready_attempts_max,
+                        nanvixd_ready_retry_interval_ms: config.nanvixd_ready_retry_interval_ms,
+                    })
+                })
+            },
+        };
+
+        nanvixd.try_wait_ready().await?;
+
+        Ok(nanvixd)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Waits until the Nanvix Daemon accepts TCP connections on the configured HTTP socket.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `Ok(())` once the daemon becomes reachable; returns an error if the readiness
+    /// attempts are exhausted without success.
+    ///
+    async fn try_wait_ready(&self) -> Result<()> {
+        let http_endpoint: String = self.http_address();
+        for attempt in 0..self.nanvixd_ready_attempts_max {
+            match TcpStream::connect(http_endpoint.as_str()).await {
+                Ok(stream) => {
+                    drop(stream);
+                    debug!(
+                        "try_wait_ready(): nanvixd reachable (attempt={}, context={})",
+                        attempt + 1,
+                        self.inner.context_label()
+                    );
+                    return Ok(());
+                },
+                Err(error) => {
+                    debug!(
+                        "try_wait_ready(): attempt {} failed (context={}, error={error})",
+                        attempt + 1,
+                        self.inner.context_label()
+                    );
+                },
+            }
+            sleep(::tokio::time::Duration::from_millis(self.nanvixd_ready_retry_interval_ms)).await;
+        }
+
+        let reason: String = format!(
+            "nanvixd did not expose HTTP endpoint after {} attempts (context={})",
+            self.nanvixd_ready_attempts_max,
+            self.inner.context_label()
+        );
+        error!("try_wait_ready(): {reason}");
+        Err(::anyhow::anyhow!(reason))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the IPv4:port endpoint exposed by this Nanvix Daemon handle.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the socket address formatted as `addr:port`.
+    ///
+    fn http_address(&self) -> String {
+        format!("{}:{}", self.ipv4_addr, self.port_num)
+    }
+}
+
+//==================================================================================================
+// Nanvix Daemon HTTP Arguments
+//==================================================================================================
+
+///
+/// Bundles the file handles and runtime parameters required when spawning the Nanvix Daemon in
+/// HTTP mode.
+///
+pub struct NanvixdHttpArgs {
+    /// File handle that captures Nanvix Daemon stdout.
+    stdout_file_handle: File,
+    /// File handle that captures Nanvix Daemon stderr.
+    stderr_file_handle: File,
+    /// Optional hwloc topology file forwarded to the Nanvix Daemon.
+    hwloc_file_path: Option<String>,
+    /// Indicates whether L2 deployment mode is enabled.
+    l2: bool,
+    /// IPv4 address exposed by the daemon instance.
+    ipv4_addr: String,
+    /// TCP port bound by the daemon instance.
+    port_num: u16,
+    /// Directory where Nanvix Daemon components should emit logs.
+    log_directory: PathBuf,
+}
+
+impl NanvixdHttpArgs {
+    ///
+    /// # Description
+    ///
+    /// Builds the log file and runtime bundle needed to launch the Nanvix Daemon in HTTP mode.
+    ///
+    /// # Parameters
+    ///
+    /// - `stdout_file_path`: Path to the file that captures Nanvix Daemon standard output.
+    /// - `stderr_file_path`: Path to the file that captures Nanvix Daemon standard error.
+    /// - `ipv4_addr`: IPv4 address where the Nanvix Daemon should expose its HTTP interface.
+    /// - `port_num`: TCP port used by the Nanvix Daemon HTTP interface.
+    /// - `hwloc_file_path`: Optional hwloc topology file passed to the Nanvix Daemon.
+    /// - `l2`: Flag indicating whether the Nanvix Daemon should enable L2 deployment mode.
+    /// - `log_directory`: Path where component logs should be persisted.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a ready-to-use argument bundle when both log files can be created; returns an error
+    /// when the stdout or stderr log file cannot be opened.
+    ///
+    pub fn new(
+        stdout_file_path: &Path,
+        stderr_file_path: &Path,
+        ipv4_addr: &str,
+        port_num: u16,
+        hwloc_file_path: Option<String>,
+        l2: bool,
+        log_directory: &Path,
+    ) -> Result<Self> {
+        let stdout_file_handle: File = match OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(stdout_file_path)
+        {
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to open nanvixd stdout log file (path={}, error={error})",
+                    stdout_file_path.display()
+                );
+                error!("new(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            Ok(file) => file,
+        };
+
+        let stderr_file_handle: File = match OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(stderr_file_path)
+        {
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to open nanvixd stderr log file (path={}, error={error})",
+                    stderr_file_path.display()
+                );
+                error!("new(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            Ok(file) => file,
+        };
+
+        Ok(Self {
+            stdout_file_handle,
+            stderr_file_handle,
+            hwloc_file_path,
+            l2,
+            ipv4_addr: ipv4_addr.to_string(),
+            port_num,
+            log_directory: log_directory.to_path_buf(),
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the stdout log handle used by the Nanvix Daemon when running in HTTP mode.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a reference to the stdout file handle.
+    ///
+    fn stdout_file_handle(&self) -> &File {
+        &self.stdout_file_handle
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the stderr log handle used by the Nanvix Daemon when running in HTTP mode.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a reference to the stderr file handle.
+    ///
+    fn stderr_file_handle(&self) -> &File {
+        &self.stderr_file_handle
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the optional hwloc topology file path passed to the Nanvix Daemon.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the optional hwloc path as a string slice.
+    ///
+    fn hwloc_file_path(&self) -> Option<&str> {
+        self.hwloc_file_path.as_deref()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reports whether L2 deployment mode is enabled for the Nanvix Daemon.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `true` when L2 mode is enabled; otherwise returns `false`.
+    ///
+    fn l2(&self) -> bool {
+        self.l2
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the TCP port bound by the Nanvix Daemon HTTP endpoint.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the TCP port number configured for the daemon.
+    ///
+    fn port_num(&self) -> u16 {
+        self.port_num
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the IPv4 address bound by the Nanvix Daemon HTTP endpoint.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the IPv4 string configured for the daemon.
+    ///
+    fn ipv4_addr(&self) -> &str {
+        self.ipv4_addr.as_str()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the directory where the Nanvix Daemon should persist component logs.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the component log directory as a path reference.
+    ///
+    fn log_directory(&self) -> &Path {
+        self.log_directory.as_path()
+    }
+}

--- a/src/utils/nanvix-test/src/nanvixd/mod.rs
+++ b/src/utils/nanvix-test/src/nanvixd/mod.rs
@@ -1,0 +1,484 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+mod http;
+mod terminal;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+pub use self::{
+    http::{
+        NanvixdHttp,
+        NanvixdHttpArgs,
+    },
+    terminal::{
+        NanvixdTerminal,
+        NanvixdTerminalArgs,
+    },
+};
+use crate::{
+    config::RunnerConfig,
+    environment,
+    warn_with_policy,
+};
+use ::anyhow::Result;
+use ::libc;
+use ::nanvix::log::{
+    debug,
+    error,
+    trace,
+};
+use ::std::{
+    path::{
+        Path,
+        PathBuf,
+    },
+    thread,
+    time::Duration,
+};
+use ::tokio::process::{
+    Child,
+    ChildStderr,
+    ChildStdin,
+    ChildStdout,
+    Command,
+};
+
+//==================================================================================================
+// Nanvix Daemon Shared State
+//==================================================================================================
+
+///
+/// Internal structure that encapsulates shared Nanvix Daemon lifecycle management.
+///
+struct Nanvixd {
+    /// Child process handle for the Nanvix Daemon binary.
+    cmd: Child,
+    /// Maximum number of attempts to wait for a graceful shutdown.
+    shutdown_attempts_max: usize,
+    /// Delay (in milliseconds) between shutdown polling attempts.
+    shutdown_retry_interval_ms: u64,
+    /// Label describing the runtime context, used in log messages.
+    context_label: String,
+    /// Guard that sanitizes Nanvix artifacts when the daemon drops.
+    _cleanup_guard: EnvironmentCleanupGuard,
+}
+
+impl Nanvixd {
+    ///
+    /// # Description
+    ///
+    /// Creates a new shared daemon handle from the spawned child process.
+    ///
+    /// # Parameters
+    ///
+    /// - `cmd`: Spawned Nanvix Daemon child process.
+    /// - `shutdown_attempts_max`: Maximum number of graceful-shutdown polls.
+    /// - `shutdown_retry_interval_ms`: Delay, in milliseconds, between polling attempts.
+    /// - `context_label`: Label used when emitting log messages.
+    /// - `cleanup_guard`: Guard that sanitizes Nanvix artifacts on drop.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a `Nanvixd` handle initialized with the provided process metadata.
+    ///
+    fn new(
+        cmd: Child,
+        shutdown_attempts_max: usize,
+        shutdown_retry_interval_ms: u64,
+        context_label: &str,
+        cleanup_guard: EnvironmentCleanupGuard,
+    ) -> Self {
+        Self {
+            cmd,
+            shutdown_attempts_max,
+            shutdown_retry_interval_ms,
+            context_label: context_label.to_string(),
+            _cleanup_guard: cleanup_guard,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Builds the base command used to spawn the Nanvix Daemon, populating shared arguments.
+    ///
+    /// # Parameters
+    ///
+    /// - `config`: Runner configuration that provides binary paths.
+    /// - `hwloc_file_path`: Optional hwloc topology forwarded to the Nanvix Daemon.
+    /// - `l2_enabled`: Whether L2 networking should be enabled.
+    /// - `log_directory`: Directory where the Nanvix Daemon should persist component logs.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a configured command ready for Nanvix Daemon-specific arguments.
+    ///
+    fn build_base_command(
+        config: &RunnerConfig,
+        hwloc_file_path: Option<&str>,
+        l2_enabled: bool,
+        log_directory: &Path,
+    ) -> Command {
+        let mut command: Command = Command::new(config.nanvixd_binary_path.as_str());
+        command.current_dir(&config.working_directory);
+        command.arg(::nanvixd::args::Args::OPT_TOOLCHAIN_BIN_DIRECTORY);
+        command.arg(format!("{}/bin", config.toolchain_path));
+
+        if let Some(hwloc_file) = hwloc_file_path {
+            command.arg(::nanvixd::args::Args::OPT_HWLOC);
+            command.arg(hwloc_file);
+        }
+
+        if l2_enabled {
+            command.arg(::nanvixd::args::Args::OPT_L2);
+        }
+
+        command.arg(::nanvixd::args::Args::OPT_LOG_DIRECTORY);
+        command.arg(log_directory);
+
+        command
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a human-readable label describing the runtime context used in log messages.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the context label string.
+    ///
+    fn context_label(&self) -> &str {
+        self.context_label.as_str()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sends a Unix signal to the target Nanvix Daemon process.
+    ///
+    /// # Parameters
+    ///
+    /// - `signal`: Signal number to deliver.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `Ok(())` if the signal is delivered; returns an error when delivery fails.
+    ///
+    fn signal(&self, signal: libc::c_int) -> Result<()> {
+        let context: String = self.context_label().to_string();
+        trace!("signal(): signal={signal}, context={context}");
+
+        // Get Nanvix Daemon PID.
+        let Some(pid) = self.cmd.id() else {
+            let reason: String = "nanvixd pid is unavailable".to_string();
+            error!("signal(): {reason} (signal={signal}, context={context})");
+            return Err(::anyhow::anyhow!(reason));
+        };
+
+        // Try to convert PID.
+        let pid: libc::pid_t = match pid.try_into() {
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to convert nanvixd pid (error={error}, signal={signal}, pid={pid}, \
+                     context={context})"
+                );
+                error!("signal(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            Ok(pid) => pid,
+        };
+
+        // Send signal to the Nanvix Daemon process and check for errors.
+        debug!("signal(): sending {signal} to nanvixd (pid={pid}, context={context})");
+        let ret: libc::c_int = unsafe { libc::kill(pid, signal) };
+        if ret != 0 {
+            let os_error: ::std::io::Error = ::std::io::Error::last_os_error();
+            let reason: String = format!(
+                "failed to send {signal} to nanvixd (pid={pid}, errno={os_error}, \
+                 context={context})"
+            );
+            error!("signal(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Waits for the Nanvix Daemon process to exit.
+    ///
+    /// This function retries at fixed intervals until either the process terminates or the
+    /// configured number of attempts is exhausted.
+    ///
+    /// # Parameters
+    ///
+    /// - `sleep_duration`: Duration to sleep between successive `try_wait_exit()` calls.
+    /// - `max_attempts`: Maximum number of polling attempts before giving up.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `true` if the process exits before the attempt limit, `false` if it is still
+    /// running after all attempts, and an error if the wait operation itself fails.
+    ///
+    fn try_wait_exit(&mut self, sleep_duration: Duration, max_attempts: usize) -> Result<bool> {
+        let mut attempts: usize = 0;
+        let context: String = self.context_label().to_string();
+        loop {
+            match self.cmd.try_wait() {
+                Err(error) => {
+                    let reason: String =
+                        format!("failed to wait for nanvixd (error={error}, context={context})");
+                    error!("try_wait_exit(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                },
+                Ok(Some(_status)) => {
+                    debug!(
+                        "try_wait_exit(): nanvixd process exited after {attempts} attempts \
+                         (context={context})"
+                    );
+                    return Ok(true);
+                },
+                Ok(None) => {
+                    if attempts >= max_attempts {
+                        let reason: String = format!(
+                            "nanvixd process failed to exit after {attempts} attempts \
+                             (context={context})"
+                        );
+                        debug!("try_wait_exit(): {reason}");
+                        return Ok(false);
+                    }
+
+                    attempts += 1;
+                    thread::sleep(sleep_duration);
+                },
+            }
+        }
+    }
+
+    ///
+    ///
+    /// # Description
+    ///
+    /// Takes ownership of the stdin handle when the daemon is running in interactive mode.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the stdin handle if available; otherwise returns `None` when stdin was already
+    /// taken.
+    ///
+    fn take_stdin(&mut self) -> Option<ChildStdin> {
+        self.cmd.stdin.take()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Takes ownership of the stdout handle for interactive mode consumers.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the stdout handle if it exists; otherwise returns `None` when previously taken.
+    ///
+    fn take_stdout(&mut self) -> Option<ChildStdout> {
+        self.cmd.stdout.take()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Takes ownership of the stderr handle for interactive mode consumers.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the stderr handle if it exists; otherwise returns `None` when previously taken.
+    ///
+    fn take_stderr(&mut self) -> Option<ChildStderr> {
+        self.cmd.stderr.take()
+    }
+}
+
+impl Drop for Nanvixd {
+    ///
+    /// # Description
+    ///
+    /// Cleans up the Nanvix Daemon process by attempting a graceful shutdown via SIGINT,
+    /// followed by a forced shutdown via SIGKILL if the former fails.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `()`; logs errors when cleanup attempts fail.
+    ///
+    fn drop(&mut self) {
+        let context: String = self.context_label().to_string();
+        match self.cmd.try_wait() {
+            Ok(Some(_status)) => {
+                trace!(
+                    "drop(): skipping cleanup because process already exited (context={context})"
+                );
+                return;
+            },
+            Ok(None) => {
+                trace!("drop(): context={context}");
+            },
+            Err(error) => {
+                warn_with_policy!(
+                    "drop(): failed to probe nanvixd status before cleanup (context={context}, \
+                     error={error})"
+                );
+                trace!("drop(): context={context}");
+            },
+        }
+
+        let wait_duration: Duration = Duration::from_millis(self.shutdown_retry_interval_ms);
+        let max_attempts: usize = self.shutdown_attempts_max;
+
+        match self.try_wait_exit(wait_duration, max_attempts) {
+            Err(error) => {
+                warn_with_policy!(
+                    "drop(): failed to wait for nanvixd exit before sending signals \
+                     (context={context}, error={error})"
+                );
+            },
+            Ok(true) => {
+                debug!(
+                    "drop(): nanvixd exited while waiting for natural shutdown (context={context})"
+                );
+                return;
+            },
+            Ok(false) => {
+                trace!(
+                    "drop(): nanvixd still running after natural shutdown wait (context={context})"
+                );
+            },
+        }
+
+        // Send SIGINT for graceful shutdown and check for errors.
+        let sigint_sent: bool = match self.signal(libc::SIGINT) {
+            Err(error) => {
+                error!(
+                    "drop(): failed to send SIGINT to nanvixd (context={context}, error={error})"
+                );
+                false
+            },
+            Ok(()) => true,
+        };
+
+        // Try to wait for graceful shutdown.
+        match self.try_wait_exit(wait_duration, max_attempts) {
+            Err(error) => {
+                error!("drop(): SIGINT wait failed (error={error})");
+            },
+            Ok(exited) => {
+                if exited {
+                    debug!("drop(): nanvixd exited gracefully after SIGINT");
+                    return;
+                }
+                if sigint_sent {
+                    warn_with_policy!(
+                        "drop(): nanvixd did not exit after SIGINT, sending SIGKILL \
+                         (context={context})"
+                    );
+                } else {
+                    warn_with_policy!(
+                        "drop(): nanvixd still running and SIGINT could not be delivered, sending \
+                         SIGKILL (context={context})"
+                    );
+                }
+            },
+        }
+
+        // Send SIGKILL for forced shutdown and check for errors.
+        if let Err(error) = self.signal(libc::SIGKILL) {
+            error!("drop(): failed to send SIGKILL to nanvixd (context={context}, error={error})");
+            return;
+        }
+
+        // Try to wait for forced shutdown.
+        match self.try_wait_exit(wait_duration, max_attempts) {
+            Err(error) => {
+                error!("drop(): SIGKILL wait failed (error={error})");
+            },
+            Ok(exited) => {
+                if exited {
+                    debug!("drop(): nanvixd exited after SIGKILL (context={context})");
+                } else {
+                    error!("drop(): nanvixd failed to exit after SIGKILL (context={context})");
+                }
+            },
+        }
+    }
+}
+
+//==================================================================================================
+// Environment Cleanup Guard
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Helper that guarantees host cleanup runs even when the Nanvixd drop handler exits early.
+struct EnvironmentCleanupGuard {
+    /// Indicates whether Nanvixd was launched with L2 enabled.
+    l2_enabled: bool,
+    /// Optional HTTP port used for TIME_WAIT cleanup.
+    http_port: Option<u16>,
+    /// Directory sanitized when removing Nanvix artifacts.
+    tmp_directory: PathBuf,
+    /// Maximum seconds spent waiting for lingering TIME_WAIT sockets.
+    tcp_cleanup_max_wait_seconds: u64,
+    /// Seconds between TIME_WAIT socket inspections.
+    tcp_cleanup_poll_interval_seconds: u64,
+}
+
+impl EnvironmentCleanupGuard {
+    ///
+    /// # Description
+    ///
+    /// Creates a new guard that sanitizes the host environment when dropped.
+    ///
+    /// # Parameters
+    ///
+    /// - `l2_enabled`: Indicates whether Nanvixd used L2 networking.
+    /// - `http_port`: Optional HTTP port monitored for lingering TIME_WAIT sockets.
+    /// - `tmp_directory`: Directory sanitized when removing Nanvix artifacts.
+    /// - `tcp_cleanup_max_wait_seconds`: Maximum seconds spent waiting for lingering TIME_WAIT
+    ///   sockets.
+    /// - `tcp_cleanup_poll_interval_seconds`: Seconds between TIME_WAIT socket inspections.
+    fn new(
+        l2_enabled: bool,
+        http_port: Option<u16>,
+        tmp_directory: PathBuf,
+        tcp_cleanup_max_wait_seconds: u64,
+        tcp_cleanup_poll_interval_seconds: u64,
+    ) -> Self {
+        Self {
+            l2_enabled,
+            http_port,
+            tmp_directory,
+            tcp_cleanup_max_wait_seconds,
+            tcp_cleanup_poll_interval_seconds,
+        }
+    }
+}
+
+impl Drop for EnvironmentCleanupGuard {
+    fn drop(&mut self) {
+        environment::cleanup_after_run(
+            self.l2_enabled,
+            self.http_port,
+            self.tmp_directory.as_path(),
+            self.tcp_cleanup_max_wait_seconds,
+            self.tcp_cleanup_poll_interval_seconds,
+        );
+    }
+}

--- a/src/utils/nanvix-test/src/nanvixd/terminal.rs
+++ b/src/utils/nanvix-test/src/nanvixd/terminal.rs
@@ -1,0 +1,283 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::{
+    EnvironmentCleanupGuard,
+    Nanvixd,
+};
+use crate::config::RunnerConfig;
+use ::anyhow::Result;
+use ::nanvix::log::{
+    debug,
+    error,
+    trace,
+};
+use ::no_fail::no_fail;
+use ::std::{
+    path::{
+        Path,
+        PathBuf,
+    },
+    process::Stdio,
+};
+use ::tokio::process::{
+    ChildStderr,
+    ChildStdin,
+    ChildStdout,
+    Command,
+};
+
+//==================================================================================================
+// Nanvix Daemon Terminal Handle
+//==================================================================================================
+
+///
+/// Handle to a Nanvix Daemon instance running in interactive terminal mode.
+///
+pub struct NanvixdTerminal {
+    /// Shared process management state.
+    inner: Nanvixd,
+}
+
+impl NanvixdTerminal {
+    ///
+    /// # Description
+    ///
+    /// Spawns a Nanvix Daemon instance configured for interactive coordination over stdin/stdout.
+    ///
+    /// # Parameters
+    ///
+    /// - `config`: Configuration object describing how the Nanvix Daemon should be spawned.
+    /// - `nanvixd_args`: Runtime arguments used when spawning the Nanvix Daemon.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a handle to the interactive Nanvix Daemon on success; returns an error if the
+    /// process cannot be spawned.
+    ///
+    pub async fn spawn(config: &RunnerConfig, nanvixd_args: &NanvixdTerminalArgs) -> Result<Self> {
+        debug_assert!(!config.l2_enabled);
+
+        let hwloc_file_path: Option<&str> = nanvixd_args.hwloc_file_path();
+        let log_directory: &Path = nanvixd_args.log_directory();
+        trace!(
+            "spawn(): nanvixd_binary_path={}, working_directory={}, toolchain_path={}, mode={}, \
+             hwloc_file_path={:?}, l2=disabled",
+            config.nanvixd_binary_path,
+            config.working_directory,
+            config.toolchain_path,
+            nanvixd_args.mode_label(),
+            hwloc_file_path,
+        );
+
+        let program_path: &str = nanvixd_args.program_path();
+        let program_args: &[String] = nanvixd_args.program_args();
+
+        let mut command: Command =
+            Nanvixd::build_base_command(config, hwloc_file_path, false, log_directory);
+        command.stdin(Stdio::piped());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+        command.arg(::nanvixd::args::Args::OPT_SEPARATOR);
+        command.arg(program_path);
+        command.args(program_args);
+
+        let mode_label: &str = "mode=interactive";
+
+        // Spawn the Nanvix Daemon process.
+        let nanvixd: Self = match command.spawn() {
+            Err(error) => {
+                let reason: String = error.to_string();
+                error!("spawn(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            Ok(child) => {
+                // We cannot fail here; otherwise, `child` would linger.
+                no_fail!(Self, {
+                    debug!("spawn(): nanvixd spawned with pid {}", child.id().unwrap_or(0));
+                    let cleanup_guard: EnvironmentCleanupGuard = EnvironmentCleanupGuard::new(
+                        false,
+                        None,
+                        PathBuf::from(config.tmp_directory.as_str()),
+                        config.tcp_cleanup_max_wait_seconds,
+                        config.tcp_cleanup_poll_interval_seconds,
+                    );
+                    Ok(Self {
+                        inner: Nanvixd::new(
+                            child,
+                            config.nanvixd_shutdown_attempts_max,
+                            config.nanvixd_shutdown_retry_interval_ms,
+                            mode_label,
+                            cleanup_guard,
+                        ),
+                    })
+                })
+            },
+        };
+
+        Ok(nanvixd)
+    }
+
+    ///
+    ///
+    /// # Description
+    ///
+    /// Takes ownership of stdin for piping data into the interactive daemon.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the stdin handle when available; otherwise returns `None` if stdin has already
+    /// been taken.
+    ///
+    pub fn take_stdin(&mut self) -> Option<ChildStdin> {
+        self.inner.take_stdin()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Takes ownership of the stdout handle for interactive consumers.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the stdout handle if it has not been taken yet; otherwise returns `None`.
+    ///
+    pub fn take_stdout(&mut self) -> Option<ChildStdout> {
+        self.inner.take_stdout()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Takes ownership of the stderr handle for interactive consumers.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the stderr handle if it is still available; otherwise returns `None`.
+    ///
+    pub fn take_stderr(&mut self) -> Option<ChildStderr> {
+        self.inner.take_stderr()
+    }
+}
+
+//==================================================================================================
+// Nanvix Daemon Terminal Arguments
+//==================================================================================================
+
+///
+/// Bundles the runtime parameters required when spawning the Nanvix Daemon in interactive
+/// terminal mode.
+///
+pub struct NanvixdTerminalArgs {
+    /// Optional hwloc topology file forwarded to the Nanvix Daemon.
+    hwloc_file_path: Option<String>,
+    /// Program executed by the daemon when running interactively.
+    program_path: String,
+    /// Command-line arguments forwarded to the interactive workload.
+    program_args: Vec<String>,
+    /// Directory where Nanvix Daemon components should emit logs.
+    log_directory: PathBuf,
+}
+
+impl NanvixdTerminalArgs {
+    ///
+    /// # Description
+    ///
+    /// Builds the runtime bundle needed to launch the Nanvix Daemon in interactive mode.
+    /// Log files are managed by the caller when capturing stdout/stderr streams.
+    ///
+    /// # Parameters
+    ///
+    /// - `hwloc_file_path`: Optional hwloc topology file passed to the Nanvix Daemon.
+    /// - `program_path`: Path to the workload that should execute inside the sandbox.
+    /// - `program_args`: Command-line arguments forwarded to the workload.
+    /// - `log_directory`: Directory where the Nanvix Daemon should emit component logs.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a ready-to-use argument bundle because interactive mode does not touch the
+    /// filesystem during construction.
+    ///
+    pub fn new(
+        hwloc_file_path: Option<String>,
+        program_path: &str,
+        program_args: &[String],
+        log_directory: &Path,
+    ) -> Result<Self> {
+        Ok(Self {
+            hwloc_file_path,
+            program_path: program_path.to_string(),
+            program_args: program_args.to_vec(),
+            log_directory: log_directory.to_path_buf(),
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the optional hwloc topology file path passed to the Nanvix Daemon.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the optional hwloc path as a string slice.
+    ///
+    pub fn hwloc_file_path(&self) -> Option<&str> {
+        self.hwloc_file_path.as_deref()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the interactive program path forwarded to the Nanvix Daemon.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a reference to the program path string.
+    ///
+    pub fn program_path(&self) -> &str {
+        self.program_path.as_str()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the interactive program arguments forwarded to the Nanvix Daemon.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a slice containing the program arguments.
+    ///
+    pub fn program_args(&self) -> &[String] {
+        self.program_args.as_slice()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the directory where component logs should be persisted.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the component log directory as a path reference.
+    ///
+    pub fn log_directory(&self) -> &Path {
+        self.log_directory.as_path()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a textual label describing the launch mode (used for logging).
+    ///
+    /// # Return Value
+    ///
+    /// Returns the static label that describes interactive mode.
+    ///
+    pub fn mode_label(&self) -> &'static str {
+        "mode=interactive"
+    }
+}

--- a/src/utils/nanvix-test/src/uservm.rs
+++ b/src/utils/nanvix-test/src/uservm.rs
@@ -1,0 +1,553 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    config::RunnerConfig,
+    warn_with_policy,
+};
+use ::anyhow::Result;
+use ::nanvix::{
+    http::message::{
+        ErrorResponse,
+        HTTP_HEADER_MESSAGE_TYPE,
+        Kill,
+        KillResponse,
+        MessageType,
+        New,
+        NewResponse,
+    },
+    log::{
+        debug,
+        error,
+        trace,
+    },
+    sandbox::UserVmIdentifier,
+    syscomm::{
+        SocketStream,
+        SocketType,
+        UnboundSocket,
+    },
+};
+use ::reqwest::{
+    Client,
+    StatusCode,
+    header::{
+        CONTENT_TYPE,
+        HeaderMap,
+        HeaderValue,
+    },
+};
+use ::tokio::{
+    task::block_in_place,
+    time::{
+        Duration,
+        Instant,
+        sleep,
+    },
+};
+
+//==================================================================================================
+// User VM Handle
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Handle to a User VM started through the Nanvix Daemon REST API.
+///
+pub struct UserVm {
+    /// HTTP client reused for Nanvix Daemon requests.
+    client: Client,
+    /// Fully qualified Nanvix Daemon endpoint used when talking to the control plane.
+    request_url: String,
+    /// Identifier assigned to this User VM by the Nanvix Daemon.
+    user_vm_id: UserVmIdentifier,
+    /// Socket stream wired to the User VM gateway for I/O.
+    gateway_stream: SocketStream,
+    /// Milliseconds to wait after shutting down a User VM when L2 is disabled.
+    cleanup_uservm_sleep_duration_ms: u64,
+    /// Milliseconds to wait after shutting down a User VM when L2 is enabled.
+    cleanup_l2_uservm_sleep_duration_ms: u64,
+    /// Indicates whether this User VM handle operates in L2 mode.
+    l2_enabled: bool,
+}
+
+impl UserVm {
+    ///
+    /// # Description
+    ///
+    /// Spawns a User VM by issuing a REST request to the Nanvix Daemon and wiring up the gateway
+    /// socket returned by the service.
+    ///
+    /// # Parameters
+    ///
+    /// - `config`: Runtime configuration that provides the Nanvix Daemon endpoint and cleanup
+    ///   timings.
+    /// - `uservm_args`: Headers, workload metadata, and flags that describe the User VM to launch.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a handle bound to the newly created User VM when the REST call and gateway
+    /// connection succeed; returns an error when the request or socket setup fails.
+    ///
+    pub async fn spawn(config: &RunnerConfig, uservm_args: &UserVmArgs) -> Result<Self> {
+        let client: Client = Client::new();
+        let http_endpoint: String = config.http_endpoint();
+        let request_url: String = format!("http://{http_endpoint}");
+        let l2_enabled: bool = uservm_args.l2_enabled();
+        trace!("spawn(): http_endpoint={}, l2_enabled={}", http_endpoint, l2_enabled);
+
+        let payload: New = New {
+            tenant_id: uservm_args.tenant_id.clone(),
+            app_name: uservm_args.app_name.clone(),
+            program: uservm_args.program_path.clone(),
+            program_args: uservm_args.program_args.clone().unwrap_or_default(),
+        };
+
+        let http_response: ::reqwest::Response = match client
+            .post(request_url.as_str())
+            .headers(uservm_args.headers())
+            .json(&payload)
+            .send()
+            .await
+        {
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to send user VM spawn request (url={}, error={error})",
+                    request_url
+                );
+                error!("spawn(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            Ok(resp) => resp,
+        };
+
+        let status: StatusCode = http_response.status();
+        let response: NewResponse = if status.is_success() {
+            match http_response.json::<NewResponse>().await {
+                Err(error) => {
+                    let reason: String = format!(
+                        "failed to decode user VM spawn response (url={}, error={error})",
+                        request_url
+                    );
+                    error!("spawn(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                },
+                Ok(parsed) => parsed,
+            }
+        } else {
+            let details: String = Self::format_error_details(http_response, status).await;
+            let reason: String =
+                format!("nanvixd rejected user VM spawn (url={}, details={details})", request_url);
+            error!("spawn(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        };
+
+        debug!("spawn(): uservm id={}, gateway={}", response.user_vm_id, response.gateway_sockaddr);
+
+        let gateway_socktype: SocketType = if l2_enabled {
+            SocketType::Tcp
+        } else {
+            SocketType::Unix
+        };
+
+        let gateway_stream: SocketStream =
+            Self::connect_to_gateway(config, response.gateway_sockaddr.as_str(), gateway_socktype)
+                .await?;
+
+        debug!("spawn(): connected to uservm gateway stream");
+
+        Ok(Self {
+            client,
+            request_url,
+            user_vm_id: response.user_vm_id,
+            gateway_stream,
+            cleanup_uservm_sleep_duration_ms: config.cleanup_uservm_sleep_duration_ms,
+            cleanup_l2_uservm_sleep_duration_ms: config.cleanup_l2_uservm_sleep_duration_ms,
+            l2_enabled,
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to connect to the gateway socket created by nanvixd using a bounded retry loop
+    /// with exponential backoff. This prevents the harness from hanging indefinitely when the
+    /// gateway never becomes reachable.
+    ///
+    /// # Parameters
+    ///
+    /// - `address`: Socket address returned by nanvixd for the uservm gateway.
+    /// - `socket_type`: Indicates whether the gateway is exposed via UNIX or TCP sockets.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a connected `SocketStream` when the gateway becomes reachable before the timeout;
+    /// returns an error when the retry budget is exhausted.
+    ///
+    async fn connect_to_gateway(
+        config: &RunnerConfig,
+        address: &str,
+        socket_type: SocketType,
+    ) -> Result<SocketStream> {
+        let deadline: Duration = Duration::from_millis(config.gateway_connect_timeout_ms);
+        let start: Instant = Instant::now();
+        let mut attempts: usize = 0;
+        let mut backoff_ms: u64 = config.gateway_connect_initial_backoff_ms;
+        let max_attempts: usize = config.gateway_connect_max_attempts;
+        let max_backoff_ms: u64 = config.gateway_connect_max_backoff_ms;
+
+        loop {
+            attempts = attempts.saturating_add(1);
+            let unbound_socket: UnboundSocket = UnboundSocket::new(socket_type);
+            match unbound_socket.connect(address).await {
+                Ok(stream) => return Ok(stream),
+                Err(error) => {
+                    let elapsed: Duration = start.elapsed();
+                    debug!(
+                        "connect_to_gateway(): attempt {} failed (addr={}, elapsed_ms={}, \
+                         error={error}), retrying after {} ms",
+                        attempts,
+                        address,
+                        elapsed.as_millis(),
+                        backoff_ms
+                    );
+
+                    if attempts >= max_attempts || elapsed >= deadline {
+                        let reason: String = format!(
+                            "failed to connect to gateway socket (addr={}, attempts={}, \
+                             elapsed_ms={}, last_error={error})",
+                            address,
+                            attempts,
+                            elapsed.as_millis()
+                        );
+                        error!("connect_to_gateway(): {reason}");
+                        return Err(::anyhow::anyhow!(reason));
+                    }
+
+                    sleep(Duration::from_millis(backoff_ms)).await;
+                    backoff_ms = (backoff_ms.saturating_mul(2)).min(max_backoff_ms);
+                },
+            }
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Provides mutable access to the gateway stream used for User VM I/O.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a mutable reference to the socket stream connected to the User VM gateway.
+    ///
+    pub fn gateway_stream(&mut self) -> &mut SocketStream {
+        &mut self.gateway_stream
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Computes how long callers should wait after shutting down this User VM using the timing
+    /// configuration supplied by the test runner.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the duration callers should wait before launching another User VM.
+    ///
+    fn cleanup_delay(&self) -> Duration {
+        let sleep_ms: u64 = if self.l2_enabled {
+            self.cleanup_l2_uservm_sleep_duration_ms
+        } else {
+            self.cleanup_uservm_sleep_duration_ms
+        };
+
+        Duration::from_millis(sleep_ms)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to decode a structured error payload returned by nanvixd for better diagnostics.
+    ///
+    /// # Parameters
+    ///
+    /// - `response`: Raw HTTP response returned by nanvixd.
+    /// - `status`: HTTP status code associated with the response.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a string that either embeds the decoded error payload or contains a fallback
+    /// message when decoding fails.
+    ///
+    async fn format_error_details(response: ::reqwest::Response, status: StatusCode) -> String {
+        match response.json::<ErrorResponse>().await {
+            Ok(payload) => {
+                format!("status={}, code={}, message={}", status, payload.code, payload.message)
+            },
+            Err(error) => {
+                format!("status={}, failed to decode error payload (error={error})", status)
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Terminates the User VM by issuing a REST request to the Nanvix Daemon and waiting for the
+    /// cleanup delay to elapse.
+    ///
+    /// # Parameters
+    ///
+    /// - `client`: HTTP client reused for the shutdown request.
+    /// - `request_url`: Endpoint used to reach the Nanvix Daemon.
+    /// - `user_vm_id`: Identifier of the User VM that should be terminated.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `Ok(())` once the Nanvix Daemon confirms the User VM termination response; returns
+    /// an error if the request or response handling fails.
+    ///
+    async fn kill(
+        &self,
+        client: Client,
+        request_url: String,
+        user_vm_id: UserVmIdentifier,
+    ) -> Result<()> {
+        trace!("kill(): user_vm_id={user_vm_id}");
+
+        let mut headers: HeaderMap = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let message_type_value: HeaderValue =
+            match HeaderValue::from_str(MessageType::Kill.to_string().as_str()) {
+                Ok(value) => value,
+                Err(error) => {
+                    let reason: String =
+                        format!("failed to build header value for MessageType::Kill ({error})");
+                    error!("kill(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                },
+            };
+        headers.insert(HTTP_HEADER_MESSAGE_TYPE, message_type_value);
+
+        let kill_msg: Kill = Kill { user_vm_id };
+
+        let http_response: ::reqwest::Response = match client
+            .post(request_url.as_str())
+            .headers(headers)
+            .json(&kill_msg)
+            .send()
+            .await
+        {
+            Err(error) => {
+                let reason: String = format!(
+                    "failed to send user VM kill request (url={}, error={error})",
+                    request_url
+                );
+                error!("kill(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            },
+            Ok(resp) => resp,
+        };
+
+        let status: StatusCode = http_response.status();
+        let response: KillResponse = if status.is_success() {
+            match http_response.json::<KillResponse>().await {
+                Err(error) => {
+                    let reason: String = format!(
+                        "failed to decode user VM kill response (url={}, error={error})",
+                        request_url
+                    );
+                    error!("kill(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                },
+                Ok(parsed) => parsed,
+            }
+        } else {
+            let details: String = Self::format_error_details(http_response, status).await;
+            let reason: String = format!(
+                "nanvixd rejected user VM kill (user_vm_id={}, details={details})",
+                user_vm_id
+            );
+            error!("kill(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        };
+
+        if response.exit_code != 0 {
+            warn_with_policy!(
+                "kill(): nanvixd reported non-zero exit code (user_vm_id={}, exit_code={})",
+                user_vm_id,
+                response.exit_code
+            );
+        } else {
+            debug!("kill(): uservm {} terminated", user_vm_id);
+        }
+
+        sleep(self.cleanup_delay()).await;
+
+        Ok(())
+    }
+}
+
+impl Drop for UserVm {
+    ///
+    /// # Description
+    ///
+    /// Ensures the User VM is terminated when this handle goes out of scope by synchronously
+    /// driving the asynchronous `kill()` helper.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `()`; logs errors when termination cannot be completed.
+    ///
+    fn drop(&mut self) {
+        trace!("drop(): user_vm_id={}", self.user_vm_id);
+
+        if let Ok(handle) = ::tokio::runtime::Handle::try_current() {
+            let client: Client = self.client.clone();
+            let request_url: String = self.request_url.clone();
+            let user_vm_id: UserVmIdentifier = self.user_vm_id;
+
+            let kill_result: Result<()> =
+                block_in_place(|| handle.block_on(self.kill(client, request_url, user_vm_id)));
+
+            if let Err(error) = kill_result {
+                error!(
+                    "drop(): failed to terminate user VM (user_vm_id={}, error={error})",
+                    self.user_vm_id
+                );
+            }
+        } else {
+            match ::tokio::runtime::Runtime::new() {
+                Ok(runtime) => match runtime.block_on(self.kill(
+                    self.client.clone(),
+                    self.request_url.clone(),
+                    self.user_vm_id,
+                )) {
+                    Ok(()) => {},
+                    Err(error) => {
+                        error!(
+                            "drop(): failed to terminate user VM (user_vm_id={}, error={error})",
+                            self.user_vm_id
+                        );
+                    },
+                },
+                Err(error) => {
+                    error!(
+                        "drop(): failed to build runtime for user VM termination (user_vm_id={}, \
+                         error={error})",
+                        self.user_vm_id
+                    );
+                },
+            }
+        }
+    }
+}
+
+//==================================================================================================
+// User VM Arguments
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Arguments required to request a new User VM deployment from the Nanvix Daemon.
+pub struct UserVmArgs {
+    /// HTTP headers forwarded to the Nanvix Daemon REST endpoint.
+    headers: HeaderMap,
+    /// Tenant identifier forwarded to the Nanvix Daemon.
+    tenant_id: String,
+    /// Application workload name used to identify the sandbox.
+    app_name: String,
+    /// Binary path that should execute inside the User VM.
+    program_path: String,
+    /// Optional command-line arguments forwarded to the workload.
+    program_args: Option<String>,
+    /// Indicates whether the Nanvix Daemon should provision L2 networking.
+    l2_enabled: bool,
+}
+
+impl UserVmArgs {
+    ///
+    /// # Description
+    ///
+    /// Creates and configures the HTTP headers and workload metadata required to request a new
+    /// User VM deployment via the Nanvix Daemon REST API.
+    ///
+    /// # Parameters
+    ///
+    /// - `tenant_id`: Identifier used to isolate the sandbox resources.
+    /// - `app_name`: Human-readable application workload name.
+    /// - `program_path`: Absolute path to the executable launched inside the User VM.
+    /// - `program_args`: Optional command-line arguments forwarded to the executable.
+    /// - `l2_enabled`: Flag indicating whether the request should enable L2 networking mode.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a fully prepared argument bundle with headers, metadata, and L2 flag when header
+    /// construction succeeds; returns an error if the message-type header value cannot be built.
+    ///
+    pub fn new(
+        tenant_id: &str,
+        app_name: &str,
+        program_path: &str,
+        program_args: Option<&str>,
+        l2_enabled: bool,
+    ) -> Result<Self> {
+        let mut headers: HeaderMap = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let message_type_value: HeaderValue =
+            match HeaderValue::from_str(MessageType::New.to_string().as_str()) {
+                Ok(value) => value,
+                Err(error) => {
+                    let reason: String =
+                        format!("failed to build header value for MessageType::New ({error})");
+                    error!("new(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                },
+            };
+        headers.insert(HTTP_HEADER_MESSAGE_TYPE, message_type_value);
+
+        Ok(Self {
+            headers,
+            tenant_id: tenant_id.to_string(),
+            app_name: app_name.to_string(),
+            program_path: program_path.to_string(),
+            program_args: program_args.map(|value| value.to_string()),
+            l2_enabled,
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a fresh copy of the HTTP headers prepared for the Nanvix Daemon request.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a header map containing the content type and message type markers needed to spawn
+    /// the User VM.
+    ///
+    pub fn headers(&self) -> HeaderMap {
+        self.headers.clone()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reports whether the caller asked for L2 networking mode when building these arguments.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `true` if L2 networking mode should be enabled for the User VM; otherwise returns
+    /// `false`.
+    ///
+    pub fn l2_enabled(&self) -> bool {
+        self.l2_enabled
+    }
+}

--- a/src/utils/nanvix-test/src/warning.rs
+++ b/src/utils/nanvix-test/src/warning.rs
@@ -1,0 +1,148 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::std::sync::{
+    Mutex,
+    MutexGuard,
+    OnceLock,
+    atomic::{
+        AtomicBool,
+        Ordering,
+    },
+};
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Tracks whether warnings should be treated as fatal errors.
+static WARNINGS_FATAL_ENABLED: AtomicBool = AtomicBool::new(false);
+/// Indicates whether a warning has been emitted since fatal mode was enabled.
+static WARNING_TRIGGERED: AtomicBool = AtomicBool::new(false);
+/// Stores the first warning message captured while fatal mode is active.
+static WARNING_MESSAGE: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns the mutex used to store the warning message, initializing it on first use.
+///
+/// # Return Value
+///
+/// Returns a reference to the lazily initialized mutex that stores the warning message.
+///
+fn warning_message_storage() -> &'static Mutex<Option<String>> {
+    WARNING_MESSAGE.get_or_init(|| Mutex::new(None))
+}
+
+///
+/// # Description
+///
+/// Acquires the warning message storage guard, tolerating poisoned mutex states.
+///
+/// # Parameters
+///
+/// - `storage`: Mutex that stores the optional warning message.
+///
+/// # Return Value
+///
+/// Returns a guard that grants mutable access to the stored warning message, even when the mutex
+/// was previously poisoned.
+///
+fn lock_warning_message<'a>(storage: &'a Mutex<Option<String>>) -> MutexGuard<'a, Option<String>> {
+    match storage.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Configures whether warnings should be promoted to fatal errors.
+///
+/// # Parameters
+///
+/// - `fatal_enabled`: Indicates whether warnings should cause the test run to fail.
+///
+pub(crate) fn configure(fatal_enabled: bool) {
+    WARNINGS_FATAL_ENABLED.store(fatal_enabled, Ordering::Relaxed);
+    if !fatal_enabled {
+        WARNING_TRIGGERED.store(false, Ordering::Relaxed);
+        if let Some(storage) = WARNING_MESSAGE.get() {
+            let mut guard: MutexGuard<'_, Option<String>> = lock_warning_message(storage);
+            *guard = None;
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Records that a warning was emitted and caches the associated message for diagnostics.
+///
+/// # Parameters
+///
+/// - `message`: Fully formatted warning message.
+///
+pub(crate) fn record_warning(message: String) {
+    if !WARNINGS_FATAL_ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+
+    WARNING_TRIGGERED.store(true, Ordering::Relaxed);
+
+    let storage: &Mutex<Option<String>> = warning_message_storage();
+    let mut guard: MutexGuard<'_, Option<String>> = lock_warning_message(storage);
+    if guard.is_none() {
+        *guard = Some(message);
+    }
+}
+
+///
+/// # Description
+///
+/// Fails the current operation if a warning was recorded while fatal mode is enabled.
+///
+/// # Parameters
+///
+/// - `context`: Human-readable label that describes where the warning was detected.
+///
+/// # Return Value
+///
+/// Returns `Ok(())` when no warnings were captured with fatal mode enabled; otherwise returns an
+/// error that surfaces the first warning message.
+///
+pub(crate) fn fail_if_triggered(context: &str) -> Result<()> {
+    if !WARNINGS_FATAL_ENABLED.load(Ordering::Relaxed) {
+        return Ok(());
+    }
+
+    if !WARNING_TRIGGERED.load(Ordering::Relaxed) {
+        return Ok(());
+    }
+
+    WARNING_TRIGGERED.store(false, Ordering::Relaxed);
+    let storage: &Mutex<Option<String>> = warning_message_storage();
+    let mut guard: MutexGuard<'_, Option<String>> = lock_warning_message(storage);
+    let warning_message: String = guard
+        .take()
+        .unwrap_or_else(|| "warning emitted while fatal mode active".to_string());
+
+    let reason: String =
+        format!("warning treated as fatal (context={}, message={})", context, warning_message);
+    Err(::anyhow::anyhow!(reason))
+}

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -59,6 +59,17 @@ pub const DEFAULT_L2_SNAPSHOT_DIRECTORY: &str = "images";
 ///
 /// # Description
 ///
+/// Default name for snapshot files.
+///
+/// # Notes
+///
+/// - This file must be synced with `generate-l2-snapshot.sh` script.
+///
+pub const DEFAULT_SNAPSHOT_FILE_NAME: &str = "l2_sysvm_initramfs.img";
+
+///
+/// # Description
+///
 /// Default path for the L2 snapshot.
 ///
 /// We cannot define this variable as a pub const &str because it depends on

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -65,5 +65,5 @@ pub const DEFAULT_L2_SNAPSHOT_DIRECTORY: &str = "images";
 /// SNAPSHOT_NAME which is another build-time constant.
 ///
 pub fn default_l2_snapshot_path() -> String {
-    format!("./images/{}", ::nanvix::config::linuxd::SNAPSHOT_NAME)
+    format!("./{}/{}", DEFAULT_L2_SNAPSHOT_DIRECTORY, ::nanvix::config::linuxd::SNAPSHOT_NAME)
 }

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -52,6 +52,13 @@ pub const DEFAULT_CONSOLE_FILENAME: &str = "guest";
 ///
 /// # Description
 ///
+/// Default directory name for storing L2 snapshots.
+///
+pub const DEFAULT_L2_SNAPSHOT_DIRECTORY: &str = "images";
+
+///
+/// # Description
+///
 /// Default path for the L2 snapshot.
 ///
 /// We cannot define this variable as a pub const &str because it depends on

--- a/test/test-l2.toml
+++ b/test/test-l2.toml
@@ -1,0 +1,103 @@
+[runner]
+nanvixd_binary_path = "./bin/nanvixd.elf"
+working_directory = "."
+log_directory = "logs"
+tmp_directory = "/tmp"
+ipv4_addr = "127.0.0.1"
+port_num = 9999
+hwloc_file_path = ""
+l2_enabled = true
+fatal = true
+toolchain_path = "toolchain"
+sysroot_path = "./sysroot"
+nanvixd_shutdown_attempts_max = 10
+nanvixd_shutdown_retry_interval_ms = 100
+nanvixd_ready_attempts_max = 50
+nanvixd_ready_retry_interval_ms = 100
+cleanup_uservm_sleep_duration_ms = 10
+cleanup_l2_uservm_sleep_duration_ms = 100
+stream_collection_timeout_ms = 300000
+tcp_cleanup_max_wait_seconds = 70
+tcp_cleanup_poll_interval_seconds = 2
+gateway_connect_max_attempts = 100
+gateway_connect_initial_backoff_ms = 10
+gateway_connect_max_backoff_ms = 500
+gateway_connect_timeout_ms = 15000
+
+[[tests]]
+executor = "empty"
+iterations = 1
+
+[[tests]]
+executor = "empty"
+iterations = 2
+
+#===================================================================================================
+# HTTP Executor Tests (Non-Interactive Mode)
+#===================================================================================================
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-c.elf"
+input = "hello world!"
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-cpp.elf"
+input = '["hello world!"]'
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-rust-nostd.elf"
+input = '["hello world!"]'
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/hello-c.elf"
+input = "[]"
+expected_output = "Hello, world from C!"
+
+[[tests]]
+executor = "http"
+program = "./bin/hello-cpp.elf"
+input = "[]"
+expected_output = "Hello, world from C++!"
+
+[[tests]]
+executor = "http"
+program = "./bin/linux-app.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/thread-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/network-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/misc-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/memory-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/arch-rust.elf"
+input = "[]"
+expected_output = "ok"

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -1,0 +1,270 @@
+[runner]
+nanvixd_binary_path = "./bin/nanvixd.elf"
+working_directory = "."
+log_directory = "logs"
+tmp_directory = "/tmp"
+ipv4_addr = "127.0.0.1"
+port_num = 9999
+hwloc_file_path = ""
+l2_enabled = false
+fatal = true
+toolchain_path = "toolchain"
+sysroot_path = "./sysroot"
+nanvixd_shutdown_attempts_max = 10
+nanvixd_shutdown_retry_interval_ms = 100
+nanvixd_ready_attempts_max = 50
+nanvixd_ready_retry_interval_ms = 100
+cleanup_uservm_sleep_duration_ms = 10
+cleanup_l2_uservm_sleep_duration_ms = 100
+stream_collection_timeout_ms = 300000
+tcp_cleanup_max_wait_seconds = 70
+tcp_cleanup_poll_interval_seconds = 2
+gateway_connect_max_attempts = 100
+gateway_connect_initial_backoff_ms = 10
+gateway_connect_max_backoff_ms = 500
+gateway_connect_timeout_ms = 15000
+
+[[tests]]
+executor = "empty"
+iterations = 1
+
+[[tests]]
+executor = "empty"
+iterations = 2
+
+#===================================================================================================
+# HTTP Executor Tests (Non-Interactive Mode)
+#===================================================================================================
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-c.elf"
+input = "hello world!"
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-cpp.elf"
+input = '["hello world!"]'
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-rust-nostd.elf"
+input = '["hello world!"]'
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/hello-c.elf"
+input = "[]"
+expected_output = "Hello, world from C!"
+
+[[tests]]
+executor = "http"
+program = "./bin/hello-cpp.elf"
+input = "[]"
+expected_output = "Hello, world from C++!"
+
+[[tests]]
+executor = "http"
+program = "./bin/linux-app.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/dlfcn-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/file-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/file-rust.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/thread-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/network-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/misc-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/memory-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/arch-rust.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/python3"
+program_args = "src/user/hello-python/__main__.py"
+expected_output = "Hello, from Python!"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "src/user/hello-js/index.js"
+expected_output = "Hello, world from JavaScript!"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_bigint.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_builtin.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_closure.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_cyclic_import.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_language.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_loop.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_std.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_worker.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/wasmd.elf"
+input = '["hello world!"]'
+expected_output = "Hello, world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/wasmd.elf"
+input = "[]"
+expected_output = "Hello, world!"
+
+#===================================================================================================
+# Terminal Executor Tests (Interactive Mode)
+#===================================================================================================
+
+[[tests]]
+executor = "terminal"
+program = "./bin/echo-c.elf"
+input = "hello world"
+expected_output = "hello world"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/echo-cpp.elf"
+input = "hello world"
+expected_output = "hello world"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/echo-rust-nostd.elf"
+input = "hello world"
+expected_output = "hello world"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/hello-c.elf"
+expected_output = "Hello, world from C!"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/hello-cpp.elf"
+expected_output = "Hello, world from C++!"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/linux-app.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/dlfcn-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/file-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/file-rust.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/thread-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/network-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/misc-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/memory-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/arch-rust.elf"
+expected_output = "ok"

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -1,0 +1,270 @@
+[runner]
+nanvixd_binary_path = "./bin/nanvixd.elf"
+working_directory = "."
+log_directory = "logs"
+tmp_directory = "/tmp"
+ipv4_addr = "127.0.0.1"
+port_num = 9999
+hwloc_file_path = ""
+l2_enabled = false
+fatal = true
+toolchain_path = "toolchain"
+sysroot_path = "./sysroot"
+nanvixd_shutdown_attempts_max = 10
+nanvixd_shutdown_retry_interval_ms = 100
+nanvixd_ready_attempts_max = 50
+nanvixd_ready_retry_interval_ms = 100
+cleanup_uservm_sleep_duration_ms = 10
+cleanup_l2_uservm_sleep_duration_ms = 100
+stream_collection_timeout_ms = 300000
+tcp_cleanup_max_wait_seconds = 70
+tcp_cleanup_poll_interval_seconds = 2
+gateway_connect_max_attempts = 100
+gateway_connect_initial_backoff_ms = 10
+gateway_connect_max_backoff_ms = 500
+gateway_connect_timeout_ms = 15000
+
+[[tests]]
+executor = "empty"
+iterations = 1
+
+[[tests]]
+executor = "empty"
+iterations = 2
+
+#===================================================================================================
+# HTTP Executor Tests (Non-Interactive Mode)
+#===================================================================================================
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-c.elf"
+input = "hello world!"
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-cpp.elf"
+input = '["hello world!"]'
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-rust-nostd.elf"
+input = '["hello world!"]'
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/hello-c.elf"
+input = "[]"
+expected_output = "Hello, world from C!"
+
+[[tests]]
+executor = "http"
+program = "./bin/hello-cpp.elf"
+input = "[]"
+expected_output = "Hello, world from C++!"
+
+[[tests]]
+executor = "http"
+program = "./bin/linux-app.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/dlfcn-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/file-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/file-rust.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/thread-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/network-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/misc-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/memory-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/arch-rust.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/python3"
+program_args = "src/user/hello-python/__main__.py"
+expected_output = "Hello, from Python!"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "src/user/hello-js/index.js"
+expected_output = "Hello, world from JavaScript!"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_bigint.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_builtin.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_closure.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_cyclic_import.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_language.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_loop.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_std.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "${sysroot_path}/bin/qjs"
+program_args = "--std src/tests/quickjs/test_worker.js"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/wasmd.elf"
+input = '["hello world!"]'
+expected_output = "Hello, world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/wasmd.elf"
+input = "[]"
+expected_output = "Hello, world!"
+
+#===================================================================================================
+# Terminal Executor Tests (Interactive Mode)
+#===================================================================================================
+
+[[tests]]
+executor = "terminal"
+program = "./bin/echo-c.elf"
+input = "hello world"
+expected_output = "hello world"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/echo-cpp.elf"
+input = "hello world"
+expected_output = "hello world"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/echo-rust-nostd.elf"
+input = "hello world"
+expected_output = "hello world"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/hello-c.elf"
+expected_output = "Hello, world from C!"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/hello-cpp.elf"
+expected_output = "Hello, world from C++!"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/linux-app.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/dlfcn-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/file-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/file-rust.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/thread-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/network-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/misc-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/memory-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/arch-rust.elf"
+expected_output = "ok"

--- a/test/test.toml
+++ b/test/test.toml
@@ -1,0 +1,210 @@
+[runner]
+nanvixd_binary_path = "./bin/nanvixd.elf"
+working_directory = "."
+log_directory = "logs"
+tmp_directory = "/tmp"
+ipv4_addr = "127.0.0.1"
+port_num = 9999
+hwloc_file_path = ""
+l2_enabled = false
+fatal = false
+toolchain_path = "toolchain"
+sysroot_path = "./sysroot"
+nanvixd_shutdown_attempts_max = 10
+nanvixd_shutdown_retry_interval_ms = 100
+nanvixd_ready_attempts_max = 50
+nanvixd_ready_retry_interval_ms = 100
+cleanup_uservm_sleep_duration_ms = 10
+cleanup_l2_uservm_sleep_duration_ms = 100
+stream_collection_timeout_ms = 300000
+tcp_cleanup_max_wait_seconds = 70
+tcp_cleanup_poll_interval_seconds = 2
+gateway_connect_max_attempts = 100
+gateway_connect_initial_backoff_ms = 10
+gateway_connect_max_backoff_ms = 500
+gateway_connect_timeout_ms = 15000
+
+[[tests]]
+executor = "empty"
+iterations = 1
+
+[[tests]]
+executor = "empty"
+iterations = 2
+
+#===================================================================================================
+# HTTP Executor Tests (Non-Interactive Mode)
+#===================================================================================================
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-c.elf"
+input = "hello world!"
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-cpp.elf"
+input = '["hello world!"]'
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/echo-rust-nostd.elf"
+input = '["hello world!"]'
+expected_output = "hello world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/hello-c.elf"
+input = "[]"
+expected_output = "Hello, world from C!"
+
+[[tests]]
+executor = "http"
+program = "./bin/hello-cpp.elf"
+input = "[]"
+expected_output = "Hello, world from C++!"
+
+[[tests]]
+executor = "http"
+program = "./bin/linux-app.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/dlfcn-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/file-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/file-rust.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/thread-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/network-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/misc-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/memory-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/arch-rust.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
+program = "./bin/wasmd.elf"
+input = '["hello world!"]'
+expected_output = "Hello, world!"
+
+[[tests]]
+executor = "http"
+program = "./bin/wasmd.elf"
+input = "[]"
+expected_output = "Hello, world!"
+
+#===================================================================================================
+# Terminal Executor Tests (Interactive Mode)
+#===================================================================================================
+
+[[tests]]
+executor = "terminal"
+program = "./bin/echo-c.elf"
+input = "hello world"
+expected_output = "hello world"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/echo-cpp.elf"
+input = "hello world"
+expected_output = "hello world"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/echo-rust-nostd.elf"
+input = "hello world"
+expected_output = "hello world"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/hello-c.elf"
+expected_output = "Hello, world from C!"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/hello-cpp.elf"
+expected_output = "Hello, world from C++!"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/linux-app.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/dlfcn-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/file-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/file-rust.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/thread-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/network-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/misc-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/memory-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/arch-rust.elf"
+expected_output = "ok"


### PR DESCRIPTION
This pull request introduces the new `nanvix-test` utility and integrates it into the build system and CI workflows. It also adds a new `no_fail` helper crate and exposes additional configuration constants. The most significant changes are grouped below:

**1. Introduction of the nanvix-test Utility:**
- Added the `nanvix-test` binary crate (`src/utils/nanvix-test`) with its own Cargo manifest and initial implementation, including argument parsing and an empty executor for testing Nanvix deployments. [[1]](diffhunk://#diff-b57111d1824ead630dc4dd414fa2d0d638f56bf0a545db7b0dd6f62d87e0ad22R1-R32) [[2]](diffhunk://#diff-c68663ce227a24dc74e17519cfc4153e11099ad81387c032d750e94d0c79e72cR1-R130) [[3]](diffhunk://#diff-b14015f0aee593f936422aab7ea1c44f2c1666392df622b3d7d69481b0c3d905R1-R86)
- Integrated `nanvix-test` into the build system, adding rules for building, checking, formatting, linting, and cleaning in the `Makefile` and a dedicated `build/make/nanvix-test.mk` file. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L336-R336) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L360-R360) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L468-R468) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L481-R481) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L514-R514) [[6]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L527-R527) [[7]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L575-R575) [[8]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R685-R690) [[9]](diffhunk://#diff-ad1fec46e99d04482f50f0e8cf7898b4bb4c5c5c58cf1faa4bd6e5b1ffa77966R1-R33)
- Registered `nanvix-test` as a workspace member in `Cargo.toml` and added its dependencies. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R57) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R109) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R140)

**2. CI and Workflow Enhancements:**
- Introduced a new composite GitHub Action `.github/actions/nanvix-test/action.yml` to run `nanvix-test` with the correct configuration for different deployment types.
- Updated the self-hosted CI workflow to invoke the new `nanvix-test` action for each deployment type.

**3. New no_fail Crate:**
- Added the `no_fail` crate (`src/libs/no_fail`) providing a macro for compile-time enforcement of infallible constructions, and registered it in the workspace and as a dependency. [[1]](diffhunk://#diff-9cca4d1243d01bfb0c61e7b631331e102f51beb6d01e2ebc20d6ef01518e596cR1-R20) [[2]](diffhunk://#diff-076202fe064573bee57e29b8dd36464851c679ef54b4b90d0fcfe33ef1aa537bR1-R34) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R30) [[4]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R109)

**4. Public API Improvements:**
- Made the `UNIX_SOCKET_SUFFIX` constant public in `nanvix-sandbox` and re-exported it from the library root, improving its usability in other crates. [[1]](diffhunk://#diff-44ca3658a5e2d5d338f8951029d3162a16a5e0803ad5032a8179c5ba2722cbafL110-R118) [[2]](diffhunk://#diff-f5b055ed6c61b7998e1bb0bcc08d7aab6c496a2cd6dba4ce81bacbeb81f58c61R170)

These changes collectively improve test automation, code quality, and developer ergonomics for the Nanvix project.