### PR TITLE
[build] Batch cargo invocations

### DIFF
--- a/build/make/generic-guest-binaries.mk
+++ b/build/make/generic-guest-binaries.mk
@@ -17,12 +17,14 @@ STANDALONE_GUEST_BINARIES := file-rust linux-app thread-rust stress-rust arch-ru
 # Computes the cargo features string for a guest binary package.
 # test-kernel has its own overrides. When DEPLOYMENT_MODE=standalone, packages
 # listed in STANDALONE_GUEST_BINARIES also get the 'standalone' cargo feature.
-_standalone_feature = $(if $(and $(filter standalone,$(DEPLOYMENT_MODE)),$(filter $(STANDALONE_GUEST_BINARIES),$(1))),standalone)
+_STANDALONE_FEATURE := standalone
+_standalone_feature = $(if $(and $(filter standalone,$(DEPLOYMENT_MODE)),$(filter $(STANDALONE_GUEST_BINARIES),$(1))),$(_STANDALONE_FEATURE))
 _pkg_features = $(strip $(GUEST_BINARY_FEATURES) $(call _standalone_feature,$(1)))
 
 # Returns package-specific cargo features, falling back to generic features.
 GUEST_BINARY_PKG_FEATURES = $(if $(filter test-kernel,$(1)),$(TEST_KERNEL_CARGO_FEATURES),$(if $(call _pkg_features,$(1)),--features "$(call _pkg_features,$(1))"))
 
+# Per-package rules retained for direct invocation (e.g., make all-guest-binaries-<pkg>).
 define GUEST_BINARY_RULES
 all-guest-binaries-$(1): init all-guest-staticlibs
 	$(GUEST_CARGO_BUILD_CMD) -p $(1) $(call GUEST_BINARY_PKG_FEATURES,$(1))
@@ -50,22 +52,86 @@ endef
 
 $(foreach target,$(ALL_GUEST_BINARIES),$(eval $(call GUEST_BINARY_RULES,$(target))))
 
-all-guest-binaries: $(foreach target,$(ALL_GUEST_BINARIES),all-guest-binaries-$(target))
+# Batched build/check/lint grouping: split guest binaries by feature set.
+# - Regular: all except test-kernel (and standalone-capable in standalone mode).
+# - Standalone: standalone-capable binaries (only in standalone mode).
+# - test-kernel: always separate (unique features).
+_GUEST_BINS_COMMON := $(filter-out test-kernel,$(ALL_GUEST_BINARIES))
+
+ifeq ($(DEPLOYMENT_MODE),standalone)
+_GUEST_BINS_STANDALONE := $(filter $(STANDALONE_GUEST_BINARIES),$(_GUEST_BINS_COMMON))
+_GUEST_BINS_REGULAR := $(filter-out $(STANDALONE_GUEST_BINARIES),$(_GUEST_BINS_COMMON))
+_GUEST_BINS_STANDALONE_FEATURES := $(strip $(GUEST_BINARY_FEATURES) $(_STANDALONE_FEATURE))
+_GUEST_BINS_STANDALONE_CARGO_FEATURES := $(if $(_GUEST_BINS_STANDALONE_FEATURES),--features "$(_GUEST_BINS_STANDALONE_FEATURES)")
+else
+_GUEST_BINS_REGULAR := $(_GUEST_BINS_COMMON)
+_GUEST_BINS_STANDALONE :=
+endif
+
+_GUEST_BINS_REGULAR_PKGS := $(foreach pkg,$(_GUEST_BINS_REGULAR),-p $(pkg))
+_GUEST_BINS_STANDALONE_PKGS := $(foreach pkg,$(_GUEST_BINS_STANDALONE),-p $(pkg))
+
+# Batched build: group guest binaries by feature set, then copy all artifacts.
+all-guest-binaries: init all-guest-staticlibs
+ifneq ($(_GUEST_BINS_REGULAR_PKGS),)
+	$(GUEST_CARGO_BUILD_CMD) $(_GUEST_BINS_REGULAR_PKGS) $(GUEST_BINARY_CARGO_FEATURES)
+endif
+ifneq ($(_GUEST_BINS_STANDALONE_PKGS),)
+	$(GUEST_CARGO_BUILD_CMD) $(_GUEST_BINS_STANDALONE_PKGS) $(_GUEST_BINS_STANDALONE_CARGO_FEATURES)
+endif
+ifneq ($(filter test-kernel,$(ALL_GUEST_BINARIES)),)
+	$(GUEST_CARGO_BUILD_CMD) -p test-kernel $(TEST_KERNEL_CARGO_FEATURES)
+endif
+	@for pkg in $(ALL_GUEST_BINARIES); do \
+		$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$$pkg.elf $(BINARIES_DIR)/$$pkg.elf; \
+	done
 	$(MAKE_QUIET) -C $(SOURCES_DIR)/benchmarks all
 	$(MAKE_QUIET) -C $(SOURCES_DIR)/user all
 	$(MAKE_QUIET) -C $(SOURCES_DIR)/tests all
 
