### PR TITLE
[nanvix-sandbox-cache] Fix Network Namespace Initialization

### DIFF
--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -199,10 +199,16 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
     /// This function returns an error if network namespace pool initialization fails.
     ///
     pub fn new(config: SandboxCacheConfig<T>) -> Result<Arc<Mutex<Self>>> {
+        // Only pre-allocate network namespaces when L2 is enabled; otherwise keep it lazy so
+        // non-L2 deployments do not try to create netns at startup (which triggers sudo+sysctl).
         #[cfg(not(feature = "single-process"))]
-        let netns_init_strategy: NetnsPoolInitStrategy = match config.netns_pool_size() {
-            0 => NetnsPoolInitStrategy::Lazy,
-            size => NetnsPoolInitStrategy::Prefill(size),
+        let netns_init_strategy: NetnsPoolInitStrategy = if config.l2() {
+            match config.netns_pool_size() {
+                0 => NetnsPoolInitStrategy::Lazy,
+                size => NetnsPoolInitStrategy::Prefill(size),
+            }
+        } else {
+            NetnsPoolInitStrategy::Lazy
         };
 
         Ok(Arc::new(Mutex::new(Self {

--- a/src/libs/nanvix-sandbox/src/netns.rs
+++ b/src/libs/nanvix-sandbox/src/netns.rs
@@ -974,6 +974,7 @@ fn init_namespace(info: &NetnsInfo) -> Result<()> {
             .arg("exec")
             .arg(info.ns_name())
             .arg("sysctl")
+            .arg("-q")
             .arg("-w")
             .arg("net.ipv4.ip_forward=1"),
     )?;


### PR DESCRIPTION
This pull request introduces improvements to the initialization logic of network namespaces, ensuring that unnecessary operations are avoided in non-L2 deployments and that sysctl commands execute more quietly.