### PR TITLE
[kernel] keep root pagetables enqueued

### DIFF
--- a/src/kernel/src/mm/virt/mod.rs
+++ b/src/kernel/src/mm/virt/mod.rs
@@ -198,6 +198,7 @@ pub fn init(
                 false,
                 AccessPermission::RDWR,
             )?;
+            root_pagetables.push_back((page_table_addr, page_table));
             if raw_vaddr == (config::kernel::MEMORY_SIZE - mem::PAGE_SIZE) {
                 break;
             }
@@ -216,8 +217,6 @@ pub fn init(
                     PhysicalAddress::from_raw_value(raw_vaddr)?,
                 )?),
             };
-
-            root_pagetables.push_back((page_table_addr, page_table));
         }
     }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the order in which page tables are added to the `root_pagetables` collection during kernel virtual memory initialization. The change ensures that page tables are pushed into the collection immediately after creation, rather than after a loop.