### PR TITLE
[build] Minimal Docker Image

### DIFF
--- a/scripts/setup/.dockerignore
+++ b/scripts/setup/.dockerignore
@@ -1,0 +1,43 @@
+# Build artifacts
+target/
+bin/
+lib/
+*.o
+*.a
+*.so
+*.dylib
+
+# Version control
+.git/
+.github/
+.githooks/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Logs and temporary files
+logs/
+*.log
+tmp/
+temp/
+
+# Documentation
+doc/
+
+# Test files
+test/
+
+# Virtual environments
+venv/
+.venv/
+env/
+
+# Cache files
+.z.cache
+__pycache__/
+*.pyc
+.cargo/

--- a/scripts/setup/Dockerfile.optimized
+++ b/scripts/setup/Dockerfile.optimized
@@ -2,8 +2,7 @@
 # Licensed under the MIT License.
 
 #===================================================================================================
-# Optimized Image - Demo Version (Extract from existing image)
-# This version extracts the toolchain from the existing image and applies optimizations.
+# Optimized Image - Minimal Runtime Configuration (Extract from existing image).
 #===================================================================================================
 
 ARG TOOLCHAIN_IMAGE=nanvix/toolchain:latest
@@ -55,18 +54,18 @@ COPY --from=source /opt/nanvix/src/rust/library /opt/nanvix/rust-toolchain/lib/r
 
 # Install Rust.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
-ENV PATH=$HOME/.cargo/bin:$PATH
+ENV PATH="$HOME/.cargo/bin:$PATH"
 
 # Install Rust toolchain and components.
