### PR TITLE
[kernel] Fix Perf Issue on AMD vCPUs

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -39,14 +39,7 @@ hyperlight = [
     "arch/hyperlight",
     "puts",
     "stdio",
-    "acpi",
-    "cpuid",
-    "ioapic",
-    "madt",
-    "msr",
-    "pic",
     "pit",
-    "xapic",
     "dep:hyperlight-common",
     "dep:hyperlight-guest",
     "dep:config",
@@ -56,14 +49,7 @@ microvm = [
     "arch/microvm",
     "putb",
     "stdio",
-    "acpi",
-    "cpuid",
-    "ioapic",
-    "madt",
-    "msr",
-    "pic",
     "pit",
-    "xapic",
     "dep:config",
     "config/microvm",
 ]
@@ -75,13 +61,6 @@ pc = [
     "mboot",
     "pit",
     "warn",
-    "acpi",
-    "cpuid",
-    "ioapic",
-    "madt",
-    "msr",
-    "pic",
-    "xapic",
     "dep:config",
     "config/pc",
 ]
@@ -92,13 +71,6 @@ qemu-baremetal-smp = ["arch/qemu-baremetal-smp", "qemu-baremetal", "smp"]
 qemu-isapc = ["arch/qemu-isapc", "pc"]
 
 # Architecture Features
-acpi = []
-cpuid = []
-ioapic = []
-madt = []
-msr = []
-pic = []
-xapic = []
 
 # Platform Features
 smp = []

--- a/src/kernel/src/hal/arch/x86/cpu/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/mod.rs
@@ -122,7 +122,6 @@ pub fn init(
     let (gdtr, tss): (GdtPtr, TssRef) = unsafe { Gdt::init(&kstack)? };
     unsafe { idt::init() };
 
-    #[cfg(feature = "pic")]
     let controller: Option<InterruptController> = match interrupt::init(ioports, ioaddresses, madt)
     {
         Ok(controller) => Some(controller),
@@ -131,8 +130,6 @@ pub fn init(
             None
         },
     };
-    #[cfg(not(feature = "pic"))]
-    let controller: Option<InterruptController> = None;
 
     Ok((gdtr, tss, controller))
 }

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -277,7 +277,6 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
     Ok(BootInfo::new(None, None, LinkedList::new(), LinkedList::new(), kernel_modules))
 }
 
