### PR TITLE
[ci] Run verify in parallel with lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
   # machine-type + deployment-type) and runs once per unique pair, like lint.
   verify:
     name: "Verify (${{ matrix.machine-type }}, ${{ matrix.deployment-type }})"
-    needs: [precheck, checks, lint]
+    needs: [precheck, checks]
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
Remove `lint` from `verify`'s `needs` so that `verify` and `lint` run in parallel (both depend only on `precheck` and `checks`). The `ci-build` job already depends on both, so builds still wait for both to finish.