### PR TITLE
[ci] Add GitHub Copilot skills for Nanvix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,296 +1,52 @@
 # Copilot Instructions for Nanvix
 
-This document provides essential guidelines for the Copilot coding agent to
-effectively work with the Nanvix repository.
+This file contains only cross-cutting instructions that apply to most tasks.
+Task-specific and procedural details must live in `.github/skills/*/SKILL.md`.
 
-## Project Overview
+## Scope and Priority
 
-Nanvix is a microkernel-based research operating system written primarily in
-Rust and C/C++. It's a complex systems project that targets multiple machine
-types and supports various runtimes.
+- Follow this file for global behavior.
+- For task-specific work, load and follow the matching skill document.
+- If there is overlap, keep this file generic and keep procedures in skills.
 
-### Key Technologies
+## Skill Routing
 
-- **Languages:** Rust (kernel, daemons, libraries), C/C++ (tests), Python and Shell (tooling)
-- **Target Architecture:** x86 (32-bit)
-- **Target Machines:** microvm (default), hyperlight, qemu-pc, qemu-isapc, qemu-baremetal
-- **Runtimes:** Python 3.12.3, Libstdc++ v3, Newlib 4.4.0, WebAssembly (via QuickJS and wasmd) *(built externally)*
-- **Build System:** Bash Scripts + Make + Cargo (Rust) with custom toolchain
-- **Development Tools:** Binutils v2.40, GCC v12.4.0, G++ v12.4.0, GFortran v12.4.0, Rustc v1.93.0
-- **Supported Libraries:** OpenBLAS v0.3.29, OpenSSL v3.5.0, SQLite v3.49.0, Zlib v1.3.1 *(built externally)*
+Use the corresponding skill when the user request matches the topic:
 
-## Repository Structure
+- `benchmarking` → benchmark setup, execution, and result interpretation.
+- `build-and-test` → build, format, lint, spell-check, and test commands.
+- `ci-cd-pipeline` → CI workflow behavior, failures, and release flow.
+- `coding-standards` → detailed style, documentation, and review conventions.
+- `daemon-development` → daemon architecture, implementation, and debugging.
+- `kernel-development` → kernel internals and kernel-call paths.
+- `library-development` → crates under `src/libs` and related architecture.
+- `test-development` → writing and debugging tests.
+- `troubleshooting` → diagnosis of build/runtime/test failures.
+- `user-app-development` → user-space app implementation and execution.
 
-- **`.githook/`** - GitHub hooks
-- **`.github/`** - GitHub Actions workflows and Copilot configuration
-- **`bin/`** - Built binaries (output directory)
-- **`lib/`** - Built libraries (output directory)
-- **`logs/`** - Runtime log files
-- **`build/`** - Build system configuration (linker scripts, Makefiles, TOML configs)
-- **`doc/`** - Documentation files (setup, build, run, test, benchmark)
-- **`scripts/`** - Utility scripts for setup, testing, building, and CI/CD
-- **`src/`** - Source code (see detailed structure below)
-- **`sysroot-debug/`** - System root for debug builds
-- **`sysroot-release/`** - System root for release builds
-- **`target/`** - Cargo build artifacts and intermediate files
-- **`toolchain/`** - Custom cross-compilation toolchain (when built locally)
+## Repository-wide Engineering Rules
 
-### Source Code Structure
+- Keep changes minimal, focused, and consistent with existing style.
+- Fix root causes rather than adding superficial patches.
+- Do not modify unrelated code paths or tests.
+- Update documentation when behavior or interfaces change.
+- Prefer existing project tooling and scripts over ad-hoc commands.
 
-- **`src/benchmarks/`** - Performance benchmarks (echo, noop variants in C, C++, Rust, WASM)
-- **`src/daemons/`** - System services
-  - `linuxd/` - Linux daemon for L2 VM deployment
-  - `memd/` - Memory management daemon
-  - `procd/` - Process management daemon
-  - `wasmd/` - WebAssembly runtime daemon
-- **`src/kernel/`** - Microkernel implementation (Rust, x86 architecture)
-- **`src/libs/`** - System libraries
-  - Core libraries: `arch/`, `config/`, `error/`, `sys/`, `syscall/`
-  - Utilities: `bitmap/`, `slab/`, `raw-array/`, `profiler/`
-  - High-level: `nanvix/`, `posix/`, `nvx/`
-  - Specialized: `elf/`, `hwloc/`, `nanvix-http/`, `nanvix-registry/`, `nanvix-sandbox/`
-- **`src/uservm/`** - UserVM implementation (orchestrates user process execution)
-- **`src/tests/`** - Integration and system tests
-  - Rust tests: `arch-rust/`, `file-rust/`, `testd/`
-  - C tests: `file-c/`, `memory-c/`, `network-c/`, `thread-c/`, `misc-c/`, `dlfcn-c/`
-  - Runtime tests: `quickjs/`, `linux-app/`
-- **`src/user/`** - User-space example applications (hello-c, hello-cpp, hello-rust-nostd, etc.)
-- **`src/utils/`** - Utility programs (nanvixd, nanvix-bench, echo-client)
+## Validation
 
-## Building, Formatting, Linting, and Testing
+- Validate changes with the smallest relevant check first.
+- Expand to broader checks only as needed for confidence.
+- Report any unrelated failures without attempting broad refactors.
 
-Nanvix uses the `z` utility script to streamline building, formatting, linting, and testing.
-All operations can be performed using Docker (recommended for consistency) or a local toolchain.
+## Language and Safety Baseline
 
-### Getting Started
+- Respect language-specific style and lint rules already enforced by the repository.
+- Avoid unsafe patterns unless strictly necessary and justified.
+- Ensure robust error handling and clear diagnostics.
+- Do not introduce machine-specific paths or hardcoded environment assumptions.
 
-To get started with the `z` utility, run:
+## Notes for Maintaining This File
 
