### PR TITLE
[build] Initial Support for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,61 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Default: auto-detect and normalize to LF in the repository.
+* text=auto eol=lf
+
+# Ensure shell scripts always use LF (required for Linux/Docker execution).
+*.sh text eol=lf
+
+# Makefiles must use LF (tabs are significant, CRLF breaks recipes in Docker).
+Makefile text eol=lf
+*.mk text eol=lf
+
+# Dockerfiles must use LF.
+Dockerfile* text eol=lf
+
+# Rust source files.
+*.rs text eol=lf
+*.toml text eol=lf
+
+# Linker scripts.
+*.ld text eol=lf
+
+# Python scripts.
+*.py text eol=lf
+
+# C/C++ source files.
+*.c text eol=lf
+*.cpp text eol=lf
+*.h text eol=lf
+*.hpp text eol=lf
+
+# Assembly files.
+*.S text eol=lf
+*.s text eol=lf
+*.asm text eol=lf
+
+# Configuration files.
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.cfg text eol=lf
+
+# PowerShell scripts keep CRLF (Windows native).
+*.ps1 text eol=crlf
+*.bat text eol=crlf
+
+# Binary files — do not normalize.
+*.elf binary
+*.wasm binary
+*.o binary
+*.a binary
+*.so binary
+*.iso binary
+*.tar binary
+*.tar.gz binary
+*.tar.bz2 binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,7 @@ vfs = { path = "src/libs/vfs", default-features = false }
 vstd = { version = "=0.0.0-2026-03-15-0111", default-features = false }
 vmm-sys-util = { version = "0.15.0", default-features = false }
 wasmi = { version = "1.0.9", default-features = false }
+windows = { version = "0.61", features = ["Win32_System_Hypervisor", "Win32_System_Memory", "Win32_System_Threading"] }
 
 [profile.dev]
 opt-level = 0

--- a/src/libs/config/src/constants.rs
+++ b/src/libs/config/src/constants.rs
@@ -6,3 +6,6 @@ pub const KILOBYTE: usize = 1 << 10;
 
 /// Megabyte.
 pub const MEGABYTE: usize = 1 << 20;
