### PR TITLE
[ci] B: Ignore fatfs git dependency in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
       - dependency-name: "hyperlight-common"
       - dependency-name: "hyperlight-host"
       - dependency-name: "hyperlight-guest"
+      - dependency-name: "fatfs"
 
     groups:
       kvm-stack:


### PR DESCRIPTION
## Summary

Add `fatfs` to the Dependabot ignore list in `.github/dependabot.yml`.

## Problem

The Dependabot validation check fails with *"Your .github/dependabot.yml contained invalid details"* because the `fatfs` crate is pinned to a git revision rather than a crates.io version. Dependabot cannot manage git-based dependencies and reports the configuration as invalid.

## Fix

Add `fatfs` to the `ignore` list alongside the other unmanaged dependencies (`hyperlight-common`, `hyperlight-host`, `hyperlight-guest`).

## Relates to

- Fixes Dependabot check failure on PR #1496