### PR TITLE
[test] Cleanup Test Directories

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -272,9 +272,23 @@ jobs:
     - name: "Cleanup Dangling Resources"
       if: always()
       run: |
+        # Defensive cleanup for resources that should have been cleaned by their owners:
+        # - nvx:* directories: cleaned by TemporaryDirectory::Drop (nanvixd/tempdir.rs)
+        # - *.socket files: cleaned by SocketListener::Drop (syscomm/socket_listener.rs)
+        # - nvxns-* namespaces: cleaned by NetnsHandle::Drop (nanvix-sandbox/netns.rs)
+        # - clh-console/cloud-hypervisor.sock: cleaned by EXIT trap (generate-l2-snapshot.sh)
+        # This step catches any resources leaked due to crashes or abnormal termination.
+
         sudo rm -rf images
         sudo find /tmp -maxdepth 1 -name 'nvx:*' -exec rm -rf {} + 2>/dev/null || true
+        rm -rf /tmp/nanvix-test-* 2>/dev/null || true
         sudo rm -rf /tmp/clh-console 2>/dev/null || true
+        sudo rm -f /tmp/cloud-hypervisor.sock 2>/dev/null || true
+        sudo rm -f /tmp/*.socket 2>/dev/null || true
+        for ns in $(sudo ip netns list 2>/dev/null | grep -o 'nvxns-[0-9]*' || true); do
+          sudo ip link del "nvxgw-h-${ns#nvxns-}" 2>/dev/null || true
+          sudo ip netns del "${ns}" 2>/dev/null || true
+        done
       shell: bash
 
     - name: "Upload logs in case of failures"

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,0 +1,142 @@
+# Troubleshooting
+
+This document provides guidance for diagnosing and resolving common issues encountered when
+developing, building, or running Nanvix.
+
+## Resource Leaks
+
+Nanvix creates various temporary resources during operation. Under normal circumstances, these
+resources are automatically cleaned up by their owners. However, crashes or abnormal termination
+may leave stale resources behind that require manual cleanup.
+
+### Temporary Directories (`nvx:*`)
+
+**Description:** Runtime temporary directories created by `nanvixd` for each sandbox instance.
+
+**Location:** `/tmp/nvx:*`
+
+**Primary Cleanup:** `TemporaryDirectory::Drop` in `src/utils/nanvixd/src/tempdir.rs`
+
+**Manual Cleanup:**
+
+```bash
+sudo rm -rf /tmp/nvx:*
+```
+
+### Test Directories (`nanvix-test-*`)
+
+**Description:** Temporary directories created by unit tests in `nanvix-sandbox-cache`.
+
+**Location:** `/tmp/nanvix-test-*`
+
+**Primary Cleanup:** `TempTestDir::Drop` in `src/libs/nanvix-sandbox-cache/src/lib.rs`
+
+**Manual Cleanup:**
+
+```bash
+rm -rf /tmp/nanvix-test-*
+```
+
+### Unix Sockets (`*.socket`)
+
+**Description:** Unix domain sockets used for inter-process communication between nanvixd
+components.
+
+**Location:** `/tmp/*.socket`
+
+**Primary Cleanup:** `SocketListener::Drop` in `src/libs/syscomm/src/socket_listener.rs`
+
+**Manual Cleanup:**
+
+```bash
+sudo rm -f /tmp/*.socket
+```
+
+### Network Namespaces (`nvxns-*`)
+
+**Description:** Linux network namespaces created for L2 deployments to isolate VM networking.
+
+**Primary Cleanup:** `NetnsHandle::Drop` → `delete_namespace()` in
+`src/libs/nanvix-sandbox/src/netns.rs`
+
+**Manual Cleanup:**
+
+```bash
+# List stale namespaces
+sudo ip netns list | grep 'nvxns-'
+
+# Delete a specific namespace and its veth pair
+sudo ip link del nvxgw-h-<ID>
+sudo ip netns del nvxns-<ID>
+
+# Delete all stale namespaces
+for ns in $(sudo ip netns list | grep -o 'nvxns-[0-9]*'); do
+  sudo ip link del "nvxgw-h-${ns#nvxns-}" 2>/dev/null || true
+  sudo ip netns del "${ns}" 2>/dev/null || true
+done
+```
+
+### Cloud Hypervisor Resources
+
+**Description:** Resources created by Cloud Hypervisor during L2 snapshot generation.
+
+**Location:**
+
+- `/tmp/clh-console` - Console output directory
+- `/tmp/cloud-hypervisor.sock` - Cloud Hypervisor API socket
+
+**Primary Cleanup:** EXIT trap in `scripts/generate-l2-snapshot.sh`
+
+**Manual Cleanup:**
+
+```bash
+sudo rm -rf /tmp/clh-console
+sudo rm -f /tmp/cloud-hypervisor.sock
+```
+
+### Complete Cleanup Script
+
+To clean all stale Nanvix resources at once:
+
+```bash
+#!/bin/bash
+# Clean temporary directories
+sudo rm -rf /tmp/nvx:*
+rm -rf /tmp/nanvix-test-*
+
+# Clean Cloud Hypervisor resources
+sudo rm -rf /tmp/clh-console
+sudo rm -f /tmp/cloud-hypervisor.sock
+
+# Clean Unix sockets
+sudo rm -f /tmp/*.socket
+
+# Clean network namespaces
+for ns in $(sudo ip netns list 2>/dev/null | grep -o 'nvxns-[0-9]*' || true); do
+  sudo ip link del "nvxgw-h-${ns#nvxns-}" 2>/dev/null || true
+  sudo ip netns del "${ns}" 2>/dev/null || true
+done
+
+echo "Cleanup complete."
+```
+
+## CI/CD Failures
+
+### Stale Resources Causing Test Failures
+
+If CI tests fail with errors related to resources already existing or ports being in use, stale
+resources from a previous failed run may be the cause. The CI workflow includes a defensive cleanup
+step that runs after every job (see `.github/workflows/self-hosted-ci.yml`), but manual
+intervention may be needed on self-hosted runners.
+
+### TIME_WAIT Socket Connections
+
+After L2 deployments, TCP connections may linger in `TIME_WAIT` state. The test framework waits for
+these to clear before starting new tests. If tests timeout waiting for port availability:
+
+```bash
+# Check for lingering connections on the nanvixd port (default 8181)
+ss -tan | grep 8181
+
+# Wait for connections to clear (typically 60-120 seconds)
+```

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -712,29 +712,59 @@ mod tests {
     ///
     /// # Description
     ///
-    /// Creates a unique temporary directory for testing.
+    /// RAII wrapper for temporary test directories that automatically cleans up on drop.
     ///
-    /// # Returns
-    ///
-    /// A unique temporary directory path string.
-    ///
-    fn create_unique_tmp_dir() -> String {
-        use ::std::sync::atomic::{
-            AtomicU64,
-            Ordering,
-        };
+    struct TempTestDir {
+        /// Path to the temporary directory.
+        path: String,
+    }
 
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
+    impl TempTestDir {
+        ///
+        /// # Description
+        ///
+        /// Creates a new unique temporary directory for testing.
+        ///
+        /// # Returns
+        ///
+        /// A `TempTestDir` instance that will clean up the directory when dropped.
+        ///
+        fn new() -> Self {
+            use ::std::sync::atomic::{
+                AtomicU64,
+                Ordering,
+            };
 
-        let base_tmp: String = ::std::env::temp_dir().to_string_lossy().to_string();
-        let unique_id: u64 = ::std::time::SystemTime::now()
-            .duration_since(::std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as u64;
-        let counter: u64 = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let unique_dir: String = format!("{}/nanvix-test-{}-{}", base_tmp, unique_id, counter);
-        ::std::fs::create_dir_all(&unique_dir).unwrap();
-        unique_dir
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+            let base_tmp: String = ::std::env::temp_dir().to_string_lossy().to_string();
+            let unique_id: u64 = ::std::time::SystemTime::now()
+                .duration_since(::std::time::UNIX_EPOCH)
+                .expect("system time should be after UNIX_EPOCH")
+                .as_nanos() as u64;
+            let counter: u64 = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let unique_dir: String = format!("{}/nanvix-test-{}-{}", base_tmp, unique_id, counter);
+            ::std::fs::create_dir_all(&unique_dir).expect("failed to create test directory");
+            Self { path: unique_dir }
+        }
+
+        ///
+        /// # Description
+        ///
+        /// Returns the path to the temporary directory.
+        ///
+        fn path(&self) -> &str {
+            &self.path
+        }
+    }
+
+    impl Drop for TempTestDir {
+        fn drop(&mut self) {
+            // Best-effort cleanup; warn if removal fails.
+            if let Err(error) = ::std::fs::remove_dir_all(&self.path) {
+                error!("TempTestDir::drop(): failed to remove {} (error={})", self.path, error);
+            }
+        }
     }
 
     ///
@@ -744,12 +774,13 @@ mod tests {
     ///
     /// # Returns
     ///
-    /// A sandbox cache configuration suitable for testing.
+    /// A tuple of the sandbox cache configuration and the temp directory handle.
+    /// The temp directory is automatically cleaned up when the handle is dropped.
     ///
     #[cfg(feature = "single-process")]
-    fn create_test_config() -> SandboxCacheConfig<()> {
-        let tmp_dir: String = create_unique_tmp_dir();
-        SandboxCacheConfig::new(
+    fn create_test_config() -> (SandboxCacheConfig<()>, TempTestDir) {
+        let tmp_dir: TempTestDir = TempTestDir::new();
+        let config: SandboxCacheConfig<()> = SandboxCacheConfig::new(
             SocketType::Unix,
             SocketType::Unix,
             SocketType::Unix,
@@ -757,14 +788,15 @@ mod tests {
             None,
             None,
             128,
-            &format!("{}/kernel.elf", tmp_dir),
+            &format!("{}/kernel.elf", tmp_dir.path()),
             None,
-            &format!("{}/toolchain", tmp_dir),
-            &format!("{}/logs", tmp_dir),
+            &format!("{}/toolchain", tmp_dir.path()),
+            &format!("{}/logs", tmp_dir.path()),
             false,
-            &format!("{}/snapshot", tmp_dir),
-            &tmp_dir,
-        )
+            &format!("{}/snapshot", tmp_dir.path()),
+            tmp_dir.path(),
+        );
+        (config, tmp_dir)
     }
 
     ///
@@ -774,12 +806,13 @@ mod tests {
     ///
     /// # Returns
     ///
-    /// A sandbox cache configuration suitable for testing.
+    /// A tuple of the sandbox cache configuration and the temp directory handle.
+    /// The temp directory is automatically cleaned up when the handle is dropped.
     ///
     #[cfg(not(feature = "single-process"))]
-    fn create_test_config() -> SandboxCacheConfig<()> {
-        let tmp_dir: String = create_unique_tmp_dir();
-        SandboxCacheConfig::new(
+    fn create_test_config() -> (SandboxCacheConfig<()>, TempTestDir) {
+        let tmp_dir: TempTestDir = TempTestDir::new();
+        let config: SandboxCacheConfig<()> = SandboxCacheConfig::new(
             SocketType::Unix,
             SocketType::Unix,
             SocketType::Unix,
@@ -787,15 +820,16 @@ mod tests {
             None,
             None,
             0,
-            &format!("{}/kernel.elf", tmp_dir),
-            &format!("{}/linuxd.elf", tmp_dir),
-            &format!("{}/uservm.elf", tmp_dir),
-            &format!("{}/toolchain", tmp_dir),
-            &format!("{}/logs", tmp_dir),
+            &format!("{}/kernel.elf", tmp_dir.path()),
+            &format!("{}/linuxd.elf", tmp_dir.path()),
+            &format!("{}/uservm.elf", tmp_dir.path()),
+            &format!("{}/toolchain", tmp_dir.path()),
+            &format!("{}/logs", tmp_dir.path()),
             false,
-            &format!("{}/snapshot", tmp_dir),
-            &tmp_dir,
-        )
+            &format!("{}/snapshot", tmp_dir.path()),
+            tmp_dir.path(),
+        );
+        (config, tmp_dir)
     }
 
     ///
@@ -812,56 +846,55 @@ mod tests {
     ///
     /// # Returns
     ///
-    /// A sandbox cache configuration suitable for testing.
+    /// A tuple of the sandbox cache configuration and the temp directory handle.
+    /// The temp directory is automatically cleaned up when the handle is dropped.
     ///
     fn create_custom_test_config(
         console_file: Option<String>,
         hwloc: Option<HwLoc>,
         socket_type: SocketType,
         l2: bool,
-    ) -> SandboxCacheConfig<()> {
-        let tmp_dir: String = create_unique_tmp_dir();
+    ) -> (SandboxCacheConfig<()>, TempTestDir) {
+        let tmp_dir: TempTestDir = TempTestDir::new();
 
         #[cfg(feature = "single-process")]
-        {
-            SandboxCacheConfig::new(
-                socket_type,
-                socket_type,
-                socket_type,
-                console_file,
-                None,
-                hwloc,
-                128,
-                &format!("{}/kernel.elf", tmp_dir),
-                None,
-                &format!("{}/toolchain", tmp_dir),
-                &format!("{}/logs", tmp_dir),
-                l2,
-                &format!("{}/snapshot", tmp_dir),
-                &tmp_dir,
-            )
-        }
+        let config: SandboxCacheConfig<()> = SandboxCacheConfig::new(
+            socket_type,
+            socket_type,
+            socket_type,
+            console_file,
+            None,
+            hwloc,
+            128,
+            &format!("{}/kernel.elf", tmp_dir.path()),
+            None,
+            &format!("{}/toolchain", tmp_dir.path()),
+            &format!("{}/logs", tmp_dir.path()),
+            l2,
+            &format!("{}/snapshot", tmp_dir.path()),
+            tmp_dir.path(),
+        );
 
         #[cfg(not(feature = "single-process"))]
-        {
-            SandboxCacheConfig::new(
-                socket_type,
-                socket_type,
-                socket_type,
-                console_file,
-                None,
-                hwloc,
-                128,
-                &format!("{}/kernel.elf", tmp_dir),
-                &format!("{}/linuxd.elf", tmp_dir),
-                &format!("{}/uservm.elf", tmp_dir),
-                &format!("{}/toolchain", tmp_dir),
-                &format!("{}/logs", tmp_dir),
-                l2,
-                &format!("{}/snapshot", tmp_dir),
-                &tmp_dir,
-            )
-        }
+        let config: SandboxCacheConfig<()> = SandboxCacheConfig::new(
+            socket_type,
+            socket_type,
+            socket_type,
+            console_file,
+            None,
+            hwloc,
+            128,
+            &format!("{}/kernel.elf", tmp_dir.path()),
+            &format!("{}/linuxd.elf", tmp_dir.path()),
+            &format!("{}/uservm.elf", tmp_dir.path()),
+            &format!("{}/toolchain", tmp_dir.path()),
+            &format!("{}/logs", tmp_dir.path()),
+            l2,
+            &format!("{}/snapshot", tmp_dir.path()),
+            tmp_dir.path(),
+        );
+
+        (config, tmp_dir)
     }
 
     ///
@@ -871,7 +904,7 @@ mod tests {
     ///
     #[tokio::test]
     async fn test_new_creates_cache() {
-        let config: SandboxCacheConfig<()> = create_test_config();
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) = create_test_config();
         let result: Result<Arc<Mutex<SandboxCache<()>>>> = SandboxCache::new(config).await;
         assert!(result.is_ok());
     }
@@ -884,7 +917,7 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "single-process")]
     async fn test_new_single_process_mode() {
-        let config: SandboxCacheConfig<()> = create_test_config();
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) = create_test_config();
         let result: Result<Arc<Mutex<SandboxCache<()>>>> = SandboxCache::new(config).await;
         assert!(result.is_ok());
 
@@ -903,7 +936,7 @@ mod tests {
     #[tokio::test]
     #[cfg(not(feature = "single-process"))]
     async fn test_new_multi_process_mode() {
-        let config: SandboxCacheConfig<()> = create_test_config();
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) = create_test_config();
         let result: Result<Arc<Mutex<SandboxCache<()>>>> = SandboxCache::new(config).await;
         assert!(result.is_ok());
 
@@ -921,7 +954,7 @@ mod tests {
     #[tokio::test]
     #[cfg(not(feature = "single-process"))]
     async fn test_new_l2_mode() {
-        let config: SandboxCacheConfig<()> =
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) =
             create_custom_test_config(None, None, SocketType::Unix, true);
         let result: Result<Arc<Mutex<SandboxCache<()>>>> = SandboxCache::new(config).await;
         assert!(result.is_ok());
@@ -934,7 +967,7 @@ mod tests {
     ///
     #[tokio::test]
     async fn test_cleanup_empties_cache() {
-        let config: SandboxCacheConfig<()> = create_test_config();
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) = create_test_config();
         let cache: Arc<Mutex<SandboxCache<()>>> = SandboxCache::new(config).await.unwrap();
 
         {
@@ -951,7 +984,7 @@ mod tests {
     ///
     #[tokio::test]
     async fn test_kill_nonexistent_sandbox_fails() {
-        let config: SandboxCacheConfig<()> = create_test_config();
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) = create_test_config();
         let cache: Arc<Mutex<SandboxCache<()>>> = SandboxCache::new(config).await.unwrap();
 
         let mut cache_guard: tokio::sync::MutexGuard<SandboxCache<()>> = cache.lock().await;
@@ -1014,7 +1047,7 @@ mod tests {
     #[test]
     #[cfg(feature = "single-process")]
     fn test_config_single_process() {
-        let config: SandboxCacheConfig<()> = create_test_config();
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) = create_test_config();
         assert_eq!(config.control_plane_sockaddr_type(), SocketType::Unix);
         assert_eq!(config.gateway_sockaddr_type(), SocketType::Unix);
         assert_eq!(config.system_vm_sockaddr_type(), SocketType::Unix);
@@ -1034,7 +1067,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "single-process"))]
     fn test_config_multi_process() {
-        let config: SandboxCacheConfig<()> = create_test_config();
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) = create_test_config();
         assert_eq!(config.control_plane_sockaddr_type(), SocketType::Unix);
         assert_eq!(config.gateway_sockaddr_type(), SocketType::Unix);
         assert_eq!(config.system_vm_sockaddr_type(), SocketType::Unix);
@@ -1057,7 +1090,7 @@ mod tests {
     fn test_config_with_console_file() {
         let tmp_dir: String = ::std::env::temp_dir().to_string_lossy().to_string();
         let console_file: String = format!("{}/console.log", tmp_dir);
-        let config: SandboxCacheConfig<()> =
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) =
             create_custom_test_config(Some(console_file.clone()), None, SocketType::Unix, false);
         assert_eq!(config.console_file(), Some(console_file.as_str()));
     }
@@ -1069,7 +1102,7 @@ mod tests {
     ///
     #[test]
     fn test_config_without_hwloc() {
-        let config: SandboxCacheConfig<()> = create_test_config();
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) = create_test_config();
         assert!(config.hwloc().is_none());
     }
 
@@ -1081,7 +1114,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "single-process"))]
     fn test_config_with_l2_enabled() {
-        let config: SandboxCacheConfig<()> =
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) =
             create_custom_test_config(None, None, SocketType::Unix, true);
         assert!(config.l2());
     }
@@ -1093,7 +1126,7 @@ mod tests {
     ///
     #[test]
     fn test_config_socket_types() {
-        let config: SandboxCacheConfig<()> =
+        let (config, _tmp_dir): (SandboxCacheConfig<()>, TempTestDir) =
             create_custom_test_config(None, None, SocketType::Tcp, false);
         assert_eq!(config.control_plane_sockaddr_type(), SocketType::Tcp);
         assert_eq!(config.gateway_sockaddr_type(), SocketType::Tcp);


### PR DESCRIPTION
This pull request improves resource management and test reliability in the Nanvix sandbox cache by introducing automatic cleanup for temporary test directories, updating test utilities to use RAII patterns, and enhancing documentation and CI cleanup procedures. The changes ensure that stale resources are cleaned up both during testing and in CI environments, reducing manual intervention and preventing resource leaks.