### PR TITLE
[ci] Adding `strace` Utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
         "src/utils/nanvix-bench",
         "src/utils/nanvix-test",
         "src/utils/nanvixd",
+        "src/utils/strace",
 ]
 
 [workspace.package]
@@ -76,6 +77,10 @@ bitmap = { path = "src/libs/bitmap", default-features = false }
 cc = "1.2.26"
 cfg-if = "1.0.0"
 chrono = "0.4.42"
+clap = { version = "4.5.20", default-features = false, features = [
+        "derive",
+        "std",
+] }
 compiler_builtins = "0.1.160"
 config = { path = "src/libs/config", default-features = false }
 control-plane-api = { path = "src/libs/control-plane-api", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
         "src/libs/syscall",
         "src/libs/syscomm",
         "src/libs/syslog",
+        "src/libs/syslog-macros",
         "src/libs/libc_stdlib",
         "src/libs/libc_string",
         "src/libs/sys",
@@ -138,6 +139,7 @@ sysalloc = { path = "src/libs/sysalloc", default-features = false }
 syscall = { path = "src/libs/syscall", default-features = false }
 syscomm = { path = "src/libs/syscomm", default-features = false }
 syslog = { path = "src/libs/syslog", default-features = false }
+syslog-macros = { path = "src/libs/syslog-macros", default-features = false }
 talc = { git = "https://github.com/nanvix/talc", rev = "12e66643796be912933a369a2d556aaac4c68771", default-features = false, package = "talc" }
 tokio = { version = "1.45.1", default-features = false }
 toml = { version = "0.9.10", default-features = false, features = [

--- a/Makefile
+++ b/Makefile
@@ -313,8 +313,8 @@ export NANVIXD_SOCKADDR := $(if $(filter yes,$(RELEASE)),127.0.0.1:8181,127.0.0.
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix
-ALL_GUEST_RUST_LIBS := arch bitmap config elf error type-safe nvx proc raw-array slab static_assert sysapi syscall sysalloc syslog sys libc_stdlib libc_string
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap config elf error type-safe proc raw-array slab static_assert libc_string syslog
+ALL_GUEST_RUST_LIBS := arch bitmap config elf error type-safe nvx proc raw-array slab static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap config elf error type-safe proc raw-array slab static_assert libc_string syslog-macros syslog
 
 ALL_GUEST_DAEMONS := memd procd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd

--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 ALL_HOST_RUST_LIBS := control-plane-api hwloc profiler nanvix nanvix-http nanvix-registry nanvix-sandbox nanvix-sandbox-cache nanvix-terminal syscomm user-vm-api
-ALL_HOST_UTILS := echo-client
+ALL_HOST_UTILS := echo-client strace
 ALL_HOST_DAEMONS := linuxd
 ALL_HOST_BINARIES := $(ALL_HOST_UTILS) $(ALL_HOST_DAEMONS)
 else

--- a/build/make/generic-host-binaries.mk
+++ b/build/make/generic-host-binaries.mk
@@ -1,18 +1,22 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
-HOST_FEATURES :=
-HOST_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
-HOST_FEATURES := $(strip $(HOST_FEATURES))
-HOST_CARGO_FEATURES := $(if $(HOST_FEATURES),--features "$(HOST_FEATURES)")
+HOST_COMMON_FEATURES :=
+HOST_COMMON_FEATURES := $(strip $(HOST_COMMON_FEATURES))
+
+HOST_BINARIES_FEATURES.nanvix-bench += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
+HOST_BINARIES_FEATURES.linuxd += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
+
+host_binary_features = $(strip $(HOST_COMMON_FEATURES) $(HOST_BINARIES_FEATURES.$1))
+host_cargo_features = $(if $1,--features "$1")
 
 define HOST_BINARY_RULES
 all-host-binaries-$(1): init
-	$(HOST_CARGO_BUILD_CMD) $(HOST_CARGO_FEATURES) -p $(1)
+	$(HOST_CARGO_BUILD_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1)
 	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/$(1) $(BINARIES_DIR)/$(1).elf
 
 check-host-binaries-$(1):
-	$(HOST_CARGO_CHECK_CMD) $(HOST_CARGO_FEATURES) -p $(1)
+	$(HOST_CARGO_CHECK_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1)
 
 format-host-binaries-$(1):
 	$(HOST_CARGO_FMT_CMD) -p $(1)
@@ -25,10 +29,10 @@ clean-host-binaries-$(1):
 	$(RM_CMD) $(BINARIES_DIR)/$(1).elf
 
 rust-lint-host-binaries-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) $(HOST_CARGO_FEATURES) -p $(1) --fix --allow-dirty
+	$(HOST_CARGO_CLIPPY_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1) --fix --allow-dirty
 
 rust-lint-check-host-binaries-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) $(HOST_CARGO_FEATURES) -p $(1) -- -D warnings
+	$(HOST_CARGO_CLIPPY_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1) -- -D warnings
 endef
 
 $(foreach target,$(ALL_HOST_BINARIES),$(eval $(call HOST_BINARY_RULES,$(target))))

--- a/src/libs/posix/src/arpa/inet.rs
+++ b/src/libs/posix/src/arpa/inet.rs
@@ -16,6 +16,7 @@ use ::sysapi::{
     netinet_in::in_addr_t,
     sys_socket::socklen_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -43,8 +44,8 @@ use ::sysapi::{
 /// - `cp` points to a valid null-terminated string.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn inet_addr(cp: *const c_char) -> in_addr_t {
-    ::syslog::trace!("inet_addr(): cp={cp:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/594.
     ::syslog::debug!("inet_addr(): not implemented");
     in_addr_t::MAX
@@ -69,8 +70,8 @@ pub unsafe extern "C" fn inet_addr(cp: *const c_char) -> in_addr_t {
 /// This function is unsafe because it may return a pointer to a static buffer and does not guarantee thread safety.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn inet_ntoa(in_addr: in_addr_t) -> *const c_char {
-    ::syslog::trace!("inet_ntoa(): in_addr={in_addr:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/595.
     ::syslog::debug!("inet_ntoa(): not implemented");
     core::ptr::null()
@@ -102,13 +103,13 @@ pub unsafe extern "C" fn inet_ntoa(in_addr: in_addr_t) -> *const c_char {
 /// - `dst` points to a valid buffer of at least `size` bytes.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn inet_ntop(
     af: c_int,
     src: *const c_void,
     dst: *mut c_char,
     size: socklen_t,
 ) -> *const c_char {
-    ::syslog::trace!("inet_ntop(): af={af:?}, src={src:?}, dst={dst:?}, size={size:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/592.
     ::syslog::debug!("inet_ntop(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
@@ -140,8 +141,8 @@ pub unsafe extern "C" fn inet_ntop(
 /// - `dst` points to a valid buffer for the binary address.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn inet_pton(af: c_int, src: *const c_char, dst: *mut c_void) -> c_int {
-    ::syslog::trace!("inet_pton(): af={af:?}, src={src:?}, dst={dst:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/593.
     ::syslog::debug!("inet_pton(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();

--- a/src/libs/posix/src/dlfcn/mod.rs
+++ b/src/libs/posix/src/dlfcn/mod.rs
@@ -33,6 +33,7 @@ use ::syscall::dlfcn::{
     DlHandle,
     DlInfo,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // DlError
@@ -137,9 +138,8 @@ static DL_LAST_ERROR: Mutex<DlError> = Mutex::new(DlError::new());
 /// - No other thread modifies the error state while this function is being executed.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn dladdr(addr: *const c_void, dlip: *mut DlInfo) -> i32 {
-    ::syslog::trace!("dladdr(): addr = {:?}, dlip = {:?}", addr, dlip);
-
     // Check if `addr` is not valid.
     if addr.is_null() {
         let reason: &str = "addr is null";
@@ -195,8 +195,8 @@ pub unsafe extern "C" fn dladdr(addr: *const c_void, dlip: *mut DlInfo) -> i32 {
 /// - No other thread modifies the error state while this function is being executed.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn dlclose(handle: *mut c_void) -> i32 {
-    ::syslog::trace!("dlclose(): handle = {:?}", handle);
     // Check if handle is not valid.
     if handle.is_null() {
         let reason: &str = "handle is null";
@@ -235,6 +235,7 @@ pub unsafe extern "C" fn dlclose(handle: *mut c_void) -> i32 {
 /// - No other thread modifies the error state while this function is being executed.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn dlerror() -> *mut c_char {
     // Get the last error message.
     match DL_LAST_ERROR.lock().take() {
@@ -269,9 +270,8 @@ pub unsafe extern "C" fn dlerror() -> *mut c_char {
 /// - No other thread modifies the error state while this function is being executed.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn dlopen(filename: *const c_char, mode: c_int) -> *mut c_void {
-    ::syslog::trace!("dlopen(): filename = {:?}, mode = {}", filename, mode);
-
     // Check if filename is not valid.
     if filename.is_null() {
         let reason: &str = "filename is null";
@@ -348,9 +348,8 @@ pub unsafe extern "C" fn dlopen(filename: *const c_char, mode: c_int) -> *mut c_
 /// - No other thread modifies the error state while this function is being executed.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void {
-    ::syslog::trace!("dlsym(): handle = {:?}, symbol = {:?}", handle, symbol);
-
     // Check if handle is not valid.
     if handle.is_null() {
         let reason: &str = "handle is null";

--- a/src/libs/posix/src/dummy.rs
+++ b/src/libs/posix/src/dummy.rs
@@ -12,6 +12,7 @@ use ::sysapi::ffi::{
     c_int,
     c_void,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -45,8 +46,8 @@ use ::sysapi::ffi::{
 /// null-terminated C strings.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn popen(command: *const c_char, mode: *const c_char) -> *mut c_void {
-    ::syslog::trace!("popen(): command={command:?}, mode={mode:?}");
     ::syslog::debug!("popen(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     core::ptr::null_mut()
@@ -79,8 +80,8 @@ pub unsafe extern "C" fn popen(command: *const c_char, mode: *const c_char) -> *
 /// returned by [`popen()`] in a future, fully implemented version.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pclose(stream: *mut c_void) -> c_int {
-    ::syslog::trace!("pclose(): stream={stream:?}");
     ::syslog::debug!("pclose(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
@@ -114,8 +115,8 @@ pub unsafe extern "C" fn pclose(stream: *mut c_void) -> c_int {
 /// enough to hold a termios structure in a future, fully implemented version.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn tcgetattr(fd: c_int, termios_p: *mut c_void) -> c_int {
-    ::syslog::trace!("tcgetattr(): fd={fd}, termios_p={termios_p:?}");
     ::syslog::debug!("tcgetattr(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
@@ -150,14 +151,12 @@ pub unsafe extern "C" fn tcgetattr(fd: c_int, termios_p: *mut c_void) -> c_int {
 /// a termios structure in a future, fully implemented version.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn tcsetattr(
     fd: c_int,
     optional_actions: c_int,
     termios_p: *const c_void,
 ) -> c_int {
-    ::syslog::trace!(
-        "tcsetattr(): fd={fd}, optional_actions={optional_actions}, termios_p={termios_p:?}"
-    );
     ::syslog::debug!("tcsetattr(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
@@ -193,8 +192,8 @@ pub unsafe extern "C" fn tcsetattr(
 /// C strings and a null-terminated vector, respectively.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char) -> c_int {
-    ::syslog::trace!("execvp(): file={file:?}, argv={argv:?}");
     ::syslog::debug!("execvp(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1
@@ -231,8 +230,8 @@ pub unsafe extern "C" fn execvp(file: *const c_char, argv: *const *const c_char)
 /// canonical path in a future, fully implemented version.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn realpath(path: *const c_char, resolved_path: *mut c_char) -> *mut c_char {
-    ::syslog::trace!("realpath(): path={path:?}, resolved_path={resolved_path:?}");
     ::syslog::debug!("realpath(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     core::ptr::null_mut()
@@ -278,12 +277,12 @@ pub unsafe extern "C" fn realpath(path: *const c_char, resolved_path: *mut c_cha
 /// function with the expected signature in a future, fully implemented version.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn ftw(
     dirpath: *const c_char,
     fn_cb: Option<unsafe extern "C" fn(*const c_char, *const c_void, c_int) -> c_int>,
     nopenfd: c_int,
 ) -> c_int {
-    ::syslog::trace!("ftw(): dirpath={dirpath:?}, fn_cb={:?}, nopenfd={nopenfd}", fn_cb);
     ::syslog::debug!("ftw(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();
     -1

--- a/src/libs/posix/src/lib.rs
+++ b/src/libs/posix/src/lib.rs
@@ -18,6 +18,9 @@ extern crate nvx;
 
 extern crate alloc;
 
+#[cfg(feature = "syscall")]
+extern crate syslog;
+
 // Address and routing parameter area.
 pub mod arpa;
 

--- a/src/libs/posix/src/netdb.rs
+++ b/src/libs/posix/src/netdb.rs
@@ -16,6 +16,10 @@ use ::sysapi::{
     sys_socket::socklen_t,
     sys_types::c_size_t,
 };
+use ::syslog::{
+    trace_libcall,
+    trace_syscall,
+};
 
 //==================================================================================================
 // Standalone Functions
@@ -42,8 +46,8 @@ use ::sysapi::{
 /// - `res` points to a valid linked list of addrinfo structures previously allocated by `getaddrinfo()`.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn freeaddrinfo(res: *mut addrinfo) {
-    ::syslog::trace!("freeaddrinfo(): res={res:?}");
     ::syslog::debug!("freeaddrinfo(): not implemented");
 }
 
@@ -74,15 +78,13 @@ pub unsafe extern "C" fn freeaddrinfo(res: *mut addrinfo) {
 /// - `res` points to a valid pointer to store the result.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn getaddrinfo(
     node: *const c_char,
     service: *const c_char,
     hints: *const addrinfo,
     res: *mut *mut addrinfo,
 ) -> c_int {
-    ::syslog::trace!(
-        "getaddrinfo(): node={node:?}, service={service:?}, hints={hints:?}, res={res:?}"
-    );
     ::syslog::debug!("getaddrinfo(): not implemented");
     ErrorCode::InvalidSysCall.get()
 }
@@ -110,12 +112,12 @@ pub unsafe extern "C" fn getaddrinfo(
 /// - `addr` points to a valid network address of length `len`.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn gethostbyaddr(
     addr: *const c_void,
     len: c_size_t,
     type_: c_int,
 ) -> *mut c_void {
-    ::syslog::trace!("gethostbyaddr(): addr={addr:?}, len={len:?}, type_={type_:?}");
     ::syslog::debug!("gethostbyaddr(): not implemented");
     ::core::ptr::null_mut()
 }
@@ -141,8 +143,8 @@ pub unsafe extern "C" fn gethostbyaddr(
 /// - `name` points to a valid null-terminated string.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn gethostbyname(name: *const c_char) -> *mut c_void {
-    ::syslog::trace!("gethostbyname(): name={name:?}");
     ::syslog::debug!("gethostbyname(): not implemented");
     ::core::ptr::null_mut()
 }
@@ -168,8 +170,8 @@ pub unsafe extern "C" fn gethostbyname(name: *const c_char) -> *mut c_void {
 /// - `name` points to a valid null-terminated string.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn getprotobyname(name: *const c_char) -> *mut c_void {
-    ::syslog::trace!("getprotobyname(): name={name:?}");
     ::syslog::debug!("getprotobyname(): not implemented");
     ::core::ptr::null_mut()
 }
@@ -196,8 +198,8 @@ pub unsafe extern "C" fn getprotobyname(name: *const c_char) -> *mut c_void {
 /// - `name` and `proto` point to valid null-terminated strings.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn getservbyname(name: *const c_char, proto: *const c_char) -> *mut c_void {
-    ::syslog::trace!("getservbyname(): name={name:?}, proto={proto:?}");
     ::syslog::debug!("getservbyname(): not implemented");
     ::core::ptr::null_mut()
 }
@@ -224,8 +226,8 @@ pub unsafe extern "C" fn getservbyname(name: *const c_char, proto: *const c_char
 /// - `proto` points to a valid null-terminated string.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn getservbyport(port: c_int, proto: *const c_char) -> *mut c_void {
-    ::syslog::trace!("getservbyport(): port={port:?}, proto={proto:?}");
     ::syslog::debug!("getservbyport(): not implemented");
     ::core::ptr::null_mut()
 }
@@ -258,6 +260,7 @@ pub unsafe extern "C" fn getservbyport(port: c_int, proto: *const c_char) -> *mu
 /// - `host` and `serv` point to valid buffers of length `hostlen` and `servlen`, respectively.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn getnameinfo(
     sa: *const c_void,
     salen: socklen_t,
@@ -267,10 +270,6 @@ pub unsafe extern "C" fn getnameinfo(
     servlen: socklen_t,
     flags: c_int,
 ) -> c_int {
-    ::syslog::trace!(
-        "getnameinfo(): sa={sa:?}, salen={salen:?}, host={host:?}, hostlen={hostlen:?}, \
-         serv={serv:?}, servlen={servlen:?}, flags={flags:?}"
-    );
     ::syslog::debug!("getnameinfo(): not implemented");
     ErrorCode::InvalidSysCall.get()
 }
@@ -295,8 +294,8 @@ pub unsafe extern "C" fn getnameinfo(
 /// It is safe to call this function with any valid error code.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn gai_strerror(errcode: c_int) -> *const c_char {
-    ::syslog::trace!("gai_strerror(): errcode={errcode:?}");
     ::syslog::debug!("gai_strerror(): not implemented");
     ::core::ptr::null()
 }
@@ -317,8 +316,8 @@ pub unsafe extern "C" fn gai_strerror(errcode: c_int) -> *const c_char {
 /// It is safe to call this function if the caller expects a pointer to a thread-local or global error variable.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn __h_errno() -> *mut c_int {
-    ::syslog::trace!("__h_errno()");
     ::syslog::debug!("__h_errno(): not implemented");
     ::core::ptr::null_mut()
 }

--- a/src/libs/posix/src/pthread/mod.rs
+++ b/src/libs/posix/src/pthread/mod.rs
@@ -484,13 +484,12 @@ pub unsafe extern "C" fn pthread_attr_setguardsize(
 ///
 /// # Description
 ///
-/// Sets the scheduling parameters of a thread.
+/// Sets the scheduling parameters stored in a thread attributes object.
 ///
 /// # Parameters
 ///
-/// - `thread`: Thread identifier.
-/// - `policy`: Scheduling policy.
-/// - `param`: Scheduling parameters.
+/// - `attr`: Thread attributes object to update.
+/// - `param`: Scheduling parameters to store in `attr`.
 ///
 /// # Returns
 ///
@@ -502,15 +501,21 @@ pub unsafe extern "C" fn pthread_attr_setguardsize(
 ///
 /// It is safe to call this function if the following conditions are met:
 ///
+/// - `attr` points to a valid `pthread_attr_t` structure.
 /// - `param` points to a valid `sched_param` structure.
 ///
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_setschedparam(
-    thread: pthread_t,
-    policy: c_int,
+    attr: *mut pthread_attr_t,
     param: *const sched_param,
 ) -> c_int {
+    // Check if `attr` is not valid.
+    if attr.is_null() {
+        ::syslog::error!("pthread_attr_setschedparam(): invalid attribute pointer");
+        return ErrorCode::InvalidArgument.get();
+    }
+
     // Check if `param` is not valid.
     if param.is_null() {
         ::syslog::error!("pthread_attr_setschedparam(): invalid sched param pointer");

--- a/src/libs/posix/src/pthread/mod.rs
+++ b/src/libs/posix/src/pthread/mod.rs
@@ -25,6 +25,7 @@ use ::sysapi::{
 use ::syscall::pthread::{
     self,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Modules
@@ -64,16 +65,11 @@ pub mod tda;
 /// - `detachstate` points to a valid `c_int` variable.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_getdetachstate(
     attr: *const pthread_attr_t,
     detachstate: *mut c_int,
 ) -> c_int {
-    ::syslog::trace!(
-        "pthread_attr_getdetachstate(): attr={:?}, detachstate={:?}",
-        attr,
-        detachstate
-    );
-
     // Check if `attr` is not valid.
     if attr.is_null() {
         ::syslog::error!("pthread_attr_getdetachstate(): invalid attribute pointer");
@@ -120,12 +116,11 @@ pub unsafe extern "C" fn pthread_attr_getdetachstate(
 /// - `guardsize` points to a valid `size_t` variable.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_getguardsize(
     attr: *const pthread_attr_t,
     guardsize: *mut c_size_t,
 ) -> c_int {
-    ::syslog::trace!("pthread_attr_getguardsize(): attr={:?}, guardsize={:?}", attr, guardsize);
-
     // Check if `attr` is not valid.
     if attr.is_null() {
         ::syslog::error!("pthread_attr_getguardsize(): invalid attribute pointer");
@@ -172,12 +167,11 @@ pub unsafe extern "C" fn pthread_attr_getguardsize(
 /// - `param` points to a valid `sched_param` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_getschedparam(
     attr: *const pthread_attr_t,
     param: *mut sched_param,
 ) -> c_int {
-    ::syslog::trace!("pthread_attr_getschedparam(): attr={:?}, param={:?}", attr, param);
-
     // Check if `attr` is not valid.
     if attr.is_null() {
         ::syslog::error!("pthread_attr_getschedparam(): invalid attribute pointer");
@@ -224,12 +218,11 @@ pub unsafe extern "C" fn pthread_attr_getschedparam(
 /// - `stackaddr` points to a valid `*mut c_void` variable.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_getstackaddr(
     attr: *const pthread_attr_t,
     stackaddr: *mut *mut c_void,
 ) -> c_int {
-    ::syslog::trace!("pthread_attr_getstackaddr(): attr={:?}, stackaddr={:?}", attr, stackaddr);
-
     // Check if `attr` is not valid.
     if attr.is_null() {
         ::syslog::error!("pthread_attr_getstackaddr(): invalid attribute pointer");
@@ -276,12 +269,11 @@ pub unsafe extern "C" fn pthread_attr_getstackaddr(
 /// - `stacksize` points to a valid `size_t` variable.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_getstacksize(
     attr: *const pthread_attr_t,
     stacksize: *mut c_size_t,
 ) -> c_int {
-    ::syslog::trace!("pthread_attr_getstacksize(): attr={:?}, stacksize={:?}", attr, stacksize);
-
     // Check if `attr` is not valid.
     if attr.is_null() {
         ::syslog::error!("pthread_attr_getstacksize(): invalid attribute pointer");
@@ -306,6 +298,7 @@ pub unsafe extern "C" fn pthread_attr_getstacksize(
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub extern "C" fn pthread_detach(_thread: pthread_t) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/502
     ::syslog::debug!("pthread_detach(): not implemented");
@@ -326,6 +319,7 @@ pub extern "C" fn pthread_detach(_thread: pthread_t) -> c_int {
 /// - `retval`: Return value of the thread.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub extern "C" fn pthread_exit(retval: *mut c_void) -> ! {
     let error: Error = pthread::pthread_exit(retval as usize).unwrap_err();
     panic!("pthread_exit(): {:?}", error);
@@ -351,9 +345,8 @@ pub extern "C" fn pthread_exit(retval: *mut c_void) -> ! {
 /// If either t1 or t2 is not a valid thread ID and is not equal to `PTHREAD_NULL`, the behavior is undefined.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub extern "C" fn pthread_equal(thread1: pthread_t, thread2: pthread_t) -> c_int {
-    ::syslog::trace!("pthread_equal(): thread1={:?}, thread2={:?}", thread1, thread2);
-
     if thread1 == thread2 {
         1
     } else {
@@ -388,14 +381,11 @@ pub extern "C" fn pthread_equal(thread1: pthread_t, thread2: pthread_t) -> c_int
 /// - `init_routine` is a valid function pointer.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_once(
     once_control: *mut pthread_once_t,
     init_routine: Option<unsafe extern "C" fn()>,
 ) -> c_int {
-    ::syslog::trace!(
-        "pthread_once(): once_control={once_control:?}, init_routine={:?}",
-        init_routine
-    );
     // TODO: https://github.com/nanvix/nanvix/issues/513
     ::syslog::debug!("pthread_once(): not implemented");
     0
@@ -428,16 +418,11 @@ pub unsafe extern "C" fn pthread_once(
 /// - `attr` points to a valid `pthread_attr_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_setdetachstate(
     attr: *mut pthread_attr_t,
     detachstate: c_int,
 ) -> c_int {
-    ::syslog::trace!(
-        "pthread_attr_setdetachstate(): attr={:?}, detachstate={:?}",
-        attr,
-        detachstate
-    );
-
     // Check if `attr` is not valid.
     if attr.is_null() {
         ::syslog::error!("pthread_attr_setdetachstate(): invalid attribute pointer");
@@ -476,12 +461,11 @@ pub unsafe extern "C" fn pthread_attr_setdetachstate(
 /// - `attr` points to a valid `pthread_attr_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_setguardsize(
     attr: *mut pthread_attr_t,
     guardsize: c_size_t,
 ) -> c_int {
-    ::syslog::trace!("pthread_attr_setguardsize(): attr={:?}, guardsize={:?}", attr, guardsize);
-
     // Check if `attr` is not valid.
     if attr.is_null() {
         ::syslog::error!("pthread_attr_setguardsize(): invalid attribute pointer");
@@ -521,18 +505,12 @@ pub unsafe extern "C" fn pthread_attr_setguardsize(
 /// - `param` points to a valid `sched_param` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_setschedparam(
     thread: pthread_t,
     policy: c_int,
     param: *const sched_param,
 ) -> c_int {
-    ::syslog::trace!(
-        "pthread_attr_setschedparam(): thread={:?}, policy={}, param={:?}",
-        thread,
-        policy,
-        param
-    );
-
     // Check if `param` is not valid.
     if param.is_null() {
         ::syslog::error!("pthread_attr_setschedparam(): invalid sched param pointer");
@@ -572,18 +550,12 @@ pub unsafe extern "C" fn pthread_attr_setschedparam(
 /// - `attr` points to a valid `pthread_attr_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_setstack(
     attr: *mut pthread_attr_t,
     stackaddr: *mut c_void,
     stacksize: c_size_t,
 ) -> c_int {
-    ::syslog::trace!(
-        "pthread_attr_setstack(): attr={:?}, stackaddr={:?}, stacksize={:?}",
-        attr,
-        stackaddr,
-        stacksize
-    );
-
     // Check if `attr` is not valid.
     if attr.is_null() {
         ::syslog::error!("pthread_attr_setstack(): invalid attribute pointer");
@@ -622,12 +594,11 @@ pub unsafe extern "C" fn pthread_attr_setstack(
 /// - `attr` points to a valid `pthread_attr_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_setstackaddr(
     attr: *mut pthread_attr_t,
     stackaddr: *mut c_void,
 ) -> c_int {
-    ::syslog::trace!("pthread_attr_setstackaddr(): attr={:?}, stackaddr={:?}", attr, stackaddr);
-
     // Check if `attr` is not valid.
     if attr.is_null() {
         ::syslog::error!("pthread_attr_setstackaddr(): invalid attribute pointer");
@@ -666,6 +637,7 @@ pub unsafe extern "C" fn pthread_attr_setstackaddr(
 /// - `oldtype` points to a valid `c_int` variable.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_setcanceltype(_type_: c_int, oldtype: *mut c_int) -> c_int {
     // Check if `oldtype` is not valid.
     if oldtype.is_null() {

--- a/src/libs/posix/src/pthread/mutex.rs
+++ b/src/libs/posix/src/pthread/mutex.rs
@@ -18,6 +18,7 @@ use ::sysapi::{
     time::timespec,
 };
 use ::syscall::pthread;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // pthread_mutexattr_init()
@@ -44,8 +45,8 @@ use ::syscall::pthread;
 /// - `attr` points to a valid `pthread_mutexattr_t` object.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_mutexattr_init(attr: *mut pthread_mutexattr_t) -> c_int {
-    ::syslog::trace!("pthread_mutexattr_init(): attr={attr:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/511.
     0
 }
@@ -75,8 +76,8 @@ pub unsafe extern "C" fn pthread_mutexattr_init(attr: *mut pthread_mutexattr_t) 
 /// - `attr` points to a valid `pthread_mutexattr_t` object.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut pthread_mutexattr_t) -> c_int {
-    ::syslog::trace!("pthread_mutexattr_destroy(): attr={attr:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/509
     0
 }
@@ -108,6 +109,7 @@ pub unsafe extern "C" fn pthread_mutexattr_destroy(attr: *mut pthread_mutexattr_
 /// - `abstime` points to a valid `timespec` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_mutex_timedlock(
     mutex: *mut pthread_mutex_t,
     abstime: *const timespec,
@@ -176,6 +178,7 @@ pub unsafe extern "C" fn pthread_mutex_timedlock(
 /// - `mutex` points to a valid `pthread_mutex_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_mutex_trylock(mutex: *mut pthread_mutex_t) -> c_int {
     // Check if `mutex` is not valid.
     if mutex.is_null() {

--- a/src/libs/posix/src/pthread/tda.rs
+++ b/src/libs/posix/src/pthread/tda.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     sys_types::pthread_key_t,
 };
 use ::syscall::pthread;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // pthread_key_delete()
@@ -17,6 +18,7 @@ use ::syscall::pthread;
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_key_delete(key: pthread_key_t) -> c_int {
     match pthread::pthread_key_delete(key) {
         Ok(()) => 0,

--- a/src/libs/posix/src/pwd.rs
+++ b/src/libs/posix/src/pwd.rs
@@ -13,9 +13,11 @@ mod bindings {
         ffi::c_int,
         pwd::passwd,
     };
+    use ::syslog::trace_libcall;
 
     #[allow(clippy::missing_safety_doc)]
     #[unsafe(no_mangle)]
+    #[trace_libcall]
     pub unsafe extern "C" fn getpwuid(_uid: c_int) -> *mut passwd {
         ::syslog::debug!("getpwuid(): not implemented");
         unsafe {

--- a/src/libs/posix/src/sys/ioctl.rs
+++ b/src/libs/posix/src/sys/ioctl.rs
@@ -8,9 +8,11 @@
 #[cfg(all(feature = "syscall", feature = "staticlib"))]
 mod bindings {
     use ::sysapi::ffi::c_int;
+    use ::syslog::trace_syscall;
 
     #[allow(clippy::missing_safety_doc)]
     #[unsafe(no_mangle)]
+    #[trace_syscall]
     pub extern "C" fn ioctl(_fd: c_int, _request: c_int, _arg: *mut c_int) -> c_int {
         // TODO: https://github.com/nanvix/nanvix/issues/351
         ::syslog::debug!("ioctl(): not implemented, ignoring");

--- a/src/libs/posix/src/sys/resource.rs
+++ b/src/libs/posix/src/sys/resource.rs
@@ -11,6 +11,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_resource::rlimit,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -18,6 +19,7 @@ use ::sysapi::{
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn getrlimit(_resource: c_int, _rlim: *mut rlimit) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/459
     ::syslog::debug!("getrlimit(): not implemented");
@@ -29,6 +31,7 @@ pub unsafe extern "C" fn getrlimit(_resource: c_int, _rlim: *mut rlimit) -> c_in
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn setrlimit(_resource: c_int, _rlim: *const rlimit) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/469
     ::syslog::debug!("setrlimit(): not implemented");

--- a/src/libs/posix/src/sys/stat/mod.rs
+++ b/src/libs/posix/src/sys/stat/mod.rs
@@ -25,6 +25,10 @@ use ::sysapi::{
     time::timespec,
 };
 use ::syscall::sys::stat;
+use ::syslog::{
+    trace_libcall,
+    trace_syscall,
+};
 
 //==================================================================================================
 // Standalone Functions
@@ -53,8 +57,8 @@ use ::syscall::sys::stat;
 /// - `path` points to a valid null-terminated C string.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn chmod(path: *const c_char, mode: mode_t) -> c_int {
-    ::syslog::trace!("chmod(): path={:?}, mode={}", path, mode);
     fchmodat(AT_FDCWD, path, mode, 0)
 }
 
@@ -81,9 +85,8 @@ pub unsafe extern "C" fn chmod(path: *const c_char, mode: mode_t) -> c_int {
 /// - No other thread calls this function at the same time.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn fchmod(fd: c_int, mode: mode_t) -> c_int {
-    ::syslog::trace!("fchmod(): fd={}, mode={}", fd, mode);
-
     // Attempt to change the mode and parse the result.
     match stat::fchmod(fd, mode) {
         Ok(()) => 0,
@@ -120,20 +123,13 @@ pub unsafe extern "C" fn fchmod(fd: c_int, mode: mode_t) -> c_int {
 /// - `path` points to a valid null-terminated C string.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn fchmodat(
     dirfd: c_int,
     path: *const c_char,
     mode: mode_t,
     flag: c_int,
 ) -> c_int {
-    ::syslog::trace!(
-        "fchmodat(): dirfd={:?}, path={:?}, mode={:?}, flag={:?}",
-        dirfd,
-        path,
-        mode,
-        flag
-    );
-
     // Attempt to convert `path`.
     let pathname: &str = match ffi::CStr::from_ptr(path).to_str() {
         Ok(pathname) => pathname,
@@ -194,9 +190,8 @@ pub unsafe extern "C" fn fchmodat(
 /// - This function is not called by multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn futimens(fd: c_int, times: *const timespec) -> c_int {
-    ::syslog::trace!("futimens(): fd={}, times={:p}", fd, times);
-
     // Check if `times` is invalid.
     if times.is_null() {
         ::syslog::error!("futimens(): fd={}, times={:p}", fd, times);
@@ -251,8 +246,8 @@ pub unsafe extern "C" fn futimens(fd: c_int, times: *const timespec) -> c_int {
 ///
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn lchmod(path: *const c_char, mode: mode_t) -> c_int {
-    ::syslog::trace!("lchmod(): path={:?}, mode={}", path, mode);
     fchmodat(AT_FDCWD, path, mode, AT_SYMLINK_NOFOLLOW)
 }
 
@@ -280,6 +275,7 @@ pub unsafe extern "C" fn lchmod(path: *const c_char, mode: mode_t) -> c_int {
 /// This function has undefined because it dereferences a raw pointer (ie. `statbuf`).
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn lstat(pathname: *const c_char, statbuf: *mut sys_stat::stat) -> c_int {
     // Convert C string to Rust string.
     let pathname: &str = match ffi::CStr::from_ptr(pathname).to_str() {
@@ -331,8 +327,8 @@ pub unsafe extern "C" fn lstat(pathname: *const c_char, statbuf: *mut sys_stat::
 /// - `pathname` points to a valid null-terminated C string.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn mkdir(pathname: *const c_char, mode: mode_t) -> c_int {
-    ::syslog::trace!("mkdir(): pathname={:?}, mode={}", pathname, mode);
     mkdirat(AT_FDCWD, pathname, mode)
 }
 
@@ -360,9 +356,8 @@ pub unsafe extern "C" fn mkdir(pathname: *const c_char, mode: mode_t) -> c_int {
 /// - `pathname` points to a valid null-terminated C string.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn mkdirat(dirfd: c_int, pathname: *const c_char, mode: mode_t) -> c_int {
-    ::syslog::trace!("mkdirat(): dirfd={}, pathname={:?}, mode={}", dirfd, pathname, mode);
-
     // Attempt to convert `pathname`.
     let pathname: &str = match ffi::CStr::from_ptr(pathname).to_str() {
         Ok(pathname) => pathname,
@@ -392,6 +387,7 @@ pub unsafe extern "C" fn mkdirat(dirfd: c_int, pathname: *const c_char, mode: mo
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn truncate(_path: *const c_char, _length: u64) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/454
     ::syslog::debug!("truncate(): not implemented");
@@ -417,8 +413,8 @@ pub unsafe extern "C" fn truncate(_path: *const c_char, _length: u64) -> c_int {
 /// This function is safe to call with any valid `mask`.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn umask(mask: u16) -> u16 {
-    ::syslog::trace!("umask(): mask={mask:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/597.
     ::syslog::debug!("umask(): not implemented");
     0
@@ -450,20 +446,13 @@ pub unsafe extern "C" fn umask(mask: u16) -> u16 {
 /// - `times` points to a valid array of length 2 of `timespec` structures.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn utimensat(
     dirfd: c_int,
     filename: *const c_char,
     times: *const timespec,
     flags: c_int,
 ) -> c_int {
-    ::syslog::trace!(
-        "utimensat(): dirfd={}, filename={:?}, times={:?}, flags={}",
-        dirfd,
-        filename,
-        times,
-        flags
-    );
-
     // Convert C string to Rust string.
     let pathname: &str = match ffi::CStr::from_ptr(filename).to_str() {
         Ok(pathname) => pathname,

--- a/src/libs/posix/src/sys/time/utimes.rs
+++ b/src/libs/posix/src/sys/time/utimes.rs
@@ -20,6 +20,7 @@ use ::sysapi::{
     sys_select::timeval,
     time::timespec,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -49,9 +50,8 @@ use ::sysapi::{
 /// - `times` points to a valid array of length 2 of `timeval` structures.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn utimes(filename: *const c_char, times: *const timeval) -> c_int {
-    ::syslog::trace!("utimes(): filename={:?}, times={:?}", filename, times);
-
     // Check if `times` is invalid.
     if times.is_null() {
         ::syslog::error!("utimes(): invalid times (filename={:?}, times={:?})", filename, times);

--- a/src/libs/posix/src/sys/times/mod.rs
+++ b/src/libs/posix/src/sys/times/mod.rs
@@ -7,6 +7,7 @@
 
 use crate::errno::__errno_location;
 use ::syscall::sys::times;
+use ::syslog::trace_syscall;
 use sysapi::{
     sys_times::tms,
     sys_types::clock_t,
@@ -41,9 +42,8 @@ use sysapi::{
 /// - This function is not called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn times(buffer: *mut tms) -> clock_t {
-    ::syslog::trace!("times(): {:?}", buffer);
-
     // Convert `buffer` pointer to a reference.
     // NOTE: We provide same semantics of Linux: `buffer` can be a null pointer.
     let mut buffer: Option<&mut tms> = if buffer.is_null() {

--- a/src/libs/posix/src/sys/uio/mod.rs
+++ b/src/libs/posix/src/sys/uio/mod.rs
@@ -13,6 +13,7 @@ use ::sys::error::{
 };
 use ::sysapi::ffi::c_int;
 use ::syscall::unistd;
+use ::syslog::trace_syscall;
 use sysapi::{
     limits::IOV_MAX,
     sys_types::{
@@ -56,14 +57,13 @@ use sysapi::{
 /// - This function is called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn pwritev(
     fd: i32,
     iov: *const iovec,
     iovcnt: c_int,
     offset: off_t,
 ) -> c_ssize_t {
-    ::syslog::trace!("pwritev(): fd={fd}, iov={iov:?}, iovcnt={iovcnt}, offset={offset}");
-
     // Check if number of elements in the vector is valid.
     if iovcnt < 0 {
         ::syslog::error!("pwritev(): invalid iovcnt {iovcnt}");
@@ -188,14 +188,13 @@ pub unsafe extern "C" fn pwritev(
 /// // - This function is called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn preadv(
     fd: i32,
     iov: *const iovec,
     iovcnt: i32,
     offset: off_t,
 ) -> c_ssize_t {
-    ::syslog::trace!("preadv(): fd={fd}, iov={iov:?}, iovcnt={iovcnt}, offset={offset}");
-
     // Check if number of elements in the vector is valid.
     if (iovcnt < 0) || (iovcnt > IOV_MAX as i32) {
         ::syslog::error!("preadv(): invalid iovcnt {iovcnt}");
@@ -311,9 +310,8 @@ pub unsafe extern "C" fn preadv(
 /// - This function is called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssize_t {
-    ::syslog::trace!("readv(): fd={fd}, iov={iov:?}, iovcnt={iovcnt}");
-
     // Check if number of elements in the vector is valid.
     if (iovcnt < 0) || (iovcnt > IOV_MAX as i32) {
         ::syslog::error!("readv(): invalid iovcnt {iovcnt}");
@@ -423,9 +421,8 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssi
 /// - This function is called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> c_ssize_t {
-    ::syslog::trace!("writev(): fd={fd}, iov={iov:?}, iovcnt={iovcnt}");
-
     // Check if number of elements in the vector is valid.
     if iovcnt < 0 {
         ::syslog::error!("writev(): invalid iovcnt {iovcnt}");

--- a/src/libs/posix/src/sys/utsname/mod.rs
+++ b/src/libs/posix/src/sys/utsname/mod.rs
@@ -9,6 +9,7 @@ use crate::errno::__errno_location;
 use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
 use ::syscall::sys::utsname;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -37,6 +38,7 @@ use ::syscall::sys::utsname;
 /// - The `name` points to a valid [`utsname`] structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn uname(name: *mut utsname::utsname) -> c_int {
     // Check if name is not valid.
     if name.is_null() {

--- a/src/libs/posix/src/utime.rs
+++ b/src/libs/posix/src/utime.rs
@@ -19,6 +19,7 @@ mod bindings {
         time::timespec,
         utime::utimbuf,
     };
+    use ::syslog::trace_syscall;
 
     ///
     /// # Description
@@ -44,9 +45,8 @@ mod bindings {
     /// - `times` points to a valid `utimbuf` structures.
     ///
     #[unsafe(no_mangle)]
+    #[trace_syscall]
     pub unsafe extern "C" fn utime(filename: *const c_char, times: *const utimbuf) -> c_int {
-        ::syslog::trace!("utime(): filename={:?}, times={:?}", filename, times);
-
         // Check if `times` is invalid.
         if times.is_null() {
             ::syslog::error!("utime(): invalid times (filename={:?}, times={:?})", filename, times);

--- a/src/libs/syscall/src/dirent/bindings/closedir.rs
+++ b/src/libs/syscall/src/dirent/bindings/closedir.rs
@@ -15,6 +15,7 @@ use crate::{
 use ::alloc::boxed::Box;
 use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -50,10 +51,9 @@ use ::sysapi::ffi::c_int;
 /// `DirectoryStream` object will be deallocated and any subsequent use of the pointer results
 /// in undefined behavior.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn closedir(dirp: *mut DirectoryStream) -> c_int {
-    ::syslog::trace!("closedir(): dirp={dirp:?}");
-
     // Check if directory stream is invalid.
     if dirp.is_null() {
         ::syslog::error!("closedir(): invalid directory stream (dirp={dirp:?})");

--- a/src/libs/syscall/src/dirent/bindings/dirfd.rs
+++ b/src/libs/syscall/src/dirent/bindings/dirfd.rs
@@ -13,6 +13,7 @@ use ::alloc::boxed::Box;
 use ::core::mem::ManuallyDrop;
 use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -48,10 +49,9 @@ use ::sysapi::ffi::c_int;
 /// the file descriptor directly may lead to undefined behavior when using other directory stream
 /// functions.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dirfd(dirp: *mut DirectoryStream) -> c_int {
-    ::syslog::trace!("dirfd(): dirp={dirp:?}");
-
     // Check if directory stream is invalid.
     if dirp.is_null() {
         ::syslog::error!("dirfd(): invalid directory stream");

--- a/src/libs/syscall/src/dirent/bindings/opendir.rs
+++ b/src/libs/syscall/src/dirent/bindings/opendir.rs
@@ -18,6 +18,7 @@ use ::core::{
     ptr,
 };
 use ::sys::error::ErrorCode;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -48,10 +49,9 @@ use ::sys::error::ErrorCode;
 /// The returned pointer is owned by the caller and must be deallocated using the appropriate
 /// function (such as `closedir`). Failing to do so will result in a memory leak.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn opendir(dirname: *const i8) -> *mut DirectoryStream {
-    ::syslog::trace!("opendir(): dirname={dirname:?}");
-
     // Check if `dirname` is null.
     if dirname.is_null() {
         ::syslog::error!("opendir(): null dirname (dirname={dirname:?})");

--- a/src/libs/syscall/src/dirent/bindings/readdir.rs
+++ b/src/libs/syscall/src/dirent/bindings/readdir.rs
@@ -16,6 +16,7 @@ use ::core::{
 };
 use ::sys::error::ErrorCode;
 use ::sysapi::dirent::dirent;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -59,10 +60,9 @@ use ::sysapi::dirent::dirent;
 /// `readdir()` on the same directory stream. The caller should not attempt to free the returned
 /// pointer, as it points to internally managed memory.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn readdir(dirp: *mut DirectoryStream) -> *mut dirent {
-    ::syslog::trace!("readdir(): dirp={dirp:?}");
-
     // Check if directory stream is invalid.
     if dirp.is_null() {
         ::syslog::error!("readdir(): invalid directory stream (dirp={dirp:?})");

--- a/src/libs/syscall/src/errno.rs
+++ b/src/libs/syscall/src/errno.rs
@@ -2,6 +2,13 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Imports
+//==================================================================================================
+
+#[cfg(feature = "syscall")]
+use ::syslog::trace_libcall;
+
+//==================================================================================================
 // Global Variables
 //==================================================================================================
 
@@ -26,6 +33,7 @@ cfg_if::cfg_if! {
         ///
         /// This function is unsafe because it may interoperate with external code.
         ///
+        #[cfg_attr(feature = "syscall", trace_libcall)]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn __errno_location() -> *mut c_int {
             __errno()
@@ -49,6 +57,7 @@ cfg_if::cfg_if! {
         ///
         /// This function is unsafe because it may interoperate with external code.
         ///
+        #[cfg_attr(feature = "syscall", trace_libcall)]
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn __errno_location() -> *mut c_int {
             &raw mut errno as *mut c_int

--- a/src/libs/syscall/src/fcntl/bindings/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/bindings/fcntl.rs
@@ -13,16 +13,16 @@ use crate::{
     },
 };
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
 #[allow(clippy::missing_safety_doc)]
+#[trace_syscall]
 #[no_mangle]
 pub unsafe extern "C" fn fcntl(fd: c_int, cmd: c_int, args: ...) -> c_int {
-    ::syslog::trace!("fcntl(): fd={fd:?}, cmd={cmd:?}");
-
     // Attempt to convert the command and arguments.
     let cmd: FileControlRequest = match FileControlRequest::try_from((cmd, args)) {
         Ok(cmd) => cmd,

--- a/src/libs/syscall/src/fcntl/bindings/open.rs
+++ b/src/libs/syscall/src/fcntl/bindings/open.rs
@@ -18,6 +18,7 @@ use ::sysapi::{
     },
     sys_types::mode_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -48,10 +49,9 @@ use ::sysapi::{
 ///
 /// - `path` points to a valid null-terminated C string.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn open(path: *const c_char, flags: c_int, mode: mode_t) -> c_int {
-    ::syslog::trace!("open(): path={path:?}, flags={flags:?}, mode={mode:?}");
-
     // Check if `path` is null.
     if path.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/fcntl/bindings/posix_fadvise.rs
+++ b/src/libs/syscall/src/fcntl/bindings/posix_fadvise.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::off_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -39,6 +40,7 @@ use ::sysapi::{
 /// It is safe to call this function if the following conditions are met:
 /// - This function is not called from multiple threads at the same time.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn posix_fadvise(
     fd: c_int,
@@ -46,10 +48,6 @@ pub unsafe extern "C" fn posix_fadvise(
     len: off_t,
     advice: c_int,
 ) -> c_int {
-    ::syslog::trace!(
-        "posix_fadvise(): fd={fd:?}, offset={offset:?}, len={len:?}, advice={advice:?}"
-    );
-
     // Run system call and check for errors.
     match fcntl::posix_fadvise(fd, offset, len, advice) {
         Ok(()) => 0,

--- a/src/libs/syscall/src/fcntl/bindings/posix_fallocate.rs
+++ b/src/libs/syscall/src/fcntl/bindings/posix_fallocate.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::off_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -38,10 +39,9 @@ use ::sysapi::{
 /// It is safe to call this function if the following conditions are met:
 /// - This function is not called from multiple threads at the same time.
 ///
+#[trace_libcall]
 #[no_mangle]
 pub unsafe extern "C" fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -> c_int {
-    ::syslog::trace!("posix_fallocate(): fd={fd:?}, offset={offset:?}, len={len:?}");
-
     // Run system call and check for errors.
     match fcntl::posix_fallocate(fd, offset, len) {
         Ok(()) => 0,

--- a/src/libs/syscall/src/fcntl/bindings/renameat.rs
+++ b/src/libs/syscall/src/fcntl/bindings/renameat.rs
@@ -15,6 +15,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -46,6 +47,7 @@ use ::sysapi::ffi::{
 /// - `oldpath` points to a valid null-terminated C string.
 /// - `newpath` points to a valid null-terminated C string.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn renameat(
     olddirfd: c_int,
@@ -53,11 +55,6 @@ pub unsafe extern "C" fn renameat(
     newdirfd: c_int,
     newpath: *const c_char,
 ) -> c_int {
-    ::syslog::trace!(
-        "renameat(): olddirfd={olddirfd:?}, oldpath={oldpath:?}, newdirfd={newdirfd:?}, \
-         newpath={newpath:?}"
-    );
-
     // Check if `oldpath` is null.
     if oldpath.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/fcntl/bindings/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/bindings/unlinkat.rs
@@ -15,6 +15,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -44,10 +45,9 @@ use ::sysapi::ffi::{
 /// - This function is not called from multiple threads at the same time.
 /// - `pathname` points to a valid null-terminated C string.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn unlinkat(dirfd: c_int, pathname: *const c_char, flags: c_int) -> c_int {
-    ::syslog::trace!("unlinkat(): dirfd={dirfd:?}, pathname={pathname:?}, flags={flags:?}");
-
     // Check if `pathname` is null.
     if pathname.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -17,6 +17,9 @@
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;
 
+#[cfg(any(feature = "syscall", feature = "rustc-dep-of-std"))]
+extern crate syslog;
+
 #[cfg(any(feature = "rustc-dep-of-std", feature = "staticlib"))]
 #[allow(unused_extern_crates)]
 extern crate libc_stdlib;

--- a/src/libs/syscall/src/poll/bindings.rs
+++ b/src/libs/syscall/src/poll/bindings.rs
@@ -22,6 +22,7 @@ use ::sysapi::{
         pollfd,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -52,9 +53,8 @@ use ::sysapi::{
 /// - `fds` points to a valid array of pollfd structures of length `nfds`.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: c_int) -> c_int {
-    ::syslog::trace!("poll(): fds={fds:?}, nfds={nfds:?}, timeout={timeout:?}");
-
     let fds: &mut [pollfd] = core::slice::from_raw_parts_mut(fds, nfds as usize);
     let poll_fds: Vec<PollFd> = fds
         .iter()

--- a/src/libs/syscall/src/pthread/bindings/pthread_atfork.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_atfork.rs
@@ -7,6 +7,7 @@
 
 use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -15,6 +16,7 @@ use ::sysapi::ffi::c_int;
 // TODO: add description
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_atfork(
     prepare: Option<extern "C" fn()>,
     parent: Option<extern "C" fn()>,

--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_destroy.rs
@@ -11,6 +11,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_attr_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -56,9 +57,8 @@ use ::sysapi::{
 /// - `attr` points to a valid `pthread_attr_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_destroy(attr: *mut pthread_attr_t) -> c_int {
-    ::syslog::trace!("pthread_attr_destroy(): attr={attr:p}");
-
     // Check if `attr` is points to an invalid address.
     if attr.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_getstack.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_getstack.rs
@@ -17,6 +17,7 @@ use ::sysapi::{
         pthread_attr_t,
     },
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -62,15 +63,12 @@ use ::sysapi::{
 /// - `stacksize` points to a valid `c_size_t`.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_getstack(
     attr: *const pthread_attr_t,
     stackaddr: *mut *mut c_void,
     stacksize: *mut c_size_t,
 ) -> c_int {
-    ::syslog::trace!(
-        "pthread_attr_getstack(): attr={attr:p}, stackaddr={stackaddr:p}, stacksize={stacksize:p}"
-    );
-
     // Check if `attr` points to an invalid address.
     if attr.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_init.rs
@@ -11,6 +11,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_attr_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -59,9 +60,8 @@ use ::sysapi::{
 /// - `attr` points to a valid `pthread_attr_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_init(attr: *mut pthread_attr_t) -> c_int {
-    ::syslog::trace!("pthread_attr_init(): attr={attr:p}");
-
     // Check if `attr` is points to an invalid address.
     if attr.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/pthread/bindings/pthread_attr_setstacksize.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_attr_setstacksize.rs
@@ -9,6 +9,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_attr_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -17,9 +18,10 @@ use ::sysapi::{
 // TODO: add description
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_attr_setstacksize(
-    _attr: *mut pthread_attr_t,
-    _stacksize: usize,
+    attr: *mut pthread_attr_t,
+    stacksize: usize,
 ) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/488
     ::syslog::debug!("pthread_attr_setstacksize(): not implemented");

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_broadcast.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_broadcast.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_cond_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -37,6 +38,7 @@ use ::sysapi::{
 /// - `cond` points to a valid `pthread_cond_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_cond_broadcast(cond: *const pthread_cond_t) -> c_int {
     // Check if `cond` is not valid.
     if cond.is_null() {

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_destroy.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_cond_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -37,6 +38,7 @@ use ::sysapi::{
 /// - `cond` points to a valid `pthread_cond_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_cond_destroy(cond: *mut pthread_cond_t) -> c_int {
     // Check if `cond` is not valid.
     if cond.is_null() {

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_init.rs
@@ -13,6 +13,7 @@ use ::sysapi::{
         pthread_condattr_t,
     },
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -41,6 +42,7 @@ use ::sysapi::{
 /// - `cond` points to a valid `pthread_cond_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_cond_init(
     cond: *mut pthread_cond_t,
     attr: *const pthread_condattr_t,

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_signal.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_signal.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_cond_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -37,6 +38,7 @@ use ::sysapi::{
 /// - `cond` points to a valid `pthread_cond_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_cond_signal(cond: *const pthread_cond_t) -> c_int {
     // Check if `cond` is not valid.
     if cond.is_null() {

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_timedwait.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_timedwait.rs
@@ -17,6 +17,7 @@ use ::sysapi::{
     },
     time::timespec,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -47,6 +48,7 @@ use ::sysapi::{
 /// - `abstime` points to a valid `timespec` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_cond_timedwait(
     cond: *const pthread_cond_t,
     mutex: *mut pthread_mutex_t,

--- a/src/libs/syscall/src/pthread/bindings/pthread_cond_wait.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_cond_wait.rs
@@ -13,6 +13,7 @@ use ::sysapi::{
         pthread_mutex_t,
     },
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -42,6 +43,7 @@ use ::sysapi::{
 /// - `mutex` points to a valid `pthread_mutex_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_cond_wait(
     cond: *const pthread_cond_t,
     mutex: *mut pthread_mutex_t,

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_init.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_condattr_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -40,9 +41,8 @@ use ::sysapi::{
 /// `pthread_condattr_t` structure and is properly aligned.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_condattr_init(attr: *mut pthread_condattr_t) -> c_int {
-    ::syslog::trace!("pthread_condattr_init(): attr={attr:p}");
-
     // Check if pointer to cond attribute object is valid.
     if attr.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/pthread/bindings/pthread_condattr_setclock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_condattr_setclock.rs
@@ -13,6 +13,7 @@ use ::sysapi::{
         pthread_condattr_t,
     },
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -40,6 +41,7 @@ use ::sysapi::{
 /// - `attr` is a valid pointer to a `pthread_condattr_t` object.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_condattr_setclock(
     attr: *mut pthread_condattr_t,
     clock_id: clockid_t,

--- a/src/libs/syscall/src/pthread/bindings/pthread_create.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_create.rs
@@ -13,6 +13,7 @@ use ::sysapi::{
         pthread_t,
     },
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -45,20 +46,13 @@ use ::sysapi::{
 /// - `start_routine` is a valid function pointer.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_create(
     thread: *mut pthread_t,
     attr: *const pthread_attr_t,
     start_routine: extern "C" fn(usize) -> usize,
     arg: usize,
 ) -> c_int {
-    ::syslog::trace!(
-        "pthread_create(): thread={:?}, attr={:?}, start_routine={:#x?}, arg={:#x?}",
-        thread,
-        attr,
-        start_routine as usize,
-        arg
-    );
-
     // Check if `thread` is not valid.
     if thread.is_null() {
         ::syslog::error!("pthread_create(): invalid thread pointer");

--- a/src/libs/syscall/src/pthread/bindings/pthread_getattr_np.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_getattr_np.rs
@@ -14,6 +14,7 @@ use ::sysapi::{
         pthread_t,
     },
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -52,9 +53,8 @@ use ::sysapi::{
 /// - `attr` points to a valid `pthread_attr_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_getattr_np(thread: pthread_t, attr: *mut pthread_attr_t) -> c_int {
-    ::syslog::trace!("pthread_getattr_np(): thread={:?}, attr={attr:p}", thread);
-
     // Check if `attr` points to an invalid address.
     if attr.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/pthread/bindings/pthread_getschedparam.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_getschedparam.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     sched::sched_param,
     sys_types::pthread_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -17,10 +18,11 @@ use ::sysapi::{
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_getschedparam(
-    _thread: pthread_t,
-    _policy: *mut c_int,
-    _param: *mut sched_param,
+    thread: pthread_t,
+    policy: *mut c_int,
+    param: *mut sched_param,
 ) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/725
     ::syslog::debug!("pthread_getschedparam(): not implemented");

--- a/src/libs/syscall/src/pthread/bindings/pthread_getspecific.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_getspecific.rs
@@ -9,6 +9,7 @@ use ::sysapi::{
     ffi::c_void,
     sys_types::pthread_key_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -16,6 +17,7 @@ use ::sysapi::{
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_getspecific(key: pthread_key_t) -> *mut c_void {
     match crate::pthread::pthread_getspecific(key) {
         Ok(value) => value.into(),

--- a/src/libs/syscall/src/pthread/bindings/pthread_join.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_join.rs
@@ -12,6 +12,7 @@ use ::sysapi::{
     },
     sys_types::pthread_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -40,14 +41,8 @@ use ::sysapi::{
 /// - If `retval_ptr` is not null, it points to a valid pointer.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_join(thread: pthread_t, retval_ptr: *mut *mut c_void) -> c_int {
-    ::syslog::trace!(
-        "pthread_join(): _thread={:?}, retval_ptr={:?}, *retval={:?}",
-        thread,
-        retval_ptr,
-        *retval_ptr
-    );
-
     match crate::pthread::pthread_join(thread) {
         Ok(retval) => {
             ::syslog::trace!("pthread_join(): retval={:#x?}", retval);

--- a/src/libs/syscall/src/pthread/bindings/pthread_key_create.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_key_create.rs
@@ -13,6 +13,7 @@ use ::sysapi::{
     },
     sys_types::pthread_key_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -20,6 +21,7 @@ use ::sysapi::{
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_key_create(
     key_ptr: *mut pthread_key_t,
     destructor: Option<extern "C" fn(*mut c_void)>,

--- a/src/libs/syscall/src/pthread/bindings/pthread_kill.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_kill.rs
@@ -9,6 +9,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -17,7 +18,8 @@ use ::sysapi::{
 // TODO: add description
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn pthread_kill(_thread: pthread_t, _sig: c_int) -> c_int {
+#[trace_libcall]
+pub unsafe extern "C" fn pthread_kill(thread: pthread_t, sig: c_int) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/716
     ::syslog::debug!("pthread_kill(): not implemented");
     0

--- a/src/libs/syscall/src/pthread/bindings/pthread_mutex_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_mutex_destroy.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_mutex_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -37,6 +38,7 @@ use ::sysapi::{
 /// - `mutex` points to a valid `pthread_mutex_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_mutex_destroy(mutex: *mut pthread_mutex_t) -> c_int {
     // Check if `mutex` is not valid.
     if mutex.is_null() {

--- a/src/libs/syscall/src/pthread/bindings/pthread_mutex_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_mutex_init.rs
@@ -13,6 +13,7 @@ use ::sysapi::{
         pthread_mutexattr_t,
     },
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -41,6 +42,7 @@ use ::sysapi::{
 /// - `mutex` points to a valid `pthread_mutex_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_mutex_init(
     mutex: *mut pthread_mutex_t,
     attr: *const pthread_mutexattr_t,

--- a/src/libs/syscall/src/pthread/bindings/pthread_mutex_lock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_mutex_lock.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_mutex_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -37,6 +38,7 @@ use ::sysapi::{
 /// - `mutex` points to a valid `pthread_mutex_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_mutex_lock(mutex: *mut pthread_mutex_t) -> c_int {
     // Check if `mutex` is not valid.
     if mutex.is_null() {

--- a/src/libs/syscall/src/pthread/bindings/pthread_mutex_unlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_mutex_unlock.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_mutex_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -37,6 +38,7 @@ use ::sysapi::{
 /// - `mutex` points to a valid `pthread_mutex_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_mutex_unlock(mutex: *mut pthread_mutex_t) -> c_int {
     // Check if `mutex` is not valid.
     if mutex.is_null() {

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_destroy.rs
@@ -11,6 +11,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_rwlock_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -38,6 +39,7 @@ use ::sysapi::{
 /// - `rwlock` points to a valid `pthread_rwlock_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_rwlock_destroy(rwlock: *mut pthread_rwlock_t) -> c_int {
     // Check if `rwlock` object is invalid.
     if rwlock.is_null() {

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_init.rs
@@ -14,6 +14,7 @@ use ::sysapi::{
         pthread_rwlockattr_t,
     },
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -42,6 +43,7 @@ use ::sysapi::{
 /// - `rwlock` points to a valid `pthread_rwlock_t` object.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_rwlock_init(
     rwlock: *mut pthread_rwlock_t,
     attr: *const pthread_rwlockattr_t,

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_rdlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_rdlock.rs
@@ -11,6 +11,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_rwlock_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -38,6 +39,7 @@ use ::sysapi::{
 /// - `rwlock` points to a valid `pthread_rwlock_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_rwlock_rdlock(rwlock: *mut pthread_rwlock_t) -> c_int {
     // Check if `rwlock` object is invalid.
     if rwlock.is_null() {

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_unlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_unlock.rs
@@ -11,6 +11,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_rwlock_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -38,6 +39,7 @@ use ::sysapi::{
 /// - `rwlock` points to a valid `pthread_rwlock_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_rwlock_unlock(rwlock: *mut pthread_rwlock_t) -> c_int {
     // Check if `rwlock` object is invalid.
     if rwlock.is_null() {

--- a/src/libs/syscall/src/pthread/bindings/pthread_rwlock_wrlock.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_rwlock_wrlock.rs
@@ -11,6 +11,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pthread_rwlock_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -38,6 +39,7 @@ use ::sysapi::{
 /// - `rwlock` points to a valid `pthread_rwlock_t` structure.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_rwlock_wrlock(rwlock: *mut pthread_rwlock_t) -> c_int {
     // Check if `rwlock` object is invalid.
     if rwlock.is_null() {

--- a/src/libs/syscall/src/pthread/bindings/pthread_self.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_self.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use ::sysapi::sys_types::pthread_t;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -21,6 +22,7 @@ use ::sysapi::sys_types::pthread_t;
 /// The thread identifier of the calling thread.
 ///
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub extern "C" fn pthread_self() -> pthread_t {
     crate::pthread::pthread_self()
 }

--- a/src/libs/syscall/src/pthread/bindings/pthread_setcancelstate.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_setcancelstate.rs
@@ -7,6 +7,7 @@
 
 use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -35,7 +36,8 @@ use ::sysapi::ffi::c_int;
 /// - `oldstate` points to a valid `c_int` variable.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn pthread_setcancelstate(_state: c_int, oldstate: *mut c_int) -> c_int {
+#[trace_libcall]
+pub unsafe extern "C" fn pthread_setcancelstate(state: c_int, oldstate: *mut c_int) -> c_int {
     // Check if `oldstate` is not valid.
     if oldstate.is_null() {
         ::syslog::error!("pthread_setcancelstate(): invalid old state pointer");

--- a/src/libs/syscall/src/pthread/bindings/pthread_setspecific.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_setspecific.rs
@@ -12,6 +12,7 @@ use ::sysapi::{
     },
     sys_types::pthread_key_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -19,6 +20,7 @@ use ::sysapi::{
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_setspecific(key: pthread_key_t, value: *const c_void) -> c_int {
     match crate::pthread::pthread_setspecific(key, value.into()) {
         Ok(()) => 0,

--- a/src/libs/syscall/src/pthread/bindings/pthread_sigmask.rs
+++ b/src/libs/syscall/src/pthread/bindings/pthread_sigmask.rs
@@ -9,6 +9,7 @@ use ::sysapi::ffi::{
     c_int,
     c_void,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -17,10 +18,11 @@ use ::sysapi::ffi::{
 // TODO: add description
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_libcall]
 pub unsafe extern "C" fn pthread_sigmask(
-    _how: c_int,
-    _set: *const c_void,
-    _oldset: *mut c_void,
+    how: c_int,
+    set: *const c_void,
+    oldset: *mut c_void,
 ) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/717
     ::syslog::debug!("pthread_sigmask(): not implemented");

--- a/src/libs/syscall/src/pthread/bindings/sem_destroy.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_destroy.rs
@@ -9,6 +9,7 @@ use ::sysapi::ffi::{
     c_int,
     c_void,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -17,7 +18,8 @@ use ::sysapi::ffi::{
 // TODO: add description
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sem_destroy(_sem: *mut c_void) -> c_int {
+#[trace_libcall]
+pub unsafe extern "C" fn sem_destroy(sem: *mut c_void) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/722
     ::syslog::debug!("sem_destroy(): not implemented");
     0

--- a/src/libs/syscall/src/pthread/bindings/sem_init.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_init.rs
@@ -9,6 +9,7 @@ use ::sysapi::ffi::{
     c_int,
     c_void,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -17,7 +18,8 @@ use ::sysapi::ffi::{
 // TODO: add description
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sem_init(_sem: *mut c_void, _pshared: c_int, _value: u32) -> c_int {
+#[trace_libcall]
+pub unsafe extern "C" fn sem_init(sem: *mut c_void, pshared: c_int, value: u32) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/721
     ::syslog::debug!("sem_init(): not implemented");
     0

--- a/src/libs/syscall/src/pthread/bindings/sem_post.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_post.rs
@@ -9,6 +9,7 @@ use ::sysapi::ffi::{
     c_int,
     c_void,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -16,7 +17,8 @@ use ::sysapi::ffi::{
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sem_post(_sem: *mut c_void) -> c_int {
+#[trace_libcall]
+pub unsafe extern "C" fn sem_post(sem: *mut c_void) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/723
     ::syslog::debug!("sem_post(): not implemented");
     0

--- a/src/libs/syscall/src/pthread/bindings/sem_wait.rs
+++ b/src/libs/syscall/src/pthread/bindings/sem_wait.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_libcall;
 use sysapi::ffi::c_void;
 
 //==================================================================================================
@@ -15,7 +16,8 @@ use sysapi::ffi::c_void;
 // TODO: add description
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn sem_wait(_sem: *mut c_void) -> c_int {
+#[trace_libcall]
+pub unsafe extern "C" fn sem_wait(sem: *mut c_void) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/724
     unimplemented!()
 }

--- a/src/libs/syscall/src/sched/bindings/sched_yield.rs
+++ b/src/libs/syscall/src/sched/bindings/sched_yield.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -13,6 +14,7 @@ use ::sysapi::ffi::c_int;
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn sched_yield() -> c_int {
     match crate::sched::sched_yield() {
         Ok(()) => 0,

--- a/src/libs/syscall/src/signal/bindings/kill.rs
+++ b/src/libs/syscall/src/signal/bindings/kill.rs
@@ -11,15 +11,15 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pid_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub extern "C" fn kill(pid: pid_t, signal: c_int) -> c_int {
-    ::syslog::trace!("kill(): pid ={pid}, signal={signal}");
-
     // TODO: Implement this system call.
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();

--- a/src/libs/syscall/src/signal/bindings/sigaction.rs
+++ b/src/libs/syscall/src/signal/bindings/sigaction.rs
@@ -11,18 +11,19 @@ use ::sysapi::{
     errno::__errno_location,
     ffi::c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub extern "C" fn sigaction(
     signum: c_int,
     act: *const sigaction_t,
     oldact: *mut sigaction_t,
 ) -> c_int {
-    ::syslog::trace!("sigaction(): signum={signum}, act={act:p}, oldact = {oldact:p}");
     unsafe {
         *__errno_location() = ErrorCode::InvalidSysCall.get();
     }

--- a/src/libs/syscall/src/sys/mman/bindings/mmap.rs
+++ b/src/libs/syscall/src/sys/mman/bindings/mmap.rs
@@ -25,6 +25,7 @@ use ::sysapi::{
         off_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -73,6 +74,7 @@ use ::sysapi::{
 /// - Any flags other than `MAP_PRIVATE | MAP_ANONYMOUS` are not supported.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn mmap(
     addr: *mut u8,
     length: c_size_t,
@@ -81,11 +83,6 @@ pub unsafe extern "C" fn mmap(
     fd: c_int,
     offset: off_t,
 ) -> *mut u8 {
-    ::syslog::trace!(
-        "mmap(): addr={addr:?}, length={length}, prot={prot}, flags={flags}, fd={fd}, \
-         offset={offset}"
-    );
-
     // Check if mapping length is invalid.
     if length == 0 {
         ::syslog::error!(

--- a/src/libs/syscall/src/sys/mman/bindings/mprotect.rs
+++ b/src/libs/syscall/src/sys/mman/bindings/mprotect.rs
@@ -23,6 +23,7 @@ use ::sysapi::{
     },
     sys_types::c_size_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -30,9 +31,8 @@ use ::sysapi::{
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn mprotect(addr: *mut c_char, length: c_size_t, prot: c_int) -> isize {
-    ::syslog::trace!("mprotect(): addr={addr:?}, length={length}, prot={prot}");
-
     // Check if address is invalid.
     if addr.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/sys/mman/bindings/munmap.rs
+++ b/src/libs/syscall/src/sys/mman/bindings/munmap.rs
@@ -15,6 +15,7 @@ use ::sysapi::{
     ffi::c_void,
     sys_types::c_size_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -49,9 +50,8 @@ use ::sysapi::{
 /// - Partial unmapping is not supported.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn munmap(addr: *mut c_void, length: c_size_t) -> isize {
-    ::syslog::trace!("munmap(): addr={addr:?}, length={length}");
-
     // Check if address is invalid.
     if addr.is_null() {
         ::syslog::error!("munmap(): invalid base address (addr={addr:?}, length={length})");

--- a/src/libs/syscall/src/sys/select/bindings/mod.rs
+++ b/src/libs/syscall/src/sys/select/bindings/mod.rs
@@ -18,6 +18,7 @@ use ::sysapi::{
         FD_SETSIZE,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Structures
@@ -52,6 +53,7 @@ use ::sysapi::{
 /// - If `timeout` is not null, it points to a valid `timeval` structure
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn select(
     nfds: c_int,
     readfds: *mut fd_set,
@@ -59,11 +61,6 @@ pub unsafe extern "C" fn select(
     errorfds: *mut fd_set,
     timeout: *const timeval,
 ) -> c_int {
-    ::syslog::trace!(
-        "select(): nfds={nfds:?}, readfds={readfds:?}, writefds={writefds:?}, \
-         errorfds={errorfds:?}, timeout={timeout:?}"
-    );
-
     // Check if `nfds` is not valid.
     if nfds < 0 || nfds as usize > FD_SETSIZE {
         ::syslog::error!(

--- a/src/libs/syscall/src/sys/socket/bindings/accept.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/accept.rs
@@ -16,6 +16,7 @@ use ::sysapi::{
         socklen_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -55,13 +56,12 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn accept(
     sockfd: c_int,
     sockaddr: *mut sockaddr,
     len: *mut socklen_t,
 ) -> c_int {
-    ::syslog::trace!("accept(): sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?}");
-
     // Check if sockaddr and len is invalid.
     if !sockaddr.is_null() && len.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/sys/socket/bindings/bind.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/bind.rs
@@ -17,6 +17,7 @@ use ::sysapi::{
         socklen_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -51,9 +52,8 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn bind(sockfd: c_int, sockaddr: *const sockaddr, len: socklen_t) -> c_int {
-    ::syslog::trace!("bind(): sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?}");
-
     // Check if sock address is invalid.
     if sockaddr.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/sys/socket/bindings/connect.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/connect.rs
@@ -20,6 +20,7 @@ use ::sysapi::{
         socklen_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -57,13 +58,12 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn connect(
     sockfd: c_int,
     sockaddr: *const sockaddr,
     len: socklen_t,
 ) -> c_int {
-    ::syslog::trace!("connect(): sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?}");
-
     // Check if `sockaddr` is valid.
     if sockaddr.is_null() {
         let reason: &str = "invalid socket address";

--- a/src/libs/syscall/src/sys/socket/bindings/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/getpeername.rs
@@ -21,6 +21,7 @@ use ::sysapi::{
         socklen_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -60,13 +61,12 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn getpeername(
     sockfd: c_int,
     sockaddr: *mut sockaddr,
     len: *mut socklen_t,
 ) -> c_int {
-    ::syslog::trace!("getpeername(): sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?}");
-
     // Check if the address is valid.
     if sockaddr.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/sys/socket/bindings/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/getsockname.rs
@@ -21,6 +21,7 @@ use ::sysapi::{
         socklen_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -60,13 +61,12 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn getsockname(
     sockfd: c_int,
     sockaddr: *mut sockaddr,
     len: *mut socklen_t,
 ) -> c_int {
-    ::syslog::trace!("getsockname(): sockfd={sockfd:?}, sockaddr={sockaddr:?}, len={len:?}");
-
     // Check if the address is valid.
     if sockaddr.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/sys/socket/bindings/getsockopt.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/getsockopt.rs
@@ -14,6 +14,7 @@ use ::sysapi::{
     },
     sys_socket::socklen_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -55,6 +56,7 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn getsockopt(
     sockfd: c_int,
     level: c_int,
@@ -62,10 +64,6 @@ pub unsafe extern "C" fn getsockopt(
     optval: *mut c_void,
     optlen: *mut socklen_t,
 ) -> c_int {
-    ::syslog::trace!(
-        "getsockopt(): sockfd={sockfd:?}, level={level:?}, optname={optname:?}, \
-         optval={optval:?}, optlen={optlen:?}"
-    );
     // TODO: https://github.com/nanvix/nanvix/issues/591
     ::syslog::debug!("getsockopt(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/sys/socket/bindings/listen.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/listen.rs
@@ -7,6 +7,7 @@
 
 use crate::errno::__errno_location;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -44,9 +45,8 @@ use ::sysapi::ffi::c_int;
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn listen(sockfd: c_int, backlog: c_int) -> c_int {
-    ::syslog::trace!("listen(): sockfd={sockfd:?}, backlog={backlog:?}");
-
     // Call listen and check for errors.
     match crate::sys::socket::syscall::listen(sockfd, backlog) {
         Ok(()) => 0,

--- a/src/libs/syscall/src/sys/socket/bindings/recv.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recv.rs
@@ -21,6 +21,7 @@ use ::sysapi::{
         c_ssize_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -60,14 +61,13 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn recv(
     sockfd: c_int,
     buf: *mut c_void,
     len: c_size_t,
     flags: c_int,
 ) -> c_ssize_t {
-    ::syslog::trace!("recv(): sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?}");
-
     // Check if `buf` is valid.
     if buf.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/sys/socket/bindings/recvfrom.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recvfrom.rs
@@ -21,6 +21,7 @@ use ::sysapi::{
         c_ssize_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -68,6 +69,7 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn recvfrom(
     sockfd: c_int,
     buf: *mut c_void,
@@ -76,10 +78,6 @@ pub unsafe extern "C" fn recvfrom(
     sockaddr: *mut sockaddr,
     addrlen: *mut socklen_t,
 ) -> c_ssize_t {
-    ::syslog::trace!(
-        "recvfrom(): sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?}, \
-         sockaddr={sockaddr:?}, addrlen={addrlen:?}"
-    );
     // TODO: https://github.com/nanvix/nanvix/issues/590
     ::syslog::debug!("recvfrom(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/sys/socket/bindings/recvmsg.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recvmsg.rs
@@ -14,6 +14,7 @@ use ::sysapi::{
         msghdr,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -61,8 +62,8 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn recvmsg(sockfd: c_int, msg: *mut msghdr, flags: c_int) -> c_ssize_t {
-    ::syslog::trace!("recvmsg(): sockfd={sockfd:?}, msg={msg:?}, flags={flags:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/600
     ::syslog::debug!("recvmsg(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();

--- a/src/libs/syscall/src/sys/socket/bindings/send.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/send.rs
@@ -21,6 +21,7 @@ use ::sysapi::{
         c_ssize_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -60,14 +61,13 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn send(
     sockfd: c_int,
     buf: *const c_void,
     len: c_size_t,
     flags: c_int,
 ) -> c_ssize_t {
-    ::syslog::trace!("send(): sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?}");
-
     // Check if `buf` is valid.
     if buf.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/sys/socket/bindings/sendmsg.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/sendmsg.rs
@@ -14,6 +14,7 @@ use ::sysapi::{
         msghdr,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -60,8 +61,8 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn sendmsg(sockfd: c_int, msg: *const msghdr, flags: c_int) -> c_ssize_t {
-    ::syslog::trace!("sendmsg(): sockfd={sockfd:?}, msg={msg:?}, flags={flags:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/599.
     ::syslog::debug!("sendmsg(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/sys/socket/bindings/sendto.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/sendto.rs
@@ -21,6 +21,7 @@ use ::sysapi::{
         c_ssize_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -69,6 +70,7 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn sendto(
     sockfd: c_int,
     buf: *const c_void,
@@ -77,10 +79,6 @@ pub unsafe extern "C" fn sendto(
     sockaddr: *const sockaddr,
     addrlen: socklen_t,
 ) -> c_ssize_t {
-    ::syslog::trace!(
-        "sendto(): sockfd={sockfd:?}, buf={buf:?}, len={len:?}, flags={flags:?}, \
-         sockaddr={sockaddr:?}, addrlen={addrlen:?}"
-    );
     // TODO: https://github.com/nanvix/nanvix/issues/589
     ::syslog::debug!("sendto(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/sys/socket/bindings/setsockopt.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/setsockopt.rs
@@ -16,6 +16,7 @@ use ::sysapi::{
     },
     sys_socket::socklen_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -58,6 +59,7 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn setsockopt(
     sockfd: c_int,
     level: c_int,
@@ -65,10 +67,6 @@ pub unsafe extern "C" fn setsockopt(
     optval: *const c_void,
     optlen: socklen_t,
 ) -> c_int {
-    ::syslog::trace!(
-        "setsockopt(): sockfd={sockfd:?}, level={level:?}, optname={optname:?}, \
-         optval={optval:?}, optlen={optlen:?}"
-    );
     // TODO: https://github.com/nanvix/nanvix/issues/471
     ::syslog::debug!("setsockopt(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/sys/socket/bindings/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/shutdown.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -56,9 +57,8 @@ use ::sysapi::ffi::c_int;
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn shutdown(sockfd: c_int, how: c_int) -> c_int {
-    ::syslog::trace!("shutdown(): sockfd={sockfd:?}, how={how:?}");
-
     // Attempt to convert shutdown mode.
     let how: Shutdown = match Shutdown::try_from(how) {
         Ok(how) => how,

--- a/src/libs/syscall/src/sys/socket/bindings/socket.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/socket.rs
@@ -14,6 +14,7 @@ use crate::{
     },
 };
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -55,9 +56,8 @@ use ::sysapi::ffi::c_int;
 ///
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn socket(domain: c_int, typ: c_int, protocol: c_int) -> c_int {
-    ::syslog::trace!("socket(): domain={domain:?}, type={typ:?}, protocol={protocol:?}");
-
     // Attempt to convert socket address family.
     let domain: AddressFamily = match AddressFamily::try_from(domain) {
         Ok(domain) => domain,

--- a/src/libs/syscall/src/sys/socket/bindings/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/socketpair.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use ::core::slice;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -60,17 +61,13 @@ use ::sysapi::ffi::c_int;
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn socketpair(
     domain: c_int,
     typ: c_int,
     protocol: c_int,
     socket_fds: *mut c_int,
 ) -> c_int {
-    ::syslog::trace!(
-        "socketpair(): domain={domain:?}, typ={typ:?}, protocol={protocol:?}, \
-         socket_fds={socket_fds:?}"
-    );
-
     // Check if `socket_fds` is invalid.
     if socket_fds.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/sys/stat/bindings/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/bindings/fstat.rs
@@ -9,6 +9,7 @@ use ::sysapi::{
     errno::__errno_location,
     sys_stat,
 };
+use ::syslog::trace_syscall;
 use sysapi::ffi::c_int;
 
 //==================================================================================================
@@ -21,8 +22,8 @@ use sysapi::ffi::c_int;
 /// This function has undefined behavior if buf points to an invalid memory location.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn fstat(fd: c_int, buf: *mut sys_stat::stat) -> c_int {
-    ::syslog::trace!("fstat(): fd = {}, buf = {:?}", fd, buf);
     match crate::sys::stat::fstat(fd, &mut *buf) {
         Ok(_) => 0,
         Err(error) => {

--- a/src/libs/syscall/src/sys/stat/bindings/stat.rs
+++ b/src/libs/syscall/src/sys/stat/bindings/stat.rs
@@ -11,6 +11,7 @@ use ::sysapi::{
     ffi::c_char,
     sys_stat,
 };
+use ::syslog::trace_syscall;
 use sysapi::ffi::c_int;
 
 //==================================================================================================
@@ -41,6 +42,7 @@ use sysapi::ffi::c_int;
 /// This function has undefined because it dereferences a raw pointer (ie. `statbuf`).
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn stat(pathname: *const c_char, statbuf: *mut sys_stat::stat) -> c_int {
     // Convert C string to Rust string.
     let pathname: &str = match core::ffi::CStr::from_ptr(pathname).to_str() {

--- a/src/libs/syscall/src/time/bindings/clock_getres.rs
+++ b/src/libs/syscall/src/time/bindings/clock_getres.rs
@@ -9,6 +9,7 @@ use ::sysapi::{
     ffi::c_int,
     time::timespec,
 };
+use ::syslog::trace_syscall;
 use sysapi::{
     errno::__errno_location,
     sys_types::clockid_t,
@@ -43,10 +44,9 @@ use sysapi::{
 /// - `res` points to a valid `timespec` structure.
 /// - This function is not called by multiple threads at the same time.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn clock_getres(clock_id: clockid_t, res: *mut timespec) -> c_int {
-    ::syslog::trace!("clock_getres(): clock_id={:?}, res={:?}", clock_id, res);
-
     // Convert `res` pointer to a reference.
     let mut res: Option<&mut timespec> = if res.is_null() { None } else { Some(&mut *res) };
 

--- a/src/libs/syscall/src/time/bindings/clock_gettime.rs
+++ b/src/libs/syscall/src/time/bindings/clock_gettime.rs
@@ -9,6 +9,7 @@ use ::sysapi::{
     ffi::c_int,
     time::timespec,
 };
+use ::syslog::trace_syscall;
 use sysapi::{
     errno::__errno_location,
     sys_types::clockid_t,
@@ -37,9 +38,9 @@ use sysapi::{
 ///
 /// This function is unsafe because it may deference raw pointers.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn clock_gettime(clock_id: clockid_t, tp: *mut timespec) -> c_int {
-    ::syslog::trace!("clock_gettime(): clock_id={:?}, tp={:?}", clock_id, tp);
     let mut tp: Option<&mut timespec> = if tp.is_null() {
         None
     } else {

--- a/src/libs/syscall/src/time/bindings/gettimeofday.rs
+++ b/src/libs/syscall/src/time/bindings/gettimeofday.rs
@@ -12,12 +12,14 @@ use ::sysapi::{
     },
     sys_select::timeval,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
 #[allow(clippy::missing_safety_doc)]
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn gettimeofday(_tp: *mut timeval, _tz: *mut c_void) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/317

--- a/src/libs/syscall/src/time/bindings/nanosleep.rs
+++ b/src/libs/syscall/src/time/bindings/nanosleep.rs
@@ -10,17 +10,17 @@ use ::sysapi::{
     ffi::c_int,
     time::timespec,
 };
+use ::syslog::trace_syscall;
 use sysapi::errno::__errno_location;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
-#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
+#[trace_syscall]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn nanosleep(req: *const timespec, rem: *mut timespec) -> c_int {
-    ::syslog::trace!("nanosleep(): req={:?}, rem={:?}", req, rem);
-
     // Check if `req` is valid.
     if req.is_null() {
         ::syslog::error!("nanosleep(): invalid req pointer");

--- a/src/libs/syscall/src/time/bindings/usleep.rs
+++ b/src/libs/syscall/src/time/bindings/usleep.rs
@@ -6,12 +6,14 @@
 //==================================================================================================
 
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
 #[allow(clippy::missing_safety_doc)]
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn usleep(_usec: u32) -> c_int {
     // TODO: https://github.com/nanvix/nanvix/issues/476

--- a/src/libs/syscall/src/unistd/bindings/_exit.rs
+++ b/src/libs/syscall/src/unistd/bindings/_exit.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -49,6 +50,7 @@ use ::sysapi::ffi::c_int;
 /// - The process is not holding locks or resources that require explicit cleanup.
 /// - The exit status value is meaningful to the parent process or system.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn _exit(status: c_int) -> ! {
     match sys::kcall::pm::exit(status) {

--- a/src/libs/syscall/src/unistd/bindings/access.rs
+++ b/src/libs/syscall/src/unistd/bindings/access.rs
@@ -13,6 +13,7 @@ use ::sysapi::{
         c_int,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -51,8 +52,8 @@ use ::sysapi::{
 /// - `path` remains valid for the duration of the function call.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn access(path: *const c_char, mode: c_int) -> c_int {
-    ::syslog::trace!("access(): path={path:?}, mode={mode:?}");
     unistd::bindings::faccessat::faccessat(AT_FDCWD, path, mode, 0)
 }

--- a/src/libs/syscall/src/unistd/bindings/chdir.rs
+++ b/src/libs/syscall/src/unistd/bindings/chdir.rs
@@ -12,6 +12,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -48,6 +49,7 @@ use ::sysapi::ffi::{
 /// - `path` remains valid for the duration of the function call.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn chdir(path: *const c_char) -> c_int {
     ::syslog::error!("chdir(): path={path:?}");

--- a/src/libs/syscall/src/unistd/bindings/chdir.rs
+++ b/src/libs/syscall/src/unistd/bindings/chdir.rs
@@ -52,8 +52,6 @@ use ::syslog::trace_syscall;
 #[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn chdir(path: *const c_char) -> c_int {
-    ::syslog::error!("chdir(): path={path:?}");
-
     // Check if `path` is invalid.
     if path.is_null() {
         ::syslog::error!("chdir(): path is null (path={path:?})");

--- a/src/libs/syscall/src/unistd/bindings/chown.rs
+++ b/src/libs/syscall/src/unistd/bindings/chown.rs
@@ -16,6 +16,7 @@ use ::sysapi::{
         uid_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -60,7 +61,7 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn chown(path: *const c_char, owner: uid_t, group: gid_t) -> c_int {
-    ::syslog::trace!("chown(): path={path:?}, owner={owner:?}, group={group:?}");
     crate::unistd::bindings::fchownat::fchownat(AT_FDCWD, path, owner, group, 0)
 }

--- a/src/libs/syscall/src/unistd/bindings/chroot.rs
+++ b/src/libs/syscall/src/unistd/bindings/chroot.rs
@@ -11,6 +11,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -48,10 +49,9 @@ use ::sysapi::ffi::{
 /// - `path` remains valid for the duration of the function call.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn chroot(path: *const c_char) -> c_int {
-    ::syslog::trace!("chroot(): path={path:?}");
-
     // TODO: https://github.com/nanvix/nanvix/issues/517
     ::syslog::debug!("chroot(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/unistd/bindings/dup.rs
+++ b/src/libs/syscall/src/unistd/bindings/dup.rs
@@ -8,6 +8,7 @@
 use crate::errno::__errno_location;
 use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -44,9 +45,9 @@ use ::sysapi::ffi::c_int;
 /// - `fd` is a valid file descriptor.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dup(fd: c_int) -> c_int {
-    ::syslog::trace!("dup(): fd={fd:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/587
     ::syslog::debug!("dup(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/unistd/bindings/dup2.rs
+++ b/src/libs/syscall/src/unistd/bindings/dup2.rs
@@ -8,6 +8,7 @@
 use crate::errno::__errno_location;
 use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -48,9 +49,9 @@ use ::sysapi::ffi::c_int;
 /// - `newfd` is within the valid range of file descriptor numbers.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dup2(oldfd: c_int, newfd: c_int) -> c_int {
-    ::syslog::trace!("dup2(): oldfd={oldfd:?}, newfd={newfd:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/354
     ::syslog::debug!("dup2(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/unistd/bindings/execv.rs
+++ b/src/libs/syscall/src/unistd/bindings/execv.rs
@@ -11,6 +11,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -61,9 +62,9 @@ use ::sysapi::ffi::{
 /// - All strings referenced by `argv` remain valid for the duration of the function call.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn execv(path: *const c_char, argv: *const *const c_char) -> c_int {
-    ::syslog::trace!("execv(): path={path:?}, argv={argv:?}");
     // TODO:https://github.com/nanvix/nanvix/issues/588
     ::syslog::debug!("execv(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/unistd/bindings/execve.rs
+++ b/src/libs/syscall/src/unistd/bindings/execve.rs
@@ -11,6 +11,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -70,13 +71,13 @@ use ::sysapi::ffi::{
 /// - All strings referenced by `argv` and `envp` remain valid for the duration of the function call.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn execve(
     path: *const c_char,
     argv: *const *const c_char,
     envp: *const *const c_char,
 ) -> c_int {
-    ::syslog::trace!("execve(): path={path:?}, argv={argv:?}, envp={envp:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/320
     ::syslog::debug!("execve(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/unistd/bindings/faccessat.rs
+++ b/src/libs/syscall/src/unistd/bindings/faccessat.rs
@@ -12,6 +12,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -56,6 +57,7 @@ use ::sysapi::ffi::{
 /// - `dirfd` refers to a valid directory file descriptor or is `AT_FDCWD`.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn faccessat(
     dirfd: c_int,
@@ -63,8 +65,6 @@ pub unsafe extern "C" fn faccessat(
     mode: c_int,
     flag: c_int,
 ) -> c_int {
-    ::syslog::trace!("faccessat(): dirfd={dirfd:?}, path={path:?}, mode={mode:?}, flag={flag:?}");
-
     // Check if `path` is invalid.
     if path.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/unistd/bindings/fchdir.rs
+++ b/src/libs/syscall/src/unistd/bindings/fchdir.rs
@@ -10,6 +10,7 @@ use crate::{
     unistd,
 };
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -51,10 +52,9 @@ use ::sysapi::ffi::c_int;
 /// - The directory referenced by `fd` has appropriate search permissions for the calling process.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fchdir(fd: c_int) -> c_int {
-    ::syslog::trace!("fchdir(): fd={fd:?}");
-
     // Process system call and check for errors.
     match unistd::fchdir(fd) {
         Ok(()) => 0,

--- a/src/libs/syscall/src/unistd/bindings/fchown.rs
+++ b/src/libs/syscall/src/unistd/bindings/fchown.rs
@@ -13,6 +13,7 @@ use ::sysapi::{
         uid_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -62,10 +63,9 @@ use ::sysapi::{
 /// - The calling process has appropriate permissions to change ownership of the file.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fchown(fd: c_int, owner: uid_t, group: gid_t) -> c_int {
-    ::syslog::trace!("fchown(): fd={fd:?}, owner={owner:?}, group={group:?}");
-
     // Attempt to change file ownership and check the result.
     match crate::unistd::fchown(fd, owner, group) {
         Ok(()) => 0,

--- a/src/libs/syscall/src/unistd/bindings/fchownat.rs
+++ b/src/libs/syscall/src/unistd/bindings/fchownat.rs
@@ -18,6 +18,7 @@ use ::sysapi::{
         uid_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -64,6 +65,7 @@ use ::sysapi::{
 /// - `path` remains valid for the duration of the function call.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fchownat(
     dirfd: c_int,
@@ -72,11 +74,6 @@ pub unsafe extern "C" fn fchownat(
     group: gid_t,
     flag: c_int,
 ) -> c_int {
-    ::syslog::trace!(
-        "fchownat(): dirfd={dirfd:?}, path={path:?}, owner={owner:?}, group={group:?}, \
-         flag={flag:?}"
-    );
-
     // Check if `path` is invalid.
     if path.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/unistd/bindings/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/bindings/fdatasync.rs
@@ -7,6 +7,7 @@
 
 use crate::errno::__errno_location;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -49,10 +50,9 @@ use ::sysapi::ffi::c_int;
 /// - The underlying storage device is accessible and functioning properly.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fdatasync(fd: c_int) -> c_int {
-    ::syslog::trace!("fdatasync(): fd={fd:?}");
-
     // Attempt to synchronize the file and check the result.
     match crate::unistd::fdatasync(fd) {
         Ok(()) => 0,

--- a/src/libs/syscall/src/unistd/bindings/fork.rs
+++ b/src/libs/syscall/src/unistd/bindings/fork.rs
@@ -8,11 +8,13 @@
 use crate::errno::__errno_location;
 use ::sys::error::ErrorCode;
 use ::sysapi::sys_types::pid_t;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub extern "C" fn fork() -> pid_t {
     // TODO: https://github.com/nanvix/nanvix/issues/321

--- a/src/libs/syscall/src/unistd/bindings/fsync.rs
+++ b/src/libs/syscall/src/unistd/bindings/fsync.rs
@@ -7,6 +7,7 @@
 
 use crate::errno::__errno_location;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -52,9 +53,8 @@ use ::sysapi::ffi::c_int;
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn fsync(fd: c_int) -> c_int {
-    ::syslog::trace!("fsync(): fd={fd:?}");
-
     match crate::unistd::fsync(fd) {
         Ok(_) => 0,
         Err(error) => {

--- a/src/libs/syscall/src/unistd/bindings/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/bindings/ftruncate.rs
@@ -10,6 +10,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::off_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -59,9 +60,8 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn ftruncate(fd: c_int, length: off_t) -> c_int {
-    ::syslog::trace!("ftruncate(): fd={fd:?}, length={length:?}");
-
     // Attempt to truncate the file and check the result.
     match crate::unistd::ftruncate(fd, length) {
         Ok(()) => 0,

--- a/src/libs/syscall/src/unistd/bindings/getcwd.rs
+++ b/src/libs/syscall/src/unistd/bindings/getcwd.rs
@@ -19,6 +19,7 @@ use ::sysapi::{
     ffi::c_char,
     sys_types::c_size_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -65,10 +66,9 @@ use ::sysapi::{
 /// - `size` is greater than `0` and accurately represents the size of the buffer.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn getcwd(buf: *mut c_char, size: c_size_t) -> *mut c_char {
-    ::syslog::trace!("getcwd(): buf = {buf:?}, size = {size:?}");
-
     // Check if the buffer is valid.
     if buf.is_null() {
         ::syslog::error!("getcwd(): invalid buffer (buf={buf:?}, size={size:?})");

--- a/src/libs/syscall/src/unistd/bindings/getegid.rs
+++ b/src/libs/syscall/src/unistd/bindings/getegid.rs
@@ -9,6 +9,7 @@ use crate::unistd::{
     self,
 };
 use ::sysapi::sys_types::gid_t;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -37,10 +38,9 @@ use ::sysapi::sys_types::gid_t;
 /// or internal failures, and such errors are logged but do not set `errno` to maintain POSIX
 /// compatibility.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub extern "C" fn getegid() -> gid_t {
-    ::syslog::trace!("getegid()");
-
     // Get the effective group ID of the calling process and check for errors.
     match unistd::getegid() {
         // Success.

--- a/src/libs/syscall/src/unistd/bindings/getentropy.rs
+++ b/src/libs/syscall/src/unistd/bindings/getentropy.rs
@@ -19,6 +19,7 @@ use ::sysapi::{
     },
     sys_types::size_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -85,10 +86,9 @@ fn prng() -> i32 {
 /// - `buffer` is properly aligned for byte access.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn getentropy(buffer: *mut c_void, length: size_t) -> c_int {
-    ::syslog::trace!("getentropy(): buffer={buffer:?}, length={length:?}");
-
     // Check if buffer is null.
     if buffer.is_null() {
         ::syslog::error!("getentropy(): invalid buffer (buffer={buffer:?}, length={length:?})");

--- a/src/libs/syscall/src/unistd/bindings/geteuid.rs
+++ b/src/libs/syscall/src/unistd/bindings/geteuid.rs
@@ -7,6 +7,7 @@
 
 use crate::unistd;
 use ::sysapi::sys_types::uid_t;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -34,10 +35,9 @@ use ::sysapi::sys_types::uid_t;
 /// or internal failures, and such errors are logged but do not set `errno` to maintain POSIX
 /// compatibility.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub extern "C" fn geteuid() -> uid_t {
-    ::syslog::trace!("geteuid()");
-
     // Get the effective user ID of the calling process and check for errors.
     match unistd::geteuid() {
         // Success.

--- a/src/libs/syscall/src/unistd/bindings/getgid.rs
+++ b/src/libs/syscall/src/unistd/bindings/getgid.rs
@@ -7,6 +7,7 @@
 
 use crate::unistd;
 use ::sysapi::sys_types::gid_t;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -34,10 +35,9 @@ use ::sysapi::sys_types::gid_t;
 /// or internal failures, and such errors are logged but do not set `errno` to maintain POSIX
 /// compatibility.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub extern "C" fn getgid() -> gid_t {
-    ::syslog::trace!("getgid()");
-
     // Get the real group ID of the calling process and check for errors.
     match unistd::getgid() {
         // Success.

--- a/src/libs/syscall/src/unistd/bindings/gethostname.rs
+++ b/src/libs/syscall/src/unistd/bindings/gethostname.rs
@@ -18,6 +18,7 @@ use ::sysapi::{
     },
     sys_types::c_size_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -62,10 +63,9 @@ use ::sysapi::{
 /// - `namelen` is greater than `0` and does not exceed `isize::MAX`.
 /// - The memory referenced by `name` is not concurrently accessed by other threads.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn gethostname(name: *mut c_char, namelen: c_size_t) -> c_int {
-    ::syslog::trace!("gethostname(): name={name:?}, namelen={namelen:?}");
-
     let buf: &mut [u8] = {
         // Check if the buffer is invalid.
         if name.is_null() {

--- a/src/libs/syscall/src/unistd/bindings/getpid.rs
+++ b/src/libs/syscall/src/unistd/bindings/getpid.rs
@@ -7,6 +7,7 @@
 
 use crate::unistd;
 use ::sysapi::sys_types::pid_t;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -33,10 +34,9 @@ use ::sysapi::sys_types::pid_t;
 /// may occur due to system constraints or internal failures, and such errors are logged but do
 /// not set `errno` to maintain POSIX compatibility.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub extern "C" fn getpid() -> pid_t {
-    ::syslog::trace!("getpid()");
-
     match unistd::getpid() {
         Ok(pid) => pid.into(),
         Err(e) => {

--- a/src/libs/syscall/src/unistd/bindings/getuid.rs
+++ b/src/libs/syscall/src/unistd/bindings/getuid.rs
@@ -7,6 +7,7 @@
 
 use crate::unistd;
 use ::sysapi::sys_types::uid_t;
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -34,10 +35,9 @@ use ::sysapi::sys_types::uid_t;
 /// or internal failures, and such errors are logged but do not set `errno` to maintain POSIX
 /// compatibility.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub extern "C" fn getuid() -> uid_t {
-    ::syslog::trace!("getuid()");
-
     // Get the user ID of the calling process and check for errors.
     match unistd::getuid() {
         // Success.

--- a/src/libs/syscall/src/unistd/bindings/isatty.rs
+++ b/src/libs/syscall/src/unistd/bindings/isatty.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_int;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -55,10 +56,9 @@ use ::sysapi::ffi::c_int;
 /// It is safe to use this function if the following conditions are met:
 /// - Access to the global `errno` variable is properly synchronized in multithreaded programs.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn isatty(fd: c_int) -> c_int {
-    ::syslog::trace!("isatty(): fd={fd:?}");
-
     match unistd::isatty(fd) {
         Ok(true) => 1,
         Ok(false) => {

--- a/src/libs/syscall/src/unistd/bindings/lchown.rs
+++ b/src/libs/syscall/src/unistd/bindings/lchown.rs
@@ -19,6 +19,7 @@ use ::sysapi::{
         uid_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -64,7 +65,7 @@ use ::sysapi::{
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn lchown(path: *const c_char, owner: uid_t, group: gid_t) -> c_int {
-    ::syslog::trace!("lchown(): path={path:?}, owner={owner:?}, group={group:?}");
     crate::unistd::bindings::fchownat::fchownat(AT_FDCWD, path, owner, group, AT_SYMLINK_NOFOLLOW)
 }

--- a/src/libs/syscall/src/unistd/bindings/link.rs
+++ b/src/libs/syscall/src/unistd/bindings/link.rs
@@ -13,6 +13,7 @@ use ::sysapi::{
         c_int,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -41,8 +42,8 @@ use ::sysapi::{
 /// - `oldpath` points to a valid null-terminated string.
 /// - `newpath` points to a valid null-terminated string.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn link(oldpath: *const c_char, newpath: *const c_char) -> c_int {
-    ::syslog::trace!("link(): oldpath={oldpath:?}, newpath={newpath:?}");
     unistd::bindings::linkat::linkat(AT_FDCWD, oldpath, AT_FDCWD, newpath, 0)
 }

--- a/src/libs/syscall/src/unistd/bindings/linkat.rs
+++ b/src/libs/syscall/src/unistd/bindings/linkat.rs
@@ -15,6 +15,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -81,6 +82,7 @@ use ::sysapi::ffi::{
 /// - Access to the global `errno` variable is properly synchronized in multithreaded programs
 ///   to prevent race conditions during error reporting.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn linkat(
     olddirfd: c_int,
@@ -89,11 +91,6 @@ pub unsafe extern "C" fn linkat(
     newpath: *const c_char,
     flags: c_int,
 ) -> c_int {
-    ::syslog::trace!(
-        "linkat(): olddirfd={olddirfd:?}, oldpath={oldpath:?}, newdirfd={newdirfd:?}, \
-         newpath={newpath:?}, flags={flags:?}"
-    );
-
     // Convert `oldpath`.
     let oldpath: &str = {
         // Check if `oldpath` is invalid.

--- a/src/libs/syscall/src/unistd/bindings/lseek.rs
+++ b/src/libs/syscall/src/unistd/bindings/lseek.rs
@@ -13,6 +13,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::off_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -42,9 +43,8 @@ use ::sysapi::{
 /// - This function is not called from multiple threads at the same time.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t {
-    ::syslog::trace!("lseek(): fd={fd:?}, offset={offset:?}, whence={whence:?}");
-
     // Attempt to seek the file descriptor and check for errors.
     match unistd::lseek(fd, offset, whence) {
         Ok(offset) => offset,

--- a/src/libs/syscall/src/unistd/bindings/pread.rs
+++ b/src/libs/syscall/src/unistd/bindings/pread.rs
@@ -23,6 +23,7 @@ use ::sysapi::{
         off_t,
     },
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -55,6 +56,7 @@ use ::sysapi::{
 /// - `buffer` points to a buffer of `count` bytes.
 /// - This function is not called from multiple threads at the same time.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pread(
     fd: c_int,
@@ -62,8 +64,6 @@ pub unsafe extern "C" fn pread(
     count: c_size_t,
     offset: off_t,
 ) -> c_ssize_t {
-    ::syslog::trace!("pread(): fd={fd:?}, buffer={buffer:?}, count={count:?}, offset={offset:?}");
-
     // Check if buffer is invalid.
     if buffer.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/unistd/bindings/pwrite.rs
+++ b/src/libs/syscall/src/unistd/bindings/pwrite.rs
@@ -22,6 +22,7 @@ use ::sysapi::{
         off_t,
     },
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -54,6 +55,7 @@ use ::sysapi::{
 /// - `buffer` points to a valid memory location.
 /// - This function is not called from multiple threads at the same time.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pwrite(
     fd: c_int,
@@ -61,8 +63,6 @@ pub unsafe extern "C" fn pwrite(
     count: c_size_t,
     offset: off_t,
 ) -> c_ssize_t {
-    ::syslog::trace!("pwrite(): fd={fd:?}, buffer={buffer:?}, count={count:?}, offset={offset:?}");
-
     // Check if buffer is invalid.
     if buffer.is_null() {
         ::syslog::error!(

--- a/src/libs/syscall/src/unistd/bindings/read.rs
+++ b/src/libs/syscall/src/unistd/bindings/read.rs
@@ -16,8 +16,8 @@ use ::sysapi::{
         c_size_t,
         c_ssize_t,
     },
-    unistd::STDIN_FILENO,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -60,13 +60,9 @@ use ::sysapi::{
 /// - `fd` refers to a valid, open file descriptor with read permissions.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn read(fd: c_int, buffer: *mut c_void, count: c_size_t) -> c_ssize_t {
-    // Skip logging for stdin to avoid spamming the output.
-    if fd != STDIN_FILENO {
-        ::syslog::trace!("read(): fd={fd:?}, buffer={buffer:?}, count={count:?}");
-    }
-
     // Check if buffer is invalid.
     if buffer.is_null() {
         ::syslog::error!("read(): invalid buffer (fd={fd:?}, buffer={buffer:?}, count={count:?})");

--- a/src/libs/syscall/src/unistd/bindings/readlink.rs
+++ b/src/libs/syscall/src/unistd/bindings/readlink.rs
@@ -14,6 +14,7 @@ use ::sysapi::{
         c_ssize_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -43,12 +44,12 @@ use ::sysapi::{
 /// - `path` points to a valid null-terminated string.
 /// - `buf` points to a valid memory location of `bufsize` bytes.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn readlink(
     path: *const c_char,
     buf: *mut c_char,
     bufsize: c_size_t,
 ) -> c_ssize_t {
-    ::syslog::trace!("readlink(): path={path:?}, buf={buf:?}, bufsize={bufsize}");
     unistd::bindings::readlinkat::readlinkat(AT_FDCWD, path, buf, bufsize)
 }

--- a/src/libs/syscall/src/unistd/bindings/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/bindings/readlinkat.rs
@@ -25,6 +25,7 @@ use ::sysapi::{
         c_ssize_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -55,6 +56,7 @@ use ::sysapi::{
 /// - `path` points to a valid null-terminated string.
 /// - `buf` points to a valid memory location of `bufsize` bytes.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn readlinkat(
     dirfd: c_int,
@@ -62,10 +64,6 @@ pub unsafe extern "C" fn readlinkat(
     buf: *mut c_char,
     bufsize: c_size_t,
 ) -> c_ssize_t {
-    ::syslog::trace!(
-        "readlinkat(): dirfd={dirfd:?}, path={path:?}, buf={buf:?}, bufsize={bufsize:?}"
-    );
-
     // Attempt to convert `buf`.
     let buf: &mut [u8] = {
         // Check if `bufsize` is invalid.

--- a/src/libs/syscall/src/unistd/bindings/rmdir.rs
+++ b/src/libs/syscall/src/unistd/bindings/rmdir.rs
@@ -11,6 +11,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -18,8 +19,8 @@ use ::sysapi::ffi::{
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn rmdir(path: *const c_char) -> c_int {
-    ::syslog::trace!("rmdir(): path={path:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/348
     ::syslog::debug!("rmdir(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();

--- a/src/libs/syscall/src/unistd/bindings/sbrk.rs
+++ b/src/libs/syscall/src/unistd/bindings/sbrk.rs
@@ -9,6 +9,7 @@ use crate::{
     errno::__errno_location,
     unistd,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -32,6 +33,7 @@ use crate::{
 ///
 /// - [`crate::unistd::syscall::sbrk()`]
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub extern "C" fn sbrk(size: isize) -> *mut u8 {
     match unistd::sbrk(size) {

--- a/src/libs/syscall/src/unistd/bindings/setegid.rs
+++ b/src/libs/syscall/src/unistd/bindings/setegid.rs
@@ -14,6 +14,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::gid_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -40,6 +41,7 @@ use ::sysapi::{
 /// This function is safe to use if the following conditions are met:
 /// - This function is not called from multiple threads at the same time.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn setegid(gid: gid_t) -> c_int {
     ::syslog::error!("setegid(): gid={gid:?}");

--- a/src/libs/syscall/src/unistd/bindings/seteuid.rs
+++ b/src/libs/syscall/src/unistd/bindings/seteuid.rs
@@ -14,6 +14,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::uid_t,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -40,6 +41,7 @@ use ::sysapi::{
 /// This function is safe to use if the following conditions are met:
 /// - This function is not called from multiple threads at the same time.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn seteuid(uid: uid_t) -> c_int {
     ::syslog::error!("seteuid(): uid={uid:?}");

--- a/src/libs/syscall/src/unistd/bindings/setgid.rs
+++ b/src/libs/syscall/src/unistd/bindings/setgid.rs
@@ -14,6 +14,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::gid_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -40,6 +41,7 @@ use ::sysapi::{
 /// This function is safe to use if the following conditions are met:
 /// - This function is not called from multiple threads at the same time.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn setgid(gid: gid_t) -> c_int {
     ::syslog::error!("setgid(): gid={gid:?}");

--- a/src/libs/syscall/src/unistd/bindings/setgroups.rs
+++ b/src/libs/syscall/src/unistd/bindings/setgroups.rs
@@ -14,15 +14,16 @@ use ::sysapi::{
         gid_t,
     },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
 #[allow(clippy::missing_safety_doc)]
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub extern "C" fn setgroups(size: c_size_t, list: *const gid_t) -> c_int {
-    ::syslog::trace!("setgroups(): size={size}, list={list:p}");
     // TODO: https://github.com/nanvix/nanvix/issues/523
     ::syslog::debug!("setgroups(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/unistd/bindings/setuid.rs
+++ b/src/libs/syscall/src/unistd/bindings/setuid.rs
@@ -14,6 +14,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::uid_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -40,6 +41,7 @@ use ::sysapi::{
 /// This function is safe to use if the following conditions are met:
 /// - This function is not called from multiple threads at the same time.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn setuid(uid: uid_t) -> c_int {
     ::syslog::error!("setuid(): uid={uid:?}");

--- a/src/libs/syscall/src/unistd/bindings/sleep.rs
+++ b/src/libs/syscall/src/unistd/bindings/sleep.rs
@@ -8,15 +8,15 @@
 use crate::errno::__errno_location;
 use ::sys::error::ErrorCode;
 use ::sysapi::ffi::c_uint;
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub extern "C" fn sleep(seconds: c_uint) -> c_uint {
-    ::syslog::trace!("sleep(): seconds={seconds:?}");
-
     // TODO: https://github.com/nanvix/nanvix/issues/453
     ::syslog::debug!("sleep(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/unistd/bindings/symlink.rs
+++ b/src/libs/syscall/src/unistd/bindings/symlink.rs
@@ -44,8 +44,6 @@ use ::syslog::trace_syscall;
 #[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn symlink(target: *const c_char, linkpath: *const c_char) -> c_int {
-    syslog::trace!("symlink(): target={target:?}, linkpath={linkpath:?}");
-
     // Attempt to convert `target`.
     let target: &str = {
         // Check if `target` is invalid.

--- a/src/libs/syscall/src/unistd/bindings/symlink.rs
+++ b/src/libs/syscall/src/unistd/bindings/symlink.rs
@@ -15,6 +15,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -39,8 +40,9 @@ use ::sysapi::ffi::{
 ///
 /// - [`crate::unistd::syscall::symlink()`]
 ///
-#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
+#[trace_syscall]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn symlink(target: *const c_char, linkpath: *const c_char) -> c_int {
     syslog::trace!("symlink(): target={target:?}, linkpath={linkpath:?}");
 

--- a/src/libs/syscall/src/unistd/bindings/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/bindings/symlinkat.rs
@@ -16,6 +16,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -45,6 +46,7 @@ use ::sysapi::ffi::{
 /// - `target` points to a valid null-terminated string.
 /// - `linkpath` points to a valid null-terminated string.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn symlinkat(
     target: *const c_char,

--- a/src/libs/syscall/src/unistd/bindings/sysconf.rs
+++ b/src/libs/syscall/src/unistd/bindings/sysconf.rs
@@ -16,6 +16,7 @@ use ::sysapi::ffi::{
     c_int,
     c_long,
 };
+use ::syslog::trace_libcall;
 
 //==================================================================================================
 // Standalone Functions
@@ -43,10 +44,9 @@ use ::sysapi::ffi::{
 /// - [`sys::error::ErrorCode::ValueOutOfRange`] if the value of the specified system configuration variable
 ///   cannot be represented by the return type.
 ///
+#[trace_libcall]
 #[unsafe(no_mangle)]
 pub extern "C" fn sysconf(name: c_int) -> c_long {
-    ::syslog::trace!("sysconf(): name={name:?}");
-
     // Attempt to convert `name` to `SysConfigName`.
     let name: SysConfigName = match SysConfigName::try_from(name) {
         Ok(name) => name,

--- a/src/libs/syscall/src/unistd/bindings/unlink.rs
+++ b/src/libs/syscall/src/unistd/bindings/unlink.rs
@@ -15,6 +15,7 @@ use ::sysapi::ffi::{
     c_char,
     c_int,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -40,9 +41,8 @@ use ::sysapi::ffi::{
 ///
 #[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
+#[trace_syscall]
 pub unsafe extern "C" fn unlink(path: *const c_char) -> c_int {
-    ::syslog::trace!("unlink(): path={path:?}");
-
     // Attempt to convert `path`.
     let path: &str = {
         // Check if `path` is invalid.

--- a/src/libs/syscall/src/unistd/bindings/waitpid.rs
+++ b/src/libs/syscall/src/unistd/bindings/waitpid.rs
@@ -11,6 +11,7 @@ use ::sysapi::{
     ffi::c_int,
     sys_types::pid_t,
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -40,8 +41,8 @@ use ::sysapi::{
 /// - `status` points to a valid `c_int`.
 ///
 #[unsafe(no_mangle)]
+#[trace_syscall]
 pub unsafe extern "C" fn waitpid(pid: pid_t, status: *mut c_int, options: c_int) -> pid_t {
-    ::syslog::trace!("waitpid(): pid={pid:?}, status={status:?}, options={options:?}");
     // TODO: https://github.com/nanvix/nanvix/issues/336.
     ::syslog::debug!("waitpid(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/unistd/bindings/write.rs
+++ b/src/libs/syscall/src/unistd/bindings/write.rs
@@ -19,11 +19,8 @@ use ::sysapi::{
         c_size_t,
         c_ssize_t,
     },
-    unistd::{
-        STDERR_FILENO,
-        STDOUT_FILENO,
-    },
 };
+use ::syslog::trace_syscall;
 
 //==================================================================================================
 // Standalone Functions
@@ -65,13 +62,9 @@ use ::sysapi::{
 /// - `fd` refers to a valid, open file descriptor with write permissions.
 /// - Access to `errno` is synchronized with other threads that may modify it.
 ///
+#[trace_syscall]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn write(fd: c_int, buffer: *const c_void, count: c_size_t) -> c_ssize_t {
-    // Skip logging for stdout and stderr to avoid spamming the output.
-    if fd != STDOUT_FILENO && fd != STDERR_FILENO {
-        ::syslog::trace!("write(): fd={fd:?}, buffer={buffer:?}, count={count:?}");
-    }
-
     // Check if buffer is invalid.
     if buffer.is_null() {
         ::syslog::error!("write(): invalid buffer (fd={fd:?}, buffer={buffer:?}, count={count:?})");

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -67,10 +67,11 @@ pub fn close(fd: i32) -> Result<(), Error> {
 pub mod bindings {
     use crate::errno::__errno_location;
     use ::sysapi::ffi::c_int;
+    use ::syslog::trace_syscall;
 
     #[unsafe(no_mangle)]
+    #[trace_syscall]
     pub extern "C" fn close(fd: c_int) -> c_int {
-        ::syslog::trace!("close(): fd = {}", fd);
         match crate::unistd::close(fd) {
             Ok(()) => 0,
             Err(error) => {

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -73,6 +73,7 @@ pub fn pipe() -> Result<[i32; 2], Error> {
 pub mod bindings {
     use crate::errno::__errno_location;
     use ::sysapi::ffi::c_int;
+    use ::syslog::trace_syscall;
 
     ///
     /// # Description
@@ -89,9 +90,8 @@ pub mod bindings {
     /// indicate the error.
     ///
     #[unsafe(no_mangle)]
+    #[trace_syscall]
     pub unsafe extern "C" fn pipe(fds: *mut c_int) -> c_int {
-        ::syslog::trace!("pipe(): fds={fds:?}");
-
         match super::pipe() {
             Ok([read_fd, write_fd]) => {
                 ::syslog::trace!("pipe(): read_fd={read_fd:?}, write_fd={write_fd:?}");

--- a/src/libs/syslog-macros/Cargo.toml
+++ b/src/libs/syslog-macros/Cargo.toml
@@ -1,0 +1,26 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "syslog-macros"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Proc-macro helpers for syslog instrumentation"
+homepage.workspace = true
+
+[lib]
+proc-macro = true
+
+[features]
+default = ["std"]
+std = []
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }
+
+[lints]
+workspace = true

--- a/src/libs/syslog-macros/src/lib.rs
+++ b/src/libs/syslog-macros/src/lib.rs
@@ -1,0 +1,403 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+#![doc = "Attribute macros that inject syslog instrumentation into function bodies."]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::proc_macro::TokenStream;
+use ::proc_macro2::{
+    Ident,
+    TokenStream as TokenStream2,
+};
+use ::quote::quote;
+use ::std::{
+    string::String,
+    vec::Vec,
+};
+use ::syn::{
+    spanned::Spanned,
+    FnArg,
+    ItemFn,
+    LitStr,
+    Pat,
+    Result,
+};
+
+///
+/// # Description
+///
+/// Annotates a function so that it emits a `syscall_trace!` log message before
+/// the function body executes.
+///
+/// # Parameters
+///
+/// - `attr`: The attribute tokens supplied by the caller (unused, but validated).
+/// - `item`: The target function annotated with `trace_syscall`.
+///
+/// # Returns
+///
+/// An instrumented version of the input function with tracing injected.
+///
+/// # Errors
+///
+/// Propagates parsing errors or validation failures through the generated token
+/// stream.
+///
+#[proc_macro_attribute]
+pub fn trace_syscall(attr: TokenStream, item: TokenStream) -> TokenStream {
+    expand(attr, item, TraceKind::Syscall)
+}
+
+///
+/// # Description
+///
+/// Annotates a function so that it emits a `libcall_trace!` log message before
+/// the function body executes.
+///
+/// # Parameters
+///
+/// - `attr`: The attribute tokens supplied by the caller (unused, but validated).
+/// - `item`: The target function annotated with `trace_libcall`.
+///
+/// # Returns
+///
+/// An instrumented version of the input function with tracing injected.
+///
+/// # Errors
+///
+/// Propagates parsing errors or validation failures through the generated token
+/// stream.
+///
+#[proc_macro_attribute]
+pub fn trace_libcall(attr: TokenStream, item: TokenStream) -> TokenStream {
+    expand(attr, item, TraceKind::Libcall)
+}
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const CHATTY_LIBCALL_PREFIXES: [&str; 3] = ["pthread_", "sem_", "__errno_location"];
+const CHATTY_SYSCALL_PREFIXES: [&str; 6] = [
+    "lock_mutex",
+    "unlock_mutex",
+    "signal_cond",
+    "wait_cond",
+    "sched_yield",
+    "write",
+];
+
+//==================================================================================================
+// Enumerations
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Distinguishes whether a trace macro invocation targets syscalls or libcalls.
+///
+#[derive(Copy, Clone)]
+enum TraceKind {
+    Syscall,
+    Libcall,
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Dispatches expansion to the internal helper while converting diagnostic
+/// errors into compilable token streams.
+///
+/// # Parameters
+///
+/// - `attr`: Attribute tokens supplied to the macro.
+/// - `item`: The annotated item provided by the user.
+/// - `kind`: Indicates whether the expansion targets syscalls or libcalls.
+///
+/// # Returns
+///
+/// Instrumented tokens when expansion succeeds or compile-error tokens when it
+/// fails.
+///
+/// # Errors
+///
+/// Never directly returns errors; diagnostics are emitted through token streams.
+///
+fn expand(attr: TokenStream, item: TokenStream, kind: TraceKind) -> TokenStream {
+    match expand_inner(attr, item, kind) {
+        Ok(tokens) => tokens,
+        Err(error) => error.to_compile_error().into(),
+    }
+}
+
+///
+/// # Description
+///
+/// Parses the annotated function, injects the trace statement, and re-emits the
+/// modified function body.
+///
+/// # Parameters
+///
+/// - `attr`: Attribute tokens supplied to the macro.
+/// - `item`: The annotated function in token form.
+/// - `kind`: Indicates which syslog macro to call.
+///
+/// # Returns
+///
+/// A token stream representing the instrumented function.
+///
+/// # Errors
+///
+/// Returns a parsing error if the input item is not a function or if trace
+/// generation fails.
+///
+fn expand_inner(attr: TokenStream, item: TokenStream, kind: TraceKind) -> Result<TokenStream> {
+    let mut function: ItemFn = syn::parse::<ItemFn>(item.clone())?;
+    let attr_tokens: TokenStream2 = TokenStream2::from(attr);
+
+    let statement: syn::Stmt = if should_skip_instrumentation(&function, kind) {
+        if !attr_tokens.is_empty() {
+            return Err(syn::Error::new(
+                function.sig.ident.span(),
+                "trace_* macros no longer accept custom format strings",
+            ));
+        }
+        build_suppressed_statement(&function)?
+    } else {
+        build_statement(attr_tokens, &function, kind)?
+    };
+    function.block.stmts.insert(0, statement);
+    Ok(TokenStream::from(quote!(#function)))
+}
+
+///
+/// # Description
+///
+/// Builds the tracing statement inserted at the beginning of the annotated
+/// function.
+///
+/// # Parameters
+///
+/// - `attr_tokens`: Raw attribute tokens that must be empty.
+/// - `function`: The parsed function definition.
+/// - `kind`: Determines whether to call `syscall_trace!` or `libcall_trace!`.
+///
+/// # Returns
+///
+/// A single statement that invokes the appropriate syslog macro.
+///
+/// # Errors
+///
+/// Returns an error if custom attribute tokens are provided or if message
+/// construction fails.
+///
+fn build_statement(
+    attr_tokens: TokenStream2,
+    function: &ItemFn,
+    kind: TraceKind,
+) -> Result<syn::Stmt> {
+    if !attr_tokens.is_empty() {
+        return Err(syn::Error::new(
+            function.sig.ident.span(),
+            "trace_* macros no longer accept custom format strings",
+        ));
+    }
+
+    let target_macro: TokenStream2 = match kind {
+        TraceKind::Syscall => quote!(::syslog::syscall_trace!),
+        TraceKind::Libcall => quote!(::syslog::libcall_trace!),
+    };
+
+    let (message, args): (LitStr, Vec<TokenStream2>) = build_auto_message(function)?;
+    let statement: TokenStream2 = quote! {
+        #target_macro(#message #(, #args)*);
+    };
+
+    syn::parse2(statement)
+}
+
+///
+/// # Description
+///
+/// Emits no-op statements for functions whose instrumentation has been
+/// suppressed so that compiler warnings remain silenced.
+///
+/// # Parameters
+///
+/// - `function`: Parsed representation of the annotated function.
+///
+/// # Returns
+///
+/// A statement that references each parameter to avoid unused-variable
+/// warnings.
+///
+fn build_suppressed_statement(function: &ItemFn) -> Result<syn::Stmt> {
+    let (_, args) = build_auto_message(function)?;
+
+    if args.is_empty() {
+        return syn::parse2(quote!({}));
+    }
+
+    let statement: TokenStream2 = quote!({ #(let _ = &#args;)* });
+    syn::parse2(statement)
+}
+
+///
+/// # Description
+///
+/// Generates an automatic format string and argument list based on the function
+/// signature so traces include every parameter.
+///
+/// # Parameters
+///
+/// - `function`: The parsed function definition.
+///
+/// # Returns
+///
+/// A tuple containing a literal format string and the ordered argument tokens.
+///
+/// # Errors
+///
+/// Returns an error if any parameter pattern is unsupported (e.g., destructured
+/// bindings).
+///
+fn build_auto_message(function: &ItemFn) -> Result<(LitStr, Vec<TokenStream2>)> {
+    let ident: &Ident = &function.sig.ident;
+    let mut parts: Vec<String> = Vec::new();
+    let mut args: Vec<TokenStream2> = Vec::new();
+
+    for input in &function.sig.inputs {
+        match input {
+            FnArg::Receiver(receiver) => {
+                let is_reference: bool = receiver.reference.is_some();
+                let is_mutable: bool = receiver.mutability.is_some();
+
+                let label: String = match (is_reference, is_mutable) {
+                    (false, _) => "self={:?}".to_string(),
+                    (true, false) => "&self={:?}".to_string(),
+                    (true, true) => "&mut self={:?}".to_string(),
+                };
+
+                let capture: TokenStream2 = match (is_reference, is_mutable) {
+                    (false, _) => quote!(&self),
+                    (true, false) => quote!(self),
+                    (true, true) => quote!(&*self),
+                };
+
+                parts.push(label);
+                args.push(capture);
+            },
+            FnArg::Typed(pat_type) => {
+                if let Pat::Ident(pat_ident) = pat_type.pat.as_ref() {
+                    if pat_ident.subpat.is_some() {
+                        return Err(syn::Error::new(
+                            pat_type.pat.span(),
+                            "trace_* macros require simple identifier parameters",
+                        ));
+                    }
+
+                    let name: String = pat_ident.ident.to_string();
+                    parts.push(format!("{name}={{:?}}"));
+                    let parameter_ident: &Ident = &pat_ident.ident;
+                    args.push(quote!(&#parameter_ident));
+                } else {
+                    return Err(syn::Error::new(
+                        pat_type.pat.span(),
+                        "trace_* macros require simple identifier parameters",
+                    ));
+                }
+            },
+        }
+    }
+    let message: String = if parts.is_empty() {
+        format!("{}()", ident)
+    } else {
+        format!("{}({})", ident, parts.join(", "))
+    };
+
+    Ok((LitStr::new(&message, ident.span()), args))
+}
+
+///
+/// # Description
+///
+/// Determines whether instrumentation should be skipped for the provided
+/// function based on its namespace and the trace kind.
+///
+/// # Parameters
+///
+/// - `function`: Parsed representation of the annotated function.
+/// - `kind`: Indicates whether the macro targets syscalls or libcalls.
+///
+/// # Returns
+///
+/// Returns `true` when the macro should leave the function body untouched.
+///
+fn should_skip_instrumentation(function: &ItemFn, kind: TraceKind) -> bool {
+    let ident_name: String = function.sig.ident.to_string();
+
+    match kind {
+        TraceKind::Syscall => CHATTY_SYSCALL_PREFIXES
+            .iter()
+            .any(|name| ident_name.starts_with(name)),
+        TraceKind::Libcall => CHATTY_LIBCALL_PREFIXES
+            .iter()
+            .any(|prefix| ident_name.starts_with(prefix)),
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::syn::parse_quote;
+
+    #[test]
+    // Ensures owned arguments are borrowed before tracing so the function body retains ownership.
+    fn build_auto_message_borrows_owned_inputs() {
+        let function: ItemFn = parse_quote! {
+            fn demo(buffer: ::std::vec::Vec<u8>, count: usize) {}
+        };
+
+        let (message, args) =
+            build_auto_message(&function).expect("message generation must succeed");
+        assert_eq!(message.value(), "demo(buffer={:?}, count={:?})");
+
+        let rendered: Vec<String> = args
+            .iter()
+            .map(::std::string::ToString::to_string)
+            .collect();
+        assert_eq!(rendered, ["& buffer", "& count"]);
+    }
+
+    #[test]
+    // Verifies that `&mut self` plus additional parameters remain borrowable after instrumentation.
+    fn build_auto_message_borrows_mut_self_and_args() {
+        let mut function: ItemFn = parse_quote! {
+            fn demo(delta: usize) {}
+        };
+
+        let receiver: ::syn::Receiver = parse_quote!(&mut self);
+        function.sig.inputs.insert(0, FnArg::Receiver(receiver));
+
+        let (message, args) =
+            build_auto_message(&function).expect("message generation must succeed");
+        assert_eq!(message.value(), "demo(&mut self={:?}, delta={:?})");
+
+        let rendered: Vec<String> = args
+            .iter()
+            .map(::std::string::ToString::to_string)
+            .collect();
+        assert_eq!(rendered, ["& * self", "& delta"]);
+    }
+}

--- a/src/libs/syslog/Cargo.toml
+++ b/src/libs/syslog/Cargo.toml
@@ -17,6 +17,7 @@ compiler_builtins = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 flexi_logger = { workspace = true, optional = true }
 sys = { workspace = true, features = ["kcall"], optional = true }
+syslog-macros = { workspace = true }
 
 [features]
 default = ["dep:cfg-if", "dep:sys", "error"]

--- a/src/libs/syslog/src/lib.rs
+++ b/src/libs/syslog/src/lib.rs
@@ -24,6 +24,46 @@ mod hosted;
 mod standalone;
 
 //==================================================================================================
+// Macros
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Emits a trace-level syslog record tagged with the `SYSCALL` target so kernel
+/// instrumentation can be filtered independently. Typically invoked by the
+/// `trace_syscall` attribute macro.
+///
+/// # Parameters
+///
+/// - `$($arg:tt)*`: Format string and arguments forwarded to `trace!`.
+///
+#[macro_export]
+macro_rules! syscall_trace {
+    ($($arg:tt)*) => {
+        $crate::trace!(target: ::core::concat!("SYSCALL][", module_path!()), $($arg)*);
+    };
+}
+
+///
+/// # Description
+///
+/// Emits a trace-level syslog record tagged with the `LIBCALL` target so libc
+/// instrumentation can be filtered independently. Typically invoked by the
+/// `trace_libcall` attribute macro.
+///
+/// # Parameters
+///
+/// - `$($arg:tt)*`: Format string and arguments forwarded to `trace!`.
+///
+#[macro_export]
+macro_rules! libcall_trace {
+    ($($arg:tt)*) => {
+        $crate::trace!(target: ::core::concat!("LIBCALL][", module_path!()), $($arg)*);
+    };
+}
+
+//==================================================================================================
 // Exports
 //==================================================================================================
 
@@ -31,3 +71,12 @@ mod standalone;
 pub use hosted::*;
 #[cfg(not(feature = "std"))]
 pub use standalone::*;
+
+//==================================================================================================
+// Re-exports
+//==================================================================================================
+
+pub use ::syslog_macros::{
+    trace_libcall,
+    trace_syscall,
+};

--- a/src/libs/syslog/src/standalone.rs
+++ b/src/libs/syslog/src/standalone.rs
@@ -15,13 +15,22 @@ use ::core::{
 //==================================================================================================
 
 #[macro_export]
-macro_rules! trace{
-    ( $($arg:tt)* ) => ({
-		if $crate::MAX_LEVEL >= $crate::LogLevel::Trace {
+macro_rules! trace {
+    (target: $target:expr, $($arg:tt)+) => ({
+        if $crate::MAX_LEVEL >= $crate::LogLevel::Trace {
+            use core::fmt::Write;
+            let _ = writeln!(
+                &mut $crate::Logger::get($target, $crate::LogLevel::Trace),
+                $($arg)+
+            );
+        }
+    });
+    ( $($arg:tt)+ ) => ({
+        if $crate::MAX_LEVEL >= $crate::LogLevel::Trace {
             use core::fmt::Write;
             let _ = writeln!(
                 &mut $crate::Logger::get(module_path!(), $crate::LogLevel::Trace),
-                $($arg)*
+                $($arg)+
             );
         }
     })

--- a/src/uservm/src/io_thread.rs
+++ b/src/uservm/src/io_thread.rs
@@ -37,6 +37,7 @@ use ::tokio::{
         Sender,
     },
     task::JoinHandle,
+    time::Instant,
 };
 
 //==================================================================================================
@@ -119,6 +120,7 @@ impl IoThread {
         control_plane_stream: SocketStream,
         counters: MessageCounters,
     ) -> Result<()> {
+        let start_instant: Instant = Instant::now();
         let mut buf: [u8; mem::size_of::<Message>()] = [0; mem::size_of::<Message>()];
         let mut buf_len: usize = 0;
         let mut control_plane_buf: [u8; ::std::mem::size_of::<NanvixdControlMessage>()] =
@@ -201,7 +203,10 @@ impl IoThread {
                             })?;
                         },
                         None => {
-                            debug!("User VM channel closed, exiting I/O thread");
+                            debug!(
+                                "User VM channel closed, exiting I/O thread (elapsed_ms={})",
+                                start_instant.elapsed().as_millis()
+                            );
                             break Ok(());
                         },
                     }
@@ -229,7 +234,19 @@ impl IoThread {
 
                                 match msg.cmd() {
                                     NanvixdCommand::Shutdown => {
-                                        control_tx.send(IoControlCommand::Shutdown).await?;
+                                        if let Err(error) =
+                                            control_tx.send(IoControlCommand::Shutdown).await
+                                        {
+                                            debug!(
+                                                "control channel closed while relaying shutdown: {error} (elapsed_ms={})",
+                                                start_instant.elapsed().as_millis()
+                                            );
+                                            break Ok(());
+                                        }
+                                        debug!(
+                                            "received shutdown from control-plane (elapsed_ms={})",
+                                            start_instant.elapsed().as_millis()
+                                        );
                                     },
                                 }
                             }
@@ -249,7 +266,14 @@ impl IoThread {
                                 IoControlResponse::FlushInput => {
                                     debug!("input flush completed");
                                     // Messages are no longer buffer, nothing to flush. We should remove this.
-                                    control_tx.send(IoControlCommand::LinuxDaemonFlushed).await?;
+                                    if let Err(error) =
+                                        control_tx.send(IoControlCommand::LinuxDaemonFlushed).await
+                                    {
+                                        debug!(
+                                            "control channel closed while sending flush ack: {error}"
+                                        );
+                                        break Ok(());
+                                    }
                                 },
                                 IoControlResponse::FlushOutput => {
                                     // Messages are no longer buffer, nothing to flush. We should remove this.
@@ -262,13 +286,19 @@ impl IoThread {
                                     debug!("snapshot created");
                                 },
                                 IoControlResponse::Shutdown => {
-                                    debug!("shutdown completed");
+                                    debug!(
+                                        "shutdown completed (elapsed_ms={})",
+                                        start_instant.elapsed().as_millis()
+                                    );
                                     break Ok(());
                                 },
                             }
                         },
                         None => {
-                            error!("VMM control channel closed unexpectedly");
+                            error!(
+                                "VMM control channel closed unexpectedly (elapsed_ms={})",
+                                start_instant.elapsed().as_millis()
+                            );
                             break Err(anyhow::Error::msg("VMM control channel closed unexpectedly"));
                         },
                     }

--- a/src/utils/echo-client/Cargo.toml
+++ b/src/utils/echo-client/Cargo.toml
@@ -21,7 +21,6 @@ tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = []
-timestamp-messages = []
 
 [lints]
 workspace = true

--- a/src/utils/strace/Cargo.toml
+++ b/src/utils/strace/Cargo.toml
@@ -1,0 +1,22 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "strace"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Nanvix system call trace analyzer"
+homepage.workspace = true
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+
+[features]
+default = []
+
+[lints]
+workspace = true

--- a/src/utils/strace/src/main.rs
+++ b/src/utils/strace/src/main.rs
@@ -1,0 +1,583 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::{
+    anyhow,
+    bail,
+    Context,
+    Result,
+};
+use ::clap::Parser;
+use ::std::{
+    collections::HashMap,
+    fs::File,
+    io::{
+        BufRead,
+        BufReader,
+    },
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+//==================================================================================================
+// CLI Definition
+//==================================================================================================
+
+/// Command-line flags accepted by the Nanvix trace analyzer.
+#[derive(Debug, Parser)]
+#[command(author, version, about = "Analyze syscall trace logs", long_about = None)]
+struct Cli {
+    /// # Description
+    /// Path to a log file containing `syscall::*` trace entries.
+    #[arg(short = 't', long = "trace", value_name = "FILE")]
+    trace_path: PathBuf,
+
+    /// # Description
+    /// Fail immediately when a log line cannot be parsed.
+    #[arg(long = "strict", default_value_t = false)]
+    strict: bool,
+}
+
+//==================================================================================================
+// Data Structures
+//==================================================================================================
+
+/// Classification for parsed trace lines.
+#[derive(Clone, Debug, PartialEq)]
+enum TraceLine {
+    Syscall(TraceEntry),
+    NonSyscall,
+}
+
+/// Represents a single syscall trace entry.
+#[derive(Clone, Debug, PartialEq)]
+struct TraceEntry {
+    module: String,
+    function: String,
+}
+
+impl TraceEntry {
+    ///
+    /// # Description
+    ///
+    /// Returns a normalized identifier for the traced syscall.
+    ///
+    /// # Parameters
+    ///
+    /// - `self`: Trace entry being normalized.
+    ///
+    /// # Returns
+    ///
+    /// Fully-qualified call label for the syscall.
+    ///
+    fn qualified_call(&self) -> String {
+        self.function.clone()
+    }
+}
+
+///  Aggregated statistics collected while parsing the trace.
+#[derive(Debug, Default)]
+struct TraceStats {
+    total_events: u64,
+    skipped_lines: u64,
+    filtered_events: u64,
+    call_counts: HashMap<String, u64>,
+    cmdline: Option<String>,
+}
+
+impl TraceStats {
+    ///
+    /// # Description
+    ///
+    /// Incorporates a single trace entry into the cumulative statistics.
+    ///
+    /// # Parameters
+    ///
+    /// - `self`: Mutable reference to the accumulator.
+    /// - `entry`: Syscall invocation that should be counted.
+    ///
+    fn ingest(&mut self, entry: TraceEntry) {
+        self.total_events += 1;
+        let call_counter: &mut u64 = self.call_counts.entry(entry.qualified_call()).or_insert(0);
+        *call_counter += 1;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the fully-qualified calls by frequency.
+    ///
+    /// # Parameters
+    ///
+    /// - `self`: Immutable reference to the accumulated statistics.
+    ///
+    /// # Returns
+    ///
+    /// Sorted vector of `(call, count)` pairs.
+    ///
+    fn top_calls(&self) -> Vec<(String, u64)> {
+        Self::top_entries(&self.call_counts)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Helper that sorts map entries by descending count and ascending key.
+    ///
+    /// # Parameters
+    ///
+    /// - `source`: Map containing call counters.
+    ///
+    /// # Returns
+    ///
+    /// Sorted vector containing every entry.
+    ///
+    fn top_entries(source: &HashMap<String, u64>) -> Vec<(String, u64)> {
+        let mut entries: Vec<(String, u64)> = source
+            .iter()
+            .map(|(name, count)| (name.clone(), *count))
+            .collect();
+        entries.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+        entries
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Program entry point.
+///
+/// # Parameters
+///
+/// - None.
+///
+/// # Returns
+///
+/// `Result` conveying whether the analyzer completed successfully.
+///
+/// # Errors
+///
+/// Propagates failures reported by `analyze_trace()` or I/O initialization.
+///
+fn main() -> Result<()> {
+    let cli: Cli = Cli::parse();
+    let stats: TraceStats = analyze_trace(&cli.trace_path, cli.strict)?;
+    render_report(&stats, &cli);
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Reads the provided trace file, aggregates syscall statistics, and returns the final analysis.
+///
+/// # Parameters
+///
+/// - `trace_path`: Path to the trace log that should be parsed.
+/// - `strict`: When true, parsing errors abort the entire run.
+///
+/// # Returns
+///
+/// Aggregated statistics covering every processed entry.
+///
+/// # Errors
+///
+/// Propagates I/O errors and, when strict mode is enabled, parsing failures.
+fn analyze_trace(trace_path: &Path, strict: bool) -> Result<TraceStats> {
+    let file: File = File::open(trace_path)
+        .with_context(|| format!("Unable to open trace file: {}", trace_path.display()))?;
+    let reader: BufReader<File> = BufReader::new(file);
+    let mut stats: TraceStats = TraceStats::default();
+    for (line_number, line_result) in reader.lines().enumerate() {
+        let current_line_index: usize = line_number + 1;
+        let line: String = match line_result {
+            Ok(value) => value,
+            Err(error) => {
+                if strict {
+                    return Err(error)
+                        .with_context(|| format!("Failed to read line {current_line_index}"));
+                }
+                stats.skipped_lines += 1;
+                continue;
+            },
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        if stats.cmdline.is_none() {
+            if let Some(cmdline) = extract_cmdline_from_line(&line) {
+                stats.cmdline = Some(cmdline);
+            }
+        }
+        match parse_trace_line(&line) {
+            Ok(Some(TraceLine::Syscall(entry))) => {
+                stats.ingest(entry);
+            },
+            Ok(Some(TraceLine::NonSyscall)) => {
+                stats.filtered_events += 1;
+            },
+            Ok(None) => {
+                continue;
+            },
+            Err(error) => {
+                if strict {
+                    return Err(error)
+                        .with_context(|| format!("Failed to parse line {current_line_index}"));
+                }
+                stats.skipped_lines += 1;
+            },
+        }
+    }
+    Ok(stats)
+}
+
+///
+/// # Description
+///
+/// Searches for a kernel command-line snippet embedded in a log line.
+///
+/// # Parameters
+///
+/// - `line`: Raw log entry that may contain a `cmdline="..."` field.
+///
+/// # Returns
+///
+/// Command-line string when found, or `None` if the field is absent.
+fn extract_cmdline_from_line(line: &str) -> Option<String> {
+    let marker: &str = "cmdline=\"";
+    let start_index: usize = line.find(marker)? + marker.len();
+    let remainder: &str = &line[start_index..];
+    let end_offset: usize = remainder.find('\"')?;
+    Some(remainder[..end_offset].to_string())
+}
+
+///
+/// # Description
+///
+/// Parses a single log line and yields a structured trace entry when it originates from the syscall
+/// namespace. Non-syscall traces are surfaced as `TraceLine::NonSyscall` so they can be counted in
+/// the final report.
+///
+/// # Parameters
+///
+/// - `line`: Raw log line.
+///
+/// # Returns
+///
+/// Parsed trace classification when the line matches a supported target, or `Ok(None)` when it
+/// should be ignored entirely.
+///
+/// # Errors
+///
+/// Returns an error if the line uses a malformed trace format.
+fn parse_trace_line(line: &str) -> Result<Option<TraceLine>> {
+    let trimmed: &str = line.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let remainder: &str = if let Some(rest) = trimmed.strip_prefix("[TRACE]") {
+        rest.trim_start()
+    } else if let Some(rest) = trimmed.strip_prefix("TRACE") {
+        rest.trim_start()
+    } else {
+        return Ok(None);
+    };
+    if !remainder.starts_with('[') {
+        return Ok(None);
+    }
+
+    let (first_token, mut rest) = parse_bracket_token(remainder)?;
+    rest = rest.trim_start();
+
+    let mut namespace_token: Option<&str> = None;
+    let mut target_segment: &str = first_token;
+    if is_namespace_token(first_token) {
+        namespace_token = Some(first_token);
+        if !rest.starts_with('[') {
+            bail!("missing module path after namespace tag");
+        }
+        let (module_token, remainder_after_module) = parse_bracket_token(rest)?;
+        rest = remainder_after_module.trim_start();
+        target_segment = module_token;
+    }
+
+    if target_segment.is_empty() {
+        bail!("missing log target segment");
+    }
+
+    let message: &str = rest.trim_start();
+    if message.is_empty() {
+        bail!("missing function call in trace line");
+    }
+
+    let namespace_is_syscall: bool =
+        namespace_token.is_some_and(tag_is_syscall) || target_segment.starts_with("syscall::");
+    if !namespace_is_syscall {
+        return Ok(Some(TraceLine::NonSyscall));
+    }
+
+    let module: String = normalize_syscall_module(target_segment);
+    let open_paren_index: usize = message
+        .find('(')
+        .ok_or_else(|| anyhow!("missing '(' in trace message"))?;
+    let mut function_name: &str = &message[..open_paren_index];
+    function_name = function_name.trim_end_matches(':').trim();
+    if function_name.is_empty() {
+        bail!("empty function name in trace line");
+    }
+    let entry: TraceEntry = TraceEntry {
+        module,
+        function: function_name.to_string(),
+    };
+    Ok(Some(TraceLine::Syscall(entry)))
+}
+
+///
+/// # Description
+///
+/// Extracts the contents of a bracketed token (`[token]rest`) and returns the token plus the
+/// remaining string.
+///
+/// # Parameters
+///
+/// - `input`: String slice that must start with a '[' character.
+///
+/// # Returns
+///
+/// Tuple containing the extracted token and the remainder of the string.
+///
+/// # Errors
+///
+/// Returns an error if the brackets are missing or unterminated.
+fn parse_bracket_token(input: &str) -> Result<(&str, &str)> {
+    if !input.starts_with('[') {
+        bail!("missing '[' in trace line");
+    }
+    let closing_index: usize = input
+        .find(']')
+        .ok_or_else(|| anyhow!("unterminated log target"))?;
+    let token: &str = &input[1..closing_index];
+    let remainder: &str = &input[closing_index + 1..];
+    Ok((token, remainder))
+}
+
+///
+/// # Description
+///
+/// Determines whether the token represents a namespace tag (e.g., `SYSCALL`).
+///
+/// # Parameters
+///
+/// - `token`: Candidate token extracted from the log line.
+///
+/// # Returns
+///
+/// `true` when the token is a namespace identifier, otherwise `false`.
+fn is_namespace_token(token: &str) -> bool {
+    token.eq_ignore_ascii_case("SYSCALL") || token.eq_ignore_ascii_case("LIBCALL")
+}
+
+///
+/// # Description
+///
+/// Indicates whether the namespace tag corresponds to the syscall domain.
+///
+/// # Parameters
+///
+/// - `token`: Namespace identifier extracted from the trace line.
+///
+/// # Returns
+///
+/// `true` when the tag is `SYSCALL`, otherwise `false`.
+fn tag_is_syscall(token: &str) -> bool {
+    token.eq_ignore_ascii_case("SYSCALL")
+}
+
+///
+/// # Description
+///
+/// Removes the `syscall::` prefix so module names remain stable across instrumentation styles.
+///
+/// # Parameters
+///
+/// - `target`: Fully-qualified module name emitted by tracing instrumentation.
+///
+/// # Returns
+///
+/// Module path without the leading `syscall::` component.
+fn normalize_syscall_module(target: &str) -> String {
+    target
+        .strip_prefix("syscall::")
+        .unwrap_or(target)
+        .to_string()
+}
+
+///
+/// # Description
+///
+/// Prints a human-readable summary of the aggregated statistics.
+///
+/// # Parameters
+///
+/// - `stats`: Aggregated syscall statistics to display.
+/// - `cli`: Parsed CLI options controlling presentation.
+fn render_report(stats: &TraceStats, cli: &Cli) {
+    println!("Trace file: {}", cli.trace_path.display());
+    match stats.cmdline.as_deref() {
+        Some(cmdline) => println!("Cmdline: {cmdline}"),
+        None => println!("Cmdline: <not found>"),
+    }
+    println!("Total syscall events: {}", stats.total_events);
+    println!("Filtered events (non-syscall): {}", stats.filtered_events);
+    println!("Skipped lines: {}", stats.skipped_lines);
+    if stats.total_events == 0 {
+        println!("No syscall trace entries were found.");
+        return;
+    }
+
+    let top_calls: Vec<(String, u64)> = stats.top_calls();
+    if !top_calls.is_empty() {
+        println!("{}", format_calls_heading(top_calls.len()));
+        for (call, count) in top_calls {
+            let share: f64 = (count as f64 / stats.total_events as f64) * 100.0;
+            println!("  - {call:<32} {count:>6} ({share:>5.2}%)");
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Formats the heading for the call distribution table.
+///
+/// # Parameters
+///
+/// - `count`: Number of entries that will actually be shown.
+///
+/// # Returns
+///
+/// Heading string describing the upcoming table section.
+fn format_calls_heading(count: usize) -> String {
+    format!("\nAll System Calls ({} total):", count)
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_trace_line_parses_tagged_syscall_logs() {
+        // Verifies SYSCALL-tagged lines produce syscall entries with normalized modules.
+        let line: &str =
+            "[TRACE][SYSCALL][syscall::unistd::bindings::lseek] lseek(fd=3, offset=0, whence=0)";
+        match parse_trace_line(line).expect("parse failure") {
+            Some(TraceLine::Syscall(entry)) => {
+                assert_eq!(entry.module, "unistd::bindings::lseek");
+                assert_eq!(entry.function, "lseek");
+            },
+            other => panic!("unexpected parse result: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_trace_line_marks_libcall_logs_as_non_syscall() {
+        // Ensures LIBCALL targets are classified as filtered events.
+        let line: &str = "TRACE [libcall::posix::sys::stat] chmod(path=\"/tmp/demo\", mode=420)";
+        match parse_trace_line(line).expect("parse failure") {
+            Some(TraceLine::NonSyscall) => {},
+            other => panic!("expected non-syscall classification, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_trace_line_accepts_legacy_posix_target() {
+        // Confirms legacy TRACE prefix without namespace tags is treated as non-syscall.
+        let line: &str = "TRACE [posix::sys::stat] chmod(): path=\"/tmp/demo\", mode=420";
+        match parse_trace_line(line).expect("parse failure") {
+            Some(TraceLine::NonSyscall) => {},
+            other => panic!("expected non-syscall classification, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_trace_line_accepts_bracketed_trace_prefix() {
+        // Checks bracketed TRACE prefix with libcall modules remains filtered.
+        let line: &str = "[TRACE][libcall::posix::sys::stat] chmod(path=\"/tmp/demo\", mode=420)";
+        match parse_trace_line(line).expect("parse failure") {
+            Some(TraceLine::NonSyscall) => {},
+            other => panic!("expected non-syscall classification, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_trace_line_parses_syscall_logs() {
+        // Validates plain syscall:: targets are parsed as syscall entries.
+        let line: &str =
+            "TRACE [syscall::unistd::bindings::read] read(): fd=3, buffer=0xdeadbeef, count=4";
+        match parse_trace_line(line).expect("parse failure") {
+            Some(TraceLine::Syscall(entry)) => {
+                assert_eq!(entry.module, "unistd::bindings::read");
+                assert_eq!(entry.function, "read");
+            },
+            other => panic!("unexpected parse result: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_trace_line_ignores_other_targets() {
+        // Ensures unrelated targets (e.g., linuxd) are treated as filtered events.
+        let line: &str =
+            "TRACE [linuxd::linux::fcntl] openat(): tid=42, request=OpenAtRequest { dirfd: -100 }";
+        match parse_trace_line(line).expect("parse failure") {
+            Some(TraceLine::NonSyscall) => {},
+            other => panic!("expected non-syscall classification, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_trace_line_rejects_malformed_lines() {
+        // Asserts malformed entries without function bodies yield errors.
+        let line: &str = "TRACE [libcall::posix::sys::stat]";
+        let result: Result<Option<TraceLine>> = parse_trace_line(line);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn syscall_qualified_call_strips_module_path() {
+        // Confirms syscall entries drop module prefixes in `qualified_call()`.
+        let entry: TraceEntry = TraceEntry {
+            module: "sys::stat::bindings::fstat".to_string(),
+            function: "fstat".to_string(),
+        };
+        assert_eq!(entry.qualified_call(), "fstat");
+    }
+
+    #[test]
+    fn extract_cmdline_from_line_finds_value() {
+        // Verifies cmdline parsing when the marker is present.
+        let line: &str = "[INFO][microvm] parse_bootinfo(): cmdline=\"python3 src/user/demo\"";
+        let cmdline: Option<String> = extract_cmdline_from_line(line);
+        assert_eq!(cmdline.as_deref(), Some("python3 src/user/demo"));
+    }
+
+    #[test]
+    fn extract_cmdline_from_line_handles_absence() {
+        // Confirms absence of cmdline marker returns None.
+        let line: &str = "[INFO][kernel] kmain(): initializing";
+        assert!(extract_cmdline_from_line(line).is_none());
+    }
+}


### PR DESCRIPTION
This pull request introduces two new workspace members, `syslog-macros` and `strace`, updates dependencies, and refactors several POSIX library functions to use a new `trace_libcall` macro for standardized tracing. Additionally, it updates the build system to include the new libraries and utilities.