### PR TITLE
[build] Set SINGLE_PROCESS=yes as Default

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -222,9 +222,9 @@ jobs:
       name: "Create Release Archive"
       if: ${{ success() && github.ref == 'refs/heads/dev' && matrix.build-type == 'release' &&  matrix.deployment-type != 'l2' }}
       run: |
-        single_process="no"
-        if [[ "${{ matrix.deployment-type }}" == "single-process" ]]; then
-          single_process="yes"
+        single_process="yes"
+        if [[ "${{ matrix.deployment-type }}" == "multi-process" ]]; then
+          single_process="no"
         fi
 
         # Ensure a clean build.

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ export BUILD_OPT ?= yes
 export L2_VM ?= no
 
 # Single-process deployment?
-export SINGLE_PROCESS ?= no
+export SINGLE_PROCESS ?= yes
 
 # Log Level
 export LOG_LEVEL ?= warn

--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -2,12 +2,37 @@
 # Licensed under the MIT License.
 
 NANVIX_BENCH_FEATURES :=
-NANVIX_BENCH_FEATURES += $(if $(filter yes,$(SINGLE_PROCESS)),single-process,)
 NANVIX_BENCH_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIX_BENCH_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIX_BENCH_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
 NANVIX_BENCH_FEATURES := $(strip $(NANVIX_BENCH_FEATURES))
 NANVIX_BENCH_CARGO_FEATURES := $(if $(NANVIX_BENCH_FEATURES),--features "$(NANVIX_BENCH_FEATURES)")
