### PR TITLE
[build] F: Fix stale .o on mode switch

### DIFF
--- a/src/benchmarks/echo-c/Makefile
+++ b/src/benchmarks/echo-c/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export SOURCES := $(wildcard *.c)
 
 # Object Files
-export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C source files.
-%.$(TARGET).$(MACHINE).o: %.c
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.c
 	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/benchmarks/echo-cpp/Makefile
+++ b/src/benchmarks/echo-cpp/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBCXX) -Wl,--end-gr
 export SOURCES := $(wildcard *.cpp)
 
 # Object Files
-export OBJECTS = $(SOURCES:.cpp=.o)
+export OBJECTS = $(SOURCES:.cpp=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C++ source files.
-%.o: %.cpp
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.cpp
 	$(NANVIX_CXX) $(NANVIX_CXXFLAGS) $< -c -o $@

--- a/src/benchmarks/noop-c/Makefile
+++ b/src/benchmarks/noop-c/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export SOURCES := $(wildcard *.c)
 
 # Object Files
-export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C source files.
-%.$(TARGET).$(MACHINE).o: %.c
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.c
 	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/benchmarks/noop-cpp/Makefile
+++ b/src/benchmarks/noop-cpp/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBCXX) -Wl,--end-gr
 export SOURCES := $(wildcard *.cpp)
 
 # Object Files
-export OBJECTS = $(SOURCES:.cpp=.o)
+export OBJECTS = $(SOURCES:.cpp=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C++ source files.
-%.o: %.cpp
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.cpp
 	$(NANVIX_CXX) $(NANVIX_CXXFLAGS) $< -c -o $@

--- a/src/tests/c-bindings/Makefile
+++ b/src/tests/c-bindings/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export SOURCES := $(wildcard *.c)
 
 # Object Files
-export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C source files.
-%.$(TARGET).$(MACHINE).o: %.c
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.c
 	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/dlfcn-c/Makefile
+++ b/src/tests/dlfcn-c/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export SOURCES := $(wildcard *.c)
 
 # Object Files
-export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -48,5 +48,5 @@ libs-clean:
 	rm -rf $(LIBRARIES_DIR)/libmul.so
 
 # Builds C source files.
-%.$(TARGET).$(MACHINE).o: %.c
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.c
 	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/file-c/Makefile
+++ b/src/tests/file-c/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export SOURCES := $(wildcard *.c)
 
 # Object Files
-export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C source files.
-%.$(TARGET).$(MACHINE).o: %.c
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.c
 	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/memory-c/Makefile
+++ b/src/tests/memory-c/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export SOURCES := $(wildcard *.c)
 
 # Object Files
-export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C source files.
-%.$(TARGET).$(MACHINE).o: %.c
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.c
 	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/misc-c/Makefile
+++ b/src/tests/misc-c/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export SOURCES := $(wildcard *.c)
 
 # Object Files
-export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C source files.
-%.$(TARGET).$(MACHINE).o: %.c
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.c
 	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/network-c/Makefile
+++ b/src/tests/network-c/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export SOURCES := $(wildcard *.c)
 
 # Object Files
-export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C source files.
-%.$(TARGET).$(MACHINE).o: %.c
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.c
 	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/tests/thread-c/Makefile
+++ b/src/tests/thread-c/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export SOURCES := $(wildcard *.c)
 
 # Object Files
-export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C source files.
-%.$(TARGET).$(MACHINE).o: %.c
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.c
 	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/user/hello-c/Makefile
+++ b/src/user/hello-c/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export SOURCES := $(wildcard *.c)
 
 # Object Files
-export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).o)
+export OBJECTS = $(SOURCES:.c=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C source files.
-%.$(TARGET).$(MACHINE).o: %.c
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.c
 	$(NANVIX_CC) $(NANVIX_CFLAGS) $< -c -o $@

--- a/src/user/hello-cpp/Makefile
+++ b/src/user/hello-cpp/Makefile
@@ -16,7 +16,7 @@ export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBCXX) -Wl,--end-gr
 export SOURCES := $(wildcard *.cpp)
 
 # Object Files
-export OBJECTS = $(SOURCES:.cpp=.o)
+export OBJECTS = $(SOURCES:.cpp=.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o)
 
 # Binary
 export BINARY := $(PROGRAM_NAME).$(EXEC_FORMAT)
@@ -33,5 +33,5 @@ clean:
 	rm -rf $(BINARIES_DIR)/$(BINARY)
 
 # Builds C++ source files.
-%.o: %.cpp
+%.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o: %.cpp
 	$(NANVIX_CXX) $(NANVIX_CXXFLAGS) $< -c -o $@


### PR DESCRIPTION
When switching `DEPLOYMENT_MODE` between builds (e.g., standalone vs multi-process), stale object files from the previous mode were reused because the `.o` filenames did not encode the deployment mode.

This PR adds `$(DEPLOYMENT_MODE)` to the object file suffix in all C Makefiles, changing the naming from `*.$(TARGET).$(MACHINE).o` to `*.$(TARGET).$(MACHINE).$(DEPLOYMENT_MODE).o`.

**Files changed:**
- `src/tests/misc-c/Makefile`
- `src/tests/dlfcn-c/Makefile`
- `src/tests/c-bindings/Makefile`
- `src/tests/thread-c/Makefile`
- `src/tests/file-c/Makefile`
- `src/tests/network-c/Makefile`
- `src/tests/memory-c/Makefile`
- `src/user/hello-c/Makefile`
- `src/benchmarks/noop-c/Makefile`
- `src/benchmarks/echo-c/Makefile`