### PR TITLE
[linuxd] Coalesce remaining frame + payload write and add docs

### DIFF
--- a/src/daemons/linuxd/src/lib.rs
+++ b/src/daemons/linuxd/src/lib.rs
@@ -928,18 +928,13 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
                         let mut writer_guard: MutexGuard<'_, SocketStreamWriter> =
                             uvm_writer.lock().await;
                         let err_bytes: [u8; IPC_MESSAGE_SIZE] = err_msg.to_bytes();
-                        writer_guard
-                            .write_all(&[IkcFrame::MESSAGE_FRAME])
-                            .await
-                            .map_err(|e| {
-                                let reason: &str = "failed to send error message to user VM";
-                                error!(
-                                    "forward_user_vm_msg_to_worker_thread(): {reason} \
-                                     (error={e:?})"
-                                );
-                                Error::new(ErrorCode::IoErr, reason)
-                            })?;
-                        writer_guard.write_all(&err_bytes).await.map_err(|e| {
+                        // Coalesce frame type byte and message payload into a single write
+                        // to reduce syscall overhead and avoid sending the frame byte as a
+                        // separate tiny segment.
+                        let mut buf: [u8; 1 + IPC_MESSAGE_SIZE] = [0; 1 + IPC_MESSAGE_SIZE];
+                        buf[0] = IkcFrame::MESSAGE_FRAME;
+                        buf[1..].copy_from_slice(&err_bytes);
+                        writer_guard.write_all(&buf).await.map_err(|e| {
                             let reason: &str = "failed to send error message to user VM";
                             error!(
                                 "forward_user_vm_msg_to_worker_thread(): {reason} (error={e:?})"

--- a/src/daemons/linuxd/src/worker_thread.rs
+++ b/src/daemons/linuxd/src/worker_thread.rs
@@ -1134,9 +1134,15 @@ impl WorkerThreadHandle {
         uvm_stream: Arc<Mutex<SocketStreamWriter>>,
         message: Message,
     ) -> Result<(), std::io::Error> {
+        // Coalesce frame type byte and message payload into a single write to reduce
+        // syscall overhead and avoid sending the frame byte as a separate tiny segment.
+        let msg_bytes: [u8; std::mem::size_of::<Message>()] = message.to_bytes();
+        let mut buf: [u8; 1 + std::mem::size_of::<Message>()] =
+            [0; 1 + std::mem::size_of::<Message>()];
+        buf[0] = IkcFrame::MESSAGE_FRAME;
+        buf[1..].copy_from_slice(&msg_bytes);
         let mut guard: MutexGuard<'_, SocketStreamWriter> = uvm_stream.lock().await;
-        guard.write_all(&[IkcFrame::MESSAGE_FRAME]).await?;
-        guard.write_all(&message.to_bytes()).await?;
+        guard.write_all(&buf).await?;
         Ok(())
     }
 
@@ -1164,10 +1170,17 @@ impl WorkerThreadHandle {
             std::io::Error::new(std::io::ErrorKind::InvalidData, "bulk payload length exceeds u32")
         })?;
         let len_prefix: [u8; 4] = payload_len.to_le_bytes();
+        // Coalesce frame type byte, length prefix, and payload into a single vectored write
+        // to reduce syscall overhead and avoid extra allocation+copy.
+        let frame_byte: [u8; 1] = [IkcFrame::DATA_CHUNK_FRAME];
         let mut guard: MutexGuard<'_, SocketStreamWriter> = uvm_stream.lock().await;
-        guard.write_all(&[IkcFrame::DATA_CHUNK_FRAME]).await?;
-        guard.write_all(&len_prefix).await?;
-        guard.write_all(&payload).await?;
+        guard
+            .write_all_vectored(&mut [
+                std::io::IoSlice::new(&frame_byte),
+                std::io::IoSlice::new(&len_prefix),
+                std::io::IoSlice::new(&payload),
+            ])
+            .await?;
         Ok(())
     }
 

--- a/src/libs/syscomm/src/socket_stream_writer.rs
+++ b/src/libs/syscomm/src/socket_stream_writer.rs
@@ -7,7 +7,10 @@
 
 use crate::WriteAll;
 use ::log::error;
-use ::std::io::Result;
+use ::std::io::{
+    IoSlice,
+    Result,
+};
 use ::tokio::io::AsyncWriteExt;
 
 //==================================================================================================
@@ -70,6 +73,51 @@ impl SocketStreamWriter {
                 Err(error)
             },
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Writes all bytes from the provided I/O slices using vectored (scatter/gather) I/O.
+    /// This avoids extra allocations and copies when coalescing multi-part frames
+    /// (e.g., frame-type byte + length prefix + payload) into a single write.
+    ///
+    /// # Parameters
+    ///
+    /// - `bufs`: Mutable slice of I/O slices to write. Consumed slices are advanced internally.
+    ///
+    /// # Returns
+    ///
+    /// This function returns a future that, when resolved, yields either:
+    /// - On Success: An empty tuple after all bytes have been written.
+    /// - On Failure: An error value.
+    ///
+    /// # Cancellation
+    ///
+    /// This function is not cancel-safe. If the future is cancelled before completion, the number
+    /// of bytes that were written prior to cancellation is unspecified.
+    ///
+    pub async fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> Result<()> {
+        let mut slices: &mut [IoSlice<'_>] = bufs;
+        while !slices.is_empty() {
+            let n: usize = match self {
+                SocketStreamWriter::Tcp(stream) => stream.write_vectored(slices).await,
+                SocketStreamWriter::Unix(stream) => stream.write_vectored(slices).await,
+            }
+            .map_err(|error| {
+                let reason: String = format!("write_all_vectored(): {error}");
+                error!("{reason}");
+                error
+            })?;
+            if n == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "write_all_vectored(): write returned 0 bytes",
+                ));
+            }
+            IoSlice::advance_slices(&mut slices, n);
+        }
+        Ok(())
     }
 }
 

