### PR TITLE
[build] Make Docker Cmd to use Host Workspace

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -56,11 +56,12 @@ To build Nanvix using the latest Docker image and default build parameters, run:
 
 ```bash
 docker run \
-  -it --rm -v"$(pwd):/mnt" \
+  -it --rm \
+  -v"$(pwd -P):$(pwd -P)" \
+  -w"$(pwd -P)" \
   nanvix/toolchain \
   /bin/bash -l -c "\
     set -e; \
-    cd /mnt ; \
     git config --global --add safe.directory '*' ; \
     make TOOLCHAIN_DIR=/opt/nanvix all ; \
     chown -R $(id -u):$(id -g) . "

--- a/z
+++ b/z
@@ -196,8 +196,10 @@ build_docker_command() {
     local build_parameters="${*}"
     local user_id
     local group_id
+    local host_workspace_path
     user_id="$(id -u)"
     group_id="$(id -g)"
+    host_workspace_path="$(pwd -P)"
 
     # Check if Docker is installed.
     check_docker_installed
@@ -213,11 +215,11 @@ build_docker_command() {
     check_docker_image_available "${image_name}"
 
     echo "docker run --rm \
-        -v \"$(pwd):/mnt\" \
+        -v \"${host_workspace_path}:${host_workspace_path}\" \
+        -w \"${host_workspace_path}\" \
         ${image_name} \
         /bin/bash -l -c '\
             set -e ; \
-            cd /mnt ; \
             git config --global --add safe.directory \* ; \
             make TOOLCHAIN_DIR=${DOCKER_IMAGE_TOOLCHAIN_PATH} ${build_parameters} ; \
             chown -R \"${user_id}:${group_id}\" .\


### PR DESCRIPTION
This pull request updates the `build_docker_command()` function in the `z` file to improve how the Docker container interacts with the host workspace. The changes ensure that the container uses the absolute path of the current working directory for both mounting and working directory setup, which helps avoid issues with relative paths and improves consistency.