### PR TITLE
[ci] Update Docker build and release

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -40,9 +40,11 @@ runs:
       LOG_LEVEL: ${{ inputs.log-level }}
       BUILD_TIMEOUT: ${{ inputs.timeout }}
       RELEASE_FLAG: ${{ inputs.release == 'release' && 'RELEASE=yes' || '' }}
-      # For release builds, also run 'install' so that the sysroot is populated
-      # and can be reused directly by the release-package action without rebuilding.
-      BUILD_TARGETS: ${{ inputs.release == 'release' && 'all run-unit-tests install' || 'all run-unit-tests' }}
+      # For release builds, also run 'release' (which depends on 'all install'
+      # and creates a tar archive) so that the archive is built inside Docker
+      # with correct file permissions and can be reused directly by the
+      # release-package action.
+      BUILD_TARGETS: ${{ inputs.release == 'release' && 'all run-unit-tests release' || 'all run-unit-tests' }}
       MAKE_FLAGS: ${{ steps.deployment.outputs.make-flags }}
     run: |
       ./z build --with-minimal-docker -- ${BUILD_TARGETS} \

--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -27,26 +27,20 @@ runs:
       MACHINE_TYPE: ${{ inputs.machine-type }}
       DEPLOYMENT_TYPE: ${{ inputs.deployment-type }}
     run: |
-      sysroot_dir="sysroot-release"
-
-      # Verify that the pre-built sysroot exists (populated by docker-build's
-      # install step and downloaded from ci-build artifacts).
-      if [[ ! -d "${sysroot_dir}" ]] || [[ -z "$(ls -A "${sysroot_dir}" 2>/dev/null)" ]]; then
-        echo "::error::Pre-built sysroot '${sysroot_dir}' is missing or empty. Ensure ci-build produced it."
+      # Find the pre-built release archive produced by 'make release' inside
+      # Docker during the ci-build step. Building the archive inside Docker
+      # preserves file permissions (e.g., the execute bit on ELF binaries)
+      # that GitHub Actions artifact transfer would otherwise strip.
+      archive_src=$(ls -1t nanvix-*.tar.bz2 2>/dev/null | head -n 1)
+      if [[ -z "${archive_src}" ]]; then
+        echo "::error::No pre-built release archive found. Ensure ci-build ran 'make release'."
         exit 1
       fi
 
-      # Create the release archive directly from the pre-built sysroot,
-      # avoiding a full rebuild.
       commit_id="${GITHUB_SHA}"
       archive_name="nanvix-${MACHINE_TYPE}-${DEPLOYMENT_TYPE}-release-${commit_id}.tar.bz2"
 
-      echo "Creating release archive ${archive_name} from ${sysroot_dir}..."
-      tar -cjf "${archive_name}" --exclude=./src -C "${sysroot_dir}" .
-
-      if [[ ! -f "${archive_name}" ]]; then
-        echo "::error::Failed to create release archive '${archive_name}'."
-        exit 1
-      fi
+      echo "Reusing pre-built release archive: ${archive_src} -> ${archive_name}"
+      mv "${archive_src}" "${archive_name}"
 
       echo "archive-path=${archive_name}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
           images/
           lib/
           sysroot-${{ matrix.build-type }}/
+          nanvix-*.tar.bz2
 
     - name: "Upload logs in case of failures"
       if: failure()


### PR DESCRIPTION
**Release archive handling improvements:**

* The Docker build step (`.github/actions/docker-build/action.yml`) now runs `make release` for release builds, which creates the release archive inside Docker with correct file permissions.
* The release-package action (`.github/actions/release-package/action.yml`) now finds and reuses the pre-built release archive produced by the Docker build, instead of creating a new archive from the sysroot.

**CI workflow artifact updates:**

* The CI workflow (`.github/workflows/ci.yml`) now uploads the release archive (`nanvix-*.tar.bz2`) as an artifact, making it available for later steps or downloads.