### PR TITLE
Use Docker BuildKit for faster incremental builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,22 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
 # Build artifacts
 target/
+toolchain/
+sysroot*/
 bin/
 lib/
 *.o
 *.a
 *.so
 *.dylib
+
+# Archives and images
+*.tar
+*.tar.gz
+*.tar.bz2
+*.iso
 
 # Version control
 .git/

--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ init-repo:
 	$(MKDIR_CMD) $(BINARIES_DIR)
 	$(MKDIR_CMD) $(LIBRARIES_DIR)
 	$(MKDIR_CMD) $(LOGS_DIR)
-	git config --local core.hooksPath .githooks
+	@if [ -d .git ]; then git config --local core.hooksPath .githooks; fi
 
 # Cleans build.
 clean: \

--- a/doc/build.md
+++ b/doc/build.md
@@ -55,15 +55,13 @@ Instead of using the `z` utility, you can build Nanvix manually.
 To build Nanvix using the latest Docker image and default build parameters, run:
 
 ```bash
-docker run \
-  -it --rm -v"$(pwd):/mnt" \
-  nanvix/toolchain \
-  /bin/bash -l -c "\
-    set -e; \
-    cd /mnt ; \
-    git config --global --add safe.directory '*' ; \
-    make TOOLCHAIN_DIR=/opt/nanvix all ; \
-    chown -R $(id -u):$(id -g) . "
+DOCKER_BUILDKIT=1 docker build \
+    --build-arg BASE_IMAGE="nanvix/toolchain:v1.0.x-minimal" \
+    --build-arg BUILD_PARAMS="all" \
+    --output type=local,dest=. \
+    --progress=plain \
+    -f scripts/setup/Dockerfile.build \
+    .
 ```
 
 ### Manually Building Nanvix with a Local Toolchain

--- a/scripts/build-opt.sh
+++ b/scripts/build-opt.sh
@@ -40,8 +40,10 @@ DIRNAME=$6
 # Global Variables
 #===================================================================================================
 
-NANVIX_HOME="$(git rev-parse --show-toplevel)"
-CONTRIB_DIR="${SYSROOT_DIR}/src"
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+NANVIX_HOME="$(realpath "${SCRIPT_DIR}/..")"
+# Use CONTRIB_SRC_DIR if set (e.g., in Docker builds), otherwise fall back to sysroot/src.
+CONTRIB_DIR="${CONTRIB_SRC_DIR:-${SYSROOT_DIR}/src}"
 REPOSITORY_HOME="${CONTRIB_DIR}/${DIRNAME}"
 
 #===================================================================================================

--- a/scripts/setup/Dockerfile
+++ b/scripts/setup/Dockerfile
@@ -47,6 +47,12 @@ ENV PATH=$HOME/.cargo/bin:$PATH
 RUN rustup toolchain install $RUST_VERSION && \
     rustup default $RUST_VERSION
 
+# Install sccache for build caching.
+ARG SCCACHE_VERSION=0.10.0
+RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+    | tar xz -C /usr/local/bin --strip-components=1 --wildcards '*/sccache' && \
+    chmod +x /usr/local/bin/sccache
+
 # Build toolchain.
 RUN cd /opt/nanvix/src/nanvix && \
     ./z setup --toolchain-dir /opt/nanvix

--- a/scripts/setup/Dockerfile.build
+++ b/scripts/setup/Dockerfile.build
@@ -9,6 +9,7 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE} AS builder
 
 ARG BUILD_PARAMS
+ARG SYSROOT_SUFFIX=debug
 
 WORKDIR /mnt
 COPY . .
@@ -17,16 +18,18 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/root/.cargo/git,sharing=locked \
     --mount=type=cache,target=/root/.cache/sccache,sharing=locked \
     --mount=type=cache,target=/mnt/target,sharing=locked \
+    --mount=type=cache,target=/opt/contrib-src,sharing=locked \
     set -e && \
-    SCCACHE_DIR=/root/.cache/sccache make TOOLCHAIN_DIR=/opt/nanvix SCCACHE=/usr/local/bin/sccache ${BUILD_PARAMS}
+    SCCACHE_DIR=/root/.cache/sccache CONTRIB_SRC_DIR=/opt/contrib-src \
+    make TOOLCHAIN_DIR=/opt/nanvix SCCACHE=/usr/local/bin/sccache ${BUILD_PARAMS}
 
 # Create output directories to ensure they exist even if build produces no artifacts.
-RUN mkdir -p /mnt/sysroot-debug /mnt/sysroot-release /mnt/bin /mnt/lib
+RUN mkdir -p /mnt/bin /mnt/lib /mnt/images /mnt/sysroot-debug /mnt/sysroot-release
 
 # Output stage: only copy the actual build artifacts, not intermediate files.
 FROM scratch
+ARG SYSROOT_SUFFIX=debug
 COPY --from=builder /mnt/bin /bin
 COPY --from=builder /mnt/lib /lib
