### PR TITLE
[build] Improve Linting

### DIFF
--- a/build/make/generic-guest-rlibs.mk
+++ b/build/make/generic-guest-rlibs.mk
@@ -20,6 +20,19 @@ endef
 
 $(foreach target,$(ALL_GUEST_RUST_LIBS),$(eval $(call GUEST_RLIB_RULES,$(target))))
 
+# Guest rlib test code is compiled for the host target (not the custom guest
+# target), so a separate host-side clippy pass with --tests is needed to lint
+# #[cfg(test)] modules.
+define GUEST_RLIB_LINT_TEST_RULES
+rust-lint-guest-rlib-tests-$(1):
+	$(HOST_CARGO_CLIPPY_CMD) --tests --features=std -p $(1) --fix --allow-dirty
+
+rust-lint-check-guest-rlib-tests-$(1):
+	$(HOST_CARGO_CLIPPY_CMD) --tests --features=std -p $(1) -- -D warnings
+endef
+
+$(foreach target,$(ALL_GUEST_RUST_LIBS_TEST_LIST),$(eval $(call GUEST_RLIB_LINT_TEST_RULES,$(target))))
+
 check-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),check-guest-rlib-$(target))
 
 format-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),format-guest-rlib-$(target))
@@ -27,8 +40,10 @@ format-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),format-guest-rlib-$(
 format-check-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),format-check-guest-rlib-$(target))
 
 rust-lint-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),rust-lint-guest-rlib-$(target))
+rust-lint-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS_TEST_LIST),rust-lint-guest-rlib-tests-$(target))
 
 rust-lint-check-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),rust-lint-check-guest-rlib-$(target))
+rust-lint-check-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS_TEST_LIST),rust-lint-check-guest-rlib-tests-$(target))
 
 define GUEST_RLIB_TEST_RULES
 test-guest-rlib-$(1):

--- a/build/make/generic-host-binaries.mk
+++ b/build/make/generic-host-binaries.mk
@@ -29,10 +29,10 @@ clean-host-binaries-$(1):
 	$(RM_CMD) $(BINARIES_DIR)/$(1).elf
 
 rust-lint-host-binaries-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1) --fix --allow-dirty --allow-no-vcs
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1) --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-host-binaries-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1) -- -D warnings
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1) -- -D warnings
 endef
 
 $(foreach target,$(ALL_HOST_BINARIES),$(eval $(call HOST_BINARY_RULES,$(target))))

--- a/build/make/generic-host-rlibs.mk
+++ b/build/make/generic-host-rlibs.mk
@@ -23,10 +23,10 @@ format-check-host-rlib-$(1):
 	$(HOST_CARGO_FMT_CMD) -p $(1) --check
 
 rust-lint-host-rlib-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1) --fix --allow-dirty --allow-no-vcs
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1) --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-host-rlib-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1) -- -D warnings
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1) -- -D warnings
 
 test-host-rlib-$(1):
 	$(HOST_CARGO_TEST_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1)

--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -26,7 +26,7 @@ clean-nanvix-bench:
 	$(RM_CMD) $(BINARIES_DIR)/nanvix-bench.elf
 
 rust-lint-nanvix-bench:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench --fix --allow-dirty --allow-no-vcs
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-nanvix-bench:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench -- -D warnings
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(NANVIX_BENCH_CARGO_FEATURES) -p nanvix-bench -- -D warnings

