### PR TITLE
[kernel] Shutdown Support for Hyperlight

### DIFF
--- a/build/hyperlight_config.rs.template
+++ b/build/hyperlight_config.rs.template
@@ -11,8 +11,6 @@ pub mod hyperlight {
     pub const DEFAULT_INITRD_BASE: usize = {{DEFAULT_INITRD_BASE}};
     /// Number of bytes used to store initrd's size.
     pub const INITRD_SIZE_BYTES: usize = {{INITRD_SIZE_BYTES}};
-    /// Default VMM shutdown command.
-    pub const DEFAULT_VMM_SHUTDOWN_CMD: u8 = {{DEFAULT_VMM_SHUTDOWN_CMD}};
     /// Size of the process environment block (in bytes).
     pub const PEB_SIZE: usize = {{PEB_SIZE}};
     /// Size of the host function definitions area (in bytes).

--- a/build/hyperlight_constants.toml
+++ b/build/hyperlight_constants.toml
@@ -19,9 +19,6 @@ default_initrd_base = 0x00c02000
 # Number of bytes used to store initrd's size.
 initrd_size_bytes = 8
 
-# Default VMM shutdown command.
-default_vmm_shutdown_cmd = 0x20
-
 # Size of the process environment block (in pages).
 peb_pages = 1
 

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -223,14 +223,21 @@ pub unsafe fn vmbus_read(addr: *mut u8) {
 ///
 /// # Parameters
 ///
-/// - `status`: The shutdown status code.
+/// - `status`: The shutdown status code (low 8 bits are passed to the VMM).
 ///
 /// # Return
 ///
 /// This function never returns.
 ///
-pub fn shutdown(_status: usize) -> ! {
-    ::hyperlight_guest::exit::abort_with_code(&[::config::hyperlight::DEFAULT_VMM_SHUTDOWN_CMD]);
+pub fn shutdown(status: usize) -> ! {
+    // Pass the low 8 bits of status as the exit code to the VMM.
+    let code: u8 = (status & 0xFF) as u8;
+    // NOTE: We use abort_with_code() for all exit codes (including 0) rather than halt() because
+    // halt() takes longer to propagate through hyperlight's host machinery. Due to issue #1010,
+    // the orchestrator sends SIGKILL immediately upon receiving a shutdown command, which can
+    // kill the vCPU thread before halt() completes. Using abort_with_code() is faster and avoids
+    // this race condition.
+    ::hyperlight_guest::exit::abort_with_code(&[code]);
 }
 
 ///

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -246,7 +246,6 @@ macro_rules! define_parse_hex_or_decimal {
 
 define_parse_hex_or_decimal!(parse_hex_or_decimal_usize, usize);
 define_parse_hex_or_decimal!(parse_hex_or_decimal_u32, u32);
-define_parse_hex_or_decimal!(parse_hex_or_decimal_u8, u8);
 
 ///
 /// # Description
@@ -309,13 +308,6 @@ fn generate_hyperlight_config(
         .parse()
         .expect("Failed to parse initrd_size_bytes as usize");
     template = template.replace("{{INITRD_SIZE_BYTES}}", &initrd_size_val.to_string());
-
-    // VMM shutdown command.
-    let shutdown_cmd: &str = config
-        .get("default_vmm_shutdown_cmd")
-        .expect("default_vmm_shutdown_cmd not found in hyperlight_constants.toml");
-    let shutdown_cmd_val: u8 = parse_hex_or_decimal_u8(shutdown_cmd, "default_vmm_shutdown_cmd");
-    template = template.replace("{{DEFAULT_VMM_SHUTDOWN_CMD}}", &format!("{shutdown_cmd_val:#x}"));
 
     // PEB size (in pages -> bytes).
     let peb_pages: &str = config

--- a/src/uservm/src/orchestrator.rs
+++ b/src/uservm/src/orchestrator.rs
@@ -498,6 +498,10 @@ impl Orchestrator {
                     // itself, we kill it here. This may populate the logs with an error message
                     // during shutdown, but is functionally equivalent.
                     if #[cfg(feature = "hyperlight")] {
+                        // Wait for a grace period to allow the kernel's abort_with_code() to complete
+                        // before sending SIGKILL. See issue #1010 for context.
+                        debug!("try_receive_from_io_thread(): waiting {:?} before killing vcpu thread", crate::vmm::SHUTDOWN_GRACE_PERIOD);
+                        ::std::thread::sleep(crate::vmm::SHUTDOWN_GRACE_PERIOD);
                         debug!("try_receive_from_io_thread(): killing vcpu thread id: {}", self.vcpu_tid);
                         let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
                         unsafe { ::libc::pthread_kill(pthread_id, KILL_SIGNAL) };

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -387,21 +387,27 @@ impl Vmm {
         // Parse result.
         match result {
             Ok(_multiuse_sandbox) => {
-                error!("run(): vmm exited");
-                Ok(ErrorCode::ConnectionAborted.into())
+                // Successful completion via halt().
+                debug!("run(): vmm exited normally");
+                Ok(0)
             },
             Err(error) => {
-                // note: this is a bit of a hack to check for the shutdown command.
-                if !error
-                    .to_string()
-                    .contains(&::config::hyperlight::DEFAULT_VMM_SHUTDOWN_CMD.to_string())
-                {
-                    error!("run(): vmm aborted (error={error:?})");
-                    Ok(ErrorCode::ConnectionReset.into())
-                } else {
-                    // FIXME (#1010): the vCPU thread already returns 0 always, but we will be able to remove
-                    // this line once we can join the vCPU thread.
-                    Ok(0)
+                // Extract numeric exit code from GuestAborted error.
+                // NOTE: The kernel uses abort_with_code() for all exit codes (including 0) rather
+                // than halt() to avoid a race condition with SIGKILL. See issue #1010.
+                match error {
+                    HyperlightError::GuestAborted(code, ref message) => {
+                        if message.is_empty() {
+                            debug!("run(): guest exited (code={code})");
+                        } else {
+                            debug!("run(): guest exited (code={code}, message={message})");
+                        }
+                        Ok(code as u16)
+                    },
+                    _ => {
+                        error!("run(): vmm aborted (error={error:?})");
+                        Ok(ErrorCode::ConnectionReset.into())
+                    },
                 }
             },
         }

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -40,6 +40,7 @@ use ::std::{
     os::raw::c_int,
     path::Path,
     sync::Arc,
+    time::Duration,
 };
 use ::sys::error::ErrorCode;
 use ::syslog::{
@@ -64,6 +65,11 @@ pub const INTERRUPT_SIGNAL: c_int = libc::SIGUSR1;
 
 /// Signal used to kill the vCPU thread.
 pub const KILL_SIGNAL: c_int = libc::SIGKILL;
+
+/// Grace period before sending SIGKILL to the vCPU thread during shutdown.
+/// This allows the kernel's `abort_with_code()` to complete before the thread is killed.
+/// See issue #1010 for more context on this workaround.
+pub const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_millis(100);
 
 //==================================================================================================
 // Types


### PR DESCRIPTION
This pull request refactors how the VMM shutdown and exit codes are handled in the Hyperlight platform. The main change is the removal of the hardcoded default shutdown command in favor of passing explicit status codes, allowing for more flexible and meaningful exit signaling between the guest and the VMM. The shutdown logic, configuration, and error handling are updated accordingly.