### PR TITLE
[tests] Fix atime relatime races

### DIFF
--- a/src/tests/file-c/futimens.c
+++ b/src/tests/file-c/futimens.c
@@ -46,9 +46,9 @@ void test_futimens(void)
     assert(fstat(fd, &st) == 0);
 
     // Set new timestamps.
-    times[0].tv_sec = st.st_atime + 10; // Access time.
+    times[0].tv_sec = st.st_atime + 20; // Access time.
     times[0].tv_nsec = 0;
-    times[1].tv_sec = st.st_mtime + 20; // Modification time.
+    times[1].tv_sec = st.st_mtime + 10; // Modification time.
     times[1].tv_nsec = 0;
 
     // Update the file timestamps and check the result.

--- a/src/tests/file-c/link.c
+++ b/src/tests/file-c/link.c
@@ -52,7 +52,6 @@ void test_link(void)
     assert(st.st_nlink == st_link.st_nlink); // Link count should be the same.
     assert(st.st_mode == st_link.st_mode);   // Mode should be the same.
     assert(st.st_size == st_link.st_size);   // Size should be the same.
-    assert(st.st_atime == st_link.st_atime); // Access time should be the same.
     assert(st.st_mtime == st_link.st_mtime); // Modification time should be the same.
     assert(st.st_ctime == st_link.st_ctime); // Change time should be the same.
     assert(st.st_atime != 0);                // Access time should not be zero.

--- a/src/tests/file-c/linkat.c
+++ b/src/tests/file-c/linkat.c
@@ -52,7 +52,6 @@ void test_linkat(void)
     assert(st.st_nlink == st_link.st_nlink); // Link count should be the same.
     assert(st.st_mode == st_link.st_mode);   // Mode should be the same.
     assert(st.st_size == st_link.st_size);   // Size should be the same.
-    assert(st.st_atime == st_link.st_atime); // Access time should be the same.
     assert(st.st_mtime == st_link.st_mtime); // Modification time should be the same.
     assert(st.st_ctime == st_link.st_ctime); // Change time should be the same.
     assert(st.st_atime != 0);                // Access time should not be zero.

--- a/src/tests/file-c/mkdir.c
+++ b/src/tests/file-c/mkdir.c
@@ -44,12 +44,10 @@ void test_mkdir(void)
     assert(st.st_mode & S_IRUSR);
     assert(st.st_mode & S_IWUSR);
     assert(st.st_mode & S_IXUSR);
-    assert(st.st_nlink == 2);           // Directory has at least one link (itself).
-    assert(st.st_atime == st.st_mtime); // Access time should be equal to modification time.
-    assert(st.st_atime == st.st_ctime); // Access time should be equal to change time.
-    assert(st.st_atime != 0);           // Access time should not be zero.
-    assert(st.st_mtime != 0);           // Modification time should not be zero.
-    assert(st.st_ctime != 0);           // Change time should not be zero.
+    assert(st.st_nlink == 2); // Newly-created empty directory has 2 links: "." and "..".
+    assert(st.st_atime != 0); // Access time should not be zero.
+    assert(st.st_mtime != 0); // Modification time should not be zero.
+    assert(st.st_ctime != 0); // Change time should not be zero.
     // TODO: Uncomment the following lines when user/group ID checks are supported.
     // assert(st.st_uid == getuid()); // User ID of the owner.
     // assert(st.st_gid == getgid()); // Group ID of the owner.

--- a/src/tests/file-c/mkdirat.c
+++ b/src/tests/file-c/mkdirat.c
@@ -44,12 +44,10 @@ void test_mkdirat(void)
     assert(st.st_mode & S_IRUSR);
     assert(st.st_mode & S_IWUSR);
     assert(st.st_mode & S_IXUSR);
-    assert(st.st_nlink == 2);           // Directory has at least one link (itself).
-    assert(st.st_atime == st.st_mtime); // Access time should be equal to modification time.
-    assert(st.st_atime == st.st_ctime); // Access time should be equal to change time.
-    assert(st.st_atime != 0);           // Access time should not be zero.
-    assert(st.st_mtime != 0);           // Modification time should not be zero.
-    assert(st.st_ctime != 0);           // Change time should not be zero.
+    assert(st.st_nlink == 2); // Newly created directory typically has 2 links: "." and "..".
+    assert(st.st_atime != 0); // Access time should not be zero.
+    assert(st.st_mtime != 0); // Modification time should not be zero.
+    assert(st.st_ctime != 0); // Change time should not be zero.
     // TODO: Uncomment the following lines when user/group ID checks are supported.
     // assert(st.st_uid == getuid()); // User ID of the owner.
     // assert(st.st_gid == getgid()); // Group ID of the owner.

--- a/src/tests/file-c/symlinkat.c
+++ b/src/tests/file-c/symlinkat.c
@@ -38,28 +38,30 @@ void test_symlinkat(void)
     // Create a symbolic link.
     assert(symlinkat(filename, AT_FDCWD, linkname) == 0);
 
