### PR TITLE
[build] Fix Lint Issues

### DIFF
--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -214,7 +214,7 @@ impl WorkerThreadHandle {
         // SAFETY: we install a signal handler that is a no-op so this is safe.
         let ret = unsafe {
             let sig_action = sigaction {
-                sa_sigaction: linuxd_worker_thread_signal_handler as usize,
+                sa_sigaction: linuxd_worker_thread_signal_handler as *const () as usize,
                 // Empty set to not block any other signals that may happen during signal handling.
                 sa_mask: {
                     let mut set = mem::zeroed();

--- a/src/libs/nanvix-terminal/src/lib.rs
+++ b/src/libs/nanvix-terminal/src/lib.rs
@@ -417,7 +417,7 @@ fn install_signal_handler() {
     // SAFETY: We install a signal handler that is a no-op so this is safe.
     let ret: c_int = unsafe {
         let sig_action: sigaction = sigaction {
-            sa_sigaction: stdin_thread_signal_handler as usize,
+            sa_sigaction: stdin_thread_signal_handler as *const () as usize,
             // Empty set to not block any other signals that may happen during signal handling.
             sa_mask: {
                 let mut set: libc::sigset_t = mem::zeroed();

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -209,7 +209,7 @@ pub fn create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Er
         return Err(Error::new(ErrorCode::InvalidArgument, "user function is set"));
     }
 
-    args.user_fn = VirtualAddress::from_raw_value(_do_start_thread as usize);
+    args.user_fn = VirtualAddress::from_raw_value(_do_start_thread as *const () as usize);
 
     let result: i64 =
         kcall1!(KcallNumber::CreateThread.into(), args as *const ThreadCreateArgs as usize as u32);

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -286,7 +286,7 @@ impl Vmm {
         // SAFETY: we install a signal handler that is a no-op so this is safe.
         let ret: c_int = unsafe {
             let sig_action: sigaction = sigaction {
-                sa_sigaction: vcpu_thread_signal_handler as usize,
+                sa_sigaction: vcpu_thread_signal_handler as *const () as usize,
                 // Empty set to not block any other signals that may happen during signal handling.
                 sa_mask: {
                     let mut set: libc::sigset_t = std::mem::zeroed();

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -367,28 +367,24 @@ impl Benchmark {
 
     /// Kill the different components in order.
     pub fn cleanup(&mut self) {
-        if self.nanvixd.is_some() {
+        if let Some(nanvixd) = self.nanvixd.as_mut() {
             debug!("Sending SIGINT to nanvixd");
-            let ret_code = unsafe {
-                libc::kill(self.nanvixd.as_mut().unwrap().id() as libc::pid_t, libc::SIGINT)
-            };
+            let ret_code: i32 = unsafe { libc::kill(nanvixd.id() as libc::pid_t, libc::SIGINT) };
 
             if ret_code < 0 {
                 error!("error sending SIGINT to nanvixd: {}", std::io::Error::last_os_error());
             }
 
-            if let Some(nanvixd) = self.nanvixd.as_mut() {
-                match nanvixd.wait() {
-                    Ok(exit_status) => {
-                        if !exit_status.success() {
-                            error!(
-                                "nanvixd returned with non-zero exit status: {:?}",
-                                exit_status.code()
-                            );
-                        }
-                    },
-                    Err(e) => error!("error waiting for nanvixd: {e:?}"),
-                }
+            match nanvixd.wait() {
+                Ok(exit_status) => {
+                    if !exit_status.success() {
+                        error!(
+                            "nanvixd returned with non-zero exit status: {:?}",
+                            exit_status.code()
+                        );
+                    }
+                },
+                Err(e) => error!("error waiting for nanvixd: {e:?}"),
             }
 
             self.nanvixd = None;


### PR DESCRIPTION
This pull request primarily updates how function pointers are cast when installing signal handlers and makes a small improvement to process cleanup logic. The most significant changes ensure that function pointers are correctly cast using `as *const () as usize`, which is more idiomatic and safer in Rust FFI contexts. Additionally, the cleanup logic for the `nanvixd` process is simplified to avoid redundant code.