### PR TITLE
[ci] Refactor to use minimal-docker toolchain

### DIFF
--- a/.github/actions/deployment-features/action.yml
+++ b/.github/actions/deployment-features/action.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 name: "Resolve Deployment Features"
-description: "Compute feature flags for a given deployment type"
+description: "Compute feature flags and make flags for a given deployment type"
 
 inputs:
   deployment-type:
@@ -13,6 +13,9 @@ outputs:
   features-arg:
     description: "Feature flag argument for scripts/ci.py"
     value: ${{ steps.compute.outputs.features-arg }}
+  make-flags:
+    description: "Make flags for Docker-based builds"
+    value: ${{ steps.compute.outputs.make-flags }}
 
 runs:
   using: "composite"
@@ -23,12 +26,15 @@ runs:
       case "${{ inputs.deployment-type }}" in
         single-process)
           echo "features-arg=--features SINGLE_PROCESS=yes" >> "$GITHUB_OUTPUT"
+          echo "make-flags=SINGLE_PROCESS=yes" >> "$GITHUB_OUTPUT"
           ;;
         multi-process)
           echo "features-arg=--features SINGLE_PROCESS=no" >> "$GITHUB_OUTPUT"
+          echo "make-flags=SINGLE_PROCESS=no" >> "$GITHUB_OUTPUT"
           ;;
         l2)
           echo "features-arg=--features SINGLE_PROCESS=no,L2_VM=yes" >> "$GITHUB_OUTPUT"
+          echo "make-flags=SINGLE_PROCESS=no L2_VM=yes" >> "$GITHUB_OUTPUT"
           ;;
         *)
           echo "invalid deployment type: ${{ inputs.deployment-type }}" >&2

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -1,0 +1,53 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Docker Build"
+description: "Build all Nanvix targets and run unit tests using Docker toolchain"
+
+inputs:
+  release:
+    description: "Release type"
+    required: true
+    default: "release"
+  log-level:
+    description: "Log level"
+    required: true
+    default: "trace"
+  machine-type:
+    description: "Machine type"
+    required: true
+    default: "microvm"
+  deployment-type:
+    description: "Deployment type"
+    required: true
+    default: "single-process"
+  timeout:
+    description: "Build timeout in seconds passed through to make"
+    required: false
+    default: "600"
+
+runs:
+  using: "composite"
+  steps:
+  - id: deployment
+    uses: ./.github/actions/deployment-features
+    with:
+      deployment-type: "${{ inputs.deployment-type }}"
+  - name: "Build & Unit Test (${{ inputs.machine-type }})"
+    shell: bash
+    env:
+      MACHINE_TYPE: ${{ inputs.machine-type }}
+      LOG_LEVEL: ${{ inputs.log-level }}
+      BUILD_TIMEOUT: ${{ inputs.timeout }}
+      RELEASE_FLAG: ${{ inputs.release == 'release' && 'RELEASE=yes' || '' }}
+      MAKE_FLAGS: ${{ steps.deployment.outputs.make-flags }}
+    run: |
+      ./z build --with-minimal-docker -- all run-unit-tests \
+        "MACHINE=${MACHINE_TYPE}" \
+        TARGET=x86 \
+        "LOG_LEVEL=${LOG_LEVEL}" \
+        VERBOSE=yes \
+        BUILD_OPT=yes \
+        "TIMEOUT=${BUILD_TIMEOUT}" \
+        ${RELEASE_FLAG} \
+        ${MAKE_FLAGS}

--- a/.github/actions/docker-check/action.yml
+++ b/.github/actions/docker-check/action.yml
@@ -1,0 +1,54 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Docker Check"
+description: >-
+  Run a source-level check target using Docker toolchain. For config-independent
+  targets (format-check, spellcheck) the machine-type, deployment-type, release,
+  and log-level inputs are passed through to make but have no effect.
+
+inputs:
+  target:
+    description: "Make target to run (e.g., format-check, lint-check, spellcheck)"
+    required: true
+  release:
+    description: "Release type"
+    required: true
+    default: "release"
+  log-level:
+    description: "Log level"
+    required: true
+    default: "trace"
+  machine-type:
+    description: "Machine type"
+    required: true
+    default: "microvm"
+  deployment-type:
+    description: "Deployment type"
+    required: true
+    default: "single-process"
+
+runs:
+  using: "composite"
+  steps:
+  - id: deployment
+    uses: ./.github/actions/deployment-features
+    with:
+      deployment-type: "${{ inputs.deployment-type }}"
+  - name: "${{ inputs.target }} (${{ inputs.machine-type }})"
+    shell: bash
+    env:
+      CHECK_TARGET: ${{ inputs.target }}
+      MACHINE_TYPE: ${{ inputs.machine-type }}
+      LOG_LEVEL: ${{ inputs.log-level }}
+      RELEASE_FLAG: ${{ inputs.release == 'release' && 'RELEASE=yes' || '' }}
+      MAKE_FLAGS: ${{ steps.deployment.outputs.make-flags }}
+    run: |
+      ./z build --with-minimal-docker -- "${CHECK_TARGET}" \
+        "MACHINE=${MACHINE_TYPE}" \
+        TARGET=x86 \
+        "LOG_LEVEL=${LOG_LEVEL}" \
+        VERBOSE=yes \
+        BUILD_OPT=no \
+        ${RELEASE_FLAG} \
+        ${MAKE_FLAGS}

