### PR TITLE
[build] Fix python-init Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -580,7 +580,10 @@ endif
 PYTHON_VENV_DIRECTORY=$(ROOT_DIR)/venv
 
 python-init:
-	@if [ ! -d $(PYTHON_VENV_DIRECTORY) ]; then python3 -m venv $(PYTHON_VENV_DIRECTORY); fi
+	@if [ ! -f $(PYTHON_VENV_DIRECTORY)/bin/pip3 ]; then \
+		$(FORCE_RM_CMD) $(PYTHON_VENV_DIRECTORY); \
+		python3 -m venv $(PYTHON_VENV_DIRECTORY); \
+	fi
 	@$(PYTHON_VENV_DIRECTORY)/bin/pip3 install "black>=24.0.0" "flake8>=7.0.0" > /dev/null
 
 python-format: python-init


### PR DESCRIPTION
This pull request updates the Python virtual environment initialization logic in the `Makefile` to ensure a clean and consistent setup. The main change is to remove and recreate the virtual environment if the `pip3` binary is missing, which helps prevent issues from corrupted or incomplete environments.