### PR TITLE
[doc] Add Note For Benchmarks

### DIFF
--- a/doc/benchmark.md
+++ b/doc/benchmark.md
@@ -40,3 +40,4 @@ most importantly, if you are pinning cores, make sure to also pass the path to y
 ```
 
 > ℹ️ **Note:** All benchmarks require compiling Nanvix with `RELEASE=yes` and `LOG_LEVEL=panic`.
+> ℹ️ **Note:** If you are running the benchmarks with a high number of iterations, consider setting high system limits in the process spawning `nanvix-bench.elf` (i.e. `ulimit -u` and `ulimit -n`).


### PR DESCRIPTION
Slight tweak to the benchmark docs to remind people to increase the system resource limits if running with high iteration counts. Mostly, a note to myself too.