-check-guest-binaries: $(foreach target,$(ALL_GUEST_BINARIES),check-guest-binaries-$(target))
+check-guest-binaries:
+ifneq ($(_GUEST_BINS_REGULAR_PKGS),)
+	$(GUEST_CARGO_CHECK_CMD) $(_GUEST_BINS_REGULAR_PKGS) $(GUEST_BINARY_CARGO_FEATURES)
+endif
+ifneq ($(_GUEST_BINS_STANDALONE_PKGS),)
+	$(GUEST_CARGO_CHECK_CMD) $(_GUEST_BINS_STANDALONE_PKGS) $(_GUEST_BINS_STANDALONE_CARGO_FEATURES)
+endif
+ifneq ($(filter test-kernel,$(ALL_GUEST_BINARIES)),)
+	$(GUEST_CARGO_CHECK_CMD) -p test-kernel $(TEST_KERNEL_CARGO_FEATURES)
+endif
 
-format-guest-binaries: $(foreach target,$(ALL_GUEST_BINARIES),format-guest-binaries-$(target))
+# Batched format: single cargo invocation for all guest binaries.
+_GUEST_BINS_FMT_PKGS := $(foreach pkg,$(ALL_GUEST_BINARIES),-p $(pkg))
+format-guest-binaries:
+	$(GUEST_CARGO_FMT_CMD) $(_GUEST_BINS_FMT_PKGS)
 
-format-check-guest-binaries: $(foreach target,$(ALL_GUEST_BINARIES),format-check-guest-binaries-$(target))
+format-check-guest-binaries:
+	$(GUEST_CARGO_FMT_CMD) $(_GUEST_BINS_FMT_PKGS) --check
 
 clean-guest-binaries: $(foreach target,$(ALL_GUEST_BINARIES),clean-guest-binaries-$(target))
 	$(MAKE_QUIET) -C $(SOURCES_DIR)/benchmarks clean
 	$(MAKE_QUIET) -C $(SOURCES_DIR)/user clean
 	$(MAKE_QUIET) -C $(SOURCES_DIR)/tests clean
 
-rust-lint-guest-binaries: $(foreach target,$(ALL_GUEST_BINARIES),rust-lint-guest-binaries-$(target))
+# Batched lint: group guest binaries by feature set (same as check).
+rust-lint-guest-binaries:
+ifneq ($(_GUEST_BINS_REGULAR_PKGS),)
+	$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_BINS_REGULAR_PKGS) $(GUEST_BINARY_CARGO_FEATURES) --fix --allow-dirty --allow-no-vcs
+endif
+ifneq ($(_GUEST_BINS_STANDALONE_PKGS),)
+	$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_BINS_STANDALONE_PKGS) $(_GUEST_BINS_STANDALONE_CARGO_FEATURES) --fix --allow-dirty --allow-no-vcs
+endif
+ifneq ($(filter test-kernel,$(ALL_GUEST_BINARIES)),)
+	$(GUEST_CARGO_CLIPPY_CMD) -p test-kernel $(TEST_KERNEL_CARGO_FEATURES) --fix --allow-dirty --allow-no-vcs
+endif
 
