### PR TITLE
[kernel] Use BSS for boot page tables

### DIFF
--- a/src/kernel/src/hal/arch/x86/mem/mmu/page_directory.rs
+++ b/src/kernel/src/hal/arch/x86/mem/mmu/page_directory.rs
@@ -13,26 +13,19 @@ use crate::hal::mem::{
     PageTableAddress,
     PhysicalAddress,
 };
-use ::alloc::boxed::Box;
-use ::arch::mem::{
-    self,
-    paging::{
-        AccessedFlag,
-        DirtyFlag,
-        FrameNumber,
-        PageCacheDisableFlag,
-        PageDirectoryEntry,
-        PageDirectoryEntryFlags,
-        PageWriteThroughFlag,
-        PresentFlag,
-        ReadWriteFlag,
-        UserSupervisorFlag,
-    },
+use ::arch::mem::paging::{
+    AccessedFlag,
+    DirtyFlag,
+    FrameNumber,
+    PageCacheDisableFlag,
+    PageDirectoryEntry,
+    PageDirectoryEntryFlags,
+    PageWriteThroughFlag,
+    PresentFlag,
+    ReadWriteFlag,
+    UserSupervisorFlag,
 };
-use ::core::ops::{
-    Deref,
-    DerefMut,
-};
+use ::core::ops::DerefMut;
 use ::sys::error::{
     Error,
     ErrorCode,
@@ -42,51 +35,23 @@ use ::sys::error::{
 // Structures
 //==================================================================================================
 
-pub enum PageDirectoryStorage {
-    Heap(Box<[u32; mem::PAGE_SIZE / core::mem::size_of::<u32>()]>),
-}
-
 ///
 /// # Description
 ///
 /// A type that represents a page directory.
 ///
-pub struct PageDirectory {
+pub struct PageDirectory<T: DerefMut<Target = [u32]>> {
     /// Entries.
-    entries: PageDirectoryStorage,
+    entries: T,
 }
 
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
-impl PageDirectoryStorage {
-    pub fn new() -> Self {
-        Self::Heap(Box::new([0; mem::PAGE_SIZE / core::mem::size_of::<u32>()]))
-    }
-}
-
-impl Deref for PageDirectoryStorage {
-    type Target = [u32];
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Heap(entries) => entries.deref(),
-        }
-    }
-}
-
-impl DerefMut for PageDirectoryStorage {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        match self {
-            Self::Heap(entries) => entries.deref_mut(),
-        }
-    }
-}
-
-impl PageDirectory {
-    pub fn new(entries: PageDirectoryStorage) -> Self {
-        let mut pgdir: PageDirectory = PageDirectory { entries };
+impl<T: DerefMut<Target = [u32]>> PageDirectory<T> {
+    pub fn new(entries: T) -> Self {
+        let mut pgdir: PageDirectory<T> = PageDirectory { entries };
         pgdir.clean();
         pgdir
     }

--- a/src/kernel/src/mm/kheap.rs
+++ b/src/kernel/src/mm/kheap.rs
@@ -23,7 +23,7 @@ use ::sys::error::{
 // Constants
 //==================================================================================================
 
-pub const NUM_OF_SLABS: usize = 8;
+pub const NUM_OF_SLABS: usize = 7;
 const SLAB_COUNT: usize = 32;
 pub const MIN_SLAB_SIZE: usize = SLAB_COUNT * mem::PAGE_SIZE;
 pub const MIN_HEAP_SIZE: usize = NUM_OF_SLABS * MIN_SLAB_SIZE;
@@ -54,7 +54,6 @@ enum SlabSize {
     Slab128 = 128,
     Slab256 = 256,
     Slab512 = 512,
-    Slab4096 = 4096,
 }
 
 struct Kheap {
@@ -65,7 +64,6 @@ struct Kheap {
     slab_128_bytes: Slab,
     slab_256_bytes: Slab,
     slab_512_bytes: Slab,
-    slab_4096_bytes: Slab,
 }
 
 //==================================================================================================
@@ -145,11 +143,6 @@ impl Kheap {
                 slab_size,
                 SlabSize::Slab512 as usize,
             )?,
-            slab_4096_bytes: Slab::from_raw_parts(
-                heap_start_addr.add(7 * slab_size),
-                slab_size,
-                SlabSize::Slab4096 as usize,
-            )?,
         })
     }
 
@@ -162,7 +155,6 @@ impl Kheap {
             SlabSize::Slab128 => self.slab_128_bytes.allocate().map_err(|_| AllocError),
             SlabSize::Slab256 => self.slab_256_bytes.allocate().map_err(|_| AllocError),
             SlabSize::Slab512 => self.slab_512_bytes.allocate().map_err(|_| AllocError),
-            SlabSize::Slab4096 => self.slab_4096_bytes.allocate().map_err(|_| AllocError),
         }
     }
 
@@ -175,7 +167,6 @@ impl Kheap {
             SlabSize::Slab128 => self.slab_128_bytes.deallocate(ptr).map_err(|_| AllocError),
             SlabSize::Slab256 => self.slab_256_bytes.deallocate(ptr).map_err(|_| AllocError),
             SlabSize::Slab512 => self.slab_512_bytes.deallocate(ptr).map_err(|_| AllocError),
-            SlabSize::Slab4096 => self.slab_4096_bytes.deallocate(ptr).map_err(|_| AllocError),
         }
     }
 
@@ -188,7 +179,6 @@ impl Kheap {
             65..=128 => Ok(SlabSize::Slab128),
             129..=256 => Ok(SlabSize::Slab256),
             257..=512 => Ok(SlabSize::Slab512),
-            4096 => Ok(SlabSize::Slab4096),
             _ => Err(AllocError),
         }
     }

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -20,7 +20,6 @@ mod virt;
 //==================================================================================================
 
 pub mod kheap;
