### PR TITLE
[bitmap] bitmap allocator next_free hint

### DIFF
--- a/src/libs/bitmap/src/lib.rs
+++ b/src/libs/bitmap/src/lib.rs
@@ -40,6 +40,8 @@ pub struct Bitmap {
     usage: usize,
     /// Underlying bits.
     bits: RawArray<u8>,
+    /// Hint: first bit index that might be free. Avoids O(n) rescans.
+    next_free: usize,
 }
 
 //==================================================================================================
@@ -81,6 +83,7 @@ impl Bitmap {
             number_of_bits,
             bits: array,
             usage: 0,
+            next_free: 0,
         })
     }
 
@@ -114,6 +117,7 @@ impl Bitmap {
             number_of_bits,
             bits: array,
             usage: 0,
+            next_free: 0,
         })
     }
 
@@ -177,7 +181,7 @@ impl Bitmap {
             "bitmap length must match the number of bits"
         );
 
-        let mut start: usize = 0;
+        let mut start: usize = self.next_free;
 
         // Traverse the bitmap until the last possible starting bit.
         while start <= self.number_of_bits - size {
@@ -212,6 +216,7 @@ impl Bitmap {
                     self.bits[w] |= 1 << b;
                 }
                 self.usage += size;
+                self.next_free = start + size;
                 return Ok(start);
             }
         }
@@ -267,6 +272,9 @@ impl Bitmap {
         let (word, bit): (usize, usize) = self.index(index)?;
         self.bits[word] &= !(1 << bit);
         self.usage -= 1;
+        if index < self.next_free {
+            self.next_free = index;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Add a `next_free` hint to the bitmap allocator to avoid scanning from index 0 on every allocation. This reduces allocation time from O(n) to O(1) amortized for sequential allocation patterns.

## Changes

- **bitmap/lib.rs**: Add `next_free` field that tracks the lowest index likely to be free
  - Updated on `alloc()` to advance past allocated bits
  - Updated on `free()` to retract when a lower index becomes available
  - Scanning starts from `next_free` instead of 0

## Impact

Reduces frame allocation overhead for large contiguous allocations (e.g., 118K pages for heap growth).

---
*Split from `feature-llama-perf` branch.*