### PR TITLE
[build] Centralize kernel constants

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -1,39 +1,97 @@
-# Total size of physical memory (in bytes)
+#==================================================================================================
+# Kernel Build-Time Configuration
+#==================================================================================================
+#
+# This file defines the build-time constants for the Nanvix kernel. Values are consumed by:
+#   - src/libs/config/build.rs  (generates Rust constants for the config crate)
+#   - src/kernel/build.rs       (passes values to the linker script and assembly)
+#
+# Both build scripts validate these values at build time. Invalid configurations will cause a build
+# failure with a descriptive assertion message.
+#
+#==================================================================================================
+
+#==================================================================================================
+# Memory Layout
+#==================================================================================================
+
+# Total size of physical memory (in bytes).
+# Constraints
+# - Must be large enough to hold the kernel image plus the kernel pool.
 memory_size = 134217728
 
 # Number of processors.
 num_processors = 1
 
-# Total size of the kernel pool (in bytes)
-# Notes:
-# - This size should be a multiple of a page size.
-# - This size cannot exceed the size of a page table.
+# Total size of the kernel pool (in bytes).
+# Constraints:
+# - Must be a multiple of the page size.
+# - Must not exceed the size of a page table.
 kpool_size = 4194304
 
-# Kernel stack size (in bytes)
-# Notes:
-# - This size should be a multiple of a page size.
-# - This size must be at least two pages (one guard page + one usable page).
-# - This size cannot exceed the size of a page table.
+# Base address of the kernel pool.
+# Constraints:
+# - Must be aligned to a page table boundary (4 MB).
+# - Must be greater than the kernel image end plus any machine-reserved space.
+# - Must not cause kpool_base + kpool_size to exceed memory_size.
+kpool_base = 0x00800000
+
+#==================================================================================================
+# Stack Configuration
+#==================================================================================================
+
+# Kernel stack size (in bytes).
+# Constraints:
+# - Must be a multiple of the page size.
+# - Must be at least two pages (one guard page + one usable page).
+# - Must not exceed the size of a page table.
 kstack_size = 65536
 
-# Timer frequency (in Hz)
+# Kernel stack guard watermark pattern (repeated 32-bit word).
+# The bottom page of each kernel stack is filled with this pattern at boot. If a stack overflow
+# corrupts the guard page, the pattern mismatch is detected at runtime.
+# Constraints:
+# - Must fit in a 32-bit word.
+kstack_guard_pattern = 0xDEAD1234
+
+# Kernel red zone size (in bytes).
+# The red zone is a small memory area used for inter-processor communication during AP startup.
+# Constraints
+# - Must be a multiple of the word size (4 bytes on x86-32).
+kredzone_size = 128
+
+#==================================================================================================
+# Scheduling and Timing
+#==================================================================================================
+
+# Timer frequency (in Hz).
 timer_freq = 10000
 
-# Scheduler frequency (in ticks)
+# Scheduler frequency (in ticks).
 scheduler_freq = 1000
 
-# Maximum number of messages that can be buffered by the kernel
+#==================================================================================================
+# Inter-Kernel / Inter-Process Communication
+#==================================================================================================
+
+# Maximum number of messages that can be buffered by the kernel.
 # Notes:
 # - When this threshold is reached, inter-kernel communication is blocked.
-#  - This value should be set according to the amount of memory available in the kernel heap.
+# - This value should be set according to the amount of memory available in the kernel heap.
 max_ikc_messages = 128
 
-# Size of an IPC message.
+# Size of an IPC message (in bytes).
 # Notes:
 # - The value of this function has direct impact on IPC performance.
 # - The default value is set to match the size of a cache line in x86 processors.
 ipc_message_size = 64
+
+# Number of IKC messages to poll at a time.
+ikc_poll_batch_size = 1
+
+#==================================================================================================
+# Synchronization Limits
+#==================================================================================================
 
 # Maximum number of mutexes a process may hold at the same time.
 # Notes:
