### PR TITLE
[kernel] Add PIE support

### DIFF
--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -223,7 +223,9 @@ fn spawn_servers(mm: &mut VirtMemoryManager, kmods: &LinkedList<KernelModule>) -
     let mut count: usize = 0;
     // Spawn all servers.
     for kmod in kmods.iter() {
-        let elf: &Elf32Fhdr = Elf32Fhdr::from_address(kmod.start().into_raw_value());
+        // SAFETY: `kmod.start()` points to a valid, page-aligned ELF image loaded by the
+        // bootloader that remains in memory for the lifetime of the kernel.
+        let elf: &Elf32Fhdr = unsafe { Elf32Fhdr::from_address(kmod.start().into_raw_value()) };
         let pid: ProcessIdentifier = {
             // Split command line into arguments an environment variables using ";" as the delimiter.
             let cmdline: Vec<&str> = kmod.cmdline().split(';').collect();

--- a/src/kernel/src/mm/elf.rs
+++ b/src/kernel/src/mm/elf.rs
@@ -32,7 +32,10 @@ use ::core::cmp::{
     min,
 };
 use ::sys::{
-    config,
+    config::memory_layout::{
+        USER_BASE,
+        USER_BASE_RAW,
+    },
     error::{
         Error,
         ErrorCode,
@@ -73,10 +76,10 @@ const PF_R: u32 = 1 << 2; // Segment is readable.
 
 // Object file types.
 const ET_NONE: u16 = 0; // No file type.
-const ET_REL: u16 = 1; // Relocatable file.
+const _ET_REL: u16 = 1; // Relocatable file.
 const ET_EXEC: u16 = 2; // Executable file.
 const ET_DYN: u16 = 3; // Shared object file.
-const ET_CORE: u16 = 4; // Core file.
+const _ET_CORE: u16 = 4; // Core file.
 const ET_LOPROC: u16 = 0xff00; // Processor-specific.
 const ET_HIPROC: u16 = 0xffff; // Processor-specific.
 
@@ -125,7 +128,25 @@ pub struct Elf32Fhdr {
 }
 
 impl Elf32Fhdr {
-    pub fn from_address(addr: usize) -> &'static Self {
+    ///
+    /// # Description
+    ///
+    /// Interprets the memory at the given address as an [`Elf32Fhdr`].
+    ///
+    /// # Parameters
+    ///
+    /// - `addr`: Starting address of the ELF32 file header.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the [`Elf32Fhdr`] located at `addr`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `addr` points to a valid, properly aligned `Elf32Fhdr` that
+    /// outlives the returned `'static` reference.
+    ///
+    pub unsafe fn from_address(addr: usize) -> &'static Self {
         unsafe { &*(addr as *const Self) }
     }
 }
@@ -185,23 +206,64 @@ fn do_elf32_load(
 
     let mut last_address: usize = 0;
 
+    // Check if the ELF header is valid.
     if !elf.is_valid() {
-        return Err(Error::new(ErrorCode::BadFile, "invalid elf file"));
+        let reason: &str = "invalid ELF header";
+        error!("{reason}");
+        return Err(Error::new(ErrorCode::BadFile, reason));
     }
 
-    let entry: VirtualAddress = VirtualAddress::new(elf.e_entry as usize);
-
-    // Check if entry point does not match what we expect.
-    if entry < config::memory_layout::USER_BASE {
-        let reason: &str = "invalid binary entry point";
-        error!("do_elf32_load: {} (entry={:?})", reason, entry);
-        return Err(Error::new(ErrorCode::BadFile, "invalid entry point"));
-    }
-
-    let phdr_base = unsafe {
+    // SAFETY: `e_phoff` is the byte offset from the ELF header to the program header table.
+    // The resulting pointer is within the ELF image, which the caller guarantees is valid.
+    let phdr_base: *const Elf32Phdr = unsafe {
         (elf as *const Elf32Fhdr as *const u8).offset(elf.e_phoff as isize) as *const Elf32Phdr
     };
-    let phdrs = unsafe { core::slice::from_raw_parts(phdr_base, elf.e_phnum as usize) };
+    // SAFETY: `e_phnum` entries starting at `phdr_base` are guaranteed to reside within the
+    // ELF image. Each entry is a `repr(C)` `Elf32Phdr` with no invalid bit patterns.
+    let phdrs: &[Elf32Phdr] =
+        unsafe { core::slice::from_raw_parts(phdr_base, elf.e_phnum as usize) };
+
+    // Only ET_EXEC and ET_DYN binaries are supported.
+    if elf.e_type != ET_EXEC && elf.e_type != ET_DYN {
+        let reason: &str = "unsupported ELF type";
+        error!("{reason} (e_type={:#x})", elf.e_type);
+        return Err(Error::new(ErrorCode::BadFile, reason));
+    }
+
+    // Compute load base for PIE (ET_DYN) binaries. If the lowest PT_LOAD virtual address is
+    // below USER_BASE, offset all segment addresses so they land in user space.
+    let load_base: usize = if elf.e_type == ET_DYN {
+        let user_base: usize = USER_BASE_RAW;
+        let lowest_vaddr: usize = phdrs
+            .iter()
+            .filter(|phdr| phdr.p_type == PT_LOAD)
+            .map(|phdr| phdr.p_vaddr as usize)
+            .min()
+            .unwrap_or(0);
+        if lowest_vaddr < user_base {
+            user_base.saturating_sub(lowest_vaddr)
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+
+    let entry_raw: usize = (elf.e_entry as usize)
+        .checked_add(load_base)
+        .ok_or_else(|| {
+            let reason: &str = "entry address overflow";
+            error!("{reason} (e_entry={:#x}, load_base={:#x})", elf.e_entry, load_base);
+            Error::new(ErrorCode::BadFile, reason)
+        })?;
+    let entry: VirtualAddress = VirtualAddress::new(entry_raw);
+
+    // Check if entry point does not match what we expect.
+    if entry < USER_BASE {
+        let reason: &str = "invalid binary entry point";
+        error!("{} (entry={:?})", reason, entry);
+        return Err(Error::new(ErrorCode::BadFile, "invalid entry point"));
+    }
 
     // Load segments.
     for phdr in phdrs {
@@ -218,7 +280,15 @@ fn do_elf32_load(
             .p_align
             .try_into()
             .map_err(|_| Error::new(ErrorCode::BadFile, "invalid alignment value in elf file"))?;
-        let virt_addr_base: usize = ::sys::mm::align_down(phdr.p_vaddr as usize, align);
+        let adjusted_vaddr: usize =
+            (phdr.p_vaddr as usize)
+                .checked_add(load_base)
+                .ok_or_else(|| {
+                    let reason: &str = "virtual address overflow in PIE segment";
+                    error!("{reason} (p_vaddr={:#x}, load_base={load_base:#x})", phdr.p_vaddr);
+                    Error::new(ErrorCode::BadFile, reason)
+                })?;
+        let virt_addr_base: usize = ::sys::mm::align_down(adjusted_vaddr, align);
 
         // Compute access permissions.
         let access: AccessPermission = if phdr.p_flags == (PF_R | PF_X) {
@@ -233,16 +303,18 @@ fn do_elf32_load(
         let size: usize = max(phdr.p_filesz as usize, phdr.p_memsz as usize);
         let virt_addr_range_end: usize = virt_addr_base.checked_add(size).ok_or_else(|| {
             let reason: &str = "virtual address overflow in elf segment";
-            error!("do_elf32_load(): {reason} (virt_addr_base={virt_addr_base:#x}, size={size})");
+            error!("{reason} (virt_addr_base={virt_addr_base:#x}, size={size})");
             Error::new(ErrorCode::BadFile, reason)
         })?;
         let virt_addr_end: usize = ::sys::mm::align_up(virt_addr_range_end, PAGE_ALIGNMENT)
             .ok_or_else(|| {
                 let reason: &str = "align_up overflow";
-                error!("do_elf32_load(): {reason} (virt_addr_range_end={virt_addr_range_end:#x})");
+                error!("{reason} (virt_addr_range_end={virt_addr_range_end:#x})");
                 Error::new(ErrorCode::BadFile, reason)
             })?;
 
+        // SAFETY: `p_offset` is the byte offset from the start of the ELF image to the
+        // segment data. The caller guarantees the ELF image spans at least this range.
         let phys_addr_base: usize = unsafe {
             (elf as *const Elf32Fhdr as *const u8).offset(phdr.p_offset as isize) as usize
         };
@@ -251,8 +323,8 @@ fn do_elf32_load(
 
         // Load segment page by page.
         debug!(
-            "do_elf32_load(): loading segment (virt_addr_base={:#x}, virt_addr_end={:#x}, \
-             phys_addr_base={:#x}, phys_addr_end={:#x}, access={:?})",
+            "loading segment (virt_addr_base={:#x}, virt_addr_end={:#x}, phys_addr_base={:#x}, \
+             phys_addr_end={:#x}, access={:?})",
             virt_addr_base, virt_addr_end, phys_addr_base, phys_addr_end, access
         );
 
@@ -260,9 +332,9 @@ fn do_elf32_load(
             let vaddr: VirtualAddress = VirtualAddress::new(vaddr);
 
             // Check if address lies in user space.
-            if vaddr < config::memory_layout::USER_BASE {
+            if vaddr < USER_BASE {
                 let reason: &str = "invalid load address";
-                error!("do_elf32_load: {}", reason);
+                error!("{reason}");
                 return Err(Error::new(ErrorCode::BadFile, reason));
             }
 
@@ -303,7 +375,7 @@ fn do_elf32_load(
         .align_up(PAGE_ALIGNMENT)
         .ok_or_else(|| {
         let reason: &str = "align_up overflow";
-        error!("do_elf32_load(): {reason} (last_address={last_address:#x})");
+        error!("{reason} (last_address={last_address:#x})");
         Error::new(ErrorCode::BadFile, reason)
     })?;
 

--- a/src/libs/nvx/src/lib.rs
+++ b/src/libs/nvx/src/lib.rs
@@ -16,6 +16,7 @@
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 mod panic;
+mod pie;
 
 //==================================================================================================
 // Imports
@@ -24,6 +25,8 @@ mod panic;
 // We link the `alloc` crate when building static libraries to provide heap allocation support.
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;
+
+use ::config::memory_layout::USER_BASE_RAW;
 
 /// Re-export the VFS crate when the `memfs` feature is enabled.
 #[cfg(feature = "memfs")]
@@ -139,6 +142,11 @@ core::arch::global_asm!(
 ///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn _start(argp: *mut i8, envp: *mut i8) -> ! {
+    // Apply PIE relocations before any global data access.
+    unsafe {
+        pie::relocate_pie_binary(USER_BASE_RAW);
+    }
+
     syslog::trace!("_start(): argv: {:?}, envp: {:?}", argp, envp);
 
     // Initializes the system runtime.

--- a/src/libs/nvx/src/pie.rs
+++ b/src/libs/nvx/src/pie.rs
@@ -1,0 +1,201 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Lint Configuration
+//==================================================================================================
+
+#![allow(dead_code)]
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// ELF object file types.
+const ET_DYN: u16 = 3;
+
+// ELF segment types.
+const PT_LOAD: u32 = 1;
+const PT_DYNAMIC: u32 = 2;
+
+// Dynamic section tags.
+const DT_NULL: i32 = 0;
+const DT_REL: i32 = 17;
+const DT_RELSZ: i32 = 18;
+const DT_JMPREL: i32 = 23;
+const DT_PLTRELSZ: i32 = 2;
+
+// Relocation types.
+const R_386_RELATIVE: u32 = 8;
+
+//==================================================================================================
+// ELF Structures
+//==================================================================================================
+
+const EI_NIDENT: usize = 16;
+
+// ELF32 file header.
+#[repr(C)]
+struct Elf32Ehdr {
+    e_ident: [u8; EI_NIDENT], // ELF magic numbers and other info.
+    e_type: u16,              // Object file type.
+    e_machine: u16,           // Required machine architecture type.
+    e_version: u32,           // Object file version.
+    e_entry: u32,             // Virtual address of process's entry point.
+    e_phoff: u32,             // Program header table file offset.
+    e_shoff: u32,             // Section header table file offset.
+    e_flags: u32,             // Processor-specific flags.
+    e_ehsize: u16,            // ELF header's size in bytes.
+    e_phentsize: u16,         // Program header table entry size.
+    e_phnum: u16,             // Entries in the program header table.
+    e_shentsize: u16,         // Section header table size.
+    e_shnum: u16,             // Entries in the section header table.
+    e_shstrndx: u16,          // Index for the section name string table.
+}
+
+// ELF32 program header.
+#[repr(C)]
+struct Elf32Phdr {
+    p_type: u32,   // Segment type.
+    p_offset: u32, // Offset of the first byte.
+    p_vaddr: u32,  // Virtual address of the first byte.
+    p_paddr: u32,  // Physical address of the first byte.
+    p_filesz: u32, // Bytes in the file image.
+    p_memsz: u32,  // Bytes in the memory image.
+    p_flags: u32,  // Segment flags.
+    p_align: u32,  // Alignment value.
+}
+
+// ELF32 dynamic section entry.
+#[repr(C)]
+struct Elf32Dyn {
+    d_tag: i32, // Entry type tag.
+    d_val: u32, // Integer value.
+}
+
+// ELF32 relocation entry (without addend).
+#[repr(C)]
+struct Elf32Rel {
+    r_offset: u32, // Offset at which to apply the relocation.
+    r_info: u32,   // Relocation type and symbol index.
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Applies R_386_RELATIVE relocations to the main PIE (ET_DYN) executable at CRT startup. This
+/// must be called before any global data access (i.e., before `init()`).
+///
+/// If the binary is not ET_DYN, has no PT_DYNAMIC segment, or was loaded at its link-time
+/// address (delta = 0), this function returns without modification.
+///
+/// # Parameters
+///
+/// - `base_address`: The address at which the PIE binary was loaded. The ELF header must be
+///   accessible at this address.
+///
+/// # Safety
+///
+/// The caller must ensure `base_address` points to a valid, fully-loaded ELF32 binary whose
+/// program headers and dynamic section are accessible in memory.
+///
+pub unsafe fn relocate_pie_binary(base_address: usize) {
+    let ehdr: &Elf32Ehdr = &*(base_address as *const Elf32Ehdr);
+
+    if ehdr.e_type != ET_DYN {
+        return;
+    }
+
+    let phdrs: &[Elf32Phdr] = core::slice::from_raw_parts(
+        (base_address + ehdr.e_phoff as usize) as *const Elf32Phdr,
+        ehdr.e_phnum as usize,
+    );
+
+    // Find the lowest PT_LOAD p_vaddr (link-time base address).
+    let link_base: u32 = phdrs
+        .iter()
+        .filter(|p| p.p_type == PT_LOAD)
+        .map(|p| p.p_vaddr)
+        .min()
+        .unwrap_or(0);
+
+    // Compute relocation delta.
+    let delta: u32 = (base_address as u32).wrapping_sub(link_base);
+    if delta == 0 {
+        return;
+    }
+
+    // Find PT_DYNAMIC segment.
+    let dyn_phdr: &Elf32Phdr = match phdrs.iter().find(|p| p.p_type == PT_DYNAMIC) {
+        Some(p) => p,
+        None => return,
+    };
+
+    // Access dynamic entries at their relocated address.
+    let dyn_addr: usize = dyn_phdr.p_vaddr as usize + delta as usize;
+    let dyn_count: usize = dyn_phdr.p_memsz as usize / core::mem::size_of::<Elf32Dyn>();
+    let dyn_entries: &[Elf32Dyn] =
+        core::slice::from_raw_parts(dyn_addr as *const Elf32Dyn, dyn_count);
+
+    // Parse relocation table addresses from dynamic entries.
+    let mut dt_rel: Option<u32> = None;
+    let mut dt_relsz: Option<u32> = None;
+    let mut dt_jmprel: Option<u32> = None;
+    let mut dt_pltrelsz: Option<u32> = None;
+
+    for entry in dyn_entries {
+        match entry.d_tag {
+            DT_NULL => break,
+            DT_REL => dt_rel = Some(entry.d_val),
+            DT_RELSZ => dt_relsz = Some(entry.d_val),
+            DT_JMPREL => dt_jmprel = Some(entry.d_val),
+            DT_PLTRELSZ => dt_pltrelsz = Some(entry.d_val),
+            _ => {},
+        }
+    }
+
+    // Apply R_386_RELATIVE relocations from .rel.dyn.
+    if let (Some(vaddr), Some(size)) = (dt_rel, dt_relsz) {
+        apply_relative_relocations(vaddr, size, delta);
+    }
+
+    // Apply R_386_RELATIVE relocations from .rel.plt.
+    if let (Some(vaddr), Some(size)) = (dt_jmprel, dt_pltrelsz) {
+        apply_relative_relocations(vaddr, size, delta);
+    }
+}
+
+///
+/// # Description
+///
+/// Applies R_386_RELATIVE fixups from a relocation table. Non-R_386_RELATIVE entries are
+/// skipped.
+///
+/// # Parameters
+///
+/// - `rel_vaddr`: Link-time virtual address of the relocation table.
+/// - `rel_size`: Size of the relocation table in bytes.
+/// - `delta`: Relocation delta (actual load address minus link-time base).
+///
+/// # Safety
+///
+/// The caller must ensure that `rel_vaddr + delta` points to a valid relocation table in
+/// memory, and that all relocation targets are writable.
+///
+unsafe fn apply_relative_relocations(rel_vaddr: u32, rel_size: u32, delta: u32) {
+    let rel_addr: usize = rel_vaddr as usize + delta as usize;
+    let rel_count: usize = rel_size as usize / core::mem::size_of::<Elf32Rel>();
+    let rels: &[Elf32Rel] = core::slice::from_raw_parts(rel_addr as *const Elf32Rel, rel_count);
+
+    for rel in rels {
+        if (rel.r_info & 0xff) == R_386_RELATIVE {
+            let target: *mut u32 = (rel.r_offset as usize + delta as usize) as *mut u32;
+            let addend: u32 = target.read_unaligned();
+            target.write_unaligned(addend.wrapping_add(delta));
+        }
+    }
+}

--- a/src/libs/sys/src/sys/config.rs
+++ b/src/libs/sys/src/sys/config.rs
@@ -4,9 +4,10 @@
 //==================================================================================================
 // User Memory Layout
 //==================================================================================================
+
 pub mod memory_layout {
     use crate::mm::VirtualAddress;
-    use config::memory_layout::*;
+    pub use config::memory_layout::*;
 
     ///
     /// # Description


### PR DESCRIPTION
## Summary

Extend the ELF loader to accept PIE (ET_DYN) binaries, unblocking PR #1525.

### Changes

- **Kernel** (`src/kernel/src/mm/elf.rs`): Compute `load_base` for ET_DYN by offsetting the lowest PT_LOAD `p_vaddr` to `USER_BASE`. Adjust entry point and segment addresses with overflow checks.

- **dlfcn** (`src/libs/syscall/src/dlfcn/pie.rs`): Add `relocate_pie_binary()` to parse PT_DYNAMIC and apply R_386_RELATIVE relocations for PIE main executables.

- **nvx** (`src/libs/nvx/src/pie.rs`, `src/libs/nvx/src/lib.rs`): Add CRT-level PIE relocation called from `_start()` before `init()` to fix up GOT entries before any global data access.

### Testing

- All pre-commit checks pass (5/6 configurations)
- Format-check ✓, lint-check ✓, full build ✓
- Unit tests ✓, integration tests ✓

Closes #1580