### PR TITLE
[daemons] Add Timeout To User VM Close Task

### DIFF
--- a/src/daemons/linuxd/src/config.rs
+++ b/src/daemons/linuxd/src/config.rs
@@ -43,6 +43,13 @@ pub const READER_TASK_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
 ///
 pub const GATEWAY_ACCEPT_TIMEOUT: Duration = Duration::from_secs(60);
 
+///
+/// # Description
+///
+/// Timeout for joining a worker thread when closing a user VM connection.
+///
+pub const WORKER_THREAD_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================

--- a/src/daemons/linuxd/src/lib.rs
+++ b/src/daemons/linuxd/src/lib.rs
@@ -16,6 +16,7 @@ use crate::{
         restore_gate_sockaddr_builder,
         CONTROL_PLANE_CONNECT_TIMEOUT,
         READER_TASK_JOIN_TIMEOUT,
+        WORKER_THREAD_JOIN_TIMEOUT,
     },
     message::RequestAssembler,
     syscalls::SyscallTable,
@@ -408,7 +409,7 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
         // Send a shutdown message to all worker threads associated
         // with this user VM.
         if let Some(mut worker_threads) = worker_threads {
-            for worker_thread in worker_threads.drain(..) {
+            for mut worker_thread in worker_threads.drain(..) {
                 trace!("sending interrupt to worker thread (thread_id={:?})", worker_thread.id);
 
                 // Each worker thread may be in one of three states:
@@ -437,14 +438,46 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
                         worker_thread.id
                     );
                 }
-                if let Err(e) = worker_thread.handle.await {
-                    error!(
-                        "error joining worker thread (thread_id={:?}, error={e:?})",
-                        worker_thread.id
-                    );
+                match timeout(WORKER_THREAD_JOIN_TIMEOUT, &mut worker_thread.handle).await {
+                    Ok(Ok(())) => {
+                        trace!(
+                            "close_connection(): successfully joined worker thread \
+                             (thread_id={:?})",
+                            worker_thread.id
+                        );
+                    },
+                    Ok(Err(e)) => {
+                        error!(
+                            "error joining worker thread (thread_id={:?}, error={e:?})",
+                            worker_thread.id
+                        );
+                    },
+                    Err(_elapsed) => {
+                        warn!(
+                            "close_connection(): timeout waiting for worker thread, aborting it \
+                             (thread_id={:?})",
+                            worker_thread.id
+                        );
+                        worker_thread.handle.abort();
+                    },
                 }
             }
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Spawns asynchronous cleanup for a user VM connection so the main event loop is not blocked
+    /// by teardown of reader/worker tasks.
+    ///
+    fn spawn_connection_cleanup(
+        user_vm_handle: Option<UserVmHandle>,
+        worker_threads: Option<VecDeque<WorkerThreadHandle>>,
+    ) {
+        tokio::spawn(async move {
+            Self::close_connection(user_vm_handle, worker_threads).await;
+        });
     }
 
     fn log_and_error(code: ErrorCode, msg: &'static str) -> Error {
@@ -591,10 +624,10 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
                                         error!("run(): {reason} (uvm_id={uvm_id}, error={e:?})");
 
                                         // Shutdown faulty user VM.
-                                        Self::close_connection(
+                                        Self::spawn_connection_cleanup(
                                             user_vm_connections.remove(&uvm_id),
                                             worker_threads.lock().await.remove(&uvm_id),
-                                        ).await;
+                                        );
 
                                         continue 'main_loop;
                                     }
@@ -649,10 +682,10 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
                             debug!("run(): harvesting connection to user VM (uvm_id={uvm_id}, reason={kind_str})");
 
                             // Shutdown finished user VM.
-                            Self::close_connection(
+                            Self::spawn_connection_cleanup(
                                 user_vm_connections.remove(&uvm_id),
                                 worker_threads.lock().await.remove(&uvm_id),
-                            ).await;
+                            );
                         },
                     }
                 },


### PR DESCRIPTION
In this commit I modify the reaper task in linuxd that takes care of closing a user VM connection so that it does not block indefinitely.

Right now, an unresponsive or slow user VM can block the main linuxd loop indefintately, starving other resources. I guard against this behaviour in two different ways. First I add a timeout to the close_connection async. Second, when possible, I spawn a throwaway task that will do the (bounded-time) cleanup task in the background without affecting the main linuxd behaviour.