### PR TITLE
[syscall] Add global symbol table for dynamic loading

### DIFF
--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -26,6 +26,9 @@ ifeq ($(DEPLOYMENT_MODE),standalone)
 	@if [ -f $(LIBRARIES_DIR)/libmul.so ]; then \
 		cp -f $(LIBRARIES_DIR)/libmul.so $(BINARIES_DIR)/standalone-rootfs-seed/lib/; \
 	fi
+	@if [ -f $(LIBRARIES_DIR)/libmul-pie.so ]; then \
+		cp -f $(LIBRARIES_DIR)/libmul-pie.so $(BINARIES_DIR)/standalone-rootfs-seed/lib/; \
+	fi
 	$(BINARIES_DIR)/mkramfs.elf -o $(BINARIES_DIR)/standalone-rootfs.img $(BINARIES_DIR)/standalone-rootfs-seed/
 endif
 	# Only give nanvixd CAP_SYS_ADMIN and CAP_NET_ADMIN if we need to manage

--- a/build/user/linker/x86/user.ld
+++ b/build/user/linker/x86/user.ld
@@ -45,6 +45,29 @@ SECTIONS
 		*(.rodata*)
 	}
 
+	/* Dynamic symbol table (populated by --export-dynamic). */
+	.dynsym : ALIGN(4)
+	{
+		PROVIDE(__dynsym_start = .);
+		*(.dynsym)
+		PROVIDE(__dynsym_end = .);
+	}
+
+	/* Dynamic string table (symbol names for .dynsym). */
+	.dynstr : ALIGN(4)
+	{
+		PROVIDE(__dynstr_start = .);
+		*(.dynstr)
+		PROVIDE(__dynstr_end = .);
+	}
+
+	/* Symbol hash table. */
+	.hash : ALIGN(4)
+	{
+		*(.hash)
+		*(.gnu.hash)
+	}
+
 	/* Exception handling frame header */
 	.eh_frame_hdr : ALIGN(4)
 	{

--- a/src/libs/posix/src/dlfcn/mod.rs
+++ b/src/libs/posix/src/dlfcn/mod.rs
@@ -205,6 +205,11 @@ pub unsafe extern "C" fn dlclose(handle: *mut c_void) -> i32 {
         return -1;
     }
 
+    // The global scope handle (from dlopen(NULL)) is not closeable.
+    if DlHandle::from_mut_ptr(handle) == DlHandle::GLOBAL {
+        return 0;
+    }
+
     // Attempt to close the dynamic library handle.
     match dlfcn::dlclose(&DlHandle::from_mut_ptr(handle)) {
         Ok(()) => 0,
@@ -251,7 +256,8 @@ pub unsafe extern "C" fn dlerror() -> *mut c_char {
 ///
 /// # Parameters
 ///
-/// - `filename`: The name of the shared object file to be opened.
+/// - `filename`: The name of the shared object file to be opened, or NULL to obtain
+///   a handle to the global symbol scope (main executable + loaded libraries).
 /// - `mode`: The mode in which the object is opened.
 ///
 /// # Return Value
@@ -266,18 +272,17 @@ pub unsafe extern "C" fn dlerror() -> *mut c_char {
 /// - It may operate on global variables.
 ///
 /// It is safe to use this function if the caller ensures that:
-/// - `filename` points to a valid C-style string.
+/// - `filename` points to a valid C-style string, or is NULL.
 /// - No other thread modifies the error state while this function is being executed.
 ///
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn dlopen(filename: *const c_char, mode: c_int) -> *mut c_void {
-    // Check if filename is not valid.
+    // Per POSIX: dlopen(NULL, mode) returns a handle to the global symbol scope.
     if filename.is_null() {
-        let reason: &str = "filename is null";
-        DL_LAST_ERROR.lock().set(reason);
-        ::syslog::error!("dlopen(): {}", reason);
-        return ptr::null_mut();
+        // Populate the global symbol table from the executable's .dynsym section.
+        dlfcn::dlinit();
+        return DlHandle::GLOBAL.as_mut_ptr();
     }
 
     // Attempt to convert `filename` to a Rust string.
@@ -328,7 +333,8 @@ pub unsafe extern "C" fn dlopen(filename: *const c_char, mode: c_int) -> *mut c_
 ///
 /// # Parameters
 ///
-/// - `handle`: A handle to the shared object or executable.
+/// - `handle`: A handle to the shared object or executable, or NULL/`RTLD_DEFAULT`
+///   to search the global symbol scope (main executable + loaded libraries).
 /// - `symbol`: The name of the symbol to be resolved.
 ///
 /// # Return Value
@@ -343,20 +349,16 @@ pub unsafe extern "C" fn dlopen(filename: *const c_char, mode: c_int) -> *mut c_
 /// - It may operate on global variables.
 ///
 /// It is safe to use this function if the caller ensures that:
-/// - `handle` points to a valid dynamic library handle.
+/// - `handle` points to a valid dynamic library handle, or is NULL (`RTLD_DEFAULT`).
 /// - `symbol` points to a valid C-style string.
 /// - No other thread modifies the error state while this function is being executed.
 ///
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void {
-    // Check if handle is not valid.
-    if handle.is_null() {
-        let reason: &str = "handle is null";
-        DL_LAST_ERROR.lock().set(reason);
-        ::syslog::error!("dlsym(): {}", reason);
-        return ptr::null_mut();
-    }
+    // Per POSIX: NULL handle (RTLD_DEFAULT) searches the global symbol scope.
+    // The GLOBAL sentinel (from dlopen(NULL)) is also routed to the same path.
+    let use_global: bool = handle.is_null() || DlHandle::from_mut_ptr(handle) == DlHandle::GLOBAL;
 
     // Check if symbol is not valid.
     if symbol.is_null() {
@@ -378,7 +380,14 @@ pub unsafe extern "C" fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *m
     };
 
     // Attempt to resolve the symbol.
-    match dlfcn::dlsym(&DlHandle::from_mut_ptr(handle), symbol) {
+    // For global scope, use the GLOBAL sentinel which dlsym() in the syscall
+    // layer routes to global_symbol_lookup(). For regular handles, use as-is.
+    let effective_handle: DlHandle = if use_global {
+        DlHandle::GLOBAL
+    } else {
+        DlHandle::from_mut_ptr(handle)
+    };
+    match dlfcn::dlsym(&effective_handle, symbol) {
         Ok(symbol) => symbol.into_raw_value() as *mut c_void,
         Err(error) => {
             DL_LAST_ERROR.lock().set(error.reason);

--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -28,7 +28,7 @@ goblin = { workspace = true, optional = true, features = [
 ] }
 libc_stdlib = { workspace = true, optional = true }
 nvx = { workspace = true, optional = true }
-spin = { workspace = true, features = ["lazy", "spin_mutex"] }
+spin = { workspace = true, features = ["lazy", "once", "spin_mutex"] }
 static_assert = { workspace = true }
 syslog = { workspace = true, default-features = true, optional = true }
 sysalloc = { workspace = true, optional = true }

--- a/src/libs/syscall/src/dlfcn/mod.rs
+++ b/src/libs/syscall/src/dlfcn/mod.rs
@@ -23,6 +23,7 @@ cfg_if::cfg_if! {
         pub use syscall::dlopen;
         pub use syscall::dlsym;
         pub use syscall::dladdr;
+        pub use syscall::dlinit;
     }
 }
 

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -34,6 +34,12 @@ use ::sys::error::Error;
 pub fn dlopen(filename: &str) -> Result<DlHandle, Error> {
     ::syslog::trace!("dlopen(): filename={}", filename);
 
+    // Ensure the global symbol table is populated so that symbols exported
+    // by the main executable can be resolved during relocation, even if the
+    // caller never invoked dlopen(NULL). Guarded by Once, so subsequent
+    // calls are a no-op.
+    super::dlinit();
+
     // TODO: Normalize filename.
 
     let mut registry: MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>> =

--- a/src/libs/syscall/src/dlfcn/syscall/dlsym.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlsym.rs
@@ -26,6 +26,18 @@ use ::sys::{
 pub fn dlsym(handle: &DlHandle, symbol: &str) -> Result<VirtualAddress, Error> {
     ::syslog::trace!("dlsym(): handle={:?}, symbol={}", handle, symbol);
 
+    // Handle the global scope sentinel (returned by dlopen(NULL)).
+    if *handle == DlHandle::GLOBAL {
+        return match super::global_symbol_lookup(symbol) {
+            Some(addr) => Ok(VirtualAddress::from_raw_value(addr)),
+            None => {
+                let reason: &str = "symbol not found in global scope";
+                ::syslog::error!("dlsym(): {}", reason);
+                Err(Error::new(ErrorCode::NoSuchEntry, reason))
+            },
+        };
+    }
+
     // Get dynamic file.
     match DYNAMIC_LIBRARY_REGISTRY.lock().get_mut(handle) {
         Some(dlfile) => {

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -76,6 +76,11 @@ use ::type_safe::UnalignedPointer;
 pub struct DlHandle(c_int);
 
 impl DlHandle {
+    /// Sentinel handle returned by `dlopen(NULL)` representing the global
+    /// symbol scope (main executable + pre-loaded libraries). This value
+    /// never collides with real file-descriptor-based handles.
+    pub const GLOBAL: Self = DlHandle(c_int::MAX);
+
     /// Casts the target handle to a pointer.
     pub fn as_mut_ptr(&self) -> *mut c_void {
         self.0 as *mut c_void
@@ -479,6 +484,13 @@ impl DynamicLibrary {
                             return Ok(Some((base, symbol_value)));
                         }
                     }
+                }
+
+                // Fall back to the global symbol table (symbols from the
+                // main executable, registered via --export-dynamic).
+                if let Some(addr) = super::global_symbol_lookup(symbol_name) {
+                    // Global symbols are absolute addresses, so base is 0.
+                    return Ok(Some((0, addr)));
                 }
             } else {
                 return Ok(Some((self.load_address.into_raw_value(), symbol.value() as usize)));

--- a/src/libs/syscall/src/dlfcn/syscall/mod.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/mod.rs
@@ -27,17 +27,115 @@ pub use self::dynlib::DlHandle;
 use self::dynlib::DynamicLibrary;
 use ::alloc::{
     collections::btree_map::BTreeMap,
+    string::String,
     sync::Arc,
+};
+use ::elf::{
+    StringTable,
+    SymbolTable,
 };
 use ::spin::{
     Lazy,
     Mutex,
+    Once,
 };
 
 //==================================================================================================
 
 static DYNAMIC_LIBRARY_REGISTRY: Lazy<Mutex<BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>> =
     Lazy::new(|| Mutex::new(BTreeMap::new()));
+
+/// Global symbol table for symbols exported by the main executable.
+/// When a dynamically loaded library has unresolved symbols, this table
+/// is consulted as a last resort, enabling statically-linked executables
+/// to export symbols to their dynamically-loaded extension modules.
+///
+/// NOTE: this table only contains symbols from the main executable
+/// (populated from `.dynsym`/`.dynstr` sections emitted by
+/// `--export-dynamic`). Symbols from dynamically loaded shared
+/// libraries are *not* included; those are resolved through
+/// the per-library dependency chains in `DYNAMIC_LIBRARY_REGISTRY`.
+static GLOBAL_SYMBOL_TABLE: Lazy<Mutex<BTreeMap<String, usize>>> =
+    Lazy::new(|| Mutex::new(BTreeMap::new()));
+
+/// Ensures `dlinit` runs at most once.
+static DLINIT_ONCE: Once = Once::new();
+
+/// Populates `GLOBAL_SYMBOL_TABLE` from the executable's `.dynsym`/`.dynstr`
+/// sections. The linker script emits `__dynsym_start/__dynsym_end` and
+/// `__dynstr_start/__dynstr_end` boundary symbols around these sections when
+/// the executable is linked with `--export-dynamic`.
+///
+/// If the executable was linked without `--export-dynamic` (boundaries are
+/// equal), this function is a harmless no-op.
+pub fn dlinit() {
+    DLINIT_ONCE.call_once(|| {
+        // SAFETY: These symbols are defined by the linker script and point to
+        // valid in-memory sections that are part of the loaded executable image.
+        let (dynsym_start, dynsym_end, dynstr_start, dynstr_end) = unsafe {
+            extern "C" {
+                static __dynsym_start: u8;
+                static __dynsym_end: u8;
+                static __dynstr_start: u8;
+                static __dynstr_end: u8;
+            }
+            (
+                &__dynsym_start as *const u8 as usize,
+                &__dynsym_end as *const u8 as usize,
+                &__dynstr_start as *const u8 as usize,
+                &__dynstr_end as *const u8 as usize,
+            )
+        };
+
+        let dynsym_size: usize = dynsym_end.saturating_sub(dynsym_start);
+        let dynstr_size: usize = dynstr_end.saturating_sub(dynstr_start);
+
+        // Nothing to do if the executable has no dynamic symbol table.
+        if dynsym_size == 0 || dynstr_size == 0 {
+            ::syslog::trace!("dlinit(): no .dynsym/.dynstr sections found");
+            return;
+        }
+
+        let sym_entry_size: usize = core::mem::size_of::<elf::Symbol>();
+        let sym_count: usize = dynsym_size / sym_entry_size;
+
+        // SAFETY: The linker-script boundaries guarantee that these pointers
+        // span valid, correctly-aligned ELF symbol and string table data that
+        // is part of the loaded executable image and will not be deallocated.
+        let dynsym =
+            unsafe { SymbolTable::from_raw_parts(dynsym_start as *mut elf::Symbol, sym_count) };
+        let dynstr = unsafe { StringTable::from_raw_parts(dynstr_start as *const u8, dynstr_size) };
+
+        let mut table = GLOBAL_SYMBOL_TABLE.lock();
+        let mut count: usize = 0;
+
+        for sym in dynsym.iter() {
+            // Skip undefined symbols; names are further validated below.
+            if sym.is_undefined() {
+                continue;
+            }
+            if let Ok(name) = dynstr.get_name(sym.name_offset()) {
+                if !name.is_empty() {
+                    use ::alloc::collections::btree_map::Entry;
+                    if let Entry::Vacant(e) = table.entry(String::from(name)) {
+                        e.insert(sym.value() as usize);
+                        count += 1;
+                    }
+                }
+            }
+        }
+
+        ::syslog::trace!("dlinit(): registered {} symbols from executable", count);
+    });
+}
+
+/// Looks up a symbol in the global symbol table (main executable only).
+///
+/// Ensures the table is populated before the first lookup.
+pub(super) fn global_symbol_lookup(name: &str) -> Option<usize> {
+    dlinit();
+    GLOBAL_SYMBOL_TABLE.lock().get(name).copied()
+}
 
 //==================================================================================================
 // Exports

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -1,9 +1,9 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
-all: all-c-bindings all-dlfcn-c all-file-c all-memory all-misc-c all-network-c all-thread-c
+all: all-c-bindings all-dlfcn-c all-dlfcn-pie-c all-file-c all-memory all-misc-c all-network-c all-thread-c
 
-clean: clean-c-bindings clean-dlfcn-c clean-file-c clean-memory clean-misc-c clean-network-c clean-thread-c
+clean: clean-c-bindings clean-dlfcn-c clean-dlfcn-pie-c clean-file-c clean-memory clean-misc-c clean-network-c clean-thread-c
 
 all-c-bindings:
 	$(MAKE_QUIET) -C c-bindings
@@ -16,6 +16,12 @@ all-dlfcn-c:
 
 clean-dlfcn-c:
 	$(MAKE_QUIET) -C dlfcn-c clean
+
+all-dlfcn-pie-c:
+	$(MAKE_QUIET) -C dlfcn-pie-c
+
+clean-dlfcn-pie-c:
+	$(MAKE_QUIET) -C dlfcn-pie-c clean
 
 all-file-c:
 	$(MAKE_QUIET) -C file-c

--- a/src/tests/dlfcn-pie-c/Makefile
+++ b/src/tests/dlfcn-pie-c/Makefile
@@ -1,0 +1,43 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#===============================================================================
+
+export PROGRAM_NAME := dlfcn-pie-c
+
+#===============================================================================
+# Build Artifacts
+#===============================================================================
+
+# Libraries
+export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
+
+# Source Files
+export SOURCES := $(wildcard *.c)
+
+# Object Files
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+
+# Binary
+export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
+
+#===============================================================================
+# Build Rules
+#===============================================================================
+
+all: $(OBJECTS) libs-all
+	$(NANVIX_CC) $(NANVIX_LDFLAGS) -pie -rdynamic -Wl,--no-dynamic-linker $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+
+clean: libs-clean
+	rm -rf $(OBJECTS)
+	rm -rf $(BINARIES_DIR)/$(BINARY)
+
+libs-all:
+	$(NANVIX_CC) libs/mul.c -shared -fPIC -o $(LIBRARIES_DIR)/libmul-pie.so
+
+libs-clean:
+	rm -rf $(LIBRARIES_DIR)/libmul-pie.so
+
+# Builds C source files.
+%.$(TARGET).$(MACHINE).o: %.c
+	$(NANVIX_CC) $(NANVIX_CFLAGS) -fPIE $< -c -o $@

--- a/src/tests/dlfcn-pie-c/libs/mul.c
+++ b/src/tests/dlfcn-pie-c/libs/mul.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+// R_386_GLOB_DAT
+const char *VERSION = "0.0.1";
+
+int add(int a, int b)
+{
+    return (a + b);
+}
+
+// R_386_32
+int fast_mul(int a, int b)
+{
+    int result = 0;
+    __asm__ __volatile__("movl %1, %%ecx;"
+                         "movl $0, %0;"
+                         "test %%ecx, %%ecx;"
+                         "jz 1f;"
+                         "0:;"
+                         "pushl %2;"
+                         "pushl %0;"
+                         "call add;" // R_386_PC32
+                         "addl $8, %%esp;"
+                         "movl %%eax, %0;"
+                         "loop 0b;"
+                         "1:;"
+                         : "=r"(result)
+                         : "r"(b), "r"(a)
+                         : "ecx", "eax", "cc");
+    return result;
+}
+
+int slow_mul(int a, int b)
+{
+    int result = 0;
+
+    for (int i = 0; i < b; i++) {
+        // R_386_JUMP_SLOT
+        result = add(result, a);
+    }
+
+    return (result);
+}
+
+static int (*mul)(int, int) = &fast_mul;
+
+int multiply(int a, int b)
+{
+    return (mul(a, b));
+}
+
+const char *get_version(void)
+{
+    return (VERSION);
+}

--- a/src/tests/dlfcn-pie-c/main.c
+++ b/src/tests/dlfcn-pie-c/main.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Opens a dynamic load library.
+void *open_library(const char *path)
+{
+    void *handle = dlopen(path, RTLD_LAZY);
+    assert(handle != NULL);
+    return (handle);
+}
+
+// Closes a dynamic load library.
+void close_library(void *handle)
+{
+    assert(dlclose(handle) == 0);
+}
+
+// Resolves a symbol in a dynamic load library.
+void *resolve_symbol(void *handle, const char *symbol)
+{
+    void *sym = dlsym(handle, symbol);
+    assert(sym != NULL);
+    return (sym);
+}
+
+// A global variable exported by the main executable (via -rdynamic).
+int exe_global_value = 42;
+
+// Tests if dlopen(NULL) returns a handle to the global symbol scope and
+// dlsym() can resolve symbols exported by the main executable.
+void test_dlopen_null(void)
+{
+    // dlopen(NULL) should return a valid handle per POSIX.
+    void *handle = dlopen(NULL, RTLD_NOW);
+    assert(handle != NULL);
+
+    // Resolve a symbol that the main executable exports.
+    int *value = (int *)dlsym(handle, "exe_global_value");
+    assert(value != NULL);
+    assert(*value == 42);
+
+    // RTLD_DEFAULT (NULL handle) should also resolve the same symbol.
+    int *value2 = (int *)dlsym(RTLD_DEFAULT, "exe_global_value");
+    assert(value2 != NULL);
+    assert(*value2 == 42);
+    assert(value == value2);
+
+    // Closing the global handle should be a no-op.
+    assert(dlclose(handle) == 0);
+}
+
+// Tests if dlsym() works on a shared library loaded from a PIE executable.
+void test_dlsym(const char *path)
+{
+    void *handle = open_library(path);
+
+    int (*add)(int, int) = NULL;
+    *(void **)(&add) = resolve_symbol(handle, "add");
+    assert(add != NULL);
+    assert(add(1, 2) == 3);
+
+    int (*multiply)(int, int) = NULL;
+    *(void **)(&multiply) = resolve_symbol(handle, "multiply");
+    assert(multiply != NULL);
+    assert(multiply(7, 6) == 42);
+
+    const char **version = resolve_symbol(handle, "VERSION");
+    assert(version != NULL);
+    assert(!strcmp(*version, "0.0.1"));
+
+    close_library(handle);
+}
+
+/**
+ * @brief Tests dynamic loading from a PIE executable with exported symbols.
+ *
+ * @param argc Number of command-line arguments (unused).
+ * @param argv List of command-line arguments (unused).
+ *
+ * @returns Always returns zero. If a test fails, the program will abort.
+ */
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    test_dlopen_null();
+    test_dlsym("lib/libmul-pie.so");
+
+    // Write magic string to signal that the test passed.
+    {
+        const char *magic_string = "ok";
+        write(STDOUT_FILENO, magic_string, 3);
+    }
+
+    return (0);
+}

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -100,6 +100,12 @@ expected_output = "ok"
 
 [[tests]]
 executor = "http"
+program = "./bin/dlfcn-pie-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
 program = "./bin/file-c.elf"
 input = "[]"
 expected_output = "ok"
@@ -222,6 +228,11 @@ expected_output = "ok"
 [[tests]]
 executor = "terminal"
 program = "./bin/dlfcn-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/dlfcn-pie-c.elf"
 expected_output = "ok"
 
 [[tests]]

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -99,6 +99,12 @@ expected_output = "ok"
 
 [[tests]]
 executor = "http"
+program = "./bin/dlfcn-pie-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
 program = "./bin/file-c.elf"
 input = "[]"
 expected_output = "ok"
@@ -221,6 +227,11 @@ expected_output = "ok"
 [[tests]]
 executor = "terminal"
 program = "./bin/dlfcn-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/dlfcn-pie-c.elf"
 expected_output = "ok"
 
 [[tests]]

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -146,6 +146,13 @@ expected_output = "ok"
 
 [[tests]]
 executor = "http"
+program = "./bin/dlfcn-pie-c.elf"
+extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
 program = "./bin/file-c.elf"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
 input = "[]"
@@ -237,4 +244,16 @@ expected_output = "ok"
 [[tests]]
 executor = "terminal"
 program = "./bin/arch-rust.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/dlfcn-c.elf"
+extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/dlfcn-pie-c.elf"
+extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
 expected_output = "ok"

--- a/test/test.toml
+++ b/test/test.toml
@@ -99,6 +99,12 @@ expected_output = "ok"
 
 [[tests]]
 executor = "http"
+program = "./bin/dlfcn-pie-c.elf"
+input = "[]"
+expected_output = "ok"
+
+[[tests]]
+executor = "http"
 program = "./bin/file-c.elf"
 input = "[]"
 expected_output = "ok"
@@ -221,6 +227,11 @@ expected_output = "ok"
 [[tests]]
 executor = "terminal"
 program = "./bin/dlfcn-c.elf"
+expected_output = "ok"
+
+[[tests]]
+executor = "terminal"
+program = "./bin/dlfcn-pie-c.elf"
 expected_output = "ok"
 
 [[tests]]


### PR DESCRIPTION
This pull request implements support for exporting and resolving global symbols from the main executable (and pre-loaded libraries) to dynamically loaded modules, following the POSIX semantics for `dlopen(NULL, ...)` and `dlsym(NULL, ...)`. It adds a global symbol table populated from new linker-defined `.dynsym` and `.dynstr` sections, updates the dynamic loading API to handle global scope correctly, and introduces new tests for position-independent executables (PIE) and their dynamic libraries.