### PR TITLE
[ci] Gate concurrent benchmark on GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,7 +670,10 @@ jobs:
       matrix:
         include:
           - machine-type: microvm
-            standard-benchmarks: "boot-time cold-start cold-start-uvm concurrent round-trip-latency snapshot-restore warm-start warm-start-vmm"
+            # NOTE: concurrent is excluded on GitHub-hosted runners because the
+            # gateway handshake race condition (issue #1552) causes sporadic
+            # timeouts under the scheduling contention of shared CI machines.
+            standard-benchmarks: "boot-time cold-start cold-start-uvm round-trip-latency snapshot-restore warm-start warm-start-vmm"
             standard-iterations: "100"
             echo-benchmarks: "echo-breakdown"
             echo-iterations: "1000"
@@ -795,7 +798,7 @@ jobs:
       - name: "Report Benchmark Results"
         uses: ./.github/actions/benchmark-report
         with:
-          benchmarks: "boot-time,cold-start,cold-start-uvm,concurrent,echo-breakdown,round-trip-latency,snapshot-restore,warm-start,warm-start-vmm"
+          benchmarks: "boot-time,cold-start,cold-start-uvm,echo-breakdown,round-trip-latency,snapshot-restore,warm-start,warm-start-vmm"
           machine-types: "microvm,hyperlight"
           archs: "X64"
           dev-dir: "data/github"
@@ -806,7 +809,7 @@ jobs:
         if: github.ref_name == 'dev'
         uses: ./.github/actions/benchmark-persist
         with:
-          benchmarks: "boot-time,cold-start,cold-start-uvm,concurrent,echo-breakdown,round-trip-latency,snapshot-restore,warm-start,warm-start-vmm"
+          benchmarks: "boot-time,cold-start,cold-start-uvm,echo-breakdown,round-trip-latency,snapshot-restore,warm-start,warm-start-vmm"
           machine-types: "microvm,hyperlight"
           archs: "X64"
           target-dir: "data/github"


### PR DESCRIPTION
## Summary

Gate the `concurrent` benchmark (100 microVMs) from running on GitHub-hosted runners, where the gateway handshake race condition (issue #1552) causes sporadic timeouts under shared CI scheduling contention.

## Changes

- Remove `concurrent` from the microvm `standard-benchmarks` list in the `benchmark-ci` job (GitHub-hosted `ubuntu-24.04` runners).
- Remove `concurrent` from the `benchmark-ci-finalize` report and persist lists for consistency.
- The `concurrent` benchmark continues to run on **self-hosted runners** (the `benchmark` job) where dedicated hardware avoids the race.

## Root Cause

The gateway handshake between nanvixd and linuxd uses a throw-away probe + double-accept protocol that is fragile under high concurrency. When spawning 100 KVM-backed microVMs simultaneously on resource-constrained GitHub runners, CPU/scheduling contention widens the race window enough to trigger timeouts (`echo read timed out after 60s`).

The proper fix is tracked in #1552 (replace the probe with an explicit `GatewayReady` control-plane notification).

Refs: #1552