### PR TITLE
[nanvix-test] Graceful shutdown on interrupt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,7 @@ dependencies = [
  "serde",
  "shell-words",
  "tokio",
+ "tokio-util",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,7 @@ tempfile = "3"
 talc = { git = "https://github.com/nanvix/talc", rev = "12e66643796be912933a369a2d556aaac4c68771", default-features = false, package = "talc" }
 thiserror = "2"
 tokio = { version = "1.52.3", default-features = false }
+tokio-util = { version = "0.7.18", default-features = false }
 toml = { version = "1.1.2", default-features = false, features = [
         "parse",
         "serde",

--- a/src/utils/nanvix-test/Cargo.toml
+++ b/src/utils/nanvix-test/Cargo.toml
@@ -17,6 +17,7 @@ nanvixd = { workspace = true, default-features = false }
 nanvix = { workspace = true, features = ["internal-api"] }
 no_fail = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 toml = { workspace = true }

--- a/src/utils/nanvix-test/src/executor/empty.rs
+++ b/src/utils/nanvix-test/src/executor/empty.rs
@@ -123,27 +123,36 @@ pub(crate) async fn empty(
     iterations: usize,
     log_layout: &TestLogLayout,
     _extra_nanvixd_args: &[String],
+    cancellation_token: CancellationToken,
 ) -> Result<()> {
-    let log_root: &Path = Path::new(runner_config.log_directory.as_str());
-    let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
+    tokio::select! {
+        result = async {
+            let log_root: &Path = Path::new(runner_config.log_directory.as_str());
+            let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
 
-    for iteration in 0..iterations {
-        let RunnerLogPaths {
-            stdout: _stdout_file_path,
-            stderr: _stderr_file_path,
-        } = log_layout.allocate_runner_logs(Some(iteration));
+            for iteration in 0..iterations {
+                let RunnerLogPaths {
+                    stdout: _stdout_file_path,
+                    stderr: _stderr_file_path,
+                } = log_layout.allocate_runner_logs(Some(iteration));
 
-        ::log::info!("empty(): no-op iteration on non-Unix platform (iteration={iteration})");
+                ::log::info!("empty(): no-op iteration on non-Unix platform (iteration={iteration})");
 
-        guest_log_tracker.move_new_logs(log_layout.test_directory())?;
-        log_layout.normalize_component_logs(iteration)?;
+                guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+                log_layout.normalize_component_logs(iteration)?;
+            }
+
+            guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+            if iterations > 0 {
+                let last_iteration: usize = iterations - 1;
+                log_layout.normalize_component_logs(last_iteration)?;
+            }
+
+            Ok(())
+    } => result,
+        _ = cancellation_token.cancelled() => {
+            error!("empty(): cancellation requested");
+            Err(::anyhow::anyhow!("cancelled"))
+        },
     }
-
-    guest_log_tracker.move_new_logs(log_layout.test_directory())?;
-    if iterations > 0 {
-        let last_iteration: usize = iterations - 1;
-        log_layout.normalize_component_logs(last_iteration)?;
-    }
-
-    Ok(())
 }

--- a/src/utils/nanvix-test/src/executor/empty.rs
+++ b/src/utils/nanvix-test/src/executor/empty.rs
@@ -19,7 +19,9 @@ use crate::{
     },
 };
 use ::anyhow::Result;
+use ::log::error;
 use ::std::path::Path;
+use ::tokio_util::sync::CancellationToken;
 
 //==================================================================================================
 // Standalone Functions
@@ -49,44 +51,53 @@ pub(crate) async fn empty(
     iterations: usize,
     log_layout: &TestLogLayout,
     extra_nanvixd_args: &[String],
+    cancellation_token: CancellationToken,
 ) -> Result<()> {
-    let l2_enabled: bool = runner_config.l2_enabled;
-    let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
-    let log_root: &Path = Path::new(runner_config.log_directory.as_str());
-    let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
+    tokio::select! {
+        result = async {
+            let l2_enabled: bool = runner_config.l2_enabled;
+            let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
+            let log_root: &Path = Path::new(runner_config.log_directory.as_str());
+            let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
 
-    for iteration in 0..iterations {
-        let RunnerLogPaths {
-            stdout: stdout_file_path,
-            stderr: stderr_file_path,
-        } = log_layout.allocate_runner_logs(Some(iteration));
+            for iteration in 0..iterations {
+                let RunnerLogPaths {
+                    stdout: stdout_file_path,
+                    stderr: stderr_file_path,
+                } = log_layout.allocate_runner_logs(Some(iteration));
 
-        let nanvixd_http_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
-            (stdout_file_path.as_path(), stderr_file_path.as_path()),
-            (runner_config.ipv4_addr.as_str(), runner_config.port_num),
-            hwloc_file_path.clone(),
-            l2_enabled,
-            runner_config.netns_pool_size,
-            log_layout.test_directory(),
-            extra_nanvixd_args,
-        )?;
+                let nanvixd_http_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
+                    (stdout_file_path.as_path(), stderr_file_path.as_path()),
+                    (runner_config.ipv4_addr.as_str(), runner_config.port_num),
+                    hwloc_file_path.clone(),
+                    l2_enabled,
+                    runner_config.netns_pool_size,
+                    log_layout.test_directory(),
+                    extra_nanvixd_args,
+                )?;
 
-        {
-            let _nanvixd_handle: NanvixdHttp =
-                NanvixdHttp::spawn(runner_config, &nanvixd_http_args).await?;
-        }
+                {
+                    let _nanvixd_handle: NanvixdHttp =
+                        NanvixdHttp::spawn(runner_config, &nanvixd_http_args).await?;
+                }
 
-        guest_log_tracker.move_new_logs(log_layout.test_directory())?;
-        log_layout.normalize_component_logs(iteration)?;
+                guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+                log_layout.normalize_component_logs(iteration)?;
+            }
+
+            guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+            if iterations > 0 {
+                let last_iteration: usize = iterations - 1;
+                log_layout.normalize_component_logs(last_iteration)?;
+            }
+
+            Ok(())
+    } => result,
+        _ = cancellation_token.cancelled() => {
+            error!("empty(): cancellation requested");
+            Err(::anyhow::anyhow!("cancelled"))
+        },
     }
-
-    guest_log_tracker.move_new_logs(log_layout.test_directory())?;
-    if iterations > 0 {
-        let last_iteration: usize = iterations - 1;
-        log_layout.normalize_component_logs(last_iteration)?;
-    }
-
-    Ok(())
 }
 
 ///

--- a/src/utils/nanvix-test/src/executor/http.rs
+++ b/src/utils/nanvix-test/src/executor/http.rs
@@ -44,6 +44,7 @@ use ::std::{
     },
 };
 use ::tokio::time::timeout;
+use ::tokio_util::sync::CancellationToken;
 
 //==================================================================================================
 // Standalone Functions
@@ -74,125 +75,133 @@ pub(crate) async fn test_with_http_executor(
     workload: WorkloadSpec<'_>,
     log_layout: &TestLogLayout,
     extra_nanvixd_args: &[String],
+    cancellation_token: CancellationToken,
 ) -> Result<()> {
-    let l2_enabled: bool = runner_config.l2_enabled;
-    let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
-    let program_path: String = workload.program_path().to_string();
-    let request_payload: Option<Vec<u8>> = workload.input().map(|value| value.as_bytes().to_vec());
-    let response_timeout: Duration =
-        Duration::from_millis(runner_config.stream_collection_timeout_ms);
-    let log_root: &Path = Path::new(runner_config.log_directory.as_str());
-    let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
-    let execution_epoch_ms: u128 = match SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(duration) => duration.as_millis(),
-        Err(error) => {
-            let reason: String = format!(
-                "failed to compute execution timestamp (program_path={}, error={error})",
-                program_path
-            );
-            error!("test_with_http_executor(): {reason}");
-            return Err(::anyhow::anyhow!(reason));
-        },
-    };
+    tokio::select! {
+        result = async {
+            let l2_enabled: bool = runner_config.l2_enabled;
+            let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
+            let program_path: String = workload.program_path().to_string();
+            let request_payload: Option<Vec<u8>> = workload.input().map(|value| value.as_bytes().to_vec());
+            let response_timeout: Duration =
+                Duration::from_millis(runner_config.stream_collection_timeout_ms);
+            let log_root: &Path = Path::new(runner_config.log_directory.as_str());
+            let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
+            let execution_epoch_ms: u128 = match SystemTime::now().duration_since(UNIX_EPOCH) {
+                Ok(duration) => duration.as_millis(),
+                Err(error) => {
+                    let reason: String = format!(
+                        "failed to compute execution timestamp (program_path={}, error={error})",
+                        program_path
+                    );
+                    error!("test_with_http_executor(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                },
+            };
 
-    let RunnerLogPaths {
-        stdout: stdout_file_path,
-        stderr: stderr_file_path,
-    } = log_layout.allocate_runner_logs(None);
+            let RunnerLogPaths {
+                stdout: stdout_file_path,
+                stderr: stderr_file_path,
+            } = log_layout.allocate_runner_logs(None);
 
-    // Resolve an available port, searching for alternatives if the configured port is in use.
-    // Run in a blocking task to avoid stalling the Tokio runtime with synchronous bind calls.
-    let ipv4_addr_clone: String = runner_config.ipv4_addr.clone();
-    let port_num: u16 = runner_config.port_num;
-    let resolved_port: u16 = ::tokio::task::spawn_blocking(move || {
-        resolve_http_port(ipv4_addr_clone.as_str(), port_num)
-    })
-    .await
-    .map_err(|e| {
-        let reason: String = format!("port resolution task failed (error={e})");
-        error!("test_with_http_executor(): {reason}");
-        ::anyhow::anyhow!(reason)
-    })??;
+            // Resolve an available port, searching for alternatives if the configured port is in use.
+            // Run in a blocking task to avoid stalling the Tokio runtime with synchronous bind calls.
+            let ipv4_addr_clone: String = runner_config.ipv4_addr.clone();
+            let port_num: u16 = runner_config.port_num;
+            let resolved_port: u16 = ::tokio::task::spawn_blocking(move || {
+                resolve_http_port(ipv4_addr_clone.as_str(), port_num)
+            })
+            .await
+            .map_err(|e| {
+                let reason: String = format!("port resolution task failed (error={e})");
+                error!("test_with_http_executor(): {reason}");
+                ::anyhow::anyhow!(reason)
+            })??;
 
-    let nanvixd_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
-        (stdout_file_path.as_path(), stderr_file_path.as_path()),
-        (runner_config.ipv4_addr.as_str(), resolved_port),
-        hwloc_file_path.clone(),
-        l2_enabled,
-        runner_config.netns_pool_size,
-        log_layout.test_directory(),
-        extra_nanvixd_args,
-    )?;
-
-    // Run tests within a scoped block to ensure logs are captured before moving them.
-    {
-        let _nanvixd_handle: NanvixdHttp = NanvixdHttp::spawn(runner_config, &nanvixd_args).await?;
-
-        for iteration in 0..iterations {
-            let app_name: String = format!("{execution_epoch_ms}-{iteration}");
-            let uservm_args: UserVmArgs = UserVmArgs::new(
-                DEFAULT_TENANT_ID,
-                app_name.as_str(),
-                program_path.as_str(),
-                workload.program_args(),
+            let nanvixd_args: NanvixdHttpArgs = NanvixdHttpArgs::new(
+                (stdout_file_path.as_path(), stderr_file_path.as_path()),
+                (runner_config.ipv4_addr.as_str(), resolved_port),
+                hwloc_file_path.clone(),
                 l2_enabled,
+                runner_config.netns_pool_size,
+                log_layout.test_directory(),
+                extra_nanvixd_args,
             )?;
 
-            let mut user_vm: UserVm = UserVm::spawn(runner_config, &uservm_args).await?;
+            // Run tests within a scoped block to ensure logs are captured before moving them.
+            {
+                let _nanvixd_handle: NanvixdHttp = NanvixdHttp::spawn(runner_config, &nanvixd_args).await?;
 
-            if let Some(payload) = request_payload.as_ref() {
-                send_payload(&mut user_vm, payload.as_slice()).await?;
-            }
+                for iteration in 0..iterations {
+                    let app_name: String = format!("{execution_epoch_ms}-{iteration}");
+                    let uservm_args: UserVmArgs = UserVmArgs::new(
+                        DEFAULT_TENANT_ID,
+                        app_name.as_str(),
+                        program_path.as_str(),
+                        workload.program_args(),
+                        l2_enabled,
+                    )?;
 
-            close_gateway_input(&mut user_vm).await?;
+                    let mut user_vm: UserVm = UserVm::spawn(runner_config, &uservm_args).await?;
 
-            let expected_pattern: Option<&[u8]> = workload.expected_output().and_then(|value| {
-                if value.is_empty() {
-                    None
-                } else {
-                    Some(value.as_bytes())
+                    if let Some(payload) = request_payload.as_ref() {
+                        send_payload(&mut user_vm, payload.as_slice()).await?;
+                    }
+
+                    close_gateway_input(&mut user_vm).await?;
+
+                    let expected_pattern: Option<&[u8]> = workload.expected_output().and_then(|value| {
+                        if value.is_empty() {
+                            None
+                        } else {
+                            Some(value.as_bytes())
+                        }
+                    });
+
+                    let payload: Vec<u8> = receive_payload(
+                            &mut user_vm,
+                            expected_pattern,
+                            response_timeout,
+                            workload.expect_empty_output(),
+                        ).await?;
+                    if workload.expect_empty_output() && !payload.is_empty() {
+                        let reason: String = format!(
+                            "uservm produced unexpected stdout (bytes={:?}, len={})",
+                            payload,
+                            payload.len()
+                        );
+                        error!("test_with_http_executor(): {reason}");
+                        return Err(::anyhow::anyhow!(reason));
+                    }
+                    log_layout.persist_program_output(iteration, payload.as_slice())?;
+
+                    // Explicitly terminate the User VM to get the exit code.
+                    let exit_code: i32 = user_vm.terminate().await?;
+
+                    // Validate exit code.
+                    if exit_code != workload.expected_exit_code() {
+                        let expected: i32 = workload.expected_exit_code();
+                        let reason: String = format!(
+                            "exit code mismatch (expected={}, actual={}, program={}, iteration={})",
+                            expected, exit_code, program_path, iteration
+                        );
+                        error!("test_with_http_executor(): {reason}");
+                        return Err(::anyhow::anyhow!(reason));
+                    }
                 }
-            });
-
-            let payload: Vec<u8> = receive_payload(
-                &mut user_vm,
-                expected_pattern,
-                response_timeout,
-                workload.expect_empty_output(),
-            )
-            .await?;
-            if workload.expect_empty_output() && !payload.is_empty() {
-                let reason: String = format!(
-                    "uservm produced unexpected stdout (bytes={:?}, len={})",
-                    payload,
-                    payload.len()
-                );
-                error!("test_with_http_executor(): {reason}");
-                return Err(::anyhow::anyhow!(reason));
             }
-            log_layout.persist_program_output(iteration, payload.as_slice())?;
 
-            // Explicitly terminate the User VM to get the exit code.
-            let exit_code: i32 = user_vm.terminate().await?;
+            let last_iteration: usize = iterations.saturating_sub(1);
+            guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+            log_layout.normalize_component_logs(last_iteration)?;
 
-            // Validate exit code.
-            if exit_code != workload.expected_exit_code() {
-                let expected: i32 = workload.expected_exit_code();
-                let reason: String = format!(
-                    "exit code mismatch (expected={}, actual={}, program={}, iteration={})",
-                    expected, exit_code, program_path, iteration
-                );
-                error!("test_with_http_executor(): {reason}");
-                return Err(::anyhow::anyhow!(reason));
-            }
+            Ok(())
+        } => result,
+        _ = cancellation_token.cancelled() => {
+            error!("test_with_http_executor(): cancellation requested");
+            Err(::anyhow::anyhow!("cancelled"))
         }
     }
-
-    let last_iteration: usize = iterations.saturating_sub(1);
-    guest_log_tracker.move_new_logs(log_layout.test_directory())?;
-    log_layout.normalize_component_logs(last_iteration)?;
-
-    Ok(())
 }
 
 ///

--- a/src/utils/nanvix-test/src/executor/terminal.rs
+++ b/src/utils/nanvix-test/src/executor/terminal.rs
@@ -51,6 +51,7 @@ use ::tokio::{
     },
     task::JoinHandle,
 };
+use ::tokio_util::sync::CancellationToken;
 
 //==================================================================================================
 // Constants
@@ -86,7 +87,7 @@ type StreamCollectors = (
 ///
 /// # Description
 ///
-/// Tests a program in Nanvix using the terminal executor.
+/// Tests a program in Nanvix using the terminal executor, aborting when cancellation is requested.
 ///
 /// # Parameters
 ///
@@ -95,6 +96,7 @@ type StreamCollectors = (
 /// - `workload`: Metadata that describes the workload path, arguments, and expectations.
 /// - `log_layout`: Layout that defines the target directory for stdout/stderr/program logs.
 /// - `extra_nanvixd_args`: Command-line arguments passed directly to nanvixd.
+/// - `cancellation_token`: Token to abort test execution when cancellation is requested.
 ///
 /// # Return Value
 ///
@@ -108,175 +110,180 @@ pub async fn test_with_terminal_executor(
     workload: WorkloadSpec<'_>,
     log_layout: &TestLogLayout,
     extra_nanvixd_args: &[String],
+    cancellation_token: CancellationToken,
 ) -> Result<()> {
-    if runner_config.l2_enabled {
-        let reason: String = "terminal executor does not support L2 deployment".to_string();
-        error!("test_with_terminal_executor(): {reason}");
-        return Err(::anyhow::anyhow!(reason));
-    }
-
-    let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
-    let parsed_program_args: Vec<String> = match workload.program_args() {
-        Some(args) => match shell_words::split(args) {
-            Ok(values) => values,
-            Err(error) => {
-                let reason: String = format!(
-                    "failed to parse terminal executor program_args (args='{}', error={error})",
-                    args
-                );
+    tokio::select! {
+        result = async {
+            if runner_config.l2_enabled {
+                let reason: String = "terminal executor does not support L2 deployment".to_string();
                 error!("test_with_terminal_executor(): {reason}");
                 return Err(::anyhow::anyhow!(reason));
-            },
-        },
-        None => Vec::new(),
-    };
-    let log_root: &Path = Path::new(runner_config.log_directory.as_str());
-    let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
+            }
 
-    for iteration in 0..iterations {
-        let RunnerLogPaths {
-            stdout: stdout_file_path,
-            stderr: stderr_file_path,
-        } = log_layout.allocate_runner_logs(Some(iteration));
+            let hwloc_file_path: Option<String> = runner_config.hwloc_file_path.clone();
+            let parsed_program_args: Vec<String> = match workload.program_args() {
+                Some(args) => match shell_words::split(args) {
+                    Ok(values) => values,
+                    Err(error) => {
+                        let reason: String = format!(
+                            "failed to parse terminal executor program_args (args='{}', error={error})",
+                            args
+                        );
+                        error!("test_with_terminal_executor(): {reason}");
+                        return Err(::anyhow::anyhow!(reason));
+                    },
+                },
+                None => Vec::new(),
+            };
+            let log_root: &Path = Path::new(runner_config.log_directory.as_str());
+            let guest_log_tracker: GuestLogTracker = GuestLogTracker::capture(log_root)?;
 
-        let nanvixd_terminal_args: NanvixdTerminalArgs = NanvixdTerminalArgs::new(
-            hwloc_file_path.clone(),
-            workload.program_path(),
-            parsed_program_args.as_slice(),
-            log_layout.test_directory(),
-            extra_nanvixd_args,
-        )?;
+            for iteration in 0..iterations {
+                let RunnerLogPaths {
+                    stdout: stdout_file_path,
+                    stderr: stderr_file_path,
+                } = log_layout.allocate_runner_logs(Some(iteration));
 
-        let collection_timeout: Duration =
-            Duration::from_millis(runner_config.stream_collection_timeout_ms);
+                let nanvixd_terminal_args: NanvixdTerminalArgs = NanvixdTerminalArgs::new(
+                    hwloc_file_path.clone(),
+                    workload.program_path(),
+                    parsed_program_args.as_slice(),
+                    log_layout.test_directory(),
+                    extra_nanvixd_args,
+                )?;
 
-        let (mut nanvixd, stream_collectors) = {
-            let mut nanvixd: NanvixdTerminal =
-                NanvixdTerminal::spawn(runner_config, &nanvixd_terminal_args).await?;
+                let collection_timeout: Duration =
+                    Duration::from_millis(runner_config.stream_collection_timeout_ms);
 
-            let stdout_pipe = nanvixd.take_stdout().ok_or_else(|| {
-                let reason: String =
-                    "interactive mode requires capturing nanvixd stdout".to_string();
-                error!("test_with_terminal_executor(): {reason}");
-                ::anyhow::anyhow!(reason)
-            })?;
+                let (mut nanvixd, stream_collectors) = {
+                    let mut nanvixd: NanvixdTerminal = NanvixdTerminal::spawn(runner_config, &nanvixd_terminal_args).await?;
+                    let stdout_pipe = nanvixd.take_stdout().ok_or_else(|| {
+                        let reason: String =
+                            "interactive mode requires capturing nanvixd stdout".to_string();
+                        error!("test_with_terminal_executor(): {reason}");
+                        ::anyhow::anyhow!(reason)
+                    })?;
 
-            let stdout_buffer: Arc<AsyncMutex<Vec<u8>>> = Arc::new(AsyncMutex::new(Vec::new()));
-            let stdout_handle: JoinHandle<::std::io::Result<()>> = ::tokio::spawn(
-                collect_stream_to_buffer(stdout_pipe, Arc::clone(&stdout_buffer), None, None),
-            );
+                    let stdout_buffer: Arc<AsyncMutex<Vec<u8>>> = Arc::new(AsyncMutex::new(Vec::new()));
+                    let stdout_handle: JoinHandle<::std::io::Result<()>> = ::tokio::spawn(
+                        collect_stream_to_buffer(stdout_pipe, Arc::clone(&stdout_buffer), None, None),
+                    );
 
-            let stderr_pipe: ChildStderr = nanvixd.take_stderr().ok_or_else(|| {
-                let reason: String =
-                    "interactive mode requires capturing nanvixd stderr".to_string();
-                error!("test_with_terminal_executor(): {reason}");
-                ::anyhow::anyhow!(reason)
-            })?;
+                    let stderr_pipe: ChildStderr = nanvixd.take_stderr().ok_or_else(|| {
+                        let reason: String =
+                            "interactive mode requires capturing nanvixd stderr".to_string();
+                        error!("test_with_terminal_executor(): {reason}");
+                        ::anyhow::anyhow!(reason)
+                    })?;
 
-            let stderr_buffer: Arc<AsyncMutex<Vec<u8>>> = Arc::new(AsyncMutex::new(Vec::new()));
-            let stderr_handle: JoinHandle<::std::io::Result<()>> = ::tokio::spawn(
-                collect_stream_to_buffer(stderr_pipe, Arc::clone(&stderr_buffer), None, None),
-            );
+                    let stderr_buffer: Arc<AsyncMutex<Vec<u8>>> = Arc::new(AsyncMutex::new(Vec::new()));
+                    let stderr_handle: JoinHandle<::std::io::Result<()>> = ::tokio::spawn(
+                        collect_stream_to_buffer(stderr_pipe, Arc::clone(&stderr_buffer), None, None),
+                    );
 
-            let stdin_pipe: ChildStdin = nanvixd.take_stdin().ok_or_else(|| {
-                let reason: String = "interactive mode does not expose stdin pipe".to_string();
-                error!("test_with_terminal_executor(): {reason}");
-                ::anyhow::anyhow!(reason)
-            })?;
+                    let stdin_pipe: ChildStdin = nanvixd.take_stdin().ok_or_else(|| {
+                        let reason: String = "interactive mode does not expose stdin pipe".to_string();
+                        error!("test_with_terminal_executor(): {reason}");
+                        ::anyhow::anyhow!(reason)
+                    })?;
 
-            send_interactive_input(stdin_pipe, workload.input()).await?;
+                    send_interactive_input(stdin_pipe, workload.input()).await?;
 
-            (nanvixd, (stdout_handle, stdout_buffer, stderr_handle, stderr_buffer))
-        };
+                    (nanvixd, (stdout_handle, stdout_buffer, stderr_handle, stderr_buffer))
+                };
 
-        let (stdout_handle, stdout_buffer, stderr_handle, stderr_buffer): StreamCollectors =
-            stream_collectors;
+                let (stdout_handle, stdout_buffer, stderr_handle, stderr_buffer): StreamCollectors =
+                    stream_collectors;
 
-        let stdout_bytes: Vec<u8> = wait_stream_collector(
-            stdout_handle,
-            Arc::clone(&stdout_buffer),
-            collection_timeout,
-            "stdout",
-            iteration,
-        )
-        .await?;
-        let stderr_bytes: Vec<u8> = wait_stream_collector(
-            stderr_handle,
-            Arc::clone(&stderr_buffer),
-            collection_timeout,
-            "stderr",
-            iteration,
-        )
-        .await?;
+                let stdout_bytes: Vec<u8> = wait_stream_collector(
+                        stdout_handle,
+                        Arc::clone(&stdout_buffer),
+                        collection_timeout,
+                        "stdout",
+                        iteration,
+                    ).await?;
+                let stderr_bytes: Vec<u8> = wait_stream_collector(
+                        stderr_handle,
+                        Arc::clone(&stderr_buffer),
+                        collection_timeout,
+                        "stderr",
+                        iteration,
+                    ).await?;
 
-        // Wait for the nanvixd process to exit and get its exit code.
-        let exit_code: i32 = nanvixd.wait_exit_code().await?;
+                // Wait for the nanvixd process to exit and get its exit code.
+                let exit_code: i32 = nanvixd.wait_exit_code().await?;
 
-        if let Err(error) = write(&stdout_file_path, &stdout_bytes) {
-            let reason: String = format!(
-                "failed to write interactive stdout log (path={}, error={error})",
-                stdout_file_path.display()
-            );
-            error!("test_with_terminal_executor(): {reason}");
-            return Err(::anyhow::anyhow!(reason));
+                if let Err(error) = write(&stdout_file_path, &stdout_bytes) {
+                    let reason: String = format!(
+                        "failed to write interactive stdout log (path={}, error={error})",
+                        stdout_file_path.display()
+                    );
+                    error!("test_with_terminal_executor(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                }
+
+                if let Err(error) = write(&stderr_file_path, &stderr_bytes) {
+                    let reason: String = format!(
+                        "failed to write interactive stderr log (path={}, error={error})",
+                        stderr_file_path.display()
+                    );
+                    error!("test_with_terminal_executor(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                }
+
+                log_layout.persist_program_output(iteration, stdout_bytes.as_slice())?;
+
+                if let Some(expected) = workload.expected_output()
+                    && !buffer_contains_pattern(stdout_bytes.as_slice(), expected.as_bytes())
+                {
+                    let reason: String = format!(
+                        "interactive output mismatch (expected='{}', log={}, iteration={iteration})",
+                        expected,
+                        stdout_file_path.display()
+                    );
+                    error!("test_with_terminal_executor(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                }
+
+                if workload.expect_empty_output() && !stdout_bytes.is_empty() {
+                    let reason: String = format!(
+                        "interactive output is not empty as required (bytes={:?}, iteration={iteration})",
+                        stdout_bytes
+                    );
+                    error!("test_with_terminal_executor(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                }
+
+                // Validate exit code.
+                 if exit_code != workload.expected_exit_code() {
+                    let expected: i32 = workload.expected_exit_code();
+                    let reason: String = format!(
+                        "exit code mismatch (expected={}, actual={}, program={}, iteration={})",
+                        expected,
+                        exit_code,
+                        workload.program_path(),
+                        iteration
+                    );
+                    error!("test_with_terminal_executor(): {reason}");
+                    return Err(::anyhow::anyhow!(reason));
+                }
+
+                guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+                log_layout.normalize_component_logs(iteration)?;
+            }
+            guest_log_tracker.move_new_logs(log_layout.test_directory())?;
+            if iterations > 0 {
+                let last_iteration: usize = iterations - 1;
+                log_layout.normalize_component_logs(last_iteration)?;
+            }
+
+            Ok(())
+        } => result,
+        _ = cancellation_token.cancelled() => {
+            error!("test_with_terminal_executor(): cancellation requested");
+            Err(::anyhow::anyhow!("cancelled"))
         }
-
-        if let Err(error) = write(&stderr_file_path, &stderr_bytes) {
-            let reason: String = format!(
-                "failed to write interactive stderr log (path={}, error={error})",
-                stderr_file_path.display()
-            );
-            error!("test_with_terminal_executor(): {reason}");
-            return Err(::anyhow::anyhow!(reason));
-        }
-
-        log_layout.persist_program_output(iteration, stdout_bytes.as_slice())?;
-
-        if let Some(expected) = workload.expected_output()
-            && !buffer_contains_pattern(stdout_bytes.as_slice(), expected.as_bytes())
-        {
-            let reason: String = format!(
-                "interactive output mismatch (expected='{}', log={}, iteration={iteration})",
-                expected,
-                stdout_file_path.display()
-            );
-            error!("test_with_terminal_executor(): {reason}");
-            return Err(::anyhow::anyhow!(reason));
-        }
-
-        if workload.expect_empty_output() && !stdout_bytes.is_empty() {
-            let reason: String = format!(
-                "interactive output is not empty as required (bytes={:?}, iteration={iteration})",
-                stdout_bytes
-            );
-            error!("test_with_terminal_executor(): {reason}");
-            return Err(::anyhow::anyhow!(reason));
-        }
-
-        // Validate exit code.
-        if exit_code != workload.expected_exit_code() {
-            let expected: i32 = workload.expected_exit_code();
-            let reason: String = format!(
-                "exit code mismatch (expected={}, actual={}, program={}, iteration={})",
-                expected,
-                exit_code,
-                workload.program_path(),
-                iteration
-            );
-            error!("test_with_terminal_executor(): {reason}");
-            return Err(::anyhow::anyhow!(reason));
-        }
-
-        guest_log_tracker.move_new_logs(log_layout.test_directory())?;
-        log_layout.normalize_component_logs(iteration)?;
     }
-    guest_log_tracker.move_new_logs(log_layout.test_directory())?;
-    if iterations > 0 {
-        let last_iteration: usize = iterations - 1;
-        log_layout.normalize_component_logs(last_iteration)?;
-    }
-
-    Ok(())
 }
 
 ///

--- a/src/utils/nanvix-test/src/main.rs
+++ b/src/utils/nanvix-test/src/main.rs
@@ -94,6 +94,7 @@ use ::std::{
         },
     },
 };
+#[cfg(unix)]
 use ::tokio::signal::unix::{
     SignalKind,
     signal,
@@ -104,13 +105,18 @@ use ::tokio_util::sync::CancellationToken;
 // Constants
 //==================================================================================================
 
-// Base return code for test interrupts; actual exit code will be 128 + signal number.
+/// Base return code for test interrupts; actual exit code will be 128 + signal number.
 const BASE_RETURN_CODE: i32 = 128;
 /// Default log-level (overridden by RUST_LOG environment variable if set).
 const DEFAULT_LOG_LEVEL: &str = "error";
 /// Default tenant identifier used when creating test sandboxes.
 #[cfg(unix)]
 pub(crate) const DEFAULT_TENANT_ID: &str = "nanvix-test";
+/// Signal number for a Windows Ctrl+C event. Windows has no `SIGINT`/`SIGTERM`
+/// distinction, so we map Ctrl+C to the POSIX `SIGINT` value (2) to keep the `128 + signum`
+/// exit-code convention.
+#[cfg(not(unix))]
+const WINDOWS_CTRL_C_SIGNUM: i32 = 2;
 
 //==================================================================================================
 // Standalone Functions
@@ -142,48 +148,78 @@ fn main() -> Result<()> {
     let cancellation_token: CancellationToken = CancellationToken::new();
     let force_exit_token: CancellationToken = CancellationToken::new();
 
-    // Spawn a background task that listens for SIGINT and SIGTERM.
+    // Spawn a background task that listens for interrupt signals.
     // First signal: cancel the token so in-flight work drains gracefully.
-    // Second signal: cancel the force-exit token so that main() can shut down the runtime
-    let sig_flag: Arc<AtomicI32> = Arc::clone(&received_signal);
-    let sig_token: CancellationToken = cancellation_token.clone();
-    let sig_force_token: CancellationToken = force_exit_token.clone();
-    runtime.spawn(async move {
-        let mut sigint = match signal(SignalKind::interrupt()) {
-            Ok(stream) => stream,
-            Err(error) => {
-                error!("signal_listener(): failed to register SIGINT handler (error={error})");
-                return;
-            },
-        };
-        let mut sigterm = match signal(SignalKind::terminate()) {
-            Ok(stream) => stream,
-            Err(error) => {
-                error!("signal_listener(): failed to register SIGTERM handler (error={error})");
-                return;
-            },
-        };
+    // Second signal: cancel the force-exit token so that main() can shut down the runtime.
+    #[cfg(unix)]
+    {
+        let sig_flag: Arc<AtomicI32> = Arc::clone(&received_signal);
+        let sig_token: CancellationToken = cancellation_token.clone();
+        let sig_force_token: CancellationToken = force_exit_token.clone();
+        runtime.spawn(async move {
+            let mut sigint = match signal(SignalKind::interrupt()) {
+                Ok(stream) => stream,
+                Err(error) => {
+                    error!("signal_listener(): failed to register SIGINT handler (error={error})");
+                    return;
+                },
+            };
+            let mut sigterm = match signal(SignalKind::terminate()) {
+                Ok(stream) => stream,
+                Err(error) => {
+                    error!("signal_listener(): failed to register SIGTERM handler (error={error})");
+                    return;
+                },
+            };
 
-        // Wait for the first signal.
-        let (signum, signame): (i32, &str) = tokio::select! {
-            _ = sigint.recv() => (libc::SIGINT, "SIGINT"),
-            _ = sigterm.recv() => (libc::SIGTERM, "SIGTERM"),
-        };
-        info!("signal_listener(): received {signame}, requesting graceful shutdown...");
-        sig_flag.store(signum, Ordering::SeqCst);
-        sig_token.cancel();
+            // Wait for the first signal.
+            let (signum, signame): (i32, &str) = tokio::select! {
+                _ = sigint.recv() => (libc::SIGINT, "SIGINT"),
+                _ = sigterm.recv() => (libc::SIGTERM, "SIGTERM"),
+            };
+            info!("signal_listener(): received {signame}, requesting graceful shutdown...");
+            sig_flag.store(signum, Ordering::SeqCst);
+            sig_token.cancel();
 
-        // Wait for a second signal. Record it and cancel the force-exit token.
-        let (second_signum, second_signame): (i32, &str) = tokio::select! {
-            _ = sigint.recv() => (libc::SIGINT, "SIGINT"),
-            _ = sigterm.recv() => (libc::SIGTERM, "SIGTERM"),
-        };
-        error!(
-            "signal_listener(): received second signal {second_signame}, forcing immediate exit"
-        );
-        sig_flag.store(second_signum, Ordering::SeqCst);
-        sig_force_token.cancel();
-    });
+            // Wait for a second signal. Record it and cancel the force-exit token.
+            let (second_signum, second_signame): (i32, &str) = tokio::select! {
+                _ = sigint.recv() => (libc::SIGINT, "SIGINT"),
+                _ = sigterm.recv() => (libc::SIGTERM, "SIGTERM"),
+            };
+            error!(
+                "signal_listener(): received second signal {second_signame}, forcing immediate \
+                 exit"
+            );
+            sig_flag.store(second_signum, Ordering::SeqCst);
+            sig_force_token.cancel();
+        });
+    }
+
+    #[cfg(not(unix))]
+    {
+        let sig_flag: Arc<AtomicI32> = Arc::clone(&received_signal);
+        let sig_token: CancellationToken = cancellation_token.clone();
+        let sig_force_token: CancellationToken = force_exit_token.clone();
+        runtime.spawn(async move {
+            // First Ctrl+C: request graceful shutdown.
+            if tokio::signal::ctrl_c().await.is_err() {
+                error!("signal_listener(): failed to register Ctrl+C handler");
+                return;
+            }
+            info!("signal_listener(): received Ctrl+C, requesting graceful shutdown...");
+            sig_flag.store(WINDOWS_CTRL_C_SIGNUM, Ordering::SeqCst);
+            sig_token.cancel();
+
+            // Second Ctrl+C: force immediate exit.
+            if tokio::signal::ctrl_c().await.is_err() {
+                error!("signal_listener(): failed to register second Ctrl+C handler");
+                return;
+            }
+            error!("signal_listener(): received second Ctrl+C, forcing immediate exit");
+            sig_flag.store(WINDOWS_CTRL_C_SIGNUM, Ordering::SeqCst);
+            sig_force_token.cancel();
+        });
+    }
 
     // Run the main test loop. Abort early if a second signal forces exit.
     let result: Result<()> = runtime.block_on(async {

--- a/src/utils/nanvix-test/src/main.rs
+++ b/src/utils/nanvix-test/src/main.rs
@@ -85,12 +85,27 @@ use ::log::{
 use ::std::{
     fs::create_dir_all,
     path::Path,
+    process,
+    sync::{
+        Arc,
+        atomic::{
+            AtomicI32,
+            Ordering,
+        },
+    },
 };
+use ::tokio::signal::unix::{
+    SignalKind,
+    signal,
+};
+use ::tokio_util::sync::CancellationToken;
 
 //==================================================================================================
 // Constants
 //==================================================================================================
 
+// Base return code for test interrupts; actual exit code will be 128 + signal number.
+const BASE_RETURN_CODE: i32 = 128;
 /// Default log-level (overridden by RUST_LOG environment variable if set).
 const DEFAULT_LOG_LEVEL: &str = "error";
 /// Default tenant identifier used when creating test sandboxes.
@@ -122,7 +137,73 @@ fn main() -> Result<()> {
             ::anyhow::anyhow!(reason)
         })?;
 
-    runtime.block_on(run())
+    // Shared state: signal number received (0 = none).
+    let received_signal: Arc<AtomicI32> = Arc::new(AtomicI32::new(0));
+    let cancellation_token: CancellationToken = CancellationToken::new();
+    let force_exit_token: CancellationToken = CancellationToken::new();
+
+    // Spawn a background task that listens for SIGINT and SIGTERM.
+    // First signal: cancel the token so in-flight work drains gracefully.
+    // Second signal: cancel the force-exit token so that main() can shut down the runtime
+    let sig_flag: Arc<AtomicI32> = Arc::clone(&received_signal);
+    let sig_token: CancellationToken = cancellation_token.clone();
+    let sig_force_token: CancellationToken = force_exit_token.clone();
+    runtime.spawn(async move {
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(stream) => stream,
+            Err(error) => {
+                error!("signal_listener(): failed to register SIGINT handler (error={error})");
+                return;
+            },
+        };
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(stream) => stream,
+            Err(error) => {
+                error!("signal_listener(): failed to register SIGTERM handler (error={error})");
+                return;
+            },
+        };
+
+        // Wait for the first signal.
+        let (signum, signame): (i32, &str) = tokio::select! {
+            _ = sigint.recv() => (libc::SIGINT, "SIGINT"),
+            _ = sigterm.recv() => (libc::SIGTERM, "SIGTERM"),
+        };
+        info!("signal_listener(): received {signame}, requesting graceful shutdown...");
+        sig_flag.store(signum, Ordering::SeqCst);
+        sig_token.cancel();
+
+        // Wait for a second signal. Record it and cancel the force-exit token.
+        let (second_signum, second_signame): (i32, &str) = tokio::select! {
+            _ = sigint.recv() => (libc::SIGINT, "SIGINT"),
+            _ = sigterm.recv() => (libc::SIGTERM, "SIGTERM"),
+        };
+        error!(
+            "signal_listener(): received second signal {second_signame}, forcing immediate exit"
+        );
+        sig_flag.store(second_signum, Ordering::SeqCst);
+        sig_force_token.cancel();
+    });
+
+    // Run the main test loop. Abort early if a second signal forces exit.
+    let result: Result<()> = runtime.block_on(async {
+        tokio::select! {
+            result = run(cancellation_token) => result,
+            _ = force_exit_token.cancelled() => {
+                error!("main(): forcing exit on repeat signal...");
+                Err(::anyhow::anyhow!("force exit"))
+            },
+        }
+    });
+
+    // If a signal was caught, override the exit code to 128+signum.
+    let signum: i32 = received_signal.load(Ordering::SeqCst);
+    if signum != 0 {
+        drop(runtime);
+        process::exit(BASE_RETURN_CODE.saturating_add(signum));
+    }
+
+    result
 }
 
 ///
@@ -136,7 +217,7 @@ fn main() -> Result<()> {
 /// Returns `Ok(())` once all requested tests finish successfully; returns an error if CLI parsing,
 /// configuration loading, log directory creation, or test execution fails.
 ///
-async fn run() -> Result<()> {
+async fn run(cancellation_token: CancellationToken) -> Result<()> {
     initialize_run_timestamp();
 
     let parsed_args: args::Args =
@@ -233,14 +314,19 @@ async fn run() -> Result<()> {
         return Err(::anyhow::anyhow!(reason));
     }
 
-    prepare_runner_environment(
-        runner_config.l2_enabled,
-        runner_config.port_num,
-        Path::new(runner_config.tmp_directory.as_str()),
-        runner_config.tcp_cleanup_max_wait_seconds,
-        runner_config.tcp_cleanup_poll_interval_seconds,
-    )
-    .await;
+    tokio::select! {
+        _ = prepare_runner_environment(
+            runner_config.l2_enabled,
+            runner_config.port_num,
+            Path::new(runner_config.tmp_directory.as_str()),
+            runner_config.tcp_cleanup_max_wait_seconds,
+            runner_config.tcp_cleanup_poll_interval_seconds,
+        ) => {},
+        _ = cancellation_token.cancelled() => {
+            error!("main(): cancelled during environment preparation");
+            return Err(::anyhow::anyhow!("cancelled"));
+        },
+    }
     warning::fail_if_triggered("prepare_runner_environment")?;
 
     // Machine type used for filtering tests.
@@ -259,6 +345,12 @@ async fn run() -> Result<()> {
                 test_config.runs_on
             );
             continue;
+        }
+
+        // Check whether a signal arrived between test iterations.
+        if cancellation_token.is_cancelled() {
+            error!("main(): cancellation requested, skipping remaining tests");
+            break;
         }
 
         let TestCaseConfig {
@@ -329,7 +421,14 @@ async fn run() -> Result<()> {
                     ExecutorName::Empty.to_str(),
                     executor.as_str(),
                 )?;
-                empty(&runner_config, iterations, &log_layout, &extra_nanvixd_args).await?;
+                empty(
+                    &runner_config,
+                    iterations,
+                    &log_layout,
+                    &extra_nanvixd_args,
+                    cancellation_token.clone(),
+                )
+                .await?;
                 let context: String = format!("empty executor completed (label={})", executor);
                 warning::fail_if_triggered(context.as_str())?;
             },
@@ -366,6 +465,7 @@ async fn run() -> Result<()> {
                     workload,
                     &log_layout,
                     &extra_nanvixd_args,
+                    cancellation_token.clone(),
                 )
                 .await?;
                 let context: String = format!(
@@ -419,6 +519,7 @@ async fn run() -> Result<()> {
                     workload,
                     &log_layout,
                     &extra_nanvixd_args,
+                    cancellation_token.clone(),
                 )
                 .await?;
                 let context: String = format!(


### PR DESCRIPTION
Closes #1235. This PR introduces graceful shutdown for `nanvix-test`, with the following changes:
- Use `CancellationToken` from `tokio-util` (new dependency) to propagate signals down to executors
- Wrap executors in http.rs and terminal.rs within a `tokio::select!` block to race against the cancellation token. Triggers `Drop` on cancellation.
- Wrap the body in `main()` to setup background listeners for  SIGINT and SIGTERM before starting to execute tests, On cancellation, return 128+signum. On repeat signal, terminate immediately.

AI Disclaimer:
I used Copilot AI assistance specifically in two instances:
- To draw up an execution plan for the issue to identify places where a `tokio::select!` block would be required.
- Setting up listeners for signals in `main()`, specifically lower level code like:
```Rust
    sig_flag.store(signum, Ordering::SeqCst);
    // ...
    let signum: i32 = received_signal.load(Ordering::SeqCst);
    if signum != 0 {
        process::exit(128i32.saturating_add(signum));
    }
```
This seemed like a particularly good use of Copilot because of the safeguard against instruction re-ordering in the CPU, guaranteeing that the `load()` sees the `store()`. 