### PR TITLE
[libs] Add Verus formal verification to slab allocator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ export SETCAP_CMD := setcap
 export VERUS_DIR ?= $(TOOLCHAIN_DIR)/verus
 
 # List of crates to verify with Verus.
-VERUS_CRATES := bitmap
+VERUS_CRATES := bitmap slab
 
 # Verus verification command.
 # Uses RUSTC_BOOTSTRAP=1 because the Verus rustc wrapper identifies as a stable compiler

--- a/src/kernel/src/mm/kheap.rs
+++ b/src/kernel/src/mm/kheap.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use crate::collections::Slab;
+use ::slab::Tracked;
 use ::alloc::alloc::{
     AllocError,
     GlobalAlloc,
@@ -114,68 +115,76 @@ impl Kheap {
                 heap_start_addr,
                 slab_size,
                 SlabSize::Slab8 as usize,
-            )?,
+                Tracked::assume_new(),
+            )?.0,
             slab_16_bytes: Slab::from_raw_parts(
                 heap_start_addr.add(slab_size),
                 slab_size,
                 SlabSize::Slab16 as usize,
-            )?,
+                Tracked::assume_new(),
+            )?.0,
             slab_32_bytes: Slab::from_raw_parts(
                 heap_start_addr.add(2 * slab_size),
                 slab_size,
                 SlabSize::Slab32 as usize,
-            )?,
+                Tracked::assume_new(),
+            )?.0,
             slab_64_bytes: Slab::from_raw_parts(
                 heap_start_addr.add(3 * slab_size),
                 slab_size,
                 SlabSize::Slab64 as usize,
-            )?,
+                Tracked::assume_new(),
+            )?.0,
             slab_128_bytes: Slab::from_raw_parts(
                 heap_start_addr.add(4 * slab_size),
                 slab_size,
                 SlabSize::Slab128 as usize,
-            )?,
+                Tracked::assume_new(),
+            )?.0,
             slab_256_bytes: Slab::from_raw_parts(
                 heap_start_addr.add(5 * slab_size),
                 slab_size,
                 SlabSize::Slab256 as usize,
-            )?,
+                Tracked::assume_new(),
+            )?.0,
             slab_512_bytes: Slab::from_raw_parts(
                 heap_start_addr.add(6 * slab_size),
                 slab_size,
                 SlabSize::Slab512 as usize,
-            )?,
+                Tracked::assume_new(),
+            )?.0,
             slab_4096_bytes: Slab::from_raw_parts(
                 heap_start_addr.add(7 * slab_size),
                 slab_size,
                 SlabSize::Slab4096 as usize,
-            )?,
+                Tracked::assume_new(),
+            )?.0,
         })
     }
 
     unsafe fn allocate(&mut self, layout: Layout) -> Result<*mut u8, AllocError> {
         match Kheap::layout_to_allocator(&layout)? {
-            SlabSize::Slab8 => self.slab_8_bytes.allocate().map_err(|_| AllocError),
-            SlabSize::Slab16 => self.slab_16_bytes.allocate().map_err(|_| AllocError),
-            SlabSize::Slab32 => self.slab_32_bytes.allocate().map_err(|_| AllocError),
-            SlabSize::Slab64 => self.slab_64_bytes.allocate().map_err(|_| AllocError),
-            SlabSize::Slab128 => self.slab_128_bytes.allocate().map_err(|_| AllocError),
-            SlabSize::Slab256 => self.slab_256_bytes.allocate().map_err(|_| AllocError),
-            SlabSize::Slab512 => self.slab_512_bytes.allocate().map_err(|_| AllocError),
-            SlabSize::Slab4096 => self.slab_4096_bytes.allocate().map_err(|_| AllocError),
+            SlabSize::Slab8 => self.slab_8_bytes.allocate(Tracked::assume_new()).map(|p| p.0).map_err(|_| AllocError),
+            SlabSize::Slab16 => self.slab_16_bytes.allocate(Tracked::assume_new()).map(|p| p.0).map_err(|_| AllocError),
+            SlabSize::Slab32 => self.slab_32_bytes.allocate(Tracked::assume_new()).map(|p| p.0).map_err(|_| AllocError),
+            SlabSize::Slab64 => self.slab_64_bytes.allocate(Tracked::assume_new()).map(|p| p.0).map_err(|_| AllocError),
+            SlabSize::Slab128 => self.slab_128_bytes.allocate(Tracked::assume_new()).map(|p| p.0).map_err(|_| AllocError),
+            SlabSize::Slab256 => self.slab_256_bytes.allocate(Tracked::assume_new()).map(|p| p.0).map_err(|_| AllocError),
+            SlabSize::Slab512 => self.slab_512_bytes.allocate(Tracked::assume_new()).map(|p| p.0).map_err(|_| AllocError),
+            SlabSize::Slab4096 => self.slab_4096_bytes.allocate(Tracked::assume_new()).map(|p| p.0).map_err(|_| AllocError),
         }
     }
 
     unsafe fn deallocate(&mut self, ptr: *mut u8, layout: Layout) -> Result<(), AllocError> {
         match Kheap::layout_to_allocator(&layout)? {
-            SlabSize::Slab8 => self.slab_8_bytes.deallocate(ptr).map_err(|_| AllocError),
-            SlabSize::Slab16 => self.slab_16_bytes.deallocate(ptr).map_err(|_| AllocError),
-            SlabSize::Slab32 => self.slab_32_bytes.deallocate(ptr).map_err(|_| AllocError),
-            SlabSize::Slab64 => self.slab_64_bytes.deallocate(ptr).map_err(|_| AllocError),
-            SlabSize::Slab128 => self.slab_128_bytes.deallocate(ptr).map_err(|_| AllocError),
-            SlabSize::Slab256 => self.slab_256_bytes.deallocate(ptr).map_err(|_| AllocError),
-            SlabSize::Slab512 => self.slab_512_bytes.deallocate(ptr).map_err(|_| AllocError),
-            SlabSize::Slab4096 => self.slab_4096_bytes.deallocate(ptr).map_err(|_| AllocError),
+            SlabSize::Slab8 => self.slab_8_bytes.deallocate(ptr, Tracked::assume_new(), Tracked::assume_new()).map_err(|_| AllocError),
+            SlabSize::Slab16 => self.slab_16_bytes.deallocate(ptr, Tracked::assume_new(), Tracked::assume_new()).map_err(|_| AllocError),
+            SlabSize::Slab32 => self.slab_32_bytes.deallocate(ptr, Tracked::assume_new(), Tracked::assume_new()).map_err(|_| AllocError),
+            SlabSize::Slab64 => self.slab_64_bytes.deallocate(ptr, Tracked::assume_new(), Tracked::assume_new()).map_err(|_| AllocError),
+            SlabSize::Slab128 => self.slab_128_bytes.deallocate(ptr, Tracked::assume_new(), Tracked::assume_new()).map_err(|_| AllocError),
+            SlabSize::Slab256 => self.slab_256_bytes.deallocate(ptr, Tracked::assume_new(), Tracked::assume_new()).map_err(|_| AllocError),
+            SlabSize::Slab512 => self.slab_512_bytes.deallocate(ptr, Tracked::assume_new(), Tracked::assume_new()).map_err(|_| AllocError),
+            SlabSize::Slab4096 => self.slab_4096_bytes.deallocate(ptr, Tracked::assume_new(), Tracked::assume_new()).map_err(|_| AllocError),
         }
     }
 

--- a/src/libs/bitmap/Cargo.toml
+++ b/src/libs/bitmap/Cargo.toml
@@ -16,6 +16,7 @@ verify = true
 crate-type = ["lib"]
 
 [dependencies]
+error = { workspace = true, features = ["verus"] }
 raw-array = { workspace = true }
 sys = { workspace = true }
 vstd = { workspace = true }

--- a/src/libs/bitmap/src/lib.proof.rs
+++ b/src/libs/bitmap/src/lib.proof.rs
@@ -1,0 +1,708 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// Bitmap - Proofs
+//
+// This file contains lemmas and proof functions for Bitmap.
+
+verus! {
+
+impl Bitmap {
+    //==================================================================================================
+    // Lemmas: Layout
+    //==================================================================================================
+    /// Proves that `len` bytes fit within isize::MAX for RawArray allocation.
+    proof fn lemma_u8_array_len_fits_isize(len: usize)
+        requires
+            len <= u32::MAX as usize / (u8::BITS as usize),
+        ensures
+            len * vstd::layout::size_of::<u8>() + vstd::layout::align_of::<u8>() - 1
+                <= isize::MAX as usize,
+    {
+        broadcast use vstd::layout::layout_of_primitives, vstd::layout::align_of_u8;
+    }
+
+    //==================================================================================================
+    // Lemmas: Bit-level Operations
+    //==================================================================================================
+
+    /// Bit OR sets the target bit and preserves all other bits.
+    proof fn lemma_bit_or_effects(old_byte: u8, bit_pos: int, new_byte: u8)
+        requires
+            0 <= bit_pos < 8,
+            new_byte == (old_byte | (1u8 << bit_pos)),
+        ensures
+            (new_byte & (1u8 << bit_pos)) != 0,
+            forall|other_pos: int|
+                #![auto]
+                0 <= other_pos < 8 && other_pos != bit_pos ==> (new_byte & (1u8 << other_pos)) == (
+                old_byte & (1u8 << other_pos)),
+    {
+        let shift: u8 = bit_pos as u8;
+        assert((new_byte & (1u8 << shift)) != 0) by (bit_vector)
+            requires
+                new_byte == (old_byte | (1u8 << shift)),
+                0 <= shift < 8,
+        ;
+        assert forall|other_pos: int| #![auto] 0 <= other_pos < 8 && other_pos != bit_pos implies (
+        new_byte & (1u8 << other_pos)) == (old_byte & (1u8 << other_pos)) by {
+            let other_shift: u8 = other_pos as u8;
+            assert((new_byte & (1u8 << other_shift)) == (old_byte & (1u8 << other_shift)))
+                by (bit_vector)
+                requires
+                    new_byte == (old_byte | (1u8 << shift)),
+                    0 <= shift < 8,
+                    0 <= other_shift < 8,
+                    shift != other_shift,
+            ;
+        }
+    }
+
+    /// Bit AND NOT clears the target bit and preserves all other bits.
+    proof fn lemma_bit_and_not_effects(old_byte: u8, bit_pos: int, new_byte: u8)
+        requires
+            0 <= bit_pos < 8,
+            new_byte == (old_byte & !(1u8 << bit_pos)),
+        ensures
+            (new_byte & (1u8 << bit_pos)) == 0,
+            forall|other_pos: int|
+                #![auto]
+                0 <= other_pos < 8 && other_pos != bit_pos ==> (new_byte & (1u8 << other_pos)) == (
+                old_byte & (1u8 << other_pos)),
+    {
+        let shift: u8 = bit_pos as u8;
+        assert((new_byte & (1u8 << shift)) == 0) by (bit_vector)
+            requires
+                new_byte == (old_byte & !(1u8 << shift)),
+                0 <= shift < 8,
+        ;
+        assert forall|other_pos: int| #![auto] 0 <= other_pos < 8 && other_pos != bit_pos implies (
+        new_byte & (1u8 << other_pos)) == (old_byte & (1u8 << other_pos)) by {
+            let other_shift: u8 = other_pos as u8;
+            assert((new_byte & (1u8 << other_shift)) == (old_byte & (1u8 << other_shift)))
+                by (bit_vector)
+                requires
+                    new_byte == (old_byte & !(1u8 << shift)),
+                    0 <= shift < 8,
+                    0 <= other_shift < 8,
+                    shift != other_shift,
+            ;
+        }
+    }
+
+    /// Setting a byte bit reflects in set_bits.
+    proof fn lemma_byte_or_reflects_in_view(&self, new_self: &Self, word: int, bit: int)
+        requires
+            self@.num_bits > 0,
+            self@.num_bits == self.bits@.len() * (u8::BITS as int),
+            self.number_of_bits as int == self@.num_bits,
+            0 <= word < self.bits@.len(),
+            0 <= bit < (u8::BITS as int),
+            new_self.bits@.len() == self.bits@.len(),
+            new_self.bits@[word] == (self.bits@[word] | (1u8 << bit)),
+            forall|i: int|
+                0 <= i < self.bits@.len() && i != word ==> self.bits@[i] == new_self.bits@[i],
+            self.number_of_bits == new_self.number_of_bits,
+        ensures
+            new_self@.set_bits =~= self@.set_bits.insert(word * (u8::BITS as int) + bit),
+    {
+        Self::lemma_bit_or_effects(self.bits@[word], bit, new_self.bits@[word]);
+        let idx: int = word * (u8::BITS as int) + bit;
+        assert forall|i: int|
+            #![auto]
+            new_self@.set_bits.contains(i) == self@.set_bits.insert(idx).contains(i) by {
+            if i != idx && 0 <= i < self@.num_bits {
+                let i_word: int = i / (u8::BITS as int);
+                if i_word == word {
+                    let i_bit: int = i % (u8::BITS as int);
+                    assert((new_self.bits@[word] & (1u8 << i_bit)) == (self.bits@[word] & (1u8
+                        << i_bit)));
+                }
+            }
+        }
+    }
+
+    /// Clearing a byte bit reflects in set_bits.
+    proof fn lemma_byte_and_not_reflects_in_view(&self, new_self: &Self, word: int, bit: int)
+        requires
+            self.inv(),
+            0 <= word < self.bits@.len(),
+            0 <= bit < (u8::BITS as int),
+            new_self.bits@.len() == self.bits@.len(),
+            new_self.bits@[word] == (self.bits@[word] & !(1u8 << bit)),
+            forall|i: int|
+                0 <= i < self.bits@.len() && i != word ==> self.bits@[i] == new_self.bits@[i],
+            self.number_of_bits == new_self.number_of_bits,
+        ensures
+            new_self@.set_bits =~= self@.set_bits.remove(word * (u8::BITS as int) + bit),
+    {
+        Self::lemma_bit_and_not_effects(self.bits@[word], bit, new_self.bits@[word]);
+        let idx: int = word * (u8::BITS as int) + bit;
+        assert forall|i: int|
+            #![auto]
+            new_self@.set_bits.contains(i) == self@.set_bits.remove(idx).contains(i) by {
+            if i != idx && 0 <= i < self@.num_bits {
+                let i_word: int = i / (u8::BITS as int);
+                if i_word == word {
+                    let i_bit: int = i % (u8::BITS as int);
+                    assert((new_self.bits@[word] & (1u8 << i_bit)) == (self.bits@[word] & (1u8
+                        << i_bit)));
+                }
+            }
+        }
+    }
+
+    /// When all raw bytes are zero, set_bits is empty.
+    proof fn lemma_zero_bytes_means_empty_set(&self)
+        requires
+            self@.num_bits == self.bits@.len() * (u8::BITS as int),
+            forall|i: int| 0 <= i < self.bits@.len() ==> self.bits@[i] == 0,
+        ensures
+            self@.set_bits == Set::<int>::empty(),
+    {
+        assert forall|i: int| !self@.set_bits.contains(i) by {
+            if 0 <= i < self@.num_bits {
+                let bit_idx_u8: u8 = (i % (u8::BITS as int)) as u8;
+                assert((0u8 & (1u8 << bit_idx_u8)) == 0) by (bit_vector)
+                    requires
+                        0 <= bit_idx_u8 < 8,
+                ;
+            }
+        }
+    }
+
+    /// number_of_bits is bounded by usize::MAX.
+    pub proof fn lemma_number_of_bits_bounded(&self)
+        requires
+            self.inv(),
+        ensures
+            self@.num_bits <= usize::MAX as int,
+    {
+    }
+
+    //==========================================================================================
+    // Composite Lemmas
+    //==========================================================================================
+
+    /// Proves that a newly constructed bitmap (with zero-initialized bytes) satisfies inv().
+    proof fn lemma_new_bitmap_inv(bmp: &Self)
+        requires
+            bmp.bits.inv(),
+            bmp@.num_bits == bmp.bits@.len() * (u8::BITS as int),
+            bmp@.num_bits > 0,
+            bmp@.num_bits < u32::MAX as int,
+            bmp.usage == 0,
+            bmp.next_free == 0,
+            bmp.number_of_bits as int == bmp@.num_bits,
+            forall|i: int| 0 <= i < bmp.bits@.len() ==> is_zero(#[trigger] bmp.bits@[i]),
+        ensures
+            bmp.inv(),
+            bmp@.is_empty(),
+    {
+        assert forall|i: int| 0 <= i < bmp.bits@.len() implies (bmp.bits@[i] == 0) by {
+            axiom_u8_zero_is_0(bmp.bits@[i]);
+        };
+        bmp.lemma_zero_bytes_means_empty_set();
+    }
+
+    /// Proves inv() is preserved after setting a bit via byte OR.
+    proof fn lemma_set_bit_preserves_inv(&self, new_self: &Self, word: int, bit: int, index: int)
+        requires
+            self.inv(),
+            0 <= word < self.bits@.len(),
+            0 <= bit < (u8::BITS as int),
+            index == word * (u8::BITS as int) + bit,
+            0 <= index < self@.num_bits,
+            !self@.set_bits.contains(index),
+            new_self.bits@.len() == self.bits@.len(),
+            new_self.bits@[word] == (self.bits@[word] | (1u8 << bit)),
+            forall|i: int|
+                0 <= i < self.bits@.len() && i != word ==> self.bits@[i] == new_self.bits@[i],
+            self.number_of_bits == new_self.number_of_bits,
+            new_self.usage == self.usage,
+        ensures
+            new_self@.set_bits =~= self@.set_bits.insert(index),
+            new_self@.set_bits.finite(),
+            new_self@.set_bits.len() == self@.set_bits.len() + 1,
+            new_self@.wf(),
+            self@.set_bits.len() + 1 <= self@.num_bits,
+    {
+        self.lemma_byte_or_reflects_in_view(new_self, word, bit);
+        assert(new_self@.wf()) by {
+            assert forall|i: int| new_self@.set_bits.contains(i) implies (0 <= i
+                < new_self@.num_bits) by {
+                if i != index {
+                    assert(self@.set_bits.contains(i));
+                }
+            }
+        }
+        self@.lemma_insert_preserves_usage_bound(index);
+    }
+
+    /// Proves inv() is preserved after clearing a bit via byte AND NOT.
+    proof fn lemma_clear_bit_preserves_inv(&self, new_self: &Self, word: int, bit: int, index: int)
+        requires
+            self.inv(),
+            0 <= word < self.bits@.len(),
+            0 <= bit < (u8::BITS as int),
+            index == word * (u8::BITS as int) + bit,
+            0 <= index < self@.num_bits,
+            self@.set_bits.contains(index),
+            new_self.bits@.len() == self.bits@.len(),
+            new_self.bits@[word] == (self.bits@[word] & !(1u8 << bit)),
+            forall|i: int|
+                0 <= i < self.bits@.len() && i != word ==> self.bits@[i] == new_self.bits@[i],
+            self.number_of_bits == new_self.number_of_bits,
+            new_self.usage == self.usage,
+        ensures
+            new_self@.set_bits =~= self@.set_bits.remove(index),
+            new_self@.set_bits.finite(),
+            new_self@.set_bits.len() == self@.set_bits.len() - 1,
+            new_self@.wf(),
+    {
+        self.lemma_byte_and_not_reflects_in_view(new_self, word, bit);
+        assert(new_self@.wf()) by {
+            assert forall|i: int| new_self@.set_bits.contains(i) implies (0 <= i
+                < new_self@.num_bits) by {
+                assert(self@.set_bits.contains(i));
+            }
+        }
+    }
+
+    /// Proves no free range exists when size exceeds number_of_bits.
+    proof fn lemma_no_free_range_when_size_exceeds(&self, size: int)
+        requires
+            self.inv(),
+            size > self@.num_bits,
+        ensures
+            !self@.exists_contiguous_free_range(size),
+    {
+        assert forall|start: int|
+            #![trigger self@.has_free_range_at(start, size)]
+            0 <= start implies !self@.has_free_range_at(start, size) by {}
+    }
+
+    /// Proves no free range exists when usage exceeds capacity for given size.
+    proof fn lemma_no_free_range_when_usage_exceeds(&self, size: int)
+        requires
+            self.inv(),
+            size > 0,
+            size <= self@.num_bits,
+            self@.usage() > self@.num_bits - size,
+        ensures
+            !self@.exists_contiguous_free_range(size),
+    {
+        assert forall|p: int|
+            #![trigger self@.has_free_range_at(p, size)]
+            0 <= p <= self@.num_bits - size implies !self@.has_free_range_at(p, size) by {
+            if self@.has_free_range_at(p, size) {
+                self@.lemma_free_range_implies_usage_bound(p, size);
+            }
+        }
+    }
+
+    /// Proves that when a byte is 0xFF, all 8 bits are set and no free range starts there.
+    proof fn lemma_full_byte_no_free_range(&self, start: int, size: int)
+        requires
+            self.inv(),
+            size > 0,
+            start >= 0,
+            start + 8 <= self@.num_bits,
+            start % 8 == 0,
+            ({
+                let word: int = start / 8;
+                0 <= word < self.bits@.len() && self.bits@[word] == 0xFFu8
+            }),
+        ensures
+            forall|i: int| start <= i < start + 8 ==> self@.is_bit_set(i),
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size)]
+                start <= p < start + 8 ==> !self@.has_free_range_at(p, size),
+    {
+        assert forall|i: int| start <= i < start + 8 implies Self::bit_at(self.bits@, i) by {
+            let bit_pos_u8: u8 = (i % 8) as u8;
+            assert((0xFFu8 & (1u8 << bit_pos_u8)) != 0) by (bit_vector)
+                requires
+                    0 <= bit_pos_u8 < 8,
+            ;
+        }
+        assert forall|p: int|
+            #![trigger self@.has_free_range_at(p, size)]
+            start <= p < start + 8 implies !self@.has_free_range_at(p, size) by {
+            assert(self@.is_bit_set(p));
+        }
+    }
+
+    /// Proves that a set bit blocks any free range containing it.
+    proof fn lemma_set_bit_blocks_free_range(
+        &self,
+        start_before: usize,
+        idx: usize,
+        offset: usize,
+        size: usize,
+    )
+        requires
+            self.inv(),
+            0 <= start_before,
+            0 <= offset < size,
+            idx == start_before + offset,
+            0 <= idx < self@.num_bits,
+            self@.is_bit_set(idx as int),
+        ensures
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                start_before <= p <= idx ==> !self@.has_free_range_at(p, size as int),
+    {
+        assert forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            start_before <= p <= idx implies !self@.has_free_range_at(p, size as int) by {
+            if self@.has_free_range_at(p, size as int) {
+                assert(!self@.is_bit_set(idx as int));
+            }
+        }
+    }
+
+    /// Proves that a found free range was also free in old_self.
+    proof fn lemma_free_range_was_unset_in_old(&self, old_self: &Self, start: usize, size: usize)
+        requires
+            self.inv(),
+            old_self.inv(),
+            self@.set_bits =~= old_self@.set_bits,
+            0 <= start,
+            size > 0,
+            start + size <= self@.num_bits,
+            forall|j: int| 0 <= j < size ==> !#[trigger] self@.is_bit_set(start + j),
+        ensures
+            old_self@.all_bits_unset_in_range(start as int, start + size),
+    {
+        assert forall|i: int| start <= i < start + size implies !#[trigger] old_self@.is_bit_set(
+            i,
+        ) by {
+            assert(!self@.is_bit_set(start + (i - start)));
+        };
+    }
+
+    /// Proves inv() after allocating a full range [start, start+size).
+    proof fn lemma_alloc_range_establishes_inv(&self, old_self: &Self, start: usize, size: usize)
+        requires
+            old_self.inv(),
+            size > 0,
+            0 <= start,
+            start + size <= old_self@.num_bits,
+            old_self@.all_bits_unset_in_range(start as int, start + size),
+            self.bits.inv(),
+            self@.set_bits =~= old_self@.set_bits.union(
+                BitmapView::range_set(start as int, start + size),
+            ),
+            self@.set_bits.finite(),
+            self.number_of_bits == old_self.number_of_bits,
+            self.number_of_bits as int == self@.num_bits,
+            self@.num_bits == self.bits@.len() * (u8::BITS as int),
+            self.usage == old_self.usage + size,
+            self.next_free as int <= self@.num_bits,
+        ensures
+            self.inv(),
+            self@.usage() == old_self@.usage() + size,
+    {
+        BitmapView::lemma_range_set_finite(start as int, start + size);
+        let range: Set<int> = BitmapView::range_set(start as int, start + size);
+        assert(self@.wf()) by {
+            assert forall|i: int| self@.set_bits.contains(i) implies (0 <= i < self@.num_bits) by {
+                if !range.contains(i) {
+                    assert(old_self@.set_bits.contains(i));
+                }
+            }
+        }
+        assert(old_self@.set_bits.disjoint(range)) by {
+            assert forall|i: int|
+                #![auto]
+                !(old_self@.set_bits.contains(i) && range.contains(i)) by {
+                if range.contains(i) {
+                    assert(!old_self@.is_bit_set(i));
+                }
+            }
+        }
+        vstd::set_lib::lemma_set_disjoint_lens(old_self@.set_bits, range);
+        BitmapView::lemma_range_set_len(start as int, start + size);
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, self@.num_bits);
+        vstd::set_lib::lemma_int_range(0, self@.num_bits);
+        assert(self@.set_bits.subset_of(full_range)) by {
+            assert forall|i: int| #![auto] self@.set_bits.contains(i) implies full_range.contains(
+                i,
+            ) by {}
+        }
+        vstd::set_lib::lemma_len_subset(self@.set_bits, full_range);
+    }
+
+    /// Proves frame condition when no free range was found.
+    proof fn lemma_no_range_found_frame(&self, old_self: &Self, size: int)
+        requires
+            self.inv(),
+            old_self.inv(),
+            self@.set_bits =~= old_self@.set_bits,
+            self.number_of_bits == old_self.number_of_bits,
+            size > 0,
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size)]
+                0 <= p < self@.num_bits ==> !self@.has_free_range_at(p, size),
+        ensures
+            self@ =~= old_self@,
+            !old_self@.exists_contiguous_free_range(size),
+    {
+        self@.lemma_set_bits_equal_exists_free_range_equal(&(old_self@), size);
+    }
+
+    /// Proves loop invariant update for a single alloc_range bit-set step.
+    proof fn lemma_alloc_loop_step_inv(
+        self: &Self,
+        old_self: &Self,
+        loop_old_self: &Self,
+        start: usize,
+        alloc_offset: usize,
+        idx: usize,
+    )
+        requires
+            old_self.inv(),
+            loop_old_self@.set_bits =~= old_self@.set_bits.union(
+                BitmapView::range_set(start as int, start + alloc_offset),
+            ),
+            loop_old_self@.set_bits.finite(),
+            self@.set_bits =~= loop_old_self@.set_bits.insert(idx as int),
+            idx == start + alloc_offset,
+            0 <= start,
+            alloc_offset >= 0,
+            idx < old_self@.num_bits,
+            self@.num_bits == old_self@.num_bits,
+            self.number_of_bits as int == self@.num_bits,
+        ensures
+            self@.set_bits =~= old_self@.set_bits.union(
+                BitmapView::range_set(start as int, start + alloc_offset + 1),
+            ),
+            self@.wf(),
+            self@.set_bits.finite(),
+    {
+        assert forall|i: int|
+            self@.set_bits.contains(i) == old_self@.set_bits.union(
+                BitmapView::range_set(start as int, start + alloc_offset + 1),
+            ).contains(i) by {}
+        assert(self@.wf()) by {
+            assert forall|i: int| self@.set_bits.contains(i) implies (0 <= i < self@.num_bits) by {}
+        }
+    }
+
+    // Invariant for the first (outermost) loop in alloc_range
+    spec fn alloc_range_scan_loop_invariant(
+        self: &Self,
+        old_self: &Self,
+        size: usize,
+        start: usize,
+        initial_start: usize,
+        wrapped: bool,
+        done: bool,
+    ) -> bool {
+        &&& self.inv()
+        &&& old_self.inv()
+        &&& size > 0
+        &&& size <= self.number_of_bits
+        &&& start <= self.number_of_bits
+        &&& self@.set_bits =~= old_self@.set_bits
+        &&& self.usage <= self.number_of_bits - size
+        &&& self.number_of_bits == old_self.number_of_bits
+        &&& initial_start as int
+            <= self@.num_bits
+        // Wrap-around state consistency.
+        &&& !wrapped ==> start >= initial_start
+        &&& wrapped ==> initial_start > 0
+        // Checked positions.
+        &&& !wrapped ==> forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            initial_start as int <= p < start as int ==> !self@.has_free_range_at(p, size as int)
+        &&& wrapped ==> forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            initial_start as int <= p < self@.num_bits ==> !self@.has_free_range_at(p, size as int)
+        &&& wrapped ==> forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            0 <= p < start as int ==> !self@.has_free_range_at(
+                p,
+                size as int,
+            )
+            // When done, all positions have been checked.
+        &&& done ==> forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            0 <= p < self@.num_bits ==> !self@.has_free_range_at(p, size as int)
+    }
+
+    // Invariant for the second loop in alloc_range
+    spec fn alloc_range_probe_loop_invariant(
+        self: &Self,
+        old_self: &Self,
+        size: usize,
+        start: usize,
+        initial_start: usize,
+        offset: usize,
+        wrapped: bool,
+        free: bool,
+        checked_before: int,
+        start_before_inner: usize,
+    ) -> bool {
+        &&& self.inv()
+        &&& old_self.inv()
+        &&& 0 < size <= self.number_of_bits
+        &&& offset <= size
+        &&& start_before_inner <= self.number_of_bits - size
+        &&& self@.set_bits =~= old_self@.set_bits
+        &&& checked_before
+            == start_before_inner as int
+        // Positions before start_before_inner are already checked.
+        &&& forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            (!wrapped ==> initial_start as int <= p < checked_before ==> !self@.has_free_range_at(
+                p,
+                size as int,
+            ))
+        &&& forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            (wrapped ==> 0 <= p < checked_before ==> !self@.has_free_range_at(p, size as int))
+        &&& free ==> forall|i: int|
+            0 <= i < offset ==> !#[trigger] self@.is_bit_set((start_before_inner + i) as int)
+    }
+
+    // Loop postcondition for the second loop in alloc_range
+    spec fn alloc_range_probe_loop_ensures(
+        self: &Self,
+        size: usize,
+        start: usize,
+        initial_start: usize,
+        wrapped: bool,
+        free: bool,
+        start_before_inner: usize,
+    ) -> bool {
+        &&& start <= self.number_of_bits
+        &&& free ==> start == start_before_inner && start <= self.number_of_bits - size && forall|
+            i: int,
+        |
+            0 <= i < size ==> !#[trigger] self@.is_bit_set((start + i) as int)
+        &&& !free ==> start > start_before_inner
+        &&& !free ==> forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            (!wrapped ==> initial_start as int <= p < start as int ==> !self@.has_free_range_at(
+                p,
+                size as int,
+            ))
+        &&& !free ==> forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            (wrapped ==> 0 <= p < start as int ==> !self@.has_free_range_at(p, size as int))
+    }
+
+    // Invariant for the third loop in alloc_range
+    spec fn alloc_range_commit_loop_invariant(
+        self: &Self,
+        old_self: &Self,
+        pre_alloc_self: Self,
+        size: usize,
+        start: usize,
+        alloc_offset: usize,
+    ) -> bool {
+        &&& self.bits.inv()
+        &&& self.bits@.len() == pre_alloc_self.bits@.len()
+        &&& self.bits@.len() == old_self.bits@.len()
+        &&& self@.num_bits > 0
+        &&& self@.num_bits == self.bits@.len() * (u8::BITS as int)
+        &&& self.number_of_bits == pre_alloc_self.number_of_bits
+        &&& self.number_of_bits as int == self@.num_bits
+        &&& self.usage == pre_alloc_self.usage
+        &&& old_self.inv()
+        &&& pre_alloc_self.inv()
+        &&& 0 < size <= self.number_of_bits
+        &&& start <= self.number_of_bits - size
+        &&& alloc_offset <= size
+        &&& forall|i: int| 0 <= i < alloc_offset ==> #[trigger] self@.is_bit_set((start + i) as int)
+        &&& forall|i: int|
+            (0 <= i < self@.num_bits && (i < start as int || i >= (start + alloc_offset) as int))
+                ==> #[trigger] self@.is_bit_set(i) == #[trigger] old_self@.is_bit_set(i)
+        &&& self@.set_bits =~= old_self@.set_bits.union(
+            BitmapView::range_set(start as int, start as int + (alloc_offset as int)),
+        )
+        &&& self@.set_bits.finite()
+        &&& old_self@.all_bits_unset_in_range(start as int, start as int + (size as int))
+    }
+
+    /// Proves that positions in `[lower, N)` have no free range of given size
+    /// when all positions in `[lower, checked)` were already checked and the
+    /// remaining positions have `p + size > N`.
+    proof fn lemma_phase1_complete_no_free_range(
+        &self,
+        initial_start: usize,
+        start: usize,
+        size: usize,
+    )
+        requires
+            self.inv(),
+            size > 0,
+            initial_start >= 0,
+            initial_start <= self@.num_bits,
+            start >= initial_start,
+            start <= self@.num_bits,
+            start > self@.num_bits - size,
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                initial_start <= p < start ==> !self@.has_free_range_at(p, size as int),
+        ensures
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                initial_start <= p < self@.num_bits ==> !self@.has_free_range_at(p, size as int),
+    {
+        assert forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            initial_start <= p < self@.num_bits implies !self@.has_free_range_at(
+            p,
+            size as int,
+        ) by {}
+    }
+
+    /// Proves that all positions in `[0, N)` have no free range when both
+    /// phases have been checked.
+    proof fn lemma_all_positions_no_free_range(
+        &self,
+        initial_start: usize,
+        start: usize,
+        size: usize,
+        wrapped: bool,
+    )
+        requires
+            self.inv(),
+            size > 0,
+            start <= self@.num_bits,
+            start > self@.num_bits - size || (wrapped && start >= initial_start),
+            initial_start >= 0,
+            initial_start <= self@.num_bits,
+            // Phase 1 covered [initial_start, N).
+            wrapped ==> forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                initial_start <= p < self@.num_bits ==> !self@.has_free_range_at(p, size as int),
+            // Phase 2 covered [0, start).
+            wrapped ==> forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                0 <= p < start ==> !self@.has_free_range_at(p, size as int),
+            // If not wrapped: phase 1 covered [initial_start, start), and initial_start == 0.
+            !wrapped ==> initial_start == 0,
+            !wrapped ==> forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                0 <= p < start ==> !self@.has_free_range_at(p, size as int),
+        ensures
+            forall|p: int|
+                #![trigger self@.has_free_range_at(p, size as int)]
+                0 <= p < self@.num_bits ==> !self@.has_free_range_at(p, size as int),
+    {
+        assert forall|p: int|
+            #![trigger self@.has_free_range_at(p, size as int)]
+            0 <= p < self@.num_bits implies !self@.has_free_range_at(p, size as int) by {
+            if wrapped && p >= start && p < initial_start {
+                assert(p + size > self@.num_bits);
+            }
+        }
+    }
+
+} // impl Bitmap
+
+} // end verus!