-RUN rustup toolchain install $RUST_VERSION && \
-    rustup default $RUST_VERSION && \
+RUN rustup toolchain install "$RUST_VERSION" && \
+    rustup default "$RUST_VERSION" && \
     # Link custom Rust toolchain for Nanvix.
     rustup toolchain link nanvix-x86 /opt/nanvix/rust-toolchain && \
     # Copy cargo and other tools to stage2/bin so they're accessible.
     cp /opt/nanvix/rust-toolchain/bin-tools/* /opt/nanvix/rust-toolchain/bin/ && \
     # Clean Rust artifacts.
-    rm -rf $HOME/.cargo/registry/cache && \
-    rm -rf $HOME/.cargo/git/db
+    rm -rf "$HOME/.cargo/registry/cache" && \
+    rm -rf "$HOME/.cargo/git/db"
 
 # Set environment variables for toolchain.
 ENV PATH=/opt/nanvix/bin:$PATH

--- a/scripts/setup/Dockerfile.optimized
+++ b/scripts/setup/Dockerfile.optimized
@@ -1,0 +1,81 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#===================================================================================================
+# Optimized Image - Demo Version (Extract from existing image)
+# This version extracts the toolchain from the existing image and applies optimizations.
+#===================================================================================================
+
+ARG TOOLCHAIN_IMAGE=nanvix/toolchain:latest
+FROM ${TOOLCHAIN_IMAGE} AS source
+
+#===================================================================================================
+# Runtime Stage - Optimized
+#===================================================================================================
+
+FROM ubuntu:24.04 AS runtime
+
+ARG USER=root
+ARG HOME=/root
+USER $USER
+
+# Silence debconf prompts and pin timezone for noninteractive installs.
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+ARG RUST_VERSION=nightly-2025-10-28
+
+# Install runtime and build dependencies via shared setup script (keeps parity with full image).
+COPY --from=source /opt/nanvix/src/nanvix/scripts/setup/ubuntu.sh /tmp/ubuntu.sh
+
+RUN apt-get update && \
+    chmod +x /tmp/ubuntu.sh && \
+    /bin/bash /tmp/ubuntu.sh && \
+    # Remove bulky docs/icons/themes that are unnecessary in the runtime image.
+    apt-get purge -y --auto-remove man-db doc-base ubuntu-mono adwaita-icon-theme humanity-icon-theme hicolor-icon-theme fonts-dejavu-core fonts-dejavu-mono && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/info/* /usr/share/groff/* /usr/share/icons/* && \
+    rm -rf /var/cache/apt/*
+
+# Copy toolchain binaries and libraries only (not source code).
+COPY --from=source /opt/nanvix/bin /opt/nanvix/bin
+COPY --from=source /opt/nanvix/lib /opt/nanvix/lib
+COPY --from=source /opt/nanvix/libexec /opt/nanvix/libexec
+COPY --from=source /opt/nanvix/include /opt/nanvix/include
+COPY --from=source /opt/nanvix/share /opt/nanvix/share
+COPY --from=source /opt/nanvix/i686-nanvix /opt/nanvix/i686-nanvix
+COPY --from=source /opt/nanvix/version /opt/nanvix/version
+
+# Copy custom Rust toolchain (nanvix-x86) from source.
+COPY --from=source /opt/nanvix/src/rust/build/host/stage2 /opt/nanvix/rust-toolchain
+COPY --from=source /opt/nanvix/src/rust/build/x86_64-unknown-linux-gnu/stage2-tools-bin /opt/nanvix/rust-toolchain/bin-tools
+# Copy Rust library source code (needed for -Zbuild-std).
+COPY --from=source /opt/nanvix/src/rust/library /opt/nanvix/rust-toolchain/lib/rustlib/src/rust/library
+
+# Install Rust.
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+ENV PATH=$HOME/.cargo/bin:$PATH
+
+# Install Rust toolchain and components.
+RUN rustup toolchain install $RUST_VERSION && \
+    rustup default $RUST_VERSION && \
+    # Link custom Rust toolchain for Nanvix.
+    rustup toolchain link nanvix-x86 /opt/nanvix/rust-toolchain && \
+    # Copy cargo and other tools to stage2/bin so they're accessible.
+    cp /opt/nanvix/rust-toolchain/bin-tools/* /opt/nanvix/rust-toolchain/bin/ && \
+    # Clean Rust artifacts.
+    rm -rf $HOME/.cargo/registry/cache && \
+    rm -rf $HOME/.cargo/git/db
+
+# Set environment variables for toolchain.
+ENV PATH=/opt/nanvix/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/nanvix/lib
+
+# Verify toolchain is working.
+RUN i686-nanvix-gcc --version && \
+    i686-nanvix-g++ --version && \
+    i686-nanvix-gfortran --version && \
+    rustc --version
+
+WORKDIR /workspace

--- a/scripts/setup/build-optimized-image.sh
+++ b/scripts/setup/build-optimized-image.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+set -euo pipefail
+
+#===================================================================================================
+# Description
+#===================================================================================================
+
+# Builds a minimal Docker image for the Nanvix toolchain by extracting from the existing full image.
+# The resulting image keeps only runtime assets, reducing size while preserving build capability.
+
+#===================================================================================================
+# Imports
+#===================================================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_DIR="${SCRIPT_DIR%/setup}/common"
+
+# shellcheck source=../common/utils.sh disable=SC1091
+source "${COMMON_DIR}/utils.sh"
+
+#===================================================================================================
+# Script Arguments
+#===================================================================================================
+
+REPO_ROOT_DIR=$(get_repo_root 2>/dev/null) || {
+    echo "ERROR: Not in a git repository." >&2
+    exit 1
+}
+
+CARGO_VERSION=$(get_cargo_toml_version "${REPO_ROOT_DIR}/Cargo.toml")
+TOOLCHAIN_TAG="v${CARGO_VERSION%.*}.x"
+
+# Base image that provides the full toolchain; matches the Cargo version (same logic as z).
+TOOLCHAIN_IMAGE="nanvix/toolchain:${TOOLCHAIN_TAG}"
+
+# Default output tag suffixed with -minimal as requested.
+DEFAULT_TAG="nanvix/toolchain:${TOOLCHAIN_TAG}-minimal"
+
+TAG=${1:-"${DEFAULT_TAG}"}
+
+#===================================================================================================
+# Build
+#===================================================================================================
+
+RUST_VERSION=$(grep "^channel" "${REPO_ROOT_DIR}/rust-toolchain" | cut -d'"' -f2)
+
+echo "Building minimal Docker image..."
+echo "  Base image : ${TOOLCHAIN_IMAGE}"
+echo "  Output tag : ${TAG}"
+echo "  Rust toolchain: ${RUST_VERSION}"
+echo ""
+
+docker build \
+    --file "${REPO_ROOT_DIR}/scripts/setup/Dockerfile.optimized" \
+    --build-arg RUST_VERSION="${RUST_VERSION}" \
+    --build-arg TOOLCHAIN_IMAGE="${TOOLCHAIN_IMAGE}" \
+    --tag "${TAG}" \
+    --progress=plain \
+    "${REPO_ROOT_DIR}"
+
+echo ""
+echo "✅ Successfully built: ${TAG}"
+echo ""
+docker images | grep -E "(REPOSITORY|nanvix/toolchain)"
+echo ""
+echo "Usage:"
+echo "  docker run --rm -v \\\$(pwd):/workspace ${TAG} \\
+    bash -c 'ln -sf /opt/nanvix /workspace/toolchain && cd /workspace && ./z build -- all'"

--- a/scripts/setup/build-optimized-image.sh
+++ b/scripts/setup/build-optimized-image.sh
@@ -46,7 +46,10 @@ TAG=${1:-"${DEFAULT_TAG}"}
 # Build
 #===================================================================================================
 
-RUST_VERSION=$(grep "^channel" "${REPO_ROOT_DIR}/rust-toolchain" | cut -d'"' -f2)
+RUST_VERSION=$(grep "^channel" "${REPO_ROOT_DIR}/rust-toolchain" | cut -d'"' -f2) || {
+    echo "ERROR: Failed to extract Rust version from rust-toolchain file: ${REPO_ROOT_DIR}/rust-toolchain" >&2
+    exit 1
+}
 
 echo "Building minimal Docker image..."
 echo "  Base image : ${TOOLCHAIN_IMAGE}"
@@ -55,12 +58,12 @@ echo "  Rust toolchain: ${RUST_VERSION}"
 echo ""
 
 docker build \
-    --file "${REPO_ROOT_DIR}/scripts/setup/Dockerfile.optimized" \
+    --file "${SCRIPT_DIR}/Dockerfile.optimized" \
     --build-arg RUST_VERSION="${RUST_VERSION}" \
     --build-arg TOOLCHAIN_IMAGE="${TOOLCHAIN_IMAGE}" \
     --tag "${TAG}" \
     --progress=plain \
-    "${REPO_ROOT_DIR}"
+    "${SCRIPT_DIR}"
 
 echo ""
 echo "✅ Successfully built: ${TAG}"

--- a/z
+++ b/z
@@ -44,6 +44,7 @@ CMD_NAME_HELP="help"
 # Option names.
 OPT_NAME_SEPARATOR="--"
 OPT_NAME_WITH_DOCKER="--with-docker"
+OPT_NAME_WITH_MINIMAL_DOCKER="--with-minimal-docker"
 OPT_NAME_WITH_CACHED_OPTIONS="--with-cached-options"
 OPT_NAME_TOOLCHAIN_DIR="--toolchain-dir"
 
@@ -67,10 +68,12 @@ UBUNTU_SETUP_SCRIPT="${REPO_ROOT_DIR}/scripts/setup/ubuntu.sh"
 #==================================================================================================
 
 # Options from cache.
-LAST_BUILD_WITH_DOCKER=false  # Was the last build done with Docker?
+LAST_BUILD_WITH_DOCKER=false          # Was the last build done with Docker?
+LAST_BUILD_WITH_MINIMAL_DOCKER=false  # Was the last build done with the minimal Docker image?
 
 # Current options.
 BUILD_WITH_DOCKER=false                         # Build with Docker?
+BUILD_WITH_MINIMAL_DOCKER=false                 # Use minimal Docker image?
 WITH_CACHED_OPTIONS=false                       # Use cached options (if any)?
 TOOLCHAIN_DIR="${DEFAULT_LOCAL_TOOLCHAIN_DIR}"  # Toolchain directory for setup.
 
@@ -106,6 +109,7 @@ Commands
 
 Options
   ${OPT_NAME_WITH_DOCKER}           Build Nanvix using Docker instead of the local toolchain.
+  ${OPT_NAME_WITH_MINIMAL_DOCKER}   Build Nanvix using the minimal Docker image (implies ${OPT_NAME_WITH_DOCKER}).
   ${OPT_NAME_WITH_CACHED_OPTIONS}   Use cached options from the last build.
   ${OPT_NAME_TOOLCHAIN_DIR} <path>  Specify the toolchain directory for setup (default: ${DEFAULT_LOCAL_TOOLCHAIN_DIR}).
 EOF
@@ -156,6 +160,7 @@ check_docker_image_available() {
 #
 # Arguments
 #  $1 - The version of the Docker image to use.
+#  $2 - (Optional, default: false) Set to true to use the minimal Docker image.
 #
 # Usage Example
 #   get_docker_image_name "v1.0.0"
@@ -163,8 +168,15 @@ check_docker_image_available() {
 get_docker_image_name() {
     # Build image tag version by replacing patch with "x".
     local image_tag_version
+    local use_minimal=${2:-false}
     image_tag_version="${1%.*}.x"
-    echo "${DOCKER_IMAGE_BASE_NAME}:v${image_tag_version}"
+
+    local suffix=""
+    if ${use_minimal}; then
+        suffix="-minimal"
+    fi
+
+    echo "${DOCKER_IMAGE_BASE_NAME}:v${image_tag_version}${suffix}"
 }
 
 #
@@ -195,7 +207,7 @@ build_docker_command() {
 
     # Get the Docker image name.
     local image_name
-    image_name=$(get_docker_image_name "${current_version}")
+    image_name=$(get_docker_image_name "${current_version}" "${BUILD_WITH_MINIMAL_DOCKER}")
 
     # Check if the Docker image is available.
     check_docker_image_available "${image_name}"
@@ -237,6 +249,9 @@ write_cache() {
 #   read_cache
 #
 read_cache() {
+    LAST_BUILD_WITH_DOCKER=false
+    LAST_BUILD_WITH_MINIMAL_DOCKER=false
+
     if [[ -f "${Z_CACHE_FILE}" ]]; then
         local cache_lines
         mapfile -t cache_lines < "${Z_CACHE_FILE}"
@@ -246,7 +261,10 @@ read_cache() {
         fi
         # Process the cache lines to determine the last build options.
         for arg in "${cache_lines[@]}"; do
-            if [[ "$arg" == "${OPT_NAME_WITH_DOCKER}" ]]; then
+            if [[ "$arg" == "${OPT_NAME_WITH_MINIMAL_DOCKER}" ]]; then
+                LAST_BUILD_WITH_DOCKER=true
+                LAST_BUILD_WITH_MINIMAL_DOCKER=true
+            elif [[ "$arg" == "${OPT_NAME_WITH_DOCKER}" ]]; then
                 LAST_BUILD_WITH_DOCKER=true
             elif [[ "$arg" == "${OPT_NAME_SEPARATOR}" ]]; then
                 break
@@ -359,12 +377,17 @@ check_toolchain() {
     local expected_tag
     expected_tag="${current_version%.*}.x"
 
+    local expected_image_tag="${expected_tag}"
+    if ${BUILD_WITH_MINIMAL_DOCKER}; then
+        expected_image_tag="${expected_image_tag}-minimal"
+    fi
+
     if ${BUILD_WITH_DOCKER}; then
         # Docker-based toolchain validation.
         check_docker_installed
 
         local image_name
-        image_name=$(get_docker_image_name "${current_version}")
+        image_name=$(get_docker_image_name "${current_version}" "${BUILD_WITH_MINIMAL_DOCKER}")
 
         # Check image availability.
         if ! docker image inspect "${image_name}" >/dev/null 2>&1; then
@@ -376,13 +399,13 @@ check_toolchain() {
         local image_tag
         image_tag="${image_name##*:v}"
 
-        # Sanity check on tag consistency (defensive; should always match expected_tag).
-        if [[ "${image_tag}" != "${expected_tag}" ]]; then
-            print_error "Docker toolchain version mismatch (found tag '${image_tag}', expected '${expected_tag}'). Run './z setup --with-docker' to update the toolchain image."
+        # Sanity check on tag consistency (defensive; should always match expected_image_tag).
+        if [[ "${image_tag}" != "${expected_image_tag}" ]]; then
+            print_error "Docker toolchain version mismatch (found tag '${image_tag}', expected '${expected_image_tag}'). Run './z setup --with-docker' or './z setup --with-minimal-docker' to update the toolchain image."
             return 1
         fi
 
-        print_info "Docker toolchain version '${image_tag}' matches expected '${expected_tag}'."
+        print_info "Docker toolchain version '${image_tag}' matches expected '${expected_image_tag}'."
     else
         # Local toolchain validation.
         local version_file
@@ -457,11 +480,22 @@ main() {
     # Read last build info from cache
     read_cache
 
+    local docker_option_set=false
+    local minimal_option_set=false
+
     # Parse command options.
     while [[ $# -gt 0 ]]; do
         case "$1" in
             "${OPT_NAME_WITH_DOCKER}")
                 BUILD_WITH_DOCKER=true
+                docker_option_set=true
+                shift
+                ;;
+            "${OPT_NAME_WITH_MINIMAL_DOCKER}")
+                BUILD_WITH_DOCKER=true
+                BUILD_WITH_MINIMAL_DOCKER=true
+                docker_option_set=true
+                minimal_option_set=true
                 shift
                 ;;
             "${OPT_NAME_WITH_CACHED_OPTIONS}")
@@ -487,24 +521,31 @@ main() {
         esac
     done
 
-    # Collect build parameters.
-    local build_parameters=()
-    # Only add TOOLCHAIN_DIR for local builds, not Docker builds
-    if ! ${BUILD_WITH_DOCKER}; then
-        build_parameters+=("TOOLCHAIN_DIR=${TOOLCHAIN_DIR}")
-    fi
+    # Collect raw build parameters.
+    local user_build_parameters=()
     while [[ $# -gt 0 ]]; do
-        build_parameters+=("$1")
+        user_build_parameters+=("$1")
         shift
     done
 
-    # If using cache, restore variables from cache if not set by command line
+    # If using cache, restore variables from cache when not overridden by command line options.
     if ${WITH_CACHED_OPTIONS}; then
         print_info "Using cached build options."
-        # Only override if not set by command line
-        if ! ${BUILD_WITH_DOCKER}; then
-            BUILD_WITH_DOCKER=${LAST_BUILD_WITH_DOCKER}
+        if ! ${minimal_option_set} && ${LAST_BUILD_WITH_MINIMAL_DOCKER}; then
+            BUILD_WITH_MINIMAL_DOCKER=true
+            BUILD_WITH_DOCKER=true
+        elif ! ${docker_option_set} && ${LAST_BUILD_WITH_DOCKER}; then
+            BUILD_WITH_DOCKER=true
         fi
+    fi
+
+    # Only add TOOLCHAIN_DIR for local builds, not Docker builds.
+    local build_parameters=()
+    if ! ${BUILD_WITH_DOCKER}; then
+        build_parameters+=("TOOLCHAIN_DIR=${TOOLCHAIN_DIR}")
+    fi
+    if [[ ${#user_build_parameters[@]} -gt 0 ]]; then
+        build_parameters+=("${user_build_parameters[@]}")
     fi
 
     case "${command}" in
@@ -553,7 +594,11 @@ main() {
 
             # Save current build command and options to cache.
             cache_args=("${command}")
-            ${BUILD_WITH_DOCKER} && cache_args+=("${OPT_NAME_WITH_DOCKER}")
+            if ${BUILD_WITH_MINIMAL_DOCKER}; then
+                cache_args+=("${OPT_NAME_WITH_MINIMAL_DOCKER}")
+            elif ${BUILD_WITH_DOCKER}; then
+                cache_args+=("${OPT_NAME_WITH_DOCKER}")
+            fi
             cache_args+=("${OPT_NAME_SEPARATOR}" "${build_parameters[@]}")
             write_cache "${cache_args[@]}"
 
@@ -634,7 +679,7 @@ main() {
 
                 # Get the Docker image name.
                 local image_name
-                image_name=$(get_docker_image_name "${current_version}")
+                image_name=$(get_docker_image_name "${current_version}" "${BUILD_WITH_MINIMAL_DOCKER}")
 
                 # Pull the Docker image.
                 print_info "Pulling Docker image: ${image_name}"


### PR DESCRIPTION
This pull request introduces support for building Nanvix using a minimal Docker image, alongside the standard Docker-based workflow. It adds scripts and configuration for creating and using a reduced-size toolchain image, and updates the main build script (`z`) to recognize and handle a new `--with-minimal-docker` option. The changes focus on enabling a more lightweight build environment, optimizing Docker images, and improving user experience with clear command-line options.