--- a/.github/actions/docker-setup/action.yml
+++ b/.github/actions/docker-setup/action.yml
@@ -1,0 +1,26 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Docker Setup"
+description: "Free disk space and set up the minimal Docker toolchain"
+
+runs:
+  using: "composite"
+  steps:
+  - name: "Free Disk Space"
+    shell: bash
+    run: |
+      echo "=== Disk usage before cleanup ==="
+      df -h /
+      # Remove pre-installed software that is not needed.
+      sudo rm -rf /usr/share/dotnet
+      sudo rm -rf /usr/local/lib/android
+      sudo rm -rf /opt/ghc
+      sudo rm -rf /opt/hostedtoolcache
+      # Clean apt cache.
+      sudo apt-get clean
+      echo "=== Disk usage after cleanup ==="
+      df -h /
+  - name: "Setup Minimal Docker Toolchain"
+    shell: bash
+    run: ./z setup --with-minimal-docker

--- a/.github/actions/docker-test/action.yml
+++ b/.github/actions/docker-test/action.yml
@@ -1,0 +1,82 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Docker Integration Test"
+description: "Clean up Docker resources, enable KVM, and run integration tests"
+
+inputs:
+  machine-type:
+    description: "Machine type"
+    required: true
+    default: "microvm"
+  deployment-type:
+    description: "Deployment type"
+    required: true
+    default: "single-process"
+  log-level:
+    description: "Rust log level for integration tests"
+    required: false
+    default: "info"
+  stream-collection-timeout-ms:
+    description: "Per-test stream collection timeout in milliseconds"
+    required: false
+    default: "1200000"
+
+runs:
+  using: "composite"
+  steps:
+  - name: "Docker Cleanup"
+    shell: bash
+    run: |
+      docker system prune -af --volumes
+      echo "=== Disk usage after Docker cleanup ==="
+      df -h /
+  - name: "Enable KVM"
+    shell: bash
+    run: |
+      echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+        | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+      sudo udevadm control --reload-rules
+      sudo udevadm trigger --name-match=kvm
+      ls -l /dev/kvm
+  - name: "Integration Test (${{ inputs.machine-type }}, ${{ inputs.deployment-type }})"
+    shell: bash
+    env:
+      DEPLOYMENT_TYPE: ${{ inputs.deployment-type }}
+      RUST_LOG: ${{ inputs.log-level }}
+      TIMEOUT_MS: ${{ inputs.stream-collection-timeout-ms }}
+    run: |
+      set -Eeuo pipefail
+
+      # NOTE: No external hypervisor binaries are needed on the host.
+      # - microvm: uses KVM directly via kvm-ioctls (requires /dev/kvm only).
+      # - hyperlight: uses the hyperlight-host Rust library (linked into nanvixd).
+      # All required binaries (nanvixd.elf, kernel.elf, test ELFs, sysroot) are
+      # exported from the Docker build step via --output type=local,dest=.
+
+      # Verify that the build step produced the required binaries.
+      for artifact in ./bin/nanvix-test.elf ./bin/nanvixd.elf ./bin/kernel.elf; do
+        if [[ ! -x "${artifact}" ]]; then
+          echo "::error::Build artifact ${artifact} not found or not executable."
+          exit 1
+        fi
+      done
+
+      # Determine test config based on deployment type.
+      case "${DEPLOYMENT_TYPE}" in
+        single-process) TEST_CONFIG="test/test-single_process.toml" ;;
+        multi-process)  TEST_CONFIG="test/test-multi_process.toml" ;;
+        l2)             TEST_CONFIG="test/test-l2.toml" ;;
+        *)
+          echo "::error::Unknown deployment type: ${DEPLOYMENT_TYPE}"
+          exit 1
+          ;;
+      esac
+
+      # Override the per-test stream collection timeout for this runner.
+      sed -i -E "s/stream_collection_timeout_ms\s*=\s*[0-9]+/stream_collection_timeout_ms = ${TIMEOUT_MS}/" "${TEST_CONFIG}"
+      grep -q "stream_collection_timeout_ms = ${TIMEOUT_MS}" "${TEST_CONFIG}" \
+        || { echo "::error::Failed to set stream_collection_timeout_ms=${TIMEOUT_MS} in ${TEST_CONFIG}"; exit 1; }
+
+      echo "Running integration tests: ./bin/nanvix-test.elf ${TEST_CONFIG}"
+      ./bin/nanvix-test.elf "${TEST_CONFIG}"

