### PR TITLE
[config] Increase user stack size to 4MB and simplify stack layout

### DIFF
--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -178,6 +178,10 @@ use ::sys::error::Error;
 ::static_assert::assert_eq!(
     config::memory_layout::USER_STACK_MIN_SIZE <= config::memory_layout::USER_STACK_SIZE
 );
+// Ensure that the thread stack size is at least the minimum stack size.
+::static_assert::assert_eq!(
+    config::memory_layout::USER_THREAD_STACK_SIZE >= config::memory_layout::USER_STACK_MIN_SIZE
+);
 
 //==================================================================================================
 // Standalone Functions

--- a/src/kernel/src/pm/kcall/create_thread.rs
+++ b/src/kernel/src/pm/kcall/create_thread.rs
@@ -16,7 +16,7 @@ use crate::{
         ProcessManager,
     },
 };
-use ::config::memory_layout::USER_STACK_SIZE;
+use ::config::memory_layout::USER_STACK_MIN_SIZE;
 use ::core::mem::size_of;
 use ::sys::{
     error::ErrorCode,
@@ -97,7 +97,7 @@ pub fn create_thread(pid: ProcessIdentifier, arg0: u32) -> KcallResult {
     }
 
     // Check if user stack size is too small.
-    if thread_create_args.user_stack_size < USER_STACK_SIZE {
+    if thread_create_args.user_stack_size < USER_STACK_MIN_SIZE {
         let reason: &str = "user stack size is too small";
         error!(
             "create_thread(): {reason} (user_stack_size={})",

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -125,8 +125,7 @@ pub mod memory_layout {
     ///
     /// End address of the user stack
     ///
-    pub const USER_STACK_TOP_RAW: usize =
-        USER_STACK_BASE_RAW - USER_STACK_SIZE * NUM_USER_STACK_ENTRIES;
+    pub const USER_STACK_TOP_RAW: usize = USER_STACK_BASE_RAW - USER_STACK_SIZE;
 
     ///
     /// # Description
@@ -137,7 +136,7 @@ pub mod memory_layout {
     ///
     /// - This size should be a multiple of a page size.
     ///
-    pub const USER_STACK_SIZE: usize = 512 * crate::constants::KILOBYTE;
+    pub const USER_STACK_SIZE: usize = 4 * crate::constants::MEGABYTE;
 
     ///
     /// # Description
@@ -150,13 +149,6 @@ pub mod memory_layout {
     /// - This size should be a multiple of a page size.
     ///
     pub const USER_STACK_MIN_SIZE: usize = 32 * crate::constants::KILOBYTE;
-
-    ///
-    /// # Description
-    ///
-    /// Number of entries in the user stack. This should be a multiple of 8.
-    ///
-    pub const NUM_USER_STACK_ENTRIES: usize = 8;
 
     ///
     /// # Description

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -155,6 +155,21 @@ pub mod memory_layout {
     ///
     /// # Description
     ///
+    /// Default stack size for spawned threads.
+    ///
+    /// Unlike the main thread whose stack is demand-paged within the [`USER_STACK_SIZE`] virtual
+    /// region, additional threads have their stacks heap-allocated at this fixed size.
+    ///
+    /// # Notes:
+    ///
+    /// - This size should be a multiple of a page size.
+    /// - Must be at least [`USER_STACK_MIN_SIZE`].
+    ///
+    pub const USER_THREAD_STACK_SIZE: usize = 512 * crate::constants::KILOBYTE;
+
+    ///
+    /// # Description
+    ///
     /// Base address for the unified mmap region.
     ///
     /// All dynamic memory allocations (heap, shared libraries, and explicit memory mappings) are

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -112,7 +112,8 @@ pub mod memory_layout {
     ///
     /// # Description
     ///
-    /// Base address of user stack.
+    /// High address of the user stack region (initial stack pointer).
+    /// The stack grows downward from this address.
     ///
     /// # Notes
     ///
@@ -123,7 +124,8 @@ pub mod memory_layout {
     ///
     /// # Description
     ///
-    /// End address of the user stack
+    /// Low address of the user stack region.
+    /// The stack occupies [`USER_STACK_TOP_RAW`, [`USER_STACK_BASE_RAW`).
     ///
     pub const USER_STACK_TOP_RAW: usize = USER_STACK_BASE_RAW - USER_STACK_SIZE;
 

--- a/src/libs/sysapi/src/sys_types.rs
+++ b/src/libs/sysapi/src/sys_types.rs
@@ -29,8 +29,8 @@ use crate::{
     sys_socket::socklen_t,
 };
 use ::config::memory_layout::{
-    USER_STACK_SIZE,
     USER_STACK_TOP_RAW,
+    USER_THREAD_STACK_SIZE,
 };
 use ::core::mem::size_of;
 
@@ -171,7 +171,7 @@ impl Default for pthread_attr_t {
         Self {
             is_initialized: 1,
             stackaddr: USER_STACK_TOP_RAW as *mut _,
-            stacksize: USER_STACK_SIZE as c_size_t,
+            stacksize: USER_THREAD_STACK_SIZE as c_size_t,
             contentionscope: 0,
             inheritsched: 0,
             schedpolicy: SCHED_OTHER,

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -99,6 +99,7 @@ pub fn pthread_create(func: extern "C" fn(usize) -> usize, arg: usize) -> Result
 
     // Create a new stack.
     // NOTE: The stack is automatically deallocated if this object is dropped.
+    // TODO: Allocate thread stack on-demand via kernel mmap support (https://github.com/nanvix/nanvix/issues/1699).
     let stack: Stack = Stack::new(USER_STACK_SIZE)?;
 
     let user_tda: Option<VirtualAddress> =

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -35,7 +35,7 @@ mod pthread_getattr_np;
 
 use crate::safe::mem::stack::Stack;
 use ::alloc::collections::btree_map::BTreeMap;
-use ::config::memory_layout::USER_STACK_SIZE;
+use ::config::memory_layout::USER_THREAD_STACK_SIZE;
 use ::spin::{
     Lazy,
     Mutex,
@@ -100,7 +100,7 @@ pub fn pthread_create(func: extern "C" fn(usize) -> usize, arg: usize) -> Result
     // Create a new stack.
     // NOTE: The stack is automatically deallocated if this object is dropped.
     // TODO: Allocate thread stack on-demand via kernel mmap support (https://github.com/nanvix/nanvix/issues/1699).
-    let stack: Stack = Stack::new(USER_STACK_SIZE)?;
+    let stack: Stack = Stack::new(USER_THREAD_STACK_SIZE)?;
 
     let user_tda: Option<VirtualAddress> =
         ::sysalloc::tda::alloc()?.map(|tda_ptr| VirtualAddress::new(tda_ptr as usize));

--- a/src/tests/stress-rust/src/tests/kcall_hammer.rs
+++ b/src/tests/stress-rust/src/tests/kcall_hammer.rs
@@ -79,7 +79,7 @@ pub fn run() -> Result<(), StressError> {
         ::alloc::vec::Vec::with_capacity(KCALL_HAMMER_WORKERS);
 
     for worker_id in 0..KCALL_HAMMER_WORKERS {
-        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, kcall_hammer_worker, worker_id);
         let tid: ThreadIdentifier = create_thread(&mut args)?;
         tids.push(tid);

--- a/src/tests/stress-rust/src/tests/mutex_churn.rs
+++ b/src/tests/stress-rust/src/tests/mutex_churn.rs
@@ -77,7 +77,7 @@ pub fn run() -> Result<(), StressError> {
         ::alloc::vec::Vec::with_capacity(CHURN_WORKERS);
 
     for worker_id in 0..CHURN_WORKERS {
-        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, mutex_churn_worker, worker_id);
         let tid: ThreadIdentifier = create_thread(&mut args)?;
         tids.push(tid);

--- a/src/tests/stress-rust/src/tests/parallel_spawners.rs
+++ b/src/tests/stress-rust/src/tests/parallel_spawners.rs
@@ -70,7 +70,7 @@ pub fn run() -> Result<(), StressError> {
     let mut stacks: Vec<WorkerStack> = Vec::with_capacity(CONCURRENT_SPAWNERS);
 
     for worker_id in 0..CONCURRENT_SPAWNERS {
-        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, spawner_worker, worker_id);
         let tid: ThreadIdentifier = create_thread(&mut args)?;
         tids.push(tid);
@@ -141,7 +141,7 @@ extern "C" fn spawner_worker(worker_id: usize) -> usize {
 fn spawner_worker_impl(worker_id: usize) -> Result<usize, Error> {
     for child_index in 0..SPAWN_CHILDREN_PER_WORKER {
         let signature: usize = (worker_id << 8) | child_index;
-        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, spawn_child_worker, signature);
         let tid: ThreadIdentifier = create_thread(&mut args)?;
 

--- a/src/tests/stress-rust/src/tests/scheduler_pressure.rs
+++ b/src/tests/stress-rust/src/tests/scheduler_pressure.rs
@@ -102,7 +102,7 @@ pub fn run() -> Result<(), StressError> {
     let mut stacks: ::alloc::vec::Vec<WorkerStack> =
         ::alloc::vec::Vec::with_capacity(PRESSURE_WORKERS);
     for _ in 0..PRESSURE_WORKERS {
-        stacks.push(WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?);
+        stacks.push(WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?);
     }
 
     // Spawn all workers upfront to maximize concurrent scheduling pressure.

--- a/src/tests/stress-rust/src/tests/scoreboard_backpressure.rs
+++ b/src/tests/stress-rust/src/tests/scoreboard_backpressure.rs
@@ -112,7 +112,7 @@ pub fn run() -> Result<(), StressError> {
     let mut stacks: Vec<WorkerStack> = Vec::with_capacity(worker_count);
 
     for worker_id in 0..worker_count {
-        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, scoreboard_pressure_worker, worker_id);
         let tid: ThreadIdentifier = create_thread(&mut args)?;
         tids.push(tid);

--- a/src/tests/stress-rust/src/tests/thread_fan_out.rs
+++ b/src/tests/stress-rust/src/tests/thread_fan_out.rs
@@ -65,7 +65,7 @@ pub fn run() -> Result<(), StressError> {
     FAN_OUT_COMPLETED.store(0, Ordering::Relaxed);
 
     for round in 0..FAN_OUT_ROUNDS {
-        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, fan_out_worker, round);
         let tid: ThreadIdentifier = create_thread(&mut args)?;
 

--- a/src/tests/stress-rust/src/tests/thread_identity.rs
+++ b/src/tests/stress-rust/src/tests/thread_identity.rs
@@ -73,7 +73,7 @@ pub fn run() -> Result<(), StressError> {
     let main_pid: ProcessIdentifier = getpid()?;
     let main_tid: ThreadIdentifier = gettid()?;
 
-    let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+    let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs = thread_args(&stack, thread_identity_worker, 0);
     let tid: ThreadIdentifier = create_thread(&mut args)?;
 

--- a/src/tests/stress-rust/src/tests/zombie_join_pressure.rs
+++ b/src/tests/stress-rust/src/tests/zombie_join_pressure.rs
@@ -108,7 +108,7 @@ fn run_round(_round: usize) -> Result<(), StressError> {
 
     // Spawn all workers before joining any, so they sleep concurrently.
     for _worker_id in 0..WORKERS {
-        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?;
+        let stack: WorkerStack = WorkerStack::new(::config::memory_layout::USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs = thread_args(&stack, zombie_join_worker, 0);
         match create_thread(&mut args) {
             Ok(tid) => {

--- a/src/tests/test-kernel/src/rendezvous.rs
+++ b/src/tests/test-kernel/src/rendezvous.rs
@@ -6,7 +6,7 @@
 //==================================================================================================
 
 use ::alloc::alloc::Layout;
-use ::config::memory_layout::USER_STACK_SIZE;
+use ::config::memory_layout::USER_THREAD_STACK_SIZE;
 use ::core::sync::atomic::{
     AtomicBool,
     AtomicU32,
@@ -36,9 +36,6 @@ use ::sys::{
 
 /// Ordering used for all atomic operations.
 const ORDER: Ordering = Ordering::SeqCst;
-
-/// Size of the stack allocated for child threads.
-const STACK_SIZE: usize = USER_STACK_SIZE;
 
 /// Test payload for the basic 16-byte push/pull test.
 const TEST_PAYLOAD_16: [u8; 16] = [
@@ -76,8 +73,9 @@ static ITERATION_COUNT: AtomicU32 = AtomicU32::new(0);
 /// stack.  On failure, returns an error.
 ///
 fn alloc_thread_stack() -> Result<(*mut u8, Layout, VirtualAddress), Error> {
-    let layout: Layout = Layout::from_size_align(STACK_SIZE, core::mem::align_of::<usize>())
-        .map_err(|_| Error::new(ErrorCode::OutOfMemory, "bad stack layout"))?;
+    let layout: Layout =
+        Layout::from_size_align(USER_THREAD_STACK_SIZE, core::mem::align_of::<usize>())
+            .map_err(|_| Error::new(ErrorCode::OutOfMemory, "bad stack layout"))?;
     // SAFETY: layout has non-zero size.
     let stack_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(layout) };
     if stack_ptr.is_null() {
@@ -130,7 +128,7 @@ fn spawn_child_thread(
         user_fn_arg0: entry as *const () as usize,
         user_fn_arg1: 0,
         user_stack_base: stack_base,
-        user_stack_size: STACK_SIZE,
+        user_stack_size: USER_THREAD_STACK_SIZE,
         user_tda: None,
     };
     pm::create_thread(&mut args)
@@ -1071,7 +1069,7 @@ fn test_concurrent_push(transfer_size: usize) -> Result<(), Error> {
             user_fn_arg0: concurrent_pusher_thread as *const () as usize,
             user_fn_arg1: i,
             user_stack_base: stack_base,
-            user_stack_size: STACK_SIZE,
+            user_stack_size: USER_THREAD_STACK_SIZE,
             user_tda: None,
         };
         let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
@@ -1227,7 +1225,7 @@ fn test_concurrent_pull(transfer_size: usize) -> Result<(), Error> {
             user_fn_arg0: concurrent_puller_thread as *const () as usize,
             user_fn_arg1: i,
             user_stack_base: stack_base,
-            user_stack_size: STACK_SIZE,
+            user_stack_size: USER_THREAD_STACK_SIZE,
             user_tda: None,
         };
         let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
@@ -1471,7 +1469,7 @@ fn test_independent_pairs() -> Result<(), Error> {
             user_fn_arg0: independent_pair_thread as *const () as usize,
             user_fn_arg1: i,
             user_stack_base: stack_base,
-            user_stack_size: STACK_SIZE,
+            user_stack_size: USER_THREAD_STACK_SIZE,
             user_tda: None,
         };
         let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
@@ -2222,7 +2220,7 @@ fn test_stress_concurrent_pairs() -> Result<(), Error> {
             user_fn_arg0: stress_pair_thread as *const () as usize,
             user_fn_arg1: i,
             user_stack_base: stack_base,
-            user_stack_size: STACK_SIZE,
+            user_stack_size: USER_THREAD_STACK_SIZE,
             user_tda: None,
         };
         let tid: ThreadIdentifier = pm::create_thread(&mut args)?;

--- a/src/tests/test-kernel/src/rendezvous.rs
+++ b/src/tests/test-kernel/src/rendezvous.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use ::alloc::alloc::Layout;
+use ::config::memory_layout::USER_STACK_SIZE;
 use ::core::sync::atomic::{
     AtomicBool,
     AtomicU32,
@@ -37,7 +38,7 @@ use ::sys::{
 const ORDER: Ordering = Ordering::SeqCst;
 
 /// Size of the stack allocated for child threads.
-const STACK_SIZE: usize = 512 * 1024;
+const STACK_SIZE: usize = USER_STACK_SIZE;
 
 /// Test payload for the basic 16-byte push/pull test.
 const TEST_PAYLOAD_16: [u8; 16] = [

--- a/src/tests/test-kernel/src/tls.rs
+++ b/src/tests/test-kernel/src/tls.rs
@@ -23,7 +23,7 @@
 //==================================================================================================
 
 use ::alloc::boxed::Box;
-use ::config::memory_layout::USER_STACK_SIZE;
+use ::config::memory_layout::USER_THREAD_STACK_SIZE;
 use ::sys::{
     error::{
         Error,
@@ -59,9 +59,6 @@ const WORKER_TDA_MAGIC: u32 = 0xCAFE_BABE;
 
 /// Expected exit status returned by the worker thread.
 const WORKER_EXIT_STATUS: usize = 0xDEAD_BEEF;
-
-/// Worker stack size in bytes.
-const WORKER_STACK_SIZE: usize = USER_STACK_SIZE;
 
 //==================================================================================================
 // Types
@@ -584,7 +581,7 @@ fn test_tda_survives_create_join() -> Result<(), Error> {
     unsafe { core::ptr::write_volatile(worker_tda.as_mut_ptr(), WORKER_TDA_MAGIC) };
 
     // --- Spawn and join worker ---
-    let stack: WorkerStack = WorkerStack::new(WORKER_STACK_SIZE)?;
+    let stack: WorkerStack = WorkerStack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs =
         make_thread_args(&stack, tda_worker, worker_tda.as_mut_ptr() as usize);
     let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
@@ -636,7 +633,7 @@ fn test_repeated_create_join() -> Result<(), Error> {
         let mut worker_tda: TdaBuffer = Box::new([0u32; TDA_SLOTS]);
         unsafe { core::ptr::write_volatile(worker_tda.as_mut_ptr(), worker_magic) };
 
-        let stack: WorkerStack = WorkerStack::new(WORKER_STACK_SIZE)?;
+        let stack: WorkerStack = WorkerStack::new(USER_THREAD_STACK_SIZE)?;
         let mut args: ThreadCreateArgs =
             make_thread_args(&stack, tda_worker_generic, worker_tda.as_mut_ptr() as usize);
         let tid: ThreadIdentifier = pm::create_thread(&mut args)?;
@@ -704,7 +701,7 @@ fn test_worker_tda_independence() -> Result<(), Error> {
     let mut worker_tda: TdaBuffer = Box::new([0u32; TDA_SLOTS]);
     unsafe { core::ptr::write_volatile(worker_tda.as_mut_ptr(), WORKER_TDA_MAGIC) };
 
-    let stack: WorkerStack = WorkerStack::new(WORKER_STACK_SIZE)?;
+    let stack: WorkerStack = WorkerStack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs =
         make_thread_args(&stack, tda_worker_generic, worker_tda.as_mut_ptr() as usize);
     let tid: ThreadIdentifier = pm::create_thread(&mut args)?;

--- a/src/tests/test-kernel/src/tls.rs
+++ b/src/tests/test-kernel/src/tls.rs
@@ -23,6 +23,7 @@
 //==================================================================================================
 
 use ::alloc::boxed::Box;
+use ::config::memory_layout::USER_STACK_SIZE;
 use ::sys::{
     error::{
         Error,
@@ -59,8 +60,8 @@ const WORKER_TDA_MAGIC: u32 = 0xCAFE_BABE;
 /// Expected exit status returned by the worker thread.
 const WORKER_EXIT_STATUS: usize = 0xDEAD_BEEF;
 
-/// Worker stack size in bytes (512 KiB, matching `config::memory_layout::USER_STACK_SIZE`).
-const WORKER_STACK_SIZE: usize = 512 * 1024;
+/// Worker stack size in bytes.
+const WORKER_STACK_SIZE: usize = USER_STACK_SIZE;
 
 //==================================================================================================
 // Types

--- a/src/tests/thread-rust/src/runtime.rs
+++ b/src/tests/thread-rust/src/runtime.rs
@@ -5,7 +5,7 @@
 // Imports
 //==================================================================================================
 
-use ::config::memory_layout::USER_STACK_SIZE;
+use ::config::memory_layout::USER_THREAD_STACK_SIZE;
 use ::core::time::Duration;
 use ::sys::{
     error::{
@@ -44,7 +44,7 @@ pub struct KernelThread {
 impl KernelThread {
     /// Spawns a new kernel thread that starts executing `entry` with `arg`.
     pub fn spawn(entry: extern "C" fn(usize) -> usize, arg: usize) -> Result<Self, Error> {
-        let stack: Stack = Stack::new(USER_STACK_SIZE)?;
+        let stack: Stack = Stack::new(USER_THREAD_STACK_SIZE)?;
 
         let mut args: ThreadCreateArgs = ThreadCreateArgs {
             user_fn: ThreadCreateArgs::NULL_USER_FN,

--- a/src/tests/thread-rust/src/tests/condvars.rs
+++ b/src/tests/thread-rust/src/tests/condvars.rs
@@ -10,7 +10,7 @@ use crate::runtime::{
     raw_entry_address,
     raw_pointer_address,
 };
-use ::config::memory_layout::USER_STACK_SIZE;
+use ::config::memory_layout::USER_THREAD_STACK_SIZE;
 use ::core::{
     ptr,
     sync::atomic::{
@@ -93,7 +93,7 @@ fn test_condition_signal() -> Result<(), Error> {
     reset_sync_primitives();
     WAIT_STATE.store(0, Ordering::Relaxed);
 
-    let stack: Stack = Stack::new(USER_STACK_SIZE)?;
+    let stack: Stack = Stack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs = ThreadCreateArgs {
         user_fn: ThreadCreateArgs::NULL_USER_FN,
         user_fn_arg0: raw_entry_address(condition_wait_worker),
@@ -125,7 +125,7 @@ fn test_condition_timeout() -> Result<(), Error> {
     reset_sync_primitives();
     WAIT_STATE.store(0, Ordering::Relaxed);
 
-    let stack: Stack = Stack::new(USER_STACK_SIZE)?;
+    let stack: Stack = Stack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs = ThreadCreateArgs {
         user_fn: ThreadCreateArgs::NULL_USER_FN,
         user_fn_arg0: raw_entry_address(condition_timeout_worker),

--- a/src/tests/thread-rust/src/tests/mutexes.rs
+++ b/src/tests/thread-rust/src/tests/mutexes.rs
@@ -9,7 +9,7 @@ use crate::runtime::{
     raw_entry_address,
     raw_pointer_address,
 };
-use ::config::memory_layout::USER_STACK_SIZE;
+use ::config::memory_layout::USER_THREAD_STACK_SIZE;
 use ::core::{
     ptr,
     sync::atomic::{
@@ -79,7 +79,7 @@ fn test_mutex_contention() -> Result<(), Error> {
     let mutex_addr: MutexAddress = test_mutex_addr();
     lock_mutex(mutex_addr, None)?;
 
-    let stack: Stack = Stack::new(USER_STACK_SIZE)?;
+    let stack: Stack = Stack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs = ThreadCreateArgs {
         user_fn: ThreadCreateArgs::NULL_USER_FN,
         user_fn_arg0: raw_entry_address(mutex_worker),

--- a/src/tests/thread-rust/src/tests/scheduler.rs
+++ b/src/tests/thread-rust/src/tests/scheduler.rs
@@ -6,7 +6,7 @@
 //==================================================================================================
 
 use crate::runtime::raw_entry_address;
-use ::config::memory_layout::USER_STACK_SIZE;
+use ::config::memory_layout::USER_THREAD_STACK_SIZE;
 use ::core::sync::atomic::{
     AtomicU8,
     Ordering,
@@ -42,7 +42,7 @@ pub fn run() -> Result<(), Error> {
 
 fn test_sched_yield_progress() -> Result<(), Error> {
     SCHED_STATE.store(0, Ordering::Relaxed);
-    let stack: Stack = Stack::new(USER_STACK_SIZE)?;
+    let stack: Stack = Stack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs = ThreadCreateArgs {
         user_fn: ThreadCreateArgs::NULL_USER_FN,
         user_fn_arg0: raw_entry_address(yield_worker),

--- a/src/tests/thread-rust/src/tests/threads.rs
+++ b/src/tests/thread-rust/src/tests/threads.rs
@@ -6,7 +6,7 @@
 //==================================================================================================
 
 use crate::runtime::raw_entry_address;
-use ::config::memory_layout::USER_STACK_SIZE;
+use ::config::memory_layout::USER_THREAD_STACK_SIZE;
 use ::core::sync::atomic::{
     AtomicBool,
     AtomicUsize,
@@ -64,7 +64,7 @@ fn test_create_and_join() -> Result<(), Error> {
 
     let main_tid_raw: usize = usize::try_from(gettid()?)?;
 
-    let stack: Stack = Stack::new(USER_STACK_SIZE)?;
+    let stack: Stack = Stack::new(USER_THREAD_STACK_SIZE)?;
     let mut args: ThreadCreateArgs = ThreadCreateArgs {
         user_fn: ThreadCreateArgs::NULL_USER_FN,
         user_fn_arg0: raw_entry_address(worker_thread),


### PR DESCRIPTION
Increase the user stack size from 512KB to 4MB to provide more stack space for user-space applications.

Simplify the user stack layout by removing the `NUM_USER_STACK_ENTRIES` constant. The previous design reserved 8 × 512KB = 4MB of address space split across multiple stack entries, but the per-entry limit of 512KB was too restrictive in practice. Replace this with a single contiguous 4MB stack region, which preserves the same total address-space footprint while eliminating the artificial per-entry cap.

Adjust `USER_STACK_TOP_RAW` to reflect the simplified single-region calculation.

## Changes

- Increase `USER_STACK_SIZE` from 512KB to 4MB.
- Simplify `USER_STACK_TOP_RAW` calculation to subtract a single `USER_STACK_SIZE` and remove `NUM_USER_STACK_ENTRIES`.
- Clarify doc comments on `USER_STACK_BASE_RAW` (high address / initial SP) and `USER_STACK_TOP_RAW` (low address of the stack region).
- Fix `create_thread()` kernel call to validate thread stack size against `USER_STACK_MIN_SIZE` instead of `USER_STACK_SIZE`, so spawned threads are not forced to allocate a full 4MB stack.
- Update test-kernel rendezvous and TLS tests to use the `USER_STACK_SIZE` constant instead of a hardcoded 512KB value.