### PR TITLE
[build] Remove legacy release archive naming

### DIFF
--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -14,7 +14,7 @@ inputs:
 
 outputs:
   archive-path:
-    description: "Newline-separated paths to the generated release archives"
+    description: "Path to the generated release archive"
     value: ${{ steps.package.outputs.archive-path }}
 
 runs:
@@ -46,20 +46,9 @@ runs:
         memory_size_mb=$(( memory_size_bytes / 1048576 ))
 
         commit_id="${GITHUB_SHA}"
-        archive_ext=".tar.bz2"
+        archive_name="nanvix-${MACHINE_TYPE}-${DEPLOYMENT_TYPE}-release-${memory_size_mb}mb-${commit_id}.tar.bz2"
 
-        # Legacy format (backward-compatible; will be removed in a future release).
-        archive_legacy="nanvix-${MACHINE_TYPE}-${DEPLOYMENT_TYPE}-release-${commit_id}${archive_ext}"
-        # New format including memory size.
-        archive_new="nanvix-${MACHINE_TYPE}-${DEPLOYMENT_TYPE}-release-${memory_size_mb}mb-${commit_id}${archive_ext}"
+        echo "Reusing pre-built release archive: ${archive_src} -> ${archive_name}"
+        mv "${archive_src}" "${archive_name}"
 
-        echo "Creating release archives from: ${archive_src}"
-        cp "${archive_src}" "${archive_legacy}"
-        mv "${archive_src}" "${archive_new}"
-
-        {
-          echo "archive-path<<ARCHIVE_EOF"
-          echo "${archive_legacy}"
-          echo "${archive_new}"
-          echo "ARCHIVE_EOF"
-        } >> "${GITHUB_OUTPUT}"
+        echo "archive-path=${archive_name}" >> "${GITHUB_OUTPUT}"

--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,7 @@ RELEASE_VERSION := $(strip $(shell cargo metadata --no-deps --format-version 1 2
 MEMORY_SIZE_BYTES = $(strip $(shell sed -nE 's/^[[:space:]]*memory_size[[:space:]]*=[[:space:]]*(0x[0-9a-fA-F]+|[0-9]+).*/\1/p' $(BUILD_DIR)/kernel_config.toml | head -n1))
 MEMORY_SIZE_MB = $(shell echo $$(($(MEMORY_SIZE_BYTES) / 1048576)))
 
-# Legacy archive name (kept for backward compatibility; will be removed in a future release).
-RELEASE_ARCHIVE := nanvix-$(RELEASE_VERSION)-$(MACHINE)-$(RELEASE_DEPLOYMENT_MODE)-$(RELEASE_BUILD_MODE)-$(LOG_LEVEL).tar.bz2
-# New archive name including memory size.
-RELEASE_ARCHIVE_NEW = nanvix-$(RELEASE_VERSION)-$(MACHINE)-$(RELEASE_DEPLOYMENT_MODE)-$(RELEASE_BUILD_MODE)-$(LOG_LEVEL)-$(MEMORY_SIZE_MB)mb.tar.bz2
+RELEASE_ARCHIVE := nanvix-$(RELEASE_VERSION)-$(MACHINE)-$(RELEASE_DEPLOYMENT_MODE)-$(RELEASE_BUILD_MODE)-$(LOG_LEVEL)-$(MEMORY_SIZE_MB)mb.tar.bz2
 MANIFEST_FILE := $(SYSROOT_DIR)/manifest.json
 
 #===================================================================================================
@@ -537,9 +534,6 @@ release: all install release-generate-manifest
 	@echo "Creating release archive ${RELEASE_ARCHIVE} from ${SYSROOT_DIR}..."
 	@$(RM_CMD) ${RELEASE_ARCHIVE}
 	@tar -cjf ${RELEASE_ARCHIVE} --exclude=./src -C ${SYSROOT_DIR} .
-	@echo "Creating release archive ${RELEASE_ARCHIVE_NEW} from ${SYSROOT_DIR}..."
-	@$(RM_CMD) ${RELEASE_ARCHIVE_NEW}
-	@cp ${RELEASE_ARCHIVE} ${RELEASE_ARCHIVE_NEW}
 
 # Shows available make targets and build parameters.
 help:

--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -1496,37 +1496,19 @@ mod tests {
     ///
     #[test]
     fn test_extract_commit_id() {
-        // Test valid legacy URL with commit ID.
-        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-abc123def456.tar.bz2";
-        let commit_id: Option<String> = Registry::extract_commit_id(url);
-        assert!(commit_id.is_some());
-        assert_eq!(commit_id.expect("failed"), "abc123def456");
-
-        // Test another valid legacy URL format.
-        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-microvm-single-process-release-1a2b3c4d5e6f.tar.bz2";
-        let commit_id: Option<String> = Registry::extract_commit_id(url);
-        assert!(commit_id.is_some());
-        assert_eq!(commit_id.expect("failed"), "1a2b3c4d5e6f");
-
-        // Test new URL format with memory size.
+        // Test valid URL with commit ID and memory size.
         let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
         assert_eq!(commit_id.expect("failed"), "abc123def456");
 
-        // Test new URL format with different memory size.
+        // Test another valid URL format with different memory size.
         let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-microvm-single-process-release-256mb-1a2b3c4d5e6f.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
         assert_eq!(commit_id.expect("failed"), "1a2b3c4d5e6f");
 
         // Test valid URL with .tar.gz extension.
-        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-abc123def456.tar.gz";
-        let commit_id: Option<String> = Registry::extract_commit_id(url);
-        assert!(commit_id.is_some());
-        assert_eq!(commit_id.expect("failed"), "abc123def456");
-
-        // Test new URL format with .tar.gz extension.
         let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.gz";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());


### PR DESCRIPTION
[build] E: Remove legacy release archive naming

Remove the backward-compatible legacy archive format, keeping only the
new naming that includes memory_size_mb.

Makefile changes:
- Remove RELEASE_ARCHIVE (legacy) and RELEASE_ARCHIVE_NEW distinction.
- RELEASE_ARCHIVE now uses the new format directly:
  nanvix-VERSION-MACHINE-DEPLOY-BUILD-LOG_LEVEL-<N>mb.tar.bz2
- Produce only a single archive in the release target.

CI release-package action:
- Remove legacy archive creation (cp + multiline output).
- Produce only the new-format CI-published archive:
  nanvix-MACHINE-DEPLOY-release-<N>mb-COMMIT.tar.bz2
- Revert to single-line archive-path output.

nanvix-registry tests:
- Remove legacy URL test cases from test_extract_commit_id.
- Keep only new-format URL tests with memory size.