### PR TITLE
[doc] Fix Docker Build Setup Instruction

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -155,7 +155,7 @@ To build a Docker image with the required tools:
 
 ```bash
 # Ensure you are in the project's root directory.
-docker build --no-cache -t nanvix/toolchain ./scripts/setup/
+./scripts/setup/docker.sh
 ```
 
 ## Updating Your Development Tools


### PR DESCRIPTION
This pull request updates the Docker image build instructions in the `doc/setup.md` documentation. Instead of using the `docker build` command directly, it now recommends running a provided shell script for building the image.