### PR TITLE
[build] Enable versioning-strategy for Dependabot cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     schedule:
       interval: "daily"
       time: "03:00"
-      versioning-strategy: increase
+    versioning-strategy: increase
     labels:
       - "enhancement"
     open-pull-requests-limit: 20

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     schedule:
       interval: "daily"
       time: "03:00"
-    versioning-strategy: increase
     labels:
       - "enhancement"
     open-pull-requests-limit: 20
@@ -16,6 +15,7 @@ updates:
     schedule:
       interval: "daily"
       time: "03:00"
+      versioning-strategy: increase
     labels:
       - "enhancement"
     open-pull-requests-limit: 20

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: "daily"
       time: "03:00"
+    versioning-strategy: increase
     labels:
       - "enhancement"
     open-pull-requests-limit: 20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ kvm-bindings = "0.14.0"
 kvm-ioctls = "0.24.0"
 libc = "0.2.172"
 linuxd = { path = "src/daemons/linuxd", default-features = false }
-log = "0.4.27"
+log = "0.4.29"
 nanvix = { path = "src/libs/nanvix", default-features = false }
 nanvix-http = { path = "src/libs/nanvix-http", default-features = false }
 nanvix-registry = { path = "src/libs/nanvix-registry", default-features = false }


### PR DESCRIPTION
This PR addresses the issue reported in #1011 -  where the log crate version is not being updated.

Approach:

Steps followed to replicate the issue:
1. Check the current version of the log crate in the upstream repository.
   - The current version of the log crate in the upstream repository is - 0.4.29, referenced from [crates/log](https://crates.io/crates/log)
2. Compare it with the version specified in our Cargo.toml.
  - Currently we have `log = "0.4.27"`
3. Observe that Dependabot has not triggered an update
  - There is a discrepancy between the log version in Cargo.toml and one from crates/log. This shows that Dependabot has not triggered an update.

I took the following steps with changes:
1. Update the Cargo.toml file to have the latest `log = "0.4.29"` which corresponds to the log crate version from [crates/log](https://crates.io/crates/log)
2. Update the [ .github/dependabot.yml file](https://github.com/nanvix/nanvix/blob/dev/.github/dependabot.yml) to enforce 
` versioning-strategy: increase`. This should keep up the changes in correspondence with the [crates]((https://crates.io/crates/).


I validated the above changes with the execution of the following commands:

```
~/nanvix/my-nanvix$ cargo update
~/nanvix/my-nanvix$ cargo build
~/nanvix/my-nanvix$ cargo check
    ...
    Checking zerofrom v0.1.6
    Checking log v0.4.29
    ...
```