### PR TITLE
[syslog] Remove error feature from default features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,7 @@ help:
 	@echo "  MACHINE         hyperlight, microvm, qemu-pc, qemu-isapc, qemu-baremetal"
 	@echo "  TARGET          x86"
 	@echo "  RELEASE         yes, no"
-	@echo "  LOG_LEVEL       trace, debug, info, warn, error"
+	@echo "  LOG_LEVEL       trace, debug, info, warn, error, panic"
 	@echo "  PROFILER        yes, no"
 	@echo "  L2_VM           yes, no"
 	@echo "  MAKE_NO_PRINT   yes, no"

--- a/build/make/wasmd.mk
+++ b/build/make/wasmd.mk
@@ -1,13 +1,18 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
+WASMD_FEATURES := $(LOG_LEVEL)
+WASMD_FEATURES := $(strip $(WASMD_FEATURES))
+WASMD_CARGO_FEATURES := $(if $(WASMD_FEATURES),--features "$(WASMD_FEATURES)")
+
 all-wasmd: all-wasm-binaries all-guest-binaries
 	@echo "WASM_BINARY=$(WASM_BINARY)"
 ifneq ($(WASM_BINARY),)
 	$(eval export NANVIX_WASM_BINARY := $(realpath $(WASM_BINARY)))
 	$(eval export NANVIX_WASM_BINARY_BASENAME := $(shell basename $(NANVIX_WASM_BINARY)))
 	$(eval export NANVIX_WASM_BINARY_ARGS := =$(WASM_BINARY_ARGS))
-	$(eval export WASMD_CARGO_FEATURES := --features wasm_binary)
+	$(eval export WASMD_FEATURES := $(strip $(WASMD_FEATURES) wasm_binary))
+	$(eval export WASMD_CARGO_FEATURES := --features "$(WASMD_FEATURES)")
 endif
 	@echo "NANVIX_WASM_BINARY=$(NANVIX_WASM_BINARY)"
 	@echo "NANVIX_WASM_BINARY_BASENAME=$(NANVIX_WASM_BINARY_BASENAME)"

--- a/src/daemons/wasmd/Cargo.toml
+++ b/src/daemons/wasmd/Cargo.toml
@@ -31,6 +31,12 @@ cfg-if = { workspace = true }
 [features]
 default = []
 wasm_binary = []
+trace = ["nvx/trace", "syscall/trace", "syslog/trace"]
+debug = ["nvx/debug", "syscall/debug", "syslog/debug"]
+info = ["nvx/info", "syscall/info", "syslog/info"]
+warn = ["nvx/warn", "syscall/warn", "syslog/warn"]
+error = ["nvx/error", "syscall/error", "syslog/error"]
+panic = ["nvx/panic", "syscall/panic", "syslog/panic"]
 
 [lints]
 workspace = true

--- a/src/libs/syslog/Cargo.toml
+++ b/src/libs/syslog/Cargo.toml
@@ -20,7 +20,7 @@ sys = { workspace = true, features = ["kcall"], optional = true }
 syslog-macros = { workspace = true }
 
 [features]
-default = ["dep:cfg-if", "dep:sys", "error"]
+default = ["dep:cfg-if", "dep:sys"]
 # Enables the use of the Rust standard library.
 std = ["dep:log", "dep:flexi_logger"]
 # Enables this crate to be used as a dependency of the Rust standard library.


### PR DESCRIPTION
Critical performance fix. Remove error from syslog default features. Each error message byte triggers a PMIO write and a VMEXIT. This degraded Python startup from 0.5s to 30s in standalone mode.