### PR TITLE
[nanvix-test] Support Empty Output Check

### DIFF
--- a/src/utils/nanvix-test/src/config.rs
+++ b/src/utils/nanvix-test/src/config.rs
@@ -486,6 +486,8 @@ pub struct TestCaseConfig {
     pub input: Option<String>,
     /// Optional output payload used when validating the workload response.
     pub expected_output: Option<String>,
+    /// Flag indicating that the workload must not produce any stdout output.
+    pub expect_empty_output: bool,
 }
 
 impl TestCaseConfig {
@@ -513,6 +515,7 @@ impl TestCaseConfig {
         let program_args_field: String = format!("{entry_prefix}.program_args");
         let input_field: String = format!("{entry_prefix}.input");
         let expected_output_field: String = format!("{entry_prefix}.expected_output");
+        let expect_empty_output_field: String = format!("{entry_prefix}.expect_empty_output");
 
         Ok(Self {
             executor: read_required_string(table, "executor", executor_field.as_str())?,
@@ -529,6 +532,12 @@ impl TestCaseConfig {
                 table,
                 "expected_output",
                 expected_output_field.as_str(),
+            )?,
+            expect_empty_output: read_bool_with_default(
+                table,
+                "expect_empty_output",
+                expect_empty_output_field.as_str(),
+                false,
             )?,
         })
     }
@@ -560,6 +569,20 @@ impl TestCaseConfig {
             let reason: String = format!(
                 "tests[{index}] requires the 'program' field when executor is '{}'",
                 self.executor
+            );
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        if self.expect_empty_output
+            && self
+                .expected_output
+                .as_ref()
+                .map(|output| !output.is_empty())
+                .unwrap_or(false)
+        {
+            let reason: String = format!(
+                "tests[{index}] cannot set 'expect_empty_output=true' while also providing a \
+                 non-empty expected_output"
             );
             return Err(::anyhow::anyhow!(reason));
         }

--- a/src/utils/nanvix-test/src/executor/empty.rs
+++ b/src/utils/nanvix-test/src/executor/empty.rs
@@ -58,8 +58,7 @@ pub(crate) async fn empty(
         } = log_layout.allocate_runner_logs(Some(iteration));
 
         let nanvixd_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
-            stdout_file_path.as_path(),
-            stderr_file_path.as_path(),
+            (stdout_file_path.as_path(), stderr_file_path.as_path()),
             runner_config.ipv4_addr.as_str(),
             runner_config.port_num,
             hwloc_file_path.clone(),

--- a/src/utils/nanvix-test/src/executor/http.rs
+++ b/src/utils/nanvix-test/src/executor/http.rs
@@ -8,6 +8,7 @@
 use crate::{
     DEFAULT_TENANT_ID,
     config::RunnerConfig,
+    executor::WorkloadSpec,
     log_layout::{
         GuestLogTracker,
         RunnerLogPaths,
@@ -27,6 +28,7 @@ use ::nanvix::{
     log::{
         error,
         trace,
+        warn,
     },
     syscomm::{
         ReadExact,
@@ -57,10 +59,7 @@ use ::tokio::time::timeout;
 ///
 /// - `runner_config`: Configuration required to spawn the Nanvix Daemon and User VMs.
 /// - `iterations`: Number of times the start/run/stop cycle should execute.
-/// - `program_path`: Absolute path to the executable launched inside the User VM.
-/// - `program_args`: Optional command-line arguments forwarded to the workload.
-/// - `input`: Optional payload forwarded to the workload.
-/// - `expected_output`: Optional payload that should be received back from the workload.
+/// - `workload`: Metadata that describes the workload path, arguments, and expectations.
 /// - `log_layout`: Layout that controls how runner/program logs are timestamped and stored.
 ///
 /// # Return Value
@@ -72,16 +71,13 @@ use ::tokio::time::timeout;
 pub(crate) async fn test_with_http_executor(
     runner_config: &RunnerConfig,
     iterations: usize,
-    program_path: &str,
-    program_args: Option<&str>,
-    input: Option<&str>,
-    expected_output: Option<&str>,
+    workload: WorkloadSpec<'_>,
     log_layout: &TestLogLayout,
 ) -> Result<()> {
     let l2_enabled: bool = runner_config.l2_enabled;
     let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
-    let program_path: String = program_path.to_string();
-    let request_payload: Option<Vec<u8>> = input.map(|value| value.as_bytes().to_vec());
+    let program_path: String = workload.program_path().to_string();
+    let request_payload: Option<Vec<u8>> = workload.input().map(|value| value.as_bytes().to_vec());
     let response_timeout: Duration =
         Duration::from_millis(runner_config.stream_collection_timeout_ms);
     let log_root: &Path = Path::new(runner_config.log_directory.as_str());
@@ -104,8 +100,7 @@ pub(crate) async fn test_with_http_executor(
     } = log_layout.allocate_runner_logs(None);
 
     let nanvixd_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
-        stdout_file_path.as_path(),
-        stderr_file_path.as_path(),
+        (stdout_file_path.as_path(), stderr_file_path.as_path()),
         runner_config.ipv4_addr.as_str(),
         runner_config.port_num,
         hwloc_file_path.clone(),
@@ -124,7 +119,7 @@ pub(crate) async fn test_with_http_executor(
                 DEFAULT_TENANT_ID,
                 app_name.as_str(),
                 program_path.as_str(),
-                program_args,
+                workload.program_args(),
                 l2_enabled,
             )?;
 
@@ -136,7 +131,7 @@ pub(crate) async fn test_with_http_executor(
 
             close_gateway_input(&mut user_vm).await?;
 
-            let expected_pattern: Option<&[u8]> = expected_output.and_then(|value| {
+            let expected_pattern: Option<&[u8]> = workload.expected_output().and_then(|value| {
                 if value.is_empty() {
                     None
                 } else {
@@ -144,8 +139,22 @@ pub(crate) async fn test_with_http_executor(
                 }
             });
 
-            let payload: Vec<u8> =
-                receive_payload(&mut user_vm, expected_pattern, response_timeout).await?;
+            let payload: Vec<u8> = receive_payload(
+                &mut user_vm,
+                expected_pattern,
+                response_timeout,
+                workload.expect_empty_output(),
+            )
+            .await?;
+            if workload.expect_empty_output() && !payload.is_empty() {
+                let reason: String = format!(
+                    "uservm produced unexpected stdout (bytes={:?}, len={})",
+                    payload,
+                    payload.len()
+                );
+                error!("test_with_http_executor(): {reason}");
+                return Err(::anyhow::anyhow!(reason));
+            }
             log_layout.persist_program_output(iteration, payload.as_slice())?;
         }
     }
@@ -212,6 +221,7 @@ async fn close_gateway_input(user_vm: &mut UserVm) -> Result<()> {
 /// - `user_vm`: Handle to the running User VM gateway stream.
 /// - `expected_pattern`: Byte pattern that must appear in the payload.
 /// - `timeout_duration`: Maximum time allowed while waiting for the expected payload.
+/// - `expect_empty_output`: Indicates whether EOF/connection reset should map to an empty payload.
 ///
 /// # Return Value
 ///
@@ -222,8 +232,14 @@ async fn receive_payload(
     user_vm: &mut UserVm,
     expected_pattern: Option<&[u8]>,
     timeout_duration: Duration,
+    expect_empty_output: bool,
 ) -> Result<Vec<u8>> {
-    match timeout(timeout_duration, collect_uservm_payload(user_vm, expected_pattern)).await {
+    match timeout(
+        timeout_duration,
+        collect_uservm_payload(user_vm, expected_pattern, expect_empty_output),
+    )
+    .await
+    {
         Ok(result) => result,
         Err(_elapsed) => {
             let reason: String = match expected_pattern {
@@ -252,6 +268,7 @@ async fn receive_payload(
 ///
 /// - `user_vm`: Handle to the running User VM gateway stream.
 /// - `expected_pattern`: Byte sequence that must appear in the collected payload.
+/// - `expect_empty_output`: Allows EOF/connection-reset to be treated as empty output when set.
 ///
 /// # Return Value
 ///
@@ -261,6 +278,7 @@ async fn receive_payload(
 async fn collect_uservm_payload(
     user_vm: &mut UserVm,
     expected_pattern: Option<&[u8]>,
+    expect_empty_output: bool,
 ) -> Result<Vec<u8>> {
     trace!(
         "collect_uservm_payload(): expected_len={}, expected_pattern={:?}",
@@ -276,12 +294,30 @@ async fn collect_uservm_payload(
             Ok(_) => {
                 response_payload.push(byte[0]);
             },
-            Err(error) => {
-                if error.kind() == ErrorKind::UnexpectedEof {
+            Err(error) => match error.kind() {
+                ErrorKind::UnexpectedEof | ErrorKind::ConnectionReset => {
+                    if expect_empty_output {
+                        if response_payload.is_empty() && expected_pattern.is_none() {
+                            warn!(
+                                "collect_uservm_payload(): gateway closed before emitting payload \
+                                 (error_kind={:?})",
+                                error.kind()
+                            );
+                        } else if !response_payload.is_empty() {
+                            warn!(
+                                "collect_uservm_payload(): gateway closed after emitting \
+                                 unexpected payload (error_kind={:?}, response_len={})",
+                                error.kind(),
+                                response_payload.len()
+                            );
+                        }
+                    }
                     break;
-                }
-                error!("collect_uservm_payload(): failed to read payload (error={error})");
-                return Err(error.into());
+                },
+                _ => {
+                    error!("collect_uservm_payload(): failed to read payload (error={error})");
+                    return Err(error.into());
+                },
             },
         }
 

--- a/src/utils/nanvix-test/src/executor/mod.rs
+++ b/src/utils/nanvix-test/src/executor/mod.rs
@@ -12,6 +12,144 @@ pub mod terminal;
 use ::anyhow::Result;
 
 //==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Describes workload metadata forwarded to Nanvix executors.
+///
+#[derive(Clone, Copy)]
+pub struct WorkloadSpec<'a> {
+    ///
+    /// # Description
+    ///
+    /// Path to the workload binary executed by an executor.
+    ///
+    program_path: &'a str,
+    ///
+    /// # Description
+    ///
+    /// Optional argument string forwarded to the workload entry point.
+    ///
+    program_args: Option<&'a str>,
+    ///
+    /// # Description
+    ///
+    /// Optional payload injected into the workload stdin or HTTP stream.
+    ///
+    input: Option<&'a str>,
+    ///
+    /// # Description
+    ///
+    /// Optional substring that must appear in the collected stdout payload.
+    ///
+    expected_output: Option<&'a str>,
+    ///
+    /// # Description
+    ///
+    /// Indicates whether the workload is expected to produce an empty stdout payload.
+    ///
+    expect_empty_output: bool,
+}
+
+impl<'a> WorkloadSpec<'a> {
+    ///
+    /// # Description
+    ///
+    /// Creates a new workload specification used by Nanvix executors.
+    ///
+    /// # Parameters
+    ///
+    /// - `program_path`: Path to the workload binary executed by an executor.
+    /// - `program_args`: Optional argument string forwarded to the workload entry point.
+    /// - `input`: Optional payload injected into the workload stdin or HTTP stream.
+    /// - `expected_output`: Optional substring that must appear in the collected stdout payload.
+    /// - `expect_empty_output`: Indicates whether the workload should produce an empty stdout
+    ///   payload.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a workload specification containing the provided metadata.
+    pub const fn new(
+        program_path: &'a str,
+        program_args: Option<&'a str>,
+        input: Option<&'a str>,
+        expected_output: Option<&'a str>,
+        expect_empty_output: bool,
+    ) -> Self {
+        Self {
+            program_path,
+            program_args,
+            input,
+            expected_output,
+            expect_empty_output,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the path to the workload binary executed by an executor.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the workload binary path.
+    pub const fn program_path(&self) -> &'a str {
+        self.program_path
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the optional argument string forwarded to the workload entry point.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the optional argument string, when provided.
+    pub const fn program_args(&self) -> Option<&'a str> {
+        self.program_args
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the optional payload injected into the workload stdin or HTTP stream.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the optional payload, when provided.
+    pub const fn input(&self) -> Option<&'a str> {
+        self.input
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Retrieves the optional substring that must appear in the collected stdout payload.
+    ///
+    /// # Return Value
+    ///
+    /// Returns the optional expected stdout substring, when provided.
+    pub const fn expected_output(&self) -> Option<&'a str> {
+        self.expected_output
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Indicates whether the workload should produce an empty stdout payload.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `true` when empty stdout is required; otherwise returns `false`.
+    pub const fn expect_empty_output(&self) -> bool {
+        self.expect_empty_output
+    }
+}
+
+//==================================================================================================
 // Enumerations
 //==================================================================================================
 

--- a/src/utils/nanvix-test/src/executor/terminal.rs
+++ b/src/utils/nanvix-test/src/executor/terminal.rs
@@ -7,6 +7,7 @@
 
 use crate::{
     config::RunnerConfig,
+    executor::WorkloadSpec,
     log_layout::{
         GuestLogTracker,
         RunnerLogPaths,
@@ -88,10 +89,7 @@ type StreamCollectors = (
 ///
 /// - `runner_config`: Configuration required to spawn the Nanvix Daemon.
 /// - `iterations`: Number of times to run the workflow.
-/// - `program_path`: Path to the program executed by the daemon.
-/// - `program_args`: Optional argument string passed to the workload.
-/// - `input`: Optional payload sent over stdin.
-/// - `expected_output`: Optional substring expected in stdout.
+/// - `workload`: Metadata that describes the workload path, arguments, and expectations.
 /// - `log_layout`: Layout that defines the target directory for stdout/stderr/program logs.
 ///
 /// # Return Value
@@ -103,10 +101,7 @@ type StreamCollectors = (
 pub async fn test_with_terminal_executor(
     runner_config: &RunnerConfig,
     iterations: usize,
-    program_path: &str,
-    program_args: Option<&str>,
-    input: Option<&str>,
-    expected_output: Option<&str>,
+    workload: WorkloadSpec<'_>,
     log_layout: &TestLogLayout,
 ) -> Result<()> {
     if runner_config.l2_enabled {
@@ -116,7 +111,7 @@ pub async fn test_with_terminal_executor(
     }
 
     let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
-    let parsed_program_args: Vec<String> = match program_args {
+    let parsed_program_args: Vec<String> = match workload.program_args() {
         Some(args) => match shell_words::split(args) {
             Ok(values) => values,
             Err(error) => {
@@ -141,7 +136,7 @@ pub async fn test_with_terminal_executor(
 
         let nanvixd_args: NanvixdTerminalArgs = NanvixdTerminalArgs::new(
             hwloc_file_path.clone(),
-            program_path,
+            workload.program_path(),
             parsed_program_args.as_slice(),
             log_layout.test_directory(),
         )?;
@@ -183,7 +178,7 @@ pub async fn test_with_terminal_executor(
                 ::anyhow::anyhow!(reason)
             })?;
 
-            send_interactive_input(stdin_pipe, input).await?;
+            send_interactive_input(stdin_pipe, workload.input()).await?;
 
             (nanvixd, (stdout_handle, stdout_buffer, stderr_handle, stderr_buffer))
         };
@@ -228,13 +223,22 @@ pub async fn test_with_terminal_executor(
 
         log_layout.persist_program_output(iteration, stdout_bytes.as_slice())?;
 
-        if let Some(expected) = expected_output
+        if let Some(expected) = workload.expected_output()
             && !buffer_contains_pattern(stdout_bytes.as_slice(), expected.as_bytes())
         {
             let reason: String = format!(
                 "interactive output mismatch (expected='{}', log={}, iteration={iteration})",
                 expected,
                 stdout_file_path.display()
+            );
+            error!("test_with_terminal_executor(): {reason}");
+            return Err(::anyhow::anyhow!(reason));
+        }
+
+        if workload.expect_empty_output() && !stdout_bytes.is_empty() {
+            let reason: String = format!(
+                "interactive output is not empty as required (bytes={:?}, iteration={iteration})",
+                stdout_bytes
             );
             error!("test_with_terminal_executor(): {reason}");
             return Err(::anyhow::anyhow!(reason));

--- a/src/utils/nanvix-test/src/main.rs
+++ b/src/utils/nanvix-test/src/main.rs
@@ -60,6 +60,7 @@ use crate::{
     },
     executor::{
         ExecutorName,
+        WorkloadSpec,
         empty::empty,
         http::test_with_http_executor,
         terminal::test_with_terminal_executor,
@@ -179,6 +180,7 @@ async fn run() -> Result<()> {
             program_args,
             input,
             expected_output,
+            expect_empty_output,
         } = test_config;
 
         debug!(
@@ -188,8 +190,8 @@ async fn run() -> Result<()> {
 
         let executor_name: ExecutorName = ExecutorName::from_str(executor.as_str())?;
 
-        match (executor_name, program, program_args, input, expected_output) {
-            (ExecutorName::Empty, _, _, _, _) => {
+        match (executor_name, program, program_args, input, expected_output, expect_empty_output) {
+            (ExecutorName::Empty, _, _, _, _, _) => {
                 let log_layout: TestLogLayout = TestLogLayout::for_label(
                     log_root,
                     ExecutorName::Empty.to_str(),
@@ -199,7 +201,14 @@ async fn run() -> Result<()> {
                 let context: String = format!("empty executor completed (label={})", executor);
                 warning::fail_if_triggered(context.as_str())?;
             },
-            (ExecutorName::Http, Some(program_path), program_args, input, expected_output) => {
+            (
+                ExecutorName::Http,
+                Some(program_path),
+                program_args,
+                input,
+                expected_output,
+                expect_empty_output,
+            ) => {
                 if !Path::new(program_path.as_str()).exists() {
                     warn_with_policy!(
                         "main(): skipping tests with http executor because program path is \
@@ -216,29 +225,35 @@ async fn run() -> Result<()> {
                     program_path.as_str(),
                 )?;
 
-                test_with_http_executor(
-                    &runner_config,
-                    iterations,
+                let workload: WorkloadSpec = WorkloadSpec::new(
                     program_path.as_str(),
                     program_args.as_deref(),
                     input.as_deref(),
                     expected_output.as_deref(),
-                    &log_layout,
-                )
-                .await?;
+                    expect_empty_output,
+                );
+
+                test_with_http_executor(&runner_config, iterations, workload, &log_layout).await?;
                 let context: String = format!(
                     "http executor completed (program={}, test={})",
                     program_path, executor
                 );
                 warning::fail_if_triggered(context.as_str())?;
             },
-            (ExecutorName::Http, None, _, _, _) => {
+            (ExecutorName::Http, None, _, _, _, _) => {
                 let reason: String =
                     "tests entries with http executor must define the 'program' field".to_string();
                 error!("main(): {reason}");
                 return Err(::anyhow::anyhow!(reason));
             },
-            (ExecutorName::Terminal, Some(program_path), program_args, input, expected_output) => {
+            (
+                ExecutorName::Terminal,
+                Some(program_path),
+                program_args,
+                input,
+                expected_output,
+                expect_empty_output,
+            ) => {
                 if !Path::new(program_path.as_str()).exists() {
                     warn_with_policy!(
                         "main(): skipping tests with terminal executor because program path is \
@@ -255,23 +270,23 @@ async fn run() -> Result<()> {
                     program_path.as_str(),
                 )?;
 
-                test_with_terminal_executor(
-                    &runner_config,
-                    iterations,
+                let workload: WorkloadSpec = WorkloadSpec::new(
                     program_path.as_str(),
                     program_args.as_deref(),
                     input.as_deref(),
                     expected_output.as_deref(),
-                    &log_layout,
-                )
-                .await?;
+                    expect_empty_output,
+                );
+
+                test_with_terminal_executor(&runner_config, iterations, workload, &log_layout)
+                    .await?;
                 let context: String = format!(
                     "terminal executor completed (program={}, test={})",
                     program_path, executor
                 );
                 warning::fail_if_triggered(context.as_str())?;
             },
-            (ExecutorName::Terminal, None, _, _, _) => {
+            (ExecutorName::Terminal, None, _, _, _, _) => {
                 let reason: String = "test entries with terminal executor must define the \
                                       'program' field"
                     .to_string();

--- a/src/utils/nanvix-test/src/nanvixd/http.rs
+++ b/src/utils/nanvix-test/src/nanvixd/http.rs
@@ -254,8 +254,7 @@ impl NanvixdHttpArgs {
     ///
     /// # Parameters
     ///
-    /// - `stdout_file_path`: Path to the file that captures Nanvix Daemon standard output.
-    /// - `stderr_file_path`: Path to the file that captures Nanvix Daemon standard error.
+    /// - `log_files`: Tuple containing stdout and stderr log file paths.
     /// - `ipv4_addr`: IPv4 address where the Nanvix Daemon should expose its HTTP interface.
     /// - `port_num`: TCP port used by the Nanvix Daemon HTTP interface.
     /// - `hwloc_file_path`: Optional hwloc topology file passed to the Nanvix Daemon.
@@ -268,10 +267,8 @@ impl NanvixdHttpArgs {
     /// Returns a ready-to-use argument bundle when both log files can be created; returns an error
     /// when the stdout or stderr log file cannot be opened.
     ///
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        stdout_file_path: &Path,
-        stderr_file_path: &Path,
+        log_files: (&Path, &Path),
         ipv4_addr: &str,
         port_num: u16,
         hwloc_file_path: Option<String>,
@@ -279,6 +276,7 @@ impl NanvixdHttpArgs {
         netns_pool_size: usize,
         log_directory: &Path,
     ) -> Result<Self> {
+        let (stdout_file_path, stderr_file_path): (&Path, &Path) = log_files;
         let stdout_file_handle: File = match OpenOptions::new()
             .create(true)
             .write(true)


### PR DESCRIPTION
This pull request enhances the test infrastructure for the Nanvix project by introducing support for test cases that expect empty output from workloads. It does so by adding a new `expect_empty_output` flag to the test configuration, propagating this expectation through the executor interfaces, and updating the logic to validate that workloads produce no output when required. Additionally, the refactor consolidates workload metadata into a new `WorkloadSpec` struct, simplifying function signatures and improving maintainability.