### PR TITLE
[nanvixd] Configure Default Console File

### DIFF
--- a/src/libs/nanvix-sandbox/Cargo.toml
+++ b/src/libs/nanvix-sandbox/Cargo.toml
@@ -13,6 +13,7 @@ homepage.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 cfg-if = { workspace = true }
+chrono = { workspace = true }
 config = { workspace = true }
 control-plane-api = { workspace = true }
 hwloc = { workspace = true }

--- a/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/uservm.rs
@@ -130,8 +130,6 @@ impl UserVm {
             args.gateway_socket_info().1.to_str().to_string(),
         ];
 
-        debug!("spawning uservm (program={:?} args={:?})", args.program(), user_vm_args,);
-
         if let Some(program_args) = args.program_args() {
             user_vm_args.push(::uservm::args::Args::OPT_INITRD_ARGS.to_string());
             user_vm_args.push(program_args.to_string());
@@ -156,6 +154,7 @@ impl UserVm {
             user_vm_args.splice(0..0, taskset);
         }
 
+        debug!("spawning uservm (program={:?} args={:?})", args.program(), user_vm_args,);
         let mut cmd: Command = {
             // In an L2-deployment, spawn the user VM inside a network namespace.
             #[cfg(not(feature = "single-process"))]

--- a/src/libs/nanvix-sandbox/src/sandbox_config.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox_config.rs
@@ -12,8 +12,10 @@
 //==================================================================================================
 
 use crate::tcp_port::TcpPort;
+use ::chrono::Local;
 #[cfg(not(feature = "single-process"))]
 use ::std::marker::PhantomData;
+use ::std::path::PathBuf;
 use ::syscomm::SocketType;
 use ::user_vm_api::UserVmIdentifier;
 
@@ -99,6 +101,29 @@ impl<T> SandboxConfig<T> {
     ///
     /// # Description
     ///
+    /// Generates a default console file path for the sandbox when no explicit path is provided.
+    /// The path is constructed from the log directory and includes the user VM identifier along
+    /// with a timestamp to ensure uniqueness.
+    ///
+    /// # Arguments
+    ///
+    /// - `uservm_id`: user VM unique identifier.
+    /// - `log_dir`: log directory for the sandbox.
+    ///
+    /// # Returns
+    ///
+    /// The path to the console file as a string.
+    ///
+    fn default_console_file(uservm_id: UserVmIdentifier, log_dir: &str) -> String {
+        let console_file: PathBuf = PathBuf::from(log_dir)
+            .join(format!("guest_{uservm_id}_{}.log", Local::now().format("%Y_%m_%d_%H_%M_%S_%f")));
+
+        console_file.to_string_lossy().into_owned()
+    }
+
+    ///
+    /// # Description
+    ///
     /// Creates a new sandbox configuration with the specified parameters.
     ///
     /// # Parameters
@@ -149,7 +174,10 @@ impl<T> SandboxConfig<T> {
             uservm_id,
             gateway_socket_info,
             system_vm_socket_info,
-            console_file,
+            console_file: Some(
+                console_file
+                    .unwrap_or_else(|| Self::default_console_file(uservm_id, log_directory)),
+            ),
             hwloc,
             kernel_binary_path: kernel_binary_path.to_string(),
             #[cfg(not(feature = "single-process"))]

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -11,12 +11,14 @@
 // Imports
 //==================================================================================================
 
+#[cfg(feature = "single-process")]
+use crate::config::DEFAULT_CONSOLE_FILENAME;
 use crate::config::{
     self,
-    DEFAULT_CONSOLE_FILENAME,
     DEFAULT_TMP_DIRECTORY,
 };
 use ::anyhow::Result;
+#[cfg(feature = "single-process")]
 use ::chrono::Local;
 use ::nanvix::{
     hwloc::HwLoc,
@@ -140,6 +142,9 @@ impl Args {
         let mut binary_directory: String = config::DEFAULT_BIN_DIRECTORY.to_string();
         let mut toolchain_binary_directory: String =
             config::DEFAULT_TOOLCHAIN_BIN_DIRECTORY.to_string();
+        #[cfg(not(feature = "single-process"))]
+        let mut console_file: Option<String> = None;
+        #[cfg(feature = "single-process")]
         let mut console_file: Option<String> = Some(format!(
             "{}/{}_{}.log",
             DEFAULT_LOG_DIRECTORY,


### PR DESCRIPTION
In this PR I tweak the `nanvixd` default behaviour such that we only set a default console file in single-process mode. In multi-process mode it makes sense to set this option to `None` and let the sandbox cache take care of the naming of each console file.