### PR TITLE
[ci] Save Artifacts Only for `dev` Branch

### DIFF
--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -155,7 +155,7 @@ jobs:
         echo '::endgroup::'
 
     - name: "Save Cargo Target Cache"
-      if: ${{ always() && steps.cache-target.outputs.cache-hit != 'true' }}
+      if: ${{ always() && github.ref == 'refs/heads/dev' && steps.cache-target.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v5
       with:
         path: target

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -203,14 +203,14 @@ jobs:
         echo '::endgroup::'
 
     - name: "Save Cargo Target Cache"
-      if: ${{ always() && steps.cache-target.outputs.cache-hit != 'true' }}
+      if: ${{ always() && github.ref == 'refs/heads/dev' && steps.cache-target.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v5
       with:
         path: target
         key: ${{ runner.os }}-ci-target-${{ matrix.machine-type }}-${{ matrix.deployment-type }}-${{ matrix.build-type }}
 
     - name: "Save Optional Sysroots Cache"
-      if: ${{ always() && steps.cache-sysroot.outputs.cache-hit != 'true' }}
+      if: ${{ always() && github.ref == 'refs/heads/dev' && steps.cache-sysroot.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v5
       with:
         path: |


### PR DESCRIPTION
This pull request updates the caching conditions in the GitHub Actions workflows for both the benchmark and CI pipelines. Now, the cache for build artifacts and sysroots will only be saved when running on the `dev` branch, rather than on all branches.