### PR TITLE
[build] Remove memfs feature flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,21 +38,6 @@ ifeq ($(filter $(DEPLOYMENT_MODE),$(VALID_DEPLOYMENT_MODES)),)
 $(error Invalid DEPLOYMENT_MODE '$(DEPLOYMENT_MODE)'. Valid values: $(VALID_DEPLOYMENT_MODES))
 endif
 
-# Enable in-memory FAT32 filesystem?
-export MEMFS ?= no
-
-# Standalone mode implies memfs.
-ifeq ($(DEPLOYMENT_MODE),standalone)
-override MEMFS := yes
-endif
-
-# Validate that MEMFS is only enabled in standalone mode.
-ifeq ($(MEMFS),yes)
-ifneq ($(DEPLOYMENT_MODE),standalone)
-$(error MEMFS=yes requires DEPLOYMENT_MODE=standalone (current: $(DEPLOYMENT_MODE)))
-endif
-endif
-
 # Log Level
 export LOG_LEVEL ?= warn
 
@@ -366,7 +351,10 @@ ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap config elf error fat32 type-safe pr
 ALL_GUEST_DAEMONS := memd procd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd
 ALL_GUEST_APPLICATIONS := hello-rust-nostd
-ALL_GUEST_TESTS := testd file-rust thread-rust stress-rust test-kernel test-mmio-fault linux-app arch-rust vfs-test
+ALL_GUEST_TESTS := testd file-rust thread-rust stress-rust test-kernel test-mmio-fault linux-app arch-rust
+ifeq ($(DEPLOYMENT_MODE),standalone)
+ALL_GUEST_TESTS += vfs-test
+endif
 ALL_GUEST_BINARIES := $(ALL_GUEST_DAEMONS) $(ALL_GUEST_BENCHMARKS) $(ALL_GUEST_APPLICATIONS)
 ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 

--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -2,12 +2,8 @@
 # Licensed under the MIT License.
 
 GUEST_STATICLIB_FEATURES := staticlib $(LOG_LEVEL)
-# Enable in-memory FAT32 filesystem for POSIX file I/O interception.
-ifeq ($(MEMFS),yes)
-GUEST_STATICLIB_FEATURES += memfs
-endif
 # Enable standalone mode: routes stdout/stderr to debug kcall,
-# file I/O to memfs, and disables IPC-based syscalls (no linuxd).
+# file I/O to in-memory VFS, and disables IPC-based syscalls (no linuxd).
 ifeq ($(DEPLOYMENT_MODE),standalone)
 GUEST_STATICLIB_FEATURES += standalone
 endif