-rust-lint-check-guest-binaries: $(foreach target,$(ALL_GUEST_BINARIES),rust-lint-check-guest-binaries-$(target))
+rust-lint-check-guest-binaries:
+ifneq ($(_GUEST_BINS_REGULAR_PKGS),)
+	$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_BINS_REGULAR_PKGS) $(GUEST_BINARY_CARGO_FEATURES) -- -D warnings
+endif
+ifneq ($(_GUEST_BINS_STANDALONE_PKGS),)
+	$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_BINS_STANDALONE_PKGS) $(_GUEST_BINS_STANDALONE_CARGO_FEATURES) -- -D warnings
+endif
+ifneq ($(filter test-kernel,$(ALL_GUEST_BINARIES)),)
+	$(GUEST_CARGO_CLIPPY_CMD) -p test-kernel $(TEST_KERNEL_CARGO_FEATURES) -- -D warnings
+endif

--- a/build/make/generic-guest-rlibs.mk
+++ b/build/make/generic-guest-rlibs.mk
@@ -1,6 +1,7 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
+# Per-package rules retained for direct invocation (e.g., make check-guest-rlib-<pkg>).
 define GUEST_RLIB_RULES
 check-guest-rlib-$(1):
 	$(GUEST_CARGO_CHECK_CMD) -p $(1)
@@ -23,6 +24,7 @@ $(foreach target,$(ALL_GUEST_RUST_LIBS),$(eval $(call GUEST_RLIB_RULES,$(target)
 # Guest rlib test code is compiled for the host target (not the custom guest
 # target), so a separate host-side clippy pass with --tests is needed to lint
 # #[cfg(test)] modules.
+# Per-package rules retained for direct invocation.
 define GUEST_RLIB_LINT_TEST_RULES
 rust-lint-guest-rlib-tests-$(1):
 	$(HOST_CARGO_CLIPPY_CMD) --tests --features=std -p $(1) --fix --allow-dirty --allow-no-vcs
@@ -33,17 +35,26 @@ endef
 
 $(foreach target,$(ALL_GUEST_RUST_LIBS_TEST_LIST),$(eval $(call GUEST_RLIB_LINT_TEST_RULES,$(target))))
 
-check-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),check-guest-rlib-$(target))
+# Batched targets: single cargo invocations for all guest rlibs.
+_GUEST_RLIB_PKGS := $(foreach pkg,$(ALL_GUEST_RUST_LIBS),-p $(pkg))
+_GUEST_RLIB_LINT_TEST_PKGS := $(foreach pkg,$(ALL_GUEST_RUST_LIBS_TEST_LIST),-p $(pkg))
 
-format-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),format-guest-rlib-$(target))
+check-guest-rlibs:
+	$(GUEST_CARGO_CHECK_CMD) $(_GUEST_RLIB_PKGS)
 
-format-check-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),format-check-guest-rlib-$(target))
+format-guest-rlibs:
+	$(GUEST_CARGO_FMT_CMD) $(_GUEST_RLIB_PKGS)
 
-rust-lint-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),rust-lint-guest-rlib-$(target))
-rust-lint-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS_TEST_LIST),rust-lint-guest-rlib-tests-$(target))
+format-check-guest-rlibs:
+	$(GUEST_CARGO_FMT_CMD) $(_GUEST_RLIB_PKGS) --check
 
