### PR TITLE
[kernel] Add `mmio_info()` Kernel Call

### DIFF
--- a/build/make/generic-guest-binaries.mk
+++ b/build/make/generic-guest-binaries.mk
@@ -5,13 +5,22 @@ GUEST_BINARY_FEATURES := $(LOG_LEVEL)
 GUEST_BINARY_FEATURES := $(strip $(GUEST_BINARY_FEATURES))
 GUEST_BINARY_CARGO_FEATURES := $(if $(GUEST_BINARY_FEATURES),--features "$(GUEST_BINARY_FEATURES)")
 
+# Package-specific features for test-kernel program.
+TEST_KERNEL_FEATURES := $(GUEST_BINARY_FEATURES)
+TEST_KERNEL_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
+TEST_KERNEL_FEATURES := $(strip $(TEST_KERNEL_FEATURES))
+TEST_KERNEL_CARGO_FEATURES := $(if $(TEST_KERNEL_FEATURES),--features "$(TEST_KERNEL_FEATURES)")
+
+# Returns package-specific cargo features, falling back to generic features.
+GUEST_BINARY_PKG_FEATURES = $(if $(filter test-kernel,$(1)),$(TEST_KERNEL_CARGO_FEATURES),$(GUEST_BINARY_CARGO_FEATURES))
+
 define GUEST_BINARY_RULES
 all-guest-binaries-$(1): init all-guest-staticlibs
-	$(GUEST_CARGO_BUILD_CMD) -p $(1) $(GUEST_BINARY_CARGO_FEATURES)
+	$(GUEST_CARGO_BUILD_CMD) -p $(1) $(call GUEST_BINARY_PKG_FEATURES,$(1))
 	$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$(1).elf $(BINARIES_DIR)/$(1).elf
 
 check-guest-binaries-$(1):
-	$(GUEST_CARGO_CHECK_CMD) -p $(1) $(GUEST_BINARY_CARGO_FEATURES)
+	$(GUEST_CARGO_CHECK_CMD) -p $(1) $(call GUEST_BINARY_PKG_FEATURES,$(1))
 
 format-guest-binaries-$(1):
 	$(GUEST_CARGO_FMT_CMD) -p $(1)
@@ -24,10 +33,10 @@ clean-guest-binaries-$(1): clean-guest-staticlibs
 	$(RM_CMD) $(BINARIES_DIR)/$(1).elf
 
 rust-lint-guest-binaries-$(1):
-	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_BINARY_CARGO_FEATURES) --fix --allow-dirty
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(call GUEST_BINARY_PKG_FEATURES,$(1)) --fix --allow-dirty
 
 rust-lint-check-guest-binaries-$(1):
-	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_BINARY_CARGO_FEATURES) -- -D warnings
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(call GUEST_BINARY_PKG_FEATURES,$(1)) -- -D warnings
 endef
 
 $(foreach target,$(ALL_GUEST_BINARIES),$(eval $(call GUEST_BINARY_RULES,$(target))))

