### PR TITLE
[scripts] Add Port Availability Checks and Socket Address Validation

### DIFF
--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -223,11 +223,13 @@ validate_sockaddr() {
 
     # Check if socket address is empty.
     if [ -z "${sockaddr}" ]; then
+        print_error "validate_sockaddr: socket address is empty."
         return 1
     fi
 
     # Check if socket address contains a colon separator.
     if [[ "${sockaddr}" != *:* ]]; then
+        print_error "validate_sockaddr: missing colon separator in '${sockaddr}'."
         return 1
     fi
 
@@ -235,6 +237,7 @@ validate_sockaddr() {
     local colon_only
     colon_only=${sockaddr//[^:]/}
     if [[ "${#colon_only}" -ne 1 ]]; then
+        print_error "validate_sockaddr: multiple colons in '${sockaddr}'."
         return 1
     fi
 
@@ -245,18 +248,282 @@ validate_sockaddr() {
 
     # Check if host is empty.
     if [ -z "${host}" ]; then
+        print_error "validate_sockaddr: host is empty in '${sockaddr}'."
+        return 1
+    fi
+
+    # Validate host format: must contain only alphanumeric characters, dots, hyphens, or be an IP address.
+    # This catches obviously invalid hostnames like "invalid!!host" while allowing:
+    # - IPv4 addresses (e.g., 127.0.0.1)
+    # - Hostnames (e.g., localhost, my-server, server.example.com)
+    if ! [[ "${host}" =~ ^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$ ]]; then
+        print_error "validate_sockaddr: invalid host format in '${sockaddr}'."
         return 1
     fi
 
     # Check if port is empty or not numeric.
     if [ -z "${port}" ] || ! [[ ${port} =~ ^[0-9]+$ ]]; then
+        print_error "validate_sockaddr: port is empty or not numeric in '${sockaddr}'."
         return 1
     fi
 
     # Check if port is in valid range (1-65535).
     if [ "${port}" -lt 1 ] || [ "${port}" -gt 65535 ]; then
+        print_error "validate_sockaddr: port out of range in '${sockaddr}'."
         return 1
     fi
 
     return 0
+}
+
+#
+# Description
+#
+#   Parses a socket address and outputs its host and port components.
+#   This function assumes the socket address has already been validated.
+#
+# Arguments
+#
+#   $1 - The socket address to parse.
+#   $2 - Variable name to store the host (optional, uses PARSED_HOST if not provided).
+#   $3 - Variable name to store the port (optional, uses PARSED_PORT if not provided).
+#
+# Return Value
+#
+#   - Returns zero on success and sets the specified variables.
+#   - Returns non-zero if the socket address is invalid.
+#
+# Usage Example
+#
+#   parse_sockaddr "127.0.0.1:8181" my_host my_port
+#   echo "Host: ${my_host}, Port: ${my_port}"
+#
+parse_sockaddr() {
+    local sockaddr=$1
+    local host_var=${2:-PARSED_HOST}
+    local port_var=${3:-PARSED_PORT}
+
+    if ! validate_sockaddr "${sockaddr}"; then
+        print_error "parse_sockaddr: invalid socket address '${sockaddr}'."
+        return 1
+    fi
+
+    # Use printf -v to set the variables by name.
+    printf -v "${host_var}" '%s' "${sockaddr%%:*}"
+    printf -v "${port_var}" '%s' "${sockaddr##*:}"
+
+    return 0
+}
+
+#
+# Description
+#
+#   Checks if a TCP port is available (not in use).
+#
+# Arguments
+#
+#   $1 - The host address.
+#   $2 - The port number.
+#
+# Return Value
+#
+#   - Returns zero if the port is available.
+#   - Returns non-zero if the port is in use.
+#
+# Usage Example
+#
+#   if is_port_available "127.0.0.1" "8181"; then
+#       echo "Port is available"
+#   fi
+#
+is_port_available() {
+    local host=$1
+    local port=$2
+
+    # Validate that port is numeric.
+    if ! [[ "${port}" =~ ^[0-9]+$ ]]; then
+        print_error "is_port_available: port '${port}' is not numeric."
+        return 1
+    fi
+
+    # Check if the port is currently in LISTEN state.
+    # Note: ss and netstat check all interfaces, not the specific host.
+    if command -v ss &> /dev/null; then
+        # The -l flag already filters for listening sockets, so we just check if any output exists.
+        if ss -tln "sport = :${port}" 2>/dev/null | tail -n +2 | grep -q .; then
+            print_error "is_port_available: port ${port} is in LISTEN state."
+            return 1
+        fi
+    elif command -v netstat &> /dev/null; then
+        if netstat -tln 2>/dev/null | grep -Eq ":${port}[[:space:]]+.*LISTEN"; then
+            print_error "is_port_available: port ${port} is in LISTEN state."
+            return 1
+        fi
+    fi
+
+    # Check if the port is in TIME_WAIT state.
+    if command -v ss &> /dev/null; then
+        if ss -tan state time-wait "sport = :${port}" 2>/dev/null | tail -n +2 | grep -q .; then
+            print_error "is_port_available: port ${port} is in TIME_WAIT state."
+            return 1
+        fi
+    elif command -v netstat &> /dev/null; then
+        if netstat -tan 2>/dev/null | grep -E ":${port}[[:space:]]+" | grep -q TIME_WAIT; then
+            print_error "is_port_available: port ${port} is in TIME_WAIT state."
+            return 1
+        fi
+    fi
+
+    # As an additional check, try to connect to the specific host:port.
+    # This provides a targeted check for the specific interface, complementing the
+    # ss/netstat checks above which only verify that no process is listening on that
+    # port on any interface. A successful connection here means the port is in use.
+    # Note: The -z option behavior varies between netcat implementations (GNU vs OpenBSD).
+    # We use a short timeout (-w 1) to avoid hanging on unresponsive hosts.
+    if command -v nc &> /dev/null; then
+        if nc -z -w 1 "${host}" "${port}" 2>/dev/null; then
+            print_error "is_port_available: connection to ${host}:${port} succeeded (port in use)."
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+#
+# Description
+#
+#   Waits for a TCP port to become available.
+#
+# Arguments
+#
+#   $1 - The host address.
+#   $2 - The port number.
+#   $3 - Maximum wait time in seconds (default: 120).
+#   $4 - Poll interval in seconds (default: 1).
+#
+# Return Value
+#
+#   - Returns zero if the port becomes available.
+#   - Returns non-zero if timeout is reached.
+#
+# Note
+#
+#   There is a TOCTOU (time-of-check-time-of-use) race condition between this
+#   function returning and the caller binding to the port. Another process could
+#   bind to the port in between. This is acceptable as the probability is low.
+#
+# Usage Example
+#
+#   wait_for_port_available "127.0.0.1" "8181" 60 1
+#
+wait_for_port_available() {
+    local host=$1
+    local port=$2
+    local max_wait=${3:-120}
+    local poll_interval=${4:-1}
+    local start_time
+    start_time=$(date +%s)
+
+    print_info "[PORT-CHECK] Checking if port ${port} is available (max_wait=${max_wait}s)..."
+
+    while true; do
+        local current_time
+        current_time=$(date +%s)
+        local elapsed=$((current_time - start_time))
+
+        if [ "${elapsed}" -ge "${max_wait}" ]; then
+            print_error "[PORT-CHECK] Timeout: port ${port} not available after ${max_wait}s"
+            return 1
+        fi
+
+        if is_port_available "${host}" "${port}"; then
+            if [ "${elapsed}" -gt 0 ]; then
+                print_info "[PORT-CHECK] Port ${port} is available (waited ${elapsed}s)"
+            else
+                print_info "[PORT-CHECK] Port ${port} is available"
+            fi
+            return 0
+        fi
+
+        print_debug "[PORT-CHECK] Port ${port} is in use, waiting... (${elapsed}s elapsed)"
+        sleep "${poll_interval}"
+    done
+}
+
+#
+# Description
+#
+#   Finds an available port within a range.
+#
+# Arguments
+#
+#   $1 - The host address.
+#   $2 - Starting port number.
+#   $3 - Ending port number (inclusive).
+#
+# Return Value
+#
+#   - On success, prints an available port number and returns zero.
+#   - On failure, returns non-zero.
+#
+# Usage Example
+#
+#   available_port=$(find_available_port "127.0.0.1" 8181 8281)
+#
+find_available_port() {
+    local host=$1
+    local start_port_str=$2
+    local end_port_str=$3
+    local start_port
+    local port
+    local end_port
+    local min_port=1
+    local max_port=65535
+
+    # Validate that host is not empty.
+    if [[ -z "${host}" ]]; then
+        print_error "find_available_port: host cannot be empty."
+        return 1
+    fi
+
+    # Validate that start_port and end_port are numeric.
+    if [[ -z "${start_port_str}" || -z "${end_port_str}" ]]; then
+        print_error "find_available_port: start_port and end_port must be provided."
+        return 1
+    fi
+
+    if [[ ! "${start_port_str}" =~ ^[0-9]+$ || ! "${end_port_str}" =~ ^[0-9]+$ ]]; then
+        print_error "find_available_port: start_port and end_port must be numeric."
+        return 1
+    fi
+
+    # Force base-10 parsing to avoid octal interpretation for leading zeros.
+    start_port=$((10#${start_port_str}))
+    end_port=$((10#${end_port_str}))
+
+    # Clamp ports to valid range [1, 65535].
+    if (( start_port < min_port )); then
+        start_port=${min_port}
+    fi
+
+    if (( end_port > max_port )); then
+        end_port=${max_port}
+    fi
+
+    # If the range is invalid after clamping, fail.
+    if (( start_port > end_port )); then
+        print_error "find_available_port: invalid port range (${start_port} > ${end_port})."
+        return 1
+    fi
+
+    for ((port=start_port; port<=end_port; port++)); do
+        if is_port_available "${host}" "${port}"; then
+            echo "${port}"
+            return 0
+        fi
+    done
+
+    print_error "find_available_port: no available port found in range ${start_port}-${end_port}."
+    return 1
 }

--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -193,3 +193,70 @@ clone_repo() {
 
     return 0
 }
+
+#===================================================================================================
+# Socket Address and Port Utilities
+#===================================================================================================
+
+#
+# Description
+#
+#   Validates that a string is a valid socket address in HOST:PORT format.
+#
+# Arguments
+#
+#   $1 - The socket address to validate.
+#
+# Return Value
+#
+#   - Returns zero if the socket address is valid.
+#   - Returns non-zero if the socket address is invalid or empty.
+#
+# Usage Example
+#
+#   if validate_sockaddr "127.0.0.1:8181"; then
+#       echo "Valid socket address"
+#   fi
+#
+validate_sockaddr() {
+    local sockaddr=$1
+
+    # Check if socket address is empty.
+    if [ -z "${sockaddr}" ]; then
+        return 1
+    fi
+
+    # Check if socket address contains a colon separator.
+    if [[ "${sockaddr}" != *:* ]]; then
+        return 1
+    fi
+
+    # Ensure there is exactly one colon separator (HOST:PORT format).
+    local colon_only
+    colon_only=${sockaddr//[^:]/}
+    if [[ "${#colon_only}" -ne 1 ]]; then
+        return 1
+    fi
+
+    local host
+    local port
+    host=${sockaddr%%:*}
+    port=${sockaddr##*:}
+
+    # Check if host is empty.
+    if [ -z "${host}" ]; then
+        return 1
+    fi
+
+    # Check if port is empty or not numeric.
+    if [ -z "${port}" ] || ! [[ ${port} =~ ^[0-9]+$ ]]; then
+        return 1
+    fi
+
+    # Check if port is in valid range (1-65535).
+    if [ "${port}" -lt 1 ] || [ "${port}" -gt 65535 ]; then
+        return 1
+    fi
+
+    return 0
+}

--- a/scripts/run-nanvixd.sh
+++ b/scripts/run-nanvixd.sh
@@ -30,6 +30,13 @@ readonly OPTION_TENANT_ID="--tenant-id"
 readonly OPTION_TOOLCHAIN_BIN_DIR="--toolchain-bin-dir"
 
 #===================================================================================================
+# Imports
+#===================================================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common/utils.sh"
+
+#===================================================================================================
 # Global Variables
 #===================================================================================================
 
@@ -104,25 +111,12 @@ die() {
 set_nanvixd_endpoint() {
     local sockaddr="$1"
 
-    if [[ "${sockaddr}" != *:* ]]; then
+    if ! validate_sockaddr "${sockaddr}"; then
         die "Invalid nanvixd socket address '${sockaddr}'. Expected HOST:PORT."
     fi
 
-    local host
-    local port
-    host=${sockaddr%%:*}
-    port=${sockaddr##*:}
-
-    if [ -z "${host}" ]; then
-        die "Invalid nanvixd socket address '${sockaddr}'. Host cannot be empty."
-    fi
-
-    if [ -z "${port}" ] || ! [[ ${port} =~ ^[0-9]+$ ]]; then
-        die "Invalid nanvixd socket address '${sockaddr}'. Port must be numeric."
-    fi
-
-    NANVIXD_HOST="${host}"
-    NANVIXD_PORT="${port}"
+    NANVIXD_HOST=${sockaddr%%:*}
+    NANVIXD_PORT=${sockaddr##*:}
 }
 
 #

--- a/scripts/run-nanvixd.sh
+++ b/scripts/run-nanvixd.sh
@@ -21,6 +21,17 @@ readonly SLEEP_INTERVAL=0.1
 readonly DEFAULT_TOOLCHAIN_BIN_DIR="${PWD}/toolchain/bin"
 readonly DEFAULT_BIN_DIR="${PWD}/bin"
 readonly DEFAULT_LOG_LEVEL="warn"
+# Timeout for waiting for port availability (in seconds).
+readonly PORT_AVAILABILITY_TIMEOUT=120
+# Poll interval for port availability checks (in seconds).
+readonly PORT_POLL_INTERVAL=2
+# Timeout for cleanup operations (in seconds).
+readonly CLEANUP_GRACEFUL_TIMEOUT=10
+# Poll interval for cleanup operations (in deciseconds, i.e., tenths of a second).
+# Valid range: 1-9 (used as 0.N seconds, e.g., 1 -> 0.1s, 5 -> 0.5s).
+readonly CLEANUP_POLL_INTERVAL_DECISECONDS=1
+# Timeout for TCP connections cleanup (in seconds).
+readonly TCP_CLEANUP_TIMEOUT=120
 readonly OPTION_APP_NAME="--app-name"
 readonly OPTION_BIN_DIR="--bin-dir"
 readonly OPTION_HELP="--help"
@@ -111,12 +122,9 @@ die() {
 set_nanvixd_endpoint() {
     local sockaddr="$1"
 
-    if ! validate_sockaddr "${sockaddr}"; then
+    if ! parse_sockaddr "${sockaddr}" NANVIXD_HOST NANVIXD_PORT; then
         die "Invalid nanvixd socket address '${sockaddr}'. Expected HOST:PORT."
     fi
-
-    NANVIXD_HOST=${sockaddr%%:*}
-    NANVIXD_PORT=${sockaddr##*:}
 }
 
 #
@@ -363,7 +371,7 @@ wait_for_tcp_cleanup() {
         current_time=$(date +%s)
         local elapsed=$((current_time - start_time))
 
-        if [ ${elapsed} -ge ${max_wait_seconds} ]; then
+        if [ "${elapsed}" -ge "${max_wait_seconds}" ]; then
             echo "[TCP-CLEANUP] WARNING: Timeout reached after ${max_wait_seconds}s, some connections may still be in TIME_WAIT" 1>&2
             return 1
         fi
@@ -372,10 +380,10 @@ wait_for_tcp_cleanup() {
         local time_wait_count=0
         if command -v ss &> /dev/null; then
             # Use ss if available (preferred).
-            time_wait_count=$(ss -tan state time-wait sport "${port}" 2>/dev/null | tail -n +2 | wc -l)
+            time_wait_count=$(ss -tan state time-wait "sport = :${port}" 2>/dev/null | tail -n +2 | wc -l)
         elif command -v netstat &> /dev/null; then
             # Fall back to netstat if ss is not available.
-            time_wait_count=$(netstat -tan | grep ":${port}" | grep -c TIME_WAIT || echo 0)
+            time_wait_count=$(netstat -tan | grep -E ":${port}[[:space:]]+" | grep -c TIME_WAIT || echo 0)
         else
             echo "[TCP-CLEANUP] WARNING: Neither 'ss' nor 'netstat' available, skipping TCP cleanup check" 1>&2
             return 0
@@ -484,11 +492,13 @@ cleanup() {
         echo "[CLEANUP] Sending SIGTERM for graceful shutdown..." 1>&2
         kill -s SIGTERM -- "-${NANVIXD_PID}" 2> /dev/null || true
 
-        # Wait up to 5 seconds for graceful shutdown.
-        echo "[CLEANUP] Waiting up to 5s for graceful shutdown..." 1>&2
+        # Wait for graceful shutdown (using configurable timeout).
+        # Calculate iterations: timeout_seconds * 10 / poll_interval_deciseconds.
+        local max_wait_count="$(( (CLEANUP_GRACEFUL_TIMEOUT * 10) / CLEANUP_POLL_INTERVAL_DECISECONDS ))"
+        echo "[CLEANUP] Waiting up to ${CLEANUP_GRACEFUL_TIMEOUT}s for graceful shutdown..." 1>&2
         local count=0
-        while kill -0 -- "-${NANVIXD_PID}" 2>/dev/null && [ $count -lt 50 ]; do
-            sleep 0.1
+        while kill -0 -- "-${NANVIXD_PID}" 2>/dev/null && [ "${count}" -lt "${max_wait_count}" ]; do
+            sleep "0.${CLEANUP_POLL_INTERVAL_DECISECONDS}"
             count=$((count + 1))
         done
 
@@ -508,11 +518,10 @@ cleanup() {
     # Clean up any stale Nanvix network namespaces.
     cleanup_stale_netns
 
-    # If running in L2 mode, wait for TCP connections to clear for subsequent runs.
-    if [ "${L2_VM}" = "yes" ]; then
-        echo "[CLEANUP] Post-run: checking for lingering TCP connections..." 1>&2
-        wait_for_tcp_cleanup 70 "${NANVIXD_PORT}"
-    fi
+    # Wait for TCP connections to clear for subsequent runs.
+    # This is important to prevent port conflicts between consecutive test runs.
+    echo "[CLEANUP] Post-run: checking for lingering TCP connections..." 1>&2
+    wait_for_tcp_cleanup "${TCP_CLEANUP_TIMEOUT}" "${NANVIXD_PORT}"
 
     echo "[CLEANUP] Cleanup completed" 1>&2
 }
@@ -629,6 +638,16 @@ main() {
         echo "Error: Unable to create logs directory at ${logs_dir}." 1>&2
         return 1
     }
+
+    # Check if port is available before starting nanvixd.
+    # This prevents "Address already in use" errors from previous runs.
+    echo "[MAIN] Checking if port ${NANVIXD_PORT} is available..." 1>&2
+    if ! wait_for_port_available "${NANVIXD_HOST}" "${NANVIXD_PORT}" "${PORT_AVAILABILITY_TIMEOUT}" "${PORT_POLL_INTERVAL}" 1>&2; then
+        echo "[MAIN] ERROR: Port ${NANVIXD_PORT} is not available after waiting ${PORT_AVAILABILITY_TIMEOUT}s" 1>&2
+        echo "[MAIN] This may be caused by a previous test run that did not clean up properly." 1>&2
+        echo "[MAIN] Try running: ss -tlnp sport = :${NANVIXD_PORT}" 1>&2
+        return 1
+    fi
 
     # Run nanvixd in a new session.
     local console_file_name

--- a/scripts/test-nanvixd.sh
+++ b/scripts/test-nanvixd.sh
@@ -23,6 +23,13 @@
 set -euo pipefail
 
 #===================================================================================================
+# Constants
+#===================================================================================================
+
+# Number of ports to search when finding an available alternative port.
+readonly PORT_RANGE_SIZE=1000
+
+#===================================================================================================
 # Global Variables
 #===================================================================================================
 
@@ -56,7 +63,13 @@ fi
 
 # Check if expected program output is empty.
 if [ -z "${PROGRAM_EXPECTED_OUTPUT}" ]; then
-    print_error "expected program output is empty and it cannot."
+    print_error "Expected program output cannot be empty."
+    exit 1
+fi
+
+# For HTTP mode, validate socket address format.
+if [ "${MODE}" = "http" ] && ! validate_sockaddr "${NANVIXD_SOCKADDR}"; then
+    print_error "Invalid socket address format: '${NANVIXD_SOCKADDR}'. Expected format: <HOST>:<PORT>."
     exit 1
 fi
 
@@ -72,6 +85,37 @@ mkdir -p "${LOGS_DIR}"
 # HTTP mode: Test programs via nanvixd's HTTP API.
 # In this mode, program arguments and input are sent as JSON payloads to the HTTP endpoint.
 if [ "${MODE}" = "http" ]; then
+    # Parse socket address into host and port components.
+    # Note: validation already performed above, so parse_sockaddr should not fail.
+    parse_sockaddr "${NANVIXD_SOCKADDR}" NANVIXD_HOST NANVIXD_PORT
+
+    # Force base-10 parsing to avoid octal interpretation for leading zeros.
+    NANVIXD_PORT_INT=$((10#${NANVIXD_PORT}))
+
+    if ! is_port_available "${NANVIXD_HOST}" "${NANVIXD_PORT_INT}"; then
+        print_info "Port ${NANVIXD_PORT} is in use, searching for available port..."
+
+        # Define port range based on original port.
+        # Note: There is a TOCTOU (time-of-check-time-of-use) race condition between finding
+        # an available port and actually binding to it. Another process could bind to the port
+        # in between. This is acceptable as the probability is low and retries will handle it.
+        PORT_RANGE_START="${NANVIXD_PORT_INT}"
+        PORT_RANGE_END=$((NANVIXD_PORT_INT + PORT_RANGE_SIZE))
+
+        # Clamp port range end to maximum valid port number.
+        if [ "${PORT_RANGE_END}" -gt 65535 ]; then
+            PORT_RANGE_END=65535
+        fi
+
+        if ! AVAILABLE_PORT=$(find_available_port "${NANVIXD_HOST}" "${PORT_RANGE_START}" "${PORT_RANGE_END}"); then
+            print_error "No available port found in range ${PORT_RANGE_START}-${PORT_RANGE_END}"
+            exit 1
+        fi
+
+        print_info "Using alternative port: ${AVAILABLE_PORT}"
+        NANVIXD_SOCKADDR="${NANVIXD_HOST}:${AVAILABLE_PORT}"
+    fi
+
     # Parameters for the requests to nanvixd.
     TENANT_ID="foo"
     APP_NAME="bar"


### PR DESCRIPTION
This pull request introduces several improvements to the port management and socket address validation logic in the `run-nanvixd.sh` and `test-nanvixd.sh` scripts. The main goals are to make port usage safer and more predictable, reduce the risk of "Address already in use" errors, and provide configurable timeouts for cleanup and port availability checks. Additionally, new utility functions are added to centralize and standardize port and socket address handling.