### PR TITLE
[build] Add Build-Time Kernel Memory Layout Validation

### DIFF
--- a/build/hyperlight_config.rs.template
+++ b/build/hyperlight_config.rs.template
@@ -1,0 +1,24 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Build-time generated constants for Hyperlight VMM.
+pub mod hyperlight {
+    /// Size of a memory page (in bytes).
+    pub const PAGE_SIZE: usize = {{PAGE_SIZE}};
+    /// Magic value that identifies the virtual machine monitor.
+    pub const DEFAULT_BOOT_MAGIC: u32 = {{DEFAULT_BOOT_MAGIC}};
+    /// Base address of the RAM disk.
+    pub const DEFAULT_INITRD_BASE: usize = {{DEFAULT_INITRD_BASE}};
+    /// Number of bytes used to store initrd's size.
+    pub const INITRD_SIZE_BYTES: usize = {{INITRD_SIZE_BYTES}};
+    /// Default VMM shutdown command.
+    pub const DEFAULT_VMM_SHUTDOWN_CMD: u8 = {{DEFAULT_VMM_SHUTDOWN_CMD}};
+    /// Size of the process environment block (in bytes).
+    pub const PEB_SIZE: usize = {{PEB_SIZE}};
+    /// Size of the host function definitions area (in bytes).
+    pub const HOST_FUNCTION_DEFINITIONS_SIZE: usize = {{HOST_FUNCTION_DEFINITIONS_SIZE}};
+    /// Size of the input data buffer (in bytes).
+    pub const INPUT_DATA_BUFFER_SIZE: usize = {{INPUT_DATA_BUFFER_SIZE}};
+    /// Size of the output data buffer (in bytes).
+    pub const OUTPUT_DATA_BUFFER_SIZE: usize = {{OUTPUT_DATA_BUFFER_SIZE}};
+}

--- a/build/hyperlight_constants.toml
+++ b/build/hyperlight_constants.toml
@@ -1,0 +1,35 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#
+# This file defines build-time constants for the Hyperlight.
+#
+# WARNING: Do not change these values unless you know what you are doing.
+#
+
+# Size of a memory page (in bytes).
+page_size = 4096
+
+# Magic value that identifies the virtual machine monitor.
+default_boot_magic = 0x0c00ffee
+
+# Base address of the RAM disk.
+default_initrd_base = 0x00802000
+
+# Number of bytes used to store initrd's size.
+initrd_size_bytes = 8
+
+# Default VMM shutdown command.
+default_vmm_shutdown_cmd = 0x20
+
+# Size of the process environment block (in pages).
+peb_pages = 1
+
+# Size of host function definitions area (in pages).
+host_function_definitions_pages = 1
+
+# Size of input data buffer (in pages).
+input_data_buffer_pages = 4
+
+# Size of output data buffer (in pages).
+output_data_buffer_pages = 4

--- a/build/kernel/linker/x86/kernel.ld.in
+++ b/build/kernel/linker/x86/kernel.ld.in
@@ -21,6 +21,25 @@ BOOT_ADDR = 0x00100000;
  */
 TRAMPOLINE_ADDR = 0x00008000;
 
