### PR TITLE
[kernel] Negate `errno` In `KcallError`

### DIFF
--- a/src/kernel/src/kcall/kcall_error.rs
+++ b/src/kernel/src/kcall/kcall_error.rs
@@ -25,7 +25,9 @@ pub struct KcallError(i32);
 
 impl From<ErrorCode> for KcallError {
     fn from(code: ErrorCode) -> Self {
-        KcallError(code.get())
+        // Negate the error code following the Linux convention: kernel calls return negative errno
+        // values on failure so that they can be distinguished from non-negative success values.
+        KcallError(-code.get())
     }
 }
 

--- a/src/libs/error/src/lib.rs
+++ b/src/libs/error/src/lib.rs
@@ -286,11 +286,22 @@ impl ErrorCode {
     }
 }
 
-// Manual conversion from i32 to ErrorCode using constants
+// Manual conversion from i32 to ErrorCode using constants.
+// Accepts both positive and negative errno values (the Linux kernel call convention negates errno
+// on the kernel side, so user-space may receive either form).
 impl TryFrom<i32> for ErrorCode {
     type Error = Error;
 
     fn try_from(value: i32) -> Result<Self, Error> {
+        // Normalize to a positive errno value when possible, avoiding overflow on i32::MIN.
+        let value: i32 = if value < 0 {
+            match value.checked_abs() {
+                Some(abs) => abs,
+                None => value,
+            }
+        } else {
+            value
+        };
         match value {
             EPERM => Ok(ErrorCode::OperationNotPermitted),
             ENOENT => Ok(ErrorCode::NoSuchEntry),


### PR DESCRIPTION
KcallError returned positive errno values (e.g., EINVAL=22), but user-space kcall wrappers that use `result >= 0` to detect success (pull, signal_cond, get_thread_data_area) misinterpreted positive error codes as successful return values.

Negate the errno in KcallError so errors are always negative, matching the Linux kernel convention. Update ErrorCode::TryFrom<i32> to accept both positive and negative errno values by normalizing before matching.