### PR TITLE
fix(nanvixd): route guest output to host stderr in single-process mode

### DIFF
--- a/src/libs/nanvix-sandbox/src/sandbox_config.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox_config.rs
@@ -114,6 +114,7 @@ impl<T> SandboxConfig<T> {
     ///
     /// The path to the console file as a string.
     ///
+    #[allow(dead_code)]
     fn default_console_file(uservm_id: UserVmIdentifier, log_dir: &str) -> String {
         let console_file: PathBuf = PathBuf::from(log_dir)
             .join(format!("guest_{uservm_id}_{}.log", Local::now().format("%Y_%m_%d_%H_%M_%S_%f")));
@@ -174,10 +175,7 @@ impl<T> SandboxConfig<T> {
             uservm_id,
             gateway_socket_info,
             system_vm_socket_info,
-            console_file: Some(
-                console_file
-                    .unwrap_or_else(|| Self::default_console_file(uservm_id, log_directory)),
-            ),
+            console_file,
             hwloc,
             kernel_binary_path: kernel_binary_path.to_string(),
             #[cfg(not(feature = "single-process"))]

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -11,15 +11,11 @@
 // Imports
 //==================================================================================================
 
-#[cfg(feature = "single-process")]
-use crate::config::DEFAULT_CONSOLE_FILENAME;
 use crate::config::{
     self,
     DEFAULT_TMP_DIRECTORY,
 };
 use ::anyhow::Result;
-#[cfg(feature = "single-process")]
-use ::chrono::Local;
 use ::nanvix::{
     hwloc::HwLoc,
     log::DEFAULT_LOG_DIRECTORY,
@@ -145,12 +141,7 @@ impl Args {
         #[cfg(not(feature = "single-process"))]
         let mut console_file: Option<String> = None;
         #[cfg(feature = "single-process")]
-        let mut console_file: Option<String> = Some(format!(
-            "{}/{}_{}.log",
-            DEFAULT_LOG_DIRECTORY,
-            DEFAULT_CONSOLE_FILENAME,
-            Local::now().format("%Y_%m_%d_%H_%M")
-        ));
+        let mut console_file: Option<String> = None;
         let mut ramfs_filename: Option<String> = None;
         let mut hwloc: Option<HwLoc> = None;
         let mut netns_pool_size: usize = Self::DEFAULT_NETNS_POOL_SIZE;


### PR DESCRIPTION
Default console_file to None in single-process mode so guest output goes to host stderr instead of a log file.