### PR TITLE
[kernel] Improve IKC IRQ Notification

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -87,7 +87,7 @@ max_ikc_messages = 128
 ipc_message_size = 64
 
 # Number of IKC messages to poll at a time.
-ikc_poll_batch_size = 1
+ikc_poll_batch_size = 8
 
 #==================================================================================================
 # Synchronization Limits

--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -1063,7 +1063,17 @@ pub fn init() -> Result<(), Error> {
 
     if let Some(intman) = hal.intman() {
         for intnum in InterruptNumber::VALUES {
+            // Timer has a dedicated handler registered in pm::init().
             if intnum == InterruptNumber::Timer {
+                continue;
+            }
+            // IKC has a dedicated handler registered in pm::init() (microvm only).
+            // Unmask the interrupt here so the guest can receive IRQ 9 notifications.
+            #[cfg(feature = "microvm")]
+            if intnum == InterruptNumber::Ikc {
+                if let Err(e) = intman.unmask(intnum) {
+                    warn!("failed to unmask IKC interrupt: {:?}", e);
+                }
                 continue;
             }
             match intman.register_handler(intnum, interrupt_handler) {

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/number.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/number.rs
@@ -16,6 +16,9 @@ pub enum InterruptNumber {
     Floppy = 6,
     Lpt1 = 7,
     Cmos = 8,
+    #[cfg(feature = "microvm")]
+    Ikc = 9,
+    #[cfg(not(feature = "microvm"))]
     Free1 = 9,
     Free2 = 10,
     Free3 = 11,
@@ -26,6 +29,12 @@ pub enum InterruptNumber {
 }
 
 impl InterruptNumber {
+    /// IRQ 9 variant, which is `Ikc` on microvm and `Free1` otherwise.
+    #[cfg(feature = "microvm")]
+    const IRQ9: InterruptNumber = InterruptNumber::Ikc;
+    #[cfg(not(feature = "microvm"))]
+    const IRQ9: InterruptNumber = InterruptNumber::Free1;
+
     pub const VALUES: [InterruptNumber; 15] = [
         InterruptNumber::Timer,
         InterruptNumber::Keyboard,
@@ -35,7 +44,7 @@ impl InterruptNumber {
         InterruptNumber::Floppy,
         InterruptNumber::Lpt1,
         InterruptNumber::Cmos,
-        InterruptNumber::Free1,
+        InterruptNumber::IRQ9,
         InterruptNumber::Free2,
         InterruptNumber::Free3,
         InterruptNumber::Mouse,

--- a/src/kernel/src/kcall/mod.rs
+++ b/src/kernel/src/kcall/mod.rs
@@ -16,6 +16,8 @@ mod kcall_success;
 //==================================================================================================
 
 pub use handler::kcall_handler as handler;
+#[cfg(feature = "microvm")]
+pub use handler::poll_ikc_messages;
 pub use kcall_error::KcallError;
 pub use kcall_result::KcallResult;
 pub use kcall_success::KcallSuccess;

--- a/src/kernel/src/pm/mod.rs
+++ b/src/kernel/src/pm/mod.rs
@@ -55,6 +55,26 @@ pub use process::{
 };
 pub use thread::InterruptReason;
 
+///
+/// # Description
+///
+/// Interrupt handler for IKC (inter-kernel communication) notifications.
+///
+/// The VMM injects this interrupt (IRQ 9) whenever a new message is enqueued for the guest.
+/// The handler polls IKC messages immediately so the kernel does not have to wait for the
+/// next timer tick to process newly arrived messages.
+///
+/// # Safety
+///
+/// Called from interrupt context with interrupts disabled on a single-core system.
+/// At that point the CPU was halted (HLT), so no mutable references to kernel state
+/// are alive and it is safe to re-enter the process manager.
+///
+#[cfg(feature = "microvm")]
+unsafe fn ikc_interrupt_handler(_intnum: InterruptNumber) {
+    crate::kcall::poll_ikc_messages();
+}
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -98,6 +118,14 @@ pub fn init(root: Vmem) -> Result<(), Error> {
     if let Some(intman) = hal.intman() {
         info!("registering timer interrupt handler...");
         intman.register_handler(InterruptNumber::Timer, timer_handler)?;
+
+        // Register a dedicated IKC notification handler (microvm only). The VMM injects
+        // IRQ 9 whenever a new IKC message is enqueued, waking the kernel from HLT.
+        #[cfg(feature = "microvm")]
+        {
+            info!("registering IKC interrupt handler...");
+            intman.register_handler(InterruptNumber::Ikc, ikc_interrupt_handler)?;
+        }
     }
 
     // Initialize the thread manager.

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -248,8 +248,11 @@ impl UserVm {
 
         // Input function used for emulating I/O port reads.
         #[cfg(not(feature = "hyperlight"))]
+        let ikc_pending: std::sync::Arc<std::sync::atomic::AtomicBool> =
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        #[cfg(not(feature = "hyperlight"))]
         let vmm_stdin_fn: Box<StdinFn> =
-            build_input_fn(vcpu_thread_stdin_rx, args.counters.clone());
+            build_input_fn(vcpu_thread_stdin_rx, args.counters.clone(), ikc_pending.clone());
 
         #[cfg(feature = "hyperlight")]
         let handles: UserVmHandles = handles::UserVmHandles::default();
@@ -277,6 +280,8 @@ impl UserVm {
             initrd_args: args.initrd_args.clone(),
             ramfs_filename: args.ramfs_filename.clone(),
             restoring_from_snapshot: args.snapshot_path.is_some(),
+            #[cfg(feature = "microvm")]
+            ikc_pending: ikc_pending.clone(),
         })?;
 
         // If a snapshot path is provided, restore VM state from the snapshot.
@@ -300,7 +305,12 @@ impl UserVm {
             memory_thread_data_tx,
             memory_thread_control_rx,
             memory_thread_control_tx,
-            add_credit_fn(guest.clone(), vmem.clone()),
+            add_credit_fn(
+                guest.clone(),
+                vmem.clone(),
+                #[cfg(not(feature = "hyperlight"))]
+                microvm.ikc_notifier(),
+            ),
             args.counters.clone(),
         );
         let memory_thread: JoinHandle<()> = memory_thread.spawn();
@@ -403,14 +413,29 @@ fn resume_microvm(guest: Arc<Mutex<Guest>>, vmem: Arc<Mutex<VirtualMemory>>) -> 
     })
 }
 
-fn add_credit_fn(guest: Arc<Mutex<Guest>>, vmem: Arc<Mutex<VirtualMemory>>) -> Box<AddCreditFn> {
+fn add_credit_fn(
+    guest: Arc<Mutex<Guest>>,
+    vmem: Arc<Mutex<VirtualMemory>>,
+    #[cfg(not(feature = "hyperlight"))] notifier: crate::vmm::IkcNotifier,
+) -> Box<AddCreditFn> {
     Box::new(move || {
         let guest: Arc<Mutex<Guest>> = guest.clone();
         let vmem: Arc<Mutex<VirtualMemory>> = vmem.clone();
+        #[cfg(not(feature = "hyperlight"))]
+        let notifier: crate::vmm::IkcNotifier = notifier.clone();
         Box::pin(async move {
-            let mut guest = guest.lock().await;
-            let mut vmem = vmem.lock().await;
-            guest.add_credit(&mut vmem)
+            // Scope the locks so they are released before the IRQ injection.
+            {
+                let mut guest = guest.lock().await;
+                let mut vmem = vmem.lock().await;
+                guest.add_credit(&mut vmem)?;
+            }
+            // Inject an edge-triggered IRQ to wake the guest from HLT
+            // immediately, rather than waiting for the next PIT timer tick.
+            // This is lock-free — the notifier uses a duplicated VM fd.
+            #[cfg(not(feature = "hyperlight"))]
+            notifier.notify()?;
+            Ok(())
         })
     })
 }
@@ -474,6 +499,7 @@ pub fn get_stderr_writer(vm_stderr: Option<String>) -> Result<Box<dyn Write + Se
 pub fn build_input_fn(
     mut input_queue: Receiver<IkcFrame>,
     counters: MessageCounters,
+    ikc_pending: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) -> Box<StdinFn> {
     // Input function used for emulating I/O port reads.
     let input = move |guest: &Arc<Mutex<Guest>>,
@@ -516,6 +542,7 @@ pub fn build_input_fn(
 
                         locked_vm.write_bytes(data as u64, &msg.to_bytes())?;
                         locked_guest.consume_credit(&mut locked_vm)?;
+                        ikc_pending.store(false, std::sync::atomic::Ordering::Release);
                     },
                     IkcFrame::Bulk(mut bulk) => {
                         // Write bulk data directly into guest memory at the address specified
@@ -569,6 +596,7 @@ pub fn build_input_fn(
                         );
                         locked_vm.write_bytes(data as u64, &completion_msg.to_bytes())?;
                         locked_guest.consume_credit(&mut locked_vm)?;
+                        ikc_pending.store(false, std::sync::atomic::Ordering::Release);
                     },
                 }
             },

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -62,6 +62,14 @@ use ::std::{
     ffi::OsStr,
     fs::File,
     io::Write,
+    os::{
+        fd::OwnedFd,
+        unix::io::{
+            AsRawFd,
+            FromRawFd,
+            RawFd,
+        },
+    },
     path::{
         Path,
         PathBuf,
@@ -90,6 +98,102 @@ use ::tokio::{
 
 pub use kvm::vmem::VirtualMemory;
 pub use ramfs::RamFs;
+
+//==================================================================================================
+// IKC IRQ Notifier
+//==================================================================================================
+
+/// IRQ number used for IKC (inter-kernel communication) notifications.
+const IKC_IRQ: u32 = 9;
+
+///
+/// # Description
+///
+/// Lightweight, lock-free notifier that injects an edge-triggered IKC interrupt (IRQ 9) into
+/// the guest via a duplicated VM file descriptor.
+///
+/// The duplicated fd allows the memory thread to inject IRQs without contending on the
+/// `tokio::Mutex` that protects the main `VmFd` used by the vCPU thread.
+///
+/// # Safety
+///
+/// `KVM_IRQ_LINE` is thread-safe — the KVM subsystem serialises concurrent ioctl calls
+/// internally, so no user-space locking is required.
+///
+#[derive(Clone)]
+pub struct IkcNotifier {
+    /// Duplicated VM file descriptor for lock-free IRQ injection.
+    vm_fd: Arc<OwnedFd>,
+    /// Coalescing flag: when `true`, an IRQ has already been injected and the guest has not yet
+    /// acknowledged it by consuming a credit, so further injections are redundant.
+    pending: Arc<AtomicBool>,
+}
+
+impl IkcNotifier {
+    /// Creates a new notifier by duplicating the given VM file descriptor.
+    fn new(vm_fd: &VmFd, pending: Arc<AtomicBool>) -> Result<Self> {
+        let raw_fd: RawFd = vm_fd.as_raw_fd();
+        // SAFETY: `raw_fd` is a valid, open KVM VM file descriptor.
+        // Use `F_DUPFD_CLOEXEC` so the duplicated fd is automatically close-on-exec,
+        // preventing leaks across `exec()` if the process ever spawns children.
+        let dup_fd: RawFd = unsafe { libc::fcntl(raw_fd, libc::F_DUPFD_CLOEXEC, 0) };
+        if dup_fd < 0 {
+            anyhow::bail!("failed to dup VM fd: {}", ::std::io::Error::last_os_error());
+        }
+        // SAFETY: `dup_fd` is a freshly duplicated, valid fd we now own.
+        let owned: OwnedFd = unsafe { OwnedFd::from_raw_fd(dup_fd) };
+        Ok(Self {
+            vm_fd: Arc::new(owned),
+            pending,
+        })
+    }
+
+    /// Injects an edge-triggered IKC IRQ (assert then de-assert) into the guest.
+    ///
+    /// The call is coalesced: if a previous notification is still pending (the guest has not yet
+    /// consumed a credit), the ioctl is skipped to avoid redundant host-kernel entries.
+    pub fn notify(&self) -> Result<()> {
+        // `swap(true)` returns the previous value.  If it was already `true` a notification is
+        // outstanding and we can skip the expensive ioctl pair.
+        if self.pending.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+
+        let fd: RawFd = self.vm_fd.as_raw_fd();
+
+        // Use `kvm_bindings::kvm_irq_level` and the `KVM_IRQ_LINE` ioctl number from
+        // `vmm_sys_util` to avoid hardcoded magic constants and manual struct definitions.
+        vmm_sys_util::ioctl_iow_nr!(KVM_IRQ_LINE, KVMIO, 0x61, kvm_bindings::kvm_irq_level);
+        const KVMIO: u32 = 0xAE;
+
+        let mut irq_level: kvm_bindings::kvm_irq_level = kvm_bindings::kvm_irq_level::default();
+        irq_level.__bindgen_anon_1.irq = IKC_IRQ;
+        irq_level.level = 1;
+
+        // Assert IRQ.
+        // SAFETY: fd is a valid KVM VM fd, irq_level is correctly initialised.
+        let ret: i32 = unsafe { libc::ioctl(fd, KVM_IRQ_LINE(), &irq_level) };
+        if ret != 0 {
+            anyhow::bail!("KVM_IRQ_LINE assert failed: {}", ::std::io::Error::last_os_error());
+        }
+
+        // De-assert IRQ (edge trigger).
+        irq_level.level = 0;
+        // SAFETY: same as above.
+        let ret: i32 = unsafe { libc::ioctl(fd, KVM_IRQ_LINE(), &irq_level) };
+        if ret != 0 {
+            anyhow::bail!("KVM_IRQ_LINE de-assert failed: {}", ::std::io::Error::last_os_error());
+        }
+
+        Ok(())
+    }
+
+    /// Clears the coalescing flag so that the next [`notify`](Self::notify) call will inject an
+    /// IRQ. Call this from the vCPU thread after the guest has consumed at least one credit.
+    pub fn acknowledge(&self) {
+        self.pending.store(false, Ordering::Release);
+    }
+}
 
 //==================================================================================================
 // Constants
@@ -137,6 +241,8 @@ pub struct Vmm {
     vcpu: Arc<Mutex<VirtualProcessor>>,
     /// Wraps fields that don't require individual `Arc<Mutex<_>>`s.
     inner: Arc<Mutex<InteriorMicroVmHandle>>,
+    /// Lock-free IKC interrupt notifier (duplicated VM fd).
+    ikc_notifier: IkcNotifier,
 }
 
 ///
@@ -294,6 +400,9 @@ impl Vmm {
         let emulator: Emulator =
             Emulator::new(guest.clone(), vmem.clone(), args.input, args.output, args.stderr)?;
 
+        // Create the IKC notifier *before* moving the VmFd into InteriorMicroVmHandle.
+        let ikc_notifier: IkcNotifier = IkcNotifier::new(&vm, args.ikc_pending)?;
+
         Ok(Self {
             guest,
             vmem,
@@ -309,6 +418,7 @@ impl Vmm {
                 kernel_filename: args.kernel_filename,
                 skip_next_snapshot: false,
             })),
+            ikc_notifier,
         })
     }
 
@@ -446,6 +556,18 @@ impl Vmm {
     ///
     pub fn guest(&self) -> Arc<Mutex<Guest>> {
         self.guest.clone()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a cloneable, lock-free IKC interrupt notifier.
+    ///
+    /// The notifier uses a duplicated VM file descriptor so it can inject IRQs without
+    /// contending on the main `Mutex<InteriorMicroVmHandle>` used by the vCPU thread.
+    ///
+    pub fn ikc_notifier(&self) -> IkcNotifier {
+        self.ikc_notifier.clone()
     }
 
     ///

--- a/src/uservm/src/vmm/mod.rs
+++ b/src/uservm/src/vmm/mod.rs
@@ -43,6 +43,9 @@ pub struct MicroVmArgs {
     /// When true, skip kernel/initrd/ramfs loading and vCPU reset because the VM state will be
     /// restored from a snapshot.
     pub restoring_from_snapshot: bool,
+    /// Shared coalescing flag for IKC IRQ notification (microvm only).
+    #[cfg(feature = "microvm")]
+    pub ikc_pending: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl std::fmt::Debug for MicroVmArgs {


### PR DESCRIPTION
This pull request introduces a dedicated, lock-free inter-kernel communication (IKC) notification mechanism using a new IRQ (IRQ 9) for efficient message delivery between the host and guest kernel. The changes improve responsiveness by allowing the host to immediately wake the guest kernel when new IKC messages arrive, rather than waiting for the next timer tick. The implementation includes kernel-side interrupt handling, a lock-free notifier in the user VM, and a refactoring of the IKC polling logic for clarity and efficiency.