### PR TITLE
[build] distclean to handle mounted OBJECTS_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,11 @@ endif
 
 distclean: clean
 	$(FORCE_RM_CMD) Cargo.lock
-	$(FORCE_RM_CMD) $(OBJECTS_DIR)
+	if mountpoint -q "$(OBJECTS_DIR)" 2>/dev/null; then \
+		find "$(OBJECTS_DIR)" -mindepth 1 -delete || { echo "Error: failed to clean $(OBJECTS_DIR) with find" >&2; exit 1; }; \
+	else \
+		$(FORCE_RM_CMD) "$(OBJECTS_DIR)"; \
+	fi
 	$(FORCE_RM_CMD) $(LIBRARIES_DIR)
 	$(FORCE_RM_CMD) $(BINARIES_DIR)
 	$(FORCE_RM_CMD) $(PYTHON_VENV_DIRECTORY)


### PR DESCRIPTION
This pull request updates the `distclean` target in the `Makefile` to handle cases where `$(OBJECTS_DIR)` is a mount point. Instead of always removing the directory, it now checks if it's a mount point and deletes its contents safely if so.