### PR TITLE
[nanvixd] Workaround Concurrent Benchmark Hang Timeouts

### DIFF
--- a/src/daemons/linuxd/src/config.rs
+++ b/src/daemons/linuxd/src/config.rs
@@ -35,6 +35,14 @@ pub const CONTROL_PLANE_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
 ///
 pub const READER_TASK_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
 
+///
+/// # Description
+///
+/// Timeout for accepting a connection on the gateway socket. Prevents leaked priming tasks when the
+/// peer (nanvixd probe or benchmark client) fails to connect.
+///
+pub const GATEWAY_ACCEPT_TIMEOUT: Duration = Duration::from_secs(60);
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================

--- a/src/daemons/linuxd/src/user_vm_handle.rs
+++ b/src/daemons/linuxd/src/user_vm_handle.rs
@@ -5,6 +5,7 @@
 // Imports
 //==================================================================================================
 
+use crate::config::GATEWAY_ACCEPT_TIMEOUT;
 use ::anyhow::Result;
 use ::log::{
     error,
@@ -25,6 +26,7 @@ use ::tokio::{
         MutexGuard,
     },
     task::JoinHandle,
+    time::timeout,
 };
 
 //==================================================================================================
@@ -121,32 +123,52 @@ impl UserVmHandle {
 
         // Accept throw-away connection from Nanvixd.
         {
-            let _: SocketStream = match gateway_listener.accept().await {
-                Ok(stream) => stream,
-                Err(e) => {
+            let _: SocketStream =
+                match timeout(GATEWAY_ACCEPT_TIMEOUT, gateway_listener.accept()).await {
+                    Ok(Ok(stream)) => stream,
+                    Ok(Err(e)) => {
+                        let reason: String = format!(
+                            "failed to accept throw-away connection from nanvixd \
+                             (gateway_addr={}, error={e:?})",
+                            self.gateway_sockaddr
+                        );
+                        error!("get_gateway_vm_stream(): {reason}");
+                        return Err(anyhow::anyhow!(reason));
+                    },
+                    Err(_) => {
+                        let reason: String = format!(
+                            "timed out waiting for throw-away connection from nanvixd \
+                             (gateway_addr={}, timeout={GATEWAY_ACCEPT_TIMEOUT:?})",
+                            self.gateway_sockaddr
+                        );
+                        error!("get_gateway_vm_stream(): {reason}");
+                        return Err(anyhow::anyhow!(reason));
+                    },
+                };
+        }
+
+        // Now accept connection from gateway.
+        let stream: SocketStream =
+            match timeout(GATEWAY_ACCEPT_TIMEOUT, gateway_listener.accept()).await {
+                Ok(Ok(stream)) => stream,
+                Ok(Err(e)) => {
                     let reason: String = format!(
-                        "failed to accept throw-away connection from nanvixd (gateway_addr={}, \
-                         error={e:?})",
+                        "failed to accept connection from gateway (gateway_addr={}, error={e:?})",
+                        self.gateway_sockaddr
+                    );
+                    error!("get_gateway_vm_stream(): {reason}");
+                    return Err(anyhow::anyhow!(reason));
+                },
+                Err(_) => {
+                    let reason: String = format!(
+                        "timed out waiting for gateway connection (gateway_addr={}, \
+                         timeout={GATEWAY_ACCEPT_TIMEOUT:?})",
                         self.gateway_sockaddr
                     );
                     error!("get_gateway_vm_stream(): {reason}");
                     return Err(anyhow::anyhow!(reason));
                 },
             };
-        }
-
-        // Now accept connection from gateway.
-        let stream: SocketStream = match gateway_listener.accept().await {
-            Ok(stream) => stream,
-            Err(e) => {
-                let reason: String = format!(
-                    "failed to accept connection from gateway (gateway_addr={}, error={e:?})",
-                    self.gateway_sockaddr
-                );
-                error!("get_gateway_vm_stream(): {reason}");
-                return Err(anyhow::anyhow!(reason));
-            },
-        };
 
         trace!("Connected to gateway");
 

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -116,7 +116,10 @@ use ::std::{
 use ::tokio::{
     sync::mpsc,
     task::JoinHandle,
-    time::sleep,
+    time::{
+        sleep,
+        timeout,
+    },
 };
 
 //==================================================================================================
@@ -160,6 +163,28 @@ const NANVIXD_SHUTDOWN_TIMEOUT_SECS: u64 = 30;
 /// linuxd in an L2 VM. We need a longer clean-up for cloud-hypervisor to shutdown.
 ///
 const CLEANUP_L2_SLEEP_DURATION: u64 = 100;
+
+///
+/// # Description
+///
+/// Timeout (in seconds) for the gateway connection retry loop. Matches the nanvixd-side gateway
+/// probe timeout (`GATEWAY_CONNECT_TIMEOUT`).
+///
+const GATEWAY_CONNECT_TIMEOUT_SECS: u64 = 60;
+
+///
+/// # Description
+///
+/// Timeout (in seconds) for echo I/O operations (write + read) on the gateway stream.
+///
+const ECHO_IO_TIMEOUT_SECS: u64 = 60;
+
+///
+/// # Description
+///
+/// Sleep duration (in milliseconds) between gateway connection retry attempts.
+///
+const GATEWAY_CONNECT_RETRY_SLEEP_MS: u64 = 1;
 
 ///
 /// # Description
@@ -343,12 +368,35 @@ impl Benchmark {
         } else {
             SocketType::Unix
         };
-        let gateway_stream: SocketStream = loop {
-            let unbound_socket: UnboundSocket = UnboundSocket::new(gateway_socktype);
-            match unbound_socket.connect(&response.gateway_sockaddr).await {
-                Ok(stream) => break stream,
-                Err(_) => continue,
-            };
+        let gateway_stream: SocketStream = {
+            let deadline: Duration = Duration::from_secs(GATEWAY_CONNECT_TIMEOUT_SECS);
+            match timeout(deadline, async {
+                loop {
+                    let unbound_socket: UnboundSocket = UnboundSocket::new(gateway_socktype);
+                    match unbound_socket.connect(&response.gateway_sockaddr).await {
+                        Ok(stream) => break stream,
+                        Err(_) => {
+                            sleep(Duration::from_millis(GATEWAY_CONNECT_RETRY_SLEEP_MS)).await;
+                            continue;
+                        },
+                    };
+                }
+            })
+            .await
+            {
+                Ok(stream) => stream,
+                Err(_) => {
+                    error!(
+                        "gateway connection to {} timed out after {}s",
+                        response.gateway_sockaddr, GATEWAY_CONNECT_TIMEOUT_SECS
+                    );
+                    anyhow::bail!(
+                        "gateway connection to {} timed out after {}s",
+                        response.gateway_sockaddr,
+                        GATEWAY_CONNECT_TIMEOUT_SECS
+                    );
+                },
+            }
         };
         debug!("connected to gateway socket stream");
 
@@ -449,8 +497,21 @@ impl Benchmark {
         let (user_vm_id, mut gateway_stream): (UserVmIdentifier, SocketStream) = self
             .start(new_msg, new_msg_headers, linuxd_deployment)
             .await?;
-        gateway_stream.write_all(&payload).await?;
-        gateway_stream.read_exact(&mut response_payload).await?;
+        let echo_io_timeout: Duration = Duration::from_secs(ECHO_IO_TIMEOUT_SECS);
+        timeout(echo_io_timeout, gateway_stream.write_all(&payload))
+            .await
+            .map_err(|_| {
+                error!("echo write timed out after {}s", ECHO_IO_TIMEOUT_SECS);
+                anyhow::anyhow!("echo write timed out after {}s", ECHO_IO_TIMEOUT_SECS)
+            })?
+            .map_err(|e| anyhow::anyhow!("echo write failed: {e}"))?;
+        timeout(echo_io_timeout, gateway_stream.read_exact(&mut response_payload))
+            .await
+            .map_err(|_| {
+                error!("echo read timed out after {}s", ECHO_IO_TIMEOUT_SECS);
+                anyhow::anyhow!("echo read timed out after {}s", ECHO_IO_TIMEOUT_SECS)
+            })?
+            .map_err(|e| anyhow::anyhow!("echo read failed: {e}"))?;
         let elapsed_micros: u128 = start.elapsed().as_micros();
 
         // Only record latency if requested to.


### PR DESCRIPTION
This pull request introduces connection and I/O timeouts to both the daemon (`linuxd`) and benchmarking (`nanvix-bench`) components to prevent indefinite hangs during gateway socket operations. The main improvements are the addition of configurable timeouts for accepting and establishing gateway connections, as well as for echo I/O operations, along with corresponding error handling and logging.