### PR TITLE
[ci] Improve Docker build resilience against transient failures

### DIFF
--- a/.github/actions/docker-benchmark-build/action.yml
+++ b/.github/actions/docker-benchmark-build/action.yml
@@ -33,10 +33,13 @@ runs:
       SCCACHE_GHA_CACHE_TO: ${{ inputs.sccache-gha-enabled == 'true' && format('sccache-bench-{0}-{1}', inputs.machine-type, inputs.timestamp-msg == 'yes' && 'echo-breakdown' || 'standard') || '' }}
       SCCACHE_GHA_CACHE_FROM: ${{ inputs.sccache-gha-enabled == 'true' && format('sccache-bench-{0}-{1}', inputs.machine-type, inputs.timestamp-msg == 'yes' && 'echo-breakdown' || 'standard') || '' }}
     run: |
-      ./z build --with-minimal-docker -- all \
-        "MACHINE=${MACHINE_TYPE}" \
-        TARGET=x86 \
-        LOG_LEVEL=panic \
-        VERBOSE=yes \
-        RELEASE=yes \
-        ${TIMESTAMP_MSG_FLAG}
+      build_variant="$([[ "${TIMESTAMP_MSG_FLAG}" == *TIMESTAMP_MSG=yes* ]] && echo 'Echo-Breakdown' || echo 'Standard')"
+      ./scripts/docker-retry.sh \
+        "benchmark=${build_variant} machine=${MACHINE_TYPE}" \
+        ./z build --with-minimal-docker -- all \
+          "MACHINE=${MACHINE_TYPE}" \
+          TARGET=x86 \
+          LOG_LEVEL=panic \
+          VERBOSE=yes \
+          RELEASE=yes \
+          ${TIMESTAMP_MSG_FLAG}

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -60,12 +60,14 @@ runs:
       SCCACHE_GHA_CACHE_TO: ${{ inputs.sccache-gha-enabled == 'true' && format('sccache-{0}-{1}-{2}', inputs.machine-type, inputs.deployment-type, inputs.release) || '' }}
       SCCACHE_GHA_CACHE_FROM: ${{ inputs.sccache-gha-enabled == 'true' && format('sccache-{0}-{1}-{2}', inputs.machine-type, inputs.deployment-type, inputs.release) || '' }}
     run: |
-      ./z build --with-minimal-docker -- ${BUILD_TARGETS} \
-        "MACHINE=${MACHINE_TYPE}" \
-        TARGET=x86 \
-        "LOG_LEVEL=${LOG_LEVEL}" \
-        VERBOSE=yes \
-        BUILD_OPT=yes \
-        "TIMEOUT=${BUILD_TIMEOUT}" \
-        ${RELEASE_FLAG} \
-        ${MAKE_FLAGS}
+      ./scripts/docker-retry.sh \
+        "targets=${BUILD_TARGETS} machine=${MACHINE_TYPE}" \
+        ./z build --with-minimal-docker -- ${BUILD_TARGETS} \
+          "MACHINE=${MACHINE_TYPE}" \
+          TARGET=x86 \
+          "LOG_LEVEL=${LOG_LEVEL}" \
+          VERBOSE=yes \
+          BUILD_OPT=yes \
+          "TIMEOUT=${BUILD_TIMEOUT}" \
+          ${RELEASE_FLAG} \
+          ${MAKE_FLAGS}

--- a/.github/actions/docker-check/action.yml
+++ b/.github/actions/docker-check/action.yml
@@ -44,11 +44,13 @@ runs:
       RELEASE_FLAG: ${{ inputs.release == 'release' && 'RELEASE=yes' || '' }}
       MAKE_FLAGS: ${{ steps.deployment.outputs.make-flags }}
     run: |
-      ./z build --with-minimal-docker -- "${CHECK_TARGET}" \
-        "MACHINE=${MACHINE_TYPE}" \
-        TARGET=x86 \
-        "LOG_LEVEL=${LOG_LEVEL}" \
-        VERBOSE=yes \
-        BUILD_OPT=no \
-        ${RELEASE_FLAG} \
-        ${MAKE_FLAGS}
+      ./scripts/docker-retry.sh \
+        "target=${CHECK_TARGET} machine=${MACHINE_TYPE}" \
+        ./z build --with-minimal-docker -- "${CHECK_TARGET}" \
+          "MACHINE=${MACHINE_TYPE}" \
+          TARGET=x86 \
+          "LOG_LEVEL=${LOG_LEVEL}" \
+          VERBOSE=yes \
+          BUILD_OPT=no \
+          ${RELEASE_FLAG} \
+          ${MAKE_FLAGS}

