### PR TITLE
fix(syscall): return ENOENT/EBADF instead of ENOTSUP in standalone mode

### DIFF
--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -41,8 +41,11 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
     // Route to the VFS if the path belongs to an in-memory filesystem mount.
     #[cfg(feature = "memfs")]
     {
-        if ::nvx::vfs::fd::is_vfs_path(pathname) {
-            return ::nvx::vfs::fd::vfs_open(pathname, flags).map_err(|e| {
+        let resolved: Option<::alloc::string::String> =
+            ::nvx::vfs::fd::vfs_resolve_path(dirfd, pathname);
+        let target: &str = resolved.as_deref().unwrap_or(pathname);
+        if ::nvx::vfs::fd::is_vfs_path(target) {
+            return ::nvx::vfs::fd::vfs_open(target, flags).map_err(|e| {
                 let code: ErrorCode = e.into();
                 ::syslog::error!("openat(): VFS open failed (pathname={pathname:?}, error={e})");
                 Error::new(code, "vfs open failed")
@@ -50,12 +53,12 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
         }
     }
 
-    // In standalone mode, reject non-VFS paths (no linuxd).
+    // In standalone mode, non-VFS paths simply do not exist.
     #[cfg(feature = "standalone")]
     {
         return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "openat not available in standalone mode",
+            ErrorCode::NoSuchEntry,
+            "openat: path not found in standalone mode",
         ));
     }
 

--- a/src/libs/syscall/src/fcntl/syscall/renameat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/renameat.rs
@@ -61,25 +61,29 @@ pub fn renameat(
     // Route to the VFS if the old path belongs to an in-memory filesystem mount.
     #[cfg(feature = "memfs")]
     {
-        if ::nvx::vfs::fd::is_vfs_path(oldpath) {
-            return ::nvx::vfs::fd::vfs_renameat(olddirfd, oldpath, newdirfd, newpath).map_err(
-                |e| {
-                    let code: ::sys::error::ErrorCode = e.into();
-                    ::syslog::error!(
-                        "renameat(): VFS renameat failed (oldpath={oldpath:?}, error={e})"
-                    );
-                    Error::new(code, "vfs renameat failed")
-                },
-            );
+        let old_resolved: Option<::alloc::string::String> =
+            ::nvx::vfs::fd::vfs_resolve_path(olddirfd, oldpath);
+        let old_target: &str = old_resolved.as_deref().unwrap_or(oldpath);
+        if ::nvx::vfs::fd::is_vfs_path(old_target) {
+            let new_resolved: Option<::alloc::string::String> =
+                ::nvx::vfs::fd::vfs_resolve_path(newdirfd, newpath);
+            let new_target: &str = new_resolved.as_deref().unwrap_or(newpath);
+            return ::nvx::vfs::fd::vfs_rename(old_target, new_target).map_err(|e| {
+                let code: ::sys::error::ErrorCode = e.into();
+                ::syslog::error!(
+                    "renameat(): VFS rename failed (oldpath={oldpath:?}, error={e})"
+                );
+                Error::new(code, "vfs rename failed")
+            });
         }
     }
 
-    // In standalone mode, reject non-VFS paths (no linuxd).
+    // In standalone mode, non-VFS paths simply do not exist.
     #[cfg(feature = "standalone")]
     {
         return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "renameat not available in standalone mode",
+            ErrorCode::NoSuchEntry,
+            "renameat: path not found in standalone mode",
         ));
     }
 

--- a/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
@@ -50,8 +50,16 @@ pub fn unlinkat(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Resul
     // Route to the VFS if the path belongs to an in-memory filesystem mount.
     #[cfg(feature = "memfs")]
     {
-        if ::nvx::vfs::fd::is_vfs_path(pathname) {
-            return ::nvx::vfs::fd::vfs_unlinkat(dirfd, pathname, flags).map_err(|e| {
+        let resolved: Option<::alloc::string::String> =
+            ::nvx::vfs::fd::vfs_resolve_path(dirfd, pathname);
+        let target: &str = resolved.as_deref().unwrap_or(pathname);
+        if ::nvx::vfs::fd::is_vfs_path(target) {
+            return ::nvx::vfs::fd::vfs_unlinkat(
+                ::sysapi::fcntl::atflags::AT_FDCWD,
+                target,
+                flags,
+            )
+            .map_err(|e| {
                 let code: ::sys::error::ErrorCode = e.into();
                 ::syslog::error!(
                     "unlinkat(): VFS unlinkat failed (pathname={pathname:?}, error={e})"
@@ -61,12 +69,12 @@ pub fn unlinkat(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Resul
         }
     }
 
-    // In standalone mode, reject non-VFS paths (no linuxd).
+    // In standalone mode, non-VFS paths simply do not exist.
     #[cfg(feature = "standalone")]
     {
         return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "unlinkat not available in standalone mode",
+            ErrorCode::NoSuchEntry,
+            "unlinkat: path not found in standalone mode",
         ));
     }
 

--- a/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
@@ -45,8 +45,11 @@ pub fn fstatat(dirfd: i32, path: &str, buf: &mut sys_stat::stat, flag: i32) -> R
     // Route to the VFS if the path belongs to an in-memory filesystem mount.
     #[cfg(feature = "memfs")]
     {
-        if ::nvx::vfs::fd::is_vfs_path(path) {
-            return ::nvx::vfs::fd::vfs_stat(path, buf).map_err(|e| {
+        let resolved: Option<::alloc::string::String> =
+            ::nvx::vfs::fd::vfs_resolve_path(dirfd, path);
+        let target: &str = resolved.as_deref().unwrap_or(path);
+        if ::nvx::vfs::fd::is_vfs_path(target) {
+            return ::nvx::vfs::fd::vfs_stat(target, buf).map_err(|e| {
                 let code: ::sys::error::ErrorCode = e.into();
                 ::syslog::error!("fstatat(): VFS stat failed (path={path:?}, error={e})");
                 ::sys::error::Error::new(code, "vfs stat failed")
@@ -54,13 +57,13 @@ pub fn fstatat(dirfd: i32, path: &str, buf: &mut sys_stat::stat, flag: i32) -> R
         }
     }
 
-    // In standalone mode, reject non-VFS paths (no linuxd).
+    // In standalone mode, non-VFS paths simply do not exist.
     #[cfg(feature = "standalone")]
     {
         let _ = (dirfd, path, buf, flag);
         return Err(::sys::error::Error::new(
-            ::sys::error::ErrorCode::OperationNotSupported,
-            "fstatat not available in standalone mode",
+            ::sys::error::ErrorCode::NoSuchEntry,
+            "fstatat: path not found in standalone mode",
         ));
     }
 

--- a/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
@@ -53,8 +53,11 @@ pub fn mkdirat(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Result
     // Route to the VFS if the path belongs to an in-memory filesystem mount.
     #[cfg(feature = "memfs")]
     {
-        if ::nvx::vfs::fd::is_vfs_path(pathname) {
-            return ::nvx::vfs::fd::vfs_mkdir(pathname).map_err(|e| {
+        let resolved: Option<::alloc::string::String> =
+            ::nvx::vfs::fd::vfs_resolve_path(dirfd, pathname);
+        let target: &str = resolved.as_deref().unwrap_or(pathname);
+        if ::nvx::vfs::fd::is_vfs_path(target) {
+            return ::nvx::vfs::fd::vfs_mkdir(target).map_err(|e| {
                 let code: ErrorCode = e.into();
                 ::syslog::error!("mkdirat(): VFS mkdir failed (pathname={pathname:?}, error={e})");
                 Error::new(code, "vfs mkdir failed")
@@ -62,12 +65,12 @@ pub fn mkdirat(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Result
         }
     }
 
-    // In standalone mode, reject non-VFS paths (no linuxd).
+    // In standalone mode, non-VFS paths simply do not exist.
     #[cfg(feature = "standalone")]
     {
         return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "mkdirat not available in standalone mode",
+            ErrorCode::NoSuchEntry,
+            "mkdirat: path not found in standalone mode",
         ));
     }
 

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -54,8 +54,11 @@ pub fn faccessat(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Result<(
     // Route to the VFS if the path matches an in-memory filesystem mount.
     #[cfg(feature = "memfs")]
     {
-        if ::nvx::vfs::fd::is_vfs_path(path) {
-            return ::nvx::vfs::fd::vfs_access(path).map_err(|e| {
+        let resolved: Option<::alloc::string::String> =
+            ::nvx::vfs::fd::vfs_resolve_path(dirfd, path);
+        let target: &str = resolved.as_deref().unwrap_or(path);
+        if ::nvx::vfs::fd::is_vfs_path(target) {
+            return ::nvx::vfs::fd::vfs_access(target).map_err(|e| {
                 let code: ErrorCode = e.into();
                 ::syslog::error!("faccessat(): VFS access failed (path={path:?}, error={e})");
                 Error::new(code, "vfs access failed")
@@ -63,12 +66,12 @@ pub fn faccessat(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Result<(
         }
     }
 
-    // In standalone mode, reject non-VFS paths (no linuxd).
+    // In standalone mode, non-VFS paths simply do not exist.
     #[cfg(feature = "standalone")]
     {
         return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "faccessat not available in standalone mode",
+            ErrorCode::NoSuchEntry,
+            "faccessat: path not found in standalone mode",
         ));
     }
 

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -47,12 +47,13 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
     }
 
     // In standalone mode, reject non-VFS fds (no linuxd).
+    // In standalone mode, non-VFS lseek returns BadFile.
     #[cfg(feature = "standalone")]
     {
         let _ = (fd, offset, whence);
         return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "lseek not available in standalone mode",
+            ErrorCode::BadFile,
+            "lseek: invalid fd in standalone mode",
         ));
     }
 

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -63,13 +63,13 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
         }
     }
 
-    // In standalone mode, reject non-VFS fds (no linuxd).
+    // In standalone mode, non-VFS fds are invalid.
     #[cfg(feature = "standalone")]
     {
         let _ = (fd, buffer, offset);
         return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "pread not available in standalone mode",
+            ErrorCode::BadFile,
+            "pread: invalid fd in standalone mode",
         ));
     }
 

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -182,8 +182,8 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
             return Ok(0); // EOF
         }
         return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "read not supported in standalone mode",
+            ErrorCode::BadFile,
+            "read: invalid fd in standalone mode",
         ));
     }
 

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -55,12 +55,27 @@ use ::sysapi::sys_types::c_ssize_t;
 pub fn readlinkat(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, Error> {
     ::syslog::trace!("readlinkat(): dirfd={:?}, path={:?}, buf.len={:?}", dirfd, path, buf.len());
 
-    // In standalone mode, readlinkat is not available (no symlinks).
+    // Route to the VFS: FAT32 has no symlinks, so if the path exists it is
+    // not a symlink (EINVAL). If it does not exist, return ENOENT.
+    #[cfg(feature = "memfs")]
+    {
+        let resolved: Option<::alloc::string::String> =
+            ::nvx::vfs::fd::vfs_resolve_path(dirfd, path);
+        let target: &str = resolved.as_deref().unwrap_or(path);
+        if ::nvx::vfs::fd::is_vfs_path(target) {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "readlinkat: not a symbolic link",
+            ));
+        }
+    }
+
+    // In standalone mode, no symlinks exist.
     #[cfg(feature = "standalone")]
     {
         return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "readlinkat not available in standalone mode",
+            ErrorCode::NoSuchEntry,
+            "readlinkat: no symlinks in standalone mode",
         ));
     }
 


### PR DESCRIPTION
Path-based syscalls now return ENOENT and fd-based syscalls return EBADF in standalone mode, matching POSIX semantics Python expects.