### PR TITLE
[ci] Update Runner Configuration to Use Groups

### DIFF
--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -71,7 +71,8 @@ jobs:
   test:
     name: "Test"
     needs: build
-    runs-on: [self-hosted, Linux, X64]
+    runs-on:
+      group: Test
     timeout-minutes: 120
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,8 @@ jobs:
       matrix:
         build-type: ${{ fromJSON(github.event_name != 'pull_request' && '["debug","release"]' || '["debug"]') }}
         machine-type: [microvm, hyperlight]
-    runs-on: [self-hosted, Linux, X64]
+    runs-on:
+      group: Test
     permissions:
       contents: read
 
@@ -311,7 +312,8 @@ jobs:
     name: "Benchmark"
     needs: [precheck, checks]
     timeout-minutes: 240
-    runs-on: [self-hosted, Linux, X64, baremetal]
+    runs-on:
+      group: Benchmark
     permissions:
       contents: read
       pull-requests: write
@@ -660,7 +662,8 @@ jobs:
       github.repository == 'nanvix/nanvix' &&
       github.ref == 'refs/heads/dev' &&
       needs.release-archive.result == 'success'
-    runs-on: [self-hosted, Linux, X64]
+    runs-on:
+      group: Test
     permissions:
       contents: write
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use runner groups instead of specifying individual runner labels. This change improves maintainability and flexibility in managing CI/CD runners.