-COPY --from=builder /mnt/sysroot-debug /sysroot-debug
-COPY --from=builder /mnt/sysroot-release /sysroot-release
+COPY --from=builder /mnt/sysroot-${SYSROOT_SUFFIX} /sysroot
 COPY --from=builder /mnt/images /images

--- a/scripts/setup/Dockerfile.build
+++ b/scripts/setup/Dockerfile.build
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.4
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Dockerfile for building Nanvix using BuildKit cache mounts.
+# This Dockerfile is used by the `./z build --with-docker` command.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS builder
+
+ARG BUILD_PARAMS
+
+WORKDIR /mnt
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,target=/root/.cargo/git,sharing=locked \
+    --mount=type=cache,target=/root/.cache/sccache,sharing=locked \
+    --mount=type=cache,target=/mnt/target,sharing=locked \
+    set -e && \
+    git config --global --add safe.directory '*' && \
+    SCCACHE_DIR=/root/.cache/sccache make TOOLCHAIN_DIR=/opt/nanvix SCCACHE=/usr/local/bin/sccache ${BUILD_PARAMS}
+
+# Create output directories to ensure they exist even if build produces no artifacts.
+RUN mkdir -p /mnt/sysroot-debug /mnt/sysroot-release /mnt/bin /mnt/lib
+
+# Output stage: only copy the actual build artifacts, not intermediate files.
+FROM scratch
+COPY --from=builder /mnt/bin /bin
+COPY --from=builder /mnt/lib /lib
+COPY --from=builder /mnt/sysroot-debug /sysroot-debug
+COPY --from=builder /mnt/sysroot-release /sysroot-release
+

--- a/scripts/setup/Dockerfile.build
+++ b/scripts/setup/Dockerfile.build
@@ -18,7 +18,6 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/root/.cache/sccache,sharing=locked \
     --mount=type=cache,target=/mnt/target,sharing=locked \
     set -e && \
-    git config --global --add safe.directory '*' && \
     SCCACHE_DIR=/root/.cache/sccache make TOOLCHAIN_DIR=/opt/nanvix SCCACHE=/usr/local/bin/sccache ${BUILD_PARAMS}
 
 # Create output directories to ensure they exist even if build produces no artifacts.
@@ -30,4 +29,4 @@ COPY --from=builder /mnt/bin /bin
 COPY --from=builder /mnt/lib /lib
 COPY --from=builder /mnt/sysroot-debug /sysroot-debug
 COPY --from=builder /mnt/sysroot-release /sysroot-release
-
+COPY --from=builder /mnt/images /images

--- a/scripts/setup/Dockerfile.optimized
+++ b/scripts/setup/Dockerfile.optimized
@@ -52,6 +52,12 @@ COPY --from=source /opt/nanvix/src/rust/build/x86_64-unknown-linux-gnu/stage2-to
 # Copy Rust library source code (needed for -Zbuild-std).
 COPY --from=source /opt/nanvix/src/rust/library /opt/nanvix/rust-toolchain/lib/rustlib/src/rust/library
 
+# Install sccache for build caching.
+ARG SCCACHE_VERSION=0.10.0
+RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+    | tar xz -C /usr/local/bin --strip-components=1 --wildcards '*/sccache' && \
+    chmod +x /usr/local/bin/sccache
+
 # Install Rust.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
 ENV PATH="$HOME/.cargo/bin:$PATH"

