### PR TITLE
[nanvix-bench] Add -netns-pool-size Cli Arg

### DIFF
--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -19,6 +19,7 @@ pub struct Args {
     hwloc_file: Option<String>,
     iterations: usize,
     num_concurrent_vms: Option<usize>,
+    netns_pool_size: Option<usize>,
     toolchain_bin_dir: String,
     tmp_dir: String,
 }
@@ -33,6 +34,8 @@ impl Args {
     const OPT_HWLOC: &'static str = "-hwloc";
     const OPT_ITERATIONS: &'static str = "-iterations";
     const OPT_NUM_CONCURRENT_VMS: &'static str = "-num-concurrent-vms";
+    const OPT_NETNS_POOL_SIZE: &'static str = "-netns-pool-size";
+    const DEFAULT_NETNS_POOL_SIZE: usize = ::nanvixd::args::Args::DEFAULT_NETNS_POOL_SIZE;
     const OPT_TOOLCHAIN_BIN_DIR: &'static str = "-toolchain-bin-dir";
     const OPT_TMP_DIR: &'static str = "-tmp-dir";
 
@@ -66,6 +69,8 @@ Options:
   {iterations} <num>                  Number of iterations to run (default: 100).
   {num_concurrent_vms} <num>          Number of concurrent VMs to run (mandatory for concurrent \
              benchmarks).
+  {netns_pool_size} <size>            Netns pool prefill size for nanvixd (default: \
+             {default_netns_pool_size}; 0 enables lazy initialization).
   {toolchain_bin_dir} <toolchain_dir> Directory containing toolchain binaries (cloud-hypervisor, \
              etc.).
   {tmp_dir} <tmp_dir>                Base directory for temporary files (default: \
@@ -87,6 +92,8 @@ Examples:
             hwloc = Self::OPT_HWLOC,
             iterations = Self::OPT_ITERATIONS,
             num_concurrent_vms = Self::OPT_NUM_CONCURRENT_VMS,
+            netns_pool_size = Self::OPT_NETNS_POOL_SIZE,
+            default_netns_pool_size = Self::DEFAULT_NETNS_POOL_SIZE,
             toolchain_bin_dir = Self::OPT_TOOLCHAIN_BIN_DIR,
             tmp_dir = Self::OPT_TMP_DIR,
             DEFAULT_TMP_DIRECTORY = DEFAULT_TMP_DIRECTORY,
@@ -99,6 +106,7 @@ Examples:
         let mut hwloc_file: Option<String> = None;
         let mut iterations: usize = 100;
         let mut num_concurrent_vms: Option<usize> = None;
+        let mut netns_pool_size: Option<usize> = None;
         let mut toolchain_bin_dir: String = "./toolchain/bin".to_string();
         let mut tmp_dir: String = DEFAULT_TMP_DIRECTORY.to_string();
 
@@ -144,6 +152,17 @@ Examples:
                         ));
                     }
                     num_concurrent_vms = Some(args[i].parse::<usize>()?);
+                },
+                Self::OPT_NETNS_POOL_SIZE => {
+                    i += 1;
+                    if i >= args.len() {
+                        Self::usage(args[0].as_str());
+                        return Err(anyhow::anyhow!(
+                            "missing value for: {}",
+                            Self::OPT_NETNS_POOL_SIZE
+                        ));
+                    }
+                    netns_pool_size = Some(args[i].parse::<usize>()?);
                 },
                 Self::OPT_TOOLCHAIN_BIN_DIR => {
                     i += 1;
@@ -212,6 +231,7 @@ Examples:
                     hwloc_file,
                     iterations,
                     num_concurrent_vms,
+                    netns_pool_size,
                     toolchain_bin_dir,
                     tmp_dir,
                 })
@@ -241,6 +261,10 @@ Examples:
 
     pub fn toolchain_bin_dir(&self) -> String {
         self.toolchain_bin_dir.clone()
+    }
+
+    pub fn netns_pool_size(&self) -> Option<usize> {
+        self.netns_pool_size
     }
 
     pub fn tmp_dir(&self) -> String {

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -116,6 +116,7 @@ pub struct Benchmark {
     pub nanvixd: Option<Child>,
     pub nanvixd_client: reqwest::Client,
     pub nanvixd_toolchain_bin_dir: String,
+    pub nanvixd_netns_pool_size: Option<usize>,
     pub nanvixd_tmp_dir: String,
     pub user_vm_id: Option<String>,
 }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -240,6 +240,10 @@ impl Benchmark {
             ::nanvixd::args::Args::OPT_TMP_DIRECTORY.to_string(),
             self.nanvixd_tmp_dir.clone(),
         ];
+        if let Some(netns_pool_size) = self.nanvixd_netns_pool_size {
+            nanvixd_args.push(::nanvixd::args::Args::OPT_NETNS_POOL_SIZE.to_string());
+            nanvixd_args.push(netns_pool_size.to_string());
+        }
         if let Some(hwloc_file) = &self.hwloc_file {
             nanvixd_args.push(::nanvixd::args::Args::OPT_HWLOC.to_string());
             nanvixd_args.push(hwloc_file.clone());
@@ -1604,6 +1608,7 @@ async fn main() -> Result<()> {
             .timeout(Duration::from_secs(NANVIXD_HTTP_TIMEOUT_SECS))
             .build()?,
         nanvixd_toolchain_bin_dir: args.toolchain_bin_dir(),
+        nanvixd_netns_pool_size: args.netns_pool_size(),
         nanvixd_tmp_dir: args.tmp_dir(),
         user_vm_id: None,
     };


### PR DESCRIPTION
In this commit I extend `nanvix-bench` to take a -netns-pool-size command-line argument that makes it possible to configure the size of the pre-allocated network namespace pool. This flag is useful when prototyping and running benchmarks quickly, as it avoids the time to create a big netns pool upfront.