### PR TITLE
[syscall] ESPIPE for stdio in standalone

### DIFF
--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -10,6 +10,12 @@ use ::sys::error::{
     Error,
     ErrorCode,
 };
+#[cfg(feature = "standalone")]
+use ::sysapi::unistd::{
+    STDERR_FILENO,
+    STDIN_FILENO,
+    STDOUT_FILENO,
+};
 use ::sysapi::{
     ffi::c_int,
     sys_types::off_t,
@@ -49,11 +55,19 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
         }
     }
 
-    // In standalone mode, reject non-VFS fds (no linuxd).
+    // In standalone mode, return ESPIPE for stdio fds and reject all others.
     #[cfg(feature = "standalone")]
     {
+        if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
+            let _ = (offset, whence);
+            let reason: &str = "illegal seek on stdio";
+            ::syslog::error!("lseek(): {reason} (fd={fd})");
+            return Err(Error::new(ErrorCode::IllegalSeek, reason));
+        }
         let _ = (fd, offset, whence);
-        Err(Error::new(ErrorCode::OperationNotSupported, "lseek not available in standalone mode"))
+        let reason: &str = "lseek not available in standalone mode";
+        ::syslog::error!("lseek(): {reason} (fd={fd})");
+        Err(Error::new(ErrorCode::OperationNotSupported, reason))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -14,6 +14,12 @@ use ::sysapi::sys_types::{
     c_size_t,
     off_t,
 };
+#[cfg(feature = "standalone")]
+use ::sysapi::unistd::{
+    STDERR_FILENO,
+    STDIN_FILENO,
+    STDOUT_FILENO,
+};
 #[cfg(not(feature = "standalone"))]
 use {
     crate::{
@@ -66,11 +72,19 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
         }
     }
 
-    // In standalone mode, reject non-VFS fds (no linuxd).
+    // In standalone mode, return ESPIPE for stdio fds and reject all others.
     #[cfg(feature = "standalone")]
     {
+        if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
+            let _ = (buffer, offset);
+            let reason: &str = "illegal seek on stdio";
+            ::syslog::error!("pread(): {reason} (fd={fd})");
+            return Err(Error::new(ErrorCode::IllegalSeek, reason));
+        }
         let _ = (fd, buffer, offset);
-        Err(Error::new(ErrorCode::OperationNotSupported, "pread not available in standalone mode"))
+        let reason: &str = "pread not available in standalone mode";
+        ::syslog::error!("pread(): {reason} (fd={fd})");
+        Err(Error::new(ErrorCode::OperationNotSupported, reason))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -14,6 +14,12 @@ use ::sysapi::sys_types::{
     c_size_t,
     off_t,
 };
+#[cfg(feature = "standalone")]
+use ::sysapi::unistd::{
+    STDERR_FILENO,
+    STDIN_FILENO,
+    STDOUT_FILENO,
+};
 #[cfg(not(feature = "standalone"))]
 use {
     crate::{
@@ -66,11 +72,19 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
         }
     }
 
-    // In standalone mode, reject non-VFS fds (no linuxd).
+    // In standalone mode, return ESPIPE for stdio fds and reject all others.
     #[cfg(feature = "standalone")]
     {
+        if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
+            let _ = (buffer, offset);
+            let reason: &str = "illegal seek on stdio";
+            ::syslog::error!("pwrite(): {reason} (fd={fd})");
+            return Err(Error::new(ErrorCode::IllegalSeek, reason));
+        }
         let _ = (fd, buffer, offset);
-        Err(Error::new(ErrorCode::OperationNotSupported, "pwrite not available in standalone mode"))
+        let reason: &str = "pwrite not available in standalone mode";
+        ::syslog::error!("pwrite(): {reason} (fd={fd})");
+        Err(Error::new(ErrorCode::OperationNotSupported, reason))
     }
 
     // Forward to linuxd via IPC.


### PR DESCRIPTION
In standalone mode, pread(), pwrite(), and lseek() returned
OperationNotSupported for all file descriptors, including stdio.
POSIX requires that positional I/O and seeking on non-seekable
character devices fail with ESPIPE (ErrorCode::IllegalSeek).

Distinguish stdio fds (stdin, stdout, stderr) from other fds:
- stdio fds: return IllegalSeek (ESPIPE).
- other fds: return OperationNotSupported (no linuxd available).

This aligns with the existing pattern in read() and write(), which
already route stdio through IKC in standalone mode.