-```bash
-./z help
-```
-
-### Build Commands
-
-```bash
-# Build with previous build parameters/options (recommended)
-./z build --with-cached-options -- all
-
-# Build with Docker
-./z build --with-docker -- all
-
-# Build with local toolchain
-./z build -- all
-
-# Build specific targets
-./z build -- kernel          # Build kernel only
-./z build -- all-nanvixd     # Build nanvixd only
-./z build -- all-uservm      # Build uservm only
-```
-
-### Build Parameters
-
-Key build parameters can be set as environment variables or via the `z` utility:
-
-- `MACHINE` - Target machine: `microvm` (default), `hyperlight`, `qemu-pc`, `qemu-isapc`, `qemu-baremetal`
-- `TARGET` - Target architecture: `x86` (only supported value)
-- `RELEASE` - Release build: `yes` or `no` (default)
-- `LOG_LEVEL` - Logging level: `trace`, `debug`, `info`, `warn` (default), `error`, `panic`
-- `PROFILER` - Enable profiler: `yes` or `no` (default)
-- `SINGLE_PROCESS` - Single-process deployment: `yes` (default) or `no`
-- `L2_VM` - L2 VM deployment: `yes` or `no` (default)
-
-Example:
-
-```bash
-./z build -- all MACHINE=hyperlight RELEASE=yes LOG_LEVEL=error
-```
-
-### Code Linting Commands
-
-```bash
-# Check for linting issues in the code
-./z build --with-cached-options -- lint-check
-
-# Fix code linting issues
-./z build --with-cached-options -- lint
-```
-
-### Code Formatting Commands
-
-```bash
-# Check for code formatting issues
-./z build --with-cached-options -- format-check
-
-# Fix code formatting issues
-./z build --with-cached-options -- format
-```
-
-### Spell Check Commands
-
-```bash
-# Check for spelling errors in source code and documentation
-./z build --with-cached-options -- spellcheck
-
-# Fix spelling errors in source code and documentation
-./z build --with-cached-options -- spellcheck-fix
-```
-
-### Testing Commands
-
-#### Unit Tests
-
-```bash
-# Run all unit tests
-./z build --with-cached-options -- run-unit-tests
-```
-
-#### Benchmarking
-
-```bash
-# Compile for benchmarking (requires specific build flags)
-make all RELEASE=yes LOG_LEVEL=panic
-
-# For echo-breakdown benchmark
-make all RELEASE=yes LOG_LEVEL=panic TIMESTAMP_MSG=yes
-
-# Run benchmarks
-./bin/nanvix-bench.elf -benchmark cold-start
-./bin/nanvix-bench.elf -benchmark warm-start
-./bin/nanvix-bench.elf -benchmark warm-start-vmm
-./bin/nanvix-bench.elf -benchmark echo-breakdown
-```
-
-### CI/CD Pipeline
-
-To run the full CI pipeline locally:
-
-```bash
-./scripts/pipeline.sh
-```
-
-This runs formatting checks, linting, spell checking, building, and all tests.
-
-## Coding Standards
-
-### Style & Formatting
-
-- Always follow the existing code style.
-- Code must pass formatting checks with `./z build --with-cached-options -- format-check`.
-- Code must pass linting checks with `./z build --with-cached-options -- lint-check`.
-- Constants must be defined at module/file scope; avoid magic numbers in code paths.
-- Map errors to OS error codes consistently; prefer typed errors over ad-hoc strings.
-- Error messages should contain relevant information about the error and the context in which it occurred.
-- Keep line width to 100 characters maximum (configured in `rustfmt.toml`).
-- All files must include copyright header: `// Copyright(c) The Maintainers of Nanvix.\n// Licensed under the MIT License.`
-
-#### Style & Formatting (Rust only)
-
-- Do not use `panic!`, `unwrap()`, or `expect()` in production code, instead return `Result<T, E>`.
-  - In `#[cfg(test)]` modules, `unwrap()` and `expect()` are acceptable since test failures are expected to panic.
-  - Prefer `expect()` with a descriptive message over `unwrap()` in tests to provide failure context.
-  - Use `#![deny(...)]` instead of `#![forbid(...)]` for `clippy::unwrap_used` and `clippy::expect_used` lints so that test modules can selectively `#[allow]` them.
-- Avoid `unsafe` unless strictly necessary. When unavoidable, narrow its scope and document pre/post conditions.
-- Always add explicit type annotation when defining variables and constants, even if type can be inferred (e.g., `let x: u32 = 42;`).
-- Prefix all import statements with `::` (e.g., use `::std::fs` instead of `std::fs`).
-- Always log errors with `error!` before returning an error.
-- Use `warn!` log level for non-critical warnings that do not affect functionality.
-- Use `info!` log level for informational messages that are not errors or warnings.
-- Use `debug!` log level for debugging information that is for development purposes.
-- Use `trace!` log level for tracing execution flow and detailed debugging information.
-- Logs must be single-line, concise, and machine-parsable when feasible.
-  - Do not use multiline logs or explicit newlines (e.g., `\n`) in messages.
-  - Do not use pretty-printed debug formatting (e.g., `{:#?}`).
-- Module organization:
-  - Group imports at the top after the copyright header and configuration section.
-  - Order sections: Configuration (`#![...]`), Imports, Modules, Constants, Structures, Enumerations, Trait Implementations, Standalone Functions, Tests.
-  - Use section header comments with `//==================================================================================================`.
-
-#### Style & Formatting (C/C++ only)
-
-- Use consistent indentation and formatting as defined in the existing codebase.
-- Include proper header guards in `.h` files.
-- Follow Linux kernel style for C code where applicable.
-- All function declarations must have parameter names in headers.
-- Organize C files with section comments matching Rust style.
-
-#### Style & Formatting (Python only)
-
-- Follow PEP 8 style guidelines.
-- Use type hints for function parameters and return values.
-- Maximum line length: 100 characters.
-- Use docstrings for all public functions and classes.
-
-#### Style & Formatting (Shell scripts only)
-
-- Use `#!/bin/bash` shebang for all shell scripts.
-- Quote all variable expansions unless intentionally splitting words.
-- Use `set -e` to exit on error where appropriate.
-- Add descriptive comments for non-obvious operations.
-- Keep functions small and focused.
-
-### Documentation & Comments
-
-- Public modules, structures, classes, enumerations, types, functions, variables, constants must have doc comments.
-- Use triple-slash `///` for Rust doc comments.
-- Doc comments should start with `# Description` section.
-- Include `# Parameters` section for functions with parameters.
-- Include `# Returns` section for functions that return values.
-- Include `# Errors` section for functions that can fail.
-- Include `# Safety` section for unsafe functions explaining invariants.
-- `TODO`/`FIXME` comments must link to GitHub issues (e.g., `TODO (#1234): rationale`).
-- Terminate all comments with a period.
-- Avoid redundant comments that simply restate the code.
-- Focus comments on *why* rather than *what* (code shows what, comments explain why).
-
-## Coding Review Guidelines
-
-- Ensure that coding standards are followed.
-- Ensure that changes are minimal and focused.
-- Ensure that new code is documented.
-- Ensure that doc comments are updated when behavior changes.
-- Ensure markdown files in the source tree and documentation in `doc/` are updated when behavior changes.
-- Check for typos in comments and documentation.
-- Check for arithmetic overflows.
-- Check for potential resource leaks (e.g., file handles, memory).
-- Check for potential deadlocks.
-- Verify error handling is comprehensive and errors are logged appropriately.
-- Check that all public APIs have documentation.
-- Ensure tests are added or updated for new functionality.
-- Verify that changes work across all supported target machines when applicable.
-- Check that no hardcoded paths or machine-specific constants are introduced.
-- Ensure copyright headers are present in all new files.
-
-### Coding Review Guidelines (Rust only)
-
-- Ensure `c_size_t` is used instead of `usize` for C interoperability.
-- Ensure `c_ssize_t` is used instead of `isize` for C interoperability.
-- Ensure `c_int`, `c_uint`, `c_long`, `c_ulong`, `c_short`, and `c_ushort` are used instead of their Rust counterparts for C interoperability.
-- Member fields in `struct`s must be private and accessed via getter/setter methods.
-- Verify that all imports use the `::` prefix convention.
-- Check that error paths log before returning.
-- Ensure no `unwrap()`, `expect()`, or `panic!()` are used in production code. In `#[cfg(test)]` modules, `expect()` is preferred over `unwrap()` for better failure diagnostics.
-- Verify unsafe blocks are minimized and properly documented.
-- Check that explicit type annotations are used for variable declarations.
-
-### Coding Review Guidelines (C/C++ only)
-
-- Ensure proper memory management (no leaks, double-frees, or use-after-free).
-- Check for buffer overflows and bounds checking.
-- Verify that all pointers are validated before dereferencing.
-- Ensure consistent error handling patterns.
-- Check for proper initialization of variables.
-
-### Coding Review Guidelines (Python only)
-
-- Verify type hints are present and correct.
-- Check for proper exception handling.
-- Ensure resource cleanup (files, sockets) using context managers.
-- Verify adherence to PEP 8.
-
-### Coding Review Guidelines (Shell scripts only)
-
-- Check for proper quoting of variables.
-- Verify error handling with appropriate exit codes.
-- Ensure scripts are idempotent where applicable.
-- Check for shellcheck compliance.
+- Keep this document short and generic.
+- Move detailed command lists, workflows, and checklists to skill files.
+- Add new topics as skills rather than expanding this file with procedures.

