### PR TITLE
[ci] Run Benchmarks on GitHub Runners as Well

### DIFF
--- a/.github/actions/benchmark-persist/action.yml
+++ b/.github/actions/benchmark-persist/action.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 name: "Benchmark Persist"
-description: "Persist benchmark results to the data/ directory in the source tree"
+description: "Persist benchmark results to the target directory in the source tree"
 
 inputs:
   benchmarks:
@@ -16,20 +16,23 @@ inputs:
     description: "Comma-separated list of architectures"
     required: true
     default: "X64"
+  target-dir:
+    description: "Directory where history CSVs are stored"
+    required: true
 
 runs:
   using: "composite"
   steps:
-  - name: "Persist results to data/"
+  - name: "Persist results to ${{ inputs.target-dir }}"
     shell: bash
     env:
       BENCHMARKS: ${{ inputs.benchmarks }}
       MACHINE_TYPES: ${{ inputs.machine-types }}
       ARCHS: ${{ inputs.archs }}
+      TARGET_DIR: ${{ inputs.target-dir }}
     run: |
       set -e
-      target_dir="$(pwd)/data"
-      mkdir -p "${target_dir}"
+      mkdir -p "${TARGET_DIR}"
 
       python3 ./scripts/benchmark.py \
         persist \
@@ -37,10 +40,12 @@ runs:
         --machine-types "${MACHINE_TYPES}" \
         --archs "${ARCHS}" \
         --source-dir "$(pwd)" \
-        --target-dir "${target_dir}"
+        --target-dir "${TARGET_DIR}"
 
   - name: "Commit updated benchmark results"
     shell: bash
+    env:
+      TARGET_DIR: ${{ inputs.target-dir }}
     run: |
       # NOTE: This check uses GITHUB_REF_NAME which equals the branch name
       # on push events. On pull_request events it would be the PR branch,
@@ -59,7 +64,7 @@ runs:
       # bypass actor for branch protection rules on dev).
       git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
 
-      git add data/
+      git add "${TARGET_DIR}"
 
       echo "Pulling latest changes..."
       git pull --rebase --autostash || { echo "ERROR: git pull --rebase failed."; exit 1; }

--- a/.github/actions/benchmark-report/action.yml
+++ b/.github/actions/benchmark-report/action.yml
@@ -16,6 +16,9 @@ inputs:
     description: "Comma-separated list of architectures"
     required: true
     default: "X64"
+  dev-dir:
+    description: "Directory containing baseline results from the dev branch"
+    required: true
   github-token:
     description: "GitHub token for posting PR comments"
     required: true
@@ -30,10 +33,11 @@ runs:
       BENCHMARKS: ${{ inputs.benchmarks }}
       MACHINE_TYPES: ${{ inputs.machine-types }}
       ARCHS: ${{ inputs.archs }}
+      DEV_DIR: ${{ inputs.dev-dir }}
     run: |
       python3 ./scripts/benchmark.py \
         ci-summary \
-        --dev-dir "$(pwd)/data" \
+        --dev-dir "${DEV_DIR}" \
         --target-dir "$(pwd)" \
         --benchmarks "${BENCHMARKS}" \
         --machine-types "${MACHINE_TYPES}" \

--- a/.github/actions/benchmark-report/action.yml
+++ b/.github/actions/benchmark-report/action.yml
@@ -19,6 +19,9 @@ inputs:
   dev-dir:
     description: "Directory containing baseline results from the dev branch"
     required: true
+  runner-label:
+    description: "Label identifying the runner environment (e.g., self-hosted, github-hosted). Used to distinguish artifacts and PR comments."
+    required: true
   github-token:
     description: "GitHub token for posting PR comments"
     required: true
@@ -80,7 +83,7 @@ runs:
       token: ${{ inputs.github-token }}
       issue-number: ${{ steps.pr.outputs.pr_number }}
       comment-author: "github-actions[bot]"
