### PR TITLE
[build Update Python `venv` to `.venv`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,12 +17,12 @@ build-gdb
 toolchain
 
 # Build artifacts
+.venv/
 bin/
 /lib/
 /logs/
 images/
 target/
-venv/
 /sysroot-debug/
 /sysroot-release/
 sysroot

--- a/Makefile
+++ b/Makefile
@@ -667,13 +667,17 @@ ifneq ($(VERBOSE),yes)
 PY_VERBOSE += >> /dev/null 2>&1
 endif
 PYTHON_VENV_DIRECTORY=$(ROOT_DIR)/.venv
+PYTHON_STAMP=$(PYTHON_VENV_DIRECTORY)/.requirements.stamp
 
-python-init:
+python-init: $(PYTHON_STAMP)
+
+$(PYTHON_STAMP): $(ROOT_DIR)/requirements.txt
 	@if [ ! -f $(PYTHON_VENV_DIRECTORY)/bin/pip3 ]; then \
 		$(FORCE_RM_CMD) $(PYTHON_VENV_DIRECTORY); \
 		python3 -m venv $(PYTHON_VENV_DIRECTORY); \
 	fi
-	@$(PYTHON_VENV_DIRECTORY)/bin/pip3 install "black>=24.0.0" "flake8>=7.0.0" > /dev/null
+	@$(PYTHON_VENV_DIRECTORY)/bin/pip3 install -r $(ROOT_DIR)/requirements.txt $(PY_VERBOSE)
+	@touch $(PYTHON_STAMP)
 
 python-format: python-init
 	@$(PYTHON_VENV_DIRECTORY)/bin/python3 -m black $(PYTHON_FILES) $(PY_VERBOSE)

--- a/Makefile
+++ b/Makefile
@@ -666,7 +666,7 @@ PY_VERBOSE :=
 ifneq ($(VERBOSE),yes)
 PY_VERBOSE += >> /dev/null 2>&1
 endif
-PYTHON_VENV_DIRECTORY=$(ROOT_DIR)/venv
+PYTHON_VENV_DIRECTORY=$(ROOT_DIR)/.venv
 
 python-init:
 	@if [ ! -f $(PYTHON_VENV_DIRECTORY)/bin/pip3 ]; then \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Development tools.
+black>=24.0.0
+flake8>=7.0.0


### PR DESCRIPTION
Python environment setup improvements:

* Changed the virtual environment directory from `venv` to `.venv` for better alignment with common conventions.
* Updated the package installation step to use `requirements.txt` instead of hardcoding package versions, making dependency management easier and more scalable.