### PR TITLE
[kernel] Avoid heap allocation when selecting next ready thread

### DIFF
--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -32,7 +32,6 @@ use crate::{
 use ::alloc::boxed::Box;
 use ::sys::pm::ProcessIdentifier;
 use ::type_safe::NonEmptyVecDeque;
-use alloc::collections::vec_deque::VecDeque;
 use sys::{
     error::ErrorCode,
     mm::VirtualAddress,
@@ -111,23 +110,11 @@ impl RunnableProcess {
         mut self,
     ) -> (RunningProcess, Option<InterruptReason>, *mut ContextInformation, Option<VirtualAddress>)
     {
-        let mut ready_threads: VecDeque<ReadyThread> = self.ready_threads.into();
-
-        // Select thread with the earliest admission time.
-        let mut index_selected_thread: usize = 0;
-        for (i, thread) in ready_threads.iter().enumerate() {
-            if thread.admission_time() < ready_threads[index_selected_thread].admission_time() {
-                index_selected_thread = i;
-            }
-        }
-        let next_thread: ReadyThread = match ready_threads.remove(index_selected_thread) {
-            Some(thread) => thread,
-            None => {
-                // SAFETY: the following statement is unreachable because there should always be at
-                // least one ready thread in a runnable process.
-                unreachable!("no ready threads in runnable process");
-            },
-        };
+        // Select and remove the thread with the earliest admission time.
+        // NOTE: uses `remove_min_by_key()` to operate directly on `NonEmptyVecDeque`, avoiding
+        // the heap allocation that a `VecDeque` conversion would require.
+        let (ready_threads, next_thread) =
+            self.ready_threads.remove_min_by_key(|t| t.admission_time());
 
         let (running_thread, interrupt_reason, next_context, user_tda): (
             RunningThread,

--- a/src/tests/stress-rust/src/tests/mod.rs
+++ b/src/tests/stress-rust/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod memory_mapping_storm;
 mod mmap_rapid_cycle;
 mod mutex_churn;
 mod parallel_spawners;
+mod scheduler_pressure;
 mod scoreboard_backpressure;
 mod sleep_burst;
 mod thread_data_area;
@@ -49,6 +50,7 @@ pub fn run_all() -> Result<(), Error> {
     parallel_spawners::run()?;
     thread_identity::run()?;
     kcall_hammer::run()?;
+    scheduler_pressure::run()?;
     scoreboard_backpressure::run()?;
     heap_reclaim::run()?;
     heap_max_capacity::run()?;

--- a/src/tests/stress-rust/src/tests/scheduler_pressure.rs
+++ b/src/tests/stress-rust/src/tests/scheduler_pressure.rs
@@ -1,0 +1,219 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::common::{
+    StressError,
+    WorkerStack,
+    error_code_from_usize,
+    error_code_to_usize,
+    thread_args,
+};
+use ::core::{
+    sync::atomic::{
+        AtomicUsize,
+        Ordering,
+    },
+    time::Duration,
+};
+use ::sys::{
+    error::{
+        Error,
+        ErrorCode,
+    },
+    kcall::{
+        pm::{
+            create_thread,
+            gettime,
+            join_thread,
+            sleep,
+        },
+        sched::sched_yield,
+    },
+    pm::{
+        ThreadCreateArgs,
+        ThreadIdentifier,
+    },
+    time::SystemTime,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Number of concurrent worker threads. Chosen to keep many threads simultaneously in the ready
+/// queue, forcing the scheduler to select among them repeatedly.
+const PRESSURE_WORKERS: usize = 8;
+
+/// Rounds per worker. Each round performs a burst of fast kcalls followed by a brief sleep, causing
+/// the thread to cycle through ready → running → sleeping → ready states.
+const PRESSURE_ROUNDS: usize = 32;
+
+/// Number of `gettime` + `sched_yield` kcalls per round. High enough to saturate kernel
+/// scheduling paths with rapid, back-to-back kernel calls.
+const SYSCALLS_PER_ROUND: usize = 64;
+
+/// Sentinel value returned by a worker on failure.
+const PRESSURE_FAILURE: usize = usize::MAX;
+
+/// Brief inter-round sleep duration. Short enough to avoid slowing the test, long enough to force
+/// a sleep/wakeup transition that exercises the scheduler.
+const INTER_ROUND_SLEEP: Duration = Duration::from_micros(64);
+
+//==================================================================================================
+// Globals
+//==================================================================================================
+
+/// Tracks the total number of completed rounds across all workers.
+static PRESSURE_PROGRESS: AtomicUsize = AtomicUsize::new(0);
+
+/// Stores the error code from the first worker that fails.
+static PRESSURE_ERROR_CODE: AtomicUsize = AtomicUsize::new(0);
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Stresses the kernel scheduler by running many concurrent threads that cycle rapidly through
+/// ready, running, and sleeping states under sustained kernel-call pressure.
+///
+/// Each worker thread performs tight loops of `gettime()` + `sched_yield()` kcalls interspersed
+/// with brief sleeps, forcing frequent ready ↔ sleeping state transitions.
+///
+/// # Returns
+///
+/// `Ok(())` on success or an error if any worker fails or the total progress count is wrong.
+///
+pub fn run() -> Result<(), StressError> {
+    PRESSURE_PROGRESS.store(0, Ordering::Relaxed);
+    PRESSURE_ERROR_CODE.store(0, Ordering::Relaxed);
+
+    let mut tids: ::alloc::vec::Vec<ThreadIdentifier> =
+        ::alloc::vec::Vec::with_capacity(PRESSURE_WORKERS);
+
+    // Allocate all stacks before spawning any threads so that a late allocation failure cannot
+    // drop stacks that are already in use by running threads (use-after-free).
+    let mut stacks: ::alloc::vec::Vec<WorkerStack> =
+        ::alloc::vec::Vec::with_capacity(PRESSURE_WORKERS);
+    for _ in 0..PRESSURE_WORKERS {
+        stacks.push(WorkerStack::new(::config::memory_layout::USER_STACK_SIZE)?);
+    }
+
+    // Spawn all workers upfront to maximize concurrent scheduling pressure.
+    for (worker_id, stack) in stacks.iter().enumerate() {
+        let mut args: ThreadCreateArgs = thread_args(stack, scheduler_pressure_worker, worker_id);
+        match create_thread(&mut args) {
+            Ok(tid) => tids.push(tid),
+            Err(e) => {
+                // Join already-spawned threads before returning so their stacks remain valid.
+                for tid in &tids {
+                    let mut retval: usize = 0;
+                    let _ = join_thread(*tid, &mut retval);
+                }
+                return Err(e);
+            },
+        }
+    }
+
+    // Join each worker and check for failures. Stacks are kept alive until after the loop.
+    for tid in &tids {
+        let mut retval: usize = 0;
+        join_thread(*tid, &mut retval)?;
+        if retval == PRESSURE_FAILURE {
+            let code_raw: usize = PRESSURE_ERROR_CODE.swap(0, Ordering::Relaxed);
+            let code: ErrorCode = error_code_from_usize(code_raw);
+            return Err(Error::new(code, "scheduler pressure worker failed"));
+        }
+
+        if retval != PRESSURE_ROUNDS {
+            return Err(Error::new(
+                ErrorCode::InvalidArgument,
+                "scheduler pressure rounds mismatch",
+            ));
+        }
+    }
+
+    // NOTE: `join_thread` provides happens-before synchronization, so `Relaxed` is sufficient.
+    let observed_progress: usize = PRESSURE_PROGRESS.load(Ordering::Relaxed);
+    if observed_progress != PRESSURE_WORKERS * PRESSURE_ROUNDS {
+        return Err(Error::new(ErrorCode::InvalidArgument, "scheduler pressure missed rounds"));
+    }
+
+    Ok(())
+}
+
+//==================================================================================================
+// Worker Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Entry point for scheduler pressure workers.
+///
+/// # Parameters
+///
+/// - `worker_id`: Identifier used to stagger yield cadence across workers.
+///
+/// # Returns
+///
+/// Number of completed rounds, or `PRESSURE_FAILURE` on error.
+extern "C" fn scheduler_pressure_worker(worker_id: usize) -> usize {
+    match scheduler_pressure_worker_impl(worker_id) {
+        Ok(rounds) => rounds,
+        Err(err) => {
+            // Use compare_exchange so that the first error wins if multiple workers fail.
+            // NOTE: `join_thread` provides happens-before synchronization, so `Relaxed`
+            // suffices for both success and failure orderings.
+            let _ = PRESSURE_ERROR_CODE.compare_exchange(
+                0,
+                error_code_to_usize(err.code),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
+            PRESSURE_FAILURE
+        },
+    }
+}
+
+///
+/// # Description
+///
+/// Implements the scheduler pressure loop. Each round performs a burst of fast kcalls then briefly
+/// sleeps, cycling the thread through ready → running → sleeping → ready states.
+///
+/// # Parameters
+///
+/// - `worker_id`: Identifier used to stagger yield cadence across workers.
+///
+/// # Returns
+///
+/// `Ok(rounds)` on success where `rounds` is `PRESSURE_ROUNDS`.
+fn scheduler_pressure_worker_impl(worker_id: usize) -> Result<usize, Error> {
+    for round in 0..PRESSURE_ROUNDS {
+        // Burst of fast kcalls: alternate gettime and yield to saturate the scheduler.
+        for iteration in 0..SYSCALLS_PER_ROUND {
+            let mut now: SystemTime = SystemTime::default();
+            gettime(&mut now)?;
+
+            // Stagger yields across workers so that ready-queue membership varies each cycle.
+            if (iteration + worker_id + round) & 0x3 == 0 {
+                sched_yield()?;
+            }
+        }
+
+        PRESSURE_PROGRESS.fetch_add(1, Ordering::Relaxed);
+
+        // Brief sleep to force a sleeping → wakeup → ready transition, exercising the scheduler's
+        // thread-selection logic again from a different starting state.
+        sleep(INTER_ROUND_SLEEP)?;
+    }
+
+    Ok(PRESSURE_ROUNDS)
+}


### PR DESCRIPTION
## Summary

Fixes a kernel panic caused by heap exhaustion in the scheduler's thread-selection path, and adds a stress test that reproduces the failure scenario.

## Problem

`RunnableProcess::run()` converted its `NonEmptyVecDeque` of ready threads into a `VecDeque` to find and remove the thread with the earliest admission time. This conversion allocates on the kernel heap, which can fail under slab heap pressure: the allocator silently produces an empty `VecDeque`, causing the subsequent `remove()` to hit the `unreachable!()` panic.

## Changes

### Kernel fix (`src/kernel/src/pm/process/state/runnable.rs`)
- Replace the `VecDeque` round-trip with a direct `NonEmptyVecDeque::remove_min_by_key()` call that selects and removes the minimum element in place without any heap allocation.
- Remove the unused `VecDeque` import.

### Stress test (`src/tests/stress-rust/src/tests/scheduler_pressure.rs`)
- Add a scheduler pressure stress test that exercises the exact scheduling pattern that triggered the bug.
- Eight worker threads run 32 rounds each, performing bursts of `gettime()` + `sched_yield()` kcalls (64 per round) interspersed with brief sleeps that force ready/running/sleeping state transitions.
- Uses `compare_exchange` for error-code reporting so the first worker failure is preserved when multiple workers fail concurrently.