-rust-lint-check-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS),rust-lint-check-guest-rlib-$(target))
-rust-lint-check-guest-rlibs: $(foreach target,$(ALL_GUEST_RUST_LIBS_TEST_LIST),rust-lint-check-guest-rlib-tests-$(target))
+rust-lint-guest-rlibs:
+	$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_RLIB_PKGS) --fix --allow-dirty --allow-no-vcs
+	$(HOST_CARGO_CLIPPY_CMD) --tests --features=std $(_GUEST_RLIB_LINT_TEST_PKGS) --fix --allow-dirty --allow-no-vcs
+
+rust-lint-check-guest-rlibs:
+	$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_RLIB_PKGS) -- -D warnings
+	$(HOST_CARGO_CLIPPY_CMD) --tests --features=std $(_GUEST_RLIB_LINT_TEST_PKGS) -- -D warnings
 
 define GUEST_RLIB_TEST_RULES
 test-guest-rlib-$(1):

--- a/build/make/generic-guest-staticlibs.mk
+++ b/build/make/generic-guest-staticlibs.mk
@@ -10,6 +10,7 @@ endif
 GUEST_STATICLIB_FEATURES := $(strip $(GUEST_STATICLIB_FEATURES))
 GUEST_STATICLIB_CARGO_FEATURES := $(if $(GUEST_STATICLIB_FEATURES),--features "$(GUEST_STATICLIB_FEATURES)")
 
+# Per-package rules retained for direct invocation (e.g., make all-guest-staticlib-<pkg>).
 define GUEST_STATICLIB_RULES
 all-guest-staticlib-$(1): init
 	$(GUEST_CARGO_BUILD_CMD) -p $(1) $(GUEST_STATICLIB_CARGO_FEATURES)
@@ -38,16 +39,29 @@ endef
 
 $(foreach target,$(ALL_GUEST_STATIC_LIBS),$(eval $(call GUEST_STATICLIB_RULES,$(target))))
 
-all-guest-staticlibs: $(foreach target,$(ALL_GUEST_STATIC_LIBS),all-guest-staticlib-$(target))
+# Batched targets: single cargo invocations for all guest staticlibs.
+_GUEST_STATICLIB_PKGS := $(foreach pkg,$(ALL_GUEST_STATIC_LIBS),-p $(pkg))
 
-check-guest-staticlibs: $(foreach target,$(ALL_GUEST_STATIC_LIBS),check-guest-staticlib-$(target))
+all-guest-staticlibs: init
+	$(GUEST_CARGO_BUILD_CMD) $(_GUEST_STATICLIB_PKGS) $(GUEST_STATICLIB_CARGO_FEATURES)
+	@for pkg in $(ALL_GUEST_STATIC_LIBS); do \
+		$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/lib$$pkg.a $(LIBRARIES_DIR)/lib$$pkg.a; \
+	done
 
-format-guest-staticlibs: $(foreach target,$(ALL_GUEST_STATIC_LIBS),format-guest-staticlib-$(target))
+check-guest-staticlibs:
+	$(GUEST_CARGO_CHECK_CMD) $(_GUEST_STATICLIB_PKGS)
+	$(GUEST_CARGO_CHECK_CMD) $(_GUEST_STATICLIB_PKGS) $(GUEST_STATICLIB_CARGO_FEATURES)
 
-format-check-guest-staticlibs: $(foreach target,$(ALL_GUEST_STATIC_LIBS),format-check-guest-staticlib-$(target))
+format-guest-staticlibs:
+	$(GUEST_CARGO_FMT_CMD) $(_GUEST_STATICLIB_PKGS)
+
+format-check-guest-staticlibs:
+	$(GUEST_CARGO_FMT_CMD) $(_GUEST_STATICLIB_PKGS) --check
 
 clean-guest-staticlibs: $(foreach target,$(ALL_GUEST_STATIC_LIBS),clean-guest-staticlib-$(target))
 
