### PR TITLE
[registry] Add memory_size_mb parameter to registry APIs

### DIFF
--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //!     // Get a cached binary (downloads if not already cached).
 //!     let binary_path: String = registry
-//!         .get_cached_binary("microvm", "single-process", "kernel.elf")
+//!         .get_cached_binary("microvm", "single-process", 128, "kernel.elf")
 //!         .await?;
 //!
 //!     println!("Binary path: {}", binary_path);
@@ -73,7 +73,7 @@
 //!     // This will automatically download openssl, zlib, and other required packages.
 //!     // Use `true` to fall back to latest version if compatible version not found.
 //!     let install_path: String = registry
-//!         .install("microvm", "single-process", "python", true)
+//!         .install("microvm", "single-process", 128, "python", true)
 //!         .await?;
 //!
 //!     println!("Python installed to: {}", install_path);
@@ -96,7 +96,7 @@
 //!
 //!     // Use the registry normally - it will use the custom directory.
 //!     let binary_path: String = registry
-//!         .get_cached_binary("hyperlight", "multi-process", "kernel.elf")
+//!         .get_cached_binary("hyperlight", "multi-process", 128, "kernel.elf")
 //!         .await?;
 //!
 //!     Ok(())
@@ -258,6 +258,8 @@ struct InstallContext<'a> {
     machine: Machine,
     /// Deployment type.
     deployment: Deployment,
+    /// Memory size in megabytes.
+    memory_size_mb: u32,
     /// Nanvix commit ID.
     commit_id: &'a str,
     /// Cache directory path.