--- a/src/libs/syscomm/src/tests/tcp.rs
+++ b/src/libs/syscomm/src/tests/tcp.rs
@@ -16,6 +16,7 @@ use crate::{
     UnboundSocket,
     WriteAll,
 };
+use ::std::io::IoSlice;
 use ::tokio::task::JoinHandle;
 
 //==================================================================================================
@@ -156,4 +157,98 @@ async fn tcp_socket_connect_invalid_address() {
         .connect("127.0.0.1:99999")
         .await;
     assert!(res.is_err());
+}
+
+#[tokio::test]
+async fn tcp_socket_write_all_vectored_success() {
+    let listener: SocketListener = UnboundSocket::new(SocketType::Tcp)
+        .bind("127.0.0.1:0")
+        .await
+        .expect("bind failed");
+
+    let addr: SocketAddr = match &listener {
+        SocketListener::Tcp { listener, .. } => {
+            let bound: ::std::net::SocketAddr = listener.local_addr().expect("local_addr failed");
+            SocketAddr::Tcp(bound)
+        },
+        _ => unreachable!(),
+    };
+
+    let server: JoinHandle<()> = tokio::spawn(async move {
+        let stream: SocketStream = listener.accept().await.expect("accept failed");
+        let (mut r, _w): (SocketStreamReader, SocketStreamWriter) = stream.split();
+        let mut buf: [u8; 10] = [0u8; 10];
+        r.read_exact(&mut buf).await.expect("read_exact failed");
+        assert_eq!(&buf, b"helloworld");
+    });
+
+    let connect_target: String = match &addr {
+        SocketAddr::Tcp(addr) => addr.to_string(),
+        SocketAddr::Unix(_) => unreachable!(),
+    };
+
+    let client: SocketStream = UnboundSocket::new(SocketType::Tcp)
+        .connect(&connect_target)
+        .await
+        .expect("connect failed");
+
+    let (_r, mut w): (SocketStreamReader, SocketStreamWriter) = client.split();
+    let a: &[u8] = b"hello";
+    let b: &[u8] = b"world";
+    w.write_all_vectored(&mut [IoSlice::new(a), IoSlice::new(b)])
+        .await
+        .expect("write_all_vectored failed");
+
+    server.await.expect("server task join failed");
+}
+
+#[tokio::test]
+async fn tcp_socket_write_all_vectored_three_slices() {
+    let listener: SocketListener = UnboundSocket::new(SocketType::Tcp)
+        .bind("127.0.0.1:0")
+        .await
+        .expect("bind failed");
+
+    let addr: SocketAddr = match &listener {
+        SocketListener::Tcp { listener, .. } => {
+            let bound: ::std::net::SocketAddr = listener.local_addr().expect("local_addr failed");
+            SocketAddr::Tcp(bound)
+        },
+        _ => unreachable!(),
+    };
+
+    let server: JoinHandle<()> = tokio::spawn(async move {
+        let stream: SocketStream = listener.accept().await.expect("accept failed");
+        let (mut r, _w): (SocketStreamReader, SocketStreamWriter) = stream.split();
+        // Frame type (1) + length prefix (4) + payload (6) = 11 bytes.
+        let mut buf: [u8; 11] = [0u8; 11];
+        r.read_exact(&mut buf).await.expect("read_exact failed");
+        assert_eq!(buf[0], 0x01);
+        assert_eq!(&buf[1..5], &6u32.to_le_bytes());
+        assert_eq!(&buf[5..], b"abcdef");
+    });
+
+    let connect_target: String = match &addr {
+        SocketAddr::Tcp(addr) => addr.to_string(),
+        SocketAddr::Unix(_) => unreachable!(),
+    };
+
+    let client: SocketStream = UnboundSocket::new(SocketType::Tcp)
+        .connect(&connect_target)
+        .await
+        .expect("connect failed");
+
+    let (_r, mut w): (SocketStreamReader, SocketStreamWriter) = client.split();
+    let frame_type: [u8; 1] = [0x01];
+    let len_prefix: [u8; 4] = 6u32.to_le_bytes();
+    let payload: &[u8] = b"abcdef";
+    w.write_all_vectored(&mut [
+        IoSlice::new(&frame_type),
+        IoSlice::new(&len_prefix),
+        IoSlice::new(payload),
+    ])
+    .await
+    .expect("write_all_vectored failed");
+
+    server.await.expect("server task join failed");
 }