-    // Get information from the original file.
+    // Verify the symbolic link itself via lstat().
+    struct stat st_link = {0};
+    assert(lstat(linkname, &st_link) == 0);
+    assert(S_ISLNK(st_link.st_mode));
+
+    // Verify the stored path via readlink().
+    char buf[PATH_MAX] = {0};
+    ssize_t len = readlink(linkname, buf, sizeof(buf) - 1);
+    assert(len > 0);
+    buf[len] = '\0';
+    assert(strcmp(buf, filename) == 0);
+
+    // Verify the symbolic link resolves to the original file.
     struct stat st = {0};
     assert(stat(filename, &st) == 0);
+    struct stat st_resolved = {0};
+    assert(stat(linkname, &st_resolved) == 0);
+    assert(st.st_ino == st_resolved.st_ino);
+    assert(st.st_dev == st_resolved.st_dev);
+    assert(st.st_atime != 0); // Access time should not be zero.
+    assert(st.st_mtime != 0); // Modification time should not be zero.
+    assert(st.st_ctime != 0); // Change time should not be zero.
 
-    // Get information from the hard link.
-    struct stat st_link = {0};
-    assert(stat(linkname, &st_link) == 0);
-
-    // Check if the symbolic link points to the same inode as the original file.
-    assert(st.st_ino == st_link.st_ino);
-    assert(st.st_dev == st_link.st_dev);
-    assert(st.st_nlink == st_link.st_nlink); // Link count should be the same.
-    assert(st.st_mode == st_link.st_mode);   // Mode should be the same.
-    assert(st.st_size == st_link.st_size);   // Size should be the same.
-    assert(st.st_atime == st_link.st_atime); // Access time should be the same.
-    assert(st.st_mtime == st_link.st_mtime); // Modification time should be the same.
-    assert(st.st_ctime == st_link.st_ctime); // Change time should be the same.
-    assert(st.st_atime != 0);                // Access time should not be zero.
-    assert(st.st_mtime != 0);                // Modification time should not be zero.
-    assert(st.st_ctime != 0);                // Change time should not be zero.
-
-    // Remove the hard link.
+    // Remove the symbolic link.
     assert(unlinkat(AT_FDCWD, linkname, 0) == 0);
 
     fprintf(stderr, "passed\n");

--- a/src/tests/file-c/utime.c
+++ b/src/tests/file-c/utime.c
@@ -41,8 +41,8 @@ void test_utime(void)
 
     // Set new timestamps.
     struct utimbuf times = {
-        .actime = st.st_atime + 10, // Access time.
-        .modtime = st.st_mtime + 20 // Modification time.
+        .actime = st.st_atime + 20, // Access time.
+        .modtime = st.st_mtime + 10 // Modification time.
     };
 
     // Update the file timestamps using utime and check the result.

--- a/src/tests/file-c/utimensat.c
+++ b/src/tests/file-c/utimensat.c
@@ -46,9 +46,9 @@ void test_utimensat(void)
     assert(fstat(fd, &st) == 0);
 
     // Set new timestamps.
-    times[0].tv_sec = st.st_atime + 10; // Access time.
+    times[0].tv_sec = st.st_atime + 20; // Access time.
     times[0].tv_nsec = 0;
-    times[1].tv_sec = st.st_mtime + 20; // Modification time.
+    times[1].tv_sec = st.st_mtime + 10; // Modification time.
     times[1].tv_nsec = 0;
 
     // Update the file timestamps using utimensat and check the result.

--- a/src/tests/file-c/utimes.c
+++ b/src/tests/file-c/utimes.c
@@ -41,11 +41,11 @@ void test_utimes(void)
 
     // Set new timestamps.
     struct timeval times[2] = {{
-                                   .tv_sec = st.st_atime + 10, // Access time.
+                                   .tv_sec = st.st_atime + 20, // Access time.
                                    .tv_usec = 0,
                                },
                                {
-                                   .tv_sec = st.st_mtime + 20, // Modification time.
+                                   .tv_sec = st.st_mtime + 10, // Modification time.
                                    .tv_usec = 0,
                                }};
 


### PR DESCRIPTION
## Summary

Fix fragile `st_atime` assertions in `src/tests/file-c/` that intermittently fail on hosts with `relatime` mount option and active file watchers (e.g., VS Code).

## Root Cause

Between two IPC round-trips (a syscall and a subsequent `stat()`), a host process can access the file and trigger a `relatime` atime bump, making the asserted value stale. The `relatime` policy permits atime updates whenever `atime < ctime` or `atime < mtime` — conditions that `linkat()` and timestamp-setting syscalls create.

## Changes

### Link tests (`link.c`, `linkat.c`, `symlinkat.c`)
- Remove `assert(st.st_atime == st_link.st_atime)` between two separate `stat()` calls
- The `mtime` and `ctime` comparisons are sufficient to verify hard-link and symlink correctness

### Mkdir tests (`mkdir.c`, `mkdirat.c`)
- Remove `assert(st.st_atime == st.st_mtime)` and `assert(st.st_atime == st.st_ctime)`
- Timestamp equality at directory creation is an implementation detail, not a POSIX guarantee

### Timestamp-setting tests (`utime.c`, `utimensat.c`, `futimens.c`, `utimes.c`)
- Swap deltas so `actime = original + 20` and `modtime = original + 10`
- Post-call state becomes `atime > mtime`, which prevents `relatime` from re-bumping atime on a subsequent read
- The atime assertion is **preserved**, keeping full test coverage

All files retain `assert(st.st_atime != 0)` as a sanity guard.

Closes #1579