### PR TITLE
[uservm] Remove memory size CLI option

### DIFF
--- a/doc/run.md
+++ b/doc/run.md
@@ -241,7 +241,6 @@ Optional flags:
 
 | Flag                  | Description                                                                   |
 | --------------------- | ----------------------------------------------------------------------------- |
-| `-memory <size>`      | Guest memory size (e.g., `64M`, `256K`). Defaults to the kernel config value. |
 | `-stderr <file>`      | Redirect guest stderr to a file instead of host stderr.                       |
 | `-initrd_args <args>` | Arguments forwarded to the initrd payload.                                    |
 | `-ramfs <file>`       | Path to a RAM filesystem image exposed to the guest.                          |

--- a/src/libs/nanvix-http/src/client/standalone.rs
+++ b/src/libs/nanvix-http/src/client/standalone.rs
@@ -266,7 +266,6 @@ impl<T: Send + Sync + Default + 'static> super::HttpClient<T> {
             Some(message.program.clone()),
             initrd_args,
             state.config.ramfs_filename.clone(),
-            ::config::kernel::MEMORY_SIZE,
             state.config.console_file.clone(),
             None,
         );

--- a/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
@@ -263,7 +263,6 @@ impl UserVm {
                 // Spawn VMM thread.
                 let vmm_handle: JoinHandle<Result<u16>> =
                     EmbeddedUserVm::spawn(::uservm::UserVmArgs {
-                        memory_size: ::config::kernel::MEMORY_SIZE,
                         kernel_filename,
                         initrd_filename: Some(initrd_filename.clone()),
                         initrd_args,

--- a/src/libs/nanvix-sandbox/src/standalone/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/standalone/uservm.rs
@@ -125,7 +125,6 @@ impl UserVm {
                 // Spawn the VMM.
                 let vmm_handle: JoinHandle<Result<u16>> =
                     EmbeddedUserVm::spawn(::uservm::UserVmArgs {
-                        memory_size: ::config::kernel::MEMORY_SIZE,
                         kernel_filename,
                         initrd_filename: Some(initrd_filename.clone()),
                         initrd_args,

--- a/src/libs/nanvix-terminal/src/standalone.rs
+++ b/src/libs/nanvix-terminal/src/standalone.rs
@@ -154,7 +154,6 @@ impl Terminal {
             Some(guest_binary_path.to_string()),
             initrd_args,
             self.config.ramfs_filename.clone(),
-            ::config::kernel::MEMORY_SIZE,
             self.config.console_file.clone(),
             None,
         );

--- a/src/uservm/src/args.rs
+++ b/src/uservm/src/args.rs
@@ -44,8 +44,6 @@ pub struct Args {
     ramfs_filename: Option<String>,
     /// Arguments to be passed to the initrd.
     initrd_args: Option<String>,
-    /// Memory size.
-    memory_size: usize,
     /// Standard error.
     vm_stderr: Option<String>,
     /// System VM address.
@@ -83,8 +81,6 @@ impl Args {
     pub const OPT_INITRD: &'static str = "-initrd";
     /// Command-line option for the kernel file.
     pub const OPT_KERNEL: &'static str = "-kernel";
-    /// Command-line option for the memory size.
-    pub const OPT_MEMORY_SIZE: &'static str = "-memory";
     /// Command-line option for the standard error.
     pub const OPT_STDERR: &'static str = "-stderr";
     /// Command-line option for system VM address.
@@ -134,7 +130,6 @@ impl Args {
         let mut initrd_filename: Option<String> = None;
         let mut ramfs_filename: Option<String> = None;
         let mut initrd_args: Option<String> = None;
-        let mut memory_size: usize = ::config::kernel::MEMORY_SIZE;
         let mut vm_stderr: Option<String> = None;
         let mut system_vm_addr: String = String::new();
         let mut control_plane_addr: String = String::new();
@@ -187,53 +182,6 @@ impl Args {
                 // Set kernel file.
                 Self::OPT_KERNEL if i + 1 < args.len() => {
                     kernel_filename = args[i + 1].clone();
-                    i += 1;
-                },
-                // Set memory size.
-                Self::OPT_MEMORY_SIZE if i + 1 < args.len() => {
-                    let mem_arg: &String = &args[i + 1];
-
-                    // Parse memory size.
-                    memory_size = match mem_arg[..mem_arg.len() - 1].parse::<usize>() {
-                        Ok(size) => size,
-                        Err(e) => {
-                            anyhow::bail!("invalid memory size (error={})", e);
-                        },
-                    };
-
-                    // Parse memory size suffix.
-                    let endptr: char = match mem_arg.chars().last() {
-                        Some(c) => c,
-                        None => {
-                            anyhow::bail!("invalid memory size '{}'", mem_arg);
-                        },
-                    };
-                    match endptr {
-                        'K' | 'k' => {
-                            memory_size = memory_size
-                                .checked_mul(1024)
-                                .ok_or_else(|| anyhow::anyhow!("memory size overflow"))?;
-                        },
-                        'M' | 'm' => {
-                            memory_size = memory_size
-                                .checked_mul(1024)
-                                .ok_or_else(|| anyhow::anyhow!("memory size overflow"))?
-                                .checked_mul(1024)
-                                .ok_or_else(|| anyhow::anyhow!("memory size overflow"))?;
-                        },
-                        'G' | 'g' => {
-                            memory_size = memory_size
-                                .checked_mul(1024)
-                                .ok_or_else(|| anyhow::anyhow!("memory size overflow"))?
-                                .checked_mul(1024)
-                                .ok_or_else(|| anyhow::anyhow!("memory size overflow"))?
-                                .checked_mul(1024)
-                                .ok_or_else(|| anyhow::anyhow!("memory size overflow"))?;
-                        },
-                        ch => {
-                            anyhow::bail!("invalid memory size suffix '{}'", ch);
-                        },
-                    }
                     i += 1;
                 },
                 // Set error file.
@@ -313,12 +261,6 @@ impl Args {
         if kernel_filename.is_empty() {
             Self::usage();
             anyhow::bail!("kernel file is missing");
-        }
-
-        // Check if memory size is invalid.
-        if memory_size == 0 {
-            Self::usage();
-            anyhow::bail!("invalid memory size");
         }
 
         // In non-standalone mode, all socket addresses and types are required.
@@ -413,7 +355,6 @@ impl Args {
             initrd_filename,
             ramfs_filename,
             initrd_args,
-            memory_size,
             vm_stderr,
             system_vm_addr,
             control_plane_addr,
@@ -435,13 +376,12 @@ impl Args {
     ///
     pub fn usage() {
         eprintln!(
-            "Usage: {} [{} <id>] {} <kernel> [{} <size>] [{} <file>] [{} <file>] [{}] [{} \
-             <system-vm-addr> {} <control-plane-addr> {} <gateway-addr>] [{} [{} <dir>]] [{} \
-             <args>] [{} <file>] [{} <path>]",
+            "Usage: {} [{} <id>] {} <kernel> [{} <file>] [{} <file>] [{}] [{} <system-vm-addr> {} \
+             <control-plane-addr> {} <gateway-addr>] [{} [{} <dir>]] [{} <args>] [{} <file>] [{} \
+             <path>]",
             Self::PROGRAM_NAME,
             Self::OPT_USER_VM_ID,
             Self::OPT_KERNEL,
-            Self::OPT_MEMORY_SIZE,
             Self::OPT_INITRD,
             Self::OPT_STDERR,
             Self::OPT_STANDALONE,
@@ -522,19 +462,6 @@ impl Args {
     ///
     pub fn kernel_filename(&self) -> &str {
         &self.kernel_filename
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Returns the memory size that was passed as a command-line argument to the program.
-    ///
-    /// # Returns
-    ///
-    /// The memory size that was passed as a command-line argument to the program.
-    ///
-    pub fn memory_size(&self) -> usize {
-        self.memory_size
     }
 
     ///
@@ -750,8 +677,6 @@ mod tests {
     fn parse_returns_expected_values() -> AnyResult<()> {
         let mut args_vec: Vec<String> = build_base_args();
         let (log_dir_str, log_dir_path) = unique_log_dir()?;
-        args_vec.push(Args::OPT_MEMORY_SIZE.to_string());
-        args_vec.push(String::from("64M"));
         args_vec.push(Args::OPT_INITRD.to_string());
         args_vec.push(String::from("initrd.img"));
         args_vec.push(Args::OPT_INITRD_ARGS.to_string());
@@ -768,7 +693,6 @@ mod tests {
 
         assert_eq!(format!("{}", parsed_args.user_vm_id()), "7");
         assert_eq!(parsed_args.kernel_filename(), "kernel.elf");
-        assert_eq!(parsed_args.memory_size(), 64 * 1024 * 1024);
         let initrd: Option<String> = parsed_args.initrd_filename();
         assert!(matches!(initrd, Some(ref value) if value == "initrd.img"));
         let ramfs: Option<String> = parsed_args.ramfs_filename();
@@ -789,23 +713,6 @@ mod tests {
         fs::remove_dir_all(log_dir_path).ok();
 
         Ok(())
-    }
-
-    #[test]
-    fn parse_detects_memory_overflow() {
-        let mut args_vec: Vec<String> = build_base_args();
-        let overflow_arg: String = format!("{}K", usize::MAX);
-        args_vec.push(Args::OPT_MEMORY_SIZE.to_string());
-        args_vec.push(overflow_arg);
-
-        let result = Args::parse(args_vec);
-        assert!(result.is_err(), "expected memory size overflow to produce an error");
-        if let Err(error) = result {
-            assert!(
-                error.to_string().contains("memory size overflow"),
-                "error should mention memory size overflow"
-            );
-        }
     }
 
     #[test]

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -151,8 +151,6 @@ pub const CHANNEL_CAPACITY: usize = 1024;
 
 /// Bundles all resources required to spawn a [`UserVm`] instance.
 pub struct UserVmArgs {
-    /// Amount of guest physical memory to allocate for the virtual machine, in bytes.
-    pub memory_size: usize,
     /// Absolute or relative path to the guest kernel image to boot.
     pub kernel_filename: String,
     /// Optional path to an initrd payload that should be exposed to the guest.
@@ -273,7 +271,6 @@ impl UserVm {
             #[cfg(feature = "hyperlight")]
             bulk_output: vmm_bulk_stdout_fn,
             stderr: vmm_stderr_fn,
-            memory_size: args.memory_size,
             control_rx: vcpu_thread_control_rx,
             control_tx: vcpu_thread_control_tx,
             kernel_filename: args.kernel_filename,

--- a/src/uservm/src/main.rs
+++ b/src/uservm/src/main.rs
@@ -84,7 +84,6 @@ pub async fn main() -> Result<ExitCode> {
     let initrd_filename: Option<String> = args.initrd_filename();
     let initrd_args: Option<String> = args.initrd_args();
     let ramfs_filename: Option<String> = args.ramfs_filename();
-    let memory_size: usize = args.memory_size();
     let stderr: Option<String> = args.take_vm_stderr();
     let user_vm_id: UserVmIdentifier = args.user_vm_id();
     let standalone: bool = args.standalone();
@@ -100,12 +99,11 @@ pub async fn main() -> Result<ExitCode> {
 
     debug!(
         "main(): starting user VM (user_vm_id={:?}, kernel={:?}, initrd={:?}, ramfs={:?}, \
-         memory_size_bytes={}, standalone={})",
+         standalone={})",
         user_vm_id,
         &kernel_filename,
         initrd_filename.as_deref().unwrap_or("none"),
         ramfs_filename.as_deref().unwrap_or("none"),
-        memory_size,
         standalone
     );
 
@@ -115,22 +113,13 @@ pub async fn main() -> Result<ExitCode> {
             initrd_filename,
             initrd_args,
             ramfs_filename,
-            memory_size,
             stderr,
             snapshot_path,
         )
         .await
     } else {
-        run_managed(
-            args,
-            kernel_filename,
-            initrd_filename,
-            initrd_args,
-            ramfs_filename,
-            memory_size,
-            stderr,
-        )
-        .await
+        run_managed(args, kernel_filename, initrd_filename, initrd_args, ramfs_filename, stderr)
+            .await
     }
 }
 
@@ -147,7 +136,6 @@ pub async fn main() -> Result<ExitCode> {
 /// - `initrd_filename`: Optional path to the initrd payload.
 /// - `initrd_args`: Optional arguments forwarded to the initrd payload.
 /// - `ramfs_filename`: Optional path to a RAM filesystem image.
-/// - `memory_size`: Amount of guest physical memory in bytes.
 /// - `stderr`: Optional path to a file used to capture the guest's stderr stream.
 /// - `snapshot_path`: Optional path to a snapshot from which to restore VM state instead of
 ///   cold-booting.
@@ -166,7 +154,6 @@ async fn run_standalone(
     initrd_filename: Option<String>,
     initrd_args: Option<String>,
     ramfs_filename: Option<String>,
-    memory_size: usize,
     stderr: Option<String>,
     snapshot_path: Option<String>,
 ) -> Result<ExitCode> {
@@ -177,7 +164,6 @@ async fn run_standalone(
         initrd_filename,
         initrd_args,
         ramfs_filename,
-        memory_size,
         stderr,
         snapshot_path,
     );
@@ -198,7 +184,6 @@ async fn run_standalone(
 /// - `initrd_filename`: Optional path to the initrd payload.
 /// - `initrd_args`: Optional arguments forwarded to the initrd payload.
 /// - `ramfs_filename`: Optional path to a RAM filesystem image.
-/// - `memory_size`: Amount of guest physical memory in bytes.
 /// - `stderr`: Optional path to a file used to capture the guest's stderr stream.
 ///
 /// # Returns
@@ -217,7 +202,6 @@ async fn run_managed(
     initrd_filename: Option<String>,
     initrd_args: Option<String>,
     ramfs_filename: Option<String>,
-    memory_size: usize,
     stderr: Option<String>,
 ) -> Result<ExitCode> {
     // Only the I/O thread channels are required here; the VMM creates its own internally.
@@ -348,14 +332,12 @@ async fn run_managed(
 
     // Run virtual machine and check exit status code.
     debug!(
-        "main(): launching uservm (kernel={:?}, initrd={:?}, ramfs={:?}, memory_size_bytes={})",
+        "main(): launching uservm (kernel={:?}, initrd={:?}, ramfs={:?})",
         &kernel_filename,
         initrd_filename.as_deref().unwrap_or("none"),
         ramfs_filename.as_deref().unwrap_or("none"),
-        memory_size
     );
     let vmm_handle: JoinHandle<Result<u16>> = UserVm::spawn(UserVmArgs {
-        memory_size,
         initrd_filename,
         initrd_args,
         ramfs_filename,

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -127,7 +127,6 @@ impl StandaloneVmHandle {
     /// - `initrd_filename`: Optional path to the initrd payload.
     /// - `initrd_args`: Optional arguments forwarded to the initrd payload.
     /// - `ramfs_filename`: Optional path to a RAM filesystem image.
-    /// - `memory_size`: Amount of guest physical memory in bytes.
     /// - `stderr`: Optional path to a file used to capture the guest's stderr stream.
     /// - `snapshot_path`: Optional path to a snapshot from which to restore VM state instead of
     ///   cold-booting.
@@ -142,7 +141,6 @@ impl StandaloneVmHandle {
         initrd_filename: Option<String>,
         initrd_args: Option<String>,
         ramfs_filename: Option<String>,
-        memory_size: usize,
         stderr: Option<String>,
         snapshot_path: Option<String>,
     ) -> (Self, StandaloneVmIo) {
@@ -165,7 +163,6 @@ impl StandaloneVmHandle {
         let io_counters: MessageCounters = counters.clone();
 
         let vmm_handle: JoinHandle<Result<u16>> = UserVm::spawn(UserVmArgs {
-            memory_size,
             initrd_filename,
             initrd_args,
             ramfs_filename,

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -184,7 +184,7 @@ impl Vmm {
         // Required values for heap and stack sizes to be used by the kernel.
         let heap_size: usize = config::kernel::KPOOL_SIZE;
         let stack_size: usize = ::config::hyperlight::STACK_SIZE;
-        let memory_size: usize = args.memory_size;
+        let memory_size: usize = ::config::kernel::MEMORY_SIZE;
 
         let guest_env: GuestEnvironment = if let Some(initrd_filename) = &args.initrd_filename {
             match std::fs::read(initrd_filename) {

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -318,7 +318,8 @@ impl Vmm {
         let irqchip: IrqChip = IrqChip::new(&mut kvm, &mut vm)?;
         let timer: Timer = Timer::new(&mut kvm, &mut vm)?;
         let mut vcpu: VirtualProcessor = VirtualProcessor::new(&mut kvm, &mut vm, 0)?;
-        let mut vmem: VirtualMemory = VirtualMemory::new(&mut kvm, &mut vm, args.memory_size)?;
+        let mut vmem: VirtualMemory =
+            VirtualMemory::new(&mut kvm, &mut vm, ::config::kernel::MEMORY_SIZE)?;
         let guest: Arc<Mutex<Guest>> = if args.restoring_from_snapshot {
             // When restoring from a snapshot, skip kernel/initrd/ramfs loading and vCPU reset.
             // The snapshot restore will overwrite memory and CPU state.

--- a/src/uservm/src/vmm/mod.rs
+++ b/src/uservm/src/vmm/mod.rs
@@ -28,7 +28,6 @@ cfg_if::cfg_if! {
 }
 
 pub struct MicroVmArgs {
-    pub memory_size: usize,
     pub control_rx: Receiver<VcpuControlCommand>,
     pub control_tx: Sender<VcpuControlResponse>,
     pub kernel_filename: String,
@@ -51,7 +50,6 @@ pub struct MicroVmArgs {
 impl std::fmt::Debug for MicroVmArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MicroVmArgs")
-            .field("memory_size", &self.memory_size)
             .field("kernel_filename", &self.kernel_filename)
             .field("initrd_filename", &self.initrd_filename)
             .field("initrd_args", &self.initrd_args)

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -42,7 +42,6 @@ use ::log::{
     warn,
 };
 use ::nanvix::{
-    config::kernel::MEMORY_SIZE,
     http::{
         message,
         message::{
@@ -591,7 +590,6 @@ impl Benchmark {
 
             let start = Instant::now();
             let user_vm_handle = UserVm::spawn(UserVmArgs {
-                memory_size: MEMORY_SIZE,
                 kernel_filename,
                 initrd_filename: Some(initrd_filename),
                 initrd_args: None,
@@ -697,7 +695,6 @@ impl Benchmark {
             let counters: MessageCounters = MessageCounters::new();
 
             let user_vm_handle = UserVm::spawn(UserVmArgs {
-                memory_size: MEMORY_SIZE,
                 kernel_filename: kernel_filename.clone(),
                 initrd_filename: Some(snapshot_program),
                 initrd_args: None,
@@ -781,7 +778,6 @@ impl Benchmark {
 
             let start = Instant::now();
             let user_vm_handle = UserVm::spawn(UserVmArgs {
-                memory_size: MEMORY_SIZE,
                 kernel_filename: kernel_filename.clone(),
                 initrd_filename: None,
                 initrd_args: None,
@@ -1222,7 +1218,6 @@ impl Benchmark {
         let counters: MessageCounters = MessageCounters::new();
 
         let user_vm_handle = UserVm::spawn(UserVmArgs {
-            memory_size: MEMORY_SIZE,
             kernel_filename,
             initrd_filename: Some(program),
             initrd_args: None,


### PR DESCRIPTION
Remove the user-configurable `-memory` command-line option from the UserVM and all call sites that propagated `memory_size` through `UserVmArgs`.

The guest memory size is a kernel configuration constant (`config::kernel::MEMORY_SIZE`) and should not be overridden at runtime. Both the Hyperlight and MicroVM backends now read the value directly from the kernel config instead of receiving it through the argument struct.

### Changes

- Delete `Args::OPT_MEMORY_SIZE`, the `-memory` flag parsing logic, and the associated overflow/validation checks in `src/uservm/src/args.rs`.
- Remove the `memory_size` field from `UserVmArgs` and `MicroVmArgs`, and drop every place that set or forwarded it (`lib.rs`, `main.rs`, `standalone.rs`, `vmm/mod.rs`).
- In `vmm/hyperlight/mod.rs` and `vmm/microvm/mod.rs`, source `memory_size` from `::config::kernel::MEMORY_SIZE` directly.
- Update callers in `nanvix-sandbox` (single-process and standalone `uservm.rs`), `nanvix-terminal` (`standalone.rs`), and `nanvix-bench` (`main.rs`) to stop passing the field.
- Remove the `-memory` entry from `doc/run.md`.
- Drop the `parse_detects_memory_overflow` unit test and related assertions that are no longer applicable.