### PR TITLE
[daemons] Disambiguate Linuxd Log Files With Tenant Id

### DIFF
--- a/src/daemons/linuxd/src/args.rs
+++ b/src/daemons/linuxd/src/args.rs
@@ -19,6 +19,8 @@ use ::syslog::DEFAULT_LOG_DIRECTORY;
 /// This structure packs the command-line arguments that were passed to the program.
 ///
 pub struct Args {
+    /// Unique identifier of the tenant associated with this linuxd instance.
+    tenant_id: Option<String>,
     /// Socket address linuxd listens to for messages from the control plane.
     control_plane_sockaddr: String,
     /// Control plane socket address type.
@@ -42,6 +44,8 @@ pub struct Args {
 impl Args {
     /// Command-line option for printing the help message.
     pub const OPT_HELP: &'static str = "-help";
+    /// Command-line option for setting the tenant identifier.
+    pub const OPT_TENANT_ID: &'static str = "-tenant-id";
     /// Command-line option for setting the control-plane socket address.
     pub const OPT_CONTROL_PLANE_SOCKADDR: &'static str = "-control-plane-addr";
     /// Command-line option for setting the socket address type of the bind socket.
@@ -87,6 +91,7 @@ impl Args {
     /// program. Upon failure, the function returns an error.
     ///
     pub fn parse(args: Vec<String>) -> Result<Self> {
+        let mut tenant_id: Option<String> = None;
         let mut control_plane_sockaddr: String = String::new();
         let mut control_plane_sockaddr_type: Option<String> = None;
         let mut user_vm_bind_sockaddr: String = String::new();
@@ -101,6 +106,16 @@ impl Args {
                 Self::OPT_HELP => {
                     Self::usage(args[0].as_str());
                     return Err(anyhow::anyhow!("help message"));
+                },
+                Self::OPT_TENANT_ID => {
+                    i += 1;
+                    if i >= args.len() {
+                        return Err(anyhow::anyhow!(
+                            "missing value for {} option",
+                            Self::OPT_TENANT_ID
+                        ));
+                    }
+                    tenant_id = Some(args[i].clone());
                 },
                 Self::OPT_CONTROL_PLANE_SOCKADDR => {
                     i += 1;
@@ -197,6 +212,7 @@ impl Args {
         }
 
         Ok(Self {
+            tenant_id,
             control_plane_sockaddr,
             control_plane_sockaddr_type,
             user_vm_bind_sockaddr,
@@ -218,9 +234,10 @@ impl Args {
     ///
     pub fn usage(program_name: &str) {
         println!(
-            "Usage: {} {} <control-plane-sockaddr> {} <control-plane-socktype> {} \
-             <user-vm-sockaddr> {} <user-vm-socktype> {} {} <log-file-dir> {}",
+            "Usage: {} [{} <tenant-id>] {} <control-plane-sockaddr> {} <control-plane-socktype> \
+             {} <user-vm-sockaddr> {} <user-vm-socktype> [{} [{} <log-file-dir>]] {}",
             program_name,
+            Self::OPT_TENANT_ID,
             Self::OPT_CONTROL_PLANE_SOCKADDR,
             Self::OPT_CONTROL_PLANE_SOCKET_TYPE,
             Self::OPT_USER_VM_BIND_SOCKADDR,
@@ -229,6 +246,19 @@ impl Args {
             Self::OPT_LOGDIR,
             Self::OPT_L2
         );
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the tenant identifier associated to this linuxd instance.
+    ///
+    /// # Returns
+    ///
+    /// The optional tenant identifier.
+    ///
+    pub fn tenant_id(&self) -> Option<&str> {
+        self.tenant_id.as_deref()
     }
 
     ///

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -48,6 +48,26 @@ use ::syscomm::{
 const DEFAULT_LOG_LEVEL: &str = "error";
 
 //==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Sanitizes a tenant identifier so it is safe to use as a file-name component.
+///
+/// Only ASCII letters, digits, '.', '_' and '-' are preserved. All other characters
+/// are replaced with '_'.
+fn sanitize_tenant_id(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+//==================================================================================================
 // Implementations
 //==================================================================================================
 
@@ -55,7 +75,14 @@ const DEFAULT_LOG_LEVEL: &str = "error";
 pub async fn main() -> Result<()> {
     // Parse and retrieve command-line arguments.
     let args: Args = args::Args::parse(env::args().collect())?;
-    ::syslog::init(args.log_to_file(), DEFAULT_LOG_LEVEL, args.log_file_dir(), None);
+    let tenant_id: Option<String> = args.tenant_id().and_then(|id| {
+        if id.is_empty() {
+            None
+        } else {
+            Some(sanitize_tenant_id(id))
+        }
+    });
+    ::syslog::init(args.log_to_file(), DEFAULT_LOG_LEVEL, args.log_file_dir(), tenant_id);
 
     // Work-out the socket addresses.
     let control_plane_sockaddr: &str = args.control_plane_sockaddr();

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -543,6 +543,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                 }
 
                 let config: SandboxConfig<T> = SandboxConfig::new(
+                    tag.tenant_id(),
                     tag.sandbox_id(),
                     (gateway_socket_address.clone(), gateway_socket_type, gateway_l2_port),
                     (user_vm_sockaddr.clone(), self.config.system_vm_sockaddr_type()),

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -59,6 +59,7 @@
 //! # async fn example() -> anyhow::Result<()> {
 //! // Create configuration.
 //! let config: SandboxConfig<()> = SandboxConfig::new(
+//!     "tenant-1",  // tenant_id
 //!     UserVmIdentifier::new(0),  // uservm_id
 //!     ("127.0.0.1:8080".to_string(), SocketType::Tcp, None),  // gateway_socket_info
 //!     ("127.0.0.1:8081".to_string(), SocketType::Tcp),  // system_vm_socket_info

--- a/src/libs/nanvix-sandbox/src/linuxd_args.rs
+++ b/src/libs/nanvix-sandbox/src/linuxd_args.rs
@@ -30,6 +30,8 @@ use ::syscomm::SocketType;
 ///   single-process mode. Use `()` if no custom state is required.
 ///
 pub struct LinuxDaemonArgs<T> {
+    /// Unique tenant identifier.
+    tenant_id: String,
     /// Information on control plane connect socket (address, socket type).
     control_plane_connect_socket_info: (String, SocketType),
     /// Information on System VM socket (address, socket type).
@@ -70,6 +72,7 @@ impl<T> LinuxDaemonArgs<T> {
     ///
     /// # Parameters
     ///
+    /// - `tenant_id`: Unique identifier of the tenant associated with a linuxd instance.
     /// - `control_plane_connect_socket_info`: Information on control plane socket (address, socket type).
     /// - `system_vm_socket_info`: Information on System VM socket (address, socket type).
     /// - `hwloc`: Optional hardware locality configuration for CPU affinity and topology information.
@@ -87,6 +90,7 @@ impl<T> LinuxDaemonArgs<T> {
     ///
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        tenant_id: &str,
         control_plane_connect_socket_info: (String, SocketType),
         system_vm_socket_info: (String, SocketType),
         hwloc: Option<hwloc::HwLoc>,
@@ -101,6 +105,7 @@ impl<T> LinuxDaemonArgs<T> {
         >,
     ) -> Self {
         Self {
+            tenant_id: tenant_id.to_string(),
             control_plane_connect_socket_info,
             system_vm_socket_info,
             hwloc,
@@ -116,6 +121,19 @@ impl<T> LinuxDaemonArgs<T> {
             #[cfg(not(feature = "single-process"))]
             _phantom: PhantomData,
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns information on the tenant identifier.
+    ///
+    /// # Returns
+    ///
+    /// A unique tenant identifier.
+    ///
+    pub fn tenant_id(&self) -> &str {
+        &self.tenant_id
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
@@ -483,6 +483,8 @@ impl LinuxDaemon {
         } else {
             vec![
                 args.linuxd_binary_path().to_string(),
+                args::Args::OPT_TENANT_ID.to_string(),
+                args.tenant_id().to_string(),
                 args::Args::OPT_LOGFILE.to_string(),
                 args::Args::OPT_LOGDIR.to_string(),
                 args.log_directory().to_string(),

--- a/src/libs/nanvix-sandbox/src/sandbox_config.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox_config.rs
@@ -38,6 +38,8 @@ use ::user_vm_api::UserVmIdentifier;
 ///   single-process mode. Use `()` if no custom state is required.
 ///
 pub struct SandboxConfig<T> {
+    /// Unique identifier for the tenant.
+    tenant_id: String,
     /// Unique identifier for the User VM.
     uservm_id: UserVmIdentifier,
     /// Information on gateway socket (address, socket type, optional L2 TCP port).
@@ -151,6 +153,7 @@ impl<T> SandboxConfig<T> {
     ///
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        tenant_id: &str,
         uservm_id: UserVmIdentifier,
         gateway_socket_info: (String, SocketType, Option<TcpPort>),
         system_vm_socket_info: (String, SocketType),
@@ -171,6 +174,7 @@ impl<T> SandboxConfig<T> {
         l2_snapshot_path: Option<String>,
     ) -> Self {
         Self {
+            tenant_id: tenant_id.to_string(),
             uservm_id,
             gateway_socket_info,
             system_vm_socket_info,
@@ -196,6 +200,19 @@ impl<T> SandboxConfig<T> {
             #[cfg(not(feature = "single-process"))]
             _phantom: PhantomData,
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the unique tenant identifier for the sandbox.
+    ///
+    /// # Returns
+    ///
+    /// The tenant identifier.
+    ///
+    pub fn tenant_id(&self) -> &str {
+        &self.tenant_id
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/uninitialized.rs
+++ b/src/libs/nanvix-sandbox/src/uninitialized.rs
@@ -287,6 +287,7 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
                     };
 
                     LinuxDaemonArgs::new(
+                        config.tenant_id(),
                         // We pass linuxd the control plane socket's connect address, which may
                         // depend on the network namespace.
                         (


### PR DESCRIPTION
I was experiencing crashes in my test environment at high concurrency, where concurrent linuxd instances trying to operate on a log file with the same name would crash. Disambiguating the file name with the tenant ID fixes the issue locally.

This PR does not address the issue for L2 VMs, because L2 VMs do not rely on log files. Instead, they compete for CLH's console file. This is related to #1203 and I will address it in a follow-up PR.
