### PR TITLE
[scripts] Quote paths in shell scripts

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,8 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Minimum severity level to report.
+severity=warning
+
+# SC1091: do not follow sourced files (paths use dynamic variables like ${NANVIX_HOME})
+disable=SC1091

--- a/scripts/generate-l2-initramfs.sh
+++ b/scripts/generate-l2-initramfs.sh
@@ -40,9 +40,9 @@ done
 
 # Do a clean build if requested.
 if ${CLEAN}; then
-    if [ -d ${INITRAMFS_DIR} ]; then
+    if [ -d "${INITRAMFS_DIR}" ]; then
         print_warning "removing initramfs from ${INITRAMFS_DIR}"
-        rm -rf ${INITRAMFS_DIR}
+        rm -rf "${INITRAMFS_DIR}"
     fi
 fi
 
@@ -74,7 +74,7 @@ UBUNTU_MIRROR="$(
 export DEBIAN_FRONTEND=noninteractive
 
 build_initramfs() {
-    mkdir -p ${IMAGES_DIR}
+    mkdir -p "${IMAGES_DIR}"
 
     if [ ! -d "$INITRAMFS_DIR" ]; then
         print_info "Creating minimal ubuntu (${UBUNTU_VERSION}, mirror: ${UBUNTU_MIRROR}) initramfs..."

--- a/scripts/generate-l2-snapshot.sh
+++ b/scripts/generate-l2-snapshot.sh
@@ -87,11 +87,11 @@ boot_clh_vm() {
 }
 
 snapshot_clh_vm() {
-    rm -rf ${SNAPSHOT_PATH}
-    mkdir -p ${SNAPSHOT_PATH}
-    ${CLOUD_HYPERVISOR_REMOTE_PATH} --api-socket=${CLH_API_SOCKET} pause
+    rm -rf "${SNAPSHOT_PATH}"
+    mkdir -p "${SNAPSHOT_PATH}"
+    "${CLOUD_HYPERVISOR_REMOTE_PATH}" --api-socket="${CLH_API_SOCKET}" pause
     sleep 1
-    ${CLOUD_HYPERVISOR_REMOTE_PATH} --api-socket=${CLH_API_SOCKET} snapshot file://${SNAPSHOT_PATH}
+    "${CLOUD_HYPERVISOR_REMOTE_PATH}" --api-socket="${CLH_API_SOCKET}" snapshot file://"${SNAPSHOT_PATH}"
 }
 
 # Create a named pipe (FIFO) for capturing the VM's stdout, and know when it has finished booting.
@@ -106,7 +106,7 @@ vm_pid=$(boot_clh_vm)
 # has already been properly killed.
 trap 'kill -s SIGKILL ${vm_pid} || true' EXIT
 
-( tail -F ${CLH_CONSOLE} > $fifo 2> /dev/null ) &
+( tail -F "${CLH_CONSOLE}" > "$fifo" 2> /dev/null ) &
 
 print_info "Waiting for CLH VM to boot..."
 while IFS= read -r line; do
@@ -123,10 +123,10 @@ print_success "Snapshot done!"
 
 # Clean-up.
 rm "$fifo"
-rm -f ${CLH_CONSOLE}
+rm -f -- "${CLH_CONSOLE}"
 
 print_info "Killing CLH VM..."
-kill -s SIGTERM ${vm_pid}
-rm -f ${CLH_API_SOCKET}
+kill -s SIGTERM "${vm_pid}"
+rm -f -- "${CLH_API_SOCKET}"
 
 print_success "Snapshot is available at: ${SNAPSHOT_PATH}"

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -254,13 +254,14 @@ run_step() {
 
     # Run the step and capture return code.
     if [[ -z "${machine}" ]]; then
-        if "${Z_SCRIPT}" build -- LOG_LEVEL=trace "${release_flag}" ${make_target} > "${tmpfile}" 2>&1; then
+        if "${Z_SCRIPT}" build -- LOG_LEVEL=trace "${release_flag}" "${make_target}" > "${tmpfile}" 2>&1; then
             return_code=0
         else
             return_code=$?
         fi
     else
-        if "${Z_SCRIPT}" build -- MACHINE="${machine}" LOG_LEVEL=trace "${release_flag}" ${deployment_flags} ${make_target} > "${tmpfile}" 2>&1; then
+        # shellcheck disable=SC2086 # deployment_flags is a list of VAR=VAL words; allow word splitting into separate args
+        if "${Z_SCRIPT}" build -- MACHINE="${machine}" LOG_LEVEL=trace "${release_flag}" ${deployment_flags} "${make_target}" > "${tmpfile}" 2>&1; then
             return_code=0
         else
             return_code=$?

--- a/scripts/run-qemu.sh
+++ b/scripts/run-qemu.sh
@@ -200,6 +200,7 @@ function run_qemu
 	# Debug mode: attach GDB server and wait.
 	if [[ "${mode}" = "--debug" ]]; then
 		cmd="${cmd} -gdb tcp::${GDB_PORT} -S"
+		# shellcheck disable=SC2086 # cmd is a composed command string; allow word splitting into separate args
 		${cmd}
 		return
 	fi
@@ -216,6 +217,7 @@ function run_qemu
 		cmd="timeout -s SIGINT --preserve-status --foreground ${timeout} ${cmd}"
 	fi
 
+	# shellcheck disable=SC2086 # cmd is a composed command string; allow word splitting into separate args
 	${cmd} 2> stderr.log
 }
 
@@ -245,6 +247,7 @@ function run_qemu_wait_for_string
 
 	# Run QEMU in the background with stdout teed to a log file.
 	# Use setsid to create a new process group for clean termination.
+	# shellcheck disable=SC2086 # cmd is a composed command string; allow word splitting into separate args
 	setsid ${cmd} > >(tee "${log_file}") 2>&1 &
 	local qemu_pid=$!
 

--- a/scripts/setup/cloud-hypervisor.sh
+++ b/scripts/setup/cloud-hypervisor.sh
@@ -37,22 +37,22 @@ CLOUD_HYPERVISOR_LINUX_TAG="ch-6.12.8"
 #===================================================================================================
 
 build_clh() {
-    mkdir -p ${SRC_DIR}
+    mkdir -p "${SRC_DIR}"
     if [ ! -d "${CLOUD_HYPERVISOR_HOME}" ];
     then
-        git clone ${CLOUD_HYPERVISOR_REPOSITORY} ${CLOUD_HYPERVISOR_HOME}
-        pushd ${CLOUD_HYPERVISOR_HOME} >> /dev/null
-        git checkout ${CLOUD_HYPERVISOR_COMMIT}
+        git clone "${CLOUD_HYPERVISOR_REPOSITORY}" "${CLOUD_HYPERVISOR_HOME}"
+        pushd "${CLOUD_HYPERVISOR_HOME}" >> /dev/null
+        git checkout "${CLOUD_HYPERVISOR_COMMIT}"
     else
-        pushd ${CLOUD_HYPERVISOR_HOME} >> /dev/null
+        pushd "${CLOUD_HYPERVISOR_HOME}" >> /dev/null
         git fetch origin
-        git reset --hard ${CLOUD_HYPERVISOR_COMMIT}
+        git reset --hard "${CLOUD_HYPERVISOR_COMMIT}"
     fi
 
     cargo build --release
 
     # Copy built binaries.
-    mkdir -p ${BIN_DIR}
+    mkdir -p "${BIN_DIR}"
     cp ./target/release/cloud-hypervisor "${BIN_DIR}/cloud-hypervisor"
     cp ./target/release/ch-remote "${BIN_DIR}/ch-remote"
 
@@ -70,17 +70,17 @@ build_clh() {
 }
 
 build_clh_linux() {
-    mkdir -p ${SRC_DIR}
+    mkdir -p "${SRC_DIR}"
     if [ ! -d "${CLOUD_HYPERVISOR_LINUX_HOME}" ]; then
         git clone \
             --depth 1 \
-            ${CLOUD_HYPERVISOR_LINUX_REPOSITORY} \
-            -b ${CLOUD_HYPERVISOR_LINUX_TAG} \
-            ${CLOUD_HYPERVISOR_LINUX_HOME}
-        pushd ${CLOUD_HYPERVISOR_LINUX_HOME} >> /dev/null
+            "${CLOUD_HYPERVISOR_LINUX_REPOSITORY}" \
+            -b "${CLOUD_HYPERVISOR_LINUX_TAG}" \
+            "${CLOUD_HYPERVISOR_LINUX_HOME}"
+        pushd "${CLOUD_HYPERVISOR_LINUX_HOME}" >> /dev/null
     else
-        pushd ${CLOUD_HYPERVISOR_LINUX_HOME} >> /dev/null
-        git reset --hard ${CLOUD_HYPERVISOR_LINUX_TAG}
+        pushd "${CLOUD_HYPERVISOR_LINUX_HOME}" >> /dev/null
+        git reset --hard "${CLOUD_HYPERVISOR_LINUX_TAG}"
     fi
 
     # Build linuxd kernel.
@@ -88,7 +88,7 @@ build_clh_linux() {
     KCFLAGS="-Wa,-mx86-used-note=no" make bzImage -j "$(nproc)"
 
     # Copy built image.
-    mkdir -p ${SHARE_DIR}
+    mkdir -p "${SHARE_DIR}"
     cp "${CLOUD_HYPERVISOR_LINUX_HOME}/arch/x86/boot/bzImage" "${L2_SYSTEM_VM_KERNEL}"
 
     popd >> /dev/null

--- a/scripts/setup/python.sh
+++ b/scripts/setup/python.sh
@@ -22,8 +22,8 @@ export CPYTHON_BRANCH=7158004b255e8b848562b7f537a9e3c44188997e
 # Get Sources
 #===================================================================================================
 
-mkdir -p ${CONTRIB_DIR}
-git clone ${CPYTHON_REPOSITORY} ${CPYTHON_HOME}
+mkdir -p "${CONTRIB_DIR}"
+git clone "${CPYTHON_REPOSITORY}" "${CPYTHON_HOME}"
 cd "${CPYTHON_HOME}" || exit
 git checkout "${CPYTHON_BRANCH}"
 git clean -fdx
@@ -39,8 +39,8 @@ CFLAGS="-m32" \
     --host=x86_64-pc-linux-gnux32 \
     --disable-shared \
     --disable-test-modules \
-    --prefix=${PREFIX} \
-    --exec-prefix=${PREFIX} \
+    --prefix="${PREFIX}" \
+    --exec-prefix="${PREFIX}" \
     --with-ensurepip=no \
     --with-pkg-config=no \
     --disable-ipv6 \

--- a/scripts/setup/qemu.sh
+++ b/scripts/setup/qemu.sh
@@ -33,7 +33,7 @@ function setup_qemu
     # Build and install.
     cd "qemu-$VERSION" || exit
     ./configure \
-        --prefix=$PREFIX --target-list=$TARGET --enable-sdl --enable-curses
+        --prefix="$PREFIX" --target-list="$TARGET" --enable-sdl --enable-curses
     make all
     make install
 
@@ -55,7 +55,7 @@ fi
 
 case "$TARGET" in
 	"x86")
-        setup_qemu "i386" $PREFIX
+        setup_qemu "i386" "$PREFIX"
         ;;
     *)
         echo "Unsupported target: $TARGET"


### PR DESCRIPTION
## Summary

This PR addresses the enhancement mentioned in #646. Quote unquoted paths in shell scripts inside `scripts/` to prevent word splitting on paths that may contain spaces and/or special characters.

Supersedes #1554.

## Changes

- Quote filesystem paths in `scripts/generate-l2-initramfs.sh`, `scripts/generate-l2-snapshot.sh`, `scripts/pipeline.sh`, `scripts/setup/cloud-hypervisor.sh`, `scripts/setup/python.sh`, and `scripts/setup/qemu.sh`.
- Add `.shellcheckrc` to document shellcheck enforcement policy (severity=warning, disable SC1091).
- Add inline `shellcheck disable=SC2086` for intentional word-splitting in `scripts/run-qemu.sh` (`${cmd}`) and `scripts/pipeline.sh` (`${deployment_flags}`).
- Quote `${CLOUD_HYPERVISOR_REMOTE_PATH}` and `--api-socket` values in `scripts/generate-l2-snapshot.sh`.

## Validation

```
shellcheck --format=gcc $(find ./scripts -name "*.sh") | grep SC2086
```

All SC2086 warnings addressed. Remaining intentional word-splits are annotated with inline `shellcheck disable` directives.

## Authorship

Original work by @iantei. Squashed and rebased with review fixes applied.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>