### PR TITLE
[Libs] Kernel Call Wrapper Does not Distinguish Success from Error

### DIFF
--- a/src/libs/sys/src/lib.rs
+++ b/src/libs/sys/src/lib.rs
@@ -9,6 +9,7 @@
 #![forbid(clippy::large_stack_frames)]
 #![forbid(clippy::large_stack_arrays)]
 #![feature(never_type)] // exit() uses this.
+#![feature(likely_unlikely)] // Branch hints for unlikely error paths.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 //==================================================================================================

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -82,7 +82,7 @@ pub fn gettid() -> Result<ThreadIdentifier, Error> {
 ///
 /// - `status`: Exit status.
 ///
-/// # Return Values
+/// # Returns
 ///
 /// Upon successful completion, this function does not return. Upon failure, an error is returned
 /// instead.
@@ -96,6 +96,20 @@ pub fn exit(status: i32) -> Result<!, Error> {
 // Capability Control
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Controls a capability for the calling process.
+///
+/// # Parameters
+///
+/// - `capability`: Capability to control.
+/// - `value`: Whether to enable or disable the capability.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
 pub fn capctl(capability: Capability, value: bool) -> Result<(), Error> {
     let result: i64 = kcall2!(KcallNumber::CapCtl.into(), capability as u32, value as u32);
 
@@ -110,6 +124,19 @@ pub fn capctl(capability: Capability, value: bool) -> Result<(), Error> {
 // Terminate
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Terminates a target process.
+///
+/// # Parameters
+///
+/// - `pid`: Process identifier of the process to terminate.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
 pub fn terminate(pid: ProcessIdentifier) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::Terminate.into(), u32::try_from(pid)?);
 
@@ -191,12 +218,37 @@ pub fn terminate(pid: ProcessIdentifier) -> Result<(), Error> {
     "#
 );
 
+///
+/// # Description
+///
+/// Exit handler for newly created threads. Called by the `_do_start_thread` assembly stub when the
+/// thread function returns. Invokes [`exit_thread()`] with the thread's return status.
+///
+/// # Parameters
+///
+/// - `status`: Exit status returned by the thread function.
+///
 #[unsafe(no_mangle)]
 pub extern "C" fn _do_exit_thread(status: usize) -> ! {
     let _ = exit_thread(status);
     unreachable!("failed to exit thread");
 }
 
+///
+/// # Description
+///
+/// Creates a new thread in the calling process.
+///
+/// # Parameters
+///
+/// - `args`: Mutable reference to thread creation arguments, including the entry point and
+///   stack configuration. The `user_fn` field is overwritten with the internal thread entry stub.
+///
+/// # Returns
+///
+/// Upon successful completion, the thread identifier of the new thread is returned. Upon failure,
+/// an error is returned instead.
+///
 pub fn create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Error> {
     unsafe extern "C" {
         fn _do_start_thread() -> !;
@@ -221,6 +273,20 @@ pub fn create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Er
 // Exit Thread
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Exits the calling thread.
+///
+/// # Parameters
+///
+/// - `status`: Exit status of the thread.
+///
+/// # Returns
+///
+/// Upon successful completion, this function does not return. Upon failure, an error is returned
+/// instead.
+///
 pub fn exit_thread(status: usize) -> Result<!, Error> {
     let result: i64 = kcall1!(KcallNumber::ExitThread.into(), status as u32);
 
@@ -231,6 +297,20 @@ pub fn exit_thread(status: usize) -> Result<!, Error> {
 // Join Thread
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Waits for a target thread to terminate and retrieves its exit status.
+///
+/// # Parameters
+///
+/// - `tid`: Thread identifier of the thread to join.
+/// - `retval`: Mutable reference to store the exit status of the joined thread.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
 pub fn join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<(), Error> {
     let result: i64 =
         kcall2!(KcallNumber::JoinThread.into(), i32::from(tid) as u32, retval as *mut usize as u32);
@@ -246,6 +326,21 @@ pub fn join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<(), Erro
 // Lock Mutex
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Locks a mutex. If the mutex is already held, the calling thread blocks until the mutex becomes
+/// available or the optional timeout expires.
+///
+/// # Parameters
+///
+/// - `mutex_addr`: Address of the mutex to lock.
+/// - `timeout`: Optional timeout. If `None`, the call blocks indefinitely.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
 pub fn lock_mutex(mutex_addr: MutexAddress, timeout: Option<SystemTime>) -> Result<(), Error> {
     // Attempt to convert the timeout.
     let (seconds, nanoseconds): (u32, u32) = match timeout {
@@ -277,6 +372,19 @@ pub fn lock_mutex(mutex_addr: MutexAddress, timeout: Option<SystemTime>) -> Resu
 // Unlock Mutex
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Unlocks a mutex previously locked by the calling thread.
+///
+/// # Parameters
+///
+/// - `mutex_addr`: Address of the mutex to unlock.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
 pub fn unlock_mutex(mutex_addr: MutexAddress) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::MutexUnlock.into(), usize::from(mutex_addr) as u32);
 
@@ -291,6 +399,21 @@ pub fn unlock_mutex(mutex_addr: MutexAddress) -> Result<(), Error> {
 // Signal Condition Variable
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Signals a condition variable, waking one or all waiting threads.
+///
+/// # Parameters
+///
+/// - `cond_addr`: Address of the condition variable to signal.
+/// - `broadcast`: If `true`, wakes all waiting threads. If `false`, wakes at most one.
+///
+/// # Returns
+///
+/// Upon successful completion, the number of threads awakened is returned. Upon failure, an error
+/// is returned instead.
+///
 pub fn signal_cond(cond_addr: ConditionAddress, broadcast: bool) -> Result<usize, Error> {
     let result: i64 = kcall4!(
         KcallNumber::CondSignal.into(),
@@ -311,6 +434,22 @@ pub fn signal_cond(cond_addr: ConditionAddress, broadcast: bool) -> Result<usize
 // Wait Condition Variable
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Waits on a condition variable. The calling thread atomically releases the associated mutex and
+/// blocks until the condition variable is signaled or the optional timeout expires.
+///
+/// # Parameters
+///
+/// - `cond_addr`: Address of the condition variable to wait on.
+/// - `mutex_addr`: Address of the mutex associated with the condition variable.
+/// - `timeout`: Optional timeout. If `None`, the call blocks indefinitely.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Upon failure, an error is returned instead.
+///
 pub fn wait_cond(
     cond_addr: ConditionAddress,
     mutex_addr: MutexAddress,
@@ -414,7 +553,7 @@ pub fn sleep(timeout: Duration) -> Result<(), Error> {
 ///
 /// Gets the base address for the user-space thread data area of the calling thread.
 ///
-/// # Return Value
+/// # Returns
 ///
 /// On successful completion, this function returns the base address for the user-space thread data
 /// area of the calling thread. On failure, this function returns an error code that indicates the
@@ -451,7 +590,7 @@ pub fn get_thread_data_area() -> Result<*mut u8, Error> {
 ///
 /// - `user_tda`: Base address for the user-space thread data area. If null, clears the thread data area.
 ///
-/// # Return Value
+/// # Returns
 ///
 /// On successful completion, this function returns empty. On failure, this function returns an
 /// error code that indicates the reason of failure.

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -53,7 +53,7 @@ pub fn getpid() -> Result<ProcessIdentifier, Error> {
     if unlikely(result < 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to getpid()"))
     } else {
-    ProcessIdentifier::try_from(result)
+        ProcessIdentifier::try_from(result)
     }
 }
 
@@ -78,7 +78,7 @@ pub fn gettid() -> Result<ThreadIdentifier, Error> {
     if unlikely(result < 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to gettid()"))
     } else {
-    ThreadIdentifier::try_from(result)
+        ThreadIdentifier::try_from(result)
     }
 }
 
@@ -126,10 +126,11 @@ pub fn exit(status: i32) -> Result<!, Error> {
 pub fn capctl(capability: Capability, value: bool) -> Result<(), Error> {
     let result: i64 = kcall2!(KcallNumber::CapCtl.into(), capability as u32, value as u32);
 
-    if result == 0 {
-        Ok(())
-    } else {
+    // NOTE: errors are unlikely because capability control typically succeeds.
+    if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to capctl()"))
+    } else {
+        Ok(())
     }
 }
 
@@ -153,10 +154,11 @@ pub fn capctl(capability: Capability, value: bool) -> Result<(), Error> {
 pub fn terminate(pid: ProcessIdentifier) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::Terminate.into(), u32::try_from(pid)?);
 
-    if result == 0 {
-        Ok(())
-    } else {
+    // NOTE: errors are unlikely because terminate typically succeeds for a valid process.
+    if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to terminate()"))
+    } else {
+        Ok(())
     }
 }
 
@@ -283,7 +285,7 @@ pub fn create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Er
     if unlikely(result < 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to create_thread()"))
     } else {
-    ThreadIdentifier::try_from(result)
+        ThreadIdentifier::try_from(result)
     }
 }
 
@@ -333,7 +335,8 @@ pub fn join_thread(tid: ThreadIdentifier, retval: &mut usize) -> Result<(), Erro
     let result: i64 =
         kcall2!(KcallNumber::JoinThread.into(), i32::from(tid) as u32, retval as *mut usize as u32);
 
-    if result != 0 {
+    // NOTE: errors are unlikely because join typically succeeds for a valid thread.
+    if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to join thread"))
     } else {
         Ok(())
@@ -379,10 +382,11 @@ pub fn lock_mutex(mutex_addr: MutexAddress, timeout: Option<SystemTime>) -> Resu
         nanoseconds
     );
 
-    if result == 0 {
-        Ok(())
-    } else {
+    // NOTE: errors are unlikely because lock typically succeeds for a valid mutex.
+    if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to lock mutex"))
+    } else {
+        Ok(())
     }
 }
 
@@ -406,10 +410,11 @@ pub fn lock_mutex(mutex_addr: MutexAddress, timeout: Option<SystemTime>) -> Resu
 pub fn unlock_mutex(mutex_addr: MutexAddress) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::MutexUnlock.into(), usize::from(mutex_addr) as u32);
 
-    if result == 0 {
-        Ok(())
-    } else {
+    // NOTE: errors are unlikely because unlock typically succeeds for a valid, held mutex.
+    if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to unlock mutex"))
+    } else {
+        Ok(())
     }
 }
 
@@ -441,10 +446,11 @@ pub fn signal_cond(cond_addr: ConditionAddress, broadcast: bool) -> Result<usize
         u32::MAX
     );
 
-    if result >= 0 {
-        Ok(result as usize)
-    } else {
+    // NOTE: errors are unlikely because signal typically succeeds for a valid condition variable.
+    if unlikely(result < 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to signal condition variable"))
+    } else {
+        Ok(result as usize)
     }
 }
 
@@ -493,10 +499,11 @@ pub fn wait_cond(
         nanoseconds
     );
 
-    if result == 0 {
-        Ok(())
-    } else {
+    // NOTE: errors are unlikely because wait typically succeeds for valid condition/mutex.
+    if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to wait condition variable"))
+    } else {
+        Ok(())
     }
 }
 
@@ -522,10 +529,11 @@ pub fn gettime(buffer: &mut SystemTime) -> Result<(), Error> {
     let result: i64 =
         kcall1!(KcallNumber::GetTime.into(), buffer as *mut SystemTime as usize as u32);
 
-    if result == 0 {
-        Ok(())
-    } else {
+    // NOTE: errors are unlikely because gettime typically succeeds for a valid buffer.
+    if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to get time"))
+    } else {
+        Ok(())
     }
 }
 
@@ -555,10 +563,11 @@ pub fn sleep(timeout: Duration) -> Result<(), Error> {
 
     let result: i64 = kcall2!(KcallNumber::Sleep.into(), seconds, nanoseconds);
 
-    if result == 0 {
-        Ok(())
-    } else {
+    // NOTE: errors are unlikely because sleep typically succeeds for a valid timeout.
+    if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to sleep"))
+    } else {
+        Ok(())
     }
 }
 
@@ -588,10 +597,11 @@ pub fn sleep(timeout: Duration) -> Result<(), Error> {
 pub fn get_thread_data_area() -> Result<*mut u8, Error> {
     let result: i64 = kcall0!(KcallNumber::GetThreadDataArea.into());
 
-    if result >= 0 {
-        Ok(result as *mut u8)
-    } else {
+    // NOTE: errors are unlikely because get_thread_data_area typically succeeds.
+    if unlikely(result < 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to get thread data area"))
+    } else {
+        Ok(result as *mut u8)
     }
 }
 
@@ -625,9 +635,10 @@ pub fn get_thread_data_area() -> Result<*mut u8, Error> {
 pub fn set_thread_data_area(user_tda: *mut u8) -> Result<(), Error> {
     let result: i64 = kcall1!(KcallNumber::SetThreadDataArea.into(), user_tda as usize as u32);
 
-    if result == 0 {
-        Ok(())
-    } else {
+    // NOTE: errors are unlikely because set_thread_data_area typically succeeds.
+    if unlikely(result != 0) {
         Err(Error::new(ErrorCode::try_from(result)?, "failed to set data area"))
+    } else {
+        Ok(())
     }
 }

--- a/src/libs/sys/src/sys/kcall/pm.rs
+++ b/src/libs/sys/src/sys/kcall/pm.rs
@@ -27,7 +27,10 @@ use crate::{
     },
     time::SystemTime,
 };
-use ::core::time::Duration;
+use ::core::{
+    hint::unlikely,
+    time::Duration,
+};
 
 //==================================================================================================
 // Get Process Identifier
@@ -38,7 +41,7 @@ use ::core::time::Duration;
 ///
 /// Gets the process identifier of the calling process.
 ///
-/// # Return Values
+/// # Returns
 ///
 /// Upon successful completion, the process identifier of the calling process is returned. Upon
 /// failure, an error is returned instead.
@@ -46,7 +49,12 @@ use ::core::time::Duration;
 pub fn getpid() -> Result<ProcessIdentifier, Error> {
     let result: i64 = kcall0!(KcallNumber::GetPid.into());
 
+    // NOTE: errors are unlikely because getpid() always succeeds for a valid calling process.
+    if unlikely(result < 0) {
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to getpid()"))
+    } else {
     ProcessIdentifier::try_from(result)
+    }
 }
 
 //==================================================================================================
@@ -58,7 +66,7 @@ pub fn getpid() -> Result<ProcessIdentifier, Error> {
 ///
 /// Gets the thread identifier of the calling thread.
 ///
-/// # Return Values
+/// # Returns
 ///
 /// Upon successful completion, the thread identifier of the calling thread is returned. Upon
 /// failure, an error is returned instead.
@@ -66,7 +74,12 @@ pub fn getpid() -> Result<ProcessIdentifier, Error> {
 pub fn gettid() -> Result<ThreadIdentifier, Error> {
     let result: i64 = kcall0!(KcallNumber::GetTid.into());
 
+    // NOTE: errors are unlikely because gettid() always succeeds for a valid calling thread.
+    if unlikely(result < 0) {
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to gettid()"))
+    } else {
     ThreadIdentifier::try_from(result)
+    }
 }
 
 //==================================================================================================
@@ -266,7 +279,12 @@ pub fn create_thread(args: &mut ThreadCreateArgs) -> Result<ThreadIdentifier, Er
     let result: i64 =
         kcall1!(KcallNumber::CreateThread.into(), args as *const ThreadCreateArgs as usize as u32);
 
+    // NOTE: errors may happen on resource exhaustion, but are still unlikely in general.
+    if unlikely(result < 0) {
+        Err(Error::new(ErrorCode::try_from(result)?, "failed to create_thread()"))
+    } else {
     ThreadIdentifier::try_from(result)
+    }
 }
 
 //==================================================================================================


### PR DESCRIPTION
This pull request enhances the process and thread management system calls in the `sys` library by improving error handling and documentation. The main focus is on making error paths more explicit and efficient using branch prediction hints, as well as adding comprehensive documentation for API clarity.

This PR closes 1447.