### PR TITLE
[nanvix-test] Support for nanvixd CLI Args

### DIFF
--- a/src/utils/nanvix-test/src/config.rs
+++ b/src/utils/nanvix-test/src/config.rs
@@ -488,6 +488,8 @@ pub struct TestCaseConfig {
     pub expected_output: Option<String>,
     /// Flag indicating that the workload must not produce any stdout output.
     pub expect_empty_output: bool,
+    /// Optional extra arguments passed directly to nanvixd.
+    pub extra_nanvixd_args: Option<String>,
 }
 
 impl TestCaseConfig {
@@ -516,6 +518,7 @@ impl TestCaseConfig {
         let input_field: String = format!("{entry_prefix}.input");
         let expected_output_field: String = format!("{entry_prefix}.expected_output");
         let expect_empty_output_field: String = format!("{entry_prefix}.expect_empty_output");
+        let extra_nanvixd_args_field: String = format!("{entry_prefix}.extra_nanvixd_args");
 
         Ok(Self {
             executor: read_required_string(table, "executor", executor_field.as_str())?,
@@ -538,6 +541,11 @@ impl TestCaseConfig {
                 "expect_empty_output",
                 expect_empty_output_field.as_str(),
                 false,
+            )?,
+            extra_nanvixd_args: read_optional_string(
+                table,
+                "extra_nanvixd_args",
+                extra_nanvixd_args_field.as_str(),
             )?,
         })
     }

--- a/src/utils/nanvix-test/src/executor/empty.rs
+++ b/src/utils/nanvix-test/src/executor/empty.rs
@@ -35,6 +35,7 @@ use ::std::path::Path;
 /// - `runner_config`: Configuration required to spawn the Nanvix Daemon.
 /// - `iterations`: Number of Empty Executor cycles to execute.
 /// - `log_layout`: Layout that controls where stdout/stderr artifacts for each iteration land.
+/// - `extra_nanvixd_args`: Command-line arguments passed directly to nanvixd.
 ///
 /// # Return Value
 ///
@@ -45,6 +46,7 @@ pub(crate) async fn empty(
     runner_config: &RunnerConfig,
     iterations: usize,
     log_layout: &TestLogLayout,
+    extra_nanvixd_args: &[String],
 ) -> Result<()> {
     let l2_enabled: bool = runner_config.l2_enabled;
     let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
@@ -57,19 +59,19 @@ pub(crate) async fn empty(
             stderr: stderr_file_path,
         } = log_layout.allocate_runner_logs(Some(iteration));
 
-        let nanvixd_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
+        let nanvixd_http_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
             (stdout_file_path.as_path(), stderr_file_path.as_path()),
-            runner_config.ipv4_addr.as_str(),
-            runner_config.port_num,
+            (runner_config.ipv4_addr.as_str(), runner_config.port_num),
             hwloc_file_path.clone(),
             l2_enabled,
             runner_config.netns_pool_size,
             log_layout.test_directory(),
+            extra_nanvixd_args,
         )?;
 
         {
             let _nanvixd_handle: NanvixdHttp =
-                NanvixdHttp::spawn(runner_config, &nanvixd_args).await?;
+                NanvixdHttp::spawn(runner_config, &nanvixd_http_args).await?;
         }
 
         guest_log_tracker.move_new_logs(log_layout.test_directory())?;

--- a/src/utils/nanvix-test/src/executor/http.rs
+++ b/src/utils/nanvix-test/src/executor/http.rs
@@ -61,6 +61,7 @@ use ::tokio::time::timeout;
 /// - `iterations`: Number of times the start/run/stop cycle should execute.
 /// - `workload`: Metadata that describes the workload path, arguments, and expectations.
 /// - `log_layout`: Layout that controls how runner/program logs are timestamped and stored.
+/// - `extra_nanvixd_args`: Command-line arguments passed directly to nanvixd.
 ///
 /// # Return Value
 ///
@@ -73,6 +74,7 @@ pub(crate) async fn test_with_http_executor(
     iterations: usize,
     workload: WorkloadSpec<'_>,
     log_layout: &TestLogLayout,
+    extra_nanvixd_args: &[String],
 ) -> Result<()> {
     let l2_enabled: bool = runner_config.l2_enabled;
     let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
@@ -101,12 +103,12 @@ pub(crate) async fn test_with_http_executor(
 
     let nanvixd_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
         (stdout_file_path.as_path(), stderr_file_path.as_path()),
-        runner_config.ipv4_addr.as_str(),
-        runner_config.port_num,
+        (runner_config.ipv4_addr.as_str(), runner_config.port_num),
         hwloc_file_path.clone(),
         l2_enabled,
         runner_config.netns_pool_size,
         log_layout.test_directory(),
+        extra_nanvixd_args,
     )?;
 
     // Run tests within a scoped block to ensure logs are captured before moving them.

--- a/src/utils/nanvix-test/src/executor/terminal.rs
+++ b/src/utils/nanvix-test/src/executor/terminal.rs
@@ -91,6 +91,7 @@ type StreamCollectors = (
 /// - `iterations`: Number of times to run the workflow.
 /// - `workload`: Metadata that describes the workload path, arguments, and expectations.
 /// - `log_layout`: Layout that defines the target directory for stdout/stderr/program logs.
+/// - `extra_nanvixd_args`: Command-line arguments passed directly to nanvixd.
 ///
 /// # Return Value
 ///
@@ -103,6 +104,7 @@ pub async fn test_with_terminal_executor(
     iterations: usize,
     workload: WorkloadSpec<'_>,
     log_layout: &TestLogLayout,
+    extra_nanvixd_args: &[String],
 ) -> Result<()> {
     if runner_config.l2_enabled {
         let reason: String = "terminal executor does not support L2 deployment".to_string();
@@ -134,11 +136,12 @@ pub async fn test_with_terminal_executor(
             stderr: stderr_file_path,
         } = log_layout.allocate_runner_logs(Some(iteration));
 
-        let nanvixd_args: NanvixdTerminalArgs = NanvixdTerminalArgs::new(
+        let nanvixd_terminal_args: NanvixdTerminalArgs = NanvixdTerminalArgs::new(
             hwloc_file_path.clone(),
             workload.program_path(),
             parsed_program_args.as_slice(),
             log_layout.test_directory(),
+            extra_nanvixd_args,
         )?;
 
         let collection_timeout: Duration =
@@ -146,7 +149,7 @@ pub async fn test_with_terminal_executor(
 
         let (_nanvixd, stream_collectors) = {
             let mut nanvixd: NanvixdTerminal =
-                NanvixdTerminal::spawn(runner_config, &nanvixd_args).await?;
+                NanvixdTerminal::spawn(runner_config, &nanvixd_terminal_args).await?;
 
             let stdout_pipe = nanvixd.take_stdout().ok_or_else(|| {
                 let reason: String =

--- a/src/utils/nanvix-test/src/main.rs
+++ b/src/utils/nanvix-test/src/main.rs
@@ -181,11 +181,29 @@ async fn run() -> Result<()> {
             input,
             expected_output,
             expect_empty_output,
+            extra_nanvixd_args,
         } = test_config;
 
+        // Parse extra_nanvixd_args string into a vector of arguments.
+        let extra_nanvixd_args: Vec<String> = match extra_nanvixd_args.as_ref() {
+            Some(args) => match ::shell_words::split(args) {
+                Ok(values) => values,
+                Err(parse_error) => {
+                    let reason: String = format!(
+                        "failed to parse extra_nanvixd_args (args='{}', error={parse_error})",
+                        args
+                    );
+                    error!("main(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                },
+            },
+            None => Vec::new(),
+        };
+
         debug!(
-            "main(): running test (executor={}, iterations={}, program={:?}, program_args={:?})",
-            executor, iterations, program, program_args,
+            "main(): running test (executor={}, iterations={}, program={:?}, program_args={:?}, \
+             extra_nanvixd_args={:?})",
+            executor, iterations, program, program_args, extra_nanvixd_args,
         );
 
         let executor_name: ExecutorName = ExecutorName::from_str(executor.as_str())?;
@@ -197,7 +215,7 @@ async fn run() -> Result<()> {
                     ExecutorName::Empty.to_str(),
                     executor.as_str(),
                 )?;
-                empty(&runner_config, iterations, &log_layout).await?;
+                empty(&runner_config, iterations, &log_layout, &extra_nanvixd_args).await?;
                 let context: String = format!("empty executor completed (label={})", executor);
                 warning::fail_if_triggered(context.as_str())?;
             },
@@ -233,7 +251,14 @@ async fn run() -> Result<()> {
                     expect_empty_output,
                 );
 
-                test_with_http_executor(&runner_config, iterations, workload, &log_layout).await?;
+                test_with_http_executor(
+                    &runner_config,
+                    iterations,
+                    workload,
+                    &log_layout,
+                    &extra_nanvixd_args,
+                )
+                .await?;
                 let context: String = format!(
                     "http executor completed (program={}, test={})",
                     program_path, executor
@@ -278,8 +303,14 @@ async fn run() -> Result<()> {
                     expect_empty_output,
                 );
 
-                test_with_terminal_executor(&runner_config, iterations, workload, &log_layout)
-                    .await?;
+                test_with_terminal_executor(
+                    &runner_config,
+                    iterations,
+                    workload,
+                    &log_layout,
+                    &extra_nanvixd_args,
+                )
+                .await?;
                 let context: String = format!(
                     "terminal executor completed (program={}, test={})",
                     program_path, executor

--- a/src/utils/nanvix-test/src/nanvixd/http.rs
+++ b/src/utils/nanvix-test/src/nanvixd/http.rs
@@ -63,17 +63,17 @@ impl NanvixdHttp {
     /// # Parameters
     ///
     /// - `config`: Configuration object describing how the Nanvix Daemon should be spawned.
-    /// - `nanvixd_args`: File handles and runtime arguments used when spawning the Nanvix Daemon.
+    /// - `args`: File handles and runtime arguments used when spawning the Nanvix Daemon.
     ///
     /// # Return Value
     ///
     /// Returns a handle to the HTTP-enabled Nanvix Daemon on success; returns an error when the
     /// child process cannot be spawned or the readiness checks fail.
     ///
-    pub async fn spawn(config: &RunnerConfig, nanvixd_args: &NanvixdHttpArgs) -> Result<Self> {
-        let hwloc_file_path: Option<&str> = nanvixd_args.hwloc_file_path();
-        let l2_enabled: bool = nanvixd_args.l2();
-        let log_directory: &Path = nanvixd_args.log_directory();
+    pub async fn spawn(config: &RunnerConfig, args: &NanvixdHttpArgs) -> Result<Self> {
+        let hwloc_file_path: Option<&str> = args.hwloc_file_path();
+        let l2_enabled: bool = args.l2();
+        let log_directory: &Path = args.log_directory();
         trace!(
             "spawn(): nanvixd_binary_path={}, working_directory={}, toolchain_path={}, mode=http, \
              hwloc_file_path={:?}, l2={}",
@@ -84,39 +84,36 @@ impl NanvixdHttp {
             l2_enabled,
         );
 
-        let port_num: u16 = nanvixd_args.port_num();
-        let http_address: String = format!("{}:{}", nanvixd_args.ipv4_addr(), port_num);
+        let port_num: u16 = args.port_num();
+        let http_address: String = format!("{}:{}", args.ipv4_addr(), port_num);
 
         let mut command: Command =
             Nanvixd::build_base_command(config, hwloc_file_path, l2_enabled, log_directory);
 
-        let stdout_file: File = nanvixd_args
-            .stdout_file_handle()
-            .try_clone()
-            .map_err(|error| {
-                let reason: String =
-                    format!("failed to clone nanvixd stdout log file (error={error})");
-                error!("spawn(): {reason}");
-                ::anyhow::anyhow!(reason)
-            })?;
+        let stdout_file: File = args.stdout_file_handle().try_clone().map_err(|error| {
+            let reason: String = format!("failed to clone nanvixd stdout log file (error={error})");
+            error!("spawn(): {reason}");
+            ::anyhow::anyhow!(reason)
+        })?;
 
-        let stderr_file: File = nanvixd_args
-            .stderr_file_handle()
-            .try_clone()
-            .map_err(|error| {
-                let reason: String =
-                    format!("failed to clone nanvixd stderr log file (error={error})");
-                error!("spawn(): {reason}");
-                ::anyhow::anyhow!(reason)
-            })?;
+        let stderr_file: File = args.stderr_file_handle().try_clone().map_err(|error| {
+            let reason: String = format!("failed to clone nanvixd stderr log file (error={error})");
+            error!("spawn(): {reason}");
+            ::anyhow::anyhow!(reason)
+        })?;
 
         command.stdin(Stdio::null());
         command.stdout(Stdio::from(stdout_file));
         command.stderr(Stdio::from(stderr_file));
         command.arg(::nanvixd::args::Args::OPT_NETNS_POOL_SIZE);
-        command.arg(nanvixd_args.netns_pool_size().to_string());
+        command.arg(args.netns_pool_size().to_string());
         command.arg(::nanvixd::args::Args::OPT_HTTP_SOCKADDR);
         command.arg(http_address.as_str());
+
+        // Append command-line arguments passed directly to nanvixd.
+        for extra_nanvixd_arg in args.extra_nanvixd_args() {
+            command.arg(extra_nanvixd_arg);
+        }
 
         let mode_label: String = format!("http_address={http_address}");
 
@@ -131,7 +128,7 @@ impl NanvixdHttp {
                 // We cannot fail here; otherwise, `child` would linger.
                 no_fail!(Self, {
                     debug!("spawn(): nanvixd spawned with pid {}", child.id().unwrap_or(0));
-                    let ipv4_addr: String = nanvixd_args.ipv4_addr().to_string();
+                    let ipv4_addr: String = args.ipv4_addr().to_string();
                     let cleanup_guard: EnvironmentCleanupGuard = EnvironmentCleanupGuard::new(
                         l2_enabled,
                         Some(port_num),
@@ -244,6 +241,8 @@ pub struct NanvixdHttpArgs {
     netns_pool_size: usize,
     /// Directory where Nanvix Daemon components should emit logs.
     log_directory: PathBuf,
+    /// Command-line arguments passed directly to nanvixd.
+    extra_nanvixd_args: Vec<String>,
 }
 
 impl NanvixdHttpArgs {
@@ -255,12 +254,12 @@ impl NanvixdHttpArgs {
     /// # Parameters
     ///
     /// - `log_files`: Tuple containing stdout and stderr log file paths.
-    /// - `ipv4_addr`: IPv4 address where the Nanvix Daemon should expose its HTTP interface.
-    /// - `port_num`: TCP port used by the Nanvix Daemon HTTP interface.
+    /// - `http_endpoint`: Tuple containing the IPv4 address and TCP port for the HTTP interface.
     /// - `hwloc_file_path`: Optional hwloc topology file passed to the Nanvix Daemon.
     /// - `l2`: Flag indicating whether the Nanvix Daemon should enable L2 deployment mode.
     /// - `netns_pool_size`: Netns pool prefill size forwarded to the Nanvix Daemon.
     /// - `log_directory`: Path where component logs should be persisted.
+    /// - `extra_nanvixd_args`: Command-line arguments passed directly to nanvixd.
     ///
     /// # Return Value
     ///
@@ -269,14 +268,15 @@ impl NanvixdHttpArgs {
     ///
     pub fn new(
         log_files: (&Path, &Path),
-        ipv4_addr: &str,
-        port_num: u16,
+        http_endpoint: (&str, u16),
         hwloc_file_path: Option<String>,
         l2: bool,
         netns_pool_size: usize,
         log_directory: &Path,
+        extra_nanvixd_args: &[String],
     ) -> Result<Self> {
         let (stdout_file_path, stderr_file_path): (&Path, &Path) = log_files;
+        let (ipv4_addr, port_num): (&str, u16) = http_endpoint;
         let stdout_file_handle: File = match OpenOptions::new()
             .create(true)
             .write(true)
@@ -320,6 +320,7 @@ impl NanvixdHttpArgs {
             port_num,
             netns_pool_size,
             log_directory: log_directory.to_path_buf(),
+            extra_nanvixd_args: extra_nanvixd_args.to_vec(),
         })
     }
 
@@ -425,5 +426,18 @@ impl NanvixdHttpArgs {
     ///
     fn log_directory(&self) -> &Path {
         self.log_directory.as_path()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the command-line arguments passed directly to nanvixd.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a slice containing the nanvixd arguments.
+    ///
+    pub fn extra_nanvixd_args(&self) -> &[String] {
+        self.extra_nanvixd_args.as_slice()
     }
 }

--- a/src/utils/nanvix-test/src/nanvixd/terminal.rs
+++ b/src/utils/nanvix-test/src/nanvixd/terminal.rs
@@ -52,36 +52,42 @@ impl NanvixdTerminal {
     /// # Parameters
     ///
     /// - `config`: Configuration object describing how the Nanvix Daemon should be spawned.
-    /// - `nanvixd_args`: Runtime arguments used when spawning the Nanvix Daemon.
+    /// - `args`: Runtime arguments used when spawning the Nanvix Daemon.
     ///
     /// # Return Value
     ///
     /// Returns a handle to the interactive Nanvix Daemon on success; returns an error if the
     /// process cannot be spawned.
     ///
-    pub async fn spawn(config: &RunnerConfig, nanvixd_args: &NanvixdTerminalArgs) -> Result<Self> {
+    pub async fn spawn(config: &RunnerConfig, args: &NanvixdTerminalArgs) -> Result<Self> {
         debug_assert!(!config.l2_enabled);
 
-        let hwloc_file_path: Option<&str> = nanvixd_args.hwloc_file_path();
-        let log_directory: &Path = nanvixd_args.log_directory();
+        let hwloc_file_path: Option<&str> = args.hwloc_file_path();
+        let log_directory: &Path = args.log_directory();
         trace!(
             "spawn(): nanvixd_binary_path={}, working_directory={}, toolchain_path={}, mode={}, \
              hwloc_file_path={:?}, l2=disabled",
             config.nanvixd_binary_path,
             config.working_directory,
             config.toolchain_path,
-            nanvixd_args.mode_label(),
+            args.mode_label(),
             hwloc_file_path,
         );
 
-        let program_path: &str = nanvixd_args.program_path();
-        let program_args: &[String] = nanvixd_args.program_args();
+        let program_path: &str = args.program_path();
+        let program_args: &[String] = args.program_args();
 
         let mut command: Command =
             Nanvixd::build_base_command(config, hwloc_file_path, false, log_directory);
         command.stdin(Stdio::piped());
         command.stdout(Stdio::piped());
         command.stderr(Stdio::piped());
+
+        // Append extra command-line arguments passed directly to nanvixd.
+        for extra_nanvixd_arg in args.extra_nanvixd_args() {
+            command.arg(extra_nanvixd_arg);
+        }
+
         command.arg(::nanvixd::args::Args::OPT_SEPARATOR);
         command.arg(program_path);
         command.args(program_args);
@@ -181,6 +187,8 @@ pub struct NanvixdTerminalArgs {
     program_args: Vec<String>,
     /// Directory where Nanvix Daemon components should emit logs.
     log_directory: PathBuf,
+    /// Command-line arguments passed directly to nanvixd.
+    extra_nanvixd_args: Vec<String>,
 }
 
 impl NanvixdTerminalArgs {
@@ -196,6 +204,7 @@ impl NanvixdTerminalArgs {
     /// - `program_path`: Path to the workload that should execute inside the sandbox.
     /// - `program_args`: Command-line arguments forwarded to the workload.
     /// - `log_directory`: Directory where the Nanvix Daemon should emit component logs.
+    /// - `extra_nanvixd_args`: Command-line arguments passed directly to nanvixd.
     ///
     /// # Return Value
     ///
@@ -207,12 +216,14 @@ impl NanvixdTerminalArgs {
         program_path: &str,
         program_args: &[String],
         log_directory: &Path,
+        extra_nanvixd_args: &[String],
     ) -> Result<Self> {
         Ok(Self {
             hwloc_file_path,
             program_path: program_path.to_string(),
             program_args: program_args.to_vec(),
             log_directory: log_directory.to_path_buf(),
+            extra_nanvixd_args: extra_nanvixd_args.to_vec(),
         })
     }
 
@@ -279,5 +290,18 @@ impl NanvixdTerminalArgs {
     ///
     pub fn mode_label(&self) -> &'static str {
         "mode=interactive"
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the command-line arguments passed directly to nanvixd.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a slice containing the nanvixd arguments.
+    ///
+    pub fn extra_nanvixd_args(&self) -> &[String] {
+        self.extra_nanvixd_args.as_slice()
     }
 }


### PR DESCRIPTION
This PR closes https://github.com/nanvix/nanvix/issues/1317

This pull request extends the `nanvix-test` utility to allow passing additional command-line arguments directly to the `nanvixd` daemon for each test case. This adds flexibility for test authors to customize the daemon's behavior without modifying the test harness code. The main changes include support for the new `extra_nanvixd_args` configuration in test cases, propagating these arguments through the test execution pipeline, and updating the relevant executor and argument-construction logic.