### PR TITLE
[build] add --allow-no-vcs to cargo clippy

### DIFF
--- a/build/make/generic-guest-binaries.mk
+++ b/build/make/generic-guest-binaries.mk
@@ -33,7 +33,7 @@ clean-guest-binaries-$(1): clean-guest-staticlibs
 	$(RM_CMD) $(BINARIES_DIR)/$(1).elf
 
 rust-lint-guest-binaries-$(1):
-	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(call GUEST_BINARY_PKG_FEATURES,$(1)) --fix --allow-dirty
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(call GUEST_BINARY_PKG_FEATURES,$(1)) --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-guest-binaries-$(1):
 	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(call GUEST_BINARY_PKG_FEATURES,$(1)) -- -D warnings

--- a/build/make/generic-guest-rlibs.mk
+++ b/build/make/generic-guest-rlibs.mk
@@ -12,7 +12,7 @@ format-check-guest-rlib-$(1):
 	$(GUEST_CARGO_FMT_CMD) -p $(1) --check
 
 rust-lint-guest-rlib-$(1):
-	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) --fix --allow-dirty
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-guest-rlib-$(1):
 	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) -- -D warnings

--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -25,7 +25,7 @@ clean-guest-staticlib-$(1):
 	$(RM_CMD) $(LIBRARIES_DIR)/lib$(1).a
 
 rust-lint-guest-staticlib-$(1):
-	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES) --fix --allow-dirty
+	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES) --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-guest-staticlib-$(1):
 	$(GUEST_CARGO_CLIPPY_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES) -- -D warnings

--- a/build/make/generic-host-binaries.mk
+++ b/build/make/generic-host-binaries.mk
@@ -29,7 +29,7 @@ clean-host-binaries-$(1):
 	$(RM_CMD) $(BINARIES_DIR)/$(1).elf
 
 rust-lint-host-binaries-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1) --fix --allow-dirty
+	$(HOST_CARGO_CLIPPY_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1) --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-host-binaries-$(1):
 	$(HOST_CARGO_CLIPPY_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1) -- -D warnings

--- a/build/make/generic-host-rlibs.mk
+++ b/build/make/generic-host-rlibs.mk
@@ -23,7 +23,7 @@ format-check-host-rlib-$(1):
 	$(HOST_CARGO_FMT_CMD) -p $(1) --check
 
 rust-lint-host-rlib-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1) --fix --allow-dirty
+	$(HOST_CARGO_CLIPPY_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1) --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-host-rlib-$(1):
 	$(HOST_CARGO_CLIPPY_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1) -- -D warnings

--- a/build/make/generic-wasm-binaries.mk
+++ b/build/make/generic-wasm-binaries.mk
@@ -20,7 +20,7 @@ clean-wasm-binaries-$(1):
 	$(RM_CMD) $(BINARIES_DIR)/$(1).wasm
 
 rust-lint-wasm-binaries-$(1):
-	$(WASM_CARGO_CLIPPY_CMD) -p $(1) --fix --allow-dirty
+	$(WASM_CARGO_CLIPPY_CMD) -p $(1) --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-wasm-binaries-$(1):
 	$(WASM_CARGO_CLIPPY_CMD) -p $(1) -- -D warnings

--- a/build/make/kernel.mk
+++ b/build/make/kernel.mk
@@ -23,7 +23,7 @@ clean-kernel:
 	$(RM_CMD) $(BINARIES_DIR)/kernel.elf
 
 rust-lint-kernel:
-	$(KERNEL_CARGO_CLIPPY_CMD) $(KERNEL_CARGO_FEATURES) -p kernel --fix --allow-dirty
+	$(KERNEL_CARGO_CLIPPY_CMD) $(KERNEL_CARGO_FEATURES) -p kernel --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-kernel:
 	$(KERNEL_CARGO_CLIPPY_CMD) $(KERNEL_CARGO_FEATURES) -p kernel -- -D warnings

--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -26,7 +26,7 @@ clean-nanvix-bench:
 	$(RM_CMD) $(BINARIES_DIR)/nanvix-bench.elf
 
 rust-lint-nanvix-bench:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench --fix --allow-dirty
+	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-nanvix-bench:
 	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench -- -D warnings

--- a/build/make/nanvix-test.mk
+++ b/build/make/nanvix-test.mk
@@ -26,7 +26,7 @@ clean-nanvix-test:
 	$(RM_CMD) $(BINARIES_DIR)/nanvix-test.elf
 
 rust-lint-nanvix-test:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test --fix --allow-dirty
+	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-nanvix-test:
 	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test -- -D warnings

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -33,7 +33,7 @@ clean-nanvixd:
 	$(RM_CMD) $(BINARIES_DIR)/nanvixd.elf
 
 rust-lint-nanvixd:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd --fix --allow-dirty
+	$(HOST_CARGO_CLIPPY_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-nanvixd:
 	$(HOST_CARGO_CLIPPY_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd -- -D warnings

--- a/build/make/uservm.mk
+++ b/build/make/uservm.mk
@@ -27,7 +27,7 @@ clean-uservm:
 	$(RM_CMD) $(BINARIES_DIR)/uservm.elf
 
 rust-lint-uservm:
-	$(HOST_CARGO_CLIPPY_CMD) $(USERVM_CARGO_FEATURES) -p uservm --fix --allow-dirty
+	$(HOST_CARGO_CLIPPY_CMD) $(USERVM_CARGO_FEATURES) -p uservm --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-uservm:
 	$(HOST_CARGO_CLIPPY_CMD) $(USERVM_CARGO_FEATURES) -p uservm -- -D warnings

--- a/build/make/wasmd.mk
+++ b/build/make/wasmd.mk
@@ -29,7 +29,7 @@ clean-wasmd: clean-wasm-binaries clean-guest-binaries
 	$(RM_CMD) $(BINARIES_DIR)/wasmd.elf
 
 rust-lint-wasmd:
-	$(GUEST_CARGO_CLIPPY_CMD) -p wasmd --fix --allow-dirty
+	$(GUEST_CARGO_CLIPPY_CMD) -p wasmd --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-wasmd:
 	$(GUEST_CARGO_CLIPPY_CMD) -p wasmd -- -D warnings


### PR DESCRIPTION
When building inside Docker with --with-minimal-docker, the .git directory is not available in the container. This causes cargo fix to fail with 'no VCS found for this package' because it cannot find a Git repository to protect against destructive changes.

Add --allow-no-vcs alongside --allow-dirty in all cargo clippy --fix invocations across the build system to support VCS-less environments such as Docker containers.