### PR TITLE
[nanvixd] Standalone Deployment Mode

### DIFF
--- a/.github/skills/build-and-test/SKILL.md
+++ b/.github/skills/build-and-test/SKILL.md
@@ -55,6 +55,7 @@ Set these as environment variables or pass them after `--` in the `z` command:
 |                  | `error`, `panic`         |           |
 | `PROFILER`       | `yes`, `no`              | `no`      |
 | `SINGLE_PROCESS` | `yes`, `no`              | `no`      |
+| `STANDALONE`     | `yes`, `no`              | `no`      |
 | `L2_VM`          | `yes`, `no`              | `no`      |
 
 Example with custom parameters:

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,14 @@ export SINGLE_PROCESS ?= no
 # Enable in-memory FAT32 filesystem?
 export MEMFS ?= no
 
+# Enable standalone mode (no linuxd, routes I/O to debug/memfs)?
+export STANDALONE ?= no
+
+# Standalone mode implies single-process deployment (no separate linuxd binary).
+ifeq ($(STANDALONE),yes)
+override SINGLE_PROCESS := yes
+endif
+
 # Log Level
 export LOG_LEVEL ?= warn
 

--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -102,3 +102,13 @@ mutex_open_max = 32
 # Notes:
 # - This number was arbitrarily chosen.
 cond_open_max = 32
+
+#==================================================================================================
+# Debug
+#==================================================================================================
+
+# Maximum size (in bytes) of a single debug message buffer.
+# Notes:
+# - This value must be smaller than a page.
+# - The kernel debug handler rejects messages larger than this limit.
+debug_buffer_size = 256

