### PR TITLE
[build] Add Deployment Mode Build Parameter

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -61,13 +61,13 @@ is_excluded() {
 
 #
 # DESCRIPTION
-#   Converts deployment type to SINGLE_PROCESS and L2_VM flags.
+#   Converts deployment type to DEPLOYMENT_MODE flag.
 #
 # ARGUMENTS
 #   $1 - Deployment type.
 #
 # RETURNS
-#   String with SINGLE_PROCESS and L2_VM values.
+#   String with DEPLOYMENT_MODE value.
 #
 # USAGE EXAMPLE
 #   flags=$(get_deployment_flags "multi-process")
@@ -76,11 +76,8 @@ get_deployment_flags() {
     local deployment="${1}"
 
     case "${deployment}" in
-        single-process)
-            echo "SINGLE_PROCESS=yes"
-            ;;
-        multi-process)
-            echo "SINGLE_PROCESS=no"
+        standalone|single-process|multi-process|l2)
+            echo "DEPLOYMENT_MODE=${deployment}"
             ;;
         *)
             print_error "(pre-commit) Invalid deployment type: ${deployment}"

--- a/.github/actions/benchmark-build/action.yml
+++ b/.github/actions/benchmark-build/action.yml
@@ -33,5 +33,5 @@ runs:
         VERBOSE=yes \
         RELEASE=yes \
         ${SCCACHE:+"SCCACHE=${SCCACHE}"} \
-        L2_VM=yes \
+        DEPLOYMENT_MODE=l2 \
         ${TIMESTAMP_MSG_FLAG}

--- a/.github/actions/deployment-features/action.yml
+++ b/.github/actions/deployment-features/action.yml
@@ -21,14 +21,8 @@ runs:
     shell: bash
     run: |
       case "${{ inputs.deployment-type }}" in
-        single-process)
-          echo "make-flags=SINGLE_PROCESS=yes" >> "$GITHUB_OUTPUT"
-          ;;
-        multi-process)
-          echo "make-flags=SINGLE_PROCESS=no" >> "$GITHUB_OUTPUT"
-          ;;
-        l2)
-          echo "make-flags=SINGLE_PROCESS=no L2_VM=yes" >> "$GITHUB_OUTPUT"
+        standalone|single-process|multi-process|l2)
+          echo "make-flags=DEPLOYMENT_MODE=${{ inputs.deployment-type }}" >> "$GITHUB_OUTPUT"
           ;;
         *)
           echo "invalid deployment type: ${{ inputs.deployment-type }}" >&2

--- a/.github/skills/build-and-test/SKILL.md
+++ b/.github/skills/build-and-test/SKILL.md
@@ -43,20 +43,20 @@ Nanvix. This covers all build-system operations exposed through the `z` utility.
 
 Set these as environment variables or pass them after `--` in the `z` command:
 
-| Parameter        | Values                   | Default   |
-|------------------|--------------------------|-----------|
-| `MACHINE`        | `microvm`, `hyperlight`, | `microvm` |
-|                  | `qemu-pc`, `qemu-isapc`, |           |
-|                  | `qemu-baremetal`         |           |
-| `TARGET`         | `x86`                    | `x86`     |
-| `RELEASE`        | `yes`, `no`              | `no`      |
-| `LOG_LEVEL`      | `trace`, `debug`,        | `warn`    |
-|                  | `info`, `warn`,          |           |
-|                  | `error`, `panic`         |           |
-| `PROFILER`       | `yes`, `no`              | `no`      |
-| `SINGLE_PROCESS` | `yes`, `no`              | `no`      |
-| `STANDALONE`     | `yes`, `no`              | `no`      |
-| `L2_VM`          | `yes`, `no`              | `no`      |
+| Parameter        | Values                   | Default         |
+|------------------|--------------------------|-----------------|
+| `MACHINE`        | `microvm`, `hyperlight`, | `microvm`       |
+|                  | `qemu-pc`, `qemu-isapc`, |                 |
+|                  | `qemu-baremetal`         |                 |
+| `TARGET`         | `x86`                    | `x86`           |
+| `RELEASE`        | `yes`, `no`              | `no`            |
+| `LOG_LEVEL`      | `trace`, `debug`,        | `warn`          |
+|                  | `info`, `warn`,          |                 |
+|                  | `error`, `panic`         |                 |
+| `PROFILER`       | `yes`, `no`              | `no`            |
+| `DEPLOYMENT_MODE`| `standalone`,            | `multi-process` |
+|                  | `single-process`,        |                 |
+|                  | `multi-process`, `l2`    |                 |
 
 Example with custom parameters:
 

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -46,11 +46,12 @@ excluded in `is_excluded()`).
 
 ### Build Parameter Mapping
 
