### PR TITLE
[build] Cleanup Staled Dependencies and Fix Lints

### DIFF
--- a/src/libs/nanvix-http/Cargo.toml
+++ b/src/libs/nanvix-http/Cargo.toml
@@ -21,7 +21,6 @@ linuxd = { workspace = true, optional = true }
 log = { workspace = true }
 nanvix-registry = { workspace = true }
 nanvix-sandbox-cache = { workspace = true }
-nanvix-terminal = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 syscomm = { workspace = true }
@@ -34,19 +33,16 @@ default = ["microvm"]
 single-process = [
     "linuxd",
     "nanvix-sandbox-cache/single-process",
-    "nanvix-terminal/single-process",
 ]
 hyperlight = [
     "config/hyperlight",
     "uservm/hyperlight",
     "nanvix-sandbox-cache/hyperlight",
-    "nanvix-terminal/hyperlight",
 ]
 microvm = [
     "config/microvm",
     "uservm/microvm",
     "nanvix-sandbox-cache/microvm",
-    "nanvix-terminal/microvm",
 ]
 
 [lints]

--- a/src/libs/syscall/src/unistd/syscall/chdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/chdir.rs
@@ -60,7 +60,7 @@ pub fn chdir(path: &str) -> Result<(), Error> {
     // In standalone mode, succeed as a no-op for non-VFS paths (no linuxd).
     #[cfg(feature = "standalone")]
     {
-        return Ok(());
+        Ok(())
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -54,10 +54,7 @@ pub fn close(fd: i32) -> Result<(), Error> {
             return Ok(());
         }
         let _ = fd;
-        return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "close not available in standalone mode",
-        ));
+        Err(Error::new(ErrorCode::OperationNotSupported, "close not available in standalone mode"))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -69,10 +69,10 @@ pub fn faccessat(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Result<(
     // In standalone mode, reject non-VFS paths (no linuxd).
     #[cfg(feature = "standalone")]
     {
-        return Err(Error::new(
+        Err(Error::new(
             ErrorCode::OperationNotSupported,
             "faccessat not available in standalone mode",
-        ));
+        ))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/fchdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchdir.rs
@@ -53,7 +53,7 @@ pub fn fchdir(fd: c_int) -> Result<(), Error> {
     #[cfg(feature = "standalone")]
     {
         let _ = fd;
-        return Ok(());
+        Ok(())
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -59,7 +59,7 @@ pub fn fchown(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<(), E
     #[cfg(feature = "standalone")]
     {
         let _ = (fd, owner, group);
-        return Ok(());
+        Ok(())
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/fchownat.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchownat.rs
@@ -78,7 +78,7 @@ pub fn fchownat(
     #[cfg(feature = "standalone")]
     {
         let _ = (dirfd, path, owner, group, flag);
-        return Ok(());
+        Ok(())
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fdatasync.rs
@@ -59,7 +59,7 @@ pub fn fdatasync(fd: RawFileDescriptor) -> Result<(), Error> {
     #[cfg(feature = "standalone")]
     {
         let _ = fd;
-        return Ok(());
+        Ok(())
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/fsync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fsync.rs
@@ -57,7 +57,7 @@ pub fn fsync(fd: c_int) -> Result<(), Error> {
     #[cfg(feature = "standalone")]
     {
         let _ = fd;
-        return Ok(());
+        Ok(())
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/syscall/ftruncate.rs
@@ -63,10 +63,10 @@ pub fn ftruncate(fd: c_int, length: off_t) -> Result<(), Error> {
     #[cfg(feature = "standalone")]
     {
         let _ = (fd, length);
-        return Err(Error::new(
+        Err(Error::new(
             ErrorCode::OperationNotSupported,
             "ftruncate not available in standalone mode",
-        ));
+        ))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/linkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/linkat.rs
@@ -84,10 +84,7 @@ pub fn linkat(
     // In standalone mode, reject non-VFS paths (no linuxd).
     #[cfg(feature = "standalone")]
     {
-        return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "linkat not available in standalone mode",
-        ));
+        Err(Error::new(ErrorCode::OperationNotSupported, "linkat not available in standalone mode"))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -53,10 +53,7 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
     #[cfg(feature = "standalone")]
     {
         let _ = (fd, offset, whence);
-        return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "lseek not available in standalone mode",
-        ));
+        Err(Error::new(ErrorCode::OperationNotSupported, "lseek not available in standalone mode"))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/pipe.rs
+++ b/src/libs/syscall/src/unistd/syscall/pipe.rs
@@ -35,10 +35,7 @@ pub fn pipe() -> Result<[i32; 2], Error> {
     // In standalone mode, pipe is not available (no linuxd).
     #[cfg(feature = "standalone")]
     {
-        return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "pipe not available in standalone mode",
-        ));
+        Err(Error::new(ErrorCode::OperationNotSupported, "pipe not available in standalone mode"))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -70,10 +70,7 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
     #[cfg(feature = "standalone")]
     {
         let _ = (fd, buffer, offset);
-        return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "pread not available in standalone mode",
-        ));
+        Err(Error::new(ErrorCode::OperationNotSupported, "pread not available in standalone mode"))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -70,10 +70,7 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
     #[cfg(feature = "standalone")]
     {
         let _ = (fd, buffer, offset);
-        return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "pwrite not available in standalone mode",
-        ));
+        Err(Error::new(ErrorCode::OperationNotSupported, "pwrite not available in standalone mode"))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -183,10 +183,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
         if fd == STDIN_FILENO {
             return Ok(0); // EOF
         }
-        return Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "read not supported in standalone mode",
-        ));
+        Err(Error::new(ErrorCode::OperationNotSupported, "read not supported in standalone mode"))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -61,10 +61,10 @@ pub fn readlinkat(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, E
     // In standalone mode, readlinkat is not available (no symlinks).
     #[cfg(feature = "standalone")]
     {
-        return Err(Error::new(
+        Err(Error::new(
             ErrorCode::OperationNotSupported,
             "readlinkat not available in standalone mode",
-        ));
+        ))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/symlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/symlinkat.rs
@@ -71,10 +71,10 @@ pub fn symlinkat(target: &str, dirfd: i32, linkpath: &str) -> Result<(), Error> 
     // In standalone mode, reject non-VFS paths (no linuxd).
     #[cfg(feature = "standalone")]
     {
-        return Err(Error::new(
+        Err(Error::new(
             ErrorCode::OperationNotSupported,
             "symlinkat not available in standalone mode",
-        ));
+        ))
     }
 
     // Forward to linuxd via IPC.


### PR DESCRIPTION
This pull request primarily refactors how standalone mode errors and no-op returns are handled in the `syscall` library, and removes the dependency on `nanvix-terminal` from the `nanvix-http` crate. The changes simplify error handling by using more concise Rust idioms and clean up optional feature dependencies.