### PR TITLE
[kernel] Support for Concurrent Kernel Calls

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -44,6 +44,11 @@ mutex_open_max = 32
 # - This number was arbitrarily chosen.
 cond_open_max = 32
 
+# Number of scoreboard slots used by the kernel call dispatcher/handler rendezvous.
+# Notes:
+# - This number should reflect expected kernel call concurrency.
+scoreboard_slots = 8
+
 # Number of IKC messages to poll at a time.
 ikc_poll_batch_size = 1
 

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -9,6 +9,7 @@ use crate::{
     event,
     ipc,
     kcall::{
+        KcallArgs,
         KcallResult,
         ScoreBoard,
     },
@@ -125,15 +126,20 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         },
 
         // Dispatch kernel call for remote execution.
-        _ => match ScoreBoard::get_mut() {
-            // SAFETY: The calling thread is not the kernel and no resources are held.
-            Ok(scoreboard) => {
-                match unsafe { scoreboard.dispatch(number, pid, tid, arg0, arg1, arg2, arg3) } {
-                    Ok(result) => result,
-                    Err(sleep_error) => handle_sleep_error(sleep_error),
-                }
-            },
-            Err(e) => KcallResult::Error(e.code.into()),
+        _ => {
+            let args: KcallArgs = KcallArgs {
+                number,
+                pid,
+                tid,
+                arg0,
+                arg1,
+                arg2,
+                arg3,
+            };
+            match unsafe { ScoreBoard::dispatch(args) } {
+                Ok(result) => result,
+                Err(sleep_error) => handle_sleep_error(sleep_error),
+            }
         },
     }
     .into()

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -67,68 +67,68 @@ pub fn kcall_handler(hal: &mut Hal, mm: &mut VirtMemoryManager) -> ExitStatus {
     let status: ExitStatus = loop {
         // Attempt to handle a kernel call.
         let mut kcall_handled: bool = false;
-        match ScoreBoard::get_mut() {
-            Ok(scoreboard) => match scoreboard.handle() {
-                Ok(args) => {
-                    let ret: KcallResult = match KcallNumber::from(args.number) {
-                        KcallNumber::Debug => debug::debug(pm!(), args),
-                        KcallNumber::GetPid => {
-                            // NOTE: this should be handled by the dispatcher.
-                            // However we emit an invalid system call, just in case.
-                            error!("cannot handle getpid()");
-                            KcallResult::Error(ErrorCode::InvalidSysCall.into())
-                        },
-                        KcallNumber::GetTid => {
-                            // NOTE: this should be handled by the dispatcher.
-                            // However we emit an invalid system call, just in case.
-                            error!("cannot handle gettid()");
-                            KcallResult::Error(ErrorCode::InvalidSysCall.into())
-                        },
-                        KcallNumber::CapCtl => pm::capctl(pm!(), args),
-                        KcallNumber::Terminate => pm::terminate(pm!(), args),
-                        KcallNumber::EventCtrl => event::evctrl(pm!(), args),
-                        KcallNumber::MemoryMap => pm::mmap(pm!(), mm, args),
-                        KcallNumber::MemoryUnmap => pm::munmap(pm!(), mm, args),
-                        KcallNumber::MemoryCtrl => pm::mctrl(pm!(), mm, args),
-                        KcallNumber::MemoryCopy => pm::mcopy(pm!(), mm, args),
-                        KcallNumber::Send => ipc::send(pm!(), args),
-                        KcallNumber::AllocMmio => io::mmio_alloc(hal, pm!(), args),
-                        KcallNumber::FreeMmio => io::mmio_free(pm!(), args),
-                        KcallNumber::MmioInfo => io::mmio_info(pm!(), args),
-                        KcallNumber::AllocPmio => io::pmio_alloc(hal, pm!(), args),
-                        KcallNumber::FreePmio => io::pmio_free(pm!(), args),
-                        KcallNumber::ReadPmio => io::pmio_read(pm!(), args),
-                        KcallNumber::WritePmio => io::pmio_write(pm!(), args),
-                        KcallNumber::GetTime => pm::gettime(pm!(), args),
-                        KcallNumber::CreateThread => pm::create_thread(pm!(), mm, args),
-                        KcallNumber::SetThreadDataArea => pm::set_thread_data_area(pm!(), args),
-                        KcallNumber::GetThreadDataArea => pm::get_thread_data_area(pm!(), args),
-                        _ => {
-                            error!("invalid kernel call");
-                            KcallResult::Error(ErrorCode::InvalidSysCall.into())
-                        },
-                    };
-
-                    // SAFETY: the calling process does not hold a reference to the inner state of the process manager.
-                    if let Err(e) = unsafe { scoreboard.handled(ret) } {
-                        warn!("failed to signal kernel call handled: {:?}", e)
-                    }
-
-                    kcall_handled = true;
-                },
-                Err(error) => match error.code {
-                    ErrorCode::TryAgain => {},
-                    _ => {
-                        // This condition should never happen because the only error that should
-                        // happen for `ScoreBoard::handle()` is `OperationWouldBlock`.
-                        unreachable!("failed to handle kernel call (error={:?})", error);
+        match unsafe { ScoreBoard::handle() } {
+            Ok((slot_index, args)) => {
+                let ret: KcallResult = match KcallNumber::from(args.number) {
+                    KcallNumber::Debug => debug::debug(pm!(), args),
+                    KcallNumber::GetPid => {
+                        // NOTE: this should be handled by the dispatcher.
+                        // However we emit an invalid system call, just in case.
+                        error!("cannot handle getpid()");
+                        KcallResult::Error(ErrorCode::InvalidSysCall.into())
                     },
-                },
+                    KcallNumber::GetTid => {
+                        // NOTE: this should be handled by the dispatcher.
+                        // However we emit an invalid system call, just in case.
+                        error!("cannot handle gettid()");
+                        KcallResult::Error(ErrorCode::InvalidSysCall.into())
+                    },
+                    KcallNumber::CapCtl => pm::capctl(pm!(), args),
+                    KcallNumber::Terminate => pm::terminate(pm!(), args),
+                    KcallNumber::EventCtrl => event::evctrl(pm!(), args),
+                    KcallNumber::MemoryMap => pm::mmap(pm!(), mm, args),
+                    KcallNumber::MemoryUnmap => pm::munmap(pm!(), mm, args),
+                    KcallNumber::MemoryCtrl => pm::mctrl(pm!(), mm, args),
+                    KcallNumber::MemoryCopy => pm::mcopy(pm!(), mm, args),
+                    KcallNumber::Send => ipc::send(pm!(), args),
+                    KcallNumber::AllocMmio => io::mmio_alloc(hal, pm!(), args),
+                    KcallNumber::FreeMmio => io::mmio_free(pm!(), args),
+                    KcallNumber::MmioInfo => io::mmio_info(pm!(), args),
+                    KcallNumber::AllocPmio => io::pmio_alloc(hal, pm!(), args),
+                    KcallNumber::FreePmio => io::pmio_free(pm!(), args),
+                    KcallNumber::ReadPmio => io::pmio_read(pm!(), args),
+                    KcallNumber::WritePmio => io::pmio_write(pm!(), args),
+                    KcallNumber::GetTime => pm::gettime(pm!(), args),
+                    KcallNumber::CreateThread => pm::create_thread(pm!(), mm, args),
+                    KcallNumber::SetThreadDataArea => pm::set_thread_data_area(pm!(), args),
+                    KcallNumber::GetThreadDataArea => pm::get_thread_data_area(pm!(), args),
+                    _ => {
+                        error!("invalid kernel call");
+                        KcallResult::Error(ErrorCode::InvalidSysCall.into())
+                    },
+                };
+
+                // SAFETY: the calling process does not hold a reference to the inner state of
+                // the process manager.
+                if let Err(e) = unsafe { ScoreBoard::handled(slot_index, ret) } {
+                    error!("failed to signal kernel call handled (error={e:?})");
+                }
+
+                kcall_handled = true;
             },
-            Err(error) => {
-                // This condition should never occur because the scoreboard is accessed exclusively,
-                // and no process should block while holding a reference to it.
-                unreachable!("failed to get scoreboard (error={:?})", error);
+            Err(error) => match error.code {
+                ErrorCode::TryAgain => {},
+                _ => {
+                    // This condition should never happen because the only expected error from
+                    // `ScoreBoard::handle()` is `ErrorCode::TryAgain`. Any other error may
+                    // indicate memory corruption or a logic bug in the scoreboard protocol.
+                    error!("unexpected error while handling kernel call (error={error:?})");
+                    debug_assert_eq!(
+                        error.code,
+                        ErrorCode::TryAgain,
+                        "scoreboard returned unexpected error"
+                    );
+                },
             },
         };
 

--- a/src/kernel/src/kcall/kcall_args.rs
+++ b/src/kernel/src/kcall/kcall_args.rs
@@ -1,0 +1,50 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::fmt::{
+    self,
+    Debug,
+    Formatter,
+};
+use ::sys::pm::{
+    ProcessIdentifier,
+    ThreadIdentifier,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Stores identifiers and up to four raw arguments describing a kernel call request.
+///
+pub struct KcallArgs {
+    pub pid: ProcessIdentifier,
+    pub tid: ThreadIdentifier,
+    pub number: u32,
+    pub arg0: u32,
+    pub arg1: u32,
+    pub arg2: u32,
+    pub arg3: u32,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Debug for KcallArgs {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "KcallArgs {{ pid: {:?}, tid: {:?}, number: {}, arg0: {:#010x}, arg1: {:#010x}, arg2: \
+             {:#010x}, arg3: {:#010x} }}",
+            self.pid, self.tid, self.number, self.arg0, self.arg1, self.arg2, self.arg3
+        )
+    }
+}

--- a/src/kernel/src/kcall/kcall_args.rs
+++ b/src/kernel/src/kcall/kcall_args.rs
@@ -24,18 +24,36 @@ use ::sys::pm::{
 ///
 /// Stores identifiers and up to four raw arguments describing a kernel call request.
 ///
+/// # Note
+///
+/// Fields are intentionally public because this structure is an internal kernel data type used
+/// exclusively within the kernel call dispatch and handling paths. Encapsulation via getters would
+/// add overhead without providing meaningful abstraction, as the structure is never exposed to
+/// user-space or external modules.
+///
+/// This deviates from the project coding standard that requires private fields with
+/// getter/setter methods. The deviation is accepted here because `KcallArgs` is a plain data
+/// carrier with no invariants to protect.
+///
 pub struct KcallArgs {
+    /// Identifier of the calling process.
     pub pid: ProcessIdentifier,
+    /// Identifier of the calling thread.
     pub tid: ThreadIdentifier,
+    /// Kernel call number to execute.
     pub number: u32,
+    /// First kernel call argument.
     pub arg0: u32,
+    /// Second kernel call argument.
     pub arg1: u32,
+    /// Third kernel call argument.
     pub arg2: u32,
+    /// Fourth kernel call argument.
     pub arg3: u32,
 }
 
 //==================================================================================================
-// Implementations
+// Trait Implementations
 //==================================================================================================
 
 impl Debug for KcallArgs {

--- a/src/kernel/src/kcall/mod.rs
+++ b/src/kernel/src/kcall/mod.rs
@@ -11,31 +11,7 @@ mod kcall_args;
 mod kcall_error;
 mod kcall_result;
 mod kcall_success;
-
-//==================================================================================================
-// Imports
-//==================================================================================================
-
-use crate::pm::{
-    sync::{
-        mutex::{
-            Mutex,
-            MutexGuard,
-        },
-        semaphore::Semaphore,
-    },
-    SleepError,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    pm::{
-        ProcessIdentifier,
-        ThreadIdentifier,
-    },
-};
+mod scoreboard;
 
 //==================================================================================================
 // Exports
@@ -46,124 +22,7 @@ pub use kcall_args::KcallArgs;
 pub use kcall_error::KcallError;
 pub use kcall_result::KcallResult;
 pub use kcall_success::KcallSuccess;
-
-//==================================================================================================
-// Scoreboard
-//==================================================================================================
-
-static mut SCOREBOARD: Option<ScoreBoard> = None;
-
-struct ScoreBoard {
-    lock: Mutex,
-    dispatched: Semaphore,
-    handled: Semaphore,
-    args: KcallArgs,
-    ret: KcallResult,
-}
-
-impl ScoreBoard {
-    fn init() {
-        unsafe {
-            SCOREBOARD = Some(ScoreBoard {
-                lock: Mutex::new(),
-                dispatched: Semaphore::new(0),
-                handled: Semaphore::new(0),
-                args: KcallArgs {
-                    pid: ProcessIdentifier::from(i32::MAX),
-                    tid: ThreadIdentifier::from(i32::MAX),
-                    arg0: 0,
-                    arg1: 0,
-                    arg2: 0,
-                    arg3: 0,
-                    number: 0,
-                },
-                ret: KcallResult::ok(),
-            });
-        }
-    }
-
-    pub fn get_mut() -> Result<&'static mut ScoreBoard, Error> {
-        unsafe {
-            if let Some(scoreboard) = SCOREBOARD.as_mut() {
-                Ok(scoreboard)
-            } else {
-                let reason: &str = "uninitialized scoreboard";
-                error!("{reason}");
-                Err(Error::new(ErrorCode::TryAgain, reason))
-            }
-        }
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Dispatches a kernel to be executed by the kernel thread.
-    ///
-    /// # Parameters
-    ///
-    /// - `number`: Number of the kernel call.
-    /// - `pid`: Identifier of the process that is invoking the kernel call.
-    /// - `tid`: Identifier of the thread that is invoking the kernel call.
-    /// - `arg0`: First kernel call argument.
-    /// - `arg1`: Second kernel call argument.
-    /// - `arg2`: Third kernel call argument.
-    /// - `arg3`: Fourth kernel call argument.
-    ///
-    /// # Returns
-    ///
-    /// Upon successful completion, the return value of the kernel call is returned. Otherwise, an
-    /// error is returned instead.
-    ///
-    /// # Safety
-    ///
-    /// This function panics if the kernel process tries to sleep.
-    ///
-    /// This function is unsafe because it blocks the calling thread until it is woken up by another
-    /// thread.
-    ///
-    /// This function is safe to use if and only if the following conditions are met:
-    ///
-    /// - The calling process is not the kernel process.
-    /// - This function is invoked without holding any resources.
-    ///
-    #[allow(clippy::too_many_arguments)]
-    pub unsafe fn dispatch(
-        &mut self,
-        number: u32,
-        pid: ProcessIdentifier,
-        tid: ThreadIdentifier,
-        arg0: u32,
-        arg1: u32,
-        arg2: u32,
-        arg3: u32,
-    ) -> Result<KcallResult, SleepError> {
-        let _guard: MutexGuard = self.lock.lock(None)?;
-        self.args = KcallArgs {
-            pid,
-            tid,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            number,
-        };
-        self.dispatched.up().map_err(SleepError::Generic)?;
-        self.handled.down()?;
-
-        Ok(self.ret)
-    }
-
-    pub fn handle(&self) -> Result<&KcallArgs, Error> {
-        self.dispatched.try_down()?;
-
-        Ok(&self.args)
-    }
-
-    pub unsafe fn handled(&mut self, ret: KcallResult) -> Result<(), Error> {
-        self.ret = ret;
-        self.handled.up()
-    }
-}
+pub(crate) use scoreboard::ScoreBoard;
 
 //==================================================================================================
 // Standalone Functions

--- a/src/kernel/src/kcall/mod.rs
+++ b/src/kernel/src/kcall/mod.rs
@@ -7,6 +7,7 @@
 
 mod dispatcher;
 mod handler;
+mod kcall_args;
 mod kcall_error;
 mod kcall_result;
 mod kcall_success;
@@ -25,7 +26,6 @@ use crate::pm::{
     },
     SleepError,
 };
-use ::core::fmt::Debug;
 use ::sys::{
     error::{
         Error,
@@ -42,6 +42,7 @@ use ::sys::{
 //==================================================================================================
 
 pub use handler::kcall_handler as handler;
+pub use kcall_args::KcallArgs;
 pub use kcall_error::KcallError;
 pub use kcall_result::KcallResult;
 pub use kcall_success::KcallSuccess;
@@ -51,27 +52,6 @@ pub use kcall_success::KcallSuccess;
 //==================================================================================================
 
 static mut SCOREBOARD: Option<ScoreBoard> = None;
-
-pub struct KcallArgs {
-    pub pid: ProcessIdentifier,
-    pub tid: ThreadIdentifier,
-    pub number: u32,
-    pub arg0: u32,
-    pub arg1: u32,
-    pub arg2: u32,
-    pub arg3: u32,
-}
-
-impl Debug for KcallArgs {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(
-            f,
-            "KcallArgs {{ pid: {:?}, tid: {:?}, number: {}, arg0: {:#010x}, arg1: {:#010x}, arg2: \
-             {:#010x}, arg3: {:#010x} }}",
-            self.pid, self.tid, self.number, self.arg0, self.arg1, self.arg2, self.arg3
-        )
-    }
-}
 
 struct ScoreBoard {
     lock: Mutex,

--- a/src/kernel/src/kcall/mod.rs
+++ b/src/kernel/src/kcall/mod.rs
@@ -28,7 +28,13 @@ pub(crate) use scoreboard::ScoreBoard;
 // Standalone Functions
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Initializes the kernel call subsystem, including the global scoreboard used for dispatching
+/// kernel calls to the handler thread.
+///
 pub fn init() {
     info!("initializing kernel call handler...");
-    ScoreBoard::init();
+    unsafe { ScoreBoard::init() };
 }

--- a/src/kernel/src/kcall/scoreboard.rs
+++ b/src/kernel/src/kcall/scoreboard.rs
@@ -1,0 +1,169 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::pm::{
+    sync::{
+        mutex::{
+            Mutex,
+            MutexGuard,
+        },
+        semaphore::Semaphore,
+    },
+    SleepError,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+};
+
+use super::{
+    KcallArgs,
+    KcallResult,
+};
+
+//==================================================================================================
+// Statistics
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Global scoreboard used to coordinate kernel call dispatching and completion signaling between
+/// user and kernel threads.
+///
+static mut SCOREBOARD: Option<ScoreBoard> = None;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Coordinates kernel call dispatching and completion signaling between user and kernel threads.
+///
+pub(crate) struct ScoreBoard {
+    lock: Mutex,
+    dispatched: Semaphore,
+    handled: Semaphore,
+    args: KcallArgs,
+    ret: KcallResult,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl ScoreBoard {
+    pub(crate) fn init() {
+        unsafe {
+            SCOREBOARD = Some(ScoreBoard {
+                lock: Mutex::new(),
+                dispatched: Semaphore::new(0),
+                handled: Semaphore::new(0),
+                args: KcallArgs {
+                    pid: ProcessIdentifier::from(i32::MAX),
+                    tid: ThreadIdentifier::from(i32::MAX),
+                    arg0: 0,
+                    arg1: 0,
+                    arg2: 0,
+                    arg3: 0,
+                    number: 0,
+                },
+                ret: KcallResult::ok(),
+            });
+        }
+    }
+
+    pub(crate) fn get_mut() -> Result<&'static mut ScoreBoard, Error> {
+        unsafe {
+            if let Some(scoreboard) = SCOREBOARD.as_mut() {
+                Ok(scoreboard)
+            } else {
+                let reason: &str = "uninitialized scoreboard";
+                error!("{reason}");
+                Err(Error::new(ErrorCode::TryAgain, reason))
+            }
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Dispatches a kernel to be executed by the kernel thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `number`: Number of the kernel call.
+    /// - `pid`: Identifier of the process that is invoking the kernel call.
+    /// - `tid`: Identifier of the thread that is invoking the kernel call.
+    /// - `arg0`: First kernel call argument.
+    /// - `arg1`: Second kernel call argument.
+    /// - `arg2`: Third kernel call argument.
+    /// - `arg3`: Fourth kernel call argument.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, the return value of the kernel call is returned. Otherwise, an
+    /// error is returned instead.
+    ///
+    /// # Safety
+    ///
+    /// This function panics if the kernel process tries to sleep.
+    ///
+    /// This function is unsafe because it blocks the calling thread until it is woken up by another
+    /// thread.
+    ///
+    /// This function is safe to use if and only if the following conditions are met:
+    ///
+    /// - The calling process is not the kernel process.
+    /// - This function is invoked without holding any resources.
+    ///
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) unsafe fn dispatch(
+        &mut self,
+        number: u32,
+        pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
+        arg0: u32,
+        arg1: u32,
+        arg2: u32,
+        arg3: u32,
+    ) -> Result<KcallResult, SleepError> {
+        let _guard: MutexGuard = self.lock.lock(None)?;
+        self.args = KcallArgs {
+            pid,
+            tid,
+            arg0,
+            arg1,
+            arg2,
+            arg3,
+            number,
+        };
+        self.dispatched.up().map_err(SleepError::Generic)?;
+        self.handled.down()?;
+
+        Ok(self.ret)
+    }
+
+    pub(crate) fn handle(&self) -> Result<&KcallArgs, Error> {
+        self.dispatched.try_down()?;
+
+        Ok(&self.args)
+    }
+
+    pub(crate) unsafe fn handled(&mut self, ret: KcallResult) -> Result<(), Error> {
+        self.ret = ret;
+        self.handled.up()
+    }
+}

--- a/src/kernel/src/kcall/scoreboard.rs
+++ b/src/kernel/src/kcall/scoreboard.rs
@@ -5,16 +5,17 @@
 // Imports
 //==================================================================================================
 
-use crate::pm::{
-    sync::{
-        mutex::{
-            Mutex,
-            MutexGuard,
-        },
-        semaphore::Semaphore,
+use crate::{
+    kcall::{
+        KcallArgs,
+        KcallResult,
     },
-    SleepError,
+    pm::{
+        sync::semaphore::Semaphore,
+        SleepError,
+    },
 };
+use ::config::kernel::SCOREBOARD_SLOTS;
 use ::sys::{
     error::{
         Error,
@@ -26,13 +27,8 @@ use ::sys::{
     },
 };
 
-use super::{
-    KcallArgs,
-    KcallResult,
-};
-
 //==================================================================================================
-// Statistics
+// Global Variables
 //==================================================================================================
 
 ///
@@ -41,10 +37,20 @@ use super::{
 /// Global scoreboard used to coordinate kernel call dispatching and completion signaling between
 /// user and kernel threads.
 ///
+/// # Safety
+///
+/// This global is accessed through [`ScoreBoard::get_mut()`], which returns `&'static mut`.
+/// Multiple `&mut` references to the same allocation technically violate Rust's aliasing rules.
+/// This is accepted here because the kernel runs on a single core with interrupts disabled
+/// (cooperative scheduling), so no two threads execute concurrently. Under this execution model
+/// only one `&mut` is active at any program point, making the access pattern sound in practice.
+/// If the kernel ever moves to a preemptive or multi-core model, this must be replaced with an
+/// `UnsafeCell`-based container that upholds interior-mutability invariants.
+///
 static mut SCOREBOARD: Option<ScoreBoard> = None;
 
 //==================================================================================================
-// Structures
+// Scoreboard
 //==================================================================================================
 
 ///
@@ -52,118 +58,621 @@ static mut SCOREBOARD: Option<ScoreBoard> = None;
 ///
 /// Coordinates kernel call dispatching and completion signaling between user and kernel threads.
 ///
-pub(crate) struct ScoreBoard {
-    lock: Mutex,
-    dispatched: Semaphore,
-    handled: Semaphore,
-    args: KcallArgs,
-    ret: KcallResult,
+pub struct ScoreBoard {
+    /// Synchronizes number of slots available for kernel call dispatching.
+    available_slots: Semaphore,
+    /// Synchronizes number of kernel calls ready to be handled.
+    pending_kcalls: Semaphore,
+    /// Slots for kernel call dispatching.
+    slots: [ScoreBoardSlot; SCOREBOARD_SLOTS],
+    /// Next slot index to inspect when searching for pending kernel calls.
+    next_handle_index: usize,
+    /// Next slot index to inspect when searching for free slots during dispatch.
+    next_dispatch_index: usize,
 }
 
-//==================================================================================================
-// Implementations
-//==================================================================================================
-
 impl ScoreBoard {
-    pub(crate) fn init() {
-        unsafe {
-            SCOREBOARD = Some(ScoreBoard {
-                lock: Mutex::new(),
-                dispatched: Semaphore::new(0),
-                handled: Semaphore::new(0),
-                args: KcallArgs {
-                    pid: ProcessIdentifier::from(i32::MAX),
-                    tid: ThreadIdentifier::from(i32::MAX),
-                    arg0: 0,
-                    arg1: 0,
-                    arg2: 0,
-                    arg3: 0,
-                    number: 0,
-                },
-                ret: KcallResult::ok(),
-            });
-        }
+    ///
+    /// # Description
+    ///
+    /// Initializes the global scoreboard.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it mutates the global scoreboard without explicit
+    /// synchronization.
+    ///
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - The caller is running with interrupts disabled when invoking this function.
+    ///
+    pub unsafe fn init() {
+        SCOREBOARD = Some(ScoreBoard {
+            available_slots: Semaphore::new(SCOREBOARD_SLOTS),
+            pending_kcalls: Semaphore::new(0),
+            slots: ::core::array::from_fn(|_| ScoreBoardSlot::new()),
+            next_handle_index: 0,
+            next_dispatch_index: 0,
+        });
     }
 
-    pub(crate) fn get_mut() -> Result<&'static mut ScoreBoard, Error> {
-        unsafe {
-            if let Some(scoreboard) = SCOREBOARD.as_mut() {
-                Ok(scoreboard)
-            } else {
-                let reason: &str = "uninitialized scoreboard";
-                error!("{reason}");
-                Err(Error::new(ErrorCode::TryAgain, reason))
-            }
+    ///
+    /// # Description
+    ///
+    /// Gets a mutable reference to the global scoreboard instance.
+    ///
+    /// # Returns
+    ///
+    /// On successful completion, this function returns a mutable reference to the global scoreboard.
+    /// On failure, it returns an object that describes the error encountered.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the global scoreboard has not been initialized.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it provides direct mutable access to the global scoreboard
+    /// without explicit synchronization.
+    ///
+    /// Although multiple callers (dispatcher threads and the kernel handler thread) may hold
+    /// references obtained through this function concurrently, they always operate on disjoint
+    /// slot indices:
+    /// - A dispatcher thread only touches its own slot (identified by `find_free_slot`).
+    /// - The handler thread only touches slots discovered via `handle()`.
+    /// - The semaphore protocol ensures a slot transitions through `Free -> InUse -> Signaled`
+    ///   on the dispatcher side before the handler observes it, and back to `Free` only after
+    ///   the handler has finished.
+    ///
+    /// The shared fields `next_dispatch_index`, `next_handle_index`, as well as the
+    /// `available_slots` / `pending_kcalls` semaphores, are mutated by multiple callers.
+    /// This is sound because the kernel uses cooperative scheduling on a single core with
+    /// interrupts disabled, so only one caller executes at any program point and no concurrent
+    /// mutation of these fields can occur.
+    ///
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - The caller is running with interrupts disabled when invoking this function.
+    ///
+    unsafe fn get_mut() -> Result<&'static mut ScoreBoard, Error> {
+        if let Some(scoreboard) = SCOREBOARD.as_mut() {
+            Ok(scoreboard)
+        } else {
+            let reason: &str = "uninitialized scoreboard";
+            error!("{reason}");
+            Err(Error::new(ErrorCode::InvalidArgument, reason))
         }
     }
 
     ///
     /// # Description
     ///
-    /// Dispatches a kernel to be executed by the kernel thread.
+    /// Dispatches a kernel call to be handled by the kernel thread.
     ///
     /// # Parameters
     ///
-    /// - `number`: Number of the kernel call.
-    /// - `pid`: Identifier of the process that is invoking the kernel call.
-    /// - `tid`: Identifier of the thread that is invoking the kernel call.
-    /// - `arg0`: First kernel call argument.
-    /// - `arg1`: Second kernel call argument.
-    /// - `arg2`: Third kernel call argument.
-    /// - `arg3`: Fourth kernel call argument.
+    /// - `args`: Kernel call arguments describing the request.
     ///
     /// # Returns
     ///
-    /// Upon successful completion, the return value of the kernel call is returned. Otherwise, an
-    /// error is returned instead.
+    /// On successful completion, this function returns the result of the kernel call. On failure,
+    /// it returns an object that describes the error encountered.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if:
+    /// - The global scoreboard has not been initialized.
+    /// - No scoreboard slot is available for dispatching.
+    /// - Signaling the pending kernel call fails.
+    /// - Waiting for the kernel call result fails (e.g., the dispatcher is aborted).
+    /// - The kernel call result is missing after the handler completes.
     ///
     /// # Safety
     ///
-    /// This function panics if the kernel process tries to sleep.
+    /// This function is unsafe because:
+    /// - It mutates the global scoreboard without explicit synchronization.
+    /// - It suspends the execution of the calling thread until the kernel call is handled.
+    /// - It must be called only by a user thread.
     ///
-    /// This function is unsafe because it blocks the calling thread until it is woken up by another
-    /// thread.
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - The caller is running with interrupts disabled when invoking this function.
+    /// - The caller does not hold kernel resources while waiting on the kernel call to complete.
+    /// - The caller must be a user thread.
     ///
-    /// This function is safe to use if and only if the following conditions are met:
-    ///
-    /// - The calling process is not the kernel process.
-    /// - This function is invoked without holding any resources.
-    ///
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) unsafe fn dispatch(
-        &mut self,
-        number: u32,
-        pid: ProcessIdentifier,
-        tid: ThreadIdentifier,
-        arg0: u32,
-        arg1: u32,
-        arg2: u32,
-        arg3: u32,
-    ) -> Result<KcallResult, SleepError> {
-        let _guard: MutexGuard = self.lock.lock(None)?;
-        self.args = KcallArgs {
-            pid,
-            tid,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            number,
+    pub unsafe fn dispatch(args: KcallArgs) -> Result<KcallResult, SleepError> {
+        let scoreboard: &'static mut ScoreBoard =
+            unsafe { Self::get_mut() }.map_err(SleepError::Generic)?;
+
+        // Wait for a scoreboard slot to become available.
+        if let Err(error) = unsafe { scoreboard.available_slots.down() } {
+            let reason: &str = "failed to acquire scoreboard slot";
+            error!("{reason} (error={error:?})");
+            return Err(error);
+        }
+
+        // Find slot that became available.
+        let slot_index: usize = match scoreboard.find_free_slot(args) {
+            // Found a free slot.
+            Some(index) => index,
+            // No free slot found.
+            None => {
+                // This is unlikely to happen, as we just waited for one above. Still, instead
+                // of panicking, we fail gracefully. Semaphore::up() always increments the
+                // counter before calling notify_first(), so even on failure the available slot
+                // count is restored.
+                let reason: &str = "no free scoreboard slots";
+                error!("{reason}");
+
+                if let Err(rollback_error) = unsafe { scoreboard.available_slots.up() } {
+                    let rollback_reason: &str =
+                        "failed to notify on available scoreboard slots rollback";
+                    warn!("{rollback_reason}: {rollback_error:?}");
+                }
+                return Err(SleepError::Generic(Error::new(ErrorCode::TryAgain, reason)));
+            },
         };
-        self.dispatched.up().map_err(SleepError::Generic)?;
-        self.handled.down()?;
 
-        Ok(self.ret)
+        // Mark the slot as signaled before incrementing the pending_kcalls semaphore.
+        // This ordering is critical: the handler checks `is_pending()` which requires
+        // `Signaled` state. If we signaled the semaphore first, the handler could wake
+        // and find the slot still in `InUse` state, missing the pending kernel call.
+        let slot: &mut ScoreBoardSlot = &mut scoreboard.slots[slot_index];
+        slot.mark_signaled();
+
+        // Signal that a new kernel call is pending.
+        if let Err(error) = unsafe { scoreboard.pending_kcalls.up() } {
+            let reason: &str = "failed to signal pending kernel calls";
+            error!("{reason} (error={error:?})");
+
+            // At this point, Semaphore::up() has already incremented the internal
+            // pending_kcalls counter before failing to notify a waiter. To preserve the
+            // rendezvous invariant between pending_kcalls and slot states, we must not
+            // make this slot appear free again while leaving the semaphore count
+            // incremented. Instead, we mark the slot as aborted so that the handler can
+            // observe and retire it consistently.
+            slot.mark_aborted();
+
+            return Err(SleepError::Generic(error));
+        }
+
+        // Wait for the kernel call to be handled.
+        let wait_result: Result<(), SleepError> = {
+            let handled: &Semaphore = &scoreboard.slots[slot_index].handled;
+            unsafe { handled.down() }
+        };
+
+        // Get the slot.
+        let slot: &mut ScoreBoardSlot = &mut scoreboard.slots[slot_index];
+
+        if let Err(error) = wait_result {
+            slot.mark_aborted();
+            let reason: &str = "failed to wait for kernel call handling";
+            error!("{reason} (error={error:?})");
+            return Err(error);
+        }
+
+        // Retrieve the result.
+        let result: Option<KcallResult> = slot.result.take();
+
+        // Attempt to signal slot availability. Semaphore::up() always increments the internal
+        // counter before calling notify_first(), so even on failure the available slot count is
+        // already restored. We mark the slot as free regardless because the kernel call was
+        // already handled successfully and the counter is consistent.
+        if let Err(error) = unsafe { scoreboard.available_slots.up() } {
+            let reason: &str = "failed to notify on available scoreboard slots";
+            warn!("{reason} (error={error:?})");
+        }
+        slot.mark_free();
+
+        match result {
+            Some(ret) => Ok(ret),
+            None => {
+                let reason: &str = "missing kernel call result";
+                error!("{reason}");
+                Err(SleepError::Generic(Error::new(ErrorCode::TryAgain, reason)))
+            },
+        }
     }
 
-    pub(crate) fn handle(&self) -> Result<&KcallArgs, Error> {
-        self.dispatched.try_down()?;
+    ///
+    /// # Description
+    ///
+    /// Acquires the next pending slot and returns its arguments for processing.
+    ///
+    /// # Returns
+    ///
+    /// On successful completion, this function returns the slot index paired with its corresponding
+    /// kernel arguments. On failure, it returns an object that describes the error.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if:
+    /// - The global scoreboard has not been initialized.
+    /// - No kernel calls are pending ([`ErrorCode::TryAgain`]).
+    /// - A pending kernel call count exists but no matching slot is found.
+    /// - A pending slot was found but had been aborted by the dispatcher; the slot is recycled
+    ///   and [`ErrorCode::TryAgain`] is returned.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because:
+    /// - It mutates the global scoreboard without explicit synchronization.
+    /// - It must be called only by the kernel thread.
+    ///
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - The caller is running with interrupts disabled when invoking this function.
+    /// - The caller must be the kernel thread.
+    ///
+    pub unsafe fn handle() -> Result<(ScoreBoardSlotIndex, &'static KcallArgs), Error> {
+        let scoreboard: &'static mut ScoreBoard = unsafe { Self::get_mut() }?;
 
-        Ok(&self.args)
+        // Wait for a pending kernel call.
+        if let Err(error) = scoreboard.pending_kcalls.try_down() {
+            // Only log actual errors. ErrorCode::TryAgain is the expected non-error case when no
+            // kernel calls are pending, so we skip logging for it.
+            if error.code != ErrorCode::TryAgain {
+                error!("failed to wait for pending kernel calls (error={error:?})");
+            }
+            return Err(error);
+        }
+
+        // Find a pending slot, resuming from the previously handled index to avoid starvation.
+        let total_slots: usize = scoreboard.slots.len();
+        let start_index: usize = scoreboard.next_handle_index;
+        let mut found_index: Option<usize> = None;
+
+        for offset in 0..total_slots {
+            let current_index: usize = (start_index + offset) % total_slots;
+            if scoreboard.slots[current_index].is_pending() {
+                found_index = Some(current_index);
+                scoreboard.next_handle_index = (current_index + 1) % total_slots;
+                break;
+            }
+        }
+
+        let slot_index: usize = match found_index {
+            Some(index) => index,
+            None => {
+                let reason: &str = "no dispatched slot available";
+                error!("{reason}");
+
+                let original_error: Error = Error::new(ErrorCode::TryAgain, reason);
+
+                if let Err(error) = unsafe { scoreboard.pending_kcalls.up() } {
+                    let rollback_reason: &str = "failed to rollback pending kernel calls";
+                    warn!("{rollback_reason}: {error:?}");
+                }
+
+                return Err(original_error);
+            },
+        };
+
+        // If the slot was aborted by the dispatcher, recycle it without executing the kernel
+        // call. The dispatcher already returned an error to its caller, so applying side effects
+        // for an abandoned request is incorrect.
+        if scoreboard.slots[slot_index].state == ScoreBoardSlotState::Aborted {
+            if let Err(error) = unsafe { scoreboard.available_slots.up() } {
+                let reason: &str = "failed to recycle aborted scoreboard slot";
+                warn!("{reason} (error={error:?})");
+            }
+            scoreboard.slots[slot_index].mark_free();
+            return Err(Error::new(ErrorCode::TryAgain, "recycled aborted scoreboard slot"));
+        }
+
+        let args: &'static KcallArgs = &scoreboard.slots[slot_index].args;
+
+        Ok((ScoreBoardSlotIndex(slot_index), args))
     }
 
-    pub(crate) unsafe fn handled(&mut self, ret: KcallResult) -> Result<(), Error> {
-        self.ret = ret;
-        self.handled.up()
+    ///
+    /// # Description
+    ///
+    /// Stores the handler result back into the referenced slot and wakes the waiting dispatcher.
+    ///
+    /// # Parameters
+    ///
+    /// - `index`: Slot index that was previously obtained via `handle()`.
+    /// - `ret`: Kernel call result to deliver to the dispatcher.
+    ///
+    /// # Returns
+    ///
+    /// On successful completion, this function returns `Ok(())`. On failure, it returns an object
+    /// that describes the error encountered.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if:
+    /// - The global scoreboard has not been initialized.
+    /// - The slot index is out of bounds.
+    /// - The slot is not in a state that accepts a result (neither `Signaled` nor `Aborted`).
+    /// - Notifying the waiting dispatcher fails.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because:
+    /// - It mutates the global scoreboard without explicit synchronization.
+    /// - It must be called only by the kernel thread.
+    ///
+    /// It is safe to call this function if and only if the following conditions are met:
+    /// - The caller is running with interrupts disabled when invoking this function.
+    /// - The caller must be the kernel thread.
+    ///
+    pub unsafe fn handled(index: ScoreBoardSlotIndex, ret: KcallResult) -> Result<(), Error> {
+        let scoreboard: &'static mut ScoreBoard = unsafe { Self::get_mut() }?;
+
+        // Get the slot.
+        let slot: &mut ScoreBoardSlot =
+            scoreboard.slots.get_mut(index.as_usize()).ok_or_else(|| {
+                let reason: &str = "invalid scoreboard slot index";
+                error!("{reason}");
+                Error::new(ErrorCode::InvalidArgument, reason)
+            })?;
+
+        match slot.state {
+            ScoreBoardSlotState::Signaled => {
+                slot.result = Some(ret);
+
+                // Notify the waiting dispatcher.
+                if let Err(error) = unsafe { slot.handled.up() } {
+                    // Roll back: clear the stored result and mark the slot as aborted so
+                    // the next `handle()` iteration can recycle it and recover the
+                    // available-slot semaphore count.
+                    slot.mark_aborted();
+                    let reason: &str = "failed to notify waiting dispatcher";
+                    error!("{reason} (error={error:?})");
+                    return Err(error);
+                }
+
+                Ok(())
+            },
+            ScoreBoardSlotState::Aborted => {
+                // This arm handles a race between `handle()` and `handled()`: a slot can
+                // transition to `Aborted` *after* `handle()` has already selected it (i.e.,
+                // between the `is_pending()` check and the state comparison in `handle()`).
+                // When the dispatcher's `Condvar::wait()` is interrupted it marks the slot as
+                // `Aborted`, but the handler may have already dequeued the `pending_kcalls`
+                // semaphore count for this slot and received it via `handle()`. In that
+                // scenario `handled()` observes `Aborted` and must recycle the slot here.
+                slot.result = None;
+
+                // Release the slot back to the available pool. This is safe because when the
+                // dispatcher aborted, it did not release the slot to ensure the handler could
+                // process it exactly once. Semaphore::up() always increments the counter before
+                // calling notify_first(), so even on failure the available slot count is already
+                // restored. We mark the slot as free regardless.
+                if let Err(error) = unsafe { scoreboard.available_slots.up() } {
+                    let reason: &str = "failed to notify on available scoreboard slot recycle";
+                    warn!("{reason} (error={error:?})");
+                }
+
+                slot.mark_free();
+
+                Ok(())
+            },
+            _ => {
+                let reason: &str = "slot is not in a signalable state";
+                error!("{reason} (state={:?})", slot.state);
+                Err(Error::new(ErrorCode::TryAgain, reason))
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Searches for a free slot, fills it with kernel call arguments, and returns its index.
+    ///
+    /// # Parameters
+    ///
+    /// - `args`: Kernel call arguments describing the request.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns `Some(index)` of the slot that was filled. Returns `None` if no free
+    /// slot is available.
+    ///
+    fn find_free_slot(&mut self, args: KcallArgs) -> Option<usize> {
+        let total_slots: usize = self.slots.len();
+        let start_index: usize = self.next_dispatch_index;
+
+        for offset in 0..total_slots {
+            let current_index: usize = (start_index + offset) % total_slots;
+            if self.slots[current_index].is_free() {
+                self.slots[current_index].fill(args);
+                self.next_dispatch_index = (current_index + 1) % total_slots;
+                return Some(current_index);
+            }
+        }
+
+        None
+    }
+}
+
+//==================================================================================================
+// Scoreboard State
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Represents lifecycle states for a scoreboard slot.
+///
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScoreBoardSlotState {
+    /// Slot is available for a new kernel call.
+    Free,
+    /// Transitional state: slot has been acquired and filled with arguments but not yet made
+    /// visible to the handler. This state is never matched by `is_pending()` or `is_free()`,
+    /// preventing the handler from observing a half-initialized slot.
+    InUse,
+    /// Slot has been signaled and is ready for the kernel to process.
+    Signaled,
+    /// Slot was abandoned by the dispatcher and requires reclamation by the handler.
+    Aborted,
+}
+
+//==================================================================================================
+// Scoreboard Slot Index
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Identifies a slot within the scoreboard storage.
+///
+/// This is a wrapper around a `usize` that provides type safety and prevents accidental misuse of
+/// raw indices. It is returned by `ScoreBoard::handle()` and must be passed back to
+/// `ScoreBoard::handled()` to complete the kernel call handling cycle.
+///
+#[derive(Debug)]
+pub struct ScoreBoardSlotIndex(usize);
+
+impl ScoreBoardSlotIndex {
+    ///
+    /// # Description
+    ///
+    /// Converts the slot index into a `usize` for array access.
+    ///
+    fn as_usize(&self) -> usize {
+        self.0
+    }
+}
+
+//==================================================================================================
+// Scoreboard Slot
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Tracks the arguments, result, and synchronization primitive for a single slot.
+///
+struct ScoreBoardSlot {
+    /// Current lifecycle state of the slot.
+    state: ScoreBoardSlotState,
+    /// Kernel call arguments provided by the dispatcher.
+    args: KcallArgs,
+    /// Kernel call result set by the handler, or `None` if not yet handled.
+    result: Option<KcallResult>,
+    /// Semaphore used to wake the dispatcher when the kernel call is handled.
+    handled: Semaphore,
+}
+
+impl ScoreBoardSlot {
+    ///
+    /// # Description
+    ///
+    /// Creates a scoreboard slot initialized with sentinel arguments.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a new instance of a scoreboard slot.
+    ///
+    fn new() -> Self {
+        ScoreBoardSlot {
+            state: ScoreBoardSlotState::Free,
+            args: KcallArgs {
+                pid: ProcessIdentifier::from(i32::MAX),
+                tid: ThreadIdentifier::from(i32::MAX),
+                number: 0,
+                arg0: 0,
+                arg1: 0,
+                arg2: 0,
+                arg3: 0,
+            },
+            result: None,
+            handled: Semaphore::new(0),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks whether the slot is currently free.
+    ///
+    /// # Returns
+    ///
+    /// True if the slot is free, false otherwise.
+    ///
+    fn is_free(&self) -> bool {
+        matches!(self.state, ScoreBoardSlotState::Free)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks whether the slot is pending processing.
+    ///
+    /// This predicate matches both `Signaled` and `Aborted` states because `handle()` needs to
+    /// discover aborted slots to recycle them. After `is_pending()` returns `true`, `handle()`
+    /// performs a second state check to distinguish `Signaled` from `Aborted` and either
+    /// dispatches the kernel call or recycles the slot, respectively.
+    ///
+    /// The `result.is_none()` guard is required because `handled()` stores the result into the
+    /// slot *before* waking the dispatcher via `notify_first()`. If the handler loop re-enters
+    /// `handle()` before the dispatcher wakes, clears the result, and calls `mark_free()`, the
+    /// slot is still in `Signaled` state with `result.is_some()`. Without this guard the handler
+    /// would re-pick the same slot and attempt to process it a second time.
+    ///
+    /// The guard is always satisfied for `Aborted` slots because [`mark_aborted()`](Self::mark_aborted)
+    /// unconditionally clears `result` to `None`. See the invariant documented on that method.
+    ///
+    /// # Returns
+    ///
+    /// True if the slot is pending processing, false otherwise.
+    ///
+    fn is_pending(&self) -> bool {
+        matches!(self.state, ScoreBoardSlotState::Signaled | ScoreBoardSlotState::Aborted)
+            && self.result.is_none()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Fills the slot with kernel call arguments and marks it as in use.
+    ///
+    /// # Parameters
+    ///
+    /// - `args`: Kernel call arguments describing the request.
+    ///
+    fn fill(&mut self, args: KcallArgs) {
+        self.state = ScoreBoardSlotState::InUse;
+        self.args = args;
+        self.result = None;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Marks the slot as free and clears any pending result.
+    ///
+    fn mark_free(&mut self) {
+        self.state = ScoreBoardSlotState::Free;
+        self.result = None;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Marks the slot as aborted so the kernel handler can recycle it safely.
+    ///
+    /// # Invariant
+    ///
+    /// This method must always clear `result` to `None`. The [`is_pending()`](Self::is_pending)
+    /// predicate relies on `result.is_none()` to distinguish genuinely pending slots from slots
+    /// that have already been handled but not yet freed. If `result` were left as `Some`, the
+    /// handler would skip the aborted slot entirely.
+    ///
+    fn mark_aborted(&mut self) {
+        self.state = ScoreBoardSlotState::Aborted;
+        self.result = None;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Marks the slot as visible to the kernel thread. Must be called before signaling the
+    /// pending semaphore so the handler never observes the slot in `InUse` state.
+    ///
+    fn mark_signaled(&mut self) {
+        self.state = ScoreBoardSlotState::Signaled;
     }
 }

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -148,6 +148,12 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     constants.push_str(&format!("pub const COND_OPEN_MAX: usize = {val};\n"));
 
     let val: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "scoreboard_slots"),
+        "scoreboard_slots",
+    );
+    constants.push_str(&format!("pub const SCOREBOARD_SLOTS: usize = {val};\n"));
+
+    let val: usize = parse_hex_or_decimal_usize(
         required_key(&kernel_config_toml, "ikc_poll_batch_size"),
         "ikc_poll_batch_size",
     );

--- a/src/tests/stress-rust/src/tests/mod.rs
+++ b/src/tests/stress-rust/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod memory_mapping_storm;
 mod mutex_churn;
 mod parallel_spawners;
 mod scoreboard_backpressure;
+mod scoreboard_saturation;
 mod sleep_burst;
 mod thread_data_area;
 mod thread_fan_out;
@@ -45,6 +46,7 @@ pub fn run_all() -> Result<(), Error> {
     thread_identity::run()?;
     kcall_hammer::run()?;
     scoreboard_backpressure::run()?;
+    scoreboard_saturation::run()?;
     heap_reclaim::run()?;
     sleep_burst::run()?;
     debug_console_spam::run()?;

--- a/src/tests/stress-rust/src/tests/scoreboard_backpressure.rs
+++ b/src/tests/stress-rust/src/tests/scoreboard_backpressure.rs
@@ -15,7 +15,10 @@ use super::common::{
     thread_args,
 };
 use ::alloc::vec::Vec;
-use ::config::constants::KILOBYTE;
+use ::config::{
+    constants::KILOBYTE,
+    kernel::SCOREBOARD_SLOTS,
+};
 use ::core::{
     cmp,
     convert::TryFrom,
@@ -59,21 +62,29 @@ use ::sys::{
 //==================================================================================================
 
 const SCOREBOARD_PRESSURE_ITERATIONS: usize = 48;
-const SCOREBOARD_SLOT_HINT: usize = 1;
+const SCOREBOARD_SLOT_COUNT: usize = SCOREBOARD_SLOTS;
 const SCOREBOARD_PRESSURE_PAGE_BYTES: usize = 4 * KILOBYTE;
 const SCOREBOARD_PRESSURE_REGION_STRIDE_BYTES: usize =
     SCOREBOARD_PRESSURE_PAGE_BYTES * SCOREBOARD_PRESSURE_ITERATIONS * 2;
 const SCOREBOARD_PRESSURE_YIELD_MASK: usize = 0x7;
 const SCOREBOARD_PRESSURE_BYTE_MASK: usize = 0xff;
 const MIN_SCOREBOARD_PRESSURE_WORKERS: usize = 8;
-const SCOREBOARD_PRESSURE_FAILURE: usize = usize::MAX;
+/// Number of workers beyond the scoreboard slot limit to test backpressure handling.
+/// Setting this to 1 ensures at least one worker must wait for a slot, exercising the
+/// semaphore-based flow control in the scoreboard dispatcher.
+const SCOREBOARD_PRESSURE_OVERSUBSCRIPTION: usize = 1;
+const SCOREBOARD_PRESSURE_CONCURRENCY_LIMIT: usize =
+    SCOREBOARD_SLOT_COUNT + SCOREBOARD_PRESSURE_OVERSUBSCRIPTION;
+/// Base value for encoding worker errors in the return value. A return value at or above this
+/// threshold indicates failure, with the error code encoded as
+/// `retval - SCOREBOARD_PRESSURE_ERROR_BASE`.
+const SCOREBOARD_PRESSURE_ERROR_BASE: usize = usize::MAX - 0xFFFF;
 
 //==================================================================================================
 // Globals
 //==================================================================================================
 
 static SCOREBOARD_PRESSURE_PROGRESS: AtomicUsize = AtomicUsize::new(0);
-static SCOREBOARD_PRESSURE_ERROR_CODE: AtomicUsize = AtomicUsize::new(0);
 
 //==================================================================================================
 // Public Functions
@@ -85,47 +96,76 @@ static SCOREBOARD_PRESSURE_ERROR_CODE: AtomicUsize = AtomicUsize::new(0);
 /// Launches enough mmap/munmap workers to over-subscribe the kernel call scoreboard and verify
 /// that concurrent rendezvous slots make forward progress.
 ///
+/// The test uses a batched concurrency model: instead of spawning all workers at once (which could
+/// exhaust system resources), it spawns workers in batches limited by `concurrency_limit`. Each
+/// batch runs to completion before the next batch starts. This ensures that at least
+/// `SCOREBOARD_PRESSURE_OVERSUBSCRIPTION` workers beyond the scoreboard slot limit are active
+/// simultaneously, exercising the semaphore-based backpressure mechanism in the dispatcher.
+///
 /// # Returns
 ///
 /// `Ok(())` on success or an error if thread or kernel call operations fail.
 ///
 pub fn run() -> Result<(), StressError> {
     SCOREBOARD_PRESSURE_PROGRESS.store(0, Ordering::Relaxed);
-    SCOREBOARD_PRESSURE_ERROR_CODE.store(0, Ordering::Relaxed);
 
     let mut capability_guard: CapabilityGuard =
         CapabilityGuard::enable(Capability::MemoryManagement)?;
 
-    let worker_count: usize = cmp::max(SCOREBOARD_SLOT_HINT * 2, MIN_SCOREBOARD_PRESSURE_WORKERS);
+    let worker_count: usize = cmp::max(SCOREBOARD_SLOT_COUNT * 2, MIN_SCOREBOARD_PRESSURE_WORKERS);
+    let desired_concurrency: usize =
+        cmp::max(SCOREBOARD_PRESSURE_CONCURRENCY_LIMIT, MIN_SCOREBOARD_PRESSURE_WORKERS);
+    let concurrency_limit: usize = cmp::min(desired_concurrency, worker_count);
 
-    let mut tids: Vec<ThreadIdentifier> = Vec::with_capacity(worker_count);
-    let mut stacks: Vec<WorkerStack> = Vec::with_capacity(worker_count);
+    let mut tids: Vec<ThreadIdentifier> = Vec::with_capacity(concurrency_limit);
+    let mut stacks: Vec<WorkerStack> = Vec::with_capacity(concurrency_limit);
 
-    for worker_id in 0..worker_count {
-        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
-        let mut args: ThreadCreateArgs = thread_args(&stack, scoreboard_pressure_worker, worker_id);
-        let tid: ThreadIdentifier = create_thread(&mut args)?;
-        tids.push(tid);
-        stacks.push(stack);
-    }
+    let mut next_worker_id: usize = 0;
+    while next_worker_id < worker_count {
+        let batch_size: usize = cmp::min(concurrency_limit, worker_count - next_worker_id);
 
-    for (tid, stack) in tids.into_iter().zip(stacks.into_iter()) {
-        let mut retval: usize = 0;
-        join_thread(tid, &mut retval)?;
-        drop(stack);
-
-        if retval == SCOREBOARD_PRESSURE_FAILURE {
-            let encoded: usize = SCOREBOARD_PRESSURE_ERROR_CODE.swap(0, Ordering::AcqRel);
-            let code = error_code_from_usize(encoded);
-            return Err(Error::new(code, "scoreboard pressure worker failed"));
+        for worker_offset in 0..batch_size {
+            let worker_id: usize = next_worker_id + worker_offset;
+            let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+            let mut args: ThreadCreateArgs =
+                thread_args(&stack, scoreboard_pressure_worker, worker_id);
+            match create_thread(&mut args) {
+                Ok(tid) => {
+                    tids.push(tid);
+                    stacks.push(stack);
+                },
+                Err(e) => {
+                    // Best-effort cleanup: join already-spawned threads before dropping stacks.
+                    for (tid, stack) in tids.drain(..).zip(stacks.drain(..)) {
+                        let mut retval: usize = 0;
+                        let _: Result<(), StressError> = join_thread(tid, &mut retval);
+                        drop(stack);
+                    }
+                    return Err(e);
+                },
+            }
         }
 
-        if retval != SCOREBOARD_PRESSURE_ITERATIONS {
-            return Err(Error::new(
-                ErrorCode::InvalidArgument,
-                "scoreboard pressure worker iterations mismatch",
-            ));
+        for (tid, stack) in tids.drain(..).zip(stacks.drain(..)) {
+            let mut retval: usize = 0;
+            join_thread(tid, &mut retval)?;
+            drop(stack);
+
+            if retval >= SCOREBOARD_PRESSURE_ERROR_BASE {
+                let code: ErrorCode =
+                    error_code_from_usize(retval.wrapping_sub(SCOREBOARD_PRESSURE_ERROR_BASE));
+                return Err(Error::new(code, "scoreboard pressure worker failed"));
+            }
+
+            if retval != SCOREBOARD_PRESSURE_ITERATIONS {
+                return Err(Error::new(
+                    ErrorCode::InvalidArgument,
+                    "scoreboard pressure worker iterations mismatch",
+                ));
+            }
         }
+
+        next_worker_id += batch_size;
     }
 
     let expected_progress: usize = worker_count * SCOREBOARD_PRESSURE_ITERATIONS;
@@ -156,15 +196,12 @@ pub fn run() -> Result<(), StressError> {
 ///
 /// # Returns
 ///
-/// Number of successful iterations performed or `SCOREBOARD_PRESSURE_FAILURE` on error.
+/// Number of successful iterations performed or an encoded error on failure.
 ///
 extern "C" fn scoreboard_pressure_worker(worker_id: usize) -> usize {
     match scoreboard_pressure_worker_impl(worker_id) {
         Ok(iterations) => iterations,
-        Err(err) => {
-            SCOREBOARD_PRESSURE_ERROR_CODE.store(error_code_to_usize(err.code), Ordering::Release);
-            SCOREBOARD_PRESSURE_FAILURE
-        },
+        Err(err) => SCOREBOARD_PRESSURE_ERROR_BASE.wrapping_add(error_code_to_usize(err.code)),
     }
 }
 
@@ -201,6 +238,12 @@ fn scoreboard_pressure_worker_impl(worker_id: usize) -> Result<usize, Error> {
         unsafe {
             let ptr: *mut u8 = exposed_addr_to_mut_u8(addr_raw);
             ptr.write_volatile(byte);
+            // Verify the written value can be read back correctly. This catches potential
+            // result corruption if the scoreboard delivers a result to the wrong dispatcher.
+            let readback: u8 = ptr.read_volatile();
+            if readback != byte {
+                return Err(Error::new(ErrorCode::InvalidArgument, "memory readback mismatch"));
+            }
         }
         munmap(pid, addr)?;
 

--- a/src/tests/stress-rust/src/tests/scoreboard_saturation.rs
+++ b/src/tests/stress-rust/src/tests/scoreboard_saturation.rs
@@ -1,0 +1,615 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::common::{
+    CapabilityGuard,
+    StressError,
+    WorkerStack,
+    error_code_from_usize,
+    error_code_to_usize,
+    exposed_addr_to_mut_u8,
+    thread_args,
+};
+use ::alloc::vec::Vec;
+use ::config::{
+    constants::KILOBYTE,
+    kernel::SCOREBOARD_SLOTS,
+};
+use ::core::{
+    cmp,
+    convert::TryFrom,
+    sync::atomic::{
+        AtomicUsize,
+        Ordering,
+    },
+};
+use ::sys::{
+    config::memory_layout::USER_MMAP_BASE,
+    error::{
+        Error,
+        ErrorCode,
+    },
+    kcall::{
+        mm::{
+            mmap,
+            munmap,
+        },
+        pm::{
+            create_thread,
+            getpid,
+            gettime,
+            join_thread,
+        },
+        sched::sched_yield,
+    },
+    mm::{
+        AccessPermission,
+        VirtualAddress,
+    },
+    pm::{
+        Capability,
+        ProcessIdentifier,
+        ThreadCreateArgs,
+        ThreadIdentifier,
+    },
+    time::SystemTime,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Number of rapid serial iterations per worker in the recycling test.
+const RAPID_RECYCLE_ITERATIONS: usize = 64;
+
+/// Workers for the rapid serial recycling test (single thread exercises slot reuse).
+const RAPID_RECYCLE_WORKERS: usize = 1;
+
+/// Workers for the mixed kcall test -- enough to fill all slots simultaneously.
+const MIXED_KCALL_WORKERS: usize = SCOREBOARD_SLOTS;
+
+/// Iterations per worker in the mixed kcall test.
+const MIXED_KCALL_ITERATIONS: usize = 32;
+
+/// Workers for the full saturation test -- exceeds scoreboard capacity.
+const SATURATION_WORKERS: usize = SCOREBOARD_SLOTS * 3;
+
+/// Iterations per worker in the saturation test.
+const SATURATION_ITERATIONS: usize = 16;
+
+/// Page size used for mmap/munmap operations.
+const PAGE_BYTES: usize = 4 * KILOBYTE;
+
+/// Byte mask for verification patterns.
+const BYTE_MASK: usize = 0xff;
+
+/// Yield cadence mask -- yield every 4th iteration on average.
+const YIELD_MASK: usize = 0x3;
+
+/// Base value for encoding worker errors in the return value. A return value at or above this
+/// threshold indicates failure, with the error code encoded as `retval - WORKER_ERROR_BASE`.
+const WORKER_ERROR_BASE: usize = usize::MAX - 0xFFFF;
+
+/// Region stride to prevent virtual address overlap between workers.
+const REGION_STRIDE_BYTES: usize = PAGE_BYTES * 128;
+
+//==================================================================================================
+// Globals
+//==================================================================================================
+
+/// Tracks total progress across all workers in the current test phase.
+static PROGRESS: AtomicUsize = AtomicUsize::new(0);
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Runs three scoreboard saturation scenarios that complement the backpressure test:
+///
+/// 1. **Rapid serial recycling**: A single thread dispatches many kernel calls in tight succession,
+///    verifying that slot allocation and release cycle correctly without leaks.
+///
+/// 2. **Mixed concurrent kcall types**: Workers issue different kernel call types (`gettime`,
+///    `mmap`/`munmap`) concurrently, exercising the scoreboard with varied kcall numbers flowing
+///    through the same slot pool.
+///
+/// 3. **Full saturation**: Three times the scoreboard capacity worth of workers compete for slots,
+///    pushing the semaphore-based backpressure mechanism to its limits and verifying no deadlocks
+///    or lost wakeups occur under heavy contention.
+///
+/// # Returns
+///
+/// `Ok(())` on success or an error if any scenario fails.
+///
+pub fn run() -> Result<(), StressError> {
+    run_rapid_serial_recycling()?;
+    run_mixed_concurrent_kcalls()?;
+    run_full_saturation()?;
+    Ok(())
+}
+
+//==================================================================================================
+// Scenario 1: Rapid Serial Recycling
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Verifies that a single thread can rapidly dispatch many kernel calls without scoreboard slot
+/// exhaustion. Each mmap/munmap pair exercises the full dispatch-handle-handled-release cycle,
+/// confirming that slot recycling is immediate and correct.
+///
+/// # Returns
+///
+/// `Ok(())` on success or an error if the worker fails.
+///
+fn run_rapid_serial_recycling() -> Result<(), StressError> {
+    reset_globals();
+
+    let mut capability_guard: CapabilityGuard =
+        CapabilityGuard::enable(Capability::MemoryManagement)?;
+
+    let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+    let mut args: ThreadCreateArgs = thread_args(&stack, rapid_recycle_worker, 0);
+    let tid: ThreadIdentifier = create_thread(&mut args)?;
+
+    let mut retval: usize = 0;
+    join_thread(tid, &mut retval)?;
+    drop(stack);
+
+    check_worker_result(retval, RAPID_RECYCLE_ITERATIONS)?;
+    check_progress(RAPID_RECYCLE_WORKERS * RAPID_RECYCLE_ITERATIONS)?;
+
+    capability_guard.disable()?;
+    Ok(())
+}
+
+//==================================================================================================
+// Scenario 2: Mixed Concurrent Kernel Call Types
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Verifies that the scoreboard correctly handles concurrent dispatch of different kernel call
+/// types. Even-numbered workers perform `mmap`/`munmap` cycles while odd-numbered workers call
+/// `gettime` repeatedly, ensuring the scoreboard does not conflate slot states across kcall types.
+///
+/// # Returns
+///
+/// `Ok(())` on success or an error if any worker fails.
+///
+fn run_mixed_concurrent_kcalls() -> Result<(), StressError> {
+    reset_globals();
+
+    let mut capability_guard: CapabilityGuard =
+        CapabilityGuard::enable(Capability::MemoryManagement)?;
+
+    // MIXED_KCALL_WORKERS equals SCOREBOARD_SLOTS by definition; the variable is kept for
+    // clarity and to allow adjusting the constant independently without breaking this call site.
+    let worker_count: usize = MIXED_KCALL_WORKERS;
+    let mut tids: Vec<ThreadIdentifier> = Vec::with_capacity(worker_count);
+    let mut stacks: Vec<WorkerStack> = Vec::with_capacity(worker_count);
+
+    for worker_id in 0..worker_count {
+        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+        let mut args: ThreadCreateArgs = thread_args(&stack, mixed_kcall_worker, worker_id);
+        match create_thread(&mut args) {
+            Ok(tid) => {
+                tids.push(tid);
+                stacks.push(stack);
+            },
+            Err(e) => {
+                // Best-effort cleanup: join already-spawned threads before dropping their stacks.
+                for (tid, stack) in tids.into_iter().zip(stacks.into_iter()) {
+                    let mut retval: usize = 0;
+                    let _: Result<(), StressError> = join_thread(tid, &mut retval);
+                    drop(stack);
+                }
+                return Err(e);
+            },
+        }
+    }
+
+    for (tid, stack) in tids.into_iter().zip(stacks.into_iter()) {
+        let mut retval: usize = 0;
+        join_thread(tid, &mut retval)?;
+        drop(stack);
+        check_worker_result(retval, MIXED_KCALL_ITERATIONS)?;
+    }
+
+    check_progress(worker_count * MIXED_KCALL_ITERATIONS)?;
+
+    capability_guard.disable()?;
+    Ok(())
+}
+
+//==================================================================================================
+// Scenario 3: Full Saturation
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Spawns workers in excess of the scoreboard slot count to confirm that the semaphore-based
+/// backpressure mechanism prevents deadlocks and allows all workers to eventually complete. Workers
+/// are batched at a concurrency level of `SCOREBOARD_SLOTS + 4` to stress the flow-control path.
+///
+/// # Returns
+///
+/// `Ok(())` on success or an error if any worker fails.
+///
+fn run_full_saturation() -> Result<(), StressError> {
+    reset_globals();
+
+    let mut capability_guard: CapabilityGuard =
+        CapabilityGuard::enable(Capability::MemoryManagement)?;
+
+    let worker_count: usize = SATURATION_WORKERS;
+    // Use a higher oversubscription factor than the basic backpressure test.
+    let concurrency_limit: usize = cmp::min(SCOREBOARD_SLOTS + 4, worker_count);
+
+    let mut tids: Vec<ThreadIdentifier> = Vec::with_capacity(concurrency_limit);
+    let mut stacks: Vec<WorkerStack> = Vec::with_capacity(concurrency_limit);
+
+    let mut next_worker_id: usize = 0;
+    while next_worker_id < worker_count {
+        let batch_size: usize = cmp::min(concurrency_limit, worker_count - next_worker_id);
+
+        for worker_offset in 0..batch_size {
+            let worker_id: usize = next_worker_id + worker_offset;
+            let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+            let mut args: ThreadCreateArgs = thread_args(&stack, saturation_worker, worker_id);
+            match create_thread(&mut args) {
+                Ok(tid) => {
+                    tids.push(tid);
+                    stacks.push(stack);
+                },
+                Err(e) => {
+                    // Best-effort cleanup: join already-spawned threads before dropping stacks.
+                    for (tid, stack) in tids.drain(..).zip(stacks.drain(..)) {
+                        let mut retval: usize = 0;
+                        let _: Result<(), StressError> = join_thread(tid, &mut retval);
+                        drop(stack);
+                    }
+                    return Err(e);
+                },
+            }
+        }
+
+        for (tid, stack) in tids.drain(..).zip(stacks.drain(..)) {
+            let mut retval: usize = 0;
+            join_thread(tid, &mut retval)?;
+            drop(stack);
+            check_worker_result(retval, SATURATION_ITERATIONS)?;
+        }
+
+        next_worker_id += batch_size;
+    }
+
+    check_progress(worker_count * SATURATION_ITERATIONS)?;
+
+    capability_guard.disable()?;
+    Ok(())
+}
+
+//==================================================================================================
+// Worker Entry Points
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Entry point for the rapid serial recycling worker.
+///
+/// # Parameters
+///
+/// - `worker_id`: Unique identifier assigned to the worker thread.
+///
+/// # Returns
+///
+/// Number of successful iterations or an encoded error on failure.
+///
+extern "C" fn rapid_recycle_worker(worker_id: usize) -> usize {
+    match rapid_recycle_worker_impl(worker_id) {
+        Ok(iterations) => iterations,
+        Err(err) => WORKER_ERROR_BASE.wrapping_add(error_code_to_usize(err.code)),
+    }
+}
+
+///
+/// # Description
+///
+/// Entry point for mixed kernel call workers.
+///
+/// # Parameters
+///
+/// - `worker_id`: Unique identifier assigned to the worker thread.
+///
+/// # Returns
+///
+/// Number of successful iterations or an encoded error on failure.
+///
+extern "C" fn mixed_kcall_worker(worker_id: usize) -> usize {
+    match mixed_kcall_worker_impl(worker_id) {
+        Ok(iterations) => iterations,
+        Err(err) => WORKER_ERROR_BASE.wrapping_add(error_code_to_usize(err.code)),
+    }
+}
+
+///
+/// # Description
+///
+/// Entry point for full saturation workers.
+///
+/// # Parameters
+///
+/// - `worker_id`: Unique identifier assigned to the worker thread.
+///
+/// # Returns
+///
+/// Number of successful iterations or an encoded error on failure.
+///
+extern "C" fn saturation_worker(worker_id: usize) -> usize {
+    match saturation_worker_impl(worker_id) {
+        Ok(iterations) => iterations,
+        Err(err) => WORKER_ERROR_BASE.wrapping_add(error_code_to_usize(err.code)),
+    }
+}
+
+//==================================================================================================
+// Worker Implementations
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Rapidly maps and unmaps pages in a tight loop to exercise scoreboard slot recycling. Each
+/// iteration is a full round-trip through the scoreboard (dispatch, handle, handled, release).
+///
+/// # Parameters
+///
+/// - `worker_id`: Unique identifier assigned to the worker thread.
+///
+/// # Returns
+///
+/// Total iterations completed on success.
+///
+/// # Errors
+///
+/// Propagates failures from kernel calls or address calculations.
+///
+fn rapid_recycle_worker_impl(worker_id: usize) -> Result<usize, Error> {
+    let pid: ProcessIdentifier = getpid()?;
+    let region_base: usize = worker_region_base(worker_id)?;
+
+    for iteration in 0..RAPID_RECYCLE_ITERATIONS {
+        let addr_raw: usize = region_base + (iteration * PAGE_BYTES);
+        let addr: VirtualAddress = VirtualAddress::from_raw_value(addr_raw);
+
+        // Map, touch, unmap -- three dispatched kcalls per iteration.
+        mmap(pid, addr, AccessPermission::RDWR)?;
+        let byte: u8 = u8::try_from(iteration & BYTE_MASK)
+            .map_err(|_| Error::new(ErrorCode::ValueOutOfRange, "byte overflow"))?;
+        unsafe {
+            let ptr: *mut u8 = exposed_addr_to_mut_u8(addr_raw);
+            ptr.write_volatile(byte);
+        }
+        munmap(pid, addr)?;
+
+        PROGRESS.fetch_add(1, Ordering::AcqRel);
+    }
+
+    Ok(RAPID_RECYCLE_ITERATIONS)
+}
+
+///
+/// # Description
+///
+/// Performs a mix of kernel call types: even-numbered workers map/unmap pages while odd-numbered
+/// workers call `gettime`. This exercises the scoreboard with heterogeneous kcall numbers flowing
+/// through the same slot pool.
+///
+/// # Parameters
+///
+/// - `worker_id`: Unique identifier assigned to the worker thread.
+///
+/// # Returns
+///
+/// Total iterations completed on success.
+///
+/// # Errors
+///
+/// Propagates failures from kernel calls.
+///
+fn mixed_kcall_worker_impl(worker_id: usize) -> Result<usize, Error> {
+    let pid: ProcessIdentifier = getpid()?;
+    let is_memory_worker: bool = worker_id.is_multiple_of(2);
+
+    if is_memory_worker {
+        let region_base: usize = worker_region_base(worker_id)?;
+        for iteration in 0..MIXED_KCALL_ITERATIONS {
+            let addr_raw: usize = region_base + (iteration * PAGE_BYTES);
+            let addr: VirtualAddress = VirtualAddress::from_raw_value(addr_raw);
+
+            mmap(pid, addr, AccessPermission::RDWR)?;
+            munmap(pid, addr)?;
+
+            PROGRESS.fetch_add(1, Ordering::AcqRel);
+
+            if (iteration + worker_id) & YIELD_MASK == 0 {
+                sched_yield()?;
+            }
+        }
+    } else {
+        for iteration in 0..MIXED_KCALL_ITERATIONS {
+            let mut now: SystemTime = SystemTime::default();
+            gettime(&mut now)?;
+
+            PROGRESS.fetch_add(1, Ordering::AcqRel);
+
+            if (iteration + worker_id) & YIELD_MASK == 0 {
+                sched_yield()?;
+            }
+        }
+    }
+
+    Ok(MIXED_KCALL_ITERATIONS)
+}
+
+///
+/// # Description
+///
+/// Performs a tight mmap/munmap loop under heavy contention. Workers exceeding the scoreboard
+/// capacity must wait for a slot via the semaphore, stressing the backpressure mechanism.
+///
+/// # Parameters
+///
+/// - `worker_id`: Unique identifier assigned to the worker thread.
+///
+/// # Returns
+///
+/// Total iterations completed on success.
+///
+/// # Errors
+///
+/// Propagates failures from kernel calls or address calculations.
+///
+fn saturation_worker_impl(worker_id: usize) -> Result<usize, Error> {
+    let pid: ProcessIdentifier = getpid()?;
+    let region_base: usize = worker_region_base(worker_id)?;
+
+    for iteration in 0..SATURATION_ITERATIONS {
+        let addr_raw: usize = region_base + (iteration * PAGE_BYTES);
+        let addr: VirtualAddress = VirtualAddress::from_raw_value(addr_raw);
+
+        mmap(pid, addr, AccessPermission::RDWR)?;
+        let byte_raw: usize = (worker_id ^ iteration) & BYTE_MASK;
+        let byte: u8 = u8::try_from(byte_raw)
+            .map_err(|_| Error::new(ErrorCode::ValueOutOfRange, "byte overflow"))?;
+        unsafe {
+            let ptr: *mut u8 = exposed_addr_to_mut_u8(addr_raw);
+            ptr.write_volatile(byte);
+            let readback: u8 = ptr.read_volatile();
+            if readback != byte {
+                return Err(Error::new(ErrorCode::InvalidArgument, "memory readback mismatch"));
+            }
+        }
+        munmap(pid, addr)?;
+
+        PROGRESS.fetch_add(1, Ordering::AcqRel);
+
+        if (iteration ^ worker_id) & YIELD_MASK == 0 {
+            sched_yield()?;
+        }
+    }
+
+    Ok(SATURATION_ITERATIONS)
+}
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Resets the shared atomic counters before each test scenario.
+///
+fn reset_globals() {
+    PROGRESS.store(0, Ordering::Relaxed);
+}
+
+///
+/// # Description
+///
+/// Validates that a worker returned the expected iteration count.
+///
+/// # Parameters
+///
+/// - `retval`: Value returned by the worker thread.
+/// - `expected`: Expected number of successful iterations.
+///
+/// # Returns
+///
+/// `Ok(())` when validation passes.
+///
+/// # Errors
+///
+/// Returns an error if the worker reported a failure or an iteration count mismatch.
+///
+fn check_worker_result(retval: usize, expected: usize) -> Result<(), StressError> {
+    if retval >= WORKER_ERROR_BASE {
+        let code: ErrorCode = error_code_from_usize(retval.wrapping_sub(WORKER_ERROR_BASE));
+        return Err(Error::new(code, "scoreboard worker failed"));
+    }
+
+    if retval != expected {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "scoreboard worker iterations mismatch",
+        ));
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Validates that the global progress counter matches the expected total.
+///
+/// # Parameters
+///
+/// - `expected`: Expected total progress.
+///
+/// # Returns
+///
+/// `Ok(())` when validation passes.
+///
+/// # Errors
+///
+/// Returns an error if the progress counter does not match.
+///
+fn check_progress(expected: usize) -> Result<(), StressError> {
+    let observed: usize = PROGRESS.load(Ordering::Acquire);
+    if observed != expected {
+        return Err(Error::new(ErrorCode::InvalidArgument, "scoreboard progress mismatch"));
+    }
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Computes the base virtual address for a worker's mapping region to avoid overlap.
+///
+/// # Parameters
+///
+/// - `worker_id`: Unique identifier assigned to the worker thread.
+///
+/// # Returns
+///
+/// Base address for the worker's mapping range.
+///
+/// # Errors
+///
+/// Returns `ValueOutOfRange` when address arithmetic overflows.
+///
+fn worker_region_base(worker_id: usize) -> Result<usize, Error> {
+    let user_base: usize = usize::from(USER_MMAP_BASE);
+    let offset: usize = worker_id
+        .checked_mul(REGION_STRIDE_BYTES)
+        .ok_or_else(|| Error::new(ErrorCode::ValueOutOfRange, "worker offset overflow"))?;
+
+    user_base
+        .checked_add(offset)
+        .ok_or_else(|| Error::new(ErrorCode::ValueOutOfRange, "virtual address overflow"))
+}


### PR DESCRIPTION
This pull request refactors the kernel call scoreboard system to support multiple concurrent kernel calls, improving scalability and concurrency. It introduces a new `ScoreBoard` implementation that manages multiple slots, updates related kernel call dispatch and handler logic to use this new system, and moves the `KcallArgs` struct to its own module. Additionally, configuration and documentation changes align the codebase with these improvements.