### PR TITLE
[sysalloc] Reclaim physical memory on dealloc

### DIFF
--- a/src/libs/sysalloc/src/allocator.rs
+++ b/src/libs/sysalloc/src/allocator.rs
@@ -234,6 +234,9 @@ pub fn init(base: VirtualAddress, capacity: usize) -> Result<(), Error> {
 pub unsafe fn alloc(layout: Layout) -> *mut u8 {
     let mut locked_heap: MutexGuard<'_, Option<Talc<NanvixOomHandler>>> = HEAP.lock();
     if let Some(heap) = locked_heap.as_mut() {
+        // Attempt to reclaim tail pages.
+        try_reclaim(heap);
+
         match heap.malloc(layout) {
             Ok(ptr) => ptr.as_ptr(),
             Err(_) => core::ptr::null_mut(),
@@ -246,11 +249,97 @@ pub unsafe fn alloc(layout: Layout) -> *mut u8 {
 
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
+    let nn_ptr = match ptr::NonNull::new(ptr) {
+        Some(p) => p,
+        None => return,
+    };
+
     let mut locked_heap: MutexGuard<'_, Option<Talc<NanvixOomHandler>>> = HEAP.lock();
     if let Some(heap) = locked_heap.as_mut() {
-        if let Some(ptr) = ptr::NonNull::new(ptr) {
-            heap.free(ptr, layout)
+        heap.free(nn_ptr, layout);
+
+        // Attempt to reclaim tail pages.
+        try_reclaim(heap);
+    }
+}
+
+/// Attempts to shrink the backing heap by unmapping tail pages that no longer
+/// contain live allocations. This returns physical frames to the kernel.
+fn try_reclaim(talc: &mut Talc<NanvixOomHandler>) {
+    // Only reclaim when the heap has reached its maximum capacity.
+    let heap_size: usize = talc.oom_handler.heap.size();
+    let capacity: usize = talc.oom_handler.heap.capacity();
+    if heap_size < capacity || heap_size <= PAGE_SIZE {
+        return;
+    }
+
+    let current_span: Span = match talc.oom_handler.span {
+        Some(span) => span,
+        None => {
+            ::syslog::trace!("try_reclaim(): no span, skipping");
+            return;
+        },
+    };
+
+    // Find the minimum span that contains all live allocations.
+    let allocated_span: Span = unsafe { talc.get_allocated_span(current_span) };
+
+    let base_raw: usize = talc.oom_handler.heap.base().into_raw_value();
+
+    // Compute the page-aligned high-water mark of live allocations.
+    let alloc_end: usize = if allocated_span.is_empty() {
+        // No live allocations — shrink to the initial page.
+        PAGE_SIZE
+    } else {
+        // Round up end of live allocations to a page boundary.
+        let (_, acme) = match allocated_span.get_base_acme() {
+            Some(pair) => pair,
+            None => {
+                ::syslog::error!("try_reclaim(): non-empty span returned None from get_base_acme");
+                return;
+            },
+        };
+        let raw_end: usize = acme as usize;
+        let relative_end: usize = match raw_end.checked_sub(base_raw) {
+            Some(v) => v,
+            None => {
+                ::syslog::error!("try_reclaim(): acme precedes heap base");
+                return;
+            },
+        };
+        match mm::align_up(relative_end, PAGE_ALIGNMENT) {
+            Some(v) => v,
+            None => {
+                ::syslog::error!(
+                    "try_reclaim(): align_up overflow (relative_end={:X?})",
+                    relative_end
+                );
+                return;
+            },
         }
+    };
+
+    let current_size: usize = talc.oom_handler.heap.size();
+
+    // Only reclaim if we can free at least one page.
+    if alloc_end >= current_size {
+        return;
+    }
+
+    // Truncate Talc's span BEFORE unmapping pages. The truncate() call reads
+    // metadata (gap sizes, tags) from the old heap region. If we unmap first,
+    // those reads hit unmapped pages and cause a guest page fault.
+    let new_span: Span = Span::from_base_size(talc.oom_handler.heap.base().as_mut_ptr(), alloc_end);
+    let span: Span = unsafe { talc.truncate(current_span, new_span) };
+    talc.oom_handler.span = Some(span);
+
+    // Now unmap the freed tail pages. If this fails, shrink() stops at the
+    // first failing page and updates heap.size() to reflect the actual mapped
+    // extent. Talc's span is already truncated so unmapped pages won't be
+    // reused; the still-mapped (but now outside Talc's view) pages are a
+    // benign leak that the next OOM cycle can reclaim.
+    if let Err(_error) = talc.oom_handler.heap.shrink(alloc_end) {
+        ::syslog::warn!("try_reclaim(): failed to shrink heap (error={:?})", _error);
     }
 }
 
@@ -268,4 +357,37 @@ unsafe impl GlobalAlloc for Allocator {
 /// Cleanups the memory management runtime.
 pub fn cleanup() -> Result<(), Error> {
     Ok(())
+}
+
+/// Returns the committed size of the heap in bytes.
+///
+/// This is the number of bytes currently backed by physical pages. It increases when the OOM
+/// handler grows the heap via `mmap` and decreases when `try_reclaim` shrinks it via `munmap`.
+pub fn heap_committed_size() -> usize {
+    let locked_heap: MutexGuard<'_, Option<Talc<NanvixOomHandler>>> = HEAP.lock();
+    match locked_heap.as_ref() {
+        Some(heap) => heap.oom_handler.heap.size(),
+        None => 0,
+    }
+}
+
+/// Returns the maximum capacity of the heap in bytes.
+pub fn heap_capacity() -> usize {
+    let locked_heap: MutexGuard<'_, Option<Talc<NanvixOomHandler>>> = HEAP.lock();
+    match locked_heap.as_ref() {
+        Some(heap) => heap.oom_handler.heap.capacity(),
+        None => 0,
+    }
+}
+
+/// C-callable wrapper for [`heap_committed_size`].
+#[unsafe(no_mangle)]
+pub extern "C" fn sysalloc_heap_committed_size() -> usize {
+    heap_committed_size()
+}
+
+/// C-callable wrapper for [`heap_capacity`].
+#[unsafe(no_mangle)]
+pub extern "C" fn sysalloc_heap_capacity() -> usize {
+    heap_capacity()
 }

--- a/src/libs/sysalloc/src/heap.rs
+++ b/src/libs/sysalloc/src/heap.rs
@@ -89,6 +89,10 @@ impl Heap {
         self.size
     }
 
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
     pub fn grow(&mut self, increment: usize) -> Result<(), Error> {
         ::syslog::trace!("grow(): increment={:X?}", increment);
 
@@ -123,6 +127,58 @@ impl Heap {
         // Update metadata.
         self.size += increment;
 
+        Ok(())
+    }
+
+    /// Shrinks the heap by unmapping tail pages from the end backwards.
+    ///
+    /// Pages are unmapped in reverse order (highest address first). If a `munmap` call fails,
+    /// unmapping stops immediately and `self.size` is updated to reflect the lowest still-mapped
+    /// boundary. This guarantees that `self.size` always represents the actual contiguous mapped
+    /// extent, preventing inconsistencies between metadata and the page table.
+    ///
+    /// # Parameters
+    ///
+    /// - `new_size`: New committed size in bytes. Must be page-aligned and smaller than the
+    ///   current size. Values below a single page are clamped.
+    pub fn shrink(&mut self, new_size: usize) -> Result<(), Error> {
+        ::syslog::trace!("shrink(): new_size={:X?}, current_size={:X?}", new_size, self.size);
+
+        // Check if new size is page-aligned.
+        if !mm::is_aligned(new_size, PAGE_ALIGNMENT) {
+            ::syslog::error!("shrink(): unaligned new_size");
+            return Err(Error::new(ErrorCode::BadAddress, "unaligned new_size"));
+        }
+
+        // Clamp values below a single page.
+        let new_size: usize = new_size.max(mem::PAGE_SIZE);
+
+        // Nothing to do if the (possibly clamped) new size is not smaller.
+        if new_size >= self.size {
+            return Ok(());
+        }
+
+        // Unmap tail pages from the end backwards, stopping at the first failure so that
+        // self.size always reflects the actual contiguous mapped extent.
+        let base_raw: usize = self.base.into_raw_value();
+        let new_end: usize = base_raw + new_size;
+        let old_end: usize = base_raw + self.size;
+
+        for page in (new_end..old_end).step_by(mem::PAGE_SIZE).rev() {
+            let page_addr: VirtualAddress = VirtualAddress::from_raw_value(page);
+            if let Err(error) = kcall::mm::munmap(self.pid, page_addr) {
+                ::syslog::error!(
+                    "shrink(): failed to unmap page at {:X?}, stopping (error={:?})",
+                    page_addr,
+                    error
+                );
+                self.size = (page + mem::PAGE_SIZE) - base_raw;
+                return Err(error);
+            }
+        }
+
+        // All tail pages unmapped successfully.
+        self.size = new_size;
         Ok(())
     }
 }

--- a/src/tests/memory-c/common.h
+++ b/src/tests/memory-c/common.h
@@ -24,4 +24,8 @@ extern void test_heap_reclaim(void);
 // Tests the allocator by attempting to consume the maximum allowed heap capacity.
 extern void test_heap_max_capacity(void);
 
+// Exercises the heap shrink path through bulk-free, shrink-to-minimum, anchor-pinned,
+// repeated cycles, and small-heap scenarios.
+extern void test_heap_shrink(void);
+
 #endif

--- a/src/tests/memory-c/heap_shrink.c
+++ b/src/tests/memory-c/heap_shrink.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Integration tests for the heap shrink path (Heap::shrink / try_reclaim).
+ *
+ * All scenarios exercise shrink() indirectly through malloc()/free(). The allocator triggers
+ * try_reclaim() when the heap is at capacity (heap_size >= capacity), which calls
+ * Heap::shrink() to unmap tail pages no longer containing live allocations.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// 1 KB.
+#define KB (1024u)
+
+// 1 MB.
+#define MB (1024u * KB)
+
+// Block size used in bulk-free, anchor, and cycle scenarios.
+#define LARGE_BLOCK_SIZE MB
+
+// Number of large blocks in bulk-free and anchor scenarios.
+#define NUM_LARGE_BLOCKS 4u
+
+// Size of small anchor allocations.
+#define ANCHOR_SIZE 64u
+
+// Number of shrink-grow iterations.
+#define SHRINK_GROW_CYCLES 16u
+
+// Number of small allocations in the small-heap scenario.
+#define NUM_SMALL_ALLOCS 8u
+
+// Size of each small allocation (well below one page).
+#define SMALL_ALLOC_SIZE 128u
+
+// Number of regrowth blocks after shrink-to-minimum.
+#define REGROWTH_BLOCKS 4u
+
+// Size of each regrowth block (64 KB).
+#define REGROWTH_BLOCK_SIZE (64u * KB)
+
+//==================================================================================================
+// Private Functions — Scenarios
+//==================================================================================================
+
+// Scenario 1: Bulk-free triggers shrink.
+//
+// Allocate several large blocks so the heap grows well beyond one page, then free them all.
+// Each free at capacity triggers try_reclaim() → Heap::shrink() to unmap tail pages.
+// Re-allocate the same total to confirm pages were reclaimed and can be re-mapped.
+static void scenario_bulk_free(void)
+{
+    unsigned char *blocks[NUM_LARGE_BLOCKS];
+
+    // Allocate large blocks.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        blocks[i] = (unsigned char *)malloc(LARGE_BLOCK_SIZE);
+        assert(blocks[i] != NULL);
+        memset(blocks[i], 0, LARGE_BLOCK_SIZE);
+        blocks[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Verify integrity.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        assert(blocks[i][0] == (unsigned char)(i & 0xFFu));
+    }
+
+    // Free all — each free at capacity triggers try_reclaim() → shrink.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        free(blocks[i]);
+    }
+
+    // Re-allocate to confirm reclaimed pages are re-mappable.
+    unsigned char *blocks2[NUM_LARGE_BLOCKS];
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        blocks2[i] = (unsigned char *)malloc(LARGE_BLOCK_SIZE);
+        assert(blocks2[i] != NULL);
+        memset(blocks2[i], 0, LARGE_BLOCK_SIZE);
+        blocks2[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Verify integrity.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        assert(blocks2[i][0] == (unsigned char)(i & 0xFFu));
+    }
+
+    // Cleanup.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        free(blocks2[i]);
+    }
+}
+
+// Scenario 2: All-freed shrinks to minimum.
+//
+// Allocate a single large block (2 MB) to force heap growth, free it. With no live allocations,
+// try_reclaim() sees an empty span and shrinks the heap to PAGE_SIZE. Then allocate multiple
+// medium blocks to verify the heap grows back from minimum.
+static void scenario_shrink_to_minimum(void)
+{
+    // Grow the heap with a 2 MB allocation.
+    unsigned char *block = (unsigned char *)malloc(2 * MB);
+    assert(block != NULL);
+    memset(block, 0, 2 * MB);
+    block[0] = 0xAA;
+    free(block);
+    // Heap should now be at PAGE_SIZE (empty span → minimum).
+
+    // Verify regrowth from minimum.
+    unsigned char *regrowth[REGROWTH_BLOCKS];
+    for (size_t i = 0; i < REGROWTH_BLOCKS; ++i) {
+        regrowth[i] = (unsigned char *)malloc(REGROWTH_BLOCK_SIZE);
+        assert(regrowth[i] != NULL);
+        memset(regrowth[i], 0, REGROWTH_BLOCK_SIZE);
+        regrowth[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Verify integrity.
+    for (size_t i = 0; i < REGROWTH_BLOCKS; ++i) {
+        assert(regrowth[i][0] == (unsigned char)(i & 0xFFu));
+    }
+
+    // Cleanup.
+    for (size_t i = 0; i < REGROWTH_BLOCKS; ++i) {
+        free(regrowth[i]);
+    }
+}
+
+// Scenario 3: Anchors prevent full shrink.
+//
+// Allocate large blocks interleaved with small persistent anchors. Free the large blocks.
+// try_reclaim() can only reclaim tail pages above the highest live anchor. Then free anchors
+// and reallocate large blocks to verify full reclaimability.
+static void scenario_anchors_prevent_full_shrink(void)
+{
+    unsigned char *blocks[NUM_LARGE_BLOCKS];
+    unsigned char *anchors[NUM_LARGE_BLOCKS];
+
+    // Interleave: large block, anchor, large block, anchor, ...
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        blocks[i] = (unsigned char *)malloc(LARGE_BLOCK_SIZE);
+        assert(blocks[i] != NULL);
+        memset(blocks[i], 0, LARGE_BLOCK_SIZE);
+        blocks[i][0] = (unsigned char)(i & 0xFFu);
+
+        anchors[i] = (unsigned char *)malloc(ANCHOR_SIZE);
+        assert(anchors[i] != NULL);
+        memset(anchors[i], 0, ANCHOR_SIZE);
+        anchors[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Free large blocks; anchors persist and pin the heap above minimum.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        free(blocks[i]);
+    }
+
+    // Free anchors — now the heap can fully reclaim.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        free(anchors[i]);
+    }
+
+    // Verify full reclaimability by re-allocating large blocks.
+    unsigned char *blocks2[NUM_LARGE_BLOCKS];
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        blocks2[i] = (unsigned char *)malloc(LARGE_BLOCK_SIZE);
+        assert(blocks2[i] != NULL);
+        memset(blocks2[i], 0, LARGE_BLOCK_SIZE);
+        blocks2[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Verify integrity.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        assert(blocks2[i][0] == (unsigned char)(i & 0xFFu));
+    }
+
+    // Cleanup.
+    for (size_t i = 0; i < NUM_LARGE_BLOCKS; ++i) {
+        free(blocks2[i]);
+    }
+}
+
+// Scenario 4: Repeated shrink-grow cycles.
+//
+// In a tight loop, allocate a large block then immediately free it. Each free triggers
+// try_reclaim() → shrink(), and the next allocation triggers the OOM handler → grow().
+// This exercises the self-healing path repeatedly.
+static void scenario_shrink_grow_cycles(void)
+{
+    for (size_t i = 0; i < SHRINK_GROW_CYCLES; ++i) {
+        unsigned char *block = (unsigned char *)malloc(LARGE_BLOCK_SIZE);
+        assert(block != NULL);
+        memset(block, 0, LARGE_BLOCK_SIZE);
+        unsigned char tag = (unsigned char)(i & 0xFFu);
+        block[0] = tag;
+        assert(block[0] == tag);
+        free(block);
+    }
+}
+
+// Scenario 5: Small heap stays at minimum.
+//
+// Allocate only small blocks whose total is well below a single page. Free them. The heap
+// should remain at PAGE_SIZE because try_reclaim() returns early when heap.size() <= PAGE_SIZE.
+// Verify stability by allocating and freeing small blocks again.
+static void scenario_small_heap_minimum(void)
+{
+    unsigned char *small[NUM_SMALL_ALLOCS];
+
+    // Allocate small blocks that fit within the initial page.
+    for (size_t i = 0; i < NUM_SMALL_ALLOCS; ++i) {
+        small[i] = (unsigned char *)malloc(SMALL_ALLOC_SIZE);
+        assert(small[i] != NULL);
+        memset(small[i], 0, SMALL_ALLOC_SIZE);
+        small[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Free all — heap remains at PAGE_SIZE (no shrink below minimum).
+    for (size_t i = 0; i < NUM_SMALL_ALLOCS; ++i) {
+        free(small[i]);
+    }
+
+    // Reallocate to verify stability.
+    unsigned char *small2[NUM_SMALL_ALLOCS];
+    for (size_t i = 0; i < NUM_SMALL_ALLOCS; ++i) {
+        small2[i] = (unsigned char *)malloc(SMALL_ALLOC_SIZE);
+        assert(small2[i] != NULL);
+        memset(small2[i], 0, SMALL_ALLOC_SIZE);
+        small2[i][0] = (unsigned char)(i & 0xFFu);
+    }
+
+    // Cleanup.
+    for (size_t i = 0; i < NUM_SMALL_ALLOCS; ++i) {
+        free(small2[i]);
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Exercises the heap shrink path through five scenarios that cover bulk-free, shrink-to-minimum,
+// anchor-pinned partial shrink, repeated shrink-grow cycles, and small-heap early-return.
+void test_heap_shrink(void)
+{
+    fprintf(stderr, "testing heap shrink ... ");
+
+    scenario_bulk_free();
+    scenario_shrink_to_minimum();
+    scenario_anchors_prevent_full_shrink();
+    scenario_shrink_grow_cycles();
+    scenario_small_heap_minimum();
+
+    fprintf(stderr, "passed\n");
+}

--- a/src/tests/memory-c/main.c
+++ b/src/tests/memory-c/main.c
@@ -68,6 +68,7 @@ int main(int argc, const char *argv[])
     test_malloc_usable_size();
     test_heap_reclaim();
     test_heap_max_capacity();
+    test_heap_shrink();
 
     // Write magic string to signal that the test passed.
     {

--- a/src/tests/stress-rust/src/tests/heap_max_capacity.rs
+++ b/src/tests/stress-rust/src/tests/heap_max_capacity.rs
@@ -223,11 +223,19 @@ pub fn run() -> Result<(), StressError> {
 /// Attempts to allocate a tagged block, returning `Err` on allocation failure instead of
 /// panicking. This is used in phases where running out of memory is an expected outcome.
 fn try_alloc_tagged_block(size: usize, index: usize) -> Result<Box<[u8]>, Error> {
-    // `Vec::try_reserve` returns Err on OOM instead of aborting.
+    // Use try_reserve to check capacity, then fill via write_bytes + set_len to avoid
+    // the infallible reallocation path in Vec::resize.
     let mut v: Vec<u8> = Vec::new();
     v.try_reserve(size)
         .map_err(|_| Error::new(ErrorCode::OutOfMemory, "allocation failed"))?;
-    v.resize(size, 0u8);
+
+    // SAFETY: try_reserve succeeded so the buffer has capacity for `size` bytes.
+    // We zero the memory before exposing it.
+    unsafe {
+        ::core::ptr::write_bytes(v.as_mut_ptr(), 0u8, size);
+        v.set_len(size);
+    }
+
     let mut block: Box<[u8]> = v.into_boxed_slice();
     let tag: u8 = u8::try_from(index & 0xFF).unwrap_or(0);
     block[0] = tag;

--- a/src/tests/stress-rust/src/tests/heap_shrink.rs
+++ b/src/tests/stress-rust/src/tests/heap_shrink.rs
@@ -1,0 +1,253 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::common::StressError;
+use ::alloc::{
+    boxed::Box,
+    vec::Vec,
+};
+use ::config::constants::{
+    KILOBYTE,
+    MEGABYTE,
+};
+use ::core::convert::TryFrom;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Block size used in bulk-free, anchor, and cycle scenarios. Large enough to push the heap
+/// to capacity, where the allocator triggers `try_reclaim()` on both dealloc and alloc paths.
+const LARGE_BLOCK_SIZE: usize = MEGABYTE;
+
+/// Number of large blocks allocated in the bulk-free and anchor scenarios.
+const NUM_LARGE_BLOCKS: usize = 4;
+
+/// Size of small anchor allocations that pin the heap and prevent full tail reclamation.
+const ANCHOR_SIZE: usize = 64;
+
+/// Number of shrink-grow iterations in the repeated-cycle scenario.
+const SHRINK_GROW_CYCLES: usize = 16;
+
+/// Number of small allocations in the small-heap scenario.
+const NUM_SMALL_ALLOCS: usize = 8;
+
+/// Size of each small allocation. Must be well below a single page (4 KB).
+const SMALL_ALLOC_SIZE: usize = 128;
+
+/// Number of small blocks allocated after shrink-to-minimum to verify regrowth.
+const REGROWTH_BLOCKS: usize = 4;
+
+/// Size of each regrowth block (64 KB each; total 256 KB forces multiple pages).
+const REGROWTH_BLOCK_SIZE: usize = 64 * KILOBYTE;
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Exercises the heap shrink path introduced in `Heap::shrink()` and the `try_reclaim()` logic
+/// that triggers it during `dealloc()`. Five scenarios cover all major code paths:
+///
+/// 1. Bulk-free triggers shrink — frees at capacity trigger `try_reclaim()`.
+/// 2. All-freed shrinks to minimum — empty span causes shrink to `PAGE_SIZE`.
+/// 3. Anchors prevent full shrink — persistent small allocations limit tail reclamation.
+/// 4. Repeated shrink-grow cycles — self-healing OOM→grow after each shrink.
+/// 5. Small heap stays at minimum — heap at `PAGE_SIZE` triggers early-return in `try_reclaim`.
+///
+/// # Returns
+///
+/// `Ok(())` on success or an error if any allocation or integrity check fails.
+///
+pub fn run() -> Result<(), StressError> {
+    scenario_bulk_free()?;
+    scenario_shrink_to_minimum()?;
+    scenario_anchors_prevent_full_shrink()?;
+    scenario_shrink_grow_cycles()?;
+    scenario_small_heap_minimum()?;
+    Ok(())
+}
+
+//==================================================================================================
+// Private Functions — Scenarios
+//==================================================================================================
+
+/// Scenario 1: Bulk-free triggers shrink.
+///
+/// Allocate several large blocks so the heap grows well beyond one page, then free them all.
+/// Each free at capacity triggers `try_reclaim()` which calls `Heap::shrink()` to unmap tail
+/// pages. Re-allocate the same total to confirm pages were reclaimed and can be re-mapped.
+///
+/// Exercises: `shrink()` normal unmap path, capacity-based `try_reclaim()` trigger.
+fn scenario_bulk_free() -> Result<(), StressError> {
+    let mut blocks: Vec<Box<[u8]>> = Vec::with_capacity(NUM_LARGE_BLOCKS);
+
+    for i in 0..NUM_LARGE_BLOCKS {
+        blocks.push(alloc_tagged_block(LARGE_BLOCK_SIZE, i)?);
+    }
+
+    // Verify integrity before freeing.
+    verify_tags(&blocks)?;
+
+    // Free all — cumulative freed (4 MB) exceeds heap.size()/4, triggering shrink.
+    drop(blocks);
+
+    // Re-allocate the same total to confirm reclaimed pages are re-mappable.
+    let mut blocks2: Vec<Box<[u8]>> = Vec::with_capacity(NUM_LARGE_BLOCKS);
+    for i in 0..NUM_LARGE_BLOCKS {
+        blocks2.push(alloc_tagged_block(LARGE_BLOCK_SIZE, i)?);
+    }
+    verify_tags(&blocks2)?;
+    drop(blocks2);
+
+    Ok(())
+}
+
+/// Scenario 2: All-freed shrinks to minimum.
+///
+/// Allocate a single large block to force heap growth, then free it. With no live allocations,
+/// `try_reclaim()` sees an empty span and shrinks the heap to `PAGE_SIZE`. Then allocate several
+/// medium blocks to verify the heap can grow back from the minimum.
+///
+/// Exercises: `try_reclaim()` empty-span path, `shrink()` clamp to `PAGE_SIZE`.
+fn scenario_shrink_to_minimum() -> Result<(), StressError> {
+    // Grow the heap with a 2 MB allocation.
+    let block: Box<[u8]> = alloc_tagged_block(2 * MEGABYTE, 0xAA)?;
+    drop(block);
+    // Heap should now be shrunk to PAGE_SIZE (empty span → minimum).
+
+    // Verify regrowth from minimum by allocating multiple blocks.
+    let mut regrowth: Vec<Box<[u8]>> = Vec::with_capacity(REGROWTH_BLOCKS);
+    for i in 0..REGROWTH_BLOCKS {
+        regrowth.push(alloc_tagged_block(REGROWTH_BLOCK_SIZE, i)?);
+    }
+    verify_tags(&regrowth)?;
+    drop(regrowth);
+
+    Ok(())
+}
+
+/// Scenario 3: Anchors prevent full shrink.
+///
+/// Allocate large blocks interleaved with small persistent anchors. Free the large blocks.
+/// `try_reclaim()` can only reclaim tail pages above the highest live allocation (an anchor),
+/// so the heap does not shrink to minimum. Then free anchors and reallocate large blocks to
+/// verify full reclaimability.
+///
+/// Exercises: `try_reclaim()` partial-reclaim path where `alloc_end < current_size` but
+/// `alloc_end > PAGE_SIZE`.
+fn scenario_anchors_prevent_full_shrink() -> Result<(), StressError> {
+    let mut blocks: Vec<Box<[u8]>> = Vec::with_capacity(NUM_LARGE_BLOCKS);
+    let mut anchors: Vec<Box<[u8; ANCHOR_SIZE]>> = Vec::with_capacity(NUM_LARGE_BLOCKS);
+
+    // Interleave: large block, anchor, large block, anchor, ...
+    for i in 0..NUM_LARGE_BLOCKS {
+        blocks.push(alloc_tagged_block(LARGE_BLOCK_SIZE, i)?);
+
+        let mut anchor: Box<[u8; ANCHOR_SIZE]> = Box::new([0u8; ANCHOR_SIZE]);
+        anchor[0] = u8::try_from(i & 0xFF).unwrap_or(0);
+        anchors.push(anchor);
+    }
+
+    // Free large blocks; anchors persist and pin the heap above minimum.
+    drop(blocks);
+
+    // Free anchors — now the heap can fully reclaim.
+    drop(anchors);
+
+    // Verify full reclaimability by re-allocating large blocks.
+    let mut blocks2: Vec<Box<[u8]>> = Vec::with_capacity(NUM_LARGE_BLOCKS);
+    for i in 0..NUM_LARGE_BLOCKS {
+        blocks2.push(alloc_tagged_block(LARGE_BLOCK_SIZE, i)?);
+    }
+    verify_tags(&blocks2)?;
+    drop(blocks2);
+
+    Ok(())
+}
+
+/// Scenario 4: Repeated shrink-grow cycles.
+///
+/// In a tight loop, allocate a large block then immediately free it. Each free triggers
+/// `try_reclaim()` → `shrink()`, and the next allocation triggers the OOM handler → `grow()`.
+/// This exercises the self-healing path where the Talc span is repeatedly truncated and
+/// re-extended.
+///
+/// Exercises: shrink→OOM→grow cycle, capacity-based reclaim trigger.
+fn scenario_shrink_grow_cycles() -> Result<(), StressError> {
+    for i in 0..SHRINK_GROW_CYCLES {
+        let block: Box<[u8]> = alloc_tagged_block(LARGE_BLOCK_SIZE, i)?;
+        let expected_tag: u8 = u8::try_from(i & 0xFF).unwrap_or(0);
+        if block[0] != expected_tag {
+            return Err(Error::new(ErrorCode::InvalidArgument, "cycle tag mismatch"));
+        }
+        drop(block);
+        // Each drop frees 1 MB; the heap is at capacity so dealloc triggers
+        // try_reclaim() → shrink. The next iteration's alloc triggers OOM → grow.
+    }
+
+    Ok(())
+}
+
+/// Scenario 5: Small heap stays at minimum.
+///
+/// Allocate only small blocks whose total is well below a single page. Free them. The heap
+/// should remain at `PAGE_SIZE` throughout because `try_reclaim()` returns early when
+/// `heap.size() <= PAGE_SIZE`. Verify stability by allocating and freeing small blocks again.
+///
+/// Exercises: `try_reclaim()` early-return for minimum-sized heap.
+fn scenario_small_heap_minimum() -> Result<(), StressError> {
+    // Allocate small blocks that fit within the initial page.
+    let mut small: Vec<Box<[u8]>> = Vec::with_capacity(NUM_SMALL_ALLOCS);
+    for i in 0..NUM_SMALL_ALLOCS {
+        small.push(alloc_tagged_block(SMALL_ALLOC_SIZE, i)?);
+    }
+
+    // Free all — heap should remain at PAGE_SIZE (no shrink below minimum).
+    drop(small);
+
+    // Reallocate to verify stability.
+    let mut small2: Vec<Box<[u8]>> = Vec::with_capacity(NUM_SMALL_ALLOCS);
+    for i in 0..NUM_SMALL_ALLOCS {
+        small2.push(alloc_tagged_block(SMALL_ALLOC_SIZE, i)?);
+    }
+    drop(small2);
+
+    Ok(())
+}
+
+//==================================================================================================
+// Private Functions — Helpers
+//==================================================================================================
+
+/// Allocates a zeroed block of `size` bytes and writes a tag into the first byte.
+fn alloc_tagged_block(size: usize, index: usize) -> Result<Box<[u8]>, Error> {
+    let mut block: Box<[u8]> = ::alloc::vec![0u8; size].into_boxed_slice();
+    let tag: u8 = u8::try_from(index & 0xFF).unwrap_or(0);
+    block[0] = tag;
+    if block[0] != tag {
+        return Err(Error::new(ErrorCode::InvalidArgument, "block tag mismatch"));
+    }
+    Ok(block)
+}
+
+/// Verifies tag integrity on a slice of tagged blocks.
+fn verify_tags(blocks: &[Box<[u8]>]) -> Result<(), StressError> {
+    for (index, block) in blocks.iter().enumerate() {
+        let expected_tag: u8 = u8::try_from(index & 0xFF).unwrap_or(0);
+        if block[0] != expected_tag {
+            return Err(Error::new(ErrorCode::InvalidArgument, "tag verification failed"));
+        }
+    }
+    Ok(())
+}

--- a/src/tests/stress-rust/src/tests/mod.rs
+++ b/src/tests/stress-rust/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod debug_console_spam;
 mod event_registration;
 mod heap_max_capacity;
 mod heap_reclaim;
+mod heap_shrink;
 mod kcall_hammer;
 mod memory_mapping_storm;
 mod mmap_rapid_cycle;
@@ -49,6 +50,7 @@ pub fn run_all() -> Result<(), Error> {
     scoreboard_backpressure::run()?;
     heap_reclaim::run()?;
     heap_max_capacity::run()?;
+    heap_shrink::run()?;
     sleep_burst::run()?;
     debug_console_spam::run()?;
     event_registration::run()?;


### PR DESCRIPTION
## Summary

Add heap shrinking support to the system allocator so that physical frames backing unused tail pages are returned to the kernel after deallocation, and add integration tests covering all major reclamation code paths.

## Changes

### sysalloc

- **`Heap::shrink()`**: Unmaps committed pages from the end of the heap down to a given page-aligned size, acting as the inverse of `Heap::grow()`. Updates `self.size` even on partial unmap failure so metadata never advertises unmapped pages.
- **`try_reclaim()`**: Called from both `dealloc()` and `alloc()` when `heap_size >= capacity`. Uses Talc's `get_allocated_span()` to find the high-water mark of live allocations, truncates the Talc span, and unmaps freed tail pages.
- **Capacity-based gate**: Reclamation only fires when the heap cannot grow further (`heap_size >= capacity`), avoiding unnecessary metadata probes while the heap still has room. Below capacity, frees are zero-overhead.
- **Proactive alloc-path reclaim**: On `alloc()`, proactive reclaim before `malloc` allows the OOM handler to re-grow into freshly unmapped address space, keeping allocation responsive at the capacity boundary.
- **Null-pointer guard**: `dealloc()` guards against null pointers early, before acquiring the heap lock.
- **Minimum-size guard**: Skips the probe entirely when the heap is already at one page.
- **Safe arithmetic**: Uses `checked_sub` instead of unchecked subtraction for pointer offset calculation.
- **Self-healing failure**: If `shrink()` fails, Talc's span is already truncated but backing pages remain mapped; the next OOM cycle re-extends without new mmaps.
- **Query API**: Expose `heap_committed_size()` and `heap_capacity()` (with C-callable wrappers) so user-space tests can query the allocator state.

### stress-rust

- Fix `try_alloc_tagged_block()` to avoid the infallible reallocation path in `Vec::resize` by using `write_bytes` + `set_len` after `try_reserve`.
- Add `heap_shrink.rs` with five scenarios: bulk-free, shrink-to-minimum, anchor-pinned, shrink-grow cycles, and small-heap guard.

### memory-c

- Add `heap_shrink.c` with equivalent five C scenarios, wired into `main.c` and declared in `common.h`.