+
+/// Microseconds per second.
+pub const MICROSECONDS_PER_SECOND: u32 = 1_000_000;

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -217,6 +217,10 @@ pub mod microvm {
     /// I/O port that is connected to the standard input of the virtual machine.
     pub const DEFAULT_STDIN_PORT: u16 = 0xea;
 
+    /// Timer period in microseconds, derived from the kernel timer frequency.
+    pub const TIMER_PERIOD_US: u64 =
+        (crate::constants::MICROSECONDS_PER_SECOND as u64) / (crate::kernel::TIMER_FREQ as u64);
+
     /// I/O port that enables the guest to invoke functionalities of the virtual machine monitor.
     pub const DEFAULT_VMM_PORT: u16 = 0x604;
 

--- a/src/libs/hwloc/src/lib.rs
+++ b/src/libs/hwloc/src/lib.rs
@@ -5,19 +5,21 @@
 // Imports
 //==================================================================================================
 
-use ::log::error;
-use anyhow::Result;
-use libc::{
+#[cfg(unix)]
+use ::libc::{
     cpu_set_t,
     sched_setaffinity,
     CPU_SET,
     CPU_ZERO,
 };
-use serde::Deserialize;
-use std::{
-    mem,
-    str::FromStr,
-};
+#[cfg(unix)]
+use ::log::error;
+use ::serde::Deserialize;
+#[cfg(unix)]
+use ::std::mem;
+#[cfg(unix)]
+use ::std::str::FromStr;
+use anyhow::Result;
 
 //==================================================================================================
 // Structures
@@ -45,6 +47,7 @@ impl HwLoc {
 }
 
 /// Parses a CPU mask string (e.g., "0-3,5,7-8") into a Vec of CPU indices.
+#[cfg(unix)]
 fn parse_cpu_mask(mask: &str) -> Result<Vec<usize>> {
     let mut cpus = Vec::new();
     for part in mask.split(',') {
@@ -67,6 +70,7 @@ fn parse_cpu_mask(mask: &str) -> Result<Vec<usize>> {
 }
 
 /// Pins the current thread to a given CPU set parsed from a mask string.
+#[cfg(unix)]
 fn pin_current_thread_to_mask(mask: &str) -> Result<()> {
     match parse_cpu_mask(mask) {
         Ok(cpus) => unsafe {
@@ -95,5 +99,13 @@ fn pin_current_thread_to_mask(mask: &str) -> Result<()> {
 
 /// This method pins the client (running thread) to a pre-defined CPU core.
 pub fn pin_main_thread(mask: String) -> Result<()> {
-    pin_current_thread_to_mask(&mask)
+    #[cfg(unix)]
+    {
+        pin_current_thread_to_mask(&mask)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = mask;
+        Ok(())
+    }
 }

--- a/src/libs/nanvix-sandbox/src/standalone/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/standalone/uservm.rs
@@ -26,9 +26,12 @@ use ::log::{
 };
 use ::std::{
     convert::TryInto,
-    os::unix::process::ExitStatusExt,
     process::ExitStatus,
 };
+#[cfg(unix)]
+use ::std::os::unix::process::ExitStatusExt;
+#[cfg(windows)]
+use ::std::os::windows::process::ExitStatusExt;
 use ::sys::ipc::IkcFrame;
 use ::tokio::{
     runtime::Handle,
@@ -263,5 +266,14 @@ impl UserVm {
 ///
 fn exit_status_from_exit_code(raw_code: u8) -> ExitStatus {
     let code: i32 = i32::from(raw_code) & 0xff;
-    ExitStatus::from_raw(code << 8)
+    // On Unix, encode as a wait status (exit code in upper byte).
+    #[cfg(unix)]
+    {
+        ExitStatus::from_raw(code << 8)
+    }
+    // On Windows, use the exit code directly.
+    #[cfg(windows)]
+    {
+        ExitStatus::from_raw(code as u32)
+    }
 }

--- a/src/libs/syscomm/src/socket_address.rs
+++ b/src/libs/syscomm/src/socket_address.rs
@@ -15,6 +15,7 @@ pub enum SocketAddr {
     /// TCP socket address.
     Tcp(::std::net::SocketAddr),
     /// Unix socket address.
+    #[cfg(unix)]
     Unix(::tokio::net::unix::SocketAddr),
 }
 

--- a/src/libs/syscomm/src/socket_listener.rs
+++ b/src/libs/syscomm/src/socket_listener.rs
@@ -10,8 +10,9 @@ use ::log::{
     error,
     trace,
 };
+#[cfg(unix)]
+use ::std::fs;
 use ::std::{
-    fs,
     io::{
         Error,
         Result,
@@ -21,6 +22,9 @@ use ::std::{
 use ::tokio::net::{
     TcpListener,
     TcpStream,
+};
+#[cfg(unix)]
+use ::tokio::net::{
     UnixListener,
     UnixStream,
 };
@@ -40,6 +44,7 @@ pub enum SocketListener {
         addr: SocketAddr,
     },
     /// Unix socket.
+    #[cfg(unix)]
     Unix {
         /// Unix listener.
         listener: UnixListener,
@@ -93,6 +98,7 @@ impl SocketListener {
                 Ok(SocketStream::Tcp(stream))
             },
             // Unix socket.
+            #[cfg(unix)]
             SocketListener::Unix {
                 listener,
                 path: _path,
@@ -120,6 +126,7 @@ impl Drop for SocketListener {
                 listener: _,
                 addr: _,
             } => {},
+            #[cfg(unix)]
             SocketListener::Unix { listener: _, path } => {
                 // Remove underlying socket file, because dropping the listener just closes the file
                 // descriptor.

--- a/src/libs/syscomm/src/socket_stream.rs
+++ b/src/libs/syscomm/src/socket_stream.rs
@@ -17,6 +17,11 @@ use ::log::{
     trace,
 };
 use ::std::io::Result;
+#[cfg(unix)]
+use ::tokio::net::{
+    unix,
+    UnixStream,
+};
 use ::tokio::{
     io::{
         AsyncReadExt,
@@ -24,9 +29,7 @@ use ::tokio::{
     },
     net::{
         tcp,
-        unix,
         TcpStream,
-        UnixStream,
     },
 };
 
@@ -40,6 +43,7 @@ pub enum SocketStream {
     /// Underlying TCP socket stream.
     Tcp(TcpStream),
     /// Underlying Unix socket stream.
+    #[cfg(unix)]
     Unix(UnixStream),
 }
 
@@ -69,6 +73,7 @@ impl SocketStream {
                 (SocketStreamReader::Tcp(reader), SocketStreamWriter::Tcp(writer))
             },
             // Split a Unix socket stream.
+            #[cfg(unix)]
             SocketStream::Unix(stream) => {
                 let (reader, writer): (unix::OwnedReadHalf, unix::OwnedWriteHalf) =
                     stream.into_split();
@@ -103,6 +108,7 @@ impl SocketStream {
         // Read bytes.
         let result: Result<usize> = match self {
             SocketStream::Tcp(stream) => stream.read(buf).await,
+            #[cfg(unix)]
             SocketStream::Unix(stream) => stream.read(buf).await,
         };
 
@@ -144,6 +150,7 @@ impl SocketStream {
         // Write bytes.
         let result: Result<usize> = match self {
             SocketStream::Tcp(stream) => stream.write(buf).await,
+            #[cfg(unix)]
             SocketStream::Unix(stream) => stream.write(buf).await,
         };
 
@@ -171,6 +178,7 @@ impl SocketStream {
     pub async fn shutdown_write(&mut self) -> Result<()> {
         let result: Result<()> = match self {
             SocketStream::Tcp(stream) => stream.shutdown().await,
+            #[cfg(unix)]
             SocketStream::Unix(stream) => stream.shutdown().await,
         };
 
@@ -204,6 +212,7 @@ impl SocketStream {
                     Err(error)
                 },
             },
+            #[cfg(unix)]
             SocketStream::Unix(stream) => match stream.peer_addr() {
                 Ok(addr) => Ok(SocketAddr::Unix(addr)),
                 Err(error) => {
@@ -243,6 +252,7 @@ impl ReadExact for SocketStream {
         // Read bytes.
         let result: Result<usize> = match self {
             SocketStream::Tcp(stream) => stream.read_exact(buf).await,
+            #[cfg(unix)]
             SocketStream::Unix(stream) => stream.read_exact(buf).await,
         };
 
@@ -285,6 +295,7 @@ impl WriteAll for SocketStream {
         // Write bytes.
         let result: Result<()> = match self {
             SocketStream::Tcp(stream) => stream.write_all(buf).await,
+            #[cfg(unix)]
             SocketStream::Unix(stream) => stream.write_all(buf).await,
         };
 

--- a/src/libs/syscomm/src/socket_stream_reader.rs
+++ b/src/libs/syscomm/src/socket_stream_reader.rs
@@ -8,12 +8,11 @@
 use crate::ReadExact;
 use ::log::error;
 use ::std::io::Result;
+#[cfg(unix)]
+use ::tokio::net::unix;
 use ::tokio::{
     io::AsyncReadExt,
-    net::{
-        tcp,
-        unix,
-    },
+    net::tcp,
 };
 
 //==================================================================================================
@@ -29,6 +28,7 @@ pub enum SocketStreamReader {
     /// Underlying TCP read half.
     Tcp(tcp::OwnedReadHalf),
     /// Underlying Unix read half.
+    #[cfg(unix)]
     Unix(unix::OwnedReadHalf),
 }
 
@@ -63,6 +63,7 @@ impl SocketStreamReader {
         // Read bytes.
         let result: Result<usize> = match self {
             SocketStreamReader::Tcp(reader) => reader.read(buf).await,
+            #[cfg(unix)]
             SocketStreamReader::Unix(reader) => reader.read(buf).await,
         };
 
@@ -105,6 +106,7 @@ impl ReadExact for SocketStreamReader {
         // Read bytes.
         let result: Result<usize> = match self {
             SocketStreamReader::Tcp(stream) => stream.read_exact(buf).await,
+            #[cfg(unix)]
             SocketStreamReader::Unix(stream) => stream.read_exact(buf).await,
         };
 

--- a/src/libs/syscomm/src/socket_stream_writer.rs
+++ b/src/libs/syscomm/src/socket_stream_writer.rs
@@ -26,6 +26,7 @@ pub enum SocketStreamWriter {
     /// Underlying TCP write half.
     Tcp(tokio::net::tcp::OwnedWriteHalf),
     /// Underlying Unix write half.
+    #[cfg(unix)]
     Unix(tokio::net::unix::OwnedWriteHalf),
 }
 
@@ -61,6 +62,7 @@ impl SocketStreamWriter {
         // Write bytes.
         let result: Result<usize> = match self {
             SocketStreamWriter::Tcp(stream) => stream.write(buf).await,
+            #[cfg(unix)]
             SocketStreamWriter::Unix(stream) => stream.write(buf).await,
         };
 
@@ -102,6 +104,7 @@ impl SocketStreamWriter {
         while !slices.is_empty() {
             let n: usize = match self {
                 SocketStreamWriter::Tcp(stream) => stream.write_vectored(slices).await,
+                #[cfg(unix)]
                 SocketStreamWriter::Unix(stream) => stream.write_vectored(slices).await,
             }
             .map_err(|error| {
@@ -148,6 +151,7 @@ impl WriteAll for SocketStreamWriter {
         // Write bytes.
         let result: Result<()> = match self {
             SocketStreamWriter::Tcp(stream) => stream.write_all(buf).await,
+            #[cfg(unix)]
             SocketStreamWriter::Unix(stream) => stream.write_all(buf).await,
         };
 

--- a/src/libs/syscomm/src/socket_unbound.rs
+++ b/src/libs/syscomm/src/socket_unbound.rs
@@ -14,10 +14,11 @@ use ::log::{
     error,
     trace,
 };
+#[cfg(unix)]
+use ::std::io::Error;
 use ::std::{
     io::{
         self,
-        Error,
         ErrorKind,
         Result,
     },
@@ -26,6 +27,9 @@ use ::std::{
 use ::tokio::net::{
     TcpListener,
     TcpStream,
+};
+#[cfg(unix)]
+use ::tokio::net::{
     UnixListener,
     UnixStream,
 };
@@ -109,6 +113,7 @@ impl UnboundSocket {
                 Ok(SocketStream::Tcp(stream))
             },
             // Connect to a unix domain socket.
+            #[cfg(unix)]
             SocketType::Unix => {
                 let stream: UnixStream = match UnixStream::connect(addr).await {
                     Ok(stream) => stream,
@@ -118,6 +123,11 @@ impl UnboundSocket {
                 };
                 Ok(SocketStream::Unix(stream))
             },
+            #[cfg(not(unix))]
+            SocketType::Unix => Err(io::Error::new(
+                ErrorKind::Unsupported,
+                "Unix domain sockets are not supported on this platform",
+            )),
         }
     }
 
@@ -162,6 +172,7 @@ impl UnboundSocket {
                 }
             },
             // Bind a unix domain socket.
+            #[cfg(unix)]
             SocketType::Unix => match UnixListener::bind(addr) {
                 Ok(listener) => Ok(SocketListener::Unix {
                     listener,
@@ -172,6 +183,14 @@ impl UnboundSocket {
                     error!("bind(): {reason}");
                     Err(Error::new(error.kind(), reason))
                 },
+            },
+            #[cfg(not(unix))]
+            SocketType::Unix => {
+                let _ = addr;
+                Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "Unix domain sockets are not supported on this platform",
+                ))
             },
         }
     }

--- a/src/uservm/Cargo.toml
+++ b/src/uservm/Cargo.toml
@@ -35,16 +35,19 @@ serde = { workspace = true, features = ["derive"] }
 static_assert = { workspace = true }
 sys = { workspace = true, features = ["std"] }
 syscall = { workspace = true }
-syscomm = { workspace = true }
 syslog = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
-user-vm-api = { workspace = true }
-vmm-sys-util = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { workspace = true, features = ["fam-wrappers", "serde"] }
 kvm-ioctls = { workspace = true }
 libc = { workspace = true }
+syscomm = { workspace = true }
+user-vm-api = { workspace = true }
+vmm-sys-util = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { workspace = true }
 
 [features]
 default = ["microvm"]

--- a/src/uservm/src/args.rs
+++ b/src/uservm/src/args.rs
@@ -22,7 +22,34 @@ use ::std::{
     process,
 };
 use ::syslog::DEFAULT_LOG_DIRECTORY;
+#[cfg(target_os = "linux")]
 use ::user_vm_api::UserVmIdentifier;
+
+/// Minimal cross-platform replacement for [`user_vm_api::UserVmIdentifier`] on non-Linux targets.
+#[cfg(not(target_os = "linux"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UserVmIdentifier(u32);
+
+#[cfg(not(target_os = "linux"))]
+impl UserVmIdentifier {
+    pub const fn new(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+impl From<UserVmIdentifier> for u32 {
+    fn from(id: UserVmIdentifier) -> Self {
+        id.0
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+impl std::fmt::Display for UserVmIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 //==================================================================================================
 // Public Structures

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -47,6 +47,7 @@ pub mod args;
 pub mod counters;
 /// Library module for manipulating ELF binaries.
 pub mod elf;
+#[cfg(target_os = "linux")]
 pub mod io_thread;
 pub mod memory_thread;
 pub mod orchestrator;
@@ -236,7 +237,6 @@ impl UserVm {
             Receiver<VcpuControlResponse>,
         ) = mpsc::channel::<VcpuControlResponse>(CHANNEL_CAPACITY);
 
-        #[cfg(not(feature = "hyperlight"))]
         let vmm_stderr_fn: Box<dyn Write + Send> = match get_stderr_writer(args.stderr.clone()) {
             Ok(vmm_stderr_fn) => vmm_stderr_fn,
             Err(e) => {
@@ -257,10 +257,10 @@ impl UserVm {
         let vmm_stdout_fn: Box<StdoutFn> = output_fn(args.vcpu_thread_stdout_tx);
 
         // Input function used for emulating I/O port reads.
-        #[cfg(not(feature = "hyperlight"))]
+        #[cfg(all(feature = "microvm", not(feature = "hyperlight")))]
         let ikc_pending: std::sync::Arc<std::sync::atomic::AtomicBool> =
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        #[cfg(not(feature = "hyperlight"))]
+        #[cfg(all(feature = "microvm", not(feature = "hyperlight")))]
         let vmm_stdin_fn: Box<StdinFn> =
             build_input_fn(vcpu_thread_stdin_rx, args.counters.clone(), ikc_pending.clone());
 
@@ -281,7 +281,6 @@ impl UserVm {
             output: vmm_stdout_fn,
             #[cfg(feature = "hyperlight")]
             bulk_output: vmm_bulk_stdout_fn,
-            #[cfg(not(feature = "hyperlight"))]
             stderr: vmm_stderr_fn,
             #[cfg(feature = "hyperlight")]
             stderr_path: args.stderr.clone(),
@@ -322,7 +321,7 @@ impl UserVm {
             add_credit_fn(
                 guest.clone(),
                 vmem.clone(),
-                #[cfg(not(feature = "hyperlight"))]
+                #[cfg(all(feature = "microvm", not(feature = "hyperlight")))]
                 microvm.ikc_notifier(),
             ),
             args.counters.clone(),
@@ -430,12 +429,12 @@ fn resume_microvm(guest: Arc<Mutex<Guest>>, vmem: Arc<Mutex<VirtualMemory>>) -> 
 fn add_credit_fn(
     guest: Arc<Mutex<Guest>>,
     vmem: Arc<Mutex<VirtualMemory>>,
-    #[cfg(not(feature = "hyperlight"))] notifier: crate::vmm::IkcNotifier,
+    #[cfg(all(feature = "microvm", not(feature = "hyperlight")))] notifier: crate::vmm::IkcNotifier,
 ) -> Box<AddCreditFn> {
     Box::new(move || {
         let guest: Arc<Mutex<Guest>> = guest.clone();
         let vmem: Arc<Mutex<VirtualMemory>> = vmem.clone();
-        #[cfg(not(feature = "hyperlight"))]
+        #[cfg(all(feature = "microvm", not(feature = "hyperlight")))]
         let notifier: crate::vmm::IkcNotifier = notifier.clone();
         Box::pin(async move {
             // Scope the locks so they are released before the IRQ injection.
@@ -444,10 +443,10 @@ fn add_credit_fn(
                 let mut vmem = vmem.lock().await;
                 guest.add_credit(&mut vmem)?;
             }
-            // Inject an edge-triggered IRQ to wake the guest from HLT
-            // immediately, rather than waiting for the next PIT timer tick.
-            // This is lock-free — the notifier uses a duplicated VM fd.
-            #[cfg(not(feature = "hyperlight"))]
+            // Inject an edge-triggered IRQ to wake the guest from HLT immediately, rather than
+            // waiting for the next PIT timer tick.  This is lock-free — the notifier uses a
+            // duplicated VM fd (KVM) or cancels the vCPU (WHP).
+            #[cfg(all(feature = "microvm", not(feature = "hyperlight")))]
             notifier.notify()?;
             Ok(())
         })
@@ -509,7 +508,7 @@ pub fn get_stderr_writer(vm_stderr: Option<String>) -> Result<Box<dyn Write + Se
 ///
 /// A boxed closure compatible with the VMM's stdin handler implementation.
 ///
-#[cfg(not(feature = "hyperlight"))]
+#[cfg(all(feature = "microvm", not(feature = "hyperlight")))]
 pub fn build_input_fn(
     mut input_queue: Receiver<IkcFrame>,
     counters: MessageCounters,
@@ -780,7 +779,7 @@ pub fn build_input_fn(
 ///
 pub fn output_fn(queue: Sender<IkcFrame>) -> Box<StdoutFn> {
     // Output function used for emulating I/O port writes.
-    #[cfg(not(feature = "hyperlight"))]
+    #[cfg(all(feature = "microvm", not(feature = "hyperlight")))]
     let output =
         move |vm: &Arc<Mutex<VirtualMemory>>, envelope: &::sys::ipc::VmBusMessage| -> Result<()> {
             use std::mem;

--- a/src/uservm/src/main.rs
+++ b/src/uservm/src/main.rs
@@ -22,44 +22,54 @@ use ::log::{
     error,
     info,
 };
+#[cfg(target_os = "linux")]
+use ::std::str::FromStr;
 use ::std::{
     convert::TryInto,
     env,
     process::ExitCode,
-    str::FromStr,
 };
+#[cfg(target_os = "linux")]
 use ::sys::ipc::IkcFrame;
+#[cfg(target_os = "linux")]
 use ::syscomm::{
     SocketStream,
     SocketType,
     UnboundSocket,
     WriteAll,
 };
+#[cfg(target_os = "linux")]
 use ::tokio::{
     sync::mpsc,
     task::JoinHandle,
     time::timeout,
 };
+#[cfg(target_os = "linux")]
 use ::user_vm_api::{
     NEW_USER_VM_MESSAGE_LEN,
     NewUserVm,
     UserVmIdentifier,
 };
+#[cfg(not(target_os = "linux"))]
+use ::uservm::args::UserVmIdentifier;
+#[cfg(target_os = "linux")]
 use ::uservm::{
     CHANNEL_CAPACITY,
     CONTROL_PLANE_CONNECT_TIMEOUT,
     SYSTEM_VM_CONNECT_TIMEOUT,
     UserVm,
     UserVmArgs,
-    args::{
-        self,
-        Args,
-    },
     counters::MessageCounters,
     io_thread::IoThread,
     orchestrator::{
         IoControlCommand,
         IoControlResponse,
+    },
+};
+use ::uservm::{
+    args::{
+        self,
+        Args,
     },
     standalone,
     standalone::StandaloneVmHandle,
@@ -92,12 +102,8 @@ pub async fn main() -> Result<ExitCode> {
     let gdb_port: Option<u16> = args.gdb_port();
 
     // Initialize logger. If this fails, the program will panic.
-    ::syslog::init(
-        args.log_to_file(),
-        DEFAULT_LOG_LEVEL,
-        args.log_directory(),
-        Some(format!("uservm{}", u32::from(user_vm_id))),
-    );
+    let log_suffix: String = format!("uservm{}", u32::from(user_vm_id));
+    ::syslog::init(args.log_to_file(), DEFAULT_LOG_LEVEL, args.log_directory(), Some(log_suffix));
 
     debug!(
         "main(): starting user VM (user_vm_id={:?}, kernel={:?}, initrd={:?}, ramfs={:?}, \
@@ -122,8 +128,17 @@ pub async fn main() -> Result<ExitCode> {
         )
         .await
     } else {
-        run_managed(args, kernel_filename, initrd_filename, initrd_args, ramfs_filename, stderr)
-            .await
+        #[cfg(target_os = "linux")]
+        {
+            run_managed(args, kernel_filename, initrd_filename, initrd_args, ramfs_filename, stderr)
+                .await
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = args;
+            error!("main(): managed mode is not supported on this platform, use -standalone");
+            Err(anyhow::anyhow!("managed mode is not supported on this platform"))
+        }
     }
 }
 
@@ -203,6 +218,7 @@ async fn run_standalone(
 /// control-plane fail or time out, or if the exit status cannot be converted to a process exit
 /// code.
 ///
+#[cfg(target_os = "linux")]
 async fn run_managed(
     args: Args,
     kernel_filename: String,

--- a/src/uservm/src/orchestrator.rs
+++ b/src/uservm/src/orchestrator.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+#[cfg(target_os = "linux")]
 use crate::vmm::KILL_SIGNAL;
 use ::anyhow::Result;
 use ::log::{
@@ -251,8 +252,18 @@ impl Orchestrator {
                             SHUTDOWN_TIMEOUT.as_millis()
                         );
                         // Forcefully terminate the vCPU thread.
-                        let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
-                        unsafe { ::libc::pthread_kill(pthread_id, KILL_SIGNAL) };
+                        #[cfg(target_os = "linux")]
+                        {
+                            let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
+                            unsafe { ::libc::pthread_kill(pthread_id, KILL_SIGNAL) };
+                        }
+                        // TODO: on Windows, implement forceful vCPU termination.
+                        // The WHP backend currently relies on cooperative shutdown
+                        // (guest writes to the VMM exit port), so if the guest hangs
+                        // this timeout path is a no-op. A possible approach is to
+                        // pass a cancellation callback into the orchestrator that
+                        // calls `WHvCancelRunVirtualProcessor` and sets the SHUTDOWN
+                        // flag, similar to the existing `pause_microvm` callback.
                         break;
                     },
                 }
@@ -510,9 +521,21 @@ impl Orchestrator {
                     } else {
                         // SAFETY: we call pthread_kill on a non-zero TID that we have received from
                         // the VCPU thread after boot, so this is safe.
-                        let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
                         debug!("try_receive_from_io_thread(): signaling to vcpu thread (tid={})", self.vcpu_tid);
-                        unsafe { ::libc::pthread_kill(pthread_id, crate::vmm::INTERRUPT_SIGNAL) };
+                        #[cfg(target_os = "linux")]
+                        {
+                            let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
+                            unsafe { ::libc::pthread_kill(pthread_id, crate::vmm::INTERRUPT_SIGNAL) };
+                        }
+                        #[cfg(target_os = "windows")]
+                        {
+                            // TODO: Set shared shutdown flag so the WHP run loop exits on next
+                            // iteration.  Then cancel the blocking WHvRunVirtualProcessor call.
+                            // Currently not possible because:
+                            //   1. SHUTDOWN is thread-local, not accessible from the orchestrator
+                            //   2. The orchestrator doesn't hold the WHP partition handle
+                            // A cancellation callback (like pause_microvm) would solve both.
+                        }
 
                         // Transition to shutting down state.
                         self.state = State::ShuttingDown;

--- a/src/uservm/src/pal/mod.rs
+++ b/src/uservm/src/pal/mod.rs
@@ -14,9 +14,15 @@
 #[cfg(target_os = "linux")]
 mod linux;
 
+#[cfg(target_os = "windows")]
+mod windows;
+
 //==================================================================================================
 // Exports
 //==================================================================================================
 
 #[cfg(target_os = "linux")]
 pub use linux::*;
+
+#[cfg(target_os = "windows")]
+pub use self::windows::*;

--- a/src/uservm/src/pal/windows.rs
+++ b/src/uservm/src/pal/windows.rs
@@ -1,0 +1,151 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! # Platform abstraction layer for Windows
+//!
+//! This module provides platform-specific functionalities for Windows-based systems.
+//!
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::log::{
+    error,
+    trace,
+};
+use ::std::{
+    fs,
+    path::Path,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// A file loaded into memory.
+#[derive(Debug)]
+pub struct FileMapping {
+    /// Contents of the file.
+    data: Vec<u8>,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl FileMapping {
+    ///
+    /// # Description
+    ///
+    /// Reads a file into memory.
+    ///
+    /// # Parameters
+    ///
+    /// * `filename` - Name of the file to be loaded.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an object representing the loaded file. On failure,
+    /// an error object that describes the error is returned instead.
+    ///
+    pub fn open(filename: &str) -> Result<Self> {
+        trace!("open(): filename={filename}");
+
+        let path: &Path = Path::new(filename);
+
+        let data: Vec<u8> = match fs::read(path) {
+            Ok(data) => data,
+            Err(e) => {
+                let reason: String = format!("failed to read file (error={e})");
+                error!("open(): {reason} (filename={filename})");
+                anyhow::bail!(reason);
+            },
+        };
+
+        Ok(Self { data })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a pointer to the loaded file data.
+    ///
+    /// # Returns
+    ///
+    /// A pointer to the file data.
+    ///
+    pub fn ptr(&self) -> *const u8 {
+        self.data.as_ptr()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the size of the loaded file (in bytes).
+    ///
+    /// # Returns
+    ///
+    /// The size of the file (in bytes).
+    ///
+    pub fn size(&self) -> usize {
+        self.data.len()
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use ::anyhow::Result;
+    use ::std::{
+        env,
+        fs,
+        path::PathBuf,
+        process,
+        time::{
+            SystemTime,
+            UNIX_EPOCH,
+        },
+    };
+
+    /// Returns a unique file path in the system temp directory for test isolation.
+    fn unique_temp_path(suffix: &str) -> Result<(String, PathBuf)> {
+        let mut path: PathBuf = env::temp_dir();
+        let nanos: u128 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|error| anyhow::anyhow!("failed to compute timestamp (error={:?})", error))?
+            .as_nanos();
+        let file_name: String =
+            format!("nanvix-pal-test-{}-{}-{}.tmp", process::id(), nanos, suffix);
+        path.push(&file_name);
+        Ok((path.to_string_lossy().into_owned(), path))
+    }
+
+    #[test]
+    fn open_returns_file_contents() -> Result<()> {
+        let (path_str, path_buf): (String, PathBuf) = unique_temp_path("open")?;
+        let payload: &[u8] = b"hello world";
+        fs::write(&path_buf, payload)?;
+
+        let mapping: FileMapping = FileMapping::open(&path_str)?;
+        assert_eq!(mapping.size(), payload.len());
+
+        let loaded: &[u8] = unsafe { ::std::slice::from_raw_parts(mapping.ptr(), mapping.size()) };
+        assert_eq!(loaded, payload);
+
+        fs::remove_file(path_buf).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn open_returns_error_for_missing_file() {
+        let result: Result<FileMapping> = FileMapping::open("/non/existent/path/to/file");
+        assert!(result.is_err());
+    }
+}

--- a/src/uservm/src/vmm/mod.rs
+++ b/src/uservm/src/vmm/mod.rs
@@ -19,6 +19,9 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "hyperlight")] {
         mod hyperlight;
         pub use hyperlight::*;
+    } else if #[cfg(all(feature = "microvm", target_os = "windows"))] {
+        mod whp;
+        pub use whp::*;
     } else if #[cfg(feature = "microvm")] {
         mod microvm;
         pub use microvm::*;
@@ -38,11 +41,8 @@ pub struct MicroVmArgs {
     pub output: Box<StdoutFn>,
     #[cfg(feature = "hyperlight")]
     pub bulk_output: Box<BulkStdoutFn>,
-    #[cfg(not(feature = "hyperlight"))]
     pub stderr: Box<StderrFn>,
-    /// Optional file path for guest stderr redirection (hyperlight only).
-    /// When set, process stderr is redirected to this file via `dup2` so that
-    /// `DebugPrint` VM-exit output reaches the custom destination.
+    /// Optional path to a file used to capture the guest's stderr stream (hyperlight only).
     #[cfg(feature = "hyperlight")]
     pub stderr_path: Option<String>,
     /// When true, skip kernel/initrd/ramfs loading and vCPU reset because the VM state will be

--- a/src/uservm/src/vmm/whp/emulator.rs
+++ b/src/uservm/src/vmm/whp/emulator.rs
@@ -1,0 +1,247 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::vmm::{
+    StderrFn,
+    StdinFn,
+    StdoutFn,
+    guest::Guest,
+    whp::{
+        vcpu::exit::{
+            PmioAccess,
+            PmioWidth,
+        },
+        vmem::VirtualMemory,
+    },
+};
+use ::anyhow::Result;
+use ::log::{
+    error,
+    trace,
+    warn,
+};
+use ::std::{
+    io::Write,
+    sync::Arc,
+};
+use ::sys::ipc::VmBusMessage;
+use ::tokio::sync::Mutex;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A structure that represents an instruction emulator for the virtual machine.
+///
+pub struct Emulator {
+    /// State of the guest.
+    guest: Arc<Mutex<Guest>>,
+    /// Virtual memory of the guest.
+    vmem: Arc<Mutex<VirtualMemory>>,
+    /// Function used for emulating reads from standard input.
+    stdin_fn: Box<StdinFn>,
+    /// Function used for emulating writes to standard output.
+    stdout_fn: Box<StdoutFn>,
+    /// Function used for emulating writes to standard error.
+    stderr_fn: Box<StderrFn>,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Emulator {
+    ///
+    /// # Description
+    ///
+    /// Creates a new emulator.
+    ///
+    /// # Parameters
+    ///
+    /// - `guest`: State of the guest.
+    /// - `vmem`: Virtual memory of the guest.
+    /// - `stdin_fn`: Function used for emulating reads from standard input.
+    /// - `stdout_fn`: Function used for emulating writes to standard output.
+    /// - `stderr_fn`: Function used for emulating writes to standard error.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns the new emulator. Otherwise, it returns an
+    /// error.
+    ///
+    pub fn new(
+        guest: Arc<Mutex<Guest>>,
+        vmem: Arc<Mutex<VirtualMemory>>,
+        stdin_fn: Box<StdinFn>,
+        stdout_fn: Box<StdoutFn>,
+        stderr_fn: Box<StderrFn>,
+    ) -> Result<Self> {
+        trace!("new()");
+        Ok(Self {
+            guest,
+            vmem,
+            stdin_fn,
+            stdout_fn,
+            stderr_fn,
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reads a [`VmBusMessage`] from guest virtual memory at the given address.
+    ///
+    /// # Parameters
+    ///
+    /// - `envelope_addr`: Guest virtual address of the vmbus message.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns the parsed vmbus message. If an error is
+    /// encountered, an error is returned instead.
+    ///
+    fn read_envelope(&self, envelope_addr: u32) -> Result<VmBusMessage> {
+        let mut envelope_bytes: [u8; VmBusMessage::SIZE] = [0; VmBusMessage::SIZE];
+        self.vmem
+            .blocking_lock()
+            .read_bytes(envelope_addr as u64, &mut envelope_bytes)?;
+        let envelope: VmBusMessage = VmBusMessage::try_from_bytes(envelope_bytes).map_err(|e| {
+            let reason: String = format!("failed to parse vmbus message: {e:?}");
+            error!("read_envelope(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+        Ok(envelope)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Emulates an I/O port access.
+    ///
+    /// # Parameters
+    ///
+    /// - `exit_context`: Context in which the I/O port access occurred.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns `Ok(None)` if the virtual machine should
+    /// be resumed or `Ok(Some(status))` if the virtual machine should be stopped.
+    ///
+    pub fn handle_pmio_access(&mut self, exit_context: &PmioAccess) -> Result<Option<u16>> {
+        match exit_context {
+            // Read from an I/O port.
+            PmioAccess::PmioIn(port, _data) => {
+                // Silently return zero for well-known hardware ports read during boot.
+                match *port {
+                    0x20
+                    | 0x21
+                    | 0x22
+                    | 0x23
+                    | 0xA0
+                    | 0xA1
+                    | 0x40..=0x43
+                    | 0x61
+                    | 0x70
+                    | 0x71
+                    | 0x3F8..=0x3FF
+                    | 0xCF8
+                    | 0xCFC..=0xCFF => {
+                        trace!(
+                            "handle_pmio_access(): ignoring read from port (port={:#06x})",
+                            port
+                        );
+                    },
+                    _ => {
+                        warn!(
+                            "handle_pmio_access(): ignoring read from unknown port (port={:#06x})",
+                            port
+                        );
+                    },
+                }
+            },
+            // Write to an I/O port.
+            PmioAccess::PmioOut(port, data, width) => match *port {
+                // Write to standard output.
+                ::config::microvm::DEFAULT_STDOUT_PORT => {
+                    if *width == PmioWidth::Byte {
+                        let ch: char = match char::from_u32(*data) {
+                            Some(ch) => ch,
+                            None => {
+                                let reason: String = format!("invalid character (data={data:?})");
+                                error!("output(): {reason}");
+                                anyhow::bail!(reason);
+                            },
+                        };
+                        let buf: &[u8] = &[ch as u8];
+                        self.stderr_fn.write_all(buf)?;
+                    } else if *width == PmioWidth::Dword {
+                        let envelope: VmBusMessage = self.read_envelope(*data)?;
+                        (self.stdout_fn)(&self.vmem, &envelope)?;
+                    } else {
+                        warn!("handle_pmio_access(): invalid write size (size={width:?})");
+                    }
+                },
+                // Read from standard input.
+                ::config::microvm::DEFAULT_STDIN_PORT => {
+                    let envelope: VmBusMessage = self.read_envelope(*data)?;
+                    (self.stdin_fn)(
+                        &self.guest,
+                        &self.vmem,
+                        envelope.message_addr(),
+                        width.into(),
+                    )?;
+                },
+                // Write to the virtual machine monitor port.
+                ::config::microvm::DEFAULT_VMM_PORT => match (*data >> 16) as u16 {
+                    ::config::microvm::DEFAULT_VMM_SHUTDOWN_CMD => {
+                        let status: u16 = (*data & 0xffff) as u16;
+                        trace!("VMM port shutdown: raw_data={data:#010x}, status={status}");
+                        return Ok(Some(status));
+                    },
+                    ::config::microvm::DEFAULT_VMM_PAUSE_CMD => {
+                        return Ok(Some(::config::microvm::DEFAULT_VMM_PAUSE_CMD));
+                    },
+                    cmd => anyhow::bail!("unknown virtual machine command (cmd={cmd:#06x})"),
+                },
+                // Write to an I/O port that is not emulated.
+                // Silently ignore writes to well-known hardware initialization ports
+                // (PIC, PIT, CMOS, etc.) that the kernel programs during boot.
+                0x20 | 0x21 | 0xA0 | 0xA1 | 0x22 | 0x23 => {
+                    // PIC (8259A) and IMCR initialization — silently ignore.
+                    trace!("handle_pmio_access(): ignoring PIC/IMCR write (port={port:#06x})");
+                },
+                0x40..=0x43 | 0x61 => {
+                    // PIT (8254) and speaker port — silently ignore.
+                    trace!("handle_pmio_access(): ignoring PIT write (port={port:#06x})");
+                },
+                0x70 | 0x71 => {
+                    // CMOS/RTC — silently ignore.
+                    trace!("handle_pmio_access(): ignoring CMOS write (port={port:#06x})");
+                },
+                0x3F8..=0x3FF => {
+                    // COM1 serial port — silently ignore.
+                    trace!("handle_pmio_access(): ignoring COM1 write (port={port:#06x})");
+                },
+                0xCF8 | 0xCFC..=0xCFF => {
+                    // PCI configuration space — silently ignore.
+                    trace!("handle_pmio_access(): ignoring PCI write (port={port:#06x})");
+                },
+                // Write to an I/O port that is truly unsupported.
+                _ => {
+                    warn!(
+                        "handle_pmio_access(): ignoring write to unknown port (port={port:#06x})"
+                    );
+                },
+            },
+        }
+
+        Ok(None)
+    }
+}

--- a/src/uservm/src/vmm/whp/guest.rs
+++ b/src/uservm/src/vmm/whp/guest.rs
@@ -1,0 +1,352 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    elf,
+    pal::FileMapping,
+    vmm::whp::{
+        vcpu::VirtualProcessor,
+        vmem::VirtualMemory,
+    },
+};
+use ::anyhow::Result;
+use ::log::{
+    debug,
+    error,
+    trace,
+};
+use ::std::{
+    mem,
+    ptr,
+};
+
+/// Page size in bytes (4 KiB, matching the x86 architecture).
+const PAGE_SIZE: usize = 4096;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+#[derive(Debug, Default)]
+pub struct Guest {
+    /// Kernel location and size.
+    kernel: Option<(usize, usize)>,
+    /// Initial RAM disk location and size.
+    initrd: Option<(usize, usize)>,
+    /// Control register used to inform the guest about the number of messages ready to be consumed.
+    credits: u32,
+    /// Entry point of the guest.
+    entry: usize,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Guest {
+    ///
+    /// # Description
+    ///
+    /// Loads the kernel into the virtual memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `kernel_filename`: Path to the kernel binary file.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns the entry point of the kernel that was
+    /// loaded into the virtual memory. Otherwise, it returns an error.
+    ///
+    pub fn load_kernel(&mut self, vmem: &mut VirtualMemory, kernel_filename: &str) -> Result<()> {
+        trace!("load_kernel(): {kernel_filename}");
+
+        let (ptr, size) = (vmem.get_raw_ptr(), vmem.get_size());
+
+        let elf: FileMapping = FileMapping::open(kernel_filename)?;
+        let (entry, first_address, size): (usize, usize, usize) =
+            unsafe { elf::load(ptr.cast::<::std::ffi::c_void>(), elf.ptr(), size)? };
+
+        self.kernel = Some((first_address, size));
+        self.entry = entry;
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Loads the initial RAM disk into the virtual memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `initrd_filename`: Path to the initial RAM disk.
+    /// - `initrd_args`: Optional arguments forwarded to the initrd payload.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns. Otherwise, it returns an error.
+    ///
+    pub fn load_initrd(
+        &mut self,
+        vmem: &mut VirtualMemory,
+        initrd_filename: &str,
+        initrd_args: Option<String>,
+    ) -> Result<()> {
+        trace!("load_initrd(): initrd_filename={}, initrd_args={:?}", initrd_filename, initrd_args);
+
+        debug!("load_initrd(): mapping initrd file");
+        let initrd: FileMapping = FileMapping::open(initrd_filename)?;
+
+        // Check if initrd would overlap with kernel in guest physical address space.
+        if let Some((kernel_base, kernel_size)) = self.kernel
+            && ::config::microvm::DEFAULT_INITRD_BASE < (kernel_base + kernel_size)
+        {
+            let reason: String = "initrd overlaps with kernel".to_string();
+            error!("load_initrd(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        // Check if initrd fits into virtual memory.
+        let (ptr, size) = (vmem.get_raw_ptr(), vmem.get_size());
+        if (::config::microvm::DEFAULT_INITRD_BASE + initrd.size()) > size {
+            let reason: String = "initrd does not fit into virtual memory".to_string();
+            error!("load_initrd(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        if (ptr as usize) + ::config::microvm::DEFAULT_INITRD_BASE + initrd.size()
+            > (ptr as usize) + size
+        {
+            let reason: String = "initrd would cause address overflow".to_string();
+            error!("load_initrd(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        unsafe {
+            let src: *const u8 = initrd.ptr();
+            let dst: *mut u8 = ptr.add(::config::microvm::DEFAULT_INITRD_BASE);
+
+            if src.is_null() || dst.is_null() {
+                let reason: String = "null pointer encountered while copying initrd".to_string();
+                error!("load_initrd(): {reason}");
+                return Err(anyhow::anyhow!(reason));
+            }
+
+            debug!(
+                "load_initrd(): copying initrd into virtual memory (src={:?}, dst={:?}, size={})",
+                src,
+                dst,
+                initrd.size()
+            );
+
+            ptr::copy_nonoverlapping(src, dst, initrd.size());
+        }
+
+        debug!("load_initrd(): adjusting initrd size to page size");
+
+        // Ensure initrd size is aligned to page size.
+        let initrd_size: usize = if !initrd.size().is_multiple_of(PAGE_SIZE) {
+            debug!("load_initrd(): aligning initrd size to page size");
+            initrd.size() + (PAGE_SIZE - (initrd.size() % PAGE_SIZE))
+        } else {
+            initrd.size()
+        };
+
+        self.initrd = Some((::config::microvm::DEFAULT_INITRD_BASE, initrd_size));
+
+        // Write arguments to the virtual machine.
+        let mut args: String = ::std::path::Path::new(initrd_filename)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(initrd_filename)
+            .to_string();
+
+        if let Some(ref initrd_args) = initrd_args {
+            args.push_str(&format!(" {initrd_args}"));
+        }
+
+        debug!("load_initrd(): writing args to virtual memory: {}", args);
+        self.write_args(vmem, &args)?;
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the base address and size (in bytes) of the initrd currently loaded in memory.
+    ///
+    pub fn initrd_region(&self) -> Option<(usize, usize)> {
+        self.initrd
+    }
+
+    /// Writes command line arguments into the virtual memory.
+    fn write_args(&mut self, vmem: &mut VirtualMemory, args: &str) -> Result<()> {
+        trace!("write_args(): {args}");
+        let args_bytes: &[u8] = args.as_bytes();
+
+        let initrd_end: usize = match self.initrd {
+            Some((initrd_base, initrd_size)) => initrd_base + initrd_size,
+            None => {
+                let reason: String = "initrd not loaded".to_string();
+                error!("write_args(): {reason}");
+                return Err(anyhow::anyhow!(reason));
+            },
+        };
+
+        let (ptr, size) = (vmem.get_raw_ptr(), vmem.get_size());
+
+        if initrd_end + mem::size_of::<u8>() + args_bytes.len() > size {
+            let reason: String = "not enough space to write command line arguments".to_string();
+            error!("write_args(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        unsafe {
+            trace!(
+                "write_args(): initrd_end={initrd_end:#010x}, args_bytes_len={:?}, \
+                 args_bytes={args_bytes:?}",
+                args_bytes.len(),
+            );
+
+            let args_len: u8 = match u8::try_from(args_bytes.len()) {
+                Ok(v) => v,
+                Err(_) => {
+                    let reason: String =
+                        format!("command line arguments too long (len={})", args_bytes.len());
+                    error!("write_args(): {reason}");
+                    return Err(anyhow::anyhow!(reason));
+                },
+            };
+
+            ptr::copy_nonoverlapping(&args_len, ptr.add(initrd_end), 1);
+            ptr::copy_nonoverlapping(
+                args_bytes.as_ptr(),
+                ptr.add(initrd_end + mem::size_of::<u8>()),
+                args_bytes.len(),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Resets the value of the credits control register.
+    fn reset_credits(&mut self, vmem: &mut VirtualMemory) -> Result<()> {
+        trace!("reset_credits()");
+        self.credits = 0;
+        vmem.write_bytes(
+            config::microvm::DEFAULT_MICROVM_CTRL_CREDITS as u64,
+            &self.credits.to_le_bytes(),
+        )
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Resets the virtual machine.
+    ///
+    pub fn reset(&mut self, vmem: &mut VirtualMemory, vcpu: &mut VirtualProcessor) -> Result<()> {
+        trace!("reset(): {:?}", &self);
+        let rax: u64 = ::config::microvm::DEFAULT_BOOT_MAGIC as u64;
+
+        self.reset_credits(vmem)?;
+
+        // Check if initrd is too large.
+        let nzeros: usize = ::config::microvm::DEFAULT_INITRD_BASE.trailing_zeros() as usize;
+        let max_initrd_size: usize = (1 << 12) * ((1 << nzeros) - 1);
+        if let Some((_, initrd_size)) = self.initrd
+            && initrd_size > max_initrd_size
+        {
+            return Err(anyhow::anyhow!(
+                "initrd is too large (initrd_size={initrd_size}, \
+                 max_initrd_size={max_initrd_size:?})",
+            ));
+        }
+
+        // Retrieve initrd information.
+        let (initrd_base, initrd_size): (u64, u64) = match self.initrd {
+            Some((base, size)) => {
+                assert_eq!(base % PAGE_SIZE, 0, "initrd base is not aligned to page size");
+                assert_eq!(size % PAGE_SIZE, 0, "initrd size is not aligned to page size");
+
+                let base: u64 = match u64::try_from(base) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        let reason: String = format!("invalid initrd base address ({base:#010x})");
+                        error!("reset(): {reason}");
+                        return Err(anyhow::anyhow!(reason));
+                    },
+                };
+                let size: u64 = match u64::try_from(size) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        let reason: String = format!("invalid initrd size ({size:#010x})");
+                        error!("reset(): {reason}");
+                        return Err(anyhow::anyhow!(reason));
+                    },
+                };
+
+                (base, size)
+            },
+            None => (0, 0),
+        };
+
+        let rbx: u64 =
+            (initrd_base & !((1 << nzeros) - 1)) | ((initrd_size >> 12) & ((1 << nzeros) - 1));
+
+        vcpu.reset(self.entry as u64, rax, rbx)
+    }
+
+    /// Adds a credit to the credits control register.
+    pub fn add_credit(&mut self, vmem: &mut VirtualMemory) -> Result<()> {
+        trace!("add_credits()");
+        if self.credits == u32::MAX {
+            let reason: String = "credits overflow".to_string();
+            error!("add_credits(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        self.credits += 1;
+        vmem.write_bytes(
+            config::microvm::DEFAULT_MICROVM_CTRL_CREDITS as u64,
+            &self.credits.to_le_bytes(),
+        )
+    }
+
+    /// Consumes a credit from the credits control register.
+    pub fn consume_credit(&mut self, vmem: &mut VirtualMemory) -> Result<()> {
+        trace!("consume_credits()");
+        if self.credits == 0 {
+            let reason: String = "no credits available".to_string();
+            error!("consume_credits(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        self.credits -= 1;
+        vmem.write_bytes(
+            config::microvm::DEFAULT_MICROVM_CTRL_CREDITS as u64,
+            &self.credits.to_le_bytes(),
+        )
+    }
+
+    pub fn pause_vm(&mut self, vmem: &mut VirtualMemory) -> Result<()> {
+        trace!("pause_vm()");
+        vmem.write_bytes(
+            config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
+            &::config::microvm::PAUSE_REQUEST.to_le_bytes(),
+        )
+    }
+
+    pub fn resume_vm(&mut self, vmem: &mut VirtualMemory) -> Result<()> {
+        trace!("resume_vm()");
+        vmem.write_bytes(
+            config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
+            &::config::microvm::RUNNING.to_le_bytes(),
+        )
+    }
+}

--- a/src/uservm/src/vmm/whp/lapic.rs
+++ b/src/uservm/src/vmm/whp/lapic.rs
@@ -1,0 +1,10 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// LAPIC Constants
+//==================================================================================================
+
+/// Hardcoded timer interrupt vector. The Nanvix kernel remaps IRQ0 to
+/// vector 0x20 via PIC ICW2, so we inject this vector directly.
+pub const TIMER_VECTOR: u32 = 0x20;

--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -1,0 +1,773 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(clippy::module_inception)]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod emulator;
+pub mod guest;
+pub mod lapic;
+pub mod partition;
+pub mod ramfs;
+pub mod timer;
+pub mod vcpu;
+pub mod vmem;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    orchestrator::{
+        VcpuControlCommand,
+        VcpuControlResponse,
+    },
+    vmm::{
+        MicroVmArgs,
+        emulator::Emulator,
+        guest::Guest,
+        whp::vcpu::{
+            VirtualProcessor,
+            VirtualProcessorExitReasonRef,
+        },
+    },
+};
+use ::anyhow::Result;
+use ::log::{
+    error,
+    trace,
+    warn,
+};
+use ::std::{
+    io::Write,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{
+            AtomicBool,
+            Ordering,
+        },
+    },
+};
+use ::sys::error::ErrorCode;
+use ::tokio::{
+    runtime::Handle,
+    sync::{
+        Mutex,
+        MutexGuard,
+        mpsc::{
+            Receiver,
+            Sender,
+        },
+    },
+    task,
+};
+
+pub use vmem::VirtualMemory;
+
+//==================================================================================================
+// Re-exports
+//==================================================================================================
+
+pub use crate::vmm::whp::vcpu::exit::{
+    PmioAccess,
+    PmioWidth,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Signal used to interrupt the vCPU thread (unused on Windows, but required by orchestrator).
+pub const INTERRUPT_SIGNAL: i32 = 0;
+
+/// Signal used to kill the vCPU thread (unused on Windows, but required by orchestrator).
+pub const KILL_SIGNAL: i32 = 0;
+
+/// IDT vector for IRQ 9 (IKC): PIC2 base (0x28) + (IRQ 9 - 8) = 0x29.
+const IKC_VECTOR: u32 = 0x29;
+
+//==================================================================================================
+// IKC Notifier
+//==================================================================================================
+
+/// Notifier that signals the VMM loop to inject an IKC interrupt after the host writes credits.
+#[derive(Clone)]
+pub struct IkcNotifier {
+    pending: Arc<AtomicBool>,
+    /// Set to true after the VMM has shut down. Prevents `WHvCancelRunVirtualProcessor` calls
+    /// on a partition whose vCPU is no longer running, which can trigger STATUS_ACCESS_VIOLATION
+    /// on Windows.
+    shutdown: Arc<AtomicBool>,
+    partition: windows::Win32::System::Hypervisor::WHV_PARTITION_HANDLE,
+    vp_index: u32,
+}
+
+// SAFETY: WHV_PARTITION_HANDLE is a raw handle that is safe to send between threads.
+unsafe impl Send for IkcNotifier {}
+unsafe impl Sync for IkcNotifier {}
+
+impl IkcNotifier {
+    fn new(
+        partition: windows::Win32::System::Hypervisor::WHV_PARTITION_HANDLE,
+        vp_index: u32,
+    ) -> Self {
+        Self {
+            pending: Arc::new(AtomicBool::new(false)),
+            shutdown: Arc::new(AtomicBool::new(false)),
+            partition,
+            vp_index,
+        }
+    }
+
+    /// Signals that an IKC message is available. Cancels the vCPU to wake it.
+    ///
+    /// After the VMM has called [`mark_shutdown`](Self::mark_shutdown), this method becomes a
+    /// no-op to avoid calling WHP APIs on a partition whose vCPU has been powered off.
+    pub fn notify(&self) -> Result<()> {
+        if self.shutdown.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        if self.pending.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+        unsafe {
+            let _ = windows::Win32::System::Hypervisor::WHvCancelRunVirtualProcessor(
+                self.partition,
+                self.vp_index,
+                0,
+            );
+        }
+        Ok(())
+    }
+
+    /// Returns true if an IKC notification is pending, and clears the flag.
+    fn take_pending(&self) -> bool {
+        self.pending.swap(false, Ordering::AcqRel)
+    }
+
+    /// Marks the notifier as shut down, preventing future `notify()` calls from invoking
+    /// WHP APIs.
+    fn mark_shutdown(&self) {
+        self.shutdown.store(true, Ordering::Release);
+    }
+}
+
+//==================================================================================================
+// Thread-Local Variables
+//==================================================================================================
+
+thread_local! {
+    /// Shutdown flag, set to true when the vCPU thread should stop running.
+    static SHUTDOWN: AtomicBool = const { AtomicBool::new(false) };
+}
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A structure that represents a VMM backed by Windows Hypervisor Platform (WHP).
+///
+#[derive(Clone)]
+pub struct Vmm {
+    /// Guest of the virtual machine.
+    guest: Arc<Mutex<Guest>>,
+    /// Virtual memory of the virtual machine.
+    vmem: Arc<Mutex<VirtualMemory>>,
+    /// Virtual processor of the virtual machine.
+    vcpu: Arc<Mutex<VirtualProcessor>>,
+    /// Host-side timer for periodic interrupt injection.
+    timer: Arc<std::sync::Mutex<timer::Timer>>,
+    /// IKC notifier for waking the guest when credits are added.
+    ikc_notifier: IkcNotifier,
+    /// Partition handle (for future interrupt injection use).
+    #[allow(dead_code)]
+    partition_handle: windows::Win32::System::Hypervisor::WHV_PARTITION_HANDLE,
+    /// Wraps fields that don't require individual `Arc<Mutex<_>>`s.
+    inner: Arc<Mutex<InteriorWhpHandle>>,
+}
+
+///
+/// # Description
+///
+/// An internal structure to the VMM that wraps its contents in `Arc<Mutex<_>>`. It allows
+/// the VMM to be clonable without wrapping each field in `Arc<Mutex<_>>`.
+///
+struct InteriorWhpHandle {
+    /// WHP partition handle (must outlive vCPU and vmem).
+    _partition: partition::WhpPartition,
+    /// Emulator of the virtual machine.
+    emulator: Emulator,
+    /// Channel to receive commands from the VMM.
+    control_rx: Receiver<VcpuControlCommand>,
+    /// Channel to send control responses to the VMM.
+    control_tx: Sender<VcpuControlResponse>,
+}
+
+//==================================================================================================
+// Types
+//==================================================================================================
+
+pub type StdinFn =
+    dyn FnMut(&Arc<Mutex<Guest>>, &Arc<Mutex<VirtualMemory>>, u32, usize) -> Result<()> + Send;
+
+pub type StdoutFn =
+    dyn FnMut(&Arc<Mutex<VirtualMemory>>, &::sys::ipc::VmBusMessage) -> Result<()> + Send;
+
+pub type StderrFn = dyn Write + Send;
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Vmm {
+    ///
+    /// # Description
+    ///
+    /// Creates a VMM backed by Windows Hypervisor Platform.
+    ///
+    /// # Parameters
+    ///
+    /// - `args`: Arguments for creating the VMM.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns the VMM that was created. Otherwise, it
+    /// returns an error.
+    ///
+    pub fn new(args: MicroVmArgs) -> Result<Self> {
+        trace!("new(): args={:?}", args);
+
+        let partition: partition::WhpPartition = partition::WhpPartition::new()?;
+        let mut vmem: VirtualMemory =
+            VirtualMemory::new(&partition, ::config::kernel::MEMORY_SIZE)?;
+        let mut vcpu: VirtualProcessor = VirtualProcessor::new(&partition, 0)?;
+
+        let guest: Arc<Mutex<Guest>> = if args.restoring_from_snapshot {
+            Arc::new(Mutex::new(Guest::default()))
+        } else {
+            let mut guest: Guest = Guest::default();
+
+            guest.load_kernel(&mut vmem, &args.kernel_filename)?;
+            args.initrd_filename
+                .as_ref()
+                .map(|initrd_filename| {
+                    guest.load_initrd(&mut vmem, initrd_filename, args.initrd_args)
+                })
+                .transpose()?;
+
+            let ramfs_region: Option<(usize, usize)> =
+                if let Some(ramfs_filename) = args.ramfs_filename.as_deref() {
+                    let initrd_end: usize = match guest.initrd_region() {
+                        Some((base, size)) => match base.checked_add(size) {
+                            Some(end) => end,
+                            None => {
+                                let reason: String = "initrd region overflowed while computing \
+                                                      ramfs placement"
+                                    .to_string();
+                                error!("new(): {reason}");
+                                anyhow::bail!(reason)
+                            },
+                        },
+                        None => ::config::microvm::DEFAULT_INITRD_BASE,
+                    };
+
+                    let ramfs: ramfs::RamFs = ramfs::RamFs::open(Path::new(ramfs_filename))?;
+                    let (ramfs_base, ramfs_size) =
+                        ramfs.load_into_virtual_memory(&mut vmem, initrd_end)?;
+                    Some((ramfs_base, ramfs_size))
+                } else {
+                    None
+                };
+
+            ramfs::RamFs::write_registers(&mut vmem, ramfs_region)?;
+
+            guest.reset(&mut vmem, &mut vcpu)?;
+
+            // Populate the pvclock page so the kernel uses TSC-based time instead
+            // of PIT tick counting. This must run AFTER load_kernel() because the
+            // ELF loader zero-fills the page at DEFAULT_PVCLOCK_PAGE.
+            Self::setup_pvclock(&mut vmem)?;
+
+            Arc::new(Mutex::new(guest))
+        };
+
+        let partition_handle = partition.handle();
+        let vmem: Arc<Mutex<VirtualMemory>> = Arc::new(Mutex::new(vmem));
+        let vcpu: Arc<Mutex<VirtualProcessor>> = Arc::new(Mutex::new(vcpu));
+        let timer: Arc<std::sync::Mutex<timer::Timer>> =
+            Arc::new(std::sync::Mutex::new(timer::Timer::new(partition_handle)));
+
+        let ikc_notifier = IkcNotifier::new(partition_handle, 0);
+
+        let emulator: Emulator =
+            Emulator::new(guest.clone(), vmem.clone(), args.input, args.output, args.stderr)?;
+
+        Ok(Self {
+            guest,
+            vmem,
+            vcpu,
+            timer,
+            ikc_notifier,
+            partition_handle,
+            inner: Arc::new(Mutex::new(InteriorWhpHandle {
+                _partition: partition,
+                emulator,
+                control_rx: args.control_rx,
+                control_tx: args.control_tx,
+            })),
+        })
+    }
+
+    pub fn spawn(mut self) -> tokio::task::JoinHandle<Result<u16>> {
+        task::spawn_blocking(move || {
+            let thread_id: u64 =
+                unsafe { windows::Win32::System::Threading::GetCurrentThreadId() as u64 };
+            Handle::current().block_on(self.send_tid(thread_id))?;
+            warn!("VMM spawn_blocking: calling run()");
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.run()));
+            warn!("VMM spawn_blocking: run() returned (is_ok={})", result.is_ok());
+            match result {
+                Ok(inner) => inner,
+                Err(panic_info) => {
+                    let msg = format!("VMM panicked: {:?}", panic_info);
+                    error!("{msg}");
+                    Err(anyhow::anyhow!(msg))
+                },
+            }
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Runs the virtual machine.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns the exit status of the virtual machine.
+    /// Otherwise, it returns an error.
+    ///
+    pub fn run(&mut self) -> Result<u16> {
+        trace!("run()");
+
+        // Reset shutdown flag from any previous runs.
+        SHUTDOWN.with(|shutdown| shutdown.store(false, Ordering::SeqCst));
+
+        let loop_start = std::time::Instant::now();
+        // Track guest instruction execution to detect hangs.
+        let mut last_progress_time: std::time::Instant = std::time::Instant::now();
+
+        // Pvclock: VMM-driven system_time updates.
+        // Version starts at 2 (set by setup_pvclock). Each update does +1
+        // (odd = writing) then +1 (even = stable).
+        let mut pvclock_version: u32 = 2;
+
+        // Spawn a background clock-refresh thread that periodically cancels
+        // the vCPU to force VMM loop re-entry for pvclock updates. Without
+        // this, before the PV timer starts (early boot) or if the timer is
+        // stopped, the vCPU can execute guest code indefinitely and the
+        // pvclock system_time field stays frozen.
+        let clock_refresh_stop = Arc::new(AtomicBool::new(false));
+        let clock_refresh_thread = {
+            let stop = clock_refresh_stop.clone();
+            let partition = self.partition_handle;
+            std::thread::spawn(move || {
+                // Set Windows timer resolution to 1 ms for accurate sleep.
+                unsafe { super::timer::timeBeginPeriod(1) };
+                while !stop.load(Ordering::Relaxed) {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                    if stop.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    unsafe {
+                        let _ = windows::Win32::System::Hypervisor::WHvCancelRunVirtualProcessor(
+                            partition, 0, 0,
+                        );
+                    }
+                }
+                unsafe { super::timer::timeEndPeriod(1) };
+            })
+        };
+
+        // Start the timer with the compile-time constant period.
+        self.timer
+            .lock()
+            .unwrap()
+            .start(::config::microvm::TIMER_PERIOD_US);
+
+        let result = loop {
+            // Check shutdown flag.
+            if SHUTDOWN.with(|shutdown| shutdown.load(Ordering::SeqCst)) {
+                let exit_status: u16 = 0;
+                warn!("VMM exit: SHUTDOWN flag (elapsed={:?})", loop_start.elapsed());
+                Handle::current().block_on(self.handle_shutdown(exit_status));
+                break Ok(exit_status);
+            }
+
+            // Watchdog: if no I/O port activity for 120 seconds, the guest is
+            // likely stuck (e.g., a panic handler spin loop). Terminate with an
+            // error. Active even before the timer starts to catch boot hangs.
+            const WATCHDOG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+            if last_progress_time.elapsed() > WATCHDOG_TIMEOUT {
+                error!("VMM watchdog: no guest I/O for {:?}, terminating", WATCHDOG_TIMEOUT);
+                let exit_status: u16 = ErrorCode::OperationTimedOut.into();
+                Handle::current().block_on(self.handle_shutdown(exit_status));
+                break Ok(exit_status);
+            }
+
+            // Update pvclock before every vCPU entry so the guest always
+            // reads a fresh wall-clock value from the pvclock page.
+            Self::update_pvclock(
+                &mut self.vmem.blocking_lock(),
+                &mut pvclock_version,
+                loop_start.elapsed().as_nanos() as u64,
+            );
+
+            // Check for pending IKC notification and inject via PendingInterruption.
+            if self.ikc_notifier.take_pending() {
+                let mut locked_vcpu = self.vcpu.blocking_lock();
+                if locked_vcpu.is_online() {
+                    let rflags = locked_vcpu.get_rflags().unwrap_or(0);
+                    if rflags & vcpu::RFLAGS_INTERRUPT_ENABLE != 0 {
+                        let _ = locked_vcpu.inject_pending_interruption(IKC_VECTOR);
+                    } else {
+                        locked_vcpu.set_deliverability_notifications(true);
+                        // Re-set pending so we try again on InterruptWindow.
+                        self.ikc_notifier.pending.store(true, Ordering::Release);
+                    }
+                }
+            }
+
+            let exit_context = {
+                let mut locked_vcpu: MutexGuard<'_, VirtualProcessor> = self.vcpu.blocking_lock();
+                // Exit if the vCPU is no longer online.
+                if !locked_vcpu.is_online() {
+                    warn!(
+                        "VMM exit: vCPU offline (exit_status={}, elapsed={:?})",
+                        locked_vcpu.exit_status(),
+                        loop_start.elapsed()
+                    );
+                    break Ok(locked_vcpu.exit_status());
+                }
+                locked_vcpu.run()
+            };
+
+            // Parse exit reason.
+            match exit_context.reason_ref() {
+                // The guest requested to access an I/O port.
+                VirtualProcessorExitReasonRef::PmioAccess(access) => {
+                    // Any PMIO exit indicates guest progress.
+                    last_progress_time = std::time::Instant::now();
+
+                    // Fast-path: handle legacy hardware ports inline.
+                    if let PmioAccess::PmioOut(port, _data, _width) = access {
+                        // PIC, PIT, speaker, IMCR, CMOS, serial: no-op.
+                        match *port {
+                            0x20
+                            | 0x21
+                            | 0xA0
+                            | 0xA1
+                            | 0x22
+                            | 0x23
+                            | 0x40..=0x43
+                            | 0x61
+                            | 0x70
+                            | 0x71
+                            | 0x3F8..=0x3FF => {
+                                continue;
+                            },
+                            _ => {},
+                        }
+                    }
+                    if let PmioAccess::PmioIn(port, _data) = access {
+                        match *port {
+                            0x20
+                            | 0x21
+                            | 0x22
+                            | 0x23
+                            | 0xA0
+                            | 0xA1
+                            | 0x40..=0x43
+                            | 0x61
+                            | 0x70
+                            | 0x71
+                            | 0x3F8..=0x3FF
+                            | 0xCF8
+                            | 0xCFC..=0xCFF => {
+                                continue;
+                            },
+                            _ => {},
+                        }
+                    }
+
+                    // Slow path: application-level I/O (stdout, stdin, VMM port).
+
+                    let exit_status: Option<u16> = self
+                        .inner
+                        .blocking_lock()
+                        .emulator
+                        .handle_pmio_access(access)?;
+                    if let Some(exit_status) = exit_status {
+                        if exit_status != ::config::microvm::DEFAULT_VMM_PAUSE_CMD {
+                            warn!(
+                                "VMM exit: PMIO shutdown (exit_status={exit_status}, elapsed={:?})",
+                                loop_start.elapsed()
+                            );
+                            Handle::current().block_on(self.handle_shutdown(exit_status));
+                            break Ok(exit_status);
+                        } else {
+                            Handle::current().block_on(self.handle_pause())?;
+                            trace!("VMM resumed");
+                        }
+                    }
+                },
+
+                // HLT: the guest is waiting for an interrupt. The LAPIC
+                // emulator holds the vCPU until WHvRequestInterrupt from
+                // the timer thread (or IKC) wakes it. If HLT exits to
+                // the VMM (e.g., no LAPIC emulation), just re-enter.
+                VirtualProcessorExitReasonRef::Halt => {
+                    continue;
+                },
+
+                // The vCPU was canceled (CancelRunVP from clock-refresh
+                // thread). Brings the VMM loop back for pvclock updates,
+                // IKC delivery, and shutdown checks.
+                VirtualProcessorExitReasonRef::Interrupted => {
+                    continue;
+                },
+
+                // InterruptWindow: IF just became 1. This may fire if
+                // DeliverabilityNotifications was set (e.g., for IKC).
+                VirtualProcessorExitReasonRef::InterruptWindow => {
+                    let mut locked_vcpu = self.vcpu.blocking_lock();
+                    locked_vcpu.set_deliverability_notifications(false);
+                    if self.ikc_notifier.take_pending() && locked_vcpu.is_online() {
+                        let _ = locked_vcpu.inject_pending_interruption(IKC_VECTOR);
+                    }
+                    continue;
+                },
+
+                // Virtual machine exited due to an unknown reason.
+                VirtualProcessorExitReasonRef::Unknown => {
+                    warn!("VMM exit: Unknown exit reason (elapsed={:?})", loop_start.elapsed());
+                    break Ok(ErrorCode::IllegalByteSequence.into());
+                },
+
+                // Guest accessed an unmapped guest physical address.
+                // Lazily map a zeroed page so the instruction succeeds on retry.
+                VirtualProcessorExitReasonRef::MmioAccess(gpa) => {
+                    self.vmem
+                        .blocking_lock()
+                        .map_mmio_page(&self.inner.blocking_lock()._partition, gpa)?;
+                    continue;
+                },
+            }
+        };
+
+        // Stop the clock-refresh thread before returning.
+        clock_refresh_stop.store(true, Ordering::Relaxed);
+        let _ = clock_refresh_thread.join();
+
+        warn!("VMM run loop finished (result={result:?}, elapsed={:?})", loop_start.elapsed());
+        result
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a reference to the virtual memory of the target virtual machine.
+    ///
+    pub fn vmem(&self) -> Arc<Mutex<VirtualMemory>> {
+        self.vmem.clone()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a reference to the guest of the virtual machine.
+    ///
+    pub fn guest(&self) -> Arc<Mutex<Guest>> {
+        self.guest.clone()
+    }
+
+    /// Returns a clone of the IKC notifier for use by the memory thread.
+    pub fn ikc_notifier(&self) -> IkcNotifier {
+        self.ikc_notifier.clone()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Stub for snapshot creation (not supported on WHP backend).
+    ///
+    pub async fn create_snapshot(&self, _filepath: String) -> Result<()> {
+        warn!("create_snapshot(): snapshots are not supported on WHP backend");
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Stub for snapshot loading (not supported on WHP backend).
+    ///
+    pub async fn load_snapshot(&self, _filepath: String) -> Result<()> {
+        warn!("load_snapshot(): snapshots are not supported on WHP backend");
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sends the vCPU thread's tid to the main thread.
+    ///
+    async fn send_tid(&self, tid: u64) -> Result<()> {
+        Ok(self
+            .inner
+            .lock()
+            .await
+            .control_tx
+            .send(VcpuControlResponse::Tid(tid))
+            .await?)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Acknowledges a pause request and waits for the next command.
+    ///
+    async fn handle_pause(&mut self) -> Result<()> {
+        self.inner
+            .lock()
+            .await
+            .control_tx
+            .send(VcpuControlResponse::Paused)
+            .await?;
+
+        match self.inner.lock().await.control_rx.recv().await {
+            Some(VcpuControlCommand::Resume) => Ok(()),
+            Some(VcpuControlCommand::CreateSnapshot(_filepath)) => {
+                // Snapshots are not supported on Windows WHP backend.
+                warn!("handle_pause(): snapshot creation not supported on WHP backend");
+                Ok(())
+            },
+            None => {
+                let reason: String = "the vmm has disconnected".to_string();
+                error!("run(): {reason}");
+                anyhow::bail!(reason)
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Helper method to poweroff the vCPU with a given exit status, and send a shutdown message to
+    /// the orchestrator thread.
+    ///
+    async fn handle_shutdown(&mut self, exit_status: u16) {
+        // Mark the IKC notifier as shut down so that any pending or future notify() calls from
+        // the memory thread will skip the WHvCancelRunVirtualProcessor API call. This prevents
+        // STATUS_ACCESS_VIOLATION crashes when the vCPU is no longer running.
+        self.ikc_notifier.mark_shutdown();
+
+        // Stop the timer thread before shutting down.
+        self.timer.lock().unwrap().stop();
+
+        // Power-off vCPU.
+        self.vcpu.lock().await.poweroff(exit_status);
+
+        // Send message to orchestrator thread.
+        match self
+            .inner
+            .lock()
+            .await
+            .control_tx
+            .send(VcpuControlResponse::Shutdown)
+            .await
+        {
+            Ok(()) => {
+                trace!("handle_shutdown(): shutdown notification sent to orchestrator");
+            },
+            Err(error) => {
+                warn!("handle_shutdown(): failed to notify orchestrator thread (error={error:?})");
+            },
+        }
+    }
+
+    /// Populates the pvclock shared memory page so the kernel reads accurate
+    /// wall-clock time without relying on TSC.
+    ///
+    /// The page at `DEFAULT_PVCLOCK_PAGE` (GPA 0x1000) uses the KVM pvclock
+    /// format (`KvmPvclockVcpuTimeInfo`). On KVM this is filled by the
+    /// hypervisor itself; on WHP we write it from the VMM.
+    ///
+    /// **Strategy**: Set `tsc_to_system_mul = 0` so the TSC delta contributes
+    /// nothing. The VMM periodically updates `system_time` directly from the
+    /// host clock (see [`update_pvclock`]). This avoids depending on the
+    /// guest's `rdtsc` matching the host's TSC — which is unreliable on WHP.
+    fn setup_pvclock(vmem: &mut VirtualMemory) -> Result<()> {
+        use std::time::{
+            SystemTime,
+            UNIX_EPOCH,
+        };
+
+        // Build the KvmPvclockVcpuTimeInfo structure (32 bytes).
+        //   [0..4]   version: u32           (2 = valid, even)
+        //   [4..8]   _pad0: u32             (0)
+        //   [8..16]  tsc_timestamp: u64     (unused, 0)
+        //   [16..24] system_time: u64       (ns, updated by VMM)
+        //   [24..28] tsc_to_system_mul: u32 (0 = TSC not used)
+        //   [28]     tsc_shift: i8          (0)
+        //   [29]     flags: u8              (0x01 = TSC_STABLE)
+        //   [30..32] _pad: [u8; 2]
+        let mut data = [0u8; 32];
+        // Version 2 = pvclock enabled (VMM-driven system_time updates).
+        let pvclock_version: u32 = 2;
+        data[0..4].copy_from_slice(&pvclock_version.to_le_bytes());
+        // tsc_timestamp = 0, system_time = 0, mul = 0, shift = 0
+        data[29] = 0x01; // TSC_STABLE
+
+        let pvclock_gpa = ::config::microvm::DEFAULT_PVCLOCK_PAGE as u64;
+        vmem.write_bytes(pvclock_gpa, &data)?;
+
+        // Write boot time (UTC nanoseconds since Unix epoch) at offset 0x20.
+        let boot_time_ns: u64 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        let boot_offset = pvclock_gpa + ::config::microvm::PVCLOCK_BOOT_TIME_NS_OFFSET as u64;
+        vmem.write_bytes(boot_offset, &boot_time_ns.to_le_bytes())?;
+
+        trace!("pvclock: VMM-driven mode (mul=0), boot_ns={boot_time_ns}");
+
+        Ok(())
+    }
+
+    /// Updates the pvclock page's `system_time` field via the seqlock protocol.
+    ///
+    /// The kernel's seqlock reader retries when it sees an odd version, so
+    /// the update sequence is: version→odd, write system_time, version→even.
+    fn update_pvclock(vmem: &mut VirtualMemory, pvclock_version: &mut u32, system_time_ns: u64) {
+        let gpa = ::config::microvm::DEFAULT_PVCLOCK_PAGE as u64;
+        // Odd version signals "update in progress".
+        *pvclock_version += 1;
+        let _ = vmem.write_bytes(gpa, &pvclock_version.to_le_bytes());
+        // Update system_time (offset 16).
+        let _ = vmem.write_bytes(gpa + 16, &system_time_ns.to_le_bytes());
+        // Even version signals "stable snapshot".
+        *pvclock_version += 1;
+        let _ = vmem.write_bytes(gpa, &pvclock_version.to_le_bytes());
+    }
+}

--- a/src/uservm/src/vmm/whp/partition.rs
+++ b/src/uservm/src/vmm/whp/partition.rs
@@ -1,0 +1,149 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::log::{
+    error,
+    trace,
+};
+use windows::Win32::System::Hypervisor::{
+    WHV_PARTITION_HANDLE,
+    WHV_PARTITION_PROPERTY,
+    WHvCreatePartition,
+    WHvDeletePartition,
+    WHvPartitionPropertyCodeLocalApicEmulationMode,
+    WHvPartitionPropertyCodeProcessorCount,
+    WHvSetPartitionProperty,
+    WHvSetupPartition,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A wrapper around a Windows Hypervisor Platform partition handle.
+///
+pub struct WhpPartition {
+    /// Handle to the WHP partition.
+    handle: WHV_PARTITION_HANDLE,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl WhpPartition {
+    ///
+    /// # Description
+    ///
+    /// Creates a new WHP partition with one virtual processor.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this function returns the new partition. Otherwise, it returns
+    /// an error.
+    ///
+    pub fn new() -> Result<Self> {
+        trace!("WhpPartition::new()");
+
+        // Create the partition.
+        let handle: WHV_PARTITION_HANDLE = unsafe {
+            WHvCreatePartition().map_err(|e| {
+                let reason: String = format!("failed to create WHP partition (error={e:?})");
+                error!("WhpPartition::new(): {reason}");
+                anyhow::anyhow!(reason)
+            })?
+        };
+
+        // Set the processor count to 1.
+        unsafe {
+            let mut property: WHV_PARTITION_PROPERTY = std::mem::zeroed();
+            property.ProcessorCount = 1;
+            let property_size: u32 = u32::try_from(std::mem::size_of::<u32>())
+                .map_err(|_| anyhow::anyhow!("size_of::<u32>() does not fit in u32"))?;
+            WHvSetPartitionProperty(
+                handle,
+                WHvPartitionPropertyCodeProcessorCount,
+                (&property as *const WHV_PARTITION_PROPERTY).cast::<std::ffi::c_void>(),
+                property_size,
+            )
+            .map_err(|e| {
+                let reason: String = format!("failed to set processor count (error={e:?})");
+                error!("WhpPartition::new(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        }
+
+        // Enable LAPIC emulation in XApic mode. This is required so:
+        //   - The kernel's LAPIC MMIO accesses work during boot.
+        //   - HLT is handled internally by the LAPIC emulator
+        //     (no VM exit), which is fine because the guest signals
+        //     its idle state via the PV idle port (0xED) before HLT.
+        unsafe {
+            let mut property: WHV_PARTITION_PROPERTY = std::mem::zeroed();
+            property.LocalApicEmulationMode =
+                windows::Win32::System::Hypervisor::WHV_X64_LOCAL_APIC_EMULATION_MODE(1);
+            let property_size: u32 = u32::try_from(std::mem::size_of::<
+                windows::Win32::System::Hypervisor::WHV_X64_LOCAL_APIC_EMULATION_MODE,
+            >())
+            .map_err(|_| anyhow::anyhow!("emulation mode size does not fit in u32"))?;
+            WHvSetPartitionProperty(
+                handle,
+                WHvPartitionPropertyCodeLocalApicEmulationMode,
+                (&property as *const WHV_PARTITION_PROPERTY).cast::<std::ffi::c_void>(),
+                property_size,
+            )
+            .map_err(|e| {
+                let reason: String = format!("failed to set LAPIC emulation mode (error={e:?})");
+                error!("WhpPartition::new(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        }
+
+        // Setup the partition (finalizes configuration).
+        unsafe {
+            WHvSetupPartition(handle).map_err(|e| {
+                let reason: String = format!("failed to setup WHP partition (error={e:?})");
+                error!("WhpPartition::new(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        }
+
+        Ok(Self { handle })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the raw WHP partition handle.
+    ///
+    pub fn handle(&self) -> WHV_PARTITION_HANDLE {
+        self.handle
+    }
+}
+
+impl Drop for WhpPartition {
+    fn drop(&mut self) {
+        trace!("WhpPartition::drop()");
+        unsafe {
+            if let Err(e) = WHvDeletePartition(self.handle) {
+                error!("WhpPartition::drop(): failed to delete partition (error={e:?})");
+            }
+        }
+    }
+}
+
+// SAFETY: `WhpPartition` wraps an opaque `WHV_PARTITION_HANDLE` managed by the Windows
+// Hypervisor Platform. The WHP APIs are designed to allow a partition handle to be used from any
+// thread; all internal synchronisation is performed by the Windows kernel/hypervisor.
+// `WhpPartition` does not add any unsynchronised interior mutability beyond the underlying OS
+// object; moving it between threads or sharing references cannot create data races.
+unsafe impl Send for WhpPartition {}
+unsafe impl Sync for WhpPartition {}

--- a/src/uservm/src/vmm/whp/ramfs.rs
+++ b/src/uservm/src/vmm/whp/ramfs.rs
@@ -1,0 +1,265 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::vmm::whp::vmem::VirtualMemory;
+use ::anyhow::Result;
+use ::arch::mem::PAGE_SIZE;
+use ::log::{
+    error,
+    trace,
+};
+use ::std::{
+    fs::File,
+    io::Read,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Minimum slack size (in bytes) required between the end of the initrd and the start of the RAMFS.
+const RAMFS_MIN_SLACK_BYTES: usize = 4 * 1024 * 1024;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Encapsulates a RAM filesystem image and the operations required to load it into guest memory.
+///
+#[derive(Debug)]
+pub struct RamFs {
+    /// Filesystem path from which the RAMFS image was loaded.
+    path: PathBuf,
+    /// Contents of the RAMFS image.
+    data: Vec<u8>,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl RamFs {
+    ///
+    /// # Description
+    ///
+    /// Opens a RAMFS image from the provided path and reads it into memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the RAMFS image on the host filesystem.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns a `RamFs` descriptor. Otherwise, returns an error.
+    ///
+    pub fn open(path: &Path) -> Result<Self> {
+        trace!("RamFs::open(): path={path:?}");
+
+        let mut file: File = match File::open(path) {
+            Ok(file) => file,
+            Err(error) => {
+                let reason: String =
+                    format!("failed to open ramfs image (path={path:?}, error={error:?})");
+                error!("RamFs::open(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let mut data: Vec<u8> = Vec::new();
+        if let Err(error) = file.read_to_end(&mut data) {
+            let reason: String =
+                format!("failed to read ramfs image (path={path:?}, error={error:?})");
+            error!("RamFs::open(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        Ok(Self {
+            path: path.to_path_buf(),
+            data,
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Loads this RAMFS image near the end of the provided virtual memory while maintaining the
+    /// alignment and slack guarantees required by the initrd.
+    ///
+    /// # Parameters
+    ///
+    /// - `vmem`: Virtual memory that will host the RAMFS.
+    /// - `initrd_end`: The first byte immediately after the initrd contents in guest memory.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns the guest-physical base address and size where the RAMFS was loaded.
+    /// Otherwise, returns an error.
+    ///
+    pub fn load_into_virtual_memory(
+        &self,
+        vmem: &mut VirtualMemory,
+        initrd_end: usize,
+    ) -> Result<(usize, usize)> {
+        trace!(
+            "RamFs::load_into_virtual_memory(): path={:?}, initrd_end={:#010x}",
+            self.path, initrd_end
+        );
+
+        let ramfs_size: usize = self.data.len();
+        let memory_size: usize = vmem.get_size();
+
+        if ramfs_size > memory_size {
+            let reason: String = format!(
+                "ramfs image exceeds guest memory size (ramfs_size={ramfs_size}, memory_size={})",
+                memory_size
+            );
+            error!("RamFs::load_into_virtual_memory(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        let min_available_base: usize = match initrd_end.checked_add(RAMFS_MIN_SLACK_BYTES) {
+            Some(value) => value,
+            None => {
+                let reason: &str = "overflow while computing required ramfs slack";
+                error!("RamFs::load_into_virtual_memory(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        if min_available_base > memory_size {
+            let reason: String = format!(
+                "guest memory ({memory_size}) is smaller than initrd end plus slack \
+                 ({min_available_base})",
+            );
+            error!("RamFs::load_into_virtual_memory(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        let ramfs_base_unaligned: usize = match memory_size.checked_sub(ramfs_size) {
+            Some(base) => base,
+            None => {
+                let reason: String = format!(
+                    "ramfs image does not fit in guest memory (ramfs_size={ramfs_size}, \
+                     memory_size={memory_size})",
+                );
+                error!("RamFs::load_into_virtual_memory(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let ramfs_base: usize = ramfs_base_unaligned - (ramfs_base_unaligned % PAGE_SIZE);
+
+        if ramfs_base < min_available_base {
+            let available: usize = match memory_size.checked_sub(min_available_base) {
+                Some(value) => value,
+                None => {
+                    let reason: &str = "underflow while computing available guest memory for ramfs";
+                    error!("RamFs::load_into_virtual_memory(): {reason}");
+                    anyhow::bail!(reason)
+                },
+            };
+            let reason: String = format!(
+                "ramfs image conflicts with initrd requirements (ramfs_size={ramfs_size}, \
+                 available_for_ramfs={available}, required_slack={} bytes)",
+                RAMFS_MIN_SLACK_BYTES,
+            );
+            error!("RamFs::load_into_virtual_memory(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        // Copy RAMFS data into guest memory.
+        vmem.write_bytes(ramfs_base as u64, &self.data)
+            .map_err(|e| {
+                let reason: String = format!(
+                    "failed to write ramfs image into guest memory (path={:?}, error={e})",
+                    self.path
+                );
+                error!("RamFs::load_into_virtual_memory(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+
+        trace!(
+            "RamFs::load_into_virtual_memory(): loaded ramfs (path={:?}, base={:#010x}, \
+             size={ramfs_size})",
+            self.path, ramfs_base
+        );
+
+        Ok((ramfs_base, ramfs_size))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Writes the RAMFS base and size registers exposed to the guest.
+    ///
+    /// # Note
+    ///
+    /// The RAMFS registers at GPA `0xC` and GPA `0x10` fall inside the kernel ELF's `.zero`
+    /// section (`LOAD` segment at GPA `0x0` with `MemSiz=0x8000`). The ELF loader zero-fills
+    /// this range when `load_kernel()` runs. This method must therefore execute **after** the
+    /// ELF has been loaded, so that the VMM-written values are not overwritten.
+    ///
+    /// # Parameters
+    ///
+    /// - `vmem`: Virtual memory instance that holds the control registers.
+    /// - `ramfs_region`: Optional tuple containing the guest-physical base and size of the RAMFS.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn write_registers(
+        vmem: &mut VirtualMemory,
+        ramfs_region: Option<(usize, usize)>,
+    ) -> Result<()> {
+        let base_register_addr: u64 = ::config::microvm::DEFAULT_MICROVM_CTRL_RAMFS_BASE as u64;
+        let size_register_addr: u64 = ::config::microvm::DEFAULT_MICROVM_CTRL_RAMFS_SIZE as u64;
+
+        let (base_value, size_value): (u32, u32) = match ramfs_region {
+            Some((base, size)) => {
+                trace!("RamFs::write_registers(): base={:#010x}, size={:#x}", base, size);
+
+                let base_value: u32 = match u32::try_from(base) {
+                    Ok(value) => value,
+                    Err(_) => {
+                        let reason: String =
+                            format!("ramfs base does not fit into 32 bits (base={base:#010x})");
+                        error!("RamFs::write_registers(): {reason}");
+                        anyhow::bail!(reason)
+                    },
+                };
+                let size_value: u32 = match u32::try_from(size) {
+                    Ok(value) => value,
+                    Err(_) => {
+                        let reason: String =
+                            format!("ramfs size does not fit into 32 bits (size={size:#010x})");
+                        error!("RamFs::write_registers(): {reason}");
+                        anyhow::bail!(reason)
+                    },
+                };
+
+                (base_value, size_value)
+            },
+            None => (0, 0),
+        };
+
+        let base_bytes: [u8; 4] = base_value.to_le_bytes();
+        let size_bytes: [u8; 4] = size_value.to_le_bytes();
+
+        vmem.write_bytes(base_register_addr, &base_bytes)?;
+        vmem.write_bytes(size_register_addr, &size_bytes)?;
+
+        Ok(())
+    }
+}

--- a/src/uservm/src/vmm/whp/timer.rs
+++ b/src/uservm/src/vmm/whp/timer.rs
@@ -1,0 +1,151 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::log::trace;
+use ::std::{
+    mem,
+    sync::{
+        Arc,
+        atomic::{
+            AtomicBool,
+            Ordering,
+        },
+    },
+    thread::{
+        self,
+        JoinHandle,
+    },
+    time::Duration,
+};
+use windows::Win32::System::Hypervisor::{
+    WHV_INTERRUPT_CONTROL,
+    WHV_PARTITION_HANDLE,
+    WHvRequestInterrupt,
+};
+
+// Windows Multimedia timer functions for high-resolution sleep.
+#[link(name = "winmm")]
+unsafe extern "system" {
+    pub(super) fn timeBeginPeriod(uPeriod: u32) -> u32;
+    pub(super) fn timeEndPeriod(uPeriod: u32) -> u32;
+}
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A host-side timer that periodically injects a timer interrupt into
+/// the guest vCPU via `WHvRequestInterrupt`. This replaces the earlier
+/// two-stage mechanism (cancel vCPU + inject at idle port exit) with
+/// direct LAPIC-level interrupt injection from the timer thread.
+///
+/// The timer thread fires at the guest-requested period and injects
+/// IRQ0 (vector 0x20) as a Fixed, Edge-triggered interrupt through
+/// `WHvRequestInterrupt`. The WHP LAPIC emulator handles IF checks,
+/// IRR/ISR management, and HLT wake-up — so the guest can use a
+/// standard `sti; hlt` idle loop.
+///
+/// A separate clock-refresh thread in the VMM module handles periodic
+/// `WHvCancelRunVirtualProcessor` calls for pvclock updates, IKC
+/// delivery, and shutdown checks.
+///
+pub struct Timer {
+    /// WHP partition handle (for `WHvRequestInterrupt`).
+    partition: WHV_PARTITION_HANDLE,
+    /// Flag used to signal the timer thread to stop.
+    stop: Arc<AtomicBool>,
+    /// Handle to the background timer thread (if running).
+    thread: Option<JoinHandle<()>>,
+}
+
+// SAFETY: `WHV_PARTITION_HANDLE` is an opaque OS handle that can be used from
+// any thread. The `Timer` struct has no thread-affine state.
+unsafe impl Send for Timer {}
+unsafe impl Sync for Timer {}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Timer {
+    /// Creates a new timer for the given WHP partition. The timer is initially stopped.
+    pub fn new(partition: WHV_PARTITION_HANDLE) -> Self {
+        Self {
+            partition,
+            stop: Arc::new(AtomicBool::new(false)),
+            thread: None,
+        }
+    }
+
+    /// Starts the timer thread with the given period in microseconds.
+    ///
+    /// Each tick: `WHvRequestInterrupt` injects vector 0x20 (IRQ0)
+    /// as a Fixed, Edge-triggered interrupt via the WHP LAPIC. This
+    /// wakes the vCPU from HLT and delivers the interrupt when IF=1.
+    pub fn start(&mut self, period_us: u64) {
+        if self.thread.is_some() {
+            return;
+        }
+
+        trace!("Timer::start(): period_us={period_us}");
+        self.stop.store(false, Ordering::Relaxed);
+
+        let stop = self.stop.clone();
+        let partition = self.partition;
+        let period = Duration::from_micros(period_us);
+
+        self.thread = Some(thread::spawn(move || {
+            // Set Windows timer resolution to 1ms for accurate sleep.
+            unsafe { timeBeginPeriod(1) };
+
+            // Build the interrupt control structure for Fixed, Edge-triggered,
+            // Physical destination mode, vector 0x20, destination 0 (BSP).
+            // Bitfield layout: bits 0-7 = InterruptType (Fixed=0),
+            // bit 8 = DestinationMode (Physical=0), bit 9 = TriggerMode (Edge=0).
+            let interrupt: WHV_INTERRUPT_CONTROL = WHV_INTERRUPT_CONTROL {
+                _bitfield: 0, // Fixed=0, Physical=0, Edge=0.
+                Destination: 0,
+                Vector: super::lapic::TIMER_VECTOR,
+            };
+            let interrupt_size: u32 = mem::size_of::<WHV_INTERRUPT_CONTROL>() as u32;
+
+            while !stop.load(Ordering::Relaxed) {
+                thread::sleep(period);
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                // SAFETY: `partition` is a valid WHP partition handle that outlives
+                // the timer thread (the Vmm struct owns both). `interrupt` is a valid
+                // WHV_INTERRUPT_CONTROL on the stack with correct size.
+                unsafe {
+                    let _ = WHvRequestInterrupt(partition, &interrupt, interrupt_size);
+                }
+            }
+
+            unsafe { timeEndPeriod(1) };
+            trace!("Timer thread exiting");
+        }));
+    }
+
+    /// Stops the timer thread, waiting for it to finish.
+    pub fn stop(&mut self) {
+        if let Some(thread) = self.thread.take() {
+            trace!("Timer::stop()");
+            self.stop.store(true, Ordering::Relaxed);
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for Timer {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/src/uservm/src/vmm/whp/vcpu/exit.rs
+++ b/src/uservm/src/vmm/whp/vcpu/exit.rs
@@ -1,0 +1,153 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Port-mapped I/O transfer widths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PmioWidth {
+    /// Byte-sized (1 byte) access.
+    Byte = 1,
+    /// Word-sized (2 bytes) access.
+    Word = 2,
+    /// Doubleword-sized (4 bytes) access.
+    Dword = 4,
+}
+
+/// Port-mapped I/O access details.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PmioAccess {
+    /// Port-mapped I/O input. Tuple members are `(port, payload_bytes)`.
+    PmioIn(u16, Vec<u8>),
+    /// Port-mapped I/O output. Tuple members are `(port, value, width)`.
+    PmioOut(u16, u32, PmioWidth),
+}
+
+/// Virtual processor exit reasons.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VirtualProcessorExitReason {
+    /// Port-mapped I/O access.
+    PmioAccess(PmioAccess),
+    /// Memory-mapped I/O access at the given guest physical address.
+    MmioAccess(u64),
+    /// Halt virtual processor.
+    Halt,
+    /// Interrupted.
+    Interrupted,
+    /// Interrupt window opened (IF transitioned to 1).
+    InterruptWindow,
+    /// Unknown.
+    Unknown,
+}
+
+/// Virtual processor exit contexts.
+pub enum VirtualProcessorExitContext {
+    /// Port-mapped I/O.
+    Pmio(PmioAccess),
+    /// Memory-mapped I/O at the given guest physical address.
+    Mmio(u64),
+    /// Halt virtual processor.
+    Halt,
+    /// Interrupt virtual processor.
+    Interrupted,
+    /// Interrupt window opened (IF transitioned to 1).
+    InterruptWindow,
+    /// Unknown.
+    Unknown,
+}
+
+/// Borrowed view of the virtual processor exit reason.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VirtualProcessorExitReasonRef<'a> {
+    /// Port-mapped I/O access.
+    PmioAccess(&'a PmioAccess),
+    /// Memory-mapped I/O access at the given guest physical address.
+    MmioAccess(u64),
+    /// Halt virtual processor.
+    Halt,
+    /// Interrupted.
+    Interrupted,
+    /// Interrupt window opened (IF transitioned to 1).
+    InterruptWindow,
+    /// Unknown.
+    Unknown,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl From<PmioWidth> for usize {
+    fn from(value: PmioWidth) -> Self {
+        value as usize
+    }
+}
+
+impl From<&PmioWidth> for usize {
+    fn from(value: &PmioWidth) -> Self {
+        *value as usize
+    }
+}
+
+impl TryFrom<usize> for PmioWidth {
+    type Error = usize;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Byte),
+            2 => Ok(Self::Word),
+            4 => Ok(Self::Dword),
+            invalid => Err(invalid),
+        }
+    }
+}
+
+impl VirtualProcessorExitContext {
+    ///
+    /// # Description
+    ///
+    /// Gets the reason for a virtual processor exit.
+    ///
+    pub fn reason(&self) -> VirtualProcessorExitReason {
+        self.reason_ref().into()
+    }
+
+    /// Returns the virtual processor exit reason without cloning.
+    pub fn reason_ref(&self) -> VirtualProcessorExitReasonRef<'_> {
+        match self {
+            VirtualProcessorExitContext::Pmio(access) => {
+                VirtualProcessorExitReasonRef::PmioAccess(access)
+            },
+            VirtualProcessorExitContext::Mmio(gpa) => {
+                VirtualProcessorExitReasonRef::MmioAccess(*gpa)
+            },
+            VirtualProcessorExitContext::Halt => VirtualProcessorExitReasonRef::Halt,
+            VirtualProcessorExitContext::Interrupted => VirtualProcessorExitReasonRef::Interrupted,
+            VirtualProcessorExitContext::InterruptWindow => {
+                VirtualProcessorExitReasonRef::InterruptWindow
+            },
+            VirtualProcessorExitContext::Unknown => VirtualProcessorExitReasonRef::Unknown,
+        }
+    }
+}
+
+impl<'a> From<VirtualProcessorExitReasonRef<'a>> for VirtualProcessorExitReason {
+    fn from(value: VirtualProcessorExitReasonRef<'a>) -> Self {
+        match value {
+            VirtualProcessorExitReasonRef::PmioAccess(access) => {
+                VirtualProcessorExitReason::PmioAccess(access.clone())
+            },
+            VirtualProcessorExitReasonRef::MmioAccess(gpa) => {
+                VirtualProcessorExitReason::MmioAccess(gpa)
+            },
+            VirtualProcessorExitReasonRef::Halt => VirtualProcessorExitReason::Halt,
+            VirtualProcessorExitReasonRef::Interrupted => VirtualProcessorExitReason::Interrupted,
+            VirtualProcessorExitReasonRef::InterruptWindow => {
+                VirtualProcessorExitReason::InterruptWindow
+            },
+            VirtualProcessorExitReasonRef::Unknown => VirtualProcessorExitReason::Unknown,
+        }
+    }
+}

--- a/src/uservm/src/vmm/whp/vcpu/mod.rs
+++ b/src/uservm/src/vmm/whp/vcpu/mod.rs
@@ -1,0 +1,531 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod exit;
+
+//==================================================================================================
+// Re-exports
+//==================================================================================================
+
+pub use exit::*;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::vmm::whp::partition::WhpPartition;
+use ::anyhow::Result;
+use ::log::{
+    error,
+    trace,
+    warn,
+};
+use ::std::mem;
+use windows::Win32::System::Hypervisor::{
+    WHV_PARTITION_HANDLE,
+    WHV_REGISTER_NAME,
+    WHV_REGISTER_VALUE,
+    WHV_RUN_VP_EXIT_CONTEXT,
+    WHV_RUN_VP_EXIT_REASON,
+    WHvCancelRunVirtualProcessor,
+    WHvCreateVirtualProcessor,
+    WHvDeleteVirtualProcessor,
+    WHvGetVirtualProcessorInterruptControllerState2,
+    WHvGetVirtualProcessorRegisters,
+    WHvRunVirtualProcessor,
+    WHvSetVirtualProcessorInterruptControllerState2,
+    WHvSetVirtualProcessorRegisters,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// RFLAGS interrupt enable flag (bit 9).
+pub const RFLAGS_INTERRUPT_ENABLE: u64 = 1 << 9;
+
+/// RFLAGS reserved bit that must always be set.
+const RFLAGS_RESERVED_BIT1: u64 = 1 << 1;
+
+// WHP register name constants.
+const WHV_X64_REGISTER_RIP: WHV_REGISTER_NAME = WHV_REGISTER_NAME(16);
+const WHV_X64_REGISTER_RFLAGS: WHV_REGISTER_NAME = WHV_REGISTER_NAME(17);
+const WHV_X64_REGISTER_RAX: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0);
+const WHV_X64_REGISTER_RBX: WHV_REGISTER_NAME = WHV_REGISTER_NAME(3);
+const WHV_X64_REGISTER_CS: WHV_REGISTER_NAME = WHV_REGISTER_NAME(19);
+/// Deliverability notifications register (controls interrupt-window exits).
+const WHV_X64_REGISTER_DELIVERABILITY_NOTIFICATIONS: WHV_REGISTER_NAME =
+    WHV_REGISTER_NAME(-2_147_483_644i32);
+/// Pending interruption register (inject interrupts into the vCPU).
+const WHV_X64_REGISTER_PENDING_INTERRUPTION: WHV_REGISTER_NAME = WHV_REGISTER_NAME(i32::MIN); // 0x80000000
+/// TSC register.
+const WHV_X64_REGISTER_TSC: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0x00000011);
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A structure that represents a virtual processor backed by WHP.
+///
+pub struct VirtualProcessor {
+    /// Handle to the WHP partition.
+    partition: windows::Win32::System::Hypervisor::WHV_PARTITION_HANDLE,
+    /// Processor index.
+    index: u32,
+    /// Processor state.
+    online: bool,
+    /// Exit status code.
+    exit_status: u16,
+}
+
+// SAFETY: `VirtualProcessor` only stores a `WHV_PARTITION_HANDLE` (an opaque OS handle) and
+// primitive scalar fields (`u32`, `bool`, `u16`). None of these contain thread-affine state or
+// Rust references. The WHP API synchronises concurrent access to the partition at the OS level.
+// Therefore it is sound to move or share `VirtualProcessor` across threads.
+unsafe impl Send for VirtualProcessor {}
+unsafe impl Sync for VirtualProcessor {}
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+/// Register count for WHP get/set operations.
+fn reg_count(names: &[WHV_REGISTER_NAME]) -> u32 {
+    u32::try_from(names.len()).unwrap_or(u32::MAX)
+}
+
+/// Gets virtual processor registers using raw WHP API.
+unsafe fn whp_get_registers(
+    partition: windows::Win32::System::Hypervisor::WHV_PARTITION_HANDLE,
+    vp_index: u32,
+    names: &[WHV_REGISTER_NAME],
+    values: &mut [WHV_REGISTER_VALUE],
+) -> windows::core::Result<()> {
+    unsafe {
+        WHvGetVirtualProcessorRegisters(
+            partition,
+            vp_index,
+            names.as_ptr(),
+            reg_count(names),
+            values.as_mut_ptr(),
+        )
+    }
+}
+
+/// Sets virtual processor registers using raw WHP API.
+unsafe fn whp_set_registers(
+    partition: windows::Win32::System::Hypervisor::WHV_PARTITION_HANDLE,
+    vp_index: u32,
+    names: &[WHV_REGISTER_NAME],
+    values: &[WHV_REGISTER_VALUE],
+) -> windows::core::Result<()> {
+    unsafe {
+        WHvSetVirtualProcessorRegisters(
+            partition,
+            vp_index,
+            names.as_ptr(),
+            reg_count(names),
+            values.as_ptr(),
+        )
+    }
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl VirtualProcessor {
+    ///
+    /// # Description
+    ///
+    /// Creates a new virtual processor inside the given WHP partition.
+    ///
+    pub fn new(partition: &WhpPartition, index: u32) -> Result<Self> {
+        trace!("VirtualProcessor::new(): index={index}");
+
+        unsafe {
+            WHvCreateVirtualProcessor(partition.handle(), index, 0).map_err(|e| {
+                let reason: String = format!("failed to create virtual processor (error={e:?})");
+                error!("VirtualProcessor::new(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        }
+
+        Ok(Self {
+            partition: partition.handle(),
+            index,
+            online: false,
+            exit_status: 0,
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Resets the virtual processor registers to boot state.
+    ///
+    pub fn reset(&mut self, rip: u64, rax: u64, rbx: u64) -> Result<()> {
+        trace!("reset(): rip={rip:#010x}, rax={rax:#010x}, rbx={rbx:#010x}");
+
+        // Get current CS register.
+        let cs_name: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_CS];
+        let mut cs_value: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+        unsafe {
+            whp_get_registers(self.partition, self.index, &cs_name, &mut cs_value).map_err(
+                |e| {
+                    let reason: String = format!("failed to get CS register (error={e:?})");
+                    error!("reset(): {reason}");
+                    anyhow::anyhow!(reason)
+                },
+            )?;
+        }
+
+        // Modify CS: set base = 0 and selector = 0.
+        cs_value[0].Segment.Base = 0;
+        cs_value[0].Segment.Selector = 0;
+
+        // Set the CS register.
+        unsafe {
+            whp_set_registers(self.partition, self.index, &cs_name, &cs_value).map_err(|e| {
+                let reason: String = format!("failed to set CS register (error={e:?})");
+                error!("reset(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        }
+
+        // Set RIP, RAX, RBX, RFLAGS.
+        let reg_names: [WHV_REGISTER_NAME; 4] = [
+            WHV_X64_REGISTER_RIP,
+            WHV_X64_REGISTER_RAX,
+            WHV_X64_REGISTER_RBX,
+            WHV_X64_REGISTER_RFLAGS,
+        ];
+
+        let mut reg_values: [WHV_REGISTER_VALUE; 4] = [unsafe { mem::zeroed() }; 4];
+        reg_values[0].Reg64 = rip;
+        reg_values[1].Reg64 = rax;
+        reg_values[2].Reg64 = rbx;
+        reg_values[3].Reg64 = RFLAGS_RESERVED_BIT1;
+
+        unsafe {
+            whp_set_registers(self.partition, self.index, &reg_names, &reg_values).map_err(
+                |e| {
+                    let reason: String =
+                        format!("failed to set general purpose registers (error={e:?})");
+                    error!("reset(): {reason}");
+                    anyhow::anyhow!(reason)
+                },
+            )?;
+        }
+
+        self.online = true;
+        Ok(())
+    }
+
+    /// Powers off the virtual processor.
+    pub fn poweroff(&mut self, exit_status: u16) {
+        trace!("poweroff(): exit_status={exit_status}");
+        self.online = false;
+        self.exit_status = exit_status;
+    }
+
+    /// Gets the exit status code of the virtual processor.
+    pub fn exit_status(&self) -> u16 {
+        self.exit_status
+    }
+
+    /// Checks if the virtual processor is online.
+    pub fn is_online(&self) -> bool {
+        self.online
+    }
+
+    /// Returns the raw WHP partition handle (for use by the timer thread).
+    pub fn partition_handle(&self) -> WHV_PARTITION_HANDLE {
+        self.partition
+    }
+
+    /// Retrieves the LAPIC interrupt controller state as a raw byte vector.
+    pub fn get_lapic_state(&self) -> Result<Vec<u8>> {
+        // The WHP xAPIC state blob size is not publicly documented.
+        // Use a 4 KiB buffer (the full APIC register page) which is
+        // large enough for the xAPIC emulation state.
+        let mut state = vec![0u8; 4096];
+        let mut written: u32 = 0;
+        unsafe {
+            WHvGetVirtualProcessorInterruptControllerState2(
+                self.partition,
+                self.index,
+                state.as_mut_ptr().cast(),
+                state.len() as u32,
+                Some(&mut written),
+            )
+            .map_err(|e| anyhow::anyhow!("failed to get LAPIC state (error={e:?})"))?;
+        }
+        state.truncate(written as usize);
+        Ok(state)
+    }
+
+    /// Sets the LAPIC interrupt controller state from a raw byte slice.
+    pub fn set_lapic_state(&mut self, state: &[u8]) -> Result<()> {
+        unsafe {
+            WHvSetVirtualProcessorInterruptControllerState2(
+                self.partition,
+                self.index,
+                state.as_ptr().cast(),
+                state.len() as u32,
+            )
+            .map_err(|e| anyhow::anyhow!("failed to set LAPIC state (error={e:?})"))?;
+        }
+        Ok(())
+    }
+
+    /// Performs a fast LAPIC EOI for the given vector by reading and clearing
+    /// the corresponding ISR bit via individual register access. This is much
+    /// faster than the bulk `WHvGet/SetVirtualProcessorInterruptControllerState2`
+    /// API because it reads/writes a single register instead of 4 KiB.
+    pub fn write_apic_eoi(&self) -> Result<()> {
+        // Vector 0x20 = 32: ISR register index 1 (32/32), bit 0 (32%32).
+        // ISR register names: ApicIsr0=12304, ApicIsr1=12305, ...
+        let isr_reg = WHV_REGISTER_NAME(12305); // WHvX64RegisterApicIsr1
+        let mut values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+        unsafe {
+            whp_get_registers(self.partition, self.index, &[isr_reg], &mut values)
+                .map_err(|e| anyhow::anyhow!("failed to read APIC ISR1 (error={e:?})"))?;
+            // Clear bit 0 (vector 0x20 = 32, which maps to ISR1 bit 0).
+            let isr_val = values[0].Reg64 & !1u64;
+            values[0].Reg64 = isr_val;
+            whp_set_registers(self.partition, self.index, &[isr_reg], &values)
+                .map_err(|e| anyhow::anyhow!("failed to write APIC ISR1 (error={e:?})"))?;
+        }
+        Ok(())
+    }
+
+    /// Cancels a running virtual processor, causing `WHvRunVirtualProcessor` to
+    /// return with the `Canceled` exit reason.
+    pub fn cancel(&self) {
+        unsafe {
+            if let Err(e) = WHvCancelRunVirtualProcessor(self.partition, self.index, 0) {
+                warn!("cancel(): failed to cancel vCPU (error={e:?})");
+            }
+        }
+    }
+
+    /// Reads the current RFLAGS register value.
+    pub fn get_rflags(&self) -> Result<u64> {
+        let names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_RFLAGS];
+        let mut values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+        unsafe {
+            whp_get_registers(self.partition, self.index, &names, &mut values)
+                .map_err(|e| anyhow::anyhow!("failed to get RFLAGS (error={e:?})"))?;
+        }
+        Ok(unsafe { values[0].Reg64 })
+    }
+
+    /// Sets the RFLAGS register to the given value.
+    pub fn set_rflags(&mut self, rflags: u64) -> Result<()> {
+        let names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_RFLAGS];
+        let mut values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+        values[0].Reg64 = rflags;
+        unsafe {
+            whp_set_registers(self.partition, self.index, &names, &values)
+                .map_err(|e| anyhow::anyhow!("failed to set RFLAGS (error={e:?})"))?;
+        }
+        Ok(())
+    }
+
+    /// Reads the current TSC register value.
+    pub fn get_tsc(&self) -> Result<u64> {
+        let names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_TSC];
+        let mut values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+        unsafe {
+            whp_get_registers(self.partition, self.index, &names, &mut values)
+                .map_err(|e| anyhow::anyhow!("failed to get TSC (error={e:?})"))?;
+        }
+        Ok(unsafe { values[0].Reg64 })
+    }
+
+    /// Reads the current RIP register value.
+    pub fn get_rip(&self) -> Result<u64> {
+        let names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_RIP];
+        let mut values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+        unsafe {
+            whp_get_registers(self.partition, self.index, &names, &mut values)
+                .map_err(|e| anyhow::anyhow!("failed to get RIP (error={e:?})"))?;
+        }
+        Ok(unsafe { values[0].Reg64 })
+    }
+
+    /// Sets the RIP register to the given value.
+    pub fn set_rip(&mut self, rip: u64) -> Result<()> {
+        let names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_RIP];
+        let mut values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+        values[0].Reg64 = rip;
+        unsafe {
+            whp_set_registers(self.partition, self.index, &names, &values)
+                .map_err(|e| anyhow::anyhow!("failed to set RIP (error={e:?})"))?;
+        }
+        Ok(())
+    }
+
+    /// Enables or disables interrupt deliverability notifications.
+    /// When enabled, the vCPU will exit with `InterruptWindow` when IF transitions to 1.
+    pub fn set_deliverability_notifications(&mut self, enable: bool) {
+        let names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_DELIVERABILITY_NOTIFICATIONS];
+        let mut values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+        if enable {
+            // Bit 1 = InterruptNotification.
+            values[0].Reg64 = 0x2;
+        }
+        unsafe {
+            if let Err(e) = whp_set_registers(self.partition, self.index, &names, &values) {
+                warn!("set_deliverability_notifications(): failed (error={e:?})");
+            }
+        }
+    }
+
+    /// Injects an external interrupt using the WHP PendingInterruption register.
+    /// The vCPU must be in an interruptible state (IF=1) for this to work.
+    pub fn inject_pending_interruption(&mut self, vector: u32) -> Result<()> {
+        // WHV_X64_PENDING_INTERRUPTION_REGISTER layout (64-bit):
+        //   Bit  0:     InterruptionPending = 1
+        //   Bits 1-3:   InterruptionType = 0 (External interrupt)
+        //   Bits 16-31: InterruptionVector
+        let pending_val: u64 = ((vector as u64) << 16) | 1u64;
+
+        let names = [WHV_X64_REGISTER_PENDING_INTERRUPTION];
+        let mut values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+        values[0].Reg64 = pending_val;
+
+        unsafe {
+            whp_set_registers(self.partition, self.index, &names, &values)
+                .map_err(|e| anyhow::anyhow!("inject_pending_interruption: {e:?}"))?;
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Runs the virtual processor until it exits.
+    ///
+    pub fn run(&mut self) -> VirtualProcessorExitContext {
+        let mut exit_context: WHV_RUN_VP_EXIT_CONTEXT = unsafe { mem::zeroed() };
+        let exit_context_size: u32 =
+            u32::try_from(mem::size_of::<WHV_RUN_VP_EXIT_CONTEXT>()).unwrap_or(u32::MAX);
+
+        let result: windows::core::Result<()> = unsafe {
+            WHvRunVirtualProcessor(
+                self.partition,
+                self.index,
+                (&mut exit_context as *mut WHV_RUN_VP_EXIT_CONTEXT).cast::<std::ffi::c_void>(),
+                exit_context_size,
+            )
+        };
+
+        match result {
+            Ok(()) => self.parse_exit_context(&exit_context),
+            Err(error) => {
+                error!("run(): error running vCPU (error={error:?})");
+                VirtualProcessorExitContext::Interrupted
+            },
+        }
+    }
+
+    /// Parses the WHP exit context and returns the appropriate exit context variant.
+    fn parse_exit_context(
+        &mut self,
+        exit_context: &WHV_RUN_VP_EXIT_CONTEXT,
+    ) -> VirtualProcessorExitContext {
+        match exit_context.ExitReason {
+            // I/O port access (WHvRunVpExitReasonX64IoPortAccess = 2).
+            WHV_RUN_VP_EXIT_REASON(2) => {
+                let io_context = unsafe { &exit_context.Anonymous.IoPortAccess };
+                let port: u16 = io_context.PortNumber;
+
+                // Extract fields from the AccessInfo bitfield.
+                let access_info_raw: u32 = unsafe { io_context.AccessInfo.Anonymous._bitfield };
+                let is_write: bool = (access_info_raw & 1) != 0;
+                let access_size: u8 = ((access_info_raw >> 1) & 0x7) as u8;
+
+                if access_size == 0 {
+                    warn!("run(): unsupported pmio access width (width={access_size})");
+                    return VirtualProcessorExitContext::Unknown;
+                }
+
+                if is_write {
+                    let value: u32 = (io_context.Rax & 0xFFFF_FFFF) as u32;
+                    let width: exit::PmioWidth = match access_size {
+                        1 => exit::PmioWidth::Byte,
+                        2 => exit::PmioWidth::Word,
+                        4 => exit::PmioWidth::Dword,
+                        _ => {
+                            warn!("run(): unsupported pmio write width (width={access_size})");
+                            return VirtualProcessorExitContext::Unknown;
+                        },
+                    };
+                    self.advance_rip(exit_context);
+                    VirtualProcessorExitContext::Pmio(exit::PmioAccess::PmioOut(port, value, width))
+                } else {
+                    let data: Vec<u8> = vec![0u8; access_size as usize];
+                    self.advance_rip(exit_context);
+                    VirtualProcessorExitContext::Pmio(exit::PmioAccess::PmioIn(port, data))
+                }
+            },
+            // Halt (WHvRunVpExitReasonX64Halt = 0x0008).
+            WHV_RUN_VP_EXIT_REASON(8) => VirtualProcessorExitContext::Halt,
+            // Canceled (WHvRunVpExitReasonCanceled = 0x2001).
+            WHV_RUN_VP_EXIT_REASON(0x2001) => VirtualProcessorExitContext::Interrupted,
+            // Interrupt window (WHvRunVpExitReasonX64InterruptWindow = 7).
+            WHV_RUN_VP_EXIT_REASON(7) => VirtualProcessorExitContext::InterruptWindow,
+            // Memory access (WHvRunVpExitReasonMemoryAccess = 1).
+            WHV_RUN_VP_EXIT_REASON(1) => {
+                let gpa: u64 = unsafe { exit_context.Anonymous.MemoryAccess.Gpa };
+                trace!("run(): MMIO access at GPA {gpa:#010x}");
+                VirtualProcessorExitContext::Mmio(gpa)
+            },
+            // Other exit reasons.
+            reason => {
+                warn!("run(): unhandled WHP exit reason ({reason:?})");
+                VirtualProcessorExitContext::Unknown
+            },
+        }
+    }
+
+    /// Advances the instruction pointer past the current instruction after handling a VM exit.
+    fn advance_rip(&mut self, exit_context: &WHV_RUN_VP_EXIT_CONTEXT) {
+        // InstructionLength is packed in the lower 4 bits of VpContext._bitfield
+        // (the InstructionLengthCr8 byte), NOT in ExecutionState._bitfield.
+        let instruction_length: u64 = u64::from(exit_context.VpContext._bitfield & 0xF);
+        let current_rip: u64 = exit_context.VpContext.Rip;
+        let new_rip: u64 = current_rip + instruction_length;
+
+        let reg_names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_RIP];
+        let mut reg_values: [WHV_REGISTER_VALUE; 1] = [unsafe { mem::zeroed() }];
+        reg_values[0].Reg64 = new_rip;
+
+        unsafe {
+            if let Err(e) = whp_set_registers(self.partition, self.index, &reg_names, &reg_values) {
+                warn!("advance_rip(): failed to advance RIP (error={e:?})");
+            }
+        }
+    }
+}
+
+impl Drop for VirtualProcessor {
+    fn drop(&mut self) {
+        trace!("VirtualProcessor::drop()");
+        unsafe {
+            if let Err(e) = WHvDeleteVirtualProcessor(self.partition, self.index) {
+                error!("VirtualProcessor::drop(): failed to delete vCPU (error={e:?})");
+            }
+        }
+    }
+}

--- a/src/uservm/src/vmm/whp/vmem.rs
+++ b/src/uservm/src/vmm/whp/vmem.rs
@@ -1,0 +1,439 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::vmm::whp::partition::WhpPartition;
+use ::anyhow::Result;
+use ::log::{
+    error,
+    trace,
+};
+use ::std::{
+    fs::File,
+    io::{
+        Read,
+        Write,
+    },
+    mem,
+    path::Path,
+    ptr,
+    slice,
+};
+use windows::Win32::System::{
+    Hypervisor::{
+        WHV_MAP_GPA_RANGE_FLAGS,
+        WHvMapGpaRange,
+    },
+    Memory::{
+        MEM_COMMIT,
+        MEM_RELEASE,
+        MEM_RESERVE,
+        PAGE_READWRITE,
+        VirtualAlloc,
+        VirtualFree,
+    },
+};
+
+/// Page size in bytes (4 KiB, matching the x86 architecture).
+#[allow(dead_code)]
+const PAGE_SIZE: usize = 4096;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A structure that represents the memory of a virtual machine backed by WHP.
+///
+pub struct VirtualMemory {
+    /// Virtual memory pointer.
+    ptr: *mut u8,
+    /// Size of the virtual memory.
+    size: usize,
+    /// Pointers to lazily-mapped MMIO dummy pages (freed on drop).
+    mmio_pages: Vec<*mut u8>,
+}
+
+///
+/// # Description
+///
+/// A structure that represents the header in virtual memory snapshot files.
+///
+#[repr(C)]
+struct SnapshotHeader {
+    /// Memory size (8 bytes): usize.
+    memory_size: usize,
+}
+
+// SAFETY: `VirtualMemory` is a thin owner of a contiguous region of virtual memory allocated
+// with `VirtualAlloc` and released in `Drop` via `VirtualFree`. The fields (`ptr: *mut u8` and
+// `size: usize`) are plain data without thread-affine state. All operations that mutate or
+// deallocate the region require exclusive access (`&mut self`), and the allocation is released
+// exactly once during `Drop`. Synchronisation of concurrent access to the pointed-to memory is
+// the responsibility of higher-level code.
+unsafe impl Send for VirtualMemory {}
+unsafe impl Sync for VirtualMemory {}
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+const SIZE_OF_HEADER: usize = mem::size_of::<SnapshotHeader>();
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl VirtualMemory {
+    ///
+    /// # Description
+    ///
+    /// Creates a new virtual memory region and maps it into the WHP partition.
+    ///
+    /// # Parameters
+    ///
+    /// - `partition`: WHP partition that hosts the virtual machine.
+    /// - `size`: Size of the virtual memory.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, the function returns the new virtual memory. Otherwise, it
+    /// returns an error.
+    ///
+    pub fn new(partition: &WhpPartition, size: usize) -> Result<Self> {
+        trace!("VirtualMemory::new(): size={size}");
+
+        // Allocate memory using VirtualAlloc.
+        let ptr: *mut u8 = unsafe {
+            VirtualAlloc(Some(ptr::null()), size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE)
+                .cast::<u8>()
+        };
+
+        if ptr.is_null() {
+            let reason: String = "failed to allocate memory for the virtual machine".to_string();
+            error!("VirtualMemory::new(): {reason} (memory_size={size:?})");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        // Create the VirtualMemory instance (destructor will free memory on error).
+        let vmem: Self = Self {
+            ptr,
+            size,
+            mmio_pages: Vec::new(),
+        };
+
+        // Map the memory into the WHP partition at guest physical address 0.
+        unsafe {
+            WHvMapGpaRange(
+                partition.handle(),
+                ptr as *const std::ffi::c_void,
+                0, // Guest physical address.
+                size as u64,
+                WHV_MAP_GPA_RANGE_FLAGS(7), // Read | Write | Execute.
+            )
+            .map_err(|e| {
+                let reason: String =
+                    format!("failed to map memory into WHP partition (error={e:?})");
+                error!("VirtualMemory::new(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        }
+
+        Ok(vmem)
+    }
+
+    pub fn get_raw_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    pub fn get_size(&self) -> usize {
+        self.size
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Lazily maps a zeroed page at the given guest physical address. This allows guest accesses
+    /// to unmapped MMIO regions to succeed (reads return zero, writes are discarded).
+    ///
+    /// # Parameters
+    ///
+    /// - `partition`: WHP partition that hosts the virtual machine.
+    /// - `gpa`: Guest physical address that caused the memory-access exit.
+    ///
+    pub fn map_mmio_page(&mut self, partition: &WhpPartition, gpa: u64) -> Result<()> {
+        let page_gpa: u64 = gpa & !(PAGE_SIZE as u64 - 1);
+
+        // Allocate a zeroed host page.
+        let page_ptr: *mut u8 = unsafe {
+            VirtualAlloc(Some(ptr::null()), PAGE_SIZE, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE)
+                .cast::<u8>()
+        };
+        if page_ptr.is_null() {
+            anyhow::bail!("map_mmio_page(): failed to allocate MMIO page for GPA {page_gpa:#010x}");
+        }
+
+        // If this is the LAPIC register page (0xFEE00000), pre-populate it
+        // with valid register values so the kernel's LAPIC init code
+        // succeeds without LAPIC emulation.
+        const LAPIC_BASE: u64 = 0xFEE0_0000;
+        if page_gpa == LAPIC_BASE {
+            trace!("map_mmio_page(): populating LAPIC page at GPA {page_gpa:#010x}");
+            let page_slice = unsafe { std::slice::from_raw_parts_mut(page_ptr, PAGE_SIZE) };
+            let write_u32 = |s: &mut [u8], off: usize, val: u32| {
+                s[off..off + 4].copy_from_slice(&val.to_le_bytes());
+            };
+            // APIC ID: 0 (processor 0).
+            write_u32(page_slice, 0x20, 0);
+            // APIC Version: 0x50014 (version 0x14, max LVT entries 5).
+            write_u32(page_slice, 0x30, 0x0005_0014);
+            // SVR: 0xFF (APIC disabled, spurious vector 0xFF — kernel default).
+            write_u32(page_slice, 0xF0, 0xFF);
+        }
+
+        // Map the page into the WHP partition.
+        let result = unsafe {
+            WHvMapGpaRange(
+                partition.handle(),
+                page_ptr as *const std::ffi::c_void,
+                page_gpa,
+                PAGE_SIZE as u64,
+                WHV_MAP_GPA_RANGE_FLAGS(7), // Read | Write | Execute.
+            )
+        };
+
+        if let Err(e) = result {
+            // Free the page on mapping failure.
+            unsafe {
+                let _ = VirtualFree(page_ptr.cast(), 0, MEM_RELEASE);
+            }
+            anyhow::bail!(
+                "map_mmio_page(): failed to map MMIO page at GPA {page_gpa:#010x} (error={e:?})"
+            );
+        }
+
+        trace!("map_mmio_page(): mapped zeroed page at GPA {page_gpa:#010x}");
+        self.mmio_pages.push(page_ptr);
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Writes bytes into the virtual memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `addr`: Address in the virtual memory.
+    /// - `data`: Data to write.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn write_bytes(&mut self, addr: u64, data: &[u8]) -> Result<()> {
+        let addr: usize = match usize::try_from(addr) {
+            Ok(v) => v,
+            Err(_) => {
+                let reason: String = format!("invalid address (addr={addr:#010x})");
+                error!("write_bytes(): {reason}");
+                return Err(anyhow::anyhow!(reason));
+            },
+        };
+
+        // Check if region lies within the virtual memory.
+        if addr + data.len() > self.size {
+            let reason: String = format!("invalid memory access (addr={addr:#010x})");
+            error!("write_bytes(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        unsafe {
+            ptr::copy_nonoverlapping(data.as_ptr(), self.ptr.add(addr), data.len());
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reads bytes from the virtual memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `addr`: Address in the virtual memory.
+    /// - `data`: Buffer to read into.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn read_bytes(&self, addr: u64, data: &mut [u8]) -> Result<()> {
+        let addr: usize = match usize::try_from(addr) {
+            Ok(v) => v,
+            Err(_) => {
+                let reason: String = format!("invalid address (addr={addr:#010x})");
+                error!("read_bytes(): {reason}");
+                return Err(anyhow::anyhow!(reason));
+            },
+        };
+
+        // Check if region lies within the virtual memory.
+        if addr + data.len() > self.size {
+            let reason: String = format!("invalid memory access (addr={addr:#010x})");
+            error!("read_bytes(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        unsafe {
+            ptr::copy_nonoverlapping(self.ptr.add(addr), data.as_mut_ptr(), data.len());
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Saves the current state of the virtual memory to a snapshot file.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the snapshot file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn save_snapshot(&self, path: &Path) -> Result<()> {
+        trace!("save_snapshot(): writing to {:?}", path);
+
+        let mut file: File = match File::create(path) {
+            Ok(f) => f,
+            Err(e) => {
+                let reason: String =
+                    format!("failed creating virtual memory snapshot file (error={e:?})");
+                error!("save_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let header: SnapshotHeader = SnapshotHeader {
+            memory_size: self.size,
+        };
+
+        // SAFETY: `SnapshotHeader` is `#[repr(C)]` plain-old-data with no padding or
+        // invalid bit patterns. We create a byte slice of exactly `SIZE_OF_HEADER` bytes
+        // from a live, properly aligned reference, which is safe to write out.
+        let header_bytes: &[u8] = unsafe {
+            slice::from_raw_parts((&header as *const SnapshotHeader).cast::<u8>(), SIZE_OF_HEADER)
+        };
+
+        if let Err(e) = file.write_all(header_bytes) {
+            let reason: String =
+                format!("failed writing the header to virtual memory snapshot file (error={e:?})");
+            error!("save_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        let memory_slice: &[u8] = unsafe { slice::from_raw_parts(self.ptr, self.size) };
+        if let Err(e) = file.write_all(memory_slice) {
+            let reason: String = format!("failed to write memory contents (error={e:?})");
+            error!("save_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        if let Err(e) = file.sync_all() {
+            let reason: String = format!("failed to sync snapshot file (error={e:?})");
+            error!("save_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Loads a virtual memory snapshot from a snapshot file.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the snapshot file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn load_snapshot(&mut self, path: &Path) -> Result<()> {
+        trace!("load_snapshot(): reading from {:?}", path);
+
+        let mut file: File = match File::open(path) {
+            Ok(f) => f,
+            Err(e) => {
+                let reason: String =
+                    format!("failed opening virtual memory snapshot file (error={e:?})");
+                error!("load_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let mut header_bytes: [u8; SIZE_OF_HEADER] = [0u8; SIZE_OF_HEADER];
+        match file.read_exact(&mut header_bytes) {
+            Ok(()) => {},
+            Err(e) => {
+                let reason: String = format!(
+                    "failed reading header from virtual memory snapshot file (error={e:?})"
+                );
+                error!("load_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        // SAFETY: `SnapshotHeader` is `#[repr(C)]` with a single `usize` field, so every
+        // bit pattern of `SIZE_OF_HEADER` bytes is a valid `SnapshotHeader` (no invalid
+        // representations). We have read exactly `SIZE_OF_HEADER` bytes from the file.
+        let header: SnapshotHeader =
+            unsafe { ptr::read_unaligned(header_bytes.as_ptr().cast::<SnapshotHeader>()) };
+
+        if header.memory_size != self.size {
+            let reason: String =
+                format!("memory size mismatch: expected {}, got {}", self.size, header.memory_size);
+            error!("load_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        let memory_slice: &mut [u8] = unsafe { slice::from_raw_parts_mut(self.ptr, self.size) };
+        if let Err(e) = file.read_exact(memory_slice) {
+            let reason: String = format!("failed to read memory contents (error={e:?})");
+            error!("load_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for VirtualMemory {
+    fn drop(&mut self) {
+        // Free MMIO dummy pages first.
+        for page_ptr in self.mmio_pages.drain(..) {
+            unsafe {
+                if VirtualFree(page_ptr.cast(), 0, MEM_RELEASE).is_err() {
+                    error!("VirtualFree() failed for MMIO page");
+                }
+            }
+        }
+        unsafe {
+            if VirtualFree(self.ptr.cast(), 0, MEM_RELEASE).is_err() {
+                error!("VirtualFree() failed");
+            }
+        }
+    }
+}

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -30,7 +30,16 @@ pub const DEFAULT_TOOLCHAIN_BIN_DIRECTORY: &str = "./toolchain/bin";
 ///
 /// Default path to the temporary directory.
 ///
+#[cfg(unix)]
 pub const DEFAULT_TMP_DIRECTORY: &str = "/tmp";
+
+///
+/// # Description
+///
+/// Default path to the temporary directory.
+///
+#[cfg(windows)]
+pub const DEFAULT_TMP_DIRECTORY: &str = ".";
 
 ///
 /// # Description

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -465,8 +465,12 @@ async fn create_tmp_dir(tmp_directory: &str) -> Result<TemporaryDirectory> {
 
     // Encode timestamp in base64url using RFC 4648 compliant filename-safe characters.
     let tmp_dirname: String = encode_base64_filename(timestamp_micros);
+    #[cfg(unix)]
     let tmp_directory_path: PathBuf =
         PathBuf::from(tmp_directory).join(format!("{NAMED_RESOURCE_PREFIX}:{}", tmp_dirname));
+    #[cfg(windows)]
+    let tmp_directory_path: PathBuf =
+        PathBuf::from(tmp_directory).join(format!("{NAMED_RESOURCE_PREFIX}-{}", tmp_dirname));
 
     // Check if temporary directory already exists (extremely unlikely with timestamp-based naming).
     if tmp_directory_path.exists() {

--- a/src/utils/nanvixd/src/tempdir.rs
+++ b/src/utils/nanvixd/src/tempdir.rs
@@ -239,7 +239,10 @@ mod tests {
     #[tokio::test]
     async fn test_create_failure() {
         // Use an invalid path that cannot be created.
+        #[cfg(unix)]
         let path: PathBuf = PathBuf::from("/proc/invalid/path/that/cannot/be/created");
+        #[cfg(windows)]
+        let path: PathBuf = PathBuf::from("\\\\?\\invalid:\\<>|path");
         let result: Result<TemporaryDirectory> = TemporaryDirectory::new(path).await;
 
         assert!(result.is_err(), "Expected new() to fail for invalid path");

--- a/z.bat
+++ b/z.bat
@@ -1,0 +1,4 @@
+@echo off
+REM Copyright(c) The Maintainers of Nanvix.
+REM Licensed under the MIT License.
+powershell.exe -ExecutionPolicy Bypass -NoProfile -File "%~dp0z.ps1" %*

--- a/z.ps1
+++ b/z.ps1
@@ -1,0 +1,577 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Utility for building and running Nanvix on Windows.
+
+.DESCRIPTION
+    Windows counterpart of the './z' bash script. Mirrors the same CLI interface.
+    Builds the UserVM natively on Windows with the microvm backend, and builds guest
+    components (kernel, hello-rust-nostd) via Docker.
+
+.EXAMPLE
+    .\z.ps1 help
+    .\z.ps1 build -- all
+    .\z.ps1 build -- uservm
+    .\z.ps1 build -- guest
+    .\z.ps1 build -- lint-check
+    .\z.ps1 clean
+    .\z.ps1 distclean
+    .\z.ps1 setup
+    .\z.ps1 run
+#>
+
+# ==================================================================================================
+# Configuration
+# ==================================================================================================
+
+$ErrorActionPreference = "Stop"
+
+$RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+if (-not $RootDir) { $RootDir = Get-Location }
+$BinDir = Join-Path $RootDir "bin"
+
+# ==================================================================================================
+# Logging
+# ==================================================================================================
+
+function Write-Info { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundColor Cyan }
+function Write-Success { param([string]$Msg) Write-Host "[OK]   $Msg" -ForegroundColor Green }
+function Write-Warn { param([string]$Msg) Write-Host "[WARN] $Msg" -ForegroundColor Yellow }
+function Write-Err { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red }
+
+# ==================================================================================================
+# Help
+# ==================================================================================================
+
+function Show-Help {
+    Write-Host @"
+
+Utility for building Nanvix on Windows.
+
+Usage:
+  .\z.ps1 COMMAND [OPTIONS] [-- BUILD_TARGET BUILD_PARAMETERS]
+  .\z.ps1 build [-- BUILD_TARGET BUILD_PARAMETERS]
+  .\z.ps1 clean
+  .\z.ps1 distclean
+  .\z.ps1 setup
+  .\z.ps1 run [-- RUN_OPTIONS]
+  .\z.ps1 help
+
+Commands
+  build       Builds Nanvix.
+  clean       Removes build artifacts (quick clean).
+  distclean   Removes everything (full clean).
+  setup       Sets up the Nanvix development environment (pulls Docker image).
+  run         Runs UserVM in standalone mode.
+  help        Prints this help message.
+
+Options
+  --release               Build in release mode.
+  --with-docker           Use the full Docker toolchain image.
+  --with-minimal-docker   Use the minimal Docker toolchain image (default).
+
+Build Targets (after --)
+  all                     Build everything (guest + uservm + nanvixd).
+  uservm                  Build UserVM only (native Windows, microvm backend).
+  nanvixd                 Build nanvixd only (native Windows, standalone + microvm).
+  nanvix-test             Build nanvix-test only (native Windows, standalone + microvm).
+  guest                   Build guest components only (kernel + hello-rust-nostd).
+  format-check            Check code formatting (via Docker).
+  lint-check              Check for linting issues (via Docker).
+  format                  Fix code formatting (via Docker).
+  lint                    Fix linting issues (via Docker).
+  spellcheck              Check spelling (via Docker).
+  spellcheck-fix          Fix spelling errors (via Docker).
+  check                   Run cargo check (via Docker).
+  run-unit-tests          Run unit tests (via Docker).
+  run-nanvix-tests        Run system integration tests (via Docker).
+  test                    Run all tests (via Docker).
+  verify                  Run Verus formal verification (via Docker).
+  <any-make-target>       Any other target is forwarded to make via Docker.
+
+Run Options (after --)
+  -kernel <path>          Path to kernel binary (default: bin/kernel.elf).
+  -initrd <path>          Path to guest binary (default: bin/hello-rust-nostd.elf).
+  -memory <size>          Memory size with suffix K/M/G (default: 32M).
+
+Build Parameters (after --)
+  RELEASE=yes             Enable release mode.
+  MACHINE=microvm         Target machine (default: microvm).
+  LOG_LEVEL=warn          Log level (default: warn).
+
+Prerequisites
+  - Docker Desktop for Windows (with Linux containers enabled).
+  - Windows Hypervisor Platform enabled (for running the UserVM).
+  - Rust toolchain on Windows (via rustup).
+
+"@
+}
+
+# ==================================================================================================
+# Symlink Helpers
+# ==================================================================================================
+
+# On Windows with core.symlinks=false, Git checks out symlinks as missing files (or small text files
+# containing the target path). This function detects such entries and materializes them as copies of
+# the target so that the Docker build context includes the correct file content.
+function Restore-GitSymlinks {
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    Write-Info "Restoring Git symlinks as file copies (Windows workaround)..."
+    $restored = 0
+    # List all git symlinks (mode 120000).
+    $symlinkLines = git ls-files -s 2>$null | Where-Object { $_ -match '^120000' }
+    foreach ($line in $symlinkLines) {
+        # Format: "120000 <hash> <stage>\t<path>"
+        $parts = $line -split '\t', 2
+        if ($parts.Count -lt 2) { continue }
+        $filePath = $parts[1].Trim()
+        if (-not $filePath) { continue }
+
+        # Extract the blob hash from the metadata portion.
+        $metaParts = $parts[0] -split '\s+'
+        if ($metaParts.Count -lt 2) { continue }
+        $blobHash = $metaParts[1]
+
+        $absPath = Join-Path $RootDir $filePath
+
+        # Read the raw symlink target from the blob object.
+        # For mode 120000, the blob content is the relative target path.
+        # NOTE: Do NOT use 'git show HEAD:<path>' - it follows symlinks
+        # and returns the resolved file content instead of the target path.
+        $target = (git cat-file blob $blobHash 2>$null)
+        if (-not $target) { continue }
+        # cat-file may return an array of lines; join them first.
+        if ($target -is [array]) { $target = $target -join "`n" }
+        $target = $target.Trim()
+
+        # Sanity check: symlink targets are short relative paths (e.g.
+        # "../../shared/build.rs"). If the blob content looks like source
+        # code (multi-line or very long), the entry is not a real symlink
+        # or has already been resolved - skip it.
+        if ($target.Contains("`n") -or $target.Length -gt 500) {
+            continue
+        }
+
+        # Resolve the target relative to the symlink's directory.
+        $fileDir = Split-Path $absPath -Parent
+        $targetAbsPath = Join-Path $fileDir $target
+        $targetAbsPath = [System.IO.Path]::GetFullPath($targetAbsPath)
+
+        if (-not (Test-Path $targetAbsPath)) {
+            Write-Warn "Symlink target not found: $filePath -> $target"
+            continue
+        }
+
+        # Create parent directory if needed.
+        $parentDir = Split-Path $absPath -Parent
+        if (-not (Test-Path $parentDir)) {
+            New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+        }
+
+        # Copy the target content as the symlink file.
+        if (Test-Path $targetAbsPath -PathType Container) {
+            # Target is a directory; copy as directory.
+            if (Test-Path $absPath) { Remove-Item $absPath -Recurse -Force }
+            Copy-Item -Path $targetAbsPath -Destination $absPath -Recurse -Force
+        }
+        else {
+            Copy-Item -Path $targetAbsPath -Destination $absPath -Force
+        }
+        $restored++
+    }
+    if ($restored -gt 0) {
+        Write-Info "Restored $restored symlink(s) as file copies."
+    }
+    else {
+        Write-Info "No symlinks needed restoring."
+    }
+}
+
+# Removes the materialized symlink copies and restores the original Git symlink
+# text files so they don't pollute the working tree.
+function Remove-RestoredSymlinks {
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    $symlinkPaths = @()
+    $symlinkLines = git ls-files -s 2>$null | Where-Object { $_ -match '^120000' }
+    foreach ($line in $symlinkLines) {
+        $parts = $line -split '\t', 2
+        if ($parts.Count -lt 2) { continue }
+        $filePath = $parts[1].Trim()
+        if (-not $filePath) { continue }
+        $absPath = Join-Path $RootDir $filePath
+        if (Test-Path $absPath) {
+            Remove-Item $absPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        $symlinkPaths += $filePath
+    }
+
+    # Restore the original symlink text files from Git so the working tree stays clean.
+    if ($symlinkPaths.Count -gt 0) {
+        foreach ($sp in $symlinkPaths) {
+            git checkout -- $sp 2>$null
+        }
+    }
+}
+
+# ==================================================================================================
+# Docker
+# ==================================================================================================
+
+function Assert-DockerAvailable {
+    $dockerAvailable = Get-Command docker -ErrorAction SilentlyContinue
+    if (-not $dockerAvailable) {
+        Write-Err "Docker is not available. Install Docker Desktop for Windows."
+        exit 1
+    }
+}
+
+function Assert-DockerImageAvailable {
+    param([string]$ImageName)
+    # Temporarily suppress errors from native commands so that Docker stderr
+    # does not trigger a terminating error under $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'SilentlyContinue'
+    docker image inspect $ImageName >$null 2>&1
+    $exitCode = $LASTEXITCODE
+    $ErrorActionPreference = 'Stop'
+    if ($exitCode -ne 0) {
+        Write-Err "Docker image '$ImageName' not found locally. Run '.\z setup' to pull it."
+        exit 1
+    }
+}
+
+function Get-DockerImageName {
+    param([bool]$UseMinimal = $true)
+    $cargoToml = Join-Path $RootDir "Cargo.toml"
+    $versionLine = Select-String -Path $cargoToml -Pattern '^version\s*=\s*"([^"]+)"' | Select-Object -First 1
+    if ($versionLine -and $versionLine.Matches[0].Groups[1].Value) {
+        $v = $versionLine.Matches[0].Groups[1].Value -split '\.'
+        $imageTag = "v$($v[0]).$($v[1]).x"
+    }
+    else {
+        $imageTag = "latest"
+        Write-Warn "Could not parse version from Cargo.toml, using '$imageTag'."
+    }
+    $suffix = if ($UseMinimal) { "-minimal" } else { "" }
+    return "nanvix/toolchain:$imageTag$suffix"
+}
+
+function Invoke-DockerBuild {
+    param([string]$BuildParams, [bool]$IsRelease = $false, [bool]$UseMinimal = $true)
+
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    Assert-DockerAvailable
+
+    $imageName = Get-DockerImageName -UseMinimal $UseMinimal
+
+    # Validate that the Docker image exists locally before attempting the build.
+    Assert-DockerImageAvailable -ImageName $imageName
+
+    # Restore Git symlinks as file copies so the Docker build context is complete.
+    Restore-GitSymlinks
+
+    Write-Host "  Image: $imageName" -ForegroundColor DarkGray
+
+    $sysrootSuffix = if ($IsRelease) { "release" } else { "debug" }
+
+    $dockerfilePath = Join-Path $RootDir "scripts/setup/Dockerfile.build"
+    if (-not (Test-Path $dockerfilePath)) {
+        Remove-RestoredSymlinks
+        Write-Err "Build Dockerfile not found at $dockerfilePath"
+        exit 1
+    }
+
+    $env:DOCKER_BUILDKIT = "1"
+    Write-Host "  docker build (params: $BuildParams)" -ForegroundColor DarkGray
+
+    # Remove the local .venv directory if it exists. Docker builds may create a
+    # .venv inside the container with a lib64 -> lib symlink (standard Linux Python
+    # venv). If a previous Docker export left a broken reparse point at .venv\lib64
+    # on Windows, the output exporter fails with "The file cannot be accessed by
+    # the system." Removing it beforehand prevents this.
+    $localVenv = Join-Path $RootDir ".venv"
+    if (Test-Path $localVenv) {
+        # Use cmd to remove in case of broken reparse points that PowerShell can't handle.
+        cmd /c "rmdir /s /q `"$localVenv`"" 2>$null
+        if (Test-Path $localVenv) {
+            Remove-Item $localVenv -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    docker build `
+        --build-arg "BASE_IMAGE=$imageName" `
+        --build-arg "BUILD_PARAMS=$BuildParams" `
+        --build-arg "SYSROOT_SUFFIX=$sysrootSuffix" `
+        --build-arg "WORKSPACE_PATH=/mnt" `
+        --output "type=local,dest=." `
+        --progress=plain `
+        -f $dockerfilePath `
+        $RootDir
+
+    $buildExitCode = $LASTEXITCODE
+
+    # Clean up materialized symlink copies.
+    Remove-RestoredSymlinks
+
+    if ($buildExitCode -ne 0) {
+        Write-Err "Docker build failed (params: $BuildParams)."
+        exit 1
+    }
+}
+
+# ==================================================================================================
+# Build Functions
+# ==================================================================================================
+
+function Build-UserVm {
+    param([bool]$IsRelease)
+
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    $mode = if ($IsRelease) { "release" } else { "debug" }
+    $profile = if ($IsRelease) { "--release" } else { "" }
+
+    Write-Info "Building UserVM (microvm backend, $mode mode)..."
+
+    if (-not (Test-Path $BinDir)) {
+        New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+    }
+
+    $cmd = "cargo build --no-default-features --features `"microvm`" -p uservm $profile"
+    Write-Host "  $cmd" -ForegroundColor DarkGray
+    Invoke-Expression $cmd
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Failed to build UserVM."
+        exit 1
+    }
+
+    $src = Join-Path (Join-Path (Join-Path $RootDir "target") $mode) "uservm.exe"
+    $dst = Join-Path $BinDir "uservm.exe"
+    if (Test-Path $src) {
+        Copy-Item $src $dst -Force
+        Write-Info "Output: $dst"
+    }
+    else {
+        Write-Err "UserVM binary not found at $src"
+        exit 1
+    }
+}
+
+function Build-Guest {
+    param([bool]$IsRelease, [bool]$UseMinimal = $true, [string[]]$ExtraMakeParams = @())
+
+    Write-Info "Building guest components (Docker)..."
+    $releaseFlag = if ($IsRelease) { "RELEASE=yes" } else { "" }
+    $buildParams = "all-guest-staticlibs all-kernel all-guest-binaries all-nanvixd $releaseFlag MACHINE=microvm DEPLOYMENT_MODE=standalone"
+    if ($ExtraMakeParams.Count -gt 0) {
+        $buildParams += " " + ($ExtraMakeParams -join ' ')
+    }
+    Invoke-DockerBuild -BuildParams $buildParams -IsRelease $IsRelease -UseMinimal $UseMinimal
+    Write-Info "Guest components built successfully."
+}
+
+# ==================================================================================================
+# Clean
+# ==================================================================================================
+
+function Invoke-Clean {
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    Write-Info "Removing build artifacts (quick clean)..."
+    cargo clean -p uservm 2>$null
+    cargo clean -p nanvixd 2>$null
+    cargo clean -p nanvix-test 2>$null
+    $uvmBin = Join-Path $BinDir "uservm.exe"
+    if (Test-Path $uvmBin) { Remove-Item $uvmBin -Force }
+    $nanvixdBin = Join-Path $BinDir "nanvixd.exe"
+    if (Test-Path $nanvixdBin) { Remove-Item $nanvixdBin -Force }
+    $nanvixTestBin = Join-Path $BinDir "nanvix-test.exe"
+    if (Test-Path $nanvixTestBin) { Remove-Item $nanvixTestBin -Force }
+    Write-Success "Quick clean complete."
+}
+
+function Invoke-DistClean {
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    Write-Info "Removing everything (full clean)..."
+    cargo clean 2>$null
+    if (Test-Path $BinDir) {
+        $uvmBin = Join-Path $BinDir "uservm.exe"
+        if (Test-Path $uvmBin) { Remove-Item $uvmBin -Force }
+        $nanvixdBin = Join-Path $BinDir "nanvixd.exe"
+        if (Test-Path $nanvixdBin) { Remove-Item $nanvixdBin -Force }
+    }
+    Write-Success "Full cleanup complete."
+}
+
+# ==================================================================================================
+# Setup
+# ==================================================================================================
+
+function Invoke-Setup {
+    param([bool]$UseMinimal = $true)
+
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    Write-Info "Setting up Nanvix development environment..."
+
+    Assert-DockerAvailable
+
+    $imageName = Get-DockerImageName -UseMinimal $UseMinimal
+    Write-Info "Pulling Docker image: $imageName"
+    docker pull $imageName
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Failed to pull Docker image '$imageName'."
+        exit 1
+    }
+
+    Write-Success "Docker image '$imageName' downloaded successfully."
+    Write-Success "Setup complete."
+}
+
+# ==================================================================================================
+# Main
+# ==================================================================================================
+
+function Main {
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    if ($args.Count -eq 0) {
+        Write-Err "No command provided."
+        Show-Help
+        exit 1
+    }
+
+    $command = $args[0]
+    $remaining = @()
+    if ($args.Count -gt 1) { $remaining = $args[1..($args.Count - 1)] }
+
+    # If the first argument looks like a build target (not a known command),
+    # treat it as an implicit "build <target>" for convenience.
+    $knownCommands = @("build", "clean", "distclean", "setup", "help")
+    if ($command -notin $knownCommands) {
+        $remaining = @($command) + $remaining
+        $command = "build"
+    }
+
+    # Parse options and positional arguments.
+    $isRelease = $false
+    $useMinimalDocker = $true
+    $buildParams = @()
+
+    foreach ($arg in $remaining) {
+        if ($arg -eq "--") { continue }
+        if ($arg.StartsWith("--")) {
+            switch ($arg) {
+                "--release" { $isRelease = $true }
+                "--with-docker" { $useMinimalDocker = $false }
+                "--with-minimal-docker" { $useMinimalDocker = $true }
+                default {
+                    Write-Err "Unknown option: $arg"
+                    exit 1
+                }
+            }
+        }
+        else {
+            $buildParams += $arg
+        }
+    }
+
+    # Check for RELEASE=yes in build parameters.
+    foreach ($p in $buildParams) {
+        if ($p -eq "RELEASE=yes") { $isRelease = $true }
+    }
+
+    switch ($command) {
+
+        "build" {
+            if ($buildParams.Count -eq 0) {
+                Write-Err "No build target specified. Use: .\z.ps1 build <all|uservm|guest>"
+                exit 1
+            }
+
+            Write-Info "Command:  build"
+            Write-Info "Release:  $isRelease"
+            Write-Info "Minimal:  $useMinimalDocker"
+            Write-Info "Targets:  $($buildParams -join ' ')"
+            Write-Host ""
+
+            # Separate targets and make-style key=value parameters.
+            $targets = @()
+            $makeParams = @()
+            foreach ($param in $buildParams) {
+                if ($param -match '=') {
+                    $makeParams += $param
+                }
+                else {
+                    $targets += $param
+                }
+            }
+
+            foreach ($target in $targets) {
+                switch ($target) {
+                    "all" {
+                        Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams
+                        Build-UserVm -IsRelease $isRelease
+                    }
+                    "uservm" {
+                        Build-UserVm -IsRelease $isRelease
+                    }
+                    "guest" {
+                        Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams
+                    }
+                    default {
+                        # Forward any other target to Docker make (mirrors bash z behavior).
+                        $dockerParams = @($target) + $makeParams
+                        # Add default MACHINE if not specified by the user.
+                        if (-not ($makeParams | Where-Object { $_ -match '^MACHINE=' })) {
+                            $dockerParams += "MACHINE=microvm"
+                        }
+                        Write-Info "Forwarding '$target' to Docker..."
+                        Invoke-DockerBuild -BuildParams ($dockerParams -join ' ') -IsRelease $isRelease -UseMinimal $useMinimalDocker
+                    }
+                }
+            }
+
+            Write-Host ""
+            Write-Success "Build complete."
+        }
+
+        "clean" {
+            Invoke-Clean
+        }
+
+        "distclean" {
+            Invoke-DistClean
+        }
+
+        "setup" {
+            Invoke-Setup -UseMinimal $useMinimalDocker
+        }
+
+        "help" {
+            Show-Help
+        }
+
+        default {
+            Write-Err "Unknown command: '$command'"
+            Show-Help
+            exit 1
+        }
+    }
+}
+
+Main @args


### PR DESCRIPTION
# [build] Initial Support for Windows

Adds Windows Hypervisor Platform (WHP) backend support for running the Nanvix UserVM natively on Windows. Guest components (kernel, user binaries) remain cross-compiled inside Docker while the UserVM host binary is built natively with `cargo`.

## Changes

**35 files changed, +4 085 / −56 lines across 5 commits.**

### WHP VMM backend (`src/uservm/src/vmm/whp/`, ~3 070 lines)

Full virtual machine monitor using the Windows Hypervisor Platform API:

| Module | Purpose |
|--------|---------|
| `partition.rs` | WHP partition lifecycle (create, configure LAPIC emulation, teardown) |
| `vcpu/mod.rs` | vCPU create/reset/run loop, register access, interrupt injection |
| `vcpu/exit.rs` | Exit-reason types (`PmioAccess`, `MmioAccess`, `Halt`, `Interrupted`, …) |
| `vmem.rs` | Guest physical memory (`VirtualAlloc` + `WHvMapGpaRange`), snapshot save/load, lazy MMIO page mapping |
| `guest.rs` | Kernel & initrd loading, credits register, VM reset |
| `emulator.rs` | PMIO port dispatch (stdout, stdin, VMM control port, legacy hardware) |
| `timer.rs` | Host-side periodic timer thread injecting IRQ 0 via `WHvRequestInterrupt` |
| `lapic.rs` | LAPIC constants (timer vector) |
| `ramfs.rs` | RAM filesystem image loading into guest memory |
| `mod.rs` | Top-level VMM glue, pvclock setup/update, IKC notifier, run loop, watchdog |

### Windows build system (`z.ps1`, `z.bat`, 577 + 4 lines)

PowerShell build script mirroring the Linux `z` utility:
- Cross-compiles guest components (kernel, user binaries, daemons) via Docker.
- Builds host components (`uservm`, `nanvixd`, `nanvix-test`) natively with `cargo`.
- Handles symlink-as-text-file restoration on Windows (Git checks out symlinks as plain files).
- Supports `setup`, `build`, `run`, `test`, `clean`, `fmt`, `clippy` subcommands.

### Platform abstraction (`src/uservm/src/pal/windows.rs`)

Windows `FileMapping` implementation that reads files into `Vec<u8>` (replaces Linux `mmap`-based PAL).

### Cross-platform gating

Conditional compilation (`#[cfg(unix)]` / `#[cfg(target_os = "windows")]`) applied across libraries and the UserVM:

| Crate | What was gated |
|-------|---------------|
| `hwloc` | CPU pinning (`sched_setaffinity`, `parse_cpu_mask`) — no-op on Windows |
| `nanvix-sandbox` | `ExitStatus::from_raw` platform-specific encoding |
| `syscomm` | Unix domain socket types, listeners, streams, readers, writers |
| `uservm` | `io_thread` module, `build_input_fn`, `output_fn` variants, `IkcNotifier`, managed-mode entry point |
| `nanvixd` | Temporary directory path, colon-free path formatting on Windows |
| `config` | `MICROSECONDS_PER_SECOND` constant, `TIMER_PERIOD_US` derivation, `DEFAULT_TMP_DIRECTORY` |

### Other

- `.gitattributes`: Line-ending normalisation rules (`eol=lf` for source, `eol=crlf` for `.ps1`/`.bat`).
- `Cargo.toml` (workspace): `windows` crate dependency with `Win32_System_Hypervisor`, `Win32_System_Memory`, `Win32_System_Threading` features.
- `UserVmIdentifier` shim for non-Linux targets in `src/uservm/src/args.rs`.

## Prerequisites

- Windows 10/11 with **Windows Hypervisor Platform** enabled.
- **Docker Desktop** (Linux containers mode) for cross-compiling guest binaries.
- **Rust toolchain** (stable, installed via `rustup`).

## How to Build

```powershell
# One-time setup: pull the Docker toolchain image.
.\z.ps1 setup

# Build everything (guest via Docker + UserVM natively).
.\z.ps1 build -- all

# Guest components only (kernel + user binaries, via Docker).
.\z.ps1 build -- guest

# UserVM only (native Windows, WHP backend).
.\z.ps1 build -- uservm

# Release build.
.\z.ps1 build -- all RELEASE=yes
```

## How to Test

```powershell
# Run all passing Windows tests.
.\bin\nanvix-test.exe test\test-standalone-windows.toml

# Run specific test subsets.
.\bin\nanvix-test.exe -test "terminal/echo*" test\test-standalone-windows.toml
.\bin\nanvix-test.exe -test "terminal/hello*" test\test-standalone-windows.toml
.\bin\nanvix-test.exe -test "empty*" test\test-standalone-windows.toml

# Run the UserVM directly (without test harness).
.\z.ps1 run
.\z.ps1 run -- -kernel bin\kernel.elf -initrd bin\hello-rust-nostd.elf -memory 64M
```

## Known Limitations

- **Snapshot support**: Not implemented on the WHP backend (stubs return `Ok`).
- **Managed mode**: Disabled on Windows; only `-standalone` execution is supported.
- **vCPU force-kill**: Cooperative shutdown only; the orchestrator cannot forcefully terminate a hung vCPU on Windows (requires a cancellation callback — see TODO comments).
- **Unix domain sockets**: Gated out on Windows; TCP sockets are used instead.
