### PR TITLE
[ci] B: Preserve `hostedtoolcache` for Copilot agent

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -4,6 +4,12 @@
 name: "Free Disk Space"
 description: "Remove pre-installed software from GitHub-hosted runners to reclaim disk space"
 
+inputs:
+  remove-hostedtoolcache:
+    description: "Remove /opt/hostedtoolcache (pre-installed runner tools such as Node.js and Python). Set to 'false' when the runner still needs these tools (e.g., Copilot agent)."
+    required: false
+    default: 'true'
+
 runs:
   using: "composite"
   steps:
@@ -26,7 +32,9 @@ runs:
       sudo rm -rf /opt/microsoft /opt/google &          # Microsoft Edge / Google Chrome
       sudo rm -rf /opt/az &                             # Azure CLI
       sudo rm -rf /usr/local/share/powershell &         # PowerShell
-      sudo rm -rf /opt/hostedtoolcache &                # GitHub hosted tool cache
+      if [[ "${{ inputs.remove-hostedtoolcache }}" == "true" ]]; then
+        sudo rm -rf /opt/hostedtoolcache &              # GitHub hosted tool cache
+      fi
       sudo apt-get clean &
       wait
       docker system prune -af || true

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: "Free Disk Space"
         uses: ./.github/actions/free-disk-space
+        with:
+          remove-hostedtoolcache: 'false'
 
       - name: Install Rust
         run: |


### PR DESCRIPTION
The free-disk-space composite action unconditionally removed /opt/hostedtoolcache, which contains pre-installed runner tools (Node.js, Python, etc.) that the Copilot coding agent depends on.

Add an optional `remove-hostedtoolcache` input (default: true) to the free-disk-space action so callers can opt out. Set it to false in copilot-setup-steps.yml to keep the tools the agent needs.