### PR TITLE
[sysalloc] Improve OOM Handler

### DIFF
--- a/src/libs/sysalloc/src/allocator.rs
+++ b/src/libs/sysalloc/src/allocator.rs
@@ -124,7 +124,36 @@ impl NanvixOomHandler {
 
 impl OomHandler for NanvixOomHandler {
     fn handle_oom(talc: &mut Talc<Self>, layout: core::alloc::Layout) -> Result<(), ()> {
-        let increment: usize = match mm::align_up(layout.size(), PAGE_ALIGNMENT) {
+        let old_heap: Span = talc
+            .oom_handler
+            .span
+            .expect("heap should have an initial span");
+
+        // If the Talc span does not yet cover all committed backing memory, extend the span
+        // without growing. This reclaims committed pages that are not yet visible to Talc and
+        // avoids unnecessary heap growth.
+        if old_heap.size() < talc.oom_handler.heap.size() {
+            let req_heap: Span = Span::from_base_size(
+                talc.oom_handler.heap.base().as_mut_ptr(),
+                talc.oom_handler.heap.size(),
+            );
+
+            unsafe {
+                let span: Span = talc.extend(old_heap, req_heap);
+                talc.oom_handler.span = Some(span);
+            }
+
+            return Ok(());
+        }
+
+        // The span already covers all committed memory — grow the backing heap.
+        //
+        // Round up to page alignment and add one extra page so that the allocator's per-chunk
+        // metadata overhead never causes the growth to fall just short of the required chunk
+        // size. Without this margin, a page-aligned layout.size() produces a growth of exactly
+        // layout.size() bytes, but the allocator needs layout.size() + TAG_SIZE for the chunk,
+        // triggering a redundant second OOM call that doubles heap consumption per allocation.
+        let aligned: usize = match mm::align_up(layout.size(), PAGE_ALIGNMENT) {
             Some(v) => v,
             None => {
                 #[cfg(feature = "warn")]
@@ -136,25 +165,21 @@ impl OomHandler for NanvixOomHandler {
                 return Err(());
             },
         };
+        let increment: usize = aligned.saturating_add(PAGE_SIZE);
 
-        let old_heap: Span = talc
-            .oom_handler
-            .span
-            .expect("heap should have an initial span");
-
-        // Check if we have to grow the heap.
-        if old_heap.size() + increment > talc.oom_handler.heap.size() {
-            // let increment: usize = mm::align_up(increment, PAGE_ALIGNMENT);
-            // Attempt to grow the heap.
-            if talc.oom_handler.heap.grow(increment).is_err() {
-                #[cfg(feature = "warn")]
-                let _ = writeln!(
-                    &mut Logger::get(module_path!(), LogLevel::Warn),
-                    "failed to grow heap by {} bytes",
-                    increment
-                );
-                return Err(());
-            }
+        // Attempt to grow with the overhead page. If that fails (near capacity), fall back to
+        // the exact aligned increment — existing free space inside Talc may supply the missing
+        // metadata bytes.
+        if talc.oom_handler.heap.grow(increment).is_err()
+            && talc.oom_handler.heap.grow(aligned).is_err()
+        {
+            #[cfg(feature = "warn")]
+            let _ = writeln!(
+                &mut Logger::get(module_path!(), LogLevel::Warn),
+                "failed to grow heap by {} bytes",
+                increment
+            );
+            return Err(());
         }
 
         let req_heap: Span = Span::from_base_size(
@@ -163,7 +188,7 @@ impl OomHandler for NanvixOomHandler {
         );
 
         unsafe {
-            let span = talc.extend(old_heap, req_heap);
+            let span: Span = talc.extend(old_heap, req_heap);
             if span.size() != req_heap.size() {
                 let _diff: usize = req_heap.size().abs_diff(span.size());
                 #[cfg(feature = "warn")]

--- a/src/libs/sysalloc/src/allocator.rs
+++ b/src/libs/sysalloc/src/allocator.rs
@@ -140,6 +140,15 @@ impl OomHandler for NanvixOomHandler {
 
             unsafe {
                 let span: Span = talc.extend(old_heap, req_heap);
+                #[cfg(feature = "warn")]
+                if span.size() != req_heap.size() {
+                    let diff: usize = req_heap.size().abs_diff(span.size());
+                    let _ = writeln!(
+                        &mut Logger::get(module_path!(), LogLevel::Warn),
+                        "handle_oom(): span reclamation claimed {} fewer bytes",
+                        diff
+                    );
+                }
                 talc.oom_handler.span = Some(span);
             }
 

--- a/src/tests/stress-rust/src/tests/heap_reclaim.rs
+++ b/src/tests/stress-rust/src/tests/heap_reclaim.rs
@@ -1,0 +1,153 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::common::StressError;
+use ::alloc::{
+    boxed::Box,
+    vec::Vec,
+};
+use ::config::constants::KILOBYTE;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Number of alloc/free rounds. Each round performs `ALLOCS_PER_ROUND` allocations of varying
+/// sizes, keeps some alive as anchors, and frees the rest. This exercises the OOM handler under
+/// realistic fragmentation: a mix of large stack-sized blocks and medium/small blocks that
+/// prevent coalescing.
+const ROUNDS: usize = 32;
+
+/// Number of allocations per round.
+const ALLOCS_PER_ROUND: usize = 8;
+
+/// Block sizes to cycle through. The mix of large (512 KB, 256 KB) and medium (128 KB, 64 KB)
+/// sizes creates fragmentation that Talc cannot always resolve by reusing a single freed block.
+const BLOCK_SIZES: [usize; 4] = [
+    512 * KILOBYTE,
+    256 * KILOBYTE,
+    128 * KILOBYTE,
+    64 * KILOBYTE,
+];
+
+/// Size of small anchor allocations placed between freed blocks.
+const ANCHOR_SIZE: usize = 64;
+
+/// Simple deterministic hasher seeded per iteration to vary allocation sizes without requiring
+/// a random number generator. Uses a 32-bit xorshift.
+const XORSHIFT_SEED: u32 = 0xDEAD_BEEF;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Stresses the heap allocator with many alloc/free cycles of varying sizes under fragmentation
+/// pressure.
+///
+/// Each round allocates 8 blocks of pseudo-random sizes drawn from `BLOCK_SIZES`, interleaves
+/// them with small persistent anchors, then frees the large blocks while keeping the anchors.
+/// The varying sizes prevent the allocator from trivially reusing a same-sized freed block and
+/// force the OOM handler to run. Accumulated anchors create address-space fragmentation that
+/// stresses heap reclamation under realistic workloads.
+///
+/// # Returns
+///
+/// `Ok(())` on success or an error if any allocation fails.
+///
+pub fn run() -> Result<(), StressError> {
+    let mut anchors: Vec<Box<[u8; ANCHOR_SIZE]>> = Vec::with_capacity(ROUNDS * ALLOCS_PER_ROUND);
+    let mut rng: u32 = XORSHIFT_SEED;
+
+    for round in 0..ROUNDS {
+        let mut blocks: Vec<Box<[u8]>> = Vec::with_capacity(ALLOCS_PER_ROUND);
+
+        for slot in 0..ALLOCS_PER_ROUND {
+            // Pick a block size pseudo-randomly.
+            rng = xorshift32(rng);
+            let size_index: usize = usize::try_from(rng).unwrap_or(0) % BLOCK_SIZES.len();
+            let size: usize = BLOCK_SIZES[size_index];
+
+            let block: Box<[u8]> = alloc_block(size, round * ALLOCS_PER_ROUND + slot)?;
+            blocks.push(block);
+
+            // Place an anchor after every second block to fragment the heap without
+            // anchoring every single allocation (which would use too much metadata space).
+            if slot % 2 == 1 {
+                let mut anchor: Box<[u8; ANCHOR_SIZE]> = Box::new([0u8; ANCHOR_SIZE]);
+                anchor[0] = u8::try_from((round + slot) & 0xFF).unwrap_or(0);
+                anchors.push(anchor);
+            }
+        }
+
+        // Free all large blocks from this round. Anchors persist, splitting the free list.
+        drop(blocks);
+    }
+
+    // Clean up all anchors.
+    drop(anchors);
+
+    Ok(())
+}
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// 32-bit xorshift PRNG. Produces a deterministic pseudo-random sequence from a non-zero seed.
+///
+/// # Parameters
+///
+/// - `state`: Current PRNG state (must be non-zero).
+///
+/// # Returns
+///
+/// Next pseudo-random value.
+///
+fn xorshift32(state: u32) -> u32 {
+    let mut s: u32 = state;
+    s ^= s << 13;
+    s ^= s >> 17;
+    s ^= s << 5;
+    s
+}
+
+///
+/// # Description
+///
+/// Allocates a zeroed block of `size` bytes and writes a tag into the first byte for
+/// verification. Note that allocation failure will abort the process (Rust's default global
+/// allocator behavior); only the tag verification can return an error.
+///
+/// # Parameters
+///
+/// - `size`: Number of bytes to allocate.
+/// - `index`: Block index (used for the tag byte).
+///
+/// # Returns
+///
+/// A boxed byte slice on success, or an error if the tag verification fails.
+///
+fn alloc_block(size: usize, index: usize) -> Result<Box<[u8]>, Error> {
+    let mut block: Box<[u8]> = ::alloc::vec![0u8; size].into_boxed_slice();
+    // Write a tag so the allocation is not optimized away.
+    let tag: u8 = u8::try_from(index & 0xFF).unwrap_or(0);
+    block[0] = tag;
+    if block[0] != tag {
+        return Err(Error::new(ErrorCode::InvalidArgument, "block tag mismatch"));
+    }
+    Ok(block)
+}

--- a/src/tests/stress-rust/src/tests/mod.rs
+++ b/src/tests/stress-rust/src/tests/mod.rs
@@ -8,6 +8,7 @@
 mod common;
 mod debug_console_spam;
 mod event_registration;
+mod heap_reclaim;
 mod kcall_hammer;
 mod memory_mapping_storm;
 mod mutex_churn;
@@ -44,6 +45,7 @@ pub fn run_all() -> Result<(), Error> {
     thread_identity::run()?;
     kcall_hammer::run()?;
     scoreboard_backpressure::run()?;
+    heap_reclaim::run()?;
     sleep_burst::run()?;
     debug_console_spam::run()?;
     event_registration::run()?;


### PR DESCRIPTION
This pull request introduces significant improvements to the heap allocator's out-of-memory (OOM) handling logic and adds a new stress test to verify heap reclamation under fragmentation. The allocator changes optimize how committed memory is reclaimed and how heap growth is managed, reducing unnecessary memory usage. The new test exercises the allocator under realistic fragmentation scenarios to ensure robust OOM handling.