### PR TITLE
[scripts] Rename VERUS_DIR to VERUS_HOME

### DIFF
--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -118,7 +118,7 @@ Nanvix uses Verus for formal verification of selected kernel crates. The expecte
 ```
 
 - The `ensure-verus` prerequisite downloads the correct Verus release automatically.
-- Override the install location with `VERUS_DIR=/path/to/verus`.
+- Override the install location with `VERUS_EXECUTABLE_DIR=/path/to/verus`.
 - The `vstd` crate version in `Cargo.toml` is exact-pinned (`=`) to match the Verus binary.
 
 ## Cleaning

--- a/Makefile
+++ b/Makefile
@@ -339,8 +339,12 @@ export SETCAP_CMD := setcap
 # Verus Formal Verification
 #===================================================================================================
 
-# Path to the Verus installation directory.
-export VERUS_DIR ?= $(TOOLCHAIN_DIR)/verus
+# Path to the directory containing the Verus executable.
+export VERUS_EXECUTABLE_DIR ?= $(TOOLCHAIN_DIR)/verus
+
+# Default Verus directory (used to detect custom VERUS_EXECUTABLE_DIR overrides).
+# patsubst strips trailing slashes so `toolchain/verus/` is not treated as custom.
+VERUS_DEFAULT_EXECUTABLE_DIR := $(patsubst %/,%,$(TOOLCHAIN_DIR)/verus)
 
 # List of crates to verify with Verus.
 VERUS_CRATES := bitmap
@@ -348,7 +352,7 @@ VERUS_CRATES := bitmap
 # Verus verification command.
 # Uses RUSTC_BOOTSTRAP=1 because the Verus rustc wrapper identifies as a stable compiler
 # but needs to accept -Z flags passed by -Z build-std.
-export VERUS_VERIFY_CMD = RUSTC_BOOTSTRAP=1 RUSTFLAGS=$(KERNEL_RUST_FLAGS) PATH="$(VERUS_DIR):$$PATH" \
+export VERUS_VERIFY_CMD = RUSTC_BOOTSTRAP=1 RUSTFLAGS=$(KERNEL_RUST_FLAGS) PATH="$(VERUS_EXECUTABLE_DIR):$$PATH" \
 	$(CARGO) +$(RUST_CHANNEL) verus verify --no-default-features
 
 #===================================================================================================
@@ -578,7 +582,7 @@ help:
 	@echo "  TARGET           Target architecture (default: $(TARGET))"
 	@echo "  TIMEOUT          Execution timeout in seconds (default: $(TIMEOUT))"
 	@echo "  TOOLCHAIN_DIR    Toolchain location (default: $(TOOLCHAIN_DIR))"
-	@echo "  VERUS_DIR        Path to Verus installation (default: $(VERUS_DIR))"
+	@echo "  VERUS_EXECUTABLE_DIR  Path to directory containing the verus binary (default: $(VERUS_EXECUTABLE_DIR))"
 	@echo ""
 	@echo "Parameter Values"
 	@echo "  DEPLOYMENT_MODE standalone, single-process, multi-process, l2"
@@ -594,9 +598,20 @@ help:
 verify: $(addprefix verify-,$(VERUS_CRATES))
 
 # Ensures the correct Verus version is installed before verification.
+# When VERUS_EXECUTABLE_DIR points to a custom location, we assume the user has pre-built or
+# pre-downloaded Verus there and just validate the binary exists (read-only; no writes to that
+# directory).  Otherwise the prebuilt release is downloaded into the default location.
 .PHONY: ensure-verus
 ensure-verus:
-	@$(SCRIPTS_DIR)/setup/verus.sh "$(VERUS_DIR)"
+ifneq ($(patsubst %/,%,$(VERUS_EXECUTABLE_DIR)),$(VERUS_DEFAULT_EXECUTABLE_DIR))
+	@if [ ! -x "$(VERUS_EXECUTABLE_DIR)/verus" ]; then \
+		echo "Error: VERUS_EXECUTABLE_DIR is set to '$(VERUS_EXECUTABLE_DIR)' but no verus binary found there."; \
+		exit 1; \
+	fi
+	@echo "Using custom Verus installation at $(VERUS_EXECUTABLE_DIR)."
+else
+	@$(SCRIPTS_DIR)/setup/verus.sh "$(VERUS_EXECUTABLE_DIR)"
+endif
 
 # Pattern rule for verifying individual crates.
 $(addprefix verify-,$(VERUS_CRATES)): verify-%: ensure-verus

--- a/doc/build.md
+++ b/doc/build.md
@@ -104,8 +104,14 @@ To run formal verification:
 ./z build --with-cached-options -- verify-bitmap
 ```
 
