### PR TITLE
[nanvix-sandbox] Make Control-Plane Addresses Independent Of Tenant Id

### DIFF
--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -436,7 +436,6 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                 let netns_info: Option<NetnsInfo> = uninitialized_sandbox.netns_info();
                 let control_plane_sockaddr: String = (control_plane_sockaddr_builder)(
                     self.config.tmp_directory(),
-                    tag.tenant_id(),
                     #[cfg(not(feature = "single-process"))]
                     netns_info.clone(),
                 )?;

--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -193,8 +193,8 @@ pub(crate) fn get_clh_api_socket_path(tmp_dir: &str) -> String {
 ///
 /// # Description
 ///
-/// Builds the control plane socket address for a given tenant ID. If nanvixd is configured to
-/// spawn linuxd in an L2 VM, it will return a TCP socket address, otherwise a Unix socket one.
+/// Builds the control plane socket address. If nanvixd is configured to spawn linuxd in an L2 VM, it
+/// will return a TCP socket address, otherwise a Unix socket one.
 ///
 /// When binding to a TCP address we want to make sure that any L2 VM can connect to us, so we bind
 /// to 0.0.0.0.
@@ -202,7 +202,6 @@ pub(crate) fn get_clh_api_socket_path(tmp_dir: &str) -> String {
 /// # Parameters
 ///
 /// - `tmp_str`: Temporary directory path.
-/// - `tenant_id`: Tenant ID.
 /// - `netns_info`: Optional information about the network namespace (L2-mode only).
 ///
 /// # Returns
@@ -211,7 +210,6 @@ pub(crate) fn get_clh_api_socket_path(tmp_dir: &str) -> String {
 ///
 pub fn control_plane_sockaddr_builder(
     tmp_str: &str,
-    tenant_id: &str,
     #[cfg(not(feature = "single-process"))] netns_info: Option<NetnsInfo>,
 ) -> Result<String> {
     // In an L2 deployment, linuxd and the user VM are deployed inside a separate network
@@ -223,7 +221,7 @@ pub fn control_plane_sockaddr_builder(
     }
 
     let unix_socket_name: String =
-        format!("{tmp_str}/{NAMED_RESOURCE_PREFIX}:{tenant_id}:cp{UNIX_SOCKET_SUFFIX}");
+        format!("{tmp_str}/{NAMED_RESOURCE_PREFIX}:cp{UNIX_SOCKET_SUFFIX}");
 
     // Check if socket name exceeds the maximum length.
     if unix_socket_name.len() > UNIX_PATH_MAX {


### PR DESCRIPTION
In this PR I modify the signature of the control-plane sockaddr builder to return an address that is indpendent of the tenant ID.

It was a logic error to include it in the first place, and it only works because we cache the control-plane socket address in the sandbox cache, so subsequent tenants would use a control-plane address with a previous tenant's id.
