### PR TITLE
[ci] Fix Artifact Caching

### DIFF
--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -64,6 +64,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: "Cache Cargo Target"
+      id: cache-target
       uses: actions/cache@v5
       with:
         path: target
@@ -152,6 +153,13 @@ jobs:
         sudo find /tmp -maxdepth 1 -name 'nvx*' -print || true
         sudo find /tmp -maxdepth 2 -name 'nanvixd-clh.*' -print || true
         echo '::endgroup::'
+
+    - name: "Save Cargo Target Cache"
+      if: ${{ always() && steps.cache-target.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v5
+      with:
+        path: target
+        key: ${{ runner.os }}-benchmark-target-${{ matrix.arch }}-${{ matrix.build-type }}
 
 
     - name: "Cleanup Dangling Resources"

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -77,6 +77,7 @@ jobs:
         ln -sfn "${HOME}/toolchain" toolchain
 
     - name: "Cache Cargo Target"
+      id: cache-target
       uses: actions/cache@v5
       with:
         path: target
@@ -87,6 +88,7 @@ jobs:
           ${{ runner.os }}-ci-target
 
     - name: "Cache Optional Sysroots"
+      id: cache-sysroot
       uses: actions/cache@v5
       with:
         path: |
@@ -198,6 +200,22 @@ jobs:
         sudo find /tmp -maxdepth 1 -name 'nvx*' -print || true
         sudo find /tmp -maxdepth 2 -name 'nanvixd-clh.*' -print || true
         echo '::endgroup::'
+
+    - name: "Save Cargo Target Cache"
+      if: ${{ always() && steps.cache-target.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v5
+      with:
+        path: target
+        key: ${{ runner.os }}-ci-target-${{ matrix.machine-type }}-${{ matrix.deployment-type }}-${{ matrix.build-type }}
+
+    - name: "Save Optional Sysroots Cache"
+      if: ${{ always() && steps.cache-sysroot.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v5
+      with:
+        path: |
+          sysroot-debug
+          sysroot-release
+        key: ${{ runner.os }}-ci-sysroot-${{ matrix.build-type }}-${{ hashFiles('Makefile', 'scripts/build-opt.sh', 'scripts/common/logging.sh', 'scripts/common/utils.sh') }}
 
     - id: release-archive
       name: "Create Release Archive"


### PR DESCRIPTION
This pull request enhances the caching strategy in the self-hosted CI and benchmark GitHub Actions workflows. The main improvements are the addition of explicit cache save steps for both Cargo build artifacts and optional sysroots, as well as the introduction of step IDs for cache actions to enable conditional cache saving. These changes aim to improve build efficiency and reliability by ensuring that caches are saved even if previous steps fail.