### PR TITLE
[kernel] Rollback in `mmio_alloc()` when MMIO page mapping fails

### DIFF
--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -1177,6 +1177,15 @@ impl Vmem {
         vaddr: PageAligned<VirtualAddress>,
         access: AccessPermission,
     ) -> Result<(), Error> {
+        self.kctrl_impl(vaddr, access, false)
+    }
+
+    fn kctrl_impl(
+        &mut self,
+        vaddr: PageAligned<VirtualAddress>,
+        access: AccessPermission,
+        dry_run: bool,
+    ) -> Result<(), Error> {
         trace!("{vaddr:?}");
 
         // Check if the provided address lies outside the kernel space.
@@ -1213,13 +1222,26 @@ impl Vmem {
 
         let page_address: PageAddress = PageAddress::new(vaddr);
 
-        // Change access permissions on the page.
-        page_table
-            .borrow_mut()
-            .1
-            .ctrl(false, page_address, access)?;
+        if dry_run {
+            page_table.borrow().1.lookup(page_address)?;
+        } else {
+            page_table
+                .borrow_mut()
+                .1
+                .ctrl(false, page_address, access)?;
+        }
 
         Ok(())
+    }
+
+    /// Validates that [`kctrl`](Self::kctrl) would succeed for the given address without
+    /// modifying any page table entries.
+    pub fn kctrl_dry_run(
+        &mut self,
+        vaddr: PageAligned<VirtualAddress>,
+        access: AccessPermission,
+    ) -> Result<(), Error> {
+        self.kctrl_impl(vaddr, access, true)
     }
 }
 

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1850,11 +1850,18 @@ impl ProcessManager {
             error!("{reason} (base={base:#x}, size={:#?})", region.size());
             Error::new(ErrorCode::ValueOverflow, reason)
         })?;
+        let perm: AccessPermission = region.perm();
+
+        // Validate that every page can be mapped before modifying any state.
         for raw_vaddr in (base..end).step_by(PAGE_SIZE) {
-            // FIXME (#1482): Use infallible logic for address conversion.
             let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(raw_vaddr)?;
-            // FIXME (#1481): If we fail, we need to revert operation.
-            vmem.kctrl(vaddr, region.perm())?;
+            vmem.kctrl_dry_run(vaddr, perm)?;
+        }
+
+        // All validations passed — apply the permission changes for real.
+        for raw_vaddr in (base..end).step_by(PAGE_SIZE) {
+            let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(raw_vaddr)?;
+            vmem.kctrl(vaddr, perm)?;
         }
 
         state.add_mmio(region);


### PR DESCRIPTION
`mmio_alloc()` previously applied `kctrl()` page-by-page without any pre-validation, so a failure mid-loop left earlier pages with modified permissions while `add_mmio()` was never called, producing partial state. This follows the dry-run pattern: a first pass validates that every page can be mapped without modifying any page table entries, then a second pass that actually applies the changes.

Closes #1481 