### PR TITLE
[kernel] E: IKC polling improvements

### DIFF
--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -10,7 +10,10 @@ use crate::{
     event,
     io,
     ipc,
-    kcall::KcallResult,
+    kcall::{
+        handler::poll_ikc_messages,
+        KcallResult,
+    },
     pm::{
         self,
         InterruptReason,
@@ -54,7 +57,7 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
     let pid: ProcessIdentifier = unsafe { ProcessManager::get() }.get_pid();
     let tid: ThreadIdentifier = unsafe { ProcessManager::get() }.get_tid();
 
-    match KcallNumber::from(number) {
+    let result: KcallResult = match KcallNumber::from(number) {
         // Handle `getpid()` locally.
         KcallNumber::GetPid => KcallResult::Success(<i64>::from(pid).into()),
         // Handle `gettid()` locally.
@@ -181,8 +184,15 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
             error!("invalid kernel call (number={})", number);
             KcallResult::Error(ErrorCode::InvalidSysCall.into())
         },
-    }
-    .into()
+    };
+
+    // Poll for inter-kernel communication messages after handling the kernel call. Polling after
+    // (rather than before) ensures that any outbound messages produced by the current kernel call
+    // are already enqueued, so the poll can immediately dispatch replies and follow-up messages
+    // without waiting for the next scheduling opportunity.
+    poll_ikc_messages();
+
+    result.into()
 }
 
 fn handle_sleep_error(sleep_error: SleepError) -> KcallResult {

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -68,39 +68,7 @@ pub fn kcall_handler() -> ExitStatus {
 
     let status: ExitStatus = loop {
         // Check if inter-kernel communication messages are available.
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "stdio")] {
-                let mut message_received: bool = false;
-                for _ in 0..IKC_POLL_BATCH_SIZE {
-                    // Check if the number of buffered messages in the kernel is not too high. We don't
-                    // want to keep pushing messages to the kernel and then run out of memory.
-                    let number_buffered_messages: usize = pm!().number_buffered_messages();
-                    if number_buffered_messages < config::kernel::MAX_IKC_MESSAGES {
-                        // The number of messages that are buffered in the kernel is not too high,
-                        // So attempt to read an inter-kernel communication message from the
-                        // kernel's standard input.
-                        match crate::stdio::read() {
-                            // No message is available.
-                            Ok(None) => break,
-                            // A message is available.
-                            Ok(Some(message)) => {
-                                if let Err(e) = EventManager::post_message(pm!(), message.destination, message) {
-                                    warn!("failed to post message (error={:?})", e);
-                                }
-                                message_received = true;
-                            }
-                            // Failed to read message.
-                            Err(e) => {
-                                warn!("failed to read message (error={:?})", e);
-                            }
-                        }
-                    }
-                }
-            } else {
-                // No inter-kernel communication messages are available.
-                let message_received: bool = false;
-            }
-        }
+        let message_received: bool = poll_ikc_messages();
 
         // Attempt to harvest zombie processes.
         let mut harvested_process: bool = false;
@@ -143,4 +111,53 @@ pub fn kcall_handler() -> ExitStatus {
     }
 
     status
+}
+
+///
+/// # Description
+///
+/// Polls inter-kernel communication messages from the kernel's standard input and dispatches them
+/// to the appropriate destination process.
+///
+/// # Returns
+///
+/// `true` if at least one message was received, `false` otherwise.
+///
+pub fn poll_ikc_messages() -> bool {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "stdio")] {
+            let mut message_received: bool = false;
+            for _ in 0..IKC_POLL_BATCH_SIZE {
+                // Check if the number of buffered messages in the kernel is too high. We don't want
+                // to keep pushing messages to the kernel and then run out of memory.
+                let number_buffered_messages: usize = pm!().number_buffered_messages();
+                if number_buffered_messages >= config::kernel::MAX_IKC_MESSAGES {
+                    break;
+                }
+
+                // The number of messages that are buffered in the kernel is not too high,
+                // So attempt to read an inter-kernel communication message from the
+                // kernel's standard input.
+                match crate::stdio::read() {
+                    // No more messages are available.
+                    Ok(None) => break,
+                    // A message is available.
+                    Ok(Some(message)) => {
+                        if let Err(e) = EventManager::post_message(pm!(), message.destination, message) {
+                            warn!("failed to post message (error={:?})", e);
+                        }
+                        message_received = true;
+                    }
+                    // Failed to read message.
+                    Err(e) => {
+                        warn!("failed to read message (error={:?})", e);
+                    }
+                }
+            }
+            message_received
+        } else {
+            // No inter-kernel communication messages are available.
+            false
+        }
+    }
 }


### PR DESCRIPTION
## Summary

This PR refactors IKC (Inter-Kernel Communication) message polling in the kernel:

- **Extract `poll_ikc_messages()` into a standalone function** so it can be reused from multiple call sites.
- **Poll IKC messages after every kernel call** in `do_kcall()`, ensuring outbound messages produced by a kcall are dispatched immediately rather than waiting for the next scheduling opportunity.

## Motivation

Previously, IKC messages were only polled in the main `kcall_handler` loop. This meant that replies or follow-up messages triggered by a kernel call had to wait until the next loop iteration, adding unnecessary latency.

## Next Steps

A follow-up branch will add event-driven IKC notification via KVM IRQ injection (`set_irq_line`) and increase `IKC_POLL_BATCH_SIZE` to further reduce message delivery latency.