### PR TITLE
[build] Add release manifest generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ RELEASE_DEPLOYMENT_MODE := $(subst -,_,$(DEPLOYMENT_MODE))
 RELEASE_BUILD_MODE := $(if $(filter yes,$(RELEASE)),release,debug)
 RELEASE_VERSION := $(strip $(shell cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.packages[0].version'))
 RELEASE_ARCHIVE := nanvix-$(RELEASE_VERSION)-$(MACHINE)-$(RELEASE_DEPLOYMENT_MODE)-$(RELEASE_BUILD_MODE)-$(LOG_LEVEL).tar.bz2
+MANIFEST_FILE := $(SYSROOT_DIR)/manifest.json
 
 #===================================================================================================
 # Artifacts
@@ -515,7 +516,15 @@ endif
 	@cp -r ${BUILD_DIR}/user/linker/$(TARGET)/user.ld ${SYSROOT_DIR}/lib/
 	@$(MAKE_QUIET) update-sysroot-link
 
-release: all install
+# Generates a JSON manifest with build metadata and git info.
+.PHONY: release-generate-manifest
+release-generate-manifest:
+	@echo "Generating manifest $(MANIFEST_FILE)..."
+	@bash $(SCRIPTS_DIR)/generate-manifest.sh $(MANIFEST_FILE) \
+		$(RELEASE_VERSION) $(MACHINE) $(TARGET) $(DEPLOYMENT_MODE) $(RELEASE_BUILD_MODE) $(LOG_LEVEL) \
+		$(BUILD_DIR)/kernel_config.toml
+
+release: all install release-generate-manifest
 	@echo "Creating release archive ${RELEASE_ARCHIVE} from ${SYSROOT_DIR}..."
 	@$(RM_CMD) ${RELEASE_ARCHIVE}
 	@tar -cjf ${RELEASE_ARCHIVE} --exclude=./src -C ${SYSROOT_DIR} .

--- a/scripts/generate-manifest.sh
+++ b/scripts/generate-manifest.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#
+# Generates a JSON manifest file with build metadata and git info.
+#
+# Run './generate-manifest.sh --help' for usage information.
+#
+# Arguments:
+#   $1 - output-file      Path to the manifest JSON file to generate.
+#   $2 - version          Release version string.
+#   $3 - machine          Target machine type.
+#   $4 - target           Target architecture.
+#   $5 - deployment_mode  Deployment mode.
+#   $6 - build_mode       Build mode (debug or release).
+#   $7 - log_level        Log level.
+#   $8 - kernel-config    Path to the kernel configuration TOML file.
+#
+
+#===================================================================================================
+
+# Fast fail on errors, unset variables, and pipe failures
+set -euo pipefail
+
+#==================================================================================================
+# Imports
+#==================================================================================================
+
+# Directory where to find scripts to import.
+IMPORT_DIR="$(cd "$(dirname "$0")" && pwd)/common"
+
+source "${IMPORT_DIR}/logging.sh"
+source "${IMPORT_DIR}/utils.sh"
+
+#===================================================================================================
+# Functions
+#===================================================================================================
+
+#
+# Description
+#
+#   Prints usage information for this script.
+#
+# Usage Example
+#
+#   print_help
+#
+print_help() {
+    cat << EOF
+Generates a JSON manifest file with build metadata and git information.
+
+Usage: $0 <output-file> <version> <machine> <target> <deployment_mode> <build_mode> <log_level> <kernel-config>
+
+Arguments:
+  output-file      Path to the manifest JSON file to generate.
+  version          Release version string.
+  machine          Target machine type.
+  target           Target architecture.
+  deployment_mode  Deployment mode.
+  build_mode       Build mode (debug or release).
+  log_level        Log level.
+  kernel-config    Path to the kernel configuration TOML file.
+EOF
+}
+
+#===================================================================================================
+# Main
+#===================================================================================================
+
+# Check that all required external utilities are installed.
+for cmd in jq date; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        print_error "'${cmd}' is required but not installed."
+        exit 1
+    fi
+done
+
+if [[ "${1:-}" == "--help" ]]; then
+    print_help
+    exit 0
+fi
+
+if [[ $# -ne 8 ]]; then
+    print_error "Expected 8 arguments, got $#."
+    print_help >&2
+    exit 1
+fi
+
+OUTPUT_FILE="$1"
+VERSION="$2"
+MACHINE="$3"
+TARGET="$4"
+DEPLOYMENT_MODE="$5"
+BUILD_MODE="$6"
+LOG_LEVEL="$7"
+KERNEL_CONFIG="$8"
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# Get git commit hash, or "unknown" if we're not in a git repository.
+if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
+    GIT_COMMIT="$(git rev-parse HEAD)"
+else
+    GIT_COMMIT="unknown"
+fi
+
+# Ensure the output directory exists.
+mkdir -p "$(dirname "${OUTPUT_FILE}")"
+
+# Extract memory_size from the kernel configuration.
+MEMORY_SIZE="$(get_value_from_toml "${KERNEL_CONFIG}" "memory_size")"
+
+# Generate the manifest using jq to safely escape all values.
+# Write to a temporary file and move into place for an atomic update. If jq fails unexpectedly, we
+# don't leave behind a corrupted manifest.
+TMP_FILE="$(mktemp)"
+trap 'rm -f "${TMP_FILE}"' EXIT
+jq -n \
+  --arg version         "${VERSION}" \
+  --arg machine         "${MACHINE}" \
+  --arg target          "${TARGET}" \
+  --arg deployment_mode "${DEPLOYMENT_MODE}" \
+  --arg build_mode      "${BUILD_MODE}" \
+  --arg log_level       "${LOG_LEVEL}" \
+  --arg timestamp       "${TIMESTAMP}" \
+  --arg git_commit      "${GIT_COMMIT}" \
+  --argjson memory_size "${MEMORY_SIZE}" \
+  '{
+    version: $version,
+    machine: $machine,
+    target: $target,
+    deployment_mode: $deployment_mode,
+    build_mode: $build_mode,
+    log_level: $log_level,
+    timestamp: $timestamp,
+    git_commit: $git_commit,
+    memory_size: $memory_size
+  }' > "${TMP_FILE}"
+mv "${TMP_FILE}" "${OUTPUT_FILE}"


### PR DESCRIPTION
## Summary

Add a `generate-manifest.sh` script that produces a JSON manifest (`manifest.json`) with build metadata, kernel configuration, and git info, included in the release archive.

## Changes

- **Makefile**: Add `MANIFEST_FILE` variable and `release-generate-manifest` target, wired into the `release` target. Pass `kernel_config.toml` path to the script.
- **scripts/generate-manifest.sh**: New script that:
  - Validates required external utilities (`jq`, `date`) are installed.
  - Collects build parameters (version, machine, target, deployment mode, build mode, log level).
  - Extracts `memory_size` from `kernel_config.toml` using the existing `get_value_from_toml()` utility.
  - Collects git commit hash when available (git is optional).
  - Writes a safely-escaped JSON manifest via `jq` atomically through a temp file.

## Manifest Fields

| Field             | Source                          |
|-------------------|---------------------------------|
| `version`         | Cargo metadata                  |
| `machine`         | Build parameter                 |
| `target`          | Build parameter                 |
| `deployment_mode` | Build parameter                 |
| `build_mode`      | debug or release                |
| `log_level`       | Build parameter                 |
| `timestamp`       | UTC build time                  |
| `git_commit`      | HEAD SHA (or "unknown")         |
| `memory_size`     | `build/kernel_config.toml`      |