### PR TITLE
[build] Add `memory_size_mb` to release archive

### DIFF
--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -14,33 +14,52 @@ inputs:
 
 outputs:
   archive-path:
-    description: "Path to the generated release archive"
+    description: "Newline-separated paths to the generated release archives"
     value: ${{ steps.package.outputs.archive-path }}
 
 runs:
   using: "composite"
   steps:
-  - id: package
-    name: "Package Release Archive"
-    shell: bash
-    env:
-      MACHINE_TYPE: ${{ inputs.machine-type }}
-      DEPLOYMENT_TYPE: ${{ inputs.deployment-type }}
-    run: |
-      # Find the pre-built release archive produced by 'make release' inside
-      # Docker during the ci-build step. Building the archive inside Docker
-      # preserves file permissions (e.g., the execute bit on ELF binaries)
-      # that GitHub Actions artifact transfer would otherwise strip.
-      archive_src=$(ls -1t nanvix-*.tar.bz2 2>/dev/null | head -n 1)
-      if [[ -z "${archive_src}" ]]; then
-        echo "::error::No pre-built release archive found. Ensure ci-build ran 'make release'."
-        exit 1
-      fi
+    - id: package
+      name: "Package Release Archive"
+      shell: bash
+      env:
+        MACHINE_TYPE: ${{ inputs.machine-type }}
+        DEPLOYMENT_TYPE: ${{ inputs.deployment-type }}
+      run: |
+        # Find the pre-built release archive produced by 'make release' inside
+        # Docker during the ci-build step. Building the archive inside Docker
+        # preserves file permissions (e.g., the execute bit on ELF binaries)
+        # that GitHub Actions artifact transfer would otherwise strip.
+        archive_src=$(ls -1t nanvix-*.tar.bz2 2>/dev/null | head -n 1)
+        if [[ -z "${archive_src}" ]]; then
+          echo "::error::No pre-built release archive found. Ensure ci-build ran 'make release'."
+          exit 1
+        fi
 
-      commit_id="${GITHUB_SHA}"
-      archive_name="nanvix-${MACHINE_TYPE}-${DEPLOYMENT_TYPE}-release-${commit_id}.tar.bz2"
+        # Extract memory_size from kernel config and convert to megabytes.
+        memory_size_bytes=$(sed -nE 's/^[[:space:]]*memory_size[[:space:]]*=[[:space:]]*(0x[0-9a-fA-F]+|[0-9]+).*/\1/p' build/kernel_config.toml | head -n1)
+        if [[ -z "${memory_size_bytes}" ]]; then
+          echo "::error::Failed to extract memory_size from build/kernel_config.toml."
+          exit 1
+        fi
+        memory_size_mb=$(( memory_size_bytes / 1048576 ))
 
-      echo "Reusing pre-built release archive: ${archive_src} -> ${archive_name}"
-      mv "${archive_src}" "${archive_name}"
+        commit_id="${GITHUB_SHA}"
+        archive_ext=".tar.bz2"
 
