### PR TITLE
[scripts] Deployment Types in pipeline.sh

### DIFF
--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -25,17 +25,19 @@ source "${IMPORT_DIR}/logging.sh"
 #===================================================================================================
 
 # Configuration matrix for testing all supported machines.
-declare -a MACHINE_TYPES=("qemu-isapc" "qemu-pc" "qemu-baremetal" "microvm" "hyperlight")
+declare -a MACHINE_TYPES=("qemu-isapc" "qemu-baremetal" "qemu-pc" "microvm" "hyperlight")
 declare -a BUILD_TYPES=("debug" "release")
+declare -a DEPLOYMENT_TYPES=("single-process" "multi-process" "l2")
 declare -a STEP_TYPES=("spellcheck" "format" "lint" "build" "test")
 declare -a MACHINE_INDEPENDENT_STEPS=("spellcheck" "format")
 
 # Padding to force aligned formatting.
-PADDING=40
+PADDING=60
 
 # Counters for passed and failed steps.
 passed_count=0
 failed_count=0
+skipped_count=0
 
 # Total elapsed time.
 total_elapsed_time=0
@@ -69,6 +71,39 @@ get_release_flag() {
             ;;
         *)
             print_error "(pipeline) Invalid build type: ${build_type}"
+            exit 1
+            ;;
+    esac
+}
+
+#
+# Description
+#   Converts deployment type to build flags.
+#
+# Arguments
+#   $1 - Deployment type.
+#
+# Returns
+#   String with SINGLE_PROCESS and L2_VM values.
+#
+# Usage Example
+#   flags=$(get_deployment_flags "single-process")
+#
+get_deployment_flags() {
+    local deployment_type="${1}"
+
+    case "${deployment_type}" in
+        single-process)
+            echo "SINGLE_PROCESS=yes L2_VM=no"
+            ;;
+        multi-process)
+            echo "SINGLE_PROCESS=no L2_VM=no"
+            ;;
+        l2)
+            echo "SINGLE_PROCESS=no L2_VM=yes"
+            ;;
+        *)
+            print_error "(pipeline) Invalid deployment type: ${deployment_type}"
             exit 1
             ;;
     esac
