### PR TITLE
[kernel] Fix PIC slave IRQ EOI

### DIFF
--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/pic.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/pic.rs
@@ -236,13 +236,14 @@ impl Pic {
     /// - `irq`: Interrupt request.
     ///
     pub fn ack(&mut self, irq: u32) {
-        // Check for invalid interrupt request. IRQ 2 is reserved for the cascade.
-        if irq == 2 || irq >= pic::PIC_NUM_IRQS as u32 {
+        // Check for invalid interrupt request. IRQ 2 is reserved for the cascade
+        // and IRQs beyond the dual-PIC range (0-15) are out of bounds.
+        if irq == 2 || irq >= 2 * pic::PIC_NUM_IRQS as u32 {
             error!("invalid irq {}", irq);
             return;
         }
 
-        // Check if EOI is managed by slave PIC.
+        // Check if EOI is managed by slave PIC (IRQs 8-15).
         if irq >= pic::PIC_NUM_IRQS as u32 {
             // Send EOI to slave PIC.
             self.ctrl_slave.write8(pic::ocw2::Eoi::NonSpecific as u8);


### PR DESCRIPTION
## Summary

Fix PIC `ack()` guard that silently blocks all slave PIC interrupts (IRQs 8-15).

## Problem

The guard condition `irq >= PIC_NUM_IRQS` (where `PIC_NUM_IRQS=8`) in `Pic::ack()` rejects
all slave PIC IRQs (8-15) before the EOI can be sent. Without EOI, the PIC keeps the IRQ
in-service and blocks all subsequent interrupts on that line — only the **first** interrupt
ever reaches the kernel; all others are silently dropped.

This bug was latent because no slave PIC interrupt was used until the IKC IRQ notification
feature (IRQ 9) was introduced in #1508.

## Fix

Change the guard from `irq >= pic::PIC_NUM_IRQS` to `irq >= 2 * pic::PIC_NUM_IRQS` so
only truly out-of-range IRQs (≥16) are rejected, allowing slave PIC IRQs 8-15 to be
properly acknowledged with EOI.

## Impact

**Blocks PR #1508** — without this fix, the IKC IRQ notification has no effect beyond the
first message because subsequent IRQ 9 injections are never acknowledged.

### Local benchmark results (500 iterations × 2 runs, WSL baremetal)

| Benchmark | dev p50 | With fix + #1508 p50 | Delta |
|-----------|---------|---------------------|-------|
| warm-start | 528µs | 493µs | **-6.5%** |
| RT 128B | 1284µs | 1189µs | **-7.4%** |
| RT 256B | 1282µs | 1155µs | **-9.9%** |
| RT 4KiB | 1294µs | 1171µs | **-9.5%** |

Under stress config (1kHz timer, halt_poll=0): **-48% warm-start**, **-65% round-trip**.

## Files Changed

- `src/kernel/src/hal/arch/x86/cpu/interrupt/pic.rs`: Fix guard in `ack()` (line 240)
