### PR TITLE
[build] Enable MEMFS in Standalone Mode and Fix Warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ export STANDALONE ?= no
 # Standalone mode implies single-process deployment (no separate linuxd binary).
 ifeq ($(STANDALONE),yes)
 override SINGLE_PROCESS := yes
+override MEMFS := yes
 endif
 
 # Log Level

--- a/src/libs/syscall/src/unistd/syscall/chdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/chdir.rs
@@ -5,20 +5,23 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    message::MessagePartitioner,
-    unistd::message::ChangeDirectoryRequest,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
-use ::alloc::vec::Vec;
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        message::MessagePartitioner,
+        unistd::message::ChangeDirectoryRequest,
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
     },
-    ipc::Message,
-    pm::ThreadIdentifier,
+    ::alloc::vec::Vec,
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -5,21 +5,24 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    unistd::message::{
-        CloseRequest,
-        CloseResponse,
-    },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::{
+            CloseRequest,
+            CloseResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
     },
-    ipc::Message,
-    pm::ThreadIdentifier,
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -5,22 +5,25 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    message::MessagePartitioner,
-    unistd::message::FileAccessAtRequest,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::alloc::vec::Vec;
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 use ::sysapi::ffi::c_int;
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        message::MessagePartitioner,
+        unistd::message::FileAccessAtRequest,
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::alloc::vec::Vec,
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/unistd/syscall/fchdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchdir.rs
@@ -5,16 +5,19 @@
 // Imports
 //==================================================================================================
 
-use crate::unistd::message::FileChdirRequest;
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 use ::sysapi::ffi::c_int;
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::unistd::message::FileChdirRequest,
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -5,23 +5,24 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    safe::RawFileDescriptor,
-    unistd::message::FileChownRequest,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
-};
+use crate::safe::RawFileDescriptor;
+use ::sys::error::Error;
 use ::sysapi::sys_types::{
     gid_t,
     uid_t,
+};
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::FileChownRequest,
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::sys::{
+        error::ErrorCode,
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/fchownat.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchownat.rs
@@ -5,26 +5,27 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    message::MessagePartitioner,
-    unistd::message::FileChownAtRequest,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::alloc::vec::Vec;
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
-};
+use ::sys::error::Error;
 use ::sysapi::{
     ffi::c_int,
     sys_types::{
         gid_t,
         uid_t,
+    },
+};
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        message::MessagePartitioner,
+        unistd::message::FileChownAtRequest,
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::alloc::vec::Vec,
+    ::sys::{
+        error::ErrorCode,
+        ipc::Message,
+        pm::ThreadIdentifier,
     },
 };
 

--- a/src/libs/syscall/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fdatasync.rs
@@ -5,19 +5,22 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    safe::RawFileDescriptor,
-    unistd::message::FileDataSyncRequest,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+use crate::safe::RawFileDescriptor;
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::FileDataSyncRequest,
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
     },
