### PR TITLE
[kernel] Singleton VirtMemoryManager

### DIFF
--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -52,12 +52,27 @@ macro_rules! pm {
     };
 }
 
+// Convenience macro to obtain a mutable reference to the virtual memory manager.
+//
+// # Safety
+//
+// Each expansion produces a fresh `&mut VirtMemoryManager` via `get_mut()`. Callers must ensure
+// that borrows from separate expansions do not overlap (i.e., drop the reference before the
+// next `mm!()` invocation).
+macro_rules! mm {
+    () => {
+        // SAFETY: the memory manager is initialized, this is a single-core system,
+        // and the kernel runs with interrupts disabled.
+        unsafe { VirtMemoryManager::get_mut() }
+    };
+}
+
 ///
 /// # Description
 ///
 /// Kernel call handler.
 ///
-pub fn kcall_handler(hal: &mut Hal, mm: &mut VirtMemoryManager) -> ExitStatus {
+pub fn kcall_handler(hal: &mut Hal) -> ExitStatus {
     if let Err(e) = event::init(hal) {
         panic!("failed to initialize event manager: {:?}", e);
     }
@@ -69,13 +84,13 @@ pub fn kcall_handler(hal: &mut Hal, mm: &mut VirtMemoryManager) -> ExitStatus {
             Ok(scoreboard) => match scoreboard.handle() {
                 Ok(args) => {
                     let ret: KcallResult = match KcallNumber::from(args.number) {
-                        KcallNumber::MemoryMap => pm::mmap(pm!(), mm, args),
-                        KcallNumber::MemoryUnmap => pm::munmap(pm!(), mm, args),
-                        KcallNumber::MemoryCtrl => pm::mctrl(pm!(), mm, args),
-                        KcallNumber::MemoryCopy => pm::mcopy(pm!(), mm, args),
+                        KcallNumber::MemoryMap => pm::mmap(pm!(), mm!(), args),
+                        KcallNumber::MemoryUnmap => pm::munmap(pm!(), mm!(), args),
+                        KcallNumber::MemoryCtrl => pm::mctrl(pm!(), mm!(), args),
+                        KcallNumber::MemoryCopy => pm::mcopy(pm!(), mm!(), args),
                         KcallNumber::AllocMmio => io::mmio_alloc(hal, pm!(), args),
                         KcallNumber::AllocPmio => io::pmio_alloc(hal, pm!(), args),
-                        KcallNumber::CreateThread => pm::create_thread(pm!(), mm, args),
+                        KcallNumber::CreateThread => pm::create_thread(pm!(), mm!(), args),
                         _ => {
                             error!("invalid kernel call");
                             KcallResult::Error(ErrorCode::InvalidSysCall.into())
@@ -142,7 +157,7 @@ pub fn kcall_handler(hal: &mut Hal, mm: &mut VirtMemoryManager) -> ExitStatus {
 
         // Attempt to harvest zombie processes.
         let mut harvested_process: bool = false;
-        match pm!().harvest_zombies(mm) {
+        match pm!().harvest_zombies(mm!()) {
             Ok(None) => {},
             Ok(Some((pid, status))) => {
                 // Check if init daemon process terminated.
@@ -176,7 +191,7 @@ pub fn kcall_handler(hal: &mut Hal, mm: &mut VirtMemoryManager) -> ExitStatus {
         }
     };
 
-    while let Ok(Some((pid, status))) = pm!().harvest_zombies(mm) {
+    while let Ok(Some((pid, status))) = pm!().harvest_zombies(mm!()) {
         info!("harvested zombie process: pid={:?}, status={:?}", pid, status);
     }
 

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -321,13 +321,12 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
         };
 
     // Initialize the memory manager.
-    let (root, mut mm): (Vmem, VirtMemoryManager) =
-        match mm::init(&kimage, memory_regions, mmio_regions) {
-            Ok((root, mm)) => (root, mm),
-            Err(err) => {
-                panic!("failed to initialize memory manager: {:?}", err);
-            },
-        };
+    let root: Vmem = match mm::init(&kimage, memory_regions, mmio_regions) {
+        Ok(root) => root,
+        Err(err) => {
+            panic!("failed to initialize memory manager: {:?}", err);
+        },
+    };
 
     // Check boot stack guard watermark for corruption.
     if let Err(err) = mm::kstack::check_boot_stack_guard() {
@@ -374,15 +373,17 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
                 info!("starting application core {}...", coreid);
 
                 // Allocate a kernel stack for the application core.
-                let kstack: KernelStack = match KernelStack::new(&mut mm) {
-                    Ok(kstack) => kstack,
-                    Err(err) => {
-                        panic!(
-                            "failed to allocate kernel stack for application core (error={:?})",
-                            err
-                        );
-                    },
-                };
+                // SAFETY: the memory manager is initialized and access is synchronized.
+                let kstack: KernelStack =
+                    match KernelStack::new(unsafe { VirtMemoryManager::get_mut() }) {
+                        Ok(kstack) => kstack,
+                        Err(err) => {
+                            panic!(
+                                "failed to allocate kernel stack for application core (error={:?})",
+                                err
+                            );
+                        },
+                    };
 
                 // Obtain a cached version of the number of cores online.
                 let cores_online: usize = CORES_ONLINE.load(Ordering::Acquire);
@@ -418,21 +419,23 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     let cores_online: usize = CORES_ONLINE.load(Ordering::Acquire);
     info!("number of cores online: {}", cores_online);
 
-    let status: ExitStatus = if spawn_servers(&mut mm, &kernel_modules) > 0 {
-        // Initialize kernel call dispatcher.
-        kcall::init();
+    // SAFETY: the memory manager is initialized and access is synchronized.
+    let status: ExitStatus =
+        if spawn_servers(unsafe { VirtMemoryManager::get_mut() }, &kernel_modules) > 0 {
+            // Initialize kernel call dispatcher.
+            kcall::init();
 
-        // Enable timer interrupts, if they are supported.
-        if let Some(intman) = &mut hal.intman {
-            if let Err(e) = intman.unmask(hal::arch::InterruptNumber::Timer) {
-                panic!("failed to mask timer interrupt: {:?}", e);
+            // Enable timer interrupts, if they are supported.
+            if let Some(intman) = &mut hal.intman {
+                if let Err(e) = intman.unmask(hal::arch::InterruptNumber::Timer) {
+                    panic!("failed to mask timer interrupt: {:?}", e);
+                }
             }
-        }
 
-        kcall::handler(&mut hal, &mut mm)
-    } else {
-        ExitStatus::ok()
-    };
+            kcall::handler(&mut hal)
+        } else {
+            ExitStatus::ok()
+        };
 
     #[cfg(feature = "smp")]
     startup::wait().expect("failed to synchronize application cores");

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -245,7 +245,7 @@ pub fn init(
     kimage: &KernelImage,
     memory_regions: LinkedList<MemoryRegion<VirtualAddress>>,
     mmio_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
-) -> Result<(Vmem, VirtMemoryManager), Error> {
+) -> Result<Vmem, Error> {
     info!("initializing the memory manager ...");
 
     type VirtMemRegions = LinkedList<TruncatedMemoryRegion<VirtualAddress>>;
@@ -269,8 +269,7 @@ pub fn init(
         LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>,
     ) = (LinkedList::new(), virt::init(virtual_memory_regions, mmio_regions)?);
 
-    let (mut vmem, mut mm): (Vmem, VirtMemoryManager) =
-        VirtMemoryManager::init(kernel_pages, kernel_page_tables, physman)?;
+    let mut vmem: Vmem = VirtMemoryManager::init(kernel_pages, kernel_page_tables, physman)?;
 
     // Map virtual memory regions that lie outside the physical memory.
     while let Some(region) = other_virtual_memory_regions.pop_front() {
@@ -279,25 +278,29 @@ pub fn init(
         let end: VirtualAddress =
             VirtualAddress::new(region.start().into_raw_value() + (region.size() - 1));
 
-        while vaddr.into_inner() < end {
-            let kpage: KernelPage = mm.alloc_kpage(false)?;
+        {
+            // SAFETY: the memory manager is initialized and access is synchronized.
+            let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+            while vaddr.into_inner() < end {
+                let kpage: KernelPage = mm.alloc_kpage(false)?;
 
-            let page_table_allocator = || {
-                let pgtable_storage: PageTableStorage = PageTableStorage::Heap(Box::new(
-                    [0; mem::PAGE_SIZE / core::mem::size_of::<u32>()],
-                ));
-                let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
-                Ok(page_table)
-            };
+                let page_table_allocator = || {
+                    let pgtable_storage: PageTableStorage = PageTableStorage::Heap(Box::new(
+                        [0; mem::PAGE_SIZE / core::mem::size_of::<u32>()],
+                    ));
+                    let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
+                    Ok(page_table)
+                };
 
-            vmem.map_kpage(kpage, vaddr, page_table_allocator)?;
+                vmem.map_kpage(kpage, vaddr, page_table_allocator)?;
 
-            match vaddr.into_raw_value().checked_add(mem::PAGE_SIZE) {
-                Some(raw_addr) => vaddr = PageAligned::from_raw_value(raw_addr)?,
-                None => break,
-            };
+                match vaddr.into_raw_value().checked_add(mem::PAGE_SIZE) {
+                    Some(raw_addr) => vaddr = PageAligned::from_raw_value(raw_addr)?,
+                    None => break,
+                };
+            }
         }
     }
 
-    Ok((vmem, mm))
+    Ok(vmem)
 }

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -41,9 +41,11 @@ use ::alloc::{
 use ::arch::mem;
 use ::core::{
     cell::RefCell,
-    hint::{
-        cold_path,
-        unlikely,
+    hint::unlikely,
+    mem::MaybeUninit,
+    sync::atomic::{
+        AtomicBool,
+        Ordering,
     },
 };
 use ::sys::error::{
@@ -52,11 +54,23 @@ use ::sys::error::{
 };
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+// Use relaxed ordering for all atomic operations to mitigate synchronization overhead. It is safe
+// to use this ordering semantics because Nanvix is a single-core system, and the kernel runs with
+// interrupts disabled.
+const ORDER: Ordering = Ordering::Relaxed;
+
+//==================================================================================================
 // Global Variables
 //==================================================================================================
 
-/// Memory manager.
-static mut MEMORY_MANAGER: Option<VirtMemoryManager> = None;
+/// Memory manager storage.
+static mut MEMORY_MANAGER: MaybeUninit<VirtMemoryManager> = MaybeUninit::uninit();
+
+/// Whether the memory manager has been initialized.
+static MEMORY_MANAGER_INIT: AtomicBool = AtomicBool::new(false);
 
 //==================================================================================================
 // Structures
@@ -67,7 +81,6 @@ static mut MEMORY_MANAGER: Option<VirtMemoryManager> = None;
 ///
 /// Memory manager.
 ///
-#[derive(Clone)]
 pub struct VirtMemoryManager {
     /// Physical memory manager.
     physman: Rc<RefCell<PhysMemoryManager>>,
@@ -88,9 +101,9 @@ impl VirtMemoryManager {
         kernel_pages: LinkedList<KernelPage>,
         kernel_page_tables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>,
         physman: PhysMemoryManager,
-    ) -> Result<(Vmem, VirtMemoryManager), Error> {
+    ) -> Result<Vmem, Error> {
         // Check if the memory manager is already initialized.
-        if unlikely(unsafe { MEMORY_MANAGER.is_some() }) {
+        if unlikely(MEMORY_MANAGER_INIT.load(ORDER)) {
             panic!("memory manager was already initialized");
         }
 
@@ -98,10 +111,10 @@ impl VirtMemoryManager {
             VirtMemoryManager::new(kernel_pages, kernel_page_tables, physman)?;
 
         // SAFETY: This happens during kernel initialization and no other threads are running.
-        unsafe {
-            MEMORY_MANAGER = Some(manager.clone());
-        }
-        Ok((root, manager))
+        unsafe { MEMORY_MANAGER.write(manager) };
+        MEMORY_MANAGER_INIT.store(true, ORDER);
+
+        Ok(root)
     }
 
     ///
@@ -119,14 +132,14 @@ impl VirtMemoryManager {
     ///
     /// - Access to the memory manager is synchronized.
     ///
-    #[allow(dead_code)] // TODO: remove this ling allowance when the function is used.
+    #[allow(dead_code)] // TODO: remove this lint allowance when the function is used.
     pub unsafe fn get<'a>() -> &'a VirtMemoryManager {
-        if let Some(ref mm) = MEMORY_MANAGER {
-            mm
-        } else {
-            cold_path();
-            panic!("the memory manager is not initialized");
+        if unlikely(!MEMORY_MANAGER_INIT.load(ORDER)) {
+            panic!("memory manager is not initialized");
         }
+
+        // SAFETY: The memory manager has been initialized, so the value is valid.
+        MEMORY_MANAGER.assume_init_ref()
     }
 
     ///
@@ -145,12 +158,12 @@ impl VirtMemoryManager {
     /// - Access to the memory manager is synchronized.
     ///
     pub unsafe fn get_mut<'a>() -> &'a mut VirtMemoryManager {
-        if let Some(ref mut mm) = MEMORY_MANAGER {
-            mm
-        } else {
-            cold_path();
-            panic!("the memory manager is not initialized");
+        if unlikely(!MEMORY_MANAGER_INIT.load(ORDER)) {
+            panic!("memory manager is not initialized");
         }
+
+        // SAFETY: The memory manager has been initialized, so the value is valid.
+        MEMORY_MANAGER.assume_init_mut()
     }
 
     ///


### PR DESCRIPTION
Replace the Option<VirtMemoryManager> global with
MaybeUninit<VirtMemoryManager> guarded by an AtomicBool, eliminating the need to clone the manager on initialization and removing it from function signatures that previously threaded it through.

- VirtMemoryManager::init() now writes directly into the global and returns only Vmem instead of (Vmem, VirtMemoryManager).
- mm::init() and kcall_handler() no longer take or return the manager; callers access it via VirtMemoryManager::get_mut().
- Add mm!() convenience macro in kcall handler, mirroring the existing pm!() pattern.
- Fix typo in dead_code lint allowance comment ("ling" -> "lint").