### PR TITLE
[nanvix-sandbox] Improve Linux Daemon Shutdown

### DIFF
--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -673,13 +673,16 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
         }
 
         // Shutdown all linuxd instances.
-        for (tenant_id, linuxd_instance) in self.linuxd_instances.iter_mut() {
-            debug!("cleaning linuxd instance (tenant_id={tenant_id:?})");
-            if let Some(linuxd_instance_mut) = Arc::get_mut(linuxd_instance) {
-                linuxd_instance_mut.shutdown().await;
-            } else {
-                error!("error cleaning-up linuxd instance: not found (tenant_id={tenant_id})");
+        for (tenant_id, linuxd_instance) in self.linuxd_instances.drain() {
+            debug!("cleanup(): cleaning linuxd instance (tenant_id={tenant_id:?})");
+            let strong_count: usize = Arc::strong_count(&linuxd_instance);
+            if strong_count > 1 {
+                warn!(
+                    "cleanup(): linuxd has {} outstanding Arc references (tenant_id={tenant_id})",
+                    strong_count - 1
+                );
             }
+            linuxd_instance.shutdown().await;
         }
 
         let summary: SandboxCacheStateSummary = self.state_summary();

--- a/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
@@ -75,6 +75,7 @@ use ::tokio::{
         ChildStderr,
         Command,
     },
+    sync::Mutex,
     time::{
         sleep,
         timeout,
@@ -143,8 +144,20 @@ impl StdError for WaitForSocketError {
 }
 
 //==================================================================================================
-// LinuxDaemon
+// Structures
 //==================================================================================================
+
+///
+/// # Description
+///
+/// Interior mutable state for a Linux Daemon instance.
+///
+struct LinuxDaemonInner {
+    /// Child process handle.
+    child: Child,
+    /// Control-plane socket stream.
+    control_plane_stream: SocketStream,
+}
 
 ///
 /// # Description
@@ -152,13 +165,15 @@ impl StdError for WaitForSocketError {
 /// Handle to a running Linux Daemon instance spawned as a separate process.
 ///
 pub struct LinuxDaemon {
-    /// Child process handle.
-    child: Child,
-    /// Control-plane socket stream.
-    control_plane_stream: SocketStream,
+    /// Interior mutable state.
+    inner: Mutex<Option<LinuxDaemonInner>>,
     /// RAII handle to the network namespace linuxd runs in (L2-mode only).
     netns_handle: Option<NetnsHandle>,
 }
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
 
 impl LinuxDaemon {
     ///
@@ -474,7 +489,10 @@ impl LinuxDaemon {
                 args::Args::OPT_CONTROL_PLANE_SOCKADDR.to_string(),
                 args.control_plane_connect_socket_info().0.clone(),
                 args::Args::OPT_CONTROL_PLANE_SOCKET_TYPE.to_string(),
-                args.control_plane_connect_socket_info().1.to_str().to_string(),
+                args.control_plane_connect_socket_info()
+                    .1
+                    .to_str()
+                    .to_string(),
                 args::Args::OPT_USER_VM_BIND_SOCKADDR.to_string(),
                 args.system_vm_socket_info().0.clone(),
                 args::Args::OPT_USER_VM_BIND_SOCKET_TYPE.to_string(),
@@ -586,8 +604,10 @@ impl LinuxDaemon {
         debug!("nanvixd received connection from linuxd's control-plane socket");
 
         Ok(Self {
-            child,
-            control_plane_stream,
+            inner: Mutex::new(Some(LinuxDaemonInner {
+                child,
+                control_plane_stream,
+            })),
             netns_handle,
         })
     }
@@ -597,8 +617,23 @@ impl LinuxDaemon {
     ///
     /// Shuts down the Linux Daemon instance.
     ///
-    pub async fn shutdown(&mut self) {
+    /// # Notes
+    ///
+    /// - The method is idempotent - calling it multiple times is safe and has no effect after the
+    ///   first successful shutdown.
+    ///
+    pub async fn shutdown(&self) {
         trace!("shutdown()");
+
+        // Proceed with shutdown if we have the inner state.
+        let Some(LinuxDaemonInner {
+            mut control_plane_stream,
+            mut child,
+        }) = self.inner.lock().await.take()
+        else {
+            warn!("shutdown(): inner state already taken, skipping shutdown");
+            return;
+        };
 
         // Prepare shutdown message.
         let msg_bytes: [u8; mem::size_of::<NanvixdControlMessage>()] = {
@@ -610,14 +645,14 @@ impl LinuxDaemon {
         };
 
         // Send shutdown command to Linux Daemon.
-        if let Err(error) = self.control_plane_stream.write_all(&msg_bytes).await {
+        if let Err(error) = control_plane_stream.write_all(&msg_bytes).await {
             if error.kind() != ErrorKind::BrokenPipe {
                 error!("shutdown(): failed to send shutdown command to linuxd (error={error:?})");
             }
         }
 
         // Wait for linuxd instance to finish.
-        match timeout(SHUTDOWN_TIMEOUT, self.child.wait()).await {
+        match timeout(SHUTDOWN_TIMEOUT, child.wait()).await {
             Ok(Ok(exit_status)) => {
                 if !exit_status.success() {
                     warn!(
@@ -628,11 +663,11 @@ impl LinuxDaemon {
             },
             Ok(Err(error)) => {
                 warn!("shutdown(): error waiting for linuxd (error={error:?})");
-                Self::send_sigkill_to_child(&self.child);
+                Self::send_sigkill_to_child(&child);
             },
             Err(elapsed) => {
                 warn!("shutdown(): timed-out waiting for linuxd (error={elapsed:?})");
-                Self::send_sigkill_to_child(&self.child);
+                Self::send_sigkill_to_child(&child);
             },
         }
     }

--- a/src/libs/nanvix-sandbox/src/single_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/single_process/linuxd.rs
@@ -55,13 +55,23 @@ use ::tokio::{
 ///
 /// # Description
 ///
+/// Interior mutable state for a Linux Daemon instance.
+///
+struct LinuxDaemonInner {
+    /// Underlying task.
+    linuxd_task: JoinHandle<Result<()>>,
+    /// Control-plane socket stream.
+    control_plane_stream: SocketStream,
+}
+
+///
+/// # Description
+///
 /// Handle to a running Linux Daemon instance.
 ///
 pub struct LinuxDaemon {
-    /// Underlying task.
-    linuxd_task: Mutex<Option<JoinHandle<Result<()>>>>,
-    /// Control-plane socket stream.
-    control_plane_stream: SocketStream,
+    /// Interior mutable state.
+    inner: Mutex<Option<LinuxDaemonInner>>,
 }
 
 //==================================================================================================
@@ -172,8 +182,10 @@ impl LinuxDaemon {
         debug!("spawn(): nanvixd received connection from linuxd control-plane socket");
 
         Ok(Self {
-            linuxd_task: Mutex::new(Some(linuxd_task)),
-            control_plane_stream,
+            inner: Mutex::new(Some(LinuxDaemonInner {
+                linuxd_task,
+                control_plane_stream,
+            })),
         })
     }
 
@@ -182,8 +194,23 @@ impl LinuxDaemon {
     ///
     /// Shuts down the Linux Daemon instance.
     ///
-    pub async fn shutdown(&mut self) {
+    /// # Notes
+    ///
+    /// - The method is idempotent - calling it multiple times is safe and has no effect after the
+    ///   first successful shutdown.
+    ///
+    pub async fn shutdown(&self) {
         trace!("shutdown()");
+
+        // Proceed with shutdown if we have the inner state.
+        let Some(LinuxDaemonInner {
+            mut control_plane_stream,
+            linuxd_task,
+        }) = self.inner.lock().await.take()
+        else {
+            warn!("shutdown(): inner state already taken, skipping shutdown");
+            return;
+        };
 
         // Prepare shutdown message.
         let msg_bytes: [u8; mem::size_of::<NanvixdControlMessage>()] = {
@@ -195,29 +222,24 @@ impl LinuxDaemon {
         };
 
         // Send shutdown command to Linux Daemon.
-        if let Err(error) = self.control_plane_stream.write_all(&msg_bytes).await {
+        if let Err(error) = control_plane_stream.write_all(&msg_bytes).await {
             warn!("shutdown(): failed to send shutdown command to linuxd (error={error:?})");
         }
 
         // Wait for the Linux Daemon to finish.
-        if let Some(linuxd_task) = self.linuxd_task.lock().await.take() {
-            match timeout(SHUTDOWN_TIMEOUT, linuxd_task).await {
-                Ok(join_result) => match join_result {
-                    Ok(Ok(())) => {},
-                    Ok(Err(error)) => {
-                        warn!("shutdown(): linuxd terminated with error (error={error:?})");
-                    },
-                    Err(join_error) => {
-                        warn!("shutdown(): failed to join linuxd task (error={join_error:?})");
-                    },
+        match timeout(SHUTDOWN_TIMEOUT, linuxd_task).await {
+            Ok(join_result) => match join_result {
+                Ok(Ok(())) => {},
+                Ok(Err(error)) => {
+                    warn!("shutdown(): linuxd terminated with error (error={error:?})");
                 },
-                Err(elapsed) => {
-                    warn!(
-                        "shutdown(): timed-out waiting for linuxd to shutdown \
-                         (elapsed={elapsed:?})"
-                    );
+                Err(join_error) => {
+                    warn!("shutdown(): failed to join linuxd task (error={join_error:?})");
                 },
-            }
+            },
+            Err(elapsed) => {
+                warn!("shutdown(): timed-out waiting for linuxd to shutdown (elapsed={elapsed:?})");
+            },
         }
     }
 }


### PR DESCRIPTION
This pull request refactors the shutdown logic and internal state management for the `LinuxDaemon` in both multi-process and single-process sandbox implementations. The main focus is to make the shutdown process idempotent, improve thread safety using `Mutex`, and ensure proper cleanup of resources. Additionally, the shutdown logic is updated to handle multiple outstanding references more gracefully.

This PR closes #1236 