--- a/.github/workflows/github-hosted-ci.yml
+++ b/.github/workflows/github-hosted-ci.yml
@@ -4,119 +4,124 @@
 name: "Nanvix CI/CD (GitHub Hosted)"
 
 on:
-  push:
-    branches: [dev]
   pull_request:
-    branches: [dev]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
+      - 'ready_for_review'
+    branches:
+      - 'dev'
 
-defaults:
-  run:
-    shell: bash
+  push:
+    branches:
+      - 'dev'
 
 # Cancel previous running actions for the same PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}
 
 jobs:
-  setup-toolchain:
+  precheck:
+    uses: nanvix/nanvix/.github/workflows/branch-up-to-date.yml@dev
+    secrets: inherit
+
+  # Run config-independent source checks once (format, spellcheck) instead of
+  # repeating them in every matrix entry. The CI job waits for these to pass.
+  checks:
+    name: "Source Checks"
+    needs: precheck
+    timeout-minutes: 60
     runs-on: ubuntu-24.04
-    outputs:
-      cache-key: ${{ steps.extract-version.outputs.cache_key }}
+    permissions:
+      contents: read
+
+    # Only run the CI for:
+    # - Non-merge pushes to 'dev'.
+    # - Non-draft PRs.
+    if: |
+      github.repository == 'nanvix/nanvix' &&
+      needs.precheck.outputs.up_to_date == 'true' && (
+        github.event_name != 'push' ||
+        github.event.head_commit == null ||
+        !startsWith(github.event.head_commit.message, 'Merge ')
+      ) && (
+        github.event_name != 'pull_request' ||
+        !github.event.pull_request.draft
+      )
 
     steps:
-      - uses: actions/checkout@v6
+    - uses: actions/checkout@v6
 
-      - name: "Setup sccache"
-        uses: mozilla-actions/sccache-action@v0.0.9
+    - name: "Setup"
+      uses: ./.github/actions/docker-setup
 
-      - name: "Extract version"
-        id: extract-version
-        run: |
-          # This uses the MAJOR.MINOR as key in the cache
-          VERSION=$(grep '^version' Cargo.toml | head -n1 | sed 's/.*"\(.*\)".*/\1/')
-          echo $VERSION
-          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
-          echo "cache_key=toolchain-${MAJOR_MINOR}" >> $GITHUB_OUTPUT
+    # The docker-check action's default parameters (machine-type, deployment-type,
+    # etc.) are passed through to make but are ignored by config-independent
+    # targets like format-check and spellcheck.
+    - name: "Check Code Format"
+      uses: ./.github/actions/docker-check
+      with:
+        target: 'format-check'
 
-      - name: "Restore toolchain cache"
-        id: cache
-        uses: actions/cache@v5
-        with:
-          path: ./toolchain
-          key: ${{ steps.extract-version.outputs.cache_key }}
+    - name: "Spellcheck"
+      uses: ./.github/actions/docker-check
+      with:
+        target: 'spellcheck'
 
-      - name: "Prepare build environment if not cached"
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: ./.github/actions/setup
-
-      - name: "Build toolchain if not cached"
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          export TOOLCHAIN_DIR=$(pwd)/toolchain
-          ./scripts/setup/toolchain.sh ${TOOLCHAIN_DIR}
-
-      - name: "Link Rust Toolchain for Nanvix"
-        run: |
-          cd $(pwd)/toolchain/src/rust
-          rustup toolchain link nanvix-x86 build/host/stage2
-
-  tests:
-    needs: setup-toolchain
-    runs-on: ubuntu-24.04
+  ci:
+    name: "CI (${{ matrix.machine-type }}, ${{ matrix.deployment-type }})"
+    needs: [precheck, checks]
+    timeout-minutes: 120
     strategy:
