### PR TITLE
[ci] sccache GitHub Actions as cache backend

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Build timeout in seconds passed through to make"
     required: false
     default: "600"
+  sccache-gha-enabled:
+    description: "Enable sccache GitHub Actions cache backend (true/false)"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -46,6 +50,11 @@ runs:
       # release-package action.
       BUILD_TARGETS: ${{ inputs.release == 'release' && 'all run-unit-tests release' || 'all run-unit-tests' }}
       MAKE_FLAGS: ${{ steps.deployment.outputs.make-flags }}
+      # sccache GitHub Actions cache backend variables. When sccache-gha-enabled
+      # is true, these are forwarded into the Docker build so that sccache inside
+      # the container uses the GHA cache as a remote storage backend.
+      SCCACHE_GHA_ENABLED: ${{ inputs.sccache-gha-enabled == 'true' && 'true' || '' }}
+      SCCACHE_GHA_CACHE_TO: ${{ inputs.sccache-gha-enabled == 'true' && format('sccache-{0}-{1}-{2}', inputs.machine-type, inputs.deployment-type, inputs.release) || '' }}
     run: |
       ./z build --with-minimal-docker -- ${BUILD_TARGETS} \
         "MACHINE=${MACHINE_TYPE}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,11 @@ jobs:
     - name: "Setup"
       uses: ./.github/actions/docker-setup
 
+    - name: "Setup sccache"
+      uses: Mozilla-Actions/sccache-action@v0.0.9
+      with:
+        version: "v0.10.0"
+
     - name: "Build & Unit Test"
       uses: ./.github/actions/docker-build
       with:
@@ -182,6 +187,7 @@ jobs:
         log-level: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
         machine-type: '${{ matrix.machine-type }}'
         deployment-type: '${{ matrix.deployment-type }}'
+        sccache-gha-enabled: 'true'
 
     - name: "Upload Build Artifacts"
       uses: actions/upload-artifact@v6

--- a/scripts/setup/Dockerfile.build
+++ b/scripts/setup/Dockerfile.build
@@ -28,16 +28,44 @@ COPY . .
 # paths ($(TOOLCHAIN_DIR)/bin/...), so they do not depend on PATH ordering.
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}
 
+# GitHub Actions cache backend for sccache (optional).
+# When SCCACHE_GHA_ENABLED is set to "true", sccache uses the GitHub Actions
+# cache as a remote backend instead of the local disk cache.
+# SCCACHE_GHA_ENABLED and SCCACHE_GHA_CACHE_TO are passed as build args.
+# ACTIONS_RESULTS_URL and ACTIONS_RUNTIME_TOKEN are injected as Docker secrets
+# so that their per-run values do not bust the BuildKit layer cache.
+ARG SCCACHE_GHA_ENABLED
+ARG SCCACHE_GHA_CACHE_TO
+
 RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/root/.cargo/git,sharing=locked \
     --mount=type=cache,target=/root/.cache/sccache,sharing=locked \
     --mount=type=cache,target=${WORKSPACE_PATH}/target,sharing=locked \
     --mount=type=cache,target=/opt/contrib-src,sharing=locked \
+    --mount=type=secret,id=actions_results_url \
+    --mount=type=secret,id=actions_runtime_token \
     set -e && \
     SCCACHE_ARG="" && \
     if [ -x /usr/local/bin/sccache ]; then SCCACHE_ARG="SCCACHE=/usr/local/bin/sccache"; fi && \
+    if [ -n "${SCCACHE_GHA_ENABLED}" ]; then \
+        export SCCACHE_GHA_ENABLED="${SCCACHE_GHA_ENABLED}"; \
+        export ACTIONS_CACHE_SERVICE_V2="on"; \
+        if [ -f /run/secrets/actions_results_url ]; then \
+            export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)"; \
+        fi; \
+        if [ -f /run/secrets/actions_runtime_token ]; then \
+            export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)"; \
+        fi; \
+    fi && \
+    if [ -n "${SCCACHE_GHA_CACHE_TO}" ]; then \
+        export SCCACHE_GHA_CACHE_TO="${SCCACHE_GHA_CACHE_TO}"; \
+    fi && \
     SCCACHE_DIR=/root/.cache/sccache CONTRIB_SRC_DIR=/opt/contrib-src \
