### PR TITLE
[kernel] Introduce multibinary initrd format for microvm and hyperlight

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -18,6 +18,47 @@ inputs:
 runs:
   using: "composite"
   steps:
+  # For microvm/hyperlight: smoke test that boots nanvixd and checks for the
+  # kernel magic string, verifying the multibin initrd (procd, testd, memd).
+  - name: "Smoke Test (microvm/hyperlight)"
+    if: inputs.machine-type == 'microvm' || inputs.machine-type == 'hyperlight'
+    shell: bash
+    env:
+      RUST_LOG: debug
+    run: |
+      set -Eeuo pipefail
+
+      MAGIC_STRING="hello, world!"
+      TIMEOUT=120
+
+      # Build multibin image from pre-built artifacts.
+      ./bin/mkimage.elf -o nanvix.img \
+          "bin/procd.elf;procd" \
+          "bin/memd.elf;memd" \
+          "bin/testd.elf;testd"
+
+      if [[ "${{ inputs.build-type }}" == "release" ]]; then
+        # In release builds, CI sets LOG_LEVEL=error, which suppresses the
+        # debug-level magic string. Validate success by requiring nanvixd to
+        # exit cleanly before timeout.
+        if ! bash scripts/run-nanvixd.sh \
+              "${{ inputs.machine-type }}" nanvix.img "${TIMEOUT}"; then
+          echo "::error::Smoke test failed: nanvixd did not exit cleanly within ${TIMEOUT}s."
+          exit 1
+        fi
+      else
+        # In debug builds, assert successful boot by waiting for kernel magic
+        # string in console output.
+        if ! bash scripts/run-nanvixd.sh \
+              "${{ inputs.machine-type }}" nanvix.img "${TIMEOUT}" \
+              --wait-for-string "${MAGIC_STRING}"; then
+          echo "::error::Smoke test failed: magic string '${MAGIC_STRING}' not found within ${TIMEOUT}s."
+          exit 1
+        fi
+      fi
+
+      echo "Smoke test passed."
+
   # For microvm/hyperlight: run test binary directly from downloaded artifacts.
   - name: "Integration Test (microvm/hyperlight)"
     if: inputs.machine-type == 'microvm' || inputs.machine-type == 'hyperlight'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
         "src/user/hello-rust-nostd",
         "src/user/hello-wasm",
         "src/utils/echo-client",
+        "src/utils/mkimage",
         "src/utils/nanvix-bench",
         "src/utils/nanvix-test",
         "src/utils/nanvixd",
@@ -122,6 +123,7 @@ kvm-ioctls = "0.24.0"
 libc = "0.2.182"
 linuxd = { path = "src/daemons/linuxd", default-features = false }
 log = "0.4.29"