--- a/.github/actions/docker-setup/action.yml
+++ b/.github/actions/docker-setup/action.yml
@@ -45,3 +45,31 @@ runs:
       echo "[INFO] Saving Docker image to cache for future runs..."
       docker save ${{ steps.image-tag.outputs.image }} | zstd -T0 -3 > /tmp/docker-image.tar.zst
       echo "[INFO] Docker image saved to cache."
+
+  # Pre-pull the BuildKit Dockerfile frontend image so that subsequent
+  # 'docker build' invocations (which use the '# syntax=' line from
+  # scripts/setup/Dockerfile.build) resolve the frontend locally instead
+  # of fetching it from Docker Hub. This avoids transient Docker Hub
+  # outages (e.g., 504 Gateway Timeout) from failing the build.
+  - name: "Pre-pull BuildKit Frontend"
+    shell: bash
+    run: |
+      # Derive the BuildKit frontend image reference from the Dockerfile syntax line.
+      frontend_ref="$(sed -n 's/^# syntax=//p' scripts/setup/Dockerfile.build | head -n1)"
+      if [[ -z "$frontend_ref" ]]; then
+        frontend_ref="docker/dockerfile:1.4"
+      fi
+
+      max_retries=3
+      for attempt in $(seq 1 "$max_retries"); do
+        if docker pull "$frontend_ref"; then
+          echo "[INFO] BuildKit frontend image '$frontend_ref' pulled successfully."
+          break
+        fi
+        if [[ "$attempt" -eq "$max_retries" ]]; then
+          echo "::warning::Failed to pre-pull BuildKit frontend '$frontend_ref' after $max_retries attempts; builds will attempt to pull it on demand."
+          break
+        fi
+        echo "::warning::BuildKit frontend pull attempt $attempt/$max_retries for '$frontend_ref' failed. Retrying in $((attempt * 15))s..."
+        sleep $((attempt * 15))
+      done

--- a/scripts/docker-retry.sh
+++ b/scripts/docker-retry.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Retry wrapper for Docker-based build commands.
+#
+# Usage: docker-retry.sh <context-label> <command> [args...]
+#
+# Retries the given command up to 3 times with exponential backoff (30s base).
+# On exhaustion, emits a GitHub Actions ::error:: annotation that includes
+# <context-label> for easier triage, then exits 1.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <context-label> <command> [args...]" >&2
+    exit 2
+fi
+
+context_label="$1"
+shift
+
+max_retries=3
+for attempt in $(seq 1 "$max_retries"); do
+    if "$@"; then
+        exit 0
+    fi
+    if [[ "$attempt" -eq "$max_retries" ]]; then
+        echo "::error::Docker build failed after $max_retries attempts ($context_label)."
+        exit 1
+    fi
+    echo "::warning::Docker build attempt $attempt/$max_retries failed ($context_label). Retrying in $((attempt * 30))s..."
+    sleep $((attempt * 30))
+done


### PR DESCRIPTION
## Summary

Improve CI resilience against transient Docker Hub outages (e.g., 504 Gateway Timeout) that can fail jobs when resolving the BuildKit frontend image.

## Root Cause

Job 65747066478 from workflow run 22679884048 (**Verify (qemu-pc, multi-process)**) failed because Docker Hub returned a `504 Gateway Timeout` when `docker build` tried to pull the `docker/dockerfile:1.4` BuildKit frontend image specified in the `# syntax=` directive of `Dockerfile.build`.

## Changes

### Commit 1: Pre-pull BuildKit frontend image during Docker setup
- Adds a new step to the `docker-setup` composite action that pre-pulls `docker/dockerfile:1.4` with retry logic (3 attempts, 15s exponential backoff).
- Non-fatal on exhaustion — emits a warning so builds can still attempt an on-demand pull as fallback.

### Commit 2: Add retry logic to Docker build composite actions
- Wraps `./z build --with-minimal-docker` in `docker-check`, `docker-build`, and `docker-benchmark-build` with a retry loop (3 attempts, 30s exponential backoff).
- Fails on exhaustion with an `::error::` annotation to preserve existing failure behavior.

## Testing

CI-only changes — validated by running the workflow.