### PR TITLE
[kernel] Rollback in `mmio_alloc()` when MMIO page mapping fails

### DIFF
--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -1171,11 +1171,36 @@ impl Vmem {
         Ok(())
     }
 
-    // Changes access permissions on a kernel page.
+    ///
+    /// # Description
+    ///
+    /// Changes access permissions on a kernel page. When `dry_run` is `true`, validates that the
+    /// operation would succeed without modifying any page table entries.
+    ///
+    /// # Parameters
+    ///
+    /// - `vaddr`: Virtual address of the target kernel page.
+    /// - `access`: New access permissions for the page.
+    /// - `dry_run`: If `true`, only validates the operation without applying changes.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this function returns empty. Upon failure, this function returns
+    /// an error that indicates the reason for the failure.
+    ///
+    /// # Errors
+    ///
+    /// This function fails with the following error codes:
+    /// - [`ErrorCode::BadAddress`]: The provided address does not lie in kernel space.
+    /// - [`ErrorCode::TryAgain`]: Failed to read the page directory entry.
+    /// - [`ErrorCode::NoSuchEntry`]: The corresponding page table is not present.
+    /// - [`ErrorCode::NoSuchEntry`]: The page table entry was not found (dry run only).
+    ///
     pub fn kctrl(
         &mut self,
         vaddr: PageAligned<VirtualAddress>,
         access: AccessPermission,
+        dry_run: bool,
     ) -> Result<(), Error> {
         trace!("{vaddr:?}");
 
@@ -1213,11 +1238,14 @@ impl Vmem {
 
         let page_address: PageAddress = PageAddress::new(vaddr);
 
-        // Change access permissions on the page.
-        page_table
-            .borrow_mut()
-            .1
-            .ctrl(false, page_address, access)?;
+        if dry_run {
+            page_table.borrow().1.lookup(page_address)?;
+        } else {
+            page_table
+                .borrow_mut()
+                .1
+                .ctrl(false, page_address, access)?;
+        }
 
         Ok(())
     }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1850,11 +1850,18 @@ impl ProcessManager {
             error!("{reason} (base={base:#x}, size={:#?})", region.size());
             Error::new(ErrorCode::ValueOverflow, reason)
         })?;
+        let perm: AccessPermission = region.perm();
+
+        // Validate that every page can be mapped before modifying any state.
         for raw_vaddr in (base..end).step_by(PAGE_SIZE) {
-            // FIXME (#1482): Use infallible logic for address conversion.
             let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(raw_vaddr)?;
-            // FIXME (#1481): If we fail, we need to revert operation.
-            vmem.kctrl(vaddr, region.perm())?;
+            vmem.kctrl(vaddr, perm, true)?;
+        }
+
+        // All validations passed — apply the permission changes for real.
+        for raw_vaddr in (base..end).step_by(PAGE_SIZE) {
+            let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(raw_vaddr)?;
+            vmem.kctrl(vaddr, perm, false)?;
         }
 
         state.add_mmio(region);


### PR DESCRIPTION
`mmio_alloc()` previously applied `kctrl()` page-by-page without any pre-validation, so a failure mid-loop left earlier pages with modified permissions while `add_mmio()` was never called, producing partial state. This follows the dry-run pattern: a first pass validates that every page can be mapped without modifying any page table entries, then a second pass that actually applies the changes.

Workaround for #1481
Supersedes #1510

Original author: @cachebag