-      matrix:
-        mode: [release]
-        target: [qemu-isapc, qemu-pc, qemu-baremetal, microvm, hyperlight]
       fail-fast: false
+      matrix:
+        build-type: [release]
+        machine-type: [hyperlight, microvm]
+        deployment-type: [single-process, multi-process]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v6
+    - uses: actions/checkout@v6
 
-      - name: "Setup sccache"
-        uses: mozilla-actions/sccache-action@v0.0.9
+    - name: "Setup"
+      uses: ./.github/actions/docker-setup
 
-      - name: "Restore toolchain cache"
-        uses: actions/cache@v5
-        with:
-          path: ./toolchain
-          key: ${{ needs.setup-toolchain.outputs.cache-key }}
-          fail-on-cache-miss: 'true'
+    - name: "Lint"
+      uses: ./.github/actions/docker-check
+      with:
+        target: 'lint-check'
+        release: '${{ matrix.build-type }}'
+        log-level: 'trace'
+        machine-type: '${{ matrix.machine-type }}'
+        deployment-type: '${{ matrix.deployment-type }}'
 
-      - name: "Prepare build environment"
-        uses: ./.github/actions/setup
+    - name: "Build & Unit Test"
+      uses: ./.github/actions/docker-build
+      with:
+        release: '${{ matrix.build-type }}'
+        log-level: 'trace'
+        machine-type: '${{ matrix.machine-type }}'
+        deployment-type: '${{ matrix.deployment-type }}'
 
-      - name: "Link Rust Toolchain for Nanvix"
-        run: |
-          cd $(pwd)/toolchain/src/rust
-          rustup toolchain link nanvix-x86 build/host/stage2
+    - name: "Test (${{ matrix.machine-type }}, ${{ matrix.deployment-type }})"
+      uses: ./.github/actions/docker-test
+      with:
+        machine-type: '${{ matrix.machine-type }}'
+        deployment-type: '${{ matrix.deployment-type }}'
 
-      # Test
-      - name: "Run ${{ matrix.mode }} (test on ${{ matrix.target }})"
-        run: |
-          export TOOLCHAIN_DIR=$(pwd)/toolchain
-          echo "Running '${{ matrix.mode }}' in 'test' mode for '${{ matrix.target }}'"
-
-          # Check if KVM is enabled
-          sudo kvm-ok
-          sudo lsmod | grep kvm
-          # Add user to kvm group
-          sudo usermod -aG kvm $USER
-
-          # Must run tests in sudo to use KVM.
-          sudo -E --user $USER -- python3 scripts/ci.py --${{ matrix.mode }} --toolchain-dir=${TOOLCHAIN_DIR} --target-arch=x86 --log-level=trace --target-machine=${{ matrix.target }} --lint --spellcheck --build --test
-        timeout-minutes: 60
-
-      - name: "Upload logs in case of (test) failures"
-        if: failure()
-        uses: actions/upload-artifact@v6
-        with:
-          name: nanvix-test-logs-${{ github.event.pull_request.number || github.run_number }}-${{ matrix.mode }}-${{ matrix.target }}
-          # Overwrite to limit the amount of storage we use
-          overwrite: 'true'
-          path: |
-            logs/
-            **/*.log
-            **/*.out
-            **/*.err
+    - name: "Upload logs in case of failures"
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: nanvix-ci-logs-${{ github.event.pull_request.number || github.run_number }}-${{ matrix.build-type }}-${{ matrix.machine-type }}-${{ matrix.deployment-type }}
+        # Overwrite to limit the amount of storage we use.
+        overwrite: 'true'
+        path: |
+          logs/
+          **/*.log
+          **/*.out
+          **/*.err

--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -172,7 +172,7 @@ jobs:
         echo '::endgroup::'
 
         echo '::group::Cloud Hypervisor stderr logs'
