### PR TITLE
[uservm] Change snapshot protocol

### DIFF
--- a/src/libs/control-plane-api/src/lib.rs
+++ b/src/libs/control-plane-api/src/lib.rs
@@ -61,6 +61,16 @@ use ::syslog::error;
 pub enum NanvixdCommand {
     /// Shutdown.
     Shutdown,
+    /// Pause.
+    Pause,
+    /// CreateSnapshot.
+    CreateSnapshot,
+    /// Resume.
+    Resume,
+    /// LoadSnapshot.
+    LoadSnapshot,
+    /// Start.
+    Start,
 }
 
 ///

--- a/src/uservm/src/io_thread.rs
+++ b/src/uservm/src/io_thread.rs
@@ -228,9 +228,12 @@ impl IoThread {
                                 control_plane_buf_len = 0;
 
                                 match msg.cmd() {
-                                    NanvixdCommand::Shutdown => {
-                                        control_tx.send(IoControlCommand::Shutdown).await?;
-                                    },
+                                    NanvixdCommand::Shutdown => {control_tx.send(IoControlCommand::Shutdown).await?;},
+                                    NanvixdCommand::Pause => {control_tx.send(IoControlCommand::Pause).await?;},
+                                    NanvixdCommand::CreateSnapshot => {control_tx.send(IoControlCommand::CreateSnapshot).await?;},
+                                    NanvixdCommand::Resume => {control_tx.send(IoControlCommand::Resume).await?;},
+                                    NanvixdCommand::LoadSnapshot => {control_tx.send(IoControlCommand::LoadSnapshot).await?;},
+                                    NanvixdCommand::Start => {control_tx.send(IoControlCommand::StartMicroVm).await?;},
                                 }
                             }
                         },