-Verus is installed to `$(TOOLCHAIN_DIR)/verus` by default. Override with `VERUS_DIR`:
+Verus is installed to `$(TOOLCHAIN_DIR)/verus` by default. When `VERUS_EXECUTABLE_DIR` points
+to a custom location, the build assumes pre-built or locally compiled Verus binaries are already
+present there and skips the automatic download (the directory is used read-only; nothing is
+written to it). `VERUS_EXECUTABLE_DIR` must point to the directory that contains the `verus`
+executable (and required companion binaries), not just the Verus source tree.
 
 ```bash
-./z build --with-cached-options -- verify VERUS_DIR=/path/to/verus
+# Use a custom Verus installation (pre-built or source-built).
+# VERUS_EXECUTABLE_DIR must be the directory that contains the verus binary.
+./z build --with-cached-options -- verify VERUS_EXECUTABLE_DIR=~/verus/target-verus/release
 ```

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -178,6 +178,26 @@ compatibility. Follow these steps to update your environment:
 Verus is installed automatically when you run `make verify`. The expected version is pinned in
 `build/verus-version` and installed to `toolchain/verus`. No manual setup is required.
 
+#### Using a Custom Verus Installation
+
+If you need a specific Verus version (e.g., to test a new feature or a nightly commit), you can
+build Verus from source and point `VERUS_EXECUTABLE_DIR` at the resulting binaries:
+
+```bash
+# 1. Clone and build Verus (see https://github.com/verus-lang/verus/blob/main/INSTALL.md).
+git clone https://github.com/verus-lang/verus.git ~/verus-src
+cd ~/verus-src/source
+# Follow the Verus build instructions to produce binaries.
+
+# 2. Point VERUS_EXECUTABLE_DIR at the directory containing the verus binary.
+make verify VERUS_EXECUTABLE_DIR=~/verus-src/source/target-verus/release
+```
+
+> **Note:** When `VERUS_EXECUTABLE_DIR` is overridden, the automatic download is skipped and
+> the build validates that a `verus` binary exists at the given path (the directory is used
+> read-only; nothing is written to it). You are responsible for ensuring the Verus version is
+> compatible with the `vstd` crate version pinned in `Cargo.toml`.
+
 ## Setup Your IDE (Optional)
 
 Choose one of the following options to set up your IDE for Nanvix development.


### PR DESCRIPTION
## Summary

Rename `VERUS_DIR` to `VERUS_HOME` and simplify custom Verus installation support. Instead of building Verus from source inside the setup script, users point `VERUS_HOME` at a directory containing pre-built or locally compiled Verus binaries.

## Changes

- **`Makefile`** — renamed `VERUS_DIR` → `VERUS_HOME`; `ensure-verus` validates the binary exists when a custom path is set, skips the automatic download.
- **`doc/build.md`** — updated usage examples to reference `VERUS_HOME`.
- **`doc/setup.md`** — added "Using a Custom Verus Installation" section.
- **`.github/skills/build/SKILL.md`** — updated override reference.

## Usage

```bash
# Default (prebuilt download, unchanged)
./z build -- verify

# Custom Verus installation (pre-built or source-built)
./z build -- verify VERUS_HOME=~/verus/target-verus/release
```

## Validation

- `make help` shows `VERUS_HOME` correctly.
- Custom `VERUS_HOME` with missing binary: clear error message.
- Custom `VERUS_HOME` with source-built Verus: **69 verified, 0 errors** on bitmap crate.
- Default prebuilt path: unchanged behavior.