--- a/.github/skills/benchmarking/SKILL.md
+++ b/.github/skills/benchmarking/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: benchmarking
+description: Guide for building, running, and analyzing Nanvix performance benchmarks. Use this when asked about benchmark setup, execution, or interpretation.
+---
+
+# Benchmarking Nanvix
+
+Use this skill when the user asks about running, creating, or analyzing performance benchmarks in
+Nanvix.
+
+## Benchmark Tool
+
+Nanvix includes `nanvix-bench` (`src/utils/nanvix-bench/`) for measuring system performance.
+Benchmarks require a release build with panic-level logging.
+
+## Building for Benchmarks
+
+```bash
+# Standard benchmarks.
+./z build -- all RELEASE=yes LOG_LEVEL=panic
+
+# Echo-breakdown benchmark (requires message timestamping).
+./z build -- all RELEASE=yes LOG_LEVEL=panic TIMESTAMP_MSG=yes
+```
+
+## Available Benchmarks
+
+| Benchmark               | Description                           |
+|-------------------------|---------------------------------------|
+| `boot-time`             | Start a user VM (no linuxd)           |
+| `cold-start`            | Start linuxd + VM + HTTP echo         |
+| `cold-start-l2`         | `cold-start` with linuxd in L2 VM     |
+| `cold-start-uvm`        | `cold-start` reusing linuxd           |
+| `concurrent`            | `cold-start` with many VMs alive      |
+| `concurrent-l2`         | `concurrent` with linuxd in L2 VM     |
+| `echo-breakdown`        | HTTP echo step-by-step breakdown      |
+| `echo-breakdown-l2`     | `echo-breakdown` with linuxd in L2 VM |
+| `round-trip-latency`    | Latency vs. echo payload size         |
+| `warm-start`            | Fixed-size HTTP echo latency          |
+| `warm-start-l2`         | `warm-start` with linuxd in L2 VM     |
+| `warm-start-vmm`        | `warm-start` without linuxd           |
+
+
+## Running Benchmarks
+
+```bash
+# Basic usage.
+./bin/nanvix-bench.elf -benchmark cold-start
+./bin/nanvix-bench.elf -benchmark warm-start
+./bin/nanvix-bench.elf -benchmark echo-breakdown
+
+# See all options.
+./bin/nanvix-bench.elf -help
+```
+
+## Core Pinning (Recommended)
+
+For best performance, pin components to different CPU dies.  Create a JSON config:
+
+```json
+{
+    "client_core_str": "0-9",
+    "linuxd_core_str": "10-14",
+    "nanovm_core_str": "15-19"
+}
+```
+
+Then pass it to the benchmark:
+
+```bash
+./bin/nanvix-bench.elf \
+    -benchmark <benchmark> \
+    -hwloc <path_to_config.json>
+```
+
+## High-Iteration Runs
+
+For benchmarks with many iterations, increase system limits:
+
+```bash
+ulimit -u 65536    # Max user processes.
+ulimit -n 65536    # Max open files.
+```
+
+## Benchmark Applications
+
+Source code for benchmark programs:
+
+| Benchmark App     | Path                                | Lang |
+|-------------------|-------------------------------------|------|
+| `echo-c`          | `src/benchmarks/echo-c/`            | C    |
+| `echo-cpp`        | `src/benchmarks/echo-cpp/`          | C++  |
+| `echo-rust-nostd` | `src/benchmarks/echo-rust-nostd/`   | Rust |
+| `echo-wasm-rust`  | `src/benchmarks/echo-wasm-rust/`    | WASM |
+| `noop-c`          | `src/benchmarks/noop-c/`            | C    |
+| `noop-cpp`        | `src/benchmarks/noop-cpp/`          | C++  |
+| `noop-js`         | `src/benchmarks/noop-js/`           | JS   |
+| `noop-rust-nostd` | `src/benchmarks/noop-rust-nostd/`   | Rust |
+| `noop-wasm-rust`  | `src/benchmarks/noop-wasm-rust/`    | WASM |
+
+## Analyzing Results
+
+Benchmark results can be visualized with the plotting script:
+
+```bash
+python3 scripts/plot-performance.py
+```
+
+Additional analysis can be done with the automation script:
+
+```bash
+python3 scripts/benchmark.py
+```

--- a/.github/skills/build-and-test/SKILL.md
+++ b/.github/skills/build-and-test/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: build-and-test
+description: Guide for building, formatting, linting, spell-checking, and testing Nanvix with z. Use this when asked to build or validate the repository.
+---
+
+# Build and Test Nanvix
+
+Use this skill when the user asks to build, compile, format, lint, spell-check, or run tests on
+Nanvix. This covers all build-system operations exposed through the `z` utility.
+
+## Prerequisites
+
+- Development environment set up per `doc/setup.md`.
+- Either a local cross-compilation toolchain (`toolchain/`) or Docker installed.
+
+## Building
+
+### Preferred Build Commands (using `z` utility)
+
+```bash
+# Build everything with previously cached build options.
+./z build --with-cached-options -- all
+
+# Build everything with Docker.
+./z build --with-docker -- all
+
+# Build everything with the local toolchain.
+./z build -- all
+```
+
+### Building Individual Components
+
+```bash
+# Kernel only.
+./z build --with-cached-options -- kernel
+# Nanvixd only.
+./z build --with-cached-options -- all-nanvixd
+# UserVM only.
+./z build --with-cached-options -- all-uservm
+```
+
+### Build Parameters
+
+Set these as environment variables or pass them after `--` in the `z` command:
+
+| Parameter        | Values                   | Default   |
+|------------------|--------------------------|-----------|
+| `MACHINE`        | `microvm`, `hyperlight`, | `microvm` |
+|                  | `qemu-pc`, `qemu-isapc`, |           |
+|                  | `qemu-baremetal`         |           |
+| `TARGET`         | `x86`                    | `x86`     |
+| `RELEASE`        | `yes`, `no`              | `no`      |
+| `LOG_LEVEL`      | `trace`, `debug`,        | `warn`    |
+|                  | `info`, `warn`,          |           |
+|                  | `error`, `panic`         |           |
+| `PROFILER`       | `yes`, `no`              | `no`      |
+| `SINGLE_PROCESS` | `yes`, `no`              | `no`      |
+| `L2_VM`          | `yes`, `no`              | `no`      |
+
+Example with custom parameters:
+
+```bash
+./z build -- all MACHINE=hyperlight \
+    RELEASE=yes LOG_LEVEL=error
+```
+
+### Manual Build Variants
+
+```bash
+# Default debug build.
+./z build -- all
+# Release build.
+./z build -- all RELEASE=yes LOG_LEVEL=panic
+# For echo-breakdown benchmark.
+./z build -- all RELEASE=yes LOG_LEVEL=panic TIMESTAMP_MSG=yes
+```
+
+## Code Quality
+
+### Formatting
+
+```bash
+# Check formatting issues.
+./z build --with-cached-options -- format-check
+# Auto-fix formatting issues.
+./z build --with-cached-options -- format
+```
+
+### Linting
+
+```bash
+# Check linting issues.
+./z build --with-cached-options -- lint-check
+# Auto-fix linting issues.
+./z build --with-cached-options -- lint
+```
+
+### Spell Checking
+
+```bash
+# Check spelling errors.
+./z build --with-cached-options -- spellcheck
+# Fix spelling errors.
+./z build --with-cached-options -- spellcheck-fix
+```
+
+## Testing
+
+### Unit Tests
+
+```bash
+./z build --with-cached-options -- run-unit-tests
+```
+
+### System Integration Tests (microvm and hyperlight only)
+
+```bash
+./z build --with-cached-options -- run-nanvix-tests
+```
+
+Test configurations are auto-selected based on deployment mode:
+
+- Single-process: `test/test-single_process.toml`
+- L2 VM: `test/test-l2.toml`
+- Multi-process: `test/test-multi_process.toml`
+
+### All Tests
+
+```bash
+./z build --with-cached-options -- test
+```
+
+## Cleaning
+
+```bash
+./z clean        # Clean build artifacts.
+./z distclean    # Remove all generated files.
+```
+
+## CI/CD Pipeline
+
+```bash
+# Run the full CI pipeline locally.
+./scripts/pipeline.sh
+```
+
+The pipeline covers: spell checking, formatting, linting, building, and testing across multiple
+machine and deployment configurations.
+
+## Troubleshooting Build Issues
+
+- If builds fail with toolchain errors, verify `toolchain/` symlink points to a valid toolchain.
+- If Docker builds fail, ensure Docker is running and the image is available.
+- Use `./z help` for usage information.
+- Cached build options are stored in `.z.cache` — delete this file to reset.

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: ci-cd-pipeline
+description: Guide for Nanvix CI and GitHub Actions workflow behavior, including local pipeline execution and matrix coverage. Use this when asked about CI checks, workflow failures, or release flow.
+---
+
+# CI/CD Pipeline
+
+Use this skill when the user asks about the continuous integration and deployment pipeline, GitHub
+Actions workflows, or automated quality checks.
+
+## Running the Full Pipeline Locally
+
+```bash
+./scripts/pipeline.sh
+```
+
+The pipeline runs all quality checks and tests across the supported configuration matrix.
+
+## Pipeline Steps
+
+The pipeline runs these steps in order:
+
+1. **Spell Check** — Checks spelling in source code.
+2. **Format Check** — Verifies code formatting.
+3. **Lint Check** — Runs Clippy and other linters.
+4. **Build** — Compiles all targets.
+5. **Test** — Runs unit and system integration tests.
+
+## Configuration Matrix
+
+### Machine-Independent Steps
+
+- `spellcheck` and `format` run once (not per-machine).
+
+### Machine-Dependent Steps
+
+`scripts/pipeline.sh` currently executes machine-dependent
+steps only for `microvm` and `hyperlight` (qemu variants are
+excluded in `is_excluded()`).
+
+| Machine       | Build Types    | Deployment Types     |
+|---------------|----------------|----------------------|
+| `microvm`     | debug, release | single, multi, l2    |
+| `hyperlight`  | debug, release | single, multi, l2    |
+
+### Build Parameter Mapping
+
+| Deployment Type | `SINGLE_PROCESS` | `L2_VM` |
+|-----------------|------------------|---------|
+| single-process  | `yes`            | `no`    |
+| multi-process   | `no`             | `no`    |
+| l2              | `no`             | `yes`   |
+
+## Individual Quality Checks
+
+```bash
+# Spell check.
+./z build --with-cached-options -- spellcheck
+
+# Format check.
+./z build --with-cached-options -- format-check
+
+# Lint check.
+./z build --with-cached-options -- lint-check
+
+# Unit tests.
+./z build --with-cached-options -- run-unit-tests
+```
+
+## GitHub Actions Workflows
+
+Workflows are defined in `.github/workflows/`. They follow the same quality gates as the local
+pipeline, but matrix coverage is split across multiple jobs (including dedicated L2 jobs) and run on
+pull requests and pushes to `dev`.
+
+Matrix coverage in GitHub Actions:
+
+- `checks`: format + spellcheck (single run).
+- `lint`, `ci-build`, `ci-test`: `qemu-pc`, `microvm`, `hyperlight` with `single-process` and
+  `multi-process` (excluding `qemu-pc + single-process`).
+- `ci-l2`: separate L2 jobs for `microvm` and `hyperlight`.
+
+## Release Process
+
+```bash
+# Create a release archive.
+./z build -- release
+
+# The archive name follows this pattern:
+# nanvix-<ver>-<machine>-<deploy>-<mode>-<log>.tar.bz2
+```
+
+Minor releases can be created with:
+
+```bash
+./scripts/create-minor-release.sh
+```
+
+## Pipeline Output
+
+The pipeline tracks and reports:
+
+- Pass/fail/skip counts per step.
+- Total elapsed time.
+- Detailed error output for failed steps.

