### PR TITLE
[uservm] Drain messages on I/O thread shutdown

### DIFF
--- a/src/uservm/src/io_thread.rs
+++ b/src/uservm/src/io_thread.rs
@@ -343,3 +343,171 @@ impl IoThread {
 fn on_message_received_from_system_vm(counters: &MessageCounters) {
     counters.increment_io_thread_messages_received();
 }
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::orchestrator::IoControlResponse;
+    use ::std::mem;
+    use ::sys::ipc::Message;
+    use ::syscomm::SocketStream;
+    use ::tokio::{
+        net::UnixStream,
+        sync::mpsc,
+        task::JoinHandle,
+        time::{
+            Duration,
+            timeout,
+        },
+    };
+
+    /// Maximum time any single test is allowed to run before it is considered hung.
+    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// Creates a pair of connected [`SocketStream`] instances backed by Unix sockets.
+    fn unix_stream_pair() -> (SocketStream, SocketStream) {
+        let (a, b): (UnixStream, UnixStream) =
+            UnixStream::pair().expect("failed to create unix stream pair");
+        (SocketStream::Unix(a), SocketStream::Unix(b))
+    }
+
+    /// Validates that when `IoControlResponse::Shutdown` is received, all messages previously
+    /// buffered in `data_rx` are forwarded to the system VM socket before the I/O thread exits.
+    #[tokio::test]
+    async fn shutdown_drains_buffered_outbound_messages() {
+        let result: ::anyhow::Result<()> = timeout(TEST_TIMEOUT, async {
+            // Wire up the channels.
+            let (data_tx, data_rx): (mpsc::Sender<Message>, mpsc::Receiver<Message>) =
+                mpsc::channel(64);
+            let (inbound_tx, _inbound_rx): (mpsc::Sender<Message>, mpsc::Receiver<Message>) =
+                mpsc::channel(1);
+            let (ctrl_cmd_tx, _ctrl_cmd_rx): (
+                mpsc::Sender<IoControlCommand>,
+                mpsc::Receiver<IoControlCommand>,
+            ) = mpsc::channel(1);
+            let (ctrl_resp_tx, ctrl_resp_rx): (
+                mpsc::Sender<IoControlResponse>,
+                mpsc::Receiver<IoControlResponse>,
+            ) = mpsc::channel(1);
+
+            // System VM socket: the I/O thread writes to one end, we read from the other.
+            let (system_vm_stream, system_vm_peer): (SocketStream, SocketStream) =
+                unix_stream_pair();
+            // Control-plane socket: unused, but required by IoThread::run().
+            let (cp_stream, _cp_peer): (SocketStream, SocketStream) = unix_stream_pair();
+
+            let counters: MessageCounters = MessageCounters::new();
+
+            // Pre-load 3 outbound messages with distinguishable payloads.
+            let num_messages: usize = 3;
+            for i in 0..num_messages {
+                let mut msg: Message = Message::default();
+                msg.payload[0] = u8::try_from(i).expect("num_messages fits in u8");
+                data_tx.send(msg).await.expect("send message");
+            }
+            // Drop the only sender so the channel will close after draining.
+            drop(data_tx);
+
+            // Spawn the I/O thread.
+            let io_handle: JoinHandle<::anyhow::Result<()>> = IoThread::spawn(
+                system_vm_stream,
+                data_rx,
+                inbound_tx,
+                ctrl_cmd_tx,
+                ctrl_resp_rx,
+                cp_stream,
+                counters,
+            )
+            .expect("spawn io thread");
+
+            // Send Shutdown to trigger the drain path.
+            ctrl_resp_tx
+                .send(IoControlResponse::Shutdown)
+                .await
+                .expect("send shutdown");
+
+            // Wait for the I/O thread to finish.
+            let io_result: ::anyhow::Result<()> = io_handle.await.expect("join io thread");
+            assert!(io_result.is_ok(), "I/O thread returned an error: {io_result:?}");
+
+            // Read back all messages from the peer end of the system VM socket.
+            let msg_size: usize = mem::size_of::<Message>();
+            let mut buf: Vec<u8> = vec![0u8; msg_size * num_messages];
+            let mut total_read: usize = 0;
+            let (mut peer_rx, _peer_tx) = system_vm_peer.split();
+            while total_read < buf.len() {
+                let n: usize = peer_rx
+                    .read(&mut buf[total_read..])
+                    .await
+                    .expect("read from peer socket");
+                assert!(n > 0, "peer socket returned 0 bytes before all messages were read");
+                total_read += n;
+            }
+
+            assert_eq!(
+                total_read,
+                msg_size * num_messages,
+                "expected {} bytes ({} messages), got {} bytes",
+                msg_size * num_messages,
+                num_messages,
+                total_read
+            );
+
+            // Verify that message content arrived intact and in order.
+            for i in 0..num_messages {
+                let offset: usize = i * msg_size;
+                let received: Message = Message::try_from_bytes(
+                    buf[offset..offset + msg_size]
+                        .try_into()
+                        .expect("slice len"),
+                )
+                .expect("decode message");
+                let expected: u8 = u8::try_from(i).expect("num_messages fits in u8");
+                assert_eq!(
+                    received.payload[0], expected,
+                    "message {i} payload mismatch: expected {expected}, got {}",
+                    received.payload[0]
+                );
+            }
+
+            Ok(())
+        })
+        .await
+        .expect("test timed out — I/O thread likely hung (regression of issue #1450)");
+        result.expect("test failed");
+    }
+
+    /// Validates that an `mpsc` channel's `recv()` returns `None` once the sole `Sender` is
+    /// dropped, after all buffered messages have been consumed. This property is a prerequisite
+    /// for the shutdown drain loop: if the channel never closes, the drain would block forever.
+    #[tokio::test]
+    async fn channel_closes_when_sole_sender_dropped() {
+        let result: ::anyhow::Result<()> = timeout(TEST_TIMEOUT, async {
+            let (tx, mut rx): (mpsc::Sender<Message>, mpsc::Receiver<Message>) = mpsc::channel(64);
+
+            // Enqueue some messages, then drop the only sender.
+            tx.send(Message::default()).await.expect("send");
+            tx.send(Message::default()).await.expect("send");
+            drop(tx);
+
+            // Drain buffered messages.
+            let mut drained: usize = 0;
+            while let Some(_msg) = rx.recv().await {
+                drained += 1;
+            }
+
+            // recv() must have returned None after draining, proving the channel closed.
+            assert_eq!(drained, 2, "expected to drain 2 buffered messages");
+
+            Ok(())
+        })
+        .await
+        .expect("test timed out — channel did not close (sender lifetime leak)");
+        result.expect("test failed");
+    }
+}

