### PR TITLE
Cast function pointers to usize via *const ()

### DIFF
--- a/src/kernel/src/hal/arch/x86/cpu/idt.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/idt.rs
@@ -89,7 +89,7 @@ unsafe extern "C" {
 macro_rules! idt_entry {
     ( $handler:expr, $dpl:expr, $type:expr) => {
         Idte::new(
-            $handler as usize as u32,
+            $handler as *const () as usize as u32,
             SegmentSelector::KernelCode as u16,
             Flags::new(PresentBit::Present, $dpl, $type),
         )

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -218,7 +218,7 @@ impl ProcessManagerInner {
         debug_assert!(Vmem::is_user_addr(args.user_fn));
 
         let kernel_func: VirtualAddress =
-            VirtualAddress::from_raw_value(__leave_kernel_to_user_mode as usize);
+            VirtualAddress::from_raw_value(__leave_kernel_to_user_mode as *const () as usize);
 
         // Alloc kernel pages for the kernel stack. If we fail beyond this point, `kernel_stack`
         // gets dropped as soon as we exit this scope and underlying pages are released.


### PR DESCRIPTION
This eliminates a warning that in some cases blocks builds.