--- a/.github/skills/coding-standards/SKILL.md
+++ b/.github/skills/coding-standards/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: coding-standards
+description: Detailed Nanvix coding, documentation, and review standards across Rust, C/C++, Python, and Shell. Use this when asked to implement or review code quality conventions.
+---
+
+# Coding Standards and Review Guidelines
+
+Use this skill when the user asks about style rules, documentation requirements, code review checks,
+or language-specific conventions.
+
+## General Standards
+
+- Always follow the existing code style in the touched component.
+- Keep changes minimal and focused.
+- Use module/file-scope constants; avoid magic numbers in logic.
+- Prefer typed errors and consistent OS error mapping over ad-hoc strings.
+- Keep diagnostics concise and informative.
+- Respect the repository line width limit (100 columns).
+- Add/update docs when behavior or interfaces change.
+- Avoid machine-specific paths and hardcoded environment assumptions.
+
+## Documentation and Comments
+
+- Public modules, types, functions, constants, and variables should have doc comments.
+- Rust doc comments use `///`.
+- For APIs, include sections as applicable: `# Description`, `# Parameters`, `# Returns`, `# Errors`.
+- For unsafe APIs, include a `# Safety` section describing invariants.
+- `TODO` and `FIXME` comments should reference an issue (for example: `TODO (#1234): ...`).
+- Prefer comments that explain *why*.
+- End comments with a period.
+
+## Rust-Specific Rules
+
+- Avoid `panic!`, `unwrap()`, and `expect()` in production code; return `Result<T, E>`.
+- In `#[cfg(test)]`, `expect()` is preferred over `unwrap()` for diagnostics.
+- Prefer `#![deny(...)]` over `#![forbid(...)]` for unwrap/expect lints to allow scoped test
+  exceptions.
+- Minimize `unsafe`; keep scope narrow and document pre/post conditions.
+- Use explicit type annotations for local variables and constants.
+- Prefix imports with `::`.
+- Log errors before returning from error paths.
+- Keep logs single-line and machine-friendly; avoid multiline and pretty debug formatting.
+- For C interop, prefer C ABI types (`c_size_t`, `c_ssize_t`, `c_int`, `c_uint`, `c_long`,
+  `c_ulong`, `c_short`, `c_ushort`) over Rust primitive aliases.
+- Keep struct fields private and expose accessors when API-facing.
+
+## C/C++-Specific Rules
+
+- Follow existing formatting and indentation patterns.
+- Use proper header guards in headers.
+- Use Linux-kernel-style C conventions where applicable.
+- Include parameter names in function declarations in headers.
+- Validate pointers before dereferencing and check bounds on buffers.
+- Ensure robust memory management (no leaks, double-free, use-after-free).
+
+## Python-Specific Rules
+
+- Follow PEP 8.
+- Use type hints for function signatures.
+- Keep line length at or below 100 characters.
+- Add docstrings for public functions and classes.
+- Use context managers for resource management.
+
+## Shell-Specific Rules
+
+- Use `#!/bin/bash` shebang.
+- Quote variable expansions unless word-splitting is intentional.
+- Use `set -e` where appropriate.
+- Keep scripts small and focused.
+- Add comments for non-obvious operations.
+
+## Review Checklist
+
+- Ensure style and lint rules are satisfied.
+- Verify docs/comments were updated where behavior changed.
+- Check for arithmetic overflow risks.
+- Check for resource leaks and deadlocks.
+- Verify comprehensive error handling and error logging.
+- Ensure relevant tests are added/updated.
+- Verify no hardcoded machine-specific behavior was introduced.