-      body-includes: "🔬 Benchmark Results"
+      body-includes: "🔬 Benchmark Results (${{ inputs.runner-label }})"
 
   - name: "Post comment to PR (Create)"
     if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.pr.outputs.pr_number != '' && steps.comment-strategy.outputs.can_comment_directly == 'true' && steps.fc.outputs.comment-id == '' }}
@@ -89,7 +92,7 @@ runs:
       token: ${{ inputs.github-token }}
       issue-number: ${{ steps.pr.outputs.pr_number }}
       body: |
-        ## 🔬 Benchmark Results
+        ## 🔬 Benchmark Results (${{ inputs.runner-label }})
         ${{ steps.format.outputs.BENCHMARK_RESULT }}
 
   - name: "Post comment to PR (Update)"
@@ -100,7 +103,7 @@ runs:
       comment-id: ${{ steps.fc.outputs.comment-id }}
       edit-mode: replace
       body: |
-        ## 🔬 Benchmark Results
+        ## 🔬 Benchmark Results (${{ inputs.runner-label }})
         ${{ steps.format.outputs.BENCHMARK_RESULT }}
 
   - name: "Prepare benchmark comment payload"
@@ -110,11 +113,12 @@ runs:
     env:
       BENCHMARK_RESULT: ${{ steps.format.outputs.BENCHMARK_RESULT }}
       NEEDS_DEFERRED: ${{ steps.comment-strategy.outputs.needs_deferred_comment || 'false' }}
+      RUNNER_LABEL: ${{ inputs.runner-label }}
     run: |
       mkdir -p comment-payload
 
       {
-        printf '## 🔬 Benchmark Results\n'
+        printf '## 🔬 Benchmark Results (%s)\n' "${RUNNER_LABEL}"
         printf '%s\n' "${BENCHMARK_RESULT}"
       } > comment-payload/body.md
 
@@ -136,6 +140,6 @@ runs:
     if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.pr.outputs.pr_number != '' }}
     uses: actions/upload-artifact@v6
     with:
-      name: benchmark-comment-${{ github.run_id }}
+      name: benchmark-comment-${{ inputs.runner-label }}-${{ github.run_id }}
       path: comment-payload
       retention-days: 7

--- a/.github/actions/docker-benchmark-build/action.yml
+++ b/.github/actions/docker-benchmark-build/action.yml
@@ -1,0 +1,32 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Docker Benchmark Build"
+description: "Build Nanvix for benchmarking using the Docker toolchain"
+
+inputs:
+  machine-type:
+    description: "Target machine type"
+    required: true
+    default: "microvm"
+  timestamp-msg:
+    description: "Enable TIMESTAMP_MSG for echo-breakdown benchmarks (yes/no)"
+    required: false
+    default: "no"
+
+runs:
+  using: "composite"
+  steps:
+  - name: "Build (${{ inputs.timestamp-msg == 'yes' && 'Echo-Breakdown' || 'Standard' }})"
+    shell: bash
+    env:
+      MACHINE_TYPE: ${{ inputs.machine-type }}
+      TIMESTAMP_MSG_FLAG: ${{ inputs.timestamp-msg == 'yes' && 'TIMESTAMP_MSG=yes' || '' }}
+    run: |
+      ./z build --with-minimal-docker -- all \
+        "MACHINE=${MACHINE_TYPE}" \
+        TARGET=x86 \
+        LOG_LEVEL=panic \
+        VERBOSE=yes \
+        RELEASE=yes \
+        ${TIMESTAMP_MSG_FLAG}

