### PR TITLE
[ci] Update Release Dispatch Logic

### DIFF
--- a/.github/workflows/major-release-dispatch.yml
+++ b/.github/workflows/major-release-dispatch.yml
@@ -14,8 +14,7 @@ permissions:
 env:
   TARGET_REPOSITORIES: |
     rusty_v8
-    nanvix-registry
-    nanvix-sandbox
+    quickjs
 
 jobs:
   dispatch:

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -381,31 +381,40 @@ jobs:
           exit 0
         fi
 
-        API_URL="https://api.github.com/repos/nanvix/rusty_v8/dispatches"
-        PAYLOAD=$(cat <<JSON
+        repos=("rusty_v8" "quickjs")
+        failed=0
+
+        for repo in "${repos[@]}"; do
+          API_URL="https://api.github.com/repos/nanvix/${repo}/dispatches"
+          PAYLOAD=$(cat <<JSON
         {
           "event_type": "nanvix-minor-release",
           "client_payload": {
             "source_repo": "nanvix/nanvix",
             "ref": "${GITHUB_REF}",
             "sha": "${GITHUB_SHA}",
-            "component": "rusty_v8",
+            "component": "${repo}",
             "reason": "sync build from nanvix/nanvix"
           }
         }
         JSON
         )
 
-        http_response=$(curl -sS -o /dev/null -w "%{http_code}" -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          "$API_URL" \
-          -d "${PAYLOAD}")
+          http_response=$(curl -sS -o /dev/null -w "%{http_code}" -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$API_URL" \
+            -d "${PAYLOAD}")
 
-        if [[ "${http_response}" -ge 200 && "${http_response}" -lt 300 ]]; then
-          echo "Dispatched nanvix-release event to nanvix/rusty_v8 (HTTP ${http_response})."
-        else
-          echo "::error::Failed to dispatch nanvix-release event to nanvix/rusty_v8 (HTTP ${http_response})."
+          if [[ "${http_response}" -ge 200 && "${http_response}" -lt 300 ]]; then
+            echo "Dispatched nanvix-release event to nanvix/${repo} (HTTP ${http_response})."
+          else
+            echo "::error::Failed to dispatch nanvix-release event to nanvix/${repo} (HTTP ${http_response})."
+            failed=1
+          fi
+        done
+
+        if [[ "${failed}" -eq 1 ]]; then
           exit 1
         fi


### PR DESCRIPTION
This pull request updates the release dispatch workflow to add support for the `quickjs` repository and ensures that release events are dispatched to both `rusty_v8` and `quickjs`. It also improves error handling by tracking failures across multiple dispatches.