### PR TITLE
[uservm] Handle VM shutdown correctly

### DIFF
--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -223,7 +223,7 @@ impl RunningProcess {
         if let Some(interrupted_threads) = interrupted_threads {
             let interrupted_process: InterruptedProcess = InterruptedProcess::from_sleeping(
                 self.state,
-                self.sleeping_threads.take(),
+                None, // Sleeping threads were converted to interrupted above.
                 interrupted_threads,
                 Some(zombie_threads),
             );

--- a/src/uservm/src/vmm/microvm/kvm/vcpu/exit.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vcpu/exit.rs
@@ -18,6 +18,8 @@ pub enum VirtualProcessorExitReason {
     PmioAccess(PmioAccess),
     /// Halt virtual processor.
     Halt,
+    /// Shutdown virtual processor (e.g., triple fault).
+    Shutdown,
     /// Interrupted.
     Interrupted,
     /// Unknown.
@@ -30,6 +32,8 @@ pub enum VirtualProcessorExitContext {
     Pmio(PmioAccess),
     /// Halt virtual processor.
     Halt,
+    /// Shutdown virtual processor (e.g., triple fault).
+    Shutdown,
     /// Interrupt virtual processor.
     Interrupted,
     /// Unknown.
@@ -43,6 +47,8 @@ pub enum VirtualProcessorExitReasonRef<'a> {
     PmioAccess(&'a PmioAccess),
     /// Halt virtual processor.
     Halt,
+    /// Shutdown virtual processor (e.g., triple fault).
+    Shutdown,
     /// Interrupted.
     Interrupted,
     /// Unknown.
@@ -78,6 +84,7 @@ impl VirtualProcessorExitContext {
                 VirtualProcessorExitReasonRef::PmioAccess(access)
             },
             VirtualProcessorExitContext::Halt => VirtualProcessorExitReasonRef::Halt,
+            VirtualProcessorExitContext::Shutdown => VirtualProcessorExitReasonRef::Shutdown,
             VirtualProcessorExitContext::Interrupted => VirtualProcessorExitReasonRef::Interrupted,
             VirtualProcessorExitContext::Unknown => VirtualProcessorExitReasonRef::Unknown,
         }
@@ -91,6 +98,7 @@ impl<'a> From<VirtualProcessorExitReasonRef<'a>> for VirtualProcessorExitReason 
                 VirtualProcessorExitReason::PmioAccess(access.clone())
             },
             VirtualProcessorExitReasonRef::Halt => VirtualProcessorExitReason::Halt,
+            VirtualProcessorExitReasonRef::Shutdown => VirtualProcessorExitReason::Shutdown,
             VirtualProcessorExitReasonRef::Interrupted => VirtualProcessorExitReason::Interrupted,
             VirtualProcessorExitReasonRef::Unknown => VirtualProcessorExitReason::Unknown,
         }

--- a/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -526,11 +526,10 @@ impl VirtualProcessor {
                 },
                 // Halt the virtual processor.
                 VcpuExit::Hlt => VirtualProcessorExitContext::Halt,
-                // Shutdown the virtual processor.
+                // Shutdown the virtual processor (e.g., triple fault).
                 VcpuExit::Shutdown => {
-                    // TODO: handle shutdown.
                     warn!("run(): shutdown");
-                    VirtualProcessorExitContext::Unknown
+                    VirtualProcessorExitContext::Shutdown
                 },
                 // Fail to run the virtual processor.
                 VcpuExit::FailEntry(reason, cpud) => {

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -525,6 +525,14 @@ impl Vmm {
                     break Ok(exit_status);
                 },
 
+                // The guest was shutdown (triple fault).
+                VirtualProcessorExitReasonRef::Shutdown => {
+                    error!("run(): guest shutdown (triple fault)");
+                    let exit_status: u16 = ErrorCode::IllegalByteSequence.into();
+                    Handle::current().block_on(self.handle_shutdown(exit_status));
+                    break Ok(exit_status);
+                },
+
                 // Virtual machine exited due to an unknown reason.
                 VirtualProcessorExitReasonRef::Unknown => {
                     error!("run(): guest exited due to an unknown reason");

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -527,7 +527,10 @@ impl Vmm {
 
                 // Virtual machine exited due to an unknown reason.
                 VirtualProcessorExitReasonRef::Unknown => {
-                    break Ok(ErrorCode::IllegalByteSequence.into());
+                    error!("run(): guest exited due to an unknown reason");
+                    let exit_status: u16 = ErrorCode::IllegalByteSequence.into();
+                    Handle::current().block_on(self.handle_shutdown(exit_status));
+                    break Ok(exit_status);
                 },
             }
         }


### PR DESCRIPTION
## Summary

Fix handling of KVM vCPU shutdown exits (e.g., triple faults) and unknown exit reasons so the VMM performs a proper shutdown instead of silently returning an error code.

## Changes

### Commit 1: Handle shutdown on unknown VM exit
- Call `handle_shutdown()` before breaking out of the run loop when the vCPU exits with an **Unknown** reason, matching the existing behavior for Shutdown and Halt/Interrupted paths.
- Log unknown exit events at error level.

### Commit 2: Handle VM shutdown correctly
- Add a dedicated **Shutdown** variant to `VirtualProcessorExitReason`, `VirtualProcessorExitContext`, and `VirtualProcessorExitReasonRef`.
- Map KVM's `VcpuExit::Shutdown` (triple fault) to the new variant instead of `Unknown`.
- Add a corresponding match arm in the VMM run loop that logs the triple fault and invokes `handle_shutdown()` before returning an error status.
- Update the Unknown exit path to also call `handle_shutdown()` and log at error level.

### Commit 3: Clean up redundant .take()
- Remove unnecessary `.take()` call in kernel scheduler (closes #1637).