### PR TITLE
[kernel] Don't use `ProcessManagerInner::number_buffered_messages` directly

### DIFF
--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1535,10 +1535,12 @@ impl ProcessManagerInner {
     ///
     /// An error if and only if incrementing by one would overflow the number of buffered messages.
     ///
-
     pub fn note_message_posted(&mut self) -> Result<(), Error> {
         match self.number_buffered_messages.checked_add(1) {
-            Some(_) => Ok(()),
+            Some(n) => {
+                self.number_buffered_messages = n;
+                Ok(())
+            }
             None => Err(Error::new(ErrorCode::ValueOverflow, "number of buffered messages overflowed")),
         }
     }
@@ -1552,12 +1554,16 @@ impl ProcessManagerInner {
     ///
     /// Self alone
     ///
+    /// # Returns
+    ///
     /// An error if and only if decrementing by one would underflow the number of buffered messages.
     ///
-
     pub fn note_message_received(&mut self) -> Result<(), Error> {
         match self.number_buffered_messages.checked_sub(1) {
-            Some(_) => Ok(()),
+            Some(n) => {
+                self.number_buffered_messages = n;
+                Ok(())
+            },
             None => Err(Error::new(ErrorCode::ValueOverflow, "number of buffered messages underflowed")),
         }
     }
@@ -1575,7 +1581,6 @@ impl ProcessManagerInner {
     ///
     /// The count of buffered messages.
     ///
-
     pub fn count_buffered_messages(&self) -> usize {
         self.number_buffered_messages
     }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1543,10 +1543,7 @@ impl ProcessManagerInner {
             },
             None => {
                 error!("number of buffered messages overflowed");
-                Err(Error::new(
-                    ErrorCode::ValueOverflow,
-                    "number of buffered messages overflowed",
-                ))
+                Err(Error::new(ErrorCode::ValueOverflow, "number of buffered messages overflowed"))
             },
         }
     }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1545,7 +1545,7 @@ impl ProcessManagerInner {
                 error!("number of buffered messages overflowed");
                 Err(Error::new(
                     ErrorCode::ValueOverflow,
-                    "number of buffered messages overflowed"
+                    "number of buffered messages overflowed",
                 ))
             },
         }
@@ -1574,7 +1574,7 @@ impl ProcessManagerInner {
                 error!("number of buffered messages underflowed");
                 Err(Error::new(
                     ErrorCode::InvalidArgument,
-                    "number of buffered messages underflowed"
+                    "number of buffered messages underflowed",
                 ))
             },
         }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1543,7 +1543,10 @@ impl ProcessManagerInner {
             },
             None => {
                 error!("number of buffered messages overflowed");
-                Err(Error::new(ErrorCode::ValueOverflow, "number of buffered messages overflowed"))
+                Err(Error::new(
+                    ErrorCode::ValueOverflow,
+                    "number of buffered messages overflowed"
+                ))
             },
         }
     }
@@ -1569,7 +1572,10 @@ impl ProcessManagerInner {
             },
             None => {
                 error!("number of buffered messages underflowed");
-                Err(Error::new(ErrorCode::InvalidArgument, "number of buffered messages underflowed"))
+                Err(Error::new(
+                    ErrorCode::InvalidArgument,
+                    "number of buffered messages underflowed"
+                ))
             },
         }
     }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1590,6 +1590,7 @@ impl ProcessManagerInner {
     ///
     /// The count of buffered messages.
     ///
+    #[cfg(feature = "stdio")]
     pub fn count_buffered_messages(&self) -> usize {
         self.number_buffered_messages
     }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1525,11 +1525,11 @@ impl ProcessManagerInner {
     ///
     /// # Description
     ///
-    /// Notes that a message was posted
+    /// Notes that a message was posted.
     ///
     /// # Parameters
     ///
-    /// Self alone
+    /// None.
     ///
     /// # Returns
     ///
@@ -1540,19 +1540,22 @@ impl ProcessManagerInner {
             Some(n) => {
                 self.number_buffered_messages = n;
                 Ok(())
-            }
-            None => Err(Error::new(ErrorCode::ValueOverflow, "number of buffered messages overflowed")),
+            },
+            None => {
+                error!("number of buffered messages overflowed");
+                Err(Error::new(ErrorCode::ValueOverflow, "number of buffered messages overflowed"))
+            },
         }
     }
 
     ///
     /// # Description
     ///
