### PR TITLE
[vfs] Add directory support, timestamps, and getdents routing

### DIFF
--- a/src/libs/syscall/src/dirent/syscall/getdents.rs
+++ b/src/libs/syscall/src/dirent/syscall/getdents.rs
@@ -63,6 +63,18 @@ pub fn posix_getdents(fd: c_int, count: usize) -> Result<Vec<posix_dent>, Error>
     const MESSAGE_ASSEMBLER_CAPACITY: usize =
         GetDirectoryEntriesResponse::MAX_SIZE.div_ceil(LinuxDaemonMessagePart::PAYLOAD_SIZE);
 
+    // Route VFS directory fds to the VFS backend.
+    #[cfg(feature = "memfs")]
+    {
+        if ::nvx::vfs::fd::is_vfs_fd(fd) {
+            return ::nvx::vfs::fd::vfs_getdents(fd, count).map_err(|e| {
+                let code: ErrorCode = e.into();
+                error!("posix_getdents(): VFS getdents failed (fd={fd}, error={e})");
+                Error::new(code, "vfs getdents failed")
+            });
+        }
+    }
+
     // In standalone mode, getdents is not available (no linuxd).
     #[cfg(feature = "standalone")]
     {

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -21,10 +21,17 @@
 //==================================================================================================
 
 use crate::fat32_backend;
+use ::alloc::{
+    string::String,
+    vec::Vec,
+};
 use ::fat32::Fat32Error;
 use ::spin::Mutex;
 use ::sysapi::{
-    fcntl::file_control_request,
+    fcntl::{
+        file_control_request,
+        file_creation_flags,
+    },
     ffi::c_int,
     sys_stat::{
         file_mode,
@@ -55,6 +62,12 @@ const STAT_BLOCK_SIZE: i64 = 4096;
 
 /// Sector size used for `st_blocks` computation (POSIX convention: 512 bytes).
 const STAT_SECTOR_SIZE: u64 = 512;
+
+/// Fixed timestamp (2024-01-01T00:00:00 UTC) used for stat results.
+///
+/// FAT32 does not store POSIX timestamps, so a fixed epoch is returned
+/// to keep consumers (e.g. Python's zipfile module) happy.
+const STAT_FIXED_TIMESTAMP: i64 = 1704067200;
 
 //==================================================================================================
 // Metadata
@@ -159,6 +172,39 @@ impl DirectReadHandle {
 // VFS File Handle
 //==================================================================================================
 
+/// An open directory handle for reading directory entries.
+pub struct DirHandle {
+    /// Absolute path of the directory.
+    path: String,
+    /// Unconsumed directory entries.
+    entries: Vec<crate::DirEntry>,
+    /// Whether the directory listing has been loaded.
+    loaded: bool,
+}
+
+impl DirHandle {
+    /// Creates a new directory handle.
+    pub fn new(path: String) -> Self {
+        Self {
+            path,
+            entries: Vec::new(),
+            loaded: false,
+        }
+    }
+
+    /// Reads the next batch of directory entries.
+    pub fn read_entries(&mut self, count: usize) -> Result<Vec<crate::DirEntry>, Fat32Error> {
+        // Load the directory listing on the first call.
+        if !self.loaded {
+            self.entries = crate::read_dir(&self.path)?;
+            self.loaded = true;
+        }
+        let to_take: usize = self.entries.len().min(count);
+        let result: Vec<crate::DirEntry> = self.entries.drain(..to_take).collect();
+        Ok(result)
+    }
+}
+
 /// An open file handle managed by the VFS.
 ///
 /// Each variant corresponds to a concrete filesystem backend or an
@@ -169,6 +215,8 @@ pub enum VfsFileHandle {
     Fat32(crate::File),
     /// Zero-copy direct memory read (contiguous file optimization).
     DirectRead(DirectReadHandle),
+    /// An open directory for readdir iteration.
+    Directory(DirHandle),
 }
 
 impl VfsFileHandle {
@@ -177,6 +225,7 @@ impl VfsFileHandle {
         match self {
             VfsFileHandle::Fat32(file) => file.read(buf),
             VfsFileHandle::DirectRead(handle) => Ok(handle.read(buf)),
+            VfsFileHandle::Directory(_) => Err(Fat32Error::InvalidArgument),
         }
     }
 
@@ -185,6 +234,7 @@ impl VfsFileHandle {
         match self {
             VfsFileHandle::Fat32(file) => file.write(buf),
             VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
+            VfsFileHandle::Directory(_) => Err(Fat32Error::InvalidArgument),
         }
     }
 
@@ -196,6 +246,7 @@ impl VfsFileHandle {
                 Ok(pos as off_t)
             },
             VfsFileHandle::DirectRead(handle) => handle.seek(offset, whence),
+            VfsFileHandle::Directory(_) => Err(Fat32Error::InvalidArgument),
         }
     }
 
@@ -204,7 +255,13 @@ impl VfsFileHandle {
         match self {
             VfsFileHandle::Fat32(file) => file.size(),
             VfsFileHandle::DirectRead(handle) => Ok(handle.size() as u64),
+            VfsFileHandle::Directory(_) => Ok(0),
         }
+    }
+
+    /// Returns whether this handle is a directory.
+    pub fn is_dir(&self) -> bool {
+        matches!(self, VfsFileHandle::Directory(_))
     }
 }
 
@@ -295,12 +352,67 @@ pub fn is_vfs_fd(fd: c_int) -> bool {
     fd >= VFS_FD_BASE && fd < VFS_FD_BASE + VFS_MAX_OPEN_FILES as c_int
 }
 
+/// Resolves a `dirfd` + `path` pair into an absolute VFS path.
+///
+/// If `path` is absolute, it is returned as-is (dirfd is ignored per POSIX).
+/// If `dirfd` is `AT_FDCWD`, the path is resolved against the VFS current
+/// working directory. If `dirfd` is a VFS directory fd, the path is resolved
+/// relative to that directory's path.
+///
+/// Returns `None` if `dirfd` is not a VFS fd and not `AT_FDCWD`, indicating
+/// that VFS cannot handle this request.
+pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Option<String> {
+    use ::sysapi::fcntl::atflags::AT_FDCWD;
+
+    // Absolute paths are always resolved directly (dirfd ignored per POSIX).
+    if path.starts_with('/') {
+        return Some(String::from(path));
+    }
+
+    // Relative path with AT_FDCWD: resolve against VFS cwd.
+    if dirfd == AT_FDCWD {
+        let cwd: String = crate::cwd().ok()?;
+        return if cwd.ends_with('/') {
+            Some(alloc::format!("{}{}", cwd, path))
+        } else {
+            Some(alloc::format!("{}/{}", cwd, path))
+        };
+    }
+
+    // Relative path with a VFS directory fd: resolve against that directory.
+    if !is_vfs_fd(dirfd) {
+        return None;
+    }
+
+    let slot: spin::MutexGuard<'_, Option<VfsEntry>> = FD_TABLE.lock(dirfd).ok()?;
+    let entry: &VfsEntry = slot.as_ref()?;
+    let dir_path: &str = match &entry.handle {
+        VfsFileHandle::Directory(dh) => &dh.path,
+        _ => return None, // fd is not a directory
+    };
+
+    if dir_path.ends_with('/') {
+        Some(alloc::format!("{}{}", dir_path, path))
+    } else {
+        Some(alloc::format!("{}/{}", dir_path, path))
+    }
+}
+
 //==================================================================================================
 // POSIX-Compatible Operations
 //==================================================================================================
 
 /// Opens a file through the VFS and allocates a system-wide FD.
 pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
+    // If O_DIRECTORY is set, verify the path is a directory before opening.
+    if flags & file_creation_flags::O_DIRECTORY != 0 {
+        let info: VfsStat = fat32_backend::stat(path)?;
+        if !info.is_dir() {
+            return Err(Fat32Error::NotADirectory);
+        }
+        let handle: VfsFileHandle = VfsFileHandle::Directory(DirHandle::new(path.into()));
+        return FD_TABLE.alloc(handle);
+    }
     let handle: VfsFileHandle = fat32_backend::open(path, flags)?;
     FD_TABLE.alloc(handle)
 }
@@ -332,6 +444,7 @@ pub fn vfs_lseek(fd: c_int, offset: off_t, whence: c_int) -> Result<off_t, Fat32
 pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fat32Error> {
     let mut slot: spin::MutexGuard<'_, Option<VfsEntry>> = FD_TABLE.lock(fd)?;
     let entry: &mut VfsEntry = slot.as_mut().ok_or(Fat32Error::InvalidFd)?;
+    let is_dir: bool = entry.handle.is_dir();
     let size: u64 = entry.handle.size()?;
 
     // Zero-initialize the stat buffer.
@@ -340,9 +453,25 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
     }
 
     buf.st_size = size as off_t;
-    buf.st_mode = file_type::S_IFREG | file_mode::S_IRUSR | file_mode::S_IRGRP | file_mode::S_IROTH;
+    buf.st_mode = if is_dir {
+        file_type::S_IFDIR
+            | file_mode::S_IRWXU
+            | file_mode::S_IRGRP
+            | file_mode::S_IXGRP
+            | file_mode::S_IROTH
+            | file_mode::S_IXOTH
+    } else {
+        file_type::S_IFREG | file_mode::S_IRUSR | file_mode::S_IRGRP | file_mode::S_IROTH
+    };
     buf.st_blksize = STAT_BLOCK_SIZE;
     buf.st_blocks = size.div_ceil(STAT_SECTOR_SIZE) as off_t;
+    let ts: ::sysapi::time::timespec = ::sysapi::time::timespec {
+        tv_sec: STAT_FIXED_TIMESTAMP,
+        tv_nsec: 0,
+    };
+    buf.st_atim = ts;
+    buf.st_mtim = ts;
+    buf.st_ctim = ts;
 
     Ok(())
 }
