### PR TITLE
[vfs] Add chmod, fchmodat, fchownat, utimensat to standalone VFS

### DIFF
--- a/src/libs/syscall/src/sys/stat/syscall/chmod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/chmod.rs
@@ -31,14 +31,15 @@ use ::sysapi::sys_types::mode_t;
 /// Upon successful completion, the `fchmodat()` system call returns empty. Otherwise, it returns an
 /// error.
 ///
-pub fn chmod(_path: &str, _mode: mode_t) -> Result<(), Error> {
-    // In standalone mode, this operation is not supported.
-    // TODO: https://github.com/nanvix/nanvix/issues/1606
+pub fn chmod(path: &str, mode: mode_t) -> Result<(), Error> {
     #[cfg(feature = "standalone")]
     {
-        Ok(())
+        ::nvx::vfs::fd::vfs_chmod(path, mode).map_err(|e| {
+            let code: ::sys::error::ErrorCode = e.into();
+            Error::new(code, "vfs chmod failed")
+        })
     }
 
     #[cfg(not(feature = "standalone"))]
-    fchmodat(AT_FDCWD, _path, _mode, 0)
+    fchmodat(AT_FDCWD, path, mode, 0)
 }

--- a/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
@@ -48,17 +48,20 @@ use {
 /// error.
 ///
 #[allow(unreachable_code)]
-pub fn fchmodat(_dirfd: c_int, _path: &str, _mode: mode_t, _flag: c_int) -> Result<(), Error> {
-    // In standalone mode, this operation is not supported.
-    // TODO: https://github.com/nanvix/nanvix/issues/1607
+pub fn fchmodat(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Result<(), Error> {
+    // In standalone mode, forward operation to virtual file system (VFS).
     #[cfg(feature = "standalone")]
     {
-        Ok(())
+        ::nvx::vfs::fd::vfs_fchmodat(dirfd, path, mode, flag).map_err(|e| {
+            let code: ::sys::error::ErrorCode = e.into();
+            ::syslog::error!("fchmodat(): VFS fchmodat failed (path={path:?}, error={e})");
+            ::sys::error::Error::new(code, "vfs fchmodat failed")
+        })
     }
 
     // Forward to linuxd via IPC.
     #[cfg(not(feature = "standalone"))]
-    fchmodat_linuxd(_dirfd, _path, _mode, _flag)
+    fchmodat_linuxd(dirfd, path, mode, flag)
 }
 
 /// Forwards a `fchmodat` request to linuxd via IPC.

--- a/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/utimensat.rs
@@ -62,11 +62,12 @@ pub fn utimensat(
         flags
     );
 
-    // In standalone mode, this operation is not supported.
-    // TODO: https://github.com/nanvix/nanvix/issues/1608
     #[cfg(feature = "standalone")]
     {
-        Ok(())
+        ::nvx::vfs::fd::vfs_utimensat(dirfd, pathname, times, flags).map_err(|e| {
+            let code: ::sys::error::ErrorCode = e.into();
+            Error::new(code, "vfs utimensat failed")
+        })
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/fchownat.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchownat.rs
@@ -66,11 +66,16 @@ pub fn fchownat(
         flag
     );
 
-    // In standalone mode, this operation is not supported.
-    // TODO: https://github.com/nanvix/nanvix/issues/1609
+    // In standalone mode, forward to VFS.
     #[cfg(feature = "standalone")]
     {
-        Ok(())
+        ::nvx::vfs::fd::vfs_fchownat(dirfd, path, owner, group, flag).map_err(|e| {
+            let code: ::sys::error::ErrorCode = e.into();
+            ::syslog::error!(
+                "fchownat(): VFS fchownat failed (dirfd={dirfd:?}, path={path:?}, error={e})"
+            );
+            Error::new(code, "vfs fchownat failed")
+        })
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -807,6 +807,14 @@ pub fn vfs_pwrite(fd: c_int, buf: &[u8], offset: off_t) -> Result<c_size_t, Fat3
     Ok(n as c_size_t)
 }
 
+/// Changes file mode bits through the VFS.
+///
+/// FAT32 does not support POSIX permission bits, so the mode is accepted
+/// but silently ignored. Returns `Err` if the path does not exist.
+pub fn vfs_chmod(path: &str, _mode: ::sysapi::sys_types::mode_t) -> Result<(), Fat32Error> {
+    crate::stat(path).map(|_| ())
+}
+
 /// Checks file accessibility through the VFS.
 ///
 /// Returns `Ok(())` if the path exists, `Err` otherwise.
@@ -985,6 +993,33 @@ pub fn vfs_linkat(
 /// Always returns [`Fat32Error::NotSupported`].
 pub fn vfs_symlinkat(_target: &str, _dirfd: c_int, _linkpath: &str) -> Result<(), Fat32Error> {
     Err(Fat32Error::NotSupported)
+}
+
+/// Changes the mode of a file relative to a directory file descriptor through the VFS.
+///
+/// FAT32 does not support POSIX permission bits. This function validates
+/// its arguments and returns success without modifying any permissions.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor for relative path resolution.
+/// - `path`: Path to the target file.
+/// - `_mode`: File mode bits (ignored on FAT32).
+/// - `_flag`: Flags (ignored on FAT32).
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidArgument`] if the path cannot be resolved.
+/// Returns [`Fat32Error::FileNotFound`] if the resolved path does not exist.
+pub fn vfs_fchmodat(
+    dirfd: c_int,
+    path: &str,
+    _mode: ::sysapi::sys_types::mode_t,
+    _flag: c_int,
+) -> Result<(), Fat32Error> {
+    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    // Verify that the target exists using the VFS-level stat for consistent semantics.
+    crate::stat(&resolved).map(|_| ())
 }
 
 //==================================================================================================

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -1053,6 +1053,38 @@ pub fn vfs_fchownat(
     crate::stat(&resolved).map(|_| ())
 }
 
+/// Sets file access and modification times through the VFS.
+///
+/// FAT32 does not support fine-grained POSIX timestamps. This function
+/// validates its arguments and returns success without modifying any
+/// timestamps.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor for relative path resolution.
+/// - `pathname`: Path to the target file.
+/// - `_times`: Access and modification times (ignored on FAT32).
+/// - `flags`: Flags (must be zero; unsupported flags are rejected).
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidArgument`] if the path cannot be resolved.
+/// Returns [`Fat32Error::FileNotFound`] if the resolved path does not exist.
+pub fn vfs_utimensat(
+    dirfd: c_int,
+    pathname: &str,
+    _times: &[timespec; 2],
+    flags: c_int,
+) -> Result<(), Fat32Error> {
+    // Reject unsupported flags since FAT32 does not handle them.
+    if flags != 0 {
+        return Err(Fat32Error::InvalidArgument);
+    }
+    let path: String = vfs_resolve_path(dirfd, pathname).ok_or(Fat32Error::InvalidArgument)?;
+    // Verify that the target exists using the VFS-level stat for consistent semantics.
+    crate::stat(&path).map(|_| ())
+}
+
 //==================================================================================================
 // Unit Tests
 //==================================================================================================

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -39,7 +39,9 @@ use ::sysapi::{
     },
     sys_types::{
         c_size_t,
+        gid_t,
         off_t,
+        uid_t,
     },
     time::timespec,
     unistd::file_seek,
@@ -1015,6 +1017,35 @@ pub fn vfs_fchmodat(
     dirfd: c_int,
     path: &str,
     _mode: ::sysapi::sys_types::mode_t,
+    _flag: c_int,
+) -> Result<(), Fat32Error> {
+    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    // Verify that the target exists using the VFS-level stat for consistent semantics.
+    crate::stat(&resolved).map(|_| ())
+}
+
+/// Changes the owner and group of a file relative to a directory file descriptor through the VFS.
+///
+/// FAT32 does not support POSIX ownership. This function validates
+/// its arguments and returns success without modifying any ownership.
+///
+/// # Parameters
+///
+/// - `dirfd`: Directory file descriptor for relative path resolution.
+/// - `path`: Path to the target file.
+/// - `_owner`: Owner of the file (ignored on FAT32).
+/// - `_group`: Group of the file (ignored on FAT32).
+/// - `_flag`: Flags (ignored on FAT32).
+///
+/// # Errors
+///
+/// Returns [`Fat32Error::InvalidArgument`] if the path cannot be resolved.
+/// Returns [`Fat32Error::FileNotFound`] if the resolved path does not exist.
+pub fn vfs_fchownat(
+    dirfd: c_int,
+    path: &str,
+    _owner: uid_t,
+    _group: gid_t,
     _flag: c_int,
 ) -> Result<(), Fat32Error> {
     let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;

--- a/src/tests/vfs-test/src/main.rs
+++ b/src/tests/vfs-test/src/main.rs
@@ -47,6 +47,7 @@ use ::sysapi::{
         file_type,
         stat,
     },
+    time::timespec,
 };
 
 //==================================================================================================
@@ -89,6 +90,10 @@ pub fn main() -> Result<(), Error> {
     test_stat_timestamps()?;
     test_fcntl_fd_flags()?;
     test_resolve_path()?;
+    test_chmod()?;
+    test_fchmodat()?;
+    test_fchownat()?;
+    test_utimensat()?;
     test_ramfs_mount()?;
 
     Ok(())
@@ -840,6 +845,220 @@ fn test_resolve_path() -> Result<(), Error> {
     vfs::unmount("/rp").map_err(|e| fat_err(e, "unmount /rp"))?;
 
     ::syslog::info!("vfs-test: test_resolve_path passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Chmod
+//==================================================================================================
+
+/// Tests that `vfs_chmod()` succeeds on an existing file and fails on a missing one.
+fn test_chmod() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_chmod begin");
+
+    vfs::create_mount("/chm", 128 * 1024).map_err(|e| fat_err(e, "create_mount /chm failed"))?;
+
+    // Create a file.
+    {
+        let mut file: vfs::File = vfs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("/chm/f.txt")
+            .map_err(|e| fat_err(e, "create f.txt"))?;
+        file.write(b"chmod test")
+            .map_err(|e| fat_err(e, "write f.txt"))?;
+        file.flush().map_err(|e| fat_err(e, "flush f.txt"))?;
+    }
+
+    // chmod on an existing file should succeed (FAT32 ignores mode).
+    vfs::fd::vfs_chmod("/chm/f.txt", 0o644).map_err(|e| fat_err(e, "chmod existing file"))?;
+
+    // chmod on a non-existent file should fail.
+    if vfs::fd::vfs_chmod("/chm/missing.txt", 0o644).is_ok() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "chmod on missing file should fail"));
+    }
+
+    // Clean up.
+    vfs::unlink("/chm/f.txt").map_err(|e| fat_err(e, "unlink f.txt"))?;
+    vfs::unmount("/chm").map_err(|e| fat_err(e, "unmount /chm"))?;
+
+    ::syslog::info!("vfs-test: test_chmod passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Fchmodat
+//==================================================================================================
+
+/// Tests that `vfs_fchmodat()` validates path resolution and file existence.
+fn test_fchmodat() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_fchmodat begin");
+
+    vfs::create_mount("/fca", 128 * 1024).map_err(|e| fat_err(e, "create_mount /fca failed"))?;
+
+    // Create a file.
+    {
+        let mut file: vfs::File = vfs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("/fca/f.txt")
+            .map_err(|e| fat_err(e, "create f.txt"))?;
+        file.write(b"fchmodat test")
+            .map_err(|e| fat_err(e, "write f.txt"))?;
+        file.flush().map_err(|e| fat_err(e, "flush f.txt"))?;
+    }
+
+    // fchmodat with absolute path should succeed regardless of dirfd.
+    vfs::fd::vfs_fchmodat(0, "/fca/f.txt", 0o755, 0)
+        .map_err(|e| fat_err(e, "fchmodat absolute path"))?;
+
+    // fchmodat with AT_FDCWD and relative path.
+    vfs::chdir("/fca").map_err(|e| fat_err(e, "chdir /fca"))?;
+    let result = vfs::fd::vfs_fchmodat(::sysapi::fcntl::atflags::AT_FDCWD, "f.txt", 0o755, 0);
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    result.map_err(|e| fat_err(e, "fchmodat AT_FDCWD relative"))?;
+
+    // fchmodat with a VFS directory fd and relative path.
+    let dir_fd: i32 = vfs::fd::vfs_open("/fca", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "open /fca O_DIRECTORY"))?;
+    vfs::fd::vfs_fchmodat(dir_fd, "f.txt", 0o755, 0)
+        .map_err(|e| fat_err(e, "fchmodat dirfd relative"))?;
+    vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir fd"))?;
+
+    // fchmodat on a non-existent file should fail.
+    if vfs::fd::vfs_fchmodat(0, "/fca/missing.txt", 0o755, 0).is_ok() {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "fchmodat on missing file should fail",
+        ));
+    }
+
+    // Clean up.
+    vfs::unlink("/fca/f.txt").map_err(|e| fat_err(e, "unlink f.txt"))?;
+    vfs::unmount("/fca").map_err(|e| fat_err(e, "unmount /fca"))?;
+
+    ::syslog::info!("vfs-test: test_fchmodat passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Fchownat
+//==================================================================================================
+
+/// Tests that `vfs_fchownat()` validates path resolution and file existence.
+fn test_fchownat() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_fchownat begin");
+
+    vfs::create_mount("/fco", 128 * 1024).map_err(|e| fat_err(e, "create_mount /fco failed"))?;
+
+    // Create a file.
+    {
+        let mut file: vfs::File = vfs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("/fco/f.txt")
+            .map_err(|e| fat_err(e, "create f.txt"))?;
+        file.write(b"fchownat test")
+            .map_err(|e| fat_err(e, "write f.txt"))?;
+        file.flush().map_err(|e| fat_err(e, "flush f.txt"))?;
+    }
+
+    // fchownat with absolute path should succeed (FAT32 ignores owner/group).
+    vfs::fd::vfs_fchownat(0, "/fco/f.txt", 1000, 1000, 0)
+        .map_err(|e| fat_err(e, "fchownat absolute path"))?;
+
+    // fchownat with AT_FDCWD and relative path.
+    vfs::chdir("/fco").map_err(|e| fat_err(e, "chdir /fco"))?;
+    let result = vfs::fd::vfs_fchownat(::sysapi::fcntl::atflags::AT_FDCWD, "f.txt", 0, 0, 0);
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    result.map_err(|e| fat_err(e, "fchownat AT_FDCWD relative"))?;
+
+    // fchownat with a VFS directory fd and relative path.
+    let dir_fd: i32 = vfs::fd::vfs_open("/fco", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "open /fco O_DIRECTORY"))?;
+    vfs::fd::vfs_fchownat(dir_fd, "f.txt", 0, 0, 0)
+        .map_err(|e| fat_err(e, "fchownat dirfd relative"))?;
+    vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir fd"))?;
+
+    // fchownat on a non-existent file should fail.
+    if vfs::fd::vfs_fchownat(0, "/fco/missing.txt", 0, 0, 0).is_ok() {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "fchownat on missing file should fail",
+        ));
+    }
+
+    // Clean up.
+    vfs::unlink("/fco/f.txt").map_err(|e| fat_err(e, "unlink f.txt"))?;
+    vfs::unmount("/fco").map_err(|e| fat_err(e, "unmount /fco"))?;
+
+    ::syslog::info!("vfs-test: test_fchownat passed");
+    Ok(())
+}
+
+//==================================================================================================
+// Test: Utimensat
+//==================================================================================================
+
+/// Tests that `vfs_utimensat()` validates path resolution and file existence.
+fn test_utimensat() -> Result<(), Error> {
+    ::syslog::info!("vfs-test: test_utimensat begin");
+
+    vfs::create_mount("/uts", 128 * 1024).map_err(|e| fat_err(e, "create_mount /uts failed"))?;
+
+    // Create a file.
+    {
+        let mut file: vfs::File = vfs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("/uts/f.txt")
+            .map_err(|e| fat_err(e, "create f.txt"))?;
+        file.write(b"utimensat test")
+            .map_err(|e| fat_err(e, "write f.txt"))?;
+        file.flush().map_err(|e| fat_err(e, "flush f.txt"))?;
+    }
+
+    let times: [timespec; 2] = [
+        timespec {
+            tv_sec: 1_000_000,
+            tv_nsec: 0,
+        },
+        timespec {
+            tv_sec: 2_000_000,
+            tv_nsec: 0,
+        },
+    ];
+
+    // utimensat with absolute path should succeed (FAT32 ignores times).
+    vfs::fd::vfs_utimensat(0, "/uts/f.txt", &times, 0)
+        .map_err(|e| fat_err(e, "utimensat absolute path"))?;
+
+    // utimensat with AT_FDCWD and relative path.
+    vfs::chdir("/uts").map_err(|e| fat_err(e, "chdir /uts"))?;
+    let result = vfs::fd::vfs_utimensat(::sysapi::fcntl::atflags::AT_FDCWD, "f.txt", &times, 0);
+    vfs::chdir("/").map_err(|e| fat_err(e, "chdir /"))?;
+    result.map_err(|e| fat_err(e, "utimensat AT_FDCWD relative"))?;
+
+    // utimensat with a VFS directory fd and relative path.
+    let dir_fd: i32 = vfs::fd::vfs_open("/uts", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "open /uts O_DIRECTORY"))?;
+    vfs::fd::vfs_utimensat(dir_fd, "f.txt", &times, 0)
+        .map_err(|e| fat_err(e, "utimensat dirfd relative"))?;
+    vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir fd"))?;
+
+    // utimensat on a non-existent file should fail.
+    if vfs::fd::vfs_utimensat(0, "/uts/missing.txt", &times, 0).is_ok() {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "utimensat on missing file should fail",
+        ));
+    }
+
+    // Clean up.
+    vfs::unlink("/uts/f.txt").map_err(|e| fat_err(e, "unlink f.txt"))?;
+    vfs::unmount("/uts").map_err(|e| fat_err(e, "unmount /uts"))?;
+
+    ::syslog::info!("vfs-test: test_utimensat passed");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Implement four POSIX metadata operations in the VFS layer for standalone mode. FAT32 does not support POSIX permission bits, ownership, or fine-grained timestamps, so these functions validate that the target path exists (via VFS-level stat) and return success without modifying metadata. Unsupported flags are rejected with `InvalidArgument`.

