### PR TITLE
[scripts] Fix setup hang on debconf prompts

### DIFF
--- a/scripts/setup/ubuntu.sh
+++ b/scripts/setup/ubuntu.sh
@@ -3,6 +3,9 @@
 # Copyright(c) 2011-2024 The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
+# Prevent debconf prompts from blocking the script (e.g., grub2 install dialog).
+export DEBIAN_FRONTEND=noninteractive
+
 # Update package repository.
 apt-get update
 
@@ -16,6 +19,7 @@ apt-get install -y        \
     bison                 \
     bridge-utils          \
     build-essential       \
+    bzip2                 \
     clang-format          \
     cmake                 \
     codespell             \


### PR DESCRIPTION
The ubuntu.sh setup script hangs when packages like grub2 or
libvirt-daemon-system trigger interactive debconf configuration
dialogs. The apt-get -y flag only auto-confirms yes/no prompts,
not debconf screens, so the script blocks waiting for stdin.
Workaround `./z setup < /dev/null` works but is not intuitive.

### Changes

- Set `DEBIAN_FRONTEND=noninteractive` before `apt-get` calls to suppress
  all debconf prompts, matching the pattern already used in
  `Dockerfile.optimized` and `generate-l2-initramfs.sh`.
- Add `bzip2` to the package list (needed by downstream build steps).