### PR TITLE
[kernel] Move Kernel Calls to Dispatcher

### DIFF
--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -112,6 +112,8 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         KcallNumber::MemoryCtrl => pm::mctrl(pid, arg0, arg1, arg2),
         // Handle `mcopy()` locally.
         KcallNumber::MemoryCopy => pm::mcopy(pid, arg0, arg1, arg2, arg3),
+        // Handle `create_thread()` locally.
+        KcallNumber::CreateThread => pm::create_thread(pid, arg0),
         // Handle `send()` locally.
         KcallNumber::Send => ipc::send(pid, tid, arg0),
         // SAFETY: The calling thread is not the kernel and no resources are held.

--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -104,6 +104,14 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         KcallNumber::GetTime => pm::gettime(pid, arg0),
         // Handle `debug()` locally.
         KcallNumber::Debug => debug::debug(pid, arg0, arg1),
+        // Handle `mmap()` locally.
+        KcallNumber::MemoryMap => pm::mmap(pid, arg0, arg1, arg2),
+        // Handle `munmap()` locally.
+        KcallNumber::MemoryUnmap => pm::munmap(pid, arg0, arg1),
+        // Handle `mctrl()` locally.
+        KcallNumber::MemoryCtrl => pm::mctrl(pid, arg0, arg1, arg2),
+        // Handle `mcopy()` locally.
+        KcallNumber::MemoryCopy => pm::mcopy(pid, arg0, arg1, arg2, arg3),
         // Handle `send()` locally.
         KcallNumber::Send => ipc::send(pid, tid, arg0),
         // SAFETY: The calling thread is not the kernel and no resources are held.

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -17,10 +17,7 @@ use crate::{
         ScoreBoard,
     },
     mm::VirtMemoryManager,