-rust-lint-guest-staticlibs: $(foreach target,$(ALL_GUEST_STATIC_LIBS),rust-lint-guest-staticlib-$(target))
+rust-lint-guest-staticlibs:
+	$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_STATICLIB_PKGS) $(GUEST_STATICLIB_CARGO_FEATURES) --fix --allow-dirty --allow-no-vcs
 
-rust-lint-check-guest-staticlibs: $(foreach target,$(ALL_GUEST_STATIC_LIBS),rust-lint-check-guest-staticlib-$(target))
+rust-lint-check-guest-staticlibs:
+	$(GUEST_CARGO_CLIPPY_CMD) $(_GUEST_STATICLIB_PKGS) $(GUEST_STATICLIB_CARGO_FEATURES) -- -D warnings

--- a/build/make/generic-host-binaries.mk
+++ b/build/make/generic-host-binaries.mk
@@ -10,6 +10,7 @@ HOST_BINARIES_FEATURES.linuxd += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-m
 host_binary_features = $(strip $(HOST_COMMON_FEATURES) $(HOST_BINARIES_FEATURES.$1))
 host_cargo_features = $(if $1,--features "$1")
 
+# Per-package rules used by feature-specific prerequisite targets and direct invocation.
 define HOST_BINARY_RULES
 all-host-binaries-$(1): init
 	$(HOST_CARGO_BUILD_CMD) $(call host_cargo_features,$(call host_binary_features,$(1))) -p $(1)
@@ -37,16 +38,49 @@ endef
 
 $(foreach target,$(ALL_HOST_BINARIES),$(eval $(call HOST_BINARY_RULES,$(target))))
 
-all-host-binaries: $(foreach target,$(ALL_HOST_BINARIES),all-host-binaries-$(target))
+# Batched build/check/lint grouping: split host binaries by feature set.
+# Binaries with package-specific features are handled individually.
+# All remaining binaries are batched into a single cargo invocation.
+_HOST_BINS_WITH_FEATURES := $(strip $(foreach pkg,$(ALL_HOST_BINARIES),$(if $(call host_binary_features,$(pkg)),$(pkg))))
+_HOST_BINS_PLAIN := $(filter-out $(_HOST_BINS_WITH_FEATURES),$(ALL_HOST_BINARIES))
+_HOST_BINS_PLAIN_PKGS := $(foreach pkg,$(_HOST_BINS_PLAIN),-p $(pkg))
 
-check-host-binaries: $(foreach target,$(ALL_HOST_BINARIES),check-host-binaries-$(target))
+# Batched build: group host binaries by feature set.
+# GNU Make merges prerequisites from multiple rule headers for the same target;
+# the first line adds feature-specific per-package builds as prerequisites
+# (each per-package rule handles its own build and copy), the second provides
+# the recipe that batches all featureless packages into a single cargo call.
+all-host-binaries: $(foreach pkg,$(_HOST_BINS_WITH_FEATURES),all-host-binaries-$(pkg))
+all-host-binaries: init
+ifneq ($(_HOST_BINS_PLAIN_PKGS),)
+	$(HOST_CARGO_BUILD_CMD) $(_HOST_BINS_PLAIN_PKGS)
+	@for pkg in $(_HOST_BINS_PLAIN); do \
+		$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/$$pkg $(BINARIES_DIR)/$$pkg.elf; \
+	done
+endif
 
-format-host-binaries: $(foreach target,$(ALL_HOST_BINARIES),format-host-binaries-$(target))
+check-host-binaries: $(foreach pkg,$(_HOST_BINS_WITH_FEATURES),check-host-binaries-$(pkg))
+ifneq ($(_HOST_BINS_PLAIN_PKGS),)
+	$(HOST_CARGO_CHECK_CMD) $(_HOST_BINS_PLAIN_PKGS)
+endif
 