-| Deployment Type | `SINGLE_PROCESS` | `L2_VM` |
-|-----------------|------------------|---------|
-| single-process  | `yes`            | `no`    |
-| multi-process   | `no`             | `no`    |
-| l2              | `no`             | `yes`   |
+| Deployment Type | `DEPLOYMENT_MODE` |
+|-----------------|-------------------|
+| standalone      | `standalone`      |
+| single-process  | `single-process`  |
+| multi-process   | `multi-process`   |
+| l2              | `l2`              |
 
 ## Individual Quality Checks
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,10 @@ jobs:
       fail-fast: false
       matrix:
         machine-type: [qemu-pc, microvm, hyperlight]
-        deployment-type: [single-process, multi-process]
+        deployment-type: [standalone, single-process, multi-process]
         exclude:
+          - machine-type: qemu-pc
+            deployment-type: standalone
           - machine-type: qemu-pc
             deployment-type: single-process
     runs-on: ubuntu-24.04
@@ -163,8 +165,10 @@ jobs:
       fail-fast: false
       matrix:
         machine-type: [qemu-pc, microvm, hyperlight]
-        deployment-type: [single-process, multi-process]
+        deployment-type: [standalone, single-process, multi-process]
         exclude:
+          - machine-type: qemu-pc
+            deployment-type: standalone
           - machine-type: qemu-pc
             deployment-type: single-process
     runs-on: ubuntu-24.04
@@ -222,9 +226,9 @@ jobs:
           machine-type: "${{ matrix.machine-type }}"
           deployment-type: "${{ matrix.deployment-type }}"
 
-    # Save the Verus archive to the cache only when it was not already
-    # cached. The first matrix leg to reach this step wins the cache
-    # reservation; the rest skip gracefully.
+      # Save the Verus archive to the cache only when it was not already
+      # cached. The first matrix leg to reach this step wins the cache
+      # reservation; the rest skip gracefully.
       - name: "Save Verus Archive Cache"
         if: steps.verus-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
@@ -246,8 +250,10 @@ jobs:
       matrix:
         build-type: [debug, release]
         machine-type: [qemu-pc, microvm, hyperlight]
-        deployment-type: [single-process, multi-process]
+        deployment-type: [standalone, single-process, multi-process]
         exclude:
+          - machine-type: qemu-pc
+            deployment-type: standalone
           - machine-type: qemu-pc
             deployment-type: single-process
     runs-on: ubuntu-24.04
