### PR TITLE
[build] B: Update PATH Order in Docker Image

### DIFF
--- a/scripts/setup/Dockerfile.optimized
+++ b/scripts/setup/Dockerfile.optimized
@@ -74,7 +74,7 @@ RUN rustup toolchain install "$RUST_VERSION" && \
     rm -rf "$HOME/.cargo/git/db"
 
 # Set environment variables for toolchain.
-ENV PATH=/opt/nanvix/bin:$PATH
+ENV PATH=$PATH:/opt/nanvix/bin
 ENV LD_LIBRARY_PATH=/opt/nanvix/lib
 
 # Verify toolchain is working.


### PR DESCRIPTION
Fix PATH order in docker image so that system binaries have precedence over binaries in the toolchain of Nanvix.