### PR TITLE
[build] Resolve .tls NOBITS section overlap

### DIFF
--- a/build/user/linker/x86/user.ld
+++ b/build/user/linker/x86/user.ld
@@ -45,15 +45,6 @@ SECTIONS
 		*(.rodata*)
 	}
 
-	/* Thread-local storage. */
-	.tls : ALIGN(PAGE_SIZE)
-	{
-		__TLS_START = .;
-		*(.tdata)
-		*(.tbss)
-		__TLS_END = .;
-	}
-
 	/* Exception handling frame header */
 	.eh_frame_hdr : ALIGN(4)
 	{
@@ -68,6 +59,34 @@ SECTIONS
 		PROVIDE(__eh_frame_start = .);
 		KEEP(*(.eh_frame))
 		PROVIDE(__eh_frame_end = .);
+	}
+
+	/*
+	 * Thread-local storage.
+	 *
+	 * Must appear after all PROGBITS sections (.eh_frame, etc.) so that the NOBITS .tbss
+	 * sub-section does not cause virtual-address (VMA) overlap with subsequent PROGBITS sections.
+	 */
+	.tls : ALIGN(PAGE_SIZE)
+	{
+		__TLS_START = .;
+		*(.tdata)
+		*(.tbss)
+		__TLS_END = .;
+	}
+
+	/*
+	 * PROGBITS companion for .tls.
+	 *
+	 * Because .tbss is NOBITS it does not produce a LOAD segment.  The TDA allocator (tda.rs)
+	 * copies __TLS_START..__TLS_END into each new thread, so the kernel must have allocated and
+	 * zero-filled the pages backing that range.  This zero-filled PROGBITS section creates a LOAD
+	 * segment that covers the .tbss region, causing the ELF loader to map and clear those pages.
+	 */
+	.tls_init ADDR(.tls) : AT(ADDR(.tls))
+	{
+		FILL(0x00000000);
+		. = __TLS_END;
 	}
 
 	/* Discarded. */

--- a/src/tests/thread-c/thread_local.c
+++ b/src/tests/thread-c/thread_local.c
@@ -37,6 +37,15 @@ static const int EXPECTED_WORKER_THREAD_THREAD_LOCAL_VARIABLE_VALUE = 0xabcd;
  */
 _Thread_local volatile int thread_local_var = 0;
 
+/*
+ * Zero-initialized thread-local variable for regression testing of overlapping TLS.
+ *
+ * NOTE: Do NOT add an explicit `= 0` initializer. Without one, the compiler places this variable in
+ * .tbss (NOBITS); adding `= 0` would move it to .tdata (PROGBITS), which would mask the overlap bug
+ * this test is designed to catch.
+ */
+_Thread_local volatile int thread_local_zero_init_var;
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -45,6 +54,9 @@ _Thread_local volatile int thread_local_var = 0;
 static void *worker_thread(void *arg)
 {
     (void)arg;
+
+    // Verify that zero-initialized thread-local variable starts at zero (GitHub issue #1486).
+    assert(thread_local_zero_init_var == 0);
 
     // Set thread-local variable.
     thread_local_var = EXPECTED_WORKER_THREAD_THREAD_LOCAL_VARIABLE_VALUE;
@@ -59,6 +71,9 @@ static void *worker_thread(void *arg)
 // Main thread for thread-local storage test.
 static void main_thread(void)
 {
+    // Verify that zero-initialized thread-local variable starts at zero (GitHub issue #1486).
+    assert(thread_local_zero_init_var == 0);
+
     // Set thread-local variable.
     thread_local_var = EXPECTED_MAIN_THREAD_THREAD_LOCAL_VARIABLE_VALUE;
 


### PR DESCRIPTION
Move .eh_frame_hdr and .eh_frame before .tls so that the NOBITS .tbss section no longer causes subsequent sections to share the same VMA. Add a .tls_init PROGBITS overlay to ensure the kernel ELF loader allocates and zero-fills the TLS page.

Update the thread_local test to assert that an uninitialized _Thread_local variable starts at zero, which exposes the original bug.

Closes #1486 