@@ -246,15 +249,6 @@ impl IoThread {
                     match result {
                         Some(response) => {
                             match response {
-                                IoControlResponse::FlushInput => {
-                                    debug!("input flush completed");
-                                    // Messages are no longer buffer, nothing to flush. We should remove this.
-                                    control_tx.send(IoControlCommand::LinuxDaemonFlushed).await?;
-                                },
-                                IoControlResponse::FlushOutput => {
-                                    // Messages are no longer buffer, nothing to flush. We should remove this.
-                                    debug!("output flush completed");
-                                },
                                 IoControlResponse::MicroVmPaused => {
                                     debug!("microvm pause acknowledged");
                                 },
@@ -264,6 +258,15 @@ impl IoThread {
                                 IoControlResponse::Shutdown => {
                                     debug!("shutdown completed");
                                     break Ok(());
+                                },
+                                IoControlResponse::CreateSnapshotMarker => {
+                                    // Drain the vCPU's channel and forward it to system VM.
+                                    // TODO (#1241): for now we assume the channel is empty.
+                                    debug!("vcpu's output drained");
+
+                                    // Forward the marker to system VM.
+                                    // TODO (#1241): create a new syscall that echoes a marker.
+                                    debug!("marker forwarded to system VM");
                                 },
                             }
                         },

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -305,7 +305,6 @@ impl UserVm {
             vcpu_control_tx,
             pause_microvm(guest.clone(), vmem.clone()),
             resume_microvm(guest.clone(), vmem.clone()),
-            create_snapshot_fn(microvm.clone(), filename.clone()),
             load_snapshot_fn(microvm.clone(), filename.clone()),
         );
 
@@ -332,14 +331,6 @@ impl UserVm {
 
         exit_code
     }
-}
-
-fn create_snapshot_fn(microvm: Vmm, filename: String) -> Box<LoadSnapshotFn> {
-    Box::new(move || {
-        let microvm = microvm.clone();
-        let filename = filename.clone();
-        Box::pin(async move { microvm.create_snapshot(filename).await })
-    })
 }
 
 fn load_snapshot_fn(microvm: Vmm, filename: String) -> Box<LoadSnapshotFn> {

--- a/src/uservm/src/orchestrator.rs
+++ b/src/uservm/src/orchestrator.rs
@@ -90,8 +90,6 @@ pub struct Orchestrator {
     pause_microvm: Box<PauseFn>,
     /// Callback function to erase a pause request from the kernel's memory.
     resume_microvm: Box<ResumeFn>,
-    /// Callback function to create a snapshot.
-    _create_snapshot: Box<CreateSnapshotFn>,
     /// Callback function to load a snapshot.
     load_snapshot: Box<LoadSnapshotFn>,
 }
@@ -124,12 +122,11 @@ enum State {
 ///
 #[derive(PartialEq)]
 pub enum IoControlCommand {
-    _StartMicroVm,
-    _LoadSnapshotAndRun,
-    _PauseMicroVm,
-    _CreateSnapshot(String),
-    _ResumeMicroVm,
-    LinuxDaemonFlushed,
+    StartMicroVm,
+    LoadSnapshot,
+    Pause,
+    CreateSnapshot,
+    Resume,
     Shutdown,
 }
 
@@ -140,10 +137,9 @@ pub enum IoControlCommand {
 ///
 #[derive(Debug, PartialEq)]
 pub enum IoControlResponse {
+    CreateSnapshotMarker,
     MicroVmPaused,
     SnapshotCreated,
-    FlushOutput,
-    FlushInput,
     Shutdown,
 }
 
@@ -172,7 +168,7 @@ pub enum MemoryControlResponse {}
 ///
 #[derive(PartialEq)]
 pub enum VcpuControlCommand {
-    CreateSnapshot(String),
+    CreateSnapshot,
     Resume,
 }
 
@@ -206,7 +202,6 @@ impl Orchestrator {
         vcpu_control_tx: Sender<VcpuControlCommand>,
         pause_microvm: Box<PauseFn>,
         resume_microvm: Box<ResumeFn>,
-        create_snapshot: Box<CreateSnapshotFn>,
         load_snapshot: Box<LoadSnapshotFn>,
     ) -> Self {
         Self {
@@ -220,7 +215,6 @@ impl Orchestrator {
             vcpu_control_tx,
             pause_microvm,
             resume_microvm,
-            _create_snapshot: create_snapshot,
             load_snapshot,
         }
     }
@@ -386,7 +380,7 @@ impl Orchestrator {
         command: IoControlCommand,
     ) -> Result<ControlFlow<()>> {
         match command {
-            IoControlCommand::_StartMicroVm => {
+            IoControlCommand::StartMicroVm => {
                 if self.state == State::PreBoot {
                     // TODO: separate starting logic from `spawn()` and put it here
                     // This only makes sense when snapshots can already be loaded https://github.com/nanvix/nanvix/issues/948
@@ -395,29 +389,20 @@ impl Orchestrator {
                 }
                 Ok(Continue(()))
             },
-            IoControlCommand::_LoadSnapshotAndRun => {
+            IoControlCommand::LoadSnapshot => {
                 if self.state == State::PreBoot {
                     if let Err(e) = (self.load_snapshot)().await {
                         let reason: String =
-                            format!("LoadSnapshotAndRun: failed to load snapshot: {e:?}");
-                        error!("handle_command(): {reason}");
-                        anyhow::bail!(reason);
-                    }
-                    trace!("State: PreBoot -> Paused");
-
-                    // The Linux daemon should send messages to PreBoot VMMs by default,
-                    // so there's no need to tell it to resume sending messages.
-
-                    if let Err(e) = self.resume_protocol().await {
-                        let reason: String =
-                            format!("LoadSnapshotAndRun: failed to resume microvm: {e:?}");
+                            format!("LoadSnapshot: failed to load snapshot: {e:?}");
                         error!("try_receive_from_io_thread(): {reason}");
                         anyhow::bail!(reason);
                     }
+                    self.state = State::Paused;
+                    trace!("State: PreBoot -> Paused");
                 }
                 Ok(Continue(()))
             },
-            IoControlCommand::_PauseMicroVm => {
+            IoControlCommand::Pause => {
                 if self.state == State::Running
                     && let Err(e) = self.pause_protocol().await
                 {
@@ -427,64 +412,26 @@ impl Orchestrator {
                 }
                 Ok(Continue(()))
             },
-            IoControlCommand::_CreateSnapshot(filepath) => {
-                if self.state == State::Paused {
-                    if let Err(error) = self
-                        .vcpu_control_tx
-                        .send(VcpuControlCommand::CreateSnapshot(filepath))
-                        .await
-                    {
-                        let reason: String = format!(
-                            "CreateSnapshot: failed to send CreateSnapshot command to vCPU: \
-                             {error:?}"
-                        );
-                        error!("try_receive_from_io_thread(): {reason}");
-                        anyhow::bail!(reason);
-                    }
-
-                    match self.vcpu_control_rx.recv().await {
-                        Some(VcpuControlResponse::SnapshotCreated) => {
-                            trace!("Snapshot created");
-                        },
-                        Some(VcpuControlResponse::SnapshotCreationFailed) => {
-                            let reason: String =
-                                "vCPU reported snapshot creation failure".to_string();
-                            error!("try_receive_from_io_thread(): {reason}");
-                            anyhow::bail!(reason);
-                        },
-                        Some(other) => {
-                            let reason: String = format!(
-                                "unexpected vCPU response during snapshot creation: {other:?}"
-                            );
-                            error!("try_receive_from_io_thread(): {reason}");
-                            anyhow::bail!(reason);
-                        },
-                        None => {
-                            let reason: String =
-                                "disconnected from the vCPU control response channel".to_string();
-                            error!("try_receive_from_io_thread(): {reason}");
-                            anyhow::bail!(reason);
-                        },
-                    }
+            IoControlCommand::CreateSnapshot => {
+                if self.state == State::Paused
+                    && let Err(e) = self.create_snapshot_protocol().await
+                {
+                    let reason: String =
+                        format!("CreateSnapshot: failed to create snapshot: {e:?}");
+                    error!("try_receive_from_io_thread(): {reason}");
+                    anyhow::bail!(reason);
                 }
                 Ok(Continue(()))
             },
-            IoControlCommand::_ResumeMicroVm => {
-                if self.state == State::Paused {
-                    // TODO: tell linuxd it's fine to send more messages https://github.com/nanvix/nanvix/issues/945
-                    if let Err(error) = self.resume_protocol().await {
-                        let reason: String =
-                            format!("ResumeMicroVm: failed to resume microvm: {error:?}");
-                        error!("try_receive_from_io_thread(): {reason}");
-                        anyhow::bail!(reason);
-                    }
+            IoControlCommand::Resume => {
+                if self.state == State::Paused
+                    && let Err(error) = self.resume_protocol().await
+                {
+                    let reason: String =
+                        format!("ResumeMicroVm: failed to resume microvm: {error:?}");
+                    error!("try_receive_from_io_thread(): {reason}");
+                    anyhow::bail!(reason);
                 }
-                Ok(Continue(()))
-            },
-            IoControlCommand::LinuxDaemonFlushed => {
-                // NOTE: this will be unreachable once the communication is fully implemented
-                // `LinuxDaemonFlushed` should only be sent in the middle of `pause_protocol`.
-                // In fact, it should already be unreachable, but it cannot be tested ATM.
                 Ok(Continue(()))
             },
             IoControlCommand::Shutdown => {
@@ -569,7 +516,6 @@ impl Orchestrator {
     /// Upon success, empty is returned. Otherwise, an error is returned.
     ///
     async fn pause_protocol(&mut self) -> Result<()> {
-        // TODO: tell linuxd to flush (Running -> Flushing) https://github.com/nanvix/nanvix/issues/945
         (self.pause_microvm)().await?;
         // Wait for the MicroVM to confirm it has paused without busy spinning.
         let start: Instant = Instant::now();
@@ -603,17 +549,6 @@ impl Orchestrator {
                 },
             }
         }
-        trace!("MicroVM paused");
-        // Flush output to linuxd
-        self.io_control_tx
-            .send(IoControlResponse::FlushOutput)
-            .await?;
-        // TODO: tell linuxd to stop sending messages (Flushing -> Paused) https://github.com/nanvix/nanvix/issues/945
-        // TODO: get a response from linuxd https://github.com/nanvix/nanvix/issues/945
-        self.io_control_tx
-            .send(IoControlResponse::FlushInput)
-            .await?;
-        self.receive_linux_daemon_flushed().await?;
         self.state = State::Paused;
         trace!("State: Running -> Paused");
         self.io_control_tx
@@ -625,36 +560,84 @@ impl Orchestrator {
     ///
     /// # Description
     ///
-    /// Attempts to receive a `LinuxDaemonFlushed` message from the control input.
+    /// Attempts to create a snapshot of a paused MicroVM and the channel state.
     ///
     /// # Returns
     ///
-    /// Upon success, empty is returned. Otherwise, an error is returned instead.
+    /// Upon success, returns empty. Otherwise, returns an error.
     ///
-    async fn receive_linux_daemon_flushed(&mut self) -> Result<()> {
-        let start: Instant = Instant::now();
-        let warn_interval: Duration = Duration::from_millis(TIMEOUT_WARNING_INTERVAL_IN_MS as u64);
-        loop {
-            match timeout(warn_interval, self.io_control_rx.recv()).await {
-                Ok(Some(IoControlCommand::LinuxDaemonFlushed)) => break,
-                Ok(Some(_other)) => {
-                    // Ignore unrelated messages during flushing.
-                    continue;
-                },
-                Ok(None) => {
-                    let reason: String =
-                        "io_control_rx closed while waiting for LinuxDaemonFlushed".to_string();
-                    error!("receive_linux_daemon_flushed(): {reason}");
-                    anyhow::bail!(reason)
-                },
-                Err(_) => {
-                    let elapsed_ms: usize = start.elapsed().as_millis() as usize;
-                    warn!("{}ms have passed waiting for `LinuxDaemonFlushed`", elapsed_ms);
-                    continue;
-                },
-            }
+    async fn create_snapshot_protocol(&mut self) -> Result<()> {
+        // At this point, two conditions must be achieved, and they can happen
+        // concurrently:
+        //
+        // A) the vCPU must save the local state; and
+        // B) the entire distributed system must pool all outstanding messages in a
+        // single spot. This pool is the `channel state` in the snapshot. The channel
+        // state must be saved.
+        //
+        // "B" is already in progress either way, so start "A":
+        if let Err(error) = self
+            .vcpu_control_tx
+            .send(VcpuControlCommand::CreateSnapshot)
+            .await
+        {
+            let reason: String =
+                format!("CreateSnapshot: failed to send CreateSnapshot command to vCPU: {error:?}");
+            error!("create_snapshot_protocol(): {reason}");
+            anyhow::bail!(reason);
         }
-        Ok(())
+
+        // Now send a round-trip marker to ensure all channels are drained. Send to the
+        // I/O thread, but receive from the vCPU. This starts the final step in "B".
+        if let Err(error) = self
+            .io_control_tx
+            .send(IoControlResponse::CreateSnapshotMarker)
+            .await
+        {
+            let reason: String = format!(
+                "CreateSnapshot: failed to send CreateSnapshotMarker to I/O thread: {error:?}"
+            );
+            error!("create_snapshot_protocol(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        // Receiving from the vCPU means it has saved the local state and the channel
+        // state as files.
+        match self.vcpu_control_rx.recv().await {
+            Some(VcpuControlResponse::SnapshotCreated) => {
+                trace!("Snapshot created");
+                if let Err(error) = self
+                    .io_control_tx
+                    .send(IoControlResponse::SnapshotCreated)
+                    .await
+                {
+                    let reason: String = format!(
+                        "CreateSnapshot: failed to send SnapshotCreated response to I/O thread: \
+                         {error:?}"
+                    );
+                    error!("create_snapshot_protocol(): {reason}");
+                    anyhow::bail!(reason);
+                }
+                Ok(())
+            },
+            Some(VcpuControlResponse::SnapshotCreationFailed) => {
+                let reason: String = "vCPU reported snapshot creation failure".to_string();
+                error!("create_snapshot_protocol(): {reason}");
+                anyhow::bail!(reason);
+            },
+            Some(other) => {
+                let reason: String =
+                    format!("unexpected vCPU response during snapshot creation: {other:?}");
+                error!("create_snapshot_protocol(): {reason}");
+                anyhow::bail!(reason);
+            },
+            None => {
+                let reason: String =
+                    "disconnected from the vCPU control response channel".to_string();
+                error!("create_snapshot_protocol(): {reason}");
+                anyhow::bail!(reason);
+            },
+        }
     }
 
     ///
@@ -764,13 +747,6 @@ mod tests {
                     Ok(())
                 })
             }),
-            Box::new(move || {
-                let flag = snapshot_flag.clone();
-                Box::pin(async move {
-                    flag.store(true, Ordering::SeqCst);
-                    Ok(())
-                })
-            }),
         );
 
         Harness {
@@ -824,35 +800,35 @@ mod tests {
         let handle: JoinHandle<Result<()>> = h.orchestrator.spawn();
 
         // Move to Running state.
-        h.io_cmd_tx.send(IoControlCommand::_StartMicroVm).await?;
+        h.io_cmd_tx
+            .send(IoControlCommand::StartMicroVm)
+            .await
+            .expect("send StartMicroVm");
         // Request pause.
-        h.io_cmd_tx.send(IoControlCommand::_PauseMicroVm).await?;
+        h.io_cmd_tx
+            .send(IoControlCommand::Pause)
+            .await
+            .expect("send Pause");
 
-        // Simulate vCPU acknowledging pause and linux daemon flush.
+        // Simulate vCPU acknowledging pause.
         let vcpu_resp_tx_clone: mpsc::Sender<VcpuControlResponse> = h.vcpu_resp_tx.clone();
         let io_cmd_tx_clone: mpsc::Sender<IoControlCommand> = h.io_cmd_tx.clone();
         tokio::spawn(async move {
             // Allow orchestrator to enter pause_protocol loop.
             sleep(Duration::from_millis(5)).await;
             let _ = vcpu_resp_tx_clone.send(VcpuControlResponse::Paused).await;
-            // Allow orchestrator to send FlushOutput & FlushInput, then provide LinuxDaemonFlushed.
-            sleep(Duration::from_millis(5)).await;
-            let _ = io_cmd_tx_clone
-                .send(IoControlCommand::LinuxDaemonFlushed)
-                .await;
         });
 
-        // Expect FlushOutput, FlushInput, MicroVmPaused in order.
-        let r1 = recv_io_resp(&mut h.io_resp_rx).await;
-        assert!(matches!(r1, IoControlResponse::FlushOutput));
-        let r2 = recv_io_resp(&mut h.io_resp_rx).await;
-        assert!(matches!(r2, IoControlResponse::FlushInput));
-        let r3 = recv_io_resp(&mut h.io_resp_rx).await;
-        assert!(matches!(r3, IoControlResponse::MicroVmPaused));
+        // Expect MicroVmPaused.
+        let r = recv_io_resp(&mut h.io_resp_rx).await;
+        assert!(matches!(r, IoControlResponse::MicroVmPaused));
         assert!(h.pause_called.load(Ordering::SeqCst));
 
         // Resume.
-        h.io_cmd_tx.send(IoControlCommand::_ResumeMicroVm).await?;
+        h.io_cmd_tx
+            .send(IoControlCommand::Resume)
+            .await
+            .expect("send Resume");
         // Expect a Resume command sent to vCPU thread.
         let resume_cmd: VcpuControlCommand =
             timeout(Duration::from_millis(500), h.vcpu_cmd_rx.recv())
@@ -862,7 +838,10 @@ mod tests {
         assert!(h.resume_called.load(Ordering::SeqCst));
 
         // Now shut everything down.
-        h.vcpu_resp_tx.send(VcpuControlResponse::Shutdown).await?;
+        h.vcpu_resp_tx
+            .send(VcpuControlResponse::Shutdown)
+            .await
+            .expect("send Shutdown");
         let _mem_cmd = timeout(Duration::from_millis(500), h.mem_cmd_rx.recv()).await?;
         let _shutdown_resp = recv_io_resp(&mut h.io_resp_rx).await; // Shutdown
 

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -31,6 +31,7 @@ use crate::vmm::{
 #[cfg(target_os = "linux")]
 use crate::{
     orchestrator::{
+        SHUTDOWN_TIMEOUT,
         VcpuControlCommand,
         VcpuControlResponse,
     },
@@ -99,6 +100,21 @@ pub const INTERRUPT_SIGNAL: c_int = SIGUSR1;
 /// Signal used to kill the vCPU thread.
 pub const KILL_SIGNAL: c_int = libc::SIGKILL;
 
+/// Filename used for snapshot files when no name is provided.
+const DEFAULT_SNAPSHOT_FILENAME: &str = "default";
+
+/// Exit status for success.
+const EXIT_SUCCESS: u16 = 0;
+
+/// Extension for files holding the virtual memory contents from a snapshot.
+const VMEM_EXTENSION: &str = "vmem";
+
+/// Extension for files holding the KVM state contents from a snapshot.
+const KVM_EXTENSION: &str = "kvm";
+
+/// Check for shutdown every TIMEOUT / TIMEOUT_TOLERANCE interval.
+const TIMEOUT_TOLERANCE: u32 = 10;
+
 //==================================================================================================
 // Thread-Local Variables
 //==================================================================================================
@@ -108,12 +124,29 @@ thread_local! {
     /// # Description
     ///
     /// Shutdown flag, set to true when the vCPU thread receives a shutdown signal.
-    /// This will prevent the vCPU from entering KVM_RUN again and blocking indefinitely.
+    /// This will prevent the vCPU from entering KVM_RUN again and blocking indefinitely,
+    /// or from waiting indefinitely for a `Resume` command while paused.
     ///
     /// This variable must be thread-safe to enable multiple VMM instances to co-exist in the same
     /// process.
     ///
     static SHUTDOWN: AtomicBool = const { AtomicBool::new(false) };
+}
+
+//==================================================================================================
+// Enums
+//==================================================================================================
+
+///
+/// # Description
+///
+/// An enumeration of the cases for exiting the pause loop.
+///
+pub enum VmPauseReturn {
+    /// Exited the loop to resume execution.
+    Resumed,
+    /// Exited the loop to shutdown.
+    ShutdownRequested,
 }
 
 //==================================================================================================
@@ -301,7 +334,7 @@ impl Vmm {
         loop {
             // Check shutdown flag before entering KVM_RUN, and blocking indefinitely.
             if SHUTDOWN.with(|shutdown| shutdown.load(Ordering::SeqCst)) {
-                let exit_status: u16 = 0;
+                let exit_status: u16 = EXIT_SUCCESS;
                 Handle::current().block_on(self.handle_shutdown(exit_status));
                 break Ok(exit_status);
             }
@@ -330,8 +363,21 @@ impl Vmm {
 
                             break Ok(exit_status);
                         } else {
-                            Handle::current().block_on(self.handle_pause())?;
-                            trace!("VMM resumed");
+                            match Handle::current().block_on(self.handle_pause()) {
+                                Ok(pause_return) => match pause_return {
+                                    VmPauseReturn::Resumed => trace!("VMM resumed"),
+                                    VmPauseReturn::ShutdownRequested => {
+                                        let exit_status: u16 = EXIT_SUCCESS;
+                                        Handle::current()
+                                            .block_on(self.handle_shutdown(exit_status));
+                                        break Ok(exit_status);
+                                    },
+                                },
+                                Err(error) => {
+                                    error!("run(): failed to handle pause: {error:?}");
+                                    return Err(error);
+                                },
+                            }
                         }
                     }
                 },
@@ -420,23 +466,24 @@ impl Vmm {
 
         let stem: &OsStr = Path::new(filepath)
             .file_stem()
-            .unwrap_or(OsStr::new("default"));
+            .unwrap_or(OsStr::new(DEFAULT_SNAPSHOT_FILENAME));
 
-        let vmem_filepath: PathBuf = snapshots_dir.join(stem).with_extension("vmem");
-        let kvm_filepath: PathBuf = snapshots_dir.join(stem).with_extension("kvm.json");
+        let vmem_filepath: PathBuf = snapshots_dir.join(stem).with_extension(VMEM_EXTENSION);
+        let kvm_filepath: PathBuf = snapshots_dir.join(stem).with_extension(KVM_EXTENSION);
         (vmem_filepath, kvm_filepath)
     }
 
     ///
     /// # Description
     ///
-    /// Acknowledges a pause request and waits for the next command, either `Resume` or `CreateSnapshot`.
+    /// Acknowledges a pause request and waits for the next command, either `Resume` or
+    /// `CreateSnapshot`.
     ///
     /// # Returns
     ///
-    /// Upon success, return empty. Otherwise, returns an error.
+    /// Upon success, returns an enum specifying why it exited the loop. Otherwise, returns an error.
     ///
-    async fn handle_pause(&mut self) -> Result<()> {
+    async fn handle_pause(&mut self) -> Result<VmPauseReturn> {
         self.inner
             .lock()
             .await
@@ -444,19 +491,38 @@ impl Vmm {
             .send(VcpuControlResponse::Paused)
             .await?;
 
-        match self.inner.lock().await.control_rx.recv().await {
-            Some(VcpuControlCommand::Resume) => Ok(()),
-            Some(VcpuControlCommand::CreateSnapshot(filepath)) => {
-                self.handle_create_snapshot(filepath).await?;
-                Ok(())
-            },
-            // NOTE: Should we add an option for shutting down? Like so:
-            // Some(VcpuControlCommand::Shutdown) => self.vcpu.poweroff(0),
-            None => {
-                let reason: String = "the vmm has disconnected".to_string();
-                error!("run(): {reason}");
-                anyhow::bail!(reason)
-            },
+        // We should not exit this loop when creating a snapshot.
+        loop {
+            tokio::select! {
+                cmd = async {
+                    self.inner.lock().await.control_rx.recv().await
+                } => {
+                    match cmd {
+                        Some(VcpuControlCommand::Resume) => {
+                            // TODO (#1241): if buffered messages exist, we must ingest them as if they were
+                            // in the `input_queue`, writing them to virtual memory.
+                            return Ok(VmPauseReturn::Resumed);
+                        },
+                        Some(VcpuControlCommand::CreateSnapshot) => {
+                            self.handle_create_snapshot(DEFAULT_SNAPSHOT_FILENAME.to_string())
+                            .await?;
+                        },
+                        None => {
+                            let reason: String = "the vmm has disconnected".to_string();
+                            error!("handle_pause(): {reason}");
+                            anyhow::bail!(reason)
+                        },
+                    }
+                }
+                // Check shutdown flag for exiting the loop.
+                _ = async {
+                    while !SHUTDOWN.with(|s| s.load(Ordering::SeqCst)) {
+                        tokio::time::sleep(SHUTDOWN_TIMEOUT / TIMEOUT_TOLERANCE).await;
+                    }
+                } => {
+                    return Ok(VmPauseReturn::ShutdownRequested);
+                }
+            }
         }
     }
 
@@ -526,6 +592,13 @@ impl Vmm {
     ///
     /// Saves the virtual memory and the KVM state to files.
     ///
+    /// Creating a snapshot is designed to have 3 stages for the vCPU thread:
+    /// 1) Save the virtual memory and the KVM state to files (currently implemented);
+    /// 2) Drain every message and buffer them until we receive a marker (planned, not yet implemented);
+    /// 3) Save the buffered messages to a file (planned, not yet implemented).
+    ///
+    /// At present, this function only performs stage 1.
+    ///
     /// # Parameters
     ///
     /// - `filepath`: Path to the executable file.
@@ -535,6 +608,7 @@ impl Vmm {
     /// Upon success, returns empty. Otherwise, returns an error.
     ///
     pub async fn create_snapshot(&self, filepath: String) -> Result<()> {
+        // 1) Save files.
         let (vmem_filepath, kvm_filepath) = Self::make_snapshot_paths(&filepath);
 
         if let Err(e) = self.vmem.lock().await.save_snapshot(&vmem_filepath) {
@@ -569,6 +643,16 @@ impl Vmm {
                 anyhow::bail!(reason)
             },
         }
+
+        // 2) Drain messages to buffer.
+        // TODO (#1241): This requires a significant refactor to get the `input_queue` channel here.
+        // It is currently accessed through `Emulator.stdin_fn`, but we want to read it without
+        // writing it to the virtual memory. We will split it into two functions, one that reads
+        // from the channel, and another that writes to the virtual memory, so we decouple the two
+        // operations.
+
+        // 3) Save the buffer to a file.
+        // TODO (#1241): we must have the buffer in order to save it.
     }
 
     ///


### PR DESCRIPTION
# Overview

The pause protocol is now is much simpler. There's no need to flush messages back and forth, just pause the vCPU. In contrast, the snapshot protocol became more complex, and includes flushing, so we can save all messages that aren't captured in the virtual memory. Also, the system VM no longer cares about the pause/resume/snapshot protocols. It just keeps responding to messages as they arrive.

## Details

In the snapshot protocol, the main thread sends a marker that will travel through the channels. Since they're FIFO, it ensures that every message sent before the marker is delivered when it arrives back.

The I/O thread drains vCPU's channel before forwarding the marker to the system VM, so those messages arrive at the system VM first. Then, the marker follows the regular path: system VM → I/O thread → memory thread → vCPU thread. This ensures that, when the marker arrives at the vCPU thread, every outstanding message that follows this path was already received.

Theoretically we could buffer vCPU's outstanding messages to system VM rather than drain the channel, and send the marker first, but this would require storing two buffers, and in practice vCPU's channel will highly likely already be empty, since the I/O thread will keep polling the channel while the user VM is paused, before snapshot creation is requested.

## Fixes

Some closures were removed since snapshot creation was refactored to happen in the vCPU thread through message passing, instead of happening in the main thread / orchestrator. This change happened in The Major Refactor, but got fixed now. It is very likely the same will happen for loading snapshots in the near future.

There was another bug introduced in The Major Refactor (#1054 ). A loop was now introduced to fix the bug, making the vCPU thread stay in the paused state upon receiving a "create snapshot" command. Perhaps we should include a "shutdown" command, as the old `NOTE` says, so we can gracefully shutdown a paused user VM. Closes #1054.