--- a/src/kernel/src/io/kcall/mmio_free.rs
+++ b/src/kernel/src/io/kcall/mmio_free.rs
@@ -6,14 +6,7 @@
 //==================================================================================================
 
 use crate::{
-    hal::{
-        io::MmioTag,
-        mem::{
-            Address,
-            PageAligned,
-            VirtualAddress,
-        },
-    },
+    hal::io::MmioTag,
     kcall::{
         KcallArgs,
         KcallResult,
@@ -35,13 +28,27 @@ use ::sys::{
 // Standalone Functions
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Detaches a memory-mapped I/O region identified by `tag` from a process.
+///
+/// # Parameters
+///
+/// - `pm`: Reference to the process manager.
+/// - `pid`: Identifier of the calling process.
+/// - `tag`: Tag that uniquely identifies the MMIO region.
+///
+/// # Returns
+///
+/// Upon success, empty is returned. Upon failure, an error is returned instead.
+///
 fn do_mmio_free(
     pm: &mut ProcessManager,
     pid: ProcessIdentifier,
     tag: MmioTag,
-    addr: PageAligned<VirtualAddress>,
 ) -> Result<(), Error> {
-    trace!("pid={:?}, tag={:?}, addr={:?}", pid, tag, addr.into_inner());
+    trace!("pid={:?}, tag={:?}", pid, tag);
 
     // Check if process does not have I/O management capabilities.
     if !pm.has_capability(pid, Capability::IoManagement)? {
@@ -50,22 +57,32 @@ fn do_mmio_free(
         return Err(Error::new(ErrorCode::PermissionDenied, reason));
     }
 
-    // Detached I/O memory region from the process.
-    pm.mmio_free(pid, tag, addr)?;
+    // Detach I/O memory region from the process.
+    pm.mmio_free(pid, tag)?;
 
     Ok(())
 }
 
+///
+/// # Description
+///
+/// Kernel call handler for releasing an MMIO region.
+///
+/// # Parameters
+///
+/// - `pm`: Reference to the process manager.
+/// - `args`: Kernel call arguments containing the encoded tag.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
 pub fn mmio_free(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
     // Parse arguments.
     let tag_value: u64 = ((args.arg1 as u64) << 32) | args.arg0 as u64;
     let tag: MmioTag = MmioTag::from_u64(tag_value);
-    let addr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(args.arg2 as usize) {
-        Ok(base) => base,
-        Err(e) => return KcallResult::Error(e.code.into()),
-    };
 
-    match do_mmio_free(pm, args.pid, tag, addr) {
+    match do_mmio_free(pm, args.pid, tag) {
         Ok(_) => KcallResult::ok(),
         Err(e) => KcallResult::Error(e.code.into()),
     }

--- a/src/kernel/src/io/kcall/mmio_info.rs
+++ b/src/kernel/src/io/kcall/mmio_info.rs
@@ -1,0 +1,102 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    hal::io::MmioTag,
+    kcall::{
+        KcallArgs,
+        KcallResult,
+    },
+    pm::{
+        self,
+        ProcessManager,
+    },
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    mm::MmioRegionInfo,
+    pm::{
+        Capability,
+        ProcessIdentifier,
+    },
+};
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Retrieves metadata for a memory-mapped I/O region attached to a process.
+///
+/// # Parameters
+///
+/// - `pm`: Reference to the process manager.
+/// - `pid`: Identifier of the calling process.
+/// - `tag`: Tag that uniquely identifies the MMIO region.
+///
+/// # Returns
+///
+/// Upon success, a populated [`MmioRegionInfo`] is returned. Upon failure, an error is returned
+/// instead.
+///
+fn do_mmio_info(
+    pm: &ProcessManager,
+    pid: ProcessIdentifier,
+    tag: MmioTag,
+) -> Result<MmioRegionInfo, Error> {
+    trace!("pid={pid:?}, tag={tag:?}");
+
+    if !pm.has_capability(pid, Capability::IoManagement)? {
+        let reason: &'static str = "process does not have I/O management capabilities";
+        error!("{reason}");
+        return Err(Error::new(ErrorCode::PermissionDenied, reason));
+    }
+
+    let (base, size, perm) = pm.mmio_info(pid, tag)?;
+    MmioRegionInfo::new(base.into_inner(), size, perm)
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Kernel call handler for querying metadata of an MMIO region.
+///
+/// # Parameters
+///
+/// - `pm`: Reference to the process manager.
+/// - `args`: Kernel call arguments containing the encoded tag and a pointer to the output buffer.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn mmio_info(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
+    let tag_value: u64 = ((args.arg1 as u64) << 32) | args.arg0 as u64;
+    let tag: MmioTag = MmioTag::from_u64(tag_value);
+    let buffer_ptr: *mut MmioRegionInfo = args.arg2 as usize as *mut MmioRegionInfo;
+
+    if buffer_ptr.is_null() {
+        return KcallResult::Error(ErrorCode::BadAddress.into());
+    }
+
+    match do_mmio_info(pm, args.pid, tag) {
+        Ok(info) => match pm::copy_to_user(pm, args.pid, buffer_ptr, &info) {
+            Ok(_) => KcallResult::ok(),
+            Err(e) => KcallResult::Error(e.code.into()),
+        },
+        Err(e) => KcallResult::Error(e.code.into()),
+    }
+}

--- a/src/kernel/src/io/kcall/mod.rs
+++ b/src/kernel/src/io/kcall/mod.rs
@@ -7,6 +7,7 @@
 
 mod mmio_alloc;
 mod mmio_free;
+mod mmio_info;
 mod pmio_alloc;
 mod pmio_free;
 mod pmio_read;
@@ -18,6 +19,7 @@ mod pmio_write;
 
 pub use mmio_alloc::mmio_alloc;
 pub use mmio_free::mmio_free;
+pub use mmio_info::mmio_info;
 pub use pmio_alloc::pmio_alloc;
 pub use pmio_free::pmio_free;
 pub use pmio_read::pmio_read;

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -83,6 +83,7 @@ pub fn kcall_handler(
                         KcallNumber::Send => ipc::send(pm, args),
                         KcallNumber::AllocMmio => io::mmio_alloc(hal, pm, args),
                         KcallNumber::FreeMmio => io::mmio_free(pm, args),
+                        KcallNumber::MmioInfo => io::mmio_info(pm, args),
                         KcallNumber::AllocPmio => io::pmio_alloc(hal, pm, args),
                         KcallNumber::FreePmio => io::pmio_free(pm, args),
                         KcallNumber::ReadPmio => io::pmio_read(pm, args),

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1861,6 +1861,40 @@ impl ProcessManager {
         Ok(())
     }
 
+    ///
+    /// # Description
+    ///
+    /// Retrieves metadata for the MMIO region identified by `tag` attached to a process.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the process that owns the region.
+    /// - `tag`: Tag that uniquely identifies the MMIO region.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, a tuple containing the base address, size, and access permissions of the
+    /// region is returned. Upon failure, an error is returned instead.
+    ///
+    pub fn mmio_info(
+        &self,
+        pid: ProcessIdentifier,
+        tag: MmioTag,
+    ) -> Result<(PageAligned<VirtualAddress>, usize, AccessPermission), Error> {
+        let pm: Ref<ProcessManagerInner> = self.try_borrow()?;
+        let process: ProcessRef = pm.find_process(pid)?;
+        let state: &ProcessState = process.state();
+
+        match state.mmio_info(tag) {
+            Some(region) => Ok((region.base(), region.size(), region.perm())),
+            None => {
+                let reason: &'static str = "mmio region not found";
+                error!("{reason}");
+                Err(Error::new(ErrorCode::NoSuchEntry, reason))
+            },
+        }
+    }
+
     pub fn attach_pmio(&mut self, pid: ProcessIdentifier, port: AnyIoPort) -> Result<(), Error> {
         let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
         let mut process: ProcessRefMut = pm.find_process_mut(pid)?;

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1838,16 +1838,25 @@ impl ProcessManager {
         Ok(())
     }
 
-    pub fn mmio_free(
-        &mut self,
-        pid: ProcessIdentifier,
-        tag: MmioTag,
-        addr: PageAligned<VirtualAddress>,
-    ) -> Result<(), Error> {
+    ///
+    /// # Description
+    ///
+    /// Detaches a memory-mapped I/O region identified by `tag` from the process.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the process from which to detach the region.
+    /// - `tag`: Tag that uniquely identifies the MMIO region to detach.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Upon failure, an error is returned instead.
+    ///
+    pub fn mmio_free(&mut self, pid: ProcessIdentifier, tag: MmioTag) -> Result<(), Error> {
         let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
         let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
         let state: &mut ProcessState = process.state_mut();
-        state.remove_mmio(tag, addr);
+        state.remove_mmio(tag);
 
         Ok(())
     }

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -31,10 +31,7 @@ use crate::{
             IoPortWidth,
             MmioTag,
         },
-        mem::{
-            PageAligned,
-            VirtualAddress,
-        },
+        mem::VirtualAddress,
     },
     ipc::Mailbox,
     mm::Vmem,
@@ -268,12 +265,41 @@ impl ProcessState {
         self.mailbox.receive(tid)
     }
 
+    /// # Description
+    ///
+    /// Adds an MMIO region to the process state.
+    ///
+    /// # Parameters
+    ///
+    /// - `region`: The I/O memory region to add.
+    ///
+    /// # Note
+    ///
+    /// Tag uniqueness is enforced by [`IoMemoryAllocator`], which guarantees that no two regions
+    /// with the same tag can be allocated simultaneously.
+    ///
     pub fn add_mmio(&mut self, region: IoMemoryRegion) {
         self.mmio.push_back(region)
     }
 
-    pub fn remove_mmio(&mut self, tag: MmioTag, addr: PageAligned<VirtualAddress>) {
-        self.mmio.retain(|r| r.tag() != tag || r.base() != addr)
+    ///
+    /// # Description
+    ///
+    /// Removes the MMIO region identified by the given tag from the process state.
+    ///
+    /// # Parameters
+    ///
+    /// - `tag`: Tag that uniquely identifies the region to remove.
+    ///
+    /// # Note
+    ///
+    /// Tag uniqueness is enforced by [`IoMemoryAllocator`], so at most one region will match.
+    ///
+    pub fn remove_mmio(&mut self, tag: MmioTag) {
+        if let Some(index) = self.mmio.iter().position(|r| r.tag() == tag) {
+            // Remove only the first region that matches the given tag.
+            self.mmio.remove(index);
+        }
     }
 
     pub fn add_pmio(&mut self, port: AnyIoPort) {

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -302,6 +302,23 @@ impl ProcessState {
         }
     }
 
+    ///
+    /// # Description
+    ///
+    /// Retrieves a reference to the MMIO region identified by the given tag.
+    ///
+    /// # Parameters
+    ///
+    /// - `tag`: Tag that uniquely identifies the region to look up.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the [`IoMemoryRegion`] if found, or `None` otherwise.
+    ///
+    pub fn mmio_info(&self, tag: MmioTag) -> Option<&IoMemoryRegion> {
+        self.mmio.iter().find(|r| r.tag() == tag)
+    }
+
     pub fn add_pmio(&mut self, port: AnyIoPort) {
         self.pmio.push_back(port)
     }

--- a/src/libs/sys/src/sys/kcall/mm/kcalls.rs
+++ b/src/libs/sys/src/sys/kcall/mm/kcalls.rs
@@ -22,6 +22,16 @@ use crate::{
 };
 
 //==================================================================================================
+// Helpers
+//==================================================================================================
+
+fn split_tag(tag: u64) -> (u32, u32) {
+    let lower: u32 = tag as u32;
+    let upper: u32 = (tag >> 32) as u32;
+    (lower, upper)
+}
+
+//==================================================================================================
 // Map Memory Page
 //==================================================================================================
 
@@ -83,61 +93,60 @@ pub fn mprotect(
 }
 
 //==================================================================================================
-// Allocate Memory-Mapped I/O Region
+// Allocate MMIO Region
 //==================================================================================================
 
 ///
 /// # Description
 ///
-/// Allocates a memory-mapped I/O region identified by the given tag.
+/// Requests the kernel to attach a memory-mapped I/O region identified by `tag` to the
+/// calling process. The tag must match one registered via the hardware abstraction layer and must
+/// be encoded as up to 16 hexadecimal digits packed into a 64-bit value (four bits per digit).
 ///
 /// # Parameters
 ///
-/// - `tag`: A 64-bit tag that uniquely identifies the MMIO region (e.g., 8-byte ASCII name).
+/// - `tag`: Encoded identifier of the MMIO region to allocate.
 ///
 /// # Returns
 ///
-/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+/// `Ok(())` on success, or an error describing why the allocation failed.
 ///
 pub fn mmio_alloc(tag: u64) -> Result<(), Error> {
-    let tag_lo: u32 = tag as u32;
-    let tag_hi: u32 = (tag >> 32) as u32;
-    let result: i64 = kcall2!(KcallNumber::AllocMmio.into(), tag_lo, tag_hi);
+    let (lower, upper): (u32, u32) = split_tag(tag);
+    let result: i64 = kcall2!(KcallNumber::AllocMmio.into(), lower, upper);
 
     if result == 0 {
         Ok(())
     } else {
-        Err(Error::new(ErrorCode::try_from(result)?, "failed to mmio_alloc()"))
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to allocate mmio region"))
     }
 }
 
 //==================================================================================================
-// Free Memory-Mapped I/O Region
+// Release MMIO Region
 //==================================================================================================
 
 ///
 /// # Description
 ///
-/// Frees a memory-mapped I/O region identified by the given tag and address.
+/// Releases a previously allocated memory-mapped I/O region identified by `tag` from the calling
+/// process.
 ///
 /// # Parameters
 ///
-/// - `tag`: A 64-bit tag that uniquely identifies the MMIO region.
-/// - `vaddr`: Virtual address of the memory-mapped I/O region.
+/// - `tag`: Encoded identifier of the MMIO region to release.
 ///
 /// # Returns
 ///
-/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+/// `Ok(())` on success, or an error describing why the release failed.
 ///
-pub fn mmio_free(tag: u64, vaddr: VirtualAddress) -> Result<(), Error> {
-    let tag_lo: u32 = tag as u32;
-    let tag_hi: u32 = (tag >> 32) as u32;
-    let result: i64 =
-        kcall3!(KcallNumber::FreeMmio.into(), tag_lo, tag_hi, vaddr.into_raw_value() as u32);
+pub fn mmio_free(tag: u64) -> Result<(), Error> {
+    let (lower, upper): (u32, u32) = split_tag(tag);
+    let result: i64 = kcall2!(KcallNumber::FreeMmio.into(), lower, upper);
 
     if result == 0 {
         Ok(())
     } else {
-        Err(Error::new(ErrorCode::try_from(result)?, "failed to mmio_free()"))
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to free mmio region"))
     }
 }

--- a/src/libs/sys/src/sys/kcall/mm/kcalls.rs
+++ b/src/libs/sys/src/sys/kcall/mm/kcalls.rs
@@ -15,6 +15,7 @@ use crate::{
     mm::{
         AccessPermission,
         Address,
+        MmioRegionInfo,
         VirtualAddress,
     },
     number::KcallNumber,
@@ -148,5 +149,37 @@ pub fn mmio_free(tag: u64) -> Result<(), Error> {
         Ok(())
     } else {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to free mmio region"))
+    }
+}
+
+//==================================================================================================
+// Query MMIO Region
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Queries metadata for the memory-mapped I/O region identified by `tag` and returns information
+/// such as the mapped base address, size, and permissions.
+///
+/// # Parameters
+///
+/// - `tag`: Encoded identifier of the MMIO region to query.
+///
+/// # Returns
+///
+/// On success, returns an [`MmioRegionInfo`] structure populated by the kernel.
+///
+pub fn mmio_info(tag: u64) -> Result<MmioRegionInfo, Error> {
+    let (lower, upper): (u32, u32) = split_tag(tag);
+    let mut info: MmioRegionInfo = MmioRegionInfo::default();
+    let buffer: *mut MmioRegionInfo = &mut info;
+
+    let result: i64 = kcall3!(KcallNumber::MmioInfo.into(), lower, upper, buffer as usize as u32);
+
+    if result == 0 {
+        Ok(info)
+    } else {
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to query mmio region"))
     }
 }

--- a/src/libs/sys/src/sys/mm/mmio.rs
+++ b/src/libs/sys/src/sys/mm/mmio.rs
@@ -1,0 +1,181 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    mm::{
+        AccessPermission,
+        Address,
+        VirtualAddress,
+    },
+};
+use ::core::convert::TryFrom;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Describes the attributes of a memory-mapped I/O region that is attached to a process.
+///
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MmioRegionInfo {
+    /// Base virtual address of the MMIO mapping (32-bit).
+    base: u32,
+    /// Size of the MMIO mapping in bytes.
+    size: u32,
+    /// Encoded access permissions (bitmask compatible with [`AccessPermission`]).
+    permissions: u32,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl MmioRegionInfo {
+    ///
+    /// # Description
+    ///
+    /// Creates a new [`MmioRegionInfo`] from strongly-typed components.
+    ///
+    /// # Parameters
+    ///
+    /// - `base`: Page-aligned virtual address of the mapping.
+    /// - `size`: Size of the mapping in bytes.
+    /// - `permissions`: Access permissions granted to the mapping.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, a populated [`MmioRegionInfo`] is returned. Upon failure, an error is returned
+    /// instead.
+    ///
+    pub fn new(
+        base: VirtualAddress,
+        size: usize,
+        permissions: AccessPermission,
+    ) -> Result<Self, Error> {
+        let base_raw: u32 = u32::try_from(base.into_raw_value()).map_err(|_| {
+            Error::new(ErrorCode::ValueOutOfRange, "mmio base address exceeds 32 bits")
+        })?;
+        let size_raw: u32 = u32::try_from(size)
+            .map_err(|_| Error::new(ErrorCode::ValueOutOfRange, "mmio size exceeds 32 bits"))?;
+
+        Ok(Self {
+            base: base_raw,
+            size: size_raw,
+            permissions: permissions.into(),
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Instantiates a new [`MmioRegionInfo`] directly from raw primitives.
+    ///
+    /// # Parameters
+    ///
+    /// - `base`: Raw base virtual address.
+    /// - `size`: Size of the region in bytes.
+    /// - `permissions`: Encoded access permissions bitmask.
+    ///
+    /// # Returns
+    ///
+    /// A new [`MmioRegionInfo`] initialized with the provided values.
+    ///
+    pub const fn from_raw_parts(base: u32, size: u32, permissions: u32) -> Self {
+        Self {
+            base,
+            size,
+            permissions,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the raw base virtual address encoded in the structure.
+    ///
+    /// # Returns
+    ///
+    /// The base address as a 32-bit unsigned integer.
+    ///
+    pub const fn base_raw(&self) -> u32 {
+        self.base
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the base address as a [`VirtualAddress`].
+    ///
+    /// # Returns
+    ///
+    /// The base address of the MMIO region.
+    ///
+    pub fn base(&self) -> VirtualAddress {
+        VirtualAddress::from_raw_value(self.base as usize)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the raw size in bytes.
+    ///
+    /// # Returns
+    ///
+    /// The size of the MMIO region as a 32-bit unsigned integer.
+    ///
+    pub const fn size_raw(&self) -> u32 {
+        self.size
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the size of the region as a host `usize`.
+    ///
+    /// # Returns
+    ///
+    /// The size of the MMIO region in bytes.
+    ///
+    pub fn size(&self) -> usize {
+        self.size as usize
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the raw permission field.
+    ///
+    /// # Returns
+    ///
+    /// The encoded permissions as a 32-bit unsigned integer.
+    ///
+    pub const fn permissions_raw(&self) -> u32 {
+        self.permissions
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the decoded permissions as an [`AccessPermission`].
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the access permissions are returned. Upon failure, an error is returned
+    /// instead.
+    ///
+    pub fn permissions(&self) -> Result<AccessPermission, Error> {
+        AccessPermission::try_from(self.permissions)
+    }
+}

--- a/src/libs/sys/src/sys/mm/mod.rs
+++ b/src/libs/sys/src/sys/mm/mod.rs
@@ -8,6 +8,7 @@
 mod access;
 mod address;
 mod alignment;
+mod mmio;
 
 //==================================================================================================
 // Exports
@@ -16,3 +17,4 @@ mod alignment;
 pub use access::*;
 pub use address::*;
 pub use alignment::*;
+pub use mmio::*;

--- a/src/libs/sys/src/sys/number.rs
+++ b/src/libs/sys/src/sys/number.rs
@@ -45,6 +45,8 @@ pub enum KcallNumber {
     AllocMmio = KcallNumber::NR_ALLOC_MMIO_SYSCALL,
     /// Releases a memory-mapped I/O region.
     FreeMmio = KcallNumber::NR_FREE_MMIO_SYSCALL,
+    /// Retrieves metadata for a memory-mapped I/O region.
+    MmioInfo = KcallNumber::NR_MMIO_INFO_SYSCALL,
     /// Allocates a port-mapped I/O port.
     AllocPmio = KcallNumber::NR_ALLOC_PMIO_SYSCALL,
     /// Frees a port-mapped I/O port.
@@ -98,6 +100,7 @@ impl KcallNumber {
     const NR_MEMORY_COPY_SYSCALL: u32 = 13;
     const NR_ALLOC_MMIO_SYSCALL: u32 = 14;
     const NR_FREE_MMIO_SYSCALL: u32 = 15;
+    const NR_MMIO_INFO_SYSCALL: u32 = 32;
     const NR_ALLOC_PMIO_SYSCALL: u32 = 16;
     const NR_FREE_PMIO_SYSCALL: u32 = 17;
     const NR_READ_PMIO_SYSCALL: u32 = 18;
@@ -137,6 +140,7 @@ impl From<u32> for KcallNumber {
             Self::NR_MEMORY_COPY_SYSCALL => KcallNumber::MemoryCopy,
             Self::NR_ALLOC_MMIO_SYSCALL => KcallNumber::AllocMmio,
             Self::NR_FREE_MMIO_SYSCALL => KcallNumber::FreeMmio,
+            Self::NR_MMIO_INFO_SYSCALL => KcallNumber::MmioInfo,
             Self::NR_ALLOC_PMIO_SYSCALL => KcallNumber::AllocPmio,
             Self::NR_FREE_PMIO_SYSCALL => KcallNumber::FreePmio,
             Self::NR_READ_PMIO_SYSCALL => KcallNumber::ReadPmio,
@@ -178,6 +182,7 @@ impl From<KcallNumber> for u32 {
             KcallNumber::MemoryCopy => KcallNumber::NR_MEMORY_COPY_SYSCALL,
             KcallNumber::AllocMmio => KcallNumber::NR_ALLOC_MMIO_SYSCALL,
             KcallNumber::FreeMmio => KcallNumber::NR_FREE_MMIO_SYSCALL,
+            KcallNumber::MmioInfo => KcallNumber::NR_MMIO_INFO_SYSCALL,
             KcallNumber::AllocPmio => KcallNumber::NR_ALLOC_PMIO_SYSCALL,
             KcallNumber::FreePmio => KcallNumber::NR_FREE_PMIO_SYSCALL,
             KcallNumber::ReadPmio => KcallNumber::NR_READ_PMIO_SYSCALL,

--- a/src/tests/test-kernel/Cargo.toml
+++ b/src/tests/test-kernel/Cargo.toml
@@ -7,16 +7,18 @@ version.workspace = true
 license-file.workspace = true
 edition.workspace = true
 authors.workspace = true
-description = "Test program that exits with a specific exit code via kernel call"
+description = "Focused user-level regression tests for kernel interfaces"
 homepage.workspace = true
 
 [[bin]]
 name = "test-kernel"
 
 [dependencies]
+arch = { workspace = true }
 libc_string = { workspace = true }
-sys = { workspace = true }
 nvx = { workspace = true }
+sys = { workspace = true, features = ["kcall"] }
+syslog = { workspace = true, default-features = true }
 
 [build-dependencies]
 cc = { workspace = true }
@@ -24,12 +26,13 @@ cfg-if = { workspace = true }
 
 [features]
 default = ["panic"]
-trace = ["nvx/trace"]
-debug = ["nvx/debug"]
-info = ["nvx/info"]
-warn = ["nvx/warn"]
-error = ["nvx/error"]
-panic = ["nvx/panic"]
+trace = ["nvx/trace", "syslog/trace"]
+debug = ["nvx/debug", "syslog/debug"]
+info = ["nvx/info", "syslog/info"]
+warn = ["nvx/warn", "syslog/warn"]
+error = ["nvx/error", "syslog/error"]
+panic = ["nvx/panic", "syslog/panic"]
+hyperlight = []
 
 [lints]
 workspace = true

--- a/src/tests/test-kernel/src/main.rs
+++ b/src/tests/test-kernel/src/main.rs
@@ -8,6 +8,7 @@
 // Imports
 //==================================================================================================
 
+extern crate alloc;
 extern crate libc_string;
 extern crate nvx;
 
@@ -15,6 +16,13 @@ use ::sys::error::{
     Error,
     ErrorCode,
 };
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+#[cfg(not(feature = "hyperlight"))]
+mod mmio_ramfs;
 
 //==================================================================================================
 // Constants
@@ -30,8 +38,9 @@ const EXIT_CODE: i32 = 13;
 ///
 /// # Description
 ///
-/// Entry point of the test program. This function returns an error with a specific error code
-/// to test that the expected_exit_code assertion works correctly in nanvix-test.
+/// Entry point of the test program. This function runs kernel interface tests and returns an
+/// error with a specific error code to test that the expected_exit_code assertion works correctly
+/// in nanvix-test.
 ///
 /// # Returns
 ///
@@ -39,6 +48,9 @@ const EXIT_CODE: i32 = 13;
 ///
 #[no_mangle]
 pub fn main() -> Result<(), Error> {
+    #[cfg(not(feature = "hyperlight"))]
+    mmio_ramfs::run()?;
+
     // Return an error with the specified exit code.
     // The nvx runtime will convert this to the process exit code.
     Err(Error::new(

--- a/src/tests/test-kernel/src/mmio_ramfs.rs
+++ b/src/tests/test-kernel/src/mmio_ramfs.rs
@@ -1,0 +1,261 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::alloc::string::String;
+use ::arch::mem::PAGE_SIZE;
+use ::core::{
+    cmp,
+    fmt::Write,
+    ptr,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    kcall::{
+        mm,
+        pm,
+    },
+    mm::{
+        AccessPermission,
+        Address,
+        MmioRegionInfo,
+    },
+    pm::Capability,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Encoded 8-byte "RAMFS   " tag exposed by the MicroVM RAMFS MMIO region.
+const RAMFS_MMIO_TAG: u64 = u64::from_be_bytes(*b"RAMFS   ");
+
+/// Maximum number of bytes dumped per run to avoid overwhelming the logger.
+const RAMFS_DUMP_MAX_BYTES: usize = 512;
+
+/// Number of bytes rendered per hexdump line.
+const RAMFS_DUMP_LINE_BYTES: usize = 16;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Runs the RAMFS `mmio_info()` regression test.
+///
+/// # Description
+///
+/// Allocates the RAMFS MMIO mapping, queries `mmio_info()`, and validates the metadata reported by
+/// the kernel. This test requires the `-ramfs` option to be passed to nanvixd.
+///
+/// # Returns
+///
+/// `Ok(())` on success, or an error if the RAMFS region is not available or any invariant fails.
+///
+/// # Errors
+///
+/// Returns an error if the RAMFS region is not registered or if any validation fails.
+pub fn run() -> Result<(), Error> {
+    let mut cap_acquired: bool = false;
+    let mut region_attached: bool = false;
+
+    let mut result: Result<(), Error> = (|| {
+        pm::capctl(Capability::IoManagement, true)?;
+        cap_acquired = true;
+
+        match mm::mmio_alloc(RAMFS_MMIO_TAG) {
+            Ok(()) => region_attached = true,
+            Err(err) if err.code == ErrorCode::NoSuchEntry => {
+                let reason: &'static str =
+                    "RAMFS MMIO region not found; ensure -ramfs option is passed to nanvixd";
+                ::syslog::error!("test-kernel: {}", reason);
+                return Err(Error::new(ErrorCode::NoSuchEntry, reason));
+            },
+            Err(err) => return Err(err),
+        }
+
+        let info: MmioRegionInfo = mm::mmio_info(RAMFS_MMIO_TAG)?;
+        validate_info(&info)?;
+        dump_ramfs_contents(&info)?;
+
+        Ok(())
+    })();
+
+    if region_attached {
+        if let Err(err) = mm::mmio_free(RAMFS_MMIO_TAG) {
+            ::syslog::error!("test-kernel: failed to free RAMFS region (error={:?})", err);
+            if result.is_ok() {
+                result = Err(err);
+            }
+        }
+    }
+
+    if cap_acquired {
+        if let Err(err) = pm::capctl(Capability::IoManagement, false) {
+            ::syslog::error!(
+                "test-kernel: failed to drop IoManagement capability (error={:?})",
+                err
+            );
+            if result.is_ok() {
+                result = Err(err);
+            }
+        }
+    }
+
+    result
+}
+
+///
+/// # Description
+///
+/// Validates that the MMIO region metadata conforms to expected invariants.
+///
+/// # Parameters
+///
+/// - `info`: Reference to the MMIO region info structure returned by the kernel.
+///
+/// # Returns
+///
+/// `Ok(())` if all invariants hold, or an error describing which invariant failed.
+///
+fn validate_info(info: &MmioRegionInfo) -> Result<(), Error> {
+    let permissions: AccessPermission = info.permissions()?;
+    if permissions != AccessPermission::RDONLY {
+        return Err(Error::new(ErrorCode::InvalidArgument, "ramfs permissions mismatch"));
+    }
+
+    let base_raw: usize = info.base().into_raw_value();
+    if base_raw == 0 || !base_raw.is_multiple_of(PAGE_SIZE) {
+        return Err(Error::new(ErrorCode::InvalidArgument, "ramfs base is not page aligned"));
+    }
+
+    let size: usize = info.size();
+    if size == 0 || !size.is_multiple_of(PAGE_SIZE) {
+        return Err(Error::new(ErrorCode::InvalidArgument, "ramfs size is not page aligned"));
+    }
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Dumps the initial bytes of the RAMFS region to the kernel log for diagnostic purposes.
+///
+/// # Parameters
+///
+/// - `info`: Reference to the MMIO region info structure containing base address and size.
+///
+/// # Returns
+///
+/// `Ok(())` on success, or an error if the base pointer is null.
+///
+fn dump_ramfs_contents(info: &MmioRegionInfo) -> Result<(), Error> {
+    let total_size: usize = info.size();
+    if total_size == 0 {
+        ::syslog::warn!("test-kernel: skipped ramfs dump because region is empty");
+        return Ok(());
+    }
+
+    let base_raw: usize = info.base().into_raw_value();
+    if base_raw == 0 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "ramfs base pointer is null"));
+    }
+
+    let dump_size: usize = cmp::min(total_size, RAMFS_DUMP_MAX_BYTES);
+
+    ::syslog::info!(
+        "test-kernel: ramfs dump begin (base={:#010x}, total_size_bytes={}, dump_size_bytes={})",
+        base_raw,
+        total_size,
+        dump_size,
+    );
+
+    // SAFETY: The base pointer was validated to be non-null and the kernel guarantees the MMIO
+    // region is mapped into the process address space for at least `dump_size` bytes. We use
+    // volatile reads to prevent the compiler from optimizing away accesses to device memory.
+    unsafe {
+        let base_ptr: *const u8 = info.base().as_ptr();
+        dump_ramfs_bytes(base_ptr, dump_size);
+    }
+
+    if total_size > dump_size {
+        ::syslog::info!(
+            "test-kernel: ramfs dump truncated (total_size_bytes={}, dumped_bytes={})",
+            total_size,
+            dump_size,
+        );
+    }
+
+    ::syslog::info!("test-kernel: ramfs dump end");
+
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Reads bytes from the RAMFS region using volatile reads and logs them in hexdump format.
+///
+/// # Parameters
+///
+/// - `base_ptr`: Pointer to the start of the MMIO region.
+/// - `dump_size`: Number of bytes to read and log.
+///
+/// # Safety
+///
+/// The caller must ensure that `base_ptr` is valid for reads of `dump_size` bytes and that the
+/// memory region remains mapped for the duration of this function.
+///
+unsafe fn dump_ramfs_bytes(base_ptr: *const u8, dump_size: usize) {
+    let mut offset: usize = 0;
+
+    while offset < dump_size {
+        let remaining: usize = dump_size - offset;
+        let chunk_len: usize = cmp::min(remaining, RAMFS_DUMP_LINE_BYTES);
+        let mut chunk_buf: [u8; RAMFS_DUMP_LINE_BYTES] = [0; RAMFS_DUMP_LINE_BYTES];
+
+        for (idx, byte_ref) in chunk_buf.iter_mut().enumerate().take(chunk_len) {
+            *byte_ref = ptr::read_volatile(base_ptr.add(offset + idx));
+        }
+
+        log_ramfs_line(offset, &chunk_buf[..chunk_len]);
+        offset += chunk_len;
+    }
+}
+
+///
+/// # Description
+///
+/// Formats a single line of hexdump output and logs it via syslog.
+///
+/// # Parameters
+///
+/// - `offset`: Byte offset within the region for this line.
+/// - `chunk`: Slice of bytes to render in hex and ASCII.
+///
+fn log_ramfs_line(offset: usize, chunk: &[u8]) {
+    let mut line: String = String::with_capacity(64);
+    let _ = line.write_fmt(format_args!("test-kernel: ramfs[{offset:#06x}]:"));
+
+    for byte in chunk {
+        let _ = line.write_fmt(format_args!(" {byte:02x}"));
+    }
+
+    line.push(' ');
+
+    for &byte in chunk {
+        let printable: char = match byte {
+            0x20..=0x7e => char::from(byte),
+            _ => '.',
+        };
+        line.push(printable);
+    }
+
+    ::syslog::info!("{}", line);
+}

--- a/test/test-l2.toml
+++ b/test/test-l2.toml
@@ -40,6 +40,8 @@ iterations = 2
 [[tests]]
 executor = "http"
 program = "./bin/test-kernel.elf"
+extra_nanvixd_args = "-ramfs README.md"
+input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -40,6 +40,8 @@ iterations = 2
 [[tests]]
 executor = "http"
 program = "./bin/test-kernel.elf"
+extra_nanvixd_args = "-ramfs README.md"
+input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -218,6 +220,8 @@ expected_output = "Hello, world!"
 [[tests]]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
+extra_nanvixd_args = "-ramfs README.md"
+input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -39,6 +39,8 @@ iterations = 2
 [[tests]]
 executor = "http"
 program = "./bin/test-kernel.elf"
+extra_nanvixd_args = "-ramfs README.md"
+input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -217,6 +219,8 @@ expected_output = "Hello, world!"
 [[tests]]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
+extra_nanvixd_args = "-ramfs README.md"
+input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 

--- a/test/test.toml
+++ b/test/test.toml
@@ -7,7 +7,7 @@ ipv4_addr = "127.0.0.1"
 port_num = 9999
 hwloc_file_path = ""
 l2_enabled = false
-fatal = false
+fatal = true
 toolchain_path = "toolchain"
 sysroot_path = "./sysroot"
 nanvixd_shutdown_attempts_max = 10
@@ -39,6 +39,8 @@ iterations = 2
 [[tests]]
 executor = "http"
 program = "./bin/test-kernel.elf"
+extra_nanvixd_args = "-ramfs README.md"
+input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 
@@ -157,6 +159,8 @@ expected_output = "Hello, world!"
 [[tests]]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
+extra_nanvixd_args = "-ramfs README.md"
+input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
 


### PR DESCRIPTION
This pull request refactors the kernel and userspace interfaces for memory-mapped I/O (MMIO) region management, simplifying the MMIO release API and adding a new kernel call to query MMIO region metadata. The changes streamline how MMIO regions are detached and queried, and update build/test infrastructure to reflect these changes.