--- a/src/uservm/src/io_thread.rs
+++ b/src/uservm/src/io_thread.rs
@@ -287,6 +287,25 @@ impl IoThread {
                                 },
                                 IoControlResponse::Shutdown => {
                                     debug!(
+                                        "shutdown received, draining outbound messages (elapsed_ms={})",
+                                        start_instant.elapsed().as_millis()
+                                    );
+                                    // Close the channel and drain any buffered outbound
+                                    // messages before dropping the system VM socket.
+                                    data_rx.close();
+                                    while let Some(mut msg) = data_rx.recv().await {
+                                        // Label: uservm::io_thread::system_vm::write()
+                                        profiler::timestamp_message!(&mut msg.payload,
+                                            std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+                                                + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
+                                        );
+                                        let bytes: [u8; ::std::mem::size_of::<Message>()] = msg.to_bytes();
+                                        if let Err(e) = system_vm_tx.write_all(&bytes).await {
+                                            error!("failed to flush message to system VM during shutdown: {e}");
+                                            break;
+                                        }
+                                    }
+                                    debug!(
                                         "shutdown completed (elapsed_ms={})",
                                         start_instant.elapsed().as_millis()
                                     );

--- a/src/uservm/src/io_thread.rs
+++ b/src/uservm/src/io_thread.rs
@@ -21,6 +21,7 @@ use ::log::{
     debug,
     error,
     trace,
+    warn,
 };
 use ::std::mem;
 use ::sys::ipc::Message;
@@ -46,6 +47,27 @@ use ::tokio::{
 
 /// Event loop responsible for bridging the system VM, control-plane, and guest channels.
 pub struct IoThread;
+
+/// Timestamps, serialises, and writes a single [`Message`] to the system VM socket.
+async fn forward_message_to_system_vm(
+    msg: &mut Message,
+    system_vm_tx: &mut SocketStreamWriter,
+) -> Result<()> {
+    // Label: uservm::io_thread::system_vm::write()
+    profiler::timestamp_message!(
+        &mut msg.payload,
+        std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
+            + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
+    );
+    // SAFETY: `Message` derives `Clone`; cloning avoids consuming the caller's binding.
+    let bytes: [u8; ::std::mem::size_of::<Message>()] = msg.clone().to_bytes();
+    system_vm_tx.write_all(&bytes).await.map_err(|e| {
+        let reason: String = format!("failed writing message to system VM socket: {e}");
+        error!("{reason}");
+        anyhow::Error::msg(reason)
+    })?;
+    Ok(())
+}
 
 impl IoThread {
     ///
@@ -189,18 +211,7 @@ impl IoThread {
                     trace!("forwarding message to system VM");
                     match result {
                         Some(mut msg) => {
-                            // Label: uservm::io_thread::system_vm::write()
-                            profiler::timestamp_message!(&mut msg.payload,
-                                std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
-                                    + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
-                            );
-
-                            let bytes: [u8; ::std::mem::size_of::<Message>()] = msg.to_bytes();
-                            system_vm_tx.write_all(&bytes).await.map_err(|e| {
-                                let reason: String = format!("failed writing message to system VM socket: {e}");
-                                error!("{reason}");
-                                anyhow::Error::msg(reason)
-                            })?;
+                            forward_message_to_system_vm(&mut msg, &mut system_vm_tx).await?;
                         },
                         None => {
                             debug!(
@@ -293,18 +304,16 @@ impl IoThread {
                                     // Close the channel and drain any buffered outbound
                                     // messages before dropping the system VM socket.
                                     data_rx.close();
+                                    let mut drained: usize = 0;
                                     while let Some(mut msg) = data_rx.recv().await {
-                                        // Label: uservm::io_thread::system_vm::write()
-                                        profiler::timestamp_message!(&mut msg.payload,
-                                            std::mem::offset_of!(syscall::LinuxDaemonMessage, payload)
-                                                + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
-                                        );
-                                        let bytes: [u8; ::std::mem::size_of::<Message>()] = msg.to_bytes();
-                                        if let Err(e) = system_vm_tx.write_all(&bytes).await {
-                                            error!("failed to flush message to system VM during shutdown: {e}");
+                                        if let Err(e) = forward_message_to_system_vm(&mut msg, &mut system_vm_tx).await {
+                                            let remaining: usize = data_rx.len();
+                                            warn!("drain aborted after {drained} messages, {remaining} messages dropped: {e}");
                                             break;
                                         }
+                                        drained += 1;
                                     }
+                                    debug!("drained {drained} outbound messages");
                                     debug!(
                                         "shutdown completed (elapsed_ms={})",
                                         start_instant.elapsed().as_millis()

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -231,8 +231,10 @@ impl UserVm {
             },
         };
 
+        // Move the stdout sender out of args so no extra clone keeps the
+        // data_rx channel alive after the VMM thread finishes.
         // Output function used for emulating I/O port writes.
-        let vmm_stdout_fn: Box<StdoutFn> = output_fn(args.vcpu_thread_stdout_tx.clone());
+        let vmm_stdout_fn: Box<StdoutFn> = output_fn(args.vcpu_thread_stdout_tx);
 
         // Input function used for emulating I/O port reads.
         #[cfg(not(feature = "hyperlight"))]

--- a/src/uservm/src/memory_thread.rs
+++ b/src/uservm/src/memory_thread.rs
@@ -244,7 +244,7 @@ mod tests {
         control_rx: Receiver<MemoryControlCommand>,
         control_tx: Sender<MemoryControlResponse>,
         mut add_credit: impl FnMut() -> Result<()> + Send + 'static,
-    ) -> JoinHandle<()> {
+    ) -> (JoinHandle<()>, MessageCounters) {
         // Wrap the synchronous test closure into the asynchronous AddCreditFn expected by
         // `MemoryThread::new` in test builds.
         let add_credit_box: Box<AddCreditFn> = Box::new(move || {
@@ -252,8 +252,16 @@ mod tests {
             Box::pin(async move { res })
         });
         let counters: MessageCounters = MessageCounters::new();
-        MemoryThread::new(data_rx, data_tx, control_rx, control_tx, add_credit_box, counters)
-            .spawn()
+        let handle: JoinHandle<()> = MemoryThread::new(
+            data_rx,
+            data_tx,
+            control_rx,
+            control_tx,
+            add_credit_box,
+            counters.clone(),
+        )
+        .spawn();
+        (handle, counters)
     }
 
     // Helper: small timeout to avoid hanging tests.
@@ -277,13 +285,17 @@ mod tests {
         let credits: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
         let credits_clone: Arc<AtomicUsize> = credits.clone();
 
-        let handle: JoinHandle<()> = spawn(io_rx, vm_tx, control_rx, resp_tx, move || {
-            credits_clone.fetch_add(1, Ordering::SeqCst);
-            Ok(())
-        });
+        let (handle, counters): (JoinHandle<()>, MessageCounters) =
+            spawn(io_rx, vm_tx, control_rx, resp_tx, move || {
+                credits_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            });
 
         // Send a message that should be forwarded.
         let original: Message = Message::default();
+        // Pre-increment the I/O counter to satisfy the debug_assert in
+        // on_message_received_from_io_thread (mem_received <= io_received).
+        counters.increment_io_thread_messages_received();
         io_tx
             .send(original.clone())
             .await
@@ -330,10 +342,11 @@ mod tests {
 
         let credits: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
         let credits_clone: Arc<AtomicUsize> = credits.clone();
-        let handle: JoinHandle<()> = spawn(io_rx, vm_tx, control_rx, resp_tx, move || {
-            credits_clone.fetch_add(1, Ordering::SeqCst);
-            Ok(())
-        });
+        let (handle, _counters): (JoinHandle<()>, MessageCounters) =
+            spawn(io_rx, vm_tx, control_rx, resp_tx, move || {
+                credits_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            });
 
         // Immediate shutdown.
         control_tx
@@ -364,12 +377,16 @@ mod tests {
             ::tokio::sync::mpsc::channel::<MemoryControlResponse>(1);
 
         let credits: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-        let handle: JoinHandle<()> = spawn(io_rx, vm_tx, control_rx, resp_tx, move || {
-            // Simulate a failure on first credit attempt.
-            Err(anyhow!("simulated credit failure"))
-        });
+        let (handle, counters): (JoinHandle<()>, MessageCounters) =
+            spawn(io_rx, vm_tx, control_rx, resp_tx, move || {
+                // Simulate a failure on first credit attempt.
+                Err(anyhow!("simulated credit failure"))
+            });
 
         let msg: Message = Message::default();
+        // Pre-increment the I/O counter to satisfy the debug_assert in
+        // on_message_received_from_io_thread (mem_received <= io_received).
+        counters.increment_io_thread_messages_received();
         io_tx.send(msg.clone()).await.expect("send first message");
 
         // Forwarded even though credit fails afterwards.


### PR DESCRIPTION
This PR closes #1450

Improvements to shutdown and message draining:

* Refactored the message forwarding logic by extracting it into an async helper function `forward_message_to_system_vm`, simplifying and centralizing error handling for writing messages to the system VM socket. [[1]](diffhunk://#diff-dbba3643e2968a019dd2d091ecf549b4cf004cab74c4e40771a5d7eff58524ffR51-R71) [[2]](diffhunk://#diff-dbba3643e2968a019dd2d091ecf549b4cf004cab74c4e40771a5d7eff58524ffL192-R214)
* Enhanced the shutdown path in `IoThread` to close the outbound channel and drain all buffered messages, logging the number of messages drained or dropped, and using the new forwarding helper.

Testing and validation:

* Added a suite of tests to `src/uservm/src/io_thread.rs` to verify that shutdown drains all buffered outbound messages and that channels close correctly when the sole sender is dropped, preventing lifetime leaks and hangs.

Channel and ownership fixes:

* Updated `UserVm` initialization to avoid cloning the stdout sender, ensuring the outbound data channel is not kept alive unintentionally after the VMM thread completes.

Memory thread test adjustments:

* Modified memory thread test helpers to return both the join handle and message counters, and updated tests to pre-increment counters as needed to satisfy assertions, improving test reliability and correctness. [[1]](diffhunk://#diff-96bbb1b4c82b8ffa5cbd3be7a17085e5cd58e1b0a817363a8a89336fea3ff6b0L247-R264) [[2]](diffhunk://#diff-96bbb1b4c82b8ffa5cbd3be7a17085e5cd58e1b0a817363a8a89336fea3ff6b0L280-R298) [[3]](diffhunk://#diff-96bbb1b4c82b8ffa5cbd3be7a17085e5cd58e1b0a817363a8a89336fea3ff6b0L333-R346) [[4]](diffhunk://#diff-96bbb1b4c82b8ffa5cbd3be7a17085e5cd58e1b0a817363a8a89336fea3ff6b0L367-R389)