### PR TITLE
[arch] Extract x86 IDT/GDT magic values into named constants and add accessors

### DIFF
--- a/src/kernel/src/hal/arch/x86/cpu/exception/info.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/exception/info.rs
@@ -61,11 +61,17 @@ impl core::fmt::Debug for ExceptionInformation {
         let code: u32 = self.code;
         let addr: u32 = self.addr;
         let instr: u32 = self.instruction;
-        let excp: Exception = num.into();
-        write!(
-            f,
-            "{excp:?} (error code={code}, faulting addr={addr:#010x}, faulting \
-             instruction={instr:#010x})",
-        )
+        match Exception::try_from(num) {
+            Ok(excp) => write!(
+                f,
+                "{excp:?} (error code={code}, faulting addr={addr:#010x}, faulting \
+                 instruction={instr:#010x})",
+            ),
+            Err(_) => write!(
+                f,
+                "unknown exception {num} (error code={code}, faulting addr={addr:#010x}, faulting \
+                 instruction={instr:#010x})",
+            ),
+        }
     }
 }

--- a/src/libs/arch/src/x86/cpu/excp.rs
+++ b/src/libs/arch/src/x86/cpu/excp.rs
@@ -91,32 +91,42 @@ impl core::fmt::Debug for Exception {
     }
 }
 