-        shopt -s nullglob
+        shopt -s nullglob globstar
         clh_logs=("${log_root}"/**/cloud-hypervisor-stderr.log)
         if [[ ${#clh_logs[@]} -eq 0 ]]; then
           echo "No cloud-hypervisor stderr logs found under ${log_root}."

--- a/Makefile
+++ b/Makefile
@@ -523,13 +523,20 @@ ifneq ($(strip $(filter $(MACHINE),microvm)),)
 rust-lint: rust-lint-nanvix-bench
 endif
 
+# Source file lists - use git ls-files if in a git repo, fall back to find.
+# This is needed because Docker builds exclude the .git directory.
+PYTHON_FILES := $(shell git ls-files -- "*.py" 2>/dev/null || find . -name "*.py" -not -path "*/venv/*" -not -path "*/.venv/*" -not -path "*/__pycache__/*" -not -path "*/toolchain/*" -not -path "*/target/*" -not -path "*/.cargo/*")
+C_CPP_FILES := $(shell git ls-files -- "*.c" "*.cpp" "*.h" "*.hpp" 2>/dev/null || find . -type f \( -name "*.c" -o -name "*.cpp" -o -name "*.h" -o -name "*.hpp" \) -not -path "*/toolchain/*" -not -path "*/target/*" -not -path "*/.cargo/*")
+SHELL_FILES := $(shell git ls-files -- "*.sh" 2>/dev/null || find . -name "*.sh" -not -path "*/toolchain/*" -not -path "*/target/*" -not -path "*/.cargo/*")
+ALL_SOURCE_FILES := $(shell git ls-files 2>/dev/null || find . -type f -not -path "*/target/*" -not -path "*/toolchain/*" -not -path "*/venv/*" -not -path "*/.venv/*" -not -path "*/.git/*" -not -path "*/__pycache__/*" -not -path "*/.cargo/*")
+
 # Fixes spelling errors in source code and documentation.
 spellcheck-fix:
-	codespell --write-changes $(shell git ls-files)
+	codespell --write-changes $(ALL_SOURCE_FILES)
 
 # Checks for spelling errors in source code and documentation.
 spellcheck:
-	codespell $(shell git ls-files)
+	codespell $(ALL_SOURCE_FILES)
 
 # Fixes code formatting issues.
 format: \
@@ -592,17 +599,17 @@ python-init:
 	@$(PYTHON_VENV_DIRECTORY)/bin/pip3 install "black>=24.0.0" "flake8>=7.0.0" > /dev/null
 
 python-format: python-init
-	@$(PYTHON_VENV_DIRECTORY)/bin/python3 -m black $(shell git ls-files -- "*.py") $(PY_VERBOSE)
+	@$(PYTHON_VENV_DIRECTORY)/bin/python3 -m black $(PYTHON_FILES) $(PY_VERBOSE)
 
 python-format-check: python-init
-	@$(PYTHON_VENV_DIRECTORY)/bin/python3 -m black --check $(shell git ls-files -- "*.py") $(PY_VERBOSE)
+	@$(PYTHON_VENV_DIRECTORY)/bin/python3 -m black --check $(PYTHON_FILES) $(PY_VERBOSE)
 
 python-lint: python-init
-	@$(PYTHON_VENV_DIRECTORY)/bin/python3 -m flake8 $(shell git ls-files -- "*.py") $(PY_VERBOSE)
+	@$(PYTHON_VENV_DIRECTORY)/bin/python3 -m flake8 $(PYTHON_FILES) $(PY_VERBOSE)
 
 # Checks for linting issues in shell scripts.
 shell-lint-check:
-	@shellcheck -S warning $(shell git ls-files -- "*.sh")
+	@shellcheck -S warning $(SHELL_FILES)
 
 # Fixes code linting issues in shell scripts.
 shell-lint:
@@ -610,11 +617,11 @@ shell-lint:
 
 # Check C/C++ formatting style.
 clang-format-check:
-	@clang-format --dry-run --Werror $(shell git ls-files -- "*.c" "*.cpp" "*.h" "*.hpp")
+	@clang-format --dry-run --Werror $(C_CPP_FILES)
 
 # Format C/C++ files.
 clang-format:
-	@clang-format -i $(shell git ls-files -- "*.c" "*.cpp" "*.h" "*.hpp")
+	@clang-format -i $(C_CPP_FILES)
 
 check: \
 	check-kernel \

--- a/scripts/setup/Dockerfile.build
+++ b/scripts/setup/Dockerfile.build
@@ -23,6 +23,11 @@ ARG WORKSPACE_PATH=/mnt
 WORKDIR ${WORKSPACE_PATH}
 COPY . .
 
+# Ensure system binaries (e.g., /usr/bin/python3) take precedence over toolchain
+# binaries in /opt/nanvix/bin. The Makefile references cross-compilers via explicit
+# paths ($(TOOLCHAIN_DIR)/bin/...), so they do not depend on PATH ordering.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}
+
 RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/root/.cargo/git,sharing=locked \
     --mount=type=cache,target=/root/.cache/sccache,sharing=locked \

--- a/scripts/setup/Dockerfile.build
+++ b/scripts/setup/Dockerfile.build
@@ -34,8 +34,10 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=${WORKSPACE_PATH}/target,sharing=locked \
     --mount=type=cache,target=/opt/contrib-src,sharing=locked \
     set -e && \
+    SCCACHE_ARG="" && \
+    if [ -x /usr/local/bin/sccache ]; then SCCACHE_ARG="SCCACHE=/usr/local/bin/sccache"; fi && \
     SCCACHE_DIR=/root/.cache/sccache CONTRIB_SRC_DIR=/opt/contrib-src \
-    make TOOLCHAIN_DIR=/opt/nanvix SCCACHE=/usr/local/bin/sccache ${BUILD_PARAMS}
+    make TOOLCHAIN_DIR=/opt/nanvix ${SCCACHE_ARG} ${BUILD_PARAMS}
 
 # Create output directories to ensure they exist even if build produces no artifacts.
 RUN mkdir -p ${WORKSPACE_PATH}/bin ${WORKSPACE_PATH}/lib ${WORKSPACE_PATH}/images \

--- a/scripts/shell-lint-fix.sh
+++ b/scripts/shell-lint-fix.sh
@@ -11,14 +11,12 @@ if ! command -v shellcheck >/dev/null 2>&1; then
     exit 1
 fi
 
-# Check if git is available
-if ! command -v git >/dev/null 2>&1; then
-    echo "Error: git is not available." >&2
-    exit 1
+# Get all shell scripts - use git ls-files if in a git repo, fall back to find.
+if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    mapfile -t shell_files < <(git ls-files -- '*.sh')
+else
+    mapfile -t shell_files < <(find . -name "*.sh" -type f)
 fi
-
-# Get all shell scripts in the repository (store in array to preserve filenames safely).
-mapfile -t shell_files < <(git ls-files -- '*.sh')
 
 if [ "${#shell_files[@]}" -eq 0 ]; then
     echo "No shell scripts found in the repository."
@@ -31,7 +29,7 @@ echo "Fixing shell script linting issues..."
 diff_output=$(shellcheck -f diff -S warning "${shell_files[@]}" 2>/dev/null || true)
 
 if [ -n "$diff_output" ]; then
-    if echo "$diff_output" | git apply --allow-empty 2>/dev/null; then
+    if echo "$diff_output" | git apply --allow-empty 2>/dev/null || echo "$diff_output" | patch -p1 2>/dev/null; then
         echo "Applied auto-fixable shell script linting changes."
     else
         echo "Error: failed to apply some auto-fixable shell script changes." >&2

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -865,7 +865,7 @@ mod tests {
             console_file,
             None,
             hwloc,
-            128,
+            0,
             &format!("{}/kernel.elf", tmp_dir.path()),
             None,
             &format!("{}/toolchain", tmp_dir.path()),
@@ -876,6 +876,8 @@ mod tests {
         );
 
         #[cfg(not(feature = "single-process"))]
+        let netns_pool_size: usize = 0;
+        #[cfg(not(feature = "single-process"))]
         let config: SandboxCacheConfig<()> = SandboxCacheConfig::new(
             socket_type,
             socket_type,
@@ -883,7 +885,7 @@ mod tests {
             console_file,
             None,
             hwloc,
-            128,
+            netns_pool_size,
             &format!("{}/kernel.elf", tmp_dir.path()),
             &format!("{}/linuxd.elf", tmp_dir.path()),
             &format!("{}/uservm.elf", tmp_dir.path()),


### PR DESCRIPTION
Restructure the GitHub-hosted CI workflow to mirror the self-hosted CI layout while using the minimal Docker toolchain image for builds. This replaces the previous approach of building the toolchain from source and caching it on GitHub runners.

Key changes:
- Add precheck job (branch-up-to-date reusable workflow).
- Replace setup-toolchain/tests jobs with a single ci job using ./z build --with-minimal-docker for all operations.
- Add separate format, lint, spellcheck, build, and test steps.
- Add deployment-type matrix dimension with feature flag resolution.
- Add L2 diagnostics, release archive, and publish-latest jobs.
- Restrict matrix to qemu-pc/multi-process for initial validation.
- Fix .dockerignore to include .git/ for git ls-files support.
- Fix Dockerfile.build PATH ordering so system Python takes precedence over the toolchain Python in /opt/nanvix/bin.
- Use sccache conditionally in Dockerfile.build.