### PR TITLE
[syslog] Add Timestamp To Logs

### DIFF
--- a/src/libs/syslog/src/hosted.rs
+++ b/src/libs/syslog/src/hosted.rs
@@ -53,6 +53,7 @@ pub fn init(
     INIT_LOG.call_once(|| {
         let logger: Logger = Logger::try_with_env_or_str(default_level)
             .expect("malformed RUST_LOG environment variable")
+            .format(::flexi_logger::colored_detailed_format)
             .write_mode(::flexi_logger::WriteMode::Direct);
         if log_to_file {
             let mut file_spec: FileSpec = FileSpec::default().directory(log_dir);


### PR DESCRIPTION
In this commit I modify the syslog library to use flexi_logger's detailed format [1] (in its coloured version) so that log messages include a timestamp with a milisecond resolution.

These timestamps are very useful as a first profiling step, to get an overall idea of where is time spent.

[1] https://docs.rs/flexi_logger/latest/flexi_logger/fn.detailed_format.html