-impl From<u32> for Exception {
-    fn from(value: u32) -> Self {
-        match value {
-            0 => Exception::DivisionByZero,
-            1 => Exception::Debug,
-            2 => Exception::NonMaskableInterrupt,
-            3 => Exception::Breakpoint,
-            4 => Exception::Overflow,
-            5 => Exception::BoundsCheck,
-            6 => Exception::InvalidOpcode,
-            7 => Exception::CoprocessorNotAvailable,
-            8 => Exception::DoubleFault,
-            9 => Exception::CoprocessorSegmentOverrun,
-            10 => Exception::InvalidTaskStateSegment,
-            11 => Exception::SegmentNotPresent,
-            12 => Exception::StackSegmentFault,
-            13 => Exception::GeneralProtectionFault,
-            14 => Exception::PageFault,
-            15 => Exception::Reserved,
-            16 => Exception::FloatingPoint,
-            17 => Exception::AlignmentCheck,
-            18 => Exception::MachineCheck,
-            19 => Exception::SmidUnit,
-            20 => Exception::Virtualization,
-            30 => Exception::Security,
-            _ => panic!("invalid exception"),
+impl TryFrom<u32> for Exception {
+    type Error = u32;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Self::try_from_vector(value as usize).ok_or(value)
+    }
+}
+
+impl Exception {
+    /// Converts an exception vector number into an [`Exception`], returning `None` for
+    /// invalid or unrecognized vector numbers.
+    pub fn try_from_vector(vector: usize) -> Option<Self> {
+        match vector {
+            0 => Some(Exception::DivisionByZero),
+            1 => Some(Exception::Debug),
+            2 => Some(Exception::NonMaskableInterrupt),
+            3 => Some(Exception::Breakpoint),
+            4 => Some(Exception::Overflow),
+            5 => Some(Exception::BoundsCheck),
+            6 => Some(Exception::InvalidOpcode),
+            7 => Some(Exception::CoprocessorNotAvailable),
+            8 => Some(Exception::DoubleFault),
+            9 => Some(Exception::CoprocessorSegmentOverrun),
+            10 => Some(Exception::InvalidTaskStateSegment),
+            11 => Some(Exception::SegmentNotPresent),
+            12 => Some(Exception::StackSegmentFault),
+            13 => Some(Exception::GeneralProtectionFault),
+            14 => Some(Exception::PageFault),
+            15 => Some(Exception::Reserved),
+            16 => Some(Exception::FloatingPoint),
+            17 => Some(Exception::AlignmentCheck),
+            18 => Some(Exception::MachineCheck),
+            19 => Some(Exception::SmidUnit),
+            20 => Some(Exception::Virtualization),
+            30 => Some(Exception::Security),
+            _ => None,
         }
     }
 }

--- a/src/libs/arch/src/x86/cpu/idt.rs
+++ b/src/libs/arch/src/x86/cpu/idt.rs
@@ -11,35 +11,87 @@ use crate::x86::cpu::ring::PrivilegeLevel;
 // Gate Type
 //==================================================================================================
 
+/// Mask for extracting the gate type from the lower nibble of an IDT flags byte.
+const GATE_TYPE_MASK: u8 = 0x0F;
+/// Gate type value for a 32-bit task gate.
+const GATE_TYPE_TASK32: u8 = 0x5;
+/// Gate type value for a 16-bit interrupt gate.
+const GATE_TYPE_INT16: u8 = 0x6;
+/// Gate type value for a 16-bit trap gate.
+const GATE_TYPE_TRAP16: u8 = 0x7;
+/// Gate type value for a 32-bit interrupt gate.
+const GATE_TYPE_INT32: u8 = 0xe;
+/// Gate type value for a 32-bit trap gate.
+const GATE_TYPE_TRAP32: u8 = 0xf;
+
 #[repr(u8)]
 pub enum GateType {
-    Task32 = 0x5, // 32-bit task gate.
-    Int16 = 0x6,  // 16-bit interrupt gate.
-    Trap16 = 0x7, // 16-bit trap gate.
-    Int32 = 0xe,  // 32-bit interrupt gate.
-    Trap32 = 0xf, // 32-bit trap gate.
+    Task32 = GATE_TYPE_TASK32, // 32-bit task gate.
+    Int16 = GATE_TYPE_INT16,   // 16-bit interrupt gate.
+    Trap16 = GATE_TYPE_TRAP16, // 16-bit trap gate.
+    Int32 = GATE_TYPE_INT32,   // 32-bit interrupt gate.
+    Trap32 = GATE_TYPE_TRAP32, // 32-bit trap gate.
+}
+
+impl GateType {
+    /// Decodes the gate type from the lower nibble of an IDT flags byte.
+    ///
+    /// Returns `Some(GateType)` if the nibble matches a known gate type, `None` otherwise.
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value & GATE_TYPE_MASK {
+            GATE_TYPE_TASK32 => Some(Self::Task32),
+            GATE_TYPE_INT16 => Some(Self::Int16),
+            GATE_TYPE_TRAP16 => Some(Self::Trap16),
+            GATE_TYPE_INT32 => Some(Self::Int32),
+            GATE_TYPE_TRAP32 => Some(Self::Trap32),
+            _ => None,
+        }
+    }
+}
+
+impl core::fmt::Debug for GateType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", gate_type_str(self))
+    }
+}
+
+/// Returns a static string label for a [`GateType`] variant.
+const fn gate_type_str(gate: &GateType) -> &'static str {
+    match gate {
+        GateType::Task32 => "task32",
+        GateType::Int16 => "int16",
+        GateType::Trap16 => "trap16",
+        GateType::Int32 => "int32",
+        GateType::Trap32 => "trap32",
+    }
 }
 
 //==================================================================================================
 // Present Bit
 //==================================================================================================
 
+/// Bit position of the present flag in the IDT flags byte.
+const PRESENT_BIT_SHIFT: u8 = 7;
+
 #[repr(u8)]
 pub enum PresentBit {
-    NotPresent = 0 << 7,
-    Present = 1 << 7,
+    NotPresent = 0 << PRESENT_BIT_SHIFT,
+    Present = 1 << PRESENT_BIT_SHIFT,
 }
 
 //==================================================================================================
 // Descriptor Privilege Level
 //==================================================================================================
 
+/// Bit position of the descriptor privilege level field in the IDT flags byte.
+const DPL_SHIFT: u8 = 5;
+
 #[repr(u8)]
 pub enum DescriptorPrivilegeLevel {
-    Ring0 = (PrivilegeLevel::Ring0 as u8) << 5,
-    Ring1 = (PrivilegeLevel::Ring1 as u8) << 5,
-    Ring2 = (PrivilegeLevel::Ring2 as u8) << 5,
-    Ring3 = (PrivilegeLevel::Ring3 as u8) << 5,
+    Ring0 = (PrivilegeLevel::Ring0 as u8) << DPL_SHIFT,
+    Ring1 = (PrivilegeLevel::Ring1 as u8) << DPL_SHIFT,
+    Ring2 = (PrivilegeLevel::Ring2 as u8) << DPL_SHIFT,
+    Ring3 = (PrivilegeLevel::Ring3 as u8) << DPL_SHIFT,
 }
 
 //==================================================================================================