## Changes

### Commit 1: chmod + fchmodat (Closes #1606, Closes #1607)
- Add `vfs_chmod()` and `vfs_fchmodat()` to the VFS layer.
- Wire the standalone `chmod` and `fchmodat` syscall paths to forward to the VFS.
- Use `crate::stat()` instead of `fat32_backend::stat()` for consistent VFS-level path validation.
- Remove underscore-prefixed parameter names in favour of used parameters.

### Commit 2: fchownat (Closes #1609)
- Add `vfs_fchownat()` to the VFS layer.
- Wire the standalone `fchownat` syscall path to forward to the VFS.
- Use `crate::stat()` for consistent VFS-level path validation.

### Commit 3: utimensat (Closes #1608)
- Add `vfs_utimensat()` to the VFS layer.
- Wire the standalone `utimensat` syscall path to forward to the VFS.
- Reject unsupported flags (non-zero) with `InvalidArgument`.
- Use `crate::stat()` for consistent VFS-level path validation.

### Commit 4: Integration tests
- Add `test_chmod`, `test_fchmodat`, `test_fchownat`, `test_utimensat` to `vfs-test`.
- Each test validates success on existing files (absolute, AT_FDCWD-relative, dirfd-relative paths) and failure on non-existent files.
- Capture VFS operation results before restoring cwd to avoid stale working-directory issues.

## Testing

- `./z build --with-cached-options -- lint-check` — passes.
- `./z build --with-cached-options -- format-check` — passes.
- `./z build -- DEPLOYMENT_MODE=standalone test` — passes.
