### PR TITLE
[kernel] Remove Obsolete Features

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -39,14 +39,7 @@ hyperlight = [
     "arch/hyperlight",
     "puts",
     "stdio",
-    "acpi",
-    "cpuid",
-    "ioapic",
-    "madt",
-    "msr",
-    "pic",
     "pit",
-    "xapic",
     "dep:hyperlight-common",
     "dep:hyperlight-guest",
     "dep:config",
@@ -56,14 +49,7 @@ microvm = [
     "arch/microvm",
     "putb",
     "stdio",
-    "acpi",
-    "cpuid",
-    "ioapic",
-    "madt",
-    "msr",
-    "pic",
     "pit",
-    "xapic",
     "dep:config",
     "config/microvm",
 ]
@@ -75,13 +61,6 @@ pc = [
     "mboot",
     "pit",
     "warn",
-    "acpi",
-    "cpuid",
-    "ioapic",
-    "madt",
-    "msr",
-    "pic",
-    "xapic",
     "dep:config",
     "config/pc",
 ]
@@ -90,15 +69,6 @@ qemu-pc-smp = ["arch/qemu-pc-smp", "qemu-pc", "smp"]
 qemu-baremetal = ["arch/qemu-baremetal", "pc"]
 qemu-baremetal-smp = ["arch/qemu-baremetal-smp", "qemu-baremetal", "smp"]
 qemu-isapc = ["arch/qemu-isapc", "pc"]
-
-# Architecture Features
-acpi = []
-cpuid = []
-ioapic = []
-madt = []
-msr = []
-pic = []
-xapic = []
 
 # Platform Features
 smp = []

--- a/src/kernel/src/hal/arch/x86/cpu/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/mod.rs
@@ -122,7 +122,6 @@ pub fn init(
     let (gdtr, tss): (GdtPtr, TssRef) = unsafe { Gdt::init(&kstack)? };
     unsafe { idt::init() };
 
-    #[cfg(feature = "pic")]
     let controller: Option<InterruptController> = match interrupt::init(ioports, ioaddresses, madt)
     {
         Ok(controller) => Some(controller),
@@ -131,8 +130,6 @@ pub fn init(
             None
         },
     };
-    #[cfg(not(feature = "pic"))]
-    let controller: Option<InterruptController> = None;
 
     Ok((gdtr, tss, controller))
 }

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -277,7 +277,6 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
     Ok(BootInfo::new(None, None, LinkedList::new(), LinkedList::new(), kernel_modules))
 }
 
-#[cfg(feature = "pic")]
 fn register_pic_ioports(ioports: &mut IoPortAllocator) -> Result<(), Error> {
     // Register I/O ports for 8259 PIC.
     ioports.register_read_write(::arch::cpu::pic::PIC_CTRL_MASTER as u16)?;
@@ -305,7 +304,6 @@ pub fn init(
     madt: &Option<MadtInfo>,
     _mem_lower: Option<usize>,
 ) -> Result<Platform, Error> {
-    #[cfg(feature = "pic")]
     register_pic_ioports(ioports)?;
 
     extern "C" {

--- a/src/kernel/src/hal/platform/microvm.rs
+++ b/src/kernel/src/hal/platform/microvm.rs
@@ -319,7 +319,6 @@ fn log_control_registers() {
     }
 }
 
-#[cfg(feature = "pic")]
 fn register_pic_ioports(ioports: &mut IoPortAllocator) -> Result<(), Error> {
     // Register I/O ports for 8259 PIC.
     ioports.register_read_write(pic::PIC_CTRL_MASTER as u16)?;
@@ -347,7 +346,6 @@ pub fn init(
     madt: &Option<MadtInfo>,
     _mem_lower: Option<usize>,
 ) -> Result<Platform, Error> {
-    #[cfg(feature = "pic")]
     register_pic_ioports(ioports)?;
 
     // Register MicroVM control registers.


### PR DESCRIPTION
This pull request removes the `pic` feature flag and related conditional compilation for the Programmable Interrupt Controller (PIC) across several kernel platforms. The code responsible for registering PIC I/O ports and initializing the interrupt controller is now always included, simplifying the build configuration and reducing feature-flag complexity.

This PR closes #383 