@@ -68,14 +120,22 @@ impl From<Flags> for u8 {
 // Interrupt Descriptor Table Entry
 //==================================================================================================
 
+/// Bit position of the upper 16 bits of a 32-bit handler address.
+const HANDLER_HIGH_SHIFT: u32 = 16;
+/// Bit position of the middle 16 bits of a 64-bit handler address (same value
+/// as [`HANDLER_HIGH_SHIFT`] because bits 16..31 sit at the same offset in both modes).
+const HANDLER_MID_SHIFT: u32 = 16;
+/// Bit position of the upper 32 bits of a 64-bit handler address.
+const HANDLER_HIGH64_SHIFT: u32 = 32;
+
 /// Interrupt descriptor table entry (IDTE).
 #[repr(C, align(8))]
 pub struct Idte {
-    pub handler_low: u16,  // Handler low.
-    pub selector: u16,     // GDT selector.
-    pub zero: u8,          // Always zero.
-    pub flags: u8,         // Gate type and flags.
-    pub handler_high: u16, // Handler high.
+    handler_low: u16,  // Handler low.
+    selector: u16,     // GDT selector.
+    zero: u8,          // Always zero.
+    flags: u8,         // Gate type and flags.
+    handler_high: u16, // Handler high.
 }
 
 // `Idte` must be 8 bytes long. This must match the hardware specification.
@@ -85,7 +145,7 @@ impl Idte {
     /// Creates a new IDT entry.
     pub fn new(handler: u32, selector: u16, flags: Flags) -> Self {
         let handler_low = handler as u16;
-        let handler_high = (handler >> 16) as u16;
+        let handler_high = (handler >> HANDLER_HIGH_SHIFT) as u16;
 
         Self {
             handler_low,
@@ -94,5 +154,104 @@ impl Idte {
             flags: flags.into(),
             handler_high,
         }
+    }
+
+    /// Returns the full 32-bit handler address reconstructed from the split fields.
+    pub fn handler(&self) -> u32 {
+        (self.handler_low as u32) | ((self.handler_high as u32) << HANDLER_HIGH_SHIFT)
+    }
+
+    /// Returns the decoded gate type from the flags byte, or `None` if unrecognized.
+    pub fn gate_type(&self) -> Option<GateType> {
+        GateType::from_u8(self.flags)
+    }
+}
+
+impl core::fmt::Debug for Idte {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let handler: u32 = self.handler();
+        let gate_str: &str = self
+            .gate_type()
+            .as_ref()
+            .map_or("unknown", |g| gate_type_str(g));
+        write!(
+            f,
+            "Idte {{ handler={handler:#010x}, selector={:#06x}, flags={:#04x}, {gate_str} }}",
+            self.selector, self.flags
+        )
+    }
+}
+
+//==================================================================================================
+// Long-Mode Interrupt Descriptor Table Entry
+//==================================================================================================
+
+/// Long-mode (64-bit) interrupt descriptor table entry.
+///
+/// In long mode, each IDT entry is 16 bytes wide and holds a 64-bit handler address.
+#[repr(C, packed)]
+pub struct Idte64 {
+    /// Lower 16 bits of the handler address.
+    handler_low: u16,
+    /// GDT selector.
+    selector: u16,
+    /// Interrupt Stack Table index (bits 0–2) and reserved zero bits.
+    interrupt_stack_table: u8,
+    /// Gate type, DPL, and present bit.
+    flags: u8,
+    /// Middle 16 bits of the handler address.
+    handler_mid: u16,
+    /// Upper 32 bits of the handler address.
+    handler_high: u32,
+    /// Reserved (must be zero).
+    reserved: u32,
+}
+
+// `Idte64` must be 16 bytes long.
+::static_assert::assert_eq_size!(Idte64, 16);
+
+impl Idte64 {
+    /// Returns the full 64-bit handler address reconstructed from the split fields.
+    pub fn handler(&self) -> u64 {
+        // Safety: `addr_of!` + `read_unaligned` avoids creating intermediate
+        // references to packed fields, which would be undefined behavior.
+        let low: u16 = unsafe { core::ptr::addr_of!(self.handler_low).read_unaligned() };
+        let mid: u16 = unsafe { core::ptr::addr_of!(self.handler_mid).read_unaligned() };
+        let high: u32 = unsafe { core::ptr::addr_of!(self.handler_high).read_unaligned() };
+        (low as u64) | ((mid as u64) << HANDLER_MID_SHIFT) | ((high as u64) << HANDLER_HIGH64_SHIFT)
+    }
+
+    /// Returns the flags byte.
+    pub fn flags(&self) -> u8 {
+        // Safety: same rationale as [`Self::handler`].
+        unsafe { core::ptr::addr_of!(self.flags).read_unaligned() }
+    }
+
+    /// Returns the GDT selector.
+    pub fn selector(&self) -> u16 {
+        // Safety: same rationale as [`Self::handler`].
+        unsafe { core::ptr::addr_of!(self.selector).read_unaligned() }
+    }
+
+    /// Returns the decoded gate type from the flags byte, or `None` if unrecognized.
+    pub fn gate_type(&self) -> Option<GateType> {
+        GateType::from_u8(self.flags())
+    }
+}
+
+impl core::fmt::Debug for Idte64 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let handler: u64 = self.handler();
+        let flags: u8 = self.flags();
+        let selector: u16 = self.selector();
+        let gate_str: &str = self
+            .gate_type()
+            .as_ref()
+            .map_or("unknown", |g| gate_type_str(g));
+        write!(
+            f,
+            "Idte64 {{ handler={handler:#018x}, selector={selector:#06x}, flags={flags:#04x}, \
+             {gate_str} }}"
+        )
     }
 }