-      echo "archive-path=${archive_name}" >> "${GITHUB_OUTPUT}"
+        # Legacy format (backward-compatible; will be removed in a future release).
+        archive_legacy="nanvix-${MACHINE_TYPE}-${DEPLOYMENT_TYPE}-release-${commit_id}${archive_ext}"
+        # New format including memory size.
+        archive_new="nanvix-${MACHINE_TYPE}-${DEPLOYMENT_TYPE}-release-${memory_size_mb}mb-${commit_id}${archive_ext}"
+
+        echo "Creating release archives from: ${archive_src}"
+        cp "${archive_src}" "${archive_legacy}"
+        mv "${archive_src}" "${archive_new}"
+
+        {
+          echo "archive-path<<ARCHIVE_EOF"
+          echo "${archive_legacy}"
+          echo "${archive_new}"
+          echo "ARCHIVE_EOF"
+        } >> "${GITHUB_OUTPUT}"

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,15 @@ endif
 RELEASE_DEPLOYMENT_MODE := $(subst -,_,$(DEPLOYMENT_MODE))
 RELEASE_BUILD_MODE := $(if $(filter yes,$(RELEASE)),release,debug)
 RELEASE_VERSION := $(strip $(shell cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.packages[0].version'))
+
+# Extract memory_size (bytes) from kernel config and convert to megabytes.
+MEMORY_SIZE_BYTES = $(strip $(shell sed -nE 's/^[[:space:]]*memory_size[[:space:]]*=[[:space:]]*(0x[0-9a-fA-F]+|[0-9]+).*/\1/p' $(BUILD_DIR)/kernel_config.toml | head -n1))
+MEMORY_SIZE_MB = $(shell echo $$(($(MEMORY_SIZE_BYTES) / 1048576)))
+
+# Legacy archive name (kept for backward compatibility; will be removed in a future release).
 RELEASE_ARCHIVE := nanvix-$(RELEASE_VERSION)-$(MACHINE)-$(RELEASE_DEPLOYMENT_MODE)-$(RELEASE_BUILD_MODE)-$(LOG_LEVEL).tar.bz2
+# New archive name including memory size.
+RELEASE_ARCHIVE_NEW = nanvix-$(RELEASE_VERSION)-$(MACHINE)-$(RELEASE_DEPLOYMENT_MODE)-$(RELEASE_BUILD_MODE)-$(LOG_LEVEL)-$(MEMORY_SIZE_MB)mb.tar.bz2
 MANIFEST_FILE := $(SYSROOT_DIR)/manifest.json
 
 #===================================================================================================
@@ -525,9 +533,13 @@ release-generate-manifest:
 		$(BUILD_DIR)/kernel_config.toml
 
 release: all install release-generate-manifest
+	@test -n "$(MEMORY_SIZE_MB)" || { echo "ERROR: Failed to extract memory_size from kernel_config.toml"; exit 1; }
 	@echo "Creating release archive ${RELEASE_ARCHIVE} from ${SYSROOT_DIR}..."
 	@$(RM_CMD) ${RELEASE_ARCHIVE}
 	@tar -cjf ${RELEASE_ARCHIVE} --exclude=./src -C ${SYSROOT_DIR} .
+	@echo "Creating release archive ${RELEASE_ARCHIVE_NEW} from ${SYSROOT_DIR}..."
+	@$(RM_CMD) ${RELEASE_ARCHIVE_NEW}
+	@cp ${RELEASE_ARCHIVE} ${RELEASE_ARCHIVE_NEW}
 
 # Shows available make targets and build parameters.
 help:

--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -959,11 +959,11 @@ impl Registry {
     /// The commit ID is encoded in the release filename and uniquely identifies a specific
     /// build of Nanvix artifacts.
     ///
-    /// Example URL format:
-    /// `https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-abc123def456.tar.bz2`
+    /// Supported URL formats:
+    /// - Legacy: `https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-abc123def456.tar.bz2`
+    /// - New:    `https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.bz2`
     ///
-    /// This method parses the filename to extract the commit ID between "release-" and
-    /// the file extension (e.g., `abc123def456` from the example above).
+    /// The commit ID is always the last hyphen-delimited segment before the file extension.
     ///
     /// # Parameters
     ///
@@ -978,20 +978,24 @@ impl Registry {
         // Extract the filename from the URL.
         let filename: &str = url.rsplit('/').next()?;
 
-        // Find "release-" prefix.
-        let release_prefix: &str = "release-";
-        let start_idx: usize = filename.find(release_prefix)? + release_prefix.len();
+        // Strip known archive extensions.
+        let stem: &str = filename
+            .strip_suffix(".tar.bz2")
+            .or_else(|| filename.strip_suffix(".tar.gz"))?;
 
-        // Find the first dot after "release-" to identify start of file extension.
-        let remaining: &str = &filename[start_idx..];
-        let end_idx: usize = start_idx + remaining.find('.')?;
+        // Ensure the filename contains "release-" to validate the format.
+        if !stem.contains("release-") {
+            return None;
+        }
 
-        // Extract and validate the commit ID.
-        if start_idx < end_idx {
-            let commit_id: &str = &filename[start_idx..end_idx];
-            Some(commit_id.to_string())
-        } else {
+        // The commit ID is the last hyphen-delimited segment of the stem.
+        let commit_id: &str = stem.rsplit('-').next()?;
+
+        // Validate that the commit ID is a non-empty hexadecimal string.
+        if commit_id.is_empty() || !commit_id.chars().all(|c: char| c.is_ascii_hexdigit()) {
             None
+        } else {
+            Some(commit_id.to_string())
         }
     }
 
@@ -1492,17 +1496,41 @@ mod tests {
     ///
     #[test]
     fn test_extract_commit_id() {
-        // Test valid URL with commit ID.
+        // Test valid legacy URL with commit ID.
         let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-abc123def456.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
         assert_eq!(commit_id.expect("failed"), "abc123def456");
 
-        // Test another valid URL format.
+        // Test another valid legacy URL format.
         let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-microvm-single-process-release-1a2b3c4d5e6f.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
         assert_eq!(commit_id.expect("failed"), "1a2b3c4d5e6f");
+
+        // Test new URL format with memory size.
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.bz2";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_some());
+        assert_eq!(commit_id.expect("failed"), "abc123def456");
+
+        // Test new URL format with different memory size.
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-microvm-single-process-release-256mb-1a2b3c4d5e6f.tar.bz2";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_some());
+        assert_eq!(commit_id.expect("failed"), "1a2b3c4d5e6f");
+
+        // Test valid URL with .tar.gz extension.
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-abc123def456.tar.gz";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_some());
+        assert_eq!(commit_id.expect("failed"), "abc123def456");
+
+        // Test new URL format with .tar.gz extension.
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.gz";
+        let commit_id: Option<String> = Registry::extract_commit_id(url);
+        assert!(commit_id.is_some());
+        assert_eq!(commit_id.expect("failed"), "abc123def456");
 
         // Test URL without release prefix.
         let url: &str =

--- a/src/libs/nanvix-registry/src/release.rs
+++ b/src/libs/nanvix-registry/src/release.rs
@@ -252,6 +252,12 @@ mod tests {
 
         let pattern: String = format!("nanvix-{}-{}-release", machine, deployment);
         assert_eq!(pattern, "nanvix-hyperlight-multi-process-release");
+
+        // Verify the pattern matches both legacy and new archive name formats.
+        let legacy_name: &str = "nanvix-hyperlight-multi-process-release-abc123def456.tar.bz2";
+        let new_name: &str = "nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.bz2";
+        assert!(legacy_name.contains(&pattern));
+        assert!(new_name.contains(&pattern));
     }
 
     ///


### PR DESCRIPTION
Include memory size (in MB) from kernel_config.toml in release archive filenames. Both legacy and new naming formats are produced during this transition period so downstream consumers can migrate.

## Makefile changes
- Extract `MEMORY_SIZE_BYTES` and `MEMORY_SIZE_MB` from `kernel_config.toml` using deferred evaluation (`=`) so the shell commands only run when the `release` target is invoked.
- Define `RELEASE_ARCHIVE_NEW` with the new format: `nanvix-VERSION-MACHINE-DEPLOY-BUILD-LOG_LEVEL-Nmb.tar.bz2`
- Produce both legacy and new archives in the `release` target.

## CI release-package action
- Extract `memory_size_mb` from `kernel_config.toml`.
- Produce both legacy and new CI-published archives:
  - `nanvix-MACHINE-DEPLOY-release-COMMIT.tar.bz2` (legacy)
  - `nanvix-MACHINE-DEPLOY-release-Nmb-COMMIT.tar.bz2` (new)
- Output both paths for upload-artifact.

## nanvix-registry forward-compatibility
- Update `extract_commit_id()` to parse the last hyphen-delimited segment before the file extension, instead of everything between `release-` and the first dot. This handles both old and new filename formats.
- Add tests for the new URL format in `lib.rs` and `release.rs`.