@@ -374,6 +503,13 @@ pub fn vfs_stat(path: &str, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
     };
     buf.st_blksize = STAT_BLOCK_SIZE;
     buf.st_blocks = info.size().div_ceil(STAT_SECTOR_SIZE) as off_t;
+    let ts: ::sysapi::time::timespec = ::sysapi::time::timespec {
+        tv_sec: STAT_FIXED_TIMESTAMP,
+        tv_nsec: 0,
+    };
+    buf.st_atim = ts;
+    buf.st_mtim = ts;
+    buf.st_ctim = ts;
 
     Ok(())
 }
@@ -438,6 +574,7 @@ pub fn vfs_ftruncate(fd: c_int, length: off_t) -> Result<(), Fat32Error> {
             result
         },
         VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
+        VfsFileHandle::Directory(_) => Err(Fat32Error::InvalidArgument),
     }
 }
 
@@ -450,6 +587,7 @@ pub fn vfs_fsync(fd: c_int) -> Result<(), Fat32Error> {
     match &mut entry.handle {
         VfsFileHandle::Fat32(file) => file.flush(),
         VfsFileHandle::DirectRead(_) => Ok(()), // Nothing to sync for read-only.
+        VfsFileHandle::Directory(_) => Ok(()),  // Nothing to sync for directories.
     }
 }
 
