### PR TITLE
[build] Prevent rust toolchain re-download

### DIFF
--- a/scripts/setup/Dockerfile.build
+++ b/scripts/setup/Dockerfile.build
@@ -20,8 +20,19 @@ ARG SYSROOT_SUFFIX=debug
 # for proper Python stdlib path resolution.
 ARG WORKSPACE_PATH=/mnt
 
+# Save a copy of the base image's rustup state so that the cache mount
+# (which starts empty on first use) can be seeded without re-downloading.
+# A version marker is stored alongside so that cache staleness can be detected
+# when the base image ships a newer toolchain.
+# NOTE: This step is intentionally placed BEFORE `COPY . .` so that it is only
+# re-executed when the base image changes, not on every source-code change.
+RUN cp -a /root/.rustup /root/.rustup-seed && \
+    rustc --version 2>/dev/null > /root/.rustup-seed/.version-marker
+
 WORKDIR ${WORKSPACE_PATH}
-COPY . .
+# --link enables content-addressable layer storage, improving cache reuse when
+# the base image changes but the source tree has not.
+COPY --link . .
 
 # Ensure system binaries (e.g., /usr/bin/python3) take precedence over toolchain
 # binaries in /opt/nanvix/bin. The Makefile references cross-compilers via explicit
@@ -45,9 +56,24 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,target=/root/.cache/sccache,sharing=locked \
     --mount=type=cache,target=${WORKSPACE_PATH}/target,sharing=locked \
     --mount=type=cache,target=/opt/contrib-src,sharing=locked \
+    --mount=type=cache,target=/opt/nanvix/verus,sharing=locked \
+    --mount=type=cache,target=/root/.rustup,sharing=locked \
     --mount=type=secret,id=actions_results_url \
     --mount=type=secret,id=actions_runtime_token \
     set -e && \
+    # Seed rustup cache from the base image on first run, or re-seed when the
+    # base image ships a newer toolchain (detected via a version marker).
+    if [ -d /root/.rustup-seed ]; then \
+        SEED_VER=$(cat /root/.rustup-seed/.version-marker 2>/dev/null || echo ""); \
+        CACHE_VER=$(cat /root/.rustup/.version-marker 2>/dev/null || echo ""); \
+        if [ -z "$(ls -A /root/.rustup 2>/dev/null)" ] || \
+           [ "${SEED_VER}" != "${CACHE_VER}" ]; then \
+            echo "Seeding rustup cache (seed=${SEED_VER}, cache=${CACHE_VER})..."; \
+            rm -f /root/.rustup/.version-marker && \
+            rm -rf /root/.rustup/* && \
+            cp -a /root/.rustup-seed/. /root/.rustup/; \
+        fi; \
+    fi && \
     SCCACHE_ARG="" && \
     if [ -x /usr/local/bin/sccache ]; then SCCACHE_ARG="SCCACHE=/usr/local/bin/sccache"; fi && \
     if [ -n "${SCCACHE_GHA_ENABLED}" ]; then \

--- a/scripts/setup/Dockerfile.optimized
+++ b/scripts/setup/Dockerfile.optimized
@@ -22,8 +22,6 @@ USER $USER
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
-ARG RUST_VERSION=nightly-2025-12-08
-
 # Install runtime and build dependencies via shared setup script (keeps parity with full image).
 COPY --from=source /opt/nanvix/src/nanvix/scripts/setup/ubuntu.sh /tmp/ubuntu.sh
 
@@ -58,13 +56,24 @@ RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_
     | tar xz -C /usr/local/bin --strip-components=1 --wildcards '*/sccache' && \
     chmod +x /usr/local/bin/sccache
 
+# Copy rust-toolchain file so rustup installs the exact channel, components,
+# and targets specified by the project. This prevents rustup from
+# re-downloading the toolchain at build time when it detects the file in the
+# mounted workspace.
+COPY --from=source /opt/nanvix/src/nanvix/rust-toolchain /workspace/rust-toolchain
+
 # Install Rust.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
 ENV PATH="$HOME/.cargo/bin:$PATH"
 
-# Install Rust toolchain and components.
-RUN rustup toolchain install "$RUST_VERSION" && \
-    rustup default "$RUST_VERSION" && \
+# Install Rust toolchain and components from the rust-toolchain file.
+# `rustup show` reads the file and auto-installs the specified channel,
+# components (e.g. rust-src), and targets (e.g. wasm32-wasip1).
+RUN cd /workspace && rustup show && \
+    # Remove the copied rust-toolchain file and empty directory so they cannot
+    # shadow a workspace mount or leave stale artifacts in the image.
+    rm -f /workspace/rust-toolchain && \
+    rmdir /workspace 2>/dev/null || true && \
     # Link custom Rust toolchain for Nanvix.
     rustup toolchain link nanvix-x86 /opt/nanvix/rust-toolchain && \
     # Copy cargo and other tools to stage2/bin so they're accessible.