--- a/.github/actions/docker-benchmark-run/action.yml
+++ b/.github/actions/docker-benchmark-run/action.yml
@@ -1,0 +1,62 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Docker Benchmark Run"
+description: "Run micro-benchmarks using toolchain binaries extracted from the Docker image"
+
+inputs:
+  benchmarks:
+    description: "Space-separated list of benchmark names to run"
+    required: true
+  machine-type:
+    description: "Target machine type"
+    required: true
+    default: "microvm"
+  iterations:
+    description: "Number of benchmark iterations"
+    required: true
+    default: "100"
+
+runs:
+  using: "composite"
+  steps:
+  - name: "Extract Toolchain Binaries from Docker Image"
+    id: toolchain
+    shell: bash
+    run: |
+      version=$(grep -m 1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+      tag="v${version%.*}.x-minimal"
+      image="nanvix/toolchain:${tag}"
+      toolchain_dir="${HOME}/toolchain"
+      mkdir -p "${toolchain_dir}/bin"
+
+      echo "[INFO] Extracting toolchain binaries from ${image}..."
+      container_id=$(docker create "${image}")
+      docker cp "${container_id}:/opt/nanvix/bin/." "${toolchain_dir}/bin/"
+      docker rm "${container_id}" > /dev/null
+      echo "[INFO] Toolchain binaries extracted to ${toolchain_dir}/bin/"
+
+      echo "toolchain-bin-dir=${toolchain_dir}/bin" >> "$GITHUB_OUTPUT"
+
+  - name: "Setup KVM"
+    uses: ./.github/actions/setup-kvm
+
+  - name: "Run Benchmarks"
+    shell: bash
+    env:
+      BENCHMARKS: ${{ inputs.benchmarks }}
+      MACHINE_TYPE: ${{ inputs.machine-type }}
+      ITERATIONS: ${{ inputs.iterations }}
+      TOOLCHAIN_BIN_DIR: ${{ steps.toolchain.outputs.toolchain-bin-dir }}
+    run: |
+      for bench in ${BENCHMARKS}; do
+        echo "[INFO] Running benchmark '${bench}'..."
+        python3 ./scripts/benchmark.py \
+          run \
+          --benchmark "${bench}" \
+          --machine-type "${MACHINE_TYPE}" \
+          --iterations "${ITERATIONS}" \
+          --toolchain-bin-dir "${TOOLCHAIN_BIN_DIR}" \
+          --output-dir "$(pwd)" \
+          --commit "${{ github.sha }}"
+      done

--- a/.github/actions/setup-kvm/action.yml
+++ b/.github/actions/setup-kvm/action.yml
@@ -1,0 +1,16 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Setup KVM"
+description: "Enable KVM access for the current user on GitHub-hosted runners"
+
+runs:
+  using: "composite"
+  steps:
+  - name: "Setup KVM"
+    shell: bash
+    run: |
+      echo "[INFO] Configuring KVM access..."
+      sudo usermod -aG kvm "$(whoami)"
+      sudo chmod 666 /dev/kvm
+      echo "[INFO] KVM is ready."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,7 @@ jobs:
         benchmarks: 'boot-time,cold-start,cold-start-l2,cold-start-uvm,concurrent,concurrent-l2,echo-breakdown,echo-breakdown-l2,round-trip-latency,warm-start,warm-start-l2,warm-start-vmm'
         machine-types: 'microvm'
         archs: 'X64'
+        dev-dir: 'data'
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: "Persist results on dev"
@@ -455,6 +456,7 @@ jobs:
         benchmarks: 'boot-time,cold-start,cold-start-l2,cold-start-uvm,concurrent,concurrent-l2,echo-breakdown,echo-breakdown-l2,round-trip-latency,warm-start,warm-start-l2,warm-start-vmm'
         machine-types: 'microvm'
         archs: 'X64'
+        target-dir: 'data'
 
     - name: "Dump SCCACHE Statistics"
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,7 @@ jobs:
         machine-types: 'microvm'
         archs: 'X64'
         dev-dir: 'data'
+        runner-label: 'self-hosted'
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: "Persist results on dev"
@@ -473,6 +474,97 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: nanvix-benchmark-logs-${{ github.event.pull_request.number || github.run_number }}
+        overwrite: 'true'
+        path: |
+          logs/
+          **/*.log
+          **/*.out
+          **/*.err
+          bench_*.txt
+
+  # Run micro-benchmarks on a GitHub-hosted runner using Docker so that
+  # results are collected even without self-hosted hardware.
+  # L2 benchmarks are intentionally excluded as they require self-hosted
+  # infrastructure. CI runner results are stored in data/ci/ to keep them
+  # isolated from the self-hosted runner baselines in data/.
+  benchmark-ci:
+    name: "Benchmark CI"
+    needs: [precheck, checks]
+    timeout-minutes: 120
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    if: |
+      github.repository == 'nanvix/nanvix' &&
+      needs.precheck.outputs.up_to_date == 'true' && (
+        github.event_name != 'push' ||
+        github.event.head_commit == null ||
+        !startsWith(github.event.head_commit.message, 'Merge ')
+      ) && (
+        github.event_name != 'pull_request' ||
+        !github.event.pull_request.draft
+      )
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ssh-key: ${{ secrets.DEPLOY_PRIVATE_SSH_KEY }}
+
+    - name: "Setup"
+      uses: ./.github/actions/docker-setup
+
+    - name: "Build (Standard)"
+      uses: ./.github/actions/docker-benchmark-build
+      with:
+        machine-type: 'microvm'
+
+    - name: "Run Micro-Benchmarks (Standard)"
+      uses: ./.github/actions/docker-benchmark-run
+      with:
+        benchmarks: 'boot-time cold-start cold-start-uvm concurrent round-trip-latency warm-start warm-start-vmm'
+        machine-type: 'microvm'
+        iterations: '100'
+
+    - name: "Build (Echo-Breakdown)"
+      uses: ./.github/actions/docker-benchmark-build
+      with:
+        machine-type: 'microvm'
+        timestamp-msg: 'yes'
+
+    - name: "Run Echo-Breakdown Benchmarks"
+      uses: ./.github/actions/docker-benchmark-run
+      with:
+        benchmarks: 'echo-breakdown'
+        machine-type: 'microvm'
+        iterations: '1000'
+
+    - name: "Report Benchmark Results"
+      uses: ./.github/actions/benchmark-report
+      with:
+        benchmarks: 'boot-time,cold-start,cold-start-uvm,concurrent,echo-breakdown,round-trip-latency,warm-start,warm-start-vmm'
+        machine-types: 'microvm'
+        archs: 'X64'
+        dev-dir: 'data/ci'
+        runner-label: 'github-hosted'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Persist results on dev"
+      if: github.ref_name == 'dev'
+      uses: ./.github/actions/benchmark-persist
+      with:
+        benchmarks: 'boot-time,cold-start,cold-start-uvm,concurrent,echo-breakdown,round-trip-latency,warm-start,warm-start-vmm'
+        machine-types: 'microvm'
+        archs: 'X64'
+        target-dir: 'data/ci'
+
+    - name: "Upload logs in case of benchmark failures"
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: nanvix-benchmark-ci-logs-${{ github.event.pull_request.number || github.run_number }}
         overwrite: 'true'
         path: |
           logs/

--- a/.github/workflows/post-benchmark-comment.yml
+++ b/.github/workflows/post-benchmark-comment.yml
@@ -72,6 +72,10 @@ jobs:
     needs: gate-post-benchmark-comment
     if: needs.gate-post-benchmark-comment.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner-label: [self-hosted, github-hosted]
     steps:
     - name: Download benchmark comment payload
       id: download
@@ -79,7 +83,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         run_id: ${{ github.event.workflow_run.id }}
-        name: benchmark-comment-${{ github.event.workflow_run.id }}
+        name: benchmark-comment-${{ matrix.runner-label }}-${{ github.event.workflow_run.id }}
         path: payload
       continue-on-error: true
 
@@ -118,7 +122,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         issue-number: ${{ steps.metadata.outputs.pr_number }}
         comment-author: "github-actions[bot]"
-        body-includes: "🔬 Benchmark Results"
+        body-includes: "🔬 Benchmark Results (${{ matrix.runner-label }})"
 
     - name: Create benchmark comment
       if: ${{ steps.metadata.outputs.needs_comment == 'true' && steps.fc.outputs.comment-id == '' }}

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -740,7 +740,7 @@ def run_benchmark(args):
     nanvix_bench_cmd = [
         os.path.join(args.bin_dir, NANVIX_BENCH_ELF),
         f"-benchmark {args.benchmark}",
-        f"-hwloc {args.hwloc}" if not is_concurrent_bench else "",
+        f"-hwloc {args.hwloc}" if (not is_concurrent_bench and args.hwloc) else "",
         (
             f"-iterations {args.iterations}"
             if not is_concurrent_bench
@@ -996,11 +996,10 @@ if __name__ == "__main__":
         choices=[MICROVM_MACHINE_TYPE],
         help="Type of machine to run the benchmarks on",
     )
-    # Make the --hwloc file a mandatory argument for the wrapper script, to
-    # make sure that it is set.
     run_parser.add_argument(
         "--hwloc",
-        required=True,
+        required=False,
+        default=None,
         help="Path to file with the hardware locality information",
     )
     run_parser.add_argument(


### PR DESCRIPTION
**GitHub Actions Workflow Enhancements:**

* Added a new `benchmark-ci` job in `.github/workflows/ci.yml` to run micro-benchmarks on GitHub-hosted runners using Docker, with results isolated in the `data/ci/` directory. This job includes steps for building, running, reporting, and persisting benchmark results, and excludes L2 benchmarks that require self-hosted hardware.

* Introduced new composite actions:
  - [`.github/actions/docker-benchmark-build/action.yml`](diffhunk://#diff-1697416b0faf3acdc3819aebad5bf86aea07ee74c6db43c0b20040e54051f7ddR1-R32): Builds Nanvix for benchmarking using the Docker toolchain, with support for enabling TIMESTAMP_MSG for echo-breakdown benchmarks.
  - [`.github/actions/docker-benchmark-run/action.yml`](diffhunk://#diff-eb315973ceb4078772d90b7e6635d2b12fc4a056b579999c77a8bfbf649502afR1-R62): Extracts toolchain binaries from Docker images and runs specified benchmarks, supporting multiple iterations and machine types.
  - [`.github/actions/setup-kvm/action.yml`](diffhunk://#diff-4ea64c54b6171de77602b0c319e233853267b0f11e72be1426058ebe594bb6e1R1-R16): Sets up KVM access on GitHub-hosted runners for virtualization support.

**Benchmarking Action Improvements:**

* Refactored `.github/actions/benchmark-persist/action.yml` and `.github/actions/benchmark-report/action.yml` to accept configurable target and dev directories via new `target-dir` and `dev-dir` inputs, making directory management more flexible and explicit. Updated the workflow to use these new inputs. [[1]](diffhunk://#diff-2cf56a3bf2062632c4d1e539f9bb16a98e39b5946f4b70104a08429376af8d87L5-R5) [[2]](diffhunk://#diff-2cf56a3bf2062632c4d1e539f9bb16a98e39b5946f4b70104a08429376af8d87R19-R48) [[3]](diffhunk://#diff-2cf56a3bf2062632c4d1e539f9bb16a98e39b5946f4b70104a08429376af8d87L62-R67) [[4]](diffhunk://#diff-5d82d8afee989a33c0b1d9353bb3a836136cb07aaa8baef10d0414b6fd41800fR19-R21) [[5]](diffhunk://#diff-5d82d8afee989a33c0b1d9353bb3a836136cb07aaa8baef10d0414b6fd41800fR36-R40) [[6]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR449) [[7]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR459)

**Benchmark Script Updates:**

* Updated `scripts/benchmark.py` to make the `--hwloc` argument optional (defaulting to `None`) and to only include the `-hwloc` flag when appropriate, improving compatibility with different benchmark types. [[1]](diffhunk://#diff-60c58fe3cf845c9fb194d1c79c7dc58be1f049334e66eef6dd1212e995b403e5L743-R743) [[2]](diffhunk://#diff-60c58fe3cf845c9fb194d1c79c7dc58be1f049334e66eef6dd1212e995b403e5L999-R1002)