### PR TITLE
[ci] Set SCCACHE_GHA_CACHE_FROM

### DIFF
--- a/.github/actions/docker-benchmark-build/action.yml
+++ b/.github/actions/docker-benchmark-build/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Enable TIMESTAMP_MSG for echo-breakdown benchmarks (yes/no)"
     required: false
     default: "no"
+  sccache-gha-enabled:
+    description: "Enable sccache GitHub Actions cache backend (true/false)"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -22,6 +26,12 @@ runs:
     env:
       MACHINE_TYPE: ${{ inputs.machine-type }}
       TIMESTAMP_MSG_FLAG: ${{ inputs.timestamp-msg == 'yes' && 'TIMESTAMP_MSG=yes' || '' }}
+      # sccache GitHub Actions cache backend variables. When sccache-gha-enabled
+      # is true, these are forwarded into the Docker build so that sccache inside
+      # the container uses the GHA cache as a remote storage backend.
+      SCCACHE_GHA_ENABLED: ${{ inputs.sccache-gha-enabled == 'true' && 'true' || '' }}
+      SCCACHE_GHA_CACHE_TO: ${{ inputs.sccache-gha-enabled == 'true' && format('sccache-bench-{0}-{1}', inputs.machine-type, inputs.timestamp-msg == 'yes' && 'echo-breakdown' || 'standard') || '' }}
+      SCCACHE_GHA_CACHE_FROM: ${{ inputs.sccache-gha-enabled == 'true' && format('sccache-bench-{0}-{1}', inputs.machine-type, inputs.timestamp-msg == 'yes' && 'echo-breakdown' || 'standard') || '' }}
     run: |
       ./z build --with-minimal-docker -- all \
         "MACHINE=${MACHINE_TYPE}" \

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -53,8 +53,12 @@ runs:
       # sccache GitHub Actions cache backend variables. When sccache-gha-enabled
       # is true, these are forwarded into the Docker build so that sccache inside
       # the container uses the GHA cache as a remote storage backend.
+      # SCCACHE_GHA_CACHE_TO sets the cache key for writing compilation results.
+      # SCCACHE_GHA_CACHE_FROM sets the cache key for reading cached results;
+      # without it sccache writes to the cache but never reads, causing 0% hit rate.
       SCCACHE_GHA_ENABLED: ${{ inputs.sccache-gha-enabled == 'true' && 'true' || '' }}
       SCCACHE_GHA_CACHE_TO: ${{ inputs.sccache-gha-enabled == 'true' && format('sccache-{0}-{1}-{2}', inputs.machine-type, inputs.deployment-type, inputs.release) || '' }}
+      SCCACHE_GHA_CACHE_FROM: ${{ inputs.sccache-gha-enabled == 'true' && format('sccache-{0}-{1}-{2}', inputs.machine-type, inputs.deployment-type, inputs.release) || '' }}
     run: |
       ./z build --with-minimal-docker -- ${BUILD_TARGETS} \
         "MACHINE=${MACHINE_TYPE}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,10 +522,16 @@ jobs:
     - name: "Setup"
       uses: ./.github/actions/docker-setup
 
+    - name: "Setup sccache"
+      uses: Mozilla-Actions/sccache-action@v0.0.9
+      with:
+        version: "v0.10.0"
+
     - name: "Build (Standard)"
       uses: ./.github/actions/docker-benchmark-build
       with:
         machine-type: 'microvm'
+        sccache-gha-enabled: 'true'
 
     - name: "Run Micro-Benchmarks (Standard)"
       uses: ./.github/actions/docker-benchmark-run
@@ -539,6 +545,7 @@ jobs:
       with:
         machine-type: 'microvm'
         timestamp-msg: 'yes'
+        sccache-gha-enabled: 'true'
 
     - name: "Run Echo-Breakdown Benchmarks"
       uses: ./.github/actions/docker-benchmark-run

