### PR TITLE
[ci] Cache CI Artifacts

### DIFF
--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -63,6 +63,16 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: "Cache Cargo Target"
+      uses: actions/cache@v5
+      with:
+        path: target
+        key: ${{ runner.os }}-benchmark-target-${{ matrix.arch }}-${{ matrix.build-type }}
+        restore-keys: |
+          ${{ runner.os }}-benchmark-target-${{ matrix.arch }}-${{ matrix.build-type }}
+          ${{ runner.os }}-benchmark-target-${{ matrix.arch }}
+          ${{ runner.os }}-benchmark-target
+
     - name: "Benchmark"
       uses: ./.github/actions/benchmark
       with:

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -76,6 +76,27 @@ jobs:
         set -Eeuo pipefail
         ln -sfn "${HOME}/toolchain" toolchain
 
+    - name: "Cache Cargo Target"
+      uses: actions/cache@v5
+      with:
+        path: target
+        key: ${{ runner.os }}-ci-target-${{ matrix.machine-type }}-${{ matrix.deployment-type }}-${{ matrix.build-type }}
+        restore-keys: |
+          ${{ runner.os }}-ci-target-${{ matrix.machine-type }}-${{ matrix.deployment-type }}-${{ matrix.build-type }}
+          ${{ runner.os }}-ci-target-${{ matrix.machine-type }}-${{ matrix.deployment-type }}
+          ${{ runner.os }}-ci-target
+
+    - name: "Cache Optional Sysroots"
+      uses: actions/cache@v5
+      with:
+        path: |
+          sysroot-debug
+          sysroot-release
+        key: ${{ runner.os }}-ci-sysroot-${{ matrix.build-type }}-${{ hashFiles('Makefile', 'scripts/build-opt.sh', 'scripts/common/logging.sh', 'scripts/common/utils.sh') }}
+        restore-keys: |
+          ${{ runner.os }}-ci-sysroot-${{ matrix.build-type }}-
+          ${{ runner.os }}-ci-sysroot-
+
     - name: "Check Code Format"
       uses: ./.github/actions/format
       with:


### PR DESCRIPTION
This pull request improves the efficiency of the self-hosted CI and benchmark GitHub Actions workflows by adding caching for build artifacts and sysroots. These changes are designed to speed up workflow runs by reusing previously built files, reducing redundant work and saving time on subsequent runs.

**Workflow caching improvements:**

* Added a `Cache Cargo Target` step to both `.github/workflows/self-hosted-benchmark.yml` and `.github/workflows/self-hosted-ci.yml` to cache the `target` directory, which stores Rust build artifacts, using keys that depend on the OS, architecture, build type, and relevant lock files. [[1]](diffhunk://#diff-331a9af7ea0111e347b5a567d95dbb846cab81450473315ff4a7031a956144efR66-R88) [[2]](diffhunk://#diff-598919e7d0679a7709fe217f0503ddd3e8475c855ae4d62cf26e65978d484811R79-R88)
* Added a `Cache Optional Sysroots` step to `.github/workflows/self-hosted-benchmark.yml` to cache sysroot directories, with cache keys based on the OS, architecture, build type, and relevant script files.