### PR TITLE
Fix `ln` command in `setup.md`

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -127,7 +127,7 @@ exec $SHELL
 ```bash
 # Ensure you are in the project's root directory.
 ./z setup --toolchain-dir $HOME/toolchain    # Build the cross compiler toolchain and place it in $HOME/toolchain.
-ln -s $HOME/toolchain toolchain              # Create symbolic link for toolchain for convenience.
+ln -T -s $HOME/toolchain toolchain           # Create symbolic link for toolchain for convenience.
 ```
 
 #### Step 3: Build QEMU (Optional)


### PR DESCRIPTION
The documentation had said to run the following command:
```ln -s $HOME/toolchain toolchain```

However, this can cause a problem: If `./toolchain` already exists and is a directory, then it creates the new symbolic link at `./toolchain/toolchain`.

The fix is to use `-T`, which tells `ln` to always treat the target as a plain file name, and thus to fail if it's an already-existing directory.