--- a/.github/skills/daemon-development/SKILL.md
+++ b/.github/skills/daemon-development/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: daemon-development
+description: Guide for developing and debugging Nanvix daemons, including guest daemons and host linuxd behavior. Use this when asked about daemon architecture or daemon changes.
+---
+
+# Daemon Development
+
+Use this skill when the user asks about developing, modifying, or debugging system daemons in
+Nanvix. Daemons are long-running system services that run in user-space and provide core OS
+functionality.
+
+## Daemon Overview
+
+| Daemon   | Path                  | Target | Purpose              |
+|----------|-----------------------|--------|----------------------|
+| `memd`   | `src/daemons/memd/`   | Guest  | Memory management.   |
+| `procd`  | `src/daemons/procd/`  | Guest  | Process management.  |
+| `wasmd`  | `src/daemons/wasmd/`  | Guest  | WebAssembly runtime. |
+| `linuxd` | `src/daemons/linuxd/` | Host   | L2 VM management.    |
+
+## Guest Daemons (`memd`, `procd`, `wasmd`)
+
+Guest daemons are `#![no_std]`, `#![no_main]` Rust binaries that run inside the Nanvix microkernel
+environment. They communicate with the kernel through kernel calls (`sys::kcall`) and handle system
+events/messages.
+
+### Memory Daemon (`memd`)
+
+- Handles page faults by terminating faulting processes and resuming exception events.
+- Processes IPC requests for memory management.
+- Uses `sys::kcall::pm::terminate()` and `sys::kcall::event::resume()`.
+
+### Process Daemon (`procd`)
+
+- Manages process lifecycle (creation, termination, scheduling).
+- Handles IPC-based process management requests.
+
+### WebAssembly Daemon (`wasmd`)
+
+- Runs WASM modules using the `wasmi` interpreter.
+- Configured via `WASM_BINARY` and `WASMD_SOCKADDR`.
+- Socket address defaults to `127.0.0.1:8585`.
+
+## Host Daemon (`linuxd`)
+
+- Runs on the host Linux system with full `std` support.
+- Manages L2 VM deployment and host-side resources.
+- Configuration in `build/linuxd_config.toml`.
+- Only built for `microvm` and `hyperlight` machines.
+
+## Building Daemons
+
+```bash
+# Build all daemons as part of the full build.
+./z build --with-cached-options -- all
+
+# Guest daemons: GUEST_CARGO_BUILD_CMD.
+# Host daemons (linuxd): HOST_CARGO_BUILD_CMD.
+```
+
+## Creating a New Guest Daemon
+
+1. Create directory at `src/daemons/<name>/`.
+
+2. Add `Cargo.toml`:
+
+   ```toml
+   [package]
+   name = "<name>"
+   version.workspace = true
+   license-file.workspace = true
+   authors.workspace = true
+   edition.workspace = true
+
+   [[bin]]
+   name = "<name>"
+   path = "src/main.rs"
+
+   [dependencies]
+   sys = { workspace = true }
+   syslog = { workspace = true }
+   # Additional dependencies as needed.
+   ```
+
+3. Create `src/main.rs` with:
+
+   ```rust
+   // Copyright(c) The Maintainers of Nanvix.
+   // Licensed under the MIT License.
+
+   #![no_std]
+   #![no_main]
+
+   extern crate alloc;
+
+   // Daemon implementation.
+   ```
+
+4. Add the crate to the workspace `members` in root
+   `Cargo.toml`.
+
+5. Add the daemon name to `ALL_GUEST_DAEMONS` in the
+   `Makefile`.
+
+## Coding Rules (Daemon-Specific)
+
+- Guest daemons must be `#![no_std]` and `#![no_main]`.
+- Use kernel calls (`sys::kcall::*`) for system interactions.
+- Handle IPC messages by parsing `SystemMessage` structures.
+- Always handle errors gracefully — daemons must not crash.
+- Log all errors with `error!` before returning.
+- Use the `syslog` crate for logging within guest daemons.

--- a/.github/skills/kernel-development/SKILL.md
+++ b/.github/skills/kernel-development/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: kernel-development
+description: Guide for modifying and debugging the Nanvix kernel architecture and kernel-call paths. Use this when asked about kernel internals or kernel implementation changes.
+---
+
+# Kernel Development
+
+Use this skill when the user asks about developing, modifying, or debugging the Nanvix microkernel.
+The kernel is a `#![no_std]` Rust binary targeting x86 (32-bit) and lives in `src/kernel/`.
+
+## Architecture Overview
+
+The kernel is a freestanding binary (`#![no_std]`,
+`#![no_main]`) that runs in ring 0 on x86. Entry point is
+`src/kernel/src/kmain.rs`.
+
+### Key Modules
+
+| Module   | Path                      | Purpose               |
+|----------|---------------------------|-----------------------|
+| `hal`    | `src/kernel/src/hal/`     | Hardware Abstraction. |
+| `mm`     | `src/kernel/src/mm/`      | Memory Management.    |
+| `pm`     | `src/kernel/src/pm/`      | Process Management.   |
+| `ipc`    | `src/kernel/src/ipc/`     | IPC (mailboxes).      |
+| `event`  | `src/kernel/src/event/`   | Event subsystem.      |
+| `io`     | `src/kernel/src/io/`      | I/O subsystem.        |
+| `kcall`  | `src/kernel/src/kcall/`   | Kernel call dispatch. |
+| `kargs`  | `src/kernel/src/kargs.rs` | Boot args parsing.    |
+| `kimage` | `src/kernel/src/kimage.rs`| Kernel image mgmt.    |
+| `klog`   | `src/kernel/src/klog.rs`  | Kernel logging.       |
+| `kpanic` | `src/kernel/src/kpanic.rs`| Panic handler.        |
+| `uart`   | `src/kernel/src/uart.rs`  | UART serial driver.   |
+
+### Machine Configurations
+
+The kernel supports multiple machine types via Cargo
+feature flags:
+
+- `microvm` (default) — Lightweight VM for KVM.
+- `hyperlight` — Hyperlight-based VM.
+- `qemu-pc` — QEMU PC machine.
+- `qemu-isapc` — QEMU ISA PC machine.
+- `qemu-baremetal` — Bare-metal QEMU.
+
+### Virtual Memory Layout
+
+- `KERNEL_BASE_RAW` to `KPOOL_BASE_RAW` — Kernel binary.
+- `KPOOL_BASE_RAW` to `USER_BASE_RAW` — Kernel pool.
+- `USER_BASE_RAW` to `USER_MMAP_BASE_RAW` — User binary.
+- `USER_MMAP_BASE_RAW` to `USER_LIBS_BASE_RAW` — Mapped.
+- `USER_LIBS_BASE_RAW` to `USER_HEAP_BASE_RAW` — Libs.
+- `USER_HEAP_BASE_RAW` to `USER_HEAP_END_RAW` — Heap.
+- `USER_STACK_TOP_RAW` to `USER_STACK_BASE_RAW` — Stack.
+
+## Building the Kernel
+
+```bash
+./z build --with-cached-options -- kernel
+```
+
+The kernel uses a custom Cargo target
+(`build/targets/x86-kernel.json`) and custom linker scripts
+(`build/kernel/`). Kernel builds disable sccache to avoid
+issues with `compiler_builtins`.
+
+## Key Dependencies
+
+The kernel depends on workspace libraries:
+
+- `arch` — Architecture abstractions.
+- `bitmap` — Bitmap data structure.
+- `config` — Compile-time configuration.
+- `type-safe` — Type-safe wrappers.
+- `raw-array` — Fixed-size arrays.
+- `slab` — Slab allocator.
+- `sys` — System-level types (kcall, IPC, MM, PM).
+
+## Coding Rules (Kernel-Specific)
+
+- All kernel code is `#![no_std]` — only `core` and `alloc`
+  are available.
+- No `panic!`, `unwrap()`, or `expect()` in production
+  kernel code.
+- Use explicit type annotations everywhere.
+- Prefix imports with `::`.
+- Minimize `unsafe` blocks and document safety invariants.
+- Log errors with `error!` macro before returning `Err`.
+- Use kernel-specific Cargo commands:
+  `KERNEL_CARGO_BUILD_CMD`.
+- Kernel configuration is in `build/kernel_config.toml`.
+
+## Kernel Calls (System Calls)
+
+Kernel calls are dispatched through
+`src/kernel/src/kcall/dispatcher.rs`. Each subsystem (PM,
+MM, IPC, Event, IO) registers its own kernel call handlers
+in its respective `kcall/` subdirectory.

