### PR TITLE
[ci] Cleanup action for dangling resources

### DIFF
--- a/.github/actions/cleanup/action.yml
+++ b/.github/actions/cleanup/action.yml
@@ -1,0 +1,29 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Cleanup Dangling Resources"
+description: "Clean up resources that may have been left behind by previous runs or crashes"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Cleanup Dangling Resources"
+      shell: bash
+      run: |
+        # Defensive cleanup for resources that should have been cleaned by their owners:
+        # - nvx:* directories: cleaned by TemporaryDirectory::Drop (nanvixd/tempdir.rs)
+        # - *.socket files: cleaned by SocketListener::Drop (syscomm/socket_listener.rs)
+        # - nvxns-* namespaces: cleaned by NetnsHandle::Drop (nanvix-sandbox/netns.rs)
+        # - clh-console/cloud-hypervisor.sock: cleaned by EXIT trap (generate-l2-snapshot.sh)
+        # This step catches any resources leaked due to crashes or abnormal termination.
+
+        sudo rm -rf images 2>/dev/null || true
+        sudo find /tmp -maxdepth 1 -name 'nvx:*' -exec rm -rf {} + 2>/dev/null || true
+        rm -rf /tmp/nanvix-test-* 2>/dev/null || true
+        sudo rm -rf /tmp/clh-console 2>/dev/null || true
+        sudo rm -f /tmp/cloud-hypervisor.sock 2>/dev/null || true
+        sudo rm -f /tmp/*.socket 2>/dev/null || true
+        for ns in $(sudo ip netns list 2>/dev/null | grep -o 'nvxns-[0-9]*' || true); do
+          sudo ip link del "nvxgw-h-${ns#nvxns-}" 2>/dev/null || true
+          sudo ip netns del "${ns}" 2>/dev/null || true
+        done

--- a/.github/workflows/self-hosted-benchmark.yml
+++ b/.github/workflows/self-hosted-benchmark.yml
@@ -63,6 +63,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: "Pre-Cleanup Dangling Resources"
+      uses: ./.github/actions/cleanup
+
     - name: "Cache Cargo Target"
       id: cache-target
       uses: actions/cache@v5
@@ -162,13 +165,9 @@ jobs:
         key: ${{ runner.os }}-benchmark-target-${{ matrix.arch }}-${{ matrix.build-type }}
 
 
-    - name: "Cleanup Dangling Resources"
+    - name: "Post-Cleanup Dangling Resources"
       if: always()
-      run: |
-        sudo rm -rf images
-        sudo find /tmp -maxdepth 1 -name 'nvx:*' -exec rm -rf {} + 2>/dev/null || true
-        sudo rm -rf /tmp/clh-console 2>/dev/null || true
-      shell: bash
+      uses: ./.github/actions/cleanup
 
     - name: "Upload logs in case of benchmark failures"
       if: failure()

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -68,6 +68,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: "Pre-Cleanup Dangling Resources"
+      uses: ./.github/actions/cleanup
+
     # Create a link to the toolchain directory, as tests files assume the toolchain is at
     # ${GITHUB_WORKSPACE}/toolchain.
     - name: "Link Toolchain Directory"
@@ -269,27 +272,9 @@ jobs:
         path: ${{ steps.release-archive.outputs.archive-path }}
         overwrite: true
 
-    - name: "Cleanup Dangling Resources"
+    - name: "Post-Cleanup Dangling Resources"
       if: always()
-      run: |
-        # Defensive cleanup for resources that should have been cleaned by their owners:
-        # - nvx:* directories: cleaned by TemporaryDirectory::Drop (nanvixd/tempdir.rs)
-        # - *.socket files: cleaned by SocketListener::Drop (syscomm/socket_listener.rs)
-        # - nvxns-* namespaces: cleaned by NetnsHandle::Drop (nanvix-sandbox/netns.rs)
-        # - clh-console/cloud-hypervisor.sock: cleaned by EXIT trap (generate-l2-snapshot.sh)
-        # This step catches any resources leaked due to crashes or abnormal termination.
-
-        sudo rm -rf images
-        sudo find /tmp -maxdepth 1 -name 'nvx:*' -exec rm -rf {} + 2>/dev/null || true
-        rm -rf /tmp/nanvix-test-* 2>/dev/null || true
-        sudo rm -rf /tmp/clh-console 2>/dev/null || true
-        sudo rm -f /tmp/cloud-hypervisor.sock 2>/dev/null || true
-        sudo rm -f /tmp/*.socket 2>/dev/null || true
-        for ns in $(sudo ip netns list 2>/dev/null | grep -o 'nvxns-[0-9]*' || true); do
-          sudo ip link del "nvxgw-h-${ns#nvxns-}" 2>/dev/null || true
-          sudo ip netns del "${ns}" 2>/dev/null || true
-        done
-      shell: bash
+      uses: ./.github/actions/cleanup
 
     - name: "Upload logs in case of failures"
       if: failure()


### PR DESCRIPTION
This pull request refactors the cleanup logic for dangling resources in GitHub Actions workflows by introducing a reusable composite action, improving maintainability and consistency across workflows. The manual cleanup steps previously defined inline have been replaced with calls to this new action, and cleanup is now performed both before and after job execution in CI and benchmark workflows.