--- a/src/libs/arch/src/x86/mem/gdt.rs
+++ b/src/libs/arch/src/x86/mem/gdt.rs
@@ -8,6 +8,41 @@
 use crate::x86::cpu::ring::PrivilegeLevel;
 
 //==================================================================================================
+// Base Address Constants
+//==================================================================================================
+
+/// Mask for extracting the lower 16 bits of the segment base address.
+const BASE_LOW_MASK: u32 = 0xffff;
+/// Bit position of the middle 8 bits of the segment base address.
+const BASE_MIDDLE_SHIFT: u32 = 16;
+/// Mask for extracting the middle 8 bits of the segment base address.
+const BASE_MIDDLE_MASK: u32 = 0xff;
+/// Bit position of the upper 8 bits of the segment base address.
+const BASE_HIGH_SHIFT: u32 = 24;
+/// Mask for extracting the upper 8 bits of the segment base address.
+const BASE_HIGH_MASK: u32 = 0xff;
+
+//==================================================================================================
+// Segment Limit Constants
+//==================================================================================================
+
+/// Mask for extracting the lower 16 bits of the segment limit.
+const LIMIT_LOW_MASK: u32 = 0xffff;
+/// Bit position of the upper 4 bits of the segment limit.
+const LIMIT_HIGH_SHIFT: u32 = 16;
+/// Mask for extracting the upper 4 bits of the segment limit.
+const LIMIT_HIGH_MASK: u32 = 0x0f;
+
+//==================================================================================================
+// Flags/Limit Byte Layout Constants
+//==================================================================================================
+
+/// Bit position of the flags nibble in the flags/limit byte.
+const FLAGS_NIBBLE_SHIFT: u8 = 4;
+/// Mask for extracting a 4-bit nibble from the flags/limit byte.
+const FLAGS_NIBBLE_MASK: u8 = 0x0f;
+
+//==================================================================================================
 // Global Descriptor Table Entry (GDTE)
 //==================================================================================================
 