@@ -44,12 +102,3 @@ mutex_open_max = 32
 # Notes:
 # - This number was arbitrarily chosen.
 cond_open_max = 32
-
-# Number of IKC messages to poll at a time.
-ikc_poll_batch_size = 1
-
-# Base address of the kernel pool.
-# Notes:
-# - This value must be aligned to a page table boundary.
-# - This value is used in both the Rust code and the linker script.
-kpool_base = 0x00800000

--- a/src/kernel/build.rs
+++ b/src/kernel/build.rs
@@ -120,20 +120,129 @@ fn main() {
     let kernel_config_path: PathBuf = workspace_dir.join(DEFAULT_KERNEL_CONFIG_PATH);
     let kernel_config: HashMap<String, String> = load_toml(&kernel_config_path);
 
-    // Extract kstack_size from config
-    let kstack_size: usize = match kernel_config.get("kstack_size") {
-        Some(size_str) => size_str
-            .parse::<usize>()
-            .expect("Failed to parse kstack_size"),
-        None => panic!("kstack_size not found in kernel_config.toml"),
-    };
+    /// Helper to retrieve a required key from the kernel config, panicking with a clear message
+    /// if missing.
+    fn required_key<'a>(config: &'a HashMap<String, String>, key: &str) -> &'a str {
+        config
+            .get(key)
+            .unwrap_or_else(|| panic!("Missing required key '{}' in kernel_config.toml", key))
+            .as_str()
+    }
 