--- a/scripts/setup/build-optimized-image.sh
+++ b/scripts/setup/build-optimized-image.sh
@@ -46,20 +46,13 @@ TAG=${1:-"${DEFAULT_TAG}"}
 # Build
 #===================================================================================================
 
-RUST_VERSION=$(grep "^channel" "${REPO_ROOT_DIR}/rust-toolchain" | cut -d'"' -f2) || {
-    echo "ERROR: Failed to extract Rust version from rust-toolchain file: ${REPO_ROOT_DIR}/rust-toolchain" >&2
-    exit 1
-}
-
 echo "Building minimal Docker image..."
 echo "  Base image : ${TOOLCHAIN_IMAGE}"
 echo "  Output tag : ${TAG}"
-echo "  Rust toolchain: ${RUST_VERSION}"
 echo ""
 
 docker build \
     --file "${SCRIPT_DIR}/Dockerfile.optimized" \
-    --build-arg RUST_VERSION="${RUST_VERSION}" \
     --build-arg TOOLCHAIN_IMAGE="${TOOLCHAIN_IMAGE}" \
     --tag "${TAG}" \
     --progress=plain \

--- a/scripts/setup/verus.sh
+++ b/scripts/setup/verus.sh
@@ -164,17 +164,30 @@ with zipfile.ZipFile(sys.argv[1]) as z:
     rm -rf "${tmp_dir}"
     trap - EXIT
 
-    # Install the Rust toolchain that Verus was built against (read from version.json).
+    print_success "Verus ${version} installed to ${install_dir}."
+}
+
+#
+# DESCRIPTION
+#   Ensures the Rust toolchain required by Verus is installed.
+#   Reads the required toolchain from version.json and installs it if missing.
+#
+# ARGUMENTS
+#   $1 - The Verus installation directory.
+#
+ensure_verus_toolchain() {
+    local install_dir="$1"
+
     if [[ -f "${install_dir}/version.json" ]] && command -v rustup &>/dev/null; then
         local required_toolchain
         required_toolchain=$(python3 -c "
 import json, sys
 data = json.load(open(sys.argv[1]))
 print(data.get('verus', {}).get('toolchain', ''))
-" "${install_dir}/version.json" 2>/dev/null || {
-            print_warning "Failed to parse ${install_dir}/version.json; skipping toolchain install."
-            echo ""
-        })
+" "${install_dir}/version.json" 2>/dev/null) || {
+            print_warning "Failed to parse ${install_dir}/version.json; skipping toolchain check."
+            return 0
+        }
 
         if [[ -n "${required_toolchain}" ]]; then
             if ! rustup run "${required_toolchain}" rustc --version &>/dev/null; then
@@ -183,8 +196,6 @@ print(data.get('verus', {}).get('toolchain', ''))
             fi
         fi
     fi
-
-    print_success "Verus ${version} installed to ${install_dir}."
 }
 
 #===================================================================================================
@@ -202,6 +213,7 @@ main() {
 
     if [[ "${installed_version}" == "${expected_version}" ]]; then
         print_info "Verus ${expected_version} is already installed in ${install_dir}."
+        ensure_verus_toolchain "${install_dir}"
         return 0
     fi
 
@@ -222,6 +234,7 @@ main() {
     fi
 
     install_verus "${install_dir}" "${expected_version}"
+    ensure_verus_toolchain "${install_dir}"
 }
 
 main "$@"


### PR DESCRIPTION
The minimal Docker image installed the Rust toolchain without the components and targets declared in the project's rust-toolchain file (rust-src, wasm32-wasip1). At build time, rustup detected the file in the mounted workspace, found the missing pieces, and re-downloaded the entire toolchain on every invocation.

Additionally, the Verus verification target installs a separate Rust toolchain via verus.sh, and neither the Verus directory nor the rustup state were persisted across Docker builds. Every source file change invalidated the COPY layer, causing the RUN step to re-download both Verus and its required Rust toolchain from scratch.

Changes:
- Dockerfile.optimized: Copy the rust-toolchain file into the image and use 'rustup show' to pre-install the exact channel, components, and targets. Remove the hardcoded RUST_VERSION ARG.
- Dockerfile.build: Add BuildKit cache mounts for /opt/nanvix/verus and /root/.rustup. Seed the rustup cache from the base image on first use so that pre-installed toolchains are not lost when the empty cache mount overlays the image layer.
- verus.sh: Extract toolchain check into ensure_verus_toolchain() and call it unconditionally in main(), so the required Verus Rust toolchain is installed even when Verus itself is already cached.