@@ -508,10 +646,60 @@ pub fn vfs_fcntl(fd: c_int, cmd: c_int) -> Result<c_int, Fat32Error> {
     let _entry: &mut VfsEntry = slot.as_mut().ok_or(Fat32Error::InvalidFd)?;
 
     match cmd {
+        file_control_request::F_GETFD => Ok(0), // No FD flags (no close-on-exec for VFS).
+        file_control_request::F_SETFD => Ok(0), // Accept but ignore (no close-on-exec).
         file_control_request::F_GETFL => Ok(0), // No meaningful flags for FAT32.
         file_control_request::F_SETFL => Ok(0), // Accept but ignore (no O_NONBLOCK etc.).
         _ => Err(Fat32Error::NotSupported),     // Other commands not supported.
     }
+}
+
+/// Reads directory entries from a VFS directory file descriptor.
+///
+/// Returns entries as `posix_dent` structs suitable for the `getdents` syscall.
+pub fn vfs_getdents(
+    fd: c_int,
+    count: usize,
+) -> Result<Vec<::sysapi::dirent::posix_dent>, Fat32Error> {
+    use ::sysapi::{
+        dirent::{
+            dirent_file_type,
+            posix_dent,
+        },
+        limits::NAME_MAX,
+    };
+
+    let mut slot: spin::MutexGuard<'_, Option<VfsEntry>> = FD_TABLE.lock(fd)?;
+    let entry: &mut VfsEntry = slot.as_mut().ok_or(Fat32Error::InvalidFd)?;
+
+    let dir_handle: &mut DirHandle = match &mut entry.handle {
+        VfsFileHandle::Directory(dh) => dh,
+        _ => return Err(Fat32Error::InvalidArgument),
+    };
+
+    let entries: Vec<crate::DirEntry> = dir_handle.read_entries(count)?;
+
+    // FAT32 has no real inodes; use synthetic 1-based indices.
+    let mut result: Vec<posix_dent> = Vec::new();
+    for (i, de) in entries.iter().enumerate() {
+        let mut dent: posix_dent = posix_dent {
+            d_ino: (i + 1) as u64,
+            d_reclen: core::mem::size_of::<posix_dent>() as u16,
+            d_type: if de.is_dir() {
+                dirent_file_type::DT_DIR
+            } else {
+                dirent_file_type::DT_REG
+            },
+            ..posix_dent::default()
+        };
+        let name_bytes: &[u8] = de.name().as_bytes();
+        let copy_len: usize = name_bytes.len().min(NAME_MAX);
+        dent.d_name[..copy_len].copy_from_slice(&name_bytes[..copy_len]);
+        dent.d_name[copy_len] = 0;
+        result.push(dent);
+    }
+
+    Ok(result)
 }
 
 /// Renames a file or directory relative to directory file descriptors through the VFS.