@@ -493,7 +499,7 @@ jobs:
             **/*.err
 
   # Build from source and run micro-benchmarks on baremetal self-hosted runners.
-  # Benchmarks require L2_VM=yes which needs .git, so they cannot use Docker builds.
+  # Benchmarks require DEPLOYMENT_MODE=l2 which needs .git, so they cannot use Docker builds.
   # Each machine type runs in parallel; a finalize job aggregates results.
   benchmark:
     name: "Benchmark (${{ matrix.machine-type }})"
@@ -876,8 +882,10 @@ jobs:
       fail-fast: false
       matrix:
         machine-type: [qemu-pc, microvm, hyperlight]
-        deployment-type: [single-process, multi-process]
+        deployment-type: [standalone, single-process, multi-process]
         exclude:
+          - machine-type: qemu-pc
+            deployment-type: standalone
           - machine-type: qemu-pc
             deployment-type: single-process
     runs-on: ubuntu-24.04
@@ -956,11 +964,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-        - name: "Checkout repository"
-          uses: actions/checkout@v6
-          with:
-            ssh-key: ${{ secrets.DEPLOY_PRIVATE_SSH_KEY }}
-            fetch-depth: 0
+      - name: "Checkout repository"
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_PRIVATE_SSH_KEY }}
+          fetch-depth: 0
 
-        - name: "Create Minor Release"
-          uses: ./.github/actions/create-minor-release
+      - name: "Create Minor Release"
+        uses: ./.github/actions/create-minor-release

--- a/Makefile
+++ b/Makefile
@@ -29,21 +29,20 @@ export TIMESTAMP_MSG ?= no
 # Target Host CPU
 export HOST_CPU ?=
 
-# L2 VM deployment?
-export L2_VM ?= no
+# Deployment mode: standalone, single-process, multi-process, l2
+export DEPLOYMENT_MODE ?= multi-process
 
-# Single-process deployment?
-export SINGLE_PROCESS ?= no
+# Validate DEPLOYMENT_MODE.
+VALID_DEPLOYMENT_MODES := standalone single-process multi-process l2
+ifeq ($(filter $(DEPLOYMENT_MODE),$(VALID_DEPLOYMENT_MODES)),)
+$(error Invalid DEPLOYMENT_MODE '$(DEPLOYMENT_MODE)'. Valid values: $(VALID_DEPLOYMENT_MODES))
+endif
 
 # Enable in-memory FAT32 filesystem?
 export MEMFS ?= no
 
-# Enable standalone mode (no linuxd, routes I/O to debug/memfs)?
-export STANDALONE ?= no
-
-# Standalone mode implies single-process deployment (no separate linuxd binary).
-ifeq ($(STANDALONE),yes)
-override SINGLE_PROCESS := yes
+# Standalone mode implies memfs.
+ifeq ($(DEPLOYMENT_MODE),standalone)
 override MEMFS := yes
 endif
 
@@ -116,7 +115,7 @@ endif
 # Release Artifact Configuration
 #===================================================================================================
 
-RELEASE_DEPLOYMENT_MODE := $(if $(filter yes,$(SINGLE_PROCESS)),single_process,multi_process)
+RELEASE_DEPLOYMENT_MODE := $(subst -,_,$(DEPLOYMENT_MODE))
 RELEASE_BUILD_MODE := $(if $(filter yes,$(RELEASE)),release,debug)
 RELEASE_VERSION := $(strip $(shell cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.packages[0].version'))
 RELEASE_ARCHIVE := nanvix-$(RELEASE_VERSION)-$(MACHINE)-$(RELEASE_DEPLOYMENT_MODE)-$(RELEASE_BUILD_MODE)-$(LOG_LEVEL).tar.bz2
@@ -488,7 +487,7 @@ install: all-nanvix
 	@cp ${KERNEL} ${SYSROOT_DIR}/bin/
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 	@cp ${NANVIXD} ${SYSROOT_DIR}/bin/
-ifneq ($(SINGLE_PROCESS),yes)
+ifeq ($(filter standalone single-process,$(DEPLOYMENT_MODE)),)
 	@cp ${LINUXD} ${SYSROOT_DIR}/bin/
 	@cp ${USERVM} ${SYSROOT_DIR}/bin/
 endif
@@ -536,14 +535,13 @@ help:
 	@echo "  run      Run system in release mode"
 	@echo ""
 	@echo "Build Parameters (override with VAR=value, see Parameter Values section below)"
-	@echo "  L2_VM            Enable L2 VM deployment (default: $(L2_VM))"
+	@echo "  DEPLOYMENT_MODE  Deployment mode (default: $(DEPLOYMENT_MODE))"
 	@echo "  LOG_LEVEL        Logging verbosity (default: $(LOG_LEVEL))"
 	@echo "  MACHINE          Target machine type (default: $(MACHINE))"
 	@echo "  MAKE_NO_PRINT    Suppress directory printing in recursive make (default: $(MAKE_NO_PRINT))"
 	@echo "  PROFILER         Enable MicroVM profiler (default: $(PROFILER))"
 	@echo "  RELEASE          Release build mode (default: $(RELEASE)) [impacts build time]"
 	@echo "  SCCACHE          Path to compilation cache binary (default: auto-detected from PATH) [impacts build time]"
-	@echo "  SINGLE_PROCESS   Enable single-process deployment (default: $(SINGLE_PROCESS))"
 	@echo "  SYSROOT_DIR      Sysroot directory (default: $(SYSROOT_DIR))"
 	@echo "  TARGET           Target architecture (default: $(TARGET))"
 	@echo "  TIMEOUT          Execution timeout in seconds (default: $(TIMEOUT))"
@@ -551,12 +549,12 @@ help:
 	@echo "  VERUS_DIR        Path to Verus installation (default: $(VERUS_DIR))"
 	@echo ""
 	@echo "Parameter Values"
+	@echo "  DEPLOYMENT_MODE standalone, single-process, multi-process, l2"
 	@echo "  MACHINE         hyperlight, microvm, qemu-pc, qemu-isapc, qemu-baremetal"
 	@echo "  TARGET          x86"
 	@echo "  RELEASE         yes, no"
 	@echo "  LOG_LEVEL       trace, debug, info, warn, error, panic"
 	@echo "  PROFILER        yes, no"
-	@echo "  L2_VM           yes, no"
 	@echo "  MAKE_NO_PRINT   yes, no"
 
 # Verifies all Verus-annotated crates.
@@ -790,9 +788,9 @@ run-unit-tests: test-host-rlibs
 endif
 
 # Determine the test configuration file based on deployment mode.
-ifeq ($(SINGLE_PROCESS),yes)
+ifneq ($(filter standalone single-process,$(DEPLOYMENT_MODE)),)
 NANVIX_TEST_CONFIG := test/test-single_process.toml
-else ifeq ($(L2_VM),yes)
+else ifeq ($(DEPLOYMENT_MODE),l2)
 NANVIX_TEST_CONFIG := test/test-l2.toml
 else
 NANVIX_TEST_CONFIG := test/test-multi_process.toml

--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -8,7 +8,7 @@ GUEST_STATICLIB_FEATURES += memfs
 endif
 # Enable standalone mode: routes stdout/stderr to debug kcall,
 # file I/O to memfs, and disables IPC-based syscalls (no linuxd).
-ifeq ($(STANDALONE),yes)
+ifeq ($(DEPLOYMENT_MODE),standalone)
 GUEST_STATICLIB_FEATURES += standalone
 endif
 GUEST_STATICLIB_FEATURES := $(strip $(GUEST_STATICLIB_FEATURES))

--- a/build/make/generic-host-rlibs.mk
+++ b/build/make/generic-host-rlibs.mk
@@ -9,8 +9,17 @@ MACHINE_FEATURES :=
 MACHINE_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 MACHINE_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 MACHINE_FEATURES := $(strip $(MACHINE_FEATURES))
-MACHINE_CARGO_FEATURES := $(if $(MACHINE_FEATURES),--features "$(MACHINE_FEATURES)",)
-HOST_RLIBS_CARGO_FEATURES = $(if $(filter $(1),$(USERVM_DEPENDENT_RLIBS)),$(MACHINE_CARGO_FEATURES),)
+
+# Deployment-mode feature flags for host rlibs that depend on uservm.
+DEPLOYMENT_FEATURES :=
+DEPLOYMENT_FEATURES += $(if $(filter standalone,$(DEPLOYMENT_MODE)),standalone,)
+DEPLOYMENT_FEATURES += $(if $(filter standalone single-process,$(DEPLOYMENT_MODE)),single-process,)
+DEPLOYMENT_FEATURES += $(if $(filter multi-process l2,$(DEPLOYMENT_MODE)),multi-process,)
+DEPLOYMENT_FEATURES := $(strip $(DEPLOYMENT_FEATURES))
+
+ALL_HOST_RLIB_FEATURES = $(strip $(MACHINE_FEATURES) $(DEPLOYMENT_FEATURES))
+ALL_HOST_RLIB_CARGO_FEATURES = $(if $(ALL_HOST_RLIB_FEATURES),--features "$(ALL_HOST_RLIB_FEATURES)",)
+HOST_RLIBS_CARGO_FEATURES = $(if $(filter $(1),$(USERVM_DEPENDENT_RLIBS)),$(ALL_HOST_RLIB_CARGO_FEATURES),)
 
 define HOST_RLIB_RULES
 check-host-rlib-$(1):

--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -2,7 +2,9 @@
 # Licensed under the MIT License.
 
 NANVIX_BENCH_FEATURES :=
+NANVIX_BENCH_FEATURES += $(if $(filter standalone,$(DEPLOYMENT_MODE)),standalone,)
 NANVIX_BENCH_FEATURES += $(if $(filter standalone single-process,$(DEPLOYMENT_MODE)),single-process,)
+NANVIX_BENCH_FEATURES += $(if $(filter multi-process l2,$(DEPLOYMENT_MODE)),multi-process,)
 NANVIX_BENCH_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIX_BENCH_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIX_BENCH_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)

--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 NANVIX_BENCH_FEATURES :=
-NANVIX_BENCH_FEATURES += $(if $(filter yes,$(SINGLE_PROCESS)),single-process,)
+NANVIX_BENCH_FEATURES += $(if $(filter standalone single-process,$(DEPLOYMENT_MODE)),single-process,)
 NANVIX_BENCH_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIX_BENCH_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIX_BENCH_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)

--- a/build/make/nanvix-test.mk
+++ b/build/make/nanvix-test.mk
@@ -2,7 +2,9 @@
 # Licensed under the MIT License.
 
 NANVIX_TEST_FEATURES :=
+NANVIX_TEST_FEATURES += $(if $(filter standalone,$(DEPLOYMENT_MODE)),standalone,)
 NANVIX_TEST_FEATURES += $(if $(filter standalone single-process,$(DEPLOYMENT_MODE)),single-process,)
+NANVIX_TEST_FEATURES += $(if $(filter multi-process l2,$(DEPLOYMENT_MODE)),multi-process,)
 NANVIX_TEST_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIX_TEST_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIX_TEST_FEATURES := $(strip $(NANVIX_TEST_FEATURES))

--- a/build/make/nanvix-test.mk
+++ b/build/make/nanvix-test.mk
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 NANVIX_TEST_FEATURES :=
-NANVIX_TEST_FEATURES += $(if $(filter yes,$(SINGLE_PROCESS)),single-process,)
+NANVIX_TEST_FEATURES += $(if $(filter standalone single-process,$(DEPLOYMENT_MODE)),single-process,)
 NANVIX_TEST_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIX_TEST_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIX_TEST_FEATURES := $(strip $(NANVIX_TEST_FEATURES))

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 NANVIXD_FEATURES :=
-NANVIXD_FEATURES += $(if $(filter yes,$(SINGLE_PROCESS)),single-process,)
+NANVIXD_FEATURES += $(if $(filter standalone single-process,$(DEPLOYMENT_MODE)),single-process,)
 NANVIXD_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIXD_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIXD_FEATURES := $(strip $(NANVIXD_FEATURES))
@@ -12,11 +12,9 @@ all-nanvixd: init
 	$(HOST_CARGO_BUILD_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd
 	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/nanvixd $(BINARIES_DIR)/nanvixd.elf
 	# Only give nanvixd CAP_SYS_ADMIN and CAP_NET_ADMIN if we need to manage
-	# network namespaces. This is only the case in L2 (multi-process) deployments.
-ifeq ($(SINGLE_PROCESS),no)
-ifeq ($(L2_VM),yes)
+	# network namespaces. This is only the case in L2 deployments.
+ifeq ($(DEPLOYMENT_MODE),l2)
 	$(SUDO_CMD) $(SETCAP_CMD) cap_sys_admin,cap_net_admin+ep $(BINARIES_DIR)/nanvixd.elf
-endif
 endif
 
 check-nanvixd:

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -2,7 +2,9 @@
 # Licensed under the MIT License.
 
 NANVIXD_FEATURES :=
+NANVIXD_FEATURES += $(if $(filter standalone,$(DEPLOYMENT_MODE)),standalone,)
 NANVIXD_FEATURES += $(if $(filter standalone single-process,$(DEPLOYMENT_MODE)),single-process,)
+NANVIXD_FEATURES += $(if $(filter multi-process l2,$(DEPLOYMENT_MODE)),multi-process,)
 NANVIXD_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIXD_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIXD_FEATURES := $(strip $(NANVIXD_FEATURES))

--- a/build/make/snapshot.mk
+++ b/build/make/snapshot.mk
@@ -3,8 +3,8 @@
 
 # The snapshots for the L2 VM need linuxd.elf to be built first.
 all-snapshot: all-host-binaries
-# Snapshots are only generated for microvm/hyperlight machines when L2_VM is enabled.
-ifneq (,$(and $(filter yes,$(L2_VM)),$(filter $(MACHINE),microvm hyperlight)))
+# Snapshots are only generated for microvm/hyperlight machines in L2 deployment mode.
+ifneq (,$(and $(filter l2,$(DEPLOYMENT_MODE)),$(filter $(MACHINE),microvm hyperlight)))
 	bash $(SCRIPTS_DIR)/generate-l2-initramfs.sh
 	bash $(SCRIPTS_DIR)/generate-l2-snapshot.sh $(TOOLCHAIN_DIR)
 endif

--- a/doc/build.md
+++ b/doc/build.md
@@ -83,10 +83,10 @@ You can also build in **standalone mode**, which excludes `linuxd` and routes al
 local memfs VFS layer and kernel debug serial port:
 
 ```bash
-make all STANDALONE=yes
+make all DEPLOYMENT_MODE=standalone
 ```
 
-Standalone mode implies `SINGLE_PROCESS=yes` automatically.
+Standalone mode implies `MEMFS=yes` automatically.
 
 ## Formal Verification with Verus
 

--- a/doc/test.md
+++ b/doc/test.md
@@ -46,8 +46,8 @@ The system integration tests can be run directly using:
 The appropriate test configuration is automatically selected based on the
 deployment mode:
 
-- **Single-process mode** (`SINGLE_PROCESS=yes`): Uses `test/test-single_process.toml`
-- **L2 VM mode** (`L2_VM=yes`): Uses `test/test-l2.toml`
+- **Single-process mode** (`DEPLOYMENT_MODE=single-process`): Uses `test/test-single_process.toml`
+- **L2 VM mode** (`DEPLOYMENT_MODE=l2`): Uses `test/test-l2.toml`
 - **Multi-process mode** (default): Uses `test/test-multi_process.toml`
 
 ### Test Modes
@@ -63,7 +63,7 @@ The `nanvix-test.elf` utility supports two execution modes:
 
 - Programs are invoked directly by nanvixd with a terminal interface.
 - Only supports native executables (ELF binaries).
-- Not available for L2 VM deployments (`L2_VM=yes`); L2 configurations always use the HTTP executor.
+- Not available for L2 VM deployments (`DEPLOYMENT_MODE=l2`); L2 configurations always use the HTTP executor.
 
 ## Running All Tests
 

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -87,7 +87,7 @@ get_release_flag() {
 #   $1 - Deployment type.
 #
 # Returns
-#   String with SINGLE_PROCESS and L2_VM values.
+#   String with DEPLOYMENT_MODE value.
 #
 # Usage Example
 #   flags=$(get_deployment_flags "single-process")
@@ -96,14 +96,8 @@ get_deployment_flags() {
     local deployment_type="${1}"
 
     case "${deployment_type}" in
-        single-process)
-            echo "SINGLE_PROCESS=yes L2_VM=no"
-            ;;
-        multi-process)
-            echo "SINGLE_PROCESS=no L2_VM=no"
-            ;;
-        l2)
-            echo "SINGLE_PROCESS=no L2_VM=yes"
+        standalone|single-process|multi-process|l2)
+            echo "DEPLOYMENT_MODE=${deployment_type}"
             ;;
         *)
             print_error "(pipeline) Invalid deployment type: ${deployment_type}"

--- a/src/libs/nanvix-http/Cargo.toml
+++ b/src/libs/nanvix-http/Cargo.toml
@@ -29,11 +29,15 @@ uservm = { workspace = true }
 user-vm-api = { workspace = true }
 
 [features]
-default = ["microvm"]
+default = ["microvm", "multi-process"]
 single-process = [
     "linuxd",
     "nanvix-sandbox-cache/single-process",
 ]
+multi-process = [
+    "nanvix-sandbox-cache/multi-process",
+]
+standalone = ["nanvix-sandbox-cache/standalone"]
 hyperlight = [
     "config/hyperlight",
     "uservm/hyperlight",

--- a/src/libs/nanvix-sandbox-cache/Cargo.toml
+++ b/src/libs/nanvix-sandbox-cache/Cargo.toml
@@ -19,10 +19,12 @@ rand = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = ["microvm"]
+default = ["microvm", "multi-process"]
+single-process = ["nanvix-sandbox/single-process"]
+multi-process = ["nanvix-sandbox/multi-process"]
+standalone = ["nanvix-sandbox/standalone"]
 hyperlight = ["config/hyperlight", "nanvix-sandbox/hyperlight"]
 microvm = ["config/microvm", "nanvix-sandbox/microvm"]
-single-process = ["nanvix-sandbox/single-process"]
 
 [lints]
 workspace = true

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -345,10 +345,6 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
     ///
     /// ## Cache State Guarantees
     ///
-    /// - **sandbox_index**: Only updated after **successful** sandbox startup. If initialization
-    ///   or startup fails, the User VM identifier is never added to the index, preventing partial
-    ///   state from leaking into the cache.
-    ///
     /// - **running_sandboxes**: Only updated after **successful** sandbox startup. Failures during
     ///   initialization or startup do not pollute this map.
     ///
@@ -978,7 +974,6 @@ mod tests {
         let cache_guard: tokio::sync::MutexGuard<SandboxCache<()>> = cache.lock().await;
         assert_eq!(cache_guard.running_sandboxes.len(), 0);
         assert_eq!(cache_guard.linuxd_instances.len(), 0);
-        assert_eq!(cache_guard.sandbox_index.len(), 0);
     }
 
     ///

--- a/src/libs/nanvix-sandbox/Cargo.toml
+++ b/src/libs/nanvix-sandbox/Cargo.toml
@@ -30,10 +30,12 @@ user-vm-api = { workspace = true }
 uservm = { workspace = true }
 
 [features]
-default = ["microvm"]
+default = ["microvm", "multi-process"]
 # If enabled this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) are embedded
 # into the sandbox.
 single-process = []
+multi-process = []
+standalone = ["single-process"]
 hyperlight = ["config/hyperlight", "uservm/hyperlight"]
 microvm = ["config/microvm", "uservm/microvm"]
 

--- a/src/libs/nanvix-terminal/Cargo.toml
+++ b/src/libs/nanvix-terminal/Cargo.toml
@@ -19,10 +19,12 @@ tokio = { workspace = true, features = ["full"] }
 user-vm-api = { workspace = true }
 
 [features]
-default = ["microvm"]
+default = ["microvm", "multi-process"]
+single-process = ["nanvix-sandbox-cache/single-process"]
+multi-process = ["nanvix-sandbox-cache/multi-process"]
+standalone = ["nanvix-sandbox-cache/standalone"]
 hyperlight = ["nanvix-sandbox-cache/hyperlight"]
 microvm = ["nanvix-sandbox-cache/microvm"]
-single-process = ["nanvix-sandbox-cache/single-process"]
 
 [lints]
 workspace = true

--- a/src/libs/nanvix/Cargo.toml
+++ b/src/libs/nanvix/Cargo.toml
@@ -27,7 +27,7 @@ syslog = { workspace = true, features = ["std"] }
 uservm = { workspace = true, optional = true }
 
 [features]
-default = ["microvm"]
+default = ["microvm", "multi-process"]
 internal-api = ["sys", "syscall", "uservm"]
 single-process = [
     "linuxd",
@@ -35,6 +35,18 @@ single-process = [
     "nanvix-sandbox/single-process",
     "nanvix-sandbox-cache/single-process",
     "nanvix-terminal/single-process",
+]
+multi-process = [
+    "nanvix-http/multi-process",
+    "nanvix-sandbox/multi-process",
+    "nanvix-sandbox-cache/multi-process",
+    "nanvix-terminal/multi-process",
+]
+standalone = [
+    "nanvix-http/standalone",
+    "nanvix-sandbox/standalone",
+    "nanvix-sandbox-cache/standalone",
+    "nanvix-terminal/standalone",
 ]
 hyperlight = [
     "config/hyperlight",

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -25,9 +25,11 @@ serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = ["microvm"]
+default = ["microvm", "multi-process"]
 timestamp-messages = ["profiler/timestamp-messages"]
 single-process = ["nanvix/single-process"]
+multi-process = ["nanvix/multi-process"]
+standalone = ["nanvix/standalone"]
 hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 

--- a/src/utils/nanvix-test/Cargo.toml
+++ b/src/utils/nanvix-test/Cargo.toml
@@ -26,8 +26,10 @@ shell-words = { workspace = true }
 globset = { workspace = true }
 
 [features]
-default = ["microvm"]
+default = ["microvm", "multi-process"]
 single-process = ["nanvix/single-process"]
+multi-process = ["nanvix/multi-process"]
+standalone = ["nanvix/standalone"]
 hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -20,10 +20,12 @@ serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = ["microvm"]
+default = ["microvm", "multi-process"]
 # If enabled this feature is enabled, the Linux Daemon (linuxd) and User VM (uservm) are embedded
 # into Nanvix Daemon (nanvixd).
 single-process = ["nanvix/single-process"]
+multi-process = ["nanvix/multi-process"]
+standalone = ["nanvix/standalone"]
 hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 


### PR DESCRIPTION
This pull request refactors the build system and CI pipeline to standardize deployment configuration using a single `DEPLOYMENT_MODE` variable, replacing the previous `SINGLE_PROCESS`, `L2_VM`, and `STANDALONE` flags. This change simplifies deployment logic, improves clarity, and updates documentation and scripts accordingly. The update also introduces a new `standalone` deployment mode and ensures consistent feature flag handling across Makefiles, CI workflows, and documentation.