### PR TITLE
[syscomm] Set TCP_NODELAY on TCP streams

### DIFF
--- a/src/libs/nanvix-http/src/server.rs
+++ b/src/libs/nanvix-http/src/server.rs
@@ -197,6 +197,11 @@ impl<T: Send + Sync + Default + Clone + 'static> HttpServer<T> {
                     match result {
                         Ok((stream, sockaddr)) => {
                             debug!("accepted connection from {sockaddr:?}");
+                            // Disable Nagle's algorithm so small HTTP responses are sent immediately
+                            // instead of being delayed up to 40 ms by the TCP delayed-ACK interaction.
+                            if let Err(e) = stream.set_nodelay(true) {
+                                error!("failed to set TCP_NODELAY (error={e:?})");
+                            }
                             // In single-process and standalone mode, handle connections sequentially.
                             #[cfg(any(feature = "single-process", feature = "standalone"))]
                             {

--- a/src/libs/syscomm/src/socket_listener.rs
+++ b/src/libs/syscomm/src/socket_listener.rs
@@ -72,7 +72,7 @@ impl SocketListener {
                 listener,
                 addr: _addr,
             } => {
-                let (stream, _sockaddr): (TcpStream, std::net::SocketAddr) =
+                let (stream, sockaddr): (TcpStream, std::net::SocketAddr) =
                     match listener.accept().await {
                         Ok(res) => res,
                         Err(error) => {
@@ -82,6 +82,14 @@ impl SocketListener {
                         },
                     };
 
+                // Disable Nagle's algorithm so small IKC frames are sent immediately
+                // instead of being delayed up to 40 ms by the TCP delayed-ACK interaction.
+                stream.set_nodelay(true).map_err(|error| {
+                    Error::new(
+                        error.kind(),
+                        format!("accept(): set_nodelay failed: {error} (peer={sockaddr})"),
+                    )
+                })?;
                 Ok(SocketStream::Tcp(stream))
             },
             // Unix socket.

--- a/src/libs/syscomm/src/socket_unbound.rs
+++ b/src/libs/syscomm/src/socket_unbound.rs
@@ -100,6 +100,12 @@ impl UnboundSocket {
                         return Err(io::Error::new(error.kind(), format!("{error} (addr={addr})")));
                     },
                 };
+
+                // Disable Nagle's algorithm so small IKC frames are sent immediately
+                // instead of being delayed up to 40 ms by the TCP delayed-ACK interaction.
+                stream.set_nodelay(true).map_err(|error| {
+                    io::Error::new(error.kind(), format!("{error} (addr={addr})"))
+                })?;
                 Ok(SocketStream::Tcp(stream))
             },
             // Connect to a unix domain socket.

--- a/src/utils/echo-client/src/main.rs
+++ b/src/utils/echo-client/src/main.rs
@@ -141,6 +141,9 @@ async fn client(
             let handle = tokio::spawn(async move {
                 let now = std::time::Instant::now();
                 let mut stream: TcpStream = TcpStream::connect(sockaddr2).await?;
+                // Disable Nagle's algorithm so small frames are sent immediately
+                // instead of being delayed up to 40 ms by the TCP delayed-ACK interaction.
+                stream.set_nodelay(true)?;
                 debug!("connected to server");
                 stream.write_all(&http_request2).await?;
 


### PR DESCRIPTION
## Summary

Enable `TCP_NODELAY` on all TCP streams across the stack to eliminate latency caused by the interaction between Nagle's algorithm and TCP delayed ACKs.

Without this change, small IKC frames and HTTP responses can be delayed by up to 40 ms because the sender buffers small segments (Nagle) while the receiver delays its ACK.

## Changes

- **syscomm:** Set `TCP_NODELAY` on accepted streams in `SocketListener::accept()` and on outbound streams in `UnboundSocket::connect()`.
- **nanvix-http:** Set `TCP_NODELAY` on accepted streams in the HTTP server loop.
- **echo-client:** Set `TCP_NODELAY` on outbound streams in the echo client utility.

## Testing

- All modified crates compile cleanly (`cargo check`).
- No behavioral change beyond reduced latency on small TCP exchanges.