### PR TITLE
[nanvix-registry] Support Package Management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ arch = { path = "src/libs/arch", default-features = false }
 anyhow = "1.0.98"
 base64 = "0.22.1"
 bitmap = { path = "src/libs/bitmap", default-features = false }
+bytes = "1.10.1"
 cc = "1.2.26"
 cfg-if = "1.0.0"
 chrono = "0.4.42"
@@ -132,6 +133,7 @@ serde_cbor = { version = "0.11.2", default-features = false, features = [
 serde_json = { version = "1.0.140", default-features = false, features = [
         "alloc",
 ] }
+sha2 = "0.10.8"
 shell-words = "1.1"
 signal-hook = "0.4.1"
 slab = { path = "src/libs/slab", default-features = false }

--- a/src/libs/nanvix-registry/Cargo.toml
+++ b/src/libs/nanvix-registry/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bytes = { workspace = true }
 syslog = { workspace = true, features = ["std"] }
 dirs = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = [
@@ -20,6 +21,7 @@ reqwest = { workspace = true, default-features = false, features = [
 ] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true, features = ["std", "v4"] }
 

--- a/src/libs/nanvix-registry/src/checksum.rs
+++ b/src/libs/nanvix-registry/src/checksum.rs
@@ -1,0 +1,169 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sha2::{
+    Digest,
+    Sha256,
+};
+use ::syslog::debug;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Computes the SHA256 hash of a byte slice.
+///
+/// # Parameters
+///
+/// - `data`: The data to hash.
+///
+/// # Returns
+///
+/// The SHA256 hash as a lowercase hexadecimal string.
+///
+pub(crate) fn compute_sha256(data: &[u8]) -> String {
+    let mut hasher: Sha256 = Sha256::new();
+    hasher.update(data);
+    let result: sha2::digest::Output<Sha256> = hasher.finalize();
+    hex_encode(&result)
+}
+
+///
+/// # Description
+///
+/// Verifies that data matches an expected SHA256 checksum.
+///
+/// # Parameters
+///
+/// - `data`: The data to verify.
+/// - `expected_checksum`: The expected SHA256 checksum as a hexadecimal string.
+///
+/// # Returns
+///
+/// `true` if the computed checksum matches the expected checksum, `false` otherwise.
+///
+pub(crate) fn verify_sha256(data: &[u8], expected_checksum: &str) -> bool {
+    let computed: String = compute_sha256(data);
+    let expected_normalized: String = expected_checksum.to_lowercase().trim().to_string();
+    let matches: bool = computed == expected_normalized;
+    if !matches {
+        debug!("Checksum mismatch: expected '{}', computed '{}'", expected_normalized, computed);
+    }
+    matches
+}
+
+///
+/// # Description
+///
+/// Converts a byte slice to a lowercase hexadecimal string.
+///
+/// # Parameters
+///
+/// - `bytes`: The bytes to convert.
+///
+/// # Returns
+///
+/// A lowercase hexadecimal string representation of the bytes.
+///
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests SHA256 computation for known test vectors.
+    ///
+    #[test]
+    fn test_compute_sha256_empty() {
+        // SHA256 of empty string is a known value.
+        let hash: String = compute_sha256(b"");
+        assert_eq!(hash, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests SHA256 computation for "hello" string.
+    ///
+    #[test]
+    fn test_compute_sha256_hello() {
+        let hash: String = compute_sha256(b"hello");
+        assert_eq!(hash, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests SHA256 verification with matching checksum.
+    ///
+    #[test]
+    fn test_verify_sha256_match() {
+        let data: &[u8] = b"hello";
+        let checksum: &str = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+        assert!(verify_sha256(data, checksum));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests SHA256 verification with uppercase checksum.
+    ///
+    #[test]
+    fn test_verify_sha256_uppercase() {
+        let data: &[u8] = b"hello";
+        let checksum: &str = "2CF24DBA5FB0A30E26E83B2AC5B9E29E1B161E5C1FA7425E73043362938B9824";
+        assert!(verify_sha256(data, checksum));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests SHA256 verification with checksum containing whitespace.
+    ///
+    #[test]
+    fn test_verify_sha256_with_whitespace() {
+        let data: &[u8] = b"hello";
+        let checksum: &str =
+            "  2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824  \n";
+        assert!(verify_sha256(data, checksum));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests SHA256 verification with mismatched checksum.
+    ///
+    #[test]
+    fn test_verify_sha256_mismatch() {
+        let data: &[u8] = b"hello";
+        let wrong_checksum: &str =
+            "0000000000000000000000000000000000000000000000000000000000000000";
+        assert!(!verify_sha256(data, wrong_checksum));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests hex encoding.
+    ///
+    #[test]
+    fn test_hex_encode() {
+        assert_eq!(hex_encode(&[0x00, 0xff, 0x10, 0xab]), "00ff10ab");
+    }
+}

--- a/src/libs/nanvix-registry/src/deployment.rs
+++ b/src/libs/nanvix-registry/src/deployment.rs
@@ -95,7 +95,7 @@ impl TryFrom<&str> for Deployment {
             Self::SINGLE_PROCESS_STR => Ok(Deployment::SingleProcess),
             Self::MULTI_PROCESS_STR => Ok(Deployment::MultiProcess),
             _ => {
-                let reason: String = format!("Unknown deployment type: {}", value);
+                let reason: String = format!("Unknown deployment type: {value}");
                 error!("{reason}");
                 anyhow::bail!(reason)
             },

--- a/src/libs/nanvix-registry/src/github_client.rs
+++ b/src/libs/nanvix-registry/src/github_client.rs
@@ -1,0 +1,176 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::reqwest::{
+    Client,
+    RequestBuilder,
+};
+use ::syslog::{
+    debug,
+    error,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Environment variable name for GitHub token (primary).
+const GITHUB_TOKEN_ENV: &str = "GITHUB_TOKEN";
+
+/// Environment variable name for GitHub token (fallback, GitHub CLI convention).
+const GH_TOKEN_ENV: &str = "GH_TOKEN";
+
+/// User-Agent header value for all requests.
+const USER_AGENT: &str = "nanvix-registry";
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Retrieves the GitHub authentication token from environment variables.
+///
+/// Checks `GITHUB_TOKEN` first, then falls back to `GH_TOKEN` (GitHub CLI convention).
+///
+/// # Returns
+///
+/// The token as a `Some(String)` if found, or `None` if neither variable is set.
+///
+pub(crate) fn get_github_token() -> Option<String> {
+    if let Ok(token) = ::std::env::var(GITHUB_TOKEN_ENV) {
+        if !token.is_empty() {
+            debug!("Using GitHub token from {}", GITHUB_TOKEN_ENV);
+            return Some(token);
+        }
+    }
+
+    if let Ok(token) = ::std::env::var(GH_TOKEN_ENV) {
+        if !token.is_empty() {
+            debug!("Using GitHub token from {}", GH_TOKEN_ENV);
+            return Some(token);
+        }
+    }
+
+    debug!("No GitHub token found in environment");
+    None
+}
+
+///
+/// # Description
+///
+/// Returns whether a GitHub authentication token is available.
+///
+/// # Returns
+///
+/// `true` if a token is available, `false` otherwise.
+///
+pub(crate) fn is_authenticated() -> bool {
+    get_github_token().is_some()
+}
+
+///
+/// # Description
+///
+/// Builds a `reqwest::Client` with a default `User-Agent` header.
+///
+/// # Returns
+///
+/// On success, returns a configured `Client`. On failure, returns an error.
+///
+pub(crate) fn build_client() -> Result<Client> {
+    match Client::builder().user_agent(USER_AGENT).build() {
+        Ok(client) => Ok(client),
+        Err(error) => {
+            let reason: String = format!("Failed to build HTTP client: {error}");
+            error!("{reason}");
+            anyhow::bail!(reason)
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Creates an authenticated GET request using the provided client.
+///
+/// If a GitHub token is available in the environment, the `Authorization: Bearer <token>` header
+/// is added to the request. Otherwise, the request is sent without authentication.
+///
+/// # Parameters
+///
+/// - `client`: The HTTP client to use for the request.
+/// - `url`: The URL to send the GET request to.
+///
+/// # Returns
+///
+/// A `RequestBuilder` with the appropriate authentication headers set.
+///
+pub(crate) fn authenticated_get(client: &Client, url: &str) -> RequestBuilder {
+    let request: RequestBuilder = client.get(url);
+
+    if let Some(token) = get_github_token() {
+        debug!("Adding Bearer token to request");
+        request.header("Authorization", format!("Bearer {token}"))
+    } else {
+        request
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests that build_client creates a client successfully.
+    ///
+    #[test]
+    fn test_build_client() {
+        let result: Result<Client> = build_client();
+        assert!(result.is_ok());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that authenticated_get returns a request builder.
+    ///
+    #[test]
+    fn test_authenticated_get() {
+        let client: Client = build_client().expect("failed to build HTTP client");
+        let _request: RequestBuilder = authenticated_get(&client, "https://example.com");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests the user agent constant.
+    ///
+    #[test]
+    fn test_user_agent() {
+        assert_eq!(USER_AGENT, "nanvix-registry");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests the environment variable name constants.
+    ///
+    #[test]
+    fn test_env_var_names() {
+        assert_eq!(GITHUB_TOKEN_ENV, "GITHUB_TOKEN");
+        assert_eq!(GH_TOKEN_ENV, "GH_TOKEN");
+    }
+}

--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -7,7 +7,8 @@
 //! The `nanvix-registry` library provides functionality for managing a local cache of Nanvix
 //! release binaries downloaded from GitHub releases. It automatically downloads, extracts, and
 //! caches binaries for different deployment types and target machines, supporting multiple
-//! versions to coexist simultaneously.
+//! versions to coexist simultaneously. Additionally, it supports installing third-party packages
+//! with automatic dependency resolution.
 //!
 //! # Features
 //!
@@ -20,6 +21,18 @@
 //! - Cache management (automatic reuse and manual clearing).
 //! - Tracks latest downloaded artifacts via release registry.
 //! - Allows multiple versions of each machine-deployment configuration to coexist.
+//! - Package installation with transitive dependency resolution.
+//!
+//! # Supported Packages
+//!
+//! The following packages can be installed using the registry:
+//!
+//! - `openblas`: OpenBLAS library for linear algebra operations.
+//! - `openssl`: OpenSSL cryptographic library.
+//! - `sqlite`: SQLite embedded database library.
+//! - `zlib`: Zlib compression library.
+//! - `quickjs`: QuickJS JavaScript engine.
+//! - `cpython` (or `python`, `python3`): CPython interpreter.
 //!
 //! # Usage
 //!
@@ -42,6 +55,28 @@
 //!
 //!     // Clear the cache when needed.
 //!     registry.clear_cache().await?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Installing Packages
+//!
+//! ```no_run
+//! use nanvix_registry::Registry;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let registry: Registry = Registry::new(None);
+//!
+//!     // Install CPython and all its dependencies.
+//!     // This will automatically download openssl, zlib, and other required packages.
+//!     // Use `true` to fall back to latest version if compatible version not found.
+//!     let install_path: String = registry
+//!         .install("microvm", "single-process", "python", true)
+//!         .await?;
+//!
+//!     println!("Python installed to: {}", install_path);
 //!
 //!     Ok(())
 //! }
@@ -75,6 +110,7 @@
 //! - `deployment`: Defines deployment types (`SingleProcess`, `MultiProcess`).
 //! - `machine`: Defines target machine types (`Hyperlight`, `microvm`).
 //! - `metadata`: Manages release registry tracking multiple machine-deployment configurations.
+//! - `package`: Defines package types and handles package downloads from GitHub.
 //! - `release`: Handles fetching and downloading releases from GitHub API.
 //! - `tarball`: Provides tarball extraction functionality.
 //! - `tempfile`: Manages temporary files with automatic cleanup.
@@ -96,16 +132,21 @@
 //! # Metadata
 //!
 //! The registry maintains a `release-metadata.json` file in the cache directory root that tracks
-//! multiple machine-deployment configurations. Each entry in the registry contains:
+//! multiple machine-deployment configurations and installed packages. Each release entry contains:
 //! - The URL of the release tarball.
 //! - The commit ID of the downloaded artifacts.
 //!
-//! The key format is `<machine>-<deployment>` (e.g., "microvm-single-process"), and multiple
-//! versions can coexist in separate subdirectories. The registry tracks the most recent commit ID
-//! for each configuration, enabling the library to:
+//! Each package entry contains:
+//! - The URL of the package tarball.
+//! - The Nanvix commit ID the package is built for.
+//!
+//! The key format is `<machine>-<deployment>` for releases and `<machine>-<deployment>-<package>`
+//! for packages. Multiple versions can coexist in separate subdirectories. The registry tracks
+//! the most recent commit ID for each configuration, enabling the library to:
 //! - Detect when new releases are available for specific configurations.
 //! - Automatically download new releases while preserving older versions.
 //! - Support side-by-side deployment of different machine-deployment combinations.
+//! - Track installed packages and their versions.
 
 //==================================================================================================
 // Lint Configuration
@@ -132,9 +173,14 @@
 // Private Modules
 //==================================================================================================
 
+mod checksum;
 mod deployment;
+mod github_client;
 mod machine;
 mod metadata;
+mod package;
+mod progress;
+mod rate_limiter;
 mod release;
 mod tarball;
 mod tempfile;
@@ -146,6 +192,13 @@ mod tempfile;
 pub use crate::{
     deployment::Deployment,
     machine::Machine,
+    package::Package,
+    progress::{
+        LoggingProgress,
+        NoOpProgress,
+        ProgressCallback,
+        SharedProgress,
+    },
 };
 
 //==================================================================================================
@@ -154,10 +207,21 @@ pub use crate::{
 
 use crate::{
     metadata::ReleaseRegistry,
+    package::{
+        PackageDependencies,
+        PackageRelease,
+    },
     release::LatestRelease,
 };
 use ::anyhow::Result;
-use ::std::path::PathBuf;
+use ::std::{
+    collections::HashSet,
+    path::{
+        Path,
+        PathBuf,
+    },
+    sync::Arc,
+};
 use ::syslog::{
     debug,
     error,
@@ -179,6 +243,61 @@ const BINARY_DIRECTORY_NAME: &str = "bin";
 //==================================================================================================
 // Structures
 //==================================================================================================
+
+///
+/// # Description
+///
+/// Context for package installation operations.
+///
+/// This struct groups related parameters for the recursive package installation process,
+/// reducing the number of function arguments and improving code maintainability.
+///
+struct InstallContext<'a> {
+    /// Target machine type.
+    machine: Machine,
+    /// Deployment type.
+    deployment: Deployment,
+    /// Nanvix commit ID.
+    commit_id: &'a str,
+    /// Cache directory path.
+    cache_dir: &'a Path,
+    /// Whether to fall back to latest release when compatible version is not found.
+    use_latest_fallback: bool,
+    /// Progress callback for reporting installation progress.
+    progress: Arc<dyn ProgressCallback>,
+}
+
+impl<'a> InstallContext<'a> {
+    /// Returns the target machine type.
+    fn machine(&self) -> Machine {
+        self.machine
+    }
+
+    /// Returns the deployment type.
+    fn deployment(&self) -> Deployment {
+        self.deployment
+    }
+
+    /// Returns the Nanvix commit ID.
+    fn commit_id(&self) -> &str {
+        self.commit_id
+    }
+
+    /// Returns the cache directory path.
+    fn cache_dir(&self) -> &Path {
+        self.cache_dir
+    }
+
+    /// Returns whether to fall back to latest release.
+    fn use_latest_fallback(&self) -> bool {
+        self.use_latest_fallback
+    }
+
+    /// Returns the progress callback.
+    fn progress(&self) -> &dyn ProgressCallback {
+        self.progress.as_ref()
+    }
+}
 
 ///
 /// # Description
@@ -402,8 +521,7 @@ impl Registry {
                 id
             },
             None => {
-                let reason: String =
-                    format!("Failed to extract commit ID from URL: {}", latest_url);
+                let reason: String = format!("Failed to extract commit ID from URL: {latest_url}");
                 error!("{reason}");
                 anyhow::bail!(reason);
             },
@@ -459,8 +577,7 @@ impl Registry {
         if needs_download {
             // Create the artifact cache directory.
             if let Err(error) = fs::create_dir_all(&artifact_cache_dir).await {
-                let reason: String =
-                    format!("Failed to create artifact cache directory: {}", error);
+                let reason: String = format!("Failed to create artifact cache directory: {error}");
                 error!("{reason}");
                 anyhow::bail!(reason);
             }
@@ -490,6 +607,347 @@ impl Registry {
                 anyhow::bail!(reason);
             },
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Installs a package and its dependencies for the current Nanvix release.
+    ///
+    /// This method first ensures the Nanvix release is cached, then downloads and installs the
+    /// specified package and all its transitive dependencies. Packages are installed in the
+    /// cache directory matching the Nanvix version.
+    ///
+    /// # Parameters
+    ///
+    /// - `machine`: Target machine type. Supported values:
+    ///   - `"hyperlight"`: Hyperlight machine type.
+    ///   - `"microvm"`: microvm machine type.
+    /// - `deployment`: Deployment type. Supported values:
+    ///   - `"single-process"`: Single-process deployment mode.
+    ///   - `"multi-process"`: Multi-process deployment mode.
+    /// - `package_name`: Name of the package to install. Supported packages:
+    ///   - `"openblas"`: OpenBLAS library.
+    ///   - `"openssl"`: OpenSSL library.
+    ///   - `"sqlite"`: SQLite library.
+    ///   - `"zlib"`: Zlib compression library.
+    ///   - `"quickjs"`: QuickJS JavaScript engine.
+    ///   - `"cpython"` / `"python"` / `"python3"`: CPython interpreter.
+    /// - `use_latest_fallback`: If `true`, falls back to the latest available package version
+    ///   when a version compatible with the current Nanvix release is not found. If `false`,
+    ///   returns an error when no compatible version exists.
+    ///
+    /// # Returns
+    ///
+    /// The absolute path to the directory where the package was installed.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if:
+    /// - The machine type is not recognized.
+    /// - The deployment type is not recognized.
+    /// - The package name is not recognized.
+    /// - The GitHub API request fails.
+    /// - The package tarball cannot be downloaded or extracted.
+    /// - A dependency cannot be installed.
+    /// - File system operations fail.
+    /// - No compatible package version is found and `use_latest_fallback` is `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use nanvix_registry::Registry;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> anyhow::Result<()> {
+    ///     let registry: Registry = Registry::new(None);
+    ///
+    ///     // Install CPython and its dependencies (strict mode - requires compatible version).
+    ///     let install_path: String = registry
+    ///         .install("microvm", "single-process", "python", false)
+    ///         .await?;
+    ///
+    ///     // Install with fallback to latest if compatible version not found.
+    ///     let install_path: String = registry
+    ///         .install("microvm", "single-process", "python", true)
+    ///         .await?;
+    ///
+    ///     println!("Package installed to: {}", install_path);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    pub async fn install(
+        &self,
+        machine: &str,
+        deployment: &str,
+        package_name: &str,
+        use_latest_fallback: bool,
+    ) -> Result<String> {
+        self.install_with_progress(
+            machine,
+            deployment,
+            package_name,
+            use_latest_fallback,
+            Arc::new(NoOpProgress),
+        )
+        .await
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Installs a package and its dependencies with progress reporting.
+    ///
+    /// This method is identical to [`install`](Self::install) but accepts a progress callback
+    /// to receive updates during the installation process.
+    ///
+    /// # Parameters
+    ///
+    /// - `machine`: Target machine type (see [`install`](Self::install) for supported values).
+    /// - `deployment`: Deployment type (see [`install`](Self::install) for supported values).
+    /// - `package_name`: Name of the package to install.
+    /// - `use_latest_fallback`: If `true`, falls back to latest version when compatible not found.
+    /// - `progress`: A shared progress callback to receive installation updates.
+    ///
+    /// # Returns
+    ///
+    /// The absolute path to the directory where the package was installed.
+    ///
+    /// # Errors
+    ///
+    /// Same error conditions as [`install`](Self::install).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use nanvix_registry::{Registry, LoggingProgress};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> anyhow::Result<()> {
+    ///     let registry: Registry = Registry::new(None);
+    ///     let progress = Arc::new(LoggingProgress);
+    ///
+    ///     let install_path: String = registry
+    ///         .install_with_progress("microvm", "single-process", "python", true, progress)
+    ///         .await?;
+    ///
+    ///     println!("Package installed to: {}", install_path);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    pub async fn install_with_progress(
+        &self,
+        machine: &str,
+        deployment: &str,
+        package_name: &str,
+        use_latest_fallback: bool,
+        progress: SharedProgress,
+    ) -> Result<String> {
+        let cache_dir: PathBuf = self.get_cache_dir().await?;
+
+        // Convert machine from string representation.
+        let machine: Machine = Machine::try_from(machine)?;
+
+        // Convert deployment from string representation.
+        let deployment: Deployment = Deployment::try_from(deployment)?;
+
+        // Convert package from string representation.
+        let package: Package = Package::try_from(package_name)?;
+
+        // First, ensure we have the Nanvix release cached to get the commit ID.
+        let release: LatestRelease = LatestRelease::new(deployment, machine);
+        let latest_url: String = release.get_url().await?;
+
+        let commit_id: String = match Self::extract_commit_id(&latest_url) {
+            Some(id) => {
+                debug!("Nanvix commit ID: {}", id);
+                id
+            },
+            None => {
+                let reason: String = format!("Failed to extract commit ID from URL: {latest_url}");
+                error!("{reason}");
+                anyhow::bail!(reason);
+            },
+        };
+
+        // Load or create the release registry once at the start.
+        let mut registry: ReleaseRegistry = if ReleaseRegistry::exists(&cache_dir).await {
+            match ReleaseRegistry::load(&cache_dir).await {
+                Ok(reg) => reg,
+                Err(error) => {
+                    let reason: String = format!("Failed to load registry: {error}");
+                    error!("{reason}");
+                    anyhow::bail!(reason)
+                },
+            }
+        } else {
+            info!("Creating a new registry...");
+            ReleaseRegistry::new()
+        };
+
+        // Install the package (and dependencies) recursively.
+        let context: InstallContext<'_> = InstallContext {
+            machine,
+            deployment,
+            commit_id: &commit_id,
+            cache_dir: &cache_dir,
+            use_latest_fallback,
+            progress,
+        };
+        let mut in_progress: HashSet<Package> = HashSet::new();
+        self.install_package_recursive(&context, package, &mut registry, &mut in_progress)
+            .await
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Internal helper method to recursively install a package and its dependencies.
+    ///
+    /// # Parameters
+    ///
+    /// - `context`: The installation context containing machine, deployment, commit ID,
+    ///   cache directory, and fallback settings.
+    /// - `package`: The package to install.
+    /// - `registry`: Mutable reference to the release registry for tracking installations.
+    /// - `in_progress`: Set of packages currently being installed, used to detect circular
+    ///   dependencies.
+    ///
+    /// # Returns
+    ///
+    /// The absolute path to the directory where the package was installed.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the package or any dependency cannot be installed,
+    /// or if a circular dependency is detected.
+    ///
+    async fn install_package_recursive(
+        &self,
+        context: &InstallContext<'_>,
+        package: Package,
+        registry: &mut ReleaseRegistry,
+        in_progress: &mut HashSet<Package>,
+    ) -> Result<String> {
+        // Detect circular dependencies.
+        if !in_progress.insert(package) {
+            let reason: String = format!("Circular dependency detected for package {package}");
+            error!("{reason}");
+            anyhow::bail!(reason);
+        }
+
+        // Check if package is already installed for this configuration.
+        if registry.is_package_installed(
+            context.machine(),
+            context.deployment(),
+            package,
+            context.commit_id(),
+        ) {
+            let subdir_name: String =
+                format!("{}-{}-{}", context.machine(), context.deployment(), context.commit_id());
+            let package_dir: PathBuf = context.cache_dir().join(&subdir_name);
+            info!(
+                "Package {} already installed for {}-{}-{}",
+                package,
+                context.machine(),
+                context.deployment(),
+                context.commit_id()
+            );
+            in_progress.remove(&package);
+            return Ok(package_dir.to_string_lossy().to_string());
+        }
+
+        // Create package release handle.
+        let package_release: PackageRelease = PackageRelease::new(
+            package,
+            context.deployment(),
+            context.machine(),
+            context.commit_id().to_string(),
+            context.use_latest_fallback(),
+        )?;
+
+        // First, fetch and install dependencies.
+        let dependencies: PackageDependencies = package_release.get_dependencies().await?;
+        for dep_name in dependencies.dependencies() {
+            let dep_package: Package = match Package::try_from(dep_name.as_str()) {
+                Ok(p) => p,
+                Err(error) => {
+                    let reason: String = format!(
+                        "Unknown dependency '{}' for package {}: {}",
+                        dep_name, package, error
+                    );
+                    error!("{reason}");
+                    anyhow::bail!(reason)
+                },
+            };
+
+            // Notify progress callback about dependency installation.
+            context
+                .progress()
+                .on_dependency_start(dep_name, package.as_str());
+
+            info!("Installing dependency {} for package {}", dep_package, package);
+
+            // Recursively install the dependency using Box::pin to avoid recursion issues.
+            Box::pin(self.install_package_recursive(context, dep_package, registry, in_progress))
+                .await?;
+        }
+
+        // Now install the package itself.
+        let subdir_name: String =
+            format!("{}-{}-{}", context.machine(), context.deployment(), context.commit_id());
+        let package_dir: PathBuf = context.cache_dir().join(&subdir_name);
+
+        // Create the package directory if it doesn't exist.
+        if let Err(error) = fs::create_dir_all(&package_dir).await {
+            let reason: String = format!("Failed to create package directory: {error}");
+            error!("{reason}");
+            anyhow::bail!(reason);
+        }
+
+        info!(
+            "Installing package {} for {}-{}-{}",
+            package,
+            context.machine(),
+            context.deployment(),
+            context.commit_id()
+        );
+
+        // Notify progress callback about download start.
+        context.progress().on_download_start(package.as_str(), None);
+
+        // Download and extract the package.
+        let downloaded_url: String = package_release.download(&package_dir).await?;
+
+        // Notify progress callback about download completion.
+        context.progress().on_download_complete(package.as_str());
+
+        // Notify progress callback about extraction start.
+        context.progress().on_extract_start(package.as_str());
+
+        // Update and save the registry with the installed package.
+        // We save after each package to persist partial progress on failure.
+        registry.set_package(
+            context.machine(),
+            context.deployment(),
+            package,
+            downloaded_url,
+            context.commit_id().to_string(),
+        );
+        registry.save(context.cache_dir()).await?;
+
+        // Notify progress callback about extraction completion.
+        context.progress().on_extract_complete(package.as_str());
+
+        info!("Successfully installed package {} to {:?}", package, package_dir);
+
+        in_progress.remove(&package);
+        Ok(package_dir.to_string_lossy().to_string())
     }
 
     ///
@@ -677,7 +1135,7 @@ impl Registry {
                     anyhow::bail!(reason);
                 },
                 Err(error) => {
-                    let reason: String = format!("failed to spawn blocking task: {error}");
+                    let reason: String = format!("Failed to spawn blocking task: {error}");
                     error!("{reason}");
                     anyhow::bail!(reason);
                 },
@@ -1059,5 +1517,114 @@ mod tests {
         let url: &str = "not-a-valid-url";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_none());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that install returns error for invalid machine type.
+    ///
+    #[tokio::test]
+    async fn test_install_invalid_machine() {
+        let registry: Registry = Registry::new(None);
+        let result: Result<String> = registry
+            .install("invalid-machine", "single-process", "openssl", false)
+            .await;
+        assert!(result.is_err());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that install returns error for invalid deployment type.
+    ///
+    #[tokio::test]
+    async fn test_install_invalid_deployment() {
+        let registry: Registry = Registry::new(None);
+        let result: Result<String> = registry
+            .install("microvm", "invalid-deployment", "openssl", false)
+            .await;
+        assert!(result.is_err());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that install returns error for invalid package name.
+    ///
+    #[tokio::test]
+    async fn test_install_invalid_package() {
+        let registry: Registry = Registry::new(None);
+        let result: Result<String> = registry
+            .install("microvm", "single-process", "invalid-package", false)
+            .await;
+        assert!(result.is_err());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests downloading and installing all packages.
+    ///
+    /// # Note
+    ///
+    /// This unit test is marked with `#[ignore]` because it performs actual network requests to
+    /// GitHub and downloads multiple packages, which can be time-consuming and may not be suitable
+    /// for regular test runs. It can be run manually when needed to verify the installation process
+    /// end-to-end.
+    ///
+    #[tokio::test]
+    #[ignore]
+    async fn test_install_all_packages() {
+        use ::tokio::fs;
+
+        // Create a temporary directory for the test cache.
+        let temp_dir: PathBuf =
+            ::std::env::temp_dir().join("nanvix-registry-test-install-all-packages");
+
+        // Clean up any existing test directory.
+        let _ = fs::remove_dir_all(&temp_dir).await;
+
+        // Run test logic and capture result to ensure cleanup runs even on failure.
+        let test_result: Result<()> = async {
+            // Create registry with custom cache directory.
+            let registry: Registry = Registry::new(Some(temp_dir.clone()));
+
+            // Attempt to install all packages.
+            for package in Package::all() {
+                let package_name: &str = package.as_str();
+
+                // Attempt to install the package.
+                let result: Result<String> = registry
+                    .install("microvm", "single-process", package_name, true)
+                    .await;
+
+                // Verify installation succeeded.
+                let install_path: String = result?;
+                anyhow::ensure!(
+                    !install_path.is_empty(),
+                    "Install path is empty for package: {}",
+                    package_name
+                );
+
+                // Verify the install path exists.
+                let path: PathBuf = PathBuf::from(&install_path);
+                anyhow::ensure!(
+                    fs::metadata(&path).await.is_ok(),
+                    "Install path does not exist for package {}: {}",
+                    package_name,
+                    install_path
+                );
+            }
+
+            Ok(())
+        }
+        .await;
+
+        // Clean up regardless of test outcome.
+        let _ = fs::remove_dir_all(&temp_dir).await;
+
+        // Now assert the test result.
+        assert!(test_result.is_ok(), "Test failed: {:?}", test_result.err());
     }
 }

--- a/src/libs/nanvix-registry/src/machine.rs
+++ b/src/libs/nanvix-registry/src/machine.rs
@@ -95,7 +95,7 @@ impl TryFrom<&str> for Machine {
             Self::HYPERLIGHT_STR => Ok(Machine::Hyperlight),
             Self::MICROVM_STR => Ok(Machine::Microvm),
             _ => {
-                let reason: String = format!("Unknown machine type: {}", value);
+                let reason: String = format!("Unknown machine type: {value}");
                 error!("{reason}");
                 anyhow::bail!(reason)
             },

--- a/src/libs/nanvix-registry/src/metadata.rs
+++ b/src/libs/nanvix-registry/src/metadata.rs
@@ -8,6 +8,7 @@
 use crate::{
     deployment::Deployment,
     machine::Machine,
+    package::Package,
 };
 use ::anyhow::Result;
 use ::serde::{
@@ -55,6 +56,19 @@ pub(crate) struct ReleaseEntry {
 ///
 /// # Description
 ///
+/// Metadata about an installed package for a specific machine-deployment configuration.
+///
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PackageEntry {
+    /// URL of the package tarball.
+    url: String,
+    /// Nanvix commit ID this package is built for.
+    nanvix_commit_id: String,
+}
+
+///
+/// # Description
+///
 /// Registry metadata tracking multiple machine-deployment configurations.
 ///
 /// This structure maintains a map where keys are in the format "<machine>-<deployment>"
@@ -66,6 +80,10 @@ pub(crate) struct ReleaseRegistry {
     /// Map of machine-deployment configurations to their release entries.
     /// Key format: "<machine>-<deployment>" (e.g., "microvm-single-process").
     releases: HashMap<String, ReleaseEntry>,
+    /// Map of installed packages to their entries.
+    /// Key format: "<machine>-<deployment>-<package>" (e.g., "microvm-single-process-openssl").
+    #[serde(default)]
+    packages: HashMap<String, PackageEntry>,
 }
 
 //==================================================================================================
@@ -119,6 +137,56 @@ impl ReleaseEntry {
     }
 }
 
+impl PackageEntry {
+    ///
+    /// # Description
+    ///
+    /// Creates a new package entry instance.
+    ///
+    /// # Parameters
+    ///
+    /// - `url`: The URL of the package tarball.
+    /// - `nanvix_commit_id`: The Nanvix commit ID this package is built for.
+    ///
+    /// # Returns
+    ///
+    /// A new `PackageEntry` instance.
+    ///
+    pub(crate) fn new(url: String, nanvix_commit_id: String) -> Self {
+        Self {
+            url,
+            nanvix_commit_id,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the Nanvix commit ID this package is built for.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the Nanvix commit ID string.
+    ///
+    pub(crate) fn nanvix_commit_id(&self) -> &str {
+        &self.nanvix_commit_id
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the URL of the package tarball.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the URL string.
+    ///
+    #[cfg(test)]
+    pub(crate) fn url(&self) -> &str {
+        &self.url
+    }
+}
+
 impl ReleaseRegistry {
     ///
     /// # Description
@@ -132,6 +200,7 @@ impl ReleaseRegistry {
     pub(crate) fn new() -> Self {
         Self {
             releases: HashMap::new(),
+            packages: HashMap::new(),
         }
     }
 
@@ -213,6 +282,88 @@ impl ReleaseRegistry {
     ///
     /// # Description
     ///
+    /// Adds or updates a package entry for a specific machine-deployment-package configuration.
+    ///
+    /// # Parameters
+    ///
+    /// - `machine`: The target machine type.
+    /// - `deployment`: The deployment type.
+    /// - `package`: The package being installed.
+    /// - `url`: The URL of the package tarball.
+    /// - `nanvix_commit_id`: The Nanvix commit ID this package is built for.
+    ///
+    pub(crate) fn set_package(
+        &mut self,
+        machine: Machine,
+        deployment: Deployment,
+        package: Package,
+        url: String,
+        nanvix_commit_id: String,
+    ) {
+        let key: String = format!("{}-{}-{}", machine, deployment, package);
+        let entry: PackageEntry = PackageEntry::new(url, nanvix_commit_id);
+        self.packages.insert(key, entry);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets the package entry for a specific machine-deployment-package configuration.
+    ///
+    /// # Parameters
+    ///
+    /// - `machine`: The target machine type.
+    /// - `deployment`: The deployment type.
+    /// - `package`: The package to look up.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<&PackageEntry>` containing the package entry if found, or `None` otherwise.
+    ///
+    pub(crate) fn get_package(
+        &self,
+        machine: Machine,
+        deployment: Deployment,
+        package: Package,
+    ) -> Option<&PackageEntry> {
+        let key: String = format!("{}-{}-{}", machine, deployment, package);
+        self.packages.get(&key)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks whether a package is installed for a specific machine-deployment configuration
+    /// and matches the given Nanvix commit ID.
+    ///
+    /// # Parameters
+    ///
+    /// - `machine`: The target machine type.
+    /// - `deployment`: The deployment type.
+    /// - `package`: The package to check.
+    /// - `nanvix_commit_id`: The Nanvix commit ID to match.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the package is installed and matches the commit ID, `false` otherwise.
+    ///
+    pub(crate) fn is_package_installed(
+        &self,
+        machine: Machine,
+        deployment: Deployment,
+        package: Package,
+        nanvix_commit_id: &str,
+    ) -> bool {
+        if let Some(entry) = self.get_package(machine, deployment, package) {
+            entry.nanvix_commit_id() == nanvix_commit_id
+        } else {
+            false
+        }
+    }
+
+    ///
+    /// # Description
+    ///
     /// Saves the release registry to a file in the specified directory.
     ///
     /// # Parameters
@@ -229,14 +380,14 @@ impl ReleaseRegistry {
         let json: String = match serde_json::to_string_pretty(self) {
             Ok(json) => json,
             Err(error) => {
-                let reason: String = format!("Failed to serialize registry: {}", error);
+                let reason: String = format!("Failed to serialize registry: {error}");
                 error!("{reason}");
                 anyhow::bail!(reason)
             },
         };
 
         if let Err(error) = fs::write(&metadata_path, json).await {
-            let reason: String = format!("Failed to write registry file: {}", error);
+            let reason: String = format!("Failed to write registry file: {error}");
             error!("{reason}");
             anyhow::bail!(reason)
         }
@@ -273,7 +424,7 @@ impl ReleaseRegistry {
         let json: String = match fs::read_to_string(&metadata_path).await {
             Ok(content) => content,
             Err(error) => {
-                let reason: String = format!("Failed to read registry file: {}", error);
+                let reason: String = format!("Failed to read registry file: {error}");
                 error!("{reason}");
                 anyhow::bail!(reason)
             },
@@ -283,7 +434,7 @@ impl ReleaseRegistry {
         let registry: ReleaseRegistry = match serde_json::from_str(&json) {
             Ok(registry) => registry,
             Err(error) => {
-                let reason: String = format!("Failed to deserialize registry: {}", error);
+                let reason: String = format!("Failed to deserialize registry: {error}");
                 error!("{reason}");
                 anyhow::bail!(reason)
             },
@@ -330,7 +481,7 @@ impl ReleaseRegistry {
 
         if fs::metadata(&metadata_path).await.is_ok() {
             if let Err(error) = fs::remove_file(&metadata_path).await {
-                let reason: String = format!("Failed to delete metadata file: {}", error);
+                let reason: String = format!("Failed to delete metadata file: {error}");
                 error!("{reason}");
                 anyhow::bail!(reason)
             }
@@ -666,5 +817,185 @@ mod tests {
 
         let result: Result<ReleaseRegistry> = ReleaseRegistry::load(&temp_dir).await;
         assert!(result.is_err());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests package entry creation.
+    ///
+    #[test]
+    fn test_package_entry_new() {
+        let url: String = "https://github.com/nanvix/openssl/release.tar.bz2".to_string();
+        let nanvix_commit_id: String = "abc123def456".to_string();
+        let entry: PackageEntry = PackageEntry::new(url.clone(), nanvix_commit_id.clone());
+        assert_eq!(entry.url(), url);
+        assert_eq!(entry.nanvix_commit_id(), nanvix_commit_id);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests setting and getting package entries.
+    ///
+    #[test]
+    fn test_set_and_get_package() {
+        let mut registry: ReleaseRegistry = ReleaseRegistry::new();
+
+        let url: String = "https://test.com/openssl.tar.bz2".to_string();
+        let nanvix_commit_id: String = "abc123def456".to_string();
+
+        // Set a package.
+        registry.set_package(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::OpenSSL,
+            url.clone(),
+            nanvix_commit_id.clone(),
+        );
+
+        // Get the package.
+        let entry: Option<&PackageEntry> =
+            registry.get_package(Machine::Microvm, Deployment::SingleProcess, Package::OpenSSL);
+        assert!(entry.is_some());
+
+        let entry: &PackageEntry = entry.expect("package entry should exist");
+        assert_eq!(entry.url(), url);
+        assert_eq!(entry.nanvix_commit_id(), nanvix_commit_id);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests is_package_installed returns true when package is installed with matching commit.
+    ///
+    #[test]
+    fn test_is_package_installed_true() {
+        let mut registry: ReleaseRegistry = ReleaseRegistry::new();
+        let nanvix_commit_id: String = "abc123def456".to_string();
+
+        registry.set_package(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::OpenSSL,
+            "https://test.com/openssl.tar.bz2".to_string(),
+            nanvix_commit_id.clone(),
+        );
+
+        assert!(registry.is_package_installed(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::OpenSSL,
+            &nanvix_commit_id
+        ));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests is_package_installed returns false when package is not installed.
+    ///
+    #[test]
+    fn test_is_package_installed_false_not_installed() {
+        let registry: ReleaseRegistry = ReleaseRegistry::new();
+
+        assert!(!registry.is_package_installed(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::OpenSSL,
+            "abc123def456"
+        ));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests is_package_installed returns false when commit ID does not match.
+    ///
+    #[test]
+    fn test_is_package_installed_false_different_commit() {
+        let mut registry: ReleaseRegistry = ReleaseRegistry::new();
+
+        registry.set_package(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::OpenSSL,
+            "https://test.com/openssl.tar.bz2".to_string(),
+            "abc123def456".to_string(),
+        );
+
+        // Check with different commit ID.
+        assert!(!registry.is_package_installed(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::OpenSSL,
+            "different_commit"
+        ));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests multiple packages in registry.
+    ///
+    #[test]
+    fn test_multiple_packages() {
+        let mut registry: ReleaseRegistry = ReleaseRegistry::new();
+        let nanvix_commit_id: String = "abc123def456".to_string();
+
+        // Add multiple packages.
+        registry.set_package(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::OpenSSL,
+            "https://test.com/openssl.tar.bz2".to_string(),
+            nanvix_commit_id.clone(),
+        );
+
+        registry.set_package(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::Zlib,
+            "https://test.com/zlib.tar.bz2".to_string(),
+            nanvix_commit_id.clone(),
+        );
+
+        registry.set_package(
+            Machine::Hyperlight,
+            Deployment::MultiProcess,
+            Package::CPython,
+            "https://test.com/cpython.tar.bz2".to_string(),
+            nanvix_commit_id.clone(),
+        );
+
+        // Verify all packages are installed.
+        assert!(registry.is_package_installed(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::OpenSSL,
+            &nanvix_commit_id
+        ));
+
+        assert!(registry.is_package_installed(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::Zlib,
+            &nanvix_commit_id
+        ));
+
+        assert!(registry.is_package_installed(
+            Machine::Hyperlight,
+            Deployment::MultiProcess,
+            Package::CPython,
+            &nanvix_commit_id
+        ));
+
+        // Verify non-installed package returns false.
+        assert!(!registry.is_package_installed(
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::QuickJS,
+            &nanvix_commit_id
+        ));
     }
 }

--- a/src/libs/nanvix-registry/src/package.rs
+++ b/src/libs/nanvix-registry/src/package.rs
@@ -1,0 +1,1179 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    checksum::verify_sha256,
+    deployment::Deployment,
+    github_client,
+    machine::Machine,
+    rate_limiter::{
+        self,
+        RateLimiter,
+    },
+    tarball::Tarball,
+    tempfile::TemporaryFile,
+};
+use ::anyhow::Result;
+use ::bytes::Bytes;
+use ::reqwest::{
+    Client,
+    Response,
+};
+use ::serde::{
+    Deserialize,
+    Serialize,
+};
+use ::std::{
+    env,
+    path::{
+        Path,
+        PathBuf,
+    },
+    sync::Arc,
+};
+use ::syslog::{
+    debug,
+    error,
+    info,
+    warn,
+};
+use ::tokio::sync::OnceCell;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// GitHub owner for Nanvix packages.
+const GITHUB_OWNER: &str = "nanvix";
+
+/// Name of the dependencies metadata file within package releases.
+const DEPENDENCIES_FILE_NAME: &str = "dependencies.json";
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Represents a Nanvix package that can be installed from GitHub releases.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Package {
+    /// OpenBLAS library.
+    OpenBLAS,
+    /// OpenSSL library.
+    OpenSSL,
+    /// SQLite library.
+    SQLite,
+    /// Zlib compression library.
+    Zlib,
+    /// QuickJS JavaScript engine.
+    QuickJS,
+    /// CPython interpreter.
+    CPython,
+}
+
+///
+/// # Description
+///
+/// Metadata about package dependencies.
+///
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(crate) struct PackageDependencies {
+    /// List of package dependencies.
+    dependencies: Vec<String>,
+}
+
+///
+/// # Description
+///
+/// Represents a package release from a Nanvix package repository.
+///
+pub(crate) struct PackageRelease {
+    /// The package to download.
+    package: Package,
+    /// Deployment type for the release.
+    deployment: Deployment,
+    /// Target machine type for the release.
+    machine: Machine,
+    /// Target Nanvix commit ID.
+    nanvix_commit_id: String,
+    /// Cached release info to avoid duplicate API calls.
+    cached_release_info: Arc<OnceCell<serde_json::Value>>,
+    /// Whether to fall back to latest release if compatible version not found.
+    use_latest_fallback: bool,
+    /// Rate limiter for GitHub API calls.
+    rate_limiter: RateLimiter,
+    /// Reusable HTTP client.
+    client: Client,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Package {
+    /// String representation of OpenBLAS package.
+    pub const OPENBLAS_STR: &'static str = "openblas";
+    /// String representation of OpenSSL package.
+    pub const OPENSSL_STR: &'static str = "openssl";
+    /// String representation of SQLite package.
+    pub const SQLITE_STR: &'static str = "sqlite";
+    /// String representation of Zlib package.
+    pub const ZLIB_STR: &'static str = "zlib";
+    /// String representation of QuickJS package.
+    pub const QUICKJS_STR: &'static str = "quickjs";
+    /// String representation of CPython package.
+    pub const CPYTHON_STR: &'static str = "cpython";
+
+    ///
+    /// # Description
+    ///
+    /// Converts the package to its string representation.
+    ///
+    /// # Returns
+    ///
+    /// A string representation of the package.
+    ///
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Package::OpenBLAS => Package::OPENBLAS_STR,
+            Package::OpenSSL => Package::OPENSSL_STR,
+            Package::SQLite => Package::SQLITE_STR,
+            Package::Zlib => Package::ZLIB_STR,
+            Package::QuickJS => Package::QUICKJS_STR,
+            Package::CPython => Package::CPYTHON_STR,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the GitHub repository name for this package.
+    ///
+    /// # Returns
+    ///
+    /// The repository name as a string.
+    ///
+    pub fn repo_name(&self) -> &'static str {
+        match self {
+            Package::OpenBLAS => "OpenBLAS",
+            Package::OpenSSL => "openssl",
+            Package::SQLite => "sqlite",
+            Package::Zlib => "zlib",
+            Package::QuickJS => "quickjs",
+            Package::CPython => "cpython",
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the GitHub API URL for fetching the latest release of this package.
+    ///
+    /// # Returns
+    ///
+    /// The GitHub API URL as a string.
+    ///
+    pub fn api_url(&self) -> String {
+        format!(
+            "https://api.github.com/repos/{}/{}/releases/latest",
+            GITHUB_OWNER,
+            self.repo_name()
+        )
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the GitHub API URL for fetching all releases of this package.
+    ///
+    /// # Returns
+    ///
+    /// The GitHub API URL as a string.
+    ///
+    pub fn api_url_all_releases(&self) -> String {
+        format!(
+            "https://api.github.com/repos/{}/{}/releases?per_page=100",
+            GITHUB_OWNER,
+            self.repo_name()
+        )
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a list of all available packages.
+    ///
+    /// # Returns
+    ///
+    /// A vector containing all package variants.
+    ///
+    pub fn all() -> Vec<Package> {
+        vec![
+            Package::OpenBLAS,
+            Package::OpenSSL,
+            Package::SQLite,
+            Package::Zlib,
+            Package::QuickJS,
+            Package::CPython,
+        ]
+    }
+}
+
+impl ::std::fmt::Display for Package {
+    ///
+    /// # Description
+    ///
+    /// Converts the package to its string representation.
+    ///
+    /// # Parameters
+    ///
+    /// - `f`: The formatter.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an empty tuple. On failure, it returns an object that
+    /// describes the error.
+    ///
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for Package {
+    type Error = anyhow::Error;
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to convert a string slice to a `Package` enum variant.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: The string representation of the package (case-insensitive).
+    ///
+    /// # Returns
+    ///
+    /// On success, returns the corresponding `Package` variant. On failure, it returns an object
+    /// that describes the error.
+    ///
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let value_lower: String = value.to_lowercase();
+        match value_lower.as_str() {
+            Self::OPENBLAS_STR => Ok(Package::OpenBLAS),
+            Self::OPENSSL_STR => Ok(Package::OpenSSL),
+            Self::SQLITE_STR => Ok(Package::SQLite),
+            Self::ZLIB_STR => Ok(Package::Zlib),
+            Self::QUICKJS_STR => Ok(Package::QuickJS),
+            Self::CPYTHON_STR | "python" | "python3" => Ok(Package::CPython),
+            _ => {
+                let reason: String = format!("Unknown package: {value}");
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        }
+    }
+}
+
+impl PackageDependencies {
+    ///
+    /// # Description
+    ///
+    /// Creates a new empty package dependencies instance.
+    ///
+    /// # Returns
+    ///
+    /// A new `PackageDependencies` instance with no dependencies.
+    ///
+    pub(crate) fn new() -> Self {
+        Self {
+            dependencies: Vec::new(),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the list of package dependencies.
+    ///
+    /// # Returns
+    ///
+    /// A slice of dependency package names.
+    ///
+    pub(crate) fn dependencies(&self) -> &[String] {
+        &self.dependencies
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Parses package dependencies from a JSON string.
+    ///
+    /// # Parameters
+    ///
+    /// - `json`: The JSON string containing dependency information.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns a `PackageDependencies` instance. On failure, returns an error.
+    ///
+    pub(crate) fn from_json(json: &str) -> Result<Self> {
+        match serde_json::from_str(json) {
+            Ok(deps) => Ok(deps),
+            Err(error) => {
+                let reason: String = format!("Failed to parse dependencies: {error}");
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        }
+    }
+}
+
+impl PackageRelease {
+    ///
+    /// # Description
+    ///
+    /// Creates a new handle for a package release.
+    ///
+    /// # Parameters
+    ///
+    /// - `package`: The package to download.
+    /// - `deployment`: The deployment type.
+    /// - `machine`: The target machine type.
+    /// - `nanvix_commit_id`: The Nanvix commit ID to match.
+    /// - `use_latest_fallback`: If true, falls back to latest release when compatible version
+    ///   is not found. If false, returns an error.
+    ///
+    /// # Returns
+    ///
+    /// On success, a new handle for the package release. On failure, returns an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be created.
+    ///
+    pub(crate) fn new(
+        package: Package,
+        deployment: Deployment,
+        machine: Machine,
+        nanvix_commit_id: String,
+        use_latest_fallback: bool,
+    ) -> Result<Self> {
+        let client: Client = github_client::build_client()?;
+        Ok(Self {
+            package,
+            deployment,
+            machine,
+            nanvix_commit_id,
+            cached_release_info: Arc::new(OnceCell::new()),
+            use_latest_fallback,
+            rate_limiter: RateLimiter::for_github(),
+            client,
+        })
+    }
+
+    /// Returns the package type.
+    #[cfg(test)]
+    fn package(&self) -> Package {
+        self.package
+    }
+
+    /// Returns the deployment type.
+    #[cfg(test)]
+    fn deployment(&self) -> Deployment {
+        self.deployment
+    }
+
+    /// Returns the target machine type.
+    #[cfg(test)]
+    fn machine(&self) -> Machine {
+        self.machine
+    }
+
+    /// Returns the Nanvix commit ID.
+    #[cfg(test)]
+    fn nanvix_commit_id(&self) -> &str {
+        &self.nanvix_commit_id
+    }
+
+    /// Returns whether the latest fallback is enabled.
+    #[cfg(test)]
+    fn use_latest_fallback(&self) -> bool {
+        self.use_latest_fallback
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Downloads the package release tarball from GitHub and extracts it to the specified
+    /// directory.
+    ///
+    /// # Parameters
+    ///
+    /// - `dir`: The directory where the release will be extracted.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns the URL of the downloaded release. On failure, returns an error.
+    ///
+    pub(crate) async fn download(&self, dir: &Path) -> Result<String> {
+        let release_url: String = self.get_url().await?;
+
+        info!("Downloading package {} from: {}", self.package, release_url);
+
+        // Apply rate limiting before download.
+        self.rate_limiter.wait().await;
+
+        // Download the tarball.
+        let response: Response = match github_client::authenticated_get(&self.client, &release_url)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                let reason: String =
+                    format!("Failed to download package {}: {error}", self.package);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Check for rate limit errors.
+        rate_limiter::check_rate_limit(&response)?;
+
+        let bytes: Bytes = match response.bytes().await {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                let reason: String = format!("Failed to read package {}: {error}", self.package);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Verify checksum if available.
+        if let Some(expected_checksum) = self.get_checksum().await? {
+            debug!("Verifying checksum for package {}", self.package);
+            if !verify_sha256(&bytes, &expected_checksum) {
+                let reason: String =
+                    format!("Checksum verification failed for package {}", self.package);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            }
+            info!("Checksum verified for package {}", self.package);
+        } else {
+            debug!("No checksum available for package {}, skipping verification", self.package);
+        }
+
+        // Save to temp file.
+        let temp_path: PathBuf = env::temp_dir().join(format!(
+            "nanvix-package-{}-{}.tar.bz2",
+            self.package,
+            uuid::Uuid::new_v4()
+        ));
+        let temp_file: TemporaryFile = TemporaryFile::new(temp_path);
+        temp_file.write(&bytes).await?;
+
+        // Extract tarball.
+        info!("Extracting package {}...", self.package);
+        let tarball: Tarball = Tarball::open(temp_file.path())?;
+        tarball.extract(dir).await?;
+
+        Ok(release_url)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Fetches the release information from GitHub API.
+    ///
+    /// This is a helper method that fetches and validates the release metadata, caching
+    /// the result to avoid duplicate API calls between `get_url()` and `get_dependencies()`.
+    ///
+    /// First attempts to find a release matching the target Nanvix commit ID. If no compatible
+    /// release is found and `use_latest_fallback` is true, falls back to the latest available
+    /// release with a warning. Otherwise, returns an error.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns the parsed JSON release information. On failure, returns an error.
+    ///
+    async fn fetch_release_info(&self) -> Result<serde_json::Value> {
+        // Use cached release info if available.
+        if let Some(cached) = self.cached_release_info.get() {
+            debug!("Using cached release info for package {}", self.package);
+            return Ok(cached.clone());
+        }
+
+        // Extract the short commit ID (first 7 characters) for comparison.
+        // TODO: use full commit ID for matching (https://github.com/nanvix/nanvix/issues/1358)
+        let short_commit_id: &str = if self.nanvix_commit_id.len() >= 7 {
+            &self.nanvix_commit_id[..7]
+        } else {
+            &self.nanvix_commit_id
+        };
+
+        // First, try to find a release matching the target commit ID by fetching all releases.
+        let all_releases_url: String = self.package.api_url_all_releases();
+
+        // Apply rate limiting before API call.
+        self.rate_limiter.wait().await;
+
+        let response: Response =
+            match github_client::authenticated_get(&self.client, &all_releases_url)
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    let reason: String =
+                        format!("Failed to fetch package {} releases: {error}", self.package);
+                    error!("{reason}");
+                    anyhow::bail!(reason)
+                },
+            };
+
+        // Check for rate limit errors.
+        rate_limiter::check_rate_limit(&response)?;
+
+        let all_releases: Vec<serde_json::Value> = match response.json().await {
+            Ok(json) => json,
+            Err(error) => {
+                let reason: String =
+                    format!("Failed to parse package {} releases: {error}", self.package);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Search for a release matching the target commit ID.
+        // The commit ID should appear at a word boundary to avoid false positives
+        // (e.g., matching version numbers that coincidentally contain the same digits).
+        for release in all_releases.iter() {
+            let tag_name: Option<&str> = release["tag_name"].as_str();
+            if let Some(tag_name) = tag_name {
+                if Self::tag_matches_commit(tag_name, short_commit_id) {
+                    debug!(
+                        "Found compatible release for package {}: tag '{}'",
+                        self.package, tag_name
+                    );
+                    let _ = self.cached_release_info.set(release.clone());
+                    return Ok(release.clone());
+                }
+            }
+        }
+
+        // No compatible release found.
+        if !self.use_latest_fallback {
+            let reason: String = format!(
+                "No compatible release found for package {} with commit '{}'",
+                self.package, short_commit_id
+            );
+            error!("{reason}");
+            anyhow::bail!(reason)
+        }
+
+        // Fall back to the latest release.
+        warn!(
+            "No compatible release found for package {} with commit '{}', using latest release.",
+            self.package, short_commit_id
+        );
+
+        // Fetch the latest release.
+        let latest_url: String = self.package.api_url();
+
+        // Apply rate limiting before API call.
+        self.rate_limiter.wait().await;
+
+        let response: Response = match github_client::authenticated_get(&self.client, &latest_url)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                let reason: String =
+                    format!("Failed to fetch latest package {} release: {error}", self.package);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Check for rate limit errors.
+        rate_limiter::check_rate_limit(&response)?;
+
+        let release_info: serde_json::Value = match response.json().await {
+            Ok(json) => json,
+            Err(error) => {
+                let reason: String =
+                    format!("Failed to parse latest package {} release: {error}", self.package);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Verify the release has a tag.
+        let tag_name: &str = match release_info["tag_name"].as_str() {
+            Some(tag) => tag,
+            None => {
+                let reason: String = format!("No tag found for package {} release", self.package);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        warn!(
+            "Using latest release '{}' for package {} (target commit: '{}')",
+            tag_name, self.package, short_commit_id
+        );
+
+        // Cache the release info for future calls.
+        let _ = self.cached_release_info.set(release_info.clone());
+
+        Ok(release_info)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Fetches the download URL for the package release from the GitHub API.
+    ///
+    /// The release is identified by checking if the release tag contains the nanvix commit ID.
+    /// The asset is matched by the pattern: `<package>-<machine>-<deployment>.tar.bz2`
+    ///
+    /// # Returns
+    ///
+    /// On success, returns the download URL as a string. On failure, returns an error.
+    ///
+    pub(crate) async fn get_url(&self) -> Result<String> {
+        let release_info: serde_json::Value = self.fetch_release_info().await?;
+
+        // Find the release asset URL.
+        let assets: &[serde_json::Value] = match release_info["assets"].as_array() {
+            Some(assets) => assets,
+            None => {
+                let reason: String = format!("No assets found in package {} release", self.package);
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Build the expected asset name: <package>-<machine>-<deployment>.tar.bz2
+        let expected_asset_name: String =
+            format!("{}-{}-{}.tar.bz2", self.package, self.machine, self.deployment);
+
+        debug!("Searching for package asset: {}", expected_asset_name);
+
+        // Search for the matching asset.
+        for asset in assets.iter() {
+            let name: Option<&str> = asset["name"].as_str();
+            if let Some(name) = name {
+                if name == expected_asset_name {
+                    if let Some(url) = asset["browser_download_url"].as_str() {
+                        debug!("Found matching package asset: {}", name);
+                        return Ok(url.to_string());
+                    }
+                }
+            }
+        }
+
+        let reason: String = format!(
+            "Could not find package {} release for {}-{}",
+            self.package, self.machine, self.deployment
+        );
+        error!("{reason}");
+        anyhow::bail!(reason)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Fetches the package dependencies from the dependencies metadata file.
+    ///
+    /// This method downloads the `dependencies.json` file from the package release and parses it
+    /// to extract the list of required dependencies.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns a `PackageDependencies` instance. On failure, returns an error.
+    /// If no dependencies file exists, returns an empty dependencies instance.
+    ///
+    pub(crate) async fn get_dependencies(&self) -> Result<PackageDependencies> {
+        let release_info: serde_json::Value = self.fetch_release_info().await?;
+
+        // Find the dependencies file asset.
+        let assets: &[serde_json::Value] = match release_info["assets"].as_array() {
+            Some(assets) => assets,
+            None => {
+                debug!("No assets in package {} release, no dependencies", self.package);
+                return Ok(PackageDependencies::new());
+            },
+        };
+
+        // Build the pattern to match: dependencies-<machine>-<deployment>.json or dependencies.json
+        let deps_pattern: String =
+            format!("dependencies-{}-{}.json", self.machine, self.deployment);
+
+        debug!("Searching for dependencies file matching pattern: {}", deps_pattern);
+
+        // Search for the dependencies file. Prefer machine-deployment-specific file over generic.
+        let mut generic_asset: Option<&serde_json::Value> = None;
+        for asset in assets.iter() {
+            let name: Option<&str> = asset["name"].as_str();
+            if let Some(name) = name {
+                if name == deps_pattern {
+                    // Exact match for machine-deployment-specific file, use immediately.
+                    return self.download_dependencies(asset).await;
+                } else if name == DEPENDENCIES_FILE_NAME {
+                    // Generic dependencies file, save as fallback.
+                    generic_asset = Some(asset);
+                }
+            }
+        }
+
+        // Fall back to generic dependencies file if found.
+        if let Some(asset) = generic_asset {
+            return self.download_dependencies(asset).await;
+        }
+
+        // No dependencies file found, return empty dependencies.
+        debug!("No dependencies file found for package {}", self.package);
+        Ok(PackageDependencies::new())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Downloads and parses a dependencies file from a release asset.
+    ///
+    /// # Parameters
+    ///
+    /// - `asset`: The JSON object representing the release asset containing the dependencies file.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns a `PackageDependencies` instance. On failure, returns an error.
+    ///
+    async fn download_dependencies(
+        &self,
+        asset: &serde_json::Value,
+    ) -> Result<PackageDependencies> {
+        let url: &str = match asset["browser_download_url"].as_str() {
+            Some(url) => url,
+            None => {
+                let reason: String = "Dependencies asset has no download URL".to_string();
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let name: &str = asset["name"].as_str().unwrap_or("unknown");
+        debug!("Found dependencies file: {}", name);
+
+        // Apply rate limiting before download.
+        self.rate_limiter.wait().await;
+
+        // Download the dependencies file.
+        let deps_response: Response = match github_client::authenticated_get(&self.client, url)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(error) => {
+                let reason: String = format!("Failed to download dependencies file: {error}");
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // Check for rate limit errors.
+        rate_limiter::check_rate_limit(&deps_response)?;
+
+        let deps_json: String = match deps_response.text().await {
+            Ok(text) => text,
+            Err(error) => {
+                let reason: String = format!("Failed to read dependencies file: {error}");
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        PackageDependencies::from_json(&deps_json)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Fetches the SHA256 checksum for the package release from the release assets.
+    ///
+    /// This method looks for a checksum file matching the pattern:
+    /// `<package>-<machine>-<deployment>.sha256` or `<package>-<machine>-<deployment>.tar.bz2.sha256`
+    ///
+    /// # Returns
+    ///
+    /// On success, returns `Some(String)` containing the checksum if a checksum file is found,
+    /// or `None` if no checksum file exists. On failure, returns an error.
+    ///
+    pub(crate) async fn get_checksum(&self) -> Result<Option<String>> {
+        let release_info: serde_json::Value = self.fetch_release_info().await?;
+
+        // Find the checksum file asset.
+        let assets: &[serde_json::Value] = match release_info["assets"].as_array() {
+            Some(assets) => assets,
+            None => {
+                debug!("No assets in package {} release, no checksum available", self.package);
+                return Ok(None);
+            },
+        };
+
+        // Build expected checksum file names.
+        let checksum_name: String =
+            format!("{}-{}-{}.sha256", self.package, self.machine, self.deployment);
+        let checksum_name_tarball: String =
+            format!("{}-{}-{}.tar.bz2.sha256", self.package, self.machine, self.deployment);
+
+        debug!("Searching for checksum file: {} or {}", checksum_name, checksum_name_tarball);
+
+        // Search for the checksum file.
+        for asset in assets.iter() {
+            let name: Option<&str> = asset["name"].as_str();
+            if let Some(name) = name {
+                // Check if this is a checksum file for our package.
+                if name == checksum_name || name == checksum_name_tarball {
+                    if let Some(url) = asset["browser_download_url"].as_str() {
+                        debug!("Found checksum file: {}", name);
+
+                        // Apply rate limiting before download.
+                        self.rate_limiter.wait().await;
+
+                        // Download the checksum file.
+                        let checksum_response: Response =
+                            match github_client::authenticated_get(&self.client, url)
+                                .send()
+                                .await
+                            {
+                                Ok(r) => r,
+                                Err(error) => {
+                                    let reason: String =
+                                        format!("Failed to download checksum file: {error}");
+                                    error!("{reason}");
+                                    anyhow::bail!(reason)
+                                },
+                            };
+
+                        // Check for rate limit errors.
+                        rate_limiter::check_rate_limit(&checksum_response)?;
+
+                        let checksum_text: String = match checksum_response.text().await {
+                            Ok(text) => text,
+                            Err(error) => {
+                                let reason: String =
+                                    format!("Failed to read checksum file: {error}");
+                                error!("{reason}");
+                                anyhow::bail!(reason)
+                            },
+                        };
+
+                        // Parse the checksum (typically in format: "hash  filename" or just "hash").
+                        let checksum: String = checksum_text
+                            .split_whitespace()
+                            .next()
+                            .unwrap_or("")
+                            .to_string();
+
+                        if checksum.is_empty() {
+                            warn!("Empty checksum in file: {}", name);
+                            return Ok(None);
+                        }
+
+                        return Ok(Some(checksum));
+                    }
+                }
+            }
+        }
+
+        // No checksum file found.
+        debug!("No checksum file found for package {}", self.package);
+        Ok(None)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks if a release tag matches the expected commit ID pattern.
+    ///
+    /// The function validates that the commit ID appears as a distinct segment in the tag,
+    /// not as part of a version number or other identifier. Valid patterns include:
+    /// - Tag ending with the commit ID (e.g., "v1.0.0-abc1234")
+    /// - Tag containing the commit ID after a separator (e.g., "release-abc1234-build")
+    ///
+    /// # Parameters
+    ///
+    /// - `tag`: The release tag name to check.
+    /// - `commit_id`: The commit ID (or short commit ID) to match.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the tag contains the commit ID as a distinct segment, `false` otherwise.
+    ///
+    fn tag_matches_commit(tag: &str, commit_id: &str) -> bool {
+        // Check if tag ends with the commit ID.
+        if tag.ends_with(commit_id) {
+            // Verify it's after a separator (not part of another word).
+            let prefix_len: usize = tag.len().saturating_sub(commit_id.len());
+            if prefix_len == 0 {
+                return true; // Tag is exactly the commit ID.
+            }
+            let prefix_char: char = tag.chars().nth(prefix_len.saturating_sub(1)).unwrap_or('-');
+            if !prefix_char.is_alphanumeric() {
+                return true;
+            }
+        }
+
+        // Check if commit ID appears after a separator and before another separator.
+        for separator in ['-', '_', '.', '/'] {
+            let pattern: String = format!("{}{}{}", separator, commit_id, separator);
+            if tag.contains(&pattern) {
+                return true;
+            }
+            // Also check pattern at the end.
+            let end_pattern: String = format!("{}{}", separator, commit_id);
+            if tag.ends_with(&end_pattern) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests Package enum string conversion.
+    ///
+    #[test]
+    fn test_package_as_str() {
+        assert_eq!(Package::OpenBLAS.as_str(), "openblas");
+        assert_eq!(Package::OpenSSL.as_str(), "openssl");
+        assert_eq!(Package::SQLite.as_str(), "sqlite");
+        assert_eq!(Package::Zlib.as_str(), "zlib");
+        assert_eq!(Package::QuickJS.as_str(), "quickjs");
+        assert_eq!(Package::CPython.as_str(), "cpython");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests Package repo name.
+    ///
+    #[test]
+    fn test_package_repo_name() {
+        assert_eq!(Package::OpenBLAS.repo_name(), "OpenBLAS");
+        assert_eq!(Package::OpenSSL.repo_name(), "openssl");
+        assert_eq!(Package::SQLite.repo_name(), "sqlite");
+        assert_eq!(Package::Zlib.repo_name(), "zlib");
+        assert_eq!(Package::QuickJS.repo_name(), "quickjs");
+        assert_eq!(Package::CPython.repo_name(), "cpython");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests Package API URL generation.
+    ///
+    #[test]
+    fn test_package_api_url() {
+        assert_eq!(
+            Package::OpenBLAS.api_url(),
+            "https://api.github.com/repos/nanvix/OpenBLAS/releases/latest"
+        );
+        assert_eq!(
+            Package::CPython.api_url(),
+            "https://api.github.com/repos/nanvix/cpython/releases/latest"
+        );
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests Package display trait.
+    ///
+    #[test]
+    fn test_package_display() {
+        assert_eq!(format!("{}", Package::OpenBLAS), "openblas");
+        assert_eq!(format!("{}", Package::CPython), "cpython");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests Package conversion from string.
+    ///
+    #[test]
+    fn test_package_try_from_str() {
+        assert!(matches!(Package::try_from("openblas"), Ok(Package::OpenBLAS)));
+        assert!(matches!(Package::try_from("OpenBLAS"), Ok(Package::OpenBLAS)));
+        assert!(matches!(Package::try_from("openssl"), Ok(Package::OpenSSL)));
+        assert!(matches!(Package::try_from("sqlite"), Ok(Package::SQLite)));
+        assert!(matches!(Package::try_from("zlib"), Ok(Package::Zlib)));
+        assert!(matches!(Package::try_from("quickjs"), Ok(Package::QuickJS)));
+        assert!(matches!(Package::try_from("cpython"), Ok(Package::CPython)));
+        assert!(matches!(Package::try_from("python"), Ok(Package::CPython)));
+        assert!(matches!(Package::try_from("python3"), Ok(Package::CPython)));
+        assert!(Package::try_from("unknown").is_err());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests Package::all returns all variants.
+    ///
+    #[test]
+    fn test_package_all() {
+        let all: Vec<Package> = Package::all();
+        assert_eq!(all.len(), 6);
+        assert!(all.contains(&Package::OpenBLAS));
+        assert!(all.contains(&Package::OpenSSL));
+        assert!(all.contains(&Package::SQLite));
+        assert!(all.contains(&Package::Zlib));
+        assert!(all.contains(&Package::QuickJS));
+        assert!(all.contains(&Package::CPython));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests PackageDependencies creation.
+    ///
+    #[test]
+    fn test_package_dependencies_new() {
+        let deps: PackageDependencies = PackageDependencies::new();
+        assert!(deps.dependencies().is_empty());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests PackageDependencies JSON parsing.
+    ///
+    #[test]
+    fn test_package_dependencies_from_json() {
+        let json: &str = r#"{"dependencies": ["openssl", "zlib"]}"#;
+        let deps: PackageDependencies =
+            PackageDependencies::from_json(json).expect("failed to parse dependencies JSON");
+        assert_eq!(deps.dependencies().len(), 2);
+        assert!(deps.dependencies().contains(&"openssl".to_string()));
+        assert!(deps.dependencies().contains(&"zlib".to_string()));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests PackageDependencies JSON parsing with empty dependencies.
+    ///
+    #[test]
+    fn test_package_dependencies_from_json_empty() {
+        let json: &str = r#"{"dependencies": []}"#;
+        let deps: PackageDependencies =
+            PackageDependencies::from_json(json).expect("failed to parse empty dependencies JSON");
+        assert!(deps.dependencies().is_empty());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests PackageDependencies JSON parsing failure.
+    ///
+    #[test]
+    fn test_package_dependencies_from_json_invalid() {
+        let json: &str = "invalid json";
+        let result: Result<PackageDependencies> = PackageDependencies::from_json(json);
+        assert!(result.is_err());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests PackageRelease creation.
+    ///
+    #[test]
+    fn test_package_release_new() {
+        let release: PackageRelease = PackageRelease::new(
+            Package::OpenBLAS,
+            Deployment::SingleProcess,
+            Machine::Microvm,
+            "abc123".to_string(),
+            false,
+        )
+        .expect("failed to create PackageRelease for OpenBLAS");
+        assert_eq!(release.package(), Package::OpenBLAS);
+        assert!(matches!(release.deployment(), Deployment::SingleProcess));
+        assert!(matches!(release.machine(), Machine::Microvm));
+        assert_eq!(release.nanvix_commit_id(), "abc123");
+        assert!(!release.use_latest_fallback());
+
+        // Test with fallback enabled.
+        let release_fallback: PackageRelease = PackageRelease::new(
+            Package::OpenSSL,
+            Deployment::MultiProcess,
+            Machine::Hyperlight,
+            "def456".to_string(),
+            true,
+        )
+        .expect("failed to create PackageRelease for OpenSSL");
+        assert!(release_fallback.use_latest_fallback());
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests tag_matches_commit with valid patterns.
+    ///
+    #[test]
+    fn test_tag_matches_commit_valid() {
+        // Tag ending with commit ID after separator.
+        assert!(PackageRelease::tag_matches_commit("v1.0.0-abc1234", "abc1234"));
+        assert!(PackageRelease::tag_matches_commit("release-abc1234", "abc1234"));
+        assert!(PackageRelease::tag_matches_commit("v1.0.0_abc1234", "abc1234"));
+        assert!(PackageRelease::tag_matches_commit("v1.0.0.abc1234", "abc1234"));
+
+        // Commit ID in the middle with separators.
+        assert!(PackageRelease::tag_matches_commit("v1.0.0-abc1234-build", "abc1234"));
+        assert!(PackageRelease::tag_matches_commit("release-abc1234-test", "abc1234"));
+
+        // Tag is exactly the commit ID.
+        assert!(PackageRelease::tag_matches_commit("abc1234", "abc1234"));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests tag_matches_commit with invalid patterns (false positives prevention).
+    ///
+    #[test]
+    fn test_tag_matches_commit_invalid() {
+        // Commit ID is part of a larger alphanumeric sequence.
+        assert!(!PackageRelease::tag_matches_commit("v1234567890", "1234567"));
+        assert!(!PackageRelease::tag_matches_commit("release1234567build", "1234567"));
+
+        // Version numbers that happen to contain similar digits.
+        assert!(!PackageRelease::tag_matches_commit("v1.2.3", "123"));
+        assert!(!PackageRelease::tag_matches_commit("v12.34.56", "234"));
+
+        // Partial match without proper separator.
+        assert!(!PackageRelease::tag_matches_commit("abc1234xyz", "abc1234"));
+    }
+}

--- a/src/libs/nanvix-registry/src/progress.rs
+++ b/src/libs/nanvix-registry/src/progress.rs
@@ -1,0 +1,200 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::std::sync::Arc;
+
+//==================================================================================================
+// Traits
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Trait for receiving progress updates during package downloads.
+///
+/// Implement this trait to receive callbacks during download and installation operations.
+///
+pub trait ProgressCallback: Send + Sync {
+    ///
+    /// # Description
+    ///
+    /// Called when a download starts.
+    ///
+    /// # Parameters
+    ///
+    /// - `package_name`: Name of the package being downloaded.
+    /// - `total_size`: Total size in bytes, if known.
+    ///
+    fn on_download_start(&self, package_name: &str, total_size: Option<u64>);
+
+    ///
+    /// # Description
+    ///
+    /// Called when a download completes successfully.
+    ///
+    /// # Parameters
+    ///
+    /// - `package_name`: Name of the package that was downloaded.
+    ///
+    fn on_download_complete(&self, package_name: &str);
+
+    ///
+    /// # Description
+    ///
+    /// Called when extraction/installation starts.
+    ///
+    /// # Parameters
+    ///
+    /// - `package_name`: Name of the package being extracted.
+    ///
+    fn on_extract_start(&self, package_name: &str);
+
+    ///
+    /// # Description
+    ///
+    /// Called when extraction/installation completes.
+    ///
+    /// # Parameters
+    ///
+    /// - `package_name`: Name of the package that was extracted.
+    ///
+    fn on_extract_complete(&self, package_name: &str);
+
+    ///
+    /// # Description
+    ///
+    /// Called when installing a dependency.
+    ///
+    /// # Parameters
+    ///
+    /// - `dependency_name`: Name of the dependency being installed.
+    /// - `parent_package`: Name of the package that requires this dependency.
+    ///
+    fn on_dependency_start(&self, dependency_name: &str, parent_package: &str);
+}
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A no-op progress callback that does nothing.
+///
+/// This is the default progress callback used when no callback is provided.
+///
+#[derive(Debug, Clone, Default)]
+pub struct NoOpProgress;
+
+impl ProgressCallback for NoOpProgress {
+    fn on_download_start(&self, _package_name: &str, _total_size: Option<u64>) {}
+
+    fn on_download_complete(&self, _package_name: &str) {}
+
+    fn on_extract_start(&self, _package_name: &str) {}
+
+    fn on_extract_complete(&self, _package_name: &str) {}
+
+    fn on_dependency_start(&self, _dependency_name: &str, _parent_package: &str) {}
+}
+
+///
+/// # Description
+///
+/// A simple logging progress callback that logs progress to syslog.
+///
+#[derive(Debug, Clone, Default)]
+pub struct LoggingProgress;
+
+impl ProgressCallback for LoggingProgress {
+    fn on_download_start(&self, package_name: &str, total_size: Option<u64>) {
+        if let Some(size) = total_size {
+            ::syslog::info!("Starting download of {} ({} bytes)", package_name, size);
+        } else {
+            ::syslog::info!("Starting download of {}", package_name);
+        }
+    }
+
+    fn on_download_complete(&self, package_name: &str) {
+        ::syslog::info!("Download complete: {}", package_name);
+    }
+
+    fn on_extract_start(&self, package_name: &str) {
+        ::syslog::info!("Extracting: {}", package_name);
+    }
+
+    fn on_extract_complete(&self, package_name: &str) {
+        ::syslog::info!("Extraction complete: {}", package_name);
+    }
+
+    fn on_dependency_start(&self, dependency_name: &str, parent_package: &str) {
+        ::syslog::info!("Installing dependency {} for {}", dependency_name, parent_package);
+    }
+}
+
+//==================================================================================================
+// Type Aliases
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Type alias for a shared progress callback.
+///
+pub type SharedProgress = Arc<dyn ProgressCallback>;
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests that NoOpProgress implements all trait methods without errors.
+    ///
+    #[test]
+    fn test_no_op_progress() {
+        let progress: NoOpProgress = NoOpProgress;
+        progress.on_download_start("test", Some(1000));
+        progress.on_download_complete("test");
+        progress.on_extract_start("test");
+        progress.on_extract_complete("test");
+        progress.on_dependency_start("dep", "parent");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that LoggingProgress implements all trait methods without errors.
+    ///
+    #[test]
+    fn test_logging_progress() {
+        let progress: LoggingProgress = LoggingProgress;
+        progress.on_download_start("test", Some(1000));
+        progress.on_download_start("test", None);
+        progress.on_download_complete("test");
+        progress.on_extract_start("test");
+        progress.on_extract_complete("test");
+        progress.on_dependency_start("dep", "parent");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that SharedProgress can be created from NoOpProgress.
+    ///
+    #[test]
+    fn test_shared_progress() {
+        let progress: SharedProgress = Arc::new(NoOpProgress);
+        progress.on_download_start("test", Some(100));
+    }
+}

--- a/src/libs/nanvix-registry/src/rate_limiter.rs
+++ b/src/libs/nanvix-registry/src/rate_limiter.rs
@@ -1,0 +1,352 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::github_client;
+use ::anyhow::Result;
+use ::reqwest::Response;
+use ::std::{
+    sync::Arc,
+    time::{
+        Duration,
+        Instant,
+    },
+};
+use ::syslog::{
+    debug,
+    error,
+    warn,
+};
+use ::tokio::sync::Mutex;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Minimum delay between GitHub API requests for unauthenticated access (in milliseconds).
+/// GitHub's rate limit for unauthenticated requests is 60 requests per hour.
+/// This 1-second delay helps stay well within limits during bulk operations.
+const UNAUTHENTICATED_MIN_REQUEST_DELAY_MS: u64 = 1000;
+
+/// Minimum delay between GitHub API requests for authenticated access (in milliseconds).
+/// GitHub's rate limit for authenticated requests is 5000 requests per hour.
+/// This 200ms delay provides comfortable margin during bulk operations.
+const AUTHENTICATED_MIN_REQUEST_DELAY_MS: u64 = 200;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A simple rate limiter to prevent hitting GitHub API rate limits.
+///
+/// This limiter enforces a minimum delay between consecutive API requests,
+/// helping to avoid rate limit errors during bulk package installations.
+///
+#[derive(Clone)]
+pub(crate) struct RateLimiter {
+    /// Timestamp of the last API request.
+    last_request: Arc<Mutex<Option<Instant>>>,
+    /// Minimum delay between requests.
+    min_delay: Duration,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl RateLimiter {
+    ///
+    /// # Description
+    ///
+    /// Creates a new rate limiter with the default minimum delay for unauthenticated requests.
+    ///
+    /// # Returns
+    ///
+    /// A new `RateLimiter` instance.
+    ///
+    pub(crate) fn new() -> Self {
+        Self {
+            last_request: Arc::new(Mutex::new(None)),
+            min_delay: Duration::from_millis(UNAUTHENTICATED_MIN_REQUEST_DELAY_MS),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Creates a new rate limiter with a custom minimum delay.
+    ///
+    /// # Parameters
+    ///
+    /// - `min_delay_ms`: Minimum delay between requests in milliseconds.
+    ///
+    /// # Returns
+    ///
+    /// A new `RateLimiter` instance.
+    ///
+    pub(crate) fn with_delay(min_delay_ms: u64) -> Self {
+        Self {
+            last_request: Arc::new(Mutex::new(None)),
+            min_delay: Duration::from_millis(min_delay_ms),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the minimum delay between requests.
+    ///
+    /// # Returns
+    ///
+    /// The minimum delay as a `Duration`.
+    ///
+    #[allow(dead_code)]
+    pub(crate) fn min_delay(&self) -> Duration {
+        self.min_delay
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Creates a new rate limiter configured for GitHub API access.
+    ///
+    /// The delay is automatically adjusted based on whether a GitHub authentication token is
+    /// available in the environment. Authenticated requests allow 5000 requests per hour (200ms
+    /// delay), while unauthenticated requests are limited to 60 per hour (1000ms delay).
+    ///
+    /// # Returns
+    ///
+    /// A new `RateLimiter` instance with the appropriate delay.
+    ///
+    pub(crate) fn for_github() -> Self {
+        let delay_ms: u64 = if github_client::is_authenticated() {
+            debug!(
+                "Rate limiter: using authenticated delay ({}ms)",
+                AUTHENTICATED_MIN_REQUEST_DELAY_MS
+            );
+            AUTHENTICATED_MIN_REQUEST_DELAY_MS
+        } else {
+            debug!(
+                "Rate limiter: using unauthenticated delay ({}ms)",
+                UNAUTHENTICATED_MIN_REQUEST_DELAY_MS
+            );
+            UNAUTHENTICATED_MIN_REQUEST_DELAY_MS
+        };
+
+        Self::with_delay(delay_ms)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Waits if necessary to respect rate limits before making an API request.
+    ///
+    /// If the minimum delay since the last request has not elapsed, this method
+    /// will sleep for the remaining time. Otherwise, it returns immediately.
+    ///
+    pub(crate) async fn wait(&self) {
+        let mut last_request: tokio::sync::MutexGuard<'_, Option<Instant>> =
+            self.last_request.lock().await;
+
+        if let Some(last) = *last_request {
+            let elapsed: Duration = last.elapsed();
+            if elapsed < self.min_delay {
+                let sleep_duration: Duration = self.min_delay - elapsed;
+                debug!(
+                    "Rate limiter: waiting {}ms before next request",
+                    sleep_duration.as_millis()
+                );
+                tokio::time::sleep(sleep_duration).await;
+            }
+        }
+
+        *last_request = Some(Instant::now());
+    }
+}
+
+impl Default for RateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Checks an HTTP response for GitHub API rate limit errors and returns an actionable error if
+/// detected.
+///
+/// Inspects the response status code for 403 (Forbidden) and 429 (Too Many Requests), which
+/// indicate rate limit exhaustion. When detected, an error is returned with guidance on how to
+/// resolve the issue by setting `GITHUB_TOKEN` or `GH_TOKEN` environment variables.
+///
+/// # Parameters
+///
+/// - `response`: The HTTP response to check.
+///
+/// # Returns
+///
+/// On success (no rate limit issue), returns an empty tuple. On failure, returns an error with
+/// an actionable message.
+///
+pub(crate) fn check_rate_limit(response: &Response) -> Result<()> {
+    let status: ::reqwest::StatusCode = response.status();
+
+    // Log remaining rate limit if the header is present.
+    if let Some(remaining) = response.headers().get("x-ratelimit-remaining") {
+        if let Ok(remaining_str) = remaining.to_str() {
+            debug!("GitHub API rate limit remaining: {}", remaining_str);
+
+            // Warn if running low on remaining requests.
+            if let Ok(remaining_count) = remaining_str.parse::<u64>() {
+                if remaining_count <= 10 {
+                    warn!(
+                        "GitHub API rate limit nearly exhausted: {} requests remaining",
+                        remaining_count
+                    );
+                }
+            }
+        }
+    }
+
+    if status == ::reqwest::StatusCode::FORBIDDEN
+        || status == ::reqwest::StatusCode::TOO_MANY_REQUESTS
+    {
+        let reason: String = if github_client::is_authenticated() {
+            "GitHub API rate limit exceeded (authenticated).".to_string()
+        } else {
+            "GitHub API rate limit exceeded. Set GITHUB_TOKEN (or GH_TOKEN) environment variable \
+             to increase limits (60 req/hr -> 5000 req/hr)."
+                .to_string()
+        };
+        error!("{reason}");
+        anyhow::bail!(reason)
+    }
+
+    Ok(())
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests that the rate limiter creates successfully with default settings.
+    ///
+    #[test]
+    fn test_rate_limiter_new() {
+        let limiter: RateLimiter = RateLimiter::new();
+        assert_eq!(limiter.min_delay().as_millis(), UNAUTHENTICATED_MIN_REQUEST_DELAY_MS as u128);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that the rate limiter creates successfully with custom delay.
+    ///
+    #[test]
+    fn test_rate_limiter_with_delay() {
+        let limiter: RateLimiter = RateLimiter::with_delay(500);
+        assert_eq!(limiter.min_delay().as_millis(), 500);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that first request does not wait.
+    ///
+    #[tokio::test]
+    async fn test_rate_limiter_first_request_no_wait() {
+        let limiter: RateLimiter = RateLimiter::with_delay(100);
+        let start: Instant = Instant::now();
+        limiter.wait().await;
+        // First request should not wait.
+        assert!(start.elapsed().as_millis() < 50);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that consecutive requests respect the minimum delay.
+    ///
+    #[tokio::test]
+    async fn test_rate_limiter_enforces_delay() {
+        let limiter: RateLimiter = RateLimiter::with_delay(100);
+
+        // First request.
+        limiter.wait().await;
+
+        // Second request should wait.
+        let start: Instant = Instant::now();
+        limiter.wait().await;
+
+        // Should have waited approximately 100ms.
+        let elapsed: u128 = start.elapsed().as_millis();
+        assert!(elapsed >= 90, "Expected delay of ~100ms, got {}ms", elapsed);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that no wait is needed if enough time has elapsed.
+    ///
+    #[tokio::test]
+    async fn test_rate_limiter_no_wait_after_delay() {
+        let limiter: RateLimiter = RateLimiter::with_delay(50);
+
+        // First request.
+        limiter.wait().await;
+
+        // Wait longer than the minimum delay.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Second request should not need to wait.
+        let start: Instant = Instant::now();
+        limiter.wait().await;
+        assert!(start.elapsed().as_millis() < 20);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that the for_github constructor creates a rate limiter.
+    ///
+    #[test]
+    fn test_rate_limiter_for_github() {
+        let limiter: RateLimiter = RateLimiter::for_github();
+        // The delay should be one of the two known values.
+        let delay: u128 = limiter.min_delay().as_millis();
+        assert!(
+            delay == AUTHENTICATED_MIN_REQUEST_DELAY_MS as u128
+                || delay == UNAUTHENTICATED_MIN_REQUEST_DELAY_MS as u128,
+            "Unexpected delay: {}ms",
+            delay
+        );
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests the authenticated delay constant is lower than unauthenticated.
+    ///
+    #[test]
+    fn test_delay_constants() {
+        assert!(AUTHENTICATED_MIN_REQUEST_DELAY_MS < UNAUTHENTICATED_MIN_REQUEST_DELAY_MS);
+    }
+}

--- a/src/libs/nanvix-registry/src/release.rs
+++ b/src/libs/nanvix-registry/src/release.rs
@@ -7,7 +7,12 @@
 
 use crate::{
     deployment::Deployment,
+    github_client,
     machine::Machine,
+    rate_limiter::{
+        self,
+        RateLimiter,
+    },
     tarball::Tarball,
     tempfile::TemporaryFile,
 };
@@ -18,7 +23,10 @@ use ::reqwest::{
 };
 use ::std::{
     env,
-    path::PathBuf,
+    path::{
+        Path,
+        PathBuf,
+    },
 };
 use ::syslog::{
     error,
@@ -46,6 +54,8 @@ pub(crate) struct LatestRelease {
     deployment: Deployment,
     /// Target machine type for the release.
     machine: Machine,
+    /// Rate limiter for GitHub API calls.
+    rate_limiter: RateLimiter,
 }
 
 //==================================================================================================
@@ -71,6 +81,7 @@ impl LatestRelease {
         Self {
             deployment,
             machine,
+            rate_limiter: RateLimiter::for_github(),
         }
     }
 
@@ -88,25 +99,35 @@ impl LatestRelease {
     /// On success, this function returns the URL of the downloaded release. On failure, it returns
     /// an object that describes the error.
     ///
-    pub(crate) async fn download(&self, dir: &PathBuf) -> Result<String> {
+    pub(crate) async fn download(&self, dir: &Path) -> Result<String> {
         let release_url: String = self.get_url().await?;
 
         info!("Downloading release from: {}", release_url);
 
+        // Apply rate limiting before download.
+        self.rate_limiter.wait().await;
+
         // Download the tarball.
-        let response: Response = match reqwest::get(&release_url).await {
+        let client: Client = github_client::build_client()?;
+        let response: Response = match github_client::authenticated_get(&client, &release_url)
+            .send()
+            .await
+        {
             Ok(response) => response,
             Err(error) => {
-                let reason: String = format!("Failed to download release: {}", error);
+                let reason: String = format!("Failed to download release: {error}");
                 error!("{reason}");
                 anyhow::bail!(reason)
             },
         };
 
-        let bytes = match response.bytes().await {
+        // Check for rate limit errors.
+        rate_limiter::check_rate_limit(&response)?;
+
+        let bytes: ::bytes::Bytes = match response.bytes().await {
             Ok(bytes) => bytes,
             Err(error) => {
-                let reason: String = format!("Failed to read release: {}", error);
+                let reason: String = format!("Failed to read release: {error}");
                 error!("{reason}");
                 anyhow::bail!(reason)
             },
@@ -137,32 +158,36 @@ impl LatestRelease {
     /// object that describes the error.
     ///
     pub(crate) async fn get_url(&self) -> Result<String> {
-        let client: Client = Client::new();
-        let response: Response = match client
-            .get(GITHUB_API_URL)
-            .header("User-Agent", "nanvix-embedded")
+        // Apply rate limiting before API call.
+        self.rate_limiter.wait().await;
+
+        let client: Client = github_client::build_client()?;
+        let response: Response = match github_client::authenticated_get(&client, GITHUB_API_URL)
             .send()
             .await
         {
             Ok(response) => response,
             Err(error) => {
-                let reason: String = format!("Failed to fetch releases: {}", error);
+                let reason: String = format!("Failed to fetch releases: {error}");
                 error!("{reason}");
                 anyhow::bail!(reason)
             },
         };
 
+        // Check for rate limit errors.
+        rate_limiter::check_rate_limit(&response)?;
+
         let response: serde_json::Value = match response.json().await {
             Ok(json) => json,
             Err(error) => {
-                let reason: String = format!("Failed to parse releases: {}", error);
+                let reason: String = format!("Failed to parse releases: {error}");
                 error!("{reason}");
                 anyhow::bail!(reason)
             },
         };
 
         // Find the release asset URL.
-        let assets: &Vec<serde_json::Value> = match response["assets"].as_array() {
+        let assets: &[serde_json::Value] = match response["assets"].as_array() {
             Some(assets) => assets,
             None => {
                 let reason: String = "No assets found in release".to_string();

--- a/src/libs/nanvix-registry/src/tarball.rs
+++ b/src/libs/nanvix-registry/src/tarball.rs
@@ -113,7 +113,7 @@ impl Tarball {
     /// On success, this function returns an empty tuple. On failure, it returns an object that
     /// describes the error.
     ///
-    pub(crate) async fn extract(&self, dest_dir: &PathBuf) -> Result<()> {
+    pub(crate) async fn extract(&self, dest_dir: &Path) -> Result<()> {
         match self {
             Tarball::Bzip2 { path } => extract_bzip2(path, dest_dir).await,
         }
@@ -142,6 +142,11 @@ impl Tarball {
 ///
 /// Extracts a bzip2-compressed tarball using the `tar` command.
 ///
+/// # Note
+///
+/// This function does not validate extracted paths. See
+/// https://github.com/nanvix/nanvix/issues/1359 for tar slip mitigation.
+///
 /// # Parameters
 ///
 /// - `tarball_path`: Path to the tarball file.
@@ -151,7 +156,7 @@ impl Tarball {
 ///
 /// On success, returns an empty tuple. On failure, it returns an object that describes the error.
 ///
-async fn extract_bzip2(tarball_path: &PathBuf, dir: &PathBuf) -> anyhow::Result<()> {
+async fn extract_bzip2(tarball_path: &Path, dir: &Path) -> anyhow::Result<()> {
     // Spawn tar command.
     let mut child: Child = match Command::new("tar")
         .arg("-xjf")
@@ -162,7 +167,7 @@ async fn extract_bzip2(tarball_path: &PathBuf, dir: &PathBuf) -> anyhow::Result<
     {
         Ok(child) => child,
         Err(error) => {
-            let reason: String = format!("Failed to spawn tar command: {}", error);
+            let reason: String = format!("Failed to spawn tar command: {error}");
             error!("{reason}");
             anyhow::bail!(reason)
         },
@@ -172,7 +177,7 @@ async fn extract_bzip2(tarball_path: &PathBuf, dir: &PathBuf) -> anyhow::Result<
     let status: ExitStatus = match child.wait().await {
         Ok(status) => status,
         Err(error) => {
-            let reason: String = format!("Failed to wait for tar command: {}", error);
+            let reason: String = format!("Failed to wait for tar command: {error}");
             error!("{reason}");
             return Err(anyhow!(reason));
         },

--- a/src/libs/nanvix-registry/src/tempfile.rs
+++ b/src/libs/nanvix-registry/src/tempfile.rs
@@ -89,7 +89,7 @@ impl TemporaryFile {
     ///
     pub(crate) async fn write(&self, contents: &[u8]) -> Result<()> {
         if let Err(error) = fs::write(&self.path, contents).await {
-            let reason: String = format!("Failed to write to temporary file: {}", error);
+            let reason: String = format!("Failed to write to temporary file: {error}");
             error!("{reason}");
             anyhow::bail!(reason)
         }


### PR DESCRIPTION
- Introduced `PackageEntry` struct to store metadata about installed packages.
- Enhanced `ReleaseRegistry` to manage installed packages with methods to set, get, and check package installations.
- Created a new `package.rs` file containing the `Package` enum and related functionality for managing Nanvix packages.
- Implemented methods for downloading packages, fetching release information, and handling package dependencies.
- Added unit tests for package management features, ensuring correct functionality of package setting, retrieval, and installation checks.