### PR TITLE
[linuxd] Fix Close Connection Deadlock

### DIFF
--- a/src/daemons/linuxd/src/config.rs
+++ b/src/daemons/linuxd/src/config.rs
@@ -46,9 +46,10 @@ pub const GATEWAY_ACCEPT_TIMEOUT: Duration = Duration::from_secs(60);
 ///
 /// # Description
 ///
-/// Timeout for joining a worker thread when closing a user VM connection.
+/// Timeout for each step of the worker thread shutdown sequence in `close_connection()`. This
+/// bounds both the `send(Shutdown)` enqueue and the subsequent thread join.
 ///
-pub const WORKER_THREAD_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
+pub const WORKER_THREAD_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
 //==================================================================================================
 // Standalone Functions

--- a/src/daemons/linuxd/src/lib.rs
+++ b/src/daemons/linuxd/src/lib.rs
@@ -16,7 +16,7 @@ use crate::{
         restore_gate_sockaddr_builder,
         CONTROL_PLANE_CONNECT_TIMEOUT,
         READER_TASK_JOIN_TIMEOUT,
-        WORKER_THREAD_JOIN_TIMEOUT,
+        WORKER_THREAD_SHUTDOWN_TIMEOUT,
     },
     message::RequestAssembler,
     syscalls::SyscallTable,
@@ -426,22 +426,48 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
                 // interrupt will not unblock a thread waiting on a queue, so we need both
                 // mechanisms.
                 //
+                // Send the interrupt first so that a worker stuck in a syscall gets unblocked
+                // and starts draining the channel before we attempt to enqueue the shutdown
+                // command. This prevents a deadlock where the bounded channel is full and the
+                // send suspends forever because the worker never drains it.
+                //
                 // If any of the commands fail, continue trying to drain the remaining
                 // threads.
-                if let Err(e) = worker_thread.cmd_tx.send(VenvCommand::Shutdown).await {
-                    error!(
-                        "error sending shutdown command to worker thread (thread_id={:?}, \
-                         error={e:?})",
-                        worker_thread.id
-                    );
-                }
                 if let Err(e) = worker_thread.stop() {
                     error!(
                         "error sending interrupt to worker thread (thread_id={:?}, error={e:?})",
                         worker_thread.id
                     );
                 }
-                match timeout(WORKER_THREAD_JOIN_TIMEOUT, &mut worker_thread.handle).await {
+                match timeout(
+                    WORKER_THREAD_SHUTDOWN_TIMEOUT,
+                    worker_thread.cmd_tx.send(VenvCommand::Shutdown),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {
+                        trace!(
+                            "close_connection(): sent shutdown command to worker thread \
+                             (thread_id={:?})",
+                            worker_thread.id
+                        );
+                    },
+                    Ok(Err(e)) => {
+                        error!(
+                            "close_connection(): error sending shutdown command to worker thread \
+                             (thread_id={:?}, error={e:?})",
+                            worker_thread.id
+                        );
+                    },
+                    Err(_elapsed) => {
+                        warn!(
+                            "close_connection(): timeout sending shutdown command to worker \
+                             thread (thread_id={:?})",
+                            worker_thread.id
+                        );
+                    },
+                }
+                match timeout(WORKER_THREAD_SHUTDOWN_TIMEOUT, &mut worker_thread.handle).await {
                     Ok(Ok(())) => {
                         trace!(
                             "close_connection(): successfully joined worker thread \
@@ -451,7 +477,8 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
                     },
                     Ok(Err(e)) => {
                         error!(
-                            "error joining worker thread (thread_id={:?}, error={e:?})",
+                            "close_connection(): error joining worker thread (thread_id={:?}, \
+                             error={e:?})",
                             worker_thread.id
                         );
                     },


### PR DESCRIPTION
## Summary

Fixes the `close_connection()` bounded-channel deadlock described in #1561.

## Changes

Two changes to the worker-thread shutdown sequence in `close_connection()`:

1. **Reorder: `stop()` before `send()`** — Send the interrupt signal first so a worker stuck in a syscall gets unblocked and starts draining the channel before the shutdown command is enqueued.

2. **Wrap `send()` in `timeout()`** — Use `timeout(WORKER_THREAD_JOIN_TIMEOUT, cmd_tx.send(...))` so a full channel does not block indefinitely. On timeout, fall through to the existing join-timeout + abort path.

## Before (deadlock-prone)

```
cmd_tx.send(Shutdown).await   // blocks forever if channel full
worker_thread.stop()           // interrupt never sent
timeout(join)                  // never reached
```

## After (deadlock-free)

```
worker_thread.stop()           // interrupt unblocks stuck worker
timeout(send(Shutdown))        // bounded send, falls through on timeout
timeout(join)                  // bounded join, aborts on timeout
```

Closes #1561