### PR TITLE
[tests] Add getenv() tests

### DIFF
--- a/src/tests/misc-c/common.h
+++ b/src/tests/misc-c/common.h
@@ -53,6 +53,9 @@
 // Tests whether we can get the resolution of a clock with `clock_getres()`.
 extern void test_clock_getres(void);
 
+// Tests if `getenv()` works.
+extern void test_getenv(void);
+
 // Tests whether we can get the effective group ID of the calling process with `getegid()`.
 extern void test_getegid(void);
 

--- a/src/tests/misc-c/getenv.c
+++ b/src/tests/misc-c/getenv.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/**
+ * @brief Tests whether `getenv()` correctly retrieves a set environment variable.
+ */
+static void test_getenv_set(void)
+{
+    fprintf(stderr, "testing getenv() set ... ");
+
+    const char *value = getenv("NANVIX_TEST");
+    assert(value != NULL);
+    assert(strcmp(value, "1") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+/**
+ * @brief Tests whether `getenv()` returns NULL for an unset environment variable.
+ */
+static void test_getenv_unset(void)
+{
+    fprintf(stderr, "testing getenv() unset ... ");
+
+    const char *value = getenv("NANVIX_UNSET_VAR");
+    assert(value == NULL);
+
+    fprintf(stderr, "passed\n");
+}
+
+/**
+ * @brief Tests if `getenv()` works.
+ */
+void test_getenv(void)
+{
+    test_getenv_set();
+    test_getenv_unset();
+}

--- a/src/tests/misc-c/main.c
+++ b/src/tests/misc-c/main.c
@@ -53,6 +53,7 @@ int main(int argc, const char *argv[])
     test_times();
     test_uname();
     test_gethostname();
+    test_getenv();
 
     // Write magic string to signal that the test passed.
     {

--- a/test/test-l2.toml
+++ b/test/test-l2.toml
@@ -96,6 +96,7 @@ expected_output = "ok"
 [[tests]]
 executor = "http"
 program = "./bin/misc-c.elf"
+program_args = ";NANVIX_TEST=1"
 input = "[]"
 expected_output = "ok"
 

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -126,6 +126,7 @@ expected_output = "ok"
 [[tests]]
 executor = "http"
 program = "./bin/misc-c.elf"
+program_args = ";NANVIX_TEST=1"
 input = "[]"
 expected_output = "ok"
 
@@ -236,6 +237,7 @@ expected_output = "ok"
 [[tests]]
 executor = "terminal"
 program = "./bin/misc-c.elf"
+program_args = ";NANVIX_TEST=1"
 expected_output = "ok"
 
 [[tests]]

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -125,6 +125,7 @@ expected_output = "ok"
 [[tests]]
 executor = "http"
 program = "./bin/misc-c.elf"
+program_args = ";NANVIX_TEST=1"
 input = "[]"
 expected_output = "ok"
 
@@ -235,6 +236,7 @@ expected_output = "ok"
 [[tests]]
 executor = "terminal"
 program = "./bin/misc-c.elf"
+program_args = ";NANVIX_TEST=1"
 expected_output = "ok"
 
 [[tests]]

--- a/test/test.toml
+++ b/test/test.toml
@@ -125,6 +125,7 @@ expected_output = "ok"
 [[tests]]
 executor = "http"
 program = "./bin/misc-c.elf"
+program_args = ";NANVIX_TEST=1"
 input = "[]"
 expected_output = "ok"
 
@@ -235,6 +236,7 @@ expected_output = "ok"
 [[tests]]
 executor = "terminal"
 program = "./bin/misc-c.elf"
+program_args = ";NANVIX_TEST=1"
 expected_output = "ok"
 
 [[tests]]


### PR DESCRIPTION
Add test_getenv() to the misc-c test suite, covering both set and unset environment variables. Environment variables are forwarded to the guest program through the existing cmdline `;` delimiter convention.

- Add getenv.c with test_getenv_set() and test_getenv_unset().
- Pass NANVIX_TEST=1 via program_args in all test TOML configs.