-#[cfg(feature = "pic")]
 fn register_pic_ioports(ioports: &mut IoPortAllocator) -> Result<(), Error> {
     // Register I/O ports for 8259 PIC.
     ioports.register_read_write(::arch::cpu::pic::PIC_CTRL_MASTER as u16)?;
@@ -305,7 +304,6 @@ pub fn init(
     madt: &Option<MadtInfo>,
     _mem_lower: Option<usize>,
 ) -> Result<Platform, Error> {
-    #[cfg(feature = "pic")]
     register_pic_ioports(ioports)?;
 
     extern "C" {

--- a/src/kernel/src/hal/platform/microvm.rs
+++ b/src/kernel/src/hal/platform/microvm.rs
@@ -319,7 +319,6 @@ fn log_control_registers() {
     }
 }
 
-#[cfg(feature = "pic")]
 fn register_pic_ioports(ioports: &mut IoPortAllocator) -> Result<(), Error> {
     // Register I/O ports for 8259 PIC.
     ioports.register_read_write(pic::PIC_CTRL_MASTER as u16)?;
@@ -347,7 +346,6 @@ pub fn init(
     madt: &Option<MadtInfo>,
     _mem_lower: Option<usize>,
 ) -> Result<Platform, Error> {
-    #[cfg(feature = "pic")]
     register_pic_ioports(ioports)?;
 
     // Register MicroVM control registers.

--- a/src/kernel/src/hal/platform/microvm.rs
+++ b/src/kernel/src/hal/platform/microvm.rs
@@ -16,14 +16,19 @@ use crate::{
             IoPortAllocator,
         },
         mem::{
+            AccessPermission,
             MemoryRegion,
             MemoryRegionType,
+            PageAligned,
             PhysicalAddress,
             TruncatedMemoryRegion,
         },
         platform::{
             bootinfo::BootInfo,
-            madt::MadtInfo,
+            madt::{
+                MadtEntry,
+                MadtInfo,
+            },
         },
     },
     kmod::KernelModule,
@@ -33,7 +38,16 @@ use ::alloc::{
     string::ToString,
 };
 use ::arch::{
-    cpu::pic,
+    cpu::{
+        acpi::AcpiSdtHeader,
+        madt::{
+            Madt,
+            MadtEntryHeader,
+            MadtEntryLocalApic,
+            MadtEntryType,
+        },
+        pic,
+    },
     mem,
 };
 use ::sys::{
@@ -42,7 +56,6 @@ use ::sys::{
         ErrorCode,
     },
     mm::{
-        AccessPermission,
         Address,
         VirtualAddress,
     },
@@ -338,11 +351,65 @@ fn register_pit(ioports: &mut IoPortAllocator) -> Result<Pit, Error> {
     Pit::new(ioports, ::config::kernel::TIMER_FREQ)
 }
 
+fn register_lapic_mmio(
+    ioaddresses: &mut IoMemoryAllocator,
+    mmio_regions: &mut LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+) -> Result<TruncatedMemoryRegion<VirtualAddress>, Error> {
+    let base: PageAligned<VirtualAddress> =
+        PageAligned::from_raw_value(::config::microvm::DEFAULT_LAPIC_BASE)?;
+
+    let lapic_region: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new(
+        "lapic",
+        base,
+        ::config::microvm::DEFAULT_LAPIC_SIZE,
+        MemoryRegionType::Mmio,
+        AccessPermission::RDWR,
+    )?;
+
+    ioaddresses.register(lapic_region.clone())?;
+    mmio_regions.push_back(lapic_region.clone());
+
+    Ok(lapic_region)
+}
+
+fn build_synthetic_madt() -> MadtInfo {
+    let mut entries: LinkedList<MadtEntry> = LinkedList::new();
+
+    entries.push_back(MadtEntry::LocalApic(MadtEntryLocalApic {
+        header: MadtEntryHeader {
+            typ: MadtEntryType::LocalApic as u8,
+            len: core::mem::size_of::<MadtEntryLocalApic>() as u8,
+        },
+        processor_id: 0,
+        apic_id: 0,
+        flags: MadtEntryLocalApic::ENABLED,
+    }));
+
+    let sdt: AcpiSdtHeader = AcpiSdtHeader {
+        signature: [b'A' as i8, b'P' as i8, b'I' as i8, b'C' as i8],
+        length: (core::mem::size_of::<Madt>() + core::mem::size_of::<MadtEntryLocalApic>()) as u32,
+        revision: 1,
+        checksum: 0,
+        oem_id: [0; 6],
+        oem_table_id: [0; 8],
+        oem_revision: 0,
+        creator_id: 0,
+        creator_rev: 0,
+    };
+
+    MadtInfo {
+        sdt,
+        local_apic_addr: ::config::microvm::DEFAULT_LAPIC_BASE as u32,
+        flags: 0,
+        entries,
+    }
+}
+
 pub fn init(
     ioports: &mut IoPortAllocator,
     ioaddresses: &mut IoMemoryAllocator,
     memory_regions: &mut LinkedList<MemoryRegion<VirtualAddress>>,
-    _mmio_regions: &mut LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    mmio_regions: &mut LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
     madt: &Option<MadtInfo>,
     _mem_lower: Option<usize>,
 ) -> Result<Platform, Error> {
@@ -360,8 +427,24 @@ pub fn init(
 
     log_control_registers();
 
+    // Ensure the Local APIC MMIO window is registered so the kernel can attach to it even when
+    // firmware does not advertise ACPI tables (e.g., the MicroVM machine type).
+    let _lapic_region: TruncatedMemoryRegion<VirtualAddress> =
+        register_lapic_mmio(ioaddresses, mmio_regions)?;
+
+    // Build a minimal MADT describing a single enabled LAPIC if firmware did not supply one.
+    let mut synthetic_madt: Option<MadtInfo> = None;
+    if madt.is_none() {
+        synthetic_madt = Some(build_synthetic_madt());
+    }
+
+    let madt_to_use: &Option<MadtInfo> = match madt {
+        Some(_) => madt,
+        None => &synthetic_madt,
+    };
+
     Ok(Platform {
-        arch: x86::init(ioports, ioaddresses, madt)?,
+        arch: x86::init(ioports, ioaddresses, madt_to_use)?,
         #[cfg(feature = "pit")]
         _pit: register_pit(ioports)?,
     })

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -236,6 +236,12 @@ pub mod microvm {
     /// Default base address for RAMFS size register (32-bit wide read-only register)
     pub const DEFAULT_MICROVM_CTRL_RAMFS_SIZE: usize = 0x00000010;
 
+    /// Default base address for the Local APIC MMIO window.
+    pub const DEFAULT_LAPIC_BASE: usize = 0xfee0_0000;
+
+    /// Size of the Local APIC MMIO window (bytes).
+    pub const DEFAULT_LAPIC_SIZE: usize = 0x1000;
+
     /// Magic value that identifies the running state in the pause-requested register.
     pub const RUNNING: u32 = 0x00000000;
 

--- a/src/uservm/src/vmm/microvm/kvm/irqchip.rs
+++ b/src/uservm/src/vmm/microvm/kvm/irqchip.rs
@@ -13,8 +13,12 @@ use ::serde::{
 use ::syslog::{
     error,
     trace,
+    warn,
 };
-use kvm_bindings::kvm_irqchip;
+use kvm_bindings::{
+    kvm_create_device,
+    kvm_irqchip,
+};
 use kvm_ioctls::{
     Kvm,
     VmFd,
@@ -24,17 +28,31 @@ use kvm_ioctls::{
 // IrqChip State
 //==================================================================================================
 
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+enum Backend {
+    /// Traditional in-kernel PIC/IOAPIC + LAPIC setup created via `KVM_CREATE_IRQCHIP`.
+    InKernelChip,
+    /// LAPIC device created explicitly with `KVM_CREATE_DEVICE` (split irqchip setups).
+    LapicDevice,
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct IrqChipState {
     /// Interrupt controller.
-    irqchip: kvm_irqchip,
+    backend: Backend,
+    irqchip: Option<kvm_irqchip>,
 }
 
 //==================================================================================================
 // IrqChip
 //==================================================================================================
 
-pub struct IrqChip;
+pub struct IrqChip {
+    backend: Backend,
+}
+
+// kvm-bindings may not expose the LAPIC device type on all kernel versions; define it locally.
+const KVM_DEV_TYPE_APIC: u32 = 3;
 
 impl IrqChip {
     ///
@@ -54,7 +72,27 @@ impl IrqChip {
     pub fn new(kvm_fd: &mut Kvm, vm_fd: &mut VmFd) -> Result<IrqChip> {
         trace!("new(): kvm_fd={kvm_fd:?}, vm_fd={vm_fd:?}");
 
-        // Check if KVM does not support irqchip.
+        // Prefer split irqchip LAPIC device when available (e.g., microvm machine type).
+        if kvm_fd.check_extension(kvm_ioctls::Cap::SplitIrqchip) {
+            let mut device: kvm_create_device = kvm_create_device {
+                type_: KVM_DEV_TYPE_APIC,
+                fd: 0,
+                flags: 0,
+            };
+
+            match vm_fd.create_device(&mut device) {
+                Ok(_) => {
+                    return Ok(IrqChip {
+                        backend: Backend::LapicDevice,
+                    });
+                },
+                Err(e) => {
+                    warn!("new(): failed to create lapic device, falling back (error={e:?})");
+                },
+            }
+        }
+
+        // Check if KVM supports the legacy in-kernel irqchip path.
         let has_irqchip_support: bool = kvm_fd.check_extension(kvm_ioctls::Cap::Irqchip);
         if !has_irqchip_support {
             let reason: &str = "irqchip is not supported";
@@ -64,31 +102,55 @@ impl IrqChip {
 
         vm_fd.create_irq_chip()?;
 
-        Ok(IrqChip)
+        Ok(IrqChip {
+            backend: Backend::InKernelChip,
+        })
     }
 
     pub fn save_state(&self, vm_fd: &VmFd) -> Result<IrqChipState> {
         trace!("save_state()");
 
-        let mut irqchip: kvm_irqchip = kvm_irqchip::default();
-        if let Err(e) = vm_fd.get_irqchip(&mut irqchip) {
-            let reason: String = format!("failed getting irqchip (error={e:?})");
-            error!("get_state(): {reason}");
-            anyhow::bail!(reason)
-        };
+        match self.backend {
+            Backend::LapicDevice => Ok(IrqChipState {
+                backend: Backend::LapicDevice,
+                irqchip: None,
+            }),
+            Backend::InKernelChip => {
+                let mut irqchip: kvm_irqchip = kvm_irqchip::default();
+                if let Err(e) = vm_fd.get_irqchip(&mut irqchip) {
+                    let reason: String = format!("failed getting irqchip (error={e:?})");
+                    error!("get_state(): {reason}");
+                    anyhow::bail!(reason)
+                };
 
-        Ok(IrqChipState { irqchip })
+                Ok(IrqChipState {
+                    backend: Backend::InKernelChip,
+                    irqchip: Some(irqchip),
+                })
+            },
+        }
     }
 
     pub fn restore_state(&mut self, vm_fd: &VmFd, state: &IrqChipState) -> Result<()> {
         trace!("restore_state()");
 
-        if let Err(e) = vm_fd.set_irqchip(&state.irqchip) {
-            let reason: String = format!("failed setting irqchip (error={e:?})");
-            error!("set_state(): {reason}");
-            anyhow::bail!(reason)
-        };
+        match state.backend {
+            Backend::LapicDevice => Ok(()),
+            Backend::InKernelChip => {
+                let Some(irqchip) = state.irqchip else {
+                    let reason: &str = "missing irqchip state for in-kernel backend";
+                    error!("restore_state(): {reason}");
+                    anyhow::bail!(reason)
+                };
 
-        Ok(())
+                if let Err(e) = vm_fd.set_irqchip(&irqchip) {
+                    let reason: String = format!("failed setting irqchip (error={e:?})");
+                    error!("set_state(): {reason}");
+                    anyhow::bail!(reason)
+                };
+
+                Ok(())
+            },
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces major improvements to MicroVM support in both the kernel and user VM layers, focusing on correct Local APIC (LAPIC) MMIO region registration and flexible KVM IRQ chip initialization. It ensures the kernel can function even when firmware does not provide ACPI tables, and allows the user VM to prefer split irqchip setups when available. The changes also add new configuration constants and refactor relevant imports.

This PR closes #1251 