--- a/.github/skills/library-development/SKILL.md
+++ b/.github/skills/library-development/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: library-development
+description: Guide for creating and modifying Nanvix libraries under src/libs, including guest no_std and host std crates. Use this when asked about library architecture or crate changes.
+---
+
+# Library Development
+
+Use this skill when the user asks about developing, modifying, or adding system libraries in Nanvix.
+All libraries live under `src/libs/` and are part of the Cargo workspace.
+
+## Library Categories
+
+### Core Libraries (Guest — `#![no_std]`)
+
+These run inside the Nanvix guest (user-space) and are compiled with `cargo +nanvix-x86`:
+
+| Library         | Path                      | Purpose            |
+|-----------------|---------------------------|--------------------|
+| `arch`          | `src/libs/arch/`          | Arch abstractions. |
+| `config`        | `src/libs/config/`        | Config constants.  |
+| `error`         | `src/libs/error/`         | Error types.       |
+| `sys`           | `src/libs/sys/`           | System types.      |
+| `syscall`       | `src/libs/syscall/`       | Syscall interface. |
+| `sysapi`        | `src/libs/sysapi/`        | System API.        |
+| `sysalloc`      | `src/libs/sysalloc/`      | Guest allocator.   |
+| `syslog`        | `src/libs/syslog/`        | Guest logging.     |
+| `syslog-macros` | `src/libs/syslog-macros/` | Log macros.        |
+| `nvx`           | `src/libs/nvx/`           | High-level API.    |
+| `posix`         | `src/libs/posix/`         | POSIX layer.       |
+| `proc`          | `src/libs/proc/`          | Process types.     |
+| `type-safe`     | `src/libs/type-safe/`     | Type-safe values.  |
+
+### Utility Libraries (Guest — `#![no_std]`)
+
+| Library         | Path                        | Purpose         |
+|-----------------|-----------------------------|-----------------|
+| `bitmap`        | `src/libs/bitmap/`          | Bitmap.         |
+| `slab`          | `src/libs/slab/`            | Slab allocator. |
+| `raw-array`     | `src/libs/raw-array/`       | Fixed arrays.   |
+| `static_assert` | `src/libs/static_assert/`   | Compile checks. |
+| `elf`           | `src/libs/elf/`             | ELF parser.     |
+| `libc_stdlib`   | `src/libs/libc_stdlib/`     | C stdlib.       |
+| `libc_string`   | `src/libs/libc_string/`     | C strings.      |
+| `no_fail`       | `src/libs/no_fail/`         | No-fail alloc.  |
+
+### Host Libraries (Host — `std` available)
+
+These run on the host system and are compiled with the host Rust build command
+(`HOST_CARGO_BUILD_CMD`, currently `cargo +nanvix-x86`):
+
+| Library                | Path                             | Purpose      |
+|------------------------|----------------------------------|--------------|
+| `nanvix`               | `src/libs/nanvix/`               | Host API.    |
+| `nanvix-http`          | `src/libs/nanvix-http/`          | HTTP.        |
+| `nanvix-registry`      | `src/libs/nanvix-registry/`      | Registry.    |
+| `nanvix-sandbox`       | `src/libs/nanvix-sandbox/`       | Sandbox.     |
+| `nanvix-sandbox-cache` | `src/libs/nanvix-sandbox-cache/` | Cache.       |
+| `nanvix-terminal`      | `src/libs/nanvix-terminal/`      | Terminal.    |
+| `control-plane-api`    | `src/libs/control-plane-api/`    | Control API. |
+| `hwloc`                | `src/libs/hwloc/`                | HW topology. |
+| `profiler`             | `src/libs/profiler/`             | Profiling.   |
+| `syscomm`              | `src/libs/syscomm/`              | Sockets.     |
+| `user-vm-api`          | `src/libs/user-vm-api/`          | User VM API. |
+
+### Build Utilities
+
+| Library       | Path                    | Purpose        |
+|---------------|-------------------------|----------------|
+| `build-utils` | `src/libs/build-utils/` | Build helpers. |
+
+## Creating a New Library
+
+1. Create the directory under `src/libs/<name>/`.
+
+2. Add a `Cargo.toml` with workspace package metadata:
+
+   ```toml
+   [package]
+   name = "<name>"
+   version.workspace = true
+   license-file.workspace = true
+   authors.workspace = true
+   edition.workspace = true
+
+   [dependencies]
+   # Add dependencies here.
+
+   [features]
+   default = []
+   std = []
+   ```
+
+3. Add the crate to the workspace `members` list in the root `Cargo.toml`.
+
+4. Add the crate to the workspace `[workspace.dependencies]` section.
+
+5. Add the library name to the appropriate list in the
+   `Makefile`:
+   - Guest: `ALL_GUEST_RUST_LIBS` (and optionally `ALL_GUEST_RUST_LIBS_TEST_LIST`).
+   - Host: `ALL_HOST_RUST_LIBS`.
+
+6. Add the copyright header to all source files.
+
+7. Create `src/lib.rs` with proper module organization
+   (see coding standards).
+
+## Building Libraries
+
+```bash
+# Build all guest libraries.
+./z build --with-cached-options -- all
+
+# Run unit tests for host libraries.
+./z build --with-cached-options -- run-unit-tests
+```
+
+Guest libraries use `GUEST_CARGO_BUILD_CMD` (cross-compiled with `cargo +nanvix-x86`). Host
+libraries use `HOST_CARGO_BUILD_CMD`.
+
+## Coding Rules (Library-Specific)
+
+- Guest libraries must support `#![no_std]` with optional `std` feature gate.
+- Use `default-features = false` in workspace dependency declarations.
+- Use `c_size_t`, `c_ssize_t`, `c_int`, etc. for C interoperability.
+- Keep struct fields private; provide getter/setter methods.
+- All public items must have doc comments with
+  `# Description`, `# Parameters`, `# Returns`, and
+  `# Errors` sections as applicable.
+- Unit tests go in `#[cfg(test)]` modules; `expect()` is preferred over `unwrap()`.

--- a/.github/skills/test-development/SKILL.md
+++ b/.github/skills/test-development/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: test-development
+description: Guide for writing, running, and debugging Nanvix unit, integration, and system tests in Rust and C/C++. Use this when asked about test implementation or failures.
+---
+
+# Test Development
+
+Use this skill when the user asks about writing, running, or debugging tests in Nanvix. Nanvix has
+unit tests, integration tests, and system tests written in Rust and C/C++.
+
+## Test Categories
+
+### Unit Tests
+
+Unit tests are `#[cfg(test)]` modules within library crates. They run on the host system using
+`cargo test`.
+
+```bash
+./z build --with-cached-options -- run-unit-tests
+```
+
+Libraries with unit tests are listed in
+`ALL_GUEST_RUST_LIBS_TEST_LIST`: `arch`, `bitmap`, `config`,
+`elf`, `error`, `type-safe`, `proc`, `raw-array`, `slab`,
+`static_assert`, `libc_string`, `syslog-macros`, `syslog`.
+
+### Integration Tests (Guest — Rust)
+
+| Test          | Path                      | Purpose            |
+|---------------|---------------------------|--------------------|
+| `testd`       | `src/tests/testd/`        | Guest test daemon  |
+| `arch-rust`   | `src/tests/arch-rust/`    | Arch tests         |
+| `file-rust`   | `src/tests/file-rust/`    | File tests         |
+| `thread-rust` | `src/tests/thread-rust/`  | Thread tests       |
+| `stress-rust` | `src/tests/stress-rust/`  | Stress tests       |
+| `test-kernel` | `src/tests/test-kernel/`  | Kernel tests       |
+| `linux-app`   | `src/tests/linux-app/`    | Linux app tests    |
+
+### Integration Tests (Guest — C/C++)
+
+| Test         | Path                     | Purpose            |
+|--------------|--------------------------|--------------------|
+| `file-c`     | `src/tests/file-c/`      | File tests         |
+| `memory-c`   | `src/tests/memory-c/`    | Memory tests       |
+| `network-c`  | `src/tests/network-c/`   | Network tests      |
+| `thread-c`   | `src/tests/thread-c/`    | Thread tests       |
+| `misc-c`     | `src/tests/misc-c/`      | Misc tests         |
+| `dlfcn-c`    | `src/tests/dlfcn-c/`     | Dlfcn tests        |
+| `c-bindings` | `src/tests/c-bindings/`  | C bindings tests   |
+
+### System Integration Tests
+
+System tests run the full Nanvix stack (`nanvixd` + kernel + guest) and are available only on
+`microvm` and `hyperlight` machines.
+
+```bash
+./z build --with-cached-options -- run-nanvix-tests
+```
+
+Test configurations:
+
+- `test/test-single_process.toml` — Single-process mode.
+- `test/test-multi_process.toml` — Multi-process mode.
+- `test/test-l2.toml` — L2 VM mode.
+
+The `nanvix-test` utility (`src/utils/nanvix-test/`) drives
+these tests in two execution modes:
+
+- **HTTP Mode**: Programs invoked via HTTP requests to
+  `nanvixd`.
+- **Terminal Mode**: Programs invoked directly by `nanvixd`
+  (native ELF only).
+
+## Writing Unit Tests (Rust)
+
+Add `#[cfg(test)]` modules to library crates:
+
+```rust
+//============================================================
+// Tests
+//============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_example() {
+        let result: u32 = some_function();
+        assert_eq!(result, 42, "expected 42");
+    }
+}
+```
+
+Rules for tests:
+
+- `expect()` is preferred over `unwrap()` for better failure diagnostics.
+- Use `#[allow(clippy::unwrap_used)]` or `#[allow(clippy::expect_used)]` at the module level when
+  needed (the crate uses `#![deny(...)]`).
+- Provide descriptive assertion messages.
+- Keep tests focused on a single behavior.
+
+## Writing Guest Integration Tests (Rust)
+
+Guest integration tests are `#![no_std]` binaries that run inside Nanvix:
+
+1. Create directory at `src/tests/<name>/`.
+2. Structure similar to guest daemons
+   (`#![no_std]`, `#![no_main]`).
+3. Add to `ALL_GUEST_TESTS` in the `Makefile`.
+4. Add to workspace `members` in root `Cargo.toml`.
+
+## Writing C/C++ Tests
+
+C/C++ tests use the Nanvix C toolchain (`i686-nanvix-gcc`/`i686-nanvix-g++`). They link against
+`libposix.a` and the Newlib C library.  Tests follow a standalone Makefile pattern under
+`src/tests/<name>/`.
+
+## Running All Tests
+
+```bash
+# Unit tests + system tests (if applicable).
+./z build --with-cached-options -- test
+# Full CI pipeline (includes all test types).
+./scripts/pipeline.sh
+```

