### PR TITLE
[ci] dispatch releases to all nanvix-python submodules

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -97,7 +97,7 @@ runs:
         exit 0
       fi
 
-      repos=("cpython" "openblas" "openssl" "quickjs" "rusty_v8" "sqlite" "zlib")
+      repos=("bzip2" "cpython" "cymem" "kiwi" "libexpat" "libffi" "murmurhash" "numpy" "openblas" "openssl" "preshed" "quickjs" "rusty_v8" "sqlite" "srsly" "zlib")
       failed=0
 
       for repo in "${repos[@]}"; do

--- a/.github/workflows/major-release-dispatch.yml
+++ b/.github/workflows/major-release-dispatch.yml
@@ -13,12 +13,21 @@ permissions:
 
 env:
   TARGET_REPOSITORIES: |
+    bzip2
     cpython
+    cymem
+    kiwi
+    libexpat
+    libffi
+    murmurhash
+    numpy
     openblas
     openssl
+    preshed
     quickjs
     rusty_v8
     sqlite
+    srsly
     zlib
 
 jobs:


### PR DESCRIPTION
## Summary

Add all nanvix-python submodules to the release dispatch lists so they automatically rebuild when a new Nanvix version is released.

## Changes

- `.github/actions/publish-release/action.yml`: Add 9 repos to minor release dispatch (bzip2, cymem, kiwi, libexpat, libffi, murmurhash, numpy, preshed, srsly)
- `.github/workflows/major-release-dispatch.yml`: Add same 9 repos to major release dispatch

## New repos dispatched to

| Repo | Nanvix CI | Accepts trigger |
|---|---|---|
| bzip2 | nanvix-ci.yml | nanvix-minor-release, nanvix-major-release |
| cymem | nanvix-ci.yml | nanvix-minor-release, nanvix-major-release, cpython-release |
| kiwi | nanvix-ci.yml | nanvix-minor-release, nanvix-major-release, cpython-release |
| libexpat | nanvix-ci.yml | nanvix-minor-release, nanvix-major-release |
| libffi | nanvix-ci.yml | nanvix-minor-release, nanvix-major-release |
| murmurhash | nanvix-ci.yml | nanvix-minor-release, nanvix-major-release, cpython-release |
| numpy | nanvix-ci.yml | nanvix-minor-release, nanvix-major-release, cpython-release |
| preshed | nanvix-ci.yml | nanvix-minor-release, nanvix-major-release, cpython-release |
| srsly | nanvix-ci.yml | nanvix-minor-release, nanvix-major-release, cpython-release |