-    // Extract kpool_base from config
-    let kpool_base_str: &str = match kernel_config.get("kpool_base") {
-        Some(s) => s.as_str(),
-        None => panic!("kpool_base not found in kernel_config.toml"),
+    // Page size (architectural constant).
+    const PAGE_SIZE: usize = 4096;
+
+    // Extract kstack_size from config.
+    let kstack_size: usize =
+        parse_hex_or_decimal(required_key(&kernel_config, "kstack_size"), "kstack_size");
+
+    // Extract kpool_base from config.
+    let kpool_base: usize =
+        parse_hex_or_decimal(required_key(&kernel_config, "kpool_base"), "kpool_base");
+
+    // Extract kpool_size from config.
+    let kpool_size: usize =
+        parse_hex_or_decimal(required_key(&kernel_config, "kpool_size"), "kpool_size");
+
+    // Extract kredzone_size from config.
+    let kredzone_size: usize =
+        parse_hex_or_decimal(required_key(&kernel_config, "kredzone_size"), "kredzone_size");
+
+    // Extract kstack_guard_pattern from config.
+    let kstack_guard_pattern: usize = parse_hex_or_decimal(
+        required_key(&kernel_config, "kstack_guard_pattern"),
+        "kstack_guard_pattern",
+    );
+
+    //==============================================================================================
+    // Build-Time Assertions
+    //==============================================================================================
+
+    const PAGE_TABLE_SIZE: usize = 4 * 1024 * 1024;
+
+    // kstack_size must be a multiple of the page size.
+    assert!(
+        kstack_size.is_multiple_of(PAGE_SIZE),
+        "kstack_size ({}) must be a multiple of PAGE_SIZE ({})",
+        kstack_size,
+        PAGE_SIZE,
+    );
+
+    // kstack_size must be at least two pages (one guard page + one usable page).
+    assert!(
+        kstack_size >= 2 * PAGE_SIZE,
+        "kstack_size ({}) must be at least 2 * PAGE_SIZE ({})",
+        kstack_size,
+        2 * PAGE_SIZE,
+    );
+
+    // kstack_size must not exceed the size of a page table.
+    assert!(
+        kstack_size <= PAGE_TABLE_SIZE,
+        "kstack_size ({}) must not exceed PAGE_TABLE_SIZE ({})",
+        kstack_size,
+        PAGE_TABLE_SIZE,
+    );
+
+    // kpool_size must be a multiple of the page size.
+    assert!(
+        kpool_size.is_multiple_of(PAGE_SIZE),
+        "kpool_size ({}) must be a multiple of PAGE_SIZE ({})",
+        kpool_size,
+        PAGE_SIZE,
+    );
+
+    // kpool_size must not exceed the size of a page table.
+    assert!(
+        kpool_size <= PAGE_TABLE_SIZE,
+        "kpool_size ({}) must not exceed PAGE_TABLE_SIZE ({})",
+        kpool_size,
+        PAGE_TABLE_SIZE,
+    );
+
+    // kpool_base + kpool_size must fit within physical memory.
+    let memory_size: usize =
+        parse_hex_or_decimal(required_key(&kernel_config, "memory_size"), "memory_size");
+    let kpool_end: usize = match kpool_base.checked_add(kpool_size) {
+        Some(sum) => sum,
+        None => panic!(
+            "kpool_base ({:#x}) + kpool_size ({:#x}) overflows usize",
+            kpool_base, kpool_size,
+        ),
     };
-    let kpool_base: usize = parse_hex_or_decimal(kpool_base_str, "kpool_base");
+    assert!(
+        kpool_end <= memory_size,
+        "kpool_base ({:#x}) + kpool_size ({:#x}) = {:#x} exceeds memory_size ({:#x})",
+        kpool_base,
+        kpool_size,
+        kpool_end,
+        memory_size,
+    );
+
+    // kpool_base must be aligned to a page table boundary (4 MB).
+    assert!(
+        kpool_base.is_multiple_of(PAGE_TABLE_SIZE),
+        "kpool_base ({:#x}) must be aligned to a page table boundary ({:#x})",
+        kpool_base,
+        PAGE_TABLE_SIZE,
+    );
+
+    // kstack_guard_pattern must fit in a 32-bit word.
+    assert!(
+        kstack_guard_pattern <= u32::MAX as usize,
+        "kstack_guard_pattern ({:#x}) must fit in a 32-bit word",
+        kstack_guard_pattern,
+    );
+
+    // kredzone_size must be a multiple of the word size so that usize-indexed loads/stores
+    // in kredzone.rs never silently truncate the usable slot count.
+    const WORD_SIZE: usize = core::mem::size_of::<u32>();
+    assert!(
+        kredzone_size.is_multiple_of(WORD_SIZE),
+        "kredzone_size ({}) must be a multiple of the word size ({})",
+        kredzone_size,
+        WORD_SIZE,
+    );
 
     // Tell Cargo to rerun build script if config changes
     println!("cargo::rerun-if-changed={}", kernel_config_path.display());
@@ -156,8 +265,10 @@ fn main() {
         "-Werror".to_string(),
     ];
 
-    // Add KSTACK_SIZE define from config
+    // Add defines from config for assembly constants.
     cflags.push(format!("-DKSTACK_SIZE={}", kstack_size));
+    cflags.push(format!("-DKREDZONE_SIZE={}", kredzone_size));
+    cflags.push(format!("-DKSTACK_GUARD_PATTERN={:#x}", kstack_guard_pattern));
 
     cfg_if::cfg_if! {
         if #[cfg(debug_assertions)] {

--- a/src/kernel/src/hal/arch/x86/start.S
+++ b/src/kernel/src/hal/arch/x86/start.S
@@ -10,12 +10,11 @@
 /* Page size. */
 #define PAGE_SIZE 4096
 
-/* Kernel Red Zone Size */
-#define KREDZONE_SIZE 128
+/* KSTACK_SIZE is defined via -DKSTACK_SIZE=<value> from build.rs. */
 
-/* Stack guard watermark pattern (repeated 32-bit word).
- * NOTE: This value must match KSTACK_GUARD_PATTERN in src/libs/config/build.rs. */
-#define KSTACK_GUARD_PATTERN 0xDEAD1234
+/* KREDZONE_SIZE is defined via -DKREDZONE_SIZE=<value> from build.rs. */
+
+/* KSTACK_GUARD_PATTERN is defined via -DKSTACK_GUARD_PATTERN=<value> from build.rs. */
 
 /* Multiboot2 magic constant */
 #define MBOOT2_HEADER_MAGIC 0xe85250d6

--- a/src/kernel/src/mm/kredzone.rs
+++ b/src/kernel/src/mm/kredzone.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use ::config::kernel::KREDZONE_SIZE;
 use ::core::mem;
 use ::sys::error::{
     Error,
@@ -13,20 +14,6 @@ use ::sys::error::{
 extern "C" {
     static mut kredzone: usize;
 }
-
-//==================================================================================================
-// Constants
-//==================================================================================================
-
-///
-/// # Description
-///
-/// Size of the kernel red zone (in bytes).
-///
-/// # Note
-///
-/// - This size should match what is defined in start.S
-const KREDZONE_SIZE: usize = 128;
 
 //==================================================================================================
 // Standalone Public Functions

--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -14,6 +14,8 @@ use crate::{
 };
 use ::alloc::vec::Vec;
 use ::arch::mem::PAGE_ALIGNMENT;
+#[cfg(debug_assertions)]
+use ::config::kernel::KSTACK_GUARD_PATTERN;
 use ::core::fmt;
 #[cfg(debug_assertions)]
 use ::sys::error::ErrorCode;
@@ -24,15 +26,6 @@ use ::sys::{
         VirtualAddress,
     },
 };
-
-//==================================================================================================
-// Constants
-//==================================================================================================
-
-/// Watermark pattern used to detect kernel stack overflows.
-/// This value must match `KSTACK_GUARD_PATTERN` in `start.S`.
-#[cfg(debug_assertions)]
-const KSTACK_GUARD_PATTERN: u32 = config::kernel::KSTACK_GUARD_PATTERN;
 
 //==================================================================================================
 // Structures

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -114,8 +114,18 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     constants.push_str(&format!("pub const KSTACK_SIZE: usize = {val};\n"));
 
     // Stack guard watermark pattern.
-    // NOTE: This value must match KSTACK_GUARD_PATTERN in src/kernel/src/hal/arch/x86/start.S.
-    constants.push_str("pub const KSTACK_GUARD_PATTERN: u32 = 0xDEAD1234;\n");
+    let val: u32 = parse_hex_or_decimal_u32(
+        required_key(&kernel_config_toml, "kstack_guard_pattern"),
+        "kstack_guard_pattern",
+    );
+    constants.push_str(&format!("pub const KSTACK_GUARD_PATTERN: u32 = {val:#x};\n"));
+
+    // Kernel red zone size.
+    let val: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "kredzone_size"),
+        "kredzone_size",
+    );
+    constants.push_str(&format!("pub const KREDZONE_SIZE: usize = {val};\n"));
 
     let val: u32 =
         parse_hex_or_decimal_u32(required_key(&kernel_config_toml, "timer_freq"), "timer_freq");
@@ -157,13 +167,107 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     );
     constants.push_str(&format!("pub const IKC_POLL_BATCH_SIZE: usize = {val};\n"));
 
