### PR TITLE
[nanvix-bench] Add benchmark timeouts

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -12,6 +12,7 @@ import itertools
 import os
 import pathlib
 import re
+import signal
 import subprocess
 from typing import Optional
 
@@ -52,6 +53,11 @@ WARM_START_VMM_BENCH = "warm-start-vmm"
 
 # How many user VMs do we spawn in parallel in the CONCURRENT* benchmarks.
 NUM_CONCURRENT_VMS = 100
+
+# Per-benchmark timeout in seconds. The concurrent benchmark spawns 100 VMs
+# and can take up to ~25 minutes on resource-constrained GitHub runners.
+# A 45-minute timeout provides headroom while preventing indefinite hangs.
+BENCHMARK_TIMEOUT_SECS = 45 * 60
 
 # Benchmarks that report simple p50/p95/p99 percentile values.
 PERCENTILE_BENCHMARKS = [
@@ -682,6 +688,51 @@ def ci_summary(args):
         fh.write(bench_summary)
 
 
+def _kill_process_group(pid: int) -> None:
+    """Send SIGKILL to the process group led by *pid*.
+
+    Because we launch benchmarks with ``start_new_session=True``, the child
+    becomes its own process-group leader (PGID == PID).  Killing the group
+    ensures that all grandchildren are reaped, not just the direct child.
+    """
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except OSError:
+        pass  # Process group may already be gone.
+
+
+def _run_with_timeout(
+    cmd: str,
+    *,
+    timeout: int,
+    capture_output: bool = False,
+    check: bool = False,
+) -> subprocess.CompletedProcess:
+    """Run *cmd* in a new session, killing the entire process group on timeout."""
+    kwargs = {
+        "shell": True,
+        "start_new_session": True,
+    }
+    if capture_output:
+        kwargs["stdout"] = subprocess.PIPE
+        kwargs["stderr"] = subprocess.PIPE
+
+    proc = subprocess.Popen(cmd, **kwargs)
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _kill_process_group(proc.pid)
+        stdout, stderr = proc.communicate()
+        raise subprocess.TimeoutExpired(
+            proc.args, timeout, output=stdout, stderr=stderr
+        )
+
+    result = subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
+    if check and proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, proc.args, stdout, stderr)
+    return result
+
+
 def run_benchmark(args):
     """
     Run a single benchmark using nanvix-bench
@@ -765,7 +816,27 @@ def run_benchmark(args):
 
         # Run benchmark and capture raw stdout/stderr.
         print("[BENCHMARK] Starting benchmark execution...")
-        result = subprocess.run(nanvix_bench_cmd, shell=True, capture_output=True)
+        try:
+            result = _run_with_timeout(
+                nanvix_bench_cmd,
+                timeout=BENCHMARK_TIMEOUT_SECS,
+                capture_output=True,
+            )
+        except subprocess.TimeoutExpired as e:
+            print(
+                f"[BENCHMARK] ERROR: benchmark '{args.benchmark}' timed out "
+                f"after {BENCHMARK_TIMEOUT_SECS}s"
+            )
+            if e.stdout:
+                print("[BENCHMARK] Partial STDOUT:")
+                print(e.stdout.decode("utf-8", errors="replace"))
+            if e.stderr:
+                print("[BENCHMARK] Partial STDERR:")
+                print(e.stderr.decode("utf-8", errors="replace"))
+            raise RuntimeError(
+                f"Benchmark '{args.benchmark}' timed out after "
+                f"{BENCHMARK_TIMEOUT_SECS}s"
+            )
         print(f"[BENCHMARK] Benchmark completed with exit code: {result.returncode}")
         if result.returncode != 0:
             print(
@@ -812,7 +883,21 @@ def run_benchmark(args):
         print("[BENCHMARK] Results written successfully.")
     else:
         print("[BENCHMARK] Running benchmark without capturing output...")
-        subprocess.run(nanvix_bench_cmd, shell=True, check=True)
+        try:
+            _run_with_timeout(
+                nanvix_bench_cmd,
+                timeout=BENCHMARK_TIMEOUT_SECS,
+                check=True,
+            )
+        except subprocess.TimeoutExpired:
+            print(
+                f"[BENCHMARK] ERROR: benchmark '{args.benchmark}' timed out "
+                f"after {BENCHMARK_TIMEOUT_SECS}s"
+            )
+            raise RuntimeError(
+                f"Benchmark '{args.benchmark}' timed out after "
+                f"{BENCHMARK_TIMEOUT_SECS}s"
+            )
 
     # After L2 benchmarks, wait for TCP connections in TIME_WAIT to clear.
     # L2 benchmarks create many TCP connections that linger in TIME_WAIT state,

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -142,6 +142,20 @@ const CLEANUP_SLEEP_DURATION: u64 = 10;
 ///
 /// # Description
 ///
+/// Timeout (in seconds) for HTTP requests to nanvixd (start, kill, etc.).
+///
+const NANVIXD_HTTP_TIMEOUT_SECS: u64 = 60;
+
+///
+/// # Description
+///
+/// Timeout (in seconds) to wait for nanvixd to exit after SIGINT before sending SIGKILL.
+///
+const NANVIXD_SHUTDOWN_TIMEOUT_SECS: u64 = 30;
+
+///
+/// # Description
+///
 /// Sleep duration (in ms) to wait for the system to clean up after a benchmark run when deploying
 /// linuxd in an L2 VM. We need a longer clean-up for cloud-hypervisor to shutdown.
 ///
@@ -376,16 +390,37 @@ impl Benchmark {
                 error!("error sending SIGINT to nanvixd: {}", std::io::Error::last_os_error());
             }
 
-            match nanvixd.wait() {
-                Ok(exit_status) => {
-                    if !exit_status.success() {
-                        error!(
-                            "nanvixd returned with non-zero exit status: {:?}",
-                            exit_status.code()
-                        );
-                    }
-                },
-                Err(e) => error!("error waiting for nanvixd: {e:?}"),
+            // Wait for nanvixd to exit with a bounded timeout to prevent indefinite hangs.
+            let deadline = Instant::now() + Duration::from_secs(NANVIXD_SHUTDOWN_TIMEOUT_SECS);
+            loop {
+                match nanvixd.try_wait() {
+                    Ok(Some(exit_status)) => {
+                        if !exit_status.success() {
+                            error!(
+                                "nanvixd returned with non-zero exit status: {:?}",
+                                exit_status.code()
+                            );
+                        }
+                        break;
+                    },
+                    Ok(None) => {
+                        if Instant::now() >= deadline {
+                            warn!(
+                                "nanvixd did not exit within {}s after SIGINT, sending SIGKILL",
+                                NANVIXD_SHUTDOWN_TIMEOUT_SECS
+                            );
+                            let _ =
+                                unsafe { libc::kill(nanvixd.id() as libc::pid_t, libc::SIGKILL) };
+                            let _ = nanvixd.wait();
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(100));
+                    },
+                    Err(e) => {
+                        error!("error waiting for nanvixd: {e:?}");
+                        break;
+                    },
+                }
             }
 
             self.nanvixd = None;
@@ -1504,7 +1539,9 @@ async fn main() -> Result<()> {
         flavour: args.benchmark(),
         workspace_root: build_utils::find_workspace_root(),
         nanvixd: None,
-        nanvixd_client: reqwest::Client::new(),
+        nanvixd_client: reqwest::Client::builder()
+            .timeout(Duration::from_secs(NANVIXD_HTTP_TIMEOUT_SECS))
+            .build()?,
         nanvixd_toolchain_bin_dir: args.toolchain_bin_dir(),
         nanvixd_tmp_dir: args.tmp_dir(),
         user_vm_id: None,


### PR DESCRIPTION
Fixes intermittent hang in concurrent benchmark on CI runners.

Three unbounded blocking points allowed slow infrastructure to become infinite hangs:
1. reqwest Client had no per-request timeout
2. Child::wait() in cleanup() blocked indefinitely
3. subprocess.run() in benchmark.py had no timeout

Fix: 60s HTTP timeout, 30s shutdown with SIGKILL fallback, 45min per-benchmark subprocess timeout.