-    /// Notes that a message was received
+    /// Notes that a message was received.
     ///
     /// # Parameters
     ///
-    /// Self alone
+    /// None.
     ///
     /// # Returns
     ///
@@ -1564,7 +1567,10 @@ impl ProcessManagerInner {
                 self.number_buffered_messages = n;
                 Ok(())
             },
-            None => Err(Error::new(ErrorCode::ValueOverflow, "number of buffered messages underflowed")),
+            None => {
+                error!("number of buffered messages underflowed");
+                Err(Error::new(ErrorCode::InvalidArgument, "number of buffered messages underflowed"))
+            },
         }
     }
 
@@ -1575,7 +1581,7 @@ impl ProcessManagerInner {
     ///
     /// # Parameters
     ///
-    /// Self alone
+    /// None.
     ///
     /// # Returns
     ///

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1521,6 +1521,64 @@ impl ProcessManagerInner {
         error!("{reason} (tid={tid:?})");
         Err(Error::new(ErrorCode::NoSuchEntry, reason))
     }
+
+    ///
+    /// # Description
+    ///
+    /// Notes that a message was posted
+    ///
+    /// # Parameters
+    ///
+    /// Self alone
+    ///
+    /// # Returns
+    ///
+    /// An error if and only if incrementing by one would overflow the number of buffered messages.
+    ///
+
+    pub fn note_message_posted(&mut self) -> Result<(), Error> {
+        match self.number_buffered_messages.checked_add(1) {
+            Some(_) => Ok(()),
+            None => Err(Error::new(ErrorCode::ValueOverflow, "number of buffered messages overflowed")),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Notes that a message was received
+    ///
+    /// # Parameters
+    ///
+    /// Self alone
+    ///
+    /// An error if and only if decrementing by one would underflow the number of buffered messages.
+    ///
+
+    pub fn note_message_received(&mut self) -> Result<(), Error> {
+        match self.number_buffered_messages.checked_sub(1) {
+            Some(_) => Ok(()),
+            None => Err(Error::new(ErrorCode::ValueOverflow, "number of buffered messages underflowed")),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the number of messages that have been posted but not yet received.
+    ///
+    /// # Parameters
+    ///
+    /// Self alone
+    ///
+    /// # Returns
+    ///
+    /// The count of buffered messages.
+    ///
+
+    pub fn count_buffered_messages(&self) -> usize {
+        self.number_buffered_messages
+    }
 }
 
 //==================================================================================================
@@ -1962,7 +2020,7 @@ impl ProcessManager {
             Err(tid) => pm.find_process_by_tid(tid)?,
         };
         process.state_mut().post_message(message);
-        pm.number_buffered_messages += 1;
+        pm.note_message_posted()?;
         Ok(())
     }
 
@@ -1996,7 +2054,7 @@ impl ProcessManager {
     ///
     #[cfg(feature = "stdio")]
     pub fn number_buffered_messages(&self) -> Result<usize, Error> {
-        Ok(self.try_borrow()?.number_buffered_messages)
+        Ok(self.try_borrow()?.count_buffered_messages())
     }
 
     pub fn handle_fpu_exception(&mut self) -> Result<(), Error> {

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -687,7 +687,7 @@ impl ProcessManager {
         let running: &mut RunningProcess = pm.get_running_mut();
         match running.state_mut().receive_message(tid) {
             Some(message) => {
-                pm.number_buffered_messages -= 1;
+                pm.note_message_received()?;
                 Ok(Some(message))
             },
             None => Ok(None),


### PR DESCRIPTION
For encapsulation, avoid having users of `ProcessManagerInner` directly access its private fields.