### PR TITLE
[libs] Fix bitmap alloc_range not wrapping around next_free hint

### DIFF
--- a/src/libs/bitmap/src/lib.rs
+++ b/src/libs/bitmap/src/lib.rs
@@ -181,17 +181,34 @@ impl Bitmap {
             "bitmap length must match the number of bits"
         );
 
-        let mut start: usize = self.next_free;
+        let initial_start: usize = self.next_free;
+        let mut start: usize = initial_start;
+        let mut wrapped: bool = false;
 
-        // Traverse the bitmap until the last possible starting bit.
-        while start <= self.number_of_bits - size {
-            // Check for fast skip/ path.
+        // Traverse the bitmap, wrapping around once if needed.
+        loop {
+            // Stop condition: exceeded the last valid starting position.
+            if start > self.number_of_bits - size {
+                // If we haven't wrapped yet and started past 0, retry from beginning.
+                if !wrapped && initial_start > 0 {
+                    start = 0;
+                    wrapped = true;
+                } else {
+                    break;
+                }
+            }
+
+            // After wrap-around, stop if we've reached the initial position.
+            if wrapped && start >= initial_start {
+                break;
+            }
+
+            // Check for fast skip path.
             let is_aligned: bool = start.is_multiple_of(u8::BITS as usize);
             if is_aligned {
                 let word: usize = start / u8::BITS as usize;
                 // Fast skip: if the starting word is full, skip to the next word.
                 if self.bits[word] == u8::MAX {
-                    // Jump to next byte boundary.
                     start += u8::BITS as usize;
                     continue;
                 }
@@ -209,7 +226,7 @@ impl Bitmap {
                 }
             }
             if free {
-                // Allocate the range
+                // Allocate the range.
                 for offset in 0..size {
                     let idx: usize = start + offset;
                     let (w, b): (usize, usize) = self.index_unchecked(idx);

--- a/src/libs/bitmap/src/test.rs
+++ b/src/libs/bitmap/src/test.rs
@@ -301,3 +301,41 @@ fn test_alloc_random_ranges_in_partial_bitmap() {
         }
     }
 }
+
+/// Tests that `alloc()` can find free bits that exist before `next_free`.
+///
+/// This reproduces a bug where `alloc_range(n)` skips free bits that don't
+/// form a contiguous range of size n, advancing `next_free` past them.
+/// Without wrap-around, those free bits become unreachable.
+#[test]
+fn test_alloc_wraparound_next_free() {
+    let mut data: [u8; 1] = [0; 1];
+    let mut bitmap: Bitmap =
+        test_helper_create_bitmap_from_raw_array(&mut data).expect("failed to create bitmap");
+
+    // Allocate bits 0, 1, 2 -> next_free = 3.
+    assert_eq!(bitmap.alloc().expect("alloc 0"), 0);
+    assert_eq!(bitmap.alloc().expect("alloc 1"), 1);
+    assert_eq!(bitmap.alloc().expect("alloc 2"), 2);
+
+    // Free bit 1 -> creates a hole at position 1, next_free = 1.
+    bitmap.clear(1).expect("clear 1");
+
+    // alloc_range(2): starts at 1, [1,2] won't work (bit 2 is set),
+    // skips to 3 and allocates [3,4]. next_free = 5.
+    assert_eq!(bitmap.alloc_range(2).expect("alloc_range 2"), 3);
+
+    // Fill remaining bits 5, 6, 7 -> next_free = 8 (past end).
+    assert_eq!(bitmap.alloc().expect("alloc 5"), 5);
+    assert_eq!(bitmap.alloc().expect("alloc 6"), 6);
+    assert_eq!(bitmap.alloc().expect("alloc 7"), 7);
+
+    // State: [set, FREE, set, set, set, set, set, set], usage=7, next_free=8.
+    // alloc() must find bit 1 via wrap-around, not return OutOfMemory.
+    assert_eq!(
+        bitmap
+            .alloc()
+            .expect("alloc should wrap around and find bit 1"),
+        1
+    );
+}


### PR DESCRIPTION
## Problem

`alloc_range()` scans from `next_free` to the end without wrap-around. When it skips free bits that don't form a contiguous range of the requested size, `next_free` advances past them. Those bits become unreachable, causing spurious `OutOfMemory` errors. For example: alloc 3 bits, free bit 1, `alloc_range(2)` skips bit 1 and advances `next_free` to 5, fill the rest, then `alloc(1)` returns `OutOfMemory` even though bit 1 is free.

This was discovered during Verus formal verification — the postcondition `exists_contiguous_free_range ==> Ok` could not be proven.

## Fix

Retry from position 0 when the scan from `next_free` reaches the end, stopping at the initial position. Preserves O(N) amortized fast path. Added a regression test.