--- a/z
+++ b/z
@@ -181,23 +181,20 @@ get_docker_image_name() {
 
 #
 # Description
-#   Builds the Docker command to run the build process.
+#   Builds Nanvix using Docker with BuildKit cache mounts.
+#   Uses 'docker build' with --mount=type=cache for efficient caching.
 #
 # Arguments
-#   $* - The build parameters to pass to the Docker command.
+#   $* - The build parameters to pass to make.
 #
 # Return
-#   A string containing the Docker command to run.
+#   0 on success, non-zero on failure.
 #
 # Usage Example
 #   build_docker_command "all"
 #
 build_docker_command() {
     local build_parameters="${*}"
-    local user_id
-    local group_id
-    user_id="$(id -u)"
-    group_id="$(id -g)"
 
     # Check if Docker is installed.
     check_docker_installed
@@ -212,16 +209,23 @@ build_docker_command() {
     # Check if the Docker image is available.
     check_docker_image_available "${image_name}"
 
-    echo "docker run --rm \
-        -v \"$(pwd):/mnt\" \
-        ${image_name} \
-        /bin/bash -l -c '\
-            set -e ; \
-            cd /mnt ; \
-            git config --global --add safe.directory \* ; \
-            make TOOLCHAIN_DIR=${DOCKER_IMAGE_TOOLCHAIN_PATH} ${build_parameters} ; \
-            chown -R \"${user_id}:${group_id}\" .\
-        '"
+    # Path to the build Dockerfile.
+    local dockerfile_path="${REPO_ROOT_DIR}/scripts/setup/Dockerfile.build"
+
+    # Check if the Dockerfile exists.
+    if [[ ! -f "${dockerfile_path}" ]]; then
+        print_error "Build Dockerfile not found: ${dockerfile_path}"
+        return 1
+    fi
+
+    # Run the build with BuildKit using the external Dockerfile.
+    DOCKER_BUILDKIT=1 docker build \
+        --build-arg BASE_IMAGE="${image_name}" \
+        --build-arg BUILD_PARAMS="${build_parameters}" \
+        --output type=local,dest=. \
+        --progress=plain \
+        -f "${dockerfile_path}" \
+        .
 }
 
 #
@@ -559,14 +563,10 @@ main() {
             print_info "Build Parameters: ${build_parameters[*]}"
 
             # Check if we are switching build modes.
-            if ${BUILD_WITH_DOCKER} && ! ${LAST_BUILD_WITH_DOCKER}; then
-                print_warning "Switching to Docker build, forcing cleanup."
-                # Force a cleanup.
-                if ! eval "$(build_docker_command distclean)" ; then
-                    print_error "Cleanup failed with Docker."
-                    exit 1
-                fi
-            elif ! ${BUILD_WITH_DOCKER} && ${LAST_BUILD_WITH_DOCKER}; then
+            # Note: When switching TO Docker, we don't need to clean because Docker builds
+            # use isolated cache mounts. We only need to clean local artifacts when switching
+            # FROM Docker to local toolchain.
+            if ! ${BUILD_WITH_DOCKER} && ${LAST_BUILD_WITH_DOCKER}; then
                 print_warning "Switching to local toolchain build, forcing cleanup."
                 # Force a cleanup.
                 if ! make distclean ; then
@@ -583,8 +583,8 @@ main() {
 
             # Build Nanvix.
             if ${BUILD_WITH_DOCKER}; then
-                print_info "Building with Docker..."
-                if ! eval "$(build_docker_command "${build_parameters[@]}")"; then
+                print_info "Building with Docker (using BuildKit cache)..."
+                if ! build_docker_command "${build_parameters[@]}"; then
                     print_error "Build failed with Docker."
                     exit 1
                 fi
@@ -612,7 +612,7 @@ main() {
         "${CMD_NAME_CLEAN}")
             if ${BUILD_WITH_DOCKER}; then
                 print_info "Running quick cleanup with Docker..."
-                if ! eval "$(build_docker_command clean)"; then
+                if ! build_docker_command clean; then
                     print_error "Quick clean failed with Docker."
                     exit 1
                 fi
@@ -636,7 +636,7 @@ main() {
         "${CMD_NAME_DISTCLEAN}")
             if ${BUILD_WITH_DOCKER}; then
                 print_info "Running full cleanup with Docker..."
-                if ! eval "$(build_docker_command distclean)"; then
+                if ! build_docker_command distclean; then
                     print_error "Full cleanup failed with Docker."
                     exit 1
                 fi

--- a/z
+++ b/z
@@ -391,7 +391,11 @@ check_toolchain() {
 
         # Check image availability.
         if ! docker image inspect "${image_name}" >/dev/null 2>&1; then
-            print_error "Required Docker toolchain image '${image_name}' not found. Run './z setup --with-docker' to fetch it."
+            local setup_cmd="./z setup --with-docker"
+            if ${BUILD_WITH_MINIMAL_DOCKER}; then
+                setup_cmd="./z setup --with-minimal-docker"
+            fi
+            print_error "Required Docker toolchain image '${image_name}' not found. Run '${setup_cmd}' to fetch it."
             return 1
         fi
 

--- a/z
+++ b/z
@@ -218,10 +218,17 @@ build_docker_command() {
         return 1
     fi
 
+    # Extract RELEASE value from build parameters to determine sysroot suffix.
+    local sysroot_suffix="debug"
+    if [[ "${build_parameters}" =~ RELEASE=yes ]]; then
+        sysroot_suffix="release"
+    fi
+
     # Run the build with BuildKit using the external Dockerfile.
     DOCKER_BUILDKIT=1 docker build \
         --build-arg BASE_IMAGE="${image_name}" \
         --build-arg BUILD_PARAMS="${build_parameters}" \
+        --build-arg SYSROOT_SUFFIX="${sysroot_suffix}" \
         --output type=local,dest=. \
         --progress=plain \
         -f "${dockerfile_path}" \


### PR DESCRIPTION
Docker run was rebuilding on each invocation because it couldn't persist build caches between runs. By switching to BuildKit with cache mounts for cargo registry, git, sccache, and target directories, incremental builds are now ~9x faster for no-change builds (24s → 2.7s) and ~2.8x faster for changed builds (1m44s → 38s). This also adds sccache to the Docker images and makes git hooks setup conditional to support non-git contexts.

This speed up is a bit less than it was before #1279, prior to that change it was taking 6-8 mins for each build.  This still makes the docker experience better.  

this also enabled the docker builds to work in git trees since the .git folder is not passed to the docker context