--- a/src/libs/bitmap/src/lib.rs
+++ b/src/libs/bitmap/src/lib.rs
@@ -1,8 +1,10 @@
-// Copyright (c) The Maintainers of Nanvix.
-// Licensed under the MIT license.
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(test, feature = "std"), feature(random))]
+// Verus does not yet support compound assignment on struct fields (e.g., self.usage += 1).
+#![allow(clippy::assign_op_pattern)]
 
 //==================================================================================================
 // Modules
@@ -16,23 +18,43 @@ mod test;
 //==================================================================================================
 
 use ::raw_array::RawArray;
+#[cfg(verus_keep_ghost)]
+use ::raw_array::{
+    axiom_u8_zero_is_0,
+    is_zero,
+};
 use ::sys::error::{
     Error,
     ErrorCode,
 };
+use ::vstd::prelude::*;
+
+// Include specifications.
 #[cfg(verus_keep_ghost)]
-use vstd::prelude::*;
+include!("lib.spec.rs");
+
+// Include proofs.
+#[cfg(verus_keep_ghost)]
+include!("lib.proof.rs");
+
+// Include verified tests.
+#[cfg(verus_keep_ghost)]
+include!("lib.test.rs");
 
 //==================================================================================================
 // Structures
 //==================================================================================================
+
+verus! {
 
 ///
 /// # Description
 ///
 /// A bitmap.
 ///
+#[verifier::external_derive]
 #[derive(Debug)]
+#[verifier::ext_equal]
 pub struct Bitmap {
     /// Capacity of the bitmap (in bits).
     number_of_bits: usize,
@@ -42,6 +64,60 @@ pub struct Bitmap {
     bits: RawArray<u8>,
     /// Hint: first bit index that might be free. Avoids O(n) rescans.
     next_free: usize,
+}
+
+//==================================================================================================
+// View Implementation for Bitmap
+//==================================================================================================
+
+#[cfg(verus_keep_ghost)]
+impl View for Bitmap {
+    type V = BitmapView;
+
+    closed spec fn view(&self) -> BitmapView {
+        BitmapView {
+            num_bits: self.number_of_bits as int,
+            set_bits: Set::new(
+                |i: int| 0 <= i < self.number_of_bits as int && Self::bit_at(self.bits@, i),
+            ),
+        }
+    }
+}
+
+//==================================================================================================
+// Bitmap Specification Functions
+//==================================================================================================
+
+impl Bitmap {
+    /// Helper spec function: get the bit value at a specific index from raw bytes.
+    spec fn bit_at(bytes: Seq<u8>, bit_index: int) -> bool {
+        let word: int = bit_index / (u8::BITS as int);
+        let bit: int = bit_index % (u8::BITS as int);
+        if 0 <= bit_index && word < bytes.len() {
+            (bytes[word] & (1u8 << bit)) != 0
+        } else {
+            false
+        }
+    }
+
+    pub open spec fn inv(&self) -> bool {
+        &&& self@.wf()
+        &&& self.internal_inv()
+    }
+
+    /// Invariant: the bitmap's state is well-formed.
+    pub closed spec fn internal_inv(&self) -> bool {
+        &&& self.bits.inv()
+        &&& self@.num_bits > 0
+        &&& self@.num_bits == self.bits@.len() * (u8::BITS as int)
+        &&& self@.num_bits < u32::MAX as int
+        &&& self@.wf()  // set_bits only contains valid indices
+        &&& self@.set_bits.finite()  // set_bits is finite (required for len())
+        &&& self@.usage() <= self@.num_bits
+        &&& self.number_of_bits as int == self@.num_bits
+        &&& self.usage as int == self@.usage()
+        &&& self.next_free as int <= self@.num_bits
+    }
 }
 
 //==================================================================================================
@@ -62,7 +138,17 @@ impl Bitmap {
     ///
     /// Upon success, a new bitmap is returned. Upon failure, an error is returned instead.
     ///
-    pub fn new(number_of_bits: usize) -> Result<Self, Error> {
+    pub fn new(number_of_bits: usize) -> (result: Result<Self, Error>)
+        ensures
+            result matches Ok(bitmap) ==> {
+                &&& bitmap.inv()
+                &&& bitmap@.num_bits == number_of_bits as int
+                &&& bitmap@.is_empty()
+            },
+            number_of_bits == 0 ==> result is Err,
+            number_of_bits >= u32::MAX ==> result is Err,
+            number_of_bits % (u8::BITS as usize) != 0 ==> result is Err,
+    {
         // Check if the length is invalid.
         if number_of_bits == 0 || number_of_bits >= u32::MAX as usize {
             let reason: &str = "invalid length";
@@ -77,14 +163,24 @@ impl Bitmap {
 
         // Allocate the bitmap.
         // Note: RawArray::new() guarantees zero-initialization of the backing storage.
-        let array: RawArray<u8> = RawArray::new(number_of_bits / u8::BITS as usize)?;
+        let len: usize = number_of_bits / u8::BITS as usize;
+        proof {
+            Self::lemma_u8_array_len_fits_isize(len);
+        }
+        let array: RawArray<u8> = RawArray::new(len)?;
 
-        Ok(Self {
+        let result = Self {
             number_of_bits,
             bits: array,
             usage: 0,
             next_free: 0,
-        })
+        };
+
+        proof {
+            Self::lemma_new_bitmap_inv(&result);
+        }
+
+        Ok(result)
     }
 
     ///
@@ -105,20 +201,44 @@ impl Bitmap {
     ///
     /// - `InvalidArgument` if the array length multiplied by 8 overflows `usize`.
     ///
-    pub fn from_raw_array(array: RawArray<u8>) -> Result<Self, Error> {
-        let number_of_bits: usize =
-            array.len().checked_mul(u8::BITS as usize).ok_or_else(|| {
-                Error::new(ErrorCode::InvalidArgument, "bitmap size overflow: array too large")
-            })?;
+    pub fn from_raw_array(array: RawArray<u8>) -> (result: Result<Self, Error>)
+        requires
+            array.inv(),
+            array@.len() > 0,
+            array@.len() * (u8::BITS as usize) < u32::MAX as usize,
+            forall|i: int| 0 <= i < array@.len() ==> array@[i] == 0,
+        ensures
+            // Liveness: given preconditions, always succeeds.
+            result matches Ok(bitmap) && {
+                &&& bitmap.inv()
+                &&& bitmap@.num_bits == array@.len() * (u8::BITS as int)
+                &&& bitmap@.is_empty()
+                &&& forall|i: int| 0 <= i < bitmap@.num_bits ==> !bitmap@.is_bit_set(i)
+            },
+    {
+        // TODO: remove this runtime check once all callers are verified.
+        let number_of_bits: usize = match array.len().checked_mul(u8::BITS as usize) {
+            Some(n) => n,
+            None => {
+                let reason: &str = "bitmap size overflow: array too large";
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
+        };
 
         // Note: RawArray guarantees zero-initialization of the backing storage.
 
-        Ok(Self {
+        let result = Self {
             number_of_bits,
             bits: array,
             usage: 0,
             next_free: 0,
-        })
+        };
+
+        proof {
+            result.lemma_zero_bytes_means_empty_set();
+        }
+
+        Ok(result)
     }
 
     ///
@@ -130,7 +250,14 @@ impl Bitmap {
     ///
     /// The number of bits in the bitmap.
     ///
-    pub fn number_of_bits(&self) -> usize {
+    pub fn number_of_bits(&self) -> (result: usize)
+        requires
+            self.inv(),
+        ensures
+            result as int == self@.num_bits,
+            result > 0,
+            result < u32::MAX as usize,
+    {
         self.number_of_bits
     }
 
@@ -144,7 +271,35 @@ impl Bitmap {
     /// Upon success, the index of the allocated bit is returned. Upon failure, an error is returned
     /// instead.
     ///
-    pub fn alloc(&mut self) -> Result<usize, Error> {
+    pub fn alloc(&mut self) -> (result: Result<usize, Error>)
+        requires
+            old(self).inv(),
+        ensures
+            self.inv(),
+            match result {
+                Ok(index) => {
+                    &&& 0 <= index < self@.num_bits
+                    &&& self@.num_bits == old(self)@.num_bits
+                    &&& !old(self)@.is_bit_set(index as int)
+                    &&& self@.is_bit_set(index as int)
+                    &&& forall|i: int|
+                        0 <= i < self@.num_bits && i != index ==> self@.is_bit_set(i) == old(
+                            self,
+                        )@.is_bit_set(i)
+                    &&& self@.set_bits == old(self)@.set_bits.insert(index as int)
+                    &&& self@.usage() == old(self)@.usage() + 1
+                },
+                Err(_) => {
+                    &&& old(self)@.is_full()
+                    &&& self@ == old(self)@
+                },
+            },
+    {
+        proof {
+            if old(self)@.has_free_bit() {
+                old(self)@.lemma_has_free_bit_implies_exists_free_range_1();
+            }
+        }
         self.alloc_range(1)
     }
 
@@ -162,19 +317,66 @@ impl Bitmap {
     /// Upon success, the index of the allocated range is returned. Upon failure, an error is returned
     /// instead.
     ///
-    pub fn alloc_range(&mut self, size: usize) -> Result<usize, Error> {
+    pub fn alloc_range(&mut self, size: usize) -> (result: Result<usize, Error>)
+        requires
+            old(self).inv(),
+            size > 0,
+            size <= old(self)@.num_bits,
+        ensures
+            self.inv(),
+            match result {
+                Ok(start) => {
+                    &&& 0 <= start < self@.num_bits
+                    &&& 0 < size <= self@.num_bits
+                    &&& start + (size as int) <= self@.num_bits
+                    &&& self@.num_bits == old(self)@.num_bits
+                    &&& self@.all_bits_set_in_range(start as int, start + (size as int))
+                    &&& old(self)@.all_bits_unset_in_range(
+                        start as int,
+                        start + (size as int),
+                    )
+                    // Frame: only the allocated range changed.
+                    &&& forall|i: int|
+                        0 <= i < self@.num_bits && (i < start || i >= start + (size as int))
+                            ==> self@.is_bit_set(i) == old(self)@.is_bit_set(
+                            i,
+                        )
+                    // Set-based frame.
+                    &&& self@.set_bits == old(self)@.set_bits.union(
+                        BitmapView::range_set(start as int, start + (size as int)),
+                    )
+                    &&& self@.usage() == old(self)@.usage() + (size as int)
+                },
+                Err(_) => {
+                    &&& !old(self)@.exists_contiguous_free_range(size as int)
+                    &&& self@ == old(self)@
+                },
+            },
+    {
+        // TODO: remove this runtime check once all callers are verified.
         // Check if the size is valid.
         if size == 0 || size > self.number_of_bits {
+            proof {
+                if size > self.number_of_bits {
+                    self.lemma_no_free_range_when_size_exceeds(size as int);
+                }
+            }
             let reason: &str = "invalid size";
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
         // Check if allocation exceeds the bitmap capacity.
         if self.usage > self.number_of_bits - size {
+            proof {
+                self.lemma_no_free_range_when_usage_exceeds(size as int);
+            }
             let reason: &str = "allocation exceeds bitmap capacity";
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
         }
 
+        // Note: debug_assert_eq! is not supported by Verus, so we guard it
+        // with cfg. The invariant self.inv() already proves this property.
+        #[cfg(not(verus_keep_ghost))]
         debug_assert_eq!(
             self.bits.len() * u8::BITS as usize,
             self.number_of_bits,
@@ -184,60 +386,181 @@ impl Bitmap {
         let initial_start: usize = self.next_free;
         let mut start: usize = initial_start;
         let mut wrapped: bool = false;
+        let mut done: bool = false;
 
         // Traverse the bitmap, wrapping around once if needed.
-        loop {
+        while !done
+            invariant
+                self.alloc_range_scan_loop_invariant(
+                    old(self),
+                    size,
+                    start,
+                    initial_start,
+                    wrapped,
+                    done,
+                ),
+            decreases
+                    if !done {
+                        1int
+                    } else {
+                        0int
+                    },
+                    if !wrapped {
+                        1int
+                    } else {
+                        0int
+                    },
+                    self.number_of_bits - start,
+        {
             // Stop condition: exceeded the last valid starting position.
             if start > self.number_of_bits - size {
                 // If we haven't wrapped yet and started past 0, retry from beginning.
                 if !wrapped && initial_start > 0 {
+                    proof {
+                        self.lemma_phase1_complete_no_free_range(initial_start, start, size);
+                    }
                     start = 0;
                     wrapped = true;
                 } else {
-                    break;
+                    proof {
+                        self.lemma_all_positions_no_free_range(initial_start, start, size, wrapped);
+                    }
+                    done = true;
                 }
             }
 
             // After wrap-around, stop if we've reached the initial position.
-            if wrapped && start >= initial_start {
-                break;
+            if !done && wrapped && start >= initial_start {
+                proof {
+                    self.lemma_all_positions_no_free_range(initial_start, start, size, wrapped);
+                }
+                done = true;
             }
 
-            // Check for fast skip path.
-            let is_aligned: bool = start.is_multiple_of(u8::BITS as usize);
-            if is_aligned {
-                let word: usize = start / u8::BITS as usize;
-                // Fast skip: if the starting word is full, skip to the next word.
-                if self.bits[word] == u8::MAX {
-                    start += u8::BITS as usize;
-                    continue;
+            if !done {
+                // Check for fast-skip path.
+                let is_aligned: bool = start.is_multiple_of(u8::BITS as usize);
+                if is_aligned {
+                    let word: usize = start / u8::BITS as usize;
+                    // Fast skip: if the starting word is full, skip to the next word.
+                    if self.bits[word] == u8::MAX {
+                        proof {
+                            self.lemma_full_byte_no_free_range(start as int, size as int);
+                        }
+                        start += u8::BITS as usize;
+                        continue;
+                    }
                 }
-            }
 
-            // Check if all bits in the range are free.
-            let mut free: bool = true;
-            for offset in 0..size {
-                let idx: usize = start + offset;
-                let (w, b): (usize, usize) = self.index_unchecked(idx);
-                if (self.bits[w] & (1 << b)) != 0 {
-                    free = false;
-                    start += offset + 1;
-                    break;
-                }
-            }
-            if free {
-                // Allocate the range.
-                for offset in 0..size {
+                // Check if all bits in the range are free.
+                let ghost start_before_inner: usize = start;
+                let mut offset: usize = 0;
+                let mut free: bool = true;
+
+                // Ghost: snapshot the "checked before" region for the inner loop.
+                let ghost checked_before: int = start as int;
+
+                while offset < size
+                    invariant_except_break
+                        start == start_before_inner,
+                        free,
+                    invariant
+                        self.alloc_range_probe_loop_invariant(
+                            old(self),
+                            size,
+                            start,
+                            initial_start,
+                            offset,
+                            wrapped,
+                            free,
+                            checked_before,
+                            start_before_inner,
+                        ),
+                    ensures
+                        self.alloc_range_probe_loop_ensures(
+                            size,
+                            start,
+                            initial_start,
+                            wrapped,
+                            free,
+                            start_before_inner,
+                        ),
+                    decreases size - offset,
+                {
                     let idx: usize = start + offset;
                     let (w, b): (usize, usize) = self.index_unchecked(idx);
-                    self.bits[w] |= 1 << b;
+                    if (self.bits[w] & (1 << b)) != 0 {
+                        free = false;
+                        start += offset + 1;
+                        proof {
+                            self.lemma_set_bit_blocks_free_range(
+                                start_before_inner,
+                                idx,
+                                offset,
+                                size,
+                            );
+                        }
+                        break;
+                    }
+                    offset += 1;
                 }
-                self.usage += size;
-                self.next_free = start + size;
-                return Ok(start);
+
+                if free {
+                    // Found a free range at [start, start + size).
+                    proof {
+                        self.lemma_free_range_was_unset_in_old(old(self), start, size);
+                    }
+                    // Allocate the range.
+                    let ghost pre_alloc_self = *self;
+
+                    for alloc_offset in 0..size
+                        invariant
+                            self.alloc_range_commit_loop_invariant(
+                                old(self),
+                                pre_alloc_self,
+                                size,
+                                start,
+                                alloc_offset,
+                            ),
+                        decreases size - alloc_offset,
+                    {
+                        let idx: usize = start + alloc_offset;
+                        let (w, b): (usize, usize) = self.index_unchecked(idx);
+                        let ghost loop_old_self = *self;
+
+                        // Verus note:
+                        // `self.bits[w] |= 1 << b` is not supported for mutable index.
+                        self.bits.set(w, self.bits[w] | (1 << b));
+
+                        proof {
+                            loop_old_self.lemma_byte_or_reflects_in_view(self, w as int, b as int);
+                            self.lemma_alloc_loop_step_inv(
+                                old(self),
+                                &loop_old_self,
+                                start,
+                                alloc_offset,
+                                idx,
+                            );
+                        }
+                    }
+                    // Verus note: compound assignment on struct fields not supported.
+                    self.usage = self.usage + size;
+                    self.next_free = start + size;
+
+                    proof {
+                        self.lemma_alloc_range_establishes_inv(old(self), start, size);
+                    }
+
+                    return Ok(start);
+                }
+                // !free: start was advanced past the blocked position.
             }
         }
 
+        // No free range found anywhere in the bitmap.
+        proof {
+            self.lemma_no_range_found_frame(old(self), size as int);
+        }
         let reason: &str = "bitmap is full";
         Err(Error::new(ErrorCode::OutOfMemory, reason))
     }
@@ -255,15 +578,56 @@ impl Bitmap {
     ///
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
-    pub fn set(&mut self, index: usize) -> Result<(), Error> {
+    pub fn set(&mut self, index: usize) -> (result: Result<(), Error>)
+        requires
+            old(self).inv(),
+        ensures
+            self.inv(),
+            match result {
+                Ok(()) => {
+                    &&& index < self@.num_bits
+                    &&& self@.is_bit_set(index as int)
+                    &&& !old(self)@.is_bit_set(index as int)
+                    &&& self@.num_bits == old(self)@.num_bits
+                    // Frame.
+                    &&& forall|i: int|
+                        0 <= i < self@.num_bits && i != (index as int) ==> self@.is_bit_set(i)
+                            == old(self)@.is_bit_set(
+                            i,
+                        )
+                    // Set-based frame.
+                    &&& self@.set_bits == old(self)@.set_bits.insert(index as int)
+                    &&& self@.usage() == old(self)@.usage() + 1
+                },
+                Err(_) => {
+                    &&& index >= old(self)@.num_bits || old(self)@.is_bit_set(index as int)
+                    &&& *self == *old(self)
+                },
+            },
+    {
+        // TODO: remove this runtime check once all callers are verified and we add a
+        // precondition to this function requiring the bit to already be cleared.
+
         // Check if the bit is already set.
         if self.test(index)? {
             let reason: &str = "bit is already set";
             return Err(Error::new(ErrorCode::ResourceBusy, reason));
         }
         let (word, bit): (usize, usize) = self.index(index)?;
-        self.bits[word] |= 1 << bit;
-        self.usage += 1;
+        let ghost old_self = *self;
+
+        proof {
+            assert(!old_self@.set_bits.contains(index as int));
+        }
+
+        self.bits.set(word, self.bits[word] | (1 << bit));
+
+        proof {
+            old_self.lemma_set_bit_preserves_inv(self, word as int, bit as int, index as int);
+        }
+
+        self.usage = self.usage + 1;
+
         Ok(())
     }
 
@@ -280,18 +644,54 @@ impl Bitmap {
     ///
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
-    pub fn clear(&mut self, index: usize) -> Result<(), Error> {
+    pub fn clear(&mut self, index: usize) -> (result: Result<(), Error>)
+        requires
+            old(self).inv(),
+        ensures
+            self.inv(),
+            match result {
+                Ok(()) => {
+                    &&& index < self@.num_bits
+                    &&& !self@.is_bit_set(index as int)
+                    &&& self@.num_bits == old(self)@.num_bits
+                    &&& forall|i: int|
+                        0 <= i < self@.num_bits && i != (index as int) ==> self@.is_bit_set(i)
+                            == old(self)@.is_bit_set(i)
+                    &&& self@.set_bits == old(self)@.set_bits.remove(index as int)
+                    &&& self@.usage() == old(self)@.usage() - 1
+                },
+                Err(_) => {
+                    &&& index >= old(self)@.num_bits || !old(self)@.is_bit_set(index as int)
+                    &&& *self == *old(self)
+                },
+            },
+    {
+        // TODO: remove this runtime check once all callers are verified and we add a
+        // precondition to this function requiring the bit to already be set.
+
         // Check if the bit is already cleared.
         if !self.test(index)? {
             let reason: &str = "bit is already cleared";
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
         let (word, bit): (usize, usize) = self.index(index)?;
-        self.bits[word] &= !(1 << bit);
-        self.usage -= 1;
+        let ghost old_self = *self;
+
+        proof {
+            assert(old_self@.set_bits.contains(index as int));
+        }
+
+        self.bits.set(word, self.bits[word] & !(1 << bit));
+
+        proof {
+            old_self.lemma_clear_bit_preserves_inv(self, word as int, bit as int, index as int);
+        }
+
+        self.usage = self.usage - 1;
         if index < self.next_free {
             self.next_free = index;
         }
+
         Ok(())
     }
 
@@ -309,7 +709,18 @@ impl Bitmap {
     /// Upon success, `Ok(true)` is returned if the bit is set, `Ok(false)` is returned otherwise.
     /// Upon failure, an error is returned instead.
     ///
-    pub fn test(&self, index: usize) -> Result<bool, Error> {
+    pub fn test(&self, index: usize) -> (result: Result<bool, Error>)
+        requires
+            self.inv(),
+        ensures
+            match result {
+                Ok(b) => {
+                    &&& index < self@.num_bits
+                    &&& b == self@.is_bit_set(index as int)
+                },
+                Err(_) => index >= self@.num_bits,
+            },
+    {
         let (word, bit): (usize, usize) = self.index(index)?;
         Ok((self.bits[word] & (1 << bit)) != 0)
     }
@@ -328,7 +739,21 @@ impl Bitmap {
     /// Upon success, the `(word, bit)` pair of the index is returned. Upon
     /// failure, an error is returned instead.
     ///
-    fn index(&self, index: usize) -> Result<(usize, usize), Error> {
+    fn index(&self, index: usize) -> (result: Result<(usize, usize), Error>)
+        requires
+            self.inv(),
+        ensures
+            match result {
+                Ok((which_byte, which_bit)) => {
+                    &&& index < self.number_of_bits
+                    &&& which_byte < self.bits@.len()
+                    &&& which_bit < u8::BITS as usize
+                    &&& which_byte == index as int / (u8::BITS as int)
+                    &&& which_bit == index as int % (u8::BITS as int)
+                },
+                Err(_) => index >= self.number_of_bits,
+            },
+    {
         // Check if the index is out of bounds.
         if index >= self.bits.len() * u8::BITS as usize {
             let reason: &str = "index out of bounds";
@@ -351,14 +776,26 @@ impl Bitmap {
     ///
     /// The `(word, bit)` pair of the index.
     ///
-    fn index_unchecked(&self, index: usize) -> (usize, usize) {
+    fn index_unchecked(&self, index: usize) -> (result: (usize, usize))
+        requires
+            index < self.bits@.len() * u8::BITS as usize,
+        ensures
+            result.0 < self.bits@.len(),
+            result.1 < u8::BITS as usize,
+            result.0 as int == index as int / (u8::BITS as int),
+            result.1 as int == index as int % (u8::BITS as int),
+    {
         let word: usize = index / u8::BITS as usize;
         let bit: usize = index % u8::BITS as usize;
         (word, bit)
     }
 }
 
+} // verus!
+
+// Deref implementation for test support (external to verification).
 #[cfg(test)]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl ::core::ops::Deref for Bitmap {
     type Target = RawArray<u8>;
 

--- a/src/libs/bitmap/src/lib.spec.rs
+++ b/src/libs/bitmap/src/lib.spec.rs
@@ -1,0 +1,341 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// Bitmap - Specifications
+//
+// This file contains specification functions, BitmapView, and View trait for Bitmap.
+
+verus! {
+
+//==================================================================================================
+// BitmapView - Abstract Specification Model
+//==================================================================================================
+
+/// A view of the Bitmap as a set of indices where bits are set.
+#[verifier::ext_equal]
+pub struct BitmapView {
+    /// Number of bits in the bitmap.
+    pub num_bits: int,
+    /// Set of indices where bits are set (0-indexed).
+    /// Invariant: all elements are in [0, num_bits).
+    pub set_bits: Set<int>,
+}
+
+impl BitmapView {
+    /// Returns the usage (count of set bits) in the bitmap view.
+    /// Requires set_bits to be finite (enforced by Bitmap::inv()).
+    pub open spec fn usage(&self) -> int {
+        self.set_bits.len() as int
+    }
+
+    /// Returns true if there exists at least one unset bit.
+    pub open spec fn has_free_bit(&self) -> bool {
+        exists|i: int| 0 <= i < self.num_bits && !self.set_bits.contains(i)
+    }
+
+    /// Returns true if the bitmap is full (all bits set).
+    pub open spec fn is_full(&self) -> bool {
+        forall|i: int| 0 <= i < self.num_bits ==> self.set_bits.contains(i)
+    }
+
+    /// Returns true if the bitmap is empty (no bits set).
+    pub open spec fn is_empty(&self) -> bool {
+        self.set_bits == Set::<int>::empty()
+    }
+
+    /// Returns true if a specific bit is set.
+    pub open spec fn is_bit_set(&self, index: int) -> bool {
+        self.set_bits.contains(index)
+    }
+
+    /// Helper: Create a set of indices in range [start, end).
+    pub open spec fn range_set(start: int, end: int) -> Set<int> {
+        Set::new(|i: int| start <= i < end)
+    }
+
+    /// Well-formedness: set_bits only contains valid indices.
+    pub open spec fn wf(&self) -> bool {
+        forall|i: int| self.set_bits.contains(i) ==> 0 <= i < self.num_bits
+    }
+
+    /// Helper spec function: check if all bits in range [start, end) are set.
+    pub open spec fn all_bits_set_in_range(&self, start: int, end: int) -> bool {
+        forall|i: int| start <= i < end ==> self.is_bit_set(i)
+    }
+
+    /// Helper spec function: check if all bits in range [start, end) are not set.
+    pub open spec fn all_bits_unset_in_range(&self, start: int, end: int) -> bool {
+        forall|i: int| start <= i < end ==> !self.is_bit_set(i)
+    }
+
+    /// Helper spec function: check if there exists a contiguous range of n free bits starting at start.
+    pub open spec fn has_free_range_at(&self, start: int, n: int) -> bool {
+        &&& 0 <= start
+        &&& start + n <= self.num_bits
+        &&& self.all_bits_unset_in_range(start, start + n)
+    }
+
+    /// Helper spec function: check if there exists a contiguous range of n free bits.
+    pub open spec fn exists_contiguous_free_range(&self, n: int) -> bool {
+        exists|start: int|
+            #![trigger self.has_free_range_at(start, n)]
+            self.has_free_range_at(start, n)
+    }
+
+    /// A subset of a finite set is finite.
+    pub proof fn lemma_set_bits_finite(&self)
+        requires
+            self.wf(),
+            self.num_bits >= 0,
+        ensures
+            self.set_bits.finite(),
+    {
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, self.num_bits);
+        vstd::set_lib::lemma_int_range(0, self.num_bits);
+
+        assert(self.set_bits.subset_of(full_range)) by {
+            assert forall|i: int| #![auto] self.set_bits.contains(i) implies full_range.contains(
+                i,
+            ) by {}
+        }
+
+        vstd::set_lib::lemma_set_subset_finite(full_range, self.set_bits);
+    }
+
+    //==================================================================================================
+    // Lemmas: Finiteness
+    //==================================================================================================
+
+    /// range_set(lo, hi) is finite when lo <= hi.
+    pub proof fn lemma_range_set_finite(lo: int, hi: int)
+        requires
+            lo <= hi,
+        ensures
+            BitmapView::range_set(lo, hi).finite(),
+    {
+        vstd::set_lib::lemma_int_range(lo, hi);
+        assert(BitmapView::range_set(lo, hi) =~= vstd::set_lib::set_int_range(lo, hi)) by {
+            assert forall|i: int|
+                BitmapView::range_set(lo, hi).contains(i) == vstd::set_lib::set_int_range(
+                    lo,
+                    hi,
+                ).contains(i) by {}
+        }
+    }
+
+    //==================================================================================================
+    // Lemmas: Cardinality
+    //==================================================================================================
+
+    /// range_set cardinality equals range size.
+    pub proof fn lemma_range_set_len(lo: int, hi: int)
+        requires
+            lo <= hi,
+        ensures
+            BitmapView::range_set(lo, hi).len() == hi - lo,
+    {
+        vstd::set_lib::lemma_int_range(lo, hi);
+        assert(BitmapView::range_set(lo, hi) =~= vstd::set_lib::set_int_range(lo, hi)) by {
+            assert forall|i: int|
+                BitmapView::range_set(lo, hi).contains(i) == vstd::set_lib::set_int_range(
+                    lo,
+                    hi,
+                ).contains(i) by {}
+        }
+    }
+
+    //==================================================================================================
+    // Lemmas: Free Range Properties
+    //==================================================================================================
+
+    /// If a free range of size n exists starting at p, then usage <= number_of_bits - n.
+    proof fn lemma_free_range_implies_usage_bound(&self, p: int, n: int)
+        requires
+            self.wf(),
+            self.has_free_range_at(p, n),
+            n > 0,
+        ensures
+            self.usage() <= self.num_bits - n,
+    {
+        let num_bits: int = self.num_bits;
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, num_bits);
+        vstd::set_lib::lemma_int_range(0, num_bits);
+        let free_range: Set<int> = vstd::set_lib::set_int_range(p, p + n);
+        vstd::set_lib::lemma_int_range(p, p + n);
+        let available_range: Set<int> = full_range.difference(free_range);
+
+        assert(self.set_bits.subset_of(available_range)) by {
+            assert forall|i: int|
+                #![auto]
+                self.set_bits.contains(i) implies available_range.contains(i) by {
+                if p <= i && i < p + n {
+                    assert(!self.is_bit_set(i));
+                }
+            }
+        }
+
+        vstd::set_lib::lemma_set_subset_finite(full_range, available_range);
+        vstd::set_lib::lemma_len_subset(self.set_bits, available_range);
+
+        assert(free_range.subset_of(full_range)) by {
+            assert forall|i: int| free_range.contains(i) implies full_range.contains(i) by {}
+        }
+        vstd::set_lib::lemma_len_difference(full_range, free_range);
+        assert(full_range.intersect(free_range) =~= free_range);
+        assert(full_range =~= available_range.union(free_range));
+        assert(available_range.intersect(free_range) =~= Set::empty());
+        vstd::set_lib::lemma_set_disjoint_lens(available_range, free_range);
+    }
+
+    //==================================================================================================
+    // Lemmas: Miscellaneous
+    //==================================================================================================
+
+    /// Lemma: If set_bits ⊆ [0, n) and there's an element x in [0, n) not in set_bits,
+    /// then |set_bits| < n, so inserting one element still satisfies |set_bits| <= n.
+    pub proof fn lemma_insert_preserves_usage_bound(&self, x: int)
+        requires
+            self.wf(),
+            0 <= x < self.num_bits,
+            !self.set_bits.contains(x),
+        ensures
+            self.set_bits.insert(x).len() <= self.num_bits,
+    {
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, self.num_bits);
+        vstd::set_lib::lemma_int_range(0, self.num_bits);
+        assert(self.set_bits.subset_of(full_range)) by {
+            assert forall|i: int| #![auto] self.set_bits.contains(i) implies full_range.contains(
+                i,
+            ) by {}
+        }
+        self.set_bits.lemma_subset_not_in_lt(full_range, x);
+    }
+
+    /// If usage equals number_of_bits, all bits are set.
+    pub proof fn lemma_usage_equals_number_of_bits_implies_full(&self)
+        requires
+            self.wf(),
+            self.usage() == self.num_bits,
+        ensures
+            forall|i: int| 0 <= i < self.num_bits ==> self.is_bit_set(i),
+    {
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, self.num_bits);
+        vstd::set_lib::lemma_int_range(0, self.num_bits);
+        assert(self.set_bits.subset_of(full_range)) by {
+            assert forall|i: int| #![auto] self.set_bits.contains(i) implies full_range.contains(
+                i,
+            ) by {}
+        }
+        assert forall|i: int| 0 <= i < self.num_bits implies self.set_bits.contains(i) by {
+            if !self.set_bits.contains(i) {
+                let reduced: Set<int> = full_range.remove(i);
+                assert(self.set_bits.subset_of(reduced)) by {
+                    assert forall|j: int|
+                        #![auto]
+                        self.set_bits.contains(j) implies reduced.contains(j) by {}
+                }
+                vstd::set_lib::lemma_len_subset(self.set_bits, reduced);
+                vstd::set_lib::lemma_set_subset_finite(full_range, reduced);
+            }
+        }
+    }
+
+    /// If usage() < number_of_bits(), then the bitmap is not full.
+    pub proof fn lemma_usage_less_than_capacity_means_not_full(&self)
+        requires
+            self.wf(),
+            self.usage() < self.num_bits,
+        ensures
+            !self.is_full(),
+    {
+        let full_range: Set<int> = vstd::set_lib::set_int_range(0, self.num_bits);
+        vstd::set_lib::lemma_int_range(0, self.num_bits);
+        assert(self.set_bits.subset_of(full_range)) by {
+            assert forall|i: int| #![auto] self.set_bits.contains(i) implies full_range.contains(
+                i,
+            ) by {}
+        }
+        vstd::set_lib::lemma_len_subset(self.set_bits, full_range);
+        let diff: Set<int> = full_range.difference(self.set_bits);
+        vstd::set_lib::lemma_len_difference(full_range, self.set_bits);
+        assert(full_range.intersect(self.set_bits) =~= self.set_bits);
+        assert(full_range =~= diff.union(self.set_bits));
+        vstd::set_lib::lemma_set_disjoint_lens(diff, self.set_bits);
+        vstd::set_lib::lemma_set_empty_equivalency_len(diff);
+        let i: int = diff.choose();
+        assert(!self.set_bits.contains(i));
+    }
+
+    /// If a specific bit is unset, then has_free_bit() is true.
+    pub proof fn lemma_unset_bit_implies_has_free_bit(&self, i: int)
+        requires
+            self.wf(),
+            0 <= i < self.num_bits,
+            !self.is_bit_set(i),
+        ensures
+            self.has_free_bit(),
+    {
+    }
+
+    /// Lemma: if all bits are set, bitmap is full.
+    pub proof fn lemma_all_bits_set_means_full(&self)
+        requires
+            self.wf(),
+            forall|i: int| 0 <= i < self.num_bits ==> self.is_bit_set(i),
+        ensures
+            self.is_full(),
+    {
+        assert forall|i: int| 0 <= i < self.num_bits implies self.set_bits.contains(i) by {
+            assert(self.is_bit_set(i));
+        }
+    }
+
+    /// has_free_bit implies exists_contiguous_free_range(1).
+    pub proof fn lemma_has_free_bit_implies_exists_free_range_1(&self)
+        requires
+            self.wf(),
+            self.has_free_bit(),
+        ensures
+            self.exists_contiguous_free_range(1),
+    {
+        let i = choose|i: int| 0 <= i < self.num_bits && !self.set_bits.contains(i);
+        assert(self.has_free_range_at(i, 1));
+    }
+
+    /// If set_bits are equal, has_free_range_at returns the same result.
+    pub proof fn lemma_set_bits_equal_has_free_range_at_equal(&self, other: &Self, p: int, n: int)
+        requires
+            self.wf(),
+            other.wf(),
+            self.set_bits =~= other.set_bits,
+            self.num_bits == other.num_bits,
+        ensures
+            self.has_free_range_at(p, n) == other.has_free_range_at(p, n),
+    {
+    }
+
+    /// If set_bits are equal, exists_contiguous_free_range returns the same result.
+    pub proof fn lemma_set_bits_equal_exists_free_range_equal(&self, other: &Self, n: int)
+        requires
+            self.wf(),
+            other.wf(),
+            self.set_bits =~= other.set_bits,
+            self.num_bits == other.num_bits,
+        ensures
+            self.exists_contiguous_free_range(n) == other.exists_contiguous_free_range(n),
+    {
+        assert forall|p: int|
+            #![trigger self.has_free_range_at(p, n)]
+            self.has_free_range_at(p, n) == other.has_free_range_at(p, n) by {
+            self.lemma_set_bits_equal_has_free_range_at_equal(other, p, n);
+        }
+        if self.exists_contiguous_free_range(n) {
+            let p = choose|p: int| #[trigger] self.has_free_range_at(p, n);
+        }
+        if other.exists_contiguous_free_range(n) {
+            let p = choose|p: int| #[trigger] other.has_free_range_at(p, n);
+        }
+    }
+}
+
+} // verus!

--- a/src/libs/bitmap/src/lib.test.rs
+++ b/src/libs/bitmap/src/lib.test.rs
@@ -1,0 +1,459 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// Bitmap Allocator - Verified Tests.
+// Verified test functions that prove key bitmap properties.
+
+verus! {
+
+//==================================================================================================
+// Verified Test Functions
+//==================================================================================================
+
+/// Verifiable test: setting and clearing a bit should work correctly.
+fn test_bitmap_set_clear_verified(number_of_bits: usize, index: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        index < number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set the bit.
+        let set_result: Result<(), Error> = bitmap.set(index);
+        if let Ok(()) = set_result {
+            // The bit should be set.
+            assert(bitmap@.is_bit_set(index as int));
+
+            // Clear the bit.
+            let clear_result: Result<(), Error> = bitmap.clear(index);
+            if let Ok(()) = clear_result {
+                // The bit should be cleared.
+                assert(!bitmap@.is_bit_set(index as int));
+            }
+        }
+    }
+}
+
+/// Verifiable test: allocating a range should allocate contiguous bits.
+fn test_bitmap_alloc_range_verified(number_of_bits: usize, size: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        size > 0,
+        size <= number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        let alloc_result: Result<usize, Error> = bitmap.alloc_range(size);
+        if let Ok(start_index) = alloc_result {
+            // The start index should be within valid range.
+            assert(start_index + size <= number_of_bits);
+
+            // All bits in the range should be set.
+            assert(bitmap@.all_bits_set_in_range(start_index as int, (start_index + size) as int));
+        }
+    }
+}
+
+/// Verifiable test: multiple allocations should not overlap.
+fn test_bitmap_multiple_alloc_verified(number_of_bits: usize)
+    requires
+        number_of_bits >= 8,  // Need at least 8 bits (minimum valid bitmap size).
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        let alloc1: Result<usize, Error> = bitmap.alloc();
+        if let Ok(index1) = alloc1 {
+            let alloc2: Result<usize, Error> = bitmap.alloc();
+            if let Ok(index2) = alloc2 {
+                // The two allocated indices should be different.
+                assert(index1 != index2);
+                // Both bits should be set.
+                assert(bitmap@.is_bit_set(index1 as int));
+                assert(bitmap@.is_bit_set(index2 as int));
+            }
+        }
+    }
+}
+
+/// Verifiable test: clearing and re-allocating should work.
+fn test_bitmap_clear_and_realloc_verified(number_of_bits: usize, index: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        index < number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set a bit.
+        let set_result: Result<(), Error> = bitmap.set(index);
+        if let Ok(()) = set_result {
+            // Clear the bit.
+            let clear_result: Result<(), Error> = bitmap.clear(index);
+            if let Ok(()) = clear_result {
+                // The bit should be cleared.
+                assert(!bitmap@.is_bit_set(index as int));
+
+                // Usage should be back to 0.
+                assert(bitmap@.usage() == 0);
+            }
+        }
+    }
+}
+
+/// Verifiable test: setting all bits and then clearing all bits.
+fn test_set_and_clear_all_bits_verified(number_of_bits: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set all bits.
+        let mut i: usize = 0;
+        while i < number_of_bits
+            invariant
+                0 <= i <= number_of_bits,
+                bitmap.inv(),
+                bitmap@.num_bits == number_of_bits as int,
+                forall|j: int| 0 <= j < i as int ==> bitmap@.is_bit_set(j),
+            decreases number_of_bits - i,
+        {
+            let set_result: Result<(), Error> = bitmap.set(i);
+            if let Ok(()) = set_result {
+                i = i + 1;
+            } else {
+                break;
+            }
+        }
+
+        // If we set all bits successfully.
+        if i == number_of_bits {
+            // All bits should be set.
+            assert(bitmap@.all_bits_set_in_range(0, number_of_bits as int));
+
+            // Clear all bits.
+            let mut j: usize = 0;
+            while j < number_of_bits
+                invariant
+                    0 <= j <= number_of_bits,
+                    bitmap.inv(),
+                    bitmap@.num_bits == number_of_bits as int,
+                    forall|k: int| 0 <= k < j as int ==> !bitmap@.is_bit_set(k),
+                    forall|k: int| j as int <= k < number_of_bits as int ==> bitmap@.is_bit_set(k),
+                decreases number_of_bits - j,
+            {
+                let clear_result: Result<(), Error> = bitmap.clear(j);
+                if let Ok(()) = clear_result {
+                    j = j + 1;
+                } else {
+                    break;
+                }
+            }
+
+            // If we cleared all bits successfully.
+            if j == number_of_bits {
+                // All bits should be cleared.
+                assert(bitmap@.all_bits_unset_in_range(0, number_of_bits as int));
+            }
+        }
+    }
+}
+
+/// Verifiable test: allocating all bits and then clearing all bits.
+fn test_alloc_and_clear_all_bits_verified(number_of_bits: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Allocate all bits.
+        let mut count: usize = 0;
+        while count < number_of_bits
+            invariant
+                0 <= count <= number_of_bits,
+                bitmap.inv(),
+                bitmap@.num_bits == number_of_bits as int,
+                bitmap@.usage() == count as int,
+            decreases number_of_bits - count,
+        {
+            let alloc_result: Result<usize, Error> = bitmap.alloc();
+            if let Ok(_) = alloc_result {
+                count = count + 1;
+            } else {
+                break;
+            }
+        }
+
+        // If we allocated all bits successfully.
+        if count == number_of_bits {
+            // Usage should equal number_of_bits.
+            assert(bitmap@.usage() == number_of_bits as int);
+
+            // All bits must be set (usage == number_of_bits implies full).
+            proof {
+                bitmap@.lemma_usage_equals_number_of_bits_implies_full();
+            }
+
+            // Clear all bits.
+            let mut j: usize = 0;
+            while j < number_of_bits
+                invariant
+                    0 <= j <= number_of_bits,
+                    bitmap.inv(),
+                    bitmap@.num_bits == number_of_bits as int,
+                    forall|k: int| 0 <= k < j as int ==> !bitmap@.is_bit_set(k),
+                    forall|k: int| j as int <= k < number_of_bits as int ==> bitmap@.is_bit_set(k),
+                decreases number_of_bits - j,
+            {
+                let clear_result: Result<(), Error> = bitmap.clear(j);
+                if let Ok(()) = clear_result {
+                    j = j + 1;
+                } else {
+                    break;
+                }
+            }
+
+            // If we cleared all bits successfully.
+            if j == number_of_bits {
+                // All bits should be cleared.
+                assert(bitmap@.all_bits_unset_in_range(0, number_of_bits as int));
+            }
+        }
+    }
+}
+
+/// Verifiable test: allocating a range that crosses a word boundary.
+fn test_alloc_range_across_word_boundary_verified(number_of_bits: usize, start: usize, end: usize)
+    requires
+        number_of_bits >= 8,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        start < end,
+        end <= number_of_bits,
+        // Ensure the range crosses a byte boundary (e.g., bits 6..10).
+        start / 8 < (end - 1) / 8,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set all bits that are not in the range [start, end).
+        let mut i: usize = 0;
+        while i < number_of_bits
+            invariant
+                0 <= i <= number_of_bits,
+                bitmap.inv(),
+                bitmap@.num_bits == number_of_bits as int,
+            decreases number_of_bits - i,
+        {
+            if i < start || i >= end {
+                let _ = bitmap.set(i);
+            }
+            i = i + 1;
+        }
+
+        // Attempt to allocate the range.
+        let size: usize = end - start;
+        let alloc_result: Result<usize, Error> = bitmap.alloc_range(size);
+        if let Ok(alloc_start) = alloc_result {
+            // The allocated range should have all bits set.
+            assert(bitmap@.all_bits_set_in_range(alloc_start as int, (alloc_start + size) as int));
+        }
+    }
+}
+
+/// Verifiable test: allocating a bit in a partially filled bitmap.
+fn test_alloc_in_partial_bitmap_verified(number_of_bits: usize, set_index: usize)
+    requires
+        number_of_bits >= 8,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        set_index < number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set one bit to partially fill the bitmap.
+        let set_result: Result<(), Error> = bitmap.set(set_index);
+        if let Ok(()) = set_result {
+            // The set bit should be marked as set.
+            assert(bitmap@.is_bit_set(set_index as int));
+
+            // Allocate a new bit.
+            let alloc_result: Result<usize, Error> = bitmap.alloc();
+            if let Ok(index) = alloc_result {
+                // The allocated bit should be set.
+                assert(bitmap@.is_bit_set(index as int));
+
+                // Clear the allocated bit.
+                let clear_result: Result<(), Error> = bitmap.clear(index);
+                if let Ok(()) = clear_result {
+                    assert(!bitmap@.is_bit_set(index as int));
+                    // The originally set bit should still be set (if it wasn't the one we allocated).
+                    if index != set_index {
+                        assert(bitmap@.is_bit_set(set_index as int));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Verifiable test: allocating a range and then clearing it.
+fn test_alloc_range_and_clear_verified(number_of_bits: usize, size: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        size > 0,
+        size <= number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        let alloc_result: Result<usize, Error> = bitmap.alloc_range(size);
+        if let Ok(start) = alloc_result {
+            // Verify the range is allocated.
+            assert(bitmap@.all_bits_set_in_range(start as int, (start + size) as int));
+
+            // Clear the range.
+            let mut i: usize = start;
+            let end: usize = start + size;
+            while i < end
+                invariant
+                    start <= i <= end,
+                    end == start + size,
+                    end <= number_of_bits,
+                    bitmap.inv(),
+                    bitmap@.num_bits == number_of_bits as int,
+                    forall|j: int| start as int <= j < i as int ==> !bitmap@.is_bit_set(j),
+                    forall|j: int| i as int <= j < end as int ==> bitmap@.is_bit_set(j),
+                decreases end - i,
+            {
+                let clear_result: Result<(), Error> = bitmap.clear(i);
+                if let Ok(()) = clear_result {
+                    i = i + 1;
+                } else {
+                    break;
+                }
+            }
+
+            // If we cleared all bits successfully.
+            if i == end {
+                // All bits in the range should be cleared.
+                assert(bitmap@.all_bits_unset_in_range(start as int, end as int));
+            }
+        }
+    }
+}
+
+/// Verifiable test: usage tracking is correct.
+fn test_bitmap_usage_tracking_verified(number_of_bits: usize)
+    requires
+        number_of_bits >= 8,  // Need at least 8 bits (minimum valid bitmap size).
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Initially empty.
+        assert(bitmap@.is_empty());
+        assert(bitmap@.usage() == 0);
+
+        // Allocate first bit.
+        let alloc1: Result<usize, Error> = bitmap.alloc();
+        if let Ok(_) = alloc1 {
+            assert(bitmap@.usage() == 1);
+
+            // Allocate second bit.
+            let alloc2: Result<usize, Error> = bitmap.alloc();
+            if let Ok(_) = alloc2 {
+                assert(bitmap@.usage() == 2);
+
+                // Allocate third bit.
+                let alloc3: Result<usize, Error> = bitmap.alloc();
+                if let Ok(index3) = alloc3 {
+                    assert(bitmap@.usage() == 3);
+
+                    // Clear one bit.
+                    let clear_result: Result<(), Error> = bitmap.clear(index3);
+                    if let Ok(()) = clear_result {
+                        assert(bitmap@.usage() == 2);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Verifiable test: alloc_range preserves bits outside the allocated range.
+fn test_bitmap_alloc_range_preserves_others_verified(
+    number_of_bits: usize,
+    size: usize,
+    test_index: usize,
+)
+    requires
+        number_of_bits >= 8,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        size > 0,
+        size < number_of_bits,
+        test_index < number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        // Set a bit first.
+        let set_result: Result<(), Error> = bitmap.set(test_index);
+        if let Ok(()) = set_result {
+            // Allocate a range.
+            let alloc_result: Result<usize, Error> = bitmap.alloc_range(size);
+            if let Ok(start_index) = alloc_result {
+                // If test_index is outside the allocated range, it should still be set.
+                if test_index < start_index || test_index >= start_index + size {
+                    assert(bitmap@.is_bit_set(test_index as int));
+                }
+            }
+        }
+    }
+}
+
+/// Verifiable test: number_of_bits remains constant across operations.
+fn test_bitmap_number_of_bits_constant_verified(number_of_bits: usize, index: usize)
+    requires
+        number_of_bits > 0,
+        number_of_bits < u32::MAX as usize,
+        number_of_bits % (u8::BITS as usize) == 0,
+        index < number_of_bits,
+{
+    let result: Result<Bitmap, Error> = Bitmap::new(number_of_bits);
+    if let Ok(mut bitmap) = result {
+        let ghost initial_bits: int = bitmap@.num_bits;
+        assert(initial_bits == number_of_bits as int);
+
+        // After allocation.
+        let alloc_result: Result<usize, Error> = bitmap.alloc();
+        if let Ok(_) = alloc_result {
+            assert(bitmap@.num_bits == initial_bits);
+
+            // After setting a bit.
+            let set_result: Result<(), Error> = bitmap.set(index);
+            match set_result {
+                Ok(()) => {
+                    assert(bitmap@.num_bits == initial_bits);
+                },
+                Err(_) => {
+                    // If set failed (bit already set), number_of_bits should still be the same.
+                    assert(bitmap@.num_bits == initial_bits);
+                },
+            }
+        }
+    }
+}
+
+} // verus!

--- a/src/libs/error/Cargo.toml
+++ b/src/libs/error/Cargo.toml
@@ -10,6 +10,9 @@ authors.workspace = true
 description = "Error Codes for Nanvix"
 homepage.workspace = true
 
+[package.metadata.verus]
+verify = true
+
 [lib]
 crate-type = ["lib"]
 
@@ -17,10 +20,12 @@ crate-type = ["lib"]
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { workspace = true, optional = true }
 sysapi = { workspace = true }
+vstd = { workspace = true, optional = true }
 
 [features]
 default = []
 std = []
+verus = ["vstd"]
 rustc-dep-of-std = [
     "core",
     "compiler_builtins/rustc-dep-of-std",

--- a/src/libs/error/src/lib.rs
+++ b/src/libs/error/src/lib.rs
@@ -518,3 +518,28 @@ impl TryFrom<i64> for ErrorCode {
             .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid error code"))
     }
 }
+
+//==================================================================================================
+// External Function Specifications (Verus)
+//==================================================================================================
+
+#[cfg(verus_keep_ghost)]
+use ::vstd::prelude::*;
+
+#[cfg(verus_keep_ghost)]
+verus! {
+
+#[verifier::external_type_specification]
+pub struct ExError(crate::Error);
+
+#[verifier::external_type_specification]
+pub struct ExErrorCode(crate::ErrorCode);
+
+/// External specification for Error::new.
+pub assume_specification[ Error::new ](code: ErrorCode, reason: &'static str) -> (result: Error)
+    ensures
+        result.code == code,
+        result.reason == reason,
+;
+
+} // verus!

--- a/src/libs/raw-array/Cargo.toml
+++ b/src/libs/raw-array/Cargo.toml
@@ -13,9 +13,14 @@ homepage.workspace = true
 [lib]
 crate-type = ["lib"]
 
+[package.metadata.verus]
+verify = true
+
 [dependencies]
 cfg-if = { workspace = true }
+error = { workspace = true, features = ["verus"] }
 sys = { workspace = true }
+vstd = { workspace = true }
 
 [features]
 default = []

--- a/src/libs/raw-array/src/lib.rs
+++ b/src/libs/raw-array/src/lib.rs
@@ -43,6 +43,11 @@ use ::sys::error::{
     Error,
     ErrorCode,
 };
+use ::vstd::prelude::*;
+
+// Include specifications.
+#[cfg(verus_keep_ghost)]
+include!("lib.spec.rs");
 
 //==================================================================================================
 // Raw Array Storage
@@ -191,22 +196,50 @@ impl<T> RawArrayStorage<T> {
     }
 }
 
+// External type specifications for Verus verification.
+#[cfg(verus_keep_ghost)]
+verus! {
+
+// External type specification for RawArrayStorage.
+#[verifier::reject_recursive_types(T)]
+#[verifier::external_type_specification]
+#[verifier::external_body]
+pub struct ExRawArrayStorage<T>(RawArrayStorage<T>);
+
+} // verus!
+
 //==================================================================================================
 // Raw Array
 //==================================================================================================
+
+verus! {
 
 ///
 /// # Description
 ///
 /// A type that represent a fixed-size array.
 ///
+#[verifier::reject_recursive_types(T)]
+#[verifier::external_derive]
 #[derive(Debug)]
 pub struct RawArray<T> {
     /// The backing storage of the raw array.
     storage: RawArrayStorage<T>,
 }
 
+impl<T> View for RawArray<T> {
+    type V = Seq<T>;
+
+    /// Abstract view of the array as a sequence (uninterpreted).
+    uninterp spec fn view(&self) -> Seq<T>;
+}
+
 impl<T> RawArray<T> {
+    /// Invariant: length is positive and bounded.
+    pub closed spec fn inv(&self) -> bool {
+        self@.len() > 0 && self@.len() < i32::MAX as nat
+    }
+
     ///
     /// # Description
     ///
@@ -221,7 +254,23 @@ impl<T> RawArray<T> {
     /// On success, the new managed array is returned, with all bits set to zero.
     /// On failure, an error is returned instead.
     ///
-    pub fn new(len: usize) -> Result<RawArray<T>, Error> {
+    #[verifier::external_body]
+    pub fn new(len: usize) -> (result: Result<RawArray<T>, Error>)
+        requires
+            len > 0,
+            len < i32::MAX as usize,
+            len * vstd::layout::size_of::<T>() + vstd::layout::align_of::<T>() - 1
+                <= isize::MAX as usize,
+        ensures
+            match result {
+                Ok(me) => {
+                    &&& me.inv()
+                    &&& me@.len() == len
+                    &&& forall|i: int| 0 <= i < len ==> is_zero(#[trigger] me@[i])
+                },
+                Err(e) => e.code == ErrorCode::OutOfMemory,
+            },
+    {
         Ok(RawArray {
             storage: RawArrayStorage::new_managed(len)?,
         })
@@ -250,21 +299,61 @@ impl<T> RawArray<T> {
     /// - `ptr` must be properly aligned.
     /// - `ptr` must point to len consecutive properly initialized values of type `T``.
     ///
-    pub unsafe fn from_raw_parts(ptr: *mut T, len: usize) -> Result<RawArray<T>, Error> {
+    #[verifier::external_body]
+    pub unsafe fn from_raw_parts(ptr: *mut T, len: usize) -> (result: Result<RawArray<T>, Error>)
+        requires
+            len > 0,
+            len < i32::MAX as usize,
+            ptr.addr() != 0,
+            ptr.addr() + len * vstd::layout::size_of::<T>() + vstd::layout::align_of::<T>() - 1
+                <= usize::MAX as int,
+        ensures
+            match result {
+                Ok(me) => {
+                    &&& me.inv()
+                    &&& me@.len() == len
+                    &&& forall|i: int| 0 <= i < len ==> is_zero(#[trigger] me@[i])
+                },
+                Err(e) => e.code == ErrorCode::InvalidArgument,
+            },
+    {
         Ok(RawArray {
             storage: RawArrayStorage::new_unmanaged(ptr, len)?,
         })
+    }
+
+    /// Sets the element at index to value.
+    /// Verus does not support mutable indexing (arr[i] = val), so this method
+    /// provides a verified mutator with requires/ensures contracts.
+    #[inline]
+    #[verifier::external_body]
+    pub fn set(&mut self, index: usize, value: T)
+        requires
+            old(self).inv(),
+            0 <= index < old(self)@.len(),
+        ensures
+            self.inv(),
+            self@ == old(self)@.update(index as int, value),
+    {
+        self.storage.get_mut()[index] = value;
     }
 }
 
 impl<T> Deref for RawArray<T> {
     type Target = [T];
 
-    fn deref(&self) -> &Self::Target {
+    #[verifier::external_body]
+    fn deref(&self) -> (result: &Self::Target)
+        ensures
+            result@ == self@,
+    {
         self.storage.get()
     }
 }
 
+} // verus!
+
+// Verus does not support &mut return types, so DerefMut is outside verus!{}.
 impl<T> DerefMut for RawArray<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.storage.get_mut()

--- a/src/libs/raw-array/src/lib.spec.rs
+++ b/src/libs/raw-array/src/lib.spec.rs
@@ -1,0 +1,66 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// RawArray - Specifications
+//
+// This file contains specification functions, invariants, and View trait for RawArray.
+
+verus! {
+
+//==================================================================================================
+// Zero Initialization Specification
+//==================================================================================================
+
+/// Predicate: Specifies that a value is zero/default for its type.
+pub uninterp spec fn is_zero<T>(value: T) -> bool;
+
+/// Axiom: For u8, zero means the value is 0.
+pub axiom fn axiom_u8_zero_is_0(t: u8)
+    requires
+        is_zero(t),
+    ensures
+        t == 0,
+;
+
+/// Axiom: For usize, zero means the value is 0.
+pub axiom fn axiom_usize_zero_is_0(t: usize)
+    requires
+        is_zero(t),
+    ensures
+        t == 0,
+;
+
+//==================================================================================================
+// RawArrayView - Abstract Specification Model
+//==================================================================================================
+
+/// Abstract view of a RawArray as a sequence (ghost/spec-level representation).
+#[verifier::ext_equal]
+pub struct RawArrayView<T> {
+    pub contents: Seq<T>,
+}
+
+impl<T> RawArrayView<T> {
+    /// Returns the length of the array view.
+    pub open spec fn len(&self) -> nat {
+        self.contents.len()
+    }
+
+    /// Returns the element at index i.
+    pub open spec fn index(&self, i: int) -> T
+        recommends
+            0 <= i < self.len() as int,
+    {
+        self.contents[i]
+    }
+
+    /// Returns a new view with the element at index i updated to value.
+    pub open spec fn update(&self, i: int, value: T) -> RawArrayView<T>
+        recommends
+            0 <= i < self.len() as int,
+    {
+        RawArrayView { contents: self.contents.update(i, value) }
+    }
+}
+
+} // verus!

--- a/src/libs/slab/Cargo.toml
+++ b/src/libs/slab/Cargo.toml
@@ -9,13 +9,18 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 
+[package.metadata.verus]
+verify = true
+
 [lib]
 crate-type = ["lib"]
 
 [dependencies]
 bitmap = { workspace = true }
+error = { workspace = true, features = ["verus"] }
 raw-array = { workspace = true }
 sys = { workspace = true }
+vstd = { workspace = true }
 
 [features]
 default = []

--- a/src/libs/slab/src/lib.proof.rs
+++ b/src/libs/slab/src/lib.proof.rs
@@ -1,0 +1,1768 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// Proofs and lemmas.
+
+verus! {
+
+impl Slab {
+    //==============================================================================================
+
+    /// Loop invariant for the index initialization loop in `from_raw_parts`.
+    spec fn from_raw_parts_init_loop_invariant(
+        index: Bitmap,
+        i: usize,
+        num_index_blocks: usize,
+        num_data_blocks: usize,
+        total_num_blocks: usize,
+        block_size: usize,
+        data_addr: *mut u8,
+    ) -> bool {
+        &&& index.inv()
+        &&& i <= num_index_blocks
+        &&& num_index_blocks < total_num_blocks
+        &&& num_index_blocks > 0
+        &&& num_data_blocks > 0
+        &&& block_size > 0
+        &&& data_addr as int > 0
+        &&& num_index_blocks + num_data_blocks == total_num_blocks
+        &&& index@.num_bits == total_num_blocks as int
+        &&& num_index_blocks as int + num_data_blocks as int == index@.num_bits
+        &&& forall|j: int|
+            #![trigger index@.set_bits.contains(j)]
+            0 <= j < i as int ==> index@.set_bits.contains(j)
+        &&& forall|j: int|
+            #![trigger index@.set_bits.contains(j)]
+            i as int <= j < index@.num_bits ==> !index@.set_bits.contains(j)
+    }
+
+    //==============================================================================================
+    /// Lemma: Prove that a Slab satisfies the invariant given its components satisfy the conditions.
+    proof fn lemma_inv_from_components(slab: &Slab)
+        requires
+            slab.index.inv(),
+            slab.block_size > 0,
+            slab.num_data_blocks > 0,
+            slab.num_index_blocks > 0,
+            slab.num_index_blocks + slab.num_data_blocks == slab.index@.num_bits,
+            forall|i: int|
+                #![trigger slab.index@.set_bits.contains(i)]
+                0 <= i < slab.num_index_blocks as int ==> slab.index@.set_bits.contains(i),
+            slab.data_addr as int > 0,
+            (slab.num_data_blocks as int) * (slab.block_size as int) <= usize::MAX as int,
+            (slab.data_addr as int) + (slab.num_data_blocks as int) * (slab.block_size as int)
+                <= usize::MAX as int,
+            slab.data_addr as int >= slab.num_index_blocks as int * slab.block_size as int,
+            is_pow2(slab.block_size as int),
+            slab.data_addr as int % slab.block_size as int == 0,
+        ensures
+            slab.inv(),
+    {
+    }
+
+    /// Lemma: Reveal the relationship between slab view and slab fields.
+    proof fn lemma_view_fields(slab: &Slab)
+        requires
+            slab.inv(),
+        ensures
+            slab@.block_size == slab.block_size as int,
+            slab@.data_addr == slab.data_addr as int,
+            slab@.num_data_blocks == slab.num_data_blocks as int,
+    {
+    }
+
+    /// Lemma: If no block is allocated, the slab is empty.
+    /// Bridges `forall|i| !is_allocated(i)` to `is_empty()`.
+    ///
+    /// # Proof Strategy
+    ///
+    /// We prove that allocated_blocks == empty set by showing no element can be in it.
+    /// - For i in [0, num_data_blocks): !is_allocated(i) by precondition.
+    /// - For i outside this range: !is_allocated(i) by allocated_blocks_in_range (from inv).
+    /// Therefore, forall i, !allocated_blocks.contains(i), so allocated_blocks =~= Set::empty().
+    pub proof fn lemma_no_allocated_implies_empty(slab: &Slab)
+        requires
+            slab.inv(),
+            forall|i: int| 0 <= i < slab@.num_data_blocks ==> !slab@.is_allocated(i),
+        ensures
+            slab@.is_empty(),
+    {
+        // Proof: All data blocks unset means no block in allocated_blocks.
+        assert(slab@.allocated_blocks =~= Set::<int>::empty()) by {
+            // For any i, show !allocated_blocks.contains(i).
+            assert forall|i: int| !slab@.allocated_blocks.contains(i) by {
+                if 0 <= i < slab@.num_data_blocks {
+                    assert(!slab@.is_allocated(i));
+                } else {
+                    assert(slab@.allocated_blocks_in_range());
+                    assert(!slab@.is_allocated(i));
+                }
+            }
+        }
+    }
+
+    /// Lemma: Reveal that a newly created slab with no data blocks allocated has no allocated blocks.
+    proof fn lemma_new_slab_is_empty(slab: &Slab)
+        requires
+            slab.inv(),
+            forall|i: int|
+                slab.num_index_blocks as int <= i < (slab.num_index_blocks
+                    + slab.num_data_blocks) as int ==> !slab.index@.is_bit_set(i),
+        ensures
+            forall|i: int| 0 <= i < slab@.num_data_blocks ==> !slab@.is_allocated(i),
+    {
+        assert forall|i: int| 0 <= i < slab@.num_data_blocks implies !slab@.is_allocated(i) by {
+            let bitmap_idx = slab.num_index_blocks as int + i;
+            assert(!slab.index@.is_bit_set(bitmap_idx));
+        }
+    }
+
+    /// Lemma: Slab invariant implies Bitmap invariant.
+    proof fn lemma_slab_inv_implies_bitmap_inv(&self)
+        requires
+            self.inv(),
+        ensures
+            self.index.inv(),
+            self.index@.num_bits <= (usize::MAX as int),
+    {
+        self.index.lemma_number_of_bits_bounded();
+    }
+
+    //==============================================================================================
+    /// Helper lemma: allocated_blocks is a subset of set_int_range(0, num_data_blocks).
+    /// This follows from allocated_blocks_in_range: forall|i| is_allocated(i) ==> 0 <= i < num_data_blocks.
+    proof fn lemma_allocated_blocks_subset_of_range(&self)
+        requires
+            self.inv(),
+        ensures
+            self@.allocated_blocks.subset_of(set_int_range(0, self@.num_data_blocks)),
+    {
+    }
+
+    /// Helper lemma: allocated_blocks is finite.
+    /// Since allocated_blocks is a subset of set_int_range(0, num_data_blocks), and that's finite,
+    /// allocated_blocks is also finite.
+    proof fn lemma_allocated_blocks_finite(&self)
+        requires
+            self.inv(),
+        ensures
+            self@.allocated_blocks.finite(),
+    {
+        let num_data: int = self@.num_data_blocks;
+        // Now prove allocated_blocks == set_int_range(0, num_data).
+        let full_range: Set<int> = set_int_range(0, num_data);
+
+        // Prove full_range is finite.
+        lemma_int_range(0, num_data);
+        assert(full_range.finite());
+
+        // Use lemma_allocated_blocks_subset_of_range to prove the subset property.
+        self.lemma_allocated_blocks_subset_of_range();
+        assert(self@.allocated_blocks.subset_of(full_range));
+
+        lemma_set_subset_finite(full_range, self@.allocated_blocks);
+    }
+
+    /// Lemma (Liveness): If slab can_allocate(), then bitmap has_free_bit().
+    /// This is the key lemma connecting slab liveness to bitmap liveness.
+    ///
+    /// Proof sketch:
+    /// - can_allocate() means free() > 0
+    /// - free() = capacity - used = num_data_blocks - |allocated_blocks|
+    /// - If free() > 0, then |allocated_blocks| < num_data_blocks
+    /// - allocated_blocks = { i | 0 <= i < num_data_blocks && is_bit_set(num_index_blocks + i) }
+    /// - If |allocated_blocks| < num_data_blocks, there exists some data index j not in allocated_blocks
+    /// - That means is_bit_set(num_index_blocks + j) is false
+    /// - Therefore, there's an unset bit in the bitmap => has_free_bit()
+    ///
+    /// Proves that if the slab can allocate, then the bitmap has a free bit.
+    /// This connects liveness (can_allocate) to the concrete bitmap state.
+    proof fn lemma_can_allocate_implies_bitmap_has_free_bit(&self)
+        requires
+            self.inv(),
+            self@.can_allocate(),
+        ensures
+            self.index@.has_free_bit(),
+    {
+        // Strategy: We know |allocated_blocks| < num_data_blocks.
+        let num_data: int = self.num_data_blocks as int;
+        let num_idx: int = self.num_index_blocks as int;
+
+        assert(self@.allocated_blocks.len() < num_data);
+
+        let full_range: Set<int> = set_int_range(0, num_data);
+        lemma_int_range(0, num_data);
+        assert(full_range.finite());
+        assert(full_range.len() == num_data);
+
+        // Use helper lemmas to prove finiteness and subset properties.
+        self.lemma_allocated_blocks_finite();
+        assert(self@.allocated_blocks.finite());
+
+        self.lemma_allocated_blocks_subset_of_range();
+        assert(self@.allocated_blocks.subset_of(full_range));
+
+        // Prove by contradiction: if all elements of full_range were in allocated_blocks,
+        if forall|j: int| #![auto] full_range.contains(j) ==> self@.allocated_blocks.contains(j) {
+            assert(full_range.subset_of(self@.allocated_blocks));
+            lemma_len_subset(full_range, self@.allocated_blocks);
+            assert(full_range.len() <= self@.allocated_blocks.len());
+            // Contradiction: num_data <= allocated_blocks.len() < num_data is impossible.
+            assert(false);
+        }
+        let j: int = choose|j: int|
+            #![auto]
+            full_range.contains(j) && !self@.allocated_blocks.contains(j);
+
+        assert(0 <= j && j < num_data);
+
+        assert(!self@.is_allocated(j));
+
+        let bitmap_idx: int = num_idx + j;
+
+        assert(0 <= bitmap_idx);
+        assert(bitmap_idx < self.index@.num_bits);
+
+        assert(!self.index@.is_bit_set(bitmap_idx));
+
+        self.index@.lemma_unset_bit_implies_has_free_bit(bitmap_idx);
+        assert(self.index@.has_free_bit());
+    }
+
+    //==============================================================================================
+    /// Lemma: Block memory regions are disjoint for different block indices.
+    /// This proves the no_memory_aliasing property.
+    proof fn lemma_blocks_disjoint(view: &SlabView, i: int, j: int)
+        requires
+            view.block_size > 0,
+            0 <= i < view.num_data_blocks,
+            0 <= j < view.num_data_blocks,
+            i != j,
+        ensures
+            view.blocks_are_disjoint(i, j),
+    {
+        // Proof:
+        let addr_i = view.block_addr(i);
+        let addr_j = view.block_addr(j);
+        // Proof:
+        let bs = view.block_size;
+
+        assert(addr_i == view.data_addr + i * bs);
+        assert(addr_j == view.data_addr + j * bs);
+
+        vstd::arithmetic::mul::lemma_mul_is_distributive_sub(bs, j, i);
+        assert(bs * (j - i) == bs * j - bs * i);
+
+        vstd::arithmetic::mul::lemma_mul_is_commutative(bs, j - i);
+        vstd::arithmetic::mul::lemma_mul_is_commutative(bs, j);
+        vstd::arithmetic::mul::lemma_mul_is_commutative(bs, i);
+        assert((j - i) * bs == j * bs - i * bs);
+
+        vstd::arithmetic::mul::lemma_mul_is_distributive_sub(bs, i, j);
+        vstd::arithmetic::mul::lemma_mul_is_commutative(bs, i - j);
+        assert((i - j) * bs == i * bs - j * bs);
+
+        if i < j {
+            let diff = j - i;
+            assert(diff >= 1);
+            vstd::arithmetic::mul::lemma_mul_inequality(1, diff, bs);
+            assert(1 * bs <= diff * bs);
+            assert(bs <= diff * bs);
+            assert(addr_j - addr_i == j * bs - i * bs);
+            assert(addr_j - addr_i == diff * bs);
+            assert(addr_j - addr_i >= bs);
+            assert(addr_i + bs <= addr_j);
+        } else {
+            let diff = i - j;
+            assert(diff >= 1);
+            vstd::arithmetic::mul::lemma_mul_inequality(1, diff, bs);
+            assert(1 * bs <= diff * bs);
+            assert(bs <= diff * bs);
+            assert(addr_i - addr_j == i * bs - j * bs);
+            assert(addr_i - addr_j == diff * bs);
+            assert(addr_i - addr_j >= bs);
+            assert(addr_j + bs <= addr_i);
+        }
+    }
+
+    /// Lemma: block_addr(addr_to_block_idx(a)) == a for valid addresses.
+    /// This proves the inverse relationship for valid addresses.
+    proof fn lemma_block_addr_inverse(view: &SlabView, addr: int)
+        requires
+            view.block_size > 0,
+            view.is_valid_addr(addr),
+        ensures
+            view.block_addr_inverse(addr),
+    {
+        let bs = view.block_size;
+        let data_addr = view.data_addr;
+        let offset = addr - data_addr;
+
+        assert(offset >= 0);
+        assert(offset % bs == 0);
+
+        assert((offset / bs) * bs == offset) by (nonlinear_arith)
+            requires
+                bs > 0,
+                offset >= 0,
+                offset % bs == 0,
+        ;
+
+        let k = offset / bs;
+        assert(view.addr_to_block_idx(addr) == k);
+
+        assert(view.block_addr(k) == data_addr + k * bs);
+        assert(k * bs == offset);
+        assert(data_addr + offset == addr);
+    }
+
+    //==============================================================================================
+    /// Lemma: a * b is always divisible by b (when b > 0).
+    proof fn lemma_mul_divisible(a: int, b: int)
+        requires
+            b > 0,
+        ensures
+            (a * b) % b == 0,
+    {
+        assert((a * b) % b == 0) by (nonlinear_arith)
+            requires
+                b > 0,
+        ;
+    }
+
+    /// Lemma: (a * b) / b == a (when b > 0).
+    proof fn lemma_div_cancel(a: int, b: int)
+        requires
+            b > 0,
+        ensures
+            (a * b) / b == a,
+    {
+        assert((a * b) / b == a) by (nonlinear_arith)
+            requires
+                b > 0,
+        ;
+    }
+
+    /// Lemma: if a < b and c > 0, then a * c < b * c.
+    proof fn lemma_mul_inequality(a: int, b: int, c: int)
+        requires
+            a < b,
+            c > 0,
+        ensures
+            a * c < b * c,
+    {
+        assert(a * c < b * c) by (nonlinear_arith)
+            requires
+                a < b,
+                c > 0,
+        ;
+    }
+
+    /// Lemma: if q = a / b (integer division), then q * b <= a.
+    proof fn lemma_div_mul_le(a: int, b: int)
+        requires
+            b > 0,
+            a >= 0,
+        ensures
+            (a / b) * b <= a,
+    {
+        assert((a / b) * b <= a) by (nonlinear_arith)
+            requires
+                b > 0,
+                a >= 0,
+        ;
+    }
+
+    /// Lemma: distributive property (a + b) * c == a * c + b * c.
+    proof fn lemma_distributive(a: int, b: int, c: int)
+        ensures
+            (a + b) * c == a * c + b * c,
+    {
+        assert((a + b) * c == a * c + b * c) by (nonlinear_arith);
+    }
+
+    /// Trusted bridge: bitwise check `n & (n - 1) == 0` implies `is_pow2(n)`.
+    ///
+    /// # Trust Justification
+    ///
+    /// n & (n - 1) == 0 iff n is a power of two. See Hacker's Delight, Chapter 2.
+    #[verifier::external_body]
+    proof fn lemma_bitwise_implies_is_pow2(n: usize)
+        requires
+            n > 0,
+            n & sub(n, 1) == 0,
+        ensures
+            is_pow2(n as int),
+    {
+    }
+
+    /// Proves that after a failed clear, slab invariant is preserved.
+    proof fn lemma_dealloc_clear_err_preserves_inv(slab: &Slab, old_slab: &Slab)
+        requires
+            old_slab.inv(),
+            slab.index.inv(),
+            slab.index@.set_bits =~= old_slab.index@.set_bits,
+            slab.index@.num_bits == old_slab.index@.num_bits,
+            slab.num_index_blocks == old_slab.num_index_blocks,
+            slab.num_data_blocks == old_slab.num_data_blocks,
+            slab.block_size == old_slab.block_size,
+            slab.data_addr == old_slab.data_addr,
+        ensures
+            slab.inv(),
+    {
+        // Prove all index blocks are still set (using set_bits trigger for lemma_inv_from_components).
+        assert forall|j: int| 0 <= j < slab.num_index_blocks as int implies slab.index@.is_bit_set(
+            j,
+        ) by {
+            assert(old_slab.index@.is_bit_set(j));
+        }
+        // Prove inv().
+        Self::lemma_inv_from_components(slab);
+    }
+
+    //==============================================================================================
+    // Extracted proof-block lemmas
+    //==============================================================================================
+    /// Lemma: Proves layout bounds during slab construction.
+    /// Establishes that num_index_blocks >= 1, num_data_blocks > 0,
+    /// and the product num_index_blocks * block_size is bounded.
+    proof fn lemma_from_raw_parts_layout_bounds(
+        len: usize,
+        block_size: usize,
+        total_num_blocks: usize,
+        index_len: usize,
+        num_index_blocks: usize,
+        num_data_blocks: usize,
+        addr: usize,
+    )
+        requires
+            len > 0,
+            len < i32::MAX as usize,
+            block_size > 0,
+            block_size <= len,
+            addr > 0,
+            addr as int + len as int <= usize::MAX as int,
+            total_num_blocks == len / block_size,
+            total_num_blocks >= 8,
+            index_len == total_num_blocks / 8,
+            num_index_blocks == index_len / block_size + (if index_len % block_size == 0 {
+                0usize
+            } else {
+                1usize
+            }),
+            num_index_blocks <= total_num_blocks,
+            num_data_blocks == total_num_blocks - num_index_blocks,
+        ensures
+            num_index_blocks >= 1,
+            num_data_blocks > 0,
+            (num_index_blocks as int) * (block_size as int) < (total_num_blocks as int) * (
+            block_size as int),
+            (total_num_blocks as int) * (block_size as int) <= len as int,
+            (addr as int) + (num_index_blocks as int) * (block_size as int) <= (addr as int) + (
+            len as int),
+            (addr as int) + (num_index_blocks as int) * (block_size as int) <= usize::MAX as int,
+    {
+        assert(index_len >= 1);
+        // Prove num_index_blocks >= 1.
+        if index_len >= block_size {
+            assert(index_len / block_size >= 1) by (nonlinear_arith)
+                requires
+                    index_len >= block_size,
+                    block_size > 0int,
+            ;
+        } else {
+            assert(index_len % block_size == index_len) by (nonlinear_arith)
+                requires
+                    0 < index_len < block_size,
+            ;
+            assert(index_len % block_size != 0);
+        }
+        assert(num_index_blocks >= 1);
+        // Prove num_data_blocks > 0.
+        assert(num_index_blocks <= index_len + 1) by {
+            assert(index_len / block_size <= index_len) by (nonlinear_arith)
+                requires
+                    block_size >= 1int,
+                    index_len >= 0int,
+            ;
+        }
+        assert(index_len + 1 <= total_num_blocks) by {
+            assert(total_num_blocks / 8 + 1 <= total_num_blocks) by (nonlinear_arith)
+                requires
+                    total_num_blocks >= 8int,
+            ;
+        }
+        assert(num_index_blocks < total_num_blocks);
+        assert(num_data_blocks > 0);
+        // Prove product bounds.
+        Self::lemma_div_mul_le(len as int, block_size as int);
+        Self::lemma_mul_inequality(
+            num_index_blocks as int,
+            total_num_blocks as int,
+            block_size as int,
+        );
+    }
+
+    /// Lemma: Converts is_zero properties on a byte sequence to concrete equality with 0u8.
+    proof fn lemma_raw_array_storage_zeroed(s: Seq<u8>)
+        requires
+            forall|i: int| 0 <= i < s.len() ==> is_zero(#[trigger] s[i]),
+        ensures
+            forall|i: int| 0 <= i < s.len() ==> s[i] == 0u8,
+    {
+        assert forall|i: int| 0 <= i < s.len() implies s[i] == 0u8 by {
+            axiom_u8_zero_is_0(s[i]);
+        }
+    }
+
+    /// Lemma: Establishes pre-loop invariants for from_raw_parts.
+    /// Connects bitmap num_bits to total_num_blocks and layout.
+    proof fn lemma_from_raw_parts_pre_loop(
+        index_nbits: int,
+        index_len: int,
+        total_num_blocks: int,
+        num_index_blocks: int,
+        num_data_blocks: int,
+    )
+        requires
+            index_nbits == index_len * 8,
+            total_num_blocks == index_len * 8,
+            num_index_blocks + num_data_blocks == total_num_blocks,
+            num_index_blocks < total_num_blocks,
+        ensures
+            index_nbits == total_num_blocks,
+            num_index_blocks + num_data_blocks == index_nbits,
+    {
+    }
+
+    /// Lemma: Proves postconditions after the initialization loop in from_raw_parts.
+    /// Establishes slab invariant, view fields, and emptiness.
+    proof fn lemma_from_raw_parts_post_loop(slab: &Slab, addr: int, len: int, total_num_blocks: int)
+        requires
+            slab.index.inv(),
+            slab.block_size > 0,
+            slab.num_data_blocks > 0,
+            slab.num_index_blocks > 0,
+            forall|i: int|
+                #![trigger slab.index@.set_bits.contains(i)]
+                0 <= i < slab.num_index_blocks as int ==> slab.index@.set_bits.contains(i),
+            forall|i: int|
+                slab.num_index_blocks as int <= i < slab.index@.num_bits
+                    ==> !slab.index@.is_bit_set(i),
+            (slab.num_index_blocks as int) + (slab.num_data_blocks as int) == slab.index@.num_bits,
+            total_num_blocks == slab.index@.num_bits,
+            (slab.num_data_blocks as int) < total_num_blocks,
+            (slab.data_addr as int) == addr + (slab.num_index_blocks as int) * (
+            slab.block_size as int),
+            addr > 0,
+            len > 0,
+            len < i32::MAX as int,
+            slab.block_size as int <= len,
+            addr + len <= usize::MAX as int,
+            total_num_blocks == len / slab.block_size as int,
+            is_pow2(slab.block_size as int),
+            slab.data_addr as int % slab.block_size as int == 0,
+        ensures
+            slab.inv(),
+            slab@.block_size == slab.block_size as int,
+            slab@.allocated_blocks =~= Set::<int>::empty(),
+            slab@.data_addr > addr,
+            slab@.data_addr % slab.block_size as int == 0,
+            slab@.num_data_blocks > 0,
+            slab@.data_addr + slab@.num_data_blocks * slab@.block_size <= addr + len,
+    {
+        // Prove memory bounds.
+        Self::lemma_div_mul_le(len, slab.block_size as int);
+        assert(total_num_blocks == len / slab.block_size as int);
+        assert(total_num_blocks * slab.block_size as int <= len);
+        Self::lemma_mul_inequality(
+            slab.num_data_blocks as int,
+            total_num_blocks,
+            slab.block_size as int,
+        );
+        assert((slab.num_data_blocks as int) * (slab.block_size as int) < total_num_blocks
+            * slab.block_size as int);
+        assert(len < usize::MAX as int);
+        assert((slab.num_data_blocks as int) * (slab.block_size as int) <= usize::MAX as int);
+
+        // Prove metadata/data disjointness.
+        assert(slab.data_addr as int == addr + slab.num_index_blocks as int
+            * slab.block_size as int);
+        Self::lemma_distributive(
+            slab.num_index_blocks as int,
+            slab.num_data_blocks as int,
+            slab.block_size as int,
+        );
+        assert(slab.num_index_blocks as int * slab.block_size as int + slab.num_data_blocks as int
+            * slab.block_size as int == (slab.num_index_blocks as int + slab.num_data_blocks as int)
+            * slab.block_size as int);
+        assert(slab.data_addr as int + slab.num_data_blocks as int * slab.block_size as int == addr
+            + (slab.num_index_blocks as int + slab.num_data_blocks as int)
+            * slab.block_size as int);
+        assert(slab.num_index_blocks as int + slab.num_data_blocks as int == total_num_blocks);
+        assert(slab.data_addr as int + slab.num_data_blocks as int * slab.block_size as int == addr
+            + total_num_blocks * slab.block_size as int);
+        assert(total_num_blocks * slab.block_size as int <= len);
+        assert(addr + total_num_blocks * slab.block_size as int <= addr + len);
+        assert(addr + len <= usize::MAX as int);
+        assert(slab.data_addr as int + slab.num_data_blocks as int * slab.block_size as int
+            <= usize::MAX as int);
+
+        assert(slab.data_addr as int == addr + slab.num_index_blocks as int
+            * slab.block_size as int);
+        assert(addr > 0);
+        assert(slab.data_addr as int > slab.num_index_blocks as int * slab.block_size as int);
+        assert(slab.data_addr as int >= slab.num_index_blocks as int * slab.block_size as int);
+
+        Self::lemma_inv_from_components(slab);
+        Self::lemma_view_fields(slab);
+        Self::lemma_new_slab_is_empty(slab);
+        assert(slab@.allocated_blocks =~= Set::<int>::empty()) by {
+            assert forall|i: int| !slab@.allocated_blocks.contains(i) by {
+                if 0 <= i < slab@.num_data_blocks {
+                    assert(!slab@.is_allocated(i));
+                } else {
+                    assert(slab@.allocated_blocks_in_range());
+                    assert(!slab@.is_allocated(i));
+                }
+            }
+        }
+        assert(slab.data_addr as int > addr);
+        assert(slab.data_addr as int % slab.block_size as int == 0);
+        assert(slab@.data_addr + slab@.num_data_blocks * slab@.block_size <= addr + len);
+    }
+
+    /// Lemma: When bitmap alloc fails, slab state is preserved and cannot allocate.
+    proof fn lemma_alloc_error_preserves_state(slab: &Slab, old_slab: &Slab)
+        requires
+            old_slab.inv(),
+            slab.index.inv(),
+            slab.index@.set_bits =~= old_slab.index@.set_bits,
+            slab.index@.num_bits == old_slab.index@.num_bits,
+            slab.num_index_blocks == old_slab.num_index_blocks,
+            slab.num_data_blocks == old_slab.num_data_blocks,
+            slab.block_size == old_slab.block_size,
+            slab.data_addr == old_slab.data_addr,
+            !slab.index@.has_free_bit(),
+        ensures
+            slab.inv(),
+            slab@ == old_slab@,
+            !old_slab@.can_allocate(),
+    {
+        // Liveness: if can_allocate(), bitmap has_free_bit - contradiction.
+        if old_slab@.can_allocate() {
+            old_slab.lemma_can_allocate_implies_bitmap_has_free_bit();
+            assert(false);
+        }
+        // Prove index blocks still set.
+
+        assert forall|i: int|
+            0 <= i < slab.num_index_blocks as int implies #[trigger] slab.index@.set_bits.contains(
+            i,
+        ) by {
+            assert(old_slab.index@.set_bits.contains(i));
+            assert(slab.index@.set_bits.contains(i) == old_slab.index@.set_bits.contains(i));
+        }
+        Self::lemma_inv_from_components(slab);
+        // Prove view equality.
+        assert(slab@.num_data_blocks == old_slab@.num_data_blocks);
+        assert(slab@.block_size == old_slab@.block_size);
+        assert(slab@.data_addr == old_slab@.data_addr);
+        assert(slab@.allocated_blocks =~= old_slab@.allocated_blocks) by {
+            assert forall|j: int| 0 <= j < slab.num_data_blocks as int implies (
+            slab@.allocated_blocks.contains(j) == old_slab@.allocated_blocks.contains(j)) by {
+                let bitmap_idx: int = slab.num_index_blocks as int + j;
+                assert(slab.index@.set_bits.contains(bitmap_idx)
+                    == old_slab.index@.set_bits.contains(bitmap_idx));
+            }
+        }
+        assert(slab@ == old_slab@);
+    }
+
+    /// Lemma: After bitmap alloc, the returned bit is a data block with valid bounds.
+    proof fn lemma_alloc_block_is_data_block_with_bounds(slab: &Slab, old_slab: &Slab, block: int)
+        requires
+            old_slab.inv(),
+            slab.inv(),
+            0 <= block < old_slab.index@.num_bits,
+            !old_slab.index@.is_bit_set(block),
+            slab.index@.is_bit_set(block),
+            slab.num_index_blocks == old_slab.num_index_blocks,
+            slab.num_data_blocks == old_slab.num_data_blocks,
+            slab.block_size == old_slab.block_size,
+            slab.data_addr == old_slab.data_addr,
+            slab.index@.num_bits == old_slab.index@.num_bits,
+        ensures
+            block >= slab.num_index_blocks as int,
+            block < (slab.num_index_blocks + slab.num_data_blocks) as int,
+    {
+        assert(block >= slab.num_index_blocks as int) by {
+            if block < slab.num_index_blocks as int {
+                assert(old_slab.index@.is_bit_set(block));
+            }
+        };
+        assert(old_slab.num_index_blocks as int + old_slab.num_data_blocks as int
+            == slab.index@.num_bits);
+        assert(block < slab.index@.num_bits);
+        assert(block < (slab.num_index_blocks + slab.num_data_blocks) as int);
+    }
+
+    /// Lemma: block_idx * block_size and data_addr + block_idx * block_size fit in usize.
+    proof fn lemma_alloc_product_in_bounds(slab: &Slab, block_idx: int)
+        requires
+            slab.inv(),
+            0 <= block_idx < (slab.num_data_blocks as int),
+        ensures
+            block_idx * (slab.block_size as int) < (slab.num_data_blocks as int) * (
+            slab.block_size as int),
+            block_idx * (slab.block_size as int) <= usize::MAX as int,
+            (slab.data_addr as int) + block_idx * (slab.block_size as int) <= usize::MAX as int,
+    {
+        Self::lemma_mul_inequality(block_idx, slab.num_data_blocks as int, slab.block_size as int);
+    }
+
+    /// Lemma: Establishes allocate postconditions (address validity, block index, frame).
+    proof fn lemma_alloc_establishes_postconditions(
+        slab: &Slab,
+        old_slab: &Slab,
+        block: int,
+        block_idx: int,
+        block_addr: int,
+    )
+        requires
+            old_slab.inv(),
+            slab.inv(),
+            block_idx == block - (slab.num_index_blocks as int),
+            0 <= block_idx < (slab.num_data_blocks as int),
+            block_addr == (slab.data_addr as int) + block_idx * (slab.block_size as int),
+            slab.index@.is_bit_set((slab.num_index_blocks as int) + block_idx),
+            !old_slab.index@.is_bit_set((slab.num_index_blocks as int) + block_idx),
+            forall|k: int|
+                k != block && 0 <= k < slab.index@.num_bits ==> slab.index@.is_bit_set(k)
+                    == old_slab.index@.is_bit_set(k),
+            slab.num_index_blocks == old_slab.num_index_blocks,
+            slab.num_data_blocks == old_slab.num_data_blocks,
+            slab.block_size == old_slab.block_size,
+            slab.data_addr == old_slab.data_addr,
+        ensures
+            old_slab@.is_valid_addr(block_addr),
+            old_slab@.addr_to_block_idx(block_addr) == block_idx,
+            !old_slab@.is_allocated(block_idx),
+            slab@.is_allocated(block_idx),
+            slab@.num_data_blocks == old_slab@.num_data_blocks,
+            slab@.block_size == old_slab@.block_size,
+            slab@.data_addr == old_slab@.data_addr,
+            slab@.allocated_blocks =~= old_slab@.allocated_blocks.insert(block_idx),
+            block_addr > 0,
+    {
+        Self::lemma_view_fields(old_slab);
+        let bs: int = slab.block_size as int;
+        let ndb: int = slab.num_data_blocks as int;
+
+        // Address validity proofs.
+        assert(block_addr == slab.data_addr as int + block_idx * bs);
+        Self::lemma_mul_inequality(block_idx, ndb, bs);
+        assert(block_addr < slab.data_addr as int + ndb * bs);
+        Self::lemma_mul_divisible(block_idx, bs);
+        assert((block_addr - slab.data_addr as int) % bs == 0);
+        assert(old_slab@.is_valid_addr(block_addr));
+
+        // Block index computation.
+        Self::lemma_div_cancel(block_idx, bs);
+        assert(old_slab@.addr_to_block_idx(block_addr) == block_idx);
+
+        // Allocation status.
+        assert(!old_slab@.is_allocated(block_idx));
+        assert(slab@.is_allocated(block_idx));
+
+        // Other bits unchanged.
+        assert forall|i: int|
+            0 <= i < ndb && i != block_idx implies #[trigger] slab.index@.is_bit_set(
+            slab.num_index_blocks as int + i,
+        ) == #[trigger] old_slab.index@.is_bit_set(slab.num_index_blocks as int + i) by {
+            let global_idx: int = slab.num_index_blocks as int + i;
+            if global_idx == block {
+                assert(i == block_idx);
+            }
+        }
+        // Frame for allocated_blocks.
+        assert forall|i: int| 0 <= i < ndb && i != block_idx implies slab@.is_allocated(i)
+            == old_slab@.is_allocated(i) by {
+            let bitmap_idx: int = slab.num_index_blocks as int + i;
+            assert(slab.index@.is_bit_set(bitmap_idx) == old_slab.index@.is_bit_set(bitmap_idx));
+        }
+        // Prove allocated_blocks =~= old_allocated_blocks.insert(block_idx).
+        assert(slab@.allocated_blocks =~= old_slab@.allocated_blocks.insert(block_idx)) by {
+            assert forall|j: int|
+                #![auto]
+                slab@.allocated_blocks.contains(j) == old_slab@.allocated_blocks.insert(
+                    block_idx,
+                ).contains(j) by {
+                if j == block_idx {
+                    assert(slab@.is_allocated(block_idx));
+                } else if 0 <= j < ndb {
+                    assert(slab@.is_allocated(j) == old_slab@.is_allocated(j));
+                } else {
+                    assert(slab@.allocated_blocks_in_range());
+                    assert(!slab@.is_allocated(j));
+                    assert(old_slab@.allocated_blocks_in_range());
+                    assert(!old_slab@.is_allocated(j));
+                }
+            }
+        }
+    }
+
+    /// Lemma: Proves offset and index bounds for deallocate.
+    proof fn lemma_dealloc_offset_bounds(slab: &Slab, ptr: int)
+        requires
+            slab.inv(),
+            slab@.is_valid_addr(ptr),
+            slab@.can_deallocate(slab@.addr_to_block_idx(ptr)),
+        ensures
+            ptr >= (slab.data_addr as int),
+            (ptr - (slab.data_addr as int)) >= 0,
+            (ptr - (slab.data_addr as int)) < (slab.num_data_blocks as int) * (
+            slab.block_size as int),
+            ((ptr - (slab.data_addr as int)) % (slab.block_size as int)) == 0,
+            ({
+                let block_idx: int = (ptr - (slab.data_addr as int)) / (slab.block_size as int);
+                &&& 0 <= block_idx < (slab.num_data_blocks as int)
+                &&& (slab.num_index_blocks as int) + block_idx < slab.index@.num_bits
+                &&& (slab.num_index_blocks as int) + block_idx < usize::MAX as int
+            }),
+    {
+        assert(ptr >= slab.data_addr as int);
+        assert(ptr < slab.data_addr as int + slab.num_data_blocks as int * slab.block_size as int);
+        assert((ptr - slab.data_addr as int) % slab.block_size as int == 0);
+
+        let offset: int = ptr - slab.data_addr as int;
+        assert(offset >= 0);
+        assert(offset < slab.num_data_blocks as int * slab.block_size as int);
+
+        let block_idx: int = offset / slab.block_size as int;
+        assert(0 <= block_idx < slab.num_data_blocks as int);
+        assert(slab.num_index_blocks as int + block_idx < slab.index@.num_bits);
+
+        // Prove no overflow for usize computation.
+        assert(slab.num_index_blocks as int + block_idx < slab.num_index_blocks as int
+            + slab.num_data_blocks as int);
+        assert(slab.num_index_blocks as int + slab.num_data_blocks as int == slab.index@.num_bits);
+        Self::lemma_slab_inv_implies_bitmap_inv(slab);
+        assert(slab.index@.num_bits <= usize::MAX as int);
+        assert(slab.num_index_blocks as int + block_idx < usize::MAX as int);
+    }
+
+    /// Lemma: Connects the computed index to addr_to_block_idx and proves the bit is set.
+    proof fn lemma_dealloc_index_is_allocated(slab: &Slab, ptr: int, index: int)
+        requires
+            slab.inv(),
+            slab@.is_valid_addr(ptr),
+            slab@.can_deallocate(slab@.addr_to_block_idx(ptr)),
+            index == (slab.num_index_blocks as int) + (ptr - (slab.data_addr as int)) / (
+            slab.block_size as int),
+            index < slab.index@.num_bits,
+        ensures
+            slab.index@.is_bit_set(index),
+            slab@.is_allocated(slab@.addr_to_block_idx(ptr)),
+            index == (slab.num_index_blocks as int) + slab@.addr_to_block_idx(ptr),
+    {
+        let block_idx_spec: int = slab@.addr_to_block_idx(ptr);
+        assert(block_idx_spec == (ptr - slab.data_addr as int) / slab.block_size as int);
+        assert(index == slab.num_index_blocks as int + block_idx_spec);
+        assert(slab@.is_allocated(block_idx_spec));
+        assert(slab.index@.is_bit_set(index));
+    }
+
+    /// Lemma: After a successful clear in deallocate, proves inv, can_allocate, and frame.
+    proof fn lemma_dealloc_clear_ok_postconditions(
+        slab: &Slab,
+        old_slab: &Slab,
+        index: int,
+        ptr: int,
+    )
+        requires
+            old_slab.inv(),
+            slab.index.inv(),
+            slab.index@.num_bits == old_slab.index@.num_bits,
+            slab.num_index_blocks == old_slab.num_index_blocks,
+            slab.num_data_blocks == old_slab.num_data_blocks,
+            slab.block_size == old_slab.block_size,
+            slab.data_addr == old_slab.data_addr,
+            !slab.index@.is_bit_set(index),
+            old_slab.index@.is_bit_set(index),
+            forall|j: int|
+                j != index && 0 <= j < slab.index@.num_bits ==> slab.index@.is_bit_set(j)
+                    == old_slab.index@.is_bit_set(j),
+            index == (old_slab.num_index_blocks as int) + old_slab@.addr_to_block_idx(ptr),
+            old_slab@.is_valid_addr(ptr),
+            old_slab@.can_deallocate(old_slab@.addr_to_block_idx(ptr)),
+        ensures
+            slab.inv(),
+            ({
+                let block_idx_spec: int = old_slab@.addr_to_block_idx(ptr);
+                &&& !slab@.is_allocated(block_idx_spec)
+                &&& slab@.num_data_blocks == old_slab@.num_data_blocks
+                &&& slab@.block_size == old_slab@.block_size
+                &&& slab@.data_addr == old_slab@.data_addr
+                &&& slab@.allocated_blocks =~= old_slab@.allocated_blocks.remove(block_idx_spec)
+                &&& slab@.can_allocate()
+            }),
+    {
+        let block_idx_spec: int = old_slab@.addr_to_block_idx(ptr);
+
+        assert forall|j: int|
+            0 <= j < slab.num_index_blocks as int implies #[trigger] slab.index@.set_bits.contains(
+            j,
+        ) by {
+            assert(old_slab.index@.is_bit_set(j));
+        }
+        Self::lemma_inv_from_components(slab);
+
+        slab.index@.lemma_unset_bit_implies_has_free_bit(index);
+
+        // Prove allocated_blocks.len() < num_data_blocks.
+        slab.lemma_allocated_blocks_finite();
+        slab.lemma_allocated_blocks_subset_of_range();
+        let full_range: Set<int> = set_int_range(0, slab@.num_data_blocks);
+        lemma_int_range(0, slab@.num_data_blocks);
+
+        lemma_len_subset(slab@.allocated_blocks, full_range);
+
+        if slab@.allocated_blocks =~= full_range {
+        }
+        assert(slab@.allocated_blocks.len() < slab@.num_data_blocks) by {
+            let with_witness: Set<int> = slab@.allocated_blocks.insert(block_idx_spec);
+            assert forall|x: int| with_witness.contains(x) implies full_range.contains(x) by {
+                if x == block_idx_spec {
+                } else {
+                }
+            }
+            axiom_set_insert_len(slab@.allocated_blocks, block_idx_spec);
+            lemma_len_subset(with_witness, full_range);
+        }
+
+        // Prove allocated_blocks =~= old_allocated_blocks.remove(block_idx_spec).
+        assert(slab@.allocated_blocks =~= old_slab@.allocated_blocks.remove(block_idx_spec)) by {
+            assert forall|j: int|
+                #![auto]
+                slab@.allocated_blocks.contains(j) == old_slab@.allocated_blocks.remove(
+                    block_idx_spec,
+                ).contains(j) by {
+                if j == block_idx_spec {
+                } else if 0 <= j < slab@.num_data_blocks {
+                    let bitmap_idx: int = slab.num_index_blocks as int + j;
+                    assert(slab.index@.is_bit_set(bitmap_idx) == old_slab.index@.is_bit_set(
+                        bitmap_idx,
+                    ));
+                } else {
+                }
+            }
+        }
+    }
+
+    /// Combined lemma: dealloc clear postconditions + permission well-formedness.
+    /// Wraps lemma_dealloc_clear_ok_postconditions, lemma_block_addr_inverse,
+    /// and lemma_dealloc_perms_wf into a single call for proof block extraction.
+    proof fn lemma_dealloc_clear_ok_with_perms(
+        slab: &Slab,
+        old_slab: &Slab,
+        index: int,
+        ptr: int,
+        old_free_perms: Map<int, PointsToRaw>,
+        prov: Provenance,
+    )
+        requires
+            old_slab.inv(),
+            slab.index.inv(),
+            slab.index@.num_bits == old_slab.index@.num_bits,
+            slab.num_index_blocks == old_slab.num_index_blocks,
+            slab.num_data_blocks == old_slab.num_data_blocks,
+            slab.block_size == old_slab.block_size,
+            slab.data_addr == old_slab.data_addr,
+            !slab.index@.is_bit_set(index),
+            old_slab.index@.is_bit_set(index),
+            forall|j: int|
+                j != index && 0 <= j < slab.index@.num_bits ==> slab.index@.is_bit_set(j)
+                    == old_slab.index@.is_bit_set(j),
+            index == (old_slab.num_index_blocks as int) + old_slab@.addr_to_block_idx(ptr),
+            old_slab@.is_valid_addr(ptr),
+            old_slab@.can_deallocate(old_slab@.addr_to_block_idx(ptr)),
+            old_slab@.perms_wf(old_free_perms, prov),
+        ensures
+            slab.inv(),
+            ({
+                let block_idx_spec: int = old_slab@.addr_to_block_idx(ptr);
+                &&& !slab@.is_allocated(block_idx_spec)
+                &&& slab@.num_data_blocks == old_slab@.num_data_blocks
+                &&& slab@.block_size == old_slab@.block_size
+                &&& slab@.data_addr == old_slab@.data_addr
+                &&& slab@.allocated_blocks =~= old_slab@.allocated_blocks.remove(block_idx_spec)
+                &&& slab@.can_allocate()
+            }),
+    {
+        Self::lemma_dealloc_clear_ok_postconditions(slab, old_slab, index, ptr);
+        Self::lemma_block_addr_inverse(&old_slab@, ptr);
+    }
+
+    //==================================================================================================
+    // Verified Safety Properties (not called by exec code, but prove key allocator properties)
+    //==================================================================================================
+    /// Lemma: addr_to_block_idx(block_addr(i)) == i for valid block index i.
+    /// This proves the inverse relationship between address and block index.
+    proof fn lemma_addr_block_idx_inverse(view: &SlabView, i: int)
+        requires
+            view.block_size > 0,
+            0 <= i < view.num_data_blocks,
+        ensures
+            view.addr_block_idx_inverse(i),
+    {
+        let bs = view.block_size;
+        let addr = view.block_addr(i);
+
+        vstd::arithmetic::div_mod::lemma_div_by_multiple(i, bs);
+
+    }
+
+    /// Lemma: After allocating block_idx from a well-formed permission map,
+    /// removing the block's permission yields a map that is well-formed for the new slab state.
+    proof fn lemma_alloc_perms_wf(
+        old_view: SlabView,
+        new_view: SlabView,
+        perms: Map<int, PointsToRaw>,
+        block_idx: int,
+        prov: Provenance,
+    )
+        requires
+            old_view.block_size > 0,
+            old_view.num_data_blocks > 0,
+            old_view.perms_wf(perms, prov),
+            0 <= block_idx < old_view.num_data_blocks,
+            !old_view.is_allocated(block_idx),
+            new_view.num_data_blocks == old_view.num_data_blocks,
+            new_view.block_size == old_view.block_size,
+            new_view.data_addr == old_view.data_addr,
+            new_view.allocated_blocks =~= old_view.allocated_blocks.insert(block_idx),
+        ensures
+            perms.dom().contains(block_idx),
+            perms[block_idx].is_range(old_view.block_addr(block_idx), old_view.block_size),
+            perms[block_idx].provenance() == prov,
+            new_view.perms_wf(perms.remove(block_idx), prov),
+    {
+    }
+
+    /// Lemma: All allocated blocks are within valid range.
+    proof fn lemma_allocated_blocks_in_range(&self)
+        requires
+            self.inv(),
+        ensures
+            self@.allocated_blocks_in_range(),
+    {
+    }
+
+    /// Lemma (Liveness): If bitmap is full, then slab is full.
+    /// This is the converse of lemma_can_allocate_implies_bitmap_has_free_bit.
+    /// It connects bitmap fullness to slab fullness.
+    proof fn lemma_bitmap_full_implies_slab_full(&self)
+        requires
+            self.inv(),
+            self.index@.is_full(),
+        ensures
+            self@.is_full(),
+    {
+        let num_data: int = self.num_data_blocks as int;
+        let num_idx: int = self.num_index_blocks as int;
+
+        // Prove all data block indices are allocated.
+        assert forall|j: int| 0 <= j < num_data implies self@.is_allocated(j) by {
+            let bitmap_idx = num_idx + j;
+            assert(self.index@.is_bit_set(bitmap_idx));  // From bitmap.is_full() via lemma
+        }
+
+        let full_range: Set<int> = set_int_range(0, num_data);
+        lemma_int_range(0, num_data);
+
+        assert forall|j: int|
+            #![auto]
+            full_range.contains(j) implies self@.allocated_blocks.contains(j) by {}
+
+        assert forall|j: int|
+            #![auto]
+            self@.allocated_blocks.contains(j) implies full_range.contains(j) by {}
+
+        assert(self@.allocated_blocks =~= full_range);
+
+        self.lemma_allocated_blocks_finite();
+    }
+
+    /// Lemma (Liveness): Deallocation from full slab enables allocation.
+    /// If the slab was full, after deallocating one block, allocation becomes possible.
+    proof fn lemma_dealloc_from_full_enables_alloc(&self, new_self: &Self, block_idx: int)
+        requires
+            self.inv(),
+            new_self.inv(),
+            self@.used() == self@.capacity(),  // Slab was full
+            0 <= block_idx < self@.num_data_blocks,
+            self@.is_allocated(block_idx),
+            !new_self@.is_allocated(block_idx),
+            forall|i: int|
+                (0 <= i < self@.num_data_blocks && i != block_idx) ==> (self@.is_allocated(i)
+                    <==> new_self@.is_allocated(i)),
+            new_self@.num_data_blocks == self@.num_data_blocks,
+        ensures
+            new_self@.can_allocate(),
+            new_self@.free() >= 1,
+    {
+        // Step 3: new_self@.allocated_blocks is a subset of self@.allocated_blocks.remove(block_idx)
+        let old_set: Set<int> = self@.allocated_blocks;
+        let new_set: Set<int> = new_self@.allocated_blocks;
+        let removed_set: Set<int> = old_set.remove(block_idx);
+
+        // Prove old_set is finite: it's a subset of set_int_range(0, num_data_blocks)
+        let range_set: Set<int> = set_int_range(0, self@.num_data_blocks);
+
+        // Prove old_set is a subset of range_set
+        assert forall|i: int| old_set.contains(i) implies range_set.contains(i) by {}
+
+        lemma_int_range(0, self@.num_data_blocks);
+
+        lemma_set_subset_finite(range_set, old_set);
+
+        // Similarly prove new_set is finite
+        let new_range_set: Set<int> = set_int_range(0, new_self@.num_data_blocks);
+        assert forall|i: int| new_set.contains(i) implies new_range_set.contains(i) by {}
+        lemma_int_range(0, new_self@.num_data_blocks);
+        lemma_set_subset_finite(new_range_set, new_set);
+
+        assert forall|i: int| new_set.contains(i) implies removed_set.contains(i) by {
+            if new_set.contains(i) {
+                assert(new_self@.is_allocated(i));
+            }
+        }
+
+        axiom_set_remove_len(old_set, block_idx);
+
+        lemma_len_subset(new_set, removed_set);
+
+    }
+
+    /// Lemma: A freshly initialized slab has maximum free capacity.
+    proof fn lemma_fresh_slab_max_free(slab: &Slab)
+        requires
+            slab.inv(),
+            slab@.is_freshly_initialized(),
+        ensures
+            slab@.free() == slab@.capacity(),
+            slab@.used() == 0,
+    {
+    }
+
+    /// Lemma: A newly created slab is freshly initialized (no data blocks allocated).
+    proof fn lemma_new_slab_freshly_initialized(slab: &Slab)
+        requires
+            slab.inv(),
+            forall|i: int|
+                slab.num_index_blocks as int <= i < (slab.num_index_blocks
+                    + slab.num_data_blocks) as int ==> !slab.index@.is_bit_set(i),
+        ensures
+            slab@.is_freshly_initialized(),
+    {
+        assert(slab@.allocated_blocks =~= Set::<int>::empty()) by {
+            assert forall|i: int| !slab@.allocated_blocks.contains(i) by {
+                if 0 <= i < slab@.num_data_blocks {
+                    let bitmap_idx = slab.num_index_blocks as int + i;
+                    assert(!slab.index@.is_bit_set(bitmap_idx));
+                }
+            }
+        }
+    }
+
+    /// Lemma: No memory aliasing - all allocated blocks have disjoint regions.
+    proof fn lemma_no_memory_aliasing(&self)
+        requires
+            self.inv(),
+        ensures
+            self@.no_memory_aliasing(),
+    {
+        // For any two allocated blocks i, j with i != j:
+        assert forall|i: int, j: int|
+            (self@.is_allocated(i) && self@.is_allocated(j) && i
+                != j) implies self@.blocks_are_disjoint(i, j) by {
+            if self@.is_allocated(i) && self@.is_allocated(j) && i != j {
+                Self::lemma_blocks_disjoint(&self@, i, j);
+            }
+        }
+    }
+
+    //==============================================================================================
+    // Extracted proof-block lemmas (proof extraction pass)
+    //==============================================================================================
+    /// Lemma: Proves set-theoretic properties needed for memory permission splitting
+    /// in `from_raw_parts`. Establishes that the used region is a subset of the memory
+    /// region, the index region is a subset of the used region, and the data region
+    /// equals the difference of the used and index regions.
+    proof fn lemma_from_raw_parts_mem_split_properties(
+        addr: int,
+        len: int,
+        block_size: int,
+        total_num_blocks: int,
+        num_index_blocks: int,
+        num_data_blocks: int,
+        data_addr: int,
+    )
+        requires
+            len > 0,
+            block_size > 0,
+            total_num_blocks == len / block_size,
+            num_index_blocks + num_data_blocks == total_num_blocks,
+            num_index_blocks >= 1,
+            num_index_blocks < total_num_blocks,
+            num_data_blocks > 0,
+            data_addr == addr + num_index_blocks * block_size,
+        ensures
+            total_num_blocks * block_size <= len,
+            (num_index_blocks + num_data_blocks) * block_size == num_index_blocks * block_size
+                + num_data_blocks * block_size,
+            set_int_range(addr, addr + total_num_blocks * block_size).difference(
+                set_int_range(addr, addr + num_index_blocks * block_size),
+            ) =~= set_int_range(data_addr, data_addr + num_data_blocks * block_size),
+    {
+        Self::lemma_div_mul_le(len, block_size);
+        Self::lemma_mul_inequality(num_index_blocks, total_num_blocks, block_size);
+        Self::lemma_distributive(num_index_blocks, num_data_blocks, block_size);
+
+        assert forall|x: int|
+            #![trigger set_int_range(addr, addr + total_num_blocks * block_size).contains(x)]
+            set_int_range(addr, addr + total_num_blocks * block_size).contains(
+                x,
+            ) implies set_int_range(addr, addr + len).contains(x) by {}
+
+        assert forall|x: int|
+            #![trigger set_int_range(addr, addr + num_index_blocks * block_size).contains(x)]
+            set_int_range(addr, addr + num_index_blocks * block_size).contains(
+                x,
+            ) implies set_int_range(addr, addr + total_num_blocks * block_size).contains(x) by {}
+
+        assert(set_int_range(addr, addr + total_num_blocks * block_size).difference(
+            set_int_range(addr, addr + num_index_blocks * block_size),
+        ) =~= set_int_range(data_addr, data_addr + num_data_blocks * block_size)) by {
+            let used: Set<int> = set_int_range(addr, addr + total_num_blocks * block_size);
+            let idx: Set<int> = set_int_range(addr, addr + num_index_blocks * block_size);
+            let data: Set<int> = set_int_range(data_addr, data_addr + num_data_blocks * block_size);
+            assert forall|x: int|
+                #![trigger used.difference(idx).contains(x)]
+                #![trigger data.contains(x)]
+                used.difference(idx).contains(x) <==> data.contains(x) by {}
+        }
+    }
+
+    /// Lemma: Proves slab invariant and permission well-formedness after
+    /// `from_raw_parts` initialization. Combines the post-loop invariant proof
+    /// with the freshly initialized permission well-formedness proof.
+    proof fn lemma_from_raw_parts_finalize(
+        slab: &Slab,
+        addr: int,
+        len: int,
+        total_num_blocks: int,
+        free_perms: Map<int, PointsToRaw>,
+        prov: Provenance,
+    )
+        requires
+            slab.index.inv(),
+            slab.block_size > 0,
+            slab.num_data_blocks > 0,
+            slab.num_index_blocks > 0,
+            forall|i: int|
+                #![trigger slab.index@.set_bits.contains(i)]
+                0 <= i < slab.num_index_blocks as int ==> slab.index@.set_bits.contains(i),
+            forall|i: int|
+                slab.num_index_blocks as int <= i < slab.index@.num_bits
+                    ==> !slab.index@.is_bit_set(i),
+            (slab.num_index_blocks as int) + (slab.num_data_blocks as int) == slab.index@.num_bits,
+            total_num_blocks == slab.index@.num_bits,
+            (slab.num_data_blocks as int) < total_num_blocks,
+            (slab.data_addr as int) == addr + (slab.num_index_blocks as int) * (
+            slab.block_size as int),
+            addr > 0,
+            len > 0,
+            len < i32::MAX as int,
+            slab.block_size as int <= len,
+            addr + len <= usize::MAX as int,
+            total_num_blocks == len / slab.block_size as int,
+            is_pow2(slab.block_size as int),
+            slab.data_addr as int % slab.block_size as int == 0,
+            forall|i: int| 0 <= i < slab.num_data_blocks as int <==> free_perms.dom().contains(i),
+            forall|i: int|
+                #![trigger free_perms[i]]
+                0 <= i < slab.num_data_blocks as int ==> free_perms[i].is_range(
+                    slab.data_addr as int + i * slab.block_size as int,
+                    slab.block_size as int,
+                ) && free_perms[i].provenance() == prov,
+        ensures
+            slab.inv(),
+            slab@.block_size == slab.block_size as int,
+            slab@.allocated_blocks =~= Set::<int>::empty(),
+            slab@.data_addr > addr,
+            slab@.data_addr % slab.block_size as int == 0,
+            slab@.num_data_blocks > 0,
+            slab@.data_addr + slab@.num_data_blocks * slab@.block_size <= addr + len,
+            slab@.perms_wf(free_perms, prov),
+    {
+        Self::lemma_from_raw_parts_post_loop(slab, addr, len, total_num_blocks);
+        Self::lemma_view_fields(slab);
+        assert forall|i: int|
+            #![trigger free_perms[i]]
+            0 <= i < slab@.num_data_blocks implies free_perms[i].is_range(
+            slab@.block_addr(i),
+            slab@.block_size,
+        ) && free_perms[i].provenance() == prov by {
+            assert(slab@.block_addr(i) == slab.data_addr as int + i * slab.block_size as int);
+        }
+        lemma_fresh_slab_perms_wf(slab@, free_perms, prov);
+    }
+
+    /// Lemma: Establishes allocation postconditions and extracts the block's
+    /// permission from the tracked permission map.
+    proof fn lemma_alloc_take_block_perm(
+        slab: &Slab,
+        old_slab: &Slab,
+        block: int,
+        block_addr: int,
+        tracked perms: &mut SlabPerms,
+    ) -> (tracked result: PointsToRaw)
+        requires
+            old_slab.inv(),
+            slab.inv(),
+            block >= slab.num_index_blocks as int,
+            block < (slab.num_index_blocks + slab.num_data_blocks) as int,
+            slab.index@.is_bit_set(block),
+            !old_slab.index@.is_bit_set(block),
+            forall|k: int|
+                k != block && 0 <= k < slab.index@.num_bits ==> slab.index@.is_bit_set(k)
+                    == old_slab.index@.is_bit_set(k),
+            slab.num_index_blocks == old_slab.num_index_blocks,
+            slab.num_data_blocks == old_slab.num_data_blocks,
+            slab.block_size == old_slab.block_size,
+            slab.data_addr == old_slab.data_addr,
+            slab.index@.num_bits == old_slab.index@.num_bits,
+            block_addr == (slab.data_addr as int) + (block - slab.num_index_blocks as int) * (
+            slab.block_size as int),
+            old(perms).wf(old_slab@, old(perms).index_perm.provenance()),
+        ensures
+            ({
+                let block_idx: int = block - slab.num_index_blocks as int;
+                &&& old_slab@.is_valid_addr(block_addr)
+                &&& old_slab@.addr_to_block_idx(block_addr) == block_idx
+                &&& !old_slab@.is_allocated(block_idx)
+                &&& slab@.is_allocated(block_idx)
+                &&& slab@.num_data_blocks == old_slab@.num_data_blocks
+                &&& slab@.block_size == old_slab@.block_size
+                &&& slab@.data_addr == old_slab@.data_addr
+                &&& slab@.allocated_blocks =~= old_slab@.allocated_blocks.insert(block_idx)
+                &&& block_addr > 0
+                &&& result.is_range(block_addr, old_slab@.block_size)
+                &&& result.provenance() == old(perms).index_perm.provenance()
+                &&& perms.wf(slab@, old(perms).index_perm.provenance())
+                &&& perms.index_perm == old(perms).index_perm
+            }),
+    {
+        let block_idx: int = block - slab.num_index_blocks as int;
+        Self::lemma_alloc_establishes_postconditions(slab, old_slab, block, block_idx, block_addr);
+        perms.take_block_perm(block_idx)
+    }
+
+    /// Lemma: Proves deallocation postconditions and restores the block's
+    /// permission to the tracked permission map after a successful bitmap clear.
+    proof fn lemma_dealloc_ok_finalize(
+        slab: &Slab,
+        old_slab: &Slab,
+        index: int,
+        ptr: int,
+        tracked perms: &mut SlabPerms,
+        tracked block_perm: PointsToRaw,
+    )
+        requires
+            old_slab.inv(),
+            slab.index.inv(),
+            slab.index@.num_bits == old_slab.index@.num_bits,
+            slab.num_index_blocks == old_slab.num_index_blocks,
+            slab.num_data_blocks == old_slab.num_data_blocks,
+            slab.block_size == old_slab.block_size,
+            slab.data_addr == old_slab.data_addr,
+            !slab.index@.is_bit_set(index),
+            old_slab.index@.is_bit_set(index),
+            forall|j: int|
+                j != index && 0 <= j < slab.index@.num_bits ==> slab.index@.is_bit_set(j)
+                    == old_slab.index@.is_bit_set(j),
+            index == (old_slab.num_index_blocks as int) + old_slab@.addr_to_block_idx(ptr),
+            old_slab@.is_valid_addr(ptr),
+            old_slab@.can_deallocate(old_slab@.addr_to_block_idx(ptr)),
+            block_perm.is_range(ptr, old_slab@.block_size),
+            block_perm.provenance() == old(perms).index_perm.provenance(),
+            old(perms).wf(old_slab@, old(perms).index_perm.provenance()),
+        ensures
+            slab.inv(),
+            ({
+                let block_idx: int = old_slab@.addr_to_block_idx(ptr);
+                &&& !slab@.is_allocated(block_idx)
+                &&& slab@.num_data_blocks == old_slab@.num_data_blocks
+                &&& slab@.block_size == old_slab@.block_size
+                &&& slab@.data_addr == old_slab@.data_addr
+                &&& slab@.allocated_blocks =~= old_slab@.allocated_blocks.remove(block_idx)
+                &&& slab@.can_allocate()
+                &&& perms.wf(slab@, old(perms).index_perm.provenance())
+                &&& perms.index_perm == old(perms).index_perm
+            }),
+    {
+        Self::lemma_dealloc_clear_ok_with_perms(
+            slab,
+            old_slab,
+            index,
+            ptr,
+            old(perms).free_perms,
+            old(perms).index_perm.provenance(),
+        );
+        let block_idx: int = old_slab@.addr_to_block_idx(ptr);
+        Self::lemma_block_addr_inverse(&old_slab@, ptr);
+        lemma_dealloc_perms_wf(
+            old_slab@,
+            slab@,
+            old(perms).free_perms,
+            block_idx,
+            block_perm,
+            old(perms).index_perm.provenance(),
+        );
+        perms.put_block_perm(block_idx, block_perm);
+    }
+
+    /// Proves that u8 layout satisfies RawArray::from_raw_parts precondition.
+    proof fn lemma_u8_layout_for_raw_array(index_len: usize, total_num_blocks: usize, len: usize)
+        requires
+            index_len == total_num_blocks / 8,
+            total_num_blocks >= 8,
+            index_len <= len,
+        ensures
+            vstd::layout::size_of::<u8>() == 1,
+            vstd::layout::align_of::<u8>() == 1,
+            index_len <= len,
+    {
+        assert(vstd::layout::align_of::<u8>() == 1) by {
+            let a: nat = vstd::layout::align_of::<u8>();
+            assert(a == 1) by (nonlinear_arith)
+                requires
+                    1nat % a == 0,
+                    a != 0nat,
+            ;
+        }
+    }
+
+    /// Splits the initial memory permission into index and per-block data permissions.
+    proof fn split_mem_into_slab_perms(
+        tracked mem: PointsToRaw,
+        addr: int,
+        data_addr: int,
+        len: int,
+        block_size: int,
+        total_num_blocks: int,
+        num_index_blocks: int,
+        num_data_blocks: int,
+    ) -> (tracked result: (PointsToRaw, Map<int, PointsToRaw>))
+        requires
+            mem.is_range(addr, len),
+            len > 0,
+            block_size > 0,
+            total_num_blocks == len / block_size,
+            num_index_blocks >= 1,
+            num_data_blocks > 0,
+            num_index_blocks + num_data_blocks == total_num_blocks,
+            data_addr == addr + num_index_blocks * block_size,
+        ensures
+            result.0.is_range(addr, num_index_blocks * block_size),
+            result.0.provenance() == mem.provenance(),
+            forall|i: int| 0 <= i < num_data_blocks <==> result.1.dom().contains(i),
+            forall|i: int|
+                #![trigger result.1[i]]
+                0 <= i < num_data_blocks ==> result.1[i].is_range(
+                    data_addr + i * block_size,
+                    block_size,
+                ) && result.1[i].provenance() == mem.provenance(),
+    {
+        let used_size: int = total_num_blocks * block_size;
+        let used_range: Set<int> = set_int_range(addr, addr + used_size);
+        Self::lemma_div_mul_le(len, block_size);
+        assert forall|x: int| #![auto] used_range.contains(x) implies mem.dom().contains(x) by {}
+        let tracked (used_perm, _padding) = mem.split(used_range);
+
+        let idx_size: int = num_index_blocks * block_size;
+        let index_range: Set<int> = set_int_range(addr, addr + idx_size);
+        Self::lemma_distributive(num_index_blocks, num_data_blocks, block_size);
+        assert(idx_size <= used_size) by {
+            Self::lemma_mul_inequality(num_index_blocks, total_num_blocks, block_size);
+        }
+        assert forall|x: int| #![auto] index_range.contains(x) implies used_perm.dom().contains(
+            x,
+        ) by {}
+        let tracked (idx_perm, data_perm) = used_perm.split(index_range);
+
+        assert(data_perm.dom() =~= set_int_range(
+            data_addr,
+            data_addr + num_data_blocks * block_size,
+        )) by {
+            assert forall|x: int|
+                used_perm.dom().difference(index_range).contains(x) <==> set_int_range(
+                    data_addr,
+                    data_addr + num_data_blocks * block_size,
+                ).contains(x) by {}
+        }
+
+        let tracked fp = split_into_blocks(data_perm, data_addr, block_size, num_data_blocks);
+
+        (idx_perm, fp)
+    }
+}
+
+//==================================================================================================
+// PointsToRaw Memory Permission Proof Helpers
+//==================================================================================================
+/// Lemma: The last block's range is a subset of the full range.
+proof fn lemma_range_subset_last_block(base: int, block_size: int, n: int)
+    requires
+        block_size > 0,
+        n >= 1,
+    ensures
+        set_int_range(base + (n - 1) * block_size, base + n * block_size).subset_of(
+            set_int_range(base, base + n * block_size),
+        ),
+{
+    let last: Set<int> = set_int_range(base + (n - 1) * block_size, base + n * block_size);
+    let full: Set<int> = set_int_range(base, base + n * block_size);
+    assert forall|x: int| last.contains(x) implies full.contains(x) by {
+        assert((n - 1) * block_size >= 0) by (nonlinear_arith)
+            requires
+                n >= 1,
+                block_size > 0,
+        ;
+    }
+}
+
+/// Lemma: Removing the last block from the full range gives the prefix range.
+proof fn lemma_range_difference_last_block(base: int, block_size: int, n: int)
+    requires
+        block_size > 0,
+        n >= 1,
+    ensures
+        set_int_range(base, base + n * block_size).difference(
+            set_int_range(base + (n - 1) * block_size, base + n * block_size),
+        ) =~= set_int_range(base, base + (n - 1) * block_size),
+{
+    let full: Set<int> = set_int_range(base, base + n * block_size);
+    let last: Set<int> = set_int_range(base + (n - 1) * block_size, base + n * block_size);
+    let prefix: Set<int> = set_int_range(base, base + (n - 1) * block_size);
+    let diff: Set<int> = full.difference(last);
+
+    assert forall|x: int| diff.contains(x) <==> prefix.contains(x) by {
+        if diff.contains(x) {
+        }
+        if prefix.contains(x) {
+            assert(base <= x < base + (n - 1) * block_size);
+            assert((n - 1) * block_size <= n * block_size) by (nonlinear_arith)
+                requires
+                    block_size > 0,
+                    n >= 1,
+            ;
+            assert(x < base + n * block_size);
+            assert(full.contains(x));
+            assert((n - 1) * block_size < n * block_size) by (nonlinear_arith)
+                requires
+                    block_size > 0,
+                    n >= 1,
+            ;
+            assert(!last.contains(x));
+        }
+    }
+}
+
+/// Splits a contiguous PointsToRaw into per-block permissions.
+/// Given a permission for [base, base + n * block_size), returns a Map mapping
+/// block index i to a permission for [base + i * block_size, base + (i+1) * block_size).
+proof fn split_into_blocks(
+    tracked perm: PointsToRaw,
+    base: int,
+    block_size: int,
+    n: int,
+) -> (tracked result: Map<int, PointsToRaw>)
+    requires
+        perm.is_range(base, n * block_size),
+        block_size > 0,
+        n >= 0,
+    ensures
+        forall|i: int| 0 <= i < n <==> result.dom().contains(i),
+        forall|i: int|
+            #![trigger result[i]]
+            0 <= i < n ==> result[i].is_range(base + i * block_size, block_size)
+                && result[i].provenance() == perm.provenance(),
+    decreases n,
+{
+    if n == 0 {
+        let tracked _padding = perm;
+        Map::<int, PointsToRaw>::tracked_empty()
+    } else {
+        // Split off the last block (index n-1).
+        let last_start: int = base + (n - 1) * block_size;
+        let last_range: Set<int> = set_int_range(last_start, last_start + block_size);
+
+        assert((n - 1) * block_size + block_size == n * block_size) by (nonlinear_arith)
+            requires
+                block_size > 0,
+                n >= 1,
+        ;
+
+        lemma_range_subset_last_block(base, block_size, n);
+
+        let tracked (last_perm, rest_perm) = perm.split(last_range);
+
+        lemma_range_difference_last_block(base, block_size, n);
+
+        let tracked mut result = split_into_blocks(rest_perm, base, block_size, n - 1);
+        result.tracked_insert(n - 1, last_perm);
+        result
+    }
+}
+
+/// Joins per-block permissions back into a contiguous PointsToRaw.
+/// Inverse of split_into_blocks.
+/// NOTE: Currently unused. Reserved for future slab destruction / memory reclamation.
+proof fn join_block_perms(
+    tracked perms: Map<int, PointsToRaw>,
+    base: int,
+    block_size: int,
+    n: int,
+    prov: Provenance,
+) -> (tracked result: PointsToRaw)
+    requires
+        block_size > 0,
+        n >= 0,
+        forall|i: int| 0 <= i < n <==> perms.dom().contains(i),
+        forall|i: int|
+            #![trigger perms[i]]
+            0 <= i < n ==> perms[i].is_range(base + i * block_size, block_size)
+                && perms[i].provenance() == prov,
+    ensures
+        result.is_range(base, n * block_size),
+        result.provenance() == prov,
+    decreases n,
+{
+    if n == 0 {
+        assert(n * block_size == 0) by (nonlinear_arith)
+            requires
+                n == 0,
+        ;
+        PointsToRaw::empty(prov)
+    } else {
+        let tracked mut perms = perms;
+        let tracked last_perm = perms.tracked_remove(n - 1);
+        let tracked prefix_perm = join_block_perms(perms, base, block_size, n - 1, prov);
+        let tracked result = prefix_perm.join(last_perm);
+
+        let last_start: int = base + (n - 1) * block_size;
+        assert((n - 1) * block_size + block_size == n * block_size) by (nonlinear_arith)
+            requires
+                block_size > 0,
+                n >= 1,
+        ;
+
+        assert(set_int_range(base, base + (n - 1) * block_size) + set_int_range(
+            last_start,
+            last_start + block_size,
+        ) =~= set_int_range(base, base + n * block_size)) by {
+            let prefix_set: Set<int> = set_int_range(base, base + (n - 1) * block_size);
+            let last_set: Set<int> = set_int_range(last_start, last_start + block_size);
+            let full_set: Set<int> = set_int_range(base, base + n * block_size);
+            assert forall|x: int|
+                #![trigger full_set.contains(x)]
+                (prefix_set + last_set).contains(x) <==> full_set.contains(x) by {
+                assert((n - 1) * block_size >= 0) by (nonlinear_arith)
+                    requires
+                        n >= 1,
+                        block_size > 0,
+                ;
+            }
+        }
+
+        result
+    }
+}
+
+/// Lemma: After deallocating block_idx and inserting its permission back,
+/// the map is well-formed for the new slab state.
+proof fn lemma_dealloc_perms_wf(
+    old_view: SlabView,
+    new_view: SlabView,
+    perms: Map<int, PointsToRaw>,
+    block_idx: int,
+    block_perm: PointsToRaw,
+    prov: Provenance,
+)
+    requires
+        old_view.block_size > 0,
+        old_view.num_data_blocks > 0,
+        old_view.perms_wf(perms, prov),
+        0 <= block_idx < old_view.num_data_blocks,
+        old_view.is_allocated(block_idx),
+        block_perm.is_range(old_view.block_addr(block_idx), old_view.block_size),
+        block_perm.provenance() == prov,
+        new_view.num_data_blocks == old_view.num_data_blocks,
+        new_view.block_size == old_view.block_size,
+        new_view.data_addr == old_view.data_addr,
+        new_view.allocated_blocks =~= old_view.allocated_blocks.remove(block_idx),
+    ensures
+        new_view.perms_wf(perms.insert(block_idx, block_perm), prov),
+{
+    let new_perms: Map<int, PointsToRaw> = perms.insert(block_idx, block_perm);
+
+    // Prove new_view.perms_wf(new_perms, prov).
+    // For free blocks in new_view:
+    // For allocated blocks in new_view:
+    assert forall|i: int|
+        #![trigger new_perms.dom().contains(i)]
+        (0 <= i < new_view.num_data_blocks && !new_view.is_allocated(
+            i,
+        )) implies new_perms.dom().contains(i) && (#[trigger] new_perms[i]).is_range(
+        new_view.block_addr(i),
+        new_view.block_size,
+    ) && new_perms[i].provenance() == prov by {
+        if i == block_idx {
+        } else {
+        }
+    }
+    assert forall|i: int|
+        #![trigger new_perms.dom().contains(i)]
+        (0 <= i < new_view.num_data_blocks && new_view.is_allocated(
+            i,
+        )) implies !new_perms.dom().contains(i) by {}
+}
+
+proof fn lemma_fresh_slab_perms_wf(view: SlabView, perms: Map<int, PointsToRaw>, prov: Provenance)
+    requires
+        view.block_size > 0,
+        view.num_data_blocks > 0,
+        view.is_freshly_initialized(),
+        forall|i: int| 0 <= i < view.num_data_blocks <==> perms.dom().contains(i),
+        forall|i: int|
+            #![trigger perms[i]]
+            0 <= i < view.num_data_blocks ==> perms[i].is_range(view.block_addr(i), view.block_size)
+                && perms[i].provenance() == prov,
+    ensures
+        view.perms_wf(perms, prov),
+{
+    assert forall|i: int|
+        #![trigger perms.dom().contains(i)]
+        (0 <= i < view.num_data_blocks && !view.is_allocated(i)) implies perms.dom().contains(i)
+        && (#[trigger] perms[i]).is_range(view.block_addr(i), view.block_size)
+        && perms[i].provenance() == prov by {}
+    assert forall|i: int|
+        #![trigger perms.dom().contains(i)]
+        (0 <= i < view.num_data_blocks && view.is_allocated(i)) implies !perms.dom().contains(
+        i,
+    ) by {}
+}
+} // verus!

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright (c) The Maintainers of Nanvix.
-// Licensed under the MIT license.
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
 
 //==================================================================================================
 // Configuration
@@ -20,14 +20,53 @@ mod test;
 
 use ::bitmap::Bitmap;
 use ::raw_array::RawArray;
+#[cfg(verus_keep_ghost)]
+use ::raw_array::{
+    axiom_u8_zero_is_0,
+    is_zero,
+};
 use ::sys::error::{
     Error,
     ErrorCode,
 };
+#[cfg(verus_keep_ghost)]
+use ::vstd::raw_ptr::Provenance;
+use ::vstd::{
+    prelude::*,
+    raw_ptr::PointsToRaw,
+};
+
+// Re-export Tracked for callers that need to pass tracked parameters.
+pub use ::vstd::prelude::Tracked;
+
+#[cfg(verus_keep_ghost)]
+use ::vstd::{
+    arithmetic::power2::is_pow2,
+    set::*,
+    set_lib::{
+        lemma_int_range,
+        lemma_len_subset,
+        lemma_set_subset_finite,
+        set_int_range,
+    },
+};
+
+// Include specifications.
+include!("lib.spec.rs");
+
+// Include proofs.
+#[cfg(verus_keep_ghost)]
+include!("lib.proof.rs");
+
+// Include verified tests.
+#[cfg(verus_keep_ghost)]
+include!("lib.test.rs");
 
 //==================================================================================================
 // Structures
 //==================================================================================================
+
+verus! {
 
 ///
 /// # Description
@@ -42,6 +81,7 @@ use ::sys::error::{
 /// +-------------------+--------------------------------------+
 /// ```
 ///
+#[verifier::external_derive]
 #[derive(Debug)]
 pub struct Slab {
     /// An index that keeps track of free blocks.
@@ -54,6 +94,65 @@ pub struct Slab {
     num_data_blocks: usize,
     /// Size of blocks in the slab.
     block_size: usize,
+}
+
+//==================================================================================================
+// View Implementation for Slab
+//==================================================================================================
+
+#[cfg(verus_keep_ghost)]
+impl View for Slab {
+    type V = SlabView;
+
+    closed spec fn view(&self) -> SlabView {
+        let offset: int = self.num_index_blocks as int;
+        SlabView {
+            allocated_blocks: Set::new(
+                |i: int|
+                    0 <= i < self.num_data_blocks as int && self.index@.set_bits.contains(
+                        offset + i,
+                    ),
+            ),
+            num_data_blocks: self.num_data_blocks as int,
+            block_size: self.block_size as int,
+            data_addr: self.data_addr as int,
+        }
+    }
+}
+
+#[cfg(verus_keep_ghost)]
+impl Slab {
+    /// Invariant for the slab allocator.
+    pub open spec fn inv(&self) -> bool {
+        &&& self.internal_inv()
+        // Exposed properties: callers can use these without additional lemmas.
+        &&& self@.num_data_blocks > 0
+        &&& self@.block_size > 0
+        &&& self@.allocated_blocks_in_range()
+    }
+
+    /// Internal invariant — implementation details hidden from external callers.
+    pub closed spec fn internal_inv(&self) -> bool {
+        &&& self.index.inv()
+        &&& self.block_size > 0
+        &&& self.num_data_blocks > 0
+        &&& self.num_index_blocks > 0
+        &&& self.num_index_blocks + self.num_data_blocks == self.index@.num_bits
+        &&& forall|i: int|
+            #![trigger self.index@.set_bits.contains(i)]
+            0 <= i < self.num_index_blocks as int ==> self.index@.set_bits.contains(i)
+        &&& self.data_addr as int > 0
+        &&& (self.num_data_blocks as int) * (self.block_size as int) <= usize::MAX as int
+        &&& (self.data_addr as int) + (self.num_data_blocks as int) * (self.block_size as int)
+            <= usize::MAX as int
+        &&& is_pow2(self.block_size as int)
+        &&& self.data_addr as int % self.block_size as int == 0
+        &&& self.data_addr as int >= self.num_index_blocks as int * self.block_size as int
+        &&& self@.num_data_blocks == self.num_data_blocks as int
+        &&& self@.block_size == self.block_size as int
+        &&& self@.data_addr == self.data_addr as int
+        &&& self@.allocated_blocks_in_range()
+    }
 }
 
 //==================================================================================================
@@ -76,7 +175,7 @@ impl Slab {
     /// # Returns
     ///
     /// Upon success, a new slab allocator is returned. Upon failure, an error is returned instead
-    /// and the memory may be left in an modified state.
+    /// and the memory may be left in a modified state.
     ///
     /// # Safety
     ///
@@ -87,14 +186,45 @@ impl Slab {
         addr: *mut u8,
         len: usize,
         block_size: usize,
-    ) -> Result<Slab, Error> {
-        // Check if length is invalid valid.
+        Tracked(mem): Tracked<PointsToRaw>,
+    ) -> (result: Result<(Slab, Tracked<SlabPerms>), Error>)
+        requires
+            len > 0,
+            len < i32::MAX as usize,
+            block_size > 0,
+            block_size < i32::MAX as usize,
+            block_size <= len,
+            is_pow2(block_size as int),
+            (addr as usize) % block_size == 0,
+            (addr as usize) > 0,
+            (addr as int) + (len as int) <= (usize::MAX as int),
+            (len / block_size) % (u8::BITS as usize) == 0,
+            len / block_size >= 8,
+            mem.is_range(addr as int, len as int),
+        ensures
+            match result {
+                Ok((slab, perms)) => {
+                    &&& slab.inv()
+                    &&& slab@.block_size == block_size as int
+                    &&& slab@.allocated_blocks =~= Set::<int>::empty()
+                    &&& slab@.data_addr > addr as int
+                    &&& slab@.data_addr % (block_size as int) == 0
+                    &&& slab@.num_data_blocks > 0
+                    &&& slab@.data_addr + slab@.num_data_blocks * slab@.block_size <= addr as int
+                        + len as int
+                    &&& perms@.wf(slab@, mem.provenance())
+                },
+                Err(_) => true,
+            },
+    {
+        // Check if length is invalid.
         if len == 0 || len >= i32::MAX as usize {
             return Err(Error::new(ErrorCode::InvalidArgument, "invalid slab length"));
         }
 
+        // TODO: remove this runtime check once all callers are verified.
         // Check if the memory region wraps around.
-        if addr.wrapping_add(len) < addr {
+        if (addr as usize).wrapping_add(len) < (addr as usize) {
             return Err(Error::new(ErrorCode::InvalidArgument, "wrapping memory region"));
         }
 
@@ -108,7 +238,11 @@ impl Slab {
             return Err(Error::new(ErrorCode::InvalidArgument, "block size is not a power of two"));
         }
 
-        // Check if `start_addr` is aligned to `block_size`.
+        proof {
+            Self::lemma_bitwise_implies_is_pow2(block_size);
+        }
+
+        // Check if `addr` is aligned to `block_size`.
         if !(addr as usize).is_multiple_of(block_size) {
             return Err(Error::new(ErrorCode::InvalidArgument, "unaligned start address"));
         }
@@ -119,21 +253,30 @@ impl Slab {
         if !total_num_blocks.is_multiple_of(u8::BITS as usize) {
             return Err(Error::new(ErrorCode::InvalidArgument, "invalid number of blocks"));
         }
+
         let index_len: usize = total_num_blocks / u8::BITS as usize;
         // info!("index length: {:?}", index_len);
         let num_index_blocks: usize = (index_len / block_size)
-            + if index_len.is_multiple_of(block_size) {
-                0
-            } else {
-                1
-            };
+            + if index_len.is_multiple_of(block_size) { 0 } else { 1 };
         // info!("number of index blocks: {:?}", num_index_blocks);
         if num_index_blocks > total_num_blocks {
             return Err(Error::new(ErrorCode::InvalidArgument, "insufficient blocks for index"));
         }
         let num_data_blocks: usize = total_num_blocks - num_index_blocks;
         // info!("number of data blocks: {:?}", num_data_blocks);
-        let data_addr: *mut u8 = addr.add(num_index_blocks * block_size);
+
+        proof {
+            Self::lemma_from_raw_parts_layout_bounds(
+                len,
+                block_size,
+                total_num_blocks,
+                index_len,
+                num_index_blocks,
+                num_data_blocks,
+                addr as usize,
+            );
+        }
+        let data_addr: *mut u8 = addr.with_addr(addr.addr() + num_index_blocks * block_size);
 
         // Check if `data_addr` is aligned to `block_size`.
         if !(data_addr as usize).is_multiple_of(block_size) {
@@ -141,24 +284,84 @@ impl Slab {
         }
 
         // Instantiate index.
+        vstd::layout::layout_for_type_is_valid::<u8>();
+        proof {
+            Self::lemma_u8_layout_for_raw_array(index_len, total_num_blocks, len);
+        }
         let storage: RawArray<u8> = RawArray::from_raw_parts(addr, index_len)?;
+
+        proof {
+            Self::lemma_raw_array_storage_zeroed(storage@);
+        }
+
         let mut index: Bitmap = Bitmap::from_raw_array(storage)?;
+
+        proof {
+            Self::lemma_from_raw_parts_pre_loop(
+                index@.num_bits,
+                index_len as int,
+                total_num_blocks as int,
+                num_index_blocks as int,
+                num_data_blocks as int,
+            );
+        }
 
         // NOTE: The index is initialized with all blocks free, thus if we fail beyond this point
         // the memory region is left in a modified state.
 
         // Initialize index.
-        for i in 0..num_index_blocks {
+        for i in 0..num_index_blocks
+            invariant
+                Self::from_raw_parts_init_loop_invariant(
+                    index,
+                    i,
+                    num_index_blocks,
+                    num_data_blocks,
+                    total_num_blocks,
+                    block_size,
+                    data_addr,
+                ),
+        {
             index.set(i)?;
         }
 
-        Ok(Slab {
+        // After the loop, all index blocks are set.
+        let result_slab: Slab = Slab {
             num_index_blocks,
             num_data_blocks,
             block_size,
             data_addr,
             index,
-        })
+        };
+
+        // Split the memory permission into index and per-block data permissions.
+        let tracked (index_perm_val, free_perms_val) = Self::split_mem_into_slab_perms(
+            mem,
+            addr as int,
+            data_addr as int,
+            len as int,
+            block_size as int,
+            total_num_blocks as int,
+            num_index_blocks as int,
+            num_data_blocks as int,
+        );
+
+        let tracked result_perms = SlabPerms {
+            free_perms: free_perms_val,
+            index_perm: index_perm_val,
+        };
+
+        proof {
+            Self::lemma_from_raw_parts_post_loop(
+                &result_slab,
+                addr as int,
+                len as int,
+                total_num_blocks as int,
+            );
+            lemma_fresh_slab_perms_wf(result_slab@, result_perms.free_perms, mem.provenance());
+        }
+
+        Ok((result_slab, Tracked(result_perms)))
     }
 
     ///
@@ -171,14 +374,82 @@ impl Slab {
     /// Upon success, a pointer to the allocated block is returned. Upon failure, an error is
     /// returned instead.
     ///
-    pub fn allocate(&mut self) -> Result<*mut u8, Error> {
-        let block: usize = self.index.alloc()?;
-        // Safety: the start and resulting addresses are valid.
-        let block_addr: *mut u8 = unsafe {
-            self.data_addr
-                .add((block - self.num_index_blocks) * self.block_size)
+    pub fn allocate(&mut self, Tracked(perms): Tracked<&mut SlabPerms>) -> (result: Result<
+        (*mut u8, Tracked<PointsToRaw>),
+        Error,
+    >)
+        requires
+            old(self).inv(),
+            old(perms).wf(old(self)@, old(perms).index_perm.provenance()),
+        ensures
+            self.inv(),
+            match result {
+                Ok((ptr, block_perm)) => {
+                    let addr = ptr as int;
+                    let block_idx = old(self)@.addr_to_block_idx(addr);
+                    &&& old(self)@.is_valid_addr(addr)
+                    &&& 0 <= block_idx < self@.num_data_blocks
+                    &&& !old(self)@.is_allocated(block_idx)
+                    &&& self@.is_allocated(block_idx)
+                    &&& self@.num_data_blocks == old(self)@.num_data_blocks
+                    &&& self@.block_size == old(self)@.block_size
+                    &&& self@.data_addr == old(self)@.data_addr
+                    &&& self@.allocated_blocks =~= old(self)@.allocated_blocks.insert(block_idx)
+                    &&& addr > 0
+                    &&& block_perm@.is_range(addr, self@.block_size)
+                    &&& block_perm@.provenance() == old(perms).index_perm.provenance()
+                    &&& perms.wf(self@, old(perms).index_perm.provenance())
+                    &&& perms.index_perm == old(perms).index_perm
+                },
+                Err(_) => {
+                    &&& self@ == old(self)@
+                    &&& !old(self)@.can_allocate()
+                    &&& perms.free_perms == old(perms).free_perms
+                    &&& perms.index_perm == old(perms).index_perm
+                },
+            },
+            old(self)@.can_allocate() ==> result is Ok,
+    {
+        let block: usize = match self.index.alloc() {
+            Ok(b) => b,
+            Err(e) => {
+                proof {
+                    Self::lemma_alloc_error_preserves_state(self, old(self));
+                }
+                return Err(e);
+            },
         };
-        Ok(block_addr)
+
+        proof {
+            Self::lemma_alloc_block_is_data_block_with_bounds(self, old(self), block as int);
+        }
+
+        // Safety: the start and resulting addresses are valid.
+        let block_addr: *mut u8 = {
+            let block_idx: usize = block - self.num_index_blocks;
+
+            proof {
+                Self::lemma_alloc_product_in_bounds(self, block_idx as int);
+            }
+
+            self.data_addr.with_addr(self.data_addr.addr() + block_idx * self.block_size)
+        };
+
+        // Extract the block's permission from the tracked perms.
+        let tracked block_perm;
+        proof {
+            let block_idx = block as int - self.num_index_blocks as int;
+            Self::lemma_alloc_establishes_postconditions(
+                self,
+                old(self),
+                block as int,
+                block_idx,
+                block_addr as int,
+            );
+            block_perm = perms.take_block_perm(block_idx);
+        }
+
+        Ok((block_addr, Tracked(block_perm)))
     }
 
     ///
@@ -200,19 +471,56 @@ impl Slab {
     ///
     /// - It dereferences the pointer `ptr`.
     ///
-    pub unsafe fn deallocate(&mut self, ptr: *const u8) -> Result<(), Error> {
+    pub unsafe fn deallocate(
+        &mut self,
+        ptr: *const u8,
+        Tracked(block_perm): Tracked<PointsToRaw>,
+        Tracked(perms): Tracked<&mut SlabPerms>,
+    ) -> (result: Result<(), Error>)
+        requires
+            old(self).inv(),
+            old(self)@.is_valid_addr(ptr as int),
+            old(self)@.can_deallocate(old(self)@.addr_to_block_idx(ptr as int)),
+            block_perm.is_range(ptr as int, old(self)@.block_size),
+            block_perm.provenance() == old(perms).index_perm.provenance(),
+            old(perms).wf(old(self)@, old(perms).index_perm.provenance()),
+        ensures
+            self.inv(),
+            // Liveness: preconditions guarantee success.
+            result matches Ok(()) && {
+                let block_idx = old(self)@.addr_to_block_idx(ptr as int);
+                &&& !self@.is_allocated(block_idx)
+                &&& self@.num_data_blocks == old(self)@.num_data_blocks
+                &&& self@.block_size == old(self)@.block_size
+                &&& self@.data_addr == old(self)@.data_addr
+                &&& self@.allocated_blocks =~= old(self)@.allocated_blocks.remove(block_idx)
+                &&& self@.can_allocate()
+                &&& perms.wf(self@, old(perms).index_perm.provenance())
+                &&& perms.index_perm == old(perms).index_perm
+            },
+    {
         // Check if the pointer lies in a memory region that is not managed by this allocator.
         // Safety: the start and resulting addresses are valid.
-        if ptr < self.data_addr
-            || ptr >= unsafe { self.data_addr.add(self.num_data_blocks * self.block_size) }
-        {
+        proof {
+            assert((self.data_addr as int) + (self.num_data_blocks as int) * (
+            self.block_size as int) <= usize::MAX as int);
+        }
+        if (ptr as usize) < (self.data_addr as usize) || (ptr as usize) >= (self.data_addr as usize)
+            + self.num_data_blocks * self.block_size {
             return Err(Error::new(ErrorCode::BadAddress, "pointer out of bounds"));
         }
-
         // Compute the block index.
         // Safety: we have already checked that ptr is within the bounds of the slab.
-        let index: usize = self.num_index_blocks
-            + unsafe { ptr.offset_from_unsigned(self.data_addr) } / self.block_size;
+
+        proof {
+            Self::lemma_dealloc_offset_bounds(self, ptr as int);
+        }
+
+        let index: usize = self.num_index_blocks + ((ptr as usize) - (self.data_addr as usize)) / self.block_size;
+
+        proof {
+            Self::lemma_dealloc_index_is_allocated(self, ptr as int, index as int);
+        }
 
         // Check if the block is already free.
         if !self.index.test(index)? {
@@ -220,8 +528,28 @@ impl Slab {
         }
 
         // Free the block.
-        self.index.clear(index)?;
-
-        Ok(())
+        match self.index.clear(index) {
+            Ok(()) => {
+                proof {
+                    Self::lemma_dealloc_ok_finalize(
+                        self,
+                        old(self),
+                        index as int,
+                        ptr as int,
+                        perms,
+                        block_perm,
+                    );
+                }
+                Ok(())
+            },
+            Err(e) => {
+                proof {
+                    Self::lemma_dealloc_clear_err_preserves_inv(self, old(self));
+                }
+                Err(e)
+            },
+        }
     }
 }
+
+} // verus!

--- a/src/libs/slab/src/lib.spec.rs
+++ b/src/libs/slab/src/lib.spec.rs
@@ -1,0 +1,249 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// Specifications.
+
+verus! {
+
+/// A view of the Slab as an abstract specification.
+#[verifier::ext_equal]
+pub struct SlabView {
+    /// Set of allocated block indices (relative to data blocks).
+    pub allocated_blocks: Set<int>,
+    /// Total number of data blocks.
+    pub num_data_blocks: int,
+    /// Block size in bytes.
+    pub block_size: int,
+    /// Base address of data region.
+    pub data_addr: int,
+}
+
+impl SlabView {
+    /// Returns the number of allocated blocks.
+    pub open spec fn used(&self) -> int {
+        self.allocated_blocks.len() as int
+    }
+
+    /// Returns the capacity (total number of data blocks).
+    pub open spec fn capacity(&self) -> int {
+        self.num_data_blocks
+    }
+
+    /// Returns the number of free blocks.
+    pub open spec fn free(&self) -> int {
+        self.capacity() - self.used()
+    }
+
+    /// Returns true if block at given index is allocated.
+    pub open spec fn is_allocated(&self, block_idx: int) -> bool {
+        self.allocated_blocks.contains(block_idx)
+    }
+
+    /// Returns true if the slab is full.
+    pub open spec fn is_full(&self) -> bool {
+        self.used() == self.num_data_blocks
+    }
+
+    /// Returns true if the slab is empty.
+    pub open spec fn is_empty(&self) -> bool {
+        self.allocated_blocks.len() == 0
+    }
+
+    /// Returns the address of a block given its index.
+    pub open spec fn block_addr(&self, block_idx: int) -> int {
+        self.data_addr + block_idx * self.block_size
+    }
+
+    /// Returns the block index for a given address.
+    pub open spec fn addr_to_block_idx(&self, addr: int) -> int {
+        (addr - self.data_addr) / self.block_size
+    }
+
+    /// Returns true if the data address is aligned to block size.
+    pub open spec fn is_aligned(&self) -> bool {
+        self.data_addr % self.block_size == 0
+    }
+
+    /// Returns true if the address is valid for this slab.
+    pub open spec fn is_valid_addr(&self, addr: int) -> bool {
+        &&& addr >= self.data_addr
+        &&& addr < self.data_addr + self.num_data_blocks * self.block_size
+        &&& (addr - self.data_addr) % self.block_size == 0
+    }
+
+    //==============================================================================================
+    // High-Level Memory Management Properties
+    //==============================================================================================
+    /// Property: All allocated block indices are within valid range.
+    pub open spec fn allocated_blocks_in_range(&self) -> bool {
+        forall|i: int|
+            #![trigger self.is_allocated(i)]
+            self.is_allocated(i) ==> (0 <= i < self.num_data_blocks)
+    }
+
+    /// Property: Memory regions of different blocks are disjoint.
+    /// Two blocks with different indices have non-overlapping memory regions.
+    pub open spec fn blocks_are_disjoint(&self, i: int, j: int) -> bool
+        recommends
+            0 <= i < self.num_data_blocks,
+            0 <= j < self.num_data_blocks,
+            i != j,
+    {
+        let addr_i = self.block_addr(i);
+        let addr_j = self.block_addr(j);
+        // Block i's region [addr_i, addr_i + block_size) does not overlap with block j's region.
+        addr_i + self.block_size <= addr_j || addr_j + self.block_size <= addr_i
+    }
+
+    /// Property: All allocated blocks have disjoint memory regions (no aliasing).
+    pub open spec fn no_memory_aliasing(&self) -> bool {
+        forall|i: int, j: int|
+            #![trigger self.is_allocated(i), self.is_allocated(j)]
+            (self.is_allocated(i) && self.is_allocated(j) && i != j) ==> self.blocks_are_disjoint(
+                i,
+                j,
+            )
+    }
+
+    /// Property: Inverse relationship - addr_to_block_idx(block_addr(i)) == i for valid i.
+    pub open spec fn addr_block_idx_inverse(&self, i: int) -> bool
+        recommends
+            0 <= i < self.num_data_blocks,
+            self.block_size > 0,
+    {
+        self.addr_to_block_idx(self.block_addr(i)) == i
+    }
+
+    /// Property: Inverse relationship - block_addr(addr_to_block_idx(a)) == a for valid addresses.
+    pub open spec fn block_addr_inverse(&self, addr: int) -> bool
+        recommends
+            self.is_valid_addr(addr),
+            self.block_size > 0,
+    {
+        self.block_addr(self.addr_to_block_idx(addr)) == addr
+    }
+
+    //==============================================================================================
+    // Liveness Properties
+    //==============================================================================================
+    /// Property (Liveness): If there's free capacity, allocation can succeed.
+    pub open spec fn can_allocate(&self) -> bool {
+        self.free() > 0
+    }
+
+    /// Property (Liveness): If a block is allocated, it can be deallocated.
+    pub open spec fn can_deallocate(&self, block_idx: int) -> bool {
+        self.is_allocated(block_idx) && 0 <= block_idx < self.num_data_blocks
+    }
+
+    /// Property (Liveness): After deallocation, allocation becomes possible.
+    pub open spec fn dealloc_enables_alloc(&self, freed_view: &SlabView) -> bool
+        recommends
+            self.used() == self.capacity(),
+    {
+        freed_view.used() < freed_view.capacity()
+    }
+
+    //==============================================================================================
+    // Memory Initialization Properties
+    //==============================================================================================
+    /// Property: A freshly initialized slab has no allocated data blocks.
+    pub open spec fn is_freshly_initialized(&self) -> bool {
+        self.allocated_blocks =~= Set::<int>::empty()
+    }
+
+    //==============================================================================================
+    // PointsToRaw Memory Permission Properties
+    //==============================================================================================
+    /// Returns the memory domain (set of addresses) for a given block index.
+    pub open spec fn block_dom(&self, block_idx: int) -> Set<int> {
+        set_int_range(self.block_addr(block_idx), self.block_addr(block_idx) + self.block_size)
+    }
+
+    /// Returns the memory domain for the entire data region.
+    pub open spec fn data_region_dom(&self) -> Set<int> {
+        set_int_range(self.data_addr, self.data_addr + self.num_data_blocks * self.block_size)
+    }
+
+    /// Returns the union of all free block domains.
+    pub open spec fn free_region_dom(&self) -> Set<int> {
+        Set::new(
+            |addr: int|
+                exists|i: int|
+                    #![trigger self.block_dom(i)]
+                    0 <= i < self.num_data_blocks && !self.is_allocated(i) && self.block_dom(
+                        i,
+                    ).contains(addr),
+        )
+    }
+
+    /// Property: A permission map is well-formed for this slab view.
+    /// Every free block i has a permission in the map covering [block_addr(i), block_addr(i) + block_size).
+    /// Every allocated block has no permission in the map.
+    /// The map domain is exactly the set of free block indices.
+    pub open spec fn perms_wf(&self, perms: Map<int, PointsToRaw>, prov: Provenance) -> bool {
+        &&& forall|i: int|
+            #![trigger perms.dom().contains(i)]
+            (0 <= i < self.num_data_blocks && !self.is_allocated(i)) ==> perms.dom().contains(i)
+                && (#[trigger] perms[i]).is_range(self.block_addr(i), self.block_size)
+                && perms[i].provenance() == prov
+        &&& forall|i: int|
+            #![trigger perms.dom().contains(i)]
+            (0 <= i < self.num_data_blocks && self.is_allocated(i)) ==> !perms.dom().contains(
+                i,
+            )
+            // M1: domain is exactly the free block set (no extra entries).
+        &&& forall|i: int|
+            #![trigger perms.dom().contains(i)]
+            perms.dom().contains(i) ==> (0 <= i < self.num_data_blocks && !self.is_allocated(i))
+    }
+    //==============================================================================================
+
+}
+
+//==================================================================================================
+// Tracked Memory Permissions
+//==================================================================================================
+/// Tracked proof state for slab memory ownership.
+/// This struct is erased at compile time — it exists only for verification.
+/// It tracks per-block PointsToRaw permissions for the free data blocks
+/// and the index region permission (trust boundary with RawArray).
+pub tracked struct SlabPerms {
+    /// Per-block permissions for free data blocks.
+    pub free_perms: Map<int, PointsToRaw>,
+    /// Permission for the index region.
+    pub index_perm: PointsToRaw,
+}
+
+impl SlabPerms {
+    /// Well-formedness predicate linking permissions to a slab view.
+    /// The `index_perm` covers the index region (its range is established by `from_raw_parts`
+    /// and preserved by `take_block_perm`/`put_block_perm` which guarantee `index_perm` invariance).
+    pub open spec fn wf(&self, view: SlabView, prov: Provenance) -> bool {
+        &&& view.perms_wf(self.free_perms, prov)
+        &&& self.index_perm.provenance() == prov
+    }
+
+    /// Removes a block's permission from free_perms and returns it.
+    pub proof fn take_block_perm(tracked &mut self, block_idx: int) -> (tracked perm: PointsToRaw)
+        requires
+            old(self).free_perms.dom().contains(block_idx),
+        ensures
+            perm == old(self).free_perms[block_idx],
+            self.free_perms == old(self).free_perms.remove(block_idx),
+            self.index_perm == old(self).index_perm,
+    {
+        self.free_perms.tracked_remove(block_idx)
+    }
+
+    /// Inserts a block's permission back into free_perms.
+    pub proof fn put_block_perm(tracked &mut self, block_idx: int, tracked perm: PointsToRaw)
+        ensures
+            self.free_perms == old(self).free_perms.insert(block_idx, perm),
+            self.index_perm == old(self).index_perm,
+    {
+        self.free_perms.tracked_insert(block_idx, perm);
+    }
+}
+
+} // verus!

--- a/src/libs/slab/src/lib.test.rs
+++ b/src/libs/slab/src/lib.test.rs
@@ -1,0 +1,564 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// Slab Allocator - Verified Tests.
+// Verified test functions that prove key slab allocator properties.
+
+verus! {
+
+//==================================================================================================
+// Verified Test Functions
+//==================================================================================================
+
+/// Common preconditions macro-like spec for slab test parameters.
+/// All test functions share these requirements on addr, len, block_size, mem.
+
+/// Verifiable test: from_raw_parts creates a valid slab with expected properties.
+fn test_slab_from_raw_parts_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 8,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (slab, Tracked(slab_perms)) = pair;
+            assert(slab.inv());
+            assert(forall|i: int| 0 <= i < slab@.num_data_blocks ==> !slab@.is_allocated(i));
+            assert(slab@.block_size == block_size as int);
+            assert(slab@.data_addr % (block_size as int) == 0);
+            assert(slab@.num_data_blocks > 0);
+        },
+        Err(_) => {},
+    }
+}
+
+/// Verifiable test: from_raw_parts followed by allocate/deallocate works correctly.
+fn test_slab_from_raw_parts_allocate_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 8,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (mut slab, Tracked(mut slab_perms)) = pair;
+            assert(forall|i: int| 0 <= i < slab@.num_data_blocks ==> !slab@.is_allocated(i));
+
+            match slab.allocate(Tracked(&mut slab_perms)) {
+                Ok(alloc_pair) => {
+                    let (alloc_addr, Tracked(block_perm)) = alloc_pair;
+                    proof {
+                        assert(slab@.is_valid_addr(alloc_addr as int));
+                        let block_idx = slab@.addr_to_block_idx(alloc_addr as int);
+                        assert(slab@.is_allocated(block_idx));
+                        assert(block_perm.is_range(alloc_addr as int, slab@.block_size));
+                    }
+                    match unsafe {
+                        slab.deallocate(alloc_addr, Tracked(block_perm), Tracked(&mut slab_perms))
+                    } {
+                        Ok(()) => {
+                            proof {
+                                let block_idx = slab@.addr_to_block_idx(alloc_addr as int);
+                                assert(!slab@.is_allocated(block_idx));
+                            }
+                        },
+                        Err(_) => {},
+                    }
+                },
+                Err(_) => {},
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+//==================================================================================================
+
+/// Verifiable test: allocating a block and then deallocating it.
+fn test_allocate_deallocate_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 8,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (mut slab, Tracked(mut slab_perms)) = pair;
+            match slab.allocate(Tracked(&mut slab_perms)) {
+                Ok(alloc_pair) => {
+                    let (block_addr, Tracked(block_perm)) = alloc_pair;
+                    proof {
+                        let block_idx = slab@.addr_to_block_idx(block_addr as int);
+                        assert(slab@.is_allocated(block_idx));
+                    }
+                    match unsafe {
+                        slab.deallocate(block_addr, Tracked(block_perm), Tracked(&mut slab_perms))
+                    } {
+                        Ok(()) => {
+                            proof {
+                                let block_idx = slab@.addr_to_block_idx(block_addr as int);
+                                assert(!slab@.is_allocated(block_idx));
+                            }
+                        },
+                        Err(_) => {},
+                    }
+                },
+                Err(_) => {},
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+/// Verifiable test: double deallocation is prevented by linear permissions.
+/// After deallocating, the caller no longer holds the PointsToRaw permission,
+/// so a second deallocate call is impossible at the type level.
+fn test_double_deallocate_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 8,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (mut slab, Tracked(mut slab_perms)) = pair;
+            match slab.allocate(Tracked(&mut slab_perms)) {
+                Ok(alloc_pair) => {
+                    let (block_addr, Tracked(block_perm)) = alloc_pair;
+                    // First deallocation consumes block_perm.
+                    match unsafe {
+                        slab.deallocate(block_addr, Tracked(block_perm), Tracked(&mut slab_perms))
+                    } {
+                        Ok(()) => {
+                            proof {
+                                let block_idx = slab@.addr_to_block_idx(block_addr as int);
+                                assert(!slab@.is_allocated(block_idx));
+                                // block_perm was consumed — a second deallocate is
+                                // impossible because the caller has no permission to pass.
+                            }
+                        },
+                        Err(_) => {},
+                    }
+                },
+                Err(_) => {},
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+/// Verifiable test: deallocating an out-of-bounds address would violate preconditions.
+fn test_allocate_out_of_bounds_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 8,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (slab, Tracked(_perms)) = pair;
+            proof {
+                let invalid_addr = slab@.data_addr + slab@.num_data_blocks * slab@.block_size;
+                assert(!slab@.is_valid_addr(invalid_addr));
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+/// Verifiable test: multiple allocations return different addresses.
+fn test_multiple_allocations_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 16,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (mut slab, Tracked(mut slab_perms)) = pair;
+            match slab.allocate(Tracked(&mut slab_perms)) {
+                Ok(pair1) => {
+                    let (addr1, Tracked(_perm1)) = pair1;
+                    match slab.allocate(Tracked(&mut slab_perms)) {
+                        Ok(pair2) => {
+                            let (addr2, Tracked(_perm2)) = pair2;
+                            assert(addr1 != addr2);
+                            proof {
+                                let idx1 = slab@.addr_to_block_idx(addr1 as int);
+                                let idx2 = slab@.addr_to_block_idx(addr2 as int);
+                                assert(slab@.is_allocated(idx1));
+                                assert(slab@.is_allocated(idx2));
+                                assert(idx1 != idx2);
+                            }
+                        },
+                        Err(_) => {},
+                    }
+                },
+                Err(_) => {},
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+/// Verifiable test: address computation properties.
+fn test_address_computation_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 8,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (mut slab, Tracked(mut slab_perms)) = pair;
+            match slab.allocate(Tracked(&mut slab_perms)) {
+                Ok(alloc_pair) => {
+                    let (alloc_addr, Tracked(_perm)) = alloc_pair;
+                    proof {
+                        assert(slab@.is_valid_addr(alloc_addr as int));
+                        let block_idx = slab@.addr_to_block_idx(alloc_addr as int);
+                        assert(0 <= block_idx < slab@.num_data_blocks);
+                        assert(slab@.is_allocated(block_idx));
+                    }
+                },
+                Err(_) => {},
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+//==================================================================================================
+
+/// Verifiable test: after deallocation, the same block can be reallocated.
+fn test_allocation_reuse_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 8,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (mut slab, Tracked(mut slab_perms)) = pair;
+            match slab.allocate(Tracked(&mut slab_perms)) {
+                Ok(alloc_pair) => {
+                    let (addr1, Tracked(perm1)) = alloc_pair;
+                    match unsafe { slab.deallocate(addr1, Tracked(perm1), Tracked(&mut slab_perms))
+                    } {
+                        Ok(()) => {
+                            match slab.allocate(Tracked(&mut slab_perms)) {
+                                Ok(alloc_pair2) => {
+                                    let (addr2, Tracked(_perm2)) = alloc_pair2;
+                                    proof {
+                                        assert(slab@.is_valid_addr(addr2 as int));
+                                        assert(slab@.is_allocated(
+                                            slab@.addr_to_block_idx(addr2 as int),
+                                        ));
+                                    }
+                                },
+                                Err(_) => {},
+                            }
+                        },
+                        Err(_) => {},
+                    }
+                },
+                Err(_) => {},
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+/// Verifiable test: all allocated addresses are aligned to block_size.
+fn test_memory_block_alignment_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 16,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (mut slab, Tracked(mut slab_perms)) = pair;
+            match slab.allocate(Tracked(&mut slab_perms)) {
+                Ok(pair1) => {
+                    let (addr1, Tracked(_perm1)) = pair1;
+                    match slab.allocate(Tracked(&mut slab_perms)) {
+                        Ok(pair2) => {
+                            let (addr2, Tracked(_perm2)) = pair2;
+                            proof {
+                                assert(slab@.is_valid_addr(addr1 as int));
+                                assert(slab@.is_valid_addr(addr2 as int));
+                                assert(addr1 as int >= slab@.data_addr);
+                                assert(addr2 as int >= slab@.data_addr);
+                            }
+                        },
+                        Err(_) => {},
+                    }
+                },
+                Err(_) => {},
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+/// Verifiable test: deallocating one block doesn't affect other allocated blocks.
+fn test_no_data_corruption_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 16,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (mut slab, Tracked(mut slab_perms)) = pair;
+            match slab.allocate(Tracked(&mut slab_perms)) {
+                Ok(pair1) => {
+                    let (addr1, Tracked(perm1)) = pair1;
+                    match slab.allocate(Tracked(&mut slab_perms)) {
+                        Ok(pair2) => {
+                            let (addr2, Tracked(_perm2)) = pair2;
+                            proof {
+                                let idx1 = slab@.addr_to_block_idx(addr1 as int);
+                                let idx2 = slab@.addr_to_block_idx(addr2 as int);
+                                assert(slab@.is_allocated(idx1));
+                                assert(slab@.is_allocated(idx2));
+                            }
+                            // Deallocate block 1.
+                            match unsafe {
+                                slab.deallocate(addr1, Tracked(perm1), Tracked(&mut slab_perms))
+                            } {
+                                Ok(()) => {
+                                    proof {
+                                        let idx1 = slab@.addr_to_block_idx(addr1 as int);
+                                        let idx2 = slab@.addr_to_block_idx(addr2 as int);
+                                        assert(!slab@.is_allocated(idx1));
+                                        assert(slab@.is_allocated(idx2));
+                                    }
+                                },
+                                Err(_) => {},
+                            }
+                        },
+                        Err(_) => {},
+                    }
+                },
+                Err(_) => {},
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+/// Verifiable test: fresh slab has all data blocks free.
+fn test_fresh_slab_all_free_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 8,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (slab, Tracked(_perms)) = pair;
+            proof {
+                assert(forall|i: int| 0 <= i < slab@.num_data_blocks ==> !slab@.is_allocated(i));
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+/// Verifiable test: index blocks are always marked as used.
+fn test_index_blocks_always_used_verified(
+    addr: *mut u8,
+    len: usize,
+    block_size: usize,
+    Tracked(mem): Tracked<PointsToRaw>,
+)
+    requires
+        len > 0,
+        len < i32::MAX as usize,
+        block_size > 0,
+        block_size < i32::MAX as usize,
+        block_size <= len,
+        is_pow2(block_size as int),
+        (addr as usize) % block_size == 0,
+        addr as int > 0,
+        (addr as int) + (len as int) <= (usize::MAX as int),
+        (len / block_size) % (u8::BITS as usize) == 0,
+        len / block_size >= 8,
+        mem.is_range(addr as int, len as int),
+{
+    match unsafe { Slab::from_raw_parts(addr, len, block_size, Tracked(mem)) } {
+        Ok(pair) => {
+            let (mut slab, Tracked(mut slab_perms)) = pair;
+            // Invariant holds after construction.
+            assert(slab.inv());
+            match slab.allocate(Tracked(&mut slab_perms)) {
+                Ok(alloc_pair) => {
+                    let (_addr, Tracked(_perm)) = alloc_pair;
+                    // Invariant still holds after allocation.
+                    assert(slab.inv());
+                },
+                Err(_) => {},
+            }
+        },
+        Err(_) => {},
+    }
+}
+
+} // verus!


### PR DESCRIPTION
## Summary

Add Verus formal verification to the `slab` crate, proving memory safety, functional correctness, and memory ownership properties for the slab allocator.

**Verification result: 84 verified, 0 errors.**

## What's Verified

### Functional Correctness (3 core functions)
- **`from_raw_parts`**: Slab construction establishes invariant, all blocks start free, data region fits within buffer.
- **`allocate`**: Returns a valid, previously-free block; frame conditions preserve other blocks; liveness (if capacity exists, allocation succeeds).
- **`deallocate`**: Frees a valid allocated block; frame conditions; liveness (deallocation always enables future allocation).

### Memory Ownership (PointsToRaw)
- **Linear permission tracking**: Each allocated block carries a `Tracked<PointsToRaw>` permission proving the caller owns that memory region. Deallocate requires the caller to return the permission.
- **Double-free prevention**: Statically impossible — the `PointsToRaw` permission is consumed on deallocation, so a second deallocation has no permission to pass.
- **Use-after-free prevention**: Without the `PointsToRaw` permission, the freed memory cannot be accessed.
- **Permission splitting**: `from_raw_parts` splits the initial `Tracked<PointsToRaw>` into per-block permissions using a verified recursive `split_into_blocks` proof function.

### Safety Properties (verified theorems)
- **No memory aliasing**: Different allocated blocks occupy non-overlapping memory regions (`lemma_no_memory_aliasing`).
- **Block disjointness**: Formally proven via address arithmetic (`lemma_blocks_disjoint`).
- **Address ↔ index bijection**: `addr_to_block_idx(block_addr(i)) == i` and inverse (`lemma_addr_block_idx_inverse`, `lemma_block_addr_inverse`).
- **Liveness**: Deallocation from a full slab enables future allocation (`lemma_dealloc_from_full_enables_alloc`).
- **Bitmap consistency**: Bitmap full ↔ slab full (`lemma_bitmap_full_implies_slab_full`).

## Design Decisions

### API Changes (`Tracked` Parameters)

The verified API adds `Tracked<T>` parameters following the [verus-mimalloc](https://github.com/verus-lang/verified-memory-allocator) pattern. Unlike `requires`/`ensures` annotations which are erased by the `verus!` macro, **`Tracked<T>` is a real zero-sized Rust type** that persists in the compiled signature. This is Verus's design: callers must explicitly pass ownership proofs.

```rust
// Verified signature (Tracked params are zero-sized at runtime):
pub fn allocate(&mut self, Tracked(perms): Tracked<&mut SlabPerms>)
    -> Result<(*mut u8, Tracked<PointsToRaw>), Error>
```

**Impact on callers**: Non-verified callers (e.g., kernel's `kheap`) must pass `Tracked::assume_new()` and destructure the tuple return. This is a minimal, zero-cost adaptation — `Tracked::assume_new()` produces a zero-sized value, and `.0` extracts the exec result from the tuple. The current PR includes these kheap changes.

**Open question**: Whether this API change is acceptable for the project, or whether Tracked params should be confined to verification-only wrapper functions to avoid touching callers. This is a design decision for review discussion.

### `SlabPerms` Tracked Struct
Following the [verus-mimalloc](https://github.com/verus-lang/verified-memory-allocator) pattern, memory permissions are stored in a `tracked struct SlabPerms` (erased at runtime) with `take_block_perm`/`put_block_perm` methods using `tracked_swap` for field mutation.

### Pointer Arithmetic
Uses Verus's native `ptr.with_addr(ptr.addr() + offset)` and `(ptr as usize) - (origin as usize)` instead of custom `external_body` wrappers. Zero `external_body` functions except the unavoidable bitwise-to-`is_pow2` bridge (documented trust justification).

## Verification

```
$ make verify
verification results:: 84 verified, 0 errors   # slab
```