-    ipc::Message,
-    pm::ThreadIdentifier,
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/fsync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fsync.rs
@@ -5,20 +5,23 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    unistd::message::FileSyncRequest,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 use ::sysapi::ffi::c_int;
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::FileSyncRequest,
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/syscall/ftruncate.rs
@@ -5,22 +5,25 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    unistd::message::FileTruncateRequest,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 use ::sysapi::{
     ffi::c_int,
     sys_types::off_t,
+};
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::FileTruncateRequest,
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/getcwd.rs
+++ b/src/libs/syscall/src/unistd/syscall/getcwd.rs
@@ -5,30 +5,29 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    message::{
-        LinuxDaemonLongMessage,
-        LinuxDaemonMessagePart,
-        MessagePartitioner,
+use ::alloc::string::String;
+use ::sys::error::Error;
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        message::{
+            LinuxDaemonLongMessage,
+            LinuxDaemonMessagePart,
+            MessagePartitioner,
+        },
+        unistd::message::{
+            GetCurrentWorkingDirectoryRequest,
+            GetCurrentWorkingDirectoryResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
     },
-    unistd::message::{
-        GetCurrentWorkingDirectoryRequest,
-        GetCurrentWorkingDirectoryResponse,
+    ::alloc::vec::Vec,
+    ::sys::{
+        error::ErrorCode,
+        ipc::Message,
+        pm::ThreadIdentifier,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::alloc::{
-    string::String,
-    vec::Vec,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/getegid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getegid.rs
@@ -5,23 +5,24 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    unistd::message::{
-        GetIdsRequest,
-        GetIdsResponse,
+use ::sys::error::Error;
+use ::sysapi::sys_types::gid_t;
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::{
+            GetIdsRequest,
+            GetIdsResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
+    ::sys::{
+        error::ErrorCode,
+        ipc::Message,
+        pm::ThreadIdentifier,
     },
-    ipc::Message,
-    pm::ThreadIdentifier,
 };
-use sysapi::sys_types::gid_t;
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/unistd/syscall/geteuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/geteuid.rs
@@ -5,23 +5,24 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    unistd::message::{
-        GetIdsRequest,
-        GetIdsResponse,
-    },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
-};
+use ::sys::error::Error;
 use ::sysapi::sys_types::uid_t;
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::{
+            GetIdsRequest,
+            GetIdsResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::sys::{
+        error::ErrorCode,
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/unistd/syscall/getgid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getgid.rs
@@ -5,23 +5,24 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    unistd::message::{
-        GetIdsRequest,
-        GetIdsResponse,
+use ::sys::error::Error;
+use ::sysapi::sys_types::gid_t;
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::{
+            GetIdsRequest,
+            GetIdsResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
     },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
+    ::sys::{
+        error::ErrorCode,
+        ipc::Message,
+        pm::ThreadIdentifier,
     },
-    ipc::Message,
-    pm::ThreadIdentifier,
 };
-use sysapi::sys_types::gid_t;
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/unistd/syscall/getuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getuid.rs
@@ -5,23 +5,24 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    unistd::message::{
-        GetIdsRequest,
-        GetIdsResponse,
-    },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
-};
+use ::sys::error::Error;
 use ::sysapi::sys_types::uid_t;
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::{
+            GetIdsRequest,
+            GetIdsResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::sys::{
+        error::ErrorCode,
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/unistd/syscall/linkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/linkat.rs
@@ -5,26 +5,29 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    message::MessagePartitioner,
-    safe::RawFileDescriptor,
-    unistd::message::LinkAtRequest,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::alloc::{
-    string::ToString,
-    vec::Vec,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
+use crate::safe::RawFileDescriptor;
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 use ::sysapi::ffi::c_int;
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        message::MessagePartitioner,
+        unistd::message::LinkAtRequest,
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::alloc::{
+        string::ToString,
+        vec::Vec,
+    },
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -5,26 +5,29 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    safe::RawFileDescriptor,
-    unistd::message::{
-        SeekRequest,
-        SeekResponse,
-    },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
+use crate::safe::RawFileDescriptor;
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 use ::sysapi::{
     ffi::c_int,
     sys_types::off_t,
+};
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::{
+            SeekRequest,
+            SeekResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -5,21 +5,24 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    unistd::message::{
-        PipeRequest,
-        PipeResponse,
-    },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::{
+            PipeRequest,
+            PipeResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
     },
-    ipc::Message,
-    pm::ThreadIdentifier,
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -5,27 +5,30 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    safe::RawFileDescriptor,
-    unistd::message::{
-        PartialReadRequest,
-        PartialReadResponse,
-    },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+use crate::safe::RawFileDescriptor;
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
-use ::core::cmp;
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
-};
-use sysapi::sys_types::{
+use ::sysapi::sys_types::{
     c_size_t,
     off_t,
+};
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::{
+            PartialReadRequest,
+            PartialReadResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::core::cmp,
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -5,27 +5,30 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    safe::RawFileDescriptor,
-    unistd::message::{
-        PartialWriteRequest,
-        PartialWriteResponse,
-    },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::core::cmp;
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
+use crate::safe::RawFileDescriptor;
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 use ::sysapi::sys_types::{
     c_size_t,
     off_t,
+};
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        unistd::message::{
+            PartialWriteRequest,
+            PartialWriteResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::core::cmp,
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -5,29 +5,31 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    safe::RawFileDescriptor,
-    unistd::message::{
-        ReadRequest,
-        ReadResponse,
-    },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+use crate::safe::RawFileDescriptor;
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
-};
-use sysapi::{
+use ::sysapi::{
     sys_types::c_size_t,
     unistd::STDIN_FILENO,
 };
-
-use super::util::page_chunk_size;
+#[cfg(not(feature = "standalone"))]
+use {
+    super::util::page_chunk_size,
+    crate::{
+        unistd::message::{
+            ReadRequest,
+            ReadResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -5,32 +5,35 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    message::{
-        LinuxDaemonLongMessage,
-        LinuxDaemonMessagePart,
-        MessagePartitioner,
-    },
-    unistd::message::{
-        ReadLinkAtRequest,
-        ReadLinkAtResponse,
-    },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::alloc::{
-    string::ToString,
-    vec::Vec,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 use ::sysapi::sys_types::c_ssize_t;
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        message::{
+            LinuxDaemonLongMessage,
+            LinuxDaemonMessagePart,
+            MessagePartitioner,
+        },
+        unistd::message::{
+            ReadLinkAtRequest,
+            ReadLinkAtResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::alloc::{
+        string::ToString,
+        vec::Vec,
+    },
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/syscall/src/unistd/syscall/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/symlinkat.rs
@@ -5,23 +5,26 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    message::MessagePartitioner,
-    unistd::message::SymbolicLinkAtRequest,
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
-use ::alloc::{
-    string::ToString,
-    vec::Vec,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
+#[cfg(not(feature = "standalone"))]
+use {
+    crate::{
+        message::MessagePartitioner,
+        unistd::message::SymbolicLinkAtRequest,
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
     },
-    ipc::Message,
-    pm::ThreadIdentifier,
+    ::alloc::{
+        string::ToString,
+        vec::Vec,
+    },
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
 };
 
 //==================================================================================================

--- a/src/libs/syscall/src/unistd/syscall/util.rs
+++ b/src/libs/syscall/src/unistd/syscall/util.rs
@@ -5,8 +5,11 @@
 // Imports
 //==================================================================================================
 
-use ::arch::mem::PAGE_SIZE;
-use ::core::cmp;
+#[cfg(not(feature = "standalone"))]
+use {
+    ::arch::mem::PAGE_SIZE,
+    ::core::cmp,
+};
 
 //==================================================================================================
 // Standalone Functions
@@ -30,6 +33,7 @@ use ::core::cmp;
 ///
 /// The number of bytes that fit within the current page.
 ///
+#[cfg(not(feature = "standalone"))]
 pub fn page_chunk_size(ptr: usize, remaining: usize) -> usize {
     let page_offset: usize = ptr & (PAGE_SIZE - 1);
     let available: usize = PAGE_SIZE - page_offset;

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -5,22 +5,10 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    safe::RawFileDescriptor,
-    unistd::message::{
-        WriteRequest,
-        WriteResponse,
-    },
-    LinuxDaemonMessage,
-    LinuxDaemonMessageHeader,
-};
-use ::sys::{
-    error::{
-        Error,
-        ErrorCode,
-    },
-    ipc::Message,
-    pm::ThreadIdentifier,
+use crate::safe::RawFileDescriptor;
+use ::sys::error::{
+    Error,
+    ErrorCode,
 };
 use ::sysapi::{
     sys_types::c_size_t,
@@ -29,8 +17,22 @@ use ::sysapi::{
         STDOUT_FILENO,
     },
 };
-
-use super::util::page_chunk_size;
+#[cfg(not(feature = "standalone"))]
+use {
+    super::util::page_chunk_size,
+    crate::{
+        unistd::message::{
+            WriteRequest,
+            WriteResponse,
+        },
+        LinuxDaemonMessage,
+        LinuxDaemonMessageHeader,
+    },
+    ::sys::{
+        ipc::Message,
+        pm::ThreadIdentifier,
+    },
+};
 
 //==================================================================================================
 // Standalone Functions

--- a/src/libs/vfs/src/fat32_backend.rs
+++ b/src/libs/vfs/src/fat32_backend.rs
@@ -18,11 +18,11 @@ use crate::fd::{
 };
 use ::fat32::Fat32Error;
 use ::sysapi::{
-    ffi::c_int,
     fcntl::{
         file_access_mode,
         file_creation_flags,
     },
+    ffi::c_int,
 };
 
 //==================================================================================================

--- a/src/libs/vfs/src/file.rs
+++ b/src/libs/vfs/src/file.rs
@@ -14,14 +14,14 @@
 // Imports
 //==================================================================================================
 
-use ::fat32::{
-    Fat32Error,
-    FatFile,
-};
 use crate::state;
 use ::alloc::{
     string::String,
     vec::Vec,
+};
+use ::fat32::{
+    Fat32Error,
+    FatFile,
 };
 use ::sysapi::unistd::file_seek;
 
@@ -394,8 +394,7 @@ pub fn open(path: &str) -> Result<File, Fat32Error> {
 pub fn file_raw_region(path: &str) -> Option<(*const u8, usize)> {
     let (mount_idx, relative_path): (usize, String) = resolve_path(path).ok()?;
     state::with_vfs(|vfs| {
-        let mount: &crate::mount::Mount =
-            vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
+        let mount: &crate::mount::Mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
         mount
             .fat()
             .file_raw_region(&relative_path)

--- a/src/libs/vfs/src/mount.rs
+++ b/src/libs/vfs/src/mount.rs
@@ -17,13 +17,13 @@
 // Imports
 //==================================================================================================
 
-use ::fat32::{
-    Fat32Error,
-    Fat,
-};
 use ::alloc::{
     string::String,
     vec::Vec,
+};
+use ::fat32::{
+    Fat,
+    Fat32Error,
 };
 
 //==================================================================================================
@@ -514,8 +514,7 @@ mod tests {
             unsafe { ::fat32::RawMemoryStorage::new(ptr, size).expect("valid storage") };
         ::fatfs::format_volume(&mut storage, ::fatfs::FormatVolumeOptions::new())
             .expect("format should succeed");
-        let fat: ::fat32::Fat =
-            unsafe { ::fat32::Fat::from_memory(ptr, size).expect("valid fat") };
+        let fat: ::fat32::Fat = unsafe { ::fat32::Fat::from_memory(ptr, size).expect("valid fat") };
 
         let result = Mount::new(String::from("relative"), fat);
         match result {

--- a/src/libs/vfs/src/state.rs
+++ b/src/libs/vfs/src/state.rs
@@ -18,11 +18,6 @@
 // Imports
 //==================================================================================================
 
-use ::fat32::{
-    Fat32Error,
-    Fat,
-    RawMemoryStorage,
-};
 use crate::mount::{
     Mount,
     Vfs,
@@ -31,6 +26,11 @@ use ::alloc::{
     boxed::Box,
     string::String,
     vec::Vec,
+};
+use ::fat32::{
+    Fat,
+    Fat32Error,
+    RawMemoryStorage,
 };
 use ::spin::Mutex;
 


### PR DESCRIPTION
Key changes include:

### Build System

* The `Makefile` now automatically enables `MEMFS` when `STANDALONE` mode is set, ensuring the memory filesystem is always available in standalone deployments.

### Syscall Source Refactoring

* Refactored imports in all `src/libs/syscall/src/unistd/syscall/*.rs` files to:
  - Use direct imports from external crates (like `::sys::error`) for error types and system types.
  - Move daemon-related imports under a `#[cfg(not(feature = "standalone"))]` block, so they're only included for non-standalone builds.
  - Improve clarity and reduce unnecessary imports, making the codebase more modular and easier to maintain. [[1]](diffhunk://#diff-27792effd2f34e33484b4d6f99c23d5ae42310293c018696f45ae2214c7b5bb6L8-R24) [[2]](diffhunk://#diff-3a870d69cae2eb1103be1d24bd9e1021bdfb497eb84c43cc240b1e76f7c5726cL8-R25) [[3]](diffhunk://#diff-b66fb3324f0cca8e7a60f0f7e11aeda4fb17b551b47fde94072e88a425b9d51fL8-L23) [[4]](diffhunk://#diff-d519bef35987be7b6b4e4a45b223b8623ff69eb136a76400db8dd490ee3d9894L8-L17) [[5]](diffhunk://#diff-cb8ac5aa08ffb198add442a6eb5f19c3b0c8963cc9589e2873ecdb32b40ab29aL8-R25) [[6]](diffhunk://#diff-377fe1c5cdd018e74d870c740c7da51a534d30b7bb2623877e5b69722662164aL8-L27) [[7]](diffhunk://#diff-d146f9b9d4e1eb8ad3b1f7edb8613859b4544661f1a67cc0a59a1cf9407a2a0dL8-R23) [[8]](diffhunk://#diff-622ffae67caf6159f15c57483f2eb371934d70e2a37dc641763fdafa7065253dL8-L21) [[9]](diffhunk://#diff-685f87d077264bb4d7ff2783ff8c1d7e8a5ec6336c0dfb09e2d5e923488774aeL8-R27) [[10]](diffhunk://#diff-54ef48f0b8d6d6e488c1da1cfd9a053399c8e78fb5a465aee7459cbe2d1d560dL8-R12) [[11]](diffhunk://#diff-54ef48f0b8d6d6e488c1da1cfd9a053399c8e78fb5a465aee7459cbe2d1d560dL20-R30) [[12]](diffhunk://#diff-16170ed0c780d699bd699e73d39520e9cb2082e457e92cfc1a6a97a84d39637bL8-L24) [[13]](diffhunk://#diff-63e45f07507368d4f6bdd7156d77cacf91ef6bbc1288a44a042583b67f0730f3L8-L24) [[14]](diffhunk://#diff-08ae0764a7ffd2a2a48ec7442e9e9d1b10d8f7daae1f969da99677c4b7bcdb23L8-L24) [[15]](diffhunk://#diff-1f4a21da734c3f3ca995c81bb2eb852b1c108fbd28d1c00cb6b842ea4610881fL8-L24) [[16]](diffhunk://#diff-eb882e5426fdb570587d6bd42975c5a6e64b5eca1c1c0549f94a9df430c5d586L8-L27) [[17]](diffhunk://#diff-bbf8d2c36d2b20e8d536bdcda059abe84fd32d41b11e22f1baa41fa3c63c92aaL8-R30) [[18]](diffhunk://#diff-6efb07ee285965a075c9fb39d60d84c298c2f6e9b211bd0913f7ea2aeaaf7e15L8-R25) [[19]](diffhunk://#diff-5c31bbeed9f1c46f3df6daba424074f103727f804de4c6a7320de6f4b1f6a971L8-R31) [[20]](diffhunk://#diff-82a07d49735281417843436e4c0f9bd2d1b278bccc887f4da7c5283b8f62cb5dL8-R31)

These changes make the syscall codebase cleaner, more maintainable, and better suited for conditional compilation between standalone and multi-process modes.