--- a/build/make/generic-guest-rlibs.mk
+++ b/build/make/generic-guest-rlibs.mk
@@ -25,7 +25,7 @@ $(foreach target,$(ALL_GUEST_RUST_LIBS),$(eval $(call GUEST_RLIB_RULES,$(target)
 # #[cfg(test)] modules.
 define GUEST_RLIB_LINT_TEST_RULES
 rust-lint-guest-rlib-tests-$(1):
-	$(HOST_CARGO_CLIPPY_CMD) --tests --features=std -p $(1) --fix --allow-dirty
+	$(HOST_CARGO_CLIPPY_CMD) --tests --features=std -p $(1) --fix --allow-dirty --allow-no-vcs
 
 rust-lint-check-guest-rlib-tests-$(1):
 	$(HOST_CARGO_CLIPPY_CMD) --tests --features=std -p $(1) -- -D warnings

--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -6,6 +6,11 @@ GUEST_STATICLIB_FEATURES := staticlib $(LOG_LEVEL)
 ifeq ($(MEMFS),yes)
 GUEST_STATICLIB_FEATURES += memfs
 endif
+# Enable standalone mode: routes stdout/stderr to debug kcall,
+# file I/O to memfs, and disables IPC-based syscalls (no linuxd).
+ifeq ($(STANDALONE),yes)
+GUEST_STATICLIB_FEATURES += standalone
+endif
 GUEST_STATICLIB_FEATURES := $(strip $(GUEST_STATICLIB_FEATURES))
 GUEST_STATICLIB_CARGO_FEATURES := $(if $(GUEST_STATICLIB_FEATURES),--features "$(GUEST_STATICLIB_FEATURES)")
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -79,6 +79,15 @@ To build Nanvix using your local toolchain and default build parameters, run:
 make all
 ```
 
+You can also build in **standalone mode**, which excludes `linuxd` and routes all I/O through the
+local memfs VFS layer and kernel debug serial port:
+
+```bash
+make all STANDALONE=yes
+```
+
+Standalone mode implies `SINGLE_PROCESS=yes` automatically.
+
 ## Formal Verification with Verus
 
 Nanvix uses [Verus](https://github.com/verus-lang/verus) for formal verification of selected

--- a/src/kernel/src/debug.rs
+++ b/src/kernel/src/debug.rs
@@ -55,9 +55,8 @@ pub fn debug(pid: ProcessIdentifier, arg0: u32, arg1: u32) -> KcallResult {
     // SAFETY: the process manager is initialized and access is synchronized.
     let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
 
-    // Buffer size in bytes.
-    // NOTE: This value was chosen to be smaller than a page, but big enough for along messages.
-    const BUFFER_SIZE: usize = 256;
+    // Maximum size of a debug message buffer (from kernel configuration).
+    const BUFFER_SIZE: usize = config::kernel::DEBUG_BUFFER_SIZE;
     let user_buffer: usize = arg0 as usize;
     let size: usize = arg1 as usize;
 

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -178,6 +178,12 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     );
     constants.push_str(&format!("pub const IKC_POLL_BATCH_SIZE: usize = {val};\n"));
 
+    let val: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "debug_buffer_size"),
+        "debug_buffer_size",
+    );
+    constants.push_str(&format!("pub const DEBUG_BUFFER_SIZE: usize = {val};\n"));
+
     constants.push_str("}\n");
 
     //==============================================================================================

--- a/src/libs/posix/Cargo.toml
+++ b/src/libs/posix/Cargo.toml
@@ -36,6 +36,7 @@ default = ["syscall", "allocator", "staticlib"]
 allocator = ["dep:sysalloc"]
 syscall = ["syslog", "syscall/dlfcn", "syscall/sbrk"]
 memfs = ["syscall/memfs"]
+standalone = ["memfs", "syscall/standalone"]
 std = []
 staticlib = ["nvx/staticlib"]
 

--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -66,6 +66,7 @@ rustc-dep-of-std = [
 ]
 sbrk = ["dep:sysalloc"]
 memfs = ["dep:nvx", "nvx/memfs", "dep:sysalloc"]
+standalone = ["memfs"]
 
 # TODO (#798): remove this feature flag once the signal module is stable.
 sigaction = []

--- a/src/libs/syscall/src/dirent/syscall/getdents.rs
+++ b/src/libs/syscall/src/dirent/syscall/getdents.rs
@@ -55,12 +55,23 @@ use ::syslog::{
 /// On successful completion, a list with the directory entries, with at least `count` elements, is
 /// returned. On failure, an error code is returned instead.
 ///
+#[allow(unreachable_code)]
 pub fn posix_getdents(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Error> {
     trace!("posix_getdents(): fd={}, count={:?}", fd, count);
 
     // Capacity of message assembler.
     const MESSAGE_ASSEMBLER_CAPACITY: usize =
         GetDirectoryEntriesResponse::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
+
+    // In standalone mode, getdents is not available (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, count);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "getdents not available in standalone mode",
+        ));
+    }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 

--- a/src/libs/syscall/src/fcntl/syscall/fadvise.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fadvise.rs
@@ -42,6 +42,7 @@ use sysapi::sys_types::off_t;
 ///
 /// Upon success, `posix_fadvise()` empty. Otherwise, it returns an error.
 ///
+#[allow(unreachable_code)]
 pub fn posix_fadvise(
     fd: RawFileDescriptor,
     offset: off_t,
@@ -62,6 +63,13 @@ pub fn posix_fadvise(
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return Ok(());
         }
+    }
+
+    // In standalone mode, succeed as a no-op (advisory only, no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, offset, len, advice);
+        return Ok(());
     }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;

--- a/src/libs/syscall/src/fcntl/syscall/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fallocate.rs
@@ -40,6 +40,7 @@ use sysapi::sys_types::off_t;
 ///
 /// Upon success, `posix_fallocate()` empty. Otherwise, it returns an error.
 ///
+#[allow(unreachable_code)]
 pub fn posix_fallocate(fd: RawFileDescriptor, offset: off_t, len: off_t) -> Result<(), Error> {
     ::syslog::error!("posix_fallocate(): fd={:?}, offset={:?}, len={:?}", fd, offset, len);
 
@@ -49,6 +50,13 @@ pub fn posix_fallocate(fd: RawFileDescriptor, offset: off_t, len: off_t) -> Resu
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return Ok(());
         }
+    }
+
+    // In standalone mode, succeed as a no-op (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, offset, len);
+        return Ok(());
     }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;

--- a/src/libs/syscall/src/fcntl/syscall/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fcntl.rs
@@ -27,6 +27,7 @@ use ::sysapi::ffi::c_int;
 // Standalone Functions
 //==================================================================================================
 
+#[allow(unreachable_code)]
 pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
     ::syslog::trace!("fcntl(): fd={:?}, cmd={:?}, arg={:?}", fd, cmd, arg);
 
@@ -39,6 +40,24 @@ pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
                 ::syslog::error!("fcntl(): VFS fcntl failed (fd={fd}, cmd={cmd}, error={e})");
                 Error::new(code, "vfs fcntl failed")
             });
+        }
+    }
+
+    // In standalone mode, handle common fcntl commands on non-VFS fds without IPC.
+    #[cfg(feature = "standalone")]
+    {
+        use ::sysapi::fcntl::file_control_request;
+        match cmd {
+            file_control_request::F_GETFD
+            | file_control_request::F_SETFD
+            | file_control_request::F_GETFL
+            | file_control_request::F_SETFL => return Ok(0),
+            _ => {
+                return Err(Error::new(
+                    ErrorCode::OperationNotSupported,
+                    "fcntl cmd not supported in standalone mode",
+                ));
+            },
         }
     }
 

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -32,10 +32,32 @@ use ::sysapi::{
 // Standalone Functions
 //==================================================================================================
 
+#[allow(unreachable_code)]
 pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<c_int, Error> {
     ::syslog::trace!(
         "openat(): dirfd={dirfd:?}, pathname={pathname:?}, flags={flags:?}, mode={mode:?}"
     );
+
+    // Route to the VFS if the path belongs to an in-memory filesystem mount.
+    #[cfg(feature = "memfs")]
+    {
+        if ::nvx::vfs::fd::is_vfs_path(pathname) {
+            return ::nvx::vfs::fd::vfs_open(pathname, flags).map_err(|e| {
+                let code: ErrorCode = e.into();
+                ::syslog::error!("openat(): VFS open failed (pathname={pathname:?}, error={e})");
+                Error::new(code, "vfs open failed")
+            });
+        }
+    }
+
+    // In standalone mode, reject non-VFS paths (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "openat not available in standalone mode",
+        ));
+    }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 

--- a/src/libs/syscall/src/fcntl/syscall/renameat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/renameat.rs
@@ -43,6 +43,7 @@ use ::sys::{
 /// Upon successful completion, the `renameat()` system call returns empty. Otherwise, it returns an
 /// error.
 ///
+#[allow(unreachable_code)]
 pub fn renameat(
     olddirfd: RawFileDescriptor,
     oldpath: &str,
@@ -56,6 +57,31 @@ pub fn renameat(
         newdirfd,
         newpath
     );
+
+    // Route to the VFS if the old path belongs to an in-memory filesystem mount.
+    #[cfg(feature = "memfs")]
+    {
+        if ::nvx::vfs::fd::is_vfs_path(oldpath) {
+            return ::nvx::vfs::fd::vfs_renameat(olddirfd, oldpath, newdirfd, newpath).map_err(
+                |e| {
+                    let code: ::sys::error::ErrorCode = e.into();
+                    ::syslog::error!(
+                        "renameat(): VFS renameat failed (oldpath={oldpath:?}, error={e})"
+                    );
+                    Error::new(code, "vfs renameat failed")
+                },
+            );
+        }
+    }
+
+    // In standalone mode, reject non-VFS paths (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "renameat not available in standalone mode",
+        ));
+    }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 

--- a/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
@@ -43,8 +43,32 @@ use ::sysapi::ffi::c_int;
 /// Upon successful completion, the `unlinkat()` system call returns empty. Otherwise, it returns an
 /// error.
 ///
+#[allow(unreachable_code)]
 pub fn unlinkat(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Result<(), Error> {
     ::syslog::trace!("unlinkat(): dirfd={}, pathname={}, flags={}", dirfd, pathname, flags);
+
+    // Route to the VFS if the path belongs to an in-memory filesystem mount.
+    #[cfg(feature = "memfs")]
+    {
+        if ::nvx::vfs::fd::is_vfs_path(pathname) {
+            return ::nvx::vfs::fd::vfs_unlinkat(dirfd, pathname, flags).map_err(|e| {
+                let code: ::sys::error::ErrorCode = e.into();
+                ::syslog::error!(
+                    "unlinkat(): VFS unlinkat failed (pathname={pathname:?}, error={e})"
+                );
+                Error::new(code, "vfs unlinkat failed")
+            });
+        }
+    }
+
+    // In standalone mode, reject non-VFS paths (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "unlinkat not available in standalone mode",
+        ));
+    }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 

--- a/src/libs/syscall/src/poll/bindings.rs
+++ b/src/libs/syscall/src/poll/bindings.rs
@@ -55,7 +55,11 @@ use ::syslog::trace_syscall;
 #[unsafe(no_mangle)]
 #[trace_syscall]
 pub unsafe extern "C" fn poll(fds: *mut pollfd, nfds: nfds_t, timeout: c_int) -> c_int {
-    let fds: &mut [pollfd] = core::slice::from_raw_parts_mut(fds, nfds as usize);
+    let fds: &mut [pollfd] = if nfds == 0 {
+        &mut []
+    } else {
+        core::slice::from_raw_parts_mut(fds, nfds as usize)
+    };
     let poll_fds: Vec<PollFd> = fds
         .iter()
         .map(|fd| {

--- a/src/libs/syscall/src/poll/syscall.rs
+++ b/src/libs/syscall/src/poll/syscall.rs
@@ -132,11 +132,21 @@ impl PollFd {
 /// It is safe to call this function if the following conditions are met:
 /// - `fds` points to a valid array of pollfd structures of length `nfds`.
 ///
+#[allow(unreachable_code)]
 pub fn poll(
     fds: &[PollFd],
     timeout: PollTimeout,
 ) -> Result<Vec<(RawFileDescriptor, PollEvents)>, Error> {
     ::syslog::trace!("poll(): fds={fds:?}, timeout={timeout:?}");
+
+    // In standalone mode, poll is not available (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "poll not available in standalone mode",
+        ));
+    }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 

--- a/src/libs/syscall/src/sys/select/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/select/syscall/mod.rs
@@ -50,6 +50,7 @@ use ::sysapi::sys_select::{
 /// three returned descriptor sets that are ready for I/O. On failure, an error code is
 /// returned instead.
 ///
+#[allow(unreachable_code)]
 pub fn select(
     nfds: usize,
     readfds: Option<&mut fd_set>,
@@ -70,6 +71,15 @@ pub fn select(
         return Err(Error::new(
             ErrorCode::InvalidArgument,
             "number of file descriptors exceeds maximum supported",
+        ));
+    }
+
+    // In standalone mode, select is not available (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "select not available in standalone mode",
         ));
     }
 

--- a/src/libs/syscall/src/sys/socket/bindings/getsockopt.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/getsockopt.rs
@@ -57,6 +57,7 @@ use ::syslog::trace_syscall;
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
+#[allow(unreachable_code)]
 pub unsafe extern "C" fn getsockopt(
     sockfd: c_int,
     level: c_int,
@@ -64,6 +65,13 @@ pub unsafe extern "C" fn getsockopt(
     optval: *mut c_void,
     optlen: *mut socklen_t,
 ) -> c_int {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, level, optname, optval, optlen);
+        *__errno_location() = ::sys::error::ErrorCode::OperationNotSupported.get();
+        return -1;
+    }
+
     // TODO: https://github.com/nanvix/nanvix/issues/591
     ::syslog::debug!("getsockopt(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/sys/socket/bindings/recvfrom.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recvfrom.rs
@@ -70,6 +70,7 @@ use ::syslog::trace_syscall;
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
+#[allow(unreachable_code)]
 pub unsafe extern "C" fn recvfrom(
     sockfd: c_int,
     buf: *mut c_void,
@@ -78,6 +79,13 @@ pub unsafe extern "C" fn recvfrom(
     sockaddr: *mut sockaddr,
     addrlen: *mut socklen_t,
 ) -> c_ssize_t {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, buf, len, flags, sockaddr, addrlen);
+        *__errno_location() = ::sys::error::ErrorCode::OperationNotSupported.get();
+        return -1;
+    }
+
     // TODO: https://github.com/nanvix/nanvix/issues/590
     ::syslog::debug!("recvfrom(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/sys/socket/bindings/recvmsg.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/recvmsg.rs
@@ -63,7 +63,15 @@ use ::syslog::trace_syscall;
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
+#[allow(unreachable_code)]
 pub unsafe extern "C" fn recvmsg(sockfd: c_int, msg: *mut msghdr, flags: c_int) -> c_ssize_t {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, msg, flags);
+        *__errno_location() = ::sys::error::ErrorCode::OperationNotSupported.get();
+        return -1;
+    }
+
     // TODO: https://github.com/nanvix/nanvix/issues/600
     ::syslog::debug!("recvmsg(): not implemented");
     *__errno_location() = ErrorCode::InvalidSysCall.get();

--- a/src/libs/syscall/src/sys/socket/bindings/sendmsg.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/sendmsg.rs
@@ -62,7 +62,15 @@ use ::syslog::trace_syscall;
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
+#[allow(unreachable_code)]
 pub unsafe extern "C" fn sendmsg(sockfd: c_int, msg: *const msghdr, flags: c_int) -> c_ssize_t {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, msg, flags);
+        *__errno_location() = ::sys::error::ErrorCode::OperationNotSupported.get();
+        return -1;
+    }
+
     // TODO: https://github.com/nanvix/nanvix/issues/599.
     ::syslog::debug!("sendmsg(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/sys/socket/bindings/sendto.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/sendto.rs
@@ -71,6 +71,7 @@ use ::syslog::trace_syscall;
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
+#[allow(unreachable_code)]
 pub unsafe extern "C" fn sendto(
     sockfd: c_int,
     buf: *const c_void,
@@ -79,6 +80,13 @@ pub unsafe extern "C" fn sendto(
     sockaddr: *const sockaddr,
     addrlen: socklen_t,
 ) -> c_ssize_t {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, buf, len, flags, sockaddr, addrlen);
+        *__errno_location() = ::sys::error::ErrorCode::OperationNotSupported.get();
+        return -1;
+    }
+
     // TODO: https://github.com/nanvix/nanvix/issues/589
     ::syslog::debug!("sendto(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/sys/socket/bindings/setsockopt.rs
+++ b/src/libs/syscall/src/sys/socket/bindings/setsockopt.rs
@@ -60,6 +60,7 @@ use ::syslog::trace_syscall;
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]
+#[allow(unreachable_code)]
 pub unsafe extern "C" fn setsockopt(
     sockfd: c_int,
     level: c_int,
@@ -67,6 +68,13 @@ pub unsafe extern "C" fn setsockopt(
     optval: *const c_void,
     optlen: socklen_t,
 ) -> c_int {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, level, optname, optval, optlen);
+        *__errno_location() = ::sys::error::ErrorCode::OperationNotSupported.get();
+        return -1;
+    }
+
     // TODO: https://github.com/nanvix/nanvix/issues/471
     ::syslog::debug!("setsockopt(): not implemented");
     unsafe {

--- a/src/libs/syscall/src/sys/socket/syscall/accept.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/accept.rs
@@ -30,7 +30,17 @@ use ::sysapi::ffi::c_int;
 // Standalone Functions
 //==================================================================================================
 
+#[allow(unreachable_code)]
 pub fn accept(sockfd: c_int) -> Result<(c_int, SocketAddr), Error> {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = sockfd;
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "accept not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/sys/socket/syscall/bind.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/bind.rs
@@ -28,7 +28,17 @@ use ::sysapi::ffi::c_int;
 // Standalone Functions
 //==================================================================================================
 
+#[allow(unreachable_code)]
 pub fn bind(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, sockaddr);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "bind not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let sockaddr: sockaddr = sockaddr::from(sockaddr);

--- a/src/libs/syscall/src/sys/socket/syscall/connect.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/connect.rs
@@ -46,8 +46,19 @@ use ::sysapi::ffi::c_int;
 ///
 /// The `connect()` function returns empty on success. On error, it returns an error.
 ///
+#[allow(unreachable_code)]
 pub fn connect(sockfd: c_int, sockaddr: &SocketAddr) -> Result<(), Error> {
     ::syslog::trace!("connect(): fd={:?}, sockaddr={:?}", sockfd, sockaddr);
+
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, sockaddr);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "connect not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let (sockaddr, socklen): (sockaddr, socklen_t) = From::<&SocketAddr>::from(sockaddr);

--- a/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getpeername.rs
@@ -44,8 +44,18 @@ use ::sysapi::ffi::c_int;
 ///
 /// Upon successful completion, empty is returned. Otherwise, an error number is returned.
 ///
+#[allow(unreachable_code)]
 pub fn getpeername(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error> {
     ::syslog::trace!("getpeername(): sockfd={:?}, sockaddr={:?}", sockfd, sockaddr);
+
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "getpeername not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/getsockname.rs
@@ -44,8 +44,18 @@ use ::sysapi::ffi::c_int;
 ///
 /// Upon successful completion, empty is returned. Otherwise, an error number is returned.
 ///
+#[allow(unreachable_code)]
 pub fn getsockname(sockfd: c_int, sockaddr: &mut SocketAddr) -> Result<(), Error> {
     ::syslog::trace!("getsockname(): sockfd={:?}, sockaddr={:?}", sockfd, sockaddr);
+
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "getsockname not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/sys/socket/syscall/listen.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/listen.rs
@@ -24,7 +24,17 @@ use ::sysapi::ffi::c_int;
 // Standalone Functions
 //==================================================================================================
 
+#[allow(unreachable_code)]
 pub fn listen(sockfd: c_int, backlog: c_int) -> Result<(), Error> {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, backlog);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "listen not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/sys/socket/syscall/recv.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/recv.rs
@@ -28,7 +28,17 @@ use ::sysapi::ffi::c_int;
 // Standalone Functions
 //==================================================================================================
 
+#[allow(unreachable_code)]
 pub fn recv(sockfd: i32, buffer: &mut [u8], flags: c_int) -> Result<usize, Error> {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, buffer, flags);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "recv not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Check if count is invalid.

--- a/src/libs/syscall/src/sys/socket/syscall/send.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/send.rs
@@ -31,7 +31,17 @@ use ::sysapi::{
 // Standalone Functions
 //==================================================================================================
 
+#[allow(unreachable_code)]
 pub fn send(sockfd: c_int, buffer: &[u8], flags: c_int) -> Result<usize, Error> {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, buffer, flags);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "send not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Check if count is invalid.

--- a/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/shutdown.rs
@@ -27,7 +27,17 @@ use ::sysapi::ffi::c_int;
 // Standalone Functions
 //==================================================================================================
 
+#[allow(unreachable_code)]
 pub fn shutdown(sockfd: c_int, how: Shutdown) -> Result<(), Error> {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (sockfd, how);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "shutdown not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/sys/socket/syscall/socket.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socket.rs
@@ -32,7 +32,17 @@ use ::sysapi::ffi::c_int;
 // Standalone Functions
 //==================================================================================================
 
+#[allow(unreachable_code)]
 pub fn socket(domain: AddressFamily, typ: SocketType, protocol: Protocol) -> Result<c_int, Error> {
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (domain, typ, protocol);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "socket not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
+++ b/src/libs/syscall/src/sys/socket/syscall/socketpair.rs
@@ -48,6 +48,7 @@ use ::sysapi::ffi::c_int;
 ///
 /// The `socketpair()` function returns empty on success. On error, it returns an error.
 ///
+#[allow(unreachable_code)]
 pub fn socketpair(
     domain: AddressFamily,
     typ: SocketType,
@@ -55,6 +56,16 @@ pub fn socketpair(
     socket_fds: &mut [c_int],
 ) -> Result<(), Error> {
     ::syslog::trace!("socketpair(): domain={:?}, type={:?}, protocol={:?}", domain, typ, protocol);
+
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (domain, typ, protocol, socket_fds);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "socketpair not available in standalone mode",
+        ));
+    }
+
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Check if array of file descriptors has expected length.

--- a/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
@@ -39,6 +39,7 @@ use sysapi::sys_types::mode_t;
 ///
 /// Upon successful completion, `fchmod()` returns empty. Otherwise, it returns an error.
 ///
+#[allow(unreachable_code)]
 pub fn fchmod(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
     ::syslog::trace!("fchmod(): fd={:?}, mode={:o}", fd, mode);
 
@@ -48,6 +49,13 @@ pub fn fchmod(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return Ok(());
         }
+    }
+
+    // In standalone mode, succeed as a no-op (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, mode);
+        return Ok(());
     }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;

--- a/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
@@ -46,6 +46,7 @@ use ::sysapi::{
 /// Upon successful completion, the `fchmodat()` system call returns empty. Otherwise, it returns an
 /// error.
 ///
+#[allow(unreachable_code)]
 pub fn fchmodat(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Result<(), Error> {
     // FAT32 does not support permissions — silently succeed for VFS paths.
     #[cfg(feature = "memfs")]
@@ -53,6 +54,13 @@ pub fn fchmodat(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Result<(
         if ::nvx::vfs::fd::is_vfs_path(path) {
             return Ok(());
         }
+    }
+
+    // In standalone mode, succeed as a no-op (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (dirfd, path, mode, flag);
+        return Ok(());
     }
 
     // Send request.

--- a/src/libs/syscall/src/sys/stat/syscall/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstat.rs
@@ -32,6 +32,7 @@ use sysapi::sys_stat;
 /// Upon successful completion, empty result is returned. Upon failure, an error is returned
 /// instead.
 ///
+#[allow(unreachable_code)]
 pub fn fstat(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
     // Route to the VFS if this is a VFS file descriptor.
     #[cfg(feature = "memfs")]
@@ -43,6 +44,16 @@ pub fn fstat(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
                 Error::new(code, "vfs fstat failed")
             });
         }
+    }
+
+    // In standalone mode, reject non-VFS fds (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, buf);
+        return Err(Error::new(
+            ::sys::error::ErrorCode::OperationNotSupported,
+            "fstat not available in standalone mode",
+        ));
     }
 
     // Send request.

--- a/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
@@ -40,7 +40,30 @@ use ::sysapi::sys_stat;
 /// Upon successful completion, empty result is returned. Upon failure, an error is returned
 /// instead.
 ///
+#[allow(unreachable_code)]
 pub fn fstatat(dirfd: i32, path: &str, buf: &mut sys_stat::stat, flag: i32) -> Result<(), Error> {
+    // Route to the VFS if the path belongs to an in-memory filesystem mount.
+    #[cfg(feature = "memfs")]
+    {
+        if ::nvx::vfs::fd::is_vfs_path(path) {
+            return ::nvx::vfs::fd::vfs_stat(path, buf).map_err(|e| {
+                let code: ::sys::error::ErrorCode = e.into();
+                ::syslog::error!("fstatat(): VFS stat failed (path={path:?}, error={e})");
+                ::sys::error::Error::new(code, "vfs stat failed")
+            });
+        }
+    }
+
+    // In standalone mode, reject non-VFS paths (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (dirfd, path, buf, flag);
+        return Err(::sys::error::Error::new(
+            ::sys::error::ErrorCode::OperationNotSupported,
+            "fstatat not available in standalone mode",
+        ));
+    }
+
     // Send request.
     fstatat_request(dirfd, path, flag)?;
 

--- a/src/libs/syscall/src/sys/stat/syscall/futimens.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/futimens.rs
@@ -39,6 +39,7 @@ use ::sysapi::time::timespec;
 ///
 /// Upon successful completion, `futimens()` returns empty. Otherwise, it returns an error.
 ///
+#[allow(unreachable_code)]
 pub fn futimens(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), Error> {
     ::syslog::error!("futimens(): fd={:?}, times={:?}", fd, times);
 
@@ -48,6 +49,13 @@ pub fn futimens(fd: RawFileDescriptor, times: &[timespec; 2]) -> Result<(), Erro
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return Ok(());
         }
+    }
+
+    // In standalone mode, succeed as a no-op (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, times);
+        return Ok(());
     }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;

--- a/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
@@ -46,8 +46,30 @@ use ::sysapi::sys_types::mode_t;
 /// Upon successful completion, the `mkdirat()` system call returns empty. Otherwise, it returns an
 /// error.
 ///
+#[allow(unreachable_code)]
 pub fn mkdirat(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Result<(), Error> {
     ::syslog::trace!("mkdirat(): dirfd={:?}, pathname={:?}, mode={:?}", dirfd, pathname, mode);
+
+    // Route to the VFS if the path belongs to an in-memory filesystem mount.
+    #[cfg(feature = "memfs")]
+    {
+        if ::nvx::vfs::fd::is_vfs_path(pathname) {
+            return ::nvx::vfs::fd::vfs_mkdir(pathname).map_err(|e| {
+                let code: ErrorCode = e.into();
+                ::syslog::error!("mkdirat(): VFS mkdir failed (pathname={pathname:?}, error={e})");
+                Error::new(code, "vfs mkdir failed")
+            });
+        }
+    }
+
+    // In standalone mode, reject non-VFS paths (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "mkdirat not available in standalone mode",
+        ));
+    }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 

--- a/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
@@ -46,6 +46,7 @@ use ::sysapi::time::timespec;
 /// Upon successful completion, the `utimensat()` system call returns empty. Otherwise, it returns
 /// an error.
 ///
+#[allow(unreachable_code)]
 pub fn utimensat(
     dirfd: i32,
     pathname: &str,
@@ -66,6 +67,13 @@ pub fn utimensat(
         if ::nvx::vfs::fd::is_vfs_path(pathname) {
             return Ok(());
         }
+    }
+
+    // In standalone mode, succeed as a no-op (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (dirfd, pathname, times, flags);
+        return Ok(());
     }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;

--- a/src/libs/syscall/src/sys/times/syscall/times.rs
+++ b/src/libs/syscall/src/sys/times/syscall/times.rs
@@ -44,8 +44,21 @@ use sysapi::{
 /// Upon successful completion, `times()` returns the elapsed time since an arbitrary point in the
 /// past. Otherwise, an error code is returned.
 ///
+#[allow(unreachable_code)]
 pub fn times(buffer: &mut Option<&mut tms>) -> Result<clock_t, Error> {
     ::syslog::trace!("times(): {:?}", buffer);
+
+    // In standalone mode, return zeroed times with elapsed=0 (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        if let Some(buf) = buffer {
+            buf.tms_utime = 0;
+            buf.tms_stime = 0;
+            buf.tms_cutime = 0;
+            buf.tms_cstime = 0;
+        }
+        return Ok(0);
+    }
 
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 

--- a/src/libs/syscall/src/unistd/syscall/chdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/chdir.rs
@@ -54,6 +54,20 @@ pub fn chdir(path: &str) -> Result<(), Error> {
         }
     }
 
+    // In standalone mode, succeed as a no-op for non-VFS paths (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Ok(());
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    chdir_linuxd(path)
+}
+
+/// Forwards a `chdir` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn chdir_linuxd(path: &str) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -39,6 +39,32 @@ pub fn close(fd: i32) -> Result<(), Error> {
         }
     }
 
+    // In standalone mode, treat stdio fds as a no-op and reject other non-VFS fds.
+    #[cfg(feature = "standalone")]
+    {
+        use ::sysapi::unistd::{
+            STDERR_FILENO,
+            STDIN_FILENO,
+            STDOUT_FILENO,
+        };
+        if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
+            return Ok(());
+        }
+        let _ = fd;
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "close not available in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    close_linuxd(fd)
+}
+
+/// Forwards a `close` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn close_linuxd(fd: i32) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -63,6 +63,23 @@ pub fn faccessat(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Result<(
         }
     }
 
+    // In standalone mode, reject non-VFS paths (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "faccessat not available in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    faccessat_linuxd(dirfd, path, mode, flag)
+}
+
+/// Forwards a `faccessat` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn faccessat_linuxd(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: FileAccessAtRequest = FileAccessAtRequest::new(dirfd, path, mode, flag)?;

--- a/src/libs/syscall/src/unistd/syscall/fchdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchdir.rs
@@ -46,6 +46,21 @@ pub fn fchdir(fd: c_int) -> Result<(), Error> {
         }
     }
 
+    // In standalone mode, succeed as a no-op for non-VFS fds (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = fd;
+        return Ok(());
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    fchdir_linuxd(fd)
+}
+
+/// Forwards a `fchdir` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn fchdir_linuxd(fd: c_int) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -54,6 +54,21 @@ pub fn fchown(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<(), E
         }
     }
 
+    // In standalone mode, succeed as a no-op (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, owner, group);
+        return Ok(());
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    fchown_linuxd(fd, owner, group)
+}
+
+/// Forwards a `fchown` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn fchown_linuxd(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it

--- a/src/libs/syscall/src/unistd/syscall/fchownat.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchownat.rs
@@ -73,6 +73,27 @@ pub fn fchownat(
         }
     }
 
+    // In standalone mode, succeed as a no-op (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (dirfd, path, owner, group, flag);
+        return Ok(());
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    fchownat_linuxd(dirfd, path, owner, group, flag)
+}
+
+/// Forwards a `fchownat` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn fchownat_linuxd(
+    dirfd: c_int,
+    path: &str,
+    owner: uid_t,
+    group: gid_t,
+    flag: c_int,
+) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: FileChownAtRequest = FileChownAtRequest::new(dirfd, owner, group, flag, path)?;

--- a/src/libs/syscall/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fdatasync.rs
@@ -52,6 +52,21 @@ pub fn fdatasync(fd: RawFileDescriptor) -> Result<(), Error> {
         }
     }
 
+    // In standalone mode, succeed as a no-op for non-VFS fds (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = fd;
+        return Ok(());
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    fdatasync_linuxd(fd)
+}
+
+/// Forwards a `fdatasync` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn fdatasync_linuxd(fd: RawFileDescriptor) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/unistd/syscall/fsync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fsync.rs
@@ -50,6 +50,21 @@ pub fn fsync(fd: c_int) -> Result<(), Error> {
         }
     }
 
+    // In standalone mode, succeed as a no-op for non-VFS fds (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = fd;
+        return Ok(());
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    fsync_linuxd(fd)
+}
+
+/// Forwards a `fsync` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn fsync_linuxd(fd: c_int) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/syscall/ftruncate.rs
@@ -56,6 +56,24 @@ pub fn ftruncate(fd: c_int, length: off_t) -> Result<(), Error> {
         }
     }
 
+    // In standalone mode, reject non-VFS fds (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, length);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "ftruncate not available in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    ftruncate_linuxd(fd, length)
+}
+
+/// Forwards a `ftruncate` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn ftruncate_linuxd(fd: c_int, length: off_t) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/unistd/syscall/getcwd.rs
+++ b/src/libs/syscall/src/unistd/syscall/getcwd.rs
@@ -50,6 +50,18 @@ pub fn getcwd() -> Result<String, Error> {
         }
     }
 
+    // In standalone mode, return "/" as the default cwd (no linuxd).
+    #[cfg(feature = "standalone")]
+    return Ok(String::from("/"));
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    getcwd_linuxd()
+}
+
+/// Forwards a `getcwd` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn getcwd_linuxd() -> Result<String, Error> {
     // Send request.
     getcwd_request()?;
 
@@ -58,6 +70,7 @@ pub fn getcwd() -> Result<String, Error> {
 }
 
 /// Handles the request of the `getcwd()` system call.
+#[cfg(not(feature = "standalone"))]
 fn getcwd_request() -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
@@ -68,6 +81,7 @@ fn getcwd_request() -> Result<(), Error> {
 }
 
 /// Handles the response of the `getcwd()` system call.
+#[cfg(not(feature = "standalone"))]
 fn getcwd_response() -> Result<String, Error> {
     // Compute the maximum number of parts in the response.
     let capacity: usize =

--- a/src/libs/syscall/src/unistd/syscall/getegid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getegid.rs
@@ -40,6 +40,18 @@ use sysapi::sys_types::gid_t;
 pub fn getegid() -> Result<gid_t, Error> {
     ::syslog::trace!("getegid()");
 
+    // In standalone mode, return 0 (root).
+    #[cfg(feature = "standalone")]
+    return Ok(usize::from(::sys::pm::GroupIdentifier::ROOT) as gid_t);
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    getegid_linuxd()
+}
+
+/// Forwards a `getegid` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn getegid_linuxd() -> Result<gid_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it

--- a/src/libs/syscall/src/unistd/syscall/geteuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/geteuid.rs
@@ -21,7 +21,7 @@ use ::sys::{
     ipc::Message,
     pm::ThreadIdentifier,
 };
-use sysapi::sys_types::uid_t;
+use ::sysapi::sys_types::uid_t;
 
 //==================================================================================================
 // Standalone Functions
@@ -40,6 +40,18 @@ use sysapi::sys_types::uid_t;
 pub fn geteuid() -> Result<uid_t, Error> {
     ::syslog::trace!("geteuid()");
 
+    // In standalone mode, return 0 (root).
+    #[cfg(feature = "standalone")]
+    return Ok(usize::from(::sys::pm::UserIdentifier::ROOT) as uid_t);
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    geteuid_linuxd()
+}
+
+/// Forwards a `geteuid` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn geteuid_linuxd() -> Result<uid_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it

--- a/src/libs/syscall/src/unistd/syscall/getgid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getgid.rs
@@ -40,6 +40,18 @@ use sysapi::sys_types::gid_t;
 pub fn getgid() -> Result<gid_t, Error> {
     ::syslog::trace!("getgid()");
 
+    // In standalone mode, return 0 (root).
+    #[cfg(feature = "standalone")]
+    return Ok(usize::from(::sys::pm::GroupIdentifier::ROOT) as gid_t);
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    getgid_linuxd()
+}
+
+/// Forwards a `getgid` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn getgid_linuxd() -> Result<gid_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it

--- a/src/libs/syscall/src/unistd/syscall/getuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getuid.rs
@@ -40,6 +40,18 @@ use ::sysapi::sys_types::uid_t;
 pub fn getuid() -> Result<uid_t, Error> {
     ::syslog::trace!("getuid()");
 
+    // In standalone mode, return 0 (root).
+    #[cfg(feature = "standalone")]
+    return Ok(usize::from(::sys::pm::UserIdentifier::ROOT) as uid_t);
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    getuid_linuxd()
+}
+
+/// Forwards a `getuid` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn getuid_linuxd() -> Result<uid_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it

--- a/src/libs/syscall/src/unistd/syscall/linkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/linkat.rs
@@ -63,6 +63,44 @@ pub fn linkat(
         flags
     );
 
+    // FAT32 does not support hard links.
+    #[cfg(feature = "memfs")]
+    {
+        if ::nvx::vfs::fd::is_vfs_path(oldpath) {
+            return ::nvx::vfs::fd::vfs_linkat(olddirfd, oldpath, newdirfd, newpath, flags)
+                .map_err(|e| {
+                    let code: ::sys::error::ErrorCode = e.into();
+                    ::syslog::error!(
+                        "linkat(): VFS linkat failed (oldpath={oldpath:?}, error={e})"
+                    );
+                    Error::new(code, "vfs linkat failed")
+                });
+        }
+    }
+
+    // In standalone mode, reject non-VFS paths (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "linkat not available in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    linkat_linuxd(olddirfd, oldpath, newdirfd, newpath, flags)
+}
+
+/// Forwards a `linkat` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn linkat_linuxd(
+    olddirfd: RawFileDescriptor,
+    oldpath: &str,
+    newdirfd: RawFileDescriptor,
+    newpath: &str,
+    flags: c_int,
+) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: LinkAtRequest =

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -46,6 +46,24 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
         }
     }
 
+    // In standalone mode, reject non-VFS fds (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, offset, whence);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "lseek not available in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    lseek_linuxd(fd, offset, whence)
+}
+
+/// Forwards a `lseek` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn lseek_linuxd(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -29,6 +29,23 @@ use ::sys::{
 pub fn pipe() -> Result<[i32; 2], Error> {
     ::syslog::trace!("pipe()");
 
+    // In standalone mode, pipe is not available (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "pipe not available in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    pipe_linuxd()
+}
+
+/// Forwards a `pipe` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn pipe_linuxd() -> Result<[i32; 2], Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     // Build request and send it.

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -63,6 +63,28 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
         }
     }
 
+    // In standalone mode, reject non-VFS fds (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, buffer, offset);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "pread not available in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    pread_linuxd(fd, buffer, offset)
+}
+
+/// Forwards a `pread` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn pread_linuxd(
+    fd: RawFileDescriptor,
+    buffer: &mut [u8],
+    offset: off_t,
+) -> Result<c_size_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let mut total_read: c_size_t = 0;

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -63,6 +63,24 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
         }
     }
 
+    // In standalone mode, reject non-VFS fds (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        let _ = (fd, buffer, offset);
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "pwrite not available in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    pwrite_linuxd(fd, buffer, offset)
+}
+
+/// Forwards a `pwrite` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn pwrite_linuxd(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_size_t, Error> {
     let mut total_written: c_size_t = 0;
     let mut buffer_offset: usize = 0;
 

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -50,6 +50,7 @@ use super::util::page_chunk_size;
 /// Upon successful completion, the number of bytes read by linuxd is returned. Otherwise, an
 /// error is returned.
 ///
+#[cfg(not(feature = "standalone"))]
 fn read_chunk(
     tid: ThreadIdentifier,
     fd: RawFileDescriptor,
@@ -174,6 +175,27 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
         }
     }
 
+    // In standalone mode, non-VFS reads are not supported.
+    #[cfg(feature = "standalone")]
+    {
+        if fd == STDIN_FILENO {
+            return Ok(0); // EOF
+        }
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "read not supported in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    read_linuxd(fd, buffer)
+}
+
+/// Forwards a `read` request to linuxd via IPC, splitting the buffer into
+/// page-aligned chunks.
+#[cfg(not(feature = "standalone"))]
+fn read_linuxd(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let mut total_read: c_size_t = 0;

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -55,6 +55,23 @@ use ::sysapi::sys_types::c_ssize_t;
 pub fn readlinkat(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, Error> {
     ::syslog::trace!("readlinkat(): dirfd={:?}, path={:?}, buf.len={:?}", dirfd, path, buf.len());
 
+    // In standalone mode, readlinkat is not available (no symlinks).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "readlinkat not available in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    readlinkat_linuxd(dirfd, path, buf)
+}
+
+/// Forwards a `readlinkat` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn readlinkat_linuxd(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: ReadLinkAtRequest = ReadLinkAtRequest::new(dirfd, path.to_string(), buf.len())?;

--- a/src/libs/syscall/src/unistd/syscall/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/symlinkat.rs
@@ -51,6 +51,37 @@ pub fn symlinkat(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Error> 
         linkpath
     );
 
+    // FAT32 does not support symbolic links.
+    #[cfg(feature = "memfs")]
+    {
+        if ::nvx::vfs::fd::is_vfs_path(linkpath) {
+            return ::nvx::vfs::fd::vfs_symlinkat(target, dirfd, linkpath).map_err(|e| {
+                let code: ::sys::error::ErrorCode = e.into();
+                ::syslog::error!(
+                    "symlinkat(): VFS symlinkat failed (linkpath={linkpath:?}, error={e})"
+                );
+                Error::new(code, "vfs symlinkat failed")
+            });
+        }
+    }
+
+    // In standalone mode, reject non-VFS paths (no linuxd).
+    #[cfg(feature = "standalone")]
+    {
+        return Err(Error::new(
+            ErrorCode::OperationNotSupported,
+            "symlinkat not available in standalone mode",
+        ));
+    }
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    symlinkat_linuxd(target, dirfd, linkpath)
+}
+
+/// Forwards a `symlinkat` request to linuxd via IPC.
+#[cfg(not(feature = "standalone"))]
+fn symlinkat_linuxd(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let request: SymbolicLinkAtRequest =

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -53,6 +53,7 @@ use super::util::page_chunk_size;
 /// Upon successful completion, the number of bytes written by linuxd is returned. Otherwise, an
 /// error is returned.
 ///
+#[cfg(not(feature = "standalone"))]
 fn write_chunk(
     tid: ThreadIdentifier,
     fd: RawFileDescriptor,
@@ -144,6 +145,37 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
         }
     }
 
+    // In standalone mode, route stdout/stderr to the kernel debug kcall
+    // and reject all other file descriptors.
+    #[cfg(feature = "standalone")]
+    return write_standalone(fd, buffer);
+
+    // Forward to linuxd via IPC.
+    #[cfg(not(feature = "standalone"))]
+    write_linuxd(fd, buffer)
+}
+
+/// Standalone-mode write: routes stdout/stderr through the kernel debug kcall in chunks of at most
+/// [`::config::kernel::DEBUG_BUFFER_SIZE`] bytes.
+#[cfg(feature = "standalone")]
+fn write_standalone(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
+    if fd == STDOUT_FILENO || fd == STDERR_FILENO {
+        let mut offset: usize = 0;
+        while offset < buffer.len() {
+            let end: usize =
+                core::cmp::min(offset + ::config::kernel::DEBUG_BUFFER_SIZE, buffer.len());
+            ::sys::kcall::debug::debug(buffer[offset..end].as_ptr(), end - offset)?;
+            offset = end;
+        }
+        return Ok(buffer.len() as c_size_t);
+    }
+    Err(Error::new(ErrorCode::OperationNotSupported, "write not supported in standalone mode"))
+}
+
+/// Forwards a write request to linuxd via IPC, splitting the buffer into
+/// page-aligned chunks.
+#[cfg(not(feature = "standalone"))]
+fn write_linuxd(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
     let tid: ThreadIdentifier = ::sys::kcall::pm::gettid()?;
 
     let mut total_written: c_size_t = 0;

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -510,8 +510,114 @@ pub fn vfs_fcntl(fd: c_int, cmd: c_int) -> Result<c_int, Fat32Error> {
     match cmd {
         file_control_request::F_GETFL => Ok(0), // No meaningful flags for FAT32.
         file_control_request::F_SETFL => Ok(0), // Accept but ignore (no O_NONBLOCK etc.).
-        _ => Err(Fat32Error::NotSupported),      // Other commands not supported.
+        _ => Err(Fat32Error::NotSupported),     // Other commands not supported.
     }
+}
+
+/// Renames a file or directory relative to directory file descriptors through the VFS.
+///
+/// Both paths must resolve to the same VFS mount. The `olddirfd` and `newdirfd` parameters must
+/// be `AT_FDCWD`; the VFS resolves all paths from the CWD and does not support dirfd-relative
+/// resolution.
+///
+/// # Parameters
+///
+/// - `olddirfd`: Directory file descriptor for the old path (must be `AT_FDCWD`).
+/// - `oldpath`: Current path of the file or directory.
+/// - `newdirfd`: Directory file descriptor for the new path (must be `AT_FDCWD`).
+/// - `newpath`: New path for the file or directory.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidArgument`] if either dirfd is not `AT_FDCWD`.
+/// Returns a [`Fat32Error`] if the paths are on different mounts, the old path does not exist,
+/// or the new path already exists.
+pub fn vfs_renameat(
+    olddirfd: c_int,
+    oldpath: &str,
+    newdirfd: c_int,
+    newpath: &str,
+) -> Result<(), Fat32Error> {
+    use ::sysapi::fcntl::atflags::AT_FDCWD;
+    if olddirfd != AT_FDCWD || newdirfd != AT_FDCWD {
+        return Err(Fat32Error::InvalidArgument);
+    }
+    crate::rename(oldpath, newpath)
+}
+
+/// Unlinks a file or removes a directory relative to a directory file descriptor through the VFS.
+///
+/// When `AT_REMOVEDIR` is set in `flags`, the operation behaves like `rmdir()` and removes an
+/// empty directory. Otherwise, it behaves like `unlink()` and removes a regular file.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor (must be `AT_FDCWD`).
+/// - `path`: Path of the file or directory to remove.
+/// - `flags`: If `AT_REMOVEDIR` (0x8) is set, remove a directory; otherwise remove a file.
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidArgument`] if `dirfd` is not `AT_FDCWD`.
+/// Returns a [`Fat32Error`] if the path does not exist, the directory is not empty (when removing
+/// a directory), or the path refers to a directory but `AT_REMOVEDIR` is not set.
+pub fn vfs_unlinkat(dirfd: c_int, path: &str, flags: c_int) -> Result<(), Fat32Error> {
+    use ::sysapi::fcntl::atflags::{
+        AT_FDCWD,
+        AT_REMOVEDIR,
+    };
+    if dirfd != AT_FDCWD {
+        return Err(Fat32Error::InvalidArgument);
+    }
+    if flags & AT_REMOVEDIR != 0 {
+        crate::rmdir(path)
+    } else {
+        crate::unlink(path)
+    }
+}
+
+/// Attempts to create a hard link through the VFS.
+///
+/// FAT32 does not support hard links. This function always returns
+/// [`Fat32Error::NotSupported`].
+///
+/// # Parameters
+///
+/// - `_olddirfd`: Directory file descriptor for the old path (ignored).
+/// - `_oldpath`: Path to the existing file.
+/// - `_newdirfd`: Directory file descriptor for the new path (ignored).
+/// - `_newpath`: Path for the new link.
+/// - `_flags`: Link flags (ignored).
+///
+/// # Errors
+///
+/// Always returns [`Fat32Error::NotSupported`].
+pub fn vfs_linkat(
+    _olddirfd: c_int,
+    _oldpath: &str,
+    _newdirfd: c_int,
+    _newpath: &str,
+    _flags: c_int,
+) -> Result<(), Fat32Error> {
+    Err(Fat32Error::NotSupported)
+}
+
+/// Attempts to create a symbolic link through the VFS.
+///
+/// FAT32 does not support symbolic links. This function always returns
+/// [`Fat32Error::NotSupported`].
+///
+/// # Parameters
+///
+/// - `_target`: Path that the symbolic link should point to.
+/// - `_dirfd`: Directory file descriptor for the link path (ignored).
+/// - `_linkpath`: Path for the new symbolic link.
+///
+/// # Errors
+///
+/// Always returns [`Fat32Error::NotSupported`].
+pub fn vfs_symlinkat(_target: &str, _dirfd: c_int, _linkpath: &str) -> Result<(), Fat32Error> {
+    Err(Fat32Error::NotSupported)
 }
 
 //==================================================================================================

--- a/src/tests/arch-rust/Cargo.toml
+++ b/src/tests/arch-rust/Cargo.toml
@@ -29,6 +29,7 @@ cfg-if = { workspace = true }
 
 [features]
 default = ["panic"]
+standalone = ["syscall/standalone"]
 trace = ["nvx/trace", "syscall/trace", "syslog/trace"]
 debug = ["nvx/debug", "syscall/debug", "syslog/debug"]
 info = ["nvx/info", "syscall/info", "syslog/info"]

--- a/src/tests/stress-rust/Cargo.toml
+++ b/src/tests/stress-rust/Cargo.toml
@@ -28,6 +28,7 @@ cfg-if = { workspace = true }
 
 [features]
 default = ["panic"]
+standalone = ["syscall/standalone"]
 trace = ["nvx/trace", "syscall/trace", "syslog/trace"]
 debug = ["nvx/debug", "syscall/debug", "syslog/debug"]
 info = ["nvx/info", "syscall/info", "syslog/info"]

--- a/src/tests/thread-rust/Cargo.toml
+++ b/src/tests/thread-rust/Cargo.toml
@@ -28,6 +28,7 @@ cfg-if = { workspace = true }
 
 [features]
 default = ["panic"]
+standalone = ["syscall/standalone"]
 trace = ["nvx/trace", "syscall/trace", "syslog/trace"]
 debug = ["nvx/debug", "syscall/debug", "syslog/debug"]
 info = ["nvx/info", "syscall/info", "syslog/info"]


### PR DESCRIPTION
This pull request introduces a new "standalone" mode to the build and runtime system, which allows running without the `linuxd` daemon by routing I/O through the in-memory filesystem (`memfs`) and kernel debug serial port. It includes changes to the build system, documentation, and several system call implementations to handle the absence of `linuxd` in standalone mode. The most important changes are grouped below.