### PR TITLE
[kernel] IMproce Access to `ProcessManager`

### DIFF
--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -952,9 +952,7 @@ fn do_exception_handler(
     trace!("info={:?}", info);
 
     // SAFETY: This is the only thread running, thus access to the memory manager is synchronized.
-    let pid: ProcessIdentifier = unsafe { ProcessManager::get() }
-        .get_pid()
-        .map_err(SleepError::Generic)?;
+    let pid: ProcessIdentifier = unsafe { ProcessManager::get() }.get_pid();
 
     // Check if exception was triggered by the kernel.
     if pid == ProcessIdentifier::KERNEL {

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -52,14 +52,8 @@ use ::sys::{
 ///
 #[unsafe(no_mangle)]
 pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> i64 {
-    let pid: ProcessIdentifier = match unsafe { ProcessManager::get() }.get_pid() {
-        Ok(pid) => pid,
-        Err(e) => return KcallResult::Error(e.code.into()).into(),
-    };
-    let tid: ThreadIdentifier = match unsafe { ProcessManager::get() }.get_tid() {
-        Ok(tid) => tid,
-        Err(e) => return KcallResult::Error(e.code.into()).into(),
-    };
+    let pid: ProcessIdentifier = unsafe { ProcessManager::get() }.get_pid();
+    let tid: ThreadIdentifier = unsafe { ProcessManager::get() }.get_tid();
 
     match KcallNumber::from(number) {
         // Handle `getpid()` locally.

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -39,16 +39,27 @@ use ::config::kernel::IKC_POLL_BATCH_SIZE;
 //  Standalone Functions
 //==================================================================================================
 
+// Convenience macro to obtain a mutable reference to the process manager.
+//
+// # Safety
+//
+// Each expansion produces a fresh `&mut ProcessManager` via `get_mut()`. Callers must ensure
+// that borrows from separate expansions do not overlap (i.e., drop the reference before the
+// next `pm!()` invocation).
+macro_rules! pm {
+    () => {
+        // SAFETY: the process manager is initialized, this is a single-core system,
+        // and the kernel runs with interrupts disabled.
+        unsafe { ProcessManager::get_mut() }
+    };
+}
+
 ///
 /// # Description
 ///
 /// Kernel call handler.
 ///
-pub fn kcall_handler(
-    hal: &mut Hal,
-    mm: &mut VirtMemoryManager,
-    pm: &mut ProcessManager,
-) -> ExitStatus {
+pub fn kcall_handler(hal: &mut Hal, mm: &mut VirtMemoryManager) -> ExitStatus {
     if let Err(e) = event::init(hal) {
         panic!("failed to initialize event manager: {:?}", e);
     }
@@ -60,7 +71,7 @@ pub fn kcall_handler(
             Ok(scoreboard) => match scoreboard.handle() {
                 Ok(args) => {
                     let ret: KcallResult = match KcallNumber::from(args.number) {
-                        KcallNumber::Debug => debug::debug(pm, args),
+                        KcallNumber::Debug => debug::debug(pm!(), args),
                         KcallNumber::GetPid => {
                             // NOTE: this should be handled by the dispatcher.
                             // However we emit an invalid system call, just in case.
@@ -73,25 +84,25 @@ pub fn kcall_handler(
                             error!("cannot handle gettid()");
                             KcallResult::Error(ErrorCode::InvalidSysCall.into())
                         },
-                        KcallNumber::CapCtl => pm::capctl(pm, args),
-                        KcallNumber::Terminate => pm::terminate(pm, args),
-                        KcallNumber::EventCtrl => event::evctrl(pm, args),
-                        KcallNumber::MemoryMap => pm::mmap(pm, mm, args),
-                        KcallNumber::MemoryUnmap => pm::munmap(pm, mm, args),
-                        KcallNumber::MemoryCtrl => pm::mctrl(pm, mm, args),
-                        KcallNumber::MemoryCopy => pm::mcopy(pm, mm, args),
-                        KcallNumber::Send => ipc::send(pm, args),
-                        KcallNumber::AllocMmio => io::mmio_alloc(hal, pm, args),
-                        KcallNumber::FreeMmio => io::mmio_free(pm, args),
-                        KcallNumber::MmioInfo => io::mmio_info(pm, args),
-                        KcallNumber::AllocPmio => io::pmio_alloc(hal, pm, args),
-                        KcallNumber::FreePmio => io::pmio_free(pm, args),
-                        KcallNumber::ReadPmio => io::pmio_read(pm, args),
-                        KcallNumber::WritePmio => io::pmio_write(pm, args),
-                        KcallNumber::GetTime => pm::gettime(pm, args),
-                        KcallNumber::CreateThread => pm::create_thread(pm, mm, args),
-                        KcallNumber::SetThreadDataArea => pm::set_thread_data_area(pm, args),
-                        KcallNumber::GetThreadDataArea => pm::get_thread_data_area(pm, args),
+                        KcallNumber::CapCtl => pm::capctl(pm!(), args),
+                        KcallNumber::Terminate => pm::terminate(pm!(), args),
+                        KcallNumber::EventCtrl => event::evctrl(pm!(), args),
+                        KcallNumber::MemoryMap => pm::mmap(pm!(), mm, args),
+                        KcallNumber::MemoryUnmap => pm::munmap(pm!(), mm, args),
+                        KcallNumber::MemoryCtrl => pm::mctrl(pm!(), mm, args),
+                        KcallNumber::MemoryCopy => pm::mcopy(pm!(), mm, args),
+                        KcallNumber::Send => ipc::send(pm!(), args),
+                        KcallNumber::AllocMmio => io::mmio_alloc(hal, pm!(), args),
+                        KcallNumber::FreeMmio => io::mmio_free(pm!(), args),
+                        KcallNumber::MmioInfo => io::mmio_info(pm!(), args),
+                        KcallNumber::AllocPmio => io::pmio_alloc(hal, pm!(), args),
+                        KcallNumber::FreePmio => io::pmio_free(pm!(), args),
+                        KcallNumber::ReadPmio => io::pmio_read(pm!(), args),
+                        KcallNumber::WritePmio => io::pmio_write(pm!(), args),
+                        KcallNumber::GetTime => pm::gettime(pm!(), args),
+                        KcallNumber::CreateThread => pm::create_thread(pm!(), mm, args),
+                        KcallNumber::SetThreadDataArea => pm::set_thread_data_area(pm!(), args),
+                        KcallNumber::GetThreadDataArea => pm::get_thread_data_area(pm!(), args),
                         _ => {
                             error!("invalid kernel call");
                             KcallResult::Error(ErrorCode::InvalidSysCall.into())
@@ -128,25 +139,24 @@ pub fn kcall_handler(
                 for _ in 0..IKC_POLL_BATCH_SIZE {
                     // Check if the number of buffered messages in the kernel is not too high. We don't
                     // want to keep pushing messages to the kernel and then run out of memory.
-                    if let Ok(number_buffered_messages) = pm.number_buffered_messages() {
-                        if number_buffered_messages < config::kernel::MAX_IKC_MESSAGES {
-                            // The number of messages that are buffered in the kernel is not too high,
-                            // So attempt to read an inter-kernel communication message from the
-                            // kernel's standard input.
-                            match crate::stdio::read() {
-                                // No message is available.
-                                Ok(None) => break,
-                                // A message is available.
-                                Ok(Some(message)) => {
-                                    if let Err(e) = EventManager::post_message(pm, message.destination, message) {
-                                        warn!("failed to post message (error={:?})", e);
-                                    }
-                                    message_received = true;
+                    let number_buffered_messages: usize = pm!().number_buffered_messages();
+                    if number_buffered_messages < config::kernel::MAX_IKC_MESSAGES {
+                        // The number of messages that are buffered in the kernel is not too high,
+                        // So attempt to read an inter-kernel communication message from the
+                        // kernel's standard input.
+                        match crate::stdio::read() {
+                            // No message is available.
+                            Ok(None) => break,
+                            // A message is available.
+                            Ok(Some(message)) => {
+                                if let Err(e) = EventManager::post_message(pm!(), message.destination, message) {
+                                    warn!("failed to post message (error={:?})", e);
                                 }
-                                // Failed to read message.
-                                Err(e) => {
-                                    warn!("failed to read message (error={:?})", e);
-                                }
+                                message_received = true;
+                            }
+                            // Failed to read message.
+                            Err(e) => {
+                                warn!("failed to read message (error={:?})", e);
                             }
                         }
                     }
@@ -159,7 +169,7 @@ pub fn kcall_handler(
 
         // Attempt to harvest zombie processes.
         let mut harvested_process: bool = false;
-        match pm.harvest_zombies(mm) {
+        match pm!().harvest_zombies(mm) {
             Ok(None) => {},
             Ok(Some((pid, status))) => {
                 // Check if init daemon process terminated.
@@ -193,7 +203,7 @@ pub fn kcall_handler(
         }
     };
 
-    while let Ok(Some((pid, status))) = pm.harvest_zombies(mm) {
+    while let Ok(Some((pid, status))) = pm!().harvest_zombies(mm) {
         info!("harvested zombie process: pid={:?}, status={:?}", pid, status);
     }
 

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -207,18 +207,17 @@ fn test() {
 /// # Parameters
 ///
 /// - `mm`: A reference to the virtual memory manager to use.
-/// - `pm`: A reference to the process manager to use.
 /// - `kmods`: A reference to the list of kernel modules to spawn.
 ///
 /// # Returns
 ///
 /// The number of servers that were successfully spawned.
 ///
-fn spawn_servers(
-    mm: &mut VirtMemoryManager,
-    pm: &mut ProcessManager,
-    kmods: &LinkedList<KernelModule>,
-) -> usize {
+fn spawn_servers(mm: &mut VirtMemoryManager, kmods: &LinkedList<KernelModule>) -> usize {
+    // SAFETY: the process manager is initialized, this is a single-core system, interrupts are
+    // disabled, and the resulting `&mut ProcessManager` does not alias `mm`.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
     let mut count: usize = 0;
     // Spawn all servers.
     for kmod in kmods.iter() {
@@ -330,12 +329,9 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
             },
         };
 
-    let mut pm: ProcessManager = match pm::init(&mut hal, root) {
-        Ok(pm) => pm,
-        Err(err) => {
-            panic!("failed to initialize process manager: {:?}", err);
-        },
-    };
+    if let Err(err) = pm::init(&mut hal, root) {
+        panic!("failed to initialize process manager: {:?}", err);
+    }
 
     // Start application cores.
     #[cfg(feature = "smp")]
@@ -417,7 +413,7 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     let cores_online: usize = CORES_ONLINE.load(Ordering::Acquire);
     info!("number of cores online: {}", cores_online);
 
-    let status: ExitStatus = if spawn_servers(&mut mm, &mut pm, &kernel_modules) > 0 {
+    let status: ExitStatus = if spawn_servers(&mut mm, &kernel_modules) > 0 {
         // Initialize kernel call dispatcher.
         kcall::init();
 
@@ -428,7 +424,7 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
             }
         }
 
-        kcall::handler(&mut hal, &mut mm, &mut pm)
+        kcall::handler(&mut hal, &mut mm)
     } else {
         ExitStatus::ok()
     };

--- a/src/kernel/src/pm/mod.rs
+++ b/src/kernel/src/pm/mod.rs
@@ -86,7 +86,7 @@ pub fn copy_to_user<T>(
 }
 
 /// Initializes the processor manager.
-pub fn init(hal: &mut Hal, root: Vmem) -> Result<ProcessManager, Error> {
+pub fn init(hal: &mut Hal, root: Vmem) -> Result<(), Error> {
     info!("initializing the processor manager...");
 
     let interrupt_capable: bool = hal.intman.is_some();
@@ -100,7 +100,7 @@ pub fn init(hal: &mut Hal, root: Vmem) -> Result<ProcessManager, Error> {
     // Initialize the thread manager.
     info!("initializing the thread manager...");
     let (kernel, tm): (ReadyThread, ThreadManager) = thread::init();
-    let pm: ProcessManager = ProcessManager::init(interrupt_capable, kernel, root, tm);
+    ProcessManager::init(interrupt_capable, kernel, root, tm);
 
-    Ok(pm)
+    Ok(())
 }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -68,15 +68,10 @@ use ::alloc::{
         LinkedList,
     },
     ffi::CString,
-    rc::Rc,
 };
 use ::arch::mem::PAGE_SIZE;
 use ::config::memory_layout::USER_STACK_TOP_RAW;
-use ::core::cell::{
-    Ref,
-    RefCell,
-    RefMut,
-};
+
 use ::sys::{
     error::{
         Error,
@@ -1600,7 +1595,7 @@ impl ProcessManagerInner {
 // Process Manager
 //==================================================================================================
 
-pub struct ProcessManager(Rc<RefCell<ProcessManagerInner>>);
+pub struct ProcessManager(ProcessManagerInner);
 
 impl ProcessManager {
     ///
@@ -1610,12 +1605,10 @@ impl ProcessManager {
     ///
     /// # Returns
     ///
-    /// Upon successful completion, the ID of the calling process is returned. Otherwise, an error
-    /// code is returned instead.
+    /// The ID of the calling process.
     ///
-    pub fn get_pid(&self) -> Result<ProcessIdentifier, Error> {
-        // SAFETY: This is the only thread running, thus access to the process manager is synchronized.
-        Ok(self.try_borrow()?.get_running().state().pid())
+    pub fn get_pid(&self) -> ProcessIdentifier {
+        self.0.get_running().state().pid()
     }
 
     ///
@@ -1625,11 +1618,10 @@ impl ProcessManager {
     ///
     /// # Returns
     ///
-    /// Upon successful completion, the ID of the calling thread is returned. Otherwise, an error
-    /// code is returned instead.
+    /// The ID of the calling thread.
     ///
-    pub fn get_tid(&self) -> Result<ThreadIdentifier, Error> {
-        Ok(self.try_borrow()?.get_running().get_tid())
+    pub fn get_tid(&self) -> ThreadIdentifier {
+        self.0.get_running().get_tid()
     }
 
     ///
@@ -1656,7 +1648,7 @@ impl ProcessManager {
         args: &str,
         env: &str,
     ) -> Result<ProcessIdentifier, Error> {
-        self.try_borrow_mut()?.create_process(mm, elf, args, env)
+        self.0.create_process(mm, elf, args, env)
     }
 
     ///
@@ -1691,8 +1683,7 @@ impl ProcessManager {
         // Assert pre-conditions (these should have been checked by the caller).
         debug_assert!(Vmem::is_user_addr(thread_create_args.user_fn));
 
-        self.try_borrow_mut()?
-            .create_thread(mm, pid, thread_create_args)
+        self.0.create_thread(mm, pid, thread_create_args)
     }
 
     ///
@@ -1715,7 +1706,6 @@ impl ProcessManager {
     /// This function fails with the following error codes:
     ///
     /// - [`ErrorCode::NoSuchEntry`]: The specified process or thread does not exist.
-    /// - [`ErrorCode::ResourceBusy`]: The process manager is busy and cannot handle the request.
     ///
     pub fn set_thread_data_area(
         &mut self,
@@ -1723,8 +1713,7 @@ impl ProcessManager {
         tid: ThreadIdentifier,
         user_tda: Option<VirtualAddress>,
     ) -> Result<(), Error> {
-        self.try_borrow_mut()?
-            .set_thread_data_area(pid, tid, user_tda)
+        self.0.set_thread_data_area(pid, tid, user_tda)
     }
 
     ///
@@ -1747,14 +1736,13 @@ impl ProcessManager {
     /// This function fails with the following error codes:
     ///
     /// - [`ErrorCode::NoSuchEntry`]: The specified process or thread does not exist.
-    /// - [`ErrorCode::ResourceBusy`]: The process manager is busy and cannot handle the request.
     ///
     pub fn get_thread_data_area(
         &self,
         pid: ProcessIdentifier,
         tid: ThreadIdentifier,
     ) -> Result<Option<VirtualAddress>, Error> {
-        self.try_borrow()?.get_thread_data_area(pid, tid)
+        self.0.get_thread_data_area(pid, tid)
     }
 
     pub fn has_capability(
@@ -1762,11 +1750,7 @@ impl ProcessManager {
         pid: ProcessIdentifier,
         capability: Capability,
     ) -> Result<bool, Error> {
-        Ok(self
-            .try_borrow()?
-            .find_process(pid)?
-            .state()
-            .has_capability(capability))
+        Ok(self.0.find_process(pid)?.state().has_capability(capability))
     }
 
     pub fn capctl(
@@ -1775,11 +1759,11 @@ impl ProcessManager {
         capability: Capability,
         value: bool,
     ) -> Result<(), Error> {
-        self.try_borrow_mut()?.capctl(pid, capability, value)
+        self.0.capctl(pid, capability, value)
     }
 
     pub fn terminate(&mut self, pid: ProcessIdentifier) -> Result<(), Error> {
-        self.try_borrow_mut()?.terminate(pid)
+        self.0.terminate(pid)
     }
 
     pub fn vmcopy_from_user(
@@ -1789,7 +1773,7 @@ impl ProcessManager {
         src: VirtualAddress,
         size: usize,
     ) -> Result<(), Error> {
-        self.try_borrow_mut()?
+        self.0
             .find_process_mut(pid)?
             .state_mut()
             .copy_from_user_unaligned(dst, src, size)
@@ -1802,7 +1786,7 @@ impl ProcessManager {
         src: VirtualAddress,
         size: usize,
     ) -> Result<(), Error> {
-        self.try_borrow_mut()?
+        self.0
             .find_process_mut(pid)?
             .state_mut()
             .copy_to_user_unaligned(dst, src, size)
@@ -1816,7 +1800,7 @@ impl ProcessManager {
             VecDeque<ZombieThread>,
             Box<ProcessState>,
             ExitStatus,
-        ) = match self.try_borrow_mut()?.harvest_zombies() {
+        ) = match self.0.harvest_zombies() {
             Some((zombie_threads, state, status)) => (zombie_threads, state, status),
             None => return Ok(None),
         };
@@ -1862,8 +1846,7 @@ impl ProcessManager {
         vaddr: PageAligned<VirtualAddress>,
         access: AccessPermission,
     ) -> Result<(), Error> {
-        let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
-        let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
+        let mut process: ProcessRefMut = self.0.find_process_mut(pid)?;
         let vmem: &mut Vmem = process.state_mut().vmem_mut();
         mm.alloc_upage(vmem, vaddr, access, true)
     }
@@ -1874,8 +1857,7 @@ impl ProcessManager {
         pid: ProcessIdentifier,
         vaddr: PageAligned<VirtualAddress>,
     ) -> Result<(), Error> {
-        let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
-        let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
+        let mut process: ProcessRefMut = self.0.find_process_mut(pid)?;
         let vmem: &mut Vmem = process.state_mut().vmem_mut();
         mm.unmap_upage(vmem, vaddr)
     }
@@ -1887,8 +1869,7 @@ impl ProcessManager {
         vaddr: PageAligned<VirtualAddress>,
         access: AccessPermission,
     ) -> Result<(), Error> {
-        let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
-        let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
+        let mut process: ProcessRefMut = self.0.find_process_mut(pid)?;
         let vmem: &mut Vmem = process.state_mut().vmem_mut();
         mm.ctrl_upage(vmem, vaddr, access)
     }
@@ -1898,8 +1879,7 @@ impl ProcessManager {
         pid: ProcessIdentifier,
         region: IoMemoryRegion,
     ) -> Result<(), Error> {
-        let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
-        let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
+        let mut process: ProcessRefMut = self.0.find_process_mut(pid)?;
         let state: &mut ProcessState = process.state_mut();
 
         // TODO: change page permissions.
@@ -1926,8 +1906,7 @@ impl ProcessManager {
     /// Upon success, empty is returned. Upon failure, an error is returned instead.
     ///
     pub fn mmio_free(&mut self, pid: ProcessIdentifier, tag: MmioTag) -> Result<(), Error> {
-        let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
-        let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
+        let mut process: ProcessRefMut = self.0.find_process_mut(pid)?;
         let state: &mut ProcessState = process.state_mut();
         state.remove_mmio(tag);
 
@@ -1954,8 +1933,7 @@ impl ProcessManager {
         pid: ProcessIdentifier,
         tag: MmioTag,
     ) -> Result<(PageAligned<VirtualAddress>, usize, AccessPermission), Error> {
-        let pm: Ref<ProcessManagerInner> = self.try_borrow()?;
-        let process: ProcessRef = pm.find_process(pid)?;
+        let process: ProcessRef = self.0.find_process(pid)?;
         let state: &ProcessState = process.state();
 
         match state.mmio_info(tag) {
@@ -1969,8 +1947,7 @@ impl ProcessManager {
     }
 
     pub fn attach_pmio(&mut self, pid: ProcessIdentifier, port: AnyIoPort) -> Result<(), Error> {
-        let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
-        let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
+        let mut process: ProcessRefMut = self.0.find_process_mut(pid)?;
         process.state_mut().add_pmio(port);
         Ok(())
     }
@@ -1980,8 +1957,7 @@ impl ProcessManager {
         pid: ProcessIdentifier,
         port_number: u16,
     ) -> Result<AnyIoPort, Error> {
-        let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
-        let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
+        let mut process: ProcessRefMut = self.0.find_process_mut(pid)?;
         process.state_mut().remove_pmio(port_number)
     }
 
@@ -1991,8 +1967,7 @@ impl ProcessManager {
         port_number: u16,
         port_width: IoPortWidth,
     ) -> Result<u32, Error> {
-        let pm: Ref<ProcessManagerInner> = self.try_borrow()?;
-        let process: ProcessRef = pm.find_process(pid)?;
+        let process: ProcessRef = self.0.find_process(pid)?;
         process.state().read_pmio(port_number, port_width)
     }
 
@@ -2003,8 +1978,7 @@ impl ProcessManager {
         port_width: IoPortWidth,
         value: u32,
     ) -> Result<(), Error> {
-        let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
-        let mut process: ProcessRefMut = pm.find_process_mut(pid)?;
+        let mut process: ProcessRefMut = self.0.find_process_mut(pid)?;
         process
             .state_mut()
             .write_pmio(port_number, port_width, value)
@@ -2029,30 +2003,25 @@ impl ProcessManager {
         receiver: MessageReceiver,
         message: Message,
     ) -> Result<(), Error> {
-        let mut pm: RefMut<ProcessManagerInner> = self.try_borrow_mut()?;
-        let mut process: ProcessRefMut = match receiver.as_id() {
-            Ok(pid) => pm.find_process_mut(pid)?,
-            Err(tid) => pm.find_process_by_tid(tid)?,
-        };
-        process.state_mut().post_message(message);
-        pm.note_message_posted()?;
+        {
+            let mut process: ProcessRefMut = match receiver.as_id() {
+                Ok(pid) => self.0.find_process_mut(pid)?,
+                Err(tid) => self.0.find_process_by_tid(tid)?,
+            };
+            process.state_mut().post_message(message);
+        }
+        self.0.note_message_posted()?;
         Ok(())
     }
 
     pub fn add_event(&mut self, ownership: EventOwnership) -> Result<(), Error> {
-        self.try_borrow_mut()?
-            .get_running_mut()
-            .state_mut()
-            .add_event(ownership);
+        self.0.get_running_mut().state_mut().add_event(ownership);
 
         Ok(())
     }
 
     pub fn remove_event(&mut self, ev: &Event) -> Result<(), Error> {
-        self.try_borrow_mut()?
-            .get_running_mut()
-            .state_mut()
-            .remove_event(ev);
+        self.0.get_running_mut().state_mut().remove_event(ev);
 
         Ok(())
     }
@@ -2064,37 +2033,14 @@ impl ProcessManager {
     ///
     /// # Returns
     ///
-    /// Upon successful completion, the number of buffered messages is returned. Otherwise, an error
-    /// code is returned instead.
+    /// The number of buffered messages.
     ///
     #[cfg(feature = "stdio")]
-    pub fn number_buffered_messages(&self) -> Result<usize, Error> {
-        Ok(self.try_borrow()?.count_buffered_messages())
+    pub fn number_buffered_messages(&self) -> usize {
+        self.0.count_buffered_messages()
     }
 
     pub fn handle_fpu_exception(&mut self) -> Result<(), Error> {
-        self.try_borrow_mut()?.handle_fpu_exception()
-    }
-
-    fn try_borrow(&self) -> Result<Ref<'_, ProcessManagerInner>, Error> {
-        match self.0.try_borrow() {
-            Ok(pm) => Ok(pm),
-            Err(_) => {
-                let reason: &str = "cannot borrow process manager";
-                error!("{reason}");
-                Err(Error::new(ErrorCode::ResourceBusy, reason))
-            },
-        }
-    }
-
-    fn try_borrow_mut(&mut self) -> Result<RefMut<'_, ProcessManagerInner>, Error> {
-        match self.0.try_borrow_mut() {
-            Ok(pm) => Ok(pm),
-            Err(_) => {
-                let reason: &str = "cannot borrow process manager";
-                error!("{reason}");
-                Err(Error::new(ErrorCode::ResourceBusy, reason))
-            },
-        }
+        self.0.handle_fpu_exception()
     }
 }

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -52,14 +52,9 @@ use crate::{
     PERF_SCHED_SOFT_CONTEXT_SWITCHES,
     PERF_SCHED_WAKEUP,
 };
-use ::alloc::rc::Rc;
 use ::arch::mem::PAGE_SIZE;
 use ::config::kernel::SCHEDULER_FREQ;
 use ::core::{
-    cell::{
-        RefCell,
-        RefMut,
-    },
     hint::{
         cold_path,
         unlikely,
@@ -123,29 +118,22 @@ impl ProcessManager {
     /// - `root`: Root virtual memory.
     /// - `tm`: Thread manager.
     ///
-    /// # Returns
+    /// # Panics
     ///
-    /// A handle to the process manager is returned.
+    /// This function panics if the process manager is already initialized.
     ///
-    pub fn init(
-        interrupt_capable: bool,
-        kernel: ReadyThread,
-        root: Vmem,
-        tm: ThreadManager,
-    ) -> ProcessManager {
+    pub fn init(interrupt_capable: bool, kernel: ReadyThread, root: Vmem, tm: ThreadManager) {
         // Check if the process manager is already initialized.
         if unlikely(PROCESS_MANAGER_INIT.load(ORDER)) {
             panic!("process manager was already initialized");
         }
 
-        let pm: Rc<RefCell<ProcessManagerInner>> =
-            Rc::new(RefCell::new(ProcessManagerInner::new(interrupt_capable, kernel, root, tm)));
+        let inner: ProcessManagerInner =
+            ProcessManagerInner::new(interrupt_capable, kernel, root, tm);
 
         // SAFETY: This happens during kernel initialization and no other threads are running.
-        unsafe { PROCESS_MANAGER.write(ProcessManager(pm.clone())) };
+        unsafe { PROCESS_MANAGER.write(ProcessManager(inner)) };
         PROCESS_MANAGER_INIT.store(true, ORDER);
-
-        ProcessManager(pm)
     }
 
     ///
@@ -234,7 +222,7 @@ impl ProcessManager {
             *mut ContextInformation,
             *mut ContextInformation,
             Option<VirtualAddress>,
-        ) = Self::get_mut().try_borrow_mut()?.exit(status);
+        ) = Self::get_mut().0.exit(status);
 
         // SAFETY: `from` and `to` point to valid context information structures, and the processor
         // is running with interrupts disabled.
@@ -295,7 +283,7 @@ impl ProcessManager {
                 *mut ContextInformation,
                 *mut ContextInformation,
                 Option<VirtualAddress>,
-            ) = Self::get_mut().try_borrow_mut()?.exit_thread(status);
+            ) = Self::get_mut().0.exit_thread(status);
 
             join_cond.notify_all()?;
 
@@ -351,10 +339,8 @@ impl ProcessManager {
         trace!("pid={:?}, tid={:?}", pid, tid);
 
         loop {
-            let result: Result<ZombieThread, Result<Condvar, Error>> = Self::get_mut()
-                .try_borrow_mut()
-                .map_err(SleepError::Generic)?
-                .try_join_thread(pid, tid);
+            let result: Result<ZombieThread, Result<Condvar, Error>> =
+                Self::get_mut().0.try_join_thread(pid, tid);
 
             match result {
                 Ok(zombie_thread) => {
@@ -379,8 +365,7 @@ impl ProcessManager {
                             // Attempt to unmap page
                             if let Err(error) = VirtMemoryManager::get_mut().unmap_upage(
                                 Self::get_mut()
-                                    .try_borrow_mut()
-                                    .map_err(SleepError::Generic)?
+                                    .0
                                     .find_process_mut(pid)
                                     .map_err(SleepError::Generic)?
                                     .state_mut()
@@ -449,10 +434,7 @@ impl ProcessManager {
             *mut ContextInformation,
             *mut ContextInformation,
             Option<VirtualAddress>,
-        ) = Self::get_mut()
-            .try_borrow_mut()
-            .map_err(SleepError::Generic)?
-            .sleep(alarm);
+        ) = Self::get_mut().0.sleep(alarm);
 
         // SAFETY: `from` and `to` point to valid context information structures, and the processor
         // is running with interrupts disabled.
@@ -460,10 +442,7 @@ impl ProcessManager {
         Self::switch(next_pid, next_tid, from, to, user_tda);
 
         // Check the reason why the thread was woken up.
-        let interrupt_reason: Option<InterruptReason> = Self::get_mut()
-            .try_borrow_mut()
-            .map_err(SleepError::Generic)?
-            .interrupt_reason();
+        let interrupt_reason: Option<InterruptReason> = Self::get_mut().0.interrupt_reason();
 
         // Check if the thread was interrupted.
         if let Some(reason) = interrupt_reason {
@@ -546,7 +525,7 @@ impl ProcessManager {
             *mut ContextInformation,
             *mut ContextInformation,
             Option<VirtualAddress>,
-        ) = Self::get_mut().try_borrow_mut()?.schedule();
+        ) = Self::get_mut().0.schedule();
 
         // Switch to the next thread and updating the remaining quantum accordingly.
         // SAFETY: `from` and `to` point to valid context information structures, and the
@@ -581,7 +560,7 @@ impl ProcessManager {
     /// - The calling process does not hold a reference to the process manager.
     ///
     pub unsafe fn get_mutex(addr: MutexAddress) -> Result<Mutex, Error> {
-        Self::get_mut().try_borrow_mut()?.get_mutex(addr)
+        Self::get_mut().0.get_mutex(addr)
     }
 
     ///
@@ -606,9 +585,7 @@ impl ProcessManager {
         mutex_addr: MutexAddress,
         guard: MutexGuard,
     ) -> Result<(), Error> {
-        Self::get_mut()
-            .try_borrow_mut()?
-            .put_mutex_guard(mutex_addr, guard);
+        Self::get_mut().0.put_mutex_guard(mutex_addr, guard);
         Ok(())
     }
 
@@ -636,7 +613,7 @@ impl ProcessManager {
     /// - The calling process does not hold a reference to the process manager.
     ///
     pub unsafe fn get_cond(cond_addr: ConditionAddress) -> Result<Condvar, Error> {
-        Self::get_mut().try_borrow_mut()?.get_cond(cond_addr)
+        Self::get_mut().0.get_cond(cond_addr)
     }
 
     ///
@@ -661,7 +638,7 @@ impl ProcessManager {
     /// - The calling process does not hold a reference to the process manager.
     ///
     pub unsafe fn put_cond(cond_addr: ConditionAddress) -> Result<(), Error> {
-        Self::get_mut().try_borrow_mut()?.put_cond(cond_addr)
+        Self::get_mut().0.put_cond(cond_addr)
     }
 
     ///
@@ -683,11 +660,11 @@ impl ProcessManager {
     /// - The calling process does not hold a reference to the process manager.
     ///
     pub unsafe fn try_recv(tid: ThreadIdentifier) -> Result<Option<Message>, Error> {
-        let mut pm: RefMut<ProcessManagerInner> = unsafe { Self::get_mut() }.try_borrow_mut()?;
-        let running: &mut RunningProcess = pm.get_running_mut();
+        let pm: &mut ProcessManager = unsafe { Self::get_mut() };
+        let running: &mut RunningProcess = pm.0.get_running_mut();
         match running.state_mut().receive_message(tid) {
             Some(message) => {
-                pm.note_message_received()?;
+                pm.0.note_message_received()?;
                 Ok(Some(message))
             },
             None => Ok(None),
@@ -713,7 +690,7 @@ impl ProcessManager {
     ///
     pub unsafe fn wakeup(tid: ThreadIdentifier) -> Result<(), Error> {
         PERF_SCHED_WAKEUP.fetch_add(1, ORDER);
-        Self::get_mut().try_borrow_mut()?.wakeup(tid)
+        Self::get_mut().0.wakeup(tid)
     }
 
     ///
@@ -745,9 +722,7 @@ impl ProcessManager {
         tid: ThreadIdentifier,
         mutex_addr: MutexAddress,
     ) -> Result<MutexGuard, Error> {
-        Self::get_mut()
-            .try_borrow_mut()?
-            .take_mutex_guard(pid, tid, mutex_addr)
+        Self::get_mut().0.take_mutex_guard(pid, tid, mutex_addr)
     }
 
     ///

--- a/src/kernel/src/pm/sync/condvar.rs
+++ b/src/kernel/src/pm/sync/condvar.rs
@@ -282,18 +282,14 @@ impl Condvar {
     /// - This function is invoked without holding any resources.
     ///
     pub unsafe fn wait(&self, alarm: Option<SystemTime>) -> Result<(), SleepError> {
-        let pid: ProcessIdentifier = unsafe { ProcessManager::get() }
-            .get_pid()
-            .map_err(SleepError::Generic)?;
+        let pid: ProcessIdentifier = unsafe { ProcessManager::get() }.get_pid();
 
         // Check if the kernel process is trying to sleep.
         if pid == ProcessIdentifier::KERNEL {
             panic!("kernel process cannot sleep");
         }
 
-        let tid: ThreadIdentifier = unsafe { ProcessManager::get() }
-            .get_tid()
-            .map_err(SleepError::Generic)?;
+        let tid: ThreadIdentifier = unsafe { ProcessManager::get() }.get_tid();
 
         // Check if alarm has already expired.
         if let Some(alarm) = alarm {


### PR DESCRIPTION
This pull request refactors the kernel's process manager to simplify its ownership model and usage throughout the kernel code. The main change is removing the use of `Rc<RefCell<...>>` for `ProcessManager`, making it a plain struct and accessing it via a global singleton with explicit `unsafe` blocks and a new macro. This results in cleaner, more straightforward code and eliminates unnecessary error handling for process/thread ID retrieval. The changes also update various kernel interfaces and function signatures to match the new ownership model.