@@ -277,6 +279,11 @@ impl<'a> InstallContext<'a> {
     /// Returns the deployment type.
     fn deployment(&self) -> Deployment {
         self.deployment
+    }
+
+    /// Returns the memory size in megabytes.
+    fn memory_size_mb(&self) -> u32 {
+        self.memory_size_mb
     }
 
     /// Returns the Nanvix commit ID.
@@ -320,7 +327,7 @@ impl<'a> InstallContext<'a> {
 ///
 ///     // Get the kernel binary for microvm single-process deployment.
 ///     let kernel_path: String = registry
-///         .get_cached_binary("microvm", "single-process", "kernel.elf")
+///         .get_cached_binary("microvm", "single-process", 128, "kernel.elf")
 ///         .await?;
 ///
 ///     Ok(())
@@ -385,6 +392,7 @@ impl Registry {
     /// - `deployment`: Deployment type. Supported values:
     ///   - `"single-process"`: Single-process deployment mode.
     ///   - `"multi-process"`: Multi-process deployment mode.
+    /// - `memory_size_mb`: Memory size in megabytes for selecting the correct release archive.
     /// - `binary_name`: Name of the binary file (e.g., `"qjs"`, `"python3"`, `"kernel.elf"`).
     ///
     /// # Returns
@@ -412,7 +420,7 @@ impl Registry {
     ///
     ///     // Get the QuickJS binary for hyperlight multi-process deployment.
     ///     let qjs_path: String = registry
-    ///         .get_cached_binary("hyperlight", "multi-process", "qjs")
+    ///         .get_cached_binary("hyperlight", "multi-process", 128, "qjs")
     ///         .await?;
     ///
     ///     println!("QuickJS binary: {}", qjs_path);
@@ -425,11 +433,18 @@ impl Registry {
         &self,
         machine: &str,
         deployment: &str,
+        memory_size_mb: u32,
         binary_name: &str,
     ) -> Result<String> {
         // Use get_cached_artifact to search for the binary within the "bin" directory.
-        self.get_cached_artifact(machine, deployment, binary_name, Some(BINARY_DIRECTORY_NAME))
-            .await
+        self.get_cached_artifact(
+            machine,
+            deployment,
+            memory_size_mb,
+            binary_name,
+            Some(BINARY_DIRECTORY_NAME),
+        )
+        .await
     }
 
     ///
@@ -449,6 +464,7 @@ impl Registry {
     /// - `deployment`: Deployment type. Supported values:
     ///   - `"single-process"`: Single-process deployment mode.
     ///   - `"multi-process"`: Multi-process deployment mode.
+    /// - `memory_size_mb`: Memory size in megabytes for selecting the correct release archive.
     /// - `artifact_name`: Name of the artifact file to search for (e.g., `"config.json"`, `"lib.so"`).
     /// - `dir`: Optional directory path relative to the cache directory root where the artifact
     ///   should be searched. If `None`, searches from the cache directory root.
@@ -479,12 +495,12 @@ impl Registry {
     ///
     ///     // Search for a configuration file from the cache directory root.
     ///     let config_path: String = registry
-    ///         .get_cached_artifact("hyperlight", "multi-process", "config.json", None)
+    ///         .get_cached_artifact("hyperlight", "multi-process", 128, "config.json", None)
     ///         .await?;
     ///
     ///     // Search for a library file in a specific subdirectory.
     ///     let lib_path: String = registry
-    ///         .get_cached_artifact("microvm", "single-process", "libssl.so", Some("lib"))
+    ///         .get_cached_artifact("microvm", "single-process", 128, "libssl.so", Some("lib"))
     ///         .await?;
     ///
     ///     println!("Configuration file: {}", config_path);
@@ -498,9 +514,12 @@ impl Registry {
         &self,
         machine: &str,
         deployment: &str,
+        memory_size_mb: u32,
         artifact_name: &str,
         dir: Option<&str>,
     ) -> Result<String> {
+        anyhow::ensure!(memory_size_mb > 0, "memory_size_mb must be greater than 0");
+
         let cache_dir: PathBuf = self.get_cache_dir().await?;
 
         // Convert machine from string representation.
@@ -510,7 +529,7 @@ impl Registry {
         let deployment: Deployment = Deployment::try_from(deployment)?;
 
         // Create release handle for checking latest release.
-        let release: LatestRelease = LatestRelease::new(deployment, machine);
+        let release: LatestRelease = LatestRelease::new(deployment, machine, memory_size_mb);
 
         // Get the latest release URL.
         let latest_url: String = release.get_url().await?;
@@ -528,8 +547,9 @@ impl Registry {
             },
         };
 
-        // Construct the subdirectory name: <machine>-<deployment>-<commit_id>.
-        let subdir_name: String = format!("{}-{}-{}", machine, deployment, commit_id);
+        // Construct the subdirectory name: <machine>-<deployment>-<memory_size>mb-<commit_id>.
+        let subdir_name: String =
+            format!("{}-{}-{}mb-{}", machine, deployment, memory_size_mb, commit_id);
         let artifact_cache_dir: PathBuf = cache_dir.join(&subdir_name);
 
         // Load or create the release registry.
@@ -550,28 +570,33 @@ impl Registry {
 
         // Check if we need to download this specific configuration.
         let needs_download: bool =
-            if let Some(cached_entry) = registry.get_release(machine, deployment) {
+            if let Some(cached_entry) = registry.get_release(machine, deployment, memory_size_mb) {
                 if cached_entry.commit_id() != commit_id.as_str() {
                     info!(
-                        "New release detected for {}-{} (cached: {}, latest: {})",
+                        "New release detected for {}-{}-{}mb (cached: {}, latest: {})",
                         machine,
                         deployment,
+                        memory_size_mb,
                         cached_entry.commit_id(),
                         commit_id
                     );
                     true
                 } else {
                     debug!(
-                        "Using cached release for {}-{}: {}",
+                        "Using cached release for {}-{}-{}mb: {}",
                         machine,
                         deployment,
+                        memory_size_mb,
                         cached_entry.commit_id()
                     );
                     false
                 }
             } else {
                 // Configuration not in registry, need to download.
-                info!("Configuration {}-{} not cached, downloading...", machine, deployment);
+                info!(
+                    "Configuration {}-{}-{}mb not cached, downloading...",
+                    machine, deployment, memory_size_mb
+                );
                 true
             };
 
@@ -587,7 +612,7 @@ impl Registry {
             let downloaded_url: String = release.download(&artifact_cache_dir).await?;
 
             // Update the registry with the new release.
-            registry.set_release(machine, deployment, downloaded_url, commit_id);
+            registry.set_release(machine, deployment, memory_size_mb, downloaded_url, commit_id);
             registry.save(&cache_dir).await?;
         }
 
@@ -627,6 +652,7 @@ impl Registry {
     /// - `deployment`: Deployment type. Supported values:
     ///   - `"single-process"`: Single-process deployment mode.
     ///   - `"multi-process"`: Multi-process deployment mode.
+    /// - `memory_size_mb`: Memory size in megabytes for selecting the correct release archive.
     /// - `package_name`: Name of the package to install. Supported packages:
     ///   - `"openblas"`: OpenBLAS library.
     ///   - `"openssl"`: OpenSSL library.
@@ -665,12 +691,12 @@ impl Registry {
     ///
     ///     // Install CPython and its dependencies (strict mode - requires compatible version).
     ///     let install_path: String = registry
-    ///         .install("microvm", "single-process", "python", false)
+    ///         .install("microvm", "single-process", 128, "python", false)
     ///         .await?;
     ///
     ///     // Install with fallback to latest if compatible version not found.
     ///     let install_path: String = registry
-    ///         .install("microvm", "single-process", "python", true)
+    ///         .install("microvm", "single-process", 128, "python", true)
     ///         .await?;
     ///
     ///     println!("Package installed to: {}", install_path);
@@ -683,12 +709,14 @@ impl Registry {
         &self,
         machine: &str,
         deployment: &str,
+        memory_size_mb: u32,
         package_name: &str,
         use_latest_fallback: bool,
     ) -> Result<String> {
         self.install_with_progress(
             machine,
             deployment,
+            memory_size_mb,
             package_name,
             use_latest_fallback,
             Arc::new(NoOpProgress),
@@ -708,6 +736,7 @@ impl Registry {
     ///
     /// - `machine`: Target machine type (see [`install`](Self::install) for supported values).
     /// - `deployment`: Deployment type (see [`install`](Self::install) for supported values).
+    /// - `memory_size_mb`: Memory size in megabytes for selecting the correct release archive.
     /// - `package_name`: Name of the package to install.
     /// - `use_latest_fallback`: If `true`, falls back to latest version when compatible not found.
     /// - `progress`: A shared progress callback to receive installation updates.
@@ -732,7 +761,7 @@ impl Registry {
     ///     let progress = Arc::new(LoggingProgress);
     ///
     ///     let install_path: String = registry
-    ///         .install_with_progress("microvm", "single-process", "python", true, progress)
+    ///         .install_with_progress("microvm", "single-process", 128, "python", true, progress)
     ///         .await?;
     ///
     ///     println!("Package installed to: {}", install_path);
@@ -745,10 +774,13 @@ impl Registry {
         &self,
         machine: &str,
         deployment: &str,
+        memory_size_mb: u32,
         package_name: &str,
         use_latest_fallback: bool,
         progress: SharedProgress,
     ) -> Result<String> {
+        anyhow::ensure!(memory_size_mb > 0, "memory_size_mb must be greater than 0");
+
         let cache_dir: PathBuf = self.get_cache_dir().await?;
 
         // Convert machine from string representation.
@@ -761,7 +793,7 @@ impl Registry {
         let package: Package = Package::try_from(package_name)?;
 
         // First, ensure we have the Nanvix release cached to get the commit ID.
-        let release: LatestRelease = LatestRelease::new(deployment, machine);
+        let release: LatestRelease = LatestRelease::new(deployment, machine, memory_size_mb);
         let latest_url: String = release.get_url().await?;
 
         let commit_id: String = match Self::extract_commit_id(&latest_url) {
@@ -795,6 +827,7 @@ impl Registry {
         let context: InstallContext<'_> = InstallContext {
             machine,
             deployment,
+            memory_size_mb,
             commit_id: &commit_id,
             cache_dir: &cache_dir,
             use_latest_fallback,
@@ -849,14 +882,20 @@ impl Registry {
             package,
             context.commit_id(),
         ) {
-            let subdir_name: String =
-                format!("{}-{}-{}", context.machine(), context.deployment(), context.commit_id());
+            let subdir_name: String = format!(
+                "{}-{}-{}mb-{}",
+                context.machine(),
+                context.deployment(),
+                context.memory_size_mb(),
+                context.commit_id()
+            );
             let package_dir: PathBuf = context.cache_dir().join(&subdir_name);
             info!(
-                "Package {} already installed for {}-{}-{}",
+                "Package {} already installed for {}-{}-{}mb-{}",
                 package,
                 context.machine(),
                 context.deployment(),
+                context.memory_size_mb(),
                 context.commit_id()
             );
             in_progress.remove(&package);
@@ -900,8 +939,13 @@ impl Registry {
         }
 
         // Now install the package itself.
-        let subdir_name: String =
-            format!("{}-{}-{}", context.machine(), context.deployment(), context.commit_id());
+        let subdir_name: String = format!(
+            "{}-{}-{}mb-{}",
+            context.machine(),
+            context.deployment(),
+            context.memory_size_mb(),
+            context.commit_id()
+        );
         let package_dir: PathBuf = context.cache_dir().join(&subdir_name);
 
         // Create the package directory if it doesn't exist.
@@ -912,10 +956,11 @@ impl Registry {
         }
 
         info!(
-            "Installing package {} for {}-{}-{}",
+            "Installing package {} for {}-{}-{}mb-{}",
             package,
             context.machine(),
             context.deployment(),
+            context.memory_size_mb(),
             context.commit_id()
         );
 
@@ -1294,7 +1339,7 @@ mod tests {
     async fn test_invalid_machine() {
         let registry: Registry = Registry::new(None);
         let result = registry
-            .get_cached_binary("invalid-machine", "single-process", "kernel.elf")
+            .get_cached_binary("invalid-machine", "single-process", 128, "kernel.elf")
             .await;
 
         assert!(result.is_err());
@@ -1313,7 +1358,7 @@ mod tests {
     async fn test_invalid_deployment() {
         let registry: Registry = Registry::new(None);
         let result = registry
-            .get_cached_binary("microvm", "invalid-deployment", "kernel.elf")
+            .get_cached_binary("microvm", "invalid-deployment", 128, "kernel.elf")
             .await;
 
         assert!(result.is_err());
@@ -1346,7 +1391,7 @@ mod tests {
     async fn test_get_cached_artifact_invalid_machine() {
         let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
-            .get_cached_artifact("invalid-machine", "single-process", "config.json", None)
+            .get_cached_artifact("invalid-machine", "single-process", 128, "config.json", None)
             .await;
 
         assert!(result.is_err());
@@ -1365,7 +1410,7 @@ mod tests {
     async fn test_get_cached_artifact_invalid_deployment() {
         let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
-            .get_cached_artifact("microvm", "invalid-deployment", "config.json", None)
+            .get_cached_artifact("microvm", "invalid-deployment", 128, "config.json", None)
             .await;
 
         assert!(result.is_err());
@@ -1424,13 +1469,13 @@ mod tests {
 
         // Test with None (searches from cache root) - should fail gracefully since no actual cache exists.
         let result: Result<String> = registry
-            .get_cached_artifact("microvm", "single-process", "nonexistent.txt", None)
+            .get_cached_artifact("microvm", "single-process", 128, "nonexistent.txt", None)
             .await;
         assert!(result.is_err());
 
         // Test with Some custom directory - should also fail gracefully since no actual cache exists.
         let result: Result<String> = registry
-            .get_cached_artifact("microvm", "single-process", "nonexistent.txt", Some("lib"))
+            .get_cached_artifact("microvm", "single-process", 128, "nonexistent.txt", Some("lib"))
             .await;
         assert!(result.is_err());
     }
@@ -1546,7 +1591,7 @@ mod tests {
     async fn test_install_invalid_machine() {
         let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
-            .install("invalid-machine", "single-process", "openssl", false)
+            .install("invalid-machine", "single-process", 128, "openssl", false)
             .await;
         assert!(result.is_err());
     }
@@ -1560,7 +1605,7 @@ mod tests {
     async fn test_install_invalid_deployment() {
         let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
-            .install("microvm", "invalid-deployment", "openssl", false)
+            .install("microvm", "invalid-deployment", 128, "openssl", false)
             .await;
         assert!(result.is_err());
     }
@@ -1574,7 +1619,7 @@ mod tests {
     async fn test_install_invalid_package() {
         let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
-            .install("microvm", "single-process", "invalid-package", false)
+            .install("microvm", "single-process", 128, "invalid-package", false)
             .await;
         assert!(result.is_err());
     }
@@ -1614,7 +1659,7 @@ mod tests {
 
                 // Attempt to install the package.
                 let result: Result<String> = registry
-                    .install("microvm", "single-process", package_name, true)
+                    .install("microvm", "single-process", 128, package_name, true)
                     .await;
 
                 // Verify installation succeeded.

--- a/src/libs/nanvix-registry/src/metadata.rs
+++ b/src/libs/nanvix-registry/src/metadata.rs
@@ -220,10 +220,11 @@ impl ReleaseRegistry {
         &mut self,
         machine: Machine,
         deployment: Deployment,
+        memory_size_mb: u32,
         url: String,
         commit_id: String,
     ) {
-        let key: String = format!("{}-{}", machine, deployment);
+        let key: String = format!("{}-{}-{}mb", machine, deployment, memory_size_mb);
         let entry: ReleaseEntry = ReleaseEntry::new(url, commit_id);
         self.releases.insert(key, entry);
     }
@@ -246,8 +247,9 @@ impl ReleaseRegistry {
         &self,
         machine: Machine,
         deployment: Deployment,
+        memory_size_mb: u32,
     ) -> Option<&ReleaseEntry> {
-        let key: String = format!("{}-{}", machine, deployment);
+        let key: String = format!("{}-{}-{}mb", machine, deployment, memory_size_mb);
         self.releases.get(&key)
     }
 
@@ -543,13 +545,14 @@ mod tests {
         registry.set_release(
             Machine::Microvm,
             Deployment::SingleProcess,
+            128,
             url.clone(),
             commit_id.clone(),
         );
 
         // Get the release.
         let entry: Option<&ReleaseEntry> =
-            registry.get_release(Machine::Microvm, Deployment::SingleProcess);
+            registry.get_release(Machine::Microvm, Deployment::SingleProcess, 128);
         assert!(entry.is_some());
 
         let entry: &ReleaseEntry = entry.expect("failed");
@@ -570,6 +573,7 @@ mod tests {
         registry.set_release(
             Machine::Microvm,
             Deployment::SingleProcess,
+            128,
             "https://test.com/microvm-sp.tar.bz2".to_string(),
             "abc111def".to_string(),
         );
@@ -577,6 +581,7 @@ mod tests {
         registry.set_release(
             Machine::Microvm,
             Deployment::MultiProcess,
+            128,
             "https://test.com/microvm-mp.tar.bz2".to_string(),
             "abc222def".to_string(),
         );
@@ -584,6 +589,7 @@ mod tests {
         registry.set_release(
             Machine::Hyperlight,
             Deployment::SingleProcess,
+            128,
             "https://test.com/hyperlight-sp.tar.bz2".to_string(),
             "abc333def".to_string(),
         );
@@ -593,17 +599,17 @@ mod tests {
 
         // Verify each entry.
         let entry: &ReleaseEntry = registry
-            .get_release(Machine::Microvm, Deployment::SingleProcess)
+            .get_release(Machine::Microvm, Deployment::SingleProcess, 128)
             .expect("failed");
         assert_eq!(entry.commit_id(), "abc111def");
 
         let entry: &ReleaseEntry = registry
-            .get_release(Machine::Microvm, Deployment::MultiProcess)
+            .get_release(Machine::Microvm, Deployment::MultiProcess, 128)
             .expect("failed");
         assert_eq!(entry.commit_id(), "abc222def");
 
         let entry: &ReleaseEntry = registry
-            .get_release(Machine::Hyperlight, Deployment::SingleProcess)
+            .get_release(Machine::Hyperlight, Deployment::SingleProcess, 128)
             .expect("failed");
         assert_eq!(entry.commit_id(), "abc333def");
     }
@@ -621,6 +627,7 @@ mod tests {
         registry.set_release(
             Machine::Microvm,
             Deployment::SingleProcess,
+            128,
             "https://test.com/old.tar.bz2".to_string(),
             "abc111def".to_string(),
         );
@@ -631,6 +638,7 @@ mod tests {
         registry.set_release(
             Machine::Microvm,
             Deployment::SingleProcess,
+            128,
             "https://test.com/new.tar.bz2".to_string(),
             "abc222def".to_string(),
         );
@@ -639,7 +647,7 @@ mod tests {
         assert_eq!(registry.len(), 1);
 
         let entry: &ReleaseEntry = registry
-            .get_release(Machine::Microvm, Deployment::SingleProcess)
+            .get_release(Machine::Microvm, Deployment::SingleProcess, 128)
             .expect("failed");
         assert_eq!(entry.url(), "https://test.com/new.tar.bz2");
         assert_eq!(entry.commit_id(), "abc222def");
@@ -656,13 +664,14 @@ mod tests {
         registry.set_release(
             Machine::Microvm,
             Deployment::SingleProcess,
+            128,
             "https://example.com/release.tar.bz2".to_string(),
             "abc123def456".to_string(),
         );
 
         let json: String = serde_json::to_string(&registry).expect("failed");
         assert!(json.contains("releases"));
-        assert!(json.contains("microvm-single-process"));
+        assert!(json.contains("microvm-single-process-128mb"));
         assert!(json.contains("https://example.com/release.tar.bz2"));
         assert!(json.contains("abc123def456"));
     }
@@ -674,11 +683,11 @@ mod tests {
     ///
     #[test]
     fn test_deserialization() {
-        let json: &str = r#"{"releases":{"microvm-single-process":{"url":"https://example.com/release.tar.bz2","commit_id":"abc123def456"}}}"#;
+        let json: &str = r#"{"releases":{"microvm-single-process-128mb":{"url":"https://example.com/release.tar.bz2","commit_id":"abc123def456"}}}"#;
         let registry: ReleaseRegistry = serde_json::from_str(json).expect("failed");
 
         let entry: &ReleaseEntry = registry
-            .get_release(Machine::Microvm, Deployment::SingleProcess)
+            .get_release(Machine::Microvm, Deployment::SingleProcess, 128)
             .expect("failed");
         assert_eq!(entry.url(), "https://example.com/release.tar.bz2");
         assert_eq!(entry.commit_id(), "abc123def456");
@@ -699,12 +708,14 @@ mod tests {
         original.set_release(
             Machine::Microvm,
             Deployment::SingleProcess,
+            128,
             "https://test.com/file1.tar.bz2".to_string(),
             "abc111def".to_string(),
         );
         original.set_release(
             Machine::Hyperlight,
             Deployment::MultiProcess,
+            128,
             "https://test.com/file2.tar.bz2".to_string(),
             "abc222def".to_string(),
         );
@@ -721,12 +732,12 @@ mod tests {
         assert_eq!(loaded.len(), 2);
 
         let entry: &ReleaseEntry = loaded
-            .get_release(Machine::Microvm, Deployment::SingleProcess)
+            .get_release(Machine::Microvm, Deployment::SingleProcess, 128)
             .expect("failed");
         assert_eq!(entry.commit_id(), "abc111def");
 
         let entry: &ReleaseEntry = loaded
-            .get_release(Machine::Hyperlight, Deployment::MultiProcess)
+            .get_release(Machine::Hyperlight, Deployment::MultiProcess, 128)
             .expect("failed");
         assert_eq!(entry.commit_id(), "abc222def");
 
@@ -763,6 +774,7 @@ mod tests {
         registry.set_release(
             Machine::Microvm,
             Deployment::SingleProcess,
+            128,
             "https://test.com/file.tar.bz2".to_string(),
             "abc123def456".to_string(),
         );
@@ -790,6 +802,7 @@ mod tests {
         registry.set_release(
             Machine::Microvm,
             Deployment::SingleProcess,
+            128,
             "https://test.com/file.tar.bz2".to_string(),
             "abc123def456".to_string(),
         );

--- a/src/libs/nanvix-registry/src/release.rs
+++ b/src/libs/nanvix-registry/src/release.rs
@@ -54,6 +54,8 @@ pub(crate) struct LatestRelease {
     deployment: Deployment,
     /// Target machine type for the release.
     machine: Machine,
+    /// Memory size in megabytes for selecting the correct release archive.
+    memory_size_mb: u32,
     /// Rate limiter for GitHub API calls.
     rate_limiter: RateLimiter,
 }
@@ -66,21 +68,25 @@ impl LatestRelease {
     ///
     /// # Description
     ///
-    /// Creates a new handle for a latest release for the specified deployment and machine type.
+    /// Creates a new handle for a latest release for the specified deployment, machine type, and
+    /// memory size.
     ///
     /// # Parameters
     ///
     /// - `deployment`: The deployment type.
     /// - `machine`: The target machine type.
+    /// - `memory_size_mb`: The memory size in megabytes.
     ///
     /// # Returns
     ///
-    /// A new handle for a latest release for the specified deployment and machine type.
+    /// A new handle for a latest release for the specified deployment, machine type, and memory
+    /// size.
     ///
-    pub(crate) fn new(deployment: Deployment, machine: Machine) -> Self {
+    pub(crate) fn new(deployment: Deployment, machine: Machine, memory_size_mb: u32) -> Self {
         Self {
             deployment,
             machine,
+            memory_size_mb,
             rate_limiter: RateLimiter::for_github(),
         }
     }
@@ -196,8 +202,10 @@ impl LatestRelease {
             },
         };
 
-        let release_pattern: String =
-            format!("nanvix-{}-{}-release", self.machine, self.deployment);
+        let release_pattern: String = format!(
+            "nanvix-{}-{}-release-{}mb-",
+            self.machine, self.deployment, self.memory_size_mb
+        );
 
         // Search for the matching asset.
         for asset in assets {
@@ -234,30 +242,33 @@ mod tests {
     fn test_new() {
         let deployment: Deployment = Deployment::SingleProcess;
         let machine: Machine = Machine::Microvm;
-        let release: LatestRelease = LatestRelease::new(deployment, machine);
+        let release: LatestRelease = LatestRelease::new(deployment, machine, 128);
 
         assert!(matches!(release.deployment, Deployment::SingleProcess));
         assert!(matches!(release.machine, Machine::Microvm));
+        assert_eq!(release.memory_size_mb, 128);
     }
 
     ///
     /// # Description
     ///
-    /// Tests release pattern construction.
+    /// Tests release pattern construction with memory size.
     ///
     #[test]
     fn test_release_pattern() {
         let deployment: Deployment = Deployment::MultiProcess;
         let machine: Machine = Machine::Hyperlight;
 
-        let pattern: String = format!("nanvix-{}-{}-release", machine, deployment);
-        assert_eq!(pattern, "nanvix-hyperlight-multi-process-release");
+        let pattern: String = format!("nanvix-{}-{}-release-{}mb-", machine, deployment, 128);
+        assert_eq!(pattern, "nanvix-hyperlight-multi-process-release-128mb-");
 
-        // Verify the pattern matches both legacy and new archive name formats.
-        let legacy_name: &str = "nanvix-hyperlight-multi-process-release-abc123def456.tar.bz2";
-        let new_name: &str = "nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.bz2";
-        assert!(legacy_name.contains(&pattern));
-        assert!(new_name.contains(&pattern));
+        // Verify the pattern matches the memory-size archive name format.
+        let name_128: &str = "nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.bz2";
+        assert!(name_128.contains(&pattern));
+
+        // Verify the pattern does NOT match a different memory size.
+        let name_1024: &str = "nanvix-hyperlight-multi-process-release-1024mb-abc123def456.tar.bz2";
+        assert!(!name_1024.contains(&pattern));
     }
 
     ///
@@ -281,12 +292,17 @@ mod tests {
     fn test_all_release_patterns() {
         let deployments: [Deployment; 2] = [Deployment::SingleProcess, Deployment::MultiProcess];
         let machines: [Machine; 2] = [Machine::Hyperlight, Machine::Microvm];
+        let memory_sizes: [u32; 4] = [128, 256, 512, 1024];
 
         for deployment in &deployments {
             for machine in &machines {
-                let pattern: String = format!("nanvix-{}-{}-release", machine, deployment);
-                assert!(pattern.contains("nanvix-"));
-                assert!(pattern.contains("-release"));
+                for memory_size_mb in &memory_sizes {
+                    let pattern: String =
+                        format!("nanvix-{}-{}-release-{}mb-", machine, deployment, memory_size_mb);
+                    assert!(pattern.contains("nanvix-"));
+                    assert!(pattern.contains("-release-"));
+                    assert!(pattern.ends_with("mb-"));
+                }
             }
         }
     }

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -31,7 +31,11 @@ use ::nanvix::sandbox_cache::SimpleSandboxCacheConfig;
 #[cfg(feature = "standalone")]
 use ::nanvix::terminal::TerminalConfig;
 use ::nanvix::{
-    config::system::DEFAULT_MACHINE_NAME,
+    config::{
+        constants::MEGABYTE,
+        kernel::MEMORY_SIZE,
+        system::DEFAULT_MACHINE_NAME,
+    },
     http::HttpServer,
     registry::Registry,
     sandbox::NAMED_RESOURCE_PREFIX,
@@ -355,9 +359,10 @@ async fn ensure_all_binaries_available(
     log_info!("not all binaries found locally, fetching all from registry");
 
     let registry: Registry = Registry::new(None);
+    let memory_size_mb: u32 = (MEMORY_SIZE / MEGABYTE) as u32;
 
     let kernel_cached_path: String = registry
-        .get_cached_binary(machine, deployment, KERNEL_BINARY_NAME)
+        .get_cached_binary(machine, deployment, memory_size_mb, KERNEL_BINARY_NAME)
         .await?;
     log_info!("using registry binary {}: {}", KERNEL_BINARY_NAME, kernel_cached_path);
 
@@ -367,12 +372,12 @@ async fn ensure_all_binaries_available(
     #[cfg(not(any(feature = "single-process", feature = "standalone")))]
     {
         let linuxd_cached_path: String = registry
-            .get_cached_binary(machine, deployment, LINUXD_BINARY_NAME)
+            .get_cached_binary(machine, deployment, memory_size_mb, LINUXD_BINARY_NAME)
             .await?;
         log_info!("using registry binary {}: {}", LINUXD_BINARY_NAME, linuxd_cached_path);
 
         let uservm_cached_path: String = registry
-            .get_cached_binary(machine, deployment, USERVM_BINARY_NAME)
+            .get_cached_binary(machine, deployment, memory_size_mb, USERVM_BINARY_NAME)
             .await?;
         log_info!("using registry binary {}: {}", USERVM_BINARY_NAME, uservm_cached_path);
 


### PR DESCRIPTION
Add a `memory_size_mb` parameter to `get_cached_binary()`, `get_cached_artifact()`, `install()`, `install_with_progress()`, and related internal functions so the registry can select the correct release archive for each memory-size variant.

## Changes

- Thread `memory_size_mb` through `LatestRelease`, `ReleaseRegistry`, and all public/internal callers.
- Include memory size in cache subdirectory names (`<machine>-<deployment>-<size>mb-<commit>`).
- Include memory size in release-asset pattern matching.
- Update `nanvixd` to derive `memory_size_mb` from `MEMORY_SIZE / MEGABYTE`.
- Update all tests and doc examples.