-    make TOOLCHAIN_DIR=/opt/nanvix ${SCCACHE_ARG} ${BUILD_PARAMS}
+    make TOOLCHAIN_DIR=/opt/nanvix ${SCCACHE_ARG} ${BUILD_PARAMS} && \
+    if [ -x /usr/local/bin/sccache ]; then \
+        echo "=== sccache statistics ===" && \
+        /usr/local/bin/sccache --show-stats; \
+    fi
 
 # Create output directories to ensure they exist even if build produces no artifacts.
 RUN mkdir -p ${WORKSPACE_PATH}/bin ${WORKSPACE_PATH}/lib ${WORKSPACE_PATH}/images \

--- a/z
+++ b/z
@@ -51,9 +51,6 @@ OPT_NAME_TOOLCHAIN_DIR="--toolchain-dir"
 # Name of the Docker image with the Nanvix toolchain.
 DOCKER_IMAGE_BASE_NAME="nanvix/toolchain"
 
-# Path to the toolchain inside the Docker image.
-DOCKER_IMAGE_TOOLCHAIN_PATH="/opt/nanvix"
-
 # Cache file to store the last build command and options.
 Z_CACHE_FILE=".z.cache"
 
@@ -231,11 +228,30 @@ run_docker_build() {
     workspace_path="$(pwd -P)"
 
     # Run the build with BuildKit using the external Dockerfile.
+    # Forward GitHub Actions sccache cache backend variables when available.
+    # SCCACHE_GHA_ENABLED and SCCACHE_GHA_CACHE_TO are passed as build args.
+    # ACTIONS_RESULTS_URL and ACTIONS_RUNTIME_TOKEN are injected as Docker secrets
+    # so that their per-run values do not bust the BuildKit layer cache.
+    local gha_sccache_args=()
+    if [[ -n "${SCCACHE_GHA_ENABLED:-}" ]]; then
+        gha_sccache_args+=(--build-arg "SCCACHE_GHA_ENABLED=${SCCACHE_GHA_ENABLED}")
+    fi
+    if [[ -n "${SCCACHE_GHA_CACHE_TO:-}" ]]; then
+        gha_sccache_args+=(--build-arg "SCCACHE_GHA_CACHE_TO=${SCCACHE_GHA_CACHE_TO}")
+    fi
+    if [[ -n "${ACTIONS_RESULTS_URL:-}" ]]; then
+        gha_sccache_args+=(--secret "id=actions_results_url,env=ACTIONS_RESULTS_URL")
+    fi
+    if [[ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
+        gha_sccache_args+=(--secret "id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN")
+    fi
+
     DOCKER_BUILDKIT=1 docker build \
         --build-arg BASE_IMAGE="${image_name}" \
         --build-arg BUILD_PARAMS="${build_parameters}" \
         --build-arg SYSROOT_SUFFIX="${sysroot_suffix}" \
         --build-arg WORKSPACE_PATH="${workspace_path}" \
+        ${gha_sccache_args[@]+"${gha_sccache_args[@]}"} \
         --output type=local,dest=. \
         --progress=plain \
         -f "${dockerfile_path}" \


### PR DESCRIPTION
On GitHub-hosted runners, Docker BuildKit cache mounts are ephemeral and discarded when the runner is recycled. This means sccache always starts with a cold cache, rebuilding the entire source tree from scratch on every CI run.

Enable the sccache GHA cache backend (via Mozilla-Actions/sccache-action) so that compilation artifacts are persisted across CI runs in the GitHub Actions cache. The runner's ACTIONS_CACHE_URL and ACTIONS_RUNTIME_TOKEN are forwarded as Docker build args into the container, allowing sccache inside Docker to use the remote GHA cache as its storage backend.

Changes:
- ci.yml: add sccache-action step and sccache-stats to ci-build job.
- docker-build/action.yml: add sccache-gha-enabled input; set SCCACHE_GHA_ENABLED and SCCACHE_GHA_CACHE_TO env vars scoped by matrix dimensions (machine-type, deployment-type, build-type).
- Dockerfile.build: accept and export GHA cache env vars so sccache inside the container uses the remote backend when enabled.
- z: forward GHA sccache env vars as --build-arg when present; no-op for local builds.