-use ::alloc::boxed::Box;
 use ::arch::mem::{
     PAGE_ALIGNMENT,
     PGTAB_ALIGNMENT,
@@ -252,6 +251,9 @@ pub fn init(
 
     let mut vmem: Vmem = VirtMemoryManager::init(kernel_pages, kernel_page_tables, physman)?;
 
+    // SAFETY: called during single-threaded kernel init, after all boot page tables are allocated.
+    unsafe { virt::seal_boot_allocator() };
+
     // Map virtual memory regions that lie outside the physical memory.
     while let Some(region) = other_virtual_memory_regions.pop_front() {
         info!("mapping: {:?}", region);
@@ -260,15 +262,24 @@ pub fn init(
             VirtualAddress::new(region.start().into_raw_value() + (region.size() - 1));
 
         {
-            // SAFETY: the memory manager is initialized and access is synchronized.
-            let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
             while vaddr.into_inner() < end {
-                let kpage: KernelPage = mm.alloc_kpage(false)?;
+                // NOTE: each `VirtMemoryManager::get_mut()` borrow is scoped to its own inner
+                // block so that the mutable reference is dropped before any subsequent borrow,
+                // including the borrow that may occur when `page_table_allocator` is invoked
+                // inside `map_kpage`.
+                let kpage: KernelPage = {
+                    // SAFETY: the memory manager is initialized and access is synchronized.
+                    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+                    mm.alloc_kpage(false)?
+                };
 
                 let page_table_allocator = || {
-                    let pgtable_storage: PageTableStorage = PageTableStorage::Heap(Box::new(
-                        [0; mem::PAGE_SIZE / core::mem::size_of::<u32>()],
-                    ));
+                    let kpage: KernelPage = {
+                        // SAFETY: the memory manager is initialized and access is synchronized.
+                        let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+                        mm.alloc_kpage(true)?
+                    };
+                    let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
                     let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
                     Ok(page_table)
                 };

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -196,7 +196,22 @@ impl VirtMemoryManager {
 
     /// Creates a new virtual address space, based on root.
     pub fn new_vmem(&self, vmem: &Vmem) -> Result<Vmem, Error> {
-        let new_vmem: Vmem = Vmem::clone(vmem)?;
+        // Allocate a kernel page for the new page directory.
+        let pgdir_page: KernelPage = match self.physman.try_borrow_mut() {
+            Ok(mut physman) => {
+                // The page directory initialization logic (PageDirectory::new/clean)
+                // will zero the page; no need to clear the frame here.
+                let kframe: KernelFrame = physman.alloc_kernel_frame(false)?;
+                KernelPage::new(kframe)
+            },
+            Err(_) => {
+                let reason: &str = "failed to borrow physical memory manager";
+                error!("{reason}");
+                return Err(Error::new(ErrorCode::ResourceBusy, reason));
+            },
+        };
+
+        let new_vmem: Vmem = Vmem::clone(vmem, pgdir_page)?;
 
         trace!(
             "new_vmem={:?}, old_vmem={:?}",

--- a/src/kernel/src/mm/virt/mod.rs
+++ b/src/kernel/src/mm/virt/mod.rs
@@ -30,15 +30,18 @@ use crate::hal::{
     },
 };
 use ::alloc::{
-    boxed::Box,
     collections::LinkedList,
     vec::Vec,
 };
 use ::arch::{
     mem,
-    mem::PGTAB_ALIGNMENT,
+    mem::{
+        paging::PageTableEntry,
+        PGTAB_ALIGNMENT,
+    },
 };
 use ::core::{
+    cell::UnsafeCell,
     cmp::Ordering,
     ops::{
         Deref,
@@ -59,11 +62,107 @@ pub use manager::VirtMemoryManager;
 pub use vmem::Vmem;
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+// Number of page tables needed to identity-map all physical memory plus MMIO regions at boot.
+::static_assert::assert_eq!(config::kernel::MEMORY_SIZE.is_multiple_of(mem::PGTAB_SIZE));
+
+const NUM_BOOT_PAGE_TABLES: usize =
+    config::kernel::MEMORY_SIZE / mem::PGTAB_SIZE + config::platform::NUM_MMIO_BOOT_PAGE_TABLES;
+
+/// Total number of boot page-table-sized slots: page tables + 1 slot for the root page directory.
+pub(crate) const NUM_BOOT_SLOTS: usize = NUM_BOOT_PAGE_TABLES + 1;
+
+/// Number of u32 entries in a single page table / page directory (4096 / 4 = 1024).
+const PAGE_TABLE_LENGTH: usize = mem::PAGE_SIZE / PageTableEntry::SIZE;
+
+//==================================================================================================
+// Boot Page Table BSS Storage
+//==================================================================================================
+
+/// Page-aligned BSS storage for boot page tables and the root page directory.
+#[repr(align(4096))]
+struct BootPageTableStorage {
+    tables: [[u32; PAGE_TABLE_LENGTH]; NUM_BOOT_SLOTS],
+}
+
+::static_assert::assert_eq_align!(BootPageTableStorage, mem::PAGE_SIZE);
+
+struct BootPageTableStorageWrapper(UnsafeCell<BootPageTableStorage>);
+
+// SAFETY: Only accessed during single-threaded kernel init via `alloc_boot_slot()`.
+unsafe impl Sync for BootPageTableStorageWrapper {}
+
+static BOOT_STORAGE: BootPageTableStorageWrapper =
+    BootPageTableStorageWrapper(UnsafeCell::new(BootPageTableStorage {
+        tables: [[0; PAGE_TABLE_LENGTH]; NUM_BOOT_SLOTS],
+    }));
+
+/// Next available slot in the boot storage bump allocator.
+struct BootSlotNextWrapper(UnsafeCell<usize>);
+
+// SAFETY: Only accessed during single-threaded kernel init via `alloc_boot_slot()`.
+unsafe impl Sync for BootSlotNextWrapper {}
+
+static BOOT_SLOT_NEXT: BootSlotNextWrapper = BootSlotNextWrapper(UnsafeCell::new(0));
+
+/// Flag that marks the boot allocator as sealed (no further allocations allowed).
+struct BootSealedWrapper(UnsafeCell<bool>);
+
+// SAFETY: Only accessed during single-threaded kernel init.
+unsafe impl Sync for BootSealedWrapper {}
+
+static BOOT_SEALED: BootSealedWrapper = BootSealedWrapper(UnsafeCell::new(false));
+
+///
+/// # Description
+///
+/// Seals the boot page-table bump allocator, preventing further allocations.
+///
+/// This should be called once the kernel page pool is available to catch accidental late uses.
+///
+/// # Safety
+///
+/// This function mutates global state and must only be called during single-threaded kernel init.
+///
+pub(crate) unsafe fn seal_boot_allocator() {
+    *BOOT_SEALED.0.get() = true;
+}
+
+///
+/// # Description
+///
+/// Allocates the next page-aligned boot slot from BSS storage.
+///
+/// This is a simple bump allocator used during early kernel initialization before the kernel page
+/// pool is available. Each slot is exactly one page (4096 bytes) of `[u32; 1024]`.
+///
+/// # Panics
+///
+/// Panics if all boot slots have been exhausted or if the allocator has been sealed.
+///
+/// # Safety
+///
+/// This function mutates global state and must only be called during single-threaded kernel init.
+///
+pub(crate) unsafe fn alloc_boot_slot() -> &'static mut [u32; PAGE_TABLE_LENGTH] {
+    assert!(!*BOOT_SEALED.0.get(), "boot allocator is sealed; allocations are no longer allowed");
+    let next: *mut usize = BOOT_SLOT_NEXT.0.get();
+    let idx: usize = *next;
+    assert!(idx < NUM_BOOT_SLOTS, "boot page table storage exhausted");
+    *next += 1;
+    &mut (*BOOT_STORAGE.0.get()).tables[idx]
+}
+
+//==================================================================================================
 // Structures and Enums
 //==================================================================================================
 
 pub enum PageTableStorage {
-    Heap(Box<[u32; mem::PAGE_SIZE / core::mem::size_of::<u32>()]>),
+    /// Boot-time BSS-backed storage, allocated via `alloc_boot_slot()`.
+    Bss(&'static mut [u32; PAGE_TABLE_LENGTH]),
+    /// Runtime storage backed by a kernel page from the page pool.
     KernelPage(KernelPage),
 }
 
@@ -72,12 +171,10 @@ impl Deref for PageTableStorage {
 
     fn deref(&self) -> &Self::Target {
         match self {
-            Self::Heap(entries) => entries.deref(),
+            Self::Bss(entries) => entries.as_slice(),
             Self::KernelPage(page) => {
                 let base: *const u32 = page.base().into_raw_value() as *const u32;
-                unsafe {
-                    core::slice::from_raw_parts(base, mem::PAGE_SIZE / core::mem::size_of::<u32>())
-                }
+                unsafe { core::slice::from_raw_parts(base, PAGE_TABLE_LENGTH) }
             },
         }
     }
@@ -86,15 +183,61 @@ impl Deref for PageTableStorage {
 impl DerefMut for PageTableStorage {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
-            Self::Heap(entries) => entries.deref_mut(),
+            Self::Bss(entries) => entries.as_mut_slice(),
             Self::KernelPage(page) => {
                 let base: *mut u32 = page.base().into_raw_value() as *mut u32;
-                unsafe {
-                    core::slice::from_raw_parts_mut(
-                        base,
-                        mem::PAGE_SIZE / core::mem::size_of::<u32>(),
-                    )
-                }
+                unsafe { core::slice::from_raw_parts_mut(base, PAGE_TABLE_LENGTH) }
+            },
+        }
+    }
+}
+
+pub enum PageDirectoryStorage {
+    /// Boot-time BSS-backed storage, allocated via `alloc_boot_slot()`.
+    Bss(&'static mut [u32; PAGE_TABLE_LENGTH]),
+    /// Runtime storage backed by a kernel page from the page pool.
+    KernelPage(KernelPage),
+}
+
+impl PageDirectoryStorage {
+    /// Allocates a page directory from BSS boot storage (used for the root page directory during
+    /// early init, before the kernel page pool is available).
+    ///
+    /// # Safety
+    ///
+    /// This function must only be called during early single-threaded kernel init.
+    pub unsafe fn new_bss() -> Self {
+        Self::Bss(alloc_boot_slot())
+    }
+
+    /// Creates a page directory backed by a kernel page from the kernel page pool (used at runtime
+    /// for new process address spaces).
+    pub fn new_from_kpage(kpage: KernelPage) -> Self {
+        Self::KernelPage(kpage)
+    }
+}
+
+impl Deref for PageDirectoryStorage {
+    type Target = [u32];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Bss(entries) => entries.as_slice(),
+            Self::KernelPage(page) => {
+                let base: *const u32 = page.base().into_raw_value() as *const u32;
+                unsafe { core::slice::from_raw_parts(base, PAGE_TABLE_LENGTH) }
+            },
+        }
+    }
+}
+
+impl DerefMut for PageDirectoryStorage {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::Bss(entries) => entries.as_mut_slice(),
+            Self::KernelPage(page) => {
+                let base: *mut u32 = page.base().into_raw_value() as *mut u32;
+                unsafe { core::slice::from_raw_parts_mut(base, PAGE_TABLE_LENGTH) }
             },
         }
     }
@@ -157,9 +300,9 @@ pub fn init(
                     match page_table_addr.cmp(&last.0) {
                         Ordering::Greater => {
                             root_pagetables.push_back(last);
-                            let pgtable_storage: PageTableStorage = PageTableStorage::Heap(
-                                Box::new([0; mem::PAGE_SIZE / core::mem::size_of::<u32>()]),
-                            );
+                            let pgtable_storage: PageTableStorage =
+                                // SAFETY: called during single-threaded kernel init.
+                                PageTableStorage::Bss(unsafe { alloc_boot_slot() });
                             let page_table: PageTable<PageTableStorage> =
                                 PageTable::<PageTableStorage>::new(pgtable_storage);
                             let page_table_addr: PageTableAligned<VirtualAddress> =
@@ -177,9 +320,9 @@ pub fn init(
                     }
                 } else {
                     trace!("creating new page table for {:#010x}", raw_vaddr);
-                    let pgtable_storage: PageTableStorage = PageTableStorage::Heap(Box::new(
-                        [0; mem::PAGE_SIZE / core::mem::size_of::<u32>()],
-                    ));
+                    let pgtable_storage: PageTableStorage =
+                        // SAFETY: called during single-threaded kernel init.
+                        PageTableStorage::Bss(unsafe { alloc_boot_slot() });
                     let page_table: PageTable<PageTableStorage> =
                         PageTable::<PageTableStorage>::new(pgtable_storage);
                     let page_table_addr: PageTableAligned<VirtualAddress> =

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -11,10 +11,7 @@ use crate::{
     hal::{
         arch::x86::mem::mmu::{
             self,
-            page_directory::{
-                PageDirectory,
-                PageDirectoryStorage,
-            },
+            page_directory::PageDirectory,
             page_table::PageTable,
         },
         mem::{
@@ -33,6 +30,7 @@ use crate::{
         phys::UserFrame,
         virt::{
             kpage::KernelPage,
+            PageDirectoryStorage,
             PageTableStorage,
         },
     },
@@ -134,7 +132,7 @@ unsafe extern "C" {
 /// A type that represents a virtual memory space.
 pub struct Vmem {
     /// Underlying page directory.
-    pgdir: PageDirectory,
+    pgdir: PageDirectory<PageDirectoryStorage>,
     /// List of kernel page tables.
     kernel_page_tables: LinkedList<Rc<RefCell<(PageTableAddress, PageTable<PageTableStorage>)>>>,
     /// List of kernel pages mapped in the virtual address space.
@@ -155,8 +153,9 @@ impl Vmem {
         trace!("kernel_pages.len()={}", kernel_pages.len());
 
         // Create a clean page directory.
-        let mut pgdir: PageDirectory = PageDirectory::new(PageDirectoryStorage::new());
-        pgdir.clean();
+        let mut pgdir: PageDirectory<PageDirectoryStorage> =
+            // SAFETY: this constructor is only used during early single-threaded init.
+            PageDirectory::new(unsafe { PageDirectoryStorage::new_bss() });
 
         // Map and store root page tables.
         let mut kpage_tables: LinkedList<
@@ -185,10 +184,10 @@ impl Vmem {
     }
 
     /// Clones the target virtual memory space.
-    pub fn clone(from: &Vmem) -> Result<Vmem, Error> {
-        // Create a clean page directory.
-        let mut pgdir: PageDirectory = PageDirectory::new(PageDirectoryStorage::new());
-        pgdir.clean();
+    pub fn clone(from: &Vmem, pgdir_page: KernelPage) -> Result<Vmem, Error> {
+        // Create a clean page directory backed by a kernel page from the pool.
+        let mut pgdir: PageDirectory<PageDirectoryStorage> =
+            PageDirectory::new(PageDirectoryStorage::new_from_kpage(pgdir_page));
 
         // Map and store root page tables.
         let mut kernel_page_tables: LinkedList<
@@ -223,7 +222,7 @@ impl Vmem {
     }
 
     /// Returns a reference to the underlying page directory.
-    pub fn pgdir(&self) -> &PageDirectory {
+    pub fn pgdir(&self) -> &PageDirectory<PageDirectoryStorage> {
         &self.pgdir
     }
 

--- a/src/libs/arch/src/x86/mem/paging/pde.rs
+++ b/src/libs/arch/src/x86/mem/paging/pde.rs
@@ -155,6 +155,9 @@ pub struct PageDirectoryEntry {
 }
 
 impl PageDirectoryEntry {
+    /// Size in bytes of the hardware page directory entry representation (32-bit encoded value).
+    pub const SIZE: usize = ::core::mem::size_of::<u32>();
+
     ///
     /// # Description
     ///

--- a/src/libs/arch/src/x86/mem/paging/pte.rs
+++ b/src/libs/arch/src/x86/mem/paging/pte.rs
@@ -155,6 +155,9 @@ pub struct PageTableEntry {
 }
 
 impl PageTableEntry {
+    /// Size in bytes of the hardware page table entry representation (32-bit encoded value).
+    pub const SIZE: usize = ::core::mem::size_of::<u32>();
+
     ///
     /// # Description
     ///

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -49,6 +49,26 @@ pub mod system {
 }
 
 //==================================================================================================
+// Platform-Specific Constants
+//==================================================================================================
+
+pub mod platform {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "pc")] {
+            /// Number of extra boot page tables for memory-mapped I/O regions above physical
+            /// memory. On PC platforms, the LAPIC and IOAPIC are above physical memory and share
+            /// a single 4 MB page table block.
+            pub const NUM_MMIO_BOOT_PAGE_TABLES: usize = 1;
+        } else {
+            /// Number of extra boot page tables for memory-mapped I/O regions above physical
+            /// memory. On microvm and hyperlight, all MMIO is within physical memory, so no
+            /// extra page tables are needed.
+            pub const NUM_MMIO_BOOT_PAGE_TABLES: usize = 0;
+        }
+    }
+}
+
+//==================================================================================================
 // User Memory Layout
 //==================================================================================================
 


### PR DESCRIPTION
Replace heap-allocated page directories and boot page tables with
statically allocated BSS storage, eliminating the need for kernel heap
allocations during early boot before the page pool is available.

A bump allocator (`alloc_boot_slot()`) hands out page-aligned slots
from a fixed-size BSS array during single-threaded kernel init. Once
all boot page tables are allocated, `seal_boot_allocator()` prevents
accidental late allocations. Runtime page directories for new process
address spaces are backed by kernel pages from the page pool instead.

### Changes

- Add `BootPageTableStorage` BSS array and a bump allocator in
  `src/kernel/src/mm/virt/mod.rs` with `alloc_boot_slot()` and
  `seal_boot_allocator()`.
- Introduce `PageDirectoryStorage` enum with `Bss` and `KernelPage`
  variants, mirroring `PageTableStorage`.
- Make `PageDirectory` generic over its backing store
  (`PageDirectory<T: DerefMut<Target = [u32]>>`), removing the
  hard-coded `PageDirectoryStorage` enum from the HAL layer.
- Remove `PageDirectoryStorage::Heap` and `PageTableStorage::Heap`
  variants; boot-time callers now use `Bss`, runtime callers use
  `KernelPage`.
- Update `Vmem::new()` to use BSS-backed page directory and
  `Vmem::clone()` to accept a `KernelPage` for the new page
  directory.
- Update `VirtMemoryManager::new_vmem()` to allocate a kernel page
  for the cloned page directory.
- Remove the 4096-byte slab from `kheap.rs` (no longer needed),
  reducing `NUM_OF_SLABS` from 8 to 7.
- Add `PageDirectoryEntry::SIZE` and `PageTableEntry::SIZE` constants
  in `src/libs/arch`.
- Add `platform::NUM_MMIO_BOOT_PAGE_TABLES` in `src/libs/config` to
  account for MMIO page tables on PC platforms.
- Fix mutable borrow overlap in `mm/mod.rs` by scoping
  `VirtMemoryManager::get_mut()` borrows into separate blocks.