### PR TITLE
[kernel] Refactor Kernel Call Handler

### DIFF
--- a/src/kernel/src/debug.rs
+++ b/src/kernel/src/debug.rs
@@ -7,15 +7,15 @@
 
 use crate::{
     hal::mem::VirtualAddress,
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::ProcessManager,
 };
-use ::sys::error::{
-    Error,
-    ErrorCode,
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    pm::ProcessIdentifier,
 };
 
 //==================================================================================================
@@ -36,12 +36,30 @@ fn do_debug(buf: &[u8]) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn debug(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
+///
+/// # Description
+///
+/// Kernel call handler for writing a debug message from user space.
+///
+/// # Parameters
+///
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: User-space pointer to the message buffer.
+/// - `arg1`: Size of the message in bytes.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn debug(pid: ProcessIdentifier, arg0: u32, arg1: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
     // Buffer size in bytes.
     // NOTE: This value was chosen to be smaller than a page, but big enough for along messages.
     const BUFFER_SIZE: usize = 256;
-    let user_buffer: usize = args.arg0 as usize;
-    let size: usize = args.arg1 as usize;
+    let user_buffer: usize = arg0 as usize;
+    let size: usize = arg1 as usize;
 
     // skip zero-length messages
     if size == 0 {
@@ -60,7 +78,7 @@ pub fn debug(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
     let src: VirtualAddress = VirtualAddress::new(user_buffer);
     let dst: VirtualAddress = VirtualAddress::new(kernel_buffer.as_mut_ptr() as usize);
 
-    if let Err(e) = pm.vmcopy_from_user(args.pid, dst, src, size) {
+    if let Err(e) = pm.vmcopy_from_user(pid, dst, src, size) {
         return KcallResult::Error(e.code.into());
     }
 

--- a/src/kernel/src/event/kcall/evctrl.rs
+++ b/src/kernel/src/event/kcall/evctrl.rs
@@ -10,10 +10,7 @@ use crate::{
         EventManager,
         EventOwnership,
     },
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::ProcessManager,
 };
 use ::sys::{
@@ -38,20 +35,38 @@ fn do_evctrl(
     EventManager::evctrl(pm, pid, ev, req)
 }
 
-pub fn evctrl(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
-    trace!("ev={:?}, req={:?}", args.arg0, args.arg1);
+///
+/// # Description
+///
+/// Kernel call handler for controlling event ownership.
+///
+/// # Parameters
+///
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: Encoded event identifier.
+/// - `arg1`: Encoded event control request.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn evctrl(pid: ProcessIdentifier, arg0: u32, arg1: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
 
-    let ev: Event = match Event::try_from(args.arg0) {
+    trace!("ev={:?}, req={:?}", arg0, arg1);
+
+    let ev: Event = match Event::try_from(arg0) {
         Ok(ev) => ev,
         Err(e) => return KcallResult::Error(e.code.into()),
     };
 
-    let req: EventCtrlRequest = match EventCtrlRequest::try_from(args.arg1) {
+    let req: EventCtrlRequest = match EventCtrlRequest::try_from(arg1) {
         Ok(req) => req,
         Err(e) => return KcallResult::Error(e.code.into()),
     };
 
-    match do_evctrl(pm, args.pid, ev, req) {
+    match do_evctrl(pm, pid, ev, req) {
         Ok(Some(ownership)) => match pm.add_event(ownership) {
             Ok(_) => KcallResult::ok(),
             Err(e) => KcallResult::Error(e.code.into()),

--- a/src/kernel/src/io/kcall/mmio_free.rs
+++ b/src/kernel/src/io/kcall/mmio_free.rs
@@ -7,10 +7,7 @@
 
 use crate::{
     hal::io::MmioTag,
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::ProcessManager,
 };
 use ::sys::{
@@ -70,19 +67,23 @@ fn do_mmio_free(
 ///
 /// # Parameters
 ///
-/// - `pm`: Reference to the process manager.
-/// - `args`: Kernel call arguments containing the encoded tag.
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: Low 32 bits of the encoded MMIO tag.
+/// - `arg1`: High 32 bits of the encoded MMIO tag.
 ///
 /// # Returns
 ///
 /// A [`KcallResult`] indicating success or the error code.
 ///
-pub fn mmio_free(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
+pub fn mmio_free(pid: ProcessIdentifier, arg0: u32, arg1: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
     // Parse arguments.
-    let tag_value: u64 = ((args.arg1 as u64) << 32) | args.arg0 as u64;
+    let tag_value: u64 = ((arg1 as u64) << 32) | arg0 as u64;
     let tag: MmioTag = MmioTag::from_u64(tag_value);
 
-    match do_mmio_free(pm, args.pid, tag) {
+    match do_mmio_free(pm, pid, tag) {
         Ok(_) => KcallResult::ok(),
         Err(e) => KcallResult::Error(e.code.into()),
     }

--- a/src/kernel/src/io/kcall/mmio_info.rs
+++ b/src/kernel/src/io/kcall/mmio_info.rs
@@ -7,10 +7,7 @@
 
 use crate::{
     hal::io::MmioTag,
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::{
         self,
         ProcessManager,
@@ -76,24 +73,29 @@ fn do_mmio_info(
 ///
 /// # Parameters
 ///
-/// - `pm`: Reference to the process manager.
-/// - `args`: Kernel call arguments containing the encoded tag and a pointer to the output buffer.
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: Low 32 bits of the encoded MMIO tag.
+/// - `arg1`: High 32 bits of the encoded MMIO tag.
+/// - `arg2`: Pointer to the output buffer for [`MmioRegionInfo`].
 ///
 /// # Returns
 ///
 /// A [`KcallResult`] indicating success or the error code.
 ///
-pub fn mmio_info(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
-    let tag_value: u64 = ((args.arg1 as u64) << 32) | args.arg0 as u64;
+pub fn mmio_info(pid: ProcessIdentifier, arg0: u32, arg1: u32, arg2: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
+    let tag_value: u64 = ((arg1 as u64) << 32) | arg0 as u64;
     let tag: MmioTag = MmioTag::from_u64(tag_value);
-    let buffer_ptr: *mut MmioRegionInfo = args.arg2 as usize as *mut MmioRegionInfo;
+    let buffer_ptr: *mut MmioRegionInfo = arg2 as usize as *mut MmioRegionInfo;
 
     if buffer_ptr.is_null() {
         return KcallResult::Error(ErrorCode::BadAddress.into());
     }
 
-    match do_mmio_info(pm, args.pid, tag) {
-        Ok(info) => match pm::copy_to_user(pm, args.pid, buffer_ptr, &info) {
+    match do_mmio_info(pm, pid, tag) {
+        Ok(info) => match pm::copy_to_user(pm, pid, buffer_ptr, &info) {
             Ok(_) => KcallResult::ok(),
             Err(e) => KcallResult::Error(e.code.into()),
         },

--- a/src/kernel/src/io/kcall/pmio_free.rs
+++ b/src/kernel/src/io/kcall/pmio_free.rs
@@ -7,10 +7,7 @@
 
 use crate::{
     hal::io::AnyIoPort,
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::ProcessManager,
 };
 use ::sys::{
@@ -47,10 +44,26 @@ fn do_pmio_free(
     Ok(())
 }
 
-pub fn pmio_free(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
+///
+/// # Description
+///
+/// Kernel call handler for releasing a port-mapped I/O port.
+///
+/// # Parameters
+///
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: Port number to release (lower 16 bits used).
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn pmio_free(pid: ProcessIdentifier, arg0: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
     // Unpack arguments.
-    let pid: ProcessIdentifier = args.pid;
-    let port_number: u16 = args.arg0 as u16;
+    let port_number: u16 = arg0 as u16;
 
     // Execute kernel call.
     match do_pmio_free(pm, pid, port_number) {

--- a/src/kernel/src/io/kcall/pmio_read.rs
+++ b/src/kernel/src/io/kcall/pmio_read.rs
@@ -7,10 +7,7 @@
 
 use crate::{
     hal::io::IoPortWidth,
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::ProcessManager,
 };
 use ::sys::{
@@ -46,11 +43,28 @@ fn do_pmio_read(
     pm.read_pmio(pid, port_number, port_width)
 }
 
-pub fn pmio_read(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
+///
+/// # Description
+///
+/// Kernel call handler for reading from a port-mapped I/O port.
+///
+/// # Parameters
+///
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: Port number to read from (lower 16 bits used).
+/// - `arg1`: Encoded port width.
+///
+/// # Returns
+///
+/// A [`KcallResult`] containing the read value on success or the error code.
+///
+pub fn pmio_read(pid: ProcessIdentifier, arg0: u32, arg1: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
     // Unpack arguments.
-    let pid: ProcessIdentifier = args.pid;
-    let port_number: u16 = args.arg0 as u16;
-    let port_width: IoPortWidth = match IoPortWidth::try_from(args.arg1) {
+    let port_number: u16 = arg0 as u16;
+    let port_width: IoPortWidth = match IoPortWidth::try_from(arg1) {
         Ok(port_width) => port_width,
         Err(e) => return KcallResult::Error(e.code.into()),
     };

--- a/src/kernel/src/io/kcall/pmio_write.rs
+++ b/src/kernel/src/io/kcall/pmio_write.rs
@@ -7,10 +7,7 @@
 
 use crate::{
     hal::io::IoPortWidth,
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::ProcessManager,
 };
 use ::sys::{
@@ -47,15 +44,33 @@ fn do_pmio_write(
     pm.write_pmio(pid, port_number, port_width, value)
 }
 
-pub fn pmio_write(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
+///
+/// # Description
+///
+/// Kernel call handler for writing to a port-mapped I/O port.
+///
+/// # Parameters
+///
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: Port number to write to (lower 16 bits used).
+/// - `arg1`: Encoded port width.
+/// - `arg2`: Value to write.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn pmio_write(pid: ProcessIdentifier, arg0: u32, arg1: u32, arg2: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
     // Unpack arguments.
-    let pid: ProcessIdentifier = args.pid;
-    let port_number: u16 = args.arg0 as u16;
-    let port_width: IoPortWidth = match IoPortWidth::try_from(args.arg1) {
+    let port_number: u16 = arg0 as u16;
+    let port_width: IoPortWidth = match IoPortWidth::try_from(arg1) {
         Ok(port_width) => port_width,
         Err(_) => return KcallResult::Error(ErrorCode::InvalidArgument.into()),
     };
-    let value: u32 = args.arg2;
+    let value: u32 = arg2;
 
     // Execute kernel call.
     match do_pmio_write(pm, pid, port_number, port_width, value) {

--- a/src/kernel/src/ipc/kcall.rs
+++ b/src/kernel/src/ipc/kcall.rs
@@ -7,10 +7,7 @@
 
 use crate::{
     event::EventManager,
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::{
         self,
         ProcessManager,
@@ -43,13 +40,31 @@ fn do_send(pm: &mut ProcessManager, message: Message) -> Result<(), Error> {
     EventManager::post_message(pm, message.destination, message)
 }
 
-pub fn send(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
-    let src_pid: ProcessIdentifier = args.pid;
-    let src_tid: ThreadIdentifier = args.tid;
+///
+/// # Description
+///
+/// Kernel call handler for sending an inter-process message.
+///
+/// # Parameters
+///
+/// - `pid`: Identifier of the calling process.
+/// - `tid`: Identifier of the calling thread.
+/// - `arg0`: User-space pointer to the [`Message`] to send.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn send(pid: ProcessIdentifier, tid: ThreadIdentifier, arg0: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
+    let src_pid: ProcessIdentifier = pid;
+    let src_tid: ThreadIdentifier = tid;
 
     // Copy message to kernel space.
     let mut message: Message = Message::default();
-    if let Err(e) = pm::copy_from_user(pm, src_pid, &mut message, args.arg0 as *const Message) {
+    if let Err(e) = pm::copy_from_user(pm, src_pid, &mut message, arg0 as *const Message) {
         return KcallResult::Error(e.code.into());
     }
 

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -6,7 +6,9 @@
 //==================================================================================================
 
 use crate::{
+    debug,
     event,
+    io,
     ipc,
     kcall::{
         KcallResult,
@@ -78,6 +80,28 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
             let e: Error = unsafe { ProcessManager::exit_thread(arg0.into()).unwrap_err() };
             KcallResult::Error(e.code.into())
         },
+        // Handle `capctl()` locally.
+        KcallNumber::CapCtl => pm::capctl(pid, arg0, arg1),
+        // Handle `terminate()` locally.
+        KcallNumber::Terminate => pm::terminate(pid, arg0),
+        // Handle `evctrl()` locally.
+        KcallNumber::EventCtrl => event::evctrl(pid, arg0, arg1),
+        // Handle `mmio_free()` locally.
+        KcallNumber::FreeMmio => io::mmio_free(pid, arg0, arg1),
+        // Handle `mmio_info()` locally.
+        KcallNumber::MmioInfo => io::mmio_info(pid, arg0, arg1, arg2),
+        // Handle `pmio_free()` locally.
+        KcallNumber::FreePmio => io::pmio_free(pid, arg0),
+        // Handle `pmio_read()` locally.
+        KcallNumber::ReadPmio => io::pmio_read(pid, arg0, arg1),
+        // Handle `pmio_write()` locally.
+        KcallNumber::WritePmio => io::pmio_write(pid, arg0, arg1, arg2),
+        // Handle `gettime()` locally.
+        KcallNumber::GetTime => pm::gettime(pid, arg0),
+        // Handle `debug()` locally.
+        KcallNumber::Debug => debug::debug(pid, arg0, arg1),
+        // Handle `send()` locally.
+        KcallNumber::Send => ipc::send(pid, tid, arg0),
         // SAFETY: The calling thread is not the kernel and no resources are held.
         KcallNumber::Recv => match unsafe { ipc::recv(tid, pid, arg0 as usize) } {
             Ok(()) => KcallResult::ok(),

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -86,6 +86,10 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         KcallNumber::Terminate => pm::terminate(pid, arg0),
         // Handle `evctrl()` locally.
         KcallNumber::EventCtrl => event::evctrl(pid, arg0, arg1),
+        // Handle `set_thread_data_area()` locally.
+        KcallNumber::SetThreadDataArea => pm::set_thread_data_area(pid, tid, arg0),
+        // Handle `get_thread_data_area()` locally.
+        KcallNumber::GetThreadDataArea => pm::get_thread_data_area(pid, tid),
         // Handle `mmio_free()` locally.
         KcallNumber::FreeMmio => io::mmio_free(pid, arg0, arg1),
         // Handle `mmio_info()` locally.

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -76,8 +76,6 @@ pub fn kcall_handler(hal: &mut Hal, mm: &mut VirtMemoryManager) -> ExitStatus {
                         KcallNumber::AllocMmio => io::mmio_alloc(hal, pm!(), args),
                         KcallNumber::AllocPmio => io::pmio_alloc(hal, pm!(), args),
                         KcallNumber::CreateThread => pm::create_thread(pm!(), mm, args),
-                        KcallNumber::SetThreadDataArea => pm::set_thread_data_area(pm!(), args),
-                        KcallNumber::GetThreadDataArea => pm::get_thread_data_area(pm!(), args),
                         _ => {
                             error!("invalid kernel call");
                             KcallResult::Error(ErrorCode::InvalidSysCall.into())

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -2,18 +2,16 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
-// Modules
+// Imports
 //==================================================================================================
 
 use crate::{
-    debug,
     event::{
         self,
         EventManager,
     },
     hal::Hal,
     io,
-    ipc,
     kcall::{
         KcallResult,
         ScoreBoard,
@@ -71,35 +69,12 @@ pub fn kcall_handler(hal: &mut Hal, mm: &mut VirtMemoryManager) -> ExitStatus {
             Ok(scoreboard) => match scoreboard.handle() {
                 Ok(args) => {
                     let ret: KcallResult = match KcallNumber::from(args.number) {
-                        KcallNumber::Debug => debug::debug(pm!(), args),
-                        KcallNumber::GetPid => {
-                            // NOTE: this should be handled by the dispatcher.
-                            // However we emit an invalid system call, just in case.
-                            error!("cannot handle getpid()");
-                            KcallResult::Error(ErrorCode::InvalidSysCall.into())
-                        },
-                        KcallNumber::GetTid => {
-                            // NOTE: this should be handled by the dispatcher.
-                            // However we emit an invalid system call, just in case.
-                            error!("cannot handle gettid()");
-                            KcallResult::Error(ErrorCode::InvalidSysCall.into())
-                        },
-                        KcallNumber::CapCtl => pm::capctl(pm!(), args),
-                        KcallNumber::Terminate => pm::terminate(pm!(), args),
-                        KcallNumber::EventCtrl => event::evctrl(pm!(), args),
                         KcallNumber::MemoryMap => pm::mmap(pm!(), mm, args),
                         KcallNumber::MemoryUnmap => pm::munmap(pm!(), mm, args),
                         KcallNumber::MemoryCtrl => pm::mctrl(pm!(), mm, args),
                         KcallNumber::MemoryCopy => pm::mcopy(pm!(), mm, args),
-                        KcallNumber::Send => ipc::send(pm!(), args),
                         KcallNumber::AllocMmio => io::mmio_alloc(hal, pm!(), args),
-                        KcallNumber::FreeMmio => io::mmio_free(pm!(), args),
-                        KcallNumber::MmioInfo => io::mmio_info(pm!(), args),
                         KcallNumber::AllocPmio => io::pmio_alloc(hal, pm!(), args),
-                        KcallNumber::FreePmio => io::pmio_free(pm!(), args),
-                        KcallNumber::ReadPmio => io::pmio_read(pm!(), args),
-                        KcallNumber::WritePmio => io::pmio_write(pm!(), args),
-                        KcallNumber::GetTime => pm::gettime(pm!(), args),
                         KcallNumber::CreateThread => pm::create_thread(pm!(), mm, args),
                         KcallNumber::SetThreadDataArea => pm::set_thread_data_area(pm!(), args),
                         KcallNumber::GetThreadDataArea => pm::get_thread_data_area(pm!(), args),

--- a/src/kernel/src/pm/kcall/capctl.rs
+++ b/src/kernel/src/pm/kcall/capctl.rs
@@ -6,10 +6,7 @@
 //==================================================================================================
 
 use crate::{
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::ProcessManager,
 };
 use ::sys::{
@@ -37,15 +34,33 @@ fn do_capctl(
     pm.capctl(pid, capability, value)
 }
 
-pub fn capctl(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
+///
+/// # Description
+///
+/// Kernel call handler for controlling process capabilities.
+///
+/// # Parameters
+///
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: Encoded capability identifier.
+/// - `arg1`: Capability value (nonzero means enabled).
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn capctl(pid: ProcessIdentifier, arg0: u32, arg1: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
     // Unpack arguments.
-    let capability: Capability = match Capability::try_from(args.arg0) {
+    let capability: Capability = match Capability::try_from(arg0) {
         Ok(capability) => capability,
         Err(e) => return KcallResult::Error(e.code.into()),
     };
-    let value: bool = args.arg1 != 0;
+    let value: bool = arg1 != 0;
 
-    match do_capctl(pm, args.pid, capability, value) {
+    match do_capctl(pm, pid, capability, value) {
         Ok(()) => KcallResult::ok(),
         Err(e) => KcallResult::Error(e.code.into()),
     }

--- a/src/kernel/src/pm/kcall/get_thread_data_area.rs
+++ b/src/kernel/src/pm/kcall/get_thread_data_area.rs
@@ -6,10 +6,7 @@
 //==================================================================================================
 
 use crate::{
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::ProcessManager,
 };
 use ::sys::pm::{
@@ -28,8 +25,8 @@ use ::sys::pm::{
 ///
 /// # Parameters
 ///
-/// - `pm`: A reference to the process manager.
-/// - `args`: The kernel call arguments.
+/// - `pid`: The process identifier of the calling process.
+/// - `tid`: The thread identifier of the calling thread.
 ///
 /// # Return Value
 ///
@@ -43,10 +40,9 @@ use ::sys::pm::{
 /// - [`ErrorCode::NoSuchEntry`]: The specified process or thread does not exist.
 /// - [`ErrorCode::ResourceBusy`]: The process manager is busy and cannot handle the request.
 ///
-pub fn get_thread_data_area(pm: &ProcessManager, args: &KcallArgs) -> KcallResult {
-    // Unpack arguments.
-    let pid: ProcessIdentifier = args.pid;
-    let tid: ThreadIdentifier = args.tid;
+pub fn get_thread_data_area(pid: ProcessIdentifier, tid: ThreadIdentifier) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &ProcessManager = unsafe { ProcessManager::get() };
 
     trace!("pid={pid:?}, tid={tid:?}");
 

--- a/src/kernel/src/pm/kcall/gettime.rs
+++ b/src/kernel/src/pm/kcall/gettime.rs
@@ -6,10 +6,7 @@
 //==================================================================================================
 
 use crate::{
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::{
         clock,
         ProcessManager,
@@ -53,20 +50,23 @@ fn do_gettime(
 ///
 /// # Parameters
 ///
-/// - `pm`: A mutable reference to the process manager.
-/// - `args.argo0`: The address of the buffer where the system time should be stored.
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: The address of the buffer where the system time should be stored.
 ///
 /// # Returns
 ///
-/// If susccessful, `gettime` returns `KcallResult:Success`. Otherwise it returns a
+/// If successful, `gettime` returns `KcallResult::Success`. Otherwise it returns a
 /// `KcallResult::Error` to indicate the error.
 ///
-pub fn gettime(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
+pub fn gettime(pid: ProcessIdentifier, arg0: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
     // Unpack kernel call arguments.
-    let buffer_addr: VirtualAddress = VirtualAddress::new(args.arg0 as usize);
+    let buffer_addr: VirtualAddress = VirtualAddress::new(arg0 as usize);
 
     // Get system time and parse result.
-    match do_gettime(pm, args.pid, buffer_addr) {
+    match do_gettime(pm, pid, buffer_addr) {
         Ok(()) => KcallResult::ok(),
         Err(error) => KcallResult::Error(error.code.into()),
     }

--- a/src/kernel/src/pm/kcall/set_thread_data_area.rs
+++ b/src/kernel/src/pm/kcall/set_thread_data_area.rs
@@ -6,18 +6,17 @@
 //==================================================================================================
 
 use crate::{
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     mm::Vmem,
     pm::ProcessManager,
 };
-use ::sys::pm::ProcessIdentifier;
+use ::sys::pm::{
+    ProcessIdentifier,
+    ThreadIdentifier,
+};
 use sys::{
     error::ErrorCode,
     mm::VirtualAddress,
-    pm::ThreadIdentifier,
 };
 
 //==================================================================================================
@@ -31,8 +30,9 @@ use sys::{
 ///
 /// # Parameters
 ///
-/// - `pm`: A mutable reference to the process manager.
-/// - `args`: The kernel call arguments.
+/// - `pid`: The process identifier of the calling process.
+/// - `tid`: The thread identifier of the calling thread.
+/// - `arg0`: The user-space thread data area pointer.
 ///
 /// # Return Value
 ///
@@ -47,11 +47,16 @@ use sys::{
 /// - [`ErrorCode::NoSuchEntry`]: The specified process or thread does not exist.
 /// - [`ErrorCode::ResourceBusy`]: The process manager is busy and cannot handle the request.
 ///
-pub fn set_thread_data_area(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
+pub fn set_thread_data_area(
+    pid: ProcessIdentifier,
+    tid: ThreadIdentifier,
+    arg0: u32,
+) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
     // Unpack arguments.
-    let pid: ProcessIdentifier = args.pid;
-    let tid: ThreadIdentifier = args.tid;
-    let user_tda: VirtualAddress = VirtualAddress::from_raw_value(args.arg0 as usize);
+    let user_tda: VirtualAddress = VirtualAddress::from_raw_value(arg0 as usize);
 
     trace!("pid={pid:?}, tid={tid:?}, user_tda={user_tda:?}");
 

--- a/src/kernel/src/pm/kcall/terminate.rs
+++ b/src/kernel/src/pm/kcall/terminate.rs
@@ -6,10 +6,7 @@
 //==================================================================================================
 
 use crate::{
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     pm::ProcessManager,
 };
 use ::sys::pm::ProcessIdentifier;
@@ -18,9 +15,29 @@ use ::sys::pm::ProcessIdentifier;
 // Standalone Functions
 //==================================================================================================
 
-pub fn terminate(pm: &mut ProcessManager, args: &KcallArgs) -> KcallResult {
+///
+/// # Description
+///
+/// Kernel call handler for terminating a process.
+///
+/// # Parameters
+///
+/// - `caller_pid`: Identifier of the calling process.
+/// - `arg0`: Encoded process identifier of the process to terminate.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn terminate(caller_pid: ProcessIdentifier, arg0: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+
+    // TODO (#1434): check if calling process has enough privileges to terminate the target process.
+    let _: ProcessIdentifier = caller_pid;
+
     // Unpack kernel call arguments.
-    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
+    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(arg0) {
         Ok(pid) => pid,
         Err(error) => {
             error!("{error:?}");

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -395,20 +395,16 @@ impl ProcessManager {
         tid: ThreadIdentifier,
         user_tda: Option<VirtualAddress>,
     ) -> Result<(), Error> {
-        // Search for the process in the list of sleeping processes.
-        let sleeping_process: &mut SleepingProcess = self
-            .suspended
-            .iter_mut()
-            .find(|p| p.state().pid() == pid)
-            .ok_or_else(|| {
-                let reason: &str = "process not found";
-                error!("{reason} (pid={pid:?}, tid={tid:?}, user_tda={user_tda:?})");
-                Error::new(ErrorCode::NoSuchEntry, reason)
-            })?;
+        // Search for the process across all states.
+        let mut process: ProcessRefMut = self.find_process_mut(pid)?;
 
-        // Search for the thread.
-        match sleeping_process.find_thread_mut(tid) {
+        // Search for the thread and set its data area.
+        match process.find_thread_mut(tid) {
             Some(ThreadRefMut::Sleeping(thread)) => {
+                thread.set_thread_data_area(user_tda);
+                Ok(())
+            },
+            Some(ThreadRefMut::Running(thread)) => {
                 thread.set_thread_data_area(user_tda);
                 Ok(())
             },
@@ -446,20 +442,13 @@ impl ProcessManager {
         pid: ProcessIdentifier,
         tid: ThreadIdentifier,
     ) -> Result<Option<VirtualAddress>, Error> {
-        // Search for the process in the list of sleeping processes.
-        let sleeping_process: &SleepingProcess = self
-            .suspended
-            .iter()
-            .find(|p| p.state().pid() == pid)
-            .ok_or_else(|| {
-                let reason: &str = "process not found";
-                error!("{reason} (pid={pid:?}, tid={tid:?})");
-                Error::new(ErrorCode::NoSuchEntry, reason)
-            })?;
+        // Search for the process across all states.
+        let process: ProcessRef = self.find_process(pid)?;
 
-        // Attempt to get thread data area and check for errors.
-        match sleeping_process.find_thread(tid) {
+        // Search for the thread and get its data area.
+        match process.find_thread(tid) {
             Some(ThreadRef::Sleeping(thread)) => Ok(thread.get_thread_data_area()),
+            Some(ThreadRef::Running(thread)) => Ok(thread.get_thread_data_area()),
             _ => {
                 let reason: &str = "thread not found";
                 error!("{reason} (tid={tid:?}, pid={pid:?})");

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -41,6 +41,10 @@ use crate::{
             condvar::Condvar,
             mutex::Mutex,
         },
+        thread::{
+            ThreadRef,
+            ThreadRefMut,
+        },
     },
 };
 use ::alloc::collections::{
@@ -100,6 +104,29 @@ impl ProcessRefMut<'_> {
             ProcessRefMut::Zombie(process) => process.state_mut(),
         }
     }
+
+    ///
+    /// # Description
+    ///
+    /// Finds a mutable reference to a thread by identifier, searching across all process states.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Identifier of the thread to find.
+    ///
+    /// # Returns
+    ///
+    /// If found, returns `Some` with a mutable thread reference. Otherwise, returns `None`.
+    ///
+    pub fn find_thread_mut(&mut self, tid: ThreadIdentifier) -> Option<ThreadRefMut<'_>> {
+        match self {
+            ProcessRefMut::Runnable(process) => process.find_thread_mut(tid),
+            ProcessRefMut::Running(process) => process.find_thread_mut(tid),
+            ProcessRefMut::Sleeping(process) => process.find_thread_mut(tid),
+            ProcessRefMut::Interrupted(process) => process.find_thread_mut(tid),
+            ProcessRefMut::Zombie(process) => process.find_thread_mut(tid),
+        }
+    }
 }
 
 pub enum ProcessRef<'a> {
@@ -118,6 +145,29 @@ impl ProcessRef<'_> {
             ProcessRef::Sleeping(process) => process.state(),
             ProcessRef::Interrupted(process) => process.state(),
             ProcessRef::Zombie(process) => process.state(),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Finds an immutable reference to a thread by identifier, searching across all process states.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Identifier of the thread to find.
+    ///
+    /// # Returns
+    ///
+    /// If found, returns `Some` with a thread reference. Otherwise, returns `None`.
+    ///
+    pub fn find_thread(&self, tid: ThreadIdentifier) -> Option<ThreadRef<'_>> {
+        match self {
+            ProcessRef::Runnable(process) => process.find_thread(tid),
+            ProcessRef::Running(process) => process.find_thread(tid),
+            ProcessRef::Sleeping(process) => process.find_thread(tid),
+            ProcessRef::Interrupted(process) => process.find_thread(tid),
+            ProcessRef::Zombie(process) => process.find_thread(tid),
         }
     }
 }

--- a/src/kernel/src/pm/thread/running.rs
+++ b/src/kernel/src/pm/thread/running.rs
@@ -24,6 +24,7 @@ use ::alloc::boxed::Box;
 use ::core::fmt::Debug;
 use ::sys::{
     error::Error,
+    mm::VirtualAddress,
     pm::{
         MutexAddress,
         ThreadIdentifier,
@@ -218,5 +219,32 @@ impl RunningThread {
     #[inline]
     pub fn check_guard_watermark(&self) -> Result<(), Error> {
         self.state.check_guard_watermark()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sets the base address for the user-space thread data area for the target thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `user_tda`: Optional thread data area pointer to set.
+    ///
+    pub fn set_thread_data_area(&mut self, user_tda: Option<VirtualAddress>) {
+        self.state.store_thread_data_area(user_tda);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Gets the base address for user-space thread data area for the target thread.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the optional base address for user-space thread data area for the
+    /// target thread.
+    ///
+    pub fn get_thread_data_area(&self) -> Option<VirtualAddress> {
+        self.state.get_thread_data_area()
     }
 }


### PR DESCRIPTION
Refactoring kernel call handlers:

* Changed kernel call handler signatures (such as `debug`, `evctrl`, `mmio_free`, `mmio_info`, `pmio_free`, `pmio_read`, `pmio_write`, and `send`) to accept explicit parameters (`pid`, `tid`, `arg0`, `arg1`, `arg2`) instead of a `ProcessManager` reference and `KcallArgs` struct. This includes updating argument parsing and documentation for each handler. [[1]](diffhunk://#diff-dfb3b5dc2c266809913180efb36e262b97db4a84348d9c2462c714d1620bfde5L39-R62) [[2]](diffhunk://#diff-c8e3217019b288c3e195403ce16656d145b3bd37b37c23e1ce14d1bb0721f66dL41-R69) [[3]](diffhunk://#diff-28a61517865496edb684fd5d0964ae61b24cc373eb2b92f6f2591bfc5fb04aafL73-R86) [[4]](diffhunk://#diff-1a12b1c62a8fc0f7116675837dac69dacd44acd24c37947a473b463120b69360L79-R98) [[5]](diffhunk://#diff-dc0169538d4b791708587e5dacbd6df4393c47d323b494ff90aabe26d1928d52L50-R66) [[6]](diffhunk://#diff-ccf192f97b9a8dfbb0279a68ec20c1455cfa3ee3b040469d0936c7d393c6ce61L49-R67) [[7]](diffhunk://#diff-edd07bcf19b90e83a344133866d179d02759c8f4aa5d1ad49da6489d3f8d8ce2L50-R73) [[8]](diffhunk://#diff-415181028ae443ce8a209fcbdf223d4dd7dafa7658833c76a46fb402cf959b4eL46-R67)

Dispatcher improvements:

* Updated `do_kcall` in `dispatcher.rs` to call the newly refactored kernel call handlers directly with explicit parameters, improving readability and maintainability.

Code cleanup:

* Removed now-unnecessary imports and handler code from `handler.rs`, leaving only handlers that still require special handling. [[1]](diffhunk://#diff-cab264a0b755a96c8487aca060ca8b7edf7f70a1caf09a1007926297b9a4ae85L5-L16) [[2]](diffhunk://#diff-cab264a0b755a96c8487aca060ca8b7edf7f70a1caf09a1007926297b9a4ae85L74-L105)
* Simplified imports in affected files to reflect the removal of `KcallArgs` usage. [[1]](diffhunk://#diff-dfb3b5dc2c266809913180efb36e262b97db4a84348d9c2462c714d1620bfde5L10-R18) [[2]](diffhunk://#diff-c8e3217019b288c3e195403ce16656d145b3bd37b37c23e1ce14d1bb0721f66dL13-R13) [[3]](diffhunk://#diff-28a61517865496edb684fd5d0964ae61b24cc373eb2b92f6f2591bfc5fb04aafL10-R10) [[4]](diffhunk://#diff-1a12b1c62a8fc0f7116675837dac69dacd44acd24c37947a473b463120b69360L10-R10) [[5]](diffhunk://#diff-dc0169538d4b791708587e5dacbd6df4393c47d323b494ff90aabe26d1928d52L10-R10) [[6]](diffhunk://#diff-ccf192f97b9a8dfbb0279a68ec20c1455cfa3ee3b040469d0936c7d393c6ce61L10-R10) [[7]](diffhunk://#diff-edd07bcf19b90e83a344133866d179d02759c8f4aa5d1ad49da6489d3f8d8ce2L10-R10) [[8]](diffhunk://#diff-415181028ae443ce8a209fcbdf223d4dd7dafa7658833c76a46fb402cf959b4eL10-R10) [[9]](diffhunk://#diff-4517b9d6f8815f7ac279d15cfcfdee841dae3543122e933d606868481d22cb3eL9-R9)

These changes streamline kernel call handling, reduce boilerplate, and make future maintenance easier.