+
+ifeq ($(filter yes,$(SINGLE_PROCESS)),yes)
+$(warning nanvix-bench targets require multi-process mode; skipping nanvix-bench build targets.)
+
+all-nanvix-bench:
+	@true
+
+check-nanvix-bench:
+	@true
+
+format-nanvix-bench:
+	@true
+
+format-check-nanvix-bench:
+	@true
+
+rust-lint-nanvix-bench:
+	@true
+
+rust-lint-check-nanvix-bench:
+	@true
+
+clean-nanvix-bench:
+	@true
+
+else
 
 all-nanvix-bench: init
 	$(HOST_CARGO_BUILD_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench
@@ -31,3 +56,5 @@ rust-lint-nanvix-bench:
 
 rust-lint-check-nanvix-bench:
 	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench -- -D warnings
+
+endif

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 NANVIXD_FEATURES :=
-NANVIXD_FEATURES += $(if $(filter yes,$(SINGLE_PROCESS)),single-process,)
+NANVIXD_FEATURES += $(if $(filter no,$(SINGLE_PROCESS)),multi-process,)
 NANVIXD_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIXD_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIXD_FEATURES := $(strip $(NANVIXD_FEATURES))

--- a/doc/build.md
+++ b/doc/build.md
@@ -13,6 +13,7 @@ simplified build process or do it manually.
   - [Getting Started with `z`](#getting-started-with-z)
   - [Using `z` to Build Nanvix with Docker](#using-z-to-build-nanvix-with-docker)
   - [Using `z` to Build Nanvix with a Local Toolchain](#using-z-to-build-nanvix-with-a-local-toolchain)
+  - [Selecting a Deployment Mode](#selecting-a-deployment-mode)
 - [Building Nanvix Manually](#building-nanvix-manually)
   - [Manually Building Nanvix with Docker](#manually-building-nanvix-with-docker)
   - [Manually Building Nanvix with a Local Toolchain](#manually-building-nanvix-with-a-local-toolchain)
@@ -45,6 +46,32 @@ To build Nanvix using your local toolchain and default build parameters, run:
 ```bash
 ./z build -- all
 ```
+
+### Selecting a Deployment Mode
+
+Nanvix builds default to the single-process deployment path (`SINGLE_PROCESS=yes`). In this mode the
+Linux Daemon and UserVM execute within the same process, which is ideal for local development and
+faster iteration cycles. Set `SINGLE_PROCESS=no` whenever you need the multi-process deployment, which
+enables the `multi-process` Cargo feature, builds the standalone `linuxd` and `uservm` binaries, and
+matches the production topology.
+
+#### Examples
+
+Build multi-process artifacts with the `z` helper:
+
+```bash
+./z build -- all SINGLE_PROCESS=no
+```
+
+Or do the same through the raw Makefile interface:
+
+```bash
+make SINGLE_PROCESS=no all
+```
+
+You can freely switch between deployment modes by rebuilding with the desired `SINGLE_PROCESS`
+setting; subsequent `make run` or `nanvixd` invocations will use the binaries produced by the latest
+build.
 
 ## Building Nanvix Manually
 

--- a/doc/run.md
+++ b/doc/run.md
@@ -7,6 +7,7 @@ This document provides instructions on how to run Nanvix.
 ## Table of Contents
 
 - [Running Nanvix with `nanvixd` (Preferred Method)](#running-nanvix-with-nanvixd-preferred-method)
+  - [Choosing Single vs Multi-Process Mode](#choosing-single-vs-multi-process-mode)
   - [Step 1: Run `nanvixd`](#step-1-run-nanvixd)
   - [Step 2: Run an Application](#step-2-run-an-application)
   - [HTTP Error Responses](#http-error-responses)
@@ -21,6 +22,35 @@ This document provides instructions on how to run Nanvix.
 Nanvixd is a utility script that manages the deployment of User VMs in Nanvix, and their corresponding linuxd instances.
 
 Nanvixd exposes a unified RESTful API to interact with your deployment. To follow this guide we assume you have `jq` and `curl` installed.
+
+### Choosing Single vs Multi-Process Mode
+
+Nanvix builds default to the single-process deployment. No additional flags are required—`nanvixd`
+will log a banner similar to the following when it starts:
+
+```
+nanvixd X.Y.Z, single-process deployment, http mode
+```
+
+Set `SINGLE_PROCESS=no` during your build to exercise the multi-process deployment, which runs the
+Linux Daemon and UserVM as separate host processes and enables the `multi-process` Cargo feature
+across all crates:
+
+```bash
+./z build -- all SINGLE_PROCESS=no
+# or
+make SINGLE_PROCESS=no all
+```
+
+When the binaries were produced with multi-process support, the startup log switches accordingly and
+also reports the Layer-2 (L2) setting that was compiled in:
+
+```
+nanvixd X.Y.Z, multi-process deployment, http mode, l2 disabled
+```
+
+Whichever deployment mode was built most recently is the one that `nanvixd`, `make run`, and the test
+targets will use.
 
 ### Step 1: Run `nanvixd`
 

--- a/src/libs/nanvix-http/Cargo.toml
+++ b/src/libs/nanvix-http/Cargo.toml
@@ -17,10 +17,9 @@ http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["full"] }
-linuxd = { workspace = true, optional = true }
+linuxd = { workspace = true }
 nanvix-registry = { workspace = true }
 nanvix-sandbox-cache = { workspace = true }
-nanvix-terminal = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 syscomm = { workspace = true }
@@ -31,23 +30,13 @@ user-vm-api = { workspace = true }
 
 [features]
 default = ["microvm"]
-single-process = [
-    "linuxd",
-    "nanvix-sandbox-cache/single-process",
-    "nanvix-terminal/single-process",
-]
+multi-process = ["nanvix-sandbox-cache/multi-process"]
 hyperlight = [
     "config/hyperlight",
     "uservm/hyperlight",
     "nanvix-sandbox-cache/hyperlight",
-    "nanvix-terminal/hyperlight",
 ]
-microvm = [
-    "config/microvm",
-    "uservm/microvm",
-    "nanvix-sandbox-cache/microvm",
-    "nanvix-terminal/microvm",
-]
+microvm = ["config/microvm", "uservm/microvm", "nanvix-sandbox-cache/microvm"]
 
 [lints]
 workspace = true

--- a/src/libs/nanvix-http/src/server.rs
+++ b/src/libs/nanvix-http/src/server.rs
@@ -125,7 +125,7 @@ impl<T: Send + Sync + Default + Clone + 'static> HttpServer<T> {
                             debug!("accepted connection from {sockaddr:?}");
                             let sandbox_cache_clone: Arc<Mutex<SandboxCache<T>>> = sandbox_cache.clone();
                             // In single-process mode, handle connections sequentially.
-                            #[cfg(feature = "single-process")]
+                            #[cfg(not(feature = "multi-process"))]
                             {
                                 let client: HttpClient<T> = HttpClient::new(sandbox_cache_clone);
                                 let io: TokioIo<TcpStream> = TokioIo::new(stream);
@@ -133,7 +133,7 @@ impl<T: Send + Sync + Default + Clone + 'static> HttpServer<T> {
                                     error!("failed to serve connection (error={e:?})");
                                 }
                             }
-                            #[cfg(not(feature = "single-process"))]
+                            #[cfg(feature = "multi-process")]
                             {
                                 tokio::spawn(async move {
                                     let client: HttpClient<T> = HttpClient::new(sandbox_cache_clone);

--- a/src/libs/nanvix-sandbox-cache/Cargo.toml
+++ b/src/libs/nanvix-sandbox-cache/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { workspace = true, features = ["full"] }
 default = ["microvm"]
 hyperlight = ["config/hyperlight", "nanvix-sandbox/hyperlight"]
 microvm = ["config/microvm", "nanvix-sandbox/microvm"]
-single-process = ["nanvix-sandbox/single-process"]
+multi-process = ["nanvix-sandbox/multi-process"]
 
 [lints]
 workspace = true

--- a/src/libs/nanvix-sandbox-cache/src/config.rs
+++ b/src/libs/nanvix-sandbox-cache/src/config.rs
@@ -15,7 +15,7 @@ use ::nanvix_sandbox::{
     syscomm::SocketType,
     HwLoc,
 };
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use ::std::marker::PhantomData;
 
 //==================================================================================================
@@ -55,13 +55,13 @@ pub struct SandboxCacheConfig<T> {
     /// Path to kernel binary.
     kernel_binary_path: String,
     /// Path to the Linux Daemon binary.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     linuxd_binary_path: String,
     /// Path to the User VM binary.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     uservm_binary_path: String,
     /// System call table.
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     syscall_table: Option<::std::sync::Arc<::nanvix_sandbox::SyscallTable<T>>>,
     /// Path to the toolchain binary directory containing cloud-hypervisor and other tools.
     toolchain_binary_directory: String,
@@ -75,7 +75,7 @@ pub struct SandboxCacheConfig<T> {
     tmp_directory: String,
     /// Phantom data to maintain the generic type parameter `T` in the structure.
     /// This is required because `T` is only used in single-process mode for the syscall table.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     _phantom: PhantomData<T>,
 }
 
@@ -122,9 +122,9 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
         hwloc: Option<HwLoc>,
         netns_pool_size: usize,
         kernel_binary_path: &str,
-        #[cfg(not(feature = "single-process"))] linuxd_binary_path: &str,
-        #[cfg(not(feature = "single-process"))] uservm_binary_path: &str,
-        #[cfg(feature = "single-process")] syscall_table: Option<
+        #[cfg(feature = "multi-process")] linuxd_binary_path: &str,
+        #[cfg(feature = "multi-process")] uservm_binary_path: &str,
+        #[cfg(not(feature = "multi-process"))] syscall_table: Option<
             ::std::sync::Arc<::nanvix_sandbox::SyscallTable<T>>,
         >,
         toolchain_binary_directory: &str,
@@ -142,18 +142,18 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
             hwloc,
             netns_pool_size,
             kernel_binary_path: kernel_binary_path.to_string(),
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             linuxd_binary_path: linuxd_binary_path.to_string(),
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             uservm_binary_path: uservm_binary_path.to_string(),
-            #[cfg(feature = "single-process")]
+            #[cfg(not(feature = "multi-process"))]
             syscall_table,
             toolchain_binary_directory: toolchain_binary_directory.to_string(),
             log_directory: log_directory.to_string(),
             l2,
             l2_snapshot_path: l2_snapshot_path.to_string(),
             tmp_directory: tmp_directory.to_string(),
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             _phantom: PhantomData,
         }
     }
@@ -271,7 +271,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
     ///
     /// The path to the Linux Daemon binary.
     ///
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     pub fn linuxd_binary_path(&self) -> &str {
         &self.linuxd_binary_path
     }
@@ -285,7 +285,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
     ///
     /// The path to the User VM binary.
     ///
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     pub fn uservm_binary_path(&self) -> &str {
         &self.uservm_binary_path
     }
@@ -300,7 +300,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
     /// If a system call table is set, this function returns a handle to it. Otherwise, it returns
     /// empty.
     ///
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     pub fn syscall_table(&self) -> Option<::std::sync::Arc<::nanvix_sandbox::SyscallTable<T>>> {
         self.syscall_table.clone()
     }

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -32,7 +32,7 @@ pub use ::nanvix_sandbox::{
     HwLoc,
 };
 
-#[cfg(feature = "single-process")]
+#[cfg(not(feature = "multi-process"))]
 pub use ::nanvix_sandbox::SyscallTable;
 
 //==================================================================================================
@@ -40,7 +40,7 @@ pub use ::nanvix_sandbox::SyscallTable;
 //==================================================================================================
 
 use ::anyhow::Result;
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use ::nanvix_sandbox::netns::{
     NetnsHandle,
     NetnsInfo,
@@ -65,7 +65,7 @@ use ::nanvix_sandbox::{
     UninitializedSandbox,
     UserVmIdentifier,
 };
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use ::std::marker::PhantomData;
 use ::std::{
     collections::HashMap,
@@ -103,11 +103,11 @@ pub struct SandboxCache<T> {
     /// Shared control plane listener socket (reused across sandboxes for efficiency).
     control_plane_bind_socket: Option<Arc<Mutex<(SocketListener, String, SocketType)>>>,
     /// Network namespace pool for different L2 VMs.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     netns_pool: NetnsPool,
     /// Phantom data to maintain the generic type parameter `T` in the structure.
     /// This is required because `T` is only used in single-process mode for the syscall table.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     _phantom: PhantomData<T>,
 }
 
@@ -258,7 +258,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                 control_plane_bind_sockaddr,
                 control_plane_bind_socket_type,
             )))),
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             netns_pool: NetnsPool::new(
                 NetnsPoolConfig::new(
                     ::config::linuxd::GATEWAY_PORT_RANGE_BEGIN,
@@ -266,7 +266,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                 )?,
                 netns_init_strategy,
             )?,
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             _phantom: PhantomData,
         })))
     }
@@ -412,15 +412,15 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                 );
 
                 // Gateway port guard for L2 deployments.
-                #[cfg(not(feature = "single-process"))]
+                #[cfg(feature = "multi-process")]
                 let mut gateway_l2_port: Option<TcpPort> = None;
-                #[cfg(feature = "single-process")]
+                #[cfg(not(feature = "multi-process"))]
                 let gateway_l2_port: Option<TcpPort> = None;
 
                 // Add Linux Daemon instance to sandbox if one exists for the tenant.
                 let uninitialized_sandbox: UninitializedSandbox<T> =
                     if let Some(linuxd) = self.linuxd_instances.get(tag.tenant_id()) {
-                        #[cfg(not(feature = "single-process"))]
+                        #[cfg(feature = "multi-process")]
                         let uninitialized_sandbox: UninitializedSandbox<T> = {
                             // Clone ownership of the network namespace from linuxd (pre-existing) to
                             // the new user VM (only in L2-mode).
@@ -453,7 +453,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                     } else {
                         // Allocate a network namespace for the new linuxd (and user VM) instance
                         // in L2 deployments.
-                        #[cfg(not(feature = "single-process"))]
+                        #[cfg(feature = "multi-process")]
                         if self.config.l2() {
                             let netns_handle: NetnsHandle =
                                 self.netns_pool.allocate().map_err(|e| {
@@ -490,35 +490,35 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                             uninitialized_sandbox
                         }
 
-                        #[cfg(feature = "single-process")]
+                        #[cfg(not(feature = "multi-process"))]
                         uninitialized_sandbox
                     };
 
                 // Work-out socket addresses. In L2 deployments these addresses depend on the
                 // network namespace, so we assign them right after setting up the netns.
-                #[cfg(not(feature = "single-process"))]
+                #[cfg(feature = "multi-process")]
                 let netns_info: Option<NetnsInfo> = uninitialized_sandbox.netns_info();
                 let (control_plane_bind_sockaddr, control_plane_connect_sockaddr): (
                     String,
                     String,
                 ) = (control_plane_sockaddr_builder)(
                     self.config.tmp_directory(),
-                    #[cfg(not(feature = "single-process"))]
+                    #[cfg(feature = "multi-process")]
                     netns_info.clone(),
                 )?;
                 let user_vm_sockaddr: String = (user_vm_sockaddr_builder)(
                     self.config.tmp_directory(),
                     tag.tenant_id(),
-                    #[cfg(not(feature = "single-process"))]
+                    #[cfg(feature = "multi-process")]
                     self.config.l2(),
                 )?;
                 let gateway_sockaddr: String = (gateway_sockaddr_builder)(
                     self.config.tmp_directory(),
                     tag.tenant_id(),
                     tag.sandbox_id(),
-                    #[cfg(not(feature = "single-process"))]
+                    #[cfg(feature = "multi-process")]
                     netns_info.clone(),
-                    #[cfg(not(feature = "single-process"))]
+                    #[cfg(feature = "multi-process")]
                     &gateway_l2_port,
                 )?;
 
@@ -532,12 +532,12 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                     self.config.console_file().map(|s| s.to_string()),
                     self.config.hwloc().clone(),
                     self.config.kernel_binary_path(),
-                    #[cfg(not(feature = "single-process"))]
+                    #[cfg(feature = "multi-process")]
                     self.config.linuxd_binary_path(),
-                    #[cfg(not(feature = "single-process"))]
+                    #[cfg(feature = "multi-process")]
                     self.config.uservm_binary_path(),
                     self.config.log_directory(),
-                    #[cfg(feature = "single-process")]
+                    #[cfg(not(feature = "multi-process"))]
                     self.config.syscall_table(),
                     Some((
                         control_plane_bind_sockaddr.clone(),
@@ -746,7 +746,7 @@ mod tests {
     ///
     /// A sandbox cache configuration suitable for testing.
     ///
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     fn create_test_config() -> SandboxCacheConfig<()> {
         let tmp_dir: String = create_unique_tmp_dir();
         SandboxCacheConfig::new(
@@ -776,7 +776,7 @@ mod tests {
     ///
     /// A sandbox cache configuration suitable for testing.
     ///
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     fn create_test_config() -> SandboxCacheConfig<()> {
         let tmp_dir: String = create_unique_tmp_dir();
         SandboxCacheConfig::new(
@@ -822,7 +822,7 @@ mod tests {
     ) -> SandboxCacheConfig<()> {
         let tmp_dir: String = create_unique_tmp_dir();
 
-        #[cfg(feature = "single-process")]
+        #[cfg(not(feature = "multi-process"))]
         {
             SandboxCacheConfig::new(
                 socket_type,
@@ -842,7 +842,7 @@ mod tests {
             )
         }
 
-        #[cfg(not(feature = "single-process"))]
+        #[cfg(feature = "multi-process")]
         {
             SandboxCacheConfig::new(
                 socket_type,
@@ -882,7 +882,7 @@ mod tests {
     /// Tests sandbox cache creation with single-process configuration.
     ///
     #[tokio::test]
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     async fn test_new_single_process_mode() {
         let config: SandboxCacheConfig<()> = create_test_config();
         let result: Result<Arc<Mutex<SandboxCache<()>>>> = SandboxCache::new(config).await;
@@ -901,7 +901,7 @@ mod tests {
     /// Tests sandbox cache creation with multi-process configuration.
     ///
     #[tokio::test]
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     async fn test_new_multi_process_mode() {
         let config: SandboxCacheConfig<()> = create_test_config();
         let result: Result<Arc<Mutex<SandboxCache<()>>>> = SandboxCache::new(config).await;
@@ -919,7 +919,7 @@ mod tests {
     /// Tests sandbox cache creation with L2 VM configuration.
     ///
     #[tokio::test]
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     async fn test_new_l2_mode() {
         let config: SandboxCacheConfig<()> =
             create_custom_test_config(None, None, SocketType::Unix, true);
@@ -1012,7 +1012,7 @@ mod tests {
     /// Tests SandboxCacheConfig creation and getters.
     ///
     #[test]
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     fn test_config_single_process() {
         let config: SandboxCacheConfig<()> = create_test_config();
         assert_eq!(config.control_plane_sockaddr_type(), SocketType::Unix);
@@ -1032,7 +1032,7 @@ mod tests {
     /// Tests SandboxCacheConfig creation and getters for multi-process mode.
     ///
     #[test]
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     fn test_config_multi_process() {
         let config: SandboxCacheConfig<()> = create_test_config();
         assert_eq!(config.control_plane_sockaddr_type(), SocketType::Unix);
@@ -1079,7 +1079,7 @@ mod tests {
     /// Tests SandboxCacheConfig with L2 enabled.
     ///
     #[test]
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     fn test_config_with_l2_enabled() {
         let config: SandboxCacheConfig<()> =
             create_custom_test_config(None, None, SocketType::Unix, true);

--- a/src/libs/nanvix-sandbox/Cargo.toml
+++ b/src/libs/nanvix-sandbox/Cargo.toml
@@ -27,9 +27,8 @@ uservm = { workspace = true }
 
 [features]
 default = ["microvm"]
-# If enabled this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) are embedded
-# into the sandbox.
-single-process = []
+# If this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) run as separate processes.
+multi-process = []
 hyperlight = ["config/hyperlight", "uservm/hyperlight"]
 microvm = ["config/microvm", "uservm/microvm"]
 

--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -10,13 +10,13 @@
 // Imports
 //==================================================================================================
 
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use crate::{
     netns::NetnsInfo,
     tcp_port::TcpPort,
 };
 use ::anyhow::Result;
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use ::std::{
     fs,
     path::PathBuf,
@@ -139,7 +139,7 @@ pub const UNIX_SOCKET_SUFFIX: &str = ".socket";
 /// On success, the absolute path to cloud-hypervisor's binary directory. On failure, an error is
 /// returned instead.
 ///
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 pub(crate) fn get_clh_bin_dir(toolchain_bin_dir: &str) -> Result<String> {
     let clh_bin_dir_path: PathBuf =
         fs::canonicalize(PathBuf::from(toolchain_bin_dir)).map_err(|e| {
@@ -160,7 +160,7 @@ pub(crate) fn get_clh_bin_dir(toolchain_bin_dir: &str) -> Result<String> {
 ///
 /// The absolute path to cloud-hypervisor's snapshot directory.
 ///
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 pub(crate) fn get_clh_snapshot_path(l2_snapshot_path: &str) -> Result<String> {
     let l2_snapshot_path: PathBuf =
         fs::canonicalize(PathBuf::from(l2_snapshot_path)).map_err(|e| {
@@ -185,7 +185,7 @@ pub(crate) fn get_clh_snapshot_path(l2_snapshot_path: &str) -> Result<String> {
 ///
 /// The absolute path to cloud-hypervisor's API socket.
 ///
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 pub(crate) fn get_clh_api_socket_path(tmp_dir: &str) -> String {
     format!("{tmp_dir}/nanvixd-clh{UNIX_SOCKET_SUFFIX}")
 }
@@ -213,12 +213,12 @@ pub(crate) fn get_clh_api_socket_path(tmp_dir: &str) -> String {
 ///
 pub fn control_plane_sockaddr_builder(
     tmp_str: &str,
-    #[cfg(not(feature = "single-process"))] netns_info: Option<NetnsInfo>,
+    #[cfg(feature = "multi-process")] netns_info: Option<NetnsInfo>,
 ) -> Result<(String, String)> {
     // In an L2 deployment, linuxd and the user VM are deployed inside a separate network
     // namespace. To connect to the control-plane socket in nanvixd, in the root namespace, they
     // must use the host half of the VETH pair we include in the namespace.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     if let Some(netns_info) = netns_info {
         let bind_addr: String = format!("0.0.0.0:{}", config::linuxd::CONTROL_PLANE_PORT);
         let connect_addr: String =
@@ -262,14 +262,14 @@ pub fn control_plane_sockaddr_builder(
 pub fn user_vm_sockaddr_builder(
     tmp_str: &str,
     tenant_id: &str,
-    #[cfg(not(feature = "single-process"))] l2: bool,
+    #[cfg(feature = "multi-process")] l2: bool,
 ) -> Result<String> {
     // In an L2 deployment, both linuxd and the user VM are deployed inside the same network
     // namespace, isolated from nanvixd and other tenants. Linuxd, however, runs inside a VM
     // exposed to the host via a TAP device, so we need to connect to the guest-side of the TAP.
     // Note that even though the TAP's IPs are hard-coded during snapshot/restore (and hence
     // repeated among all linuxd instances), namespace isolation makes this reuse safe.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     if l2 {
         return Ok(format!(
             "{}:{}",
@@ -317,13 +317,13 @@ pub fn gateway_sockaddr_builder(
     tmp_str: &str,
     tenant_id: &str,
     sandbox_id: UserVmIdentifier,
-    #[cfg(not(feature = "single-process"))] netns_info: Option<NetnsInfo>,
-    #[cfg(not(feature = "single-process"))] l2_port: &Option<TcpPort>,
+    #[cfg(feature = "multi-process")] netns_info: Option<NetnsInfo>,
+    #[cfg(feature = "multi-process")] l2_port: &Option<TcpPort>,
 ) -> Result<String> {
     // In an L2 deployment, we expose the gateway from linuxd inside a network namespace to the
     // outside world. As a consequence, external clients must connect to the half of the VETH pair
     // that is _inside_ the namespace.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     match (netns_info.clone(), l2_port) {
         (Some(netns_info), Some(l2_port)) => {
             return Ok(format!("{}:{:?}", netns_info.veth_ns_ip(), l2_port));

--- a/src/libs/nanvix-sandbox/src/initialized.rs
+++ b/src/libs/nanvix-sandbox/src/initialized.rs
@@ -11,7 +11,7 @@
 // Imports
 //==================================================================================================
 
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use crate::netns::NetnsHandle;
 use crate::{
     config::GATEWAY_CONNECT_TIMEOUT,
@@ -23,7 +23,7 @@ use crate::{
     UserVmArgs,
 };
 use ::anyhow::Result;
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use ::std::marker::PhantomData;
 use ::std::sync::Arc;
 use ::syscomm::{
@@ -78,11 +78,11 @@ pub struct InitializedSandbox<T: Send + Sync + Default + 'static> {
     /// Complete configuration for the sandbox execution environment.
     pub(super) sandbox_config: SandboxConfig<T>,
     /// Handle to the network namespace (only set in L2-mode).
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     pub(super) netns_handle: Option<NetnsHandle>,
     /// Phantom data to maintain the generic type parameter `T` in the structure.
     /// This is required because `T` is only used in single-process mode for the syscall table.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     pub(super) _phantom: PhantomData<T>,
 }
 
@@ -98,7 +98,7 @@ impl<T: Send + Sync + Default + 'static> InitializedSandbox<T> {
     /// On success, returns a running sandbox with an active User VM. On failure, returns an
     /// error describing what went wrong during startup.
     ///
-    #[cfg_attr(feature = "single-process", allow(unused_mut))]
+    #[cfg_attr(not(feature = "multi-process"), allow(unused_mut))]
     pub async fn start(mut self) -> Result<RunningSandbox> {
         // Extract gateway socket info parts for later use.
         let gateway_sockaddr: String = self.sandbox_config.gateway_socket_info().0.clone();
@@ -114,7 +114,7 @@ impl<T: Send + Sync + Default + 'static> InitializedSandbox<T> {
         let hwloc: Option<hwloc::HwLoc> = self.sandbox_config.hwloc();
         let log_directory: String = self.sandbox_config.log_directory().to_string();
         let uservm_id: ::user_vm_api::UserVmIdentifier = self.sandbox_config.uservm_id();
-        #[cfg(not(feature = "single-process"))]
+        #[cfg(feature = "multi-process")]
         let uservm_binary_path: String = self.sandbox_config.uservm_binary_path().to_string();
 
         // Extract gateway socket info (consumes the config to get ownership of TcpPort).
@@ -143,7 +143,7 @@ impl<T: Send + Sync + Default + 'static> InitializedSandbox<T> {
                     console_file,
                     hwloc,
                     self.kernel_binary_path.clone(),
-                    #[cfg(not(feature = "single-process"))]
+                    #[cfg(feature = "multi-process")]
                     uservm_binary_path,
                     log_directory,
                     uservm_id,
@@ -152,7 +152,7 @@ impl<T: Send + Sync + Default + 'static> InitializedSandbox<T> {
                 // one connection from the new user VM.
                 &mut locked_control_plane_bind_socket_and_info.0,
                 // Pass ownership of the netns RAII handle to the user VM.
-                #[cfg(not(feature = "single-process"))]
+                #[cfg(feature = "multi-process")]
                 self.netns_handle.take(),
             )
             .await

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -37,15 +37,15 @@
 //!
 //! ## Deployment Modes
 //!
-//! ### Multi-Process Mode (default)
+//! ### Single-Process Mode (default)
 //!
-//! Linux Daemon and User VM run as separate OS processes. This is the production mode
-//! used by Nanvix Daemon for isolation and robustness.
+//! Linux Daemon and User VM run as tasks within the same process. This mode is primarily used for
+//! development, testing, and fast iteration and does not require spawning external binaries.
 //!
-//! ### Single-Process Mode
+//! ### Multi-Process Mode
 //!
-//! Linux Daemon and User VM run as tasks within the same process. Enabled via the
-//! `single-process` feature flag. This mode is primarily used for testing and development.
+//! Linux Daemon and User VM run as separate OS processes. Enable the `multi-process` feature to
+//! opt into this production-grade configuration where isolation and robustness take priority.
 //!
 //! ## Basic Usage Example
 //!
@@ -65,12 +65,12 @@
 //!     None,  // console_file
 //!     None,  // hwloc
 //!     "/path/to/kernel.elf",  // kernel_binary_path
-//!     #[cfg(not(feature = "single-process"))]
+//!     #[cfg(feature = "multi-process")]
 //!     "/path/to/linuxd.elf",  // linuxd_binary_path
-//!     #[cfg(not(feature = "single-process"))]
+//!     #[cfg(feature = "multi-process")]
 //!     "/path/to/uservm.elf",  // uservm_binary_path
 //!     "/path/to/logs",  // log_directory
-//!     #[cfg(feature = "single-process")]
+//!     #[cfg(not(feature = "multi-process"))]
 //!     None,  // syscall_table
 //!     Some(("127.0.0.1:8082".to_string(), SocketType::Tcp)),  // control_plane_bind_socket_info
 //!     ("127.0.0.1:8081".to_string(), SocketType::Tcp),  // control_plane_connect_socket_info
@@ -112,7 +112,7 @@
 //!
 //! ## Features
 //!
-//! - **`single-process`**: Enable single-process deployment mode
+//! - **`multi-process`**: Enable multi-process deployment mode
 //! - **`hyperlight`**: Enable Hyperlight virtualization backend support
 //!
 //! ## Architecture
@@ -121,7 +121,7 @@
 //!
 //! - Core state types: [`UninitializedSandbox`], [`InitializedSandbox`], [`RunningSandbox`]
 //! - Configuration: [`SandboxConfig`], [`LinuxDaemonArgs`], [`UserVmArgs`]
-//! - Implementation: [`multi_process`] (default), [`single_process`] (feature-gated)
+//! - Implementation: [`multi_process`] (feature-gated), [`single_process`] (default)
 //! - Utilities: [`netns`] for managing network namespaces, [`tcp_port`] for managing TCP port allocations
 
 //==================================================================================================
@@ -141,7 +141,7 @@ mod uservm_args;
 //==================================================================================================
 
 ::cfg_if::cfg_if! {
-    if #[cfg(feature = "single-process")] {
+    if #[cfg(not(feature = "multi-process"))] {
         pub mod single_process;
     } else {
         pub mod multi_process;
@@ -156,7 +156,7 @@ pub mod tcp_port;
 //==================================================================================================
 
 ::cfg_if::cfg_if! {
-    if #[cfg(feature = "single-process")] {
+    if #[cfg(not(feature = "multi-process"))] {
         pub use self::single_process::*;
         pub use ::linuxd::syscalls::SyscallAction;
         pub use ::linuxd::syscalls::SyscallTable;

--- a/src/libs/nanvix-sandbox/src/linuxd_args.rs
+++ b/src/libs/nanvix-sandbox/src/linuxd_args.rs
@@ -11,7 +11,7 @@
 // Imports
 //==================================================================================================
 
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use ::std::marker::PhantomData;
 use ::syscomm::SocketType;
 
@@ -37,7 +37,7 @@ pub struct LinuxDaemonArgs<T> {
     /// Optional hardware locality configuration for CPU affinity and topology information.
     hwloc: Option<hwloc::HwLoc>,
     /// Path to Linux Daemon binary.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     linuxd_binary_path: String,
     /// Path to the toolchain binary directory containing cloud-hypervisor and other tools.
     toolchain_binary_directory: String,
@@ -50,11 +50,11 @@ pub struct LinuxDaemonArgs<T> {
     /// Path to the L2 snapshot path.
     l2_snapshot_path: String,
     /// Optional system call table for overriding default system call behavior.
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>>,
     /// Phantom data to maintain the generic type parameter `T` in the structure.
     /// This is required because `T` is only used in single-process mode for the syscall table.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     _phantom: PhantomData<T>,
 }
 
@@ -90,13 +90,13 @@ impl<T> LinuxDaemonArgs<T> {
         control_plane_connect_socket_info: (String, SocketType),
         system_vm_socket_info: (String, SocketType),
         hwloc: Option<hwloc::HwLoc>,
-        #[cfg(not(feature = "single-process"))] linuxd_binary_path: String,
+        #[cfg(feature = "multi-process")] linuxd_binary_path: String,
         toolchain_binary_directory: String,
         log_directory: String,
         tmp_directory: String,
         l2: bool,
         l2_snapshot_path: String,
-        #[cfg(feature = "single-process")] syscall_table: Option<
+        #[cfg(not(feature = "multi-process"))] syscall_table: Option<
             ::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>,
         >,
     ) -> Self {
@@ -104,16 +104,16 @@ impl<T> LinuxDaemonArgs<T> {
             control_plane_connect_socket_info,
             system_vm_socket_info,
             hwloc,
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             linuxd_binary_path,
             toolchain_binary_directory,
             log_directory,
             tmp_directory,
             l2,
             l2_snapshot_path,
-            #[cfg(feature = "single-process")]
+            #[cfg(not(feature = "multi-process"))]
             syscall_table,
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             _phantom: PhantomData,
         }
     }
@@ -166,7 +166,7 @@ impl<T> LinuxDaemonArgs<T> {
     ///
     /// The path to the Linux Daemon binary.
     ///
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     pub fn linuxd_binary_path(&self) -> &str {
         &self.linuxd_binary_path
     }
@@ -245,7 +245,7 @@ impl<T> LinuxDaemonArgs<T> {
     ///
     /// An optional reference to the system call table.
     ///
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     pub fn syscall_table(&self) -> Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>> {
         self.syscall_table.clone()
     }

--- a/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     UserVmArgs,
 };
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use crate::{
     netns::NetnsHandle,
     netns_exec::command_in_netns,
@@ -70,7 +70,7 @@ pub struct UserVm {
     control_plane_stream: SocketStream,
     /// Optional RAII handle to the network namespace the user VM is spawned in. Even if unused, we
     /// tie its lifecycle to the user VM.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     _netns_handle: Option<NetnsHandle>,
 }
 
@@ -98,7 +98,7 @@ impl UserVm {
     pub async fn spawn(
         args: &UserVmArgs,
         control_plane_listener: &mut SocketListener,
-        #[cfg(not(feature = "single-process"))] netns_handle: Option<NetnsHandle>,
+        #[cfg(feature = "multi-process")] netns_handle: Option<NetnsHandle>,
     ) -> Result<Self> {
         trace!("spawn(): args={args:?}");
 
@@ -158,7 +158,7 @@ impl UserVm {
 
         let mut cmd: Command = {
             // In an L2-deployment, spawn the user VM inside a network namespace.
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             if let Some(netns_handle) = &netns_handle {
                 command_in_netns(&netns_handle.netns_info()?, &user_vm_args[0], &user_vm_args[1..])
             } else {
@@ -222,7 +222,7 @@ impl UserVm {
         Ok(Self {
             child: Some(child),
             control_plane_stream,
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             _netns_handle: netns_handle,
         })
     }

--- a/src/libs/nanvix-sandbox/src/sandbox_config.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox_config.rs
@@ -12,7 +12,7 @@
 //==================================================================================================
 
 use crate::tcp_port::TcpPort;
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use ::std::marker::PhantomData;
 use ::syscomm::SocketType;
 use ::user_vm_api::UserVmIdentifier;
@@ -49,15 +49,15 @@ pub struct SandboxConfig<T> {
     /// Path to kernel binary.
     kernel_binary_path: String,
     /// Path to the Linux Daemon binary.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     linuxd_binary_path: String,
     /// Path to the User VM binary.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     uservm_binary_path: String,
     /// Directory path for writing log files.
     log_directory: String,
     /// Optional system call table for overriding default system call behavior.
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>>,
 
     /// Optional information on the control plane listener socket (address, socket type).
@@ -87,7 +87,7 @@ pub struct SandboxConfig<T> {
 
     /// Phantom data to maintain the generic type parameter `T` in the structure.
     /// This is required because `T` is only used in single-process mode for the syscall table.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     _phantom: PhantomData<T>,
 }
 
@@ -132,10 +132,10 @@ impl<T> SandboxConfig<T> {
         console_file: Option<String>,
         hwloc: Option<hwloc::HwLoc>,
         kernel_binary_path: &str,
-        #[cfg(not(feature = "single-process"))] linuxd_binary_path: &str,
-        #[cfg(not(feature = "single-process"))] uservm_binary_path: &str,
+        #[cfg(feature = "multi-process")] linuxd_binary_path: &str,
+        #[cfg(feature = "multi-process")] uservm_binary_path: &str,
         log_directory: &str,
-        #[cfg(feature = "single-process")] syscall_table: Option<
+        #[cfg(not(feature = "multi-process"))] syscall_table: Option<
             ::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>,
         >,
         control_plane_bind_socket_info: Option<(String, SocketType)>,
@@ -152,12 +152,12 @@ impl<T> SandboxConfig<T> {
             console_file,
             hwloc,
             kernel_binary_path: kernel_binary_path.to_string(),
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             linuxd_binary_path: linuxd_binary_path.to_string(),
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             uservm_binary_path: uservm_binary_path.to_string(),
             log_directory: log_directory.to_string(),
-            #[cfg(feature = "single-process")]
+            #[cfg(not(feature = "multi-process"))]
             syscall_table,
             control_plane_bind_socket_info,
             control_plane_connect_socket_info,
@@ -165,7 +165,7 @@ impl<T> SandboxConfig<T> {
             tmp_directory,
             l2,
             l2_snapshot_path,
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             _phantom: PhantomData,
         }
     }
@@ -257,7 +257,7 @@ impl<T> SandboxConfig<T> {
     ///
     /// The path to the Linux Daemon binary.
     ///
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     pub fn linuxd_binary_path(&self) -> &str {
         &self.linuxd_binary_path
     }
@@ -271,7 +271,7 @@ impl<T> SandboxConfig<T> {
     ///
     /// The path to the User VM binary.
     ///
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     pub fn uservm_binary_path(&self) -> &str {
         &self.uservm_binary_path
     }
@@ -298,7 +298,7 @@ impl<T> SandboxConfig<T> {
     ///
     /// An optional clone of the system call table.
     ///
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     pub fn syscall_table(&self) -> Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>> {
         self.syscall_table.clone()
     }

--- a/src/libs/nanvix-sandbox/src/uninitialized.rs
+++ b/src/libs/nanvix-sandbox/src/uninitialized.rs
@@ -11,7 +11,7 @@
 // Imports
 //==================================================================================================
 
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use crate::netns::{
     NetnsHandle,
     NetnsInfo,
@@ -23,7 +23,7 @@ use crate::{
     SandboxConfig,
 };
 use ::anyhow::Result;
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 use ::std::marker::PhantomData;
 use ::std::sync::Arc;
 use ::syscomm::{
@@ -64,7 +64,7 @@ pub struct UninitializedSandbox<T> {
     /// Optional handle to an existing Linux Daemon instance.
     linuxd: Option<Arc<LinuxDaemon>>,
     /// Optional handle to a network namespace. Only used in L2 deployments.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     netns_handle: Option<NetnsHandle>,
     /// Optional control plane listener socket, address, and socket type.
     control_plane_bind_socket_and_info: Option<Arc<Mutex<(SocketListener, String, SocketType)>>>,
@@ -72,7 +72,7 @@ pub struct UninitializedSandbox<T> {
     config: Option<SandboxConfig<T>>,
     /// Phantom data to maintain the generic type parameter `T` in the structure.
     /// This is required because `T` is only used in single-process mode for the syscall table.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     _phantom: PhantomData<T>,
 }
 
@@ -109,11 +109,11 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
             program_args,
             ramfs_filename,
             linuxd: None,
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             netns_handle: None,
             control_plane_bind_socket_and_info: Some(control_plane_bind_socket_and_info),
             config: None,
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             _phantom: PhantomData,
         }
     }
@@ -167,7 +167,7 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
     ///
     /// The modified uninitialized sandbox with the network namespace handle attached.
     ///
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     pub fn with_netns_handle(mut self, netns_handle: Option<NetnsHandle>) -> Self {
         self.netns_handle = netns_handle;
         self
@@ -182,7 +182,7 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
     ///
     /// Returns the network namespace information if available, or `None` otherwise.
     ///
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     pub fn netns_info(&self) -> Option<NetnsInfo> {
         if let Some(netns_handle) = &self.netns_handle {
             netns_handle.netns_info().ok()
@@ -295,14 +295,14 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
                         ),
                         config.system_vm_socket_info().clone(),
                         config.hwloc(),
-                        #[cfg(not(feature = "single-process"))]
+                        #[cfg(feature = "multi-process")]
                         config.linuxd_binary_path().to_string(),
                         toolchain_binary_directory,
                         config.log_directory().to_string(),
                         tmp_directory,
                         l2,
                         l2_snapshot_path.to_string(),
-                        #[cfg(feature = "single-process")]
+                        #[cfg(not(feature = "multi-process"))]
                         config.syscall_table(),
                     )
                 };
@@ -315,7 +315,7 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
                     &mut locked_control_plane_bind_socket_and_info.0,
                     // Share ownership of netns handle with linux daemon process. The netns is
                     // provisioned upstream, if it is not but we are in L2 mode, spawn will fail.
-                    #[cfg(not(feature = "single-process"))]
+                    #[cfg(feature = "multi-process")]
                     self.netns_handle.clone(),
                 )
                 .await
@@ -340,9 +340,9 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
             control_plane_bind_socket_and_info,
             sandbox_config: config,
             // Pass ownership of the network namespace to the initialized sandbox.
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             netns_handle: self.netns_handle.take(),
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             _phantom: PhantomData,
         })
     }

--- a/src/libs/nanvix-sandbox/src/uservm_args.rs
+++ b/src/libs/nanvix-sandbox/src/uservm_args.rs
@@ -44,7 +44,7 @@ pub struct UserVmArgs {
     /// Path to kernel binary.
     kernel_binary_path: String,
     /// Path to the User VM binary.
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     uservm_binary_path: String,
     /// Directory path for writing log files.
     log_directory: String,
@@ -92,7 +92,7 @@ impl UserVmArgs {
         console_file: Option<String>,
         hwloc: Option<hwloc::HwLoc>,
         kernel_binary_path: String,
-        #[cfg(not(feature = "single-process"))] uservm_binary_path: String,
+        #[cfg(feature = "multi-process")] uservm_binary_path: String,
         log_directory: String,
         uservm_id: UserVmIdentifier,
     ) -> Self {
@@ -106,7 +106,7 @@ impl UserVmArgs {
             console_file,
             hwloc,
             kernel_binary_path,
-            #[cfg(not(feature = "single-process"))]
+            #[cfg(feature = "multi-process")]
             uservm_binary_path,
             log_directory,
             uservm_id,
@@ -239,7 +239,7 @@ impl UserVmArgs {
     ///
     /// The path to the User VM binary.
     ///
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     pub fn uservm_binary_path(&self) -> &str {
         &self.uservm_binary_path
     }

--- a/src/libs/nanvix-terminal/Cargo.toml
+++ b/src/libs/nanvix-terminal/Cargo.toml
@@ -22,7 +22,7 @@ user-vm-api = { workspace = true }
 default = ["microvm"]
 hyperlight = ["nanvix-sandbox-cache/hyperlight"]
 microvm = ["nanvix-sandbox-cache/microvm"]
-single-process = ["nanvix-sandbox-cache/single-process"]
+multi-process = ["nanvix-sandbox-cache/multi-process"]
 
 [lints]
 workspace = true

--- a/src/libs/nanvix/Cargo.toml
+++ b/src/libs/nanvix/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 anyhow = { workspace = true }
 config = { workspace = true }
 hwloc = { workspace = true }
-linuxd = { workspace = true, optional = true }
+linuxd = { workspace = true }
 nanvix-http = { workspace = true }
 nanvix-registry = { workspace = true }
 nanvix-sandbox = { workspace = true }
@@ -29,12 +29,11 @@ uservm = { workspace = true, optional = true }
 [features]
 default = ["microvm"]
 internal-api = ["sys", "syscall", "uservm"]
-single-process = [
-    "linuxd",
-    "nanvix-http/single-process",
-    "nanvix-sandbox/single-process",
-    "nanvix-sandbox-cache/single-process",
-    "nanvix-terminal/single-process",
+multi-process = [
+    "nanvix-http/multi-process",
+    "nanvix-sandbox/multi-process",
+    "nanvix-sandbox-cache/multi-process",
+    "nanvix-terminal/multi-process",
 ]
 hyperlight = [
     "config/hyperlight",

--- a/src/libs/nanvix/src/lib.rs
+++ b/src/libs/nanvix/src/lib.rs
@@ -44,10 +44,11 @@
 //! **Warning:** This feature provides direct access to unsafe system interfaces and should only
 //! be used by trusted system components.
 //!
-//! #### `single-process`
+//! #### `multi-process`
 //!
-//! Enables single-process execution mode where all daemons run within a single process. This
-//! feature is useful for development, testing, and resource-constrained environments.
+//! Enables the multi-process deployment mode where core daemons execute as separate processes for
+//! improved isolation. When this feature is disabled (default), Nanvix runs in single-process mode
+//! which is useful for development, testing, and resource-constrained environments.
 //!
 //! #### `hyperlight`
 //!

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -14,8 +14,8 @@ homepage.workspace = true
 anyhow = { workspace = true }
 indicatif = { workspace = true }
 libc = { workspace = true }
-nanvixd = { workspace = true }
-nanvix = { workspace = true, features = ["internal-api"] }
+nanvixd = { workspace = true, features = ["multi-process"] }
+nanvix = { workspace = true, features = ["internal-api", "multi-process"] }
 profiler = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
@@ -25,7 +25,6 @@ tokio = { workspace = true, features = ["full"] }
 [features]
 default = ["microvm"]
 timestamp-messages = ["profiler/timestamp-messages"]
-single-process = ["nanvix/single-process"]
 hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -20,9 +20,8 @@ tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = ["microvm"]
-# If enabled this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) are embedded
-# into Nanvix Daemon (nanvixd).
-single-process = ["nanvix/single-process"]
+# If this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) run as separate processes.
+multi-process = ["nanvix/multi-process"]
 hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -58,10 +58,10 @@ const DEFAULT_LOG_LEVEL: &str = "info";
 /// Binary name for Kernel.
 const KERNEL_BINARY_NAME: &str = "kernel.elf";
 /// Binary name for Linux Daemon.
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 const LINUXD_BINARY_NAME: &str = "linuxd.elf";
 /// Binary name for User VM.
-#[cfg(not(feature = "single-process"))]
+#[cfg(feature = "multi-process")]
 const USERVM_BINARY_NAME: &str = "uservm.elf";
 
 //==================================================================================================
@@ -127,20 +127,20 @@ pub async fn main() -> Result<()> {
     print_startup_info(&args);
 
     // Determine deployment type based on feature flag.
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     let deployment: &str = "single-process";
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     let deployment: &str = "multi-process";
 
     // Determine target machine type from config.
     let machine: &str = DEFAULT_MACHINE_NAME;
 
     // Ensure all required binaries are available.
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     let (kernel_binary_path, _, _) =
         ensure_all_binaries_available(&args, machine, deployment).await?;
 
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     let (kernel_binary_path, linuxd_binary_path, uservm_binary_path) =
         ensure_all_binaries_available(&args, machine, deployment).await?;
 
@@ -156,11 +156,11 @@ pub async fn main() -> Result<()> {
         args.hwloc().clone(),
         args.netns_pool_size(),
         &kernel_binary_path,
-        #[cfg(not(feature = "single-process"))]
+        #[cfg(feature = "multi-process")]
         &linuxd_binary_path,
-        #[cfg(not(feature = "single-process"))]
+        #[cfg(feature = "multi-process")]
         &uservm_binary_path,
-        #[cfg(feature = "single-process")]
+        #[cfg(not(feature = "multi-process"))]
         None,
         args.toolchain_binary_directory(),
         args.log_directory(),
@@ -240,19 +240,19 @@ async fn ensure_all_binaries_available(
 ) -> Result<(String, String, String)> {
     let kernel_binary_path: String = format!("{}/{}", args.binary_directory(), KERNEL_BINARY_NAME);
 
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     let linuxd_binary_path: String = format!("{}/{}", args.binary_directory(), LINUXD_BINARY_NAME);
 
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     let uservm_binary_path: String = format!("{}/{}", args.binary_directory(), USERVM_BINARY_NAME);
 
     // Check if all binaries are available locally.
     let kernel_available: bool = fs::metadata(&kernel_binary_path).await.is_ok();
 
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     let all_available: bool = kernel_available;
 
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     let all_available: bool = {
         let linuxd_available: bool = fs::metadata(&linuxd_binary_path).await.is_ok();
         let uservm_available: bool = fs::metadata(&uservm_binary_path).await.is_ok();
@@ -263,16 +263,16 @@ async fn ensure_all_binaries_available(
     if all_available {
         log_info!("using local binary {}: {}", KERNEL_BINARY_NAME, kernel_binary_path);
 
-        #[cfg(not(feature = "single-process"))]
+        #[cfg(feature = "multi-process")]
         {
             log_info!("using local binary {}: {}", LINUXD_BINARY_NAME, linuxd_binary_path);
             log_info!("using local binary {}: {}", USERVM_BINARY_NAME, uservm_binary_path);
         }
 
-        #[cfg(feature = "single-process")]
+        #[cfg(not(feature = "multi-process"))]
         return Ok((kernel_binary_path, String::new(), String::new()));
 
-        #[cfg(not(feature = "single-process"))]
+        #[cfg(feature = "multi-process")]
         return Ok((kernel_binary_path, linuxd_binary_path, uservm_binary_path));
     }
 
@@ -285,10 +285,10 @@ async fn ensure_all_binaries_available(
         .await?;
     log_info!("using registry binary {}: {}", KERNEL_BINARY_NAME, kernel_cached_path);
 
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     return Ok((kernel_cached_path, String::new(), String::new()));
 
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     {
         let linuxd_cached_path: String = registry
             .get_cached_binary(machine, deployment, LINUXD_BINARY_NAME)
@@ -322,7 +322,7 @@ fn print_startup_info(args: &Args) {
         "http"
     };
 
-    #[cfg(feature = "single-process")]
+    #[cfg(not(feature = "multi-process"))]
     log_info!(
         "nanvixd {}, single-process deployment, {} mode, machine {}",
         env!("CARGO_PKG_VERSION"),
@@ -330,7 +330,7 @@ fn print_startup_info(args: &Args) {
         DEFAULT_MACHINE_NAME
     );
 
-    #[cfg(not(feature = "single-process"))]
+    #[cfg(feature = "multi-process")]
     log_info!(
         "nanvixd {}, multi-process deployment, {} mode, l2 {}, machine {}",
         env!("CARGO_PKG_VERSION"),


### PR DESCRIPTION
Refactor nanvix-sandbox for multi-process deployment mode:
- Updated Cargo.toml to replace single-process feature with multi-process.
- Modified config.rs, initialized.rs, and other source files to conditionally compile based on multi-process feature.
- Adjusted documentation to reflect the new deployment modes and their purposes.
- Ensured all relevant structs and functions are compatible with the multi-process architecture.
- Updated nanvix and nanvixd to support the new multi-process feature, including changes to binary paths and startup logic.