### PR TITLE
[nanvix-sandbox] Restore L2 VMs With Different Snapshot Dirs

### DIFF
--- a/src/libs/nanvix-sandbox-cache/src/config.rs
+++ b/src/libs/nanvix-sandbox-cache/src/config.rs
@@ -69,7 +69,7 @@ pub struct SandboxCacheConfig<T> {
     log_directory: String,
     /// Flag indicating whether to deploy linuxd inside an L2 VM (using cloud-hypervisor).
     l2: bool,
-    /// Path to the snapshot file in an L2 deployment.
+    /// Path to the base snapshot file in an L2 deployment.
     l2_snapshot_path: String,
     /// Path to the temporary directory for Unix sockets and transient files.
     tmp_directory: String,
@@ -105,7 +105,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
     /// - `toolchain_binary_directory`: Path to the toolchain binary directory.
     /// - `log_directory`: Path to the log directory.
     /// - `l2`: Flag to deploy linuxd inside an L2 VM.
-    /// - `l2_snapshot_path`: Path to the L2 VM's snapshot.
+    /// - `l2_snapshot_path`: Path to the L2 VM's base snapshot.
     /// - `tmp_directory`: Path to the temporary directory.
     ///
     /// # Returns
@@ -347,11 +347,11 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
     ///
     /// # Description
     ///
-    /// Returns the L2 snapshot path.
+    /// Returns the L2 base snapshot path.
     ///
     /// # Returns
     ///
-    /// The L2 snapshot path.
+    /// The L2 base snapshot path.
     ///
     pub fn l2_snapshot_path(&self) -> &str {
         &self.l2_snapshot_path

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -46,6 +46,8 @@ use ::nanvix_sandbox::netns::{
     NetnsPoolConfig,
     NetnsPoolInitStrategy,
 };
+#[cfg(not(feature = "single-process"))]
+use ::nanvix_sandbox::SnapshotDirHandle;
 use ::nanvix_sandbox::{
     control_plane_sockaddr_builder,
     gateway_sockaddr_builder,
@@ -542,6 +544,10 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                     anyhow::bail!(reason);
                 }
 
+                #[cfg(not(feature = "single-process"))]
+                let l2_sysvm_snapshot_dir: PathBuf =
+                    sandbox_tmp_dir.join(format!("l2-sysvm-snapshot-{}", tag.sandbox_id()));
+
                 let config: SandboxConfig<T> = SandboxConfig::new(
                     tag.tenant_id(),
                     tag.sandbox_id(),
@@ -568,9 +574,35 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                     Some(self.config.toolchain_binary_directory().to_string()),
                     Some(sandbox_tmp_dir.to_string_lossy().into_owned()),
                     Some(self.config.l2()),
-                    Some(self.config.l2_snapshot_path().to_string()),
                 );
 
+                #[cfg(not(feature = "single-process"))]
+                let uninitialized_sandbox: UninitializedSandbox<T> = if self.config.l2() {
+                    let snapshot_dir_handle: SnapshotDirHandle = SnapshotDirHandle::new(
+                        &l2_sysvm_snapshot_dir,
+                        self.config.l2_snapshot_path(),
+                        config.l2_linuxd_log_file(),
+                    )
+                    .map_err(|error| {
+                        let reason: String = format!(
+                            "failed to create snapshot directory handle (tenant_id={}, \
+                             program={}, app_name={}, error={error:?})",
+                            tag.tenant_id(),
+                            tag.program(),
+                            tag.app_name()
+                        );
+                        error!("get(): {reason}");
+                        anyhow::anyhow!(reason)
+                    })?;
+
+                    uninitialized_sandbox
+                        .with_config(config)
+                        .with_snapshot_dir_handle(Some(snapshot_dir_handle))
+                } else {
+                    uninitialized_sandbox.with_config(config)
+                };
+
+                #[cfg(feature = "single-process")]
                 let uninitialized_sandbox: UninitializedSandbox<T> =
                     uninitialized_sandbox.with_config(config);
 

--- a/src/libs/nanvix-sandbox/Cargo.toml
+++ b/src/libs/nanvix-sandbox/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+build-utils = { workspace = true }
 cfg-if = { workspace = true }
 chrono = { workspace = true }
 config = { workspace = true }
@@ -21,6 +22,7 @@ linuxd = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
+serde_json = { workspace = true }
 syscomm = { workspace = true }
 sys = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -78,7 +78,6 @@
 //!     Some("/path/to/toolchain".to_string()),  // toolchain_binary_directory
 //!     Some("/tmp".to_string()),  // tmp_directory
 //!     Some(false),  // l2
-//!     Some("/path/to/l2/snapshot".to_string()), // l2_snapshot_path
 //! );
 //!
 //! // Create and bind control plane socket.
@@ -135,6 +134,8 @@ mod initialized;
 mod linuxd_args;
 mod running;
 mod sandbox_config;
+#[cfg(not(feature = "single-process"))]
+mod snapshot_dir_handle;
 mod tag;
 mod uninitialized;
 mod uservm_args;
@@ -168,6 +169,8 @@ pub mod tcp_port;
     }
 }
 
