### PR TITLE
[kernel] Check overflow when bumping PID/TID

### DIFF
--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -277,6 +277,9 @@ impl ProcessManager {
             "create_thread: pid must match the running process"
         );
 
+        // Reserve the next thread identifier early, before any resource allocation.
+        let (tid, next_tid): (ThreadIdentifier, ThreadIdentifier) = self.tm.try_next_tid()?;
+
         let ready_thread: ReadyThread = {
             let enable_interrupts: bool = self.interrupt_capable;
 
@@ -294,9 +297,17 @@ impl ProcessManager {
             //==============================================================
 
             // Create a new thread.
-            self.tm
-                .create_thread(Some(kernel_stack), None, thread_create_args.user_tda, context)
+            self.tm.create_thread(
+                tid,
+                Some(kernel_stack),
+                None,
+                thread_create_args.user_tda,
+                context,
+            )
         };
+
+        // Commit the next thread identifier now that all fallible operations have succeeded.
+        self.tm.commit_next_tid(next_tid);
 
         // Add the new thread to the running process.
         let tid: ThreadIdentifier = ready_thread.id();
@@ -425,6 +436,10 @@ impl ProcessManager {
 
         trace!("args={:?}, env={:?}", args, env);
 
+        // Reserve the next process and thread identifiers early, before any resource allocation.
+        let (pid, next_pid): (ProcessIdentifier, ProcessIdentifier) = self.try_next_pid()?;
+        let (tid, next_tid): (ThreadIdentifier, ThreadIdentifier) = self.tm.try_next_tid()?;
+
         // Strip leading and trailing spaces from arguments.
         let args: &str = args.trim();
 
@@ -531,13 +546,17 @@ impl ProcessManager {
         // NOTE: if we fail beyond this point we need to page mappings.
         //==============================================================
 
-        let thread: ReadyThread =
-            self.tm
-                .create_thread(Some(kernel_stack), Some(user_stack), args.user_tda, context);
+        let thread: ReadyThread = self.tm.create_thread(
+            tid,
+            Some(kernel_stack),
+            Some(user_stack),
+            args.user_tda,
+            context,
+        );
 
-        // Create process.
-        let pid: ProcessIdentifier = self.next_pid;
-        self.next_pid = ProcessIdentifier::from(i32::from(pid) + 1);
+        // Commit the next process and thread identifiers now that all fallible operations have succeeded.
+        self.next_pid = next_pid;
+        self.tm.commit_next_tid(next_tid);
         let process: RunnableProcess = RunnableProcess::new(pid, thread, vmem);
 
         // Add process to the queue of ready processes.
@@ -1282,6 +1301,40 @@ impl ProcessManager {
         self.get_running_mut().state_mut().put_mutex(mutex_addr)?;
 
         Ok(mutex_guard)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reserves the next process identifier, performing a checked increment.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, this function returns a tuple containing the reserved [`ProcessIdentifier`]
+    /// and the next [`ProcessIdentifier`] value. The caller must commit the next identifier by
+    /// updating `self.next_pid` after all fallible operations have succeeded.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the process identifier would overflow.
+    ///
+    /// # Known Bugs
+    ///
+    /// - FIXME (#1440): process identifiers are never recycled, so a fork bomb or repeated
+    ///   `create_process` calls can exhaust the identifier space.
+    ///
+    fn try_next_pid(&self) -> Result<(ProcessIdentifier, ProcessIdentifier), Error> {
+        let pid: ProcessIdentifier = self.next_pid;
+        let raw_pid: i32 = i32::from(pid);
+        let next_raw_pid: i32 = match raw_pid.checked_add(1) {
+            Some(val) => val,
+            None => {
+                let reason: &str = "process identifier overflow";
+                error!("{reason} (next_pid={raw_pid:?})");
+                return Err(Error::new(ErrorCode::ValueOverflow, reason));
+            },
+        };
+        Ok((pid, ProcessIdentifier::from(next_raw_pid)))
     }
 
     fn take_earliest_ready(&mut self) -> RunnableProcess {

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -16,6 +16,10 @@ use crate::{
     pm::thread::state::ThreadState,
 };
 use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
     mm::VirtualAddress,
     pm::ThreadIdentifier,
 };
@@ -178,10 +182,58 @@ impl ThreadManager {
     ///
     /// # Description
     ///
+    /// Reserves the next thread identifier, performing a checked increment.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, this function returns a tuple containing the reserved [`ThreadIdentifier`]
+    /// and the next [`ThreadIdentifier`] value. The caller must commit the next identifier via
+    /// [`commit_next_tid`] after all fallible operations have succeeded.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the thread identifier would overflow.
+    ///
+    /// # Known Bugs
+    ///
+    /// - FIXME (#1440): thread identifiers are never recycled, so a fork bomb or repeated
+    ///   `create_thread` calls can exhaust the identifier space.
+    ///
+    pub(crate) fn try_next_tid(&self) -> Result<(ThreadIdentifier, ThreadIdentifier), Error> {
+        let id: ThreadIdentifier = self.next_id;
+        let raw_id: i32 = <i32>::from(self.next_id);
+        let next_raw_id: i32 = match raw_id.checked_add(1) {
+            Some(val) => val,
+            None => {
+                let reason: &str = "thread identifier overflow";
+                error!("{reason} (next_id={raw_id:?})");
+                return Err(Error::new(ErrorCode::ValueOverflow, reason));
+            },
+        };
+        Ok((id, ThreadIdentifier::from(next_raw_id)))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Commits the next thread identifier after all fallible operations have succeeded.
+    ///
+    /// # Parameters
+    ///
+    /// - `next_tid`: The next thread identifier (obtained from [`try_next_tid`]).
+    ///
+    pub(crate) fn commit_next_tid(&mut self, next_tid: ThreadIdentifier) {
+        self.next_id = next_tid;
+    }
+
+    ///
+    /// # Description
+    ///
     /// Creates a new thread with the specified parameters.
     ///
     /// # Parameters
     ///
+    /// - `id`: Pre-allocated thread identifier (obtained from [`try_next_tid`]).
     /// - `kernel_stack`: Optional kernel stack for the thread.
     /// - `user_stack`: Optional user stack for the thread.
     /// - `user_tda`: Optional base address to user-space thread data area.
@@ -192,15 +244,13 @@ impl ThreadManager {
     /// This function returns a new [`ReadyThread`] instance.
     ///
     pub fn create_thread(
-        &mut self,
+        &self,
+        id: ThreadIdentifier,
         kernel_stack: Option<KernelStack>,
         user_stack: Option<UserStack>,
         user_tda: Option<VirtualAddress>,
         context: ContextInformation,
     ) -> ReadyThread {
-        let id: ThreadIdentifier = self.next_id;
-        self.next_id = ThreadIdentifier::from(<i32>::from(self.next_id) + 1);
-
         ReadyThread::new(
             id,
             kernel_stack,


### PR DESCRIPTION
Add checked addition when incrementing process and thread identifiers to prevent silent wraparound past the maximum value.

Introduce `try_next_pid()` on ProcessManager and `try_next_tid()` on ThreadManager that validate the increment before any resource allocation, avoiding side effects on failure. The `create_thread()` method now takes a pre-allocated identifier and remains infallible.

Closes #627 