### PR TITLE
[kernel] Store Pending Exit Status Handling

### DIFF
--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -68,6 +68,7 @@ use ::sys::{
         ProcessIdentifier,
         ThreadIdentifier,
     },
+    ExitStatus,
 };
 
 //==================================================================================================
@@ -152,6 +153,8 @@ pub struct ProcessState {
     mutexes: BTreeMap<MutexAddress, Mutex>,
     /// Condition variables.
     conditions: BTreeMap<ConditionAddress, Condvar>,
+    /// Pending exit status set when `exit()` is called with threads still running.
+    pending_exit_status: Option<ExitStatus>,
 }
 
 impl ProcessState {
@@ -166,11 +169,49 @@ impl ProcessState {
             pmio: LinkedList::new(),
             mutexes: BTreeMap::new(),
             conditions: BTreeMap::new(),
+            pending_exit_status: None,
         }
     }
 
     pub fn pid(&self) -> ProcessIdentifier {
         self.pid
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sets the pending exit status for the process if one is not already set. This is used
+    /// when a thread calls `exit()` to terminate the process, but there are other threads that
+    /// need to be terminated first. The exit status from the first thread that called `exit()`
+    /// is preserved and used as the final process exit status.
+    ///
+    /// If a pending exit status is already set (from an earlier `exit()` call), this function
+    /// does nothing, ensuring that the original exit status is not overwritten by subsequent
+    /// threads being terminated.
+    ///
+    /// # Parameters
+    ///
+    /// - `status`: The exit status to store (only if not already set).
+    ///
+    pub fn set_pending_exit_status(&mut self, status: ExitStatus) {
+        if self.pending_exit_status.is_none() {
+            self.pending_exit_status = Some(status);
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Takes the pending exit status, if any. Returns the stored exit status and clears it.
+    /// This is called when the last thread in the process terminates to retrieve the exit
+    /// status that was set by the thread that originally called `exit()`.
+    ///
+    /// # Returns
+    ///
+    /// The pending exit status if one was set, otherwise `None`.
+    ///
+    pub fn take_pending_exit_status(&mut self) -> Option<ExitStatus> {
+        self.pending_exit_status.take()
     }
 
     pub fn set_capability(&mut self, capability: Capability) {

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -38,6 +38,7 @@ use sys::{
     mm::VirtualAddress,
     pm::ThreadIdentifier,
     time::SystemTime,
+    ExitStatus,
 };
 
 //==================================================================================================
@@ -179,7 +180,13 @@ impl RunnableProcess {
         if let Some(interrupted_threads) = interrupted_threads {
             Ok(InterruptedProcess::new(self.state, interrupted_threads, Some(zombie_threads)))
         } else {
-            Err(ZombieProcess::new(self.state, zombie_threads, ErrorCode::Interrupted.into()))
+            // Use pending exit status if set (from a prior exit() call), otherwise use
+            // Interrupted error code.
+            let final_status: ExitStatus = self
+                .state
+                .take_pending_exit_status()
+                .unwrap_or_else(|| ErrorCode::Interrupted.into());
+            Err(ZombieProcess::new(self.state, zombie_threads, final_status))
         }
     }
 

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -214,6 +214,11 @@ impl RunningProcess {
         }
 
         if let Some(interrupted_threads) = interrupted_threads {
+            // Store the pending exit status so that when the last thread terminates,
+            // the process uses this status (from the thread that called exit()) instead of
+            // the status from the terminated threads.
+            self.state.set_pending_exit_status(status);
+
             let interrupted_process: InterruptedProcess = InterruptedProcess::from_sleeping(
                 self.state,
                 self.sleeping_threads.take(),
@@ -223,7 +228,10 @@ impl RunningProcess {
 
             Ok((interrupted_process.resume(), ctx))
         } else {
-            Err((ZombieProcess::new(self.state, zombie_threads, status), ctx))
+            // Use pending exit status if set (from a prior exit() call), otherwise use current
+            // thread's status.
+            let final_status: ExitStatus = self.state.take_pending_exit_status().unwrap_or(status);
+            Err((ZombieProcess::new(self.state, zombie_threads, final_status), ctx))
         }
     }
 
@@ -294,7 +302,10 @@ impl RunningProcess {
                 ctx,
             )))
         } else {
-            Err(Err((join_cond, ZombieProcess::new(self.state, zombie_threads, status), ctx)))
+            // Use pending exit status if set (from a prior exit() call), otherwise use current
+            // thread's status.
+            let final_status: ExitStatus = self.state.take_pending_exit_status().unwrap_or(status);
+            Err(Err((join_cond, ZombieProcess::new(self.state, zombie_threads, final_status), ctx)))
         }
     }
 


### PR DESCRIPTION
This pull request updates the process exit handling logic in the kernel's process manager to ensure that the exit status set by the first thread to call `exit()` is preserved and used as the final process exit status, even if other threads are still running. If multiple threads terminate, only the original exit status is kept, preventing it from being overwritten by subsequent thread terminations. The main changes introduce a new `pending_exit_status` field and related methods, and update the logic for transitioning processes to the zombie state.