+#[cfg(not(feature = "single-process"))]
+pub use self::snapshot_dir_handle::SnapshotDirHandle;
 pub use self::{
     initialized::InitializedSandbox,
     linuxd_args::LinuxDaemonArgs,

--- a/src/libs/nanvix-sandbox/src/linuxd_args.rs
+++ b/src/libs/nanvix-sandbox/src/linuxd_args.rs
@@ -49,8 +49,6 @@ pub struct LinuxDaemonArgs<T> {
     tmp_directory: String,
     /// Flag to deploy linuxd inside an L2 VM (using cloud-hypervisor).
     l2: bool,
-    /// Path to the L2 snapshot path.
-    l2_snapshot_path: String,
     /// Optional system call table for overriding default system call behavior.
     #[cfg(feature = "single-process")]
     syscall_table: Option<::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>>,
@@ -81,7 +79,6 @@ impl<T> LinuxDaemonArgs<T> {
     /// - `log_directory`: Directory path for writing log files.
     /// - `tmp_directory`: Temporary directory path for Unix sockets and transient files.
     /// - `l2`: Flag to deploy linuxd inside an L2 VM (using cloud-hypervisor).
-    /// - `l2_snapshot_path`: Path to the L2 VM snapshot.
     /// - `syscall_table`: Optional system call table for overriding default system call behavior (only if in single-process mode).
     ///
     /// # Returns
@@ -99,7 +96,6 @@ impl<T> LinuxDaemonArgs<T> {
         log_directory: String,
         tmp_directory: String,
         l2: bool,
-        l2_snapshot_path: String,
         #[cfg(feature = "single-process")] syscall_table: Option<
             ::std::sync::Arc<::linuxd::syscalls::SyscallTable<T>>,
         >,
@@ -115,7 +111,6 @@ impl<T> LinuxDaemonArgs<T> {
             log_directory,
             tmp_directory,
             l2,
-            l2_snapshot_path,
             #[cfg(feature = "single-process")]
             syscall_table,
             #[cfg(not(feature = "single-process"))]
@@ -200,19 +195,6 @@ impl<T> LinuxDaemonArgs<T> {
     ///
     pub fn toolchain_binary_directory(&self) -> &str {
         &self.toolchain_binary_directory
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Returns the L2 snapshot path.
-    ///
-    /// # Returns
-    ///
-    /// The L2 snapshot path.
-    ///
-    pub fn l2_snapshot_path(&self) -> &str {
-        &self.l2_snapshot_path
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/multi_process/linuxd.rs
@@ -15,7 +15,6 @@ use crate::{
     config::{
         get_clh_api_socket_path,
         get_clh_bin_dir,
-        get_clh_snapshot_path,
         CONTROL_PLANE_ACCEPT_TIMEOUT,
         SHUTDOWN_TIMEOUT,
     },
@@ -25,6 +24,7 @@ use crate::{
     },
     netns_exec::command_in_netns,
     LinuxDaemonArgs,
+    SnapshotDirHandle,
 };
 use ::anyhow::Result;
 use ::control_plane_api::{
@@ -159,7 +159,6 @@ struct LinuxDaemonInner {
     control_plane_stream: SocketStream,
 }
 
-///
 /// # Description
 ///
 /// Handle to a running Linux Daemon instance spawned as a separate process.
@@ -169,6 +168,8 @@ pub struct LinuxDaemon {
     inner: Mutex<Option<LinuxDaemonInner>>,
     /// RAII handle to the network namespace linuxd runs in (L2-mode only).
     netns_handle: Option<NetnsHandle>,
+    /// RAII handle to the per-instance snapshot directory used in L2 mode.
+    snapshot_dir_handle: Option<SnapshotDirHandle>,
 }
 
 //==================================================================================================
@@ -319,7 +320,7 @@ impl LinuxDaemon {
             clh_api_socket_path.to_string(),
             args::Args::OPT_CH_REMOTE_RESUME.to_string(),
         ];
-        trace!("ch-remote args: {ch_remote_args:?}");
+        debug!("resume_l2_vm(): executing ch-remote with args: {}", ch_remote_args.join(" "));
         let status: ExitStatus =
             command_in_netns(netns_info, &ch_remote_args[0], &ch_remote_args[1..])
                 .stdout(Stdio::inherit())
@@ -449,9 +450,10 @@ impl LinuxDaemon {
         args: &LinuxDaemonArgs<T>,
         control_plane_listener: &mut SocketListener,
         netns_handle: Option<NetnsHandle>,
+        snapshot_dir_handle: Option<SnapshotDirHandle>,
     ) -> Result<Self> {
         debug!(
-            "spawning linux daemon (control-plane={:?}, user-vm={:?}, l2={})",
+            "spawn(): spawning linux daemon (control-plane={:?}, user-vm={:?}, l2={})",
             args.control_plane_connect_socket_info(),
             args.system_vm_socket_info(),
             args.l2()
@@ -459,6 +461,12 @@ impl LinuxDaemon {
 
         let clh_api_socket_path: String = get_clh_api_socket_path(args.tmp_directory());
         let mut linuxd_args: Vec<String> = if args.l2() {
+            let snapshot_dir_handle: &SnapshotDirHandle =
+                snapshot_dir_handle.as_ref().ok_or_else(|| {
+                    let reason: &str = "snapshot directory handle not provided for L2 deployment";
+                    error!("spawn(): {reason}");
+                    anyhow::anyhow!(reason)
+                })?;
             match ::std::fs::remove_file(&clh_api_socket_path) {
                 Ok(()) => {},
                 Err(e) if e.kind() == ::std::io::ErrorKind::NotFound => {},
@@ -478,7 +486,10 @@ impl LinuxDaemon {
                 args::Args::OPT_CLH_SECCOMP.to_string(),
                 "false".to_string(),
                 args::Args::OPT_CLH_RESTORE.to_string(),
-                format!("source_url=file://{}", get_clh_snapshot_path(args.l2_snapshot_path())?),
+                format!(
+                    "source_url=file://{}",
+                    snapshot_dir_handle.path().to_string_lossy(),
+                ),
             ]
         } else {
             vec![
@@ -501,7 +512,6 @@ impl LinuxDaemon {
                 args.system_vm_socket_info().1.to_str().to_string(),
             ]
         };
-        trace!("linuxd args: {:?}", linuxd_args);
         if let Some(hwloc) = args.hwloc() {
             let taskset: Vec<String> = vec![
                 "taskset".to_string(),
@@ -510,6 +520,7 @@ impl LinuxDaemon {
             ];
             linuxd_args.splice(0..0, taskset);
         }
+        debug!("spawn(): spawning linuxd with args: {}", linuxd_args.join(" "));
 
         // Inherit stdout/stderr so that errors when spawning the command are surfaced to nanvixd.
         let child: Child = if let Some(netns_handle) = &netns_handle {
@@ -615,6 +626,7 @@ impl LinuxDaemon {
                 control_plane_stream,
             })),
             netns_handle,
+            snapshot_dir_handle,
         })
     }
 
@@ -690,5 +702,18 @@ impl LinuxDaemon {
     ///
     pub fn netns_handle(&self) -> Option<NetnsHandle> {
         self.netns_handle.clone()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the path to the per-instance snapshot directory, if any.
+    ///
+    /// # Returns
+    ///
+    /// The per-instance snapshot directory path in L2 mode, or `None` otherwise.
+    ///
+    pub fn snapshot_dir_path(&self) -> Option<&Path> {
+        self.snapshot_dir_handle.as_ref().map(SnapshotDirHandle::path)
     }
 }

--- a/src/libs/nanvix-sandbox/src/sandbox_config.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox_config.rs
@@ -12,6 +12,7 @@
 //==================================================================================================
 
 use crate::tcp_port::TcpPort;
+use ::build_utils::find_workspace_root;
 use ::chrono::Local;
 #[cfg(not(feature = "single-process"))]
 use ::std::marker::PhantomData;
@@ -86,9 +87,6 @@ pub struct SandboxConfig<T> {
     /// This must be provided if a Linux Daemon instance was not provided before sandbox initialization.
     l2: Option<bool>,
 
-    /// Optional path to the snapshot used to deploy an L2 VM.
-    l2_snapshot_path: Option<String>,
-
     /// Phantom data to maintain the generic type parameter `T` in the structure.
     /// This is required because `T` is only used in single-process mode for the syscall table.
     #[cfg(not(feature = "single-process"))]
@@ -145,7 +143,6 @@ impl<T> SandboxConfig<T> {
     /// - `toolchain_binary_directory`: Optional path to the toolchain binary directory.
     /// - `tmp_directory`: Optional path to the temporary directory.
     /// - `l2`: Optional flag to deploy the Linux Daemon inside an L2 VM.
-    /// - `l2_snapshot_path`: Optional path to the L2 VM's snapshot.
     ///
     /// # Returns
     ///
@@ -171,7 +168,6 @@ impl<T> SandboxConfig<T> {
         toolchain_binary_directory: Option<String>,
         tmp_directory: Option<String>,
         l2: Option<bool>,
-        l2_snapshot_path: Option<String>,
     ) -> Self {
         Self {
             tenant_id: tenant_id.to_string(),
@@ -196,7 +192,6 @@ impl<T> SandboxConfig<T> {
             toolchain_binary_directory,
             tmp_directory,
             l2,
-            l2_snapshot_path,
             #[cfg(not(feature = "single-process"))]
             _phantom: PhantomData,
         }
@@ -416,14 +411,27 @@ impl<T> SandboxConfig<T> {
     ///
     /// # Description
     ///
-    /// Returns the optional path pointing to the L2 snapshot directory.
+    /// Generates the linuxd log file in an L2 deployment. This log file is specified during
+    /// restore of the L2 snapshot.
+    ///
+    /// Each sandbox generates a different log file (with a different timestamp), but the actual
+    /// file name will be determined by the first sanbdox for the given tenant.
     ///
     /// # Returns
     ///
-    /// An optional path to the L2 snapshot directory.
+    /// The path to linuxd log file.
     ///
-    pub fn l2_snapshot_path(&self) -> Option<&str> {
-        self.l2_snapshot_path.as_deref()
+    pub fn l2_linuxd_log_file(&self) -> String {
+        let mut console_file: PathBuf = PathBuf::from(self.log_directory.clone()).join(format!(
+            "linuxd-l2_{}_{}.log",
+            self.tenant_id,
+            Local::now().format("%Y_%m_%d_%H_%M_%S_%f")
+        ));
+        if !console_file.is_absolute() {
+            console_file = find_workspace_root().join(console_file);
+        }
+
+        console_file.to_string_lossy().into_owned()
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/snapshot_dir_handle.rs
+++ b/src/libs/nanvix-sandbox/src/snapshot_dir_handle.rs
@@ -1,0 +1,220 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Snapshot directory allocation and management.
+//!
+//! This module provides an RAII handle for the per-instance snapshot directory used to restore
+//! an L2 system VM from a shared cloud-hypervisor snapshot.
+//!
+//! The main idea behind this module is to create symbolic links of the heavyweight components of a
+//! snapshot, like the memory ranges, but support modifying the configuration JSON file to tweak
+//! deployment characteristics between time-of-snapshot and time-of-restore.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::config::get_clh_snapshot_path;
+use ::anyhow::Result;
+use ::log::{
+    error,
+    trace,
+    warn,
+};
+use ::serde_json::Value;
+use ::std::{
+    fs,
+    io::ErrorKind,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// RAII handle to a per-instance snapshot directory used to restore the L2 system VM.
+///
+/// The handle materializes a private directory containing:
+/// - `state.json`: a symbolic link to the shared snapshot file.
+/// - `memory-ranges`: a symbolic link to the shared snapshot file.
+/// - `config.json`: a rewritten copy of the shared snapshot configuration with a per-instance
+///   console file path.
+///
+pub struct SnapshotDirHandle {
+    path: PathBuf,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl SnapshotDirHandle {
+    const STATE_FILE: &'static str = "state.json";
+    const MEMORY_RANGES_FILE: &'static str = "memory-ranges";
+    const CONFIG_FILE: &'static str = "config.json";
+
+    ///
+    /// # Description
+    ///
+    /// Creates a per-instance snapshot directory and populates it from the shared snapshot.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Destination directory for the per-instance snapshot files.
+    /// - `snapshot_source_dir`: Source directory containing the shared snapshot files.
+    /// - `console_file`: Console file path to embed in the rewritten `config.json`.
+    ///
+    /// # Returns
+    ///
+    /// A RAII handle to the created snapshot directory.
+    ///
+    pub fn new<P: AsRef<Path>, Q: AsRef<Path>, R: AsRef<Path>>(
+        path: P,
+        snapshot_source_dir: Q,
+        console_file: R,
+    ) -> Result<Self> {
+        let path: PathBuf = path.as_ref().to_path_buf();
+        let snapshot_source_dir: PathBuf =
+            PathBuf::from(get_clh_snapshot_path(&snapshot_source_dir.as_ref().to_string_lossy())?);
+        let console_file: String = console_file.as_ref().to_string_lossy().into_owned();
+
+        if path.exists() {
+            fs::remove_dir_all(&path).map_err(|error| {
+                let reason: String =
+                    format!("failed to reset snapshot directory (path={path:?}, error={error:?})");
+                error!("new(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        }
+
+        fs::create_dir_all(&path).map_err(|error| {
+            let reason: String =
+                format!("failed to create snapshot directory (path={path:?}, error={error:?})");
+            error!("new(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        Self::create_symlink(
+            snapshot_source_dir.join(Self::STATE_FILE),
+            path.join(Self::STATE_FILE),
+        )?;
+        Self::create_symlink(
+            snapshot_source_dir.join(Self::MEMORY_RANGES_FILE),
+            path.join(Self::MEMORY_RANGES_FILE),
+        )?;
+        Self::write_config_file(
+            &snapshot_source_dir.join(Self::CONFIG_FILE),
+            &path.join(Self::CONFIG_FILE),
+            &console_file,
+        )?;
+
+        Ok(Self { path })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the path to the per-instance snapshot directory.
+    ///
+    /// # Returns
+    ///
+    /// The path to the per-instance snapshot directory.
+    ///
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Helper method to create a symbolic link.
+    ///
+    /// # Arguments
+    ///
+    /// - `source`: source of the symbolic link.
+    /// - `destination`: destination of the symbolic link.
+    ///
+    fn create_symlink(source: PathBuf, destination: PathBuf) -> Result<()> {
+        ::std::os::unix::fs::symlink(&source, &destination).map_err(|error| {
+            let reason: String = format!(
+                "failed to create snapshot symlink (source={source:?}, \
+                 destination={destination:?}, error={error:?})"
+            );
+            error!("create_symlink(): {reason}");
+            anyhow::anyhow!(reason)
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Helper method to create a per-L2 VM config.json snapshot file with a modified log file.
+    /// Right now we only modify the console-file field, but in the future this method could be
+    /// used to modify other fields, e.g. the TAP device name, were it to proof necessary.
+    ///
+    /// # Arguments
+    ///
+    /// - `source`: path of the original configuration file, the source of truth.
+    /// - `destination`: path of the new configuration file.
+    /// - `console_file`: value to overwrite in the config.json file.
+    ///
+    fn write_config_file(source: &Path, destination: &Path, console_file: &str) -> Result<()> {
+        let config_contents: String = fs::read_to_string(source).map_err(|error| {
+            let reason: String =
+                format!("failed to read snapshot config (path={source:?}, error={error:?})");
+            error!("write_config_file(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        let mut config: Value = ::serde_json::from_str(&config_contents).map_err(|error| {
+            let reason: String = format!(
+                "failed to parse snapshot config as JSON (path={source:?}, error={error:?})"
+            );
+            error!("write_config_file(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        // Update console.file value.
+        config["console"]["file"] = Value::String(console_file.to_string());
+
+        let rendered: Vec<u8> = ::serde_json::to_vec_pretty(&config).map_err(|error| {
+            let reason: String = format!(
+                "failed to render snapshot config as JSON (path={destination:?}, error={error:?})"
+            );
+            error!("write_config_file(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        fs::write(destination, rendered).map_err(|error| {
+            let reason: String =
+                format!("failed to write snapshot config (path={destination:?}, error={error:?})");
+            error!("write_config_file(): {reason}");
+            anyhow::anyhow!(reason)
+        })
+    }
+}
+
+impl Drop for SnapshotDirHandle {
+    ///
+    /// # Description
+    ///
+    /// Drops the snapshot directory handle, removing the backing directory recursively.
+    ///
+    fn drop(&mut self) {
+        trace!("drop(): removing snapshot directory (path={:?})", self.path);
+        if let Err(error) = fs::remove_dir_all(&self.path) {
+            if error.kind() != ErrorKind::NotFound {
+                warn!(
+                    "drop(): failed to remove snapshot directory (path={:?}, error={error:?})",
+                    self.path
+                );
+            }
+        }
+    }
+}

--- a/src/libs/nanvix-sandbox/src/uninitialized.rs
+++ b/src/libs/nanvix-sandbox/src/uninitialized.rs
@@ -16,6 +16,8 @@ use crate::netns::{
     NetnsHandle,
     NetnsInfo,
 };
+#[cfg(not(feature = "single-process"))]
+use crate::SnapshotDirHandle;
 use crate::{
     linuxd::LinuxDaemon,
     InitializedSandbox,
@@ -66,6 +68,9 @@ pub struct UninitializedSandbox<T> {
     /// Optional handle to a network namespace. Only used in L2 deployments.
     #[cfg(not(feature = "single-process"))]
     netns_handle: Option<NetnsHandle>,
+    /// Optional handle to the per-instance snapshot directory. Only used in L2 deployments.
+    #[cfg(not(feature = "single-process"))]
+    snapshot_dir_handle: Option<SnapshotDirHandle>,
     /// Optional control plane listener socket, address, and socket type.
     control_plane_bind_socket_and_info: Option<Arc<Mutex<(SocketListener, String, SocketType)>>>,
     /// Optional sandbox configuration parameters.
@@ -111,6 +116,8 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
             linuxd: None,
             #[cfg(not(feature = "single-process"))]
             netns_handle: None,
+            #[cfg(not(feature = "single-process"))]
+            snapshot_dir_handle: None,
             control_plane_bind_socket_and_info: Some(control_plane_bind_socket_and_info),
             config: None,
             #[cfg(not(feature = "single-process"))]
@@ -170,6 +177,28 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
     #[cfg(not(feature = "single-process"))]
     pub fn with_netns_handle(mut self, netns_handle: Option<NetnsHandle>) -> Self {
         self.netns_handle = netns_handle;
+        self
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Adds a snapshot directory handle to the target uninitialized sandbox.
+    ///
+    /// # Parameters
+    ///
+    /// - `snapshot_dir_handle`: Optional handle to the per-instance snapshot directory.
+    ///
+    /// # Returns
+    ///
+    /// The modified uninitialized sandbox with the snapshot directory handle attached.
+    ///
+    #[cfg(not(feature = "single-process"))]
+    pub fn with_snapshot_dir_handle(
+        mut self,
+        snapshot_dir_handle: Option<SnapshotDirHandle>,
+    ) -> Self {
+        self.snapshot_dir_handle = snapshot_dir_handle;
         self
     }
 
@@ -275,17 +304,6 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
                         Some(l2) => l2,
                     };
 
-                    // Get L2 snapshot path.
-                    let l2_snapshot_path: &str = match config.l2_snapshot_path() {
-                        None => {
-                            let reason: &str =
-                                "L2 snapshot path not provided and linuxd not initialized";
-                            error!("initialize(): {reason}");
-                            anyhow::bail!(reason);
-                        },
-                        Some(l2_snapshot_path) => l2_snapshot_path,
-                    };
-
                     LinuxDaemonArgs::new(
                         config.tenant_id(),
                         // We pass linuxd the control plane socket's connect address, which may
@@ -302,7 +320,6 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
                         config.log_directory().to_string(),
                         tmp_directory,
                         l2,
-                        l2_snapshot_path.to_string(),
                         #[cfg(feature = "single-process")]
                         config.syscall_table(),
                     )
@@ -318,6 +335,9 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
                     // provisioned upstream, if it is not but we are in L2 mode, spawn will fail.
                     #[cfg(not(feature = "single-process"))]
                     self.netns_handle.clone(),
+                    // Pass ownership of the snapshot dir handle to the linuxd instance.
+                    #[cfg(not(feature = "single-process"))]
+                    self.snapshot_dir_handle.take(),
                 )
                 .await
                 {


### PR DESCRIPTION
## Context

A cloud-hypervisor snapshot consists of two config JSON files, and a heavyweight file with the state of the memory.

## Problem

All L2 VMs are restored from the same snapshot, which means that they log to the same file.
under high concurrency when restoring L2 VMs quasi in parallel this causes crashes (this is a hypothesis but it happens without L2 VMs)

The log file is specified in the console-file entry of the config.json file of the snapshot bundle

## Solution

Each L2 VM gets its own snapshot directory where two of the three files are a symbolic link to the parent one, and the third one is a copy with a different console-file entry.

The idea is to have a SnapshotDirHandle RAII handle that we give to each linuxd instance

Closes #1203 