--- a/.github/skills/troubleshooting/SKILL.md
+++ b/.github/skills/troubleshooting/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: troubleshooting
+description: Guide for diagnosing Nanvix build, runtime, and test failures, including cleanup and debugging workflows. Use this when asked to investigate errors or unstable behavior.
+---
+
+# Troubleshooting Nanvix
+
+Use this skill when the user reports problems, errors, or unexpected behavior while developing,
+building, or running Nanvix. This covers common failure modes and their resolutions.
+
+## Resource Leaks and Cleanup
+
+Crashes or abnormal termination may leave stale resources.  Clean them up with:
+
+### Quick Cleanup
+
+```bash
+# Remove all stale Nanvix resources.
+sudo rm -rf /tmp/nvx:*
+rm -rf /tmp/nanvix-test-*
+sudo rm -rf /tmp/clh-console
+sudo rm -f /tmp/cloud-hypervisor.sock
+sudo rm -f /tmp/*.socket
+
+# Clean up stale network namespaces (L2 deployments).
+for ns in $(sudo ip netns list 2>/dev/null \
+    | grep -o 'nvxns-[0-9]*' || true); do
+  sudo ip link del "nvxgw-h-${ns#nvxns-}" \
+      2>/dev/null || true
+  sudo ip netns del "${ns}" 2>/dev/null || true
+done
+```
+
+There is also a cleanup script for `nanvixd` resources:
+
+```bash
+./scripts/cleanup-nanvixd.sh
+```
+
+### Resource Types
+
+| Resource           | Location            | Created By     |
+|--------------------|---------------------|----------------|
+| Temp directories   | `/tmp/nvx:*`        | `nanvixd`      |
+| Test directories   | `/tmp/nanvix-test-*`| Unit tests     |
+| Unix sockets       | `/tmp/*.socket`     | `syscomm`      |
+| Network namespaces | `nvxns-*`           | L2 deployments |
+| Cloud Hypervisor   | `/tmp/clh-console`  | L2 snapshot    |
+
+## Build Failures
+
+### Toolchain Not Found
+
+**Symptom**: `i686-nanvix-gcc: No such file or directory` or Cargo toolchain errors.
+
+**Fix**: Ensure the `toolchain/` symlink points to a valid installation:
+
+```bash
+ls -la toolchain/
+# If missing, rebuild:
+./z setup --toolchain-dir $HOME/toolchain
+ln -s $HOME/toolchain toolchain
+```
+
+### Cached Build Options Stale
+
+**Symptom**: Build behaves unexpectedly or uses wrong parameters.
+
+**Fix**: Delete the cache file and rebuild:
+
+```bash
+rm -f .z.cache
+./z build -- all
+```
+
+### Full Reset (Last Resort)
+
+**Symptom**: Build or test issues persist after normal cleanup and cache reset.
+
+**Fix**: Perform a full cleanup, then rebuild:
+
+```bash
+./z distclean
+# If building with Docker:
+./z distclean --with-docker
+
+./z build -- all
+```
+
+### sccache Crashes
+
+**Symptom**: Intermittent build failures with sccache errors.
+
+**Fix**: sccache is automatically disabled for non-artifact targets. For manual builds, unset it:
+
+```bash
+./z build -- all SCCACHE=
+```
+
+### Docker Build Failures
+
+**Symptom**: Docker-based builds fail with permission or image errors.
+
+**Fix**:
+
+1. Check Docker is running: `docker info`.
+2. Verify image availability: `docker images | grep nanvix`.
+3. Rebuild with: `./z build --with-docker -- all`.
+
+## Runtime Failures
+
+### KVM Not Available
+
+**Symptom**: `Could not access KVM kernel module` or
+similar.
+
+**Fix**:
+
+```bash
+sudo kvm-ok
+sudo lsmod | grep kvm
+sudo usermod -aG kvm $USER
+newgrp kvm
+```
+
+### Port Already in Use
+
+**Symptom**: `Address already in use` when starting `nanvixd` in HTTP mode.
+
+**Fix**: Kill existing processes or use a different port:
+
+```bash
+lsof -i :8080
+kill <PID>
+# Or use different port:
+./bin/nanvixd.elf -http-addr 127.0.0.1:9090
+```
+
+### TIME_WAIT Socket Connections
+
+**Symptom**: After L2 deployments, connections linger.
+
+**Fix**: Check and wait for them to clear:
+
+```bash
+ss -tan | grep 8181
+```
+
+### Tests Fail Due to Stale Resources
+
+**Symptom**: CI tests fail with resource-exists or port-in-use errors.
+
+**Fix**: Run the full cleanup script (see Resource Leaks section above).
+
+## Debugging
+
+### Enable Verbose Logging
+
+```bash
+# Nanvixd daemon logging.
+RUST_LOG=debug ./bin/nanvixd.elf \
+    -console-file /dev/stdout \
+    -- ./bin/hello-rust-nostd.elf
+RUST_LOG=trace ./bin/nanvixd.elf \
+    -http-addr 127.0.0.1:8080
+
+# Build with trace-level guest logging.
+./z build -- all LOG_LEVEL=trace
+```
+
+### Standalone UserVM Debugging
+
+Bypass the full stack for low-level kernel debugging:
+
+```bash
+RUST_LOG=debug ./bin/uservm.elf \
+    -kernel ./bin/kernel.elf \
+    -initrd ./bin/hello-rust-nostd.elf \
+    -standalone
+```
+
+### Check Build Errors
+
+```bash
+# Rust check with JSON output for IDE integration.
+./z build --with-cached-options -- check
+```
+
+### Log Files
+
+Runtime logs are stored under `logs/` with timestamped
+directory names (e.g., `logs/2026_02_24_13_04_54/`).

