### PR TITLE
[linuxd] Fix missing MESSAGE_FRAME in err

### DIFF
--- a/src/daemons/linuxd/src/lib.rs
+++ b/src/daemons/linuxd/src/lib.rs
@@ -928,6 +928,17 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
                         let mut writer_guard: MutexGuard<'_, SocketStreamWriter> =
                             uvm_writer.lock().await;
                         let err_bytes: [u8; IPC_MESSAGE_SIZE] = err_msg.to_bytes();
+                        writer_guard
+                            .write_all(&[IkcFrame::MESSAGE_FRAME])
+                            .await
+                            .map_err(|e| {
+                                let reason: &str = "failed to send error message to user VM";
+                                error!(
+                                    "forward_user_vm_msg_to_worker_thread(): {reason} \
+                                     (error={e:?})"
+                                );
+                                Error::new(ErrorCode::IoErr, reason)
+                            })?;
                         writer_guard.write_all(&err_bytes).await.map_err(|e| {
                             let reason: &str = "failed to send error message to user VM";
                             error!(


### PR DESCRIPTION
When a user VM process failed to join a virtual environment, linuxd sent
the serialized error Message directly over the IKC socket without first
writing the MESSAGE_FRAME framing byte. The receiving side (user VM)
expects every IPC message to be preceded by a one-byte frame-type header
(IkcFrame::MESSAGE_FRAME) so it can distinguish message frames from data
chunk frames in the recv() protocol loop.

Without the framing byte the first byte of the serialized message was
misinterpreted as a frame type, corrupting the stream and causing the
user VM to either reject the data as an unknown frame or
desynchronize all subsequent communication on the socket.

Add the missing write_all(&[IkcFrame::MESSAGE_FRAME]) call before the
error message payload write in the forward_user_vm_msg_to_worker_thread()
venv-join error path, consistent with how recv() expects framed data.