### PR TITLE
[libs] Add Verus formal verification to bitmap and raw-array

### DIFF
--- a/src/libs/bitmap/Cargo.toml
+++ b/src/libs/bitmap/Cargo.toml
@@ -16,6 +16,7 @@ verify = true
 crate-type = ["lib"]
 
 [dependencies]
+error = { workspace = true, features = ["verus"] }
 raw-array = { workspace = true }
 sys = { workspace = true }
 vstd = { workspace = true }

--- a/src/libs/bitmap/src/lib.proof.rs
+++ b/src/libs/bitmap/src/lib.proof.rs
@@ -1,0 +1,716 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// Bitmap - Proofs
+//
+// This file contains lemmas and proof functions for Bitmap.
+
+verus! {
+
+impl Bitmap {
+    //==================================================================================================
+    // Lemmas: Layout
+    //==================================================================================================
+    /// Proves that `len` bytes fit within isize::MAX for RawArray allocation.
+    proof fn lemma_u8_array_len_fits_isize(len: usize)
+        requires
+            len <= u32::MAX as usize / (u8::BITS as usize),
+        ensures
+            len * vstd::layout::size_of::<u8>() + vstd::layout::align_of::<u8>() - 1
+                <= isize::MAX as usize,
+    {
+        broadcast use vstd::layout::layout_of_primitives, vstd::layout::align_of_u8;
+    }
+
+    //==================================================================================================
+    // Lemmas: Bit-level Operations
+    //==================================================================================================
+
+    /// Bit OR sets the target bit and preserves all other bits.
+    proof fn lemma_bit_or_effects(old_byte: u8, bit_pos: int, new_byte: u8)
+        requires
+            0 <= bit_pos < 8,
+            new_byte == (old_byte | (1u8 << bit_pos)),
+        ensures
+            (new_byte & (1u8 << bit_pos)) != 0,
+            forall|other_pos: int|
+                #![auto]
+                0 <= other_pos < 8 && other_pos != bit_pos ==> (new_byte & (1u8 << other_pos)) == (
+                old_byte & (1u8 << other_pos)),
+    {
+        let shift: u8 = bit_pos as u8;
+        assert((new_byte & (1u8 << shift)) != 0) by (bit_vector)
+            requires
+                new_byte == (old_byte | (1u8 << shift)),
+                0 <= shift < 8,
+        ;
+        assert forall|other_pos: int| #![auto] 0 <= other_pos < 8 && other_pos != bit_pos implies (
+        new_byte & (1u8 << other_pos)) == (old_byte & (1u8 << other_pos)) by {
+            let other_shift: u8 = other_pos as u8;
+            assert((new_byte & (1u8 << other_shift)) == (old_byte & (1u8 << other_shift)))
+                by (bit_vector)
+                requires
+                    new_byte == (old_byte | (1u8 << shift)),
+                    0 <= shift < 8,
+                    0 <= other_shift < 8,
+                    shift != other_shift,
+            ;
+        }
+    }
+
+    /// Bit AND NOT clears the target bit and preserves all other bits.
+    proof fn lemma_bit_and_not_effects(old_byte: u8, bit_pos: int, new_byte: u8)
+        requires
+            0 <= bit_pos < 8,
+            new_byte == (old_byte & !(1u8 << bit_pos)),
+        ensures
+            (new_byte & (1u8 << bit_pos)) == 0,
+            forall|other_pos: int|
+                #![auto]
+                0 <= other_pos < 8 && other_pos != bit_pos ==> (new_byte & (1u8 << other_pos)) == (
+                old_byte & (1u8 << other_pos)),
+    {
+        let shift: u8 = bit_pos as u8;
+        assert((new_byte & (1u8 << shift)) == 0) by (bit_vector)
+            requires
+                new_byte == (old_byte & !(1u8 << shift)),
+                0 <= shift < 8,
+        ;
+        assert forall|other_pos: int| #![auto] 0 <= other_pos < 8 && other_pos != bit_pos implies (
+        new_byte & (1u8 << other_pos)) == (old_byte & (1u8 << other_pos)) by {
+            let other_shift: u8 = other_pos as u8;
+            assert((new_byte & (1u8 << other_shift)) == (old_byte & (1u8 << other_shift)))
+                by (bit_vector)
+                requires
+                    new_byte == (old_byte & !(1u8 << shift)),
+                    0 <= shift < 8,
+                    0 <= other_shift < 8,
+                    shift != other_shift,
+            ;
+        }
+    }
+
+    /// Setting a byte bit reflects in set_bits.
+    proof fn lemma_byte_or_reflects_in_view(&self, new_self: &Self, word: int, bit: int)
+        requires
+            self@.num_bits > 0,
+            self@.num_bits == self.bits@.len() * (u8::BITS as int),
+            self.number_of_bits as int == self@.num_bits,
+            0 <= word < self.bits@.len(),
+            0 <= bit < (u8::BITS as int),
+            new_self.bits@.len() == self.bits@.len(),
+            new_self.bits@[word] == (self.bits@[word] | (1u8 << bit)),
+            forall|i: int|
+                0 <= i < self.bits@.len() && i != word ==> self.bits@[i] == new_self.bits@[i],
+            self.number_of_bits == new_self.number_of_bits,
+        ensures
+            new_self@.set_bits =~= self@.set_bits.insert(word * (u8::BITS as int) + bit),
+    {
+        Self::lemma_bit_or_effects(self.bits@[word], bit, new_self.bits@[word]);
+        let idx: int = word * (u8::BITS as int) + bit;
+        assert forall|i: int|
+            #![auto]
+            new_self@.set_bits.contains(i) == self@.set_bits.insert(idx).contains(i) by {
+            if i != idx && 0 <= i < self@.num_bits {
+                let i_word: int = i / (u8::BITS as int);
+                if i_word == word {
+                    let i_bit: int = i % (u8::BITS as int);
+                    assert((new_self.bits@[word] & (1u8 << i_bit)) == (self.bits@[word] & (1u8
+                        << i_bit)));
+                }
+            }
+        }
+    }
+
+    /// Clearing a byte bit reflects in set_bits.
+    proof fn lemma_byte_and_not_reflects_in_view(&self, new_self: &Self, word: int, bit: int)
+        requires
+            self.inv(),
+            0 <= word < self.bits@.len(),
+            0 <= bit < (u8::BITS as int),
+            new_self.bits@.len() == self.bits@.len(),
+            new_self.bits@[word] == (self.bits@[word] & !(1u8 << bit)),
+            forall|i: int|
+                0 <= i < self.bits@.len() && i != word ==> self.bits@[i] == new_self.bits@[i],
+            self.number_of_bits == new_self.number_of_bits,
+        ensures
+            new_self@.set_bits =~= self@.set_bits.remove(word * (u8::BITS as int) + bit),
+    {
+        Self::lemma_bit_and_not_effects(self.bits@[word], bit, new_self.bits@[word]);
+        let idx: int = word * (u8::BITS as int) + bit;
+        assert forall|i: int|
+            #![auto]
+            new_self@.set_bits.contains(i) == self@.set_bits.remove(idx).contains(i) by {
+            if i != idx && 0 <= i < self@.num_bits {
+                let i_word: int = i / (u8::BITS as int);
+                if i_word == word {
+                    let i_bit: int = i % (u8::BITS as int);
+                    assert((new_self.bits@[word] & (1u8 << i_bit)) == (self.bits@[word] & (1u8
+                        << i_bit)));
+                }
+            }
+        }
+    }
+
+    /// When all raw bytes are zero, set_bits is empty.
+    proof fn lemma_zero_bytes_means_empty_set(&self)
+        requires
+            self@.num_bits == self.bits@.len() * (u8::BITS as int),
+            forall|i: int| 0 <= i < self.bits@.len() ==> self.bits@[i] == 0,
+        ensures
+            self@.set_bits == Set::<int>::empty(),
+    {
+        assert forall|i: int| !self@.set_bits.contains(i) by {
+            if 0 <= i < self@.num_bits {
+                let bit_idx_u8: u8 = (i % (u8::BITS as int)) as u8;
+                assert((0u8 & (1u8 << bit_idx_u8)) == 0) by (bit_vector)
+                    requires
+                        0 <= bit_idx_u8 < 8,
+                ;
+            }
+        }
+    }
+
+    /// number_of_bits is bounded by usize::MAX.
+    pub proof fn lemma_number_of_bits_bounded(&self)
+        requires
+            self.inv(),
+        ensures
+            self@.num_bits <= usize::MAX as int,
+    {
+    }
+
+    //==========================================================================================
+    // Composite Lemmas
+    //==========================================================================================
+
+    /// Proves that a newly constructed bitmap (with zero-initialized bytes) satisfies inv().
+    proof fn lemma_new_bitmap_inv(bmp: &Self)
+        requires
+            bmp.bits.inv(),
+            bmp@.num_bits == bmp.bits@.len() * (u8::BITS as int),
+            bmp@.num_bits > 0,
+            bmp@.num_bits < u32::MAX as int,
+            bmp.usage == 0,
+            bmp.next_free == 0,
+            bmp.number_of_bits as int == bmp@.num_bits,
+            forall|i: int| 0 <= i < bmp.bits@.len() ==> is_zero(#[trigger] bmp.bits@[i]),
+        ensures
+            bmp.inv(),
+            bmp@.is_empty(),
+    {
+        assert forall|i: int| 0 <= i < bmp.bits@.len() implies (bmp.bits@[i] == 0) by {
+            axiom_u8_zero_is_0(bmp.bits@[i]);
+        };
+        bmp.lemma_zero_bytes_means_empty_set();
+    }
+
+    /// Proves inv() is preserved after setting a bit via byte OR.
+    proof fn lemma_set_bit_preserves_inv(&self, new_self: &Self, word: int, bit: int, index: int)
+        requires
+            self.inv(),
+            0 <= word < self.bits@.len(),
+            0 <= bit < (u8::BITS as int),
+            index == word * (u8::BITS as int) + bit,
+            0 <= index < self@.num_bits,
+            !self@.set_bits.contains(index),
+            new_self.bits@.len() == self.bits@.len(),
+            new_self.bits@[word] == (self.bits@[word] | (1u8 << bit)),
+            forall|i: int|
+                0 <= i < self.bits@.len() && i != word ==> self.bits@[i] == new_self.bits@[i],
+            self.number_of_bits == new_self.number_of_bits,
+            new_self.usage == self.usage,
+        ensures
+            new_self@.set_bits =~= self@.set_bits.insert(index),
+            new_self@.set_bits.finite(),
+            new_self@.set_bits.len() == self@.set_bits.len() + 1,
+            new_self@.wf(),
+            self@.set_bits.len() + 1 <= self@.num_bits,
+    {
+        self.lemma_byte_or_reflects_in_view(new_self, word, bit);
+        assert(new_self@.wf()) by {
+            assert forall|i: int| new_self@.set_bits.contains(i) implies (0 <= i
+                < new_self@.num_bits) by {
+                if i != index {
+                    assert(self@.set_bits.contains(i));
+                }
+            }
+        }
+        self@.lemma_insert_preserves_usage_bound(index);
+    }
+
+    /// Proves inv() is preserved after clearing a bit via byte AND NOT.
+    proof fn lemma_clear_bit_preserves_inv(&self, new_self: &Self, word: int, bit: int, index: int)
+        requires
+            self.inv(),
+            0 <= word < self.bits@.len(),
+            0 <= bit < (u8::BITS as int),
+            index == word * (u8::BITS as int) + bit,
+            0 <= index < self@.num_bits,
+            self@.set_bits.contains(index),
+            new_self.bits@.len() == self.bits@.len(),
+            new_self.bits@[word] == (self.bits@[word] & !(1u8 << bit)),
+            forall|i: int|
+                0 <= i < self.bits@.len() && i != word ==> self.bits@[i] == new_self.bits@[i],
+            self.number_of_bits == new_self.number_of_bits,
+            new_self.usage == self.usage,
+        ensures
+            new_self@.set_bits =~= self@.set_bits.remove(index),
+            new_self@.set_bits.finite(),
+            new_self@.set_bits.len() == self@.set_bits.len() - 1,
+            new_self@.wf(),
+    {
+        self.lemma_byte_and_not_reflects_in_view(new_self, word, bit);
+        assert(new_self@.wf()) by {
+            assert forall|i: int| new_self@.set_bits.contains(i) implies (0 <= i
+                < new_self@.num_bits) by {
+                assert(self@.set_bits.contains(i));
+            }
+        }
+    }
+
+    /// Proves no free range exists when size exceeds number_of_bits.
+    proof fn lemma_no_free_range_when_size_exceeds(&self, size: int)
+        requires
+            self.inv(),
+            size > self@.num_bits,
+        ensures
+            !self@.exists_contiguous_free_range(size),
+    {
+        assert forall|start: int|
+            #![trigger self@.has_free_range_at(start, size)]
+            0 <= start implies !self@.has_free_range_at(start, size) by {}
+    }
+
+    /// Proves no free range exists when usage exceeds capacity for given size.
+    proof fn lemma_no_free_range_when_usage_exceeds(&self, size: int)
+        requires
+            self.inv(),
+            size > 0,
+            size <= self@.num_bits,
+            self@.usage() > self@.num_bits - size,
+        ensures
+            !self@.exists_contiguous_free_range(size),
+    {
+        assert forall|p: int|
+            #![trigger self@.has_free_range_at(p, size)]
+            0 <= p <= self@.num_bits - size implies !self@.has_free_range_at(p, size) by {
+            if self@.has_free_range_at(p, size) {
+                self@.lemma_free_range_implies_usage_bound(p, size);
+            }
+        }
+    }
+
+    /// Proves that when a byte is 0xFF, all 8 bits are set and no free range starts there.
+    proof fn lemma_full_byte_no_free_range(&self, start: int, size: int)
+        requires
+            self.inv(),
+            size > 0,
+            start >= 0,
+            start + 8 <= self@.num_bits,
+            start % 8 == 0,
+            ({
+                let word: int = start / 8;
+                0 <= word < self.bits@.len() && self.bits@[word] == 0xFFu8
+            }),
+        ensures
+            forall|i: int| start <= i < start + 8 ==> self@.is_bit_set(i),
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size)]
+                start <= p < start + 8 ==> !self@.has_free_range_at(p, size),
+    {
+        assert forall|i: int| start <= i < start + 8 implies Self::bit_at(self.bits@, i) by {
+            let bit_pos_u8: u8 = (i % 8) as u8;
+            assert((0xFFu8 & (1u8 << bit_pos_u8)) != 0) by (bit_vector)
+                requires
+                    0 <= bit_pos_u8 < 8,
+            ;
+        }
+        assert forall|p: int|
+            #![trigger self@.has_free_range_at(p, size)]
+            start <= p < start + 8 implies !self@.has_free_range_at(p, size) by {
+            assert(self@.is_bit_set(p));
+        }
+    }
+
+    /// Proves that a set bit blocks any free range containing it.
+    proof fn lemma_set_bit_blocks_free_range(
+        &self,
+        start_before: usize,
+        idx: usize,
+        offset: usize,
+        size: usize,
+    )
+        requires
+            self.inv(),
+            0 <= start_before,
+            0 <= offset < size,
+            idx == start_before + offset,
+            0 <= idx < self@.num_bits,
+            self@.is_bit_set(idx as int),
+        ensures
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                start_before <= p <= idx ==> !self@.has_free_range_at(p, size as int),
+    {
+        assert forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            start_before <= p <= idx implies !self@.has_free_range_at(p, size as int) by {
+            if self@.has_free_range_at(p, size as int) {
+                assert(!self@.is_bit_set(idx as int));
+            }
+        }
+    }
+
+    /// Proves that a found free range was also free in old_self.
+    proof fn lemma_free_range_was_unset_in_old(&self, old_self: &Self, start: usize, size: usize)
+        requires
+            self.inv(),
+            old_self.inv(),
+            self@.set_bits =~= old_self@.set_bits,
+            0 <= start,
+            size > 0,
+            start + size <= self@.num_bits,
+            forall|j: int| 0 <= j < size ==> !#[trigger] self@.is_bit_set(start + j),
+        ensures
+            old_self@.all_bits_unset_in_range(start as int, start + size),
+    {
+        assert forall|i: int| start <= i < start + size implies !#[trigger] old_self@.is_bit_set(
+            i,
+        ) by {
+            assert(!self@.is_bit_set(start + (i - start)));
+        };
+    }
+
+    /// Proves inv() after allocating a full range [start, start+size).
+    proof fn lemma_alloc_range_establishes_inv(&self, old_self: &Self, start: usize, size: usize)
+        requires
+            old_self.inv(),
+            size > 0,
+            0 <= start,
+            start + size <= old_self@.num_bits,
+            old_self@.all_bits_unset_in_range(start as int, start + size),
+            self.bits.inv(),
+            self@.set_bits =~= old_self@.set_bits.union(BitmapView::range_set(start as int, start + size)),
+            self@.set_bits.finite(),
+            self.number_of_bits == old_self.number_of_bits,
+            self.number_of_bits as int == self@.num_bits,
+            self@.num_bits == self.bits@.len() * (u8::BITS as int),
+            self.usage == old_self.usage + size,
+            self.next_free as int <= self@.num_bits,
+        ensures
+            self.inv(),
+            self@.usage() == old_self@.usage() + size,
+    {
+        BitmapView::lemma_range_set_finite(start as int, start + size);
+        let range: Set<int> = BitmapView::range_set(start as int, start + size);
+        assert(self@.wf()) by {
+            assert forall|i: int| self@.set_bits.contains(i) implies (0 <= i
+                < self@.num_bits) by {
+                if !range.contains(i) {
+                    assert(old_self@.set_bits.contains(i));
+                }
+            }
+        }
+        assert(old_self@.set_bits.disjoint(range)) by {
+            assert forall|i: int| #![auto] !(old_self@.set_bits.contains(i) && range.contains(i)) by {
+                if range.contains(i) {
+                    assert(!old_self@.is_bit_set(i));
+                }
+            }
+        }
+        vstd::set_lib::lemma_set_disjoint_lens(old_self@.set_bits, range);
+        BitmapView::lemma_range_set_len(start as int, start + size);
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, self@.num_bits);
+        vstd::set_lib::lemma_int_range(0, self@.num_bits);
+        assert(self@.set_bits.subset_of(full_range)) by {
+            assert forall|i: int|
+                #![auto]
+                self@.set_bits.contains(i) implies full_range.contains(i) by {}
+        }
+        vstd::set_lib::lemma_len_subset(self@.set_bits, full_range);
+    }
+
+    /// Proves frame condition when no free range was found.
+    proof fn lemma_no_range_found_frame(&self, old_self: &Self, size: int)
+        requires
+            self.inv(),
+            old_self.inv(),
+            self@.set_bits =~= old_self@.set_bits,
+            self.number_of_bits == old_self.number_of_bits,
+            size > 0,
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size)]
+                0 <= p < self@.num_bits ==> !self@.has_free_range_at(p, size),
+        ensures
+            self@ =~= old_self@,
+            !old_self@.exists_contiguous_free_range(size),
+    {
+        self@.lemma_set_bits_equal_exists_free_range_equal(&(old_self@), size);
+    }
+
+    /// Proves loop invariant update for a single alloc_range bit-set step.
+    proof fn lemma_alloc_loop_step_inv(
+        self: &Self,
+        old_self: &Self,
+        loop_old_self: &Self,
+        start: usize,
+        alloc_offset: usize,
+        idx: usize,
+    )
+        requires
+            old_self.inv(),
+            loop_old_self@.set_bits =~= old_self@.set_bits.union(
+                BitmapView::range_set(start as int, start + alloc_offset),
+            ),
+            loop_old_self@.set_bits.finite(),
+            self@.set_bits =~= loop_old_self@.set_bits.insert(idx as int),
+            idx == start + alloc_offset,
+            0 <= start,
+            alloc_offset >= 0,
+            idx < old_self@.num_bits,
+            self@.num_bits == old_self@.num_bits,
+            self.number_of_bits as int == self@.num_bits,
+        ensures
+            self@.set_bits =~= old_self@.set_bits.union(
+                BitmapView::range_set(start as int, start + alloc_offset + 1),
+            ),
+            self@.wf(),
+            self@.set_bits.finite(),
+    {
+        assert forall|i: int|
+            self@.set_bits.contains(i) == old_self@.set_bits.union(
+                BitmapView::range_set(start as int, start + alloc_offset + 1),
+            ).contains(i) by {}
+        assert(self@.wf()) by {
+            assert forall|i: int| self@.set_bits.contains(i) implies (0 <= i
+                < self@.num_bits) by {}
+        }
+    }
+
+    // Invariant for the first (outermost) loop in alloc_range
+    spec fn alloc_range_first_loop_invariant(
+        self: &Self,
+        old_self: &Self,
+        size: usize,
+        start: usize,
+        initial_start: usize,
+        wrapped: bool,
+        done: bool
+    ) -> bool
+    {
+        &&& self.inv()
+        &&& old_self.inv()
+        &&& size > 0
+        &&& size <= self.number_of_bits
+        &&& start <= self.number_of_bits
+        &&& self@.set_bits =~= old_self@.set_bits
+        &&& self.usage <= self.number_of_bits - size
+        &&& self.number_of_bits == old_self.number_of_bits
+        &&& initial_start as int <= self@.num_bits
+        // Wrap-around state consistency.
+        &&& !wrapped ==> start >= initial_start
+        &&& wrapped ==> initial_start > 0
+        // Checked positions.
+        &&& !wrapped ==> forall|p: int|
+               #![trigger self@.has_free_range_at(p, size as int)]
+               initial_start as int <= p < start as int ==> !self@.has_free_range_at(
+                   p,
+                   size as int,
+               )
+        &&& wrapped ==> forall|p: int|
+               #![trigger self@.has_free_range_at(p, size as int)]
+               initial_start as int <= p < self@.num_bits ==> !self@.has_free_range_at(
+                   p,
+                   size as int,
+               )
+        &&& wrapped ==> forall|p: int|
+               #![trigger self@.has_free_range_at(p, size as int)]
+               0 <= p < start as int ==> !self@.has_free_range_at(p, size as int)
+        // When done, all positions have been checked.
+        &&& done ==> forall|p: int|
+               #![trigger self@.has_free_range_at(p, size as int)]
+               0 <= p < self@.num_bits ==> !self@.has_free_range_at(p, size as int)
+    }
+
+    // Invariant for the second loop in alloc_range
+    spec fn alloc_range_second_loop_invariant(
+        self: &Self,
+        old_self: &Self,
+        size: usize,
+        start: usize,
+        initial_start: usize,
+        offset: usize,
+        wrapped: bool,
+        free: bool,
+        checked_before: int,
+        start_before_inner: usize,
+    ) -> bool
+    {
+        &&& self.inv()
+        &&& old_self.inv()
+        &&& 0 < size <= self.number_of_bits
+        &&& offset <= size
+        &&& start_before_inner <= self.number_of_bits - size
+        &&& self@.set_bits =~= old_self@.set_bits
+        &&& checked_before == start_before_inner as int
+        // Positions before start_before_inner are already checked.
+        &&& forall|p: int|
+              #![trigger self@.has_free_range_at(p, size as int)]
+              (!wrapped ==> initial_start as int <= p < checked_before
+                  ==> !self@.has_free_range_at(p, size as int))
+        &&& forall|p: int|
+                  #![trigger self@.has_free_range_at(p, size as int)]
+                  (wrapped ==> 0 <= p < checked_before ==> !self@.has_free_range_at(
+                      p,
+                      size as int,
+                  ))
+        &&& free ==> forall|i: int|
+                  0 <= i < offset ==> !#[trigger] self@.is_bit_set(
+                      (start_before_inner + i) as int,
+                  )
+    }
+
+    // Loop postcondition for the second loop in alloc_range
+    spec fn alloc_range_second_loop_ensures(
+        self: &Self,
+        size: usize,
+        start: usize,
+        initial_start: usize,
+        wrapped: bool,
+        free: bool,
+        start_before_inner: usize,
+    ) -> bool
+    {
+        &&& start <= self.number_of_bits
+        &&& free ==> start == start_before_inner && start <= self.number_of_bits - size
+              && forall|i: int|
+              0 <= i < size ==> !#[trigger] self@.is_bit_set((start + i) as int)
+        &&& !free ==> start > start_before_inner
+        &&& !free ==> forall|p: int|
+              #![trigger self@.has_free_range_at(p, size as int)]
+              (!wrapped ==> initial_start as int <= p < start as int
+                  ==> !self@.has_free_range_at(p, size as int))
+        &&& !free ==> forall|p: int|
+              #![trigger self@.has_free_range_at(p, size as int)]
+              (wrapped ==> 0 <= p < start as int ==> !self@.has_free_range_at(
+                  p,
+                  size as int,
+              ))
+    }
+
+    // Invariant for the third loop in alloc_range
+    spec fn alloc_range_third_loop_invariant(
+        self: &Self,
+        old_self: &Self,
+        pre_alloc_self: Self,
+        size: usize,
+        start: usize,
+        alloc_offset: usize,
+    ) -> bool
+    {
+        &&& self.bits.inv()
+        &&& self.bits@.len() == pre_alloc_self.bits@.len()
+        &&& self.bits@.len() == old_self.bits@.len()
+        &&& self@.num_bits > 0
+        &&& self@.num_bits == self.bits@.len() * (u8::BITS as int)
+        &&& self.number_of_bits == pre_alloc_self.number_of_bits
+        &&& self.number_of_bits as int == self@.num_bits
+        &&& self.usage == pre_alloc_self.usage
+        &&& old_self.inv()
+        &&& pre_alloc_self.inv()
+        &&& 0 < size <= self.number_of_bits
+        &&& start <= self.number_of_bits - size
+        &&& alloc_offset <= size
+        &&& forall|i: int|
+               0 <= i < alloc_offset ==> #[trigger] self@.is_bit_set(
+                   (start + i) as int,
+               )
+        &&& forall|i: int|
+               (0 <= i < self@.num_bits && (i < start as int || i >= (start
+                   + alloc_offset) as int)) ==> #[trigger] self@.is_bit_set(i)
+                   == #[trigger] old_self@.is_bit_set(i)
+        &&& self@.set_bits =~= old_self@.set_bits.union(
+               BitmapView::range_set(
+                   start as int,
+                   start as int + (alloc_offset as int),
+               ),
+           )
+        &&& self@.set_bits.finite()
+        &&& old_self@.all_bits_unset_in_range(
+               start as int,
+               start as int + (size as int),
+           )
+    }
+
+    /// Proves that positions in `[lower, N)` have no free range of given size
+    /// when all positions in `[lower, checked)` were already checked and the
+    /// remaining positions have `p + size > N`.
+    proof fn lemma_phase1_complete_no_free_range(&self, initial_start: usize, start: usize, size: usize)
+        requires
+            self.inv(),
+            size > 0,
+            initial_start >= 0,
+            initial_start <= self@.num_bits,
+            start >= initial_start,
+            start <= self@.num_bits,
+            start > self@.num_bits - size,
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                initial_start <= p < start ==> !self@.has_free_range_at(p, size as int),
+        ensures
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                initial_start <= p < self@.num_bits ==> !self@.has_free_range_at(p, size as int),
+    {
+        assert forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            initial_start <= p < self@.num_bits implies !self@.has_free_range_at(p, size as int) by {}
+    }
+
+    /// Proves that all positions in `[0, N)` have no free range when both
+    /// phases have been checked.
+    proof fn lemma_all_positions_no_free_range(
+        &self,
+        initial_start: usize,
+        start: usize,
+        size: usize,
+        wrapped: bool,
+    )
+        requires
+            self.inv(),
+            size > 0,
+            start <= self@.num_bits,
+            start > self@.num_bits - size || (wrapped && start >= initial_start),
+            initial_start >= 0,
+            initial_start <= self@.num_bits,
+            // Phase 1 covered [initial_start, N).
+            wrapped ==> forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                initial_start <= p < self@.num_bits ==> !self@.has_free_range_at(p, size as int),
+            // Phase 2 covered [0, start).
+            wrapped ==> forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                0 <= p < start ==> !self@.has_free_range_at(p, size as int),
+            // If not wrapped: phase 1 covered [initial_start, start), and initial_start == 0.
+            !wrapped ==> initial_start == 0,
+            !wrapped ==> forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                0 <= p < start ==> !self@.has_free_range_at(p, size as int),
+        ensures
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                0 <= p < self@.num_bits ==> !self@.has_free_range_at(p, size as int),
+    {
+        assert forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            0 <= p < self@.num_bits implies !self@.has_free_range_at(p, size as int) by {
+            if wrapped && p >= start && p < initial_start {
+                assert(p + size > self@.num_bits);
+            }
+        }
+    }
+
+} // impl Bitmap
+
+} // end verus!

