### PR TITLE
[nanvix-sandbox-cache] Prefill Network Namespace Pool

### DIFF
--- a/scripts/run-nanvixd.sh
+++ b/scripts/run-nanvixd.sh
@@ -648,6 +648,7 @@ main() {
         -http-addr "${NANVIXD_SOCKADDR}" \
         -toolchain-bin-dir "${TOOLCHAIN_BIN_DIR}" \
         -log-dir "${logs_dir}" \
+        -netns-pool-size "0" \
         "$([ "$L2_VM" = "yes" ] && echo "-l2")" \
         -console-file "${console_file_name}" &
     NANVIXD_PID=$!

--- a/src/libs/nanvix-http/src/server.rs
+++ b/src/libs/nanvix-http/src/server.rs
@@ -110,9 +110,11 @@ impl<T: Send + Sync + Default + Clone + 'static> HttpServer<T> {
     /// describing what went wrong during server operation.
     ///
     pub async fn run(&mut self) -> Result<()> {
+        // Initialize the sandbox cache before binding the socket, as some setups may use socket
+        // readiness to probe nanvixd's readiness.
+        let sandbox_cache: Arc<Mutex<SandboxCache<T>>> = SandboxCache::new(self.config.clone())?;
         let mut signals: Signal = signal(SignalKind::interrupt())?;
         let http_listener: TcpListener = TcpListener::bind(&self.sockaddr).await?;
-        let sandbox_cache: Arc<Mutex<SandboxCache<T>>> = SandboxCache::new(self.config.clone())?;
 
         loop {
             tokio::select! {

--- a/src/libs/nanvix-sandbox-cache/src/config.rs
+++ b/src/libs/nanvix-sandbox-cache/src/config.rs
@@ -48,6 +48,8 @@ pub struct SandboxCacheConfig<T> {
     console_file: Option<String>,
     /// Optional hardware locality configuration for CPU affinity and topology information.
     hwloc: Option<HwLoc>,
+    /// Number of network namespaces to prefill in the pool (0 enables lazy initialization).
+    netns_pool_size: usize,
     /// Path to kernel binary.
     kernel_binary_path: String,
     /// Path to the Linux Daemon binary.
@@ -92,6 +94,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
     /// - `system_vm_socket_type`: Socket type for system VM communication.
     /// - `console_file`: Optional file path for redirecting console output.
     /// - `hwloc`: Optional hardware locality configuration.
+    /// - `netns_pool_size`: Number of network namespaces to prefill (0 for lazy initialization).
     /// - `kernel_binary_path`: Path to kernel binary.
     /// - `linuxd_binary_path`: Path to the Linux Daemon binary (only if not in single-process mode).
     /// - `uservm_binary_path`: Path to the User VM binary (only if not in single-process mode).
@@ -113,6 +116,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
         system_vm_socket_type: SocketType,
         console_file: Option<String>,
         hwloc: Option<HwLoc>,
+        netns_pool_size: usize,
         kernel_binary_path: &str,
         #[cfg(not(feature = "single-process"))] linuxd_binary_path: &str,
         #[cfg(not(feature = "single-process"))] uservm_binary_path: &str,
@@ -131,6 +135,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
             system_vm_socket_type,
             console_file,
             hwloc,
+            netns_pool_size,
             kernel_binary_path: kernel_binary_path.to_string(),
             #[cfg(not(feature = "single-process"))]
             linuxd_binary_path: linuxd_binary_path.to_string(),
@@ -211,6 +216,19 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
     ///
     pub fn hwloc(&self) -> Option<HwLoc> {
         self.hwloc.clone()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the size of the prefilled network namespace pool.
+    ///
+    /// # Returns
+    ///
+    /// The number of namespaces to prefill (0 for lazy initialization).
+    ///
+    pub fn netns_pool_size(&self) -> usize {
+        self.netns_pool_size
     }
 
     ///

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -199,6 +199,12 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
     /// This function returns an error if network namespace pool initialization fails.
     ///
     pub fn new(config: SandboxCacheConfig<T>) -> Result<Arc<Mutex<Self>>> {
+        #[cfg(not(feature = "single-process"))]
+        let netns_init_strategy: NetnsPoolInitStrategy = match config.netns_pool_size() {
+            0 => NetnsPoolInitStrategy::Lazy,
+            size => NetnsPoolInitStrategy::Prefill(size),
+        };
+
         Ok(Arc::new(Mutex::new(Self {
             config,
             running_sandboxes: HashMap::new(),
@@ -211,7 +217,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                     ::config::linuxd::GATEWAY_PORT_RANGE_BEGIN,
                     ::config::linuxd::GATEWAY_PORT_RANGE_END,
                 )?,
-                NetnsPoolInitStrategy::Lazy,
+                netns_init_strategy,
             )?,
             #[cfg(not(feature = "single-process"))]
             _phantom: PhantomData,
@@ -690,6 +696,7 @@ mod tests {
             SocketType::Unix,
             None,
             None,
+            128,
             &format!("{}/kernel.elf", tmp_dir),
             None,
             &format!("{}/toolchain", tmp_dir),
@@ -718,6 +725,7 @@ mod tests {
             SocketType::Unix,
             None,
             None,
+            0,
             &format!("{}/kernel.elf", tmp_dir),
             &format!("{}/linuxd.elf", tmp_dir),
             &format!("{}/uservm.elf", tmp_dir),
@@ -761,6 +769,7 @@ mod tests {
                 socket_type,
                 console_file,
                 hwloc,
+                128,
                 &format!("{}/kernel.elf", tmp_dir),
                 None,
                 &format!("{}/toolchain", tmp_dir),
@@ -779,6 +788,7 @@ mod tests {
                 socket_type,
                 console_file,
                 hwloc,
+                128,
                 &format!("{}/kernel.elf", tmp_dir),
                 &format!("{}/linuxd.elf", tmp_dir),
                 &format!("{}/uservm.elf", tmp_dir),

--- a/src/libs/nanvix-sandbox/src/netns.rs
+++ b/src/libs/nanvix-sandbox/src/netns.rs
@@ -526,9 +526,26 @@ impl NetnsPool {
 
         // Pre-initialize some namespaces if necessary.
         if let NetnsPoolInitStrategy::Prefill(count) = strategy {
+            // MAX_NAMESPACES is a u32, so we can safely cast to usize.
+            if count > (MAX_NAMESPACES as usize) {
+                let reason: String = format!(
+                    "requested prefilled netns pool size larger than max (req={count}, \
+                     max={MAX_NAMESPACES})"
+                );
+                error!("new(): {reason}");
+                anyhow::bail!(reason);
+            }
+
+            // Allocate all namespaces upfront but keep the handles to make sure we create distinct
+            // namespaces without reuse.
+            let mut handles: Vec<NetnsHandle> = Vec::new();
             for _ in 0..count {
                 let handle: NetnsHandle = inner.allocate_impl()?;
-                // Immediately drop the handle after allocation to return the netns to the pool.
+                handles.push(handle);
+            }
+
+            // Explicitly drop all handles to make sure we return the namespaces to the pool.
+            for handle in handles.drain(..) {
                 drop(handle);
             }
         }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -548,6 +548,9 @@ impl Benchmark {
         linuxd_deployment: &LinuxdDeployment,
         user_vm_deployment: &UserVmDeployment,
     ) -> Result<()> {
+        // Start nanvixd once.
+        self.setup(linuxd_deployment);
+
         // Display a progress bar
         let pb: ProgressBar = ProgressBar::new(self.iterations.try_into().unwrap());
         pb.set_style(
@@ -557,9 +560,6 @@ impl Benchmark {
                 .progress_chars("#>-"),
         );
         pb.set_message("Benchmark progress:");
-
-        // Start nanvixd once.
-        self.setup(linuxd_deployment);
 
         // Work-out the cleanup sleep duration depending on the linuxd deployment mode.
         let cleanup_sleep_duration: Duration = if *linuxd_deployment == LinuxdDeployment::L2Vm {

--- a/src/utils/nanvix-test/src/config.rs
+++ b/src/utils/nanvix-test/src/config.rs
@@ -228,6 +228,8 @@ pub struct RunnerConfig {
     pub nanvixd_ready_attempts_max: usize,
     /// Interval (in milliseconds) between readiness probes for the Nanvix Daemon HTTP endpoint.
     pub nanvixd_ready_retry_interval_ms: u64,
+    /// Netns pool prefill size forwarded to the Nanvix Daemon.
+    pub netns_pool_size: usize,
     /// Milliseconds to wait after tearing down a User VM before spawning the next workload.
     pub cleanup_uservm_sleep_duration_ms: u64,
     /// Milliseconds to wait after tearing down a User VM when L2 mode is enabled.
@@ -318,6 +320,12 @@ impl RunnerConfig {
                 "nanvixd_ready_retry_interval_ms",
                 "runner.nanvixd_ready_retry_interval_ms",
                 default_nanvixd_ready_retry_interval_ms(),
+            )?,
+            netns_pool_size: read_usize_with_default(
+                table,
+                "netns_pool_size",
+                "runner.netns_pool_size",
+                default_netns_pool_size(),
             )?,
             cleanup_uservm_sleep_duration_ms: read_u64_with_default(
                 table,
@@ -665,6 +673,19 @@ fn default_nanvixd_ready_attempts_max() -> usize {
 ///
 fn default_nanvixd_ready_retry_interval_ms() -> u64 {
     DEFAULT_NANVIXD_READY_RETRY_INTERVAL_MS
+}
+
+///
+/// # Description
+///
+/// Returns the default netns pool prefill size for the Nanvix Daemon.
+///
+/// # Return Value
+///
+/// Returns the netns pool size applied when the field is omitted.
+///
+fn default_netns_pool_size() -> usize {
+    ::nanvixd::args::Args::DEFAULT_NETNS_POOL_SIZE
 }
 
 ///

--- a/src/utils/nanvix-test/src/executor/empty.rs
+++ b/src/utils/nanvix-test/src/executor/empty.rs
@@ -64,6 +64,7 @@ pub(crate) async fn empty(
             runner_config.port_num,
             hwloc_file_path.clone(),
             l2_enabled,
+            runner_config.netns_pool_size,
             log_layout.test_directory(),
         )?;
 

--- a/src/utils/nanvix-test/src/executor/http.rs
+++ b/src/utils/nanvix-test/src/executor/http.rs
@@ -110,6 +110,7 @@ pub(crate) async fn test_with_http_executor(
         runner_config.port_num,
         hwloc_file_path.clone(),
         l2_enabled,
+        runner_config.netns_pool_size,
         log_layout.test_directory(),
     )?;
 

--- a/src/utils/nanvix-test/src/nanvixd/http.rs
+++ b/src/utils/nanvix-test/src/nanvixd/http.rs
@@ -113,6 +113,8 @@ impl NanvixdHttp {
         command.stdin(Stdio::null());
         command.stdout(Stdio::from(stdout_file));
         command.stderr(Stdio::from(stderr_file));
+        command.arg(::nanvixd::args::Args::OPT_NETNS_POOL_SIZE);
+        command.arg(nanvixd_args.netns_pool_size().to_string());
         command.arg(::nanvixd::args::Args::OPT_HTTP_SOCKADDR);
         command.arg(http_address.as_str());
 
@@ -238,6 +240,8 @@ pub struct NanvixdHttpArgs {
     ipv4_addr: String,
     /// TCP port bound by the daemon instance.
     port_num: u16,
+    /// Netns pool prefill size forwarded to the Nanvix Daemon.
+    netns_pool_size: usize,
     /// Directory where Nanvix Daemon components should emit logs.
     log_directory: PathBuf,
 }
@@ -256,6 +260,7 @@ impl NanvixdHttpArgs {
     /// - `port_num`: TCP port used by the Nanvix Daemon HTTP interface.
     /// - `hwloc_file_path`: Optional hwloc topology file passed to the Nanvix Daemon.
     /// - `l2`: Flag indicating whether the Nanvix Daemon should enable L2 deployment mode.
+    /// - `netns_pool_size`: Netns pool prefill size forwarded to the Nanvix Daemon.
     /// - `log_directory`: Path where component logs should be persisted.
     ///
     /// # Return Value
@@ -263,6 +268,7 @@ impl NanvixdHttpArgs {
     /// Returns a ready-to-use argument bundle when both log files can be created; returns an error
     /// when the stdout or stderr log file cannot be opened.
     ///
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         stdout_file_path: &Path,
         stderr_file_path: &Path,
@@ -270,6 +276,7 @@ impl NanvixdHttpArgs {
         port_num: u16,
         hwloc_file_path: Option<String>,
         l2: bool,
+        netns_pool_size: usize,
         log_directory: &Path,
     ) -> Result<Self> {
         let stdout_file_handle: File = match OpenOptions::new()
@@ -313,6 +320,7 @@ impl NanvixdHttpArgs {
             l2,
             ipv4_addr: ipv4_addr.to_string(),
             port_num,
+            netns_pool_size,
             log_directory: log_directory.to_path_buf(),
         })
     }
@@ -380,6 +388,19 @@ impl NanvixdHttpArgs {
     ///
     fn port_num(&self) -> u16 {
         self.port_num
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the netns pool prefill size forwarded to the Nanvix Daemon.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the netns pool size.
+    ///
+    fn netns_pool_size(&self) -> usize {
+        self.netns_pool_size
     }
 
     ///

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -52,6 +52,8 @@ pub struct Args {
     console_file: Option<String>,
     /// Optional hardware locality configuration for CPU affinity and topology.
     hwloc: Option<HwLoc>,
+    /// Number of network namespaces to prefill in the pool (0 enables lazy initialization).
+    netns_pool_size: usize,
     /// Directory path for writing log files when log_to_file is enabled.
     log_directory: String,
     /// Flag indicating whether to deploy linuxd inside an L2 VM.
@@ -91,6 +93,10 @@ impl Args {
     pub const OPT_HWLOC: &'static str = "-hwloc";
     /// Command-line option that sets the log directory path.
     pub const OPT_LOG_DIRECTORY: &'static str = "-log-dir";
+    /// Command-line option that sets the network namespace pool size.
+    pub const OPT_NETNS_POOL_SIZE: &'static str = "-netns-pool-size";
+    /// Default netns pool size for prefill mode.
+    pub const DEFAULT_NETNS_POOL_SIZE: usize = 128;
     /// Command-line flag that enables L2 deployment mode.
     pub const OPT_L2: &'static str = "-l2";
     /// Command-line option that sets the control plane socket type.
@@ -132,6 +138,7 @@ impl Args {
             Local::now().format("%Y_%m_%d_%H_%M")
         ));
         let mut hwloc: Option<HwLoc> = None;
+        let mut netns_pool_size: usize = Self::DEFAULT_NETNS_POOL_SIZE;
         let mut log_directory: String = DEFAULT_LOG_DIRECTORY.to_string();
         let mut l2: bool = false;
         let mut l2_snapshot_path: String = String::new();
@@ -214,6 +221,10 @@ impl Args {
                     i += 1;
                     log_directory = args[i].clone();
                 },
+                Self::OPT_NETNS_POOL_SIZE => {
+                    i += 1;
+                    netns_pool_size = args[i].parse()?;
+                },
                 arg => {
                     return Err(anyhow::anyhow!("invalid argument: {arg}"));
                 },
@@ -287,6 +298,7 @@ impl Args {
             l2_snapshot_path,
             console_file,
             hwloc,
+            netns_pool_size,
             log_directory,
             l2,
             control_plane_socket_type,
@@ -326,6 +338,8 @@ Options:
              affinity/topology.
   {log_dir} <log_dir>                       Directory for log files (Default: \
              {DEFAULT_LOG_DIRECTORY}).
+  {netns_pool_size} <size>                  Netns pool prefill size (Default: \
+             {default_netns_pool_size}; 0 enables lazy initialization).
   {control_plane_socket_type} <socket_type> Socket type for control plane communication (nanvixd \
              <-> linuxd).
   {gateway_socket_type} <socket_type>       Socket type for gateway communication (client <-> \
@@ -343,6 +357,8 @@ Options:
             toolchain_bin_dir = Self::OPT_TOOLCHAIN_BIN_DIRECTORY,
             hwloc = Self::OPT_HWLOC,
             log_dir = Self::OPT_LOG_DIRECTORY,
+            netns_pool_size = Self::OPT_NETNS_POOL_SIZE,
+            default_netns_pool_size = Self::DEFAULT_NETNS_POOL_SIZE,
             control_plane_socket_type = Self::OPT_CONTROL_PLANE_SOCKET_TYPE,
             gateway_socket_type = Self::OPT_GATEWAY_SOCKET_TYPE,
             system_vm_socket_type = Self::OPT_SYSTEM_VM_SOCKET_TYPE,
@@ -453,6 +469,19 @@ Options:
     ///
     pub fn log_directory(&self) -> &str {
         &self.log_directory
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the netns pool prefill size.
+    ///
+    /// # Returns
+    ///
+    /// The prefill size (0 for lazy initialization).
+    ///
+    pub fn netns_pool_size(&self) -> usize {
+        self.netns_pool_size
     }
 
     ///

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -153,6 +153,7 @@ pub async fn main() -> Result<()> {
         args.system_vm_socket_type(),
         args.console_file().clone(),
         args.hwloc().clone(),
+        args.netns_pool_size(),
         &kernel_binary_path,
         #[cfg(not(feature = "single-process"))]
         &linuxd_binary_path,

--- a/test/test-l2.toml
+++ b/test/test-l2.toml
@@ -14,6 +14,7 @@ nanvixd_shutdown_attempts_max = 10
 nanvixd_shutdown_retry_interval_ms = 100
 nanvixd_ready_attempts_max = 50
 nanvixd_ready_retry_interval_ms = 100
+netns_pool_size = 0
 cleanup_uservm_sleep_duration_ms = 10
 cleanup_l2_uservm_sleep_duration_ms = 100
 stream_collection_timeout_ms = 300000

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -14,6 +14,7 @@ nanvixd_shutdown_attempts_max = 10
 nanvixd_shutdown_retry_interval_ms = 100
 nanvixd_ready_attempts_max = 50
 nanvixd_ready_retry_interval_ms = 100
+netns_pool_size = 0
 cleanup_uservm_sleep_duration_ms = 10
 cleanup_l2_uservm_sleep_duration_ms = 100
 stream_collection_timeout_ms = 300000


### PR DESCRIPTION
In this PR I configure the sandbox cache to prefill a network namespace pool upon nanvixd start-up. This applies only to HTTP mode.

I expose the size of the pool as a CLI argument to `nanvixd`, `-netns-pool-size` that has a default value of `128`. Setting the value to `0` reverts to the `Lazy` initialization strategy that we were using until now.

In the process I fixed two bugs:
* In nanvixd HTTP mode, the sandbox cache must be initialized _before_ binding to the HTTP server's listener socket. Otherwise clients will try to send requests before nanvixd is ready. I should say nanvixd, given its conservative locking, was resilient to such a situation, but produced counterintuitive results.
* When prefilling the netns pool, we were dropping the handle immediately after creation, which meant that we were effectively only creating one new namespace, and reusing it for subsequent invocations.

Creating `128` network namespaces upfront takes a bit over 10 seconds in my dev server.