--- a/src/libs/syscomm/src/tests/unix.rs
+++ b/src/libs/syscomm/src/tests/unix.rs
@@ -15,7 +15,10 @@ use crate::{
     UnboundSocket,
     WriteAll,
 };
-use ::std::path::PathBuf;
+use ::std::{
+    io::IoSlice,
+    path::PathBuf,
+};
 use ::tokio::task::JoinHandle;
 
 //==================================================================================================
@@ -138,4 +141,90 @@ async fn unix_connect_missing() {
         .connect("/nonexistent/path.sock")
         .await;
     assert!(res.is_err());
+}
+
+#[tokio::test]
+async fn unix_socket_write_all_vectored_success() {
+    let mut path: PathBuf = std::env::temp_dir();
+    let now: u128 = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let unique: String = format!("sock-vec-test-{}-{}", std::process::id(), now);
+    path.push(unique);
+    let path: String = path.to_string_lossy().to_string();
+
+    let listener: SocketListener = UnboundSocket::new(SocketType::Unix)
+        .bind(&path)
+        .await
+        .expect("unix bind failed");
+
+    let server: JoinHandle<()> = tokio::spawn(async move {
+        let stream: SocketStream = listener.accept().await.expect("accept failed");
+        let (mut r, _w): (SocketStreamReader, SocketStreamWriter) = stream.split();
+        let mut buf: [u8; 10] = [0u8; 10];
+        r.read_exact(&mut buf).await.expect("read_exact failed");
+        assert_eq!(&buf, b"helloworld");
+    });
+
+    let client: SocketStream = UnboundSocket::new(SocketType::Unix)
+        .connect(&path)
+        .await
+        .expect("unix connect failed");
+
+    let (_r, mut w): (SocketStreamReader, SocketStreamWriter) = client.split();
+    let a: &[u8] = b"hello";
+    let b: &[u8] = b"world";
+    w.write_all_vectored(&mut [IoSlice::new(a), IoSlice::new(b)])
+        .await
+        .expect("write_all_vectored failed");
+
+    server.await.expect("server join failed");
+}
+
+#[tokio::test]
+async fn unix_socket_write_all_vectored_three_slices() {
+    let mut path: PathBuf = std::env::temp_dir();
+    let now: u128 = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let unique: String = format!("sock-vec3-test-{}-{}", std::process::id(), now);
+    path.push(unique);
+    let path: String = path.to_string_lossy().to_string();
+
+    let listener: SocketListener = UnboundSocket::new(SocketType::Unix)
+        .bind(&path)
+        .await
+        .expect("unix bind failed");
+
+    let server: JoinHandle<()> = tokio::spawn(async move {
+        let stream: SocketStream = listener.accept().await.expect("accept failed");
+        let (mut r, _w): (SocketStreamReader, SocketStreamWriter) = stream.split();
+        // Frame type (1) + length prefix (4) + payload (6) = 11 bytes.
+        let mut buf: [u8; 11] = [0u8; 11];
+        r.read_exact(&mut buf).await.expect("read_exact failed");
+        assert_eq!(buf[0], 0x01);
+        assert_eq!(&buf[1..5], &6u32.to_le_bytes());
+        assert_eq!(&buf[5..], b"abcdef");
+    });
+
+    let client: SocketStream = UnboundSocket::new(SocketType::Unix)
+        .connect(&path)
+        .await
+        .expect("unix connect failed");
+
+    let (_r, mut w): (SocketStreamReader, SocketStreamWriter) = client.split();
+    let frame_type: [u8; 1] = [0x01];
+    let len_prefix: [u8; 4] = 6u32.to_le_bytes();
+    let payload: &[u8] = b"abcdef";
+    w.write_all_vectored(&mut [
+        IoSlice::new(&frame_type),
+        IoSlice::new(&len_prefix),
+        IoSlice::new(payload),
+    ])
+    .await
+    .expect("write_all_vectored failed");
+
+    server.await.expect("server join failed");
 }

