### PR TITLE
[uservm] Introduce AnonymousMapping

### DIFF
--- a/src/uservm/src/pal/linux.rs
+++ b/src/uservm/src/pal/linux.rs
@@ -23,12 +23,28 @@ use ::log::{
 use ::std::{
     ffi::CString,
     mem,
+    os::unix::io::RawFd,
     ptr,
+    slice,
 };
 
 //==================================================================================================
 // Structures
 //==================================================================================================
+
+/// An anonymous memory mapping.
+#[derive(Debug)]
+pub struct AnonymousMapping {
+    /// Pointer to the memory location where the region is mapped.
+    ptr: *mut ::libc::c_void,
+    /// Size of the mapping (in bytes).
+    size: usize,
+}
+
+// SAFETY: The mapping is an isolated region of memory not shared with other threads.
+unsafe impl Send for AnonymousMapping {}
+// SAFETY: The &self accessors return borrowed slices tied to &self's lifetime.
+unsafe impl Sync for AnonymousMapping {}
 
 /// A memory-mapped file.
 #[derive(Debug)]
@@ -44,6 +60,265 @@ pub struct FileMapping {
 //==================================================================================================
 // Implementations
 //==================================================================================================
+
+impl AnonymousMapping {
+    ///
+    /// # Description
+    ///
+    /// Creates a new anonymous memory mapping.
+    ///
+    /// # Parameters
+    ///
+    /// * `size` - Size of the mapping (in bytes). Must be greater than zero.
+    /// * `noreserve` - If `true`, do not reserve swap space for the mapping (`MAP_NORESERVE`).
+    ///
+    /// # Returns
+    ///
+    /// On success, returns an object representing the anonymous mapping. On failure, returns an
+    /// error.
+    ///
+    pub fn new(size: usize, noreserve: bool) -> Result<Self> {
+        trace!("AnonymousMapping::new(): size={size}, noreserve={noreserve}");
+
+        if size == 0 {
+            let reason: &str = "cannot create zero-sized anonymous mapping";
+            error!("AnonymousMapping::new(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        let mut flags: c_int = ::libc::MAP_ANONYMOUS | ::libc::MAP_PRIVATE;
+        if noreserve {
+            flags |= ::libc::MAP_NORESERVE;
+        }
+
+        let ptr: *mut ::libc::c_void = unsafe {
+            ::libc::mmap(
+                ptr::null_mut(),
+                size,
+                ::libc::PROT_READ | ::libc::PROT_WRITE,
+                flags,
+                -1,
+                0,
+            )
+        };
+
+        if ptr == ::libc::MAP_FAILED {
+            let reason: String = format!(
+                "failed to create anonymous mapping (error={})",
+                ::std::io::Error::last_os_error()
+            );
+            error!("AnonymousMapping::new(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        Ok(Self { ptr, size })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a mutable pointer to the mapped memory region.
+    ///
+    /// # Returns
+    ///
+    /// A mutable pointer to the mapped memory region.
+    ///
+    pub fn ptr(&self) -> *mut u8 {
+        self.ptr.cast::<u8>()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the size of the mapping (in bytes).
+    ///
+    /// # Returns
+    ///
+    /// The size of the mapping (in bytes).
+    ///
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the mapping contents as an immutable byte slice.
+    ///
+    /// # Returns
+    ///
+    /// An immutable byte slice covering the entire mapping.
+    ///
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: The mapping is valid for `self.size` bytes for the lifetime of `self`.
+        unsafe { slice::from_raw_parts(self.ptr.cast::<u8>(), self.size) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the mapping contents as a mutable byte slice.
+    ///
+    /// # Returns
+    ///
+    /// A mutable byte slice covering the entire mapping.
+    ///
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: The mapping is valid for `self.size` bytes for the lifetime of `self`.
+        unsafe { slice::from_raw_parts_mut(self.ptr.cast::<u8>(), self.size) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Replaces the entire mapping with a file-backed read-write mapping using `MAP_FIXED`.
+    /// Only the backing store changes; the pointer and size remain the same.
+    ///
+    /// # Parameters
+    ///
+    /// * `fd` - File descriptor of the backing file.
+    /// * `file_offset` - Byte offset into the file where the mapping begins (must be
+    ///   page-aligned).
+    ///
+    /// # Returns
+    ///
+    /// On success, returns empty. On failure, returns an error.
+    ///
+    pub fn remap_file(&self, fd: RawFd, file_offset: ::libc::off_t) -> Result<()> {
+        self.remap_file_at(0, self.size, fd, file_offset)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Replaces a sub-region of the mapping with a file-backed read-write mapping using
+    /// `MAP_FIXED`. The region `[start, start + len)` must lie within the mapping bounds.
+    ///
+    /// # Parameters
+    ///
+    /// * `start` - Byte offset from the start of the mapping (must be page-aligned).
+    /// * `len` - Size of the region to remap (in bytes).
+    /// * `fd` - File descriptor of the backing file.
+    /// * `file_offset` - Byte offset into the file where the mapping begins (must be
+    ///   page-aligned).
+    ///
+    /// # Returns
+    ///
+    /// On success, returns empty. On failure, returns an error.
+    ///
+    pub fn remap_file_at(
+        &self,
+        start: usize,
+        len: usize,
+        fd: RawFd,
+        file_offset: ::libc::off_t,
+    ) -> Result<()> {
+        trace!(
+            "AnonymousMapping::remap_file_at(): start={start:#x}, len={len:#x}, fd={fd}, \
+             file_offset={file_offset}"
+        );
+
+        if len == 0 {
+            let reason: &str = "cannot remap zero-sized region";
+            error!("AnonymousMapping::remap_file_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        if start.checked_add(len).is_none_or(|end| end > self.size) {
+            let reason: String = format!(
+                "remap region [{start:#x}, {:#x}) exceeds mapping bounds (size={:#x})",
+                start.saturating_add(len),
+                self.size
+            );
+            error!("AnonymousMapping::remap_file_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        // SAFETY: `start` has been bounds-checked, so `self.ptr + start` stays within the mapping.
+        let addr: *mut u8 = unsafe { self.ptr.cast::<u8>().add(start) };
+        let result: *mut u8 = unsafe {
+            ::libc::mmap(
+                addr.cast::<::libc::c_void>(),
+                len,
+                ::libc::PROT_READ | ::libc::PROT_WRITE,
+                ::libc::MAP_PRIVATE | ::libc::MAP_FIXED,
+                fd,
+                file_offset,
+            )
+            .cast::<u8>()
+        };
+
+        if result == ::libc::MAP_FAILED.cast::<u8>() {
+            let reason: String = format!(
+                "failed to remap region as file-backed at {:?} (error={})",
+                addr,
+                ::std::io::Error::last_os_error()
+            );
+            error!("AnonymousMapping::remap_file_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        debug_assert_eq!(result, addr, "MAP_FIXED should return the exact requested address");
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Replaces the entire mapping with a fresh anonymous read-write mapping using `MAP_FIXED`.
+    /// This is useful for restoring a neutral memory region after a failed file-backed remap.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns empty. On failure, returns an error.
+    ///
+    pub fn remap_anonymous(&self) -> Result<()> {
+        trace!("AnonymousMapping::remap_anonymous(): size={:#x}", self.size);
+
+        let result: *mut u8 = unsafe {
+            ::libc::mmap(
+                self.ptr,
+                self.size,
+                ::libc::PROT_READ | ::libc::PROT_WRITE,
+                ::libc::MAP_PRIVATE | ::libc::MAP_ANONYMOUS | ::libc::MAP_FIXED,
+                -1,
+                0,
+            )
+            .cast::<u8>()
+        };
+
+        if result == ::libc::MAP_FAILED.cast::<u8>() {
+            let reason: String = format!(
+                "failed to restore anonymous mapping at {:?} (error={})",
+                self.ptr,
+                ::std::io::Error::last_os_error()
+            );
+            error!("AnonymousMapping::remap_anonymous(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        debug_assert_eq!(
+            result,
+            self.ptr.cast::<u8>(),
+            "MAP_FIXED should return the exact requested address"
+        );
+
+        Ok(())
+    }
+}
+
+impl Drop for AnonymousMapping {
+    fn drop(&mut self) {
+        trace!("drop(): {self:?}");
+        unsafe {
+            if ::libc::munmap(self.ptr, self.size) < 0 {
+                let errno: c_int = *::libc::__errno_location();
+                warn!("drop(): failed to unmap anonymous region (errno={errno}, self={self:?})");
+            }
+        }
+    }
+}
 
 impl FileMapping {
     ///
@@ -243,5 +518,140 @@ mod tests {
         fs::remove_file(&path)?;
 
         Ok(())
+    }
+
+    #[test]
+    fn test_anonymous_mapping_allocates_and_drops() -> Result<()> {
+        let size: usize = 4096;
+        let mapping: AnonymousMapping = AnonymousMapping::new(size, false)?;
+
+        assert!(!mapping.ptr().is_null(), "mapping pointer is null");
+        assert_eq!(mapping.size(), size, "mapping size mismatch");
+
+        // Verify the region is writable and readable.
+        let data: &mut [u8] = unsafe { slice::from_raw_parts_mut(mapping.ptr(), size) };
+        data[0] = 0xAB;
+        data[size - 1] = 0xCD;
+        assert_eq!(data[0], 0xAB, "first byte mismatch");
+        assert_eq!(data[size - 1], 0xCD, "last byte mismatch");
+
+        drop(mapping);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_anonymous_mapping_noreserve() -> Result<()> {
+        let size: usize = 4096;
+        let mapping: AnonymousMapping = AnonymousMapping::new(size, true)?;
+
+        assert!(!mapping.ptr().is_null(), "mapping pointer is null");
+        assert_eq!(mapping.size(), size, "mapping size mismatch");
+
+        drop(mapping);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_anonymous_mapping_zero_size_fails() {
+        let result: Result<AnonymousMapping> = AnonymousMapping::new(0, false);
+        assert!(result.is_err(), "zero-sized anonymous mapping should fail");
+    }
+
+    #[test]
+    fn test_anonymous_mapping_as_slice() -> Result<()> {
+        let size: usize = 4096;
+        let mut mapping: AnonymousMapping = AnonymousMapping::new(size, false)?;
+
+        // Write via mutable slice.
+        let mutable_slice: &mut [u8] = mapping.as_mut_slice();
+        mutable_slice[0] = 0x42;
+        mutable_slice[size - 1] = 0x99;
+
+        // Read via immutable slice.
+        let immutable_slice: &[u8] = mapping.as_slice();
+        assert_eq!(immutable_slice[0], 0x42, "first byte mismatch via as_slice");
+        assert_eq!(immutable_slice[size - 1], 0x99, "last byte mismatch via as_slice");
+        assert_eq!(immutable_slice.len(), size, "slice length mismatch");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_remap_file_and_remap_anonymous() -> Result<()> {
+        let path: PathBuf = unique_temp_path("nanvix-remap-file")?;
+        let content: &[u8] = b"remap file test data!!!!";
+        fs::write(&path, content)?;
+
+        let size: usize = 4096;
+        let mapping: AnonymousMapping = AnonymousMapping::new(size, false)?;
+
+        // Remap the mapping to be file-backed.
+        let file: fs::File = fs::File::open(&path)?;
+        let fd: RawFd = ::std::os::unix::io::AsRawFd::as_raw_fd(&file);
+        mapping.remap_file(fd, 0)?;
+
+        // Verify the file contents are visible.
+        let mapped: &[u8] = &mapping.as_slice()[..content.len()];
+        assert_eq!(mapped, content, "file-backed remap should expose file contents");
+
+        // Restore to anonymous.
+        mapping.remap_anonymous()?;
+
+        // After restoring, memory should be zeroed.
+        let zeroed: &[u8] = mapping.as_slice();
+        assert!(zeroed.iter().all(|&b| b == 0), "anonymous remap should zero memory");
+
+        drop(mapping);
+        drop(file);
+        fs::remove_file(&path)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_remap_file_at_sub_region() -> Result<()> {
+        let path: PathBuf = unique_temp_path("nanvix-remap-at")?;
+        let content: Vec<u8> = vec![0xAB; 4096];
+        fs::write(&path, &content)?;
+
+        let size: usize = 2 * 4096;
+        let mapping: AnonymousMapping = AnonymousMapping::new(size, false)?;
+
+        // Remap only the second page.
+        let file: fs::File = fs::File::open(&path)?;
+        let fd: RawFd = ::std::os::unix::io::AsRawFd::as_raw_fd(&file);
+        mapping.remap_file_at(4096, 4096, fd, 0)?;
+
+        // First page should still be zeroed (anonymous).
+        let first_page: &[u8] = &mapping.as_slice()[..4096];
+        assert!(first_page.iter().all(|&b| b == 0), "first page should remain anonymous");
+
+        // Second page should have file contents.
+        let second_page: &[u8] = &mapping.as_slice()[4096..8192];
+        assert_eq!(second_page, &content[..], "second page should have file contents");
+
+        drop(mapping);
+        drop(file);
+        fs::remove_file(&path)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_remap_file_at_rejects_out_of_bounds() {
+        let mapping: AnonymousMapping =
+            AnonymousMapping::new(4096, false).expect("failed to create mapping");
+        let result: Result<()> = mapping.remap_file_at(0, 8192, -1, 0);
+        assert!(result.is_err(), "remap_file_at should reject out-of-bounds region");
+    }
+
+    #[test]
+    fn test_remap_file_at_rejects_zero_len() {
+        let mapping: AnonymousMapping =
+            AnonymousMapping::new(4096, false).expect("failed to create mapping");
+        let result: Result<()> = mapping.remap_file_at(0, 0, -1, 0);
+        assert!(result.is_err(), "remap_file_at should reject zero-length region");
     }
 }

--- a/src/uservm/src/vmm/microvm/kvm/vmem.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vmem.rs
@@ -5,7 +5,10 @@
 // Imports
 //==================================================================================================
 
-use crate::vmm::microvm::ramfs::RamFs;
+use crate::{
+    pal::AnonymousMapping,
+    vmm::microvm::ramfs::RamFs,
+};
 use ::anyhow::Result;
 use ::arch::mem::PAGE_SIZE;
 use ::kvm_bindings::kvm_userspace_memory_region;
@@ -20,12 +23,11 @@ use ::std::{
         Write,
     },
     mem,
-    os::unix::io::AsRawFd,
-    path::Path,
-    ptr::{
-        self,
+    os::unix::io::{
+        AsRawFd,
+        RawFd,
     },
-    slice,
+    path::Path,
 };
 use kvm_ioctls::{
     Kvm,
@@ -42,10 +44,8 @@ use kvm_ioctls::{
 /// A structure that represents the memory of a virtual machine.
 ///
 pub struct VirtualMemory {
-    /// Virtual memory.
-    ptr: *mut u8,
-    /// Size of the virtual memory.
-    size: usize,
+    /// Anonymous memory mapping backing guest physical memory.
+    mapping: AnonymousMapping,
     /// Optional RAMFS descriptor that keeps metadata and the backing file alive.
     ramfs: Option<RamFs>,
 }
@@ -60,9 +60,6 @@ struct SnapshotHeader {
     /// Memory size (8 bytes): usize
     memory_size: usize,
 }
-
-unsafe impl Send for VirtualMemory {}
-unsafe impl Sync for VirtualMemory {}
 
 //==================================================================================================
 // Constants
@@ -109,29 +106,11 @@ impl VirtualMemory {
         }
 
         // Allocate memory.
-        let ptr: *mut u8 = unsafe {
-            libc::mmap(
-                ptr::null_mut(),
-                size,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_ANONYMOUS | libc::MAP_PRIVATE | libc::MAP_NORESERVE,
-                -1,
-                0,
-            )
-            .cast::<u8>()
-        };
-
-        // Check if we failed to allocate memory for the virtual machine.
-        if ptr.is_null() {
-            let reason: String = "failed to allocate memory for the virtual machine".to_string();
-            error!("new(): {reason} (memory_size={size:?})");
-            return Err(anyhow::anyhow!(reason));
-        }
+        let mapping: AnonymousMapping = AnonymousMapping::new(size, true)?;
 
         // Create virtual memory. If we fail, destructor will free memory.
         let vmem: Self = Self {
-            ptr,
-            size,
+            mapping,
             ramfs: None,
         };
 
@@ -141,7 +120,7 @@ impl VirtualMemory {
             flags: 0,
             guest_phys_addr: 0,
             memory_size: size as u64,
-            userspace_addr: ptr as u64,
+            userspace_addr: vmem.mapping.ptr() as u64,
         };
 
         unsafe { vm_fd.set_user_memory_region(mem_region)? };
@@ -150,11 +129,37 @@ impl VirtualMemory {
     }
 
     pub fn get_raw_ptr(&self) -> *mut u8 {
-        self.ptr
+        self.mapping.ptr()
     }
 
     pub fn get_size(&self) -> usize {
-        self.size
+        self.mapping.size()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Replaces a sub-region of guest memory with a file-backed mapping.
+    ///
+    /// # Parameters
+    ///
+    /// - `start`: Byte offset into guest memory (must be page-aligned).
+    /// - `len`: Size of the region to remap.
+    /// - `fd`: File descriptor of the backing file.
+    /// - `file_offset`: Byte offset into the file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns empty. Otherwise, returns an error.
+    ///
+    pub fn remap_file_at(
+        &self,
+        start: usize,
+        len: usize,
+        fd: RawFd,
+        file_offset: ::libc::off_t,
+    ) -> Result<()> {
+        self.mapping.remap_file_at(start, len, fd, file_offset)
     }
 
     ///
@@ -200,14 +205,18 @@ impl VirtualMemory {
         };
 
         // Check if region lies within the virtual memory.
-        if addr + data.len() > self.size {
+        if addr + data.len() > self.mapping.size() {
             let reason: String = format!("invalid memory access (addr={addr:#010x})");
             error!("write_bytes(): {reason}");
             return Err(anyhow::anyhow!(reason));
         }
 
         unsafe {
-            ptr::copy_nonoverlapping(data.as_ptr(), self.ptr.add(addr), data.len());
+            ::std::ptr::copy_nonoverlapping(
+                data.as_ptr(),
+                self.mapping.ptr().add(addr),
+                data.len(),
+            );
         }
 
         Ok(())
@@ -239,14 +248,18 @@ impl VirtualMemory {
         };
 
         // Check if region lies within the virtual memory.
-        if addr as usize + data.len() > self.size {
+        if addr as usize + data.len() > self.mapping.size() {
             let reason: String = format!("invalid memory access (addr={addr:#010x})");
             error!("read_bytes(): {reason}");
             return Err(anyhow::anyhow!(reason));
         }
 
         unsafe {
-            ptr::copy_nonoverlapping(self.ptr.add(addr), data.as_mut_ptr(), data.len());
+            ::std::ptr::copy_nonoverlapping(
+                self.mapping.ptr().add(addr),
+                data.as_mut_ptr(),
+                data.len(),
+            );
         }
 
         Ok(())
@@ -279,7 +292,15 @@ impl VirtualMemory {
             },
         };
 
-        let header = SnapshotHeader::new(self.size);
+        // Check alignment. Due to `mmap()` allocation, this should be PAGE_SIZE.
+        if !(self.mapping.ptr() as usize).is_multiple_of(PAGE_SIZE) {
+            let reason: &str = "memory pointer is not aligned to page size";
+            error!("save_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+        let memory_slice: &[u8] = self.mapping.as_slice();
+
+        let header = SnapshotHeader::new(self.mapping.size());
 
         if let Err(e) = file.write_all(header.as_bytes()) {
             let reason: String =
@@ -299,15 +320,6 @@ impl VirtualMemory {
             anyhow::bail!(reason)
         }
 
-        // Check alignment. Due to `mmap()` allocation, this should be PAGE_SIZE.
-        if !(self.ptr as usize).is_multiple_of(PAGE_SIZE) {
-            let reason: &str = "memory pointer is not aligned to page size";
-            error!("save_snapshot(): {reason}");
-            anyhow::bail!(reason)
-        }
-        // SAFETY: The pointer points to the virtual memory, which is `self.size` bytes long. We've
-        // just checked alignment.
-        let memory_slice: &[u8] = unsafe { slice::from_raw_parts(self.ptr, self.size) };
         // Write the actual memory contents.
         if let Err(e) = file.write_all(memory_slice) {
             let reason: String = format!("failed to write memory contents (error={e:?})");
@@ -363,9 +375,12 @@ impl VirtualMemory {
         let header: SnapshotHeader = SnapshotHeader::from_bytes(&header_bytes);
 
         // Validate that the memory size matches.
-        if header.memory_size != self.size {
-            let reason: String =
-                format!("memory size mismatch: expected {}, got {}", self.size, header.memory_size);
+        if header.memory_size != self.mapping.size() {
+            let reason: String = format!(
+                "memory size mismatch: expected {}, got {}",
+                self.mapping.size(),
+                header.memory_size
+            );
             error!("load_snapshot(): {reason}");
             anyhow::bail!(reason)
         }
@@ -382,7 +397,7 @@ impl VirtualMemory {
                     anyhow::bail!(reason)
                 },
             };
-            let required: u64 = (SNAPSHOT_DATA_OFFSET + self.size) as u64;
+            let required: u64 = (SNAPSHOT_DATA_OFFSET + self.mapping.size()) as u64;
             if file_len < required {
                 let reason: String = format!(
                     "snapshot file too small: expected at least {required} bytes, got {file_len}"
@@ -407,43 +422,11 @@ impl VirtualMemory {
                 anyhow::bail!(reason)
             },
         };
-        let mmap_ptr: *mut u8 = unsafe {
-            libc::mmap(
-                self.ptr.cast::<libc::c_void>(),
-                self.size,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_PRIVATE | libc::MAP_FIXED,
-                file.as_raw_fd(),
-                file_offset,
-            )
-            .cast::<u8>()
-        };
-
-        if mmap_ptr == libc::MAP_FAILED.cast::<u8>() {
-            let reason: String = format!(
-                "failed to mmap snapshot file with MAP_FIXED (error={})",
-                ::std::io::Error::last_os_error()
-            );
-            error!("load_snapshot(): {reason}");
-            anyhow::bail!(reason)
-        }
-        // MAP_FIXED guarantees the returned address equals the requested address.
-        debug_assert_eq!(mmap_ptr, self.ptr, "MAP_FIXED should return the exact requested address");
+        self.mapping.remap_file(file.as_raw_fd(), file_offset)?;
         // TODO: validate header checksum matches the checksum computed off of the memory slice https://github.com/nanvix/nanvix/issues/1014
 
         trace!("load_snapshot(): successfully loaded snapshot from {:?}", path);
         Ok(())
-    }
-}
-
-impl Drop for VirtualMemory {
-    fn drop(&mut self) {
-        unsafe {
-            let ret: libc::c_int = libc::munmap(self.ptr.cast::<libc::c_void>(), self.size);
-            if ret != 0 {
-                error!("munmap() failed (ret={ret})");
-            }
-        }
     }
 }
 

--- a/src/uservm/src/vmm/microvm/ramfs.rs
+++ b/src/uservm/src/vmm/microvm/ramfs.rs
@@ -8,7 +8,6 @@
 use crate::vmm::microvm::kvm::vmem::VirtualMemory;
 use ::anyhow::Result;
 use ::arch::mem::PAGE_SIZE;
-use ::libc::c_int;
 use ::log::{
     error,
     trace,
@@ -199,8 +198,7 @@ impl RamFs {
             anyhow::bail!(reason)
         }
 
-        let guest_ptr: *mut u8 = vmem.get_raw_ptr();
-        self.map_file_into_guest(guest_ptr, ramfs_base, ramfs_size)?;
+        self.map_file_into_guest(vmem, ramfs_base, ramfs_size)?;
 
         trace!(
             "RamFs::map_into_virtual_memory(): mapped ramfs (path={:?}, base={:#010x}, \
@@ -285,7 +283,7 @@ impl RamFs {
     ///
     /// # Parameters
     ///
-    /// - `guest_ptr`: Base pointer of the guest memory.
+    /// - `vmem`: Virtual memory that hosts the guest.
     /// - `base`: Guest-physical base address where the RAMFS should reside.
     /// - `length`: Number of bytes to map.
     ///
@@ -293,7 +291,7 @@ impl RamFs {
     ///
     /// Upon success, returns empty. Otherwise, returns an error.
     ///
-    fn map_file_into_guest(&self, guest_ptr: *mut u8, base: usize, length: usize) -> Result<()> {
+    fn map_file_into_guest(&self, vmem: &VirtualMemory, base: usize, length: usize) -> Result<()> {
         trace!(
             "RamFs::map_file_into_guest(): path={:?}, base={:#010x}, length={length}",
             self.path, base
@@ -308,37 +306,17 @@ impl RamFs {
             anyhow::bail!(reason)
         }
 
-        // Mapping with MAP_FIXED replaces the anonymous pages covering [base, base + length), while
-        // leaving the remaining guest memory untouched, effectively swapping the backing store for
-        // that specific slice.
-        // SAFETY: `base` has been bounds-checked and page-aligned, so adding it to `guest_ptr`
-        // stays within the allocated KVM userspace memory region owned by `vmem`.
-        let dst: *mut ::libc::c_void = unsafe { guest_ptr.add(base).cast::<::libc::c_void>() };
-        // SAFETY: `dst` points to a mapped, page-aligned region we own, `length` fits within that
-        // region, and `self.file` remains open for the lifetime of the mapping, making the `mmap`
-        // call well-defined.
-        let mapped_ptr: *mut ::libc::c_void = unsafe {
-            ::libc::mmap(
-                dst,
-                length,
-                ::libc::PROT_READ | ::libc::PROT_WRITE,
-                ::libc::MAP_PRIVATE | ::libc::MAP_FIXED,
-                self.file.as_raw_fd(),
-                0,
-            )
-        };
-
-        if mapped_ptr.is_null() || mapped_ptr == ::libc::MAP_FAILED || mapped_ptr != dst {
-            // SAFETY: `__errno_location()` returns a valid thread-local pointer for the current
-            // thread, so dereferencing it immediately after the syscall is sound.
-            let errno: c_int = unsafe { *::libc::__errno_location() };
-            let reason: String = format!(
-                "failed to map ramfs image into guest memory (path={:?}, errno={errno})",
-                self.path
-            );
-            error!("RamFs::map_file_into_guest(): {reason}");
-            anyhow::bail!(reason)
-        }
+        // Remaps [base, base + length) of guest memory to be file-backed by the RAMFS image,
+        // replacing the anonymous pages covering that range while leaving the rest untouched.
+        vmem.remap_file_at(base, length, self.file.as_raw_fd(), 0)
+            .map_err(|e| {
+                let reason: String = format!(
+                    "failed to map ramfs image into guest memory (path={:?}, error={e})",
+                    self.path
+                );
+                error!("RamFs::map_file_into_guest(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
 
         Ok(())
     }


### PR DESCRIPTION
**Virtual memory management refactor:**

* Replaces raw pointer and manual `mmap`/`munmap` logic in `VirtualMemory` with an `AnonymousMapping` struct that handles allocation, deallocation, and remapping, reducing unsafe code and improving encapsulation. (`src/uservm/src/vmm/microvm/kvm/vmem.rs`) [[1]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L8-R11) [[2]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L45-R48) [[3]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L112-R113) [[4]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L144-R123) [[5]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L153-R162) [[6]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L203-R219) [[7]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L242-R262) [[8]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L282-R303) [[9]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L302-L310) [[10]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L366-R383) [[11]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L385-R400) [[12]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L410-L449)
* Adds a `remap_file_at` method to `VirtualMemory`, allowing subregions of guest memory to be replaced with file-backed mappings, supporting more flexible memory management. (`src/uservm/src/vmm/microvm/kvm/vmem.rs`)

**RAMFS integration improvements:**

* Updates `RamFs` logic to use the new `remap_file_at` method instead of directly manipulating raw pointers and `mmap`, simplifying the code and leveraging the new abstraction for mapping file-backed regions into guest memory. (`src/uservm/src/vmm/microvm/ramfs.rs`) [[1]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4L202-R201) [[2]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4L288-R294) [[3]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4L311-R319)

**General code cleanup:**

* Removes now-unnecessary unsafe implementations and manual resource management in favor of safer, encapsulated abstractions. (`src/uservm/src/vmm/microvm/kvm/vmem.rs`) [[1]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L64-L66) [[2]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L410-L449)
* Cleans up imports and documentation to reflect the new abstractions and method signatures. (`src/uservm/src/vmm/microvm/kvm/vmem.rs`, `src/uservm/src/vmm/microvm/ramfs.rs`) [[1]](diffhunk://#diff-9ae5b6599c6bcafa1f212eb6e116fc9ded6c4bbc10d693729e3256c54c34adc1L23-R30) [[2]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4L11) [[3]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4L288-R294)

These changes make the virtual memory subsystem more robust, maintainable, and ready for future enhancements.