### PR TITLE
[ci] Update CI to Run on Release Builds and Reuse Artifacts

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -40,9 +40,12 @@ runs:
       LOG_LEVEL: ${{ inputs.log-level }}
       BUILD_TIMEOUT: ${{ inputs.timeout }}
       RELEASE_FLAG: ${{ inputs.release == 'release' && 'RELEASE=yes' || '' }}
+      # For release builds, also run 'install' so that the sysroot is populated
+      # and can be reused directly by the release-package action without rebuilding.
+      BUILD_TARGETS: ${{ inputs.release == 'release' && 'all run-unit-tests install' || 'all run-unit-tests' }}
       MAKE_FLAGS: ${{ steps.deployment.outputs.make-flags }}
     run: |
-      ./z build --with-minimal-docker -- all run-unit-tests \
+      ./z build --with-minimal-docker -- ${BUILD_TARGETS} \
         "MACHINE=${MACHINE_TYPE}" \
         TARGET=x86 \
         "LOG_LEVEL=${LOG_LEVEL}" \

--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -27,31 +27,26 @@ runs:
       MACHINE_TYPE: ${{ inputs.machine-type }}
       DEPLOYMENT_TYPE: ${{ inputs.deployment-type }}
     run: |
-      single_process="no"
-      if [[ "${DEPLOYMENT_TYPE}" == "single-process" ]]; then
-        single_process="yes"
-      fi
+      sysroot_dir="sysroot-release"
 
-      # Reuse the existing build artifacts (already built with LOG_LEVEL=error,
-      # RELEASE=yes). Only run install and package steps to create the release
-      # archive, avoiding a full rebuild.
-      ./z build --with-minimal-docker -- release \
-        "MACHINE=${MACHINE_TYPE}" \
-        TARGET=x86 \
-        RELEASE=yes \
-        LOG_LEVEL=error \
-        "SINGLE_PROCESS=${single_process}" \
-        VERBOSE=yes \
-        BUILD_OPT=yes
-
-      archive_path=$(ls -1t nanvix-*.tar.bz2 2>/dev/null | head -n 1)
-      if [[ -z "${archive_path}" ]]; then
-        echo "::error::No release archive found."
+      # Verify that the pre-built sysroot exists (populated by docker-build's
+      # install step and downloaded from ci-build artifacts).
+      if [[ ! -d "${sysroot_dir}" ]] || [[ -z "$(ls -A "${sysroot_dir}" 2>/dev/null)" ]]; then
+        echo "::error::Pre-built sysroot '${sysroot_dir}' is missing or empty. Ensure ci-build produced it."
         exit 1
       fi
 
+      # Create the release archive directly from the pre-built sysroot,
+      # avoiding a full rebuild.
       commit_id="${GITHUB_SHA}"
       archive_name="nanvix-${MACHINE_TYPE}-${DEPLOYMENT_TYPE}-release-${commit_id}.tar.bz2"
-      mv "${archive_path}" "${archive_name}"
+
+      echo "Creating release archive ${archive_name} from ${sysroot_dir}..."
+      tar -cjf "${archive_name}" --exclude=./src -C "${sysroot_dir}" .
+
+      if [[ ! -f "${archive_name}" ]]; then
+        echo "::error::Failed to create release archive '${archive_name}'."
+        exit 1
+      fi
 
       echo "archive-path=${archive_name}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,7 @@ jobs:
   # in a separate ci-test job (typically on self-hosted runners) that depends
   # on the completion of the entire ci-build matrix, so tests start only after
   # all builds have finished rather than as soon as an individual build
-  # completes. On pull requests, only debug builds run (release is tested on
-  # dev push).
+  # completes.
   ci-build:
     name: "Build (${{ matrix.build-type }}, ${{ matrix.machine-type }}, ${{ matrix.deployment-type }})"
     needs: [precheck, checks, lint]
@@ -147,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: ${{ fromJSON(github.event_name != 'pull_request' && '["debug","release"]' || '["debug"]') }}
+        build-type: [debug, release]
         machine-type: [qemu-pc, microvm, hyperlight]
         deployment-type: [single-process, multi-process]
         exclude:
@@ -215,7 +214,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: ${{ fromJSON(github.event_name != 'pull_request' && '["debug","release"]' || '["debug"]') }}
+        build-type: [debug, release]
         machine-type: [qemu-pc, microvm, hyperlight]
         deployment-type: [single-process, multi-process]
         exclude:
@@ -284,7 +283,6 @@ jobs:
 
   # L2 configurations require .git for generate-l2-initramfs.sh, so they build
   # from source on self-hosted runners with a local toolchain.
-  # On pull requests, only debug builds run (release is tested on dev push).
   ci-l2:
     name: "L2 (${{ matrix.build-type }}, ${{ matrix.machine-type }})"
     needs: [precheck, checks]
@@ -292,7 +290,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: ${{ fromJSON(github.event_name != 'pull_request' && '["debug","release"]' || '["debug"]') }}
+        build-type: [debug, release]
         machine-type: [microvm, hyperlight]
     runs-on:
       group: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,9 @@ jobs:
       uses: ./.github/actions/build
       with:
         release: '${{ matrix.build-type }}'
-        log-level: 'trace'
+        # Use 'error' log level for release builds to match release archive settings,
+        # enabling reuse of build artifacts and avoiding a redundant rebuild.
+        log-level: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
         machine-type: '${{ matrix.machine-type }}'
         deployment-type: 'l2'
 
@@ -339,7 +341,7 @@ jobs:
       uses: ./.github/actions/test
       with:
         release: '${{ matrix.build-type }}'
-        log-level: 'trace'
+        log-level: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
         machine-type: '${{ matrix.machine-type }}'
         deployment-type: 'l2'
 
@@ -501,9 +503,6 @@ jobs:
       with:
         name: ci-build-release-${{ matrix.machine-type }}-${{ matrix.deployment-type }}
         path: .
-
-    - name: "Setup"
-      uses: ./.github/actions/docker-setup
 
     - name: "Package Release Archive"
       id: release-archive


### PR DESCRIPTION
**CI/CD Workflow Improvements:**

* The build matrix for all jobs (`ci-build`, `ci-l2`, etc.) now always includes both `debug` and `release` builds, even on pull requests, instead of only running release builds on non-PR events. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL141-R149) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL218-R217) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL287-R293)
* For release builds, the log level is set to `error` (instead of `trace`) to match release archive settings and enable artifact reuse, avoiding redundant rebuilds.

**Artifact and Packaging Changes:**

* The `docker-build` action now runs `install` in addition to building and running unit tests for release builds, ensuring the sysroot is populated and can be reused by the release packaging step.
* The `release-package` action no longer rebuilds the release; instead, it verifies the presence of the pre-built sysroot (from the build artifact), and creates the release archive directly from it. This avoids unnecessary rebuilds and ensures consistency.

**Workflow Cleanup:**

* The redundant `docker-setup` step was removed from the release packaging workflow, as it is no longer necessary with the new artifact reuse approach.