### PR TITLE
[nanvix-sandbox-cache] Sudo-Less Netns Attachment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,8 @@ export FORCE_RM_CMD := rm -rf
 export MKDIR_CMD := mkdir -p
 export CP_CMD := cp -f --preserve
 export GRUB_CMD := grub-mkrescue
+export SUDO_CMD := sudo
+export SETCAP_CMD := setcap
 
 #===================================================================================================
 # Configuration for Tests

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -11,6 +11,13 @@ NANVIXD_CARGO_FEATURES := $(if $(NANVIXD_FEATURES),--features "$(NANVIXD_FEATURE
 all-nanvixd: init
 	$(HOST_CARGO_BUILD_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd
 	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/nanvixd $(BINARIES_DIR)/nanvixd.elf
+	# Only give nanvixd CAP_SYS_ADMIN and CAP_NET_ADMIN if we need to manage
+	# network namespaces. This is only the case in L2 (multi-process) deployments.
+ifeq ($(SINGLE_PROCESS),no)
+ifeq ($(L2_VM),yes)
+	$(SUDO_CMD) $(SETCAP_CMD) cap_sys_admin,cap_net_admin+ep $(BINARIES_DIR)/nanvixd.elf
+endif
+endif
 
 check-nanvixd:
 	$(HOST_CARGO_CHECK_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd

--- a/scripts/generate-l2-snapshot.sh
+++ b/scripts/generate-l2-snapshot.sh
@@ -65,10 +65,8 @@ SNAPSHOT_PATH="${IMAGES_DIR}/${SNAPSHOT_NAME}"
 L2_SYSVM_INITRAMFS="${IMAGES_DIR}/l2_sysvm_initramfs.img"
 
 boot_clh_vm() {
-    # FIXME(#1171): we need `sudo rm` because we restore the L2 VM in a netns using `sudo ip`. This
-    # won't be necessary once we support low-level netns management with CAP_NET_ADMIN.
-    sudo rm -f -- "${CLH_API_SOCKET}"
-    sudo rm -f -- "${CLH_CONSOLE}"
+    rm -f -- "${CLH_API_SOCKET}"
+    rm -f -- "${CLH_CONSOLE}"
     # FIXME(#1156): re-enable --seccomp true (default) when we cut a new Nanvix release that
     # includes an updated cloud-hypervisor.
     ${CLOUD_HYPERVISOR_PATH} \

--- a/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
@@ -179,8 +179,6 @@ impl LinuxDaemon {
     ///
     /// On success, returns an empty tuple. On failure, returns an error.
     ///
-    // FIXME(#1171): we will be able to get rid of this method once we have a programmatic way to
-    // spawn a task inside a namespace without spawning a different process.
     async fn wait_for_unix_socket<P: AsRef<Path>>(
         path: P,
         timeout_duration: Duration,

--- a/src/libs/nanvix-sandbox/src/multi_process/netns_exec.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/netns_exec.rs
@@ -13,96 +13,114 @@
 use crate::netns::NetnsInfo;
 use ::std::{
     io,
-    process::Stdio,
+    ffi::CString,
+    os::unix::io::RawFd,
 };
-use ::tokio::process::{
-    Child,
-    Command,
-};
+use ::syslog::error;
+use ::tokio::process::Command;
 
 //==================================================================================================
 // Standalone Functions
-//
-// FIXME(#1171): implement these stubs with low-level libc calls + CAP_NET_ADMIN to avoid having to
-// call `sudo` on the critical path, as it is known to add upwards of 10 ms of latency.
 //==================================================================================================
 
 ///
 /// # Description
 ///
-/// Constructs the command arguments for executing a program within a network namespace.
+/// Join a named network namespace by calling setns() on /var/run/netns/<name>.
 ///
-/// # Parameters
+/// This method is intended to be called inside the target process, but before calling `exec`. We
+/// can achieve this behaviour using a `pre_exec` hook, as explained in detail below.
 ///
-/// - `info`: Network namespace information.
-/// - `program`: Path to the program to execute.
-/// - `args`: Arguments to pass to the program.
+/// # Arguments
 ///
-/// # Returns
+/// - `ns_name`: name of the network namespace to enter.
 ///
-/// A vector of strings representing the full command arguments.
+/// # Safety
 ///
-pub fn netns_command_args(info: &NetnsInfo, program: &str, args: &[String]) -> Vec<String> {
-    let mut netns_command_args: Vec<String> = vec![
-        "sudo".to_string(),
-        "ip".to_string(),
-        "netns".to_string(),
-        "exec".to_string(),
-        info.ns_name().to_string(),
-        program.to_string(),
-    ];
-    netns_command_args.extend(args.iter().cloned());
-    netns_command_args
+/// This function is unsafe because it does some low-level handling of raw file descriptors. In
+/// addition, it is inserted as a pre-exec hook in tokio's command, which is also an unsafe
+/// operation.
+///
+unsafe fn setns_by_name(ns_name: &str) -> io::Result<()> {
+    let ns_path: String = format!("/var/run/netns/{}", ns_name);
+
+    // Open with O_CLOEXEC so it doesn't leak into the exec'd program.
+    let c_path: CString = CString::new(ns_path.clone()).map_err(|_| {
+        let reason: String = format!("invalid namespace path (path={ns_path})");
+        error!("setns_by_name(): {reason}");
+        io::Error::new(io::ErrorKind::InvalidInput, reason)
+    })?;
+
+    let fd: RawFd = libc::open(c_path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC);
+    if fd < 0 {
+        error!("setns_by_name(): error opening netns file (error={:?})", io::Error::last_os_error());
+        return Err(io::Error::last_os_error());
+    }
+
+    // Join the network namespace.
+    // Note: setns() returns 0 on success, -1 on error (errno set).
+    let rc: libc::c_int = libc::setns(fd, libc::CLONE_NEWNET);
+    let saved_err: Option<io::Error> = if rc != 0 { Some(io::Error::last_os_error()) } else { None };
+
+    // Close fd regardless.
+    let close_rc: libc::c_int = libc::close(fd);
+    if close_rc != 0 {
+        let close_err: io::Error = io::Error::last_os_error();
+        error!("setns_by_name(): error closing netns file descriptor (error={close_err:?})");
+    }
+
+    if let Some(e) = saved_err {
+        error!("setns_by_name(): error entering network namespace (name={ns_name}, error={e:?})");
+        return Err(e);
+    }
+
+    Ok(())
 }
 
 ///
 /// # Description
 ///
-/// Creates a Tokio command configured to execute a program within a network namespace.
+/// Spawn a program inside a network namespace.
 ///
-/// # Parameters
+/// This function spawns the provided program inside the provided network namespace without
+/// requiring `sudo ip netns exec`. This function relies on executing a hook inside the new process
+/// but before calling `exec`. This can be done using a `pre_exec` hook as exposed by tokio's
+/// `Command` [1].
 ///
-/// - `info`: Network namespace information.
-/// - `program`: Path to the program to execute.
-/// - `args`: Arguments to pass to the program.
+/// Avoiding the call to `sudo` reduces the overhead of executing a program inside a network
+/// namespace, but forces the caller to have `CAP_SYS_ADMIN` + `CAP_NET_ADMIN` privileges.
 ///
-/// # Returns
+/// [1] https://docs.rs/tokio/latest/tokio/process/struct.Command.html#method.pre_exec
 ///
-/// A configured `Command` ready to be spawned.
+/// # Arguments
 ///
-pub fn command_in_netns(info: &NetnsInfo, program: &str, args: &[String]) -> Command {
-    let netns_command_args: Vec<String> = netns_command_args(info, program, args);
-    let mut cmd: Command = Command::new(&netns_command_args[0]);
-    cmd.args(&netns_command_args[1..]);
-    cmd
-}
-
-///
-/// # Description
-///
-/// Spawns a process within a network namespace with inherited stdout and stderr.
-///
-/// # Parameters
-///
-/// - `info`: Network namespace information.
-/// - `program`: Path to the program to execute.
-/// - `args`: Arguments to pass to the program.
+/// - `info`: information on the network namespace.
+/// - `program`: binary to execute inside the namespace.
+/// - `args`: arguments to pass to the program.
 ///
 /// # Returns
 ///
-/// A `Child` process handle on success.
+/// A Command with the right hook that can be spawned.
 ///
-/// # Errors
-///
-/// Returns an I/O error if the process cannot be spawned.
-///
-pub async fn spawn_in_netns(
+pub fn command_in_netns(
     info: &NetnsInfo,
     program: &str,
     args: &[String],
-) -> io::Result<Child> {
-    let mut cmd: Command = command_in_netns(info, program, args);
-    cmd.stdout(Stdio::inherit());
-    cmd.stderr(Stdio::inherit());
-    cmd.spawn()
+) -> Command {
+    let ns_name: String = info.ns_name().to_string();
+
+    let mut cmd: Command = Command::new(program);
+    cmd.args(args);
+
+    // SAFETY: inside the `pre-exec` closure we only run the logic to open the network namespace
+    // file descriptor and call `setns` on it. It does not allocate any memory, and it only calls
+    // async-safe functions: open, setns, and close.
+    unsafe {
+        cmd.pre_exec(move || {
+            setns_by_name(&ns_name)?;
+            Ok(())
+        });
+    }
+
+    cmd
 }

--- a/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
@@ -21,7 +21,7 @@ use crate::{
 #[cfg(not(feature = "single-process"))]
 use crate::{
     netns::NetnsHandle,
-    netns_exec::netns_command_args,
+    netns_exec::command_in_netns,
 };
 use ::anyhow::Result;
 use ::control_plane_api::{
@@ -148,19 +148,28 @@ impl UserVm {
             user_vm_args.splice(0..0, taskset);
         }
 
-        // In an L2-deployment, spawn the user VM inside a network namespace.
-        #[cfg(not(feature = "single-process"))]
-        if let Some(netns_handle) = &netns_handle {
-            user_vm_args = netns_command_args(
-                &netns_handle.netns_info()?,
-                &user_vm_args[0],
-                &user_vm_args[1..],
-            );
-        }
+        let mut cmd: Command = {
+            // In an L2-deployment, spawn the user VM inside a network namespace.
+            #[cfg(not(feature = "single-process"))]
+            if let Some(netns_handle) = &netns_handle {
+                command_in_netns(
+                    &netns_handle.netns_info()?,
+                    &user_vm_args[0],
+                    &user_vm_args[1..],
+                )
+            } else {
+                let mut cmd: Command = Command::new(&user_vm_args[0]);
+                cmd.args(&user_vm_args[1..]);
+
+                cmd
+            }
+
+            #[cfg(feature = "single-process")]
+            Command::new(&user_vm_args[0]).args(&user_vm_args[1..])
+        };
 
         // Inherit stdout/stderr so that errors when spawning the command are surfaced to nanvixd.
-        let child = Command::new(&user_vm_args[0])
-            .args(&user_vm_args[1..])
+        let child: Child = cmd
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()?;


### PR DESCRIPTION
In this PR I modify the logic to spawn a process (i.e. linuxd/uservm) inside a network namespace without requiring `sudo`.

I replace the `sudo ip netns exec` logic, with a bit of code that, relying on the `libc` crate, manually opens the netns file, and calls `setns` on it. This logic is inserted as a `pre_exec` hook of tokio's `Command`, i.e. a bit of logic that runs after the process has been spawned, but before `exec` has been called.

My local benchmarks indicate that this greatly reduces the cold-start-l2 latency, from ~50-60 ms at p50, to ~20 ms.

The only drawback of this approach is that it requires the parent process, i.e. `nanvixd`, to have both CAP_NET_ADMIN and CAP_SYS_ADMIN, which I set during build-time using `setcap`.

This PR does not fully address #1171 because we still have the creation of the `netns` that, even if pooled, takes quite a lot of time and could be made more efficient.