--- a/scripts/setup/Dockerfile.build
+++ b/scripts/setup/Dockerfile.build
@@ -31,11 +31,14 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}
 # GitHub Actions cache backend for sccache (optional).
 # When SCCACHE_GHA_ENABLED is set to "true", sccache uses the GitHub Actions
 # cache as a remote backend instead of the local disk cache.
-# SCCACHE_GHA_ENABLED and SCCACHE_GHA_CACHE_TO are passed as build args.
+# SCCACHE_GHA_CACHE_TO sets the key for writing compilation results.
+# SCCACHE_GHA_CACHE_FROM sets the key for reading cached results; without it
+# sccache writes to the cache but never reads, causing 0% hit rate.
 # ACTIONS_RESULTS_URL and ACTIONS_RUNTIME_TOKEN are injected as Docker secrets
 # so that their per-run values do not bust the BuildKit layer cache.
 ARG SCCACHE_GHA_ENABLED
 ARG SCCACHE_GHA_CACHE_TO
+ARG SCCACHE_GHA_CACHE_FROM
 
 RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/root/.cargo/git,sharing=locked \
@@ -59,6 +62,9 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     fi && \
     if [ -n "${SCCACHE_GHA_CACHE_TO}" ]; then \
         export SCCACHE_GHA_CACHE_TO="${SCCACHE_GHA_CACHE_TO}"; \
+    fi && \
+    if [ -n "${SCCACHE_GHA_CACHE_FROM}" ]; then \
+        export SCCACHE_GHA_CACHE_FROM="${SCCACHE_GHA_CACHE_FROM}"; \
     fi && \
     SCCACHE_DIR=/root/.cache/sccache CONTRIB_SRC_DIR=/opt/contrib-src \
     make TOOLCHAIN_DIR=/opt/nanvix ${SCCACHE_ARG} ${BUILD_PARAMS} && \

--- a/z
+++ b/z
@@ -229,7 +229,8 @@ run_docker_build() {
 
     # Run the build with BuildKit using the external Dockerfile.
     # Forward GitHub Actions sccache cache backend variables when available.
-    # SCCACHE_GHA_ENABLED and SCCACHE_GHA_CACHE_TO are passed as build args.
+    # SCCACHE_GHA_ENABLED, SCCACHE_GHA_CACHE_TO, and SCCACHE_GHA_CACHE_FROM
+    # are passed as build args.
     # ACTIONS_RESULTS_URL and ACTIONS_RUNTIME_TOKEN are injected as Docker secrets
     # so that their per-run values do not bust the BuildKit layer cache.
     local gha_sccache_args=()
@@ -238,6 +239,9 @@ run_docker_build() {
     fi
     if [[ -n "${SCCACHE_GHA_CACHE_TO:-}" ]]; then
         gha_sccache_args+=(--build-arg "SCCACHE_GHA_CACHE_TO=${SCCACHE_GHA_CACHE_TO}")
+    fi
+    if [[ -n "${SCCACHE_GHA_CACHE_FROM:-}" ]]; then
+        gha_sccache_args+=(--build-arg "SCCACHE_GHA_CACHE_FROM=${SCCACHE_GHA_CACHE_FROM}")
     fi
     if [[ -n "${ACTIONS_RESULTS_URL:-}" ]]; then
         gha_sccache_args+=(--secret "id=actions_results_url,env=ACTIONS_RESULTS_URL")


### PR DESCRIPTION
sccache's GHA cache backend requires both SCCACHE_GHA_CACHE_TO (write key) and SCCACHE_GHA_CACHE_FROM (read key). Only CACHE_TO was configured, so every compilation wrote to the cache but never read back, yielding ~0% hit rate on subsequent runs.

 - Add SCCACHE_GHA_CACHE_FROM alongside CACHE_TO in docker-build action, Dockerfile.build, and the z script.
 - Add sccache GHA support to docker-benchmark-build action and enable it in the benchmark-ci job so benchmark builds on GitHub-hosted runners also benefit from caching.