--- a/doc/build.md
+++ b/doc/build.md
@@ -80,13 +80,11 @@ make all
 ```
 
 You can also build in **standalone mode**, which excludes `linuxd` and routes all I/O through the
-local memfs VFS layer and kernel debug serial port:
+local in-memory VFS layer and kernel debug serial port:
 
 ```bash
 make all DEPLOYMENT_MODE=standalone
 ```
-
-Standalone mode implies `MEMFS=yes` automatically.
 
 ## Formal Verification with Verus
 

--- a/src/libs/nvx/Cargo.toml
+++ b/src/libs/nvx/Cargo.toml
@@ -30,7 +30,7 @@ sysalloc = { workspace = true }
 [features]
 default = ["staticlib"]
 staticlib = []
-memfs = ["dep:vfs"]
+standalone = ["dep:vfs"]
 rustc-dep-of-std = [
     "alloc",
     "core",

--- a/src/libs/nvx/src/lib.rs
+++ b/src/libs/nvx/src/lib.rs
@@ -28,8 +28,8 @@ extern crate alloc;
 
 use ::config::memory_layout::USER_BASE_RAW;
 
-/// Re-export the VFS crate when the `memfs` feature is enabled.
-#[cfg(feature = "memfs")]
+/// Re-export the VFS crate when the `standalone` feature is enabled.
+#[cfg(feature = "standalone")]
 pub use ::vfs;
 
 #[cfg(not(feature = "staticlib"))]
@@ -334,8 +334,8 @@ fn init() {
     }
 
     // Initialize in-memory filesystem from RAMFS MMIO region (if present).
-    #[cfg(feature = "memfs")]
-    memfs_init();
+    #[cfg(feature = "standalone")]
+    vfs_init_ramfs();
 }
 
 /// Cleans up system runtime.
@@ -356,7 +356,7 @@ fn cleanup() {
 
 /// Initializes the VFS and mounts the RAMFS MMIO region at the root (`/`).
 ///
-/// Called automatically during guest startup when the `memfs` feature is
+/// Called automatically during guest startup when the `standalone` feature is
 /// enabled. The RAMFS MMIO region is provided by the hypervisor via a
 /// well-known tag. If no RAMFS region is present, this function silently
 /// returns (the guest may not have been launched with `-ramfs`).
@@ -367,8 +367,8 @@ fn cleanup() {
 /// cleanup on exit) so the mounted image remains valid. The image is
 /// mounted at `/` so it serves as the root filesystem and relative paths
 /// resolve naturally against it.
-#[cfg(feature = "memfs")]
-fn memfs_init() {
+#[cfg(feature = "standalone")]
+fn vfs_init_ramfs() {
     use ::sys::{
         mm::Address,
         pm::Capability,
@@ -382,13 +382,13 @@ fn memfs_init() {
 
     // Initialize the VFS (idempotent — ignore AlreadyInitialized).
     if ::vfs::init().is_err() && !::vfs::is_initialized() {
-        ::syslog::warn!("memfs_init(): failed to initialize VFS");
+        ::syslog::warn!("vfs_init_ramfs(): failed to initialize VFS");
         return;
     }
 
     // Acquire IO management capability.
     if ::sys::kcall::pm::capctl(Capability::IoManagement, true).is_err() {
-        ::syslog::warn!("memfs_init(): failed to acquire IoManagement capability");
+        ::syslog::warn!("vfs_init_ramfs(): failed to acquire IoManagement capability");
         return;
     }
 
@@ -413,7 +413,7 @@ fn memfs_init() {
         // Mount the FAT image directly from the MMIO region (mapped read-write by the kernel).
         // The MMIO allocation is kept for the process lifetime so the image remains valid.
         if unsafe { ::vfs::mount_image(RAMFS_MOUNT_PATH, base_ptr, total_size) }.is_err() {
-            ::syslog::warn!("memfs_init(): failed to mount RAMFS image");
+            ::syslog::warn!("vfs_init_ramfs(): failed to mount RAMFS image");
             let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
             return false;
         }
@@ -425,6 +425,6 @@ fn memfs_init() {
     let _ = ::sys::kcall::pm::capctl(Capability::IoManagement, false);
 
     if mounted {
-        ::syslog::info!("memfs_init(): mounted RAMFS at {}", RAMFS_MOUNT_PATH);
+        ::syslog::info!("vfs_init_ramfs(): mounted RAMFS at {}", RAMFS_MOUNT_PATH);
     }
 }

--- a/src/libs/posix/Cargo.toml
+++ b/src/libs/posix/Cargo.toml
@@ -35,8 +35,7 @@ type-safe = { workspace = true }
 default = ["syscall", "allocator", "staticlib"]
 allocator = ["dep:sysalloc"]
 syscall = ["syslog", "syscall/dlfcn", "syscall/sbrk"]
-memfs = ["syscall/memfs"]
-standalone = ["memfs", "syscall/standalone"]
+standalone = ["syscall/standalone"]
 std = []
 staticlib = ["nvx/staticlib"]
 

--- a/src/libs/syscall/Cargo.toml
+++ b/src/libs/syscall/Cargo.toml
@@ -65,8 +65,7 @@ rustc-dep-of-std = [
     "spin/rustc-dep-of-std",
 ]
 sbrk = ["dep:sysalloc"]
-memfs = ["dep:nvx", "nvx/memfs", "dep:sysalloc"]
-standalone = ["memfs"]
+standalone = ["dep:nvx", "nvx/standalone", "dep:sysalloc"]
 
 # TODO (#798): remove this feature flag once the signal module is stable.
 sigaction = []

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -10,10 +10,6 @@
 #![feature(never_type)] // pthread requires this.
 #![feature(c_variadic)] // fcntl requires this.
 
-// Standalone mode requires memfs — reject the invalid combination at compile time.
-#[cfg(all(feature = "standalone", not(feature = "memfs")))]
-compile_error!("the `standalone` feature requires `memfs` to be enabled");
-
 //==================================================================================================
 // Modules
 //==================================================================================================

--- a/test/test-l2.toml
+++ b/test/test-l2.toml
@@ -58,14 +58,6 @@ runs_on = ["microvm"]
 
 [[tests]]
 executor = "http"
-program = "./bin/vfs-test.elf"
-extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
-input = "[]"
-expect_empty_output = true
-runs_on = ["microvm"]
-
-[[tests]]
-executor = "http"
 program = "./bin/echo-c.elf"
 input = "hello world!"
 expected_output = "hello world!"

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -58,14 +58,6 @@ runs_on = ["microvm"]
 
 [[tests]]
 executor = "http"
-program = "./bin/vfs-test.elf"
-extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
-input = "[]"
-expect_empty_output = true
-runs_on = ["microvm"]
-
-[[tests]]
-executor = "http"
 program = "./bin/echo-c.elf"
 input = "hello world!"
 expected_output = "hello world!"
@@ -192,14 +184,6 @@ extra_nanvixd_args = "-ramfs README.md"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
-
-[[tests]]
-executor = "terminal"
-program = "./bin/vfs-test.elf"
-extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
-input = "[]"
-expect_empty_output = true
 runs_on = ["microvm"]
 
 [[tests]]

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -57,14 +57,6 @@ runs_on = ["microvm"]
 
 [[tests]]
 executor = "http"
-program = "./bin/vfs-test.elf"
-extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
-input = "[]"
-expect_empty_output = true
-runs_on = ["microvm"]
-
-[[tests]]
-executor = "http"
 program = "./bin/echo-c.elf"
 input = "hello world!"
 expected_output = "hello world!"
@@ -191,14 +183,6 @@ extra_nanvixd_args = "-ramfs README.md"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
-
-[[tests]]
-executor = "terminal"
-program = "./bin/vfs-test.elf"
-extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
-input = "[]"
-expect_empty_output = true
 runs_on = ["microvm"]
 
 [[tests]]

--- a/test/test.toml
+++ b/test/test.toml
@@ -57,14 +57,6 @@ runs_on = ["microvm"]
 
 [[tests]]
 executor = "http"
-program = "./bin/vfs-test.elf"
-extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
-input = "[]"
-expect_empty_output = true
-runs_on = ["microvm"]
-
-[[tests]]
-executor = "http"
 program = "./bin/echo-c.elf"
 input = "hello world!"
 expected_output = "hello world!"
@@ -191,14 +183,6 @@ extra_nanvixd_args = "-ramfs README.md"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
-
-[[tests]]
-executor = "terminal"
-program = "./bin/vfs-test.elf"
-extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
-input = "[]"
-expect_empty_output = true
 runs_on = ["microvm"]
 
 [[tests]]


### PR DESCRIPTION
## Summary

Remove the standalone `memfs` feature flag and fold its functionality into the existing `standalone` feature. The in-memory VFS (backed by a RAMFS MMIO region) is now activated automatically when `standalone` mode is selected, eliminating a redundant build knob.

## Changes

- **Makefile**: Remove `MEMFS` variable and its validation logic; gate `vfs-test` on `DEPLOYMENT_MODE=standalone` instead.
- **build/make/generic-guest-staticlibs.mk**: Drop the `memfs` feature injection; update comment to say "in-memory VFS".
- **src/libs/nvx**: Rename feature `memfs` to `standalone`; rename `memfs_init()` to `vfs_init_ramfs()`.
- **src/libs/syscall**: Merge `memfs` into `standalone` feature; remove the `compile_error!` guard.
- **src/libs/posix**: Remove the intermediate `memfs` feature re-export.
- **test configs**: Remove `vfs-test` entries from non-standalone test profiles.
- **doc/build.md**: Update wording from "memfs" to "in-memory VFS"; remove note about `MEMFS=yes`.