### PR TITLE
[build] Add `build-utils` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
         "src/kernel",
         "src/libs/arch",
         "src/libs/bitmap",
+        "src/libs/build-utils",
         "src/libs/config",
         "src/libs/control-plane-api",
         "src/libs/elf",
@@ -75,6 +76,7 @@ arch = { path = "src/libs/arch", default-features = false }
 anyhow = "1.0.98"
 base64 = "0.22.1"
 bitmap = { path = "src/libs/bitmap", default-features = false }
+build-utils = { path = "src/libs/build-utils" }
 bytes = "1.10.1"
 cc = "1.2.26"
 cfg-if = "1.0.0"

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -28,6 +28,7 @@ hyperlight-guest = { workspace = true, optional = true }
 static_assert = { workspace = true }
 
 [build-dependencies]
+build-utils = { workspace = true }
 cc = { workspace = true }
 cfg-if = { workspace = true }
 

--- a/src/kernel/build.rs
+++ b/src/kernel/build.rs
@@ -113,16 +113,8 @@ fn main() {
     // Read Kernel Configuration
     //==============================================================================================
 
-    // Get CARGO_MANIFEST_DIR to find workspace root
-    let manifest_dir: String = match env::var("CARGO_MANIFEST_DIR") {
-        Ok(manifest_dir) => manifest_dir,
-        Err(_) => panic!("failed to get CARGO_MANIFEST_DIR environment variable"),
-    };
-    let workspace_dir: PathBuf = Path::new(&manifest_dir)
-        .ancestors()
-        .nth(2) // kernel is 2 levels deep: workspace/src/kernel
-        .expect("Failed to find workspace root")
-        .to_path_buf();
+    // Find the workspace root by locating the Cargo.toml with [workspace].
+    let workspace_dir: PathBuf = build_utils::find_workspace_root();
 
     // Read kernel configuration
     let kernel_config_path: PathBuf = workspace_dir.join(DEFAULT_KERNEL_CONFIG_PATH);

--- a/src/libs/build-utils/Cargo.toml
+++ b/src/libs/build-utils/Cargo.toml
@@ -1,0 +1,14 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "build-utils"
+version.workspace = true
+license-file.workspace = true
+edition = "2024"
+authors.workspace = true
+description = "Shared build-script utilities for Nanvix."
+homepage.workspace = true
+
+[lints]
+workspace = true

--- a/src/libs/build-utils/src/lib.rs
+++ b/src/libs/build-utils/src/lib.rs
@@ -1,0 +1,72 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![deny(clippy::all)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::std::{
+    fs,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Finds the workspace root by walking up from `CARGO_MANIFEST_DIR` until a `Cargo.toml`
+/// containing a `[workspace]` section is found.
+///
+/// # Returns
+///
+/// The absolute path to the workspace root directory.
+///
+pub fn find_workspace_root() -> PathBuf {
+    let manifest_dir: &str = env!("CARGO_MANIFEST_DIR");
+    let mut current: &Path = Path::new(manifest_dir);
+
+    loop {
+        let cargo_toml: PathBuf = current.join("Cargo.toml");
+        if cargo_toml.exists() {
+            let content: String =
+                fs::read_to_string(&cargo_toml).expect("failed to read Cargo.toml");
+            if content.contains("[workspace]") {
+                return current.to_path_buf();
+            }
+        }
+
+        current = current
+            .parent()
+            .unwrap_or_else(|| panic!("failed to find workspace root from '{}'", manifest_dir));
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn test_find_workspace_root() {
+        let root: PathBuf = find_workspace_root();
+        assert!(root.join("Cargo.toml").exists());
+        let content: String = fs::read_to_string(root.join("Cargo.toml")).unwrap();
+        assert!(content.contains("[workspace]"));
+    }
+}

--- a/src/libs/config/Cargo.toml
+++ b/src/libs/config/Cargo.toml
@@ -30,5 +30,8 @@ rustc-dep-of-std = [
     "compiler_builtins/rustc-dep-of-std",
 ]
 
+[build-dependencies]
+build-utils = { workspace = true }
+
 [lints]
 workspace = true

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -412,14 +412,8 @@ fn generate_hyperlight_config(
 }
 
 fn main() {
-    // Read the TOML file using the workspace root for a reliable path
-    let manifest_dir: String =
-        env::var("CARGO_MANIFEST_DIR").expect("Failed to get CARGO_MANIFEST_DIR");
-    let workspace_dir: PathBuf = Path::new(&manifest_dir)
-        .ancestors()
-        .nth(3)
-        .expect("Failed to find workspace root")
-        .to_path_buf();
+    // Find the workspace root by locating the Cargo.toml with [workspace].
+    let workspace_dir: PathBuf = build_utils::find_workspace_root();
     let out_dir: String = env::var("OUT_DIR").unwrap();
 
     // Parse kernel configuration file.

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+build-utils = { workspace = true }
 indicatif = { workspace = true }
 libc = { workspace = true }
 nanvixd = { workspace = true }

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -5,10 +5,13 @@
 // Imports
 //==================================================================================================
 
-use crate::env::get_proj_root;
 use ::nanvix::hwloc::HwLoc;
 use ::std::{
     fmt,
+    path::{
+        Path,
+        PathBuf,
+    },
     process::Child,
     str::FromStr,
 };
@@ -34,9 +37,11 @@ pub enum BenchmarkFlavour {
 }
 
 impl BenchmarkFlavour {
-    pub fn get_program(&self) -> String {
+    pub fn get_program(&self, root: &Path) -> String {
         match self {
-            BenchmarkFlavour::BootTime => format!("{}/bin/noop-rust-nostd.elf", get_proj_root()),
+            BenchmarkFlavour::BootTime => {
+                format!("{}/bin/noop-rust-nostd.elf", root.display())
+            },
             BenchmarkFlavour::ColdStart
             | BenchmarkFlavour::ColdStartL2
             | BenchmarkFlavour::ColdStartUvm
@@ -48,7 +53,7 @@ impl BenchmarkFlavour {
             | BenchmarkFlavour::WarmStart
             | BenchmarkFlavour::WarmStartL2
             | BenchmarkFlavour::WarmStartVMM => {
-                format!("{}/bin/echo-rust-nostd.elf", get_proj_root())
+                format!("{}/bin/echo-rust-nostd.elf", root.display())
             },
         }
     }
@@ -101,6 +106,7 @@ pub struct Benchmark {
     pub hwloc_file: Option<String>,
     pub hwloc: Option<HwLoc>,
     pub flavour: BenchmarkFlavour,
+    pub workspace_root: PathBuf,
     pub nanvixd: Option<Child>,
     pub nanvixd_client: reqwest::Client,
     pub nanvixd_toolchain_bin_dir: String,

--- a/src/utils/nanvix-bench/src/env.rs
+++ b/src/utils/nanvix-bench/src/env.rs
@@ -1,6 +1,0 @@
-// Copyright(c) The Maintainers of Nanvix.
-// Licensed under the MIT License.
-
-pub fn get_proj_root() -> String {
-    format!("{}/../../..", env!("CARGO_MANIFEST_DIR"))
-}

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -17,7 +17,6 @@
 
 mod args;
 mod benchmark;
-mod env;
 
 //==================================================================================================
 // Imports
@@ -31,7 +30,6 @@ use crate::{
         LinuxdDeployment,
         UserVmDeployment,
     },
-    env::get_proj_root,
 };
 use ::anyhow::Result;
 use ::indicatif::{
@@ -184,7 +182,7 @@ impl Benchmark {
         let new_msg = message::New {
             tenant_id: tenant_id.unwrap_or(DEFAULT_TENANT_ID.to_string()),
             app_name: app_name.unwrap_or(DEFAULT_APP_NAME.to_string()),
-            program: self.flavour.get_program(),
+            program: self.flavour.get_program(&self.workspace_root),
             program_args: "".to_string(),
         };
 
@@ -194,7 +192,7 @@ impl Benchmark {
     /// Start nanvixd and, optionally, configure it to deploy linuxd inside an L2 VM.
     fn start_nanvixd(&self, linuxd_deployment: &LinuxdDeployment) -> Result<Child> {
         let mut nanvixd_args: Vec<String> = vec![
-            format!("{}/bin/nanvixd.elf", get_proj_root()),
+            format!("{}/bin/nanvixd.elf", self.workspace_root.display()),
             ::nanvixd::args::Args::OPT_HTTP_SOCKADDR.to_string(),
             NANVIXD_ADDRESS.to_string(),
             ::nanvixd::args::Args::OPT_TOOLCHAIN_BIN_DIRECTORY.to_string(),
@@ -215,7 +213,7 @@ impl Benchmark {
             .args(&nanvixd_args[1..])
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .current_dir(get_proj_root())
+            .current_dir(&self.workspace_root)
             .spawn()?;
 
         Ok(nanvixd_cmd)
@@ -225,13 +223,13 @@ impl Benchmark {
     /// nanvixd.
     fn start_user_vm(&self, gateway_addr: Option<String>) -> Result<Child> {
         let mut user_vm_args: Vec<String> = vec![
-            format!("{}/bin/uservm.elf", get_proj_root()),
+            format!("{}/bin/uservm.elf", self.workspace_root.display()),
             uservm::args::Args::OPT_USER_VM_ID.to_string(),
             "1".to_string(),
             uservm::args::Args::OPT_KERNEL.to_string(),
-            format!("{}/bin/kernel.elf", get_proj_root()),
+            format!("{}/bin/kernel.elf", self.workspace_root.display()),
             uservm::args::Args::OPT_INITRD.to_string(),
-            self.flavour.get_program(),
+            self.flavour.get_program(&self.workspace_root),
         ];
         if let Some(gateway_addr) = gateway_addr {
             user_vm_args.push(uservm::args::Args::OPT_SYSTEM_VM_SOCKADDR.to_string());
@@ -251,7 +249,7 @@ impl Benchmark {
             .args(&user_vm_args[1..])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .current_dir(get_proj_root())
+            .current_dir(&self.workspace_root)
             .spawn()?;
 
         Ok(user_vm_cmd)
@@ -483,8 +481,9 @@ impl Benchmark {
             let (io_thread_data_tx, memory_thread_data_rx) =
                 mpsc::channel::<Message>(CHANNEL_CAPACITY);
 
-            let kernel_filename: String = format!("{}/bin/kernel.elf", get_proj_root());
-            let initrd_filename: String = self.flavour.get_program();
+            let kernel_filename: String =
+                format!("{}/bin/kernel.elf", self.workspace_root.display());
+            let initrd_filename: String = self.flavour.get_program(&self.workspace_root);
 
             // Create shared counters for tracking message flow across threads.
             let counters: MessageCounters = MessageCounters::new();
@@ -927,8 +926,8 @@ impl Benchmark {
         let (io_control_tx, mut io_control_response_rx) =
             mpsc::channel::<IoControlResponse>(CHANNEL_CAPACITY);
 
-        let kernel_filename: String = format!("{}/bin/kernel.elf", get_proj_root());
-        let program: String = self.flavour.get_program();
+        let kernel_filename: String = format!("{}/bin/kernel.elf", self.workspace_root.display());
+        let program: String = self.flavour.get_program(&self.workspace_root);
 
         // Create shared counters for tracking message flow across threads.
         let counters: MessageCounters = MessageCounters::new();
@@ -1237,6 +1236,7 @@ async fn main() -> Result<()> {
         hwloc_file: args.hwloc_file(),
         hwloc,
         flavour: args.benchmark(),
+        workspace_root: build_utils::find_workspace_root(),
         nanvixd: None,
         nanvixd_client: reqwest::Client::new(),
         nanvixd_toolchain_bin_dir: args.toolchain_bin_dir(),


### PR DESCRIPTION
Closes #917

Key changes include:

**New shared utility crate:**
- Added a new crate `build-utils` in `src/libs/build-utils`, providing a `find_workspace_root()` function that locates the workspace root by searching for a `Cargo.toml` with a `[workspace]` section. Includes documentation and unit tests. [[1]](diffhunk://#diff-0da7cbd61427c0f89edb3c8525dadc7aeafe838d9c03b085b857f4ddae50bdb1R1-R14) [[2]](diffhunk://#diff-24afdbc77a1b994f4bba9f73c28285c4a1b3317e378f9de3fff8be51cd0dd006R1-R74)

**Refactoring build scripts to use the utility:**
- Refactored `src/kernel/build.rs` and `src/libs/config/build.rs` to use `build_utils::find_workspace_root()` instead of custom logic for finding the workspace root. [[1]](diffhunk://#diff-e1337c9914b179a828ca1ec993a2b189671928aa16abb5f63b3988486108baeaL116-R117) [[2]](diffhunk://#diff-85cf4e6b52d36f60bcdb1da3ae1bda729b02a4b0b6115636d6bdbe54b90ecc76L415-R416)

**Refactoring binaries to use the utility:**
- Updated `src/utils/nanvix-bench` to use `build_utils::find_workspace_root()` throughout, replacing the custom `get_proj_root()` function, which is now removed. All relevant path construction in `benchmark.rs` and `main.rs` is updated accordingly. [[1]](diffhunk://#diff-6ed8757d486b1d24e0b21a9acbea66aafea26f01be0134ed027a858ff7713fa0L8) [[2]](diffhunk://#diff-6ed8757d486b1d24e0b21a9acbea66aafea26f01be0134ed027a858ff7713fa0R37-R41) [[3]](diffhunk://#diff-6ed8757d486b1d24e0b21a9acbea66aafea26f01be0134ed027a858ff7713fa0L51-R53) [[4]](diffhunk://#diff-a094bef48a45bf92ea47cf5d1c0d042649abdcf2c51acfd4c7413720143d4a1dL1-L6) [[5]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bR195-R197) [[6]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL218-R218) [[7]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bR227-R233) [[8]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL254-R255) [[9]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL486-R488) [[10]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL930-R933)

**Dependency and workspace configuration:**
- Added `build-utils` as a dependency in the relevant `Cargo.toml` files for the kernel, config, and nanvix-bench crates, and registered it as a workspace member. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R19) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R79) [[3]](diffhunk://#diff-cea18f7efd1e6d15cf9f8b5507386b688bd3ae65f516ad3343cd923269b8f1c0R31) [[4]](diffhunk://#diff-b48d8648439a6a251064563b7d1265305252c87c425a2d4b1470a57b71cd5b6aR33-R35) [[5]](diffhunk://#diff-007451d36037394710392dd3001751fc278b1664e8999248ea04f32f64c4385eR15)

**Code cleanup:**
- Removed the now-unneeded `env.rs` module and all references to `get_proj_root()` in `nanvix-bench`. [[1]](diffhunk://#diff-a094bef48a45bf92ea47cf5d1c0d042649abdcf2c51acfd4c7413720143d4a1dL1-L6) [[2]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL20) [[3]](diffhunk://#diff-5db5c964699b47c009b6a846c9d97bc9994db455a2cdf123d097f49709402d5bL34)

These changes make the build and runtime path resolution more robust and easier to maintain by consolidating the logic into a single, well-tested location.