--- a/build/make/nanvix-test.mk
+++ b/build/make/nanvix-test.mk
@@ -26,7 +26,7 @@ clean-nanvix-test:
 	$(RM_CMD) $(BINARIES_DIR)/nanvix-test.elf
 
 rust-lint-nanvix-test:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test --fix --allow-dirty --allow-no-vcs
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-nanvix-test:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test -- -D warnings
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(NANVIX_TEST_CARGO_FEATURES) -p nanvix-test -- -D warnings

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -33,7 +33,7 @@ clean-nanvixd:
 	$(RM_CMD) $(BINARIES_DIR)/nanvixd.elf
 
 rust-lint-nanvixd:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd --fix --allow-dirty --allow-no-vcs
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(NANVIXD_CARGO_FEATURES) -p nanvixd --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-nanvixd:
-	$(HOST_CARGO_CLIPPY_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd -- -D warnings
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(NANVIXD_CARGO_FEATURES) -p nanvixd -- -D warnings

--- a/build/make/uservm.mk
+++ b/build/make/uservm.mk
@@ -27,10 +27,10 @@ clean-uservm:
 	$(RM_CMD) $(BINARIES_DIR)/uservm.elf
 
 rust-lint-uservm:
-	$(HOST_CARGO_CLIPPY_CMD) $(USERVM_CARGO_FEATURES) -p uservm --fix --allow-dirty --allow-no-vcs
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(USERVM_CARGO_FEATURES) -p uservm --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-uservm:
-	$(HOST_CARGO_CLIPPY_CMD) $(USERVM_CARGO_FEATURES) -p uservm -- -D warnings
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(USERVM_CARGO_FEATURES) -p uservm -- -D warnings
 
 test-uservm:
 	$(HOST_CARGO_TEST_CMD) $(USERVM_CARGO_FEATURES) -p uservm

--- a/src/libs/libc_string/src/lib.rs
+++ b/src/libs/libc_string/src/lib.rs
@@ -9,7 +9,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // Lints
 #![forbid(clippy::unwrap_used)]
-#![forbid(clippy::expect_used)]
 #![forbid(clippy::cast_possible_truncation)]
 #![forbid(clippy::cast_possible_wrap)]
 #![forbid(clippy::cast_precision_loss)]
@@ -23,6 +22,8 @@
 #![forbid(clippy::unimplemented)]
 #![forbid(clippy::todo)]
 #![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
 
 //==================================================================================================
 // Modules

--- a/src/libs/libc_string/src/memcmp.rs
+++ b/src/libs/libc_string/src/memcmp.rs
@@ -106,10 +106,14 @@ mod test {
     #[test]
     fn test_memcmp_equal() {
         let size: usize = 32;
-        let buf1: Vec<u8> = (0..size as u8).collect();
-        let buf2: Vec<u8> = (0..size as u8).collect();
+        let buf1: Vec<u8> = (0..u8::try_from(size).expect("size fits in u8")).collect();
+        let buf2: Vec<u8> = (0..u8::try_from(size).expect("size fits in u8")).collect();
         let ret: c_int = unsafe {
-            memcmp(buf1.as_ptr() as *const _, buf2.as_ptr() as *const _, size as c_size_t)
+            memcmp(
+                buf1.as_ptr().cast(),
+                buf2.as_ptr().cast(),
+                c_size_t::try_from(size).expect("size fits in c_size_t"),
+            )
         };
         assert_eq!(ret, 0, "memcmp should return 0 for identical buffers");
     }
@@ -121,8 +125,13 @@ mod test {
         // Introduce first difference: a[2] < b[2].
         a[2] = 5;
         b[2] = 9;
-        let ret: c_int =
-            unsafe { memcmp(a.as_ptr() as *const _, b.as_ptr() as *const _, a.len() as c_size_t) };
+        let ret: c_int = unsafe {
+            memcmp(
+                a.as_ptr().cast(),
+                b.as_ptr().cast(),
+                c_size_t::try_from(a.len()).expect("len fits in c_size_t"),
+            )
+        };
         assert_eq!(
             ret,
             (5_i32 - 9_i32) as c_int,
@@ -138,8 +147,13 @@ mod test {
         // Introduce first difference: a[3] > b[3].
         a[3] = 100;
         b[3] = 42;
-        let ret: c_int =
-            unsafe { memcmp(a.as_ptr() as *const _, b.as_ptr() as *const _, a.len() as c_size_t) };
+        let ret: c_int = unsafe {
+            memcmp(
+                a.as_ptr().cast(),
+                b.as_ptr().cast(),
+                c_size_t::try_from(a.len()).expect("len fits in c_size_t"),
+            )
+        };
         assert_eq!(
             ret,
             (100_i32 - 42_i32) as c_int,
@@ -152,8 +166,7 @@ mod test {
     fn test_memcmp_zero_length() {
         let a: Vec<u8> = vec![1, 2, 3, 4];
         let b: Vec<u8> = vec![5, 6, 7, 8];
-        let ret: c_int =
-            unsafe { memcmp(a.as_ptr() as *const _, b.as_ptr() as *const _, 0 as c_size_t) };
+        let ret: c_int = unsafe { memcmp(a.as_ptr().cast(), b.as_ptr().cast(), 0) };
         assert_eq!(ret, 0, "memcmp should return 0 when length is zero");
     }
 
@@ -165,8 +178,13 @@ mod test {
         a[5] = 10;
         b[5] = 20;
         let len: usize = 5; // Exclude index 5.
-        let ret: c_int =
-            unsafe { memcmp(a.as_ptr() as *const _, b.as_ptr() as *const _, len as c_size_t) };
+        let ret: c_int = unsafe {
+            memcmp(
+                a.as_ptr().cast(),
+                b.as_ptr().cast(),
+                c_size_t::try_from(len).expect("len fits in c_size_t"),
+            )
+        };
         assert_eq!(ret, 0, "memcmp should not observe differences beyond provided length");
     }
 
@@ -179,7 +197,9 @@ mod test {
         let ptr1: *const u8 = buf.as_ptr();
         let ptr2: *const u8 = unsafe { buf.as_ptr().add(1) };
         let len: usize = 16;
-        let ret: c_int = unsafe { memcmp(ptr1 as *const _, ptr2 as *const _, len as c_size_t) };
+        let ret: c_int = unsafe {
+            memcmp(ptr1.cast(), ptr2.cast(), c_size_t::try_from(len).expect("len fits in c_size_t"))
+        };
         let expected: c_int = (buf[0] as c_int) - (buf[1] as c_int);
         assert_eq!(ret, expected, "memcmp should handle overlapping readable regions correctly");
     }

--- a/src/libs/libc_string/src/memcpy.rs
+++ b/src/libs/libc_string/src/memcpy.rs
@@ -177,69 +177,63 @@ mod test {
     #[test]
     fn test_memcpy() {
         let size: usize = 10;
-        let mut src: Vec<u8> = vec![0; size];
+        let src: Vec<u8> = (0..size)
+            .map(|i| u8::try_from(i).expect("index fits in u8"))
+            .collect();
         let mut dst: Vec<u8> = vec![0; size];
 
-        // Initialize source buffer with known pattern.
-        for i in 0..size {
-            src[i] = i as u8;
-        }
-
         unsafe {
-            memcpy(dst.as_mut_ptr() as *mut _, src.as_ptr() as *const _, size as c_size_t);
+            memcpy(
+                dst.as_mut_ptr().cast(),
+                src.as_ptr().cast(),
+                c_size_t::try_from(size).expect("size fits in c_size_t"),
+            );
         }
 
         // Verify that destination buffer matches source buffer.
-        for i in 0..size {
-            assert_eq!(dst[i], src[i]);
-        }
+        assert_eq!(dst, src);
     }
 
     #[test]
     fn test_memcpy_unaligned_pointer() {
         let size: usize = 10;
         let mut src: Vec<u8> = vec![0; size + 1]; // Extra byte for unalignment
-        let mut dst: Vec<u8> = vec![0; size + 1]; // Extra byte for unalignment
+        let mut dst: Vec<u8> = vec![0xFF; size + 1]; // Extra byte for unalignment
 
-        // Initialize source buffer with known pattern.
-        for i in 0..size {
-            src[i + 1] = i as u8; // Start from index 1 to create unalignment
-            dst[i + 1] = 0xFF; // Fill destination with a different pattern.
+        // Initialize source buffer with known pattern (starting at index 1).
+        for (i, byte) in src[1..=size].iter_mut().enumerate() {
+            *byte = u8::try_from(i).expect("index fits in u8");
         }
 
         let src_ptr: *const u8 = unsafe { src.as_ptr().add(1) }; // Intentionally unaligned
         let dst_ptr: *mut u8 = unsafe { dst.as_mut_ptr().add(1) }; // Intentionally unaligned
 
         unsafe {
-            memcpy(dst_ptr as *mut _, src_ptr as *const _, size as c_size_t);
+            memcpy(
+                dst_ptr.cast(),
+                src_ptr.cast(),
+                c_size_t::try_from(size).expect("size fits in c_size_t"),
+            );
         }
 
         // Verify that destination buffer matches source buffer.
-        for i in 0..size {
-            assert_eq!(dst[i + 1], src[i + 1]);
-        }
+        assert_eq!(dst[1..=size], src[1..=size]);
     }
 
     #[test]
     fn test_memcpy_zero_length() {
         let size: usize = 10;
-        let mut src: Vec<u8> = vec![0; size];
-        let mut dst: Vec<u8> = vec![0; size];
-
-        // Initialize source buffer with known pattern.
-        for i in 0..size {
-            src[i] = i as u8;
-            dst[i] = 0xFF; // Fill destination with a different pattern.
-        }
+        let src: Vec<u8> = (0..size)
+            .map(|i| u8::try_from(i).expect("index fits in u8"))
+            .collect();
+        let mut dst: Vec<u8> = vec![0xFF; size];
 
         unsafe {
-            memcpy(dst.as_mut_ptr() as *mut _, src.as_ptr() as *const _, 0 as c_size_t);
+            memcpy(dst.as_mut_ptr().cast(), src.as_ptr().cast(), 0);
         }
 
         // Verify that destination buffer remains unchanged.
-        for i in 0..size {
-            assert_eq!(dst[i], 0xFF);
-        }
+        assert!(dst.iter().all(|&b| b == 0xFF));
     }
 
     #[test]
@@ -247,82 +241,108 @@ mod test {
         let size: usize = 10;
         let src: Vec<u8> = vec![0; size];
         let mut dst: Vec<u8> = vec![0; size];
-        let dst_ptr: *mut core::ffi::c_void = dst.as_mut_ptr() as *mut _;
-        let ret: *mut core::ffi::c_void =
-            unsafe { memcpy(dst_ptr, src.as_ptr() as *const _, size as c_size_t) };
+        let dst_ptr: *mut core::ffi::c_void = dst.as_mut_ptr().cast();
+        let ret: *mut core::ffi::c_void = unsafe {
+            memcpy(
+                dst_ptr,
+                src.as_ptr().cast(),
+                c_size_t::try_from(size).expect("size fits in c_size_t"),
+            )
+        };
         assert_eq!(ret, dst_ptr, "memcpy should return the original destination pointer");
     }
 
     #[test]
     fn test_memcpy_partial_buffer() {
         let size: usize = 64;
-        let src: Vec<u8> = (0..size as u8).collect();
+        let src: Vec<u8> = (0..u8::try_from(size).expect("size fits in u8")).collect();
         let mut dst: Vec<u8> = vec![0xEE; size];
         let copy_offset: usize = 16;
         let copy_len: usize = 32;
         unsafe {
             memcpy(
-                dst.as_mut_ptr().add(copy_offset) as *mut _,
-                src.as_ptr().add(copy_offset) as *const _,
-                copy_len as c_size_t,
+                dst.as_mut_ptr().add(copy_offset).cast(),
+                src.as_ptr().add(copy_offset).cast(),
+                c_size_t::try_from(copy_len).expect("copy_len fits in c_size_t"),
             );
         }
         // Bytes before the copied range should remain unchanged.
-        for i in 0..copy_offset {
-            assert_eq!(dst[i], 0xEE, "byte before copied region modified at index {}", i);
-        }
+        assert!(
+            dst[..copy_offset].iter().all(|&b| b == 0xEE),
+            "bytes before copied region were modified"
+        );
         // Copied range should match source.
-        for i in 0..copy_len {
-            assert_eq!(dst[copy_offset + i], src[copy_offset + i]);
-        }
+        assert_eq!(
+            dst[copy_offset..copy_offset + copy_len],
+            src[copy_offset..copy_offset + copy_len]
+        );
         // Bytes after the copied range should remain unchanged.
-        for i in copy_offset + copy_len..size {
-            assert_eq!(dst[i], 0xEE, "byte after copied region modified at index {}", i);
-        }
+        assert!(
+            dst[copy_offset + copy_len..].iter().all(|&b| b == 0xEE),
+            "bytes after copied region were modified"
+        );
     }
 
     #[test]
     fn test_memcpy_large_aligned() {
         let size: usize = 4096;
-        let src: Vec<u8> = (0..size).map(|i| (i & 0xFF) as u8).collect();
+        let src: Vec<u8> = (0..size)
+            .map(|i| u8::try_from(i & 0xFF).expect("masked value fits in u8"))
+            .collect();
         let mut dst: Vec<u8> = vec![0u8; size];
         unsafe {
-            memcpy(dst.as_mut_ptr() as *mut _, src.as_ptr() as *const _, size as c_size_t);
+            memcpy(
+                dst.as_mut_ptr().cast(),
+                src.as_ptr().cast(),
+                c_size_t::try_from(size).expect("size fits in c_size_t"),
+            );
         }
-        for i in 0..size {
-            assert_eq!(dst[i], src[i]);
-        }
+        assert_eq!(dst, src);
     }
 
     #[test]
     fn test_memcpy_misaligned_same_offset() {
         // Create buffers with identical misalignment to trigger word path with alignment fix-up.
         let size: usize = 257;
-        let src: Vec<u8> = (0..size).map(|i| (i & 0xFF) as u8).collect();
+        let copy_len: usize = size - 1;
+        let src: Vec<u8> = (0..size)
+            .map(|i| u8::try_from(i & 0xFF).expect("masked value fits in u8"))
+            .collect();
         let mut dst: Vec<u8> = vec![0u8; size];
         let src_ptr: *const u8 = unsafe { src.as_ptr().add(1) }; // Misaligned by +1.
         let dst_ptr: *mut u8 = unsafe { dst.as_mut_ptr().add(1) }; // Same misalignment.
         unsafe {
-            memcpy(dst_ptr as *mut _, src_ptr as *const _, (size - 1) as c_size_t);
+            memcpy(
+                dst_ptr.cast(),
+                src_ptr.cast(),
+                c_size_t::try_from(copy_len).expect("size fits in c_size_t"),
+            );
         }
-        for i in 0..size - 1 {
-            assert_eq!(unsafe { *dst_ptr.add(i) }, unsafe { *src_ptr.add(i) });
-        }
+        let dst_slice: &[u8] = unsafe { ::core::slice::from_raw_parts(dst_ptr, copy_len) };
+        let src_slice: &[u8] = unsafe { ::core::slice::from_raw_parts(src_ptr, copy_len) };
+        assert_eq!(dst_slice, src_slice);
     }
 
     #[test]
     fn test_memcpy_misaligned_different_offset() {
         // Different relative alignment forces byte fallback path.
         let size: usize = 513;
-        let src: Vec<u8> = (0..size).map(|i| (i & 0xFF) as u8).collect();
+        let copy_len: usize = size - 2;
+        let src: Vec<u8> = (0..size)
+            .map(|i| u8::try_from(i & 0xFF).expect("masked value fits in u8"))
+            .collect();
         let mut dst: Vec<u8> = vec![0u8; size];
         let src_ptr: *const u8 = unsafe { src.as_ptr().add(1) }; // +1
         let dst_ptr: *mut u8 = unsafe { dst.as_mut_ptr().add(2) }; // +2 (different alignment)
         unsafe {
-            memcpy(dst_ptr as *mut _, src_ptr as *const _, (size - 2) as c_size_t);
+            memcpy(
+                dst_ptr.cast(),
+                src_ptr.cast(),
+                c_size_t::try_from(copy_len).expect("size fits in c_size_t"),
+            );
         }
-        for i in 0..size - 2 {
-            assert_eq!(unsafe { *dst_ptr.add(i) }, unsafe { *src_ptr.add(i) });
-        }
+        let dst_slice: &[u8] = unsafe { ::core::slice::from_raw_parts(dst_ptr, copy_len) };
+        let src_slice: &[u8] = unsafe { ::core::slice::from_raw_parts(src_ptr, copy_len) };
+        assert_eq!(dst_slice, src_slice);
     }
 }

--- a/src/libs/libc_string/src/memmove.rs
+++ b/src/libs/libc_string/src/memmove.rs
@@ -131,7 +131,7 @@ mod test {
         unsafe {
             let dst: *mut c_void = buf.as_mut_ptr().cast::<c_void>();
             let src: *const c_void = buf.as_ptr().cast::<c_void>();
-            memmove(dst, src, buf.len() as u32);
+            memmove(dst, src, u32::try_from(buf.len()).expect("buf len fits in u32"));
         }
         assert_eq!(buf, [10, 20, 30, 40]);
     }

--- a/src/libs/libc_string/src/memset.rs
+++ b/src/libs/libc_string/src/memset.rs
@@ -80,7 +80,11 @@ mod test {
     fn test_memset() {
         let mut buffer: Vec<u8> = vec![0; 10];
         unsafe {
-            memset(buffer.as_mut_ptr() as *mut _, 0xAB, buffer.len() as c_size_t);
+            memset(
+                buffer.as_mut_ptr().cast(),
+                0xAB,
+                c_size_t::try_from(buffer.len()).expect("len fits in c_size_t"),
+            );
         }
         for &byte in &buffer {
             assert_eq!(byte, 0xAB);
@@ -92,7 +96,7 @@ mod test {
         let mut buffer: Vec<u8> = vec![0; 10];
         let ptr: *mut u8 = unsafe { buffer.as_mut_ptr().add(1) }; // Intentionally unaligned
         unsafe {
-            memset(ptr as *mut _, 0xCD, 5 as c_size_t);
+            memset(ptr.cast(), 0xCD, 5);
         }
         for &byte in &buffer[1..6] {
             assert_eq!(byte, 0xCD);
@@ -104,7 +108,7 @@ mod test {
         let mut buffer: Vec<u8> = vec![1, 2, 3, 4];
         let original: Vec<u8> = buffer.clone();
         unsafe {
-            memset(buffer.as_mut_ptr() as *mut _, 0xFF, 0 as c_size_t);
+            memset(buffer.as_mut_ptr().cast(), 0xFF, 0);
         }
         assert_eq!(buffer, original, "Buffer should be unchanged when length is zero");
     }
@@ -112,8 +116,8 @@ mod test {
     #[test]
     fn test_memset_returns_pointer() {
         let mut buffer: Vec<u8> = vec![0; 4];
-        let ptr: *mut core::ffi::c_void = buffer.as_mut_ptr() as *mut _;
-        let ret: *mut core::ffi::c_void = unsafe { memset(ptr, 0x11, 4 as c_size_t) };
+        let ptr: *mut core::ffi::c_void = buffer.as_mut_ptr().cast();
+        let ret: *mut core::ffi::c_void = unsafe { memset(ptr, 0x11, 4) };
         assert_eq!(ret, ptr, "memset should return the original pointer");
     }
 
@@ -121,14 +125,20 @@ mod test {
     fn test_memset_value_masking() {
         let mut buffer: Vec<u8> = vec![0; 8];
         // 0x1FF -> masked to 0xFF
-        unsafe { memset(buffer.as_mut_ptr() as *mut _, 0x1FF, buffer.len() as c_size_t) };
+        unsafe {
+            memset(
+                buffer.as_mut_ptr().cast(),
+                0x1FF,
+                c_size_t::try_from(buffer.len()).expect("len fits in c_size_t"),
+            )
+        };
         assert!(buffer.iter().all(|&b| b == 0xFF));
     }
 
     #[test]
     fn test_memset_partial_region() {
         let mut buffer: Vec<u8> = (0u8..16u8).collect();
-        unsafe { memset(buffer.as_mut_ptr().add(4) as *mut _, 0x77, 8 as c_size_t) };
+        unsafe { memset(buffer.as_mut_ptr().add(4).cast(), 0x77, 8) };
         // Bytes 0..4 unchanged
         assert_eq!(&buffer[0..4], &[0, 1, 2, 3]);
         // Bytes 4..12 set to 0x77
@@ -142,7 +152,13 @@ mod test {
         // Large but reasonable size for unit test.
         let size: usize = 4096;
         let mut buffer: Vec<u8> = vec![0; size];
-        unsafe { memset(buffer.as_mut_ptr() as *mut _, 0x3C, size as c_size_t) };
+        unsafe {
+            memset(
+                buffer.as_mut_ptr().cast(),
+                0x3C,
+                c_size_t::try_from(size).expect("size fits in c_size_t"),
+            )
+        };
         assert!(buffer.iter().all(|&b| b == 0x3C));
     }
 }

--- a/src/libs/libc_string/src/strlen.rs
+++ b/src/libs/libc_string/src/strlen.rs
@@ -68,7 +68,10 @@ mod test {
 
     // Helper to build a null-terminated Vec<c_char> from bytes (without the final null).
     fn make_c_string(bytes: &[u8]) -> Vec<c_char> {
-        let mut v: Vec<c_char> = bytes.iter().map(|b| *b as c_char).collect();
+        let mut v: Vec<c_char> = bytes
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
         v.push(0 as c_char); // null terminator
         v
     }
@@ -102,7 +105,10 @@ mod test {
         let mut raw: Vec<u8> = b"abc".to_vec();
         raw.push(0); // embedded null
         raw.extend_from_slice(b"def");
-        let mut buf: Vec<c_char> = raw.iter().map(|b| *b as c_char).collect();
+        let mut buf: Vec<c_char> = raw
+            .iter()
+            .map(|b| c_char::try_from(*b).expect("byte fits in c_char"))
+            .collect();
         buf.push(0 as c_char); // final terminator (technically redundant after embedded null but ok)
         let len: usize = unsafe { strlen(buf.as_ptr()) as usize };
         assert_eq!(len, 3, "strlen should stop at first embedded null");
@@ -114,7 +120,7 @@ mod test {
         let storage: Vec<c_char> = make_c_string(b"nanvix");
         // Prepend one dummy byte to shift alignment.
         let mut padded: Vec<c_char> = Vec::with_capacity(storage.len() + 1);
-        padded.push('X' as c_char); // padding (not a null)
+        padded.push(c_char::try_from(b'X').expect("ASCII fits in c_char")); // padding (not a null)
         padded.extend_from_slice(&storage);
         let unaligned_ptr: *const c_char = unsafe { padded.as_ptr().add(1) }; // Points to start of "nanvix" string.
         let len: usize = unsafe { strlen(unaligned_ptr) as usize };
@@ -125,7 +131,7 @@ mod test {
     fn test_strlen_non_ascii_bytes() {
         // Bytes above 0x7F are still single bytes, strlen counts until null.
         let bytes: [u8; 4] = [0xFF, 0x80, 0xC3, 0x00];
-        let mut buf: Vec<c_char> = bytes[..3].iter().map(|b| *b as c_char).collect();
+        let mut buf: Vec<c_char> = bytes[..3].iter().map(|b| i8::from_ne_bytes([*b])).collect();
         buf.push(0 as c_char);
         let len: usize = unsafe { strlen(buf.as_ptr()) as usize };
         assert_eq!(len, 3, "strlen should count raw bytes irrespective of UTF-8 validity");

--- a/src/libs/nanvix-registry/src/checksum.rs
+++ b/src/libs/nanvix-registry/src/checksum.rs
@@ -81,7 +81,7 @@ fn hex_encode(bytes: &[u8]) -> String {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/libs/nanvix-registry/src/deployment.rs
+++ b/src/libs/nanvix-registry/src/deployment.rs
@@ -108,7 +108,7 @@ impl TryFrom<&str> for Deployment {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -165,7 +165,7 @@ mod tests {
     fn test_try_from_valid_single_process() {
         let result: Result<Deployment> = Deployment::try_from("single-process");
         assert!(result.is_ok());
-        assert!(matches!(result.unwrap(), Deployment::SingleProcess));
+        assert!(matches!(result.expect("failed"), Deployment::SingleProcess));
     }
 
     ///
@@ -177,7 +177,7 @@ mod tests {
     fn test_try_from_valid_multi_process() {
         let result: Result<Deployment> = Deployment::try_from("multi-process");
         assert!(result.is_ok());
-        assert!(matches!(result.unwrap(), Deployment::MultiProcess));
+        assert!(matches!(result.expect("failed"), Deployment::MultiProcess));
     }
 
     ///
@@ -210,7 +210,7 @@ mod tests {
         let result: Result<Deployment> = Deployment::try_from("invalid-deployment");
         assert!(result.is_err());
         assert!(result
-            .unwrap_err()
+            .expect_err("should fail")
             .to_string()
             .contains("Unknown deployment type"));
     }

--- a/src/libs/nanvix-registry/src/github_client.rs
+++ b/src/libs/nanvix-registry/src/github_client.rs
@@ -128,7 +128,7 @@ pub(crate) fn authenticated_get(client: &Client, url: &str) -> RequestBuilder {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -152,8 +152,7 @@
 // Lint Configuration
 //==================================================================================================
 
-#![deny(clippy::unwrap_used)]
-#![deny(clippy::expect_used)]
+#![forbid(clippy::unwrap_used)]
 #![forbid(clippy::cast_possible_truncation)]
 #![forbid(clippy::cast_possible_wrap)]
 #![forbid(clippy::cast_precision_loss)]
@@ -168,6 +167,8 @@
 #![forbid(clippy::unimplemented)]
 #![forbid(clippy::todo)]
 #![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
 
 //==================================================================================================
 // Private Modules
@@ -1173,7 +1174,7 @@ impl Default for Registry {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -1228,7 +1229,7 @@ mod tests {
         let result: Result<PathBuf> = registry.get_cache_dir().await;
         assert!(result.is_ok());
 
-        let cache_dir: PathBuf = result.unwrap();
+        let cache_dir: PathBuf = result.expect("failed");
         assert!(cache_dir.to_string_lossy().contains("nanvix-registry"));
     }
 
@@ -1242,7 +1243,7 @@ mod tests {
         let custom_dir: PathBuf = ::std::env::temp_dir().join("nanvix-test-custom-cache");
         let registry: Registry = Registry::new(Some(custom_dir.clone()));
 
-        let cache_dir: PathBuf = registry.get_cache_dir().await.unwrap();
+        let cache_dir: PathBuf = registry.get_cache_dir().await.expect("failed");
         assert_eq!(cache_dir, custom_dir);
 
         // Cleanup
@@ -1264,7 +1265,7 @@ mod tests {
             ::std::process::id(),
             ::std::time::SystemTime::now()
                 .duration_since(::std::time::UNIX_EPOCH)
-                .unwrap()
+                .expect("failed")
                 .as_nanos()
         ));
 
@@ -1294,7 +1295,7 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result
-            .unwrap_err()
+            .expect_err("should fail")
             .to_string()
             .contains("Unknown machine type"));
     }
@@ -1313,7 +1314,7 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result
-            .unwrap_err()
+            .expect_err("should fail")
             .to_string()
             .contains("Unknown deployment type"));
     }
@@ -1346,7 +1347,7 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result
-            .unwrap_err()
+            .expect_err("should fail")
             .to_string()
             .contains("Unknown machine type"));
     }
@@ -1365,7 +1366,7 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result
-            .unwrap_err()
+            .expect_err("should fail")
             .to_string()
             .contains("Unknown deployment type"));
     }
@@ -1388,15 +1389,15 @@ mod tests {
         let _ = fs::remove_dir_all(&temp_dir).await;
 
         // Create directory structure.
-        fs::create_dir_all(&sub_dir).await.unwrap();
-        fs::write(&test_file, "test content").await.unwrap();
+        fs::create_dir_all(&sub_dir).await.expect("failed");
+        fs::write(&test_file, "test content").await.expect("failed");
 
         // Test that the artifact can be found.
         let result: Option<PathBuf> =
             Registry::search_artifact(temp_dir.clone(), "test-artifact.txt".to_string()).await;
 
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), test_file);
+        assert_eq!(result.expect("failed"), test_file);
 
         // Test that non-existent artifact returns None.
         let result: Option<PathBuf> =
@@ -1451,28 +1452,34 @@ mod tests {
         let _ = fs::remove_dir_all(&temp_dir).await;
 
         // Create directory structure.
-        fs::create_dir_all(&bin_dir).await.unwrap();
-        fs::create_dir_all(&lib_dir).await.unwrap();
-        fs::write(&root_artifact, "root config").await.unwrap();
-        fs::write(&bin_artifact, "bin config").await.unwrap();
-        fs::write(&lib_artifact, "lib config").await.unwrap();
+        fs::create_dir_all(&bin_dir).await.expect("failed");
+        fs::create_dir_all(&lib_dir).await.expect("failed");
+        fs::write(&root_artifact, "root config")
+            .await
+            .expect("failed");
+        fs::write(&bin_artifact, "bin config")
+            .await
+            .expect("failed");
+        fs::write(&lib_artifact, "lib config")
+            .await
+            .expect("failed");
 
         // Test that searching from cache root finds the root artifact.
         let result: Option<PathBuf> =
             Registry::search_artifact(temp_dir.clone(), "root-config.json".to_string()).await;
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), root_artifact);
+        assert_eq!(result.expect("failed"), root_artifact);
 
         // Test that searching from cache root finds artifacts in subdirectories.
         let result: Option<PathBuf> =
             Registry::search_artifact(temp_dir.clone(), "bin-config.json".to_string()).await;
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), bin_artifact);
+        assert_eq!(result.expect("failed"), bin_artifact);
 
         let result: Option<PathBuf> =
             Registry::search_artifact(temp_dir.clone(), "lib-config.json".to_string()).await;
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), lib_artifact);
+        assert_eq!(result.expect("failed"), lib_artifact);
 
         // Clean up.
         let _ = fs::remove_dir_all(&temp_dir).await;
@@ -1489,13 +1496,13 @@ mod tests {
         let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-abc123def456.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
-        assert_eq!(commit_id.unwrap(), "abc123def456");
+        assert_eq!(commit_id.expect("failed"), "abc123def456");
 
         // Test another valid URL format.
         let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-microvm-single-process-release-1a2b3c4d5e6f.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
-        assert_eq!(commit_id.unwrap(), "1a2b3c4d5e6f");
+        assert_eq!(commit_id.expect("failed"), "1a2b3c4d5e6f");
 
         // Test URL without release prefix.
         let url: &str =

--- a/src/libs/nanvix-registry/src/machine.rs
+++ b/src/libs/nanvix-registry/src/machine.rs
@@ -108,7 +108,7 @@ impl TryFrom<&str> for Machine {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -165,7 +165,7 @@ mod tests {
     fn test_try_from_valid_hyperlight() {
         let result: Result<Machine> = Machine::try_from("hyperlight");
         assert!(result.is_ok());
-        assert!(matches!(result.unwrap(), Machine::Hyperlight));
+        assert!(matches!(result.expect("failed"), Machine::Hyperlight));
     }
 
     ///
@@ -177,7 +177,7 @@ mod tests {
     fn test_try_from_valid_microvm() {
         let result: Result<Machine> = Machine::try_from("microvm");
         assert!(result.is_ok());
-        assert!(matches!(result.unwrap(), Machine::Microvm));
+        assert!(matches!(result.expect("failed"), Machine::Microvm));
     }
 
     ///
@@ -205,7 +205,7 @@ mod tests {
         let result: Result<Machine> = Machine::try_from("invalid-machine");
         assert!(result.is_err());
         assert!(result
-            .unwrap_err()
+            .expect_err("should fail")
             .to_string()
             .contains("Unknown machine type"));
     }

--- a/src/libs/nanvix-registry/src/metadata.rs
+++ b/src/libs/nanvix-registry/src/metadata.rs
@@ -497,7 +497,7 @@ impl ReleaseRegistry {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use ::std::env;
@@ -552,7 +552,7 @@ mod tests {
             registry.get_release(Machine::Microvm, Deployment::SingleProcess);
         assert!(entry.is_some());
 
-        let entry: &ReleaseEntry = entry.unwrap();
+        let entry: &ReleaseEntry = entry.expect("failed");
         assert_eq!(entry.url(), url);
         assert_eq!(entry.commit_id(), commit_id);
     }
@@ -594,17 +594,17 @@ mod tests {
         // Verify each entry.
         let entry: &ReleaseEntry = registry
             .get_release(Machine::Microvm, Deployment::SingleProcess)
-            .unwrap();
+            .expect("failed");
         assert_eq!(entry.commit_id(), "abc111def");
 
         let entry: &ReleaseEntry = registry
             .get_release(Machine::Microvm, Deployment::MultiProcess)
-            .unwrap();
+            .expect("failed");
         assert_eq!(entry.commit_id(), "abc222def");
 
         let entry: &ReleaseEntry = registry
             .get_release(Machine::Hyperlight, Deployment::SingleProcess)
-            .unwrap();
+            .expect("failed");
         assert_eq!(entry.commit_id(), "abc333def");
     }
 
@@ -640,7 +640,7 @@ mod tests {
 
         let entry: &ReleaseEntry = registry
             .get_release(Machine::Microvm, Deployment::SingleProcess)
-            .unwrap();
+            .expect("failed");
         assert_eq!(entry.url(), "https://test.com/new.tar.bz2");
         assert_eq!(entry.commit_id(), "abc222def");
     }
@@ -660,7 +660,7 @@ mod tests {
             "abc123def456".to_string(),
         );
 
-        let json: String = serde_json::to_string(&registry).unwrap();
+        let json: String = serde_json::to_string(&registry).expect("failed");
         assert!(json.contains("releases"));
         assert!(json.contains("microvm-single-process"));
         assert!(json.contains("https://example.com/release.tar.bz2"));
@@ -675,11 +675,11 @@ mod tests {
     #[test]
     fn test_deserialization() {
         let json: &str = r#"{"releases":{"microvm-single-process":{"url":"https://example.com/release.tar.bz2","commit_id":"abc123def456"}}}"#;
-        let registry: ReleaseRegistry = serde_json::from_str(json).unwrap();
+        let registry: ReleaseRegistry = serde_json::from_str(json).expect("failed");
 
         let entry: &ReleaseEntry = registry
             .get_release(Machine::Microvm, Deployment::SingleProcess)
-            .unwrap();
+            .expect("failed");
         assert_eq!(entry.url(), "https://example.com/release.tar.bz2");
         assert_eq!(entry.commit_id(), "abc123def456");
     }
@@ -717,17 +717,17 @@ mod tests {
         let load_result: Result<ReleaseRegistry> = ReleaseRegistry::load(&temp_dir).await;
         assert!(load_result.is_ok());
 
-        let loaded: ReleaseRegistry = load_result.unwrap();
+        let loaded: ReleaseRegistry = load_result.expect("failed");
         assert_eq!(loaded.len(), 2);
 
         let entry: &ReleaseEntry = loaded
             .get_release(Machine::Microvm, Deployment::SingleProcess)
-            .unwrap();
+            .expect("failed");
         assert_eq!(entry.commit_id(), "abc111def");
 
         let entry: &ReleaseEntry = loaded
             .get_release(Machine::Hyperlight, Deployment::MultiProcess)
-            .unwrap();
+            .expect("failed");
         assert_eq!(entry.commit_id(), "abc222def");
 
         // Cleanup.

--- a/src/libs/nanvix-registry/src/package.rs
+++ b/src/libs/nanvix-registry/src/package.rs
@@ -956,7 +956,7 @@ impl PackageRelease {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/libs/nanvix-registry/src/progress.rs
+++ b/src/libs/nanvix-registry/src/progress.rs
@@ -153,7 +153,7 @@ pub type SharedProgress = Arc<dyn ProgressCallback>;
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/libs/nanvix-registry/src/rate_limiter.rs
+++ b/src/libs/nanvix-registry/src/rate_limiter.rs
@@ -241,7 +241,7 @@ pub(crate) fn check_rate_limit(response: &Response) -> Result<()> {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -348,6 +348,6 @@ mod tests {
     ///
     #[test]
     fn test_delay_constants() {
-        assert!(AUTHENTICATED_MIN_REQUEST_DELAY_MS < UNAUTHENTICATED_MIN_REQUEST_DELAY_MS);
+        const { assert!(AUTHENTICATED_MIN_REQUEST_DELAY_MS < UNAUTHENTICATED_MIN_REQUEST_DELAY_MS) };
     }
 }

--- a/src/libs/nanvix-registry/src/release.rs
+++ b/src/libs/nanvix-registry/src/release.rs
@@ -221,7 +221,7 @@ impl LatestRelease {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/libs/nanvix-registry/src/tarball.rs
+++ b/src/libs/nanvix-registry/src/tarball.rs
@@ -378,7 +378,7 @@ async fn validate_extracted_paths(dir: &Path) -> anyhow::Result<()> {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -433,7 +433,7 @@ mod tests {
         let result: Result<Tarball> = Tarball::open(&path);
         assert!(result.is_err());
         assert!(result
-            .unwrap_err()
+            .expect_err("should fail")
             .to_string()
             .contains("Unsupported tarball format"));
     }
@@ -449,7 +449,7 @@ mod tests {
         let result: Result<Tarball> = Tarball::open(&path);
         assert!(result.is_ok());
 
-        match result.unwrap() {
+        match result.expect("failed") {
             Tarball::Bzip2 { path: p } => {
                 assert_eq!(p, path);
             },
@@ -501,11 +501,15 @@ mod tests {
     async fn test_validate_extracted_paths_valid() {
         let dir: PathBuf = unique_temp_dir("tarball_test_valid");
         let _ = fs::remove_dir_all(&dir).await;
-        fs::create_dir_all(dir.join("subdir")).await.unwrap();
-        fs::write(dir.join("file.txt"), "content").await.unwrap();
+        fs::create_dir_all(dir.join("subdir"))
+            .await
+            .expect("failed");
+        fs::write(dir.join("file.txt"), "content")
+            .await
+            .expect("failed");
         fs::write(dir.join("subdir/nested.txt"), "content")
             .await
-            .unwrap();
+            .expect("failed");
 
         let result: Result<()> = validate_extracted_paths(&dir).await;
         assert!(result.is_ok());
@@ -524,21 +528,21 @@ mod tests {
         let dir: PathBuf = base.join("dest");
         let outside: PathBuf = base.join("outside");
         let _ = fs::remove_dir_all(&base).await;
-        fs::create_dir_all(&dir).await.unwrap();
-        fs::create_dir_all(&outside).await.unwrap();
+        fs::create_dir_all(&dir).await.expect("failed");
+        fs::create_dir_all(&outside).await.expect("failed");
         fs::write(outside.join("secret.txt"), "secret")
             .await
-            .unwrap();
+            .expect("failed");
 
         // Create a symlink inside `dir` that points to a file outside `dir`.
         fs::symlink(outside.join("secret.txt"), dir.join("escape_link"))
             .await
-            .unwrap();
+            .expect("failed");
 
         let result: Result<()> = validate_extracted_paths(&dir).await;
         assert!(result.is_err());
         assert!(result
-            .unwrap_err()
+            .expect_err("should fail")
             .to_string()
             .contains("escapes destination directory"));
 
@@ -554,7 +558,7 @@ mod tests {
     async fn test_validate_extracted_paths_empty_dir() {
         let dir: PathBuf = unique_temp_dir("tarball_test_empty");
         let _ = fs::remove_dir_all(&dir).await;
-        fs::create_dir_all(&dir).await.unwrap();
+        fs::create_dir_all(&dir).await.expect("failed");
 
         let result: Result<()> = validate_extracted_paths(&dir).await;
         assert!(result.is_ok());

--- a/src/libs/nanvix-registry/src/tempfile.rs
+++ b/src/libs/nanvix-registry/src/tempfile.rs
@@ -121,7 +121,7 @@ impl Drop for TemporaryFile {
 //==================================================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use ::std::env;
@@ -174,7 +174,7 @@ mod tests {
         // Verify file was written.
         let contents: Result<Vec<u8>, std::io::Error> = fs::read(&path).await;
         assert!(contents.is_ok());
-        assert_eq!(contents.unwrap(), data);
+        assert_eq!(contents.expect("failed"), data);
 
         // Cleanup.
         let _: Result<(), std::io::Error> = fs::remove_file(&path).await;
@@ -215,7 +215,7 @@ mod tests {
         // Verify file size.
         let metadata: Result<std::fs::Metadata, std::io::Error> = fs::metadata(&path).await;
         assert!(metadata.is_ok());
-        assert_eq!(metadata.unwrap().len(), 1024 * 1024);
+        assert_eq!(metadata.expect("failed").len(), 1024 * 1024);
 
         // Cleanup.
         let _: Result<(), std::io::Error> = fs::remove_file(&path).await;
@@ -232,7 +232,8 @@ mod tests {
 
         // Create file in a scoped runtime.
         {
-            let runtime: ::tokio::runtime::Runtime = ::tokio::runtime::Runtime::new().unwrap();
+            let runtime: ::tokio::runtime::Runtime =
+                ::tokio::runtime::Runtime::new().expect("failed");
             runtime.block_on(async {
                 let tempfile: TemporaryFile = TemporaryFile::new(path.clone());
                 let result: Result<()> = tempfile.write(b"scoped test data").await;
@@ -242,10 +243,11 @@ mod tests {
         }
 
         // Check if file was removed by the destructor.
-        if path.exists() {
+        let still_exists: bool = path.exists();
+        if still_exists {
             // Cleanup before failing.
             let _: Result<(), std::io::Error> = ::std::fs::remove_file(&path);
-            panic!("Temporary file was not automatically removed by destructor");
         }
+        assert!(!still_exists, "Temporary file was not automatically removed by destructor");
     }
 }

--- a/src/uservm/src/args.rs
+++ b/src/uservm/src/args.rs
@@ -640,6 +640,7 @@ impl Args {
 //==================================================================================================
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use ::anyhow::Result as AnyResult;
@@ -738,17 +739,17 @@ mod tests {
     #[test]
     fn parse_detects_memory_overflow() {
         let mut args_vec: Vec<String> = build_base_args();
-        let overflow_arg: String = format!("{}K", ::std::usize::MAX);
+        let overflow_arg: String = format!("{}K", usize::MAX);
         args_vec.push(Args::OPT_MEMORY_SIZE.to_string());
         args_vec.push(overflow_arg);
 
-        match Args::parse(args_vec) {
-            Err(error) => {
-                assert!(error.to_string().contains("memory size overflow"));
-            },
-            Ok(_) => {
-                assert!(false, "expected memory size overflow to produce an error");
-            },
+        let result = Args::parse(args_vec);
+        assert!(result.is_err(), "expected memory size overflow to produce an error");
+        if let Err(error) = result {
+            assert!(
+                error.to_string().contains("memory size overflow"),
+                "error should mention memory size overflow"
+            );
         }
     }
 }

--- a/src/uservm/src/elf.rs
+++ b/src/uservm/src/elf.rs
@@ -519,6 +519,7 @@ pub unsafe fn load(
 //==================================================================================================
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use ::std::ffi::c_void;
@@ -526,16 +527,48 @@ mod tests {
     const ENTRY_POINT: u32 = 0x0040_2000;
     const VADDR: usize = 0x0010_0000;
 
+    /// Converts a `usize` to `u32`, panicking if it does not fit.
+    fn to_u32(v: usize) -> u32 {
+        u32::try_from(v).expect("value fits in u32")
+    }
+
+    /// Converts a `usize` to `u16`, panicking if it does not fit.
+    fn to_u16(v: usize) -> u16 {
+        u16::try_from(v).expect("value fits in u16")
+    }
+
     fn make_ident() -> [u8; EI_NIDENT] {
         let mut ident: [u8; EI_NIDENT] = [0; EI_NIDENT];
         ident[0] = ELFMAG0;
-        ident[1] = ELFMAG1 as u8;
-        ident[2] = ELFMAG2 as u8;
-        ident[3] = ELFMAG3 as u8;
+        ident[1] = u8::try_from(ELFMAG1).expect("ELF magic fits in u8");
+        ident[2] = u8::try_from(ELFMAG2).expect("ELF magic fits in u8");
+        ident[3] = u8::try_from(ELFMAG3).expect("ELF magic fits in u8");
         ident[4] = ELFCLASS32;
         ident[5] = ELFDATA2LSB;
-        ident[6] = EV_CURRENT as u8;
+        ident[6] = u8::try_from(EV_CURRENT).expect("EV_CURRENT fits in u8");
         ident
+    }
+
+    /// Builds a standard ELF header for tests.
+    fn make_header(e_phnum: u16) -> Elf32Fhdr {
+        let header_size: usize = mem::size_of::<Elf32Fhdr>();
+        let phdr_size: usize = mem::size_of::<Elf32Phdr>();
+        Elf32Fhdr {
+            e_ident: make_ident(),
+            e_type: ET_EXEC,
+            e_machine: EM_386,
+            e_version: EV_CURRENT,
+            e_entry: ENTRY_POINT,
+            e_phoff: to_u32(header_size),
+            e_shoff: 0,
+            e_flags: 0,
+            e_ehsize: to_u16(header_size),
+            e_phentsize: to_u16(phdr_size),
+            e_phnum,
+            e_shentsize: 0,
+            e_shnum: 0,
+            e_shstrndx: 0,
+        }
     }
 
     unsafe fn write_struct<T>(buffer: &mut [u8], value: &T) {
@@ -555,31 +588,15 @@ mod tests {
         let memsz: usize = 16;
         let segment_data: [u8; 4] = [0xaa, 0xbb, 0xcc, 0xdd];
 
-        let ident: [u8; EI_NIDENT] = make_ident();
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: ident,
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: phdr_size as u16,
-            e_phnum: 1,
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let header: Elf32Fhdr = make_header(1);
 
         let phdr: Elf32Phdr = Elf32Phdr {
             p_type: PT_LOAD,
-            p_offset: segment_offset as u32,
-            p_vaddr: VADDR as u32,
+            p_offset: to_u32(segment_offset),
+            p_vaddr: to_u32(VADDR),
             p_paddr: 0,
-            p_filesz: filesz as u32,
-            p_memsz: memsz as u32,
+            p_filesz: to_u32(filesz),
+            p_memsz: to_u32(memsz),
             p_flags: PF_R | PF_W,
             p_align: 1,
         };
@@ -613,25 +630,9 @@ mod tests {
     #[test]
     fn load_rejects_invalid_program_header_size() {
         let header_size: usize = mem::size_of::<Elf32Fhdr>();
-        let mut ident: [u8; EI_NIDENT] = make_ident();
-        ident[4] = ELFCLASS32;
 
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: ident,
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: (mem::size_of::<Elf32Phdr>() as u16) - 1,
-            e_phnum: 1,
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let mut header: Elf32Fhdr = make_header(1);
+        header.e_phentsize = to_u16(mem::size_of::<Elf32Phdr>()) - 1;
 
         let mut image: Vec<u8> = vec![0; header_size];
         unsafe {
@@ -656,30 +657,15 @@ mod tests {
         let memsz: usize = 8;
         let segment_data: [u8; 16] = [0x11; 16];
 
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: make_ident(),
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: phdr_size as u16,
-            e_phnum: 1,
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let header: Elf32Fhdr = make_header(1);
 
         let phdr: Elf32Phdr = Elf32Phdr {
             p_type: PT_LOAD,
-            p_offset: segment_offset as u32,
-            p_vaddr: VADDR as u32,
+            p_offset: to_u32(segment_offset),
+            p_vaddr: to_u32(VADDR),
             p_paddr: 0,
-            p_filesz: filesz as u32,
-            p_memsz: memsz as u32,
+            p_filesz: to_u32(filesz),
+            p_memsz: to_u32(memsz),
             p_flags: PF_R | PF_W,
             p_align: 1,
         };
@@ -711,27 +697,12 @@ mod tests {
         let phdr_size: usize = mem::size_of::<Elf32Phdr>();
         let segment_offset: usize = header_size + phdr_size;
 
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: make_ident(),
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: phdr_size as u16,
-            e_phnum: 1,
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let header: Elf32Fhdr = make_header(1);
 
         let phdr: Elf32Phdr = Elf32Phdr {
             p_type: PT_LOAD,
-            p_offset: segment_offset as u32,
-            p_vaddr: VADDR as u32,
+            p_offset: to_u32(segment_offset),
+            p_vaddr: to_u32(VADDR),
             p_paddr: 0,
             p_filesz: 0x100,
             p_memsz: 0x200,
@@ -760,22 +731,7 @@ mod tests {
         let header_size: usize = mem::size_of::<Elf32Fhdr>();
         let phdr_size: usize = mem::size_of::<Elf32Phdr>();
 
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: make_ident(),
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: phdr_size as u16,
-            e_phnum: 2,
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let header: Elf32Fhdr = make_header(2);
 
         // First segment: starts at 0x1000, size 0x100.
         let phdr1: Elf32Phdr = Elf32Phdr {
@@ -831,25 +787,9 @@ mod tests {
     #[test]
     fn memory_footprint_rejects_invalid_magic() {
         let header_size: usize = mem::size_of::<Elf32Fhdr>();
-        let mut ident: [u8; EI_NIDENT] = [0; EI_NIDENT];
-        ident[0] = 0x00; // Invalid magic.
 
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: ident,
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: mem::size_of::<Elf32Phdr>() as u16,
-            e_phnum: 1,
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let mut header: Elf32Fhdr = make_header(1);
+        header.e_ident = [0; EI_NIDENT]; // Invalid magic.
 
         let mut image: Vec<u8> = vec![0; header_size];
         unsafe {
@@ -865,25 +805,9 @@ mod tests {
     #[test]
     fn memory_footprint_rejects_invalid_class() {
         let header_size: usize = mem::size_of::<Elf32Fhdr>();
-        let mut ident: [u8; EI_NIDENT] = make_ident();
-        ident[4] = ELFCLASS64; // 64-bit class, not supported.
 
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: ident,
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: mem::size_of::<Elf32Phdr>() as u16,
-            e_phnum: 1,
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let mut header: Elf32Fhdr = make_header(1);
+        header.e_ident[4] = ELFCLASS64; // 64-bit class, not supported.
 
         let mut image: Vec<u8> = vec![0; header_size];
         unsafe {
@@ -900,22 +824,8 @@ mod tests {
     fn memory_footprint_rejects_invalid_phentsize() {
         let header_size: usize = mem::size_of::<Elf32Fhdr>();
 
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: make_ident(),
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: 1, // Invalid size.
-            e_phnum: 1,
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let mut header: Elf32Fhdr = make_header(1);
+        header.e_phentsize = 1; // Invalid size.
 
         let mut image: Vec<u8> = vec![0; header_size];
         unsafe {
@@ -931,24 +841,8 @@ mod tests {
     #[test]
     fn memory_footprint_rejects_phdr_exceeds_buffer() {
         let header_size: usize = mem::size_of::<Elf32Fhdr>();
-        let phdr_size: usize = mem::size_of::<Elf32Phdr>();
 
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: make_ident(),
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: phdr_size as u16,
-            e_phnum: 10, // Claims 10 segments but buffer is too small.
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let header: Elf32Fhdr = make_header(10); // Claims 10 segments but buffer is too small.
 
         // Buffer only has header, no room for program headers.
         let mut image: Vec<u8> = vec![0; header_size];
@@ -967,28 +861,13 @@ mod tests {
         let header_size: usize = mem::size_of::<Elf32Fhdr>();
         let phdr_size: usize = mem::size_of::<Elf32Phdr>();
 
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: make_ident(),
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: phdr_size as u16,
-            e_phnum: 1,
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let header: Elf32Fhdr = make_header(1);
 
         // Non-loadable segment (PT_NOTE instead of PT_LOAD).
         let phdr: Elf32Phdr = Elf32Phdr {
             p_type: PT_NOTE,
             p_offset: 0,
-            p_vaddr: VADDR as u32,
+            p_vaddr: to_u32(VADDR),
             p_paddr: 0,
             p_filesz: 0x100,
             p_memsz: 0x100,
@@ -1013,22 +892,7 @@ mod tests {
         let header_size: usize = mem::size_of::<Elf32Fhdr>();
         let phdr_size: usize = mem::size_of::<Elf32Phdr>();
 
-        let header: Elf32Fhdr = Elf32Fhdr {
-            e_ident: make_ident(),
-            e_type: ET_EXEC,
-            e_machine: EM_386,
-            e_version: EV_CURRENT,
-            e_entry: ENTRY_POINT,
-            e_phoff: header_size as u32,
-            e_shoff: 0,
-            e_flags: 0,
-            e_ehsize: header_size as u16,
-            e_phentsize: phdr_size as u16,
-            e_phnum: 3,
-            e_shentsize: 0,
-            e_shnum: 0,
-            e_shstrndx: 0,
-        };
+        let header: Elf32Fhdr = make_header(3);
 
         // Non-loadable segment (should be skipped).
         let phdr1: Elf32Phdr = Elf32Phdr {

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -15,7 +15,6 @@
 
 // Lints
 #![forbid(clippy::unwrap_used)]
-#![forbid(clippy::expect_used)]
 #![forbid(clippy::cast_possible_wrap)]
 #![forbid(clippy::cast_precision_loss)]
 #![forbid(clippy::char_lit_as_u8)]
@@ -29,6 +28,8 @@
 #![forbid(clippy::todo)]
 #![forbid(clippy::unreachable)]
 #![forbid(clippy::cast_possible_truncation)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
 
 //==================================================================================================
 // Public Modules
@@ -746,6 +747,7 @@ fn on_message_received_from_memory_thread(counters: &MessageCounters) {
 //==================================================================================================
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::get_stderr_writer;
     use ::anyhow::{
@@ -756,7 +758,7 @@ mod tests {
         env,
         fs,
         fs::Metadata,
-        io::Write as IoWrite,
+        io::Write,
         path::PathBuf,
         time::{
             SystemTime,
@@ -803,7 +805,7 @@ mod tests {
         file_path.push(format!("nanvix-uservm-missing-{nanos}"));
         file_path.push("stderr.log");
 
-        let result: Result<Box<dyn Write + Send>> =
+        let result: AnyResult<Box<dyn Write + Send>> =
             get_stderr_writer(Some(file_path.to_string_lossy().into_owned()));
         assert!(result.is_err(), "expected failure when parent directory does not exist");
     }

--- a/src/uservm/src/memory_thread.rs
+++ b/src/uservm/src/memory_thread.rs
@@ -214,6 +214,7 @@ fn on_message_received_from_io_thread(counters: &MessageCounters) {
 //==================================================================================================
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use ::anyhow::anyhow;

--- a/src/uservm/src/orchestrator.rs
+++ b/src/uservm/src/orchestrator.rs
@@ -688,6 +688,7 @@ impl Orchestrator {
 //==================================================================================================
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use ::anyhow::Result as AnyResult;
@@ -768,13 +769,16 @@ mod tests {
                     Ok(())
                 })
             }),
-            Box::new(move || {
-                let flag = snapshot_flag.clone();
-                Box::pin(async move {
-                    flag.store(true, Ordering::SeqCst);
-                    Ok(())
+            {
+                let snapshot_flag2: Arc<AtomicBool> = snapshot_called.clone();
+                Box::new(move || {
+                    let flag = snapshot_flag2.clone();
+                    Box::pin(async move {
+                        flag.store(true, Ordering::SeqCst);
+                        Ok(())
+                    })
                 })
-            }),
+            },
         );
 
         Harness {

--- a/src/utils/nanvix-test/src/environment.rs
+++ b/src/utils/nanvix-test/src/environment.rs
@@ -783,66 +783,84 @@ mod tests {
         Ok(dir)
     }
 
-    #[tokio::test(flavor = "multi_thread")] // Uses multi-thread runtime to mirror production
-    async fn cleanup_stale_unix_sockets_removes_only_sockets() -> Result<()> {
-        let temp_dir: PathBuf = unique_temp_dir("nvx-clean-sock")?;
-        let socket_path: PathBuf = temp_dir.join(format!("test{UNIX_SOCKET_SUFFIX}"));
-        let other_path: PathBuf = temp_dir.join("other.txt");
+    #[test]
+    fn cleanup_stale_unix_sockets_removes_only_sockets() -> Result<()> {
+        let rt: ::tokio::runtime::Runtime = ::tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| ::anyhow::anyhow!("failed to build tokio runtime: {e}"))?;
+        rt.block_on(async {
+            let temp_dir: PathBuf = unique_temp_dir("nvx-clean-sock")?;
+            let socket_path: PathBuf = temp_dir.join(format!("test{UNIX_SOCKET_SUFFIX}"));
+            let other_path: PathBuf = temp_dir.join("other.txt");
 
-        ::tokio::fs::write(&socket_path, b"socket").await?;
-        ::tokio::fs::write(&other_path, b"other").await?;
+            ::tokio::fs::write(&socket_path, b"socket").await?;
+            ::tokio::fs::write(&other_path, b"other").await?;
 
-        cleanup_stale_unix_sockets(temp_dir.as_path()).await;
+            cleanup_stale_unix_sockets(temp_dir.as_path()).await;
 
-        let socket_exists: bool = ::tokio::fs::try_exists(&socket_path).await.unwrap_or(false);
-        let other_exists: bool = ::tokio::fs::try_exists(&other_path).await.unwrap_or(false);
+            let socket_exists: bool = ::tokio::fs::try_exists(&socket_path).await.unwrap_or(false);
+            let other_exists: bool = ::tokio::fs::try_exists(&other_path).await.unwrap_or(false);
 
-        assert!(!socket_exists, "stale socket should be removed");
-        assert!(other_exists, "non-socket file must remain");
+            assert!(!socket_exists, "stale socket should be removed");
+            assert!(other_exists, "non-socket file must remain");
 
-        let _ = fs::remove_file(&other_path);
-        let _ = fs::remove_dir_all(&temp_dir);
-        Ok(())
+            let _ = fs::remove_file(&other_path);
+            let _ = fs::remove_dir_all(&temp_dir);
+            Ok(())
+        })
     }
 
-    #[tokio::test(flavor = "multi_thread")] // Ensures early return path is preserved
-    async fn prepare_l2_artifacts_reuses_existing_files() -> Result<()> {
-        let temp_dir: PathBuf = unique_temp_dir("nvx-artifacts")?;
-        let images_dir: PathBuf = temp_dir.join(DEFAULT_L2_SNAPSHOT_DIRECTORY);
-        ::tokio::fs::create_dir_all(&images_dir).await?;
+    #[test]
+    fn prepare_l2_artifacts_reuses_existing_files() -> Result<()> {
+        let rt: ::tokio::runtime::Runtime = ::tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| ::anyhow::anyhow!("failed to build tokio runtime: {e}"))?;
+        rt.block_on(async {
+            let temp_dir: PathBuf = unique_temp_dir("nvx-artifacts")?;
+            let images_dir: PathBuf = temp_dir.join(DEFAULT_L2_SNAPSHOT_DIRECTORY);
+            ::tokio::fs::create_dir_all(&images_dir).await?;
 
-        let snapshot_path: PathBuf = images_dir.join(SNAPSHOT_NAME);
-        let initramfs_path: PathBuf = images_dir.join(DEFAULT_SNAPSHOT_FILE_NAME);
-        ::tokio::fs::write(&snapshot_path, b"snapshot").await?;
-        ::tokio::fs::write(&initramfs_path, b"initramfs").await?;
+            let snapshot_path: PathBuf = images_dir.join(SNAPSHOT_NAME);
+            let initramfs_path: PathBuf = images_dir.join(DEFAULT_SNAPSHOT_FILE_NAME);
+            ::tokio::fs::write(&snapshot_path, b"snapshot").await?;
+            ::tokio::fs::write(&initramfs_path, b"initramfs").await?;
 
-        prepare_l2_artifacts("toolchain", temp_dir.as_path()).await?;
+            prepare_l2_artifacts("toolchain", temp_dir.as_path()).await?;
 
-        let snapshot_exists: bool = ::tokio::fs::try_exists(&snapshot_path)
-            .await
-            .unwrap_or(false);
-        let initramfs_exists: bool = ::tokio::fs::try_exists(&initramfs_path)
-            .await
-            .unwrap_or(false);
+            let snapshot_exists: bool = ::tokio::fs::try_exists(&snapshot_path)
+                .await
+                .unwrap_or(false);
+            let initramfs_exists: bool = ::tokio::fs::try_exists(&initramfs_path)
+                .await
+                .unwrap_or(false);
 
-        assert!(snapshot_exists, "snapshot must remain when artifacts pre-exist");
-        assert!(initramfs_exists, "initramfs must remain when artifacts pre-exist");
+            assert!(snapshot_exists, "snapshot must remain when artifacts pre-exist");
+            assert!(initramfs_exists, "initramfs must remain when artifacts pre-exist");
 
-        let _ = fs::remove_dir_all(&temp_dir);
-        Ok(())
+            let _ = fs::remove_dir_all(&temp_dir);
+            Ok(())
+        })
     }
 
-    #[tokio::test(flavor = "multi_thread")] // Validates missing script error path
-    async fn run_script_returns_error_when_missing() -> Result<()> {
-        let temp_dir: PathBuf = unique_temp_dir("nvx-run-script")?;
-        let missing_script: PathBuf = temp_dir.join("missing.sh");
+    #[test]
+    fn run_script_returns_error_when_missing() -> Result<()> {
+        let rt: ::tokio::runtime::Runtime = ::tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| ::anyhow::anyhow!("failed to build tokio runtime: {e}"))?;
+        rt.block_on(async {
+            let temp_dir: PathBuf = unique_temp_dir("nvx-run-script")?;
+            let missing_script: PathBuf = temp_dir.join("missing.sh");
 
-        let result: Result<()> =
-            run_script(missing_script.as_path(), temp_dir.as_path(), &[]).await;
+            let result: Result<()> =
+                run_script(missing_script.as_path(), temp_dir.as_path(), &[]).await;
 
-        assert!(result.is_err(), "missing script must produce an error");
+            assert!(result.is_err(), "missing script must produce an error");
 
-        let _ = fs::remove_dir_all(&temp_dir);
-        Ok(())
+            let _ = fs::remove_dir_all(&temp_dir);
+            Ok(())
+        })
     }
 }

--- a/src/utils/nanvix-test/src/main.rs
+++ b/src/utils/nanvix-test/src/main.rs
@@ -7,7 +7,6 @@
 
 #![forbid(clippy::all)]
 #![forbid(clippy::unwrap_used)]
-#![forbid(clippy::expect_used)]
 #![forbid(clippy::cast_possible_truncation)]
 #![forbid(clippy::cast_possible_wrap)]
 #![forbid(clippy::cast_precision_loss)]
@@ -22,6 +21,8 @@
 #![forbid(clippy::unimplemented)]
 #![forbid(clippy::todo)]
 #![forbid(clippy::unreachable)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
 
 //==================================================================================================
 // Modules

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -12,8 +12,9 @@
 //==================================================================================================
 
 #![deny(clippy::all)]
-#![deny(clippy::unwrap_used)]
-#![deny(clippy::expect_used)]
+#![forbid(clippy::unwrap_used)]
+// The following lints are allowed in tests to facilitate testing of error conditions.
+#![cfg_attr(not(test), forbid(clippy::expect_used))]
 
 //==================================================================================================
 // Imports
@@ -118,8 +119,25 @@ macro_rules! log_info {
 /// On success, returns the exit code of the workload in interactive mode or `ExitCode::SUCCESS`
 /// in HTTP mode. On failure, returns an error describing what went wrong.
 ///
-#[tokio::main]
-pub async fn main() -> Result<ExitCode> {
+// # NOTES
+//
+// - We build the tokio runtime manually instead of using `#[tokio::main]` because the macro
+//   expansion emits `#[allow(clippy::expect_used)]`, which is incompatible with our crate-level
+//   `#![forbid(clippy::expect_used)]` lint configuration.
+///
+pub fn main() -> Result<ExitCode> {
+    let rt: ::tokio::runtime::Runtime = ::tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| ::anyhow::anyhow!("failed to build tokio runtime: {e}"))?;
+    rt.block_on(async_main())
+}
+
+/// # Description
+///
+/// Asynchronous entry point for the nanvixd daemon.
+///
+async fn async_main() -> Result<ExitCode> {
     let args: Arc<Args> =
         Arc::new(Args::parse(std::env::args().filter(|s| !s.trim().is_empty()).collect())?);
 
@@ -447,6 +465,7 @@ fn encode_base64_filename(mut num: u128) -> String {
 //==================================================================================================
 
 #[cfg(test)]
+#[allow(clippy::needless_range_loop)]
 mod tests {
     use super::*;
 
@@ -504,19 +523,19 @@ mod tests {
         // First 26 should be A-Z.
         for i in 0..26 {
             assert_eq!(encodings[i].len(), 1);
-            assert_eq!(encodings[i].chars().next().unwrap() as u8, b'A' + i as u8);
+            assert_eq!(encodings[i].as_bytes()[0], b'A' + i as u8);
         }
 
         // Next 26 should be a-z.
         for i in 26..52 {
             assert_eq!(encodings[i].len(), 1);
-            assert_eq!(encodings[i].chars().next().unwrap() as u8, b'a' + (i - 26) as u8);
+            assert_eq!(encodings[i].as_bytes()[0], b'a' + (i - 26) as u8);
         }
 
         // Next 10 should be 0-9.
         for i in 52..62 {
             assert_eq!(encodings[i].len(), 1);
-            assert_eq!(encodings[i].chars().next().unwrap() as u8, b'0' + (i - 52) as u8);
+            assert_eq!(encodings[i].as_bytes()[0], b'0' + (i - 52) as u8);
         }
 
         // Last two should be - and _.


### PR DESCRIPTION
**Build system improvements:**

* Added `--tests` to all `clippy` linting invocations for host binaries, host rlibs, guest rlibs, and specific binaries (`nanvix-bench`, `nanvix-test`, `nanvixd`, `uservm`), ensuring that test code is also linted. For guest rlibs, new rules were added to run lints on test code specifically. [[1]](diffhunk://#diff-ab2949ec19cfc4ef87eafa8b5f6b65e598d34f6a7651b6fb111a8eb629f77dabL32-R35) [[2]](diffhunk://#diff-56b5460ed196046bab3bc8f3036a0926f84b20ac09fe893b7e34e07ef2ff92efL26-R29) [[3]](diffhunk://#diff-d7ae164e20fb717bd169817ea5a57a85c2f2045caceff42add6d315cf21bc577L29-R32) [[4]](diffhunk://#diff-ad1fec46e99d04482f50f0e8cf7898b4bb4c5c5c58cf1faa4bd6e5b1ffa77966L29-R32) [[5]](diffhunk://#diff-28dbb1490ca7d99373f640c976b8adbb86085547204d62a24ad0c7463ef20194L36-R39) [[6]](diffhunk://#diff-6c7fe4970416ffb042c5c15a7ca82378ddcf3dcf539527fead033ed66a830aabL30-R33) [[7]](diffhunk://#diff-77868e5f1fa16f2d16dbd07b9417e35c89847e3950aafda6ca2c945d492f331bR23-R46)

**Library and test code improvements:**

* All FFI calls in `libc_string` tests now use `.cast()` for pointer conversions and explicit `TryFrom` for integer conversions, replacing unchecked `as` casts. This prevents accidental truncation or unsound pointer conversions and improves test reliability. [[1]](diffhunk://#diff-492abdec88094e65dcc4459f4e07e9e2d07274da4b192bf8a3024bf0c81d5530L109-R116) [[2]](diffhunk://#diff-492abdec88094e65dcc4459f4e07e9e2d07274da4b192bf8a3024bf0c81d5530L124-R134) [[3]](diffhunk://#diff-492abdec88094e65dcc4459f4e07e9e2d07274da4b192bf8a3024bf0c81d5530L141-R156) [[4]](diffhunk://#diff-492abdec88094e65dcc4459f4e07e9e2d07274da4b192bf8a3024bf0c81d5530L155-R169) [[5]](diffhunk://#diff-492abdec88094e65dcc4459f4e07e9e2d07274da4b192bf8a3024bf0c81d5530L168-R187) [[6]](diffhunk://#diff-492abdec88094e65dcc4459f4e07e9e2d07274da4b192bf8a3024bf0c81d5530L182-R202) [[7]](diffhunk://#diff-c67a98918c0960a73b0a9e416a6b2fcc22bf280779d96904bf2c43273990ef3aL180-R346) [[8]](diffhunk://#diff-7fadacf9647a536eadc632810faa5b7bb9736fa5455ac639ff6b71a4742ecbbdL134-R134) [[9]](diffhunk://#diff-4a2ea824b7074d36d8ac1808ad12a91aec9d1161d815d7504033f0106f6cab10L83-R87) [[10]](diffhunk://#diff-4a2ea824b7074d36d8ac1808ad12a91aec9d1161d815d7504033f0106f6cab10L95-R99)

* Test assertions in `memcpy` and related modules were simplified using `assert_eq!` on slices or iterators, making the tests more concise and idiomatic. [[1]](diffhunk://#diff-492abdec88094e65dcc4459f4e07e9e2d07274da4b192bf8a3024bf0c81d5530L182-R202) [[2]](diffhunk://#diff-c67a98918c0960a73b0a9e416a6b2fcc22bf280779d96904bf2c43273990ef3aL180-R346)

**Linting policy improvements:**

* The `clippy::expect_used` lint is now only forbidden outside of tests in `libc_string`, allowing its use in tests to facilitate error condition testing. [[1]](diffhunk://#diff-fd63ff88e69d809986d88dc4f5fad4c2e8e144f6146384ac8fb31b72218abe07L12) [[2]](diffhunk://#diff-fd63ff88e69d809986d88dc4f5fad4c2e8e144f6146384ac8fb31b72218abe07R25-R26)