### PR TITLE
[uservm] Add Standalone Mode

### DIFF
--- a/doc/run.md
+++ b/doc/run.md
@@ -33,6 +33,7 @@ Run a hello-world application and see its output on the terminal:
   - [HTTP API Reference](#http-api-reference)
   - [HTTP Error Codes](#http-error-codes)
 - [Logging](#logging)
+- [Expert Mode: Standalone User VM](#expert-mode-standalone-user-vm)
 
 ## Interactive Mode
 
@@ -220,4 +221,37 @@ This applies to both interactive and HTTP modes:
 ```bash
 RUST_LOG=debug ./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/hello-rust-nostd.elf
 RUST_LOG=trace ./bin/nanvixd.elf -http-addr 127.0.0.1:8080
+```
+
+## Expert Mode: Standalone User VM
+
+> **Warning:** This is an expert-level feature intended for low-level debugging and kernel
+> development. Most users should use `nanvixd` instead (see [Interactive Mode](#interactive-mode)).
+
+The `uservm.elf` binary can be launched directly in **standalone mode**, bypassing the full Nanvix
+orchestration stack (no `nanvixd`, system VM, control-plane, or gateway connections). In this mode
+the guest kernel boots, runs the initrd payload, and exits. Outbound I/O messages from the guest
+are silently discarded.
+
+```bash
+./bin/uservm.elf -kernel ./bin/kernel.elf -initrd ./bin/hello-rust-nostd.elf -standalone
+```
+
+Optional flags:
+
+| Flag                  | Description                                                                   |
+| --------------------- | ----------------------------------------------------------------------------- |
+| `-memory <size>`      | Guest memory size (e.g., `64M`, `256K`). Defaults to the kernel config value. |
+| `-stderr <file>`      | Redirect guest stderr to a file instead of host stderr.                       |
+| `-initrd_args <args>` | Arguments forwarded to the initrd payload.                                    |
+| `-ramfs <file>`       | Path to a RAM filesystem image exposed to the guest.                          |
+| `-user-vm-id <id>`    | VM identifier (defaults to `0` in standalone mode).                           |
+| `-log-to-file`        | Write logs to files instead of stdout.                                        |
+| `-log-dir <dir>`      | Directory for log files (used with `-log-to-file`).                           |
+
+Enable verbose logging with `RUST_LOG`:
+
+```bash
+RUST_LOG=debug ./bin/uservm.elf -kernel ./bin/kernel.elf \
+    -initrd ./bin/hello-rust-nostd.elf -standalone
 ```

--- a/src/uservm/src/args.rs
+++ b/src/uservm/src/args.rs
@@ -64,6 +64,8 @@ pub struct Args {
     control_plane_socket_type: String,
     /// Socket address type of the gateway socket.
     gateway_socket_type: String,
+    /// Standalone mode: run without system VM, control-plane, or gateway connections.
+    standalone: bool,
 }
 
 //==================================================================================================
@@ -103,6 +105,8 @@ impl Args {
     pub const OPT_LOGFILE: &'static str = "-log-to-file";
     /// Log directory
     pub const OPT_LOGDIR: &'static str = "-log-dir";
+    /// Command-line option for standalone mode.
+    pub const OPT_STANDALONE: &'static str = "-standalone";
 
     /// Program name.
     const PROGRAM_NAME: &'static str = env!("CARGO_PKG_NAME");
@@ -136,6 +140,7 @@ impl Args {
         let mut system_vm_socket_type: String = String::new();
         let mut control_plane_socket_type: String = String::new();
         let mut gateway_socket_type: String = String::new();
+        let mut standalone: bool = false;
 
         // Parse command-line arguments.
         let mut i: usize = 1;
@@ -261,6 +266,10 @@ impl Args {
                     gateway_socket_type = args[i + 1].clone();
                     i += 1;
                 },
+                // Set standalone mode.
+                Self::OPT_STANDALONE => {
+                    standalone = true;
+                },
                 // Set log to file flag.
                 Self::OPT_LOGFILE => {
                     log_to_file = true;
@@ -280,10 +289,11 @@ impl Args {
             i += 1;
         }
 
-        // Parse user VM ID.
-        let user_vm_id: UserVmIdentifier = match user_vm_id_raw {
-            Some(id) => UserVmIdentifier::new(id),
-            None => {
+        // Parse user VM ID. In standalone mode, default to 0 when not provided.
+        let user_vm_id: UserVmIdentifier = match (user_vm_id_raw, standalone) {
+            (Some(id), _) => UserVmIdentifier::new(id),
+            (None, true) => UserVmIdentifier::new(0),
+            (None, false) => {
                 Self::usage();
                 anyhow::bail!("user vm id is missing");
             },
@@ -301,40 +311,43 @@ impl Args {
             anyhow::bail!("invalid memory size");
         }
 
-        // Check if gateway address is missing.
-        if gateway_addr.is_empty() {
-            Self::usage();
-            anyhow::bail!("gateway address is missing");
-        }
+        // In non-standalone mode, all socket addresses and types are required.
+        if !standalone {
+            // Check if gateway address is missing.
+            if gateway_addr.is_empty() {
+                Self::usage();
+                anyhow::bail!("gateway address is missing");
+            }
 
-        // Check if gateway socket type is missing.
-        if gateway_socket_type.is_empty() {
-            Self::usage();
-            anyhow::bail!("gateway socket type is missing");
-        }
+            // Check if gateway socket type is missing.
+            if gateway_socket_type.is_empty() {
+                Self::usage();
+                anyhow::bail!("gateway socket type is missing");
+            }
 
-        // Check if control-plane address is missing.
-        if control_plane_addr.is_empty() {
-            Self::usage();
-            anyhow::bail!("control-plane address is missing");
-        }
+            // Check if control-plane address is missing.
+            if control_plane_addr.is_empty() {
+                Self::usage();
+                anyhow::bail!("control-plane address is missing");
+            }
 
-        // Check if control-plane socket type is missing.
-        if control_plane_socket_type.is_empty() {
-            Self::usage();
-            anyhow::bail!("control-plane socket type is missing");
-        }
+            // Check if control-plane socket type is missing.
+            if control_plane_socket_type.is_empty() {
+                Self::usage();
+                anyhow::bail!("control-plane socket type is missing");
+            }
 
-        // Check if system VM address is missing.
-        if system_vm_addr.is_empty() {
-            Self::usage();
-            anyhow::bail!("system VM address is missing");
-        }
+            // Check if system VM address is missing.
+            if system_vm_addr.is_empty() {
+                Self::usage();
+                anyhow::bail!("system VM address is missing");
+            }
 
-        // Check if system VM socket type is missing.
-        if system_vm_socket_type.is_empty() {
-            Self::usage();
-            anyhow::bail!("system VM socket type is missing");
+            // Check if system VM socket type is missing.
+            if system_vm_socket_type.is_empty() {
+                Self::usage();
+                anyhow::bail!("system VM socket type is missing");
+            }
         }
 
         // Check if log file directory was set if logging to file is enabled. Set the default directory if not.
@@ -400,6 +413,7 @@ impl Args {
             system_vm_socket_type,
             control_plane_socket_type,
             gateway_socket_type,
+            standalone,
         })
     }
 
@@ -410,7 +424,7 @@ impl Args {
     ///
     pub fn usage() {
         eprintln!(
-            "Usage: {} {} <id> {} <kernel> [{} <size>] [{} <file>] [{} <file>]  [{} \
+            "Usage: {} [{} <id>] {} <kernel> [{} <size>] [{} <file>] [{} <file>] [{}] [{} \
              <system-vm-addr> {} <control-plane-addr> {} <gateway-addr>] [{} [{} <dir>]] [{} \
              <args>] [{} <file>]",
             Self::PROGRAM_NAME,
@@ -419,6 +433,7 @@ impl Args {
             Self::OPT_MEMORY_SIZE,
             Self::OPT_INITRD,
             Self::OPT_STDERR,
+            Self::OPT_STANDALONE,
             Self::OPT_SYSTEM_VM_SOCKADDR,
             Self::OPT_CONTROL_PLANE_SOCKADDR,
             Self::OPT_GATEWAY_SOCKADDR,
@@ -633,6 +648,20 @@ impl Args {
     pub fn gateway_socket_type(&self) -> &str {
         &self.gateway_socket_type
     }
+
+    ///
+    /// # Description
+    ///
+    /// Returns whether the program was launched in standalone mode.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the user VM should run without connecting to a system VM, control-plane, or
+    /// gateway. `false` otherwise.
+    ///
+    pub fn standalone(&self) -> bool {
+        self.standalone
+    }
 }
 
 //==================================================================================================
@@ -751,5 +780,48 @@ mod tests {
                 "error should mention memory size overflow"
             );
         }
+    }
+
+    #[test]
+    fn parse_standalone_skips_socket_validation() -> AnyResult<()> {
+        let args_vec: Vec<String> = vec![
+            String::from("uservm"),
+            Args::OPT_KERNEL.to_string(),
+            String::from("kernel.elf"),
+            Args::OPT_STANDALONE.to_string(),
+        ];
+
+        let parsed_args: Args = Args::parse(args_vec)?;
+
+        assert!(parsed_args.standalone(), "standalone flag should be true");
+        assert_eq!(format!("{}", parsed_args.user_vm_id()), "0");
+        assert_eq!(parsed_args.kernel_filename(), "kernel.elf");
+        assert!(parsed_args.system_vm_addr().is_empty());
+        assert!(parsed_args.control_plane_addr().is_empty());
+        assert!(parsed_args.gateway_addr().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_non_standalone_requires_socket_addrs() {
+        let args_vec: Vec<String> = vec![
+            String::from("uservm"),
+            Args::OPT_USER_VM_ID.to_string(),
+            String::from("0"),
+            Args::OPT_KERNEL.to_string(),
+            String::from("kernel.elf"),
+        ];
+
+        let result = Args::parse(args_vec);
+        assert!(result.is_err(), "non-standalone mode should require socket addresses");
+    }
+
+    #[test]
+    fn parse_standalone_is_false_by_default() -> AnyResult<()> {
+        let args_vec: Vec<String> = build_base_args();
+        let parsed_args: Args = Args::parse(args_vec)?;
+        assert!(!parsed_args.standalone(), "standalone should default to false");
+        Ok(())
     }
 }

--- a/src/uservm/src/main.rs
+++ b/src/uservm/src/main.rs
@@ -21,6 +21,7 @@ use ::log::{
     debug,
     error,
     info,
+    warn,
 };
 use ::std::{
     convert::TryInto,
@@ -85,6 +86,7 @@ pub async fn main() -> Result<ExitCode> {
     let memory_size: usize = args.memory_size();
     let stderr: Option<String> = args.take_vm_stderr();
     let user_vm_id: UserVmIdentifier = args.user_vm_id();
+    let standalone: bool = args.standalone();
 
     // Initialize logger. If this fails, the program will panic.
     ::syslog::init(
@@ -96,14 +98,154 @@ pub async fn main() -> Result<ExitCode> {
 
     debug!(
         "main(): starting user VM (user_vm_id={:?}, kernel={:?}, initrd={:?}, ramfs={:?}, \
-         memory_size_bytes={})",
+         memory_size_bytes={}, standalone={})",
         user_vm_id,
         &kernel_filename,
         initrd_filename.as_deref().unwrap_or("none"),
         ramfs_filename.as_deref().unwrap_or("none"),
-        memory_size
+        memory_size,
+        standalone
     );
 
+    if standalone {
+        run_standalone(
+            kernel_filename,
+            initrd_filename,
+            initrd_args,
+            ramfs_filename,
+            memory_size,
+            stderr,
+        )
+        .await
+    } else {
+        run_managed(
+            args,
+            kernel_filename,
+            initrd_filename,
+            initrd_args,
+            ramfs_filename,
+            memory_size,
+            stderr,
+        )
+        .await
+    }
+}
+
+///
+/// # Description
+///
+/// Runs the user VM in standalone mode without connecting to a system VM, control-plane, or
+/// gateway. The VM's stdout messages are drained and discarded; the VM's stderr is captured as
+/// usual. This mode is useful for debugging and local testing.
+///
+/// # Parameters
+///
+/// - `kernel_filename`: Path to the kernel binary.
+/// - `initrd_filename`: Optional path to the initrd payload.
+/// - `initrd_args`: Optional arguments forwarded to the initrd payload.
+/// - `ramfs_filename`: Optional path to a RAM filesystem image.
+/// - `memory_size`: Amount of guest physical memory in bytes.
+/// - `stderr`: Optional path to a file used to capture the guest's stderr stream.
+///
+/// # Returns
+///
+/// On success, returns the guest's exit code. On failure, returns an error.
+///
+/// # Errors
+///
+/// Returns an error if the VM task panics or if the exit status cannot be converted to a
+/// process exit code.
+///
+async fn run_standalone(
+    kernel_filename: String,
+    initrd_filename: Option<String>,
+    initrd_args: Option<String>,
+    ramfs_filename: Option<String>,
+    memory_size: usize,
+    stderr: Option<String>,
+) -> Result<ExitCode> {
+    info!("main(): running in standalone mode (no system VM, control-plane, or gateway)");
+
+    // Create channels. In standalone mode these are wired directly without an I/O thread.
+    let (vcpu_thread_stdout_tx, mut standalone_data_rx) =
+        mpsc::channel::<Message>(CHANNEL_CAPACITY);
+    // Nobody sends inbound data in standalone mode. The sender is kept alive so that the memory
+    // thread's receiver does not see an immediate channel close.
+    let (_inbound_data_tx, memory_thread_data_rx) = mpsc::channel::<Message>(CHANNEL_CAPACITY);
+    // Kept alive so the orchestrator's io_control_rx does not see an immediate channel close.
+    let (_io_cmd_tx, io_control_rx) = mpsc::channel::<IoControlCommand>(CHANNEL_CAPACITY);
+    // Kept alive so the orchestrator can send control responses without a closed-channel error.
+    let (io_control_tx, _io_resp_rx) = mpsc::channel::<IoControlResponse>(CHANNEL_CAPACITY);
+
+    let counters: MessageCounters = MessageCounters::new();
+
+    let vmm_handle: JoinHandle<Result<u16>> = UserVm::spawn(UserVmArgs {
+        memory_size,
+        initrd_filename,
+        initrd_args,
+        ramfs_filename,
+        stderr,
+        vcpu_thread_stdout_tx,
+        memory_thread_data_rx,
+        io_control_rx,
+        io_control_tx,
+        kernel_filename,
+        counters,
+    });
+
+    // Drain the VM's stdout channel. In standalone mode there is no system VM to forward messages
+    // to, so we simply consume and discard them to prevent the channel from blocking the VM.
+    let drain_handle: JoinHandle<()> = tokio::spawn(async move {
+        while let Some(_msg) = standalone_data_rx.recv().await {}
+        debug!("main(): standalone mode: VM stdout channel closed");
+    });
+
+    let vm_exit_status: Result<u16> = vmm_handle.await?;
+    debug!("main(): uservm completed (exit_status={vm_exit_status:?})");
+
+    // Wait for the drain task to finish.
+    if let Err(error) = drain_handle.await {
+        warn!("main(): standalone drain task failed (error={error:?})");
+    }
+
+    convert_exit_status(vm_exit_status)
+}
+
+///
+/// # Description
+///
+/// Runs the user VM in managed mode, connecting to the system VM, control-plane, and gateway as
+/// required by the full Nanvix deployment.
+///
+/// # Parameters
+///
+/// - `args`: Parsed command-line arguments (consumed for socket addresses).
+/// - `kernel_filename`: Path to the kernel binary.
+/// - `initrd_filename`: Optional path to the initrd payload.
+/// - `initrd_args`: Optional arguments forwarded to the initrd payload.
+/// - `ramfs_filename`: Optional path to a RAM filesystem image.
+/// - `memory_size`: Amount of guest physical memory in bytes.
+/// - `stderr`: Optional path to a file used to capture the guest's stderr stream.
+///
+/// # Returns
+///
+/// On success, returns the guest's exit code. On failure, returns an error.
+///
+/// # Errors
+///
+/// Returns an error if the VM task panics, if socket connections to the system VM or
+/// control-plane fail or time out, or if the exit status cannot be converted to a process exit
+/// code.
+///
+async fn run_managed(
+    args: Args,
+    kernel_filename: String,
+    initrd_filename: Option<String>,
+    initrd_args: Option<String>,
+    ramfs_filename: Option<String>,
+    memory_size: usize,
+    stderr: Option<String>,
+) -> Result<ExitCode> {
     // Only the I/O thread channels are required here; the VMM creates its own internally.
     let (vcpu_thread_stdout_tx, io_thread_data_rx) = mpsc::channel::<Message>(CHANNEL_CAPACITY);
     let (io_thread_data_tx, memory_thread_data_rx) = mpsc::channel::<Message>(CHANNEL_CAPACITY);
@@ -261,7 +403,28 @@ pub async fn main() -> Result<ExitCode> {
         error!("main(): {reason}");
     }
 
-    let result: Result<ExitCode> = match vm_exit_status {
+    convert_exit_status(vm_exit_status)
+}
+
+///
+/// # Description
+///
+/// Converts a VM exit status into a process exit code.
+///
+/// # Parameters
+///
+/// - `vm_exit_status`: The exit status returned by the virtual machine.
+///
+/// # Returns
+///
+/// On success, returns the corresponding [`ExitCode`]. On failure, returns an error.
+///
+/// # Errors
+///
+/// Returns an error if the VM itself failed or if the exit status exceeds the range of `u8`.
+///
+fn convert_exit_status(vm_exit_status: Result<u16>) -> Result<ExitCode> {
+    match vm_exit_status {
         Ok(0) => Ok(ExitCode::from(0)),
         Ok(exit_status) if exit_status != 0 => {
             let exit_code_result: ::std::result::Result<u8, ::std::num::TryFromIntError> =
@@ -281,7 +444,5 @@ pub async fn main() -> Result<ExitCode> {
             error!("main(): {reason}");
             Err(anyhow::anyhow!(reason))
         },
-    };
-
-    result
+    }
 }


### PR DESCRIPTION
Add a `-standalone` CLI flag that allows `uservm.elf` to run without connecting to a system VM, control-plane, or gateway. In this mode, the `-user-vm-id` argument is optional (defaults to 0) and all socket address arguments are skipped.

The main entry point is refactored into `run_standalone()` and `run_managed()`. In standalone mode, a lightweight drain task consumes the VM's outbound messages instead of forwarding them to a system VM.

This enables local debugging and testing of guest binaries without requiring the full nanvixd orchestration:

  ./bin/uservm.elf -kernel ./bin/kernel.elf \
    -initrd ./bin/hello-rust-nostd.elf -standalone