+multibin = { path = "src/libs/multibin", default-features = false }
 nanvix = { path = "src/libs/nanvix", default-features = false }
 nanvix-http = { path = "src/libs/nanvix-http", default-features = false }
 nanvix-registry = { path = "src/libs/nanvix-registry", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
         "src/libs/syslog-macros",
         "src/libs/libc_stdlib",
         "src/libs/libc_string",
+        "src/libs/multibin",
         "src/libs/sys",
         "src/libs/type-safe",
         "src/libs/user-vm-api",

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-ALL_HOST_RUST_LIBS := control-plane-api hwloc profiler nanvix nanvix-http nanvix-registry nanvix-sandbox nanvix-sandbox-cache nanvix-terminal syscomm user-vm-api
+ALL_HOST_RUST_LIBS := control-plane-api hwloc multibin profiler nanvix nanvix-http nanvix-registry nanvix-sandbox nanvix-sandbox-cache nanvix-terminal syscomm user-vm-api
 ALL_HOST_UTILS := echo-client strace
 ALL_HOST_DAEMONS := linuxd
 ALL_HOST_BINARIES := $(ALL_HOST_UTILS) $(ALL_HOST_DAEMONS)

--- a/Makefile
+++ b/Makefile
@@ -495,6 +495,7 @@ install: all-nanvix
 	@cp ${KERNEL} ${SYSROOT_DIR}/bin/
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 	@cp ${NANVIXD} ${SYSROOT_DIR}/bin/
+	@cp ${MKIMAGE} ${SYSROOT_DIR}/bin/
 ifeq ($(filter standalone single-process,$(DEPLOYMENT_MODE)),)
 	@cp ${LINUXD} ${SYSROOT_DIR}/bin/
 	@cp ${USERVM} ${SYSROOT_DIR}/bin/

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ export WASMD_SOCKADDR ?= 127.0.0.1:8585
 
 # Default System Image
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-export IMAGE ?= $(BINARIES_DIR)/noop-rust-nostd.elf
+export IMAGE ?= nanvix.img
 else
 export IMAGE ?= nanvix.iso
 endif
@@ -142,6 +142,7 @@ export LIBPOSIX := $(LIBRARIES_DIR)/libposix.a
 # Binaries.
 KERNEL := $(BINARIES_DIR)/kernel.$(EXEC_FORMAT)
 LINUXD := $(BINARIES_DIR)/linuxd.$(EXEC_FORMAT)
+MKIMAGE := $(BINARIES_DIR)/mkimage.elf
 NANVIXD := $(BINARIES_DIR)/nanvixd.$(EXEC_FORMAT)
 USERVM := $(BINARIES_DIR)/uservm.$(EXEC_FORMAT)
 
@@ -748,13 +749,17 @@ endif
 
 # Runs system in release mode.
 run: image
-ifeq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -toolchain-bin-dir $(TOOLCHAIN_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
+else
 	bash $(SCRIPTS_DIR)/run-qemu.sh $(TARGET) $(MACHINE) $(IMAGE) --no-debug $(TIMEOUT)
 endif
 
 # Runs system in debug mode.
 debug: image
-ifeq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -toolchain-bin-dir $(TOOLCHAIN_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
+else
 	bash $(SCRIPTS_DIR)/run-qemu.sh $(TARGET) $(MACHINE) $(IMAGE) --debug $(TIMEOUT)
 endif
 
@@ -764,7 +769,12 @@ endif
 
 # Builds the system image.
 image: all-nanvix
-ifeq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+	$(MKIMAGE) -o $(IMAGE) \
+		$(BINARIES_DIR)/procd.$(EXEC_FORMAT)\;procd \
+		$(BINARIES_DIR)/memd.$(EXEC_FORMAT)\;memd \
+		$(BINARIES_DIR)/testd.$(EXEC_FORMAT)\;testd
+else
 	$(MKDIR_CMD) $(IMAGE_DIR)/boot/grub
 	$(CP_CMD) $(GRUB_CFG_SCRIPT) $(IMAGE_DIR)/boot/grub/
 	$(CP_CMD) $(BINARIES_DIR)/*.$(EXEC_FORMAT) $(IMAGE_DIR)/
@@ -772,7 +782,9 @@ ifeq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 endif
 
 image-clean:
-ifeq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
+	$(RM_CMD) $(IMAGE)
+else
 	$(RM_CMD) $(IMAGE_DIR)/*.$(EXEC_FORMAT)
 	$(RM_CMD) $(IMAGE)
 endif

--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 ALL_HOST_RUST_LIBS := control-plane-api hwloc multibin profiler nanvix nanvix-http nanvix-registry nanvix-sandbox nanvix-sandbox-cache nanvix-terminal syscomm user-vm-api
-ALL_HOST_UTILS := echo-client strace
+ALL_HOST_UTILS := echo-client mkimage strace
 ALL_HOST_DAEMONS := linuxd
 ALL_HOST_BINARIES := $(ALL_HOST_UTILS) $(ALL_HOST_DAEMONS)
 else

--- a/scripts/run-nanvixd.sh
+++ b/scripts/run-nanvixd.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#
+# Runs Nanvix via nanvixd (microvm / hyperlight).
+#
+# Usage:
+#   run-nanvixd.sh <machine> <image> [timeout] [--wait-for-string <string>]
+#
+# Arguments:
+#   machine  Machine type (microvm or hyperlight).
+#   image    Path to the multibin system image.
+#   timeout  Timeout in seconds (default: 120).
+#
+# Options:
+#   --wait-for-string <s>  Monitor console output for <s> and terminate nanvixd
+#                          when found or on timeout.
+#
+# Environment:
+#   NANVIXD            Path to nanvixd binary  (default: ./bin/nanvixd.elf).
+#   TOOLCHAIN_BIN_DIR  Toolchain bin directory  (default: $HOME/toolchain/bin).
+#   LOG_DIR            Log output directory     (default: ./logs).
+#   RUST_LOG           Rust log level           (default: info).
+#
+
+# Fast fail on errors and unset variables.
+set -euo pipefail
+
+#==================================================================================================
+# Imports
+#==================================================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+source "${SCRIPT_DIR}/common/utils.sh"
+
+#==================================================================================================
+# Global Variables
+#==================================================================================================
+
+export SCRIPT_NAME="$0"
+export SCRIPT_DIR
+
+# Defaults for nanvixd configuration.
+NANVIXD="${NANVIXD:-./bin/nanvixd.elf}"
+TOOLCHAIN_BIN_DIR="${TOOLCHAIN_BIN_DIR:-${HOME}/toolchain/bin}"
+LOG_DIR="${LOG_DIR:-./logs}"
+export RUST_LOG="${RUST_LOG:-info}"
+
+#==================================================================================================
+# Argument Parsing
+#==================================================================================================
+
+# Positional arguments.
+MACHINE="${1:-}"
+IMAGE="${2:-}"
+TIMEOUT="${3:-120}"
+
+# Optional: --wait-for-string <string>.
+WAIT_FOR_STRING=""
+shift $(( $# > 3 ? 3 : $# ))
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--wait-for-string)
+			if [[ $# -lt 2 ]]; then
+				print_error "Missing argument for --wait-for-string."
+				exit 1
+			fi
+			WAIT_FOR_STRING="$2"
+			shift 2
+			;;
+		*)
+			print_error "Unknown option: $1"
+			exit 1
+			;;
+	esac
+done
+
+#===================================================================================================
+# usage()
+#===================================================================================================
+
+#
+# Description
+#   Prints script usage and exits.
+#
+function usage
+{
+	echo "${SCRIPT_NAME} <machine> <image> [timeout] [--wait-for-string <string>]"
+	exit 1
+}
+
+#===================================================================================================
+# check_args()
+#===================================================================================================
+
+#
+# Description
+#   Validates required script arguments.
+#
+function check_args
+{
+	# Validate machine type.
+	case "${MACHINE}" in
+		microvm | hyperlight) ;;
+		*)
+			print_error "Unsupported machine type: '${MACHINE}'. Expected 'microvm' or 'hyperlight'."
+			usage
+			;;
+	esac
+
+	# Validate image path.
+	if [[ -z "${IMAGE}" ]]; then
+		print_error "Missing image argument."
+		usage
+	fi
+	if [[ ! -f "${IMAGE}" ]]; then
+		print_error "Image file not found: ${IMAGE}"
+		exit 1
+	fi
+
+	# Validate nanvixd binary.
+	if [[ ! -x "${NANVIXD}" ]]; then
+		print_error "nanvixd binary not found or not executable: ${NANVIXD}"
+		exit 1
+	fi
+
+	# Validate timeout is a positive integer.
+	if [[ ! "${TIMEOUT}" =~ ^[0-9]+$ ]] || [[ "${TIMEOUT}" -eq 0 ]]; then
+		print_error "Timeout must be a positive integer, got: '${TIMEOUT}'"
+		exit 1
+	fi
+}
+
+#===================================================================================================
+# run_nanvixd()
+#===================================================================================================
+
+#
+# Description
+#   Runs nanvixd with optional timeout.
+#
+function run_nanvixd
+{
+	local cmd="${NANVIXD} -console-file /dev/stdout -toolchain-bin-dir ${TOOLCHAIN_BIN_DIR} -log-dir ${LOG_DIR} -- ${IMAGE}"
+
+	# Wait-for-string mode: run nanvixd in the background, monitor console output
+	# for a specific string, and terminate nanvixd when the string is found or on
+	# timeout.
+	if [[ -n "${WAIT_FOR_STRING}" ]]; then
+		run_nanvixd_wait_for_string "${cmd}" "${TIMEOUT}"
+		return
+	fi
+
+	# Normal mode: run nanvixd with timeout.
+	cmd="timeout -s SIGTERM --preserve-status --foreground ${TIMEOUT} ${cmd}"
+
+	# shellcheck disable=SC2086 # cmd is a composed command string; allow word splitting into separate args
+	${cmd} 2> stderr.log
+}
+
+#===================================================================================================
+# run_nanvixd_wait_for_string()
+#===================================================================================================
+
+#
+# Description
+#   Runs nanvixd in the background, monitors console output for a specific
+#   string, and terminates nanvixd when the string is found or on timeout.
+#
+# Arguments
+#   $1 - The full nanvixd command to run.
+#   $2 - Timeout in seconds.
+#
+function run_nanvixd_wait_for_string
+{
+	local cmd="$1"
+	local timeout="${2:-120}"
+	local log_file="run-stdout.log"
+
+	rm -f "${log_file}"
+	touch "${log_file}"
+
+	print_info "Waiting for string '${WAIT_FOR_STRING}' (timeout: ${timeout}s)..."
+
+	# Run nanvixd in the background with stdout teed to a log file.
+	# Use setsid to create a new process group for clean termination.
+	# shellcheck disable=SC2086 # cmd is a composed command string; allow word splitting into separate args
+	setsid ${cmd} > >(tee "${log_file}") 2>&1 &
+	local nanvixd_pid=$!
+
+	# Monitor console output for the magic string.
+	local elapsed=0
+	while [[ "${elapsed}" -lt "${timeout}" ]]; do
+		if grep -q "${WAIT_FOR_STRING}" "${log_file}" 2>/dev/null; then
+			print_success "String '${WAIT_FOR_STRING}' found. Terminating nanvixd."
+			kill -TERM -"${nanvixd_pid}" 2>/dev/null || true
+			wait "${nanvixd_pid}" 2>/dev/null || true
+			return 0
+		fi
+
+		# Check if nanvixd has already exited.
+		if ! kill -0 "${nanvixd_pid}" 2>/dev/null; then
+			# Process exited; check if the string appeared in the final output.
+			if grep -q "${WAIT_FOR_STRING}" "${log_file}" 2>/dev/null; then
+				print_success "String '${WAIT_FOR_STRING}' found (nanvixd exited)."
+				return 0
+			fi
+			break
+		fi
+
+		sleep 1
+		elapsed=$((elapsed + 1))
+	done
+
+	# Timeout or nanvixd exited without the expected string.
+	kill -TERM -"${nanvixd_pid}" 2>/dev/null || true
+	wait "${nanvixd_pid}" 2>/dev/null || true
+
+	print_error "String '${WAIT_FOR_STRING}' not found within ${timeout}s."
+	cat "${log_file}" || true
+	return 1
+}
+
+#===================================================================================================
+# Main
+#===================================================================================================
+
+# Verbose mode.
+echo "====================================================================="
+echo "MACHINE          = ${MACHINE}"
+echo "IMAGE            = ${IMAGE}"
+echo "NANVIXD          = ${NANVIXD}"
+echo "TOOLCHAIN_BIN_DIR= ${TOOLCHAIN_BIN_DIR}"
+echo "LOG_DIR          = ${LOG_DIR}"
+echo "RUST_LOG         = ${RUST_LOG}"
+echo "TIMEOUT          = ${TIMEOUT}"
+echo "WAIT_FOR_STRING  = ${WAIT_FOR_STRING}"
+echo "====================================================================="
+
+check_args
+
+mkdir -p "${LOG_DIR}"
+
+run_nanvixd

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -25,6 +25,7 @@ slab = { workspace = true }
 sys = { workspace = true }
 hyperlight-common = { workspace = true, optional = true }
 hyperlight-guest = { workspace = true, optional = true }
+multibin = { workspace = true, optional = true }
 static_assert = { workspace = true }
 
 [build-dependencies]
@@ -44,6 +45,7 @@ hyperlight = [
     "dep:hyperlight-common",
     "dep:hyperlight-guest",
     "dep:config",
+    "dep:multibin",
     "config/hyperlight",
 ]
 microvm = [
@@ -52,6 +54,7 @@ microvm = [
     "stdio",
     "pit",
     "dep:config",
+    "dep:multibin",
     "config/microvm",
 ]
 pc = [

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -306,33 +306,71 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
         ProcessEnvironmentBlock::set_guest_function_dispatch_ptr(0xdeadbeef)?;
     };
 
-    // Read actual size and relocate only that amount
-    let (initrd_base, initrd_size, (cmdline_len, cmdline)) = unsafe {
-        let current_data_start = (*peb_ptr).init_data.ptr as usize;
-        let total_size = (*peb_ptr).init_data.size as usize;
-
-        let (initrd_base, actual_initrd_size, initrd_cmdline) =
-            parse_initrd_image(current_data_start, total_size)?;
-
-        (initrd_base, actual_initrd_size, initrd_cmdline)
-    };
-
     let mut kernel_modules: LinkedList<KernelModule> = LinkedList::new();
 
-    // Register initrd as a kernel module.
+    // Read the init_data blob from the PEB.
+    let (current_data_start, total_size) = unsafe {
+        let start: usize = (*peb_ptr).init_data.ptr as usize;
+        let size: usize = (*peb_ptr).init_data.size as usize;
+        (start, size)
+    };
 
-    info!(
-        "initrd_base={:#010x}, initrd_size={:#010x}, cmdline_len={:?}, cmdline={:?}",
-        initrd_base,
-        initrd_size,
-        cmdline_len,
-        cmdline.as_str()
-    );
+    if total_size == 0 {
+        let reason: &str = "init_data is empty";
+        error!("parse_bootinfo(): {reason}");
+        return Err(Error::new(ErrorCode::BadFile, reason));
+    }
 
-    // Add kernel module to the list of kernel modules.
-    let module: KernelModule =
-        KernelModule::new(PhysicalAddress::from_raw_value(initrd_base)?, initrd_size, cmdline);
-    kernel_modules.push_back(module);
+    // Detect initrd format by checking for NVMB multibinary magic.
+    let init_data: &[u8] =
+        unsafe { core::slice::from_raw_parts(current_data_start as *const u8, total_size) };
+
+    if init_data.len() >= multibin::MAGIC.len()
+        && init_data[..multibin::MAGIC.len()] == multibin::MAGIC
+    {
+        // Multibinary NVMB format: relocate whole blob, then parse entries.
+        info!("parse_bootinfo(): multibinary initrd detected");
+
+        let initrd_base: usize = if current_data_start != ::config::hyperlight::DEFAULT_INITRD_BASE
+        {
+            let src_ptr: *const u8 = current_data_start as *const u8;
+            let dst_ptr: *mut u8 = ::config::hyperlight::DEFAULT_INITRD_BASE as *mut u8;
+            unsafe { core::ptr::copy(src_ptr, dst_ptr, total_size) };
+
+            debug!(
+                "parse_bootinfo(): multibinary relocated from {current_data_start:#010x} to \
+                 {:#010x}",
+                ::config::hyperlight::DEFAULT_INITRD_BASE
+            );
+            ::config::hyperlight::DEFAULT_INITRD_BASE
+        } else {
+            current_data_start
+        };
+
+        let image_data: &[u8] =
+            unsafe { core::slice::from_raw_parts(initrd_base as *const u8, total_size) };
+
+        kernel_modules.extend(crate::multibin::parse(image_data, initrd_base)?);
+    } else {
+        // Single-binary format: parse old size-header + args layout.
+        info!("parse_bootinfo(): single-binary initrd detected");
+
+        let (initrd_base, initrd_size, (_cmdline_len, cmdline)) = unsafe {
+            let (base, size, cmdline) = parse_initrd_image(current_data_start, total_size)?;
+            (base, size, cmdline)
+        };
+
+        info!(
+            "initrd_base={:#010x}, initrd_size={:#010x}, cmdline={:?}",
+            initrd_base,
+            initrd_size,
+            cmdline.as_str()
+        );
+
+        let module: KernelModule =
+            KernelModule::new(PhysicalAddress::from_raw_value(initrd_base)?, initrd_size, cmdline);
+        kernel_modules.push_back(module);
+    }
 
     Ok(BootInfo::new(
         None,

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -265,41 +265,52 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
     let nzeros: usize = ::config::microvm::DEFAULT_INITRD_BASE.trailing_zeros() as usize;
     let initrd_size: usize = info & ((1 << nzeros) - 1);
     let initrd_base: usize = info & !((1 << nzeros) - 1);
-    let initrd_cmdline_len_base: usize = initrd_base + (initrd_size * mem::PAGE_SIZE);
-    let initrd_cmdline_base: usize = initrd_cmdline_len_base + core::mem::size_of::<u8>();
 
     let mut kernel_modules: LinkedList<KernelModule> = LinkedList::new();
 
     // Register initrd as a kernel module.
     if initrd_size != 0 {
-        let cmdline_len: u8 = unsafe { *(initrd_cmdline_len_base as *const u8) };
-        let cmdline_bytes: &[u8] = unsafe {
-            core::slice::from_raw_parts(initrd_cmdline_base as *const u8, cmdline_len as usize)
-        };
-        let cmdline: &str = match core::str::from_utf8(cmdline_bytes) {
-            Ok(s) => s,
-            Err(_) => {
-                let reason: &str = "invalid UTF-8 in command line";
-                error!("invalid UTF-8 in command line");
-                return Err(Error::new(ErrorCode::InvalidArgument, reason));
-            },
-        };
+        let total_bytes: usize = initrd_size * mem::PAGE_SIZE;
+        let image_data: &[u8] =
+            unsafe { core::slice::from_raw_parts(initrd_base as *const u8, total_bytes) };
 
-        info!(
-            "initrd_base={:#010x}, initrd_size={:#010x}, cmdline_len={:?}, cmdline={:?}",
-            initrd_base,
-            (initrd_size * mem::PAGE_SIZE),
-            cmdline_len,
-            cmdline
-        );
+        // Detect initrd format by checking for NVMB multibinary magic.
+        if image_data.len() >= multibin::MAGIC.len()
+            && image_data[..multibin::MAGIC.len()] == multibin::MAGIC
+        {
+            info!("parse_bootinfo(): multibinary initrd detected");
+            kernel_modules.extend(crate::multibin::parse(image_data, initrd_base)?);
+        } else {
+            // Single ELF binary with length-prefixed args after the initrd.
+            info!("parse_bootinfo(): single-binary initrd detected");
+            let initrd_cmdline_len_base: usize = initrd_base + total_bytes;
+            let initrd_cmdline_base: usize = initrd_cmdline_len_base + core::mem::size_of::<u8>();
 
-        // Add kernel module to the list of kernel modules.
-        let module: KernelModule = KernelModule::new(
-            PhysicalAddress::from_raw_value(initrd_base)?,
-            initrd_size * mem::PAGE_SIZE,
-            cmdline.to_string(),
-        );
-        kernel_modules.push_back(module);
+            let cmdline_len: u8 = unsafe { *(initrd_cmdline_len_base as *const u8) };
+            let cmdline_bytes: &[u8] = unsafe {
+                core::slice::from_raw_parts(initrd_cmdline_base as *const u8, cmdline_len as usize)
+            };
+            let cmdline: &str = match core::str::from_utf8(cmdline_bytes) {
+                Ok(s) => s,
+                Err(_) => {
+                    let reason: &str = "invalid UTF-8 in command line";
+                    error!("invalid UTF-8 in command line");
+                    return Err(Error::new(ErrorCode::InvalidArgument, reason));
+                },
+            };
+
+            info!(
+                "initrd_base={:#010x}, initrd_size={:#010x}, cmdline_len={:?}, cmdline={:?}",
+                initrd_base, total_bytes, cmdline_len, cmdline
+            );
+
+            let module: KernelModule = KernelModule::new(
+                PhysicalAddress::from_raw_value(initrd_base)?,
+                total_bytes,
+                cmdline.to_string(),
+            );
+            kernel_modules.push_back(module);
+        }
     }
 
     Ok(BootInfo::new(

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -93,6 +93,8 @@ mod klog;
 mod kmod;
 mod kpanic;
 mod mm;
+#[cfg(any(feature = "microvm", feature = "hyperlight"))]
+mod multibin;
 mod pm;
 #[cfg(feature = "stdio")]
 mod stdio;

--- a/src/kernel/src/multibin.rs
+++ b/src/kernel/src/multibin.rs
@@ -1,0 +1,94 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    hal::mem::PhysicalAddress,
+    kmod::KernelModule,
+};
+use ::alloc::{
+    string::ToString,
+    vec::Vec,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    mm::Address,
+};
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Parses a multibinary image and returns a list of kernel modules.
+///
+/// Each entry in the multibinary image becomes a [`KernelModule`] whose physical address is
+/// computed as `initrd_base + entry.offset`.
+///
+/// # Parameters
+///
+/// - `image_data`: Raw bytes of the multibinary image.
+/// - `initrd_base`: Physical base address where the image is loaded in guest memory.
+///
+/// # Returns
+///
+/// A [`Vec`] of [`KernelModule`]s on success, or an [`Error`] if the image is malformed.
+///
+pub fn parse(image_data: &[u8], initrd_base: usize) -> Result<Vec<KernelModule>, Error> {
+    let parsed: multibin::ParseResult = multibin::parse(image_data).map_err(|e| {
+        error!("parse(): failed to parse multibinary image: {:?}", e);
+        e
+    })?;
+
+    info!(
+        "multibinary image: base={:#010x}, size={:#010x}, entries={}",
+        initrd_base,
+        image_data.len(),
+        parsed.count()
+    );
+
+    let mut modules: Vec<KernelModule> = Vec::new();
+
+    for entry in parsed.iter() {
+        let entry_phys_addr: usize = match initrd_base.checked_add(entry.offset) {
+            Some(addr) => addr,
+            None => {
+                let reason: &str = "multibinary entry offset overflows physical address";
+                error!("parse(): {}", reason);
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
+        };
+        let cmdline_bytes: &[u8] =
+            &image_data[entry.cmdline_offset..entry.cmdline_offset + entry.cmdline_size];
+        let cmdline: &str = match core::str::from_utf8(cmdline_bytes) {
+            Ok(s) => s,
+            Err(_) => {
+                let reason: &str = "invalid UTF-8 in multibinary entry cmdline";
+                error!("parse(): {}", reason);
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
+        };
+
+        info!(
+            "  entry: addr={:#010x}, size={:#010x}, cmdline={:?}",
+            entry_phys_addr, entry.size, cmdline
+        );
+
+        let module: KernelModule = KernelModule::new(
+            PhysicalAddress::from_raw_value(entry_phys_addr)?,
+            entry.size,
+            cmdline.to_string(),
+        );
+        modules.push(module);
+    }
+
+    Ok(modules)
+}

--- a/src/libs/multibin/Cargo.toml
+++ b/src/libs/multibin/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "multibin"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Multibinary image format for Nanvix"
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+error = { workspace = true }
+
+[features]
+default = []
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/multibin/src/lib.rs
+++ b/src/libs/multibin/src/lib.rs
@@ -1,0 +1,566 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Magic number identifying a multibinary image: b"NVMB".
+pub const MAGIC: [u8; 4] = *b"NVMB";
+
+/// Current format version.
+pub const VERSION: u32 = 1;
+
+/// Size of the image header in bytes.
+pub const HEADER_SIZE: usize = core::mem::size_of::<MultibinHeader>();
+
+/// Size of a single entry descriptor in bytes.
+pub const ENTRY_SIZE: usize = core::mem::size_of::<MultibinEntry>();
+
+/// Page size used for alignment of binary data.
+pub const PAGE_SIZE: usize = 4096;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Header at the start of every multibinary image.
+///
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct MultibinHeader {
+    /// Magic number (`NVMB`).
+    pub magic: [u8; 4],
+    /// Format version.
+    pub version: u32,
+    /// Number of entries in the image.
+    pub num_entries: u32,
+    /// Reserved for future use — must be zero.
+    pub reserved: u32,
+}
+
+///
+/// # Description
+///
+/// Descriptor for a single binary packed inside the image.
+///
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct MultibinEntry {
+    /// Byte offset from the start of the image to the ELF binary data.
+    pub offset: u32,
+    /// Size of the ELF binary data in bytes.
+    pub size: u32,
+    /// Byte offset from the start of the image to the command-line string.
+    pub cmdline_offset: u32,
+    /// Length of the command-line string in bytes (UTF-8, not null-terminated).
+    pub cmdline_size: u32,
+}
+
+///
+/// # Description
+///
+/// A parsed entry referencing data within a multibinary image.
+///
+#[derive(Clone, Copy, Debug)]
+pub struct ParsedEntry {
+    /// Byte offset from the start of the image to the ELF binary data.
+    pub offset: usize,
+    /// Size of the ELF binary data in bytes.
+    pub size: usize,
+    /// Byte offset from the start of the image to the command-line string.
+    pub cmdline_offset: usize,
+    /// Length of the command-line string in bytes.
+    pub cmdline_size: usize,
+}
+
+//==================================================================================================
+// Parser (no_std)
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Maximum number of entries supported in a single multibinary image.
+///
+const MAX_ENTRIES: usize = 32;
+
+///
+/// # Description
+///
+/// Result of parsing a multibinary image header.
+///
+#[derive(Debug)]
+pub struct ParseResult {
+    /// Parsed entries.
+    entries: [ParsedEntry; MAX_ENTRIES],
+    /// Number of valid entries.
+    count: usize,
+}
+
+impl ParseResult {
+    ///
+    /// # Description
+    ///
+    /// Returns the number of entries in the parsed image.
+    ///
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the entry at the given index.
+    ///
+    /// # Parameters
+    ///
+    /// - `index`: Index of the entry to retrieve.
+    ///
+    /// # Returns
+    ///
+    /// The parsed entry at the given index, or `None` if the index is out of bounds.
+    ///
+    pub fn get(&self, index: usize) -> Option<&ParsedEntry> {
+        if index < self.count {
+            Some(&self.entries[index])
+        } else {
+            None
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns an iterator over all valid entries.
+    ///
+    pub fn iter(&self) -> ParseResultIter<'_> {
+        ParseResultIter {
+            result: self,
+            index: 0,
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Iterator over parsed multibinary entries.
+///
+pub struct ParseResultIter<'a> {
+    result: &'a ParseResult,
+    index: usize,
+}
+
+impl<'a> Iterator for ParseResultIter<'a> {
+    type Item = &'a ParsedEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let entry: Option<&'a ParsedEntry> = self.result.get(self.index);
+        if entry.is_some() {
+            self.index += 1;
+        }
+        entry
+    }
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads a little-endian `u32` from a byte slice at the given offset.
+///
+fn read_u32(data: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes([
+        data[offset],
+        data[offset + 1],
+        data[offset + 2],
+        data[offset + 3],
+    ])
+}
+
+///
+/// # Description
+///
+/// Parses a multibinary image from a byte slice.
+///
+/// Validates the header magic and version, then extracts entry descriptors. Does not copy any
+/// binary or command-line data — the returned [`ParseResult`] contains offsets into the original
+/// `data` slice.
+///
+/// # Parameters
+///
+/// - `data`: The raw bytes of the multibinary image.
+///
+/// # Returns
+///
+/// A [`ParseResult`] containing the parsed entries on success, or an [`error::Error`] if the
+/// image is malformed.
+///
+pub fn parse(data: &[u8]) -> Result<ParseResult, error::Error> {
+    // Validate minimum size for the header.
+    if data.len() < HEADER_SIZE {
+        return Err(error::Error::new(
+            error::ErrorCode::InvalidArgument,
+            "multibinary image too small for header",
+        ));
+    }
+
+    // Validate magic number.
+    if data[0..4] != MAGIC {
+        return Err(error::Error::new(
+            error::ErrorCode::InvalidArgument,
+            "invalid multibinary magic number",
+        ));
+    }
+
+    // Validate version.
+    let version: u32 = read_u32(data, 4);
+    if version != VERSION {
+        return Err(error::Error::new(
+            error::ErrorCode::InvalidArgument,
+            "unsupported multibinary version",
+        ));
+    }
+
+    let num_entries: u32 = read_u32(data, 8);
+    let num_entries_usize: usize = num_entries as usize;
+
+    // Validate reserved field is zero.
+    let reserved: u32 = read_u32(data, 12);
+    if reserved != 0 {
+        return Err(error::Error::new(
+            error::ErrorCode::InvalidArgument,
+            "multibinary reserved field is non-zero",
+        ));
+    }
+
+    // Validate entry count.
+    if num_entries_usize == 0 {
+        return Err(error::Error::new(
+            error::ErrorCode::InvalidArgument,
+            "multibinary image has zero entries",
+        ));
+    }
+    if num_entries_usize > MAX_ENTRIES {
+        return Err(error::Error::new(
+            error::ErrorCode::InvalidArgument,
+            "multibinary image has too many entries",
+        ));
+    }
+
+    // Validate that the image is large enough for all entry descriptors.
+    let entries_end: usize = HEADER_SIZE + num_entries_usize * ENTRY_SIZE;
+    if data.len() < entries_end {
+        return Err(error::Error::new(
+            error::ErrorCode::InvalidArgument,
+            "multibinary image too small for entries",
+        ));
+    }
+
+    // Parse entry descriptors.
+    let mut entries: [ParsedEntry; MAX_ENTRIES] = [ParsedEntry {
+        offset: 0,
+        size: 0,
+        cmdline_offset: 0,
+        cmdline_size: 0,
+    }; MAX_ENTRIES];
+
+    for (i, entry) in entries.iter_mut().enumerate().take(num_entries_usize) {
+        let base: usize = HEADER_SIZE + i * ENTRY_SIZE;
+        let offset: usize = read_u32(data, base) as usize;
+        let size: usize = read_u32(data, base + 4) as usize;
+        let cmdline_offset: usize = read_u32(data, base + 8) as usize;
+        let cmdline_size: usize = read_u32(data, base + 12) as usize;
+
+        // Validate that binary data is within bounds.
+        if offset.checked_add(size).is_none_or(|end| end > data.len()) {
+            return Err(error::Error::new(
+                error::ErrorCode::InvalidArgument,
+                "multibinary entry binary data out of bounds",
+            ));
+        }
+
+        // Validate that command-line data is within bounds.
+        if cmdline_offset
+            .checked_add(cmdline_size)
+            .is_none_or(|end| end > data.len())
+        {
+            return Err(error::Error::new(
+                error::ErrorCode::InvalidArgument,
+                "multibinary entry cmdline data out of bounds",
+            ));
+        }
+
+        *entry = ParsedEntry {
+            offset,
+            size,
+            cmdline_offset,
+            cmdline_size,
+        };
+    }
+
+    Ok(ParseResult {
+        entries,
+        count: num_entries_usize,
+    })
+}
+
+//==================================================================================================
+// Builder (std only)
+//==================================================================================================
+
+#[cfg(feature = "std")]
+pub mod builder {
+    use super::*;
+
+    extern crate std;
+    use std::vec::Vec;
+
+    /// A single binary entry to be packed into the image.
+    struct BuildEntry {
+        elf_data: Vec<u8>,
+        cmdline: Vec<u8>,
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Builds a multibinary image from individual ELF binaries and their command lines.
+    ///
+    pub struct MultibinBuilder {
+        entries: Vec<BuildEntry>,
+    }
+
+    impl MultibinBuilder {
+        ///
+        /// # Description
+        ///
+        /// Creates a new empty builder.
+        ///
+        pub fn new() -> Self {
+            Self {
+                entries: Vec::new(),
+            }
+        }
+
+        ///
+        /// # Description
+        ///
+        /// Adds a binary with its command line to the image.
+        ///
+        /// # Parameters
+        ///
+        /// - `elf_data`: Raw bytes of the ELF binary.
+        /// - `cmdline`: Command-line string for this binary (UTF-8).
+        ///
+        pub fn add(&mut self, elf_data: Vec<u8>, cmdline: &str) -> &mut Self {
+            self.entries.push(BuildEntry {
+                elf_data,
+                cmdline: cmdline.as_bytes().to_vec(),
+            });
+            self
+        }
+
+        ///
+        /// # Description
+        ///
+        /// Builds the multibinary image.
+        ///
+        /// # Returns
+        ///
+        /// The serialized multibinary image as a byte vector.
+        ///
+        pub fn build(&self) -> Result<Vec<u8>, error::Error> {
+            let num_entries: usize = self.entries.len();
+            if num_entries > MAX_ENTRIES {
+                return Err(error::Error::new(
+                    error::ErrorCode::InvalidArgument,
+                    "too many entries for multibinary image",
+                ));
+            }
+
+            // Compute the size of the header + entry descriptors.
+            let descriptors_size: usize = HEADER_SIZE + num_entries * ENTRY_SIZE;
+
+            // Lay out command-line strings immediately after descriptors.
+            let mut cmdline_offsets: Vec<usize> = Vec::with_capacity(num_entries);
+            let mut cursor: usize = descriptors_size;
+            for entry in &self.entries {
+                cmdline_offsets.push(cursor);
+                cursor += entry.cmdline.len();
+            }
+
+            // Align to page boundary for first binary.
+            let first_binary_offset: usize = align_up(cursor, PAGE_SIZE)?;
+
+            // Lay out binary data with page alignment.
+            let mut binary_offsets: Vec<usize> = Vec::with_capacity(num_entries);
+            let mut binary_cursor: usize = first_binary_offset;
+            for entry in &self.entries {
+                binary_offsets.push(binary_cursor);
+                binary_cursor += entry.elf_data.len();
+                binary_cursor = align_up(binary_cursor, PAGE_SIZE)?;
+            }
+
+            let total_size: usize = binary_cursor;
+
+            // Build the image.
+            let mut image: Vec<u8> = std::vec![0u8; total_size];
+
+            // Write header.
+            image[0..4].copy_from_slice(&MAGIC);
+            image[4..8].copy_from_slice(&(VERSION).to_le_bytes());
+            image[8..12].copy_from_slice(&(num_entries as u32).to_le_bytes());
+            image[12..16].copy_from_slice(&0u32.to_le_bytes());
+
+            // Write entry descriptors.
+            for i in 0..num_entries {
+                let base: usize = HEADER_SIZE + i * ENTRY_SIZE;
+                if binary_offsets[i] > u32::MAX as usize
+                    || self.entries[i].elf_data.len() > u32::MAX as usize
+                    || cmdline_offsets[i] > u32::MAX as usize
+                    || self.entries[i].cmdline.len() > u32::MAX as usize
+                {
+                    return Err(error::Error::new(
+                        error::ErrorCode::InvalidArgument,
+                        "multibinary entry offset or size exceeds u32",
+                    ));
+                }
+                image[base..base + 4].copy_from_slice(&(binary_offsets[i] as u32).to_le_bytes());
+                image[base + 4..base + 8]
+                    .copy_from_slice(&(self.entries[i].elf_data.len() as u32).to_le_bytes());
+                image[base + 8..base + 12]
+                    .copy_from_slice(&(cmdline_offsets[i] as u32).to_le_bytes());
+                image[base + 12..base + 16]
+                    .copy_from_slice(&(self.entries[i].cmdline.len() as u32).to_le_bytes());
+            }
+
+            // Write command-line strings.
+            for (i, entry) in self.entries.iter().enumerate() {
+                let off: usize = cmdline_offsets[i];
+                image[off..off + entry.cmdline.len()].copy_from_slice(&entry.cmdline);
+            }
+
+            // Write binary data.
+            for (i, entry) in self.entries.iter().enumerate() {
+                let off: usize = binary_offsets[i];
+                image[off..off + entry.elf_data.len()].copy_from_slice(&entry.elf_data);
+            }
+
+            Ok(image)
+        }
+    }
+
+    impl Default for MultibinBuilder {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    /// Aligns `value` up to the next multiple of `align`.
+    fn align_up(value: usize, align: usize) -> Result<usize, error::Error> {
+        let mask: usize = align - 1;
+        match value.checked_add(mask) {
+            Some(v) => Ok(v & !mask),
+            None => Err(error::Error::new(error::ErrorCode::InvalidArgument, "align_up overflow")),
+        }
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_round_trip() {
+        let mut builder: builder::MultibinBuilder = builder::MultibinBuilder::new();
+        builder.add(vec![0x7f, b'E', b'L', b'F', 1, 2, 3, 4], "testd");
+        builder.add(vec![0x7f, b'E', b'L', b'F', 5, 6, 7, 8], "procd;ENV=1");
+
+        let image: Vec<u8> = builder.build().expect("build should succeed");
+
+        // Parse the image back.
+        let result: ParseResult = parse(&image).expect("parse should succeed");
+        assert_eq!(result.count(), 2);
+
+        // Validate first entry.
+        let e0: &ParsedEntry = result.get(0).expect("entry 0 should exist");
+        assert_eq!(&image[e0.offset..e0.offset + e0.size], &[0x7f, b'E', b'L', b'F', 1, 2, 3, 4]);
+        assert_eq!(
+            core::str::from_utf8(&image[e0.cmdline_offset..e0.cmdline_offset + e0.cmdline_size])
+                .unwrap(),
+            "testd"
+        );
+
+        // Validate second entry.
+        let e1: &ParsedEntry = result.get(1).expect("entry 1 should exist");
+        assert_eq!(&image[e1.offset..e1.offset + e1.size], &[0x7f, b'E', b'L', b'F', 5, 6, 7, 8]);
+        assert_eq!(
+            core::str::from_utf8(&image[e1.cmdline_offset..e1.cmdline_offset + e1.cmdline_size])
+                .unwrap(),
+            "procd;ENV=1"
+        );
+
+        // Validate page alignment of binary data.
+        assert_eq!(e0.offset % PAGE_SIZE, 0);
+        assert_eq!(e1.offset % PAGE_SIZE, 0);
+    }
+
+    #[test]
+    fn test_iterator() {
+        let mut builder: builder::MultibinBuilder = builder::MultibinBuilder::new();
+        builder.add(vec![1, 2, 3], "a");
+        builder.add(vec![4, 5, 6], "b");
+        builder.add(vec![7, 8, 9], "c");
+
+        let image: Vec<u8> = builder.build().expect("build should succeed");
+        let result: ParseResult = parse(&image).expect("parse should succeed");
+
+        let cmdlines: Vec<&str> = result
+            .iter()
+            .map(|e: &ParsedEntry| {
+                core::str::from_utf8(&image[e.cmdline_offset..e.cmdline_offset + e.cmdline_size])
+                    .unwrap()
+            })
+            .collect();
+        assert_eq!(cmdlines, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_parse_invalid_magic() {
+        let data: Vec<u8> = vec![0u8; HEADER_SIZE];
+        assert!(parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_too_small() {
+        let data: Vec<u8> = vec![0u8; 4];
+        assert!(parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_zero_entries() {
+        let mut data: Vec<u8> = vec![0u8; HEADER_SIZE];
+        data[0..4].copy_from_slice(&MAGIC);
+        data[4..8].copy_from_slice(&VERSION.to_le_bytes());
+        data[8..12].copy_from_slice(&0u32.to_le_bytes());
+        assert!(parse(&data).is_err());
+    }
+}

--- a/src/uservm/Cargo.toml
+++ b/src/uservm/Cargo.toml
@@ -26,6 +26,7 @@ config = { workspace = true }
 control-plane-api = { workspace = true }
 hyperlight-host = { workspace = true, optional = true }
 log = { workspace = true }
+multibin = { workspace = true, features = ["std"] }
 profiler = { workspace = true, features = ["auto-calibrate"] }
 serde = { workspace = true, features = ["derive"] }
 static_assert = { workspace = true }

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -192,6 +192,10 @@ impl Vmm {
                     let initrd_size: usize = bytes.len();
                     debug!("initrd: {} bytes", initrd_size);
 
+                    // Detect whether this is a multibinary NVMB image or a single ELF.
+                    let is_multibinary: bool = initrd_size >= ::multibin::MAGIC.len()
+                        && bytes[..::multibin::MAGIC.len()] == ::multibin::MAGIC;
+
                     // Read kernel file to compute memory footprint.
                     let kernel_bytes: Vec<u8> =
                         std::fs::read(&args.kernel_filename).map_err(|e| {
@@ -209,9 +213,6 @@ impl Vmm {
                         })?;
                     let kernel_end: usize = kernel_footprint.end();
                     let kernel_mem_size: usize = kernel_footprint.size();
-
-                    let initrd_args_bytes: Vec<u8> =
-                        Self::build_args_bytes(initrd_filename, &args.initrd_args)?;
 
                     // Fixed hyperlight structures placed after the kernel image:
                     // PEB, host function definitions, and I/O buffers.
@@ -264,14 +265,43 @@ impl Vmm {
                             anyhow::anyhow!(reason)
                         })?;
 
+                    // Build the init_data blob based on the initrd format.
+                    let init_data_bytes: Vec<u8> = if is_multibinary {
+                        // Multibinary: pass raw NVMB image, no wrapping needed.
+                        debug!("initrd: multibinary format detected, passing raw image");
+                        bytes
+                    } else {
+                        // Single ELF: prepend size header and append args (old format).
+                        let initrd_args_bytes: Vec<u8> =
+                            Self::build_args_bytes(initrd_filename, &args.initrd_args)?;
+
+                        let mut padded: Vec<u8> = Vec::with_capacity(
+                            ::config::hyperlight::INITRD_SIZE_BYTES
+                                + initrd_size
+                                + initrd_args_bytes.len(),
+                        );
+
+                        // Write the actual size as first INITRD_SIZE_BYTES (little-endian).
+                        padded.extend_from_slice(&(initrd_size as u64).to_le_bytes());
+                        padded.extend_from_slice(&bytes);
+                        padded.extend_from_slice(&initrd_args_bytes);
+
+                        debug!(
+                            "initrd blob: {} bytes total ({} byte header + {} bytes data + {} \
+                             bytes args)",
+                            padded.len(),
+                            ::config::hyperlight::INITRD_SIZE_BYTES,
+                            initrd_size,
+                            initrd_args_bytes.len(),
+                        );
+
+                        padded
+                    };
+
                     let required_memory: usize = kernel_mem_size
-                        .checked_add(initrd_size)
+                        .checked_add(init_data_bytes.len())
                         .and_then(|value| value.checked_add(heap_and_stack))
                         .and_then(|value| value.checked_add(reserved_memory))
-                        .and_then(|value| {
-                            value.checked_add(::config::hyperlight::INITRD_SIZE_BYTES)
-                        })
-                        .and_then(|value| value.checked_add(initrd_args_bytes.len()))
                         .ok_or_else(|| {
                             let reason: &str = "required memory calculation overflow";
                             error!("new(): {reason}");
@@ -293,34 +323,14 @@ impl Vmm {
                     let padding_size: usize =
                         (memory_size - required_memory + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
 
-                    // Create a new vector with size header + original data + padding
-                    let mut padded_bytes: Vec<u8> = Vec::with_capacity(
-                        ::config::hyperlight::INITRD_SIZE_BYTES
-                            + initrd_size
-                            + initrd_args_bytes.len(),
-                    );
-
-                    // Write the actual size as first INITRD_SIZE_BYTES-bytes (little-endian)
-                    padded_bytes.extend_from_slice(&(initrd_size as u64).to_le_bytes());
-
-                    // Add the actual initrd data
-                    padded_bytes.extend_from_slice(&bytes);
-
-                    // Append length-prefixed initrd arguments so the guest can consume them.
-                    padded_bytes.extend_from_slice(&initrd_args_bytes);
-
                     debug!(
-                        "initrd blob: {} bytes total ({} byte header + {} bytes data + 1 byte \
-                         args length + {} bytes args payload), extra memory: {} bytes",
-                        padded_bytes.len(),
-                        ::config::hyperlight::INITRD_SIZE_BYTES,
-                        initrd_size,
-                        initrd_args_bytes.len(),
+                        "initrd init_data: {} bytes, extra memory: {} bytes",
+                        init_data_bytes.len(),
                         padding_size
                     );
 
-                    // Box the data to extend its lifetime
-                    let boxed_data: Box<[u8]> = padded_bytes.into_boxed_slice();
+                    // Box the data to extend its lifetime.
+                    let boxed_data: Box<[u8]> = init_data_bytes.into_boxed_slice();
                     let data_ref: &'static [u8] = Box::leak(boxed_data);
 
                     let extra_memory: u64 = padding_size.try_into().map_err(|_| {

--- a/src/uservm/src/vmm/microvm/guest.rs
+++ b/src/uservm/src/vmm/microvm/guest.rs
@@ -142,6 +142,15 @@ impl Guest {
             return Err(anyhow::anyhow!(reason));
         }
 
+        // SAFETY: FileMapping guarantees that ptr() is valid for size() bytes.
+        let mapped_bytes: &[u8] =
+            unsafe { ::std::slice::from_raw_parts(initrd.ptr(), initrd.size()) };
+
+        // Detect whether this is a multibinary NVMB image or a single ELF binary.
+        let is_multibinary: bool = initrd.size() >= ::multibin::MAGIC.len()
+            && mapped_bytes[..::multibin::MAGIC.len()] == ::multibin::MAGIC;
+
+        // Copy the initrd file into guest memory (zero-copy from mmap).
         unsafe {
             let src = initrd.ptr();
             let dst = ptr.add(::config::microvm::DEFAULT_INITRD_BASE);
@@ -175,20 +184,25 @@ impl Guest {
 
         self.initrd = Some((::config::microvm::DEFAULT_INITRD_BASE, initrd_size));
 
-        // Write arguments to the virtual machine. For now, just pass the initrd filename.
-        let mut args: String = initrd_filename
-            .split('/')
-            .next_back()
-            .unwrap_or(initrd_filename)
-            .to_string();
+        if is_multibinary {
+            // Multibinary image: cmdlines are embedded in the image, no write_args needed.
+            debug!("load_initrd(): multibinary format detected, skipping write_args");
+        } else {
+            // Single ELF binary: write length-prefixed args after the initrd.
+            let mut args: String = initrd_filename
+                .split('/')
+                .next_back()
+                .unwrap_or(initrd_filename)
+                .to_string();
 
-        // Add initrd arguments if provided.
-        if let Some(ref initrd_args) = initrd_args {
-            args.push_str(&format!(" {initrd_args}"));
+            // Add initrd arguments if provided.
+            if let Some(ref initrd_args) = initrd_args {
+                args.push_str(&format!(" {initrd_args}"));
+            }
+
+            debug!("load_initrd(): writing args to virtual memory: {}", args);
+            self.write_args(vmem, &args)?;
         }
-
-        debug!("load_initrd(): writing args to virtual memory: {}", args);
-        self.write_args(vmem, &args)?;
 
         Ok(())
     }

--- a/src/uservm/src/vmm/microvm/guest.rs
+++ b/src/uservm/src/vmm/microvm/guest.rs
@@ -119,7 +119,7 @@ impl Guest {
 
         // Check if initrd would overlap with kernel.
         if let Some((kernel_base, kernel_size)) = self.kernel
-            && (initrd.ptr() as usize) < (kernel_base + kernel_size)
+            && (::config::microvm::DEFAULT_INITRD_BASE) < (kernel_base + kernel_size)
         {
             let reason: String = "initrd overlaps with kernel".to_string();
             error!("load_initrd(): {reason}");

--- a/src/utils/mkimage/Cargo.toml
+++ b/src/utils/mkimage/Cargo.toml
@@ -1,0 +1,21 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "mkimage"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Multibinary image builder for Nanvix"
+homepage.workspace = true
+
+[[bin]]
+name = "mkimage"
+path = "src/main.rs"
+
+[dependencies]
+multibin = { workspace = true, features = ["std"] }
+
+[lints]
+workspace = true

--- a/src/utils/mkimage/src/main.rs
+++ b/src/utils/mkimage/src/main.rs
@@ -1,0 +1,156 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use std::{
+    fs,
+    process,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Program name.
+const PROGRAM_NAME: &str = "mkimage";
+
+//==================================================================================================
+// Main
+//==================================================================================================
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    // Check for help flag before validating argument count.
+    if args.iter().any(|a| a == "-h" || a == "--help") {
+        usage();
+        process::exit(0);
+    }
+
+    if args.len() < 4 {
+        usage();
+        process::exit(1);
+    }
+
+    // Parse -o <output> flag.
+    let mut output_path: Option<&str> = None;
+    let mut entry_args: Vec<&str> = Vec::new();
+    let mut i: usize = 1;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "-o" => {
+                if i + 1 >= args.len() {
+                    eprintln!("{}: error: -o requires an output path", PROGRAM_NAME);
+                    process::exit(1);
+                }
+                output_path = Some(&args[i + 1]);
+                i += 2;
+            },
+            "-h" | "--help" => {
+                usage();
+                process::exit(0);
+            },
+            _ => {
+                entry_args.push(&args[i]);
+                i += 1;
+            },
+        }
+    }
+
+    let output_path: &str = match output_path {
+        Some(path) => path,
+        None => {
+            eprintln!("{}: error: -o <output> is required", PROGRAM_NAME);
+            usage();
+            process::exit(1);
+        },
+    };
+
+    if entry_args.is_empty() {
+        eprintln!("{}: error: at least one binary entry is required", PROGRAM_NAME);
+        usage();
+        process::exit(1);
+    }
+
+    // Build the multibinary image.
+    let mut builder: multibin::builder::MultibinBuilder = multibin::builder::MultibinBuilder::new();
+
+    for entry_arg in &entry_args {
+        // Format: path/to/binary.elf;cmdline
+        let (elf_path, cmdline): (&str, &str) = match entry_arg.split_once(';') {
+            Some((path, cmd)) => (path, cmd),
+            None => {
+                eprintln!(
+                    "{}: error: invalid entry '{}' (expected 'path.elf;cmdline')",
+                    PROGRAM_NAME, entry_arg
+                );
+                process::exit(1);
+            },
+        };
+
+        let elf_data: Vec<u8> = match fs::read(elf_path) {
+            Ok(data) => data,
+            Err(err) => {
+                eprintln!("{}: error: failed to read '{}': {}", PROGRAM_NAME, elf_path, err);
+                process::exit(1);
+            },
+        };
+
+        eprintln!(
+            "{}: adding '{}' ({} bytes, cmdline='{}')",
+            PROGRAM_NAME,
+            elf_path,
+            elf_data.len(),
+            cmdline
+        );
+        builder.add(elf_data, cmdline);
+    }
+
+    let image: Vec<u8> = match builder.build() {
+        Ok(image) => image,
+        Err(err) => {
+            eprintln!("{}: error: failed to build image: {:?}", PROGRAM_NAME, err);
+            process::exit(1);
+        },
+    };
+
+    match fs::write(output_path, &image) {
+        Ok(()) => {
+            eprintln!(
+                "{}: wrote '{}' ({} bytes, {} entries)",
+                PROGRAM_NAME,
+                output_path,
+                image.len(),
+                entry_args.len()
+            );
+        },
+        Err(err) => {
+            eprintln!("{}: error: failed to write '{}': {}", PROGRAM_NAME, output_path, err);
+            process::exit(1);
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Prints usage information.
+///
+fn usage() {
+    eprintln!(
+        "Usage: {} -o <output.img> <binary.elf;cmdline> [<binary.elf;cmdline> ...]",
+        PROGRAM_NAME
+    );
+    eprintln!();
+    eprintln!("Creates a Nanvix multibinary image from individual ELF binaries.");
+    eprintln!();
+    eprintln!("Each entry is specified as 'path/to/binary.elf;cmdline' where the");
+    eprintln!("semicolon separates the file path from the command line string.");
+    eprintln!();
+    eprintln!("Example:");
+    eprintln!("  {} -o nanvix.img procd.elf;procd memd.elf;memd testd.elf;testd", PROGRAM_NAME);
+}


### PR DESCRIPTION
## Summary

Introduces the NVMB multibinary file format so that microvm and hyperlight machines can bundle multiple boot-time binaries (procd, memd, testd) in a single initrd image, similar to how qemu-pc loads them via GRUB multiboot modules.

## Changes

### Commit 1: `[uservm] E: Simplify initrd loading`
Removes obsolete initrd argument construction and size header logic from the hyperlight and microvm loaders (`build_args_bytes()`, `write_args()`).

### Commit 2: `[multibin] F: Add multibinary format crate`
New `multibin` library (no_std parser + std builder) and `mkimage` CLI tool. Format: 16-byte header + per-entry descriptors + page-aligned binary data.

### Commit 3: `[kernel] F: Use multibin parser for initrd`
Rewrites `parse_bootinfo()` for both microvm and hyperlight to use `multibin::parse()`. Removes old `parse_initrd_image()`, `read_initrd_cmdline()`, and `INITRD_SIZE_BYTES` config constant.

### Commit 4: `[uservm] F: Auto-wrap ELF in multibin`
Auto-wraps single ELF binaries in multibinary format when the NVMB magic is absent, preserving backward compatibility with nanvix-test. Updates Makefile with `image` and `run` targets for microvm/hyperlight.

## Testing
- All commits pass pre-commit checks (format + lint + build) for qemu-pc, microvm, and hyperlight
- multibin crate: 5 unit tests passing
- mkimage tool: builds and produces valid NVMB images