--- a/src/uservm/src/io_thread.rs
+++ b/src/uservm/src/io_thread.rs
@@ -53,9 +53,12 @@ use ::tokio::{
 pub struct IoThread;
 
 /// Timestamps, serialises, and writes a single [`Message`] to the system VM socket.
+/// The `frame_type` byte is prepended to the message payload in a single write to reduce
+/// syscall overhead and avoid sending the frame byte as a separate tiny segment.
 async fn forward_message_to_system_vm(
     msg: &mut Message,
     system_vm_tx: &mut SocketStreamWriter,
+    frame_type: u8,
 ) -> Result<()> {
     // Label: uservm::io_thread::system_vm::write()
     profiler::timestamp_message!(
@@ -64,8 +67,12 @@ async fn forward_message_to_system_vm(
             + std::mem::offset_of!(syscall::unistd::message::WriteRequest, buffer)
     );
     // SAFETY: `Message` derives `Clone`; cloning avoids consuming the caller's binding.
-    let bytes: [u8; ::std::mem::size_of::<Message>()] = msg.clone().to_bytes();
-    system_vm_tx.write_all(&bytes).await.map_err(|e| {
+    let msg_bytes: [u8; ::std::mem::size_of::<Message>()] = msg.clone().to_bytes();
+    let mut buf: [u8; 1 + ::std::mem::size_of::<Message>()] =
+        [0; 1 + ::std::mem::size_of::<Message>()];
+    buf[0] = frame_type;
+    buf[1..].copy_from_slice(&msg_bytes);
+    system_vm_tx.write_all(&buf).await.map_err(|e| {
         let reason: String = format!("failed writing message to system VM socket: {e}");
         error!("{reason}");
         anyhow::Error::msg(reason)
@@ -78,10 +85,12 @@ async fn forward_message_to_system_vm(
 const BULK_TRANSFER_LENGTH_PREFIX_SIZE: usize = mem::size_of::<u32>();
 
 /// Serialises and writes a [`DataChunk`] to the system VM socket using a simple
-/// length-prefixed framing protocol.
+/// length-prefixed framing protocol. The `frame_type` byte, length prefix, and payload are
+/// coalesced into a single vectored write to reduce syscall overhead.
 async fn forward_bulk_to_system_vm(
     bulk: &mut DataChunk,
     system_vm_tx: &mut SocketStreamWriter,
+    frame_type: u8,
 ) -> Result<()> {
     // Label: uservm::io_thread::system_vm::write()
     profiler::timestamp_message!(bulk.data_mut(), 0);
@@ -92,38 +101,34 @@ async fn forward_bulk_to_system_vm(
             error!("{reason}");
             anyhow::Error::msg(reason)
         })?);
-    // Write length prefix followed by the serialized data chunk transfer.
-    system_vm_tx.write_all(&len_prefix).await.map_err(|e| {
-        let reason: String = format!("failed writing bulk length prefix: {e}");
-        error!("{reason}");
-        anyhow::Error::msg(reason)
-    })?;
-    system_vm_tx.write_all(&payload).await.map_err(|e| {
-        let reason: String = format!("failed writing bulk payload: {e}");
-        error!("{reason}");
-        anyhow::Error::msg(reason)
-    })?;
+    // Coalesce frame type, length prefix, and payload into a single vectored write
+    // to avoid an extra heap allocation and full-payload copy.
+    let frame_byte: [u8; 1] = [frame_type];
+    system_vm_tx
+        .write_all_vectored(&mut [
+            std::io::IoSlice::new(&frame_byte),
+            std::io::IoSlice::new(&len_prefix),
+            std::io::IoSlice::new(&payload),
+        ])
+        .await
+        .map_err(|e| {
+            let reason: String = format!("failed writing bulk transfer: {e}");
+            error!("{reason}");
+            anyhow::Error::msg(reason)
+        })?;
     Ok(())
 }
 
-/// Forwards a [`IkcFrame`] to the system VM socket. The frame type byte is written first based
-/// on the transfer variant, followed by the variant-specific payload.
+/// Forwards a [`IkcFrame`] to the system VM socket. The frame type byte is coalesced with the
+/// payload into a single write to reduce syscall overhead.
 async fn forward_transfer_to_system_vm(
     transfer: &mut IkcFrame,
     system_vm_tx: &mut SocketStreamWriter,
 ) -> Result<()> {
-    // Write frame type discriminator derived from the transfer variant.
-    system_vm_tx
-        .write_all(&[transfer.frame_type_byte()])
-        .await
-        .map_err(|e| {
-            let reason: String = format!("failed writing frame type: {e}");
-            error!("{reason}");
-            anyhow::Error::msg(reason)
-        })?;
+    let frame_type: u8 = transfer.frame_type_byte();
     match transfer {
-        IkcFrame::Message(msg) => forward_message_to_system_vm(msg, system_vm_tx).await,
-        IkcFrame::Bulk(bulk) => forward_bulk_to_system_vm(bulk, system_vm_tx).await,
+        IkcFrame::Message(msg) => forward_message_to_system_vm(msg, system_vm_tx, frame_type).await,
+        IkcFrame::Bulk(bulk) => forward_bulk_to_system_vm(bulk, system_vm_tx, frame_type).await,
     }
 }
 


### PR DESCRIPTION
Coalesce the two sequential `write_all()` calls in the error-message
path of `forward_user_vm_msg_to_worker_thread()` into a single write.
The frame-type byte and serialised message are now packed into a flat
stack buffer (`[u8; 1 + IPC_MESSAGE_SIZE]`) before writing, matching
the pattern already applied in `send()` and `send_bulk()`.  This
eliminates the Nagle-delay window between the frame discriminator
and the payload when the socket is TCP (L2 deployment).

Add structured doc comments to `SocketStreamWriter::write_all_vectored()`
(`Description`, `Parameters`, `Returns`, `Cancellation`) to match the format
used by the sibling `write()` and `write_all()` methods.