### PR TITLE
[ci] Remove Benchmark Support for Hyperlight

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -116,96 +116,6 @@ runs:
           fi
         done
 
-    # Hyperlight benchmarks
-    - name: Build (Hyperlight)
-      run: |
-        python3 scripts/ci.py \
-          --toolchain-dir=$HOME/toolchain \
-          --target-arch=x86 \
-          --log-level=panic \
-          --target-machine=hyperlight \
-          --release \
-          --without-opt \
-          --build \
-          --sccache=${SCCACHE} \
-          --features L2_VM=yes
-      shell: bash
-    - name: Run micro-benchmarks (Hyperlight)
-      id: run-hyperlight-benchmarks
-      run: |
-        # Build array from lines, strip CRs, and drop blank/whitespace-only lines.
-        mapfile -t benchmarks < <(
-          printf '%s\n' "${{ inputs.benchmark_list }}" | tr -d '\r' | sed '/^[[:space:]]*$/d'
-        )
-
-        must_run_echo_breakdown=false
-
-        for bench in "${benchmarks[@]}"; do
-          # FIXME (#709): warm-start-vmm is stuck on hyperlight
-          if [[ "$bench" == "warm-start-vmm" ]]; then
-            continue
-          fi
-
-          # FIXME (#1016): boot-time is failing on hyperlight
-          if [[ "$bench" == "boot-time" ]]; then
-            continue
-          fi
-
-          if [[ "$bench" == "echo-breakdown" || "$bench" == "echo-breakdown-l2" ]]; then
-            must_run_echo_breakdown=true
-            continue
-          fi
-
-          # FIXME(1171): the current L2 deployment involves a very slow network
-          # namespace creation, particularly at high-churn, so we must temporarily
-          # reduce the number of iterations of the benchmarks.
-          python3 ./scripts/benchmark.py \
-            run \
-            --benchmark ${bench} \
-            --machine-type hyperlight \
-            --hwloc $HOME/hwloc.json \
-            --iterations 100 \
-            --toolchain-bin-dir $HOME/toolchain/bin \
-            --output-dir $(pwd)
-        done
-
-        echo "must_run_echo_breakdown=$must_run_echo_breakdown" >> "$GITHUB_OUTPUT"
-      shell: bash
-    - name: Run the echo-breakdown benchmarks (Hyperlight, require re-compilation)
-      if: steps.run-hyperlight-benchmarks.outputs.must_run_echo_breakdown == 'true'
-      shell: bash
-      run: |
-        # Build array from lines, strip CRs, and drop blank/whitespace-only lines.
-        mapfile -t benchmarks < <(
-          printf '%s\n' "${{ inputs.benchmark_list }}" | tr -d '\r' | sed '/^[[:space:]]*$/d'
-        )
-
-        # Re-compile.
-        python3 scripts/ci.py \
-          --toolchain-dir=$HOME/toolchain \
-          --target-arch=x86 \
-          --log-level=panic \
-          --target-machine=hyperlight \
-          --release \
-          --without-opt \
-          --build \
-          --sccache=${SCCACHE} \
-          --features L2_VM=yes,TIMESTAMP_MSG=yes
-
-        # Run only the specific benchmarks.
-        for bench in "${benchmarks[@]}"; do
-          if [[ "$bench" == "echo-breakdown" || "$bench" == "echo-breakdown-l2" ]]; then
-            python3 ./scripts/benchmark.py \
-              run \
-              --benchmark ${bench} \
-              --machine-type hyperlight \
-              --hwloc $HOME/hwloc.json \
-              --iterations 1000 \
-              --toolchain-bin-dir $HOME/toolchain/bin \
-              --output-dir $(pwd)
-          fi
-        done
-
     # Post-process the results
     - name: Format benchmark results
       id: format
@@ -221,7 +131,7 @@ runs:
           --dev-dir $HOME/ubench-results-dev \
           --target-dir $(pwd) \
           --benchmarks ${comma_separated_benchmarks} \
-          --machine-types microvm,hyperlight \
+          --machine-types microvm \
           --archs X64 \
           --output-file /tmp/comment.txt
 
@@ -336,7 +246,7 @@ runs:
           printf '%s\n' "${{ inputs.benchmark_list }}" | tr -d '\r' | sed '/^[[:space:]]*$/d'
         )
         comma_separated_benchmarks=$(IFS=,; echo "${benchmarks[*]}")
-        comma_separated_machines=microvm,hyperlight
+        comma_separated_machines=microvm
         comma_separated_archs=X64
 
         python3 ./scripts/benchmark.py \

--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -3,7 +3,6 @@
 
 NANVIX_BENCH_FEATURES :=
 NANVIX_BENCH_FEATURES += $(if $(filter yes,$(SINGLE_PROCESS)),single-process,)
-NANVIX_BENCH_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIX_BENCH_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIX_BENCH_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
 NANVIX_BENCH_FEATURES := $(strip $(NANVIX_BENCH_FEATURES))

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -16,7 +16,6 @@ import subprocess
 # Constants
 # ======================================================================
 
-HYPERLIGHT_MACHINE_TYPE = "hyperlight"
 MICROVM_MACHINE_TYPE = "microvm"
 NA = "NA"
 NANVIX_BENCH_ELF = "nanvix-bench.elf"
@@ -393,11 +392,11 @@ def generate_benchmark_table(
 
         Each table has the following structure:
 
-    =================================== boot-time (us) ====================================
-    |       |            microvm (X64)             |           hyperlight (X64)           |
-    |       |    dev     |   target   |     Δ      |    dev     |   target   |     Δ      |
+    ============ boot-time (us) ============
+    |       |      microvm (X64)           |
+    |       |  dev  | target |      Δ      |
     ...
-    =======================================================================================
+    ========================================
 
         where the rows are benchmark-dependent.
     """
@@ -730,7 +729,7 @@ if __name__ == "__main__":
     run_parser.add_argument(
         "--machine-type",
         required=True,
-        choices=[MICROVM_MACHINE_TYPE, HYPERLIGHT_MACHINE_TYPE],
+        choices=[MICROVM_MACHINE_TYPE],
         help="Type of machine to run the benchmarks on",
     )
     # Make the --hwloc file a mandatory argument for the wrapper script, to

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -26,7 +26,6 @@ tokio = { workspace = true, features = ["full"] }
 default = ["microvm"]
 timestamp-messages = ["profiler/timestamp-messages"]
 single-process = ["nanvix/single-process"]
-hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 
 [lints]


### PR DESCRIPTION

This pull request removes all support for the "hyperlight" machine type from the benchmark workflow, build system, and benchmark scripts. The changes streamline the codebase by focusing exclusively on the "microvm" machine type, which affects CI workflows, build features, and benchmark result formatting.