### PR TITLE
[ci] Fix Verus cache validation and save race in verify workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,9 +181,9 @@ jobs:
         shell: bash
         run: echo "version=$(tr -d '[:space:]' < build/verus-version)" >> "$GITHUB_OUTPUT"
 
-      - name: "Cache Verus Archive"
+      - name: "Restore Verus Archive Cache"
         id: verus-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .verus-cache
           key: verus-${{ steps.verus-version.outputs.version }}
@@ -203,6 +203,16 @@ jobs:
           log-level: "trace"
           machine-type: "${{ matrix.machine-type }}"
           deployment-type: "${{ matrix.deployment-type }}"
+
+    # Save the Verus archive to the cache only when it was not already
+    # cached. The first matrix leg to reach this step wins the cache
+    # reservation; the rest skip gracefully.
+      - name: "Save Verus Archive Cache"
+        if: steps.verus-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .verus-cache
+          key: verus-${{ steps.verus-version.outputs.version }}
 
   # Each matrix entry builds on a GitHub-hosted runner. Integration tests run
   # in a separate ci-test job (typically on self-hosted runners) that depends

--- a/scripts/setup/verus.sh
+++ b/scripts/setup/verus.sh
@@ -88,6 +88,49 @@ get_curl_auth_args() {
 
 #
 # DESCRIPTION
+#   Validates that a file is a well-formed zip archive.
+#   Tries unzip first (fast, C-based), then falls back to python3's
+#   zipfile module. Returns 0 on success, 1 on failure.
+#
+# ARGUMENTS
+#   $1 - Path to the zip file to validate.
+#
+validate_zip_archive() {
+    local zip_path="$1"
+
+    if command -v unzip &>/dev/null; then
+        local rc=0
+        unzip -tq "${zip_path}" >/dev/null 2>&1 || rc=$?
+        if [[ ${rc} -eq 0 ]]; then
+            return 0
+        fi
+        print_warning "unzip validation failed for ${zip_path} (exit code ${rc})."
+        return 1
+    fi
+
+    if command -v python3 &>/dev/null; then
+        if python3 -c "
+import zipfile, sys
+try:
+    with zipfile.ZipFile(sys.argv[1]) as z:
+        bad = z.testzip()
+        sys.exit(1 if bad else 0)
+except Exception:
+    sys.exit(1)
+" "${zip_path}" 2>/dev/null; then
+            return 0
+        fi
+        print_warning "python3 zipfile validation failed for ${zip_path}."
+        return 1
+    fi
+
+    # Neither unzip nor python3 available — skip validation.
+    print_warning "Cannot validate zip archive (neither unzip nor python3 found); assuming valid."
+    return 0
+}
+
+#
+# DESCRIPTION
 #   Downloads the Verus release archive to a temporary directory, using
 #   the local zip cache when available. On a fresh download the archive
 #   is also persisted to the cache for future runs.
@@ -110,7 +153,7 @@ download_verus_archive() {
         local cached_zip="${VERUS_ZIP_CACHE_DIR}/${zip_name}"
         if [[ -f "${cached_zip}" && -s "${cached_zip}" ]]; then
             # Validate the cached archive; if invalid, delete and fall back to downloading.
-            if unzip -tq "${cached_zip}" >/dev/null 2>&1; then
+            if validate_zip_archive "${cached_zip}"; then
                 print_info "Using cached Verus archive from ${cached_zip}"
                 cp "${cached_zip}" "${dest_path}"
                 return 0
@@ -317,6 +360,20 @@ main() {
         tmp_dir=$(mktemp -d)
         trap 'rm -rf "${tmp_dir}"' EXIT
         download_verus_archive "${tmp_dir}/${zip_name}" "${expected_version}"
+
+        # Validate the cached archive to catch silent download failures.
+        local cached_zip="${VERUS_ZIP_CACHE_DIR}/verus-${expected_version}-x86-linux.zip"
+        if [[ -f "${cached_zip}" && -s "${cached_zip}" ]]; then
+            if ! validate_zip_archive "${cached_zip}"; then
+                print_error "Downloaded Verus archive failed validation: ${cached_zip}"
+                rm -f "${cached_zip}"
+                exit 1
+            fi
+        else
+            print_error "Verus archive not found in cache after download: ${cached_zip}"
+            exit 1
+        fi
+
         rm -rf "${tmp_dir}"
         trap - EXIT
         print_success "Verus ${expected_version} archive cached in ${VERUS_ZIP_CACHE_DIR}."


### PR DESCRIPTION
## Problem

Workflow run [22656474343](https://github.com/nanvix/nanvix/actions/runs/22656474343) showed two Verus cache issues in all 5 Verify jobs:

1. **Cached archive reported corrupted inside Docker** — `unzip -tq` validation silences all output (`>/dev/null 2>&1`) and has no fallback; if the binary is unavailable or behaves differently inside Docker, the valid archive is wrongly deleted and re-downloaded, negating the caching optimization from commit 812c8df40.

2. **Cache save race** — All 5 parallel Verify jobs share the same `actions/cache@v4` key. Only one can reserve the key; the other four emit `Failed to save: Unable to reserve cache` warnings.

## Fix

### `scripts/setup/verus.sh`
- Add `validate_zip_archive()` helper that tries `unzip`, falls back to `python3 zipfile`, and logs diagnostic exit codes instead of silently treating tool absence as corruption.
- Add post-download validation in `--download-only` mode to catch silent download failures early.

### `.github/workflows/ci.yml`
- Replace `actions/cache@v4` (which auto-saves at post-job) with explicit `actions/cache/restore@v4` + `actions/cache/save@v4` to eliminate the parallel save race.