### PR TITLE
[nanvix-sandbox] Kill On Drop

### DIFF
--- a/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
@@ -559,9 +559,13 @@ impl LinuxDaemon {
 
             child
         } else {
-            Command::new(&linuxd_args[0])
-                .args(&linuxd_args[1..])
-                .stdout(Stdio::inherit())
+            let mut cmd: Command = Command::new(&linuxd_args[0]);
+            cmd.args(&linuxd_args[1..]);
+            // Ensure the child process is killed if the Child handle is dropped without explicit
+            // cleanup. This acts as a best-effort safety net during normal unwinding and shutdown
+            // paths where drop handlers run, helping to prevent orphaned processes.
+            cmd.kill_on_drop(true);
+            cmd.stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .spawn()
                 .map_err(|e| {

--- a/src/libs/nanvix-sandbox/src/multi_process/netns_exec.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/netns_exec.rs
@@ -12,8 +12,8 @@
 
 use crate::netns::NetnsInfo;
 use ::std::{
-    io,
     ffi::CString,
+    io,
     os::unix::io::RawFd,
 };
 use ::syslog::error;
@@ -53,14 +53,19 @@ unsafe fn setns_by_name(ns_name: &str) -> io::Result<()> {
 
     let fd: RawFd = libc::open(c_path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC);
     if fd < 0 {
-        error!("setns_by_name(): error opening netns file (error={:?})", io::Error::last_os_error());
-        return Err(io::Error::last_os_error());
+        let open_err: io::Error = io::Error::last_os_error();
+        error!("setns_by_name(): error opening netns file (error={open_err:?})");
+        return Err(open_err);
     }
 
     // Join the network namespace.
     // Note: setns() returns 0 on success, -1 on error (errno set).
     let rc: libc::c_int = libc::setns(fd, libc::CLONE_NEWNET);
-    let saved_err: Option<io::Error> = if rc != 0 { Some(io::Error::last_os_error()) } else { None };
+    let saved_err: Option<io::Error> = if rc != 0 {
+        Some(io::Error::last_os_error())
+    } else {
+        None
+    };
 
     // Close fd regardless.
     let close_rc: libc::c_int = libc::close(fd);
@@ -102,15 +107,15 @@ unsafe fn setns_by_name(ns_name: &str) -> io::Result<()> {
 ///
 /// A Command with the right hook that can be spawned.
 ///
-pub fn command_in_netns(
-    info: &NetnsInfo,
-    program: &str,
-    args: &[String],
-) -> Command {
+pub fn command_in_netns(info: &NetnsInfo, program: &str, args: &[String]) -> Command {
     let ns_name: String = info.ns_name().to_string();
 
     let mut cmd: Command = Command::new(program);
     cmd.args(args);
+    // Ensure the child process is killed if the Child handle is dropped without explicit cleanup.
+    // This acts as a best-effort safety net during normal unwinding and shutdown paths where drop
+    // handlers run, helping to prevent orphaned processes.
+    cmd.kill_on_drop(true);
 
     // SAFETY: inside the `pre-exec` closure we only run the logic to open the network namespace
     // file descriptor and call `setns` on it. It does not allocate any memory, and it only calls

--- a/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
@@ -164,12 +164,26 @@ impl UserVm {
             } else {
                 let mut cmd: Command = Command::new(&user_vm_args[0]);
                 cmd.args(&user_vm_args[1..]);
+                // Ensure the child process is killed if the Child handle is dropped without
+                // explicit cleanup. This acts as a best-effort safety net during normal unwinding
+                // and shutdown paths where drop handlers run, helping to prevent orphaned
+                // processes.
+                cmd.kill_on_drop(true);
 
                 cmd
             }
 
             #[cfg(feature = "single-process")]
-            Command::new(&user_vm_args[0]).args(&user_vm_args[1..])
+            {
+                let mut cmd: Command = Command::new(&user_vm_args[0]);
+                cmd.args(&user_vm_args[1..]);
+                // Ensure the child process is killed if the Child handle is dropped without
+                // explicit cleanup.  This acts as a best-effort safety net during normal unwinding
+                // and shutdown paths where drop handlers run, helping to prevent orphaned
+                // processes.
+                cmd.kill_on_drop(true);
+                cmd
+            }
         };
 
         // Inherit stdout/stderr so that errors when spawning the command are surfaced to nanvixd.

--- a/src/utils/nanvix-test/src/nanvixd/mod.rs
+++ b/src/utils/nanvix-test/src/nanvixd/mod.rs
@@ -128,6 +128,10 @@ impl Nanvixd {
     ) -> Command {
         let mut command: Command = Command::new(config.nanvixd_binary_path.as_str());
         command.current_dir(&config.working_directory);
+        // Ensure the child process is killed if the Child handle is dropped without explicit
+        // cleanup.  This acts as a best-effort safety net during normal unwinding and shutdown
+        // paths where drop handlers run, helping to prevent orphaned processes.
+        command.kill_on_drop(true);
         command.arg(::nanvixd::args::Args::OPT_TOOLCHAIN_BIN_DIRECTORY);
         command.arg(format!("{}/bin", config.toolchain_path));
 


### PR DESCRIPTION
This pull request improves process management and safety throughout the codebase by ensuring that spawned child processes are automatically killed if their handles are dropped without explicit cleanup. This prevents orphaned processes when the parent process terminates unexpectedly (such as from an unhandled SIGTERM). Additionally, there are minor code formatting improvements for readability.