+/*
+ * Kernel Pool Base Address
+ *
+ * This must match config::memory_layout::KPOOL_BASE_RAW in src/libs/config/src/lib.rs.
+ *
+ * TODO (https://github.com/nanvix/nanvix/issues/1301): Replace this hardcoded value with a
+ * build-time generated value using build.rs, similar to how MACHINE_RESERVED is handled via the
+ * @MACHINE_RESERVED@ placeholder.
+ */
+KPOOL_BASE = 0x00400000;
+
+/*
+ * Machine Reserved Space
+ *
+ * Space reserved after __KERNEL_END for machine-specific structures.
+ * This value is set by build.rs based on the target machine.
+ */
+MACHINE_RESERVED = @MACHINE_RESERVED@;
+
 SECTIONS
 {
 	/* Pad with zeroes. */

--- a/build/kernel/linker/x86/kernel.ld.in
+++ b/build/kernel/linker/x86/kernel.ld.in
@@ -102,6 +102,12 @@ SECTIONS
 
 	__KERNEL_END = .;
 
+	/*
+	 * Ensure the kernel image plus machine-reserved space fits before KPOOL_BASE.
+	 */
+	ASSERT(__KERNEL_END + MACHINE_RESERVED < KPOOL_BASE,
+		"Kernel too large: __KERNEL_END + MACHINE_RESERVED must be < KPOOL_BASE")
+
 	/* Discarded. */
 	/DISCARD/ :
 	{

--- a/src/kernel/build.rs
+++ b/src/kernel/build.rs
@@ -220,7 +220,79 @@ fn main() {
     // Link Archive
     //==============================================================================================
 
-    println!("cargo::rustc-link-arg=-Tbuild/kernel/linker/x86/kernel.ld");
+    // Generate linker script from template with machine-specific MACHINE_RESERVED value.
+    //
+    // MACHINE_RESERVED is the space reserved after __KERNEL_END for machine-specific structures.
+    // The kernel must end early enough to leave room for these structures before KPOOL_BASE.
+    //
+    // For Hyperlight, this includes PEB, host function definitions, and I/O buffers.
+    // The exact sizes are defined in build/hyperlight_constants.toml.
+    //
+    // If __KERNEL_END + MACHINE_RESERVED >= KPOOL_BASE, Hyperlight creates zero-sized guard
+    // pages which KVM rejects with EINVAL. We use strictly less than to ensure at least one
+    // page of heap_padding exists.
+    //
+    // For non-Hyperlight targets, no reserved space is needed.
+    let linker_template_path: PathBuf = workspace_dir.join("build/kernel/linker/x86/kernel.ld.in");
+    let linker_output_path: String = format!("{}/kernel.ld", out_dir);
+
+    let machine_reserved: String = if cfg!(feature = "hyperlight") {
+        // Read hyperlight configuration from TOML file.
+        let hyperlight_config_path: PathBuf = workspace_dir.join("build/hyperlight_constants.toml");
+        let hyperlight_config: HashMap<String, String> = load_toml(&hyperlight_config_path);
+        println!("cargo::rerun-if-changed={}", hyperlight_config_path.display());
+
+        let page_size_str: &str = hyperlight_config
+            .get("page_size")
+            .expect("page_size not found in hyperlight_constants.toml");
+        let page_size: usize = page_size_str
+            .parse()
+            .unwrap_or_else(|_| panic!("Failed to parse page_size: '{}'", page_size_str));
+        let peb_pages_str: &str = hyperlight_config
+            .get("peb_pages")
+            .expect("peb_pages not found in hyperlight_constants.toml");
+        let peb_pages: usize = peb_pages_str
+            .parse()
+            .unwrap_or_else(|_| panic!("Failed to parse peb_pages: '{}'", peb_pages_str));
+        let hfd_pages_str: &str = hyperlight_config
+            .get("host_function_definitions_pages")
+            .expect("host_function_definitions_pages not found in hyperlight_constants.toml");
+        let hfd_pages: usize = hfd_pages_str.parse().unwrap_or_else(|_| {
+            panic!("Failed to parse host_function_definitions_pages: '{}'", hfd_pages_str)
+        });
+        let input_pages_str: &str = hyperlight_config
+            .get("input_data_buffer_pages")
+            .expect("input_data_buffer_pages not found in hyperlight_constants.toml");
+        let input_pages: usize = input_pages_str.parse().unwrap_or_else(|_| {
+            panic!("Failed to parse input_data_buffer_pages: '{}'", input_pages_str)
+        });
+        let output_pages_str: &str = hyperlight_config
+            .get("output_data_buffer_pages")
+            .expect("output_data_buffer_pages not found in hyperlight_constants.toml");
+        let output_pages: usize = output_pages_str.parse().unwrap_or_else(|_| {
+            panic!("Failed to parse output_data_buffer_pages: '{}'", output_pages_str)
+        });
+
+        let total_pages: usize = peb_pages
+            .checked_add(hfd_pages)
+            .and_then(|sum| sum.checked_add(input_pages))
+            .and_then(|sum| sum.checked_add(output_pages))
+            .expect("Overflow calculating total reserved pages");
+        let reserved: usize = total_pages
+            .checked_mul(page_size)
+            .expect("Overflow calculating reserved space in bytes");
+        format!("{:#x}", reserved)
+    } else {
+        "0x0".to_string()
+    };
+
+    let linker_template: String =
+        fs::read_to_string(&linker_template_path).expect("Failed to read linker script template");
+    let linker_script: String = linker_template.replace("@MACHINE_RESERVED@", &machine_reserved);
+    fs::write(&linker_output_path, linker_script).expect("Failed to write linker script");
+
+    println!("cargo::rerun-if-changed={}", linker_template_path.display());
+    println!("cargo::rustc-link-arg=-T{}", linker_output_path);
     println!("cargo::rustc-link-search=native={out_dir}");
     println!("cargo::rustc-link-lib=static:+whole-archive=kernel");
 }

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -322,8 +322,13 @@ pub fn init(
     )?;
     memory_regions.push_back(peb);
 
-    // Register host function definitions
-    let host_function_definitions_base: usize = peb_base + PEB_SIZE;
+    // Register host function definitions.
+    let host_function_definitions_base: usize =
+        peb_base.checked_add(PEB_SIZE).ok_or_else(|| {
+            let reason: &str = "host function definitions base address overflow";
+            error!("init(): {}", reason);
+            Error::new(ErrorCode::OutOfMemory, reason)
+        })?;
     const HOST_FUNCTION_DEFINITIONS_SIZE: usize = mem::PAGE_SIZE;
     let host_function_definitions: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "host function definitions",
@@ -335,7 +340,13 @@ pub fn init(
     memory_regions.push_back(host_function_definitions);
 
     // Register input data buffer.
-    let input_data_base: usize = host_function_definitions_base + HOST_FUNCTION_DEFINITIONS_SIZE;
+    let input_data_base: usize = host_function_definitions_base
+        .checked_add(HOST_FUNCTION_DEFINITIONS_SIZE)
+        .ok_or_else(|| {
+            let reason: &str = "input data buffer base address overflow";
+            error!("init(): {}", reason);
+            Error::new(ErrorCode::OutOfMemory, reason)
+        })?;
     const INPUT_DATA_BUFFER_SIZE: usize = 4 * mem::PAGE_SIZE;
     let input_data_buffer: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "input data buffer",
@@ -347,7 +358,13 @@ pub fn init(
     memory_regions.push_back(input_data_buffer);
 
     // Register output data buffer.
-    let output_data_base: usize = input_data_base + INPUT_DATA_BUFFER_SIZE;
+    let output_data_base: usize = input_data_base
+        .checked_add(INPUT_DATA_BUFFER_SIZE)
+        .ok_or_else(|| {
+            let reason: &str = "output data buffer base address overflow";
+            error!("init(): {}", reason);
+            Error::new(ErrorCode::OutOfMemory, reason)
+        })?;
     const OUTPUT_DATA_BUFFER_SIZE: usize = 4 * mem::PAGE_SIZE;
     let output_data_buffer: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "output data buffer",
@@ -359,9 +376,23 @@ pub fn init(
     memory_regions.push_back(output_data_buffer);
 
     // Register reserved area for heap padding.
-    let heap_padding_base: usize = output_data_base + OUTPUT_DATA_BUFFER_SIZE;
+    let heap_padding_base: usize = output_data_base
+        .checked_add(OUTPUT_DATA_BUFFER_SIZE)
+        .ok_or_else(|| {
+            let reason: &str = "heap padding base address overflow";
+            error!("init(): {}", reason);
+            Error::new(ErrorCode::OutOfMemory, reason)
+        })?;
     debug!("heap_padding_base={:#010x}", heap_padding_base);
-    let heap_padding_size: usize = memory_layout::KPOOL_BASE.into_raw_value() - heap_padding_base;
+    let kpool_base: usize = memory_layout::KPOOL_BASE.into_raw_value();
+    let heap_padding_size: usize = kpool_base.checked_sub(heap_padding_base).ok_or_else(|| {
+        let reason: &str = "kernel image exceeds KPOOL_BASE, memory regions overlap";
+        error!(
+            "init(): {} (heap_padding_base={:#010x}, kpool_base={:#010x})",
+            reason, heap_padding_base, kpool_base
+        );
+        Error::new(ErrorCode::OutOfMemory, reason)
+    })?;
     let heap_padding: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "heap padding",
         VirtualAddress::from_raw_value(heap_padding_base),
@@ -372,8 +403,13 @@ pub fn init(
     memory_regions.push_back(heap_padding);
 
     // Register kpool guard page.
-    let kpool_guard_base: usize =
-        memory_layout::KPOOL_BASE.into_raw_value() + config::kernel::KPOOL_SIZE;
+    let kpool_guard_base: usize = kpool_base
+        .checked_add(config::kernel::KPOOL_SIZE)
+        .ok_or_else(|| {
+            let reason: &str = "kpool guard base address overflow";
+            error!("init(): {}", reason);
+            Error::new(ErrorCode::OutOfMemory, reason)
+        })?;
     let kpool_guard_size: usize = mem::PAGE_SIZE;
     let kpool_guard: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "kpool guard",
@@ -385,7 +421,14 @@ pub fn init(
     memory_regions.push_back(kpool_guard);
 
     // Register hyperlight guest user stack.
-    let guest_user_stack_base: usize = kpool_guard_base + kpool_guard_size;
+    let guest_user_stack_base: usize =
+        kpool_guard_base
+            .checked_add(kpool_guard_size)
+            .ok_or_else(|| {
+                let reason: &str = "guest user stack base address overflow";
+                error!("init(): {}", reason);
+                Error::new(ErrorCode::OutOfMemory, reason)
+            })?;
     let guest_user_stack_size: usize = mem::PAGE_SIZE;
     let guest_user_stack: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "guest user stack",

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -48,6 +48,13 @@ use ::arch::{
     mem,
     mem::PAGE_ALIGNMENT,
 };
+use ::config::hyperlight::{
+    HOST_FUNCTION_DEFINITIONS_SIZE,
+    INITRD_SIZE_BYTES,
+    INPUT_DATA_BUFFER_SIZE,
+    OUTPUT_DATA_BUFFER_SIZE,
+    PEB_SIZE,
+};
 use ::hyperlight_common::mem::HyperlightPEB;
 use ::sys::{
     config::memory_layout,
@@ -312,7 +319,6 @@ pub fn init(
     // Register PEB structure.
     let peb_base: usize =
         ::sys::mm::align_up(unsafe { &__KERNEL_END } as *const u8 as usize, PAGE_ALIGNMENT);
-    const PEB_SIZE: usize = mem::PAGE_SIZE;
     let peb: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "peb",
         VirtualAddress::from_raw_value(peb_base),
@@ -329,7 +335,6 @@ pub fn init(
             error!("init(): {}", reason);
             Error::new(ErrorCode::OutOfMemory, reason)
         })?;
-    const HOST_FUNCTION_DEFINITIONS_SIZE: usize = mem::PAGE_SIZE;
     let host_function_definitions: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "host function definitions",
         VirtualAddress::from_raw_value(host_function_definitions_base),
@@ -347,7 +352,6 @@ pub fn init(
             error!("init(): {}", reason);
             Error::new(ErrorCode::OutOfMemory, reason)
         })?;
-    const INPUT_DATA_BUFFER_SIZE: usize = 4 * mem::PAGE_SIZE;
     let input_data_buffer: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "input data buffer",
         VirtualAddress::from_raw_value(input_data_base),
@@ -365,7 +369,6 @@ pub fn init(
             error!("init(): {}", reason);
             Error::new(ErrorCode::OutOfMemory, reason)
         })?;
-    const OUTPUT_DATA_BUFFER_SIZE: usize = 4 * mem::PAGE_SIZE;
     let output_data_buffer: MemoryRegion<VirtualAddress> = MemoryRegion::new(
         "output data buffer",
         VirtualAddress::from_raw_value(output_data_base),
@@ -475,17 +478,15 @@ unsafe fn parse_initrd_image(
     total_allocation_size: usize,
 ) -> Result<(usize, usize, (u8, String)), Error> {
     // Check if allocation is too small to hold the initrd header.
-    if total_allocation_size < ::config::hyperlight::INITRD_SIZE_BYTES {
+    if total_allocation_size < INITRD_SIZE_BYTES {
         let reason: &str = "insufficient initrd allocation size";
         error!("parse_initrd_image(): {reason} (total_allocation_size={total_allocation_size})");
         return Err(Error::new(ErrorCode::BadFile, reason));
     }
 
     // Read actual size and relocate only that amount
-    let initrd_header: &[u8] = core::slice::from_raw_parts(
-        init_data_start as *const u8,
-        ::config::hyperlight::INITRD_SIZE_BYTES,
-    );
+    let initrd_header: &[u8] =
+        core::slice::from_raw_parts(init_data_start as *const u8, INITRD_SIZE_BYTES);
     let actual_initrd_size: usize = u64::from_le_bytes([
         initrd_header[0],
         initrd_header[1],
@@ -498,7 +499,7 @@ unsafe fn parse_initrd_image(
     ]) as usize;
 
     // Compute offsets and check for overflows.
-    let payload_offset: usize = ::config::hyperlight::INITRD_SIZE_BYTES;
+    let payload_offset: usize = INITRD_SIZE_BYTES;
     let current_initrd_start: usize = match init_data_start.checked_add(payload_offset) {
         Some(value) => value,
         None => {

--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -22,9 +22,12 @@ use ::arch::mem::{
     paging::FrameNumber,
 };
 use ::config::constants;
-use ::sys::error::{
-    Error,
-    ErrorCode,
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    mm::Address,
 };
 
 //==================================================================================================
@@ -183,7 +186,15 @@ impl FrameAllocator {
             match self.bitmap.test(index) {
                 Ok(false) => continue,
                 Ok(true) => {
-                    return Err(Error::new(ErrorCode::OutOfMemory, "frame is already allocated"));
+                    let conflicting_addr: usize = index * mem::FRAME_SIZE;
+                    let region_start: usize = region.start().into_raw_value();
+                    let region_end: usize = region_start.saturating_add(region.size());
+                    let reason: &str = "frame is already allocated";
+                    error!(
+                        "{} (frame={:#010x}, region_start={:#010x}, region_end={:#010x})",
+                        reason, conflicting_addr, region_start, region_end
+                    );
+                    return Err(Error::new(ErrorCode::OutOfMemory, reason));
                 },
                 Err(err) => return Err(err),
             }

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -204,6 +204,180 @@ fn generate_linuxd_config(linuxd_config_toml_path: &Path, linuxd_config_output_p
     fs::write(linuxd_config_output_path, constants).expect("Failed to write linuxd_config.rs");
 }
 
+///
+/// # Description
+///
+/// Converts a page count to a size expression string for code generation.
+///
+/// # Arguments
+///
+/// - `pages`: Number of pages.
+///
+/// # Returns
+///
+/// A string representing the size expression (e.g., "PAGE_SIZE" or "N * PAGE_SIZE").
+///
+fn pages_to_size_expr(pages: usize) -> String {
+    assert!(pages > 0, "pages must be positive, got: {}", pages);
+    if pages == 1 {
+        "PAGE_SIZE".to_string()
+    } else {
+        format!("{pages} * PAGE_SIZE")
+    }
+}
+
+/// Macro to generate type-specific hex/decimal parsing functions.
+///
+/// This avoids code duplication while not requiring external dependencies like `num_traits`.
+macro_rules! define_parse_hex_or_decimal {
+    ($fn_name:ident, $type:ty) => {
+        fn $fn_name(value: &str, key: &str) -> $type {
+            if let Some(stripped) = value.strip_prefix("0x") {
+                <$type>::from_str_radix(stripped, 16)
+                    .unwrap_or_else(|_| panic!("Invalid hex value for {}: '{}'", key, value))
+            } else {
+                value
+                    .parse()
+                    .unwrap_or_else(|_| panic!("Invalid decimal value for {}: '{}'", key, value))
+            }
+        }
+    };
+}
+
+define_parse_hex_or_decimal!(parse_hex_or_decimal_usize, usize);
+define_parse_hex_or_decimal!(parse_hex_or_decimal_u32, u32);
+define_parse_hex_or_decimal!(parse_hex_or_decimal_u8, u8);
+
+///
+/// # Description
+///
+/// This method converts a TOML file with build-time constants for Hyperlight into a file with rust
+/// constants that can be consumed by rust code. It uses a template file with placeholders that are
+/// replaced with values from the TOML configuration.
+///
+/// # Arguments
+///
+/// - `hyperlight_config_toml_path`: Path to the TOML file to load.
+/// - `hyperlight_template_path`: Path to the template file.
+/// - `hyperlight_config_output_path`: Path to output the rust source file.
+///
+fn generate_hyperlight_config(
+    hyperlight_config_toml_path: &Path,
+    hyperlight_template_path: &Path,
+    hyperlight_config_output_path: &Path,
+) {
+    let config: HashMap<String, String> = load_toml(hyperlight_config_toml_path);
+
+    // Read template file.
+    let mut template: String =
+        fs::read_to_string(hyperlight_template_path).expect("Failed to read hyperlight template");
+
+    // Page size constant.
+    let page_size: &str = config
+        .get("page_size")
+        .expect("page_size not found in hyperlight_constants.toml");
+    let page_size_val: usize = page_size
+        .parse()
+        .expect("Failed to parse page_size as usize");
+    assert!(page_size_val > 0, "page_size must be positive, got: {}", page_size_val);
+    assert!(
+        page_size_val.is_power_of_two(),
+        "page_size must be a power of two, got: {}",
+        page_size_val
+    );
+    template = template.replace("{{PAGE_SIZE}}", &page_size_val.to_string());
+
+    // Boot magic.
+    let boot_magic: &str = config
+        .get("default_boot_magic")
+        .expect("default_boot_magic not found in hyperlight_constants.toml");
+    let boot_magic_val: u32 = parse_hex_or_decimal_u32(boot_magic, "default_boot_magic");
+    template = template.replace("{{DEFAULT_BOOT_MAGIC}}", &format!("{boot_magic_val:#x}"));
+
+    // Initrd base address.
+    let initrd_base: &str = config
+        .get("default_initrd_base")
+        .expect("default_initrd_base not found in hyperlight_constants.toml");
+    let initrd_base_val: usize = parse_hex_or_decimal_usize(initrd_base, "default_initrd_base");
+    template = template.replace("{{DEFAULT_INITRD_BASE}}", &format!("{initrd_base_val:#x}"));
+
+    // Initrd size bytes.
+    let initrd_size_bytes: &str = config
+        .get("initrd_size_bytes")
+        .expect("initrd_size_bytes not found in hyperlight_constants.toml");
+    let initrd_size_val: usize = initrd_size_bytes
+        .parse()
+        .expect("Failed to parse initrd_size_bytes as usize");
+    template = template.replace("{{INITRD_SIZE_BYTES}}", &initrd_size_val.to_string());
+
+    // VMM shutdown command.
+    let shutdown_cmd: &str = config
+        .get("default_vmm_shutdown_cmd")
+        .expect("default_vmm_shutdown_cmd not found in hyperlight_constants.toml");
+    let shutdown_cmd_val: u8 = parse_hex_or_decimal_u8(shutdown_cmd, "default_vmm_shutdown_cmd");
+    template = template.replace("{{DEFAULT_VMM_SHUTDOWN_CMD}}", &format!("{shutdown_cmd_val:#x}"));
+
+    // PEB size (in pages -> bytes).
+    let peb_pages: &str = config
+        .get("peb_pages")
+        .expect("peb_pages not found in hyperlight_constants.toml");
+    let peb_pages_val: usize = peb_pages
+        .parse()
+        .expect("Failed to parse peb_pages as usize");
+    assert!(peb_pages_val > 0, "peb_pages must be positive, got: {}", peb_pages_val);
+    template = template.replace("{{PEB_SIZE}}", &pages_to_size_expr(peb_pages_val));
+
+    // Host function definitions size (in pages -> bytes).
+    let hfd_pages: &str = config
+        .get("host_function_definitions_pages")
+        .expect("host_function_definitions_pages not found in hyperlight_constants.toml");
+    let hfd_pages_val: usize = hfd_pages
+        .parse()
+        .expect("Failed to parse host_function_definitions_pages as usize");
+    assert!(
+        hfd_pages_val > 0,
+        "host_function_definitions_pages must be positive, got: {}",
+        hfd_pages_val
+    );
+    template =
+        template.replace("{{HOST_FUNCTION_DEFINITIONS_SIZE}}", &pages_to_size_expr(hfd_pages_val));
+
+    // Input data buffer size (in pages -> bytes).
+    let input_pages: &str = config
+        .get("input_data_buffer_pages")
+        .expect("input_data_buffer_pages not found in hyperlight_constants.toml");
+    let input_pages_val: usize = input_pages
+        .parse()
+        .expect("Failed to parse input_data_buffer_pages as usize");
+    assert!(
+        input_pages_val > 0,
+        "input_data_buffer_pages must be positive, got: {}",
+        input_pages_val
+    );
+    template = template.replace("{{INPUT_DATA_BUFFER_SIZE}}", &pages_to_size_expr(input_pages_val));
+
+    // Output data buffer size (in pages -> bytes).
+    let output_pages: &str = config
+        .get("output_data_buffer_pages")
+        .expect("output_data_buffer_pages not found in hyperlight_constants.toml");
+    let output_pages_val: usize = output_pages
+        .parse()
+        .expect("Failed to parse output_data_buffer_pages as usize");
+    assert!(
+        output_pages_val > 0,
+        "output_data_buffer_pages must be positive, got: {}",
+        output_pages_val
+    );
+    template =
+        template.replace("{{OUTPUT_DATA_BUFFER_SIZE}}", &pages_to_size_expr(output_pages_val));
+
+    // Verify all placeholders were substituted.
+    assert!(!template.contains("{{"), "Template contains unsubstituted placeholders");
+
+    fs::write(hyperlight_config_output_path, template)
+        .expect("Failed to write hyperlight_config.rs");
+}
+
 fn main() {
     // Read the TOML file using the workspace root for a reliable path
     let manifest_dir: String =
@@ -225,7 +399,54 @@ fn main() {
     let linuxd_dst_path: PathBuf = Path::new(&out_dir).join("linuxd_config.rs");
     generate_linuxd_config(&linuxd_config_path, &linuxd_dst_path);
 
-    // Inform Cargo to rerun the build script if the TOML changes
-    println!("cargo:rerun-if-changed=build/kernel_config.toml");
-    println!("cargo:rerun-if-changed=build/linuxd_config.toml");
+    // Parse hyperlight configuration file.
+    let hyperlight_config_path: PathBuf =
+        Path::new(&workspace_dir).join("build/hyperlight_constants.toml");
+    let hyperlight_template_path: PathBuf =
+        Path::new(&workspace_dir).join("build/hyperlight_config.rs.template");
+    let hyperlight_dst_path: PathBuf = Path::new(&out_dir).join("hyperlight_config.rs");
+    generate_hyperlight_config(
+        &hyperlight_config_path,
+        &hyperlight_template_path,
+        &hyperlight_dst_path,
+    );
+
+    // Inform Cargo to rerun the build script if the TOML changes.
+    println!("cargo::rerun-if-changed=build/kernel_config.toml");
+    println!("cargo::rerun-if-changed=build/linuxd_config.toml");
+    println!("cargo::rerun-if-changed=build/hyperlight_constants.toml");
+    println!("cargo::rerun-if-changed=build/hyperlight_config.rs.template");
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pages_to_size_expr_single_page() {
+        let result: String = pages_to_size_expr(1);
+        assert_eq!(result, "PAGE_SIZE");
+    }
+
+    #[test]
+    fn test_pages_to_size_expr_multiple_pages() {
+        let result: String = pages_to_size_expr(4);
+        assert_eq!(result, "4 * PAGE_SIZE");
+    }
+
+    #[test]
+    fn test_pages_to_size_expr_large_value() {
+        let result: String = pages_to_size_expr(256);
+        assert_eq!(result, "256 * PAGE_SIZE");
+    }
+
+    #[test]
+    #[should_panic(expected = "pages must be positive")]
+    fn test_pages_to_size_expr_zero_pages_panics() {
+        pages_to_size_expr(0);
+    }
 }

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -255,14 +255,6 @@ pub mod pc {
     pub const DEFAULT_VMM_SHUTDOWN_CMD: u16 = 0x2000;
 }
 
+// Hyperlight build-time constants are generated from hyperlight_config.toml.
 #[cfg(feature = "hyperlight")]
-pub mod hyperlight {
-    /// Magic value that identifies the virtual machine monitor.
-    pub const DEFAULT_BOOT_MAGIC: u32 = 0x0c00ffee;
-    /// Base address of the RAM disk.
-    pub const DEFAULT_INITRD_BASE: usize = 0x00802000;
-    /// Number of bytes used to store initrd's size.
-    pub const INITRD_SIZE_BYTES: usize = 8;
-    /// Default VMM shutdown command
-    pub const DEFAULT_VMM_SHUTDOWN_CMD: u8 = 0x20;
-}
+include!(concat!(env!("OUT_DIR"), "/hyperlight_config.rs"));


### PR DESCRIPTION
This pull request introduces a robust, build-time configuration system for the Hyperlight VMM, improving how memory regions are defined and validated. It adds a TOML file for Hyperlight constants, generates Rust constants and linker scripts from these values, and updates the kernel initialization code to use these generated constants. Overflow checks and error handling have been enhanced throughout the memory region setup to prevent subtle bugs and improve reliability.