### PR TITLE
[tests] F: test.toml regression

### DIFF
--- a/test/test.toml
+++ b/test/test.toml
@@ -26,10 +26,12 @@ gateway_connect_timeout_ms = 15000
 
 [[tests]]
 executor = "empty"
+name = "empty/1"
 iterations = 1
 
 [[tests]]
 executor = "empty"
+name = "empty/2"
 iterations = 2
 
 #===================================================================================================


### PR DESCRIPTION
With #1459, test cases need to either have a `name`, or both `executor` and `program` defined for the test filter to work.

`test.toml` did not have a name defined for the two empty tests at the top of the file, and failed when run with `nanvix-test`.