-format-check-host-binaries: $(foreach target,$(ALL_HOST_BINARIES),format-check-host-binaries-$(target))
+# Batched format: single cargo invocation for all host binaries.
+_HOST_BINS_FMT_PKGS := $(foreach pkg,$(ALL_HOST_BINARIES),-p $(pkg))
+format-host-binaries:
+	$(HOST_CARGO_FMT_CMD) $(_HOST_BINS_FMT_PKGS)
+
+format-check-host-binaries:
+	$(HOST_CARGO_FMT_CMD) $(_HOST_BINS_FMT_PKGS) --check
 
 clean-host-binaries: $(foreach target,$(ALL_HOST_BINARIES),clean-host-binaries-$(target))
 
-rust-lint-host-binaries: $(foreach target,$(ALL_HOST_BINARIES),rust-lint-host-binaries-$(target))
+# Batched lint: group host binaries by feature set (same as check).
+rust-lint-host-binaries: $(foreach pkg,$(_HOST_BINS_WITH_FEATURES),rust-lint-host-binaries-$(pkg))
+ifneq ($(_HOST_BINS_PLAIN_PKGS),)
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(_HOST_BINS_PLAIN_PKGS) --fix --allow-dirty --allow-no-vcs
+endif
 
-rust-lint-check-host-binaries: $(foreach target,$(ALL_HOST_BINARIES),rust-lint-check-host-binaries-$(target))
+rust-lint-check-host-binaries: $(foreach pkg,$(_HOST_BINS_WITH_FEATURES),rust-lint-check-host-binaries-$(pkg))
+ifneq ($(_HOST_BINS_PLAIN_PKGS),)
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(_HOST_BINS_PLAIN_PKGS) -- -D warnings
+endif

