### PR TITLE
[uservm] Snapshot reading correction

### DIFF
--- a/src/uservm/src/vmm/microvm/kvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/kvm/mod.rs
@@ -7,8 +7,154 @@
 //! This module provides the backend implementation of MicroVM for Linux KVM.
 //!
 
+//==================================================================================================
+// Exports
+//==================================================================================================
+
 pub mod irqchip;
 pub mod pmio;
 pub mod timer;
 pub mod vcpu;
 pub mod vmem;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::vmm::{
+    guest::GuestState,
+    kvm::{
+        irqchip::IrqChipState,
+        timer::TimerState,
+        vcpu::VirtualProcessorState,
+    },
+};
+use ::anyhow::Result;
+use ::serde::{
+    Deserialize,
+    Serialize,
+};
+use ::syslog::trace;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A structure that holds all KVM components for snapshot serialization and deserialization.
+///
+#[derive(Serialize, Deserialize)]
+pub struct KvmSnapshot {
+    /// Guest component.
+    guest_state: GuestState,
+    /// Virtual processor component.
+    vcpu_state: VirtualProcessorState,
+    /// IrqChip component.
+    irqchip_state: IrqChipState,
+    /// Timer component.
+    timer_state: TimerState,
+}
+
+impl KvmSnapshot {
+    ///
+    /// # Description
+    ///
+    /// Consolidates multiple states into a single one for writing snapshots.
+    ///
+    /// # Parameters
+    ///
+    /// - `guest_state`: Guest related state.
+    /// - `vcpu_state`: vCPU related state.
+    /// - `irqchip_state`: Interrupt controller related state.
+    /// - `timer_state`: Timer related state.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns empty. Otherwise, it
+    /// returns an error.
+    ///
+    pub fn new(
+        guest_state: GuestState,
+        vcpu_state: VirtualProcessorState,
+        irqchip_state: IrqChipState,
+        timer_state: TimerState,
+    ) -> Self {
+        Self {
+            guest_state,
+            vcpu_state,
+            irqchip_state,
+            timer_state,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Validates the internal consistency of the KVM snapshot.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns empty. Otherwise, it
+    /// returns an error.
+    ///
+    pub fn validate(&self) -> Result<()> {
+        // TODO (#1227): Add some validation in case the file is malformed, corrupted,
+        // or the KVM features are incompatible.
+        trace!("validate()");
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets a reference to the underlying guest state.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the guest state.
+    ///
+    pub fn get_guest_state(&self) -> &GuestState {
+        &self.guest_state
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets a reference to the underlying vCPU state.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the vCPU state.
+    ///
+    pub fn get_vcpu_state(&self) -> &VirtualProcessorState {
+        &self.vcpu_state
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets a reference to the underlying interrupt controller state.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the interrupt controller state.
+    ///
+    pub fn get_irqchip_state(&self) -> &IrqChipState {
+        &self.irqchip_state
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets a reference to the underlying timer state.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the timer state.
+    ///
+    pub fn get_timer_state(&self) -> &TimerState {
+        &self.timer_state
+    }
+}

--- a/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -581,23 +581,6 @@ impl VirtualProcessor {
     }
 }
 
-impl VirtualProcessorState {
-    ///
-    /// # Description
-    ///
-    /// Validates the internal consistency of the virtual processor state.
-    ///
-    /// # Returns
-    ///
-    /// Upon successful completion, this method returns empty. Otherwise, it
-    /// returns an error.
-    ///
-    pub fn validate(&self) -> Result<()> {
-        trace!("validate()");
-        Ok(())
-    }
-}
-
 //==================================================================================================
 // Standalone functions
 //==================================================================================================

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -23,15 +23,9 @@ use crate::vmm::{
     MicroVmArgs,
     guest::Guest,
     kvm::{
-        irqchip::{
-            IrqChip,
-            IrqChipState,
-        },
-        timer::{
-            Timer,
-            TimerState,
-        },
-        vcpu::VirtualProcessorState,
+        KvmSnapshot,
+        irqchip::IrqChip,
+        timer::Timer,
     },
 };
 #[cfg(target_os = "linux")]
@@ -551,50 +545,18 @@ impl Vmm {
 
         let mut file: File = File::create(kvm_filepath)?;
 
-        let guest_state = self.guest.lock().await.save_state()?;
-        Self::write_snapshot_component("guest", &guest_state, &mut file)?;
-
         let locked_inner: MutexGuard<'_, InteriorMicroVmHandle> = self.inner.lock().await;
+        let kvm_snapshot: KvmSnapshot = KvmSnapshot::new(
+            self.guest.lock().await.save_state()?,
+            self.vcpu.lock().await.save_state(&locked_inner.kvm)?,
+            locked_inner.irqchip.save_state(&locked_inner.vm)?,
+            locked_inner.timer.save_state(&locked_inner.vm)?,
+        );
 
-        let vcpu_state: VirtualProcessorState =
-            self.vcpu.lock().await.save_state(&locked_inner.kvm)?;
-        Self::write_snapshot_component("vcpu", &vcpu_state, &mut file)?;
-
-        let irqchip_state: IrqChipState = locked_inner.irqchip.save_state(&locked_inner.vm)?;
-        Self::write_snapshot_component("irqchip", &irqchip_state, &mut file)?;
-
-        let timer_state: TimerState = locked_inner.timer.save_state(&locked_inner.vm)?;
-
-        Self::write_snapshot_component("timer", &timer_state, &mut file)?;
-
-        Ok(())
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Writes a snapshot component to the snapshot file.
-    ///
-    /// # Parameters
-    ///
-    /// - `component_name`: Name of the snapshot component.
-    /// - `component`: Reference to the snapshot component.
-    /// - `file`: Mutable reference to the snapshot file.
-    ///
-    /// # Returns
-    ///
-    /// Upon success, returns empty. Otherwise, returns an error.
-    ///
-    fn write_snapshot_component<T: ::serde::Serialize>(
-        component_name: &str,
-        component: &T,
-        file: &mut File,
-    ) -> Result<()> {
-        match ::serde_cbor::to_vec(component) {
+        match ::serde_cbor::to_vec(&kvm_snapshot) {
             Ok(buffer) => {
                 if let Err(e) = file.write_all(&buffer) {
-                    let reason: String =
-                        format!("failed writing {component_name} snapshot (error={e:?})",);
+                    let reason: String = format!("failed writing kvm snapshot (error={e:?})",);
                     error!("create_snapshot(): {reason}");
                     anyhow::bail!(reason)
                 }
@@ -602,8 +564,7 @@ impl Vmm {
                 Ok(())
             },
             Err(e) => {
-                let reason: String =
-                    format!("failed serializing {component_name} snapshot (error={e:?})",);
+                let reason: String = format!("failed serializing kvm snapshot (error={e:?})",);
                 error!("create_snapshot(): {reason}");
                 anyhow::bail!(reason)
             },
@@ -635,37 +596,72 @@ impl Vmm {
         let mut file: File = match File::open(kvm_filepath) {
             Ok(f) => f,
             Err(e) => {
-                let reason: String = format!("failed opening vcpu snapshot file (error={e:?})");
+                let reason: String = format!("failed opening kvm snapshot file (error={e:?})");
                 error!("load_snapshot(): {reason}");
                 anyhow::bail!(reason)
             },
         };
-        let state: VirtualProcessorState =
-            match ::serde_cbor::from_reader::<VirtualProcessorState, &mut File>(&mut file) {
-                Ok(state) => {
-                    if let Err(e) = state.validate() {
+
+        let kvm_snapshot: KvmSnapshot =
+            match ::serde_cbor::from_reader::<KvmSnapshot, &mut File>(&mut file) {
+                Ok(snapshot) => {
+                    if let Err(e) = snapshot.validate() {
                         let reason: String =
-                            format!("decoded vcpu snapshot is invalid (error={e:?})");
+                            format!("decoded kvm snapshot is invalid (error={e:?})");
                         error!("load_snapshot(): {reason}");
                         anyhow::bail!(reason)
                     } else {
-                        state
+                        snapshot
                     }
                 },
                 Err(e) => {
-                    let reason: String =
-                        format!("failed decoding vcpu snapshot file (error={e:?})");
+                    let reason: String = format!("failed decoding kvm snapshot file (error={e:?})");
                     error!("load_snapshot(): {reason}");
                     anyhow::bail!(reason)
                 },
             };
 
-        if let Err(e) = self.vcpu.lock().await.load_state(&state) {
+        // Load the snapshot.
+        if let Err(e) = self
+            .guest
+            .lock()
+            .await
+            .restore_state(kvm_snapshot.get_guest_state())
+        {
+            let reason: String = format!("failed setting guest state (error={e:?})");
+            error!("load_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        if let Err(e) = self
+            .vcpu
+            .lock()
+            .await
+            .load_state(kvm_snapshot.get_vcpu_state())
+        {
             let reason: String = format!("failed setting vcpu state (error={e:?})");
             error!("load_snapshot(): {reason}");
             anyhow::bail!(reason)
-        } else {
-            Ok(())
         }
+
+        // Destructure `locked_inner` to get the borrow checker to comply.
+        let mut locked_inner: MutexGuard<'_, InteriorMicroVmHandle> = self.inner.lock().await;
+        let InteriorMicroVmHandle {
+            vm, timer, irqchip, ..
+        } = &mut *locked_inner;
+
+        if let Err(e) = timer.restore_state(vm, kvm_snapshot.get_timer_state()) {
+            let reason: String = format!("failed setting timer state (error={e:?})");
+            error!("load_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        if let Err(e) = irqchip.restore_state(vm, kvm_snapshot.get_irqchip_state()) {
+            let reason: String = format!("failed setting irqchip state (error={e:?})");
+            error!("load_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Corrects the expected snapshot file structure for loading.

Having 4 different structs inside a file was not helpful. I created a single wrapper structure to make serialization and deserialization straighforward with a single call.

Having a single structure also provides a single source of truth for the ordering inside the file, instead of having to keep the writing and reading orders consistent manually.

Closes #1223.