-    let val: usize =
-        parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "kpool_base"), "kpool_base");
-    constants.push_str(&format!("pub const KPOOL_BASE: usize = {val};\n"));
-
     constants.push_str("}\n");
 
-    // Write the generated file
+    //==============================================================================================
+    // Build-Time Assertions
+    //==============================================================================================
+
+    // Re-read constants needed for cross-validation.
+    let memory_size: usize =
+        parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "memory_size"), "memory_size");
+    let kpool_base: usize =
+        parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "kpool_base"), "kpool_base");
+    let kpool_size: usize =
+        parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "kpool_size"), "kpool_size");
+    let kstack_size: usize =
+        parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "kstack_size"), "kstack_size");
+    let kredzone_size: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "kredzone_size"),
+        "kredzone_size",
+    );
+
+    // Architectural constants.
+    const PAGE_SIZE: usize = 4096;
+    const PAGE_TABLE_SIZE: usize = 4 * 1024 * 1024;
+    const WORD_SIZE: usize = core::mem::size_of::<u32>();
+
+    // memory_size must accommodate the kernel pool.
+    let kpool_end: usize = match kpool_base.checked_add(kpool_size) {
+        Some(sum) => sum,
+        None => panic!(
+            "kpool_base ({:#x}) + kpool_size ({:#x}) overflows usize",
+            kpool_base, kpool_size,
+        ),
+    };
+    assert!(
+        kpool_end <= memory_size,
+        "kpool_base ({:#x}) + kpool_size ({:#x}) = {:#x} exceeds memory_size ({:#x})",
+        kpool_base,
+        kpool_size,
+        kpool_end,
+        memory_size,
+    );
+
+    // kpool_base must be page-table aligned (4 MB boundary).
+    assert!(
+        kpool_base.is_multiple_of(PAGE_TABLE_SIZE),
+        "kpool_base ({:#x}) must be aligned to a page table boundary ({:#x})",
+        kpool_base,
+        PAGE_TABLE_SIZE,
+    );
+
+    // kpool_size must be page-aligned.
+    assert!(
+        kpool_size.is_multiple_of(PAGE_SIZE),
+        "kpool_size ({}) must be a multiple of PAGE_SIZE ({})",
+        kpool_size,
+        PAGE_SIZE,
+    );
+
+    // kpool_size must not exceed the size of a page table.
+    assert!(
+        kpool_size <= PAGE_TABLE_SIZE,
+        "kpool_size ({}) must not exceed PAGE_TABLE_SIZE ({})",
+        kpool_size,
+        PAGE_TABLE_SIZE,
+    );
+
+    // kstack_size must be page-aligned.
+    assert!(
+        kstack_size.is_multiple_of(PAGE_SIZE),
+        "kstack_size ({}) must be a multiple of PAGE_SIZE ({})",
+        kstack_size,
+        PAGE_SIZE,
+    );
+
+    // kstack_size must be at least two pages (one guard page + one usable page).
+    assert!(
+        kstack_size >= 2 * PAGE_SIZE,
+        "kstack_size ({}) must be at least 2 * PAGE_SIZE ({})",
+        kstack_size,
+        2 * PAGE_SIZE,
+    );
+
+    // kstack_size must not exceed the size of a page table.
+    assert!(
+        kstack_size <= PAGE_TABLE_SIZE,
+        "kstack_size ({}) must not exceed PAGE_TABLE_SIZE ({})",
+        kstack_size,
+        PAGE_TABLE_SIZE,
+    );
+
+    // kstack_guard_pattern is parsed as u32, so it is guaranteed to fit in a 32-bit word.
+
+    // kredzone_size must be a multiple of the word size.
+    assert!(
+        kredzone_size.is_multiple_of(WORD_SIZE),
+        "kredzone_size ({}) must be a multiple of the word size ({})",
+        kredzone_size,
+        WORD_SIZE,
+    );
+
+    // Write the generated file.
     fs::write(kernel_config_output_path, constants).expect("Failed to write kernel_config.rs");
 }
 


### PR DESCRIPTION
- Reorganize kernel_config.toml with section headers and improved documentation for all build-time constants.
- Move kpool_base and kredzone_size definitions from scattered sources into kernel_config.toml as the single source of truth.
- Read kstack_guard_pattern and kredzone_size from the TOML config in both build scripts (src/kernel/build.rs, src/libs/config/build.rs) instead of hardcoding them.
- Pass KREDZONE_SIZE and KSTACK_GUARD_PATTERN as -D flags to the assembler, eliminating duplicate #define constants in start.S.
- Remove local KREDZONE_SIZE constant from kredzone.rs and local KSTACK_GUARD_PATTERN alias from kstack.rs in favor of the config crate re-exports.
- Add build-time assertions in both build scripts to validate alignment, size, and range constraints for all kernel constants.