@@ -140,6 +175,34 @@ is_machine_independent() {
 
 #
 # Description
+#   Checks if a machine/deployment combination should be excluded.
+#
+# Arguments
+#   $1 - Machine type.
+#   $2 - Deployment type.
+#
+# Returns
+#   0 if excluded (should skip), 1 otherwise.
+#
+# Usage Example
+#   if is_excluded "qemu-pc" "single-process"; then
+#
+is_excluded() {
+    local machine="${1}"
+    local deployment="${2}"
+
+    # Machines not included in the CI workflow matrix.
+    if [[ "${machine}" == "qemu-pc" ]] || \
+       [[ "${machine}" == "qemu-isapc" ]] || \
+       [[ "${machine}" == "qemu-baremetal" ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+#
+# Description
 #   Runs a single pipeline step and reports the result.
 #
 # Arguments
@@ -147,20 +210,23 @@ is_machine_independent() {
 #   $2 - Step type (format, spellcheck, lint, build, test).
 #   $3 - Temporary file path for capturing output.
 #   $4 - Machine type (optional, empty for machine-independent steps).
+#   $5 - Deployment type (optional, empty for machine-independent steps).
 #
 # Returns
 #   0 on success, non-zero on failure.
 #
 # Usage Example
-#   run_step "debug" "lint" "/tmp/output" ""
-#   run_step "release" "build" "/tmp/output" "microvm"
+#   run_step "debug" "lint" "/tmp/output" "" ""
+#   run_step "release" "build" "/tmp/output" "microvm" "single-process"
 #
 run_step() {
     local build_type="${1}"
     local step="${2}"
     local tmpfile="${3}"
     local machine="${4-}"
+    local deployment="${5-}"
     local release_flag
+    local deployment_flags
     local make_target
     local msg
     local start_time
@@ -176,7 +242,8 @@ run_step() {
     if [[ -z "${machine}" ]]; then
         msg="${build_type} ${step}"
     else
-        msg="${build_type} ${step} ${machine}"
+        deployment_flags=$(get_deployment_flags "${deployment}")
+        msg="${build_type} ${step} ${machine} ${deployment}"
     fi
     printf "%-${PADDING}s" "${msg}"
 
@@ -190,7 +257,7 @@ run_step() {
             return_code=$?
         fi
     else
-        if ./z build -- MACHINE="${machine}" LOG_LEVEL=trace "${release_flag}" ${make_target} > "${tmpfile}" 2>&1; then
+        if ./z build -- MACHINE="${machine}" LOG_LEVEL=trace "${release_flag}" ${deployment_flags} ${make_target} > "${tmpfile}" 2>&1; then
             return_code=0
         else
             return_code=$?
@@ -232,19 +299,35 @@ main() {
     trap 'rm -f "$tmpfile"' EXIT
 
     print_info "(pipeline) Running CI pipeline for all configurations..."
+    print_info "(pipeline) Matrix: ${#BUILD_TYPES[@]} build types x ${#MACHINE_TYPES[@]} machines x ${#DEPLOYMENT_TYPES[@]} deployments x ${#STEP_TYPES[@]} steps"
 
-    # Iterate through all build types, machine, and steps.
+    # Track which machine-independent steps have been run for each build type.
+    declare -A run_machine_independent_steps
+
+    # Iterate through all build types, machines, deployments, and steps.
     for build_type in "${BUILD_TYPES[@]}"; do
         for machine in "${MACHINE_TYPES[@]}"; do
-            for step in "${STEP_TYPES[@]}"; do
-                # Check if this step is machine-independent.
-                if is_machine_independent "${step}"; then
-                    # Run machine-independent steps only once.
-                    run_step "${build_type}" "${step}" "${tmpfile}"
-                else
-                    # Run machine-dependent steps for each machine.
-                    run_step "${build_type}" "${step}" "${tmpfile}" "${machine}"
+            for deployment in "${DEPLOYMENT_TYPES[@]}"; do
+                # Check if this machine/deployment combination is excluded.
+                if is_excluded "${machine}" "${deployment}"; then
+                    ((skipped_count++))
+                    continue
                 fi
+
+                for step in "${STEP_TYPES[@]}"; do
+                    # Check if this step is machine-independent.
+                    if is_machine_independent "${step}"; then
+                        # Run machine-independent steps only once per build type.
+                        local key="${build_type}_${step}"
+                        if [[ -z "${run_machine_independent_steps[${key}]+isset}" ]]; then
+                            run_step "${build_type}" "${step}" "${tmpfile}" "" ""
+                            run_machine_independent_steps["${key}"]=1
+                        fi
+                    else
+                        # Run machine-dependent steps for each machine/deployment combination.
+                        run_step "${build_type}" "${step}" "${tmpfile}" "${machine}" "${deployment}"
+                    fi
+                done
             done
         done
     done
@@ -256,6 +339,7 @@ main() {
     total_milliseconds=$((total_elapsed_time % 1000))
     print_info "(pipeline) Total Passed: ${passed_count}"
     print_info "(pipeline) Total Failed: ${failed_count}"
+    print_info "(pipeline) Total Skipped (excluded): ${skipped_count}"
     print_info "(pipeline) Total Time: ${total_seconds}.${total_milliseconds}s"
 
     # Exit with error if there are failed steps.


### PR DESCRIPTION
This pull request updates the CI pipeline script to support a more flexible configuration matrix by introducing deployment types and handling exclusions more robustly. The script now iterates over build types, machine types, deployment types, and steps, allowing for finer control over which combinations are tested. Additionally, it adds logic to skip excluded configurations and tracks skipped steps for improved reporting.