-    pm::{
-        self,
-        ProcessManager,
-    },
+    pm::ProcessManager,
 };
 use ::sys::{
     error::ErrorCode,
@@ -86,7 +83,6 @@ pub fn kcall_handler(hal: &mut Hal) -> ExitStatus {
                     let ret: KcallResult = match KcallNumber::from(args.number) {
                         KcallNumber::AllocMmio => io::mmio_alloc(hal, pm!(), args),
                         KcallNumber::AllocPmio => io::pmio_alloc(hal, pm!(), args),
-                        KcallNumber::CreateThread => pm::create_thread(pm!(), mm!(), args),
                         _ => {
                             error!("invalid kernel call");
                             KcallResult::Error(ErrorCode::InvalidSysCall.into())

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -84,10 +84,6 @@ pub fn kcall_handler(hal: &mut Hal) -> ExitStatus {
             Ok(scoreboard) => match scoreboard.handle() {
                 Ok(args) => {
                     let ret: KcallResult = match KcallNumber::from(args.number) {
-                        KcallNumber::MemoryMap => pm::mmap(pm!(), mm!(), args),
-                        KcallNumber::MemoryUnmap => pm::munmap(pm!(), mm!(), args),
-                        KcallNumber::MemoryCtrl => pm::mctrl(pm!(), mm!(), args),
-                        KcallNumber::MemoryCopy => pm::mcopy(pm!(), mm!(), args),
                         KcallNumber::AllocMmio => io::mmio_alloc(hal, pm!(), args),
                         KcallNumber::AllocPmio => io::pmio_alloc(hal, pm!(), args),
                         KcallNumber::CreateThread => pm::create_thread(pm!(), mm!(), args),

--- a/src/kernel/src/pm/kcall/create_thread.rs
+++ b/src/kernel/src/pm/kcall/create_thread.rs
@@ -6,10 +6,7 @@
 //==================================================================================================
 
 use crate::{
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     mm::{
         VirtMemoryManager,
         Vmem,
@@ -40,28 +37,26 @@ use ::sys::{
 ///
 /// # Description
 ///
-/// Creates a new thread in the calling process.
+/// Kernel call handler for creating a new thread in the calling process.
 ///
 /// # Parameters
 ///
-/// - `pm`: Handler to the process manager.
-/// - `mm`: Handler to the virtual memory manager.
-/// - `args`: Kernel call arguments containing the thread creation parameters.
+/// - `pid`: Identifier of the calling process.
+/// - `arg0`: Pointer to the thread creation arguments in user space.
 ///
 /// # Returns
 ///
-/// If successful, this function returns the thread identifier of the newly created thread.
-/// Otherwise, it returns an error code.
+/// A [`KcallResult`] containing the thread identifier of the newly created thread on success or
+/// the error code.
 ///
-pub fn create_thread(
-    pm: &mut ProcessManager,
-    mm: &mut VirtMemoryManager,
-    args: &KcallArgs,
-) -> KcallResult {
+pub fn create_thread(pid: ProcessIdentifier, arg0: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+    // SAFETY: the virtual memory manager is initialized and access is synchronized.
+    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+
     // Unpack kernel call arguments.
-    let pid: ProcessIdentifier = args.pid;
-    let unsafe_thread_create_args: VirtualAddress =
-        VirtualAddress::from_raw_value(args.arg0 as usize);
+    let unsafe_thread_create_args: VirtualAddress = VirtualAddress::from_raw_value(arg0 as usize);
 
     // Check if thread_create_args does not lie in user space.
     if !Vmem::is_user_region(unsafe_thread_create_args, size_of::<ThreadCreateArgs>()) {
@@ -74,7 +69,7 @@ pub fn create_thread(
     let mut thread_create_args: ThreadCreateArgs = ThreadCreateArgs::default();
     if let Err(error) = pm::copy_from_user(
         pm,
-        args.pid,
+        pid,
         &mut thread_create_args,
         unsafe_thread_create_args.into_raw_value() as *const ThreadCreateArgs,
     ) {

--- a/src/kernel/src/pm/kcall/mcopy.rs
+++ b/src/kernel/src/pm/kcall/mcopy.rs
@@ -11,10 +11,7 @@ use crate::{
         PageAligned,
         VirtualAddress,
     },
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     mm::{
         KernelPage,
         VirtMemoryManager,
@@ -67,9 +64,37 @@ fn do_mcopy(
     Ok(())
 }
 
-pub fn mcopy(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallArgs) -> KcallResult {
+///
+/// # Description
+///
+/// Kernel call handler for copying memory between processes.
+///
+/// # Parameters
+///
+/// - `caller_pid`: Identifier of the calling process.
+/// - `arg0`: Source process identifier.
+/// - `arg1`: Source virtual address.
+/// - `arg2`: Destination process identifier.
+/// - `arg3`: Destination virtual address.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn mcopy(
+    caller_pid: ProcessIdentifier,
+    arg0: u32,
+    arg1: u32,
+    arg2: u32,
+    arg3: u32,
+) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+    // SAFETY: the virtual memory manager is initialized and access is synchronized.
+    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+
     // Check if the calling process has memory management capabilities.
-    match pm.has_capability(args.pid, Capability::MemoryManagement) {
+    match pm.has_capability(caller_pid, Capability::MemoryManagement) {
         Ok(true) => (),
         Ok(false) => {
             let reason: &str = "process does not have memory management capabilities";
@@ -80,30 +105,28 @@ pub fn mcopy(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
     }
 
     // Unpack kernel call arguments.
-    let src_pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
+    let src_pid: ProcessIdentifier = match ProcessIdentifier::try_from(arg0) {
         Ok(pid) => pid,
         Err(error) => {
             error!("{error:?}");
             return KcallResult::Error(error.code.into());
         },
     };
-    let src_vaddr: PageAligned<VirtualAddress> =
-        match PageAligned::from_raw_value(args.arg1 as usize) {
-            Ok(vaddr) => vaddr,
-            Err(e) => return KcallResult::Error(e.code.into()),
-        };
-    let dst_pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg2) {
+    let src_vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(arg1 as usize) {
+        Ok(vaddr) => vaddr,
+        Err(e) => return KcallResult::Error(e.code.into()),
+    };
+    let dst_pid: ProcessIdentifier = match ProcessIdentifier::try_from(arg2) {
         Ok(pid) => pid,
         Err(error) => {
             error!("{error:?}");
             return KcallResult::Error(error.code.into());
         },
     };
-    let dst_vaddr: PageAligned<VirtualAddress> =
-        match PageAligned::from_raw_value(args.arg3 as usize) {
-            Ok(vaddr) => vaddr,
-            Err(e) => return KcallResult::Error(e.code.into()),
-        };
+    let dst_vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(arg3 as usize) {
+        Ok(vaddr) => vaddr,
+        Err(e) => return KcallResult::Error(e.code.into()),
+    };
 
     match do_mcopy(pm, mm, src_pid, src_vaddr, dst_pid, dst_vaddr) {
         Ok(_) => KcallResult::ok(),

--- a/src/kernel/src/pm/kcall/mctrl.rs
+++ b/src/kernel/src/pm/kcall/mctrl.rs
@@ -12,14 +12,10 @@ use crate::{
         PageAligned,
         VirtualAddress,
     },
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     mm::VirtMemoryManager,
     pm::ProcessManager,
 };
-
 use ::sys::{
     error::{
         Error,
@@ -45,9 +41,30 @@ fn do_mctrl(
     pm.mctrl(mm, pid, vaddr, access)
 }
 
-pub fn mctrl(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallArgs) -> KcallResult {
+///
+/// # Description
+///
+/// Kernel call handler for controlling memory access permissions.
+///
+/// # Parameters
+///
+/// - `caller_pid`: Identifier of the calling process.
+/// - `arg0`: Target process identifier.
+/// - `arg1`: Virtual address.
+/// - `arg2`: Access permission.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn mctrl(caller_pid: ProcessIdentifier, arg0: u32, arg1: u32, arg2: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+    // SAFETY: the virtual memory manager is initialized and access is synchronized.
+    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+
     // Unpack kernel call arguments.
-    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
+    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(arg0) {
         Ok(pid) => pid,
         Err(error) => {
             error!("{error:?}");
@@ -56,8 +73,8 @@ pub fn mctrl(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
     };
 
     // Check if the calling process has memory management capabilities.
-    if pid != args.pid {
-        match pm.has_capability(args.pid, Capability::MemoryManagement) {
+    if pid != caller_pid {
+        match pm.has_capability(caller_pid, Capability::MemoryManagement) {
             Ok(true) => (),
             Ok(false) => {
                 let reason: &str = "process does not have memory management capabilities";
@@ -68,11 +85,11 @@ pub fn mctrl(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallAr
         }
     }
 
-    let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(args.arg1 as usize) {
+    let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(arg1 as usize) {
         Ok(vaddr) => vaddr,
         Err(e) => return KcallResult::Error(e.code.into()),
     };
-    let access: AccessPermission = match AccessPermission::try_from(args.arg2) {
+    let access: AccessPermission = match AccessPermission::try_from(arg2) {
         Ok(access) => access,
         Err(e) => return KcallResult::Error(e.code.into()),
     };

--- a/src/kernel/src/pm/kcall/mmap.rs
+++ b/src/kernel/src/pm/kcall/mmap.rs
@@ -12,10 +12,7 @@ use crate::{
         PageAligned,
         VirtualAddress,
     },
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     mm::VirtMemoryManager,
     pm::ProcessManager,
 };
@@ -44,28 +41,49 @@ fn do_mmap(
     pm.mmap(mm, pid, vaddr, access)
 }
 
-pub fn mmap(pm: &mut ProcessManager, mm: &mut VirtMemoryManager, args: &KcallArgs) -> KcallResult {
+///
+/// # Description
+///
+/// Kernel call handler for mapping memory.
+///
+/// # Parameters
+///
+/// - `caller_pid`: Identifier of the calling process.
+/// - `arg0`: Target process identifier.
+/// - `arg1`: Virtual address to map.
+/// - `arg2`: Access permission.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn mmap(caller_pid: ProcessIdentifier, arg0: u32, arg1: u32, arg2: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+    // SAFETY: the virtual memory manager is initialized and access is synchronized.
+    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+
     // Unpack kernel call arguments.
-    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
+    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(arg0) {
         Ok(pid) => pid,
         Err(error) => {
             error!("{error:?}");
             return KcallResult::Error(error.code.into());
         },
     };
-    let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(args.arg1 as usize) {
+    let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(arg1 as usize) {
         Ok(vaddr) => vaddr,
         Err(e) => return KcallResult::Error(e.code.into()),
     };
-    let access: AccessPermission = match AccessPermission::try_from(args.arg2) {
+    let access: AccessPermission = match AccessPermission::try_from(arg2) {
         Ok(access) => access,
         Err(e) => return KcallResult::Error(e.code.into()),
     };
 
     // Check if attempting to map memory into a different process.
-    if pid != args.pid {
+    if pid != caller_pid {
         // Check if the calling process has memory management capabilities.
-        match pm.has_capability(args.pid, Capability::MemoryManagement) {
+        match pm.has_capability(caller_pid, Capability::MemoryManagement) {
             Ok(true) => (),
             Ok(false) => {
                 let reason: &str = "process does not have memory management capabilities";

--- a/src/kernel/src/pm/kcall/munmap.rs
+++ b/src/kernel/src/pm/kcall/munmap.rs
@@ -11,10 +11,7 @@ use crate::{
         PageAligned,
         VirtualAddress,
     },
-    kcall::{
-        KcallArgs,
-        KcallResult,
-    },
+    kcall::KcallResult,
     mm::VirtMemoryManager,
     pm::ProcessManager,
 };
@@ -42,28 +39,44 @@ fn do_munmap(
     pm.munmap(mm, pid, vaddr)
 }
 
-pub fn munmap(
-    pm: &mut ProcessManager,
-    mm: &mut VirtMemoryManager,
-    args: &KcallArgs,
-) -> KcallResult {
+///
+/// # Description
+///
+/// Kernel call handler for unmapping memory.
+///
+/// # Parameters
+///
+/// - `caller_pid`: Identifier of the calling process.
+/// - `arg0`: Target process identifier.
+/// - `arg1`: Virtual address to unmap.
+///
+/// # Returns
+///
+/// A [`KcallResult`] indicating success or the error code.
+///
+pub fn munmap(caller_pid: ProcessIdentifier, arg0: u32, arg1: u32) -> KcallResult {
+    // SAFETY: the process manager is initialized and access is synchronized.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+    // SAFETY: the virtual memory manager is initialized and access is synchronized.
+    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+
     // Unpack kernel call arguments.
-    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(args.arg0) {
+    let pid: ProcessIdentifier = match ProcessIdentifier::try_from(arg0) {
         Ok(pid) => pid,
         Err(error) => {
             error!("{error:?}");
             return KcallResult::Error(error.code.into());
         },
     };
-    let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(args.arg1 as usize) {
+    let vaddr: PageAligned<VirtualAddress> = match PageAligned::from_raw_value(arg1 as usize) {
         Ok(vaddr) => vaddr,
         Err(e) => return KcallResult::Error(e.code.into()),
     };
 
-    // Check if attempting to unmap memory from  a different process.
-    if pid != args.pid {
+    // Check if attempting to unmap memory from a different process.
+    if pid != caller_pid {
         // Check if the calling process has memory management capabilities.
-        match pm.has_capability(args.pid, Capability::MemoryManagement) {
+        match pm.has_capability(caller_pid, Capability::MemoryManagement) {
             Ok(true) => (),
             Ok(false) => {
                 let reason: &str = "process does not have memory management capabilities";

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -272,36 +272,19 @@ impl ProcessManager {
 
         // Assert pre-conditions (these should have been checked by the caller).
         debug_assert!(Vmem::is_user_addr(thread_create_args.user_fn));
+        debug_assert!(
+            self.get_running().state().pid() == pid,
+            "create_thread: pid must match the running process"
+        );
 
         let ready_thread: ReadyThread = {
             let enable_interrupts: bool = self.interrupt_capable;
-
-            // Find corresponding process.
-            let mut process: ProcessRefMut = self.find_process_mut(pid)?;
-
-            // Ensure that the process is in a valid state.
-            if let ProcessRefMut::Running(_) = process {
-                // TODO: Re-evaluate this condition when we support multicore.
-                let reason: &str = "process is running";
-                error!("{reason}");
-                return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
-            }
-            if let ProcessRefMut::Interrupted(_) = process {
-                let reason: &str = "process is interrupted";
-                error!("{reason}");
-                return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
-            }
-            if let ProcessRefMut::Zombie(_) = process {
-                let reason: &str = "process is a zombie";
-                error!("{reason}");
-                return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
-            }
 
             // Create a kernel context.
             let (kernel_stack, context): (KernelStack, ContextInformation) =
                 Self::forge_user_context(
                     mm,
-                    process.state_mut().vmem_mut(),
+                    self.get_running_mut().state_mut().vmem_mut(),
                     thread_create_args,
                     enable_interrupts,
                 )?;
@@ -315,56 +298,11 @@ impl ProcessManager {
                 .create_thread(Some(kernel_stack), None, thread_create_args.user_tda, context)
         };
 
-        Ok(self.try_add_thread(pid, ready_thread))
-    }
-
-    fn try_add_thread(
-        &mut self,
-        pid: ProcessIdentifier,
-        ready_thread: ReadyThread,
-    ) -> ThreadIdentifier {
-        trace!("pid={pid:?}, ready_thread={ready_thread:?}");
+        // Add the new thread to the running process.
         let tid: ThreadIdentifier = ready_thread.id();
+        self.get_running_mut().add_thread(ready_thread);
 
-        // Search process in the list of sleeping processes.
-        let mut suspended: LinkedList<SleepingProcess> = LinkedList::new();
-        while let Some(process) = self.suspended.pop_front() {
-            // Found.
-            if process.state().pid() == pid {
-                let ready_process: RunnableProcess = process.add_thread(ready_thread);
-                // Rollback list to its original state.
-                while let Some(process) = suspended.pop_back() {
-                    self.suspended.push_front(process);
-                }
-                // Push process to the list of ready processes.
-                self.ready.push_back(ready_process);
-                return tid;
-            }
-            suspended.push_back(process);
-        }
-        // Process is not in the list of sleeping processes, rollback list to its original state.
-        self.suspended = suspended;
-
-        // Search process in the list of ready processes.
-        let mut ready: LinkedList<RunnableProcess> = LinkedList::new();
-        while let Some(process) = self.ready.pop_front() {
-            // Found.
-            if process.state().pid() == pid {
-                let ready_process: RunnableProcess = process.add_thread(ready_thread);
-                // Rollback list to its original state.
-                while let Some(process) = ready.pop_back() {
-                    self.ready.push_front(process);
-                }
-                // Push process to the list of ready processes.
-                self.ready.push_back(ready_process);
-                return tid;
-            }
-            ready.push_back(process);
-        }
-        // Process is not in the list of ready processes, rollback list to its original state.
-        self.ready = ready;
-
-        unreachable!("process must be either sleeping or runnable")
+        Ok(tid)
     }
 
     ///

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -214,12 +214,6 @@ impl RunnableProcess {
         }
     }
 
-    pub fn add_thread(mut self, ready_thread: ReadyThread) -> Self {
-        trace!("self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
-        self.ready_threads.push_back(ready_thread);
-        self
-    }
-
     pub fn earliest_admission_time(&self) -> SystemTime {
         self.ready_threads
             .iter()

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -331,6 +331,28 @@ impl RunningProcess {
         self.running.check_guard_watermark()
     }
 
+    ///
+    /// # Description
+    ///
+    /// Adds a ready thread to the running process.
+    ///
+    /// # Parameters
+    ///
+    /// - `ready_thread`: Thread to add.
+    ///
+    pub fn add_thread(&mut self, ready_thread: ReadyThread) {
+        trace!("self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
+        match self.ready.take() {
+            Some(mut ready_threads) => {
+                ready_threads.push_back(ready_thread);
+                self.ready = Some(ready_threads);
+            },
+            None => {
+                self.ready = Some(NonEmptyVecDeque::new(ready_thread));
+            },
+        }
+    }
+
     pub fn wakeup(mut self, tid: ThreadIdentifier) -> Result<RunningProcess, RunningProcess> {
         if let Some(sleeping_threads) = self.sleeping_threads.take() {
             match sleeping_threads.remove_if(|thread| thread.id() == tid) {

--- a/src/kernel/src/pm/process/state/sleeping.rs
+++ b/src/kernel/src/pm/process/state/sleeping.rs
@@ -175,17 +175,6 @@ impl SleepingProcess {
         }
     }
 
-    pub fn add_thread(mut self, ready_thread: ReadyThread) -> RunnableProcess {
-        trace!("self.pid={:?}, ready_thread={:?}", self.state.pid, ready_thread);
-        RunnableProcess::from_state(
-            self.state,
-            NonEmptyVecDeque::new(ready_thread),
-            None,
-            Some(self.sleeping_threads),
-            self.zombie_threads.take(),
-        )
-    }
-
     ///
     /// # Description
     ///


### PR DESCRIPTION
Kernel call handler interface refactoring:

* Refactored the kernel call handler functions (`mmap`, `munmap`, `mctrl`, `mcopy`, `create_thread`) to accept primitive arguments instead of manager references and argument structs, and to internally access global manager instances. This change simplifies their invocation and improves code clarity. [[1]](diffhunk://#diff-8524dbf7b45a6a59f857bc680c2b71484b3f0434f7b71e0ef99d4f04f50c2482L47-R86) [[2]](diffhunk://#diff-f38cee56746c68ef98ac479335da5db500194dcb3de64526a9e8af61344a8e14L45-R79) [[3]](diffhunk://#diff-046f07afc80cacae8ab973faab83e530adc1a3181ce9a35486c6048c6019639dL48-R67) [[4]](diffhunk://#diff-7c3c178b4c303ad9e88cbf771016eef4d528ad95ab1f096fb4949d8bfd4e2ff3L70-R97) [[5]](diffhunk://#diff-eed0f7dbc92ac6a6b44f54b2ff88eb78d80a57768b46c4cb4b1fa2fe74087548L43-R59)

* Updated the kernel call dispatcher (`do_kcall` in `dispatcher.rs`) to handle these calls locally using the new function signatures, passing the required primitive arguments directly.

Handler invocation and code simplification:

* Removed the previous handler invocation logic in `kcall_handler.rs` that passed manager references and argument structs, and replaced it with the new simplified invocation pattern.

Thread creation logic improvements:

* Modified the thread creation implementation in `ProcessManager` to always add the new thread to the currently running process, removing the need to search through sleeping or ready process lists. This ensures correctness and simplifies the code. [[1]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873R275-R287) [[2]](diffhunk://#diff-0d0daaafbfac9063cd323d54313736926bc1df354a057641361db67853007873L318-R305)

Documentation and import cleanup:

* Updated documentation comments for all affected handlers to reflect their new interfaces and clarify parameter usage. Cleaned up imports to remove unused items and improve code organization. [[1]](diffhunk://#diff-eed0f7dbc92ac6a6b44f54b2ff88eb78d80a57768b46c4cb4b1fa2fe74087548L9-R9) [[2]](diffhunk://#diff-7c3c178b4c303ad9e88cbf771016eef4d528ad95ab1f096fb4949d8bfd4e2ff3L14-R14) [[3]](diffhunk://#diff-046f07afc80cacae8ab973faab83e530adc1a3181ce9a35486c6048c6019639dL15-L22) [[4]](diffhunk://#diff-8524dbf7b45a6a59f857bc680c2b71484b3f0434f7b71e0ef99d4f04f50c2482L15-R15) [[5]](diffhunk://#diff-f38cee56746c68ef98ac479335da5db500194dcb3de64526a9e8af61344a8e14L14-R14)