@@ -61,8 +96,8 @@ impl Gdte {
             base_high: Self::compute_base_high(base),
             base_middle: Self::compute_base_middle(base),
             limit_low: Self::compute_limit_low(limit),
-            flags_limit: (Self::compute_flags_low(flags.into_u8()) << 4)
-                | (Self::compute_limit_high(limit) & 0x0f),
+            flags_limit: (Self::compute_flags_low(flags.into_u8()) << FLAGS_NIBBLE_SHIFT)
+                | (Self::compute_limit_high(limit) & FLAGS_NIBBLE_MASK),
             access: access.into_u8(),
         }
     }
@@ -112,7 +147,24 @@ impl Gdte {
     /// This function returns the base address of the target GDT entry.
     ///
     pub fn get_base(&self) -> u32 {
-        (self.base_high as u32) << 24 | (self.base_middle as u32) << 16 | (self.base_low as u32)
+        (self.base_high as u32) << BASE_HIGH_SHIFT
+            | (self.base_middle as u32) << BASE_MIDDLE_SHIFT
+            | (self.base_low as u32)
+    }
+
+    /// Returns the raw access byte of the GDT entry.
+    pub fn access_byte(&self) -> u8 {
+        self.access
+    }
+
+    /// Returns the 4-bit flags nibble (granularity, D/B, L, AVL) of the GDT entry.
+    pub fn get_flags(&self) -> u8 {
+        (self.flags_limit >> FLAGS_NIBBLE_SHIFT) & FLAGS_NIBBLE_MASK
+    }
+
+    /// Returns the 20-bit segment limit of the GDT entry.
+    pub fn get_limit(&self) -> u32 {
+        (self.flags_limit as u32 & LIMIT_HIGH_MASK) << LIMIT_HIGH_SHIFT | self.limit_low as u32
     }
 
     ///
@@ -130,7 +182,7 @@ impl Gdte {
     ///
     #[inline(always)]
     const fn compute_base_low(base: u32) -> u16 {
-        (base & 0xffff) as u16
+        (base & BASE_LOW_MASK) as u16
     }
 
     ///
@@ -148,7 +200,7 @@ impl Gdte {
     ///
     #[inline(always)]
     const fn compute_base_middle(base: u32) -> u8 {
-        ((base >> 16) & 0xff) as u8
+        ((base >> BASE_MIDDLE_SHIFT) & BASE_MIDDLE_MASK) as u8
     }
 
     ///
@@ -166,7 +218,7 @@ impl Gdte {
     ///
     #[inline(always)]
     const fn compute_base_high(base: u32) -> u8 {
-        ((base >> 24) & 0xff) as u8
+        ((base >> BASE_HIGH_SHIFT) & BASE_HIGH_MASK) as u8
     }
 
     ///
@@ -184,7 +236,7 @@ impl Gdte {
     ///
     #[inline(always)]
     const fn compute_limit_low(limit: u32) -> u16 {
-        (limit & 0xffff) as u16
+        (limit & LIMIT_LOW_MASK) as u16
     }
 
     ///
@@ -202,7 +254,7 @@ impl Gdte {
     ///
     #[inline(always)]
     const fn compute_limit_high(limit: u32) -> u8 {
-        ((limit >> 16) & 0x0f) as u8
+        ((limit >> LIMIT_HIGH_SHIFT) & LIMIT_HIGH_MASK) as u8
     }
 
     ///
@@ -220,21 +272,22 @@ impl Gdte {
     ///
     #[inline(always)]
     const fn compute_flags_low(flags: u8) -> u8 {
-        flags & 0x0f
+        flags & FLAGS_NIBBLE_MASK
     }
 }
 
 impl core::fmt::Debug for Gdte {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let base: u32 =
-            (self.base_high as u32) << 24 | (self.base_middle as u32) << 16 | self.base_low as u32;
-        let limit: u32 = (self.flags_limit as u32 & 0x0f) << 16 | self.limit_low as u32;
-        let access: u8 = self.access;
-        let flags: u8 = (self.flags_limit & 0xf0) >> 4;
+        let base: u32 = self.get_base();
+        let limit: u32 = self.get_limit();
+        let access_raw: u8 = self.access;
+        let access: GdteAccessByte = GdteAccessByte::from_u8(access_raw);
+        let flags: u8 = self.get_flags();
         write!(
             f,
-            "Gdte {{ base={:#010x}, limit={:#07x}, flags={:#03x}, access={:#04x} }}",
-            base, limit, flags, access
+            "Gdte {{ base={:#010x}, limit={:#07x}, flags={:#03x}, access={access_raw:#04x} \
+             ({access:?}) }}",
+            base, limit, flags
         )
     }
 }
@@ -278,29 +331,55 @@ impl GdteFlags {
     }
 }
 
+/// Bit position of the granularity flag in the GDT flags nibble.
+const GRANULARITY_SHIFT: u8 = 3;
+/// Bit position of the protected mode flag in the GDT flags nibble.
+const PROTECTED_MODE_SHIFT: u8 = 2;
+/// Bit position of the long mode flag in the GDT flags nibble.
+const LONG_MODE_SHIFT: u8 = 1;
+
 /// Granularity flag for a GDTE.
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum GdteGranularity {
-    ByteGranularity = (0 << 3),
-    PageGranularity = (1 << 3),
+    ByteGranularity = (0 << GRANULARITY_SHIFT),
+    PageGranularity = (1 << GRANULARITY_SHIFT),
 }
 
 /// Protected mode flag for a GDTE.
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum GdteProtectedMode {
-    ProtectedMode16 = (0 << 2),
-    ProtectedMode32 = (1 << 2),
+    ProtectedMode16 = (0 << PROTECTED_MODE_SHIFT),
+    ProtectedMode32 = (1 << PROTECTED_MODE_SHIFT),
 }
 
 /// Long mode flag for a GDTE.
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum GdteLongMode {
-    CompatibilityMode = (0 << 1),
-    LongMode = (1 << 1),
+    CompatibilityMode = (0 << LONG_MODE_SHIFT),
+    LongMode = (1 << LONG_MODE_SHIFT),
 }
+
+//==================================================================================================
+// Access Byte Constants
+//==================================================================================================
+
+/// Bit position of the read/write flag in the access byte.
+const ACCESS_RW_SHIFT: u8 = 1;
+/// Bit position of the direction/conforming flag in the access byte.
+const ACCESS_DC_SHIFT: u8 = 2;
+/// Bit position of the executable flag in the access byte.
+const ACCESS_EXECUTABLE_SHIFT: u8 = 3;
+/// Bit position of the descriptor type flag in the access byte.
+const ACCESS_DESCRIPTOR_TYPE_SHIFT: u8 = 4;
+/// Bit position of the descriptor privilege level field in the access byte.
+const ACCESS_DPL_SHIFT: u8 = 5;
+/// Mask for extracting the 2-bit DPL field from a shifted access byte.
+const ACCESS_DPL_MASK: u8 = 0x3;
+/// Bit position of the present flag in the access byte.
+const ACCESS_PRESENT_SHIFT: u8 = 7;
 
 /// Present flag in access byte.
 #[derive(Debug, Clone, Copy)]
@@ -314,16 +393,16 @@ pub enum AccessAccessed {
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessReadable {
-    NonReadable = (0 << 1),
-    Readable = (1 << 1),
+    NonReadable = (0 << ACCESS_RW_SHIFT),
+    Readable = (1 << ACCESS_RW_SHIFT),
 }
 
 /// Write flag for data segments in access byte.
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessWritable {
-    Readonly = (0 << 1),
-    ReadWrite = (1 << 1),
+    Readonly = (0 << ACCESS_RW_SHIFT),
+    ReadWrite = (1 << ACCESS_RW_SHIFT),
 }
 
 /// Read/Write flag in access byte.
@@ -338,16 +417,16 @@ pub enum AccessReadWrite {
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessDirection {
-    GrowsUp = (0 << 2),
-    GrowsDown = (1 << 2),
+    GrowsUp = (0 << ACCESS_DC_SHIFT),
+    GrowsDown = (1 << ACCESS_DC_SHIFT),
 }
 
 /// Conforming flag in access byte.
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessConforming {
-    NonConforming = (0 << 2),
-    Conforming = (1 << 2),
+    NonConforming = (0 << ACCESS_DC_SHIFT),
+    Conforming = (1 << ACCESS_DC_SHIFT),
 }
 
 /// Direction/Conforming flag in access byte.
@@ -362,34 +441,34 @@ pub enum AccessDirectionConforming {
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessExecutable {
-    Data = (0 << 3),
-    Code = (1 << 3),
+    Data = (0 << ACCESS_EXECUTABLE_SHIFT),
+    Code = (1 << ACCESS_EXECUTABLE_SHIFT),
 }
 
 /// Descriptor type flag in access byte.
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessDescriptorType {
-    System = (0 << 4),
-    CodeData = (1 << 4),
+    System = (0 << ACCESS_DESCRIPTOR_TYPE_SHIFT),
+    CodeData = (1 << ACCESS_DESCRIPTOR_TYPE_SHIFT),
 }
 
 /// Descriptor privilege level flag in access byte.
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum DescriptorPrivilegeLevel {
-    Ring0 = (PrivilegeLevel::Ring0 as u8) << 5,
-    Ring1 = (PrivilegeLevel::Ring1 as u8) << 5,
-    Ring2 = (PrivilegeLevel::Ring2 as u8) << 5,
-    Ring3 = (PrivilegeLevel::Ring3 as u8) << 5,
+    Ring0 = (PrivilegeLevel::Ring0 as u8) << ACCESS_DPL_SHIFT,
+    Ring1 = (PrivilegeLevel::Ring1 as u8) << ACCESS_DPL_SHIFT,
+    Ring2 = (PrivilegeLevel::Ring2 as u8) << ACCESS_DPL_SHIFT,
+    Ring3 = (PrivilegeLevel::Ring3 as u8) << ACCESS_DPL_SHIFT,
 }
 
 /// Present flag in access byte.
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum AccessPresent {
-    NotPresent = (0 << 7),
-    Present = (1 << 7),
+    NotPresent = (0 << ACCESS_PRESENT_SHIFT),
+    Present = (1 << ACCESS_PRESENT_SHIFT),
 }
 
 //==================================================================================================
@@ -452,5 +531,122 @@ impl GdteAccessByte {
             | (self.descriptor_type as u8)
             | (self.dpl as u8)
             | (self.present as u8)
+    }
+
+    /// Decodes a raw access byte into a [`GdteAccessByte`].
+    ///
+    /// For system descriptors (bit 4 clear), bits 0–3 encode the system-segment
+    /// type rather than the code/data flags.  In that case the returned
+    /// `executable`, `read_write`, and `direction_conforming` fields are set to
+    /// their default (data/readonly/grows-up) values and should be ignored;
+    /// only `descriptor_type`, `dpl`, and `present` are meaningful.
+    pub fn from_u8(value: u8) -> Self {
+        let descriptor_type: AccessDescriptorType =
+            if (value & (AccessDescriptorType::CodeData as u8)) != 0 {
+                AccessDescriptorType::CodeData
+            } else {
+                AccessDescriptorType::System
+            };
+        let dpl: DescriptorPrivilegeLevel = match (value >> ACCESS_DPL_SHIFT) & ACCESS_DPL_MASK {
+            0 => DescriptorPrivilegeLevel::Ring0,
+            1 => DescriptorPrivilegeLevel::Ring1,
+            2 => DescriptorPrivilegeLevel::Ring2,
+            _ => DescriptorPrivilegeLevel::Ring3,
+        };
+        let present: AccessPresent = if (value & (AccessPresent::Present as u8)) != 0 {
+            AccessPresent::Present
+        } else {
+            AccessPresent::NotPresent
+        };
+
+        // For system descriptors, bits 0–3 encode the system-segment type
+        // rather than accessed/rw/dc/executable.  Use neutral defaults.
+        let (accessed, executable, read_write, direction_conforming) = match descriptor_type {
+            AccessDescriptorType::System => (
+                AccessAccessed::NotAccessed,
+                AccessExecutable::Data,
+                AccessReadWrite::DataSegment(AccessWritable::Readonly),
+                AccessDirectionConforming::Direction(AccessDirection::GrowsUp),
+            ),
+            AccessDescriptorType::CodeData => {
+                let accessed: AccessAccessed = if (value & (AccessAccessed::Accessed as u8)) != 0 {
+                    AccessAccessed::Accessed
+                } else {
+                    AccessAccessed::NotAccessed
+                };
+                let executable: AccessExecutable = if (value & (AccessExecutable::Code as u8)) != 0
+                {
+                    AccessExecutable::Code
+                } else {
+                    AccessExecutable::Data
+                };
+                let read_write: AccessReadWrite = match executable {
+                    AccessExecutable::Code => {
+                        if (value & (AccessReadable::Readable as u8)) != 0 {
+                            AccessReadWrite::CodeSegment(AccessReadable::Readable)
+                        } else {
+                            AccessReadWrite::CodeSegment(AccessReadable::NonReadable)
+                        }
+                    },
+                    AccessExecutable::Data => {
+                        if (value & (AccessWritable::ReadWrite as u8)) != 0 {
+                            AccessReadWrite::DataSegment(AccessWritable::ReadWrite)
+                        } else {
+                            AccessReadWrite::DataSegment(AccessWritable::Readonly)
+                        }
+                    },
+                };
+                let direction_conforming: AccessDirectionConforming = match executable {
+                    AccessExecutable::Code => {
+                        if (value & (AccessConforming::Conforming as u8)) != 0 {
+                            AccessDirectionConforming::Conforming(AccessConforming::Conforming)
+                        } else {
+                            AccessDirectionConforming::Conforming(AccessConforming::NonConforming)
+                        }
+                    },
+                    AccessExecutable::Data => {
+                        if (value & (AccessDirection::GrowsDown as u8)) != 0 {
+                            AccessDirectionConforming::Direction(AccessDirection::GrowsDown)
+                        } else {
+                            AccessDirectionConforming::Direction(AccessDirection::GrowsUp)
+                        }
+                    },
+                };
+                (accessed, executable, read_write, direction_conforming)
+            },
+        };
+
+        Self {
+            accessed,
+            read_write,
+            direction_conforming,
+            executable,
+            descriptor_type,
+            dpl,
+            present,
+        }
+    }
+}
+
+impl core::fmt::Debug for GdteAccessByte {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let present: &str = match self.present {
+            AccessPresent::Present => "present",
+            AccessPresent::NotPresent => "not-present",
+        };
+        let descriptor_type: &str = match self.descriptor_type {
+            AccessDescriptorType::CodeData => match self.executable {
+                AccessExecutable::Code => "code",
+                AccessExecutable::Data => "data",
+            },
+            AccessDescriptorType::System => "system",
+        };
+        let dpl: u8 = match self.dpl {
+            DescriptorPrivilegeLevel::Ring0 => 0,
+            DescriptorPrivilegeLevel::Ring1 => 1,
+            DescriptorPrivilegeLevel::Ring2 => 2,
+            DescriptorPrivilegeLevel::Ring3 => 3,
+        };
+        write!(f, "{present}, {descriptor_type}, DPL={dpl}")
     }
 }


### PR DESCRIPTION
## Summary

Replace hardcoded numeric literals across the x86 IDT and GDT modules with documented named constants. Add accessor methods, debug formatting, and fallible conversion APIs.

## Changes

### Commit 1: Add fallible Exception conversion and update caller
- Introduce `Exception::try_from_vector()` returning `Option<Self>`.
- Replace panicking `From<u32>` with `TryFrom<u32>`.
- Update `ExceptionInformation::Debug` to handle unknown vectors gracefully.

### Commit 2: Extract IDT constants, add accessors and long-mode entry
- Extract gate-type, flag-byte, and handler-address constants.
- Add `GateType::from_u8()`, `gate_type_str()` helper, `Idte` accessors, and `Debug` impls.
- Introduce `Idte64` struct for long-mode IDT entries with safe packed-field access.
- Make `Idte`/`Idte64` fields private to prevent unaligned reference UB.

### Commit 3: Extract GDT constants, add accessors and access byte decoder
- Extract base-address, segment-limit, flags-nibble, and access-byte constants.
- Add `GdteAccessByte::from_u8()` decoder, `Gdte` accessor methods, and `Debug` impls.

## Testing

- `cargo check` passes for the full workspace.
- `cargo fmt --check` clean on all modified files.