--- a/src/tests/vfs-test/Cargo.toml
+++ b/src/tests/vfs-test/Cargo.toml
@@ -18,6 +18,7 @@ vfs = { workspace = true }
 libc_string = { workspace = true }
 nvx = { workspace = true }
 sys = { workspace = true, features = ["kcall"] }
+sysapi = { workspace = true }
 syslog = { workspace = true, default-features = true }
 
 [build-dependencies]

--- a/src/tests/vfs-test/src/main.rs
+++ b/src/tests/vfs-test/src/main.rs
@@ -34,6 +34,20 @@ use ::sys::{
     mm::Address,
     pm::Capability,
 };
+use ::sysapi::{
+    dirent::{
+        dirent_file_type,
+        posix_dent,
+    },
+    fcntl::{
+        file_control_request,
+        file_creation_flags,
+    },
+    sys_stat::{
+        file_type,
+        stat,
+    },
+};
 
 //==================================================================================================
 // Constants
@@ -41,6 +55,9 @@ use ::sys::{
 
 /// Encoded 8-byte "RAMFS   " tag exposed by the MicroVM RAMFS MMIO region.
 const RAMFS_MMIO_TAG: u64 = u64::from_be_bytes(*b"RAMFS   ");
+
+/// Fixed timestamp epoch (2024-01-01T00:00:00 UTC) used by the VFS stat layer.
+const VFS_FIXED_TIMESTAMP: i64 = 1704067200;
 
 //==================================================================================================
 // Helpers
@@ -66,6 +83,12 @@ pub fn main() -> Result<(), Error> {
     test_chdir_cwd()?;
     test_pread_pwrite()?;
     test_ftruncate_fsync()?;
+    test_open_directory()?;
+    test_getdents()?;
+    test_fstat_directory_and_timestamps()?;
+    test_stat_timestamps()?;
+    test_fcntl_fd_flags()?;
+    test_resolve_path()?;
     test_ramfs_mount()?;
 
     Ok(())
@@ -442,6 +465,381 @@ fn test_ftruncate_fsync() -> Result<(), Error> {
     vfs::unmount("/trunc").map_err(|e| fat_err(e, "unmount /trunc"))?;
 
     ::syslog::info!("vfs-test: test_ftruncate_fsync passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Open Directory with O_DIRECTORY
+//==================================================================================================
+
+/// Tests that `vfs_open()` with `O_DIRECTORY` creates a directory handle.
+fn test_open_directory() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_open_directory begin");
+
+    vfs::create_mount("/odir", 128 * 1024).map_err(|e| fat_err(e, "create_mount /odir failed"))?;
+
+    // Create a subdirectory.
+    vfs::mkdir("/odir/sub").map_err(|e| fat_err(e, "mkdir /odir/sub failed"))?;
+
+    // Open the subdirectory with O_DIRECTORY.
+    let fd: i32 = vfs::fd::vfs_open("/odir/sub", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "vfs_open O_DIRECTORY failed"))?;
+
+    // The returned fd should be a VFS fd.
+    if !vfs::fd::is_vfs_fd(fd) {
+        return Err(Error::new(ErrorCode::InvalidArgument, "fd should be a VFS fd"));
+    }
+
+    // Reading from a directory handle should fail.
+    let mut buf: [u8; 4] = [0u8; 4];
+    if vfs::fd::vfs_read(fd, &mut buf).is_ok() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "read on dir fd should fail"));
+    }
+
+    // Writing to a directory handle should fail.
+    if vfs::fd::vfs_write(fd, &[1, 2]).is_ok() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "write on dir fd should fail"));
+    }
+
+    // Opening a regular file with O_DIRECTORY should fail.
+    {
+        let mut file: vfs::File = vfs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("/odir/regular.txt")
+            .map_err(|e| fat_err(e, "create regular.txt"))?;
+        file.write(b"data")
+            .map_err(|e| fat_err(e, "write regular.txt"))?;
+        file.flush().map_err(|e| fat_err(e, "flush regular.txt"))?;
+    }
+    if vfs::fd::vfs_open("/odir/regular.txt", file_creation_flags::O_DIRECTORY).is_ok() {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "O_DIRECTORY on regular file should fail",
+        ));
+    }
+
+    // Close the directory fd.
+    vfs::fd::vfs_close(fd).map_err(|e| fat_err(e, "vfs_close dir fd failed"))?;
+
+    // Clean up.
+    vfs::unlink("/odir/regular.txt").map_err(|e| fat_err(e, "unlink regular.txt"))?;
+    vfs::rmdir("/odir/sub").map_err(|e| fat_err(e, "rmdir /odir/sub failed"))?;
+    vfs::unmount("/odir").map_err(|e| fat_err(e, "unmount /odir failed"))?;
+
+    ::syslog::info!("vfs-test: test_open_directory passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Getdents
+//==================================================================================================
+
+/// Tests that `vfs_getdents()` returns directory entries as `posix_dent` structs.
+fn test_getdents() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_getdents begin");
+
+    vfs::create_mount("/gd", 128 * 1024).map_err(|e| fat_err(e, "create_mount /gd failed"))?;
+
+    // Create a file and a subdirectory.
+    {
+        let mut file: vfs::File = vfs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("/gd/file.txt")
+            .map_err(|e| fat_err(e, "create file.txt"))?;
+        file.write(b"data")
+            .map_err(|e| fat_err(e, "write file.txt"))?;
+        file.flush().map_err(|e| fat_err(e, "flush file.txt"))?;
+    }
+    vfs::mkdir("/gd/dir1").map_err(|e| fat_err(e, "mkdir /gd/dir1 failed"))?;
+
+    // Open the mount root with O_DIRECTORY.
+    let fd: i32 = vfs::fd::vfs_open("/gd", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "vfs_open /gd O_DIRECTORY"))?;
+
+    // Read all entries.
+    let dents: alloc::vec::Vec<posix_dent> =
+        vfs::fd::vfs_getdents(fd, 64).map_err(|e| fat_err(e, "vfs_getdents failed"))?;
+
+    // Expect 2 entries: file.txt and dir1.
+    if dents.len() != 2 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "expected 2 dents"));
+    }
+
+    // Collect names and verify types.
+    let mut found_file: bool = false;
+    let mut found_dir: bool = false;
+    for dent in &dents {
+        let name_end: usize = dent
+            .d_name
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(dent.d_name.len());
+        let name: &[u8] = &dent.d_name[..name_end];
+        if name.eq_ignore_ascii_case(b"file.txt") {
+            if dent.d_type != dirent_file_type::DT_REG {
+                return Err(Error::new(ErrorCode::InvalidArgument, "file.txt should be DT_REG"));
+            }
+            found_file = true;
+        } else if name.eq_ignore_ascii_case(b"dir1") {
+            if dent.d_type != dirent_file_type::DT_DIR {
+                return Err(Error::new(ErrorCode::InvalidArgument, "dir1 should be DT_DIR"));
+            }
+            found_dir = true;
+        }
+    }
+    if !found_file || !found_dir {
+        return Err(Error::new(ErrorCode::InvalidArgument, "missing expected dent entries"));
+    }
+
+    // A second getdents call should return 0 entries (cursor exhausted).
+    let dents2: alloc::vec::Vec<posix_dent> =
+        vfs::fd::vfs_getdents(fd, 64).map_err(|e| fat_err(e, "vfs_getdents second call"))?;
+    if !dents2.is_empty() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "second getdents should be empty"));
+    }
+
+    // Calling getdents on a non-directory fd should fail.
+    let file_fd: i32 =
+        vfs::fd::vfs_open("/gd/file.txt", 0).map_err(|e| fat_err(e, "vfs_open file.txt"))?;
+    if vfs::fd::vfs_getdents(file_fd, 64).is_ok() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "getdents on file fd should fail"));
+    }
+    vfs::fd::vfs_close(file_fd).map_err(|e| fat_err(e, "close file_fd"))?;
+
+    // Clean up.
+    vfs::fd::vfs_close(fd).map_err(|e| fat_err(e, "close dir fd"))?;
+    vfs::unlink("/gd/file.txt").map_err(|e| fat_err(e, "unlink file.txt"))?;
+    vfs::rmdir("/gd/dir1").map_err(|e| fat_err(e, "rmdir /gd/dir1"))?;
+    vfs::unmount("/gd").map_err(|e| fat_err(e, "unmount /gd"))?;
+
+    ::syslog::info!("vfs-test: test_getdents passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Fstat Directory Mode and Timestamps
+//==================================================================================================
+
+/// Tests that `vfs_fstat()` returns `S_IFDIR` for directory handles and sets
+/// the fixed 2024-01-01 timestamps.
+fn test_fstat_directory_and_timestamps() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_fstat_directory_and_timestamps begin");
+
+    vfs::create_mount("/fsd", 128 * 1024).map_err(|e| fat_err(e, "create_mount /fsd failed"))?;
+
+    // Create a file for comparison.
+    {
+        let mut file: vfs::File = vfs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("/fsd/test.txt")
+            .map_err(|e| fat_err(e, "create test.txt"))?;
+        file.write(b"hello")
+            .map_err(|e| fat_err(e, "write test.txt"))?;
+        file.flush().map_err(|e| fat_err(e, "flush test.txt"))?;
+    }
+
+    // Open a file fd and fstat it: should be S_IFREG with timestamps.
+    let file_fd: i32 =
+        vfs::fd::vfs_open("/fsd/test.txt", 0).map_err(|e| fat_err(e, "open file fd"))?;
+    let mut st: stat = unsafe { core::mem::zeroed() };
+    vfs::fd::vfs_fstat(file_fd, &mut st).map_err(|e| fat_err(e, "fstat file fd"))?;
+
+    if st.st_mode & file_type::S_IFMT != file_type::S_IFREG {
+        return Err(Error::new(ErrorCode::InvalidArgument, "file should be S_IFREG"));
+    }
+    // Verify fixed timestamp.
+    if st.st_atim.tv_sec != VFS_FIXED_TIMESTAMP
+        || st.st_mtim.tv_sec != VFS_FIXED_TIMESTAMP
+        || st.st_ctim.tv_sec != VFS_FIXED_TIMESTAMP
+    {
+        return Err(Error::new(ErrorCode::InvalidArgument, "file timestamps should be 2024-01-01"));
+    }
+    vfs::fd::vfs_close(file_fd).map_err(|e| fat_err(e, "close file fd"))?;
+
+    // Open a directory fd and fstat it: should be S_IFDIR with timestamps.
+    let dir_fd: i32 = vfs::fd::vfs_open("/fsd", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "open dir fd"))?;
+    let mut dst: stat = unsafe { core::mem::zeroed() };
+    vfs::fd::vfs_fstat(dir_fd, &mut dst).map_err(|e| fat_err(e, "fstat dir fd"))?;
+
+    if dst.st_mode & file_type::S_IFMT != file_type::S_IFDIR {
+        return Err(Error::new(ErrorCode::InvalidArgument, "dir should be S_IFDIR"));
+    }
+    if dst.st_size != 0 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "dir size should be 0"));
+    }
+    if dst.st_atim.tv_sec != VFS_FIXED_TIMESTAMP
+        || dst.st_mtim.tv_sec != VFS_FIXED_TIMESTAMP
+        || dst.st_ctim.tv_sec != VFS_FIXED_TIMESTAMP
+    {
+        return Err(Error::new(ErrorCode::InvalidArgument, "dir timestamps should be 2024-01-01"));
+    }
+    vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir fd"))?;
+
+    // Clean up.
+    vfs::unlink("/fsd/test.txt").map_err(|e| fat_err(e, "unlink test.txt"))?;
+    vfs::unmount("/fsd").map_err(|e| fat_err(e, "unmount /fsd"))?;
+
+    ::syslog::info!("vfs-test: test_fstat_directory_and_timestamps passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Stat Timestamps
+//==================================================================================================
+
+/// Tests that `vfs_stat()` sets the fixed 2024-01-01 timestamps.
+fn test_stat_timestamps() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_stat_timestamps begin");
+
+    vfs::create_mount("/sts", 128 * 1024).map_err(|e| fat_err(e, "create_mount /sts failed"))?;
+
+    // Create a file.
+    {
+        let mut file: vfs::File = vfs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("/sts/ts.txt")
+            .map_err(|e| fat_err(e, "create ts.txt"))?;
+        file.write(b"timestamps")
+            .map_err(|e| fat_err(e, "write ts.txt"))?;
+        file.flush().map_err(|e| fat_err(e, "flush ts.txt"))?;
+    }
+
+    // Stat the file via path.
+    let mut st: stat = unsafe { core::mem::zeroed() };
+    vfs::fd::vfs_stat("/sts/ts.txt", &mut st).map_err(|e| fat_err(e, "vfs_stat ts.txt"))?;
+
+    if st.st_atim.tv_sec != VFS_FIXED_TIMESTAMP {
+        return Err(Error::new(ErrorCode::InvalidArgument, "stat st_atim should be 2024-01-01"));
+    }
+    if st.st_mtim.tv_sec != VFS_FIXED_TIMESTAMP {
+        return Err(Error::new(ErrorCode::InvalidArgument, "stat st_mtim should be 2024-01-01"));
+    }
+    if st.st_ctim.tv_sec != VFS_FIXED_TIMESTAMP {
+        return Err(Error::new(ErrorCode::InvalidArgument, "stat st_ctim should be 2024-01-01"));
+    }
+
+    // Clean up.
+    vfs::unlink("/sts/ts.txt").map_err(|e| fat_err(e, "unlink ts.txt"))?;
+    vfs::unmount("/sts").map_err(|e| fat_err(e, "unmount /sts"))?;
+
+    ::syslog::info!("vfs-test: test_stat_timestamps passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Fcntl F_GETFD/F_SETFD
+//==================================================================================================
+
+/// Tests that `vfs_fcntl()` supports `F_GETFD` and `F_SETFD` commands.
+fn test_fcntl_fd_flags() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_fcntl_fd_flags begin");
+
+    vfs::create_mount("/fcn", 128 * 1024).map_err(|e| fat_err(e, "create_mount /fcn failed"))?;
+
+    // Create a file.
+    {
+        let mut file: vfs::File = vfs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("/fcn/fc.txt")
+            .map_err(|e| fat_err(e, "create fc.txt"))?;
+        file.write(b"fcntl test")
+            .map_err(|e| fat_err(e, "write fc.txt"))?;
+        file.flush().map_err(|e| fat_err(e, "flush fc.txt"))?;
+    }
+
+    let fd: i32 = vfs::fd::vfs_open("/fcn/fc.txt", 0).map_err(|e| fat_err(e, "open fc.txt fd"))?;
+
+    // F_GETFD should succeed and return 0.
+    let flags: i32 = vfs::fd::vfs_fcntl(fd, file_control_request::F_GETFD)
+        .map_err(|e| fat_err(e, "fcntl F_GETFD"))?;
+    if flags != 0 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "F_GETFD should return 0"));
+    }
+
+    // F_SETFD should succeed and return 0.
+    let result: i32 = vfs::fd::vfs_fcntl(fd, file_control_request::F_SETFD)
+        .map_err(|e| fat_err(e, "fcntl F_SETFD"))?;
+    if result != 0 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "F_SETFD should return 0"));
+    }
+
+    // F_GETFL and F_SETFL should still work.
+    let fl: i32 = vfs::fd::vfs_fcntl(fd, file_control_request::F_GETFL)
+        .map_err(|e| fat_err(e, "fcntl F_GETFL"))?;
+    if fl != 0 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "F_GETFL should return 0"));
+    }
+
+    // An unsupported command (e.g. F_DUPFD) should fail.
+    if vfs::fd::vfs_fcntl(fd, file_control_request::F_DUPFD).is_ok() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "F_DUPFD should fail on VFS"));
+    }
+
+    vfs::fd::vfs_close(fd).map_err(|e| fat_err(e, "close fc.txt fd"))?;
+
+    // Clean up.
+    vfs::unlink("/fcn/fc.txt").map_err(|e| fat_err(e, "unlink fc.txt"))?;
+    vfs::unmount("/fcn").map_err(|e| fat_err(e, "unmount /fcn"))?;
+
+    ::syslog::info!("vfs-test: test_fcntl_fd_flags passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Resolve Path with dirfd
+//==================================================================================================
+
+/// Tests `vfs_resolve_path()` for absolute paths, AT_FDCWD, and VFS directory fds.
+fn test_resolve_path() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_resolve_path begin");
+
+    vfs::create_mount("/rp", 128 * 1024).map_err(|e| fat_err(e, "create_mount /rp failed"))?;
+    vfs::mkdir("/rp/sub").map_err(|e| fat_err(e, "mkdir /rp/sub failed"))?;
+
+    // Absolute path: dirfd should be ignored.
+    let resolved: alloc::string::String = vfs::fd::vfs_resolve_path(0, "/rp/sub/file.txt")
+        .ok_or(Error::new(ErrorCode::InvalidArgument, "absolute resolve failed"))?;
+    if resolved != "/rp/sub/file.txt" {
+        return Err(Error::new(ErrorCode::InvalidArgument, "absolute path mismatch"));
+    }
+
+    // AT_FDCWD: resolve relative to VFS cwd.
+    vfs::chdir("/rp").map_err(|e| fat_err(e, "chdir /rp failed"))?;
+    let resolved_cwd: alloc::string::String =
+        vfs::fd::vfs_resolve_path(::sysapi::fcntl::atflags::AT_FDCWD, "sub")
+            .ok_or(Error::new(ErrorCode::InvalidArgument, "AT_FDCWD resolve failed"))?;
+    if resolved_cwd != "/rp/sub" {
+        return Err(Error::new(ErrorCode::InvalidArgument, "AT_FDCWD path mismatch"));
+    }
+
+    // VFS directory fd: resolve relative to directory path.
+    let dir_fd: i32 = vfs::fd::vfs_open("/rp/sub", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "vfs_open /rp/sub O_DIRECTORY"))?;
+    let resolved_dir: alloc::string::String = vfs::fd::vfs_resolve_path(dir_fd, "nested.txt")
+        .ok_or(Error::new(ErrorCode::InvalidArgument, "dirfd resolve failed"))?;
+    if resolved_dir != "/rp/sub/nested.txt" {
+        return Err(Error::new(ErrorCode::InvalidArgument, "dirfd path mismatch"));
+    }
+
+    // Non-VFS fd should return None.
+    if vfs::fd::vfs_resolve_path(3, "file.txt").is_some() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "non-VFS fd should return None"));
+    }
+
+    vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir fd"))?;
+
+    // Clean up.
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir / failed"))?;
+    vfs::rmdir("/rp/sub").map_err(|e| fat_err(e, "rmdir /rp/sub"))?;
+    vfs::unmount("/rp").map_err(|e| fat_err(e, "unmount /rp"))?;
+
+    ::syslog::info!("vfs-test: test_resolve_path passed");
     Ok(())
 }
 


### PR DESCRIPTION
Add DirHandle, O_DIRECTORY handling, vfs_getdents(), F_GETFD/F_SETFD support, and fixed timestamps (2024-01-01) in vfs_fstat/vfs_stat to avoid zipfile 1980 errors.