--- a/src/libs/bitmap/src/lib.rs
+++ b/src/libs/bitmap/src/lib.rs
@@ -1,8 +1,10 @@
-// Copyright (c) The Maintainers of Nanvix.
-// Licensed under the MIT license.
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(test, feature = "std"), feature(random))]
+// Verus does not yet support compound assignment on struct fields (e.g., self.usage += 1).
+#![allow(clippy::assign_op_pattern)]
 
 //==================================================================================================
 // Modules
@@ -16,23 +18,43 @@ mod test;
 //==================================================================================================
 
 use ::raw_array::RawArray;
+#[cfg(verus_keep_ghost)]
+use ::raw_array::{
+    axiom_u8_zero_is_0,
+    is_zero,
+};
 use ::sys::error::{
     Error,
     ErrorCode,
 };
+use ::vstd::prelude::*;
+
+// Include specifications.
 #[cfg(verus_keep_ghost)]
-use vstd::prelude::*;
+include!("lib.spec.rs");
+
+// Include proofs.
+#[cfg(verus_keep_ghost)]
+include!("lib.proof.rs");
+
+// Include verified tests.
+#[cfg(verus_keep_ghost)]
+include!("lib.test.rs");
 
 //==================================================================================================
 // Structures
 //==================================================================================================
+
+verus! {
 
 ///
 /// # Description
 ///
 /// A bitmap.
 ///
+#[verifier::external_derive]
 #[derive(Debug)]
+#[verifier::ext_equal]
 pub struct Bitmap {
     /// Capacity of the bitmap (in bits).
     number_of_bits: usize,
@@ -42,6 +64,60 @@ pub struct Bitmap {
     bits: RawArray<u8>,
     /// Hint: first bit index that might be free. Avoids O(n) rescans.
     next_free: usize,
+}
+
+//==================================================================================================
+// View Implementation for Bitmap
+//==================================================================================================
+
+#[cfg(verus_keep_ghost)]
+impl View for Bitmap {
+    type V = BitmapView;
+
+    closed spec fn view(&self) -> BitmapView {
+        BitmapView {
+            num_bits: self.number_of_bits as int,
+            set_bits: Set::new(
+                |i: int| 0 <= i < self.number_of_bits as int && Self::bit_at(self.bits@, i),
+            ),
+        }
+    }
+}
+
+//==================================================================================================
+// Bitmap Specification Functions
+//==================================================================================================
+
+impl Bitmap {
+    /// Helper spec function: get the bit value at a specific index from raw bytes.
+    spec fn bit_at(bytes: Seq<u8>, bit_index: int) -> bool {
+        let word: int = bit_index / (u8::BITS as int);
+        let bit: int = bit_index % (u8::BITS as int);
+        if 0 <= bit_index && word < bytes.len() {
+            (bytes[word] & (1u8 << bit)) != 0
+        } else {
+            false
+        }
+    }
+
+    pub open spec fn inv(&self) -> bool {
+        &&& self@.wf()
+        &&& self.internal_inv()
+    }
+
+    /// Invariant: the bitmap's state is well-formed.
+    pub closed spec fn internal_inv(&self) -> bool {
+        &&& self.bits.inv()
+        &&& self@.num_bits > 0
+        &&& self@.num_bits == self.bits@.len() * (u8::BITS as int)
+        &&& self@.num_bits < u32::MAX as int
+        &&& self@.wf()  // set_bits only contains valid indices
+        &&& self@.set_bits.finite()  // set_bits is finite (required for len())
+        &&& self@.usage() <= self@.num_bits
+        &&& self.number_of_bits as int == self@.num_bits
+        &&& self.usage as int == self@.usage()
+        &&& self.next_free as int <= self@.num_bits
+    }
 }
 
 //==================================================================================================
@@ -62,7 +138,17 @@ impl Bitmap {
     ///
     /// Upon success, a new bitmap is returned. Upon failure, an error is returned instead.
     ///
-    pub fn new(number_of_bits: usize) -> Result<Self, Error> {
+    pub fn new(number_of_bits: usize) -> (result: Result<Self, Error>)
+        ensures
+            result matches Ok(bitmap) ==> {
+                &&& bitmap.inv()
+                &&& bitmap@.num_bits == number_of_bits as int
+                &&& bitmap@.is_empty()
+            },
+            number_of_bits == 0 ==> result is Err,
+            number_of_bits >= u32::MAX ==> result is Err,
+            number_of_bits % (u8::BITS as usize) != 0 ==> result is Err,
+    {
         // Check if the length is invalid.
         if number_of_bits == 0 || number_of_bits >= u32::MAX as usize {
             let reason: &str = "invalid length";
@@ -77,14 +163,24 @@ impl Bitmap {
 
         // Allocate the bitmap.
         // Note: RawArray::new() guarantees zero-initialization of the backing storage.
-        let array: RawArray<u8> = RawArray::new(number_of_bits / u8::BITS as usize)?;
+        let len: usize = number_of_bits / u8::BITS as usize;
+        proof {
+            Self::lemma_u8_array_len_fits_isize(len);
+        }
+        let array: RawArray<u8> = RawArray::new(len)?;
 
-        Ok(Self {
+        let result = Self {
             number_of_bits,
             bits: array,
             usage: 0,
             next_free: 0,
-        })
+        };
+
+        proof {
+            Self::lemma_new_bitmap_inv(&result);
+        }
+
+        Ok(result)
     }
 
     ///
@@ -105,20 +201,44 @@ impl Bitmap {
     ///
     /// - `InvalidArgument` if the array length multiplied by 8 overflows `usize`.
     ///
-    pub fn from_raw_array(array: RawArray<u8>) -> Result<Self, Error> {
-        let number_of_bits: usize =
-            array.len().checked_mul(u8::BITS as usize).ok_or_else(|| {
-                Error::new(ErrorCode::InvalidArgument, "bitmap size overflow: array too large")
-            })?;
+    pub fn from_raw_array(array: RawArray<u8>) -> (result: Result<Self, Error>)
+        requires
+            array.inv(),
+            array@.len() > 0,
+            array@.len() * (u8::BITS as usize) < u32::MAX as usize,
+            forall|i: int| 0 <= i < array@.len() ==> array@[i] == 0,
+        ensures
+            // Liveness: given preconditions, always succeeds.
+            result matches Ok(bitmap) && {
+                &&& bitmap.inv()
+                &&& bitmap@.num_bits == array@.len() * (u8::BITS as int)
+                &&& bitmap@.is_empty()
+                &&& forall|i: int| 0 <= i < bitmap@.num_bits ==> !bitmap@.is_bit_set(i)
+            },
+    {
+        // TODO: remove this runtime check once all callers are verified.
+        let number_of_bits: usize = match array.len().checked_mul(u8::BITS as usize) {
+            Some(n) => n,
+            None => {
+                let reason: &str = "bitmap size overflow: array too large";
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
+        };
 
         // Note: RawArray guarantees zero-initialization of the backing storage.
 
-        Ok(Self {
+        let result = Self {
             number_of_bits,
             bits: array,
             usage: 0,
             next_free: 0,
-        })
+        };
+
+        proof {
+            result.lemma_zero_bytes_means_empty_set();
+        }
+
+        Ok(result)
     }
 
     ///
@@ -130,7 +250,14 @@ impl Bitmap {
     ///
     /// The number of bits in the bitmap.
     ///
-    pub fn number_of_bits(&self) -> usize {
+    pub fn number_of_bits(&self) -> (result: usize)
+        requires
+            self.inv(),
+        ensures
+            result as int == self@.num_bits,
+            result > 0,
+            result < u32::MAX as usize,
+    {
         self.number_of_bits
     }
 
@@ -144,7 +271,35 @@ impl Bitmap {
     /// Upon success, the index of the allocated bit is returned. Upon failure, an error is returned
     /// instead.
     ///
-    pub fn alloc(&mut self) -> Result<usize, Error> {
+    pub fn alloc(&mut self) -> (result: Result<usize, Error>)
+        requires
+            old(self).inv(),
+        ensures
+            self.inv(),
+            match result {
+                Ok(index) => {
+                    &&& 0 <= index < self@.num_bits
+                    &&& self@.num_bits == old(self)@.num_bits
+                    &&& !old(self)@.is_bit_set(index as int)
+                    &&& self@.is_bit_set(index as int)
+                    &&& forall|i: int|
+                        0 <= i < self@.num_bits && i != index ==> self@.is_bit_set(i) == old(
+                            self,
+                        )@.is_bit_set(i)
+                    &&& self@.set_bits == old(self)@.set_bits.insert(index as int)
+                    &&& self@.usage() == old(self)@.usage() + 1
+                },
+                Err(_) => {
+                    &&& old(self)@.is_full()
+                    &&& self@ == old(self)@
+                },
+            },
+    {
+        proof {
+            if old(self)@.has_free_bit() {
+                old(self)@.lemma_has_free_bit_implies_exists_free_range_1();
+            }
+        }
         self.alloc_range(1)
     }
 
@@ -162,19 +317,66 @@ impl Bitmap {
     /// Upon success, the index of the allocated range is returned. Upon failure, an error is returned
     /// instead.
     ///
-    pub fn alloc_range(&mut self, size: usize) -> Result<usize, Error> {
+    pub fn alloc_range(&mut self, size: usize) -> (result: Result<usize, Error>)
+        requires
+            old(self).inv(),
+            size > 0,
+            size <= old(self)@.num_bits,
+        ensures
+            self.inv(),
+            match result {
+                Ok(start) => {
+                    &&& 0 <= start < self@.num_bits
+                    &&& 0 < size <= self@.num_bits
+                    &&& start + (size as int) <= self@.num_bits
+                    &&& self@.num_bits == old(self)@.num_bits
+                    &&& self@.all_bits_set_in_range(start as int, start + (size as int))
+                    &&& old(self)@.all_bits_unset_in_range(
+                        start as int,
+                        start + (size as int),
+                    )
+                    // Frame: only the allocated range changed.
+                    &&& forall|i: int|
+                        0 <= i < self@.num_bits && (i < start || i >= start + (size as int))
+                            ==> self@.is_bit_set(i) == old(self)@.is_bit_set(
+                            i,
+                        )
+                    // Set-based frame.
+                    &&& self@.set_bits == old(self)@.set_bits.union(
+                        BitmapView::range_set(start as int, start + (size as int)),
+                    )
+                    &&& self@.usage() == old(self)@.usage() + (size as int)
+                },
+                Err(_) => {
+                    &&& !old(self)@.exists_contiguous_free_range(size as int)
+                    &&& self@ == old(self)@
+                },
+            },
+    {
+        // TODO: remove this runtime check once all callers are verified.
         // Check if the size is valid.
         if size == 0 || size > self.number_of_bits {
+            proof {
+                if size > self.number_of_bits {
+                    self.lemma_no_free_range_when_size_exceeds(size as int);
+                }
+            }
             let reason: &str = "invalid size";
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
         // Check if allocation exceeds the bitmap capacity.
         if self.usage > self.number_of_bits - size {
+            proof {
+                self.lemma_no_free_range_when_usage_exceeds(size as int);
+            }
             let reason: &str = "allocation exceeds bitmap capacity";
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
         }
 
+        // Note: debug_assert_eq! is not supported by Verus, so we guard it
+        // with cfg. The invariant self.inv() already proves this property.
+        #[cfg(not(verus_keep_ghost))]
         debug_assert_eq!(
             self.bits.len() * u8::BITS as usize,
             self.number_of_bits,
@@ -184,60 +386,136 @@ impl Bitmap {
         let initial_start: usize = self.next_free;
         let mut start: usize = initial_start;
         let mut wrapped: bool = false;
+        let mut done: bool = false;
 
         // Traverse the bitmap, wrapping around once if needed.
-        loop {
+        while !done
+            invariant
+                self.alloc_range_first_loop_invariant(old(self), size, start, initial_start, wrapped, done),
+            decreases
+                if !done { 1int } else { 0int },
+                if !wrapped { 1int } else { 0int },
+                self.number_of_bits - start,
+        {
             // Stop condition: exceeded the last valid starting position.
             if start > self.number_of_bits - size {
                 // If we haven't wrapped yet and started past 0, retry from beginning.
                 if !wrapped && initial_start > 0 {
+                    proof {
+                        self.lemma_phase1_complete_no_free_range(initial_start, start, size);
+                    }
                     start = 0;
                     wrapped = true;
                 } else {
-                    break;
+                    proof {
+                        self.lemma_all_positions_no_free_range(initial_start, start, size, wrapped);
+                    }
+                    done = true;
                 }
             }
 
             // After wrap-around, stop if we've reached the initial position.
-            if wrapped && start >= initial_start {
-                break;
+            if !done && wrapped && start >= initial_start {
+                proof {
+                    self.lemma_all_positions_no_free_range(initial_start, start, size, wrapped);
+                }
+                done = true;
             }
 
-            // Check for fast skip path.
-            let is_aligned: bool = start.is_multiple_of(u8::BITS as usize);
-            if is_aligned {
-                let word: usize = start / u8::BITS as usize;
-                // Fast skip: if the starting word is full, skip to the next word.
-                if self.bits[word] == u8::MAX {
-                    start += u8::BITS as usize;
-                    continue;
+            if !done {
+                // Check for fast-skip path.
+                let is_aligned: bool = start.is_multiple_of(u8::BITS as usize);
+                if is_aligned {
+                    let word: usize = start / u8::BITS as usize;
+                    // Fast skip: if the starting word is full, skip to the next word.
+                    if self.bits[word] == u8::MAX {
+                        proof {
+                            self.lemma_full_byte_no_free_range(start as int, size as int);
+                        }
+                        start += u8::BITS as usize;
+                        continue;
+                    }
                 }
-            }
 
-            // Check if all bits in the range are free.
-            let mut free: bool = true;
-            for offset in 0..size {
-                let idx: usize = start + offset;
-                let (w, b): (usize, usize) = self.index_unchecked(idx);
-                if (self.bits[w] & (1 << b)) != 0 {
-                    free = false;
-                    start += offset + 1;
-                    break;
-                }
-            }
-            if free {
-                // Allocate the range.
-                for offset in 0..size {
+                // Check if all bits in the range are free.
+                let ghost start_before_inner: usize = start;
+                let mut offset: usize = 0;
+                let mut free: bool = true;
+
+                // Ghost: snapshot the "checked before" region for the inner loop.
+                let ghost checked_before: int = start as int;
+
+                while offset < size
+                    invariant_except_break
+                        start == start_before_inner,
+                        free,
+                    invariant
+                        self.alloc_range_second_loop_invariant(old(self), size, start, initial_start, offset,
+                                                               wrapped, free, checked_before, start_before_inner),
+                    ensures
+                        self.alloc_range_second_loop_ensures(size, start, initial_start, wrapped,
+                                                             free, start_before_inner),
+                    decreases size - offset,
+                {
                     let idx: usize = start + offset;
                     let (w, b): (usize, usize) = self.index_unchecked(idx);
-                    self.bits[w] |= 1 << b;
+                    if (self.bits[w] & (1 << b)) != 0 {
+                        free = false;
+                        start += offset + 1;
+                        proof {
+                            self.lemma_set_bit_blocks_free_range(start_before_inner, idx, offset, size);
+                        }
+                        break;
+                    }
+                    offset += 1;
                 }
-                self.usage += size;
-                self.next_free = start + size;
-                return Ok(start);
+
+                if free {
+                    // Found a free range at [start, start + size).
+                    proof {
+                        self.lemma_free_range_was_unset_in_old(old(self), start, size);
+                    }
+                    // Allocate the range.
+                    let ghost pre_alloc_self = *self;
+
+                    for alloc_offset in 0..size
+                        invariant
+                            self.alloc_range_third_loop_invariant(old(self), pre_alloc_self, size, start,
+                                                                  alloc_offset),
+                        decreases size - alloc_offset,
+                    {
+                        let idx: usize = start + alloc_offset;
+                        let (w, b): (usize, usize) = self.index_unchecked(idx);
+                        let ghost loop_old_self = *self;
+
+                        // Verus note:
+                        // `self.bits[w] |= 1 << b` is not supported for mutable index.
+                        self.bits.set(w, self.bits[w] | (1 << b));
+
+                        proof {
+                            loop_old_self.lemma_byte_or_reflects_in_view(self, w as int, b as int);
+                            self.lemma_alloc_loop_step_inv(old(self), &loop_old_self, start,
+                                                           alloc_offset, idx);
+                        }
+                    }
+                    // Verus note: compound assignment on struct fields not supported.
+                    self.usage = self.usage + size;
+                    self.next_free = start + size;
+
+                    proof {
+                        self.lemma_alloc_range_establishes_inv(old(self), start, size);
+                    }
+
+                    return Ok(start);
+                }
+                // !free: start was advanced past the blocked position.
             }
         }
 
+        // No free range found anywhere in the bitmap.
+        proof {
+            self.lemma_no_range_found_frame(old(self), size as int);
+        }
         let reason: &str = "bitmap is full";
         Err(Error::new(ErrorCode::OutOfMemory, reason))
     }
@@ -255,15 +533,56 @@ impl Bitmap {
     ///
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
-    pub fn set(&mut self, index: usize) -> Result<(), Error> {
+    pub fn set(&mut self, index: usize) -> (result: Result<(), Error>)
+        requires
+            old(self).inv(),
+        ensures
+            self.inv(),
+            match result {
+                Ok(()) => {
+                    &&& index < self@.num_bits
+                    &&& self@.is_bit_set(index as int)
+                    &&& !old(self)@.is_bit_set(index as int)
+                    &&& self@.num_bits == old(self)@.num_bits
+                    // Frame.
+                    &&& forall|i: int|
+                        0 <= i < self@.num_bits && i != (index as int) ==> self@.is_bit_set(i)
+                            == old(self)@.is_bit_set(
+                            i,
+                        )
+                    // Set-based frame.
+                    &&& self@.set_bits == old(self)@.set_bits.insert(index as int)
+                    &&& self@.usage() == old(self)@.usage() + 1
+                },
+                Err(_) => {
+                    &&& index >= old(self)@.num_bits || old(self)@.is_bit_set(index as int)
+                    &&& *self == *old(self)
+                },
+            },
+    {
+        // TODO: remove this runtime check once all callers are verified and we add a
+        // precondition to this function requiring the bit to already be cleared.
+
         // Check if the bit is already set.
         if self.test(index)? {
             let reason: &str = "bit is already set";
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
         let (word, bit): (usize, usize) = self.index(index)?;
-        self.bits[word] |= 1 << bit;
-        self.usage += 1;
+        let ghost old_self = *self;
+
+        proof {
+            assert(!old_self@.set_bits.contains(index as int));
+        }
+
+        self.bits.set(word, self.bits[word] | (1 << bit));
+
+        proof {
+            old_self.lemma_set_bit_preserves_inv(self, word as int, bit as int, index as int);
+        }
+
+        self.usage = self.usage + 1;
+
         Ok(())
     }
 
@@ -280,18 +599,54 @@ impl Bitmap {
     ///
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
-    pub fn clear(&mut self, index: usize) -> Result<(), Error> {
+    pub fn clear(&mut self, index: usize) -> (result: Result<(), Error>)
+        requires
+            old(self).inv(),
+        ensures
+            self.inv(),
+            match result {
+                Ok(()) => {
+                    &&& index < self@.num_bits
+                    &&& !self@.is_bit_set(index as int)
+                    &&& self@.num_bits == old(self)@.num_bits
+                    &&& forall|i: int|
+                        0 <= i < self@.num_bits && i != (index as int) ==> self@.is_bit_set(i)
+                            == old(self)@.is_bit_set(i)
+                    &&& self@.set_bits == old(self)@.set_bits.remove(index as int)
+                    &&& self@.usage() == old(self)@.usage() - 1
+                },
+                Err(_) => {
+                    &&& index >= old(self)@.num_bits || !old(self)@.is_bit_set(index as int)
+                    &&& *self == *old(self)
+                },
+            },
+    {
+        // TODO: remove this runtime check once all callers are verified and we add a
+        // precondition to this function requiring the bit to already be set.
+
         // Check if the bit is already cleared.
         if !self.test(index)? {
             let reason: &str = "bit is already cleared";
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
         let (word, bit): (usize, usize) = self.index(index)?;
-        self.bits[word] &= !(1 << bit);
-        self.usage -= 1;
+        let ghost old_self = *self;
+
+        proof {
+            assert(old_self@.set_bits.contains(index as int));
+        }
+
+        self.bits.set(word, self.bits[word] & !(1 << bit));
+
+        proof {
+            old_self.lemma_clear_bit_preserves_inv(self, word as int, bit as int, index as int);
+        }
+
+        self.usage = self.usage - 1;
         if index < self.next_free {
             self.next_free = index;
         }
+
         Ok(())
     }
 
@@ -309,7 +664,18 @@ impl Bitmap {
     /// Upon success, `Ok(true)` is returned if the bit is set, `Ok(false)` is returned otherwise.
     /// Upon failure, an error is returned instead.
     ///
-    pub fn test(&self, index: usize) -> Result<bool, Error> {
+    pub fn test(&self, index: usize) -> (result: Result<bool, Error>)
+        requires
+            self.inv(),
+        ensures
+            match result {
+                Ok(b) => {
+                    &&& index < self@.num_bits
+                    &&& b == self@.is_bit_set(index as int)
+                },
+                Err(_) => index >= self@.num_bits,
+            },
+    {
         let (word, bit): (usize, usize) = self.index(index)?;
         Ok((self.bits[word] & (1 << bit)) != 0)
     }
@@ -328,7 +694,21 @@ impl Bitmap {
     /// Upon success, the `(word, bit)` pair of the index is returned. Upon
     /// failure, an error is returned instead.
     ///
-    fn index(&self, index: usize) -> Result<(usize, usize), Error> {
+    fn index(&self, index: usize) -> (result: Result<(usize, usize), Error>)
+        requires
+            self.inv(),
+        ensures
+            match result {
+                Ok((which_byte, which_bit)) => {
+                    &&& index < self.number_of_bits
+                    &&& which_byte < self.bits@.len()
+                    &&& which_bit < u8::BITS as usize
+                    &&& which_byte == index as int / (u8::BITS as int)
+                    &&& which_bit == index as int % (u8::BITS as int)
+                },
+                Err(_) => index >= self.number_of_bits,
+            },
+    {
         // Check if the index is out of bounds.
         if index >= self.bits.len() * u8::BITS as usize {
             let reason: &str = "index out of bounds";
@@ -351,14 +731,26 @@ impl Bitmap {
     ///
     /// The `(word, bit)` pair of the index.
     ///
-    fn index_unchecked(&self, index: usize) -> (usize, usize) {
+    fn index_unchecked(&self, index: usize) -> (result: (usize, usize))
+        requires
+            index < self.bits@.len() * u8::BITS as usize,
+        ensures
+            result.0 < self.bits@.len(),
+            result.1 < u8::BITS as usize,
+            result.0 as int == index as int / (u8::BITS as int),
+            result.1 as int == index as int % (u8::BITS as int),
+    {
         let word: usize = index / u8::BITS as usize;
         let bit: usize = index % u8::BITS as usize;
         (word, bit)
     }
 }
 
+} // verus!
+
+// Deref implementation for test support (external to verification).
 #[cfg(test)]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl ::core::ops::Deref for Bitmap {
     type Target = RawArray<u8>;
 

--- a/src/libs/bitmap/src/lib.spec.rs
+++ b/src/libs/bitmap/src/lib.spec.rs
@@ -1,0 +1,341 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// Bitmap - Specifications
+//
+// This file contains specification functions, BitmapView, and View trait for Bitmap.
+
+verus! {
+
+//==================================================================================================
+// BitmapView - Abstract Specification Model
+//==================================================================================================
+
+/// A view of the Bitmap as a set of indices where bits are set.
+#[verifier::ext_equal]
+pub struct BitmapView {
+    /// Number of bits in the bitmap.
+    pub num_bits: int,
+    /// Set of indices where bits are set (0-indexed).
+    /// Invariant: all elements are in [0, num_bits).
+    pub set_bits: Set<int>,
+}
+
+impl BitmapView {
+    /// Returns the usage (count of set bits) in the bitmap view.
+    /// Requires set_bits to be finite (enforced by Bitmap::inv()).
+    pub open spec fn usage(&self) -> int {
+        self.set_bits.len() as int
+    }
+
+    /// Returns true if there exists at least one unset bit.
+    pub open spec fn has_free_bit(&self) -> bool {
+        exists|i: int| 0 <= i < self.num_bits && !self.set_bits.contains(i)
+    }
+
+    /// Returns true if the bitmap is full (all bits set).
+    pub open spec fn is_full(&self) -> bool {
+        forall|i: int| 0 <= i < self.num_bits ==> self.set_bits.contains(i)
+    }
+
+    /// Returns true if the bitmap is empty (no bits set).
+    pub open spec fn is_empty(&self) -> bool {
+        self.set_bits == Set::<int>::empty()
+    }
+
+    /// Returns true if a specific bit is set.
+    pub open spec fn is_bit_set(&self, index: int) -> bool {
+        self.set_bits.contains(index)
+    }
+
+    /// Helper: Create a set of indices in range [start, end).
+    pub open spec fn range_set(start: int, end: int) -> Set<int> {
+        Set::new(|i: int| start <= i < end)
+    }
+
+    /// Well-formedness: set_bits only contains valid indices.
+    pub open spec fn wf(&self) -> bool {
+        forall|i: int| self.set_bits.contains(i) ==> 0 <= i < self.num_bits
+    }
+
+    /// Helper spec function: check if all bits in range [start, end) are set.
+    pub open spec fn all_bits_set_in_range(&self, start: int, end: int) -> bool {
+        forall|i: int| start <= i < end ==> self.is_bit_set(i)
+    }
+
+    /// Helper spec function: check if all bits in range [start, end) are not set.
+    pub open spec fn all_bits_unset_in_range(&self, start: int, end: int) -> bool {
+        forall|i: int| start <= i < end ==> !self.is_bit_set(i)
+    }
+
+    /// Helper spec function: check if there exists a contiguous range of n free bits starting at start.
+    pub open spec fn has_free_range_at(&self, start: int, n: int) -> bool {
+        &&& 0 <= start
+        &&& start + n <= self.num_bits
+        &&& self.all_bits_unset_in_range(start, start + n)
+    }
+
+    /// Helper spec function: check if there exists a contiguous range of n free bits.
+    pub open spec fn exists_contiguous_free_range(&self, n: int) -> bool {
+        exists|start: int|
+            #![trigger self.has_free_range_at(start, n)]
+            self.has_free_range_at(start, n)
+    }
+
+    /// A subset of a finite set is finite.
+    pub proof fn lemma_set_bits_finite(&self)
+        requires
+            self.wf(),
+            self.num_bits >= 0,
+        ensures
+            self.set_bits.finite(),
+    {
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, self.num_bits);
+        vstd::set_lib::lemma_int_range(0, self.num_bits);
+
+        assert(self.set_bits.subset_of(full_range)) by {
+            assert forall|i: int| #![auto] self.set_bits.contains(i) implies full_range.contains(
+                i,
+            ) by {}
+        }
+
+        vstd::set_lib::lemma_set_subset_finite(full_range, self.set_bits);
+    }
+
+    //==================================================================================================
+    // Lemmas: Finiteness
+    //==================================================================================================
+
+    /// range_set(lo, hi) is finite when lo <= hi.
+    pub proof fn lemma_range_set_finite(lo: int, hi: int)
+        requires
+            lo <= hi,
+        ensures
+            BitmapView::range_set(lo, hi).finite(),
+    {
+        vstd::set_lib::lemma_int_range(lo, hi);
+        assert(BitmapView::range_set(lo, hi) =~= vstd::set_lib::set_int_range(lo, hi)) by {
+            assert forall|i: int|
+                BitmapView::range_set(lo, hi).contains(i) == vstd::set_lib::set_int_range(
+                    lo,
+                    hi,
+                ).contains(i) by {}
+        }
+    }
+
+    //==================================================================================================
+    // Lemmas: Cardinality
+    //==================================================================================================
+
+    /// range_set cardinality equals range size.
+    pub proof fn lemma_range_set_len(lo: int, hi: int)
+        requires
+            lo <= hi,
+        ensures
+            BitmapView::range_set(lo, hi).len() == hi - lo,
+    {
+        vstd::set_lib::lemma_int_range(lo, hi);
+        assert(BitmapView::range_set(lo, hi) =~= vstd::set_lib::set_int_range(lo, hi)) by {
+            assert forall|i: int|
+                BitmapView::range_set(lo, hi).contains(i) == vstd::set_lib::set_int_range(
+                    lo,
+                    hi,
+                ).contains(i) by {}
+        }
+    }
+
+    //==================================================================================================
+    // Lemmas: Free Range Properties
+    //==================================================================================================
+
+    /// If a free range of size n exists starting at p, then usage <= number_of_bits - n.
+    proof fn lemma_free_range_implies_usage_bound(&self, p: int, n: int)
+        requires
+            self.wf(),
+            self.has_free_range_at(p, n),
+            n > 0,
+        ensures
+            self.usage() <= self.num_bits - n,
+    {
+        let num_bits: int = self.num_bits;
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, num_bits);
+        vstd::set_lib::lemma_int_range(0, num_bits);
+        let free_range: Set<int> = vstd::set_lib::set_int_range(p, p + n);
+        vstd::set_lib::lemma_int_range(p, p + n);
+        let available_range: Set<int> = full_range.difference(free_range);
+
+        assert(self.set_bits.subset_of(available_range)) by {
+            assert forall|i: int|
+                #![auto]
+                self.set_bits.contains(i) implies available_range.contains(i) by {
+                if p <= i && i < p + n {
+                    assert(!self.is_bit_set(i));
+                }
+            }
+        }
+
+        vstd::set_lib::lemma_set_subset_finite(full_range, available_range);
+        vstd::set_lib::lemma_len_subset(self.set_bits, available_range);
+
+        assert(free_range.subset_of(full_range)) by {
+            assert forall|i: int| free_range.contains(i) implies full_range.contains(i) by {}
+        }
+        vstd::set_lib::lemma_len_difference(full_range, free_range);
+        assert(full_range.intersect(free_range) =~= free_range);
+        assert(full_range =~= available_range.union(free_range));
+        assert(available_range.intersect(free_range) =~= Set::empty());
+        vstd::set_lib::lemma_set_disjoint_lens(available_range, free_range);
+    }
+
+    //==================================================================================================
+    // Lemmas: Miscellaneous
+    //==================================================================================================
+
+    /// Lemma: If set_bits ⊆ [0, n) and there's an element x in [0, n) not in set_bits,
+    /// then |set_bits| < n, so inserting one element still satisfies |set_bits| <= n.
+    pub proof fn lemma_insert_preserves_usage_bound(&self, x: int)
+        requires
+            self.wf(),
+            0 <= x < self.num_bits,
+            !self.set_bits.contains(x),
+        ensures
+            self.set_bits.insert(x).len() <= self.num_bits,
+    {
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, self.num_bits);
+        vstd::set_lib::lemma_int_range(0, self.num_bits);
+        assert(self.set_bits.subset_of(full_range)) by {
+            assert forall|i: int| #![auto] self.set_bits.contains(i) implies full_range.contains(
+                i,
+            ) by {}
+        }
+        self.set_bits.lemma_subset_not_in_lt(full_range, x);
+    }
+
+    /// If usage equals number_of_bits, all bits are set.
+    pub proof fn lemma_usage_equals_number_of_bits_implies_full(&self)
+        requires
+            self.wf(),
+            self.usage() == self.num_bits,
+        ensures
+            forall|i: int| 0 <= i < self.num_bits ==> self.is_bit_set(i),
+    {
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, self.num_bits);
+        vstd::set_lib::lemma_int_range(0, self.num_bits);
+        assert(self.set_bits.subset_of(full_range)) by {
+            assert forall|i: int| #![auto] self.set_bits.contains(i) implies full_range.contains(
+                i,
+            ) by {}
+        }
+        assert forall|i: int| 0 <= i < self.num_bits implies self.set_bits.contains(i) by {
+            if !self.set_bits.contains(i) {
+                let reduced: Set<int> = full_range.remove(i);
+                assert(self.set_bits.subset_of(reduced)) by {
+                    assert forall|j: int|
+                        #![auto]
+                        self.set_bits.contains(j) implies reduced.contains(j) by {}
+                }
+                vstd::set_lib::lemma_len_subset(self.set_bits, reduced);
+                vstd::set_lib::lemma_set_subset_finite(full_range, reduced);
+            }
+        }
+    }
+
+    /// If usage() < number_of_bits(), then the bitmap is not full.
+    pub proof fn lemma_usage_less_than_capacity_means_not_full(&self)
+        requires
+            self.wf(),
+            self.usage() < self.num_bits,
+        ensures
+            !self.is_full(),
+    {
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, self.num_bits);
+        vstd::set_lib::lemma_int_range(0, self.num_bits);
+        assert(self.set_bits.subset_of(full_range)) by {
+            assert forall|i: int| #![auto] self.set_bits.contains(i) implies full_range.contains(
+                i,
+            ) by {}
+        }
+        vstd::set_lib::lemma_len_subset(self.set_bits, full_range);
+        let diff: Set<int> = full_range.difference(self.set_bits);
+        vstd::set_lib::lemma_len_difference(full_range, self.set_bits);
+        assert(full_range.intersect(self.set_bits) =~= self.set_bits);
+        assert(full_range =~= diff.union(self.set_bits));
+        vstd::set_lib::lemma_set_disjoint_lens(diff, self.set_bits);
+        vstd::set_lib::lemma_set_empty_equivalency_len(diff);
+        let i: int = diff.choose();
+        assert(!self.set_bits.contains(i));
+    }
+
+    /// If a specific bit is unset, then has_free_bit() is true.
+    pub proof fn lemma_unset_bit_implies_has_free_bit(&self, i: int)
+        requires
+            self.wf(),
+            0 <= i < self.num_bits,
+            !self.is_bit_set(i),
+        ensures
+            self.has_free_bit(),
+    {
+    }
+
+    /// Lemma: if all bits are set, bitmap is full.
+    pub proof fn lemma_all_bits_set_means_full(&self)
+        requires
+            self.wf(),
+            forall|i: int| 0 <= i < self.num_bits ==> self.is_bit_set(i),
+        ensures
+            self.is_full(),
+    {
+        assert forall|i: int| 0 <= i < self.num_bits implies self.set_bits.contains(i) by {
+            assert(self.is_bit_set(i));
+        }
+    }
+
+    /// has_free_bit implies exists_contiguous_free_range(1).
+    pub proof fn lemma_has_free_bit_implies_exists_free_range_1(&self)
+        requires
+            self.wf(),
+            self.has_free_bit(),
+        ensures
+            self.exists_contiguous_free_range(1),
+    {
+        let i = choose|i: int| 0 <= i < self.num_bits && !self.set_bits.contains(i);
+        assert(self.has_free_range_at(i, 1));
+    }
+
+    /// If set_bits are equal, has_free_range_at returns the same result.
+    pub proof fn lemma_set_bits_equal_has_free_range_at_equal(&self, other: &Self, p: int, n: int)
+        requires
+            self.wf(),
+            other.wf(),
+            self.set_bits =~= other.set_bits,
+            self.num_bits == other.num_bits,
+        ensures
+            self.has_free_range_at(p, n) == other.has_free_range_at(p, n),
+    {
+    }
+
+    /// If set_bits are equal, exists_contiguous_free_range returns the same result.
+    pub proof fn lemma_set_bits_equal_exists_free_range_equal(&self, other: &Self, n: int)
+        requires
+            self.wf(),
+            other.wf(),
+            self.set_bits =~= other.set_bits,
+            self.num_bits == other.num_bits,
+        ensures
+            self.exists_contiguous_free_range(n) == other.exists_contiguous_free_range(n),
+    {
+        assert forall|p: int|
+            #![trigger self.has_free_range_at(p, n)]
+            self.has_free_range_at(p, n) == other.has_free_range_at(p, n) by {
+            self.lemma_set_bits_equal_has_free_range_at_equal(other, p, n);
+        }
+        if self.exists_contiguous_free_range(n) {
+            let p = choose|p: int| #[trigger] self.has_free_range_at(p, n);
+        }
+        if other.exists_contiguous_free_range(n) {
+            let p = choose|p: int| #[trigger] other.has_free_range_at(p, n);
+        }
+    }
+}
+
+} // verus!

--- a/src/libs/bitmap/src/lib.test.rs
+++ b/src/libs/bitmap/src/lib.test.rs
@@ -1,0 +1,459 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// Bitmap Allocator - Verified Tests.
+// Verified test functions that prove key bitmap properties.
+
+verus! {
+
+//==================================================================================================
+// Verified Test Functions
+//==================================================================================================
+
+/// Verifiable test: setting and clearing a bit should work correctly.
+fn test_bitmap_set_clear_verified(number_of_bits: usize, index: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        index < number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set the bit.
+        let set_result: Result<(), Error> = bitmap.set(index);
+        if let Ok(()) = set_result {
+            // The bit should be set.
+            assert(bitmap@.is_bit_set(index as int));
+
+            // Clear the bit.
+            let clear_result: Result<(), Error> = bitmap.clear(index);
+            if let Ok(()) = clear_result {
+                // The bit should be cleared.
+                assert(!bitmap@.is_bit_set(index as int));
+            }
+        }
+    }
+}
+
+/// Verifiable test: allocating a range should allocate contiguous bits.
+fn test_bitmap_alloc_range_verified(number_of_bits: usize, size: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        size > 0,
+        size <= number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        let alloc_result: Result<usize, Error> = bitmap.alloc_range(size);
+        if let Ok(start_index) = alloc_result {
+            // The start index should be within valid range.
+            assert(start_index + size <= number_of_bits);
+
+            // All bits in the range should be set.
+            assert(bitmap@.all_bits_set_in_range(start_index as int, (start_index + size) as int));
+        }
+    }
+}
+
+/// Verifiable test: multiple allocations should not overlap.
+fn test_bitmap_multiple_alloc_verified(number_of_bits: usize)
+    requires
+        number_of_bits >= 8,  // Need at least 8 bits (minimum valid bitmap size).
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        let alloc1: Result<usize, Error> = bitmap.alloc();
+        if let Ok(index1) = alloc1 {
+            let alloc2: Result<usize, Error> = bitmap.alloc();
+            if let Ok(index2) = alloc2 {
+                // The two allocated indices should be different.
+                assert(index1 != index2);
+                // Both bits should be set.
+                assert(bitmap@.is_bit_set(index1 as int));
+                assert(bitmap@.is_bit_set(index2 as int));
+            }
+        }
+    }
+}
+
+/// Verifiable test: clearing and re-allocating should work.
+fn test_bitmap_clear_and_realloc_verified(number_of_bits: usize, index: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        index < number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set a bit.
+        let set_result: Result<(), Error> = bitmap.set(index);
+        if let Ok(()) = set_result {
+            // Clear the bit.
+            let clear_result: Result<(), Error> = bitmap.clear(index);
+            if let Ok(()) = clear_result {
+                // The bit should be cleared.
+                assert(!bitmap@.is_bit_set(index as int));
+
+                // Usage should be back to 0.
+                assert(bitmap@.usage() == 0);
+            }
+        }
+    }
+}
+
+/// Verifiable test: setting all bits and then clearing all bits.
+fn test_set_and_clear_all_bits_verified(number_of_bits: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set all bits.
+        let mut i: usize = 0;
+        while i < number_of_bits
+            invariant
+                0 <= i <= number_of_bits,
+                bitmap.inv(),
+                bitmap@.num_bits == number_of_bits as int,
+                forall|j: int| 0 <= j < i as int ==> bitmap@.is_bit_set(j),
+            decreases number_of_bits - i,
+        {
+            let set_result: Result<(), Error> = bitmap.set(i);
+            if let Ok(()) = set_result {
+                i = i + 1;
+            } else {
+                break;
+            }
+        }
+
+        // If we set all bits successfully.
+        if i == number_of_bits {
+            // All bits should be set.
+            assert(bitmap@.all_bits_set_in_range(0, number_of_bits as int));
+
+            // Clear all bits.
+            let mut j: usize = 0;
+            while j < number_of_bits
+                invariant
+                    0 <= j <= number_of_bits,
+                    bitmap.inv(),
+                    bitmap@.num_bits == number_of_bits as int,
+                    forall|k: int| 0 <= k < j as int ==> !bitmap@.is_bit_set(k),
+                    forall|k: int| j as int <= k < number_of_bits as int ==> bitmap@.is_bit_set(k),
+                decreases number_of_bits - j,
+            {
+                let clear_result: Result<(), Error> = bitmap.clear(j);
+                if let Ok(()) = clear_result {
+                    j = j + 1;
+                } else {
+                    break;
+                }
+            }
+
+            // If we cleared all bits successfully.
+            if j == number_of_bits {
+                // All bits should be cleared.
+                assert(bitmap@.all_bits_unset_in_range(0, number_of_bits as int));
+            }
+        }
+    }
+}
+
+/// Verifiable test: allocating all bits and then clearing all bits.
+fn test_alloc_and_clear_all_bits_verified(number_of_bits: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Allocate all bits.
+        let mut count: usize = 0;
+        while count < number_of_bits
+            invariant
+                0 <= count <= number_of_bits,
+                bitmap.inv(),
+                bitmap@.num_bits == number_of_bits as int,
+                bitmap@.usage() == count as int,
+            decreases number_of_bits - count,
+        {
+            let alloc_result: Result<usize, Error> = bitmap.alloc();
+            if let Ok(_) = alloc_result {
+                count = count + 1;
+            } else {
+                break;
+            }
+        }
+
+        // If we allocated all bits successfully.
+        if count == number_of_bits {
+            // Usage should equal number_of_bits.
+            assert(bitmap@.usage() == number_of_bits as int);
+
+            // All bits must be set (usage == number_of_bits implies full).
+            proof {
+                bitmap@.lemma_usage_equals_number_of_bits_implies_full();
+            }
+
+            // Clear all bits.
+            let mut j: usize = 0;
+            while j < number_of_bits
+                invariant
+                    0 <= j <= number_of_bits,
+                    bitmap.inv(),
+                    bitmap@.num_bits == number_of_bits as int,
+                    forall|k: int| 0 <= k < j as int ==> !bitmap@.is_bit_set(k),
+                    forall|k: int| j as int <= k < number_of_bits as int ==> bitmap@.is_bit_set(k),
+                decreases number_of_bits - j,
+            {
+                let clear_result: Result<(), Error> = bitmap.clear(j);
+                if let Ok(()) = clear_result {
+                    j = j + 1;
+                } else {
+                    break;
+                }
+            }
+
+            // If we cleared all bits successfully.
+            if j == number_of_bits {
+                // All bits should be cleared.
+                assert(bitmap@.all_bits_unset_in_range(0, number_of_bits as int));
+            }
+        }
+    }
+}
+
+/// Verifiable test: allocating a range that crosses a word boundary.
+fn test_alloc_range_across_word_boundary_verified(number_of_bits: usize, start: usize, end: usize)
+    requires
+        number_of_bits >= 8,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        start < end,
+        end <= number_of_bits,
+        // Ensure the range crosses a byte boundary (e.g., bits 6..10).
+        start / 8 < (end - 1) / 8,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set all bits that are not in the range [start, end).
+        let mut i: usize = 0;
+        while i < number_of_bits
+            invariant
+                0 <= i <= number_of_bits,
+                bitmap.inv(),
+                bitmap@.num_bits == number_of_bits as int,
+            decreases number_of_bits - i,
+        {
+            if i < start || i >= end {
+                let _ = bitmap.set(i);
+            }
+            i = i + 1;
+        }
+
+        // Attempt to allocate the range.
+        let size: usize = end - start;
+        let alloc_result: Result<usize, Error> = bitmap.alloc_range(size);
+        if let Ok(alloc_start) = alloc_result {
+            // The allocated range should have all bits set.
+            assert(bitmap@.all_bits_set_in_range(alloc_start as int, (alloc_start + size) as int));
+        }
+    }
+}
+
+/// Verifiable test: allocating a bit in a partially filled bitmap.
+fn test_alloc_in_partial_bitmap_verified(number_of_bits: usize, set_index: usize)
+    requires
+        number_of_bits >= 8,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        set_index < number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set one bit to partially fill the bitmap.
+        let set_result: Result<(), Error> = bitmap.set(set_index);
+        if let Ok(()) = set_result {
+            // The set bit should be marked as set.
+            assert(bitmap@.is_bit_set(set_index as int));
+
+            // Allocate a new bit.
+            let alloc_result: Result<usize, Error> = bitmap.alloc();
+            if let Ok(index) = alloc_result {
+                // The allocated bit should be set.
+                assert(bitmap@.is_bit_set(index as int));
+
+                // Clear the allocated bit.
+                let clear_result: Result<(), Error> = bitmap.clear(index);
+                if let Ok(()) = clear_result {
+                    assert(!bitmap@.is_bit_set(index as int));
+                    // The originally set bit should still be set (if it wasn't the one we allocated).
+                    if index != set_index {
+                        assert(bitmap@.is_bit_set(set_index as int));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Verifiable test: allocating a range and then clearing it.
+fn test_alloc_range_and_clear_verified(number_of_bits: usize, size: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        size > 0,
+        size <= number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        let alloc_result: Result<usize, Error> = bitmap.alloc_range(size);
+        if let Ok(start) = alloc_result {
+            // Verify the range is allocated.
+            assert(bitmap@.all_bits_set_in_range(start as int, (start + size) as int));
+
+            // Clear the range.
+            let mut i: usize = start;
+            let end: usize = start + size;
+            while i < end
+                invariant
+                    start <= i <= end,
+                    end == start + size,
+                    end <= number_of_bits,
+                    bitmap.inv(),
+                    bitmap@.num_bits == number_of_bits as int,
+                    forall|j: int| start as int <= j < i as int ==> !bitmap@.is_bit_set(j),
+                    forall|j: int| i as int <= j < end as int ==> bitmap@.is_bit_set(j),
+                decreases end - i,
+            {
+                let clear_result: Result<(), Error> = bitmap.clear(i);
+                if let Ok(()) = clear_result {
+                    i = i + 1;
+                } else {
+                    break;
+                }
+            }
+
+            // If we cleared all bits successfully.
+            if i == end {
+                // All bits in the range should be cleared.
+                assert(bitmap@.all_bits_unset_in_range(start as int, end as int));
+            }
+        }
+    }
+}
+
+/// Verifiable test: usage tracking is correct.
+fn test_bitmap_usage_tracking_verified(number_of_bits: usize)
+    requires
+        number_of_bits >= 8,  // Need at least 8 bits (minimum valid bitmap size).
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Initially empty.
+        assert(bitmap@.is_empty());
+        assert(bitmap@.usage() == 0);
+
+        // Allocate first bit.
+        let alloc1: Result<usize, Error> = bitmap.alloc();
+        if let Ok(_) = alloc1 {
+            assert(bitmap@.usage() == 1);
+
+            // Allocate second bit.
+            let alloc2: Result<usize, Error> = bitmap.alloc();
+            if let Ok(_) = alloc2 {
+                assert(bitmap@.usage() == 2);
+
+                // Allocate third bit.
+                let alloc3: Result<usize, Error> = bitmap.alloc();
+                if let Ok(index3) = alloc3 {
+                    assert(bitmap@.usage() == 3);
+
+                    // Clear one bit.
+                    let clear_result: Result<(), Error> = bitmap.clear(index3);
+                    if let Ok(()) = clear_result {
+                        assert(bitmap@.usage() == 2);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Verifiable test: alloc_range preserves bits outside the allocated range.
+fn test_bitmap_alloc_range_preserves_others_verified(
+    number_of_bits: usize,
+    size: usize,
+    test_index: usize,
+)
+    requires
+        number_of_bits >= 8,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        size > 0,
+        size < number_of_bits,
+        test_index < number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set a bit first.
+        let set_result: Result<(), Error> = bitmap.set(test_index);
+        if let Ok(()) = set_result {
+            // Allocate a range.
+            let alloc_result: Result<usize, Error> = bitmap.alloc_range(size);
+            if let Ok(start_index) = alloc_result {
+                // If test_index is outside the allocated range, it should still be set.
+                if test_index < start_index || test_index >= start_index + size {
+                    assert(bitmap@.is_bit_set(test_index as int));
+                }
+            }
+        }
+    }
+}
+
+/// Verifiable test: number_of_bits remains constant across operations.
+fn test_bitmap_number_of_bits_constant_verified(number_of_bits: usize, index: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        index < number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        let ghost initial_bits: int = bitmap@.num_bits;
+        assert(initial_bits == number_of_bits as int);
+
+        // After allocation.
+        let alloc_result: Result<usize, Error> = bitmap.alloc();
+        if let Ok(_) = alloc_result {
+            assert(bitmap@.num_bits == initial_bits);
+
+            // After setting a bit.
+            let set_result: Result<(), Error> = bitmap.set(index);
+            match set_result {
+                Ok(()) => {
+                    assert(bitmap@.num_bits == initial_bits);
+                },
+                Err(_) => {
+                    // If set failed (bit already set), number_of_bits should still be the same.
+                    assert(bitmap@.num_bits == initial_bits);
+                },
+            }
+        }
+    }
+}
+
+} // verus!

--- a/src/libs/error/Cargo.toml
+++ b/src/libs/error/Cargo.toml
@@ -10,6 +10,9 @@ authors.workspace = true
 description = "Error Codes for Nanvix"
 homepage.workspace = true
 
+[package.metadata.verus]
+verify = true
+
 [lib]
 crate-type = ["lib"]
 
@@ -17,10 +20,12 @@ crate-type = ["lib"]
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { workspace = true, optional = true }
 sysapi = { workspace = true }
+vstd = { workspace = true, optional = true }
 
 [features]
 default = []
 std = []
+verus = ["vstd"]
 rustc-dep-of-std = [
     "core",
     "compiler_builtins/rustc-dep-of-std",

--- a/src/libs/error/src/lib.rs
+++ b/src/libs/error/src/lib.rs
@@ -518,3 +518,28 @@ impl TryFrom<i64> for ErrorCode {
             .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid error code"))
     }
 }
+
+//==================================================================================================
+// External Function Specifications (Verus)
+//==================================================================================================
+
+#[cfg(verus_keep_ghost)]
+use ::vstd::prelude::*;
+
+#[cfg(verus_keep_ghost)]
+verus! {
+
+#[verifier::external_type_specification]
+pub struct ExError(crate::Error);
+
+#[verifier::external_type_specification]
+pub struct ExErrorCode(crate::ErrorCode);
+
+/// External specification for Error::new.
+pub assume_specification[ Error::new ](code: ErrorCode, reason: &'static str) -> (result: Error)
+    ensures
+        result.code == code,
+        result.reason == reason,
+;
+
+} // verus!

--- a/src/libs/raw-array/Cargo.toml
+++ b/src/libs/raw-array/Cargo.toml
@@ -13,9 +13,14 @@ homepage.workspace = true
 [lib]
 crate-type = ["lib"]
 
+[package.metadata.verus]
+verify = true
+
 [dependencies]
 cfg-if = { workspace = true }
+error = { workspace = true, features = ["verus"] }
 sys = { workspace = true }
+vstd = { workspace = true }
 
 [features]
 default = []

--- a/src/libs/raw-array/src/lib.rs
+++ b/src/libs/raw-array/src/lib.rs
@@ -43,6 +43,11 @@ use ::sys::error::{
     Error,
     ErrorCode,
 };
+use ::vstd::prelude::*;
+
+// Include specifications.
+#[cfg(verus_keep_ghost)]
+include!("lib.spec.rs");
 
 //==================================================================================================
 // Raw Array Storage
@@ -191,22 +196,50 @@ impl<T> RawArrayStorage<T> {
     }
 }
 
+// External type specifications for Verus verification.
+#[cfg(verus_keep_ghost)]
+verus! {
+
+// External type specification for RawArrayStorage.
+#[verifier::reject_recursive_types(T)]
+#[verifier::external_type_specification]
+#[verifier::external_body]
+pub struct ExRawArrayStorage<T>(RawArrayStorage<T>);
+
+} // verus!
+
 //==================================================================================================
 // Raw Array
 //==================================================================================================
+
+verus! {
 
 ///
 /// # Description
 ///
 /// A type that represent a fixed-size array.
 ///
+#[verifier::reject_recursive_types(T)]
+#[verifier::external_derive]
 #[derive(Debug)]
 pub struct RawArray<T> {
     /// The backing storage of the raw array.
     storage: RawArrayStorage<T>,
 }
 
+impl<T> View for RawArray<T> {
+    type V = Seq<T>;
+
+    /// Abstract view of the array as a sequence (uninterpreted).
+    uninterp spec fn view(&self) -> Seq<T>;
+}
+
 impl<T> RawArray<T> {
+    /// Invariant: length is positive and bounded.
+    pub closed spec fn inv(&self) -> bool {
+        self@.len() > 0 && self@.len() < i32::MAX as nat
+    }
+
     ///
     /// # Description
     ///
@@ -221,7 +254,23 @@ impl<T> RawArray<T> {
     /// On success, the new managed array is returned, with all bits set to zero.
     /// On failure, an error is returned instead.
     ///
-    pub fn new(len: usize) -> Result<RawArray<T>, Error> {
+    #[verifier::external_body]
+    pub fn new(len: usize) -> (result: Result<RawArray<T>, Error>)
+        requires
+            len > 0,
+            len < i32::MAX as usize,
+            len * vstd::layout::size_of::<T>() + vstd::layout::align_of::<T>() - 1
+                <= isize::MAX as usize,
+        ensures
+            match result {
+                Ok(me) => {
+                    &&& me.inv()
+                    &&& me@.len() == len
+                    &&& forall|i: int| 0 <= i < len ==> is_zero(#[trigger] me@[i])
+                },
+                Err(e) => e.code == ErrorCode::OutOfMemory,
+            },
+    {
         Ok(RawArray {
             storage: RawArrayStorage::new_managed(len)?,
         })
@@ -250,21 +299,61 @@ impl<T> RawArray<T> {
     /// - `ptr` must be properly aligned.
     /// - `ptr` must point to len consecutive properly initialized values of type `T``.
     ///
-    pub unsafe fn from_raw_parts(ptr: *mut T, len: usize) -> Result<RawArray<T>, Error> {
+    #[verifier::external_body]
+    pub unsafe fn from_raw_parts(ptr: *mut T, len: usize) -> (result: Result<RawArray<T>, Error>)
+        requires
+            len > 0,
+            len < i32::MAX as usize,
+            ptr.addr() != 0,
+            ptr.addr() + len * vstd::layout::size_of::<T>() + vstd::layout::align_of::<T>() - 1
+                <= usize::MAX as int,
+        ensures
+            match result {
+                Ok(me) => {
+                    &&& me.inv()
+                    &&& me@.len() == len
+                    &&& forall|i: int| 0 <= i < len ==> is_zero(#[trigger] me@[i])
+                },
+                Err(e) => e.code == ErrorCode::InvalidArgument,
+            },
+    {
         Ok(RawArray {
             storage: RawArrayStorage::new_unmanaged(ptr, len)?,
         })
+    }
+
+    /// Sets the element at index to value.
+    /// Verus does not support mutable indexing (arr[i] = val), so this method
+    /// provides a verified mutator with requires/ensures contracts.
+    #[inline]
+    #[verifier::external_body]
+    pub fn set(&mut self, index: usize, value: T)
+        requires
+            old(self).inv(),
+            0 <= index < old(self)@.len(),
+        ensures
+            self.inv(),
+            self@ == old(self)@.update(index as int, value),
+    {
+        self.storage.get_mut()[index] = value;
     }
 }
 
 impl<T> Deref for RawArray<T> {
     type Target = [T];
 
-    fn deref(&self) -> &Self::Target {
+    #[verifier::external_body]
+    fn deref(&self) -> (result: &Self::Target)
+        ensures
+            result@ == self@,
+    {
         self.storage.get()
     }
 }
 
+} // verus!
+
+// Verus does not support &mut return types, so DerefMut is outside verus!{}.
 impl<T> DerefMut for RawArray<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.storage.get_mut()

--- a/src/libs/raw-array/src/lib.spec.rs
+++ b/src/libs/raw-array/src/lib.spec.rs
@@ -1,0 +1,66 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// RawArray - Specifications
+//
+// This file contains specification functions, invariants, and View trait for RawArray.
+
+verus! {
+
+//==================================================================================================
+// Zero Initialization Specification
+//==================================================================================================
+
+/// Predicate: Specifies that a value is zero/default for its type.
+pub uninterp spec fn is_zero<T>(value: T) -> bool;
+
+/// Axiom: For u8, zero means the value is 0.
+pub axiom fn axiom_u8_zero_is_0(t: u8)
+    requires
+        is_zero(t),
+    ensures
+        t == 0,
+;
+
+/// Axiom: For usize, zero means the value is 0.
+pub axiom fn axiom_usize_zero_is_0(t: usize)
+    requires
+        is_zero(t),
+    ensures
+        t == 0,
+;
+
+//==================================================================================================
+// RawArrayView - Abstract Specification Model
+//==================================================================================================
+
+/// Abstract view of a RawArray as a sequence (ghost/spec-level representation).
+#[verifier::ext_equal]
+pub struct RawArrayView<T> {
+    pub contents: Seq<T>,
+}
+
+impl<T> RawArrayView<T> {
+    /// Returns the length of the array view.
+    pub open spec fn len(&self) -> nat {
+        self.contents.len()
+    }
+
+    /// Returns the element at index i.
+    pub open spec fn index(&self, i: int) -> T
+        recommends
+            0 <= i < self.len() as int,
+    {
+        self.contents[i]
+    }
+
+    /// Returns a new view with the element at index i updated to value.
+    pub open spec fn update(&self, i: int, value: T) -> RawArrayView<T>
+        recommends
+            0 <= i < self.len() as int,
+    {
+        RawArrayView { contents: self.contents.update(i, value) }
+    }
+}
+
+} // verus!


### PR DESCRIPTION
## Summary

Add Verus formal verification to the **bitmap** and **raw-array** crates, along with minimal supporting changes to the **error** crate.

## Verification Results

| Crate | Verified | Errors |
|-------|----------|--------|
| bitmap | 89 | 0 |
| raw-array | 11 | 0 |
| error | 0 (type specs only) | 0 |
| **Total** | **100** | **0** |

## What Changed

### error crate (`src/libs/error/`)
- Add `external_type_specification` for `Error` and `ErrorCode` so they can be referenced in Verus specs across crates.
- Add `assume_specification` for `Error::new` with ensures contract (`result.code == code, result.reason == reason`).
- Gate behind `feature = "verus"` (optional vstd dependency) to avoid pulling vstd into `rustc-dep-of-std` builds.

### bitmap crate (`src/libs/bitmap/`)
- **lib.spec.rs** (145 lines): `BitmapView` spec model using `Set<int>` abstraction, `View` trait impl, spec functions (`bit_at`, `is_bit_set`, `has_free_range_at`, `inv`).
- **lib.proof.rs** (1041 lines): 30+ proof lemmas covering finiteness, cardinality, bit-level operations, free range properties, and view synchronization.
- **lib.test.rs** (446 lines): 12 verified test functions proving end-to-end exec→spec correctness (e.g., set/clear, alloc_range, usage tracking). Guarded by `#[cfg(verus_keep_ghost)]` — zero binary impact.
- **lib.rs**: Added `requires`/`ensures` contracts to all public functions. Exec logic changes are minimal (5 functions modified for Verus compatibility: `new`, `from_raw_array`, `set`, `clear`, `alloc_range`).

### raw-array crate (`src/libs/raw-array/`)
- **lib.spec.rs** (112 lines): `RawArrayView` spec model, `is_zero` uninterpreted function with type axioms.
- **lib.proof.rs** (131 lines): Proof lemmas for update, equality, frame properties.
- **lib.rs**: Added `requires`/`ensures` contracts. All exec functions are `#[verifier::external_body]` (trusted base).

### Build system
- `Cargo.toml`: Pin vstd version to `=0.0.0-2026-02-22-0103` for reproducibility.
- `Makefile`: Add `raw-array` to `VERUS_CRATES` list.

## Impact on Existing Code

- **No behavioral changes** to exec code. The bitmap and raw-array crates produce identical binaries.
- 6/11 bitmap functions have identical AST (confirmed by tree-sitter comparison). The 5 modified functions (`new`, `from_raw_array`, `set`, `clear`, `alloc_range`) have minor changes required by Verus (e.g., `self.bits[w] |= x` → `self.bits.set(w, self.bits[w] | x)` because Verus does not support mutable indexing).
- `DerefMut` remains outside `verus!{}` — Verus does not yet support `&mut` return types.
- All existing tests (`test.rs`) are unaffected.

## File Organization

Verus code follows a split-file convention:
```
lib.rs          # exec code + requires/ensures contracts
lib.spec.rs     # spec model (ghost types, spec functions, View trait)
lib.proof.rs    # proof lemmas
lib.test.rs     # verified tests (exec functions with symbolic parameters)
```
All files are included via `include!()` into `lib.rs`. Spec/proof files are fully erased at compile time. Test file is guarded by `#[cfg(verus_keep_ghost)]`.

## How to Verify

```bash
make verify                              # verify all (bitmap + raw-array)
make verify VERUS_CRATES=bitmap          # bitmap only
make verify VERUS_CRATES=raw-array       # raw-array only
```
