### PR TITLE
[kernel] Add KVM paravirtualized clock support for microvm

### DIFF
--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -2,6 +2,12 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Modules
+//==================================================================================================
+
+pub mod pvclock;
+
+//==================================================================================================
 // Imports
 //==================================================================================================
 
@@ -426,6 +432,14 @@ pub fn init(
     madt: &Option<MadtInfo>,
     _mem_lower: Option<usize>,
 ) -> Result<Platform, Error> {
+    // Ensure the CPU exposes the TSC feature (CPUID.01H:EDX[4]).
+    // The pvclock subsystem and RDTSC-based timekeeping depend on this.
+    if !::arch::cpu::cpuid::has_tsc() {
+        let reason: &str = "CPU does not support TSC (RDTSC)";
+        error!("{}", reason);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
     register_pic_ioports(ioports)?;
 
     // Register MicroVM control registers.
@@ -437,6 +451,16 @@ pub fn init(
         AccessPermission::RDONLY,
     )?;
     memory_regions.push_back(scratch_region);
+
+    // Register pvclock page so the kernel can read TSC calibration data.
+    let pvclock_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+        "pvclock-page",
+        VirtualAddress::from_raw_value(::config::microvm::DEFAULT_PVCLOCK_PAGE),
+        mem::PAGE_SIZE,
+        MemoryRegionType::Mmio,
+        AccessPermission::RDONLY,
+    )?;
+    memory_regions.push_back(pvclock_region);
 
     log_control_registers();
     register_ramfs_mmio_region(ioaddresses, mmio_regions)?;

--- a/src/kernel/src/hal/platform/microvm/pvclock.rs
+++ b/src/kernel/src/hal/platform/microvm/pvclock.rs
@@ -1,0 +1,180 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! KVM paravirtualized clock — platform-specific helpers.
+//!
+//! Reads TSC calibration data and boot time from the shared pvclock page
+//! that KVM populates when `MSR_KVM_SYSTEM_TIME_NEW` is enabled.
+//!
+//! Reference: <https://docs.kernel.org/virt/kvm/x86/msr.html#pvclock>
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::sync::atomic::{
+    fence,
+    Ordering,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// KVM pvclock VCPU time info structure (defined by the KVM ABI).
+///
+/// The hypervisor writes to this structure, and the guest reads it alongside
+/// the CPU's TSC to compute the current time in nanoseconds.
+///
+/// Reference: Linux kernel `arch/x86/include/asm/pvclock.h`
+///
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct KvmPvclockVcpuTimeInfo {
+    /// Version counter — odd means update in progress.
+    /// Guest must re-read if this changes during a read sequence.
+    version: u32,
+    _pad0: u32,
+    /// TSC value when `system_time` was captured.
+    tsc_timestamp: u64,
+    /// System time in nanoseconds at `tsc_timestamp`.
+    system_time: u64,
+    /// Multiplier for TSC → nanoseconds conversion.
+    tsc_to_system_mul: u32,
+    /// Shift for TSC → nanoseconds conversion (can be negative).
+    tsc_shift: i8,
+    /// Flags (e.g., TSC stable bit).
+    _flags: u8,
+    _pad: [u8; 2],
+}
+
+// Ensure the pvclock structure matches the KVM ABI (32 bytes).
+static_assert::assert_eq_size!(KvmPvclockVcpuTimeInfo, 32);
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Computes `(a * b) >> 32` without 128-bit arithmetic.
+///
+/// This is the standard algorithm used by the Linux kernel for the pvclock
+/// TSC → nanoseconds conversion on 32-bit platforms.
+///
+/// # Parameters
+///
+/// - `a`: 64-bit multiplicand (shifted TSC delta).
+/// - `b`: 32-bit multiplier (`tsc_to_system_mul`).
+///
+/// # Returns
+///
+/// The upper 64 bits of the 96-bit product.
+///
+fn mul_u64_u32_shr32(a: u64, b: u32) -> u64 {
+    let a_lo: u64 = a & 0xFFFF_FFFF;
+    let a_hi: u64 = a >> 32;
+    let lo_result: u64 = a_lo * u64::from(b);
+    let hi_result: u64 = a_hi * u64::from(b);
+    (lo_result >> 32) + hi_result
+}
+
+///
+/// # Description
+///
+/// Reads the monotonic time in nanoseconds from the KVM pvclock page.
+///
+/// Uses the seqlock protocol: reads the version, reads the calibration data,
+/// reads the version again. If the version changed or was odd, retries.
+///
+/// # Returns
+///
+/// - `Some(ns)`: Monotonic nanoseconds since VM start.
+/// - `None`: The pvclock page is not initialized (version == 0).
+///
+pub fn monotonic_time_ns() -> Option<u64> {
+    // SAFETY: The pvclock page address is a well-known identity-mapped GPA
+    // that KVM populates when the MSR_KVM_SYSTEM_TIME_NEW MSR is enabled.
+    let page: *const KvmPvclockVcpuTimeInfo =
+        ::config::microvm::DEFAULT_PVCLOCK_PAGE as *const KvmPvclockVcpuTimeInfo;
+
+    loop {
+        // Read version counter.
+        // SAFETY: The page is mapped in guest memory at the well-known GPA.
+        let version1: u32 = unsafe { core::ptr::read_volatile(&(*page).version) };
+
+        // If version is 0, pvclock is not initialized.
+        if version1 == 0 {
+            return None;
+        }
+
+        // If version is odd, an update is in progress — spin and retry.
+        if version1 & 1 != 0 {
+            core::hint::spin_loop();
+            continue;
+        }
+
+        // Ensure all subsequent reads see values written before the version.
+        fence(Ordering::Acquire);
+
+        // Read calibration data.
+        // SAFETY: The page is mapped and version was even (stable snapshot).
+        let info: KvmPvclockVcpuTimeInfo = unsafe { core::ptr::read_volatile(page) };
+
+        // Read TSC inside the seqlock region so that the calibration
+        // parameters and the TSC snapshot form a consistent pair.
+        let tsc: u64 = ::arch::cpu::rdtsc();
+
+        // Ensure we've finished reading before re-checking the version.
+        fence(Ordering::Acquire);
+
+        // Re-read version counter to verify consistency.
+        // SAFETY: Same page, checking for concurrent updates.
+        let version2: u32 = unsafe { core::ptr::read_volatile(&(*page).version) };
+        if version1 != version2 {
+            // Data was modified during our read — retry.
+            core::hint::spin_loop();
+            continue;
+        }
+
+        // Compute TSC delta since calibration point.
+        let delta: u64 = tsc.wrapping_sub(info.tsc_timestamp);
+
+        // Use checked shifts to avoid panics if the hypervisor provides
+        // an out-of-range shift (e.g., >= 64 for a u64). Treat such cases
+        // as "pvclock unavailable".
+        let shift: u32 = u32::from(info.tsc_shift.unsigned_abs());
+        let shifted: u64 = if info.tsc_shift >= 0 {
+            delta.checked_shl(shift)?
+        } else {
+            delta.checked_shr(shift)?
+        };
+
+        // Convert shifted TSC delta to nanoseconds and add the base system time.
+        let delta_ns: u64 = mul_u64_u32_shr32(shifted, info.tsc_to_system_mul);
+        return Some(info.system_time.wrapping_add(delta_ns));
+    }
+}
+
+///
+/// # Description
+///
+/// Reads the boot time in nanoseconds since the Unix epoch.
+///
+/// This value is written by the VMM during VM initialization at a well-known
+/// offset within the pvclock page.
+///
+/// # Returns
+///
+/// UTC nanoseconds since 1970-01-01 00:00:00 at the time the VM was started.
+///
+pub fn boot_time_ns() -> u64 {
+    let offset: usize =
+        ::config::microvm::DEFAULT_PVCLOCK_PAGE + ::config::microvm::PVCLOCK_BOOT_TIME_NS_OFFSET;
+    // SAFETY: This address is identity-mapped in guest memory and written by the VMM.
+    unsafe { core::ptr::read_volatile(offset as *const u64) }
+}

--- a/src/kernel/src/pm/clock.rs
+++ b/src/kernel/src/pm/clock.rs
@@ -31,6 +31,10 @@ use ::sys::time::{
     NANOSECONDS_PER_SECOND,
 };
 
+#[cfg(feature = "microvm")]
+#[path = "pvclock.rs"]
+mod pvclock;
+
 //==================================================================================================
 // Global Variables
 //==================================================================================================
@@ -143,9 +147,24 @@ pub fn ticks() -> u64 {
 ///
 /// # Description
 ///
-/// Returns the number of timer ticks since the system started.
+/// Returns the current kernel time.
+///
+/// When the KVM paravirtualized clock is available (microvm feature), this function reads the
+/// pvclock page and TSC to compute a wall-clock timestamp (UTC) without a VM exit.
+///
+/// If pvclock is not initialized or not available, this function falls back to PIT-based tick
+/// counting derived from `TIMER_TICKS`. In that case, the returned value represents a
+/// monotonic time since system boot (uptime) and is **not** guaranteed to be an epoch-based
+/// wall-clock/UTC timestamp.
 ///
 pub fn now() -> SystemTime {
+    // Try pvclock first when running on a microvm.
+    #[cfg(feature = "microvm")]
+    if let Some(time) = pvclock::now() {
+        return time;
+    }
+
+    // Fallback: PIT-based tick counting.
     #[cfg(feature = "pit")]
     let timer_freq: u32 = crate::hal::platform::pit::get_timer_frequency();
     #[cfg(not(feature = "pit"))]

--- a/src/kernel/src/pm/pvclock.rs
+++ b/src/kernel/src/pm/pvclock.rs
@@ -1,0 +1,75 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! KVM paravirtualized clock — time conversion layer.
+//!
+//! Combines the platform-specific monotonic and boot-time readings from the
+//! microvm pvclock helpers to produce wall-clock `SystemTime` values.
+//!
+//! Reference: <https://docs.kernel.org/virt/kvm/x86/msr.html#pvclock>
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::hal::platform::pvclock::{
+    boot_time_ns,
+    monotonic_time_ns,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Number of nanoseconds per second.
+const NANOSECONDS_PER_SECOND: u64 = 1_000_000_000;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads the current wall-clock time in nanoseconds since the Unix epoch using the
+/// paravirtualized clock.
+///
+/// Wall-clock time = boot_time_ns + monotonic_time_ns
+///
+/// # Returns
+///
+/// - `Some(ns)`: UTC nanoseconds since 1970-01-01 00:00:00.
+/// - `None`: The pvclock is not initialized.
+///
+pub fn wall_clock_time_ns() -> Option<u64> {
+    let mono_ns: u64 = monotonic_time_ns()?;
+    let boot_ns: u64 = boot_time_ns();
+    Some(boot_ns.wrapping_add(mono_ns))
+}
+
+///
+/// # Description
+///
+/// Returns the current system time using the paravirtualized clock.
+///
+/// # Returns
+///
+/// - `Some(SystemTime)`: Current UTC wall-clock time.
+/// - `None`: The pvclock is not initialized.
+///
+pub fn now() -> Option<::sys::time::SystemTime> {
+    let total_ns: u64 = wall_clock_time_ns()?;
+    let seconds: u64 = total_ns / NANOSECONDS_PER_SECOND;
+    let nanos_remainder: u64 = total_ns % NANOSECONDS_PER_SECOND;
+
+    // NOTE: `nanos_remainder` is always < 1_000_000_000 which fits in u32.
+    let nanoseconds: u32 = match u32::try_from(nanos_remainder) {
+        Ok(v) => v,
+        Err(_) => {
+            // This branch is unreachable because `n % 1_000_000_000 < u32::MAX`.
+            return None;
+        },
+    };
+
+    ::sys::time::SystemTime::new(seconds, nanoseconds)
+}

--- a/src/libs/arch/src/x86/cpu/mod.rs
+++ b/src/libs/arch/src/x86/cpu/mod.rs
@@ -94,12 +94,24 @@ pub unsafe fn sti() {
 ///
 /// The value of the `rdtsc` instruction.
 ///
+/// # Note
+///
+/// An `lfence` is issued before `rdtsc` to serialize the instruction stream,
+/// preventing speculative execution from reordering the TSC read relative to
+/// preceding memory accesses.
+///
 pub fn rdtsc() -> u64 {
     let mut low: u32;
     let mut high: u32;
 
     unsafe {
-        core::arch::asm!("rdtsc", out("edx") high, out("eax") low);
+        core::arch::asm!(
+            "lfence",
+            "rdtsc",
+            out("edx") high,
+            out("eax") low,
+            options(nostack, nomem, preserves_flags)
+        );
     }
 
     ((high as u64) << 32) | (low as u64)

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -225,6 +225,15 @@ pub mod microvm {
 
     /// Magic value that flags that the VMM requested the guest OS to pause MicroVM execution.
     pub const PAUSE_REQUEST: u32 = 0x00000001;
+
+    /// Guest physical address of the pvclock page (page-aligned, 4KB).
+    /// KVM populates this page with the `KvmPvclockVcpuTimeInfo` structure
+    /// when the `MSR_KVM_SYSTEM_TIME_NEW` MSR is enabled.
+    pub const DEFAULT_PVCLOCK_PAGE: usize = 0x00001000;
+
+    /// Offset within the pvclock page for the boot time in nanoseconds since
+    /// the Unix epoch (u64). The VMM writes this value during VM initialization.
+    pub const PVCLOCK_BOOT_TIME_NS_OFFSET: usize = 0x20;
 }
 
 #[cfg(feature = "pc")]

--- a/src/uservm/src/vmm/microvm/guest.rs
+++ b/src/uservm/src/vmm/microvm/guest.rs
@@ -277,6 +277,15 @@ impl Guest {
     ///
     /// Resets the value of the credits control register.
     ///
+    /// # Note
+    ///
+    /// The credits register at [`config::microvm::DEFAULT_MICROVM_CTRL_CREDITS`] (GPA `0x4`)
+    /// falls inside the kernel ELF's `.zero` section (`LOAD` segment at GPA `0x0` with
+    /// `MemSiz=0x8000`). The ELF loader zero-fills this range when `load_kernel()` runs.
+    /// This method — and all other writes to the control registers at GPA `0x0`–`0x10` — must
+    /// therefore execute **after** the ELF has been loaded, so that the VMM-written values
+    /// are not overwritten.
+    ///
     /// # Returns
     ///
     /// Upon successful completion, this method returns empty. Otherwise, it returns an error.

--- a/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -33,9 +33,12 @@ use crate::vmm::kvm::{
     },
 };
 use ::anyhow::Result;
-use ::arch::cpu::cpuid::{
-    CPUID_FEATURES,
-    EdxFeature,
+use ::arch::{
+    cpu::cpuid::{
+        CPUID_FEATURES,
+        EdxFeature,
+    },
+    mem::PAGE_SIZE,
 };
 use ::kvm_bindings::{
     CpuId,
@@ -44,6 +47,7 @@ use ::kvm_bindings::{
     kvm_debugregs,
     kvm_lapic_state,
     kvm_mp_state,
+    kvm_msr_entry,
     kvm_regs,
     kvm_sregs,
     kvm_vcpu_events,
@@ -80,6 +84,15 @@ use ::vmm_sys_util::fam::{
 
 /// Interrupt Enable flag in RFLAGS register.
 pub const RFLAGS_INTERRUPT_ENABLE: u64 = 1 << 1;
+
+/// MSR for KVM pvclock system time (new version).
+/// Writing a GPA with bit 0 set enables KVM to populate a `KvmPvclockVcpuTimeInfo`
+/// structure at that address.
+const MSR_KVM_SYSTEM_TIME_NEW: u32 = 0x4b564d01;
+
+/// IA32_TSC MSR — holds the current value of the Time Stamp Counter.
+/// Writing this MSR sets the guest's TSC to the specified value.
+const MSR_IA32_TSC: u32 = 0x10;
 
 //==================================================================================================
 // Structures
@@ -166,6 +179,7 @@ impl VirtualProcessor {
         let mut fd: VcpuFd = vm_fd.create_vcpu(id)?;
 
         Self::setup_pentium4_cpu_features(kvm_fd, &mut fd)?;
+        Self::setup_rdtsc(&mut fd)?;
 
         let fpu: Fpu = Fpu::new(kvm_fd, &fd)?;
 
@@ -214,6 +228,75 @@ impl VirtualProcessor {
         self.online = true;
 
         Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Sets up the KVM paravirtualized clock for the guest.
+    ///
+    /// Enables the `MSR_KVM_SYSTEM_TIME_NEW` MSR so that KVM populates a shared
+    /// memory page with TSC calibration data. The guest reads this page along
+    /// with the CPU's TSC to compute the current time without VM exits.
+    ///
+    /// # Parameters
+    ///
+    /// - `clock_page_gpa`: Guest physical address of the pvclock page (must be page-aligned).
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn setup_pvclock(&mut self, clock_page_gpa: u64) -> Result<()> {
+        trace!("setup_pvclock(): clock_page_gpa={clock_page_gpa:#010x}");
+
+        // Ensure that the pvclock page GPA is page-aligned. Bit 0 is used as the enable flag
+        // in the MSR value, and KVM expects the remaining bits to contain a page-aligned GPA.
+        if !clock_page_gpa.is_multiple_of(PAGE_SIZE as u64) {
+            let reason: String = format!(
+                "pvclock page GPA is not page-aligned (clock_page_gpa={clock_page_gpa:#018x})"
+            );
+            error!("setup_pvclock(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        // Bit 0 = enable.
+        let msr_value: u64 = clock_page_gpa | 1;
+
+        let msr_entries: Vec<kvm_msr_entry> = vec![kvm_msr_entry {
+            index: MSR_KVM_SYSTEM_TIME_NEW,
+            data: msr_value,
+            ..Default::default()
+        }];
+
+        let msrs: ::kvm_bindings::Msrs = match ::kvm_bindings::Msrs::from_entries(&msr_entries) {
+            Ok(v) => v,
+            Err(e) => {
+                let reason: String = format!("failed to create MSRs for pvclock (error={e:?})");
+                error!("setup_pvclock(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        match self.fd.set_msrs(&msrs) {
+            Ok(written) if written == msr_entries.len() => {
+                trace!("setup_pvclock(): pvclock MSR set (value={msr_value:#018x})");
+                Ok(())
+            },
+            Ok(written) => {
+                let reason: String = format!(
+                    "failed to set all pvclock MSRs: written {written} of {} entries",
+                    msr_entries.len()
+                );
+                error!("setup_pvclock(): {reason}");
+                anyhow::bail!(reason)
+            },
+            Err(e) => {
+                let reason: String = format!("failed to set pvclock MSR (error={e:?})");
+                error!("setup_pvclock(): {reason}");
+                anyhow::bail!(reason)
+            },
+        }
     }
 
     ///
@@ -368,6 +451,59 @@ impl VirtualProcessor {
             Err(error) => {
                 error!("run(): error running vCPU (error={error:?})");
                 VirtualProcessorExitContext::Interrupted
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Initializes the guest's TSC by writing `IA32_TSC` MSR to zero.
+    ///
+    /// This ensures the guest has a deterministic RDTSC starting point and
+    /// that the TSC feature is functional for pvclock calibration.
+    ///
+    /// # Parameters
+    ///
+    /// - `fd`: Handle to the virtual processor.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this function returns empty. Otherwise, it returns an error.
+    ///
+    fn setup_rdtsc(fd: &mut VcpuFd) -> Result<()> {
+        let msr_entries: Vec<kvm_msr_entry> = vec![kvm_msr_entry {
+            index: MSR_IA32_TSC,
+            data: 0,
+            ..Default::default()
+        }];
+
+        let msrs: ::kvm_bindings::Msrs = match ::kvm_bindings::Msrs::from_entries(&msr_entries) {
+            Ok(v) => v,
+            Err(e) => {
+                let reason: String = format!("failed to create MSRs for RDTSC (error={e:?})");
+                error!("setup_rdtsc(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        match fd.set_msrs(&msrs) {
+            Ok(written) if written == msr_entries.len() => {
+                trace!("setup_rdtsc(): IA32_TSC MSR set to 0");
+                Ok(())
+            },
+            Ok(written) => {
+                let reason: String = format!(
+                    "failed to set all RDTSC MSRs: written {written} of {} entries",
+                    msr_entries.len()
+                );
+                error!("setup_rdtsc(): {reason}");
+                anyhow::bail!(reason)
+            },
+            Err(e) => {
+                let reason: String = format!("failed to set IA32_TSC MSR (error={e:?})");
+                error!("setup_rdtsc(): {reason}");
+                anyhow::bail!(reason)
             },
         }
     }

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -248,6 +248,33 @@ impl Vmm {
 
             guest.reset(&mut vmem, &mut vcpu)?;
 
+            // Setup KVM paravirtualized clock.
+            //
+            // NOTE: The pvclock page at DEFAULT_PVCLOCK_PAGE (GPA 0x1000) falls inside
+            // the kernel ELF's `.zero` section (LOAD segment at GPA 0x0 with MemSiz
+            // 0x8000). The ELF loader zero-fills this range when `load_kernel()` runs
+            // above. Both `setup_pvclock()` (which causes KVM to populate the page)
+            // and the boot-time write below must therefore execute **after** the ELF
+            // has been loaded. This is the same pattern used by the microvm control
+            // registers at GPA 0x0–0x10 (credits, pause-requested, ramfs).
+            let pvclock_gpa: u64 = ::config::microvm::DEFAULT_PVCLOCK_PAGE as u64;
+            vcpu.setup_pvclock(pvclock_gpa)?;
+
+            // Write boot time (UTC nanoseconds since Unix epoch) to the pvclock page so
+            // the guest can compute wall-clock time from the monotonic pvclock.
+            let boot_time_ns: u64 = {
+                let d: std::time::Duration = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default();
+                let nanos_per_sec: u64 = u64::from(::sys::time::NANOSECONDS_PER_SECOND);
+                d.as_secs() * nanos_per_sec + u64::from(d.subsec_nanos())
+            };
+            let boot_time_offset: u64 = (::config::microvm::DEFAULT_PVCLOCK_PAGE
+                + ::config::microvm::PVCLOCK_BOOT_TIME_NS_OFFSET)
+                as u64;
+            vmem.write_bytes(boot_time_offset, &boot_time_ns.to_le_bytes())?;
+            trace!("pvclock: boot_time_ns={boot_time_ns}, page_gpa={pvclock_gpa:#010x}");
+
             Arc::new(Mutex::new(guest))
         };
 

--- a/src/uservm/src/vmm/microvm/ramfs.rs
+++ b/src/uservm/src/vmm/microvm/ramfs.rs
@@ -216,6 +216,15 @@ impl RamFs {
     ///
     /// Writes the RAMFS base and size registers exposed to the guest.
     ///
+    /// # Note
+    ///
+    /// The RAMFS registers at [`config::microvm::DEFAULT_MICROVM_CTRL_RAMFS_BASE`] (GPA `0xC`)
+    /// and [`config::microvm::DEFAULT_MICROVM_CTRL_RAMFS_SIZE`] (GPA `0x10`) fall inside the
+    /// kernel ELF's `.zero` section (`LOAD` segment at GPA `0x0` with `MemSiz=0x8000`). The
+    /// ELF loader zero-fills this range when `load_kernel()` runs. This method must therefore
+    /// execute **after** the ELF has been loaded, so that the VMM-written values are not
+    /// overwritten.
+    ///
     /// # Parameters
     ///
     /// - `vmem`: Virtual memory instance that holds the control registers.


### PR DESCRIPTION
## Summary

Add KVM paravirtualized clock (pvclock) support so the guest kernel can read the current wall-clock time without VM exits, using the TSC and a shared memory page that KVM populates with calibration data.

## Changes

### Kernel
- **New `pvclock` module** (`src/kernel/src/pm/pvclock.rs`): reads monotonic time via the seqlock protocol and combines it with the VMM-written boot time to produce wall-clock `SystemTime`.
- **`clock::now()`**: tries pvclock first on microvm, falls back to PIT-based tick counting.
- **Platform init**: register pvclock page as an MMIO memory region.

### Config
- Add `DEFAULT_PVCLOCK_PAGE` and `PVCLOCK_BOOT_TIME_NS_OFFSET` constants.

### UserVM
- **`setup_pvclock()`** on VCPU: enables `MSR_KVM_SYSTEM_TIME_NEW`.
- **VMM initialization**: writes boot time and configures pvclock after ELF loading.
- **Documentation**: added ordering-constraint notes to `guest.rs` and `ramfs.rs`.

## Testing
- Build and unit tests pass for both **microvm** and **hyperlight** machines.
- Integration tests (`run-nanvix-tests`) pass for both machines.
- Formatter and linter pass cleanly.