--- a/.github/skills/user-app-development/SKILL.md
+++ b/.github/skills/user-app-development/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: user-app-development
+description: Guide for developing, building, and running Nanvix user-space applications across supported runtimes and languages. Use this when asked about guest app implementation or execution.
+---
+
+# User Application Development
+
+Use this skill when the user asks about developing, building, or running user-space applications on
+Nanvix.  User applications are programs that run inside the Nanvix guest environment.
+
+## Supported Languages and Examples
+
+| Application        | Path                         | Lang       | Runtime    |
+|--------------------|------------------------------|------------|------------|
+| `hello-c`          | `src/user/hello-c/`          | C          | Newlib     |
+| `hello-cpp`        | `src/user/hello-cpp/`        | C++        | Libstdc++  |
+| `hello-rust-nostd` | `src/user/hello-rust-nostd/` | Rust       | Bare-metal |
+| `hello-js`         | `src/user/hello-js/`         | JavaScript | QuickJS    |
+| `hello-python`     | `src/user/hello-python/`     | Python     | Python 3   |
+| `hello-wasm`       | `src/user/hello-wasm/`       | Rust/WASM  | wasmd      |
+| `webpage-js`       | `src/user/webpage-js/`       | JavaScript | QuickJS    |
+
+## Running Applications
+
+### Interactive Mode (recommended for development)
+
+```bash
+# Run a native application with console output.
+./bin/nanvixd.elf \
+    -console-file /dev/stdout \
+    -- ./bin/hello-rust-nostd.elf
+
+# Pass arguments to the application.
+./bin/nanvixd.elf \
+    -console-file /dev/stdout \
+    -- ./bin/echo-c.elf arg1 arg2
+
+# Pass arguments and environment variables.
+./bin/nanvixd.elf \
+    -console-file /dev/stdout \
+    -- ./bin/echo-c.elf \
+    "arg1 arg2;VAR1=foo VAR2=bar"
+```
+
+### HTTP Mode (for multi-application scenarios)
+
+```bash
+# Start nanvixd in HTTP mode.
+NANVIX_HTTP_ADDR=127.0.0.1:8080
+./bin/nanvixd.elf -http-addr $NANVIX_HTTP_ADDR
+
+# Spawn an application via HTTP (in another terminal).
+curl --silent \
+    --header "Content-Type: application/json" \
+    --header "X-NVX-Message-Type: NEW" \
+    --request POST \
+    --data '{"tenant_id":"foo",
+             "app_name":"bar",
+             "program":"./bin/hello-c.elf",
+             "program_args":""}' \
+    http://${NANVIX_HTTP_ADDR}
+```
+
+### Standalone UserVM Mode (expert/debugging)
+
+```bash
+./bin/uservm.elf \
+    -kernel ./bin/kernel.elf \
+    -initrd ./bin/hello-rust-nostd.elf \
+    -standalone
+```
+
+## Creating a New Rust Application (no_std)
+
+1. Create directory at `src/user/<name>/`.
+
+2. Add `Cargo.toml`:
+
+   ```toml
+   [package]
+   name = "<name>"
+   version.workspace = true
+   license-file.workspace = true
+   authors.workspace = true
+   edition.workspace = true
+
+   [[bin]]
+   name = "<name>"
+   path = "src/main.rs"
+
+   [dependencies]
+   nvx = { workspace = true }
+   sys = { workspace = true }
+   syslog = { workspace = true }
+   ```
+
+3. Create `src/main.rs`:
+
+   ```rust
+   // Copyright(c) The Maintainers of Nanvix.
+   // Licensed under the MIT License.
+
+   #![no_std]
+   #![no_main]
+
+   extern crate alloc;
+
+   // Application entry point.
+   ```
+
+4. Add to workspace `members` in root `Cargo.toml`.
+
+5. Add to `ALL_GUEST_APPLICATIONS` in the `Makefile`.
+
+## Creating a New C Application
+
+1. Create directory at `src/user/<name>/`.
+2. Create a `Makefile` following the pattern in existing C applications.
+3. Write source files using the Nanvix POSIX layer (`#include <nanvix/...>`).
+4. The application links against `libposix.a`, `libc.a`, and the custom linker script at
+   `build/user/linker/x86/user.ld`.
+
+## Creating a WASM Application
+
+1. Create directory at `src/user/<name>/` or `src/benchmarks/<name>/`.
+2. Set target to `wasm32-wasip1` in `Cargo.toml`.
+3. Add to `ALL_WASM_BINARIES` in the `Makefile`.
+4. WASM binaries are executed by the `wasmd` daemon.
+
+## Logging
+
+- Use `RUST_LOG` environment variable for `nanvixd` daemon-level logging.
+- Guest-side logging uses the `syslog` crate (`error!`, `warn!`, `info!`, `debug!`, `trace!`).
+- Console output defaults to `logs/` directory; use `-console-file /dev/stdout` to redirect to
+  terminal.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone https://github.com/nanvix/nanvix.git && cd nanvix
 - [doc/setup.md](doc/setup.md) - Instructions for setting up your development environment.
 - [doc/build.md](doc/build.md) - Instructions for building Nanvix.
 - [doc/run.md](doc/run.md) - Instructions for running Nanvix.
-- [doc/dev.md](doc/test.md) - Instructions for testing Nanvix.
+- [doc/test.md](doc/test.md) - Instructions for testing Nanvix.
 - [doc/benchmark.md](doc/benchmark.md) - Instructions for benchmarking Nanvix.
 
 ## Software Ecosystem

--- a/doc/test.md
+++ b/doc/test.md
@@ -1,6 +1,6 @@
 # Testing Nanvix
 
-> ℹ️ The instructions in this document assume that you already know how to built
+> ℹ️ The instructions in this document assume that you already know how to build
 Nanvix. For more information on how to build Nanvix, please refer to the
 [build.md](build.md) document.
 
@@ -8,6 +8,7 @@ This document guides you through testing Nanvix.
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Running Full CI Pipeline](#running-full-ci-pipeline)
 - [Running Unit Tests](#running-unit-tests)
 - [Running System Integration Tests (MicroVM and Hyperlight Only)](#running-system-integration-tests-microvm-and-hyperlight-only)
@@ -27,7 +28,7 @@ This document guides you through testing Nanvix.
 build parameters.
 
 ```bash
-make run-unit-tests
+./z build --with-cached-options -- run-unit-tests
 ```
 
 ## Running System Integration Tests (MicroVM and Hyperlight Only)
@@ -39,7 +40,7 @@ the Nanvix Daemon.
 The system integration tests can be run directly using:
 
 ```bash
-make run-nanvix-tests
+./z build --with-cached-options -- run-nanvix-tests
 ```
 
 The appropriate test configuration is automatically selected based on the
@@ -66,11 +67,12 @@ The `nanvix-test.elf` utility supports two execution modes:
 
 ## Running All Tests
 
-> ℹ️ This target sequentially invokes each underlying test suite using independent `make` calls.
+> ℹ️ This target sequentially invokes each underlying test suite.
 
 ```bash
-make test
+./z build --with-cached-options -- test
 ```
 
-On `microvm` and `hyperlight` machines, `make test` runs both unit tests and
-system integration tests. On other machines, only unit tests are executed.
+On `microvm` and `hyperlight` machines,
+`./z build --with-cached-options -- test` runs both unit tests and system
+integration tests. On other machines, only unit tests are executed.


### PR DESCRIPTION
Add 9 skill files under .github/copilot/skills/ to guide GitHub Copilot when assisting with common Nanvix development tasks:

 - build-and-test.md: Building, formatting, linting, and testing.
 - kernel-development.md: Microkernel architecture and development.
 - library-development.md: System library creation and modification.
 - daemon-development.md: System daemon development.
 - test-development.md: Writing and running tests.
 - user-app-development.md: User-space application development.
 - troubleshooting.md: Common failure modes and debugging.
 - ci-cd-pipeline.md: CI/CD pipeline and release process.
 - benchmarking.md: Performance benchmarking.