--- a/build/make/generic-host-rlibs.mk
+++ b/build/make/generic-host-rlibs.mk
@@ -37,6 +37,7 @@ MULTI_PROCESS_RLIB_CARGO_FEATURES = $(if $(MULTI_PROCESS_RLIB_FEATURES),--featur
 #  - All other crates get no extra features.
 HOST_RLIBS_CARGO_FEATURES = $(if $(filter $(1),$(USERVM_DEPENDENT_RLIBS)),$(ALL_HOST_RLIB_CARGO_FEATURES),$(if $(filter $(1),$(MULTI_PROCESS_ONLY_RLIBS)),$(MULTI_PROCESS_RLIB_CARGO_FEATURES),))
 
+# Per-package rules retained for direct invocation (e.g., make check-host-rlib-<pkg>).
 define HOST_RLIB_RULES
 check-host-rlib-$(1):
 	$(HOST_CARGO_CHECK_CMD) $(call HOST_RLIBS_CARGO_FEATURES,$(1)) -p $(1)
@@ -59,14 +60,58 @@ endef
 
 $(foreach target,$(ALL_HOST_RUST_LIBS),$(eval $(call HOST_RLIB_RULES,$(target))))
 
-check-host-rlibs: $(foreach target,$(ALL_HOST_RUST_LIBS),check-host-rlib-$(target))
+# Batched check: group host rlibs by feature set.
+# - Plain: no extra features.
+# - Uservm-dependent: machine + deployment features.
+# - Multi-process-only: machine + multi-process features.
+_HOST_RLIBS_PLAIN := $(filter-out $(USERVM_DEPENDENT_RLIBS) $(MULTI_PROCESS_ONLY_RLIBS),$(ALL_HOST_RUST_LIBS))
+_HOST_RLIBS_USERVM := $(filter $(USERVM_DEPENDENT_RLIBS),$(ALL_HOST_RUST_LIBS))
+_HOST_RLIBS_MULTI := $(filter $(MULTI_PROCESS_ONLY_RLIBS),$(ALL_HOST_RUST_LIBS))
 
-format-host-rlibs: $(foreach target,$(ALL_HOST_RUST_LIBS),format-host-rlib-$(target))
+_HOST_RLIBS_PLAIN_PKGS := $(foreach pkg,$(_HOST_RLIBS_PLAIN),-p $(pkg))
+_HOST_RLIBS_USERVM_PKGS := $(foreach pkg,$(_HOST_RLIBS_USERVM),-p $(pkg))
+_HOST_RLIBS_MULTI_PKGS := $(foreach pkg,$(_HOST_RLIBS_MULTI),-p $(pkg))
 
-format-check-host-rlibs: $(foreach target,$(ALL_HOST_RUST_LIBS),format-check-host-rlib-$(target))
+check-host-rlibs:
+ifneq ($(_HOST_RLIBS_PLAIN_PKGS),)
+	$(HOST_CARGO_CHECK_CMD) $(_HOST_RLIBS_PLAIN_PKGS)
+endif
+ifneq ($(_HOST_RLIBS_USERVM_PKGS),)
+	$(HOST_CARGO_CHECK_CMD) $(ALL_HOST_RLIB_CARGO_FEATURES) $(_HOST_RLIBS_USERVM_PKGS)
+endif
+ifneq ($(_HOST_RLIBS_MULTI_PKGS),)
+	$(HOST_CARGO_CHECK_CMD) $(MULTI_PROCESS_RLIB_CARGO_FEATURES) $(_HOST_RLIBS_MULTI_PKGS)
+endif
 
-rust-lint-host-rlibs: $(foreach target,$(ALL_HOST_RUST_LIBS),rust-lint-host-rlib-$(target))
+# Batched format: single cargo invocation for all host rlibs.
+_HOST_RLIB_FMT_PKGS := $(foreach pkg,$(ALL_HOST_RUST_LIBS),-p $(pkg))
+format-host-rlibs:
+	$(HOST_CARGO_FMT_CMD) $(_HOST_RLIB_FMT_PKGS)
 
-rust-lint-check-host-rlibs: $(foreach target,$(ALL_HOST_RUST_LIBS),rust-lint-check-host-rlib-$(target))
+format-check-host-rlibs:
+	$(HOST_CARGO_FMT_CMD) $(_HOST_RLIB_FMT_PKGS) --check
+
+# Batched lint: group host rlibs by feature set (same groups as check).
+rust-lint-host-rlibs:
+ifneq ($(_HOST_RLIBS_PLAIN_PKGS),)
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(_HOST_RLIBS_PLAIN_PKGS) --fix --allow-dirty --allow-no-vcs
+endif
+ifneq ($(_HOST_RLIBS_USERVM_PKGS),)
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(ALL_HOST_RLIB_CARGO_FEATURES) $(_HOST_RLIBS_USERVM_PKGS) --fix --allow-dirty --allow-no-vcs
+endif
+ifneq ($(_HOST_RLIBS_MULTI_PKGS),)
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(MULTI_PROCESS_RLIB_CARGO_FEATURES) $(_HOST_RLIBS_MULTI_PKGS) --fix --allow-dirty --allow-no-vcs
+endif
+
+rust-lint-check-host-rlibs:
+ifneq ($(_HOST_RLIBS_PLAIN_PKGS),)
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(_HOST_RLIBS_PLAIN_PKGS) -- -D warnings
+endif
+ifneq ($(_HOST_RLIBS_USERVM_PKGS),)
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(ALL_HOST_RLIB_CARGO_FEATURES) $(_HOST_RLIBS_USERVM_PKGS) -- -D warnings
+endif
+ifneq ($(_HOST_RLIBS_MULTI_PKGS),)
+	$(HOST_CARGO_CLIPPY_CMD) --tests $(MULTI_PROCESS_RLIB_CARGO_FEATURES) $(_HOST_RLIBS_MULTI_PKGS) -- -D warnings
+endif
 
 test-host-rlibs: $(foreach target,$(ALL_HOST_RUST_LIBS),test-host-rlib-$(target))

--- a/build/make/generic-wasm-binaries.mk
+++ b/build/make/generic-wasm-binaries.mk
@@ -1,6 +1,7 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
+# Per-package rules retained for direct invocation (e.g., make all-wasm-binaries-<pkg>).
 define WASM_BINARY_RULES
 all-wasm-binaries-$(1): init
 	$(WASM_CARGO_BUILD_CMD) -p $(1)
@@ -28,16 +29,28 @@ endef
 
 $(foreach target,$(ALL_WASM_BINARIES),$(eval $(call WASM_BINARY_RULES,$(target))))
 
-all-wasm-binaries: $(foreach target,$(ALL_WASM_BINARIES),all-wasm-binaries-$(target))
+# Batched targets: single cargo invocations for all WASM binaries.
+_WASM_BINS_PKGS := $(foreach pkg,$(ALL_WASM_BINARIES),-p $(pkg))
 
-check-wasm-binaries: $(foreach target,$(ALL_WASM_BINARIES),check-wasm-binaries-$(target))
+all-wasm-binaries: init
+	$(WASM_CARGO_BUILD_CMD) $(_WASM_BINS_PKGS)
+	@for pkg in $(ALL_WASM_BINARIES); do \
+		$(CP_CMD) $(OBJECTS_DIR)/wasm32-wasip1/$(WASM_BUILD_MODE)/$$pkg.wasm $(BINARIES_DIR)/$$pkg.wasm; \
+	done
 
-format-wasm-binaries: $(foreach target,$(ALL_WASM_BINARIES),format-wasm-binaries-$(target))
+check-wasm-binaries:
+	$(WASM_CARGO_CHECK_CMD) $(_WASM_BINS_PKGS)
 
-format-check-wasm-binaries: $(foreach target,$(ALL_WASM_BINARIES),format-check-wasm-binaries-$(target))
+format-wasm-binaries:
+	$(WASM_CARGO_FMT_CMD) $(_WASM_BINS_PKGS)
+
+format-check-wasm-binaries:
+	$(WASM_CARGO_FMT_CMD) $(_WASM_BINS_PKGS) --check
 
 clean-wasm-binaries: $(foreach target,$(ALL_WASM_BINARIES),clean-wasm-binaries-$(target))
 
-rust-lint-wasm-binaries: $(foreach target,$(ALL_WASM_BINARIES),rust-lint-wasm-binaries-$(target))
+rust-lint-wasm-binaries:
+	$(WASM_CARGO_CLIPPY_CMD) $(_WASM_BINS_PKGS) --fix --allow-dirty --allow-no-vcs
 
-rust-lint-check-wasm-binaries: $(foreach target,$(ALL_WASM_BINARIES),rust-lint-check-wasm-binaries-$(target))
+rust-lint-check-wasm-binaries:
+	$(WASM_CARGO_CLIPPY_CMD) $(_WASM_BINS_PKGS) -- -D warnings


### PR DESCRIPTION
## Summary

Replaces per-package `$(foreach)` expansion of aggregate Make targets (build, check, format, lint) with batched `cargo` invocations that pass multiple `-p <pkg>` flags at once. This reduces cargo startup and dependency-resolution overhead by consolidating N separate cargo calls into 1–3 grouped calls.

## Changes

- **generic-guest-binaries.mk** — Batch build/check/lint by feature group (regular, standalone, test-kernel); batch format in a single invocation.
- **generic-guest-rlibs.mk** — Single batched cargo call for check, format, lint, and lint-check.
- **generic-guest-staticlibs.mk** — Single batched cargo call for build, check, format, and lint.
- **generic-host-binaries.mk** — Batch featureless packages; feature-specific packages remain individual prerequisites.
- **generic-host-rlibs.mk** — Batch by feature group (plain, uservm-dependent, multi-process).
- **generic-wasm-binaries.mk** — Single batched cargo call for build, check, format, and lint.

Per-package rules are retained in `define` blocks for direct invocation (e.g., `make check-guest-rlib-<pkg>`) and for clean targets.