### PR TITLE
[libc_stdlib] Fix allocation alignment and free validation

### DIFF
--- a/src/libs/libc_stdlib/Cargo.toml
+++ b/src/libs/libc_stdlib/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["lib"]
 alloc = { version = "1.0.1", optional = true, package = "rustc-std-workspace-alloc" }
 cfg-if = { workspace = true }
 compiler_builtins = { workspace = true, optional = true }
+config = { workspace = true }
 core = { version = "1.0.1", optional = true, package = "rustc-std-workspace-core" }
 flexi_logger = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
@@ -34,6 +35,7 @@ rustc-dep-of-std = [
     "core",
     "cfg-if/rustc-dep-of-std",
     "compiler_builtins/rustc-dep-of-std",
+    "config/rustc-dep-of-std",
     "static_assert/rustc-dep-of-std",
     "sysapi/rustc-dep-of-std",
     "syslog/rustc-dep-of-std",

--- a/src/libs/libc_stdlib/src/block_header.rs
+++ b/src/libs/libc_stdlib/src/block_header.rs
@@ -11,10 +11,7 @@ use ::alloc::alloc::{
 };
 use ::core::{
     alloc::Layout,
-    mem::{
-        align_of,
-        size_of,
-    },
+    mem::size_of,
     ptr::{
         copy_nonoverlapping,
         null_mut,
@@ -29,10 +26,20 @@ use ::syslog::{
 // Constants
 //==================================================================================================
 
-/// Minimum alignment guaranteed by this allocator.
-const BLOCK_HEADER_ALIGNMENT: usize = align_of::<usize>();
+/// Alignment for allocations passed to the underlying allocator. Must be at
+/// least `align_of::<LlistNode>()` (8 on 32-bit) so that talc can safely write
+/// its free-list nodes into freed chunks without misaligned access.
+const UNDERLYING_ALIGNMENT: usize = 8;
+/// Alignment of the BlockHeader struct itself.
+const BLOCK_HEADER_ALIGNMENT: usize = core::mem::align_of::<BlockHeader>();
 /// Block header size.
 const BLOCK_HEADER_SIZE: usize = size_of::<BlockHeader>();
+/// Maximum alignment that the allocator supports.
+const MAX_ALIGNMENT: usize = 4096;
+/// Start of user mmap region.
+const USER_MMAP_BASE_RAW: usize = ::config::memory_layout::USER_MMAP_BASE_RAW;
+/// End of user mmap region.
+const USER_MMAP_END_RAW: usize = ::config::memory_layout::USER_MMAP_END_RAW;
 
 //==================================================================================================
 // Structures
@@ -89,6 +96,12 @@ impl BlockHeader {
         // Get alignment for user memory area, or default to minimum alignment.
         let alignment: usize = alignment.unwrap_or(1);
 
+        // Validate alignment invariants so that free() can trust the header.
+        if !alignment.is_power_of_two() || alignment > MAX_ALIGNMENT {
+            error!("alloc(): invalid alignment (alignment={alignment:?}, size={size:?})");
+            return null_mut();
+        }
+
         // Compute size for underlying allocation (header_size + padding_size + requested_size).
         let alloc_size: usize = {
             let Some(alloc_size) = size.checked_add(BLOCK_HEADER_SIZE) else {
@@ -106,11 +119,21 @@ impl BlockHeader {
                 return null_mut();
             };
 
-            alloc_size
+            // Round up to UNDERLYING_ALIGNMENT so that talc's free-list nodes
+            // (LlistNode, 8 bytes) are always naturally aligned when placed at
+            // the base of a freed chunk.
+            let Some(rounded) = alloc_size.checked_add(UNDERLYING_ALIGNMENT - 1) else {
+                error!(
+                    "alloc(): overflow when rounding allocation size (size={size:?}, \
+                     alignment={alignment:?})"
+                );
+                return null_mut();
+            };
+            rounded & !(UNDERLYING_ALIGNMENT - 1)
         };
 
         // Compute layout for underlying allocation.
-        let layout: Layout = match Layout::from_size_align(alloc_size, BLOCK_HEADER_ALIGNMENT) {
+        let layout: Layout = match Layout::from_size_align(alloc_size, UNDERLYING_ALIGNMENT) {
             Ok(layout) => layout,
             Err(error) => {
                 error!("alloc(): {error:?} (alignment={alignment:?}, size={size:?})");
@@ -207,18 +230,48 @@ impl BlockHeader {
 
         let header_ptr: *mut BlockHeader = Self::get_mut_ptr(user_ptr);
         let header: BlockHeader = header_ptr.read(); // move out
-        let layout: Layout =
-            match Layout::from_size_align(header.alloc_size, BLOCK_HEADER_ALIGNMENT) {
-                Ok(layout) => layout,
-                Err(error) => {
-                    // Corrupted header; cannot recover.
-                    error!(
-                        "BlockHeader::free(): corrupted header (error={error:?}, \
-                         header={header:?})"
-                    );
-                    return Err(());
-                },
-            };
+
+        // Validate header sanity.
+        // After a shrinking realloc, requested_alloc_size < original, so we only check >=.
+        let valid_alignment: bool = header.alignment > 0
+            && header.alignment.is_power_of_two()
+            && header.alignment <= MAX_ALIGNMENT;
+        let valid_alloc_size: bool = header
+            .requested_alloc_size
+            .checked_add(BLOCK_HEADER_SIZE)
+            .is_some_and(|min_size| header.alloc_size >= min_size);
+        let base_addr: usize = header.base as usize;
+        let valid_base: bool = (USER_MMAP_BASE_RAW..USER_MMAP_END_RAW).contains(&base_addr);
+        let uptr: usize = user_ptr as usize;
+        let valid_user_ptr: bool = base_addr
+            .checked_add(header.alloc_size)
+            .is_some_and(|end| uptr >= base_addr && uptr < end && end <= USER_MMAP_END_RAW);
+        let valid_underlying_alignment: bool = base_addr.is_multiple_of(UNDERLYING_ALIGNMENT)
+            && header.alloc_size.is_multiple_of(UNDERLYING_ALIGNMENT);
+        let valid: bool = valid_alignment
+            && valid_alloc_size
+            && valid_base
+            && valid_user_ptr
+            && valid_underlying_alignment;
+
+        if !valid {
+            error!(
+                "BlockHeader::free(): corrupted header detected, leaking (user_ptr={user_ptr:p}, \
+                 header={header:?})"
+            );
+            return Err(());
+        }
+
+        let layout: Layout = match Layout::from_size_align(header.alloc_size, UNDERLYING_ALIGNMENT)
+        {
+            Ok(layout) => layout,
+            Err(error) => {
+                error!(
+                    "BlockHeader::free(): corrupted header (error={error:?}, header={header:?})"
+                );
+                return Err(());
+            },
+        };
 
         dealloc(header.base, layout);
 

--- a/src/tests/memory-c/common.h
+++ b/src/tests/memory-c/common.h
@@ -28,4 +28,7 @@ extern void test_heap_max_capacity(void);
 // repeated cycles, and small-heap scenarios.
 extern void test_heap_shrink(void);
 
+// Tests realloc growth, shrink, NULL-ptr, data preservation, and alignment boundary sizes.
+extern void test_realloc(void);
+
 #endif

--- a/src/tests/memory-c/main.c
+++ b/src/tests/memory-c/main.c
@@ -69,6 +69,7 @@ int main(int argc, const char *argv[])
     test_heap_reclaim();
     test_heap_max_capacity();
     test_heap_shrink();
+    test_realloc();
 
     // Write magic string to signal that the test passed.
     {

--- a/src/tests/memory-c/realloc.c
+++ b/src/tests/memory-c/realloc.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+// Pattern byte used to fill memory before realloc.
+#define FILL_BYTE 0xA5u
+
+// Number of grow/shrink cycles in the stress test.
+#define STRESS_CYCLES 64u
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests realloc growth, shrink, NULL-ptr, data preservation, alignment boundary sizes, and
+// repeated grow/shrink cycles. Exercises the BlockHeader alignment rounding and free-path
+// header validation introduced by the libc_stdlib fix.
+void test_realloc(void)
+{
+    fprintf(stderr, "testing realloc() ... ");
+
+    //==============================================================================================
+    // Growth path: malloc then realloc to a larger size.
+    //==============================================================================================
+
+    {
+        void *ptr = malloc(64u);
+        assert(ptr != NULL);
+        memset(ptr, FILL_BYTE, 64u);
+
+        void *ptr2 = realloc(ptr, 256u);
+        assert(ptr2 != NULL);
+
+        // Verify original data is preserved in the first 64 bytes.
+        unsigned char *bytes = (unsigned char *)ptr2;
+        for (size_t i = 0; i < 64u; ++i) {
+            assert(bytes[i] == FILL_BYTE);
+        }
+
+        free(ptr2);
+    }
+
+    //==============================================================================================
+    // Shrink path: malloc a large block then realloc to a smaller size.
+    //==============================================================================================
+
+    {
+        void *ptr = malloc(512u);
+        assert(ptr != NULL);
+        memset(ptr, FILL_BYTE, 512u);
+
+        void *ptr2 = realloc(ptr, 64u);
+        assert(ptr2 != NULL);
+
+        // Verify data preserved in the smaller region.
+        unsigned char *bytes = (unsigned char *)ptr2;
+        for (size_t i = 0; i < 64u; ++i) {
+            assert(bytes[i] == FILL_BYTE);
+        }
+
+        free(ptr2);
+    }
+
+    //==============================================================================================
+    // NULL-ptr realloc: behaves like malloc.
+    //==============================================================================================
+
+    {
+        void *ptr = realloc(NULL, 128u);
+        assert(ptr != NULL);
+        memset(ptr, FILL_BYTE, 128u);
+
+        unsigned char *bytes = (unsigned char *)ptr;
+        for (size_t i = 0; i < 128u; ++i) {
+            assert(bytes[i] == FILL_BYTE);
+        }
+
+        free(ptr);
+    }
+
+    //==============================================================================================
+    // Alignment boundary sizes: exercise UNDERLYING_ALIGNMENT (8-byte) rounding.
+    //==============================================================================================
+
+    {
+        const size_t sizes[] = {1u, 7u, 8u, 9u, 15u, 16u, 17u, 31u, 32u, 33u};
+        const size_t nsizes = sizeof(sizes) / sizeof(sizes[0]);
+
+        for (size_t i = 0; i < nsizes; ++i) {
+            size_t sz = sizes[i];
+            void *ptr = malloc(sz);
+            assert(ptr != NULL);
+            memset(ptr, FILL_BYTE, sz);
+
+            // Grow to double size.
+            size_t new_sz = sz * 2;
+            void *ptr2 = realloc(ptr, new_sz);
+            assert(ptr2 != NULL);
+
+            // Verify original data preserved.
+            unsigned char *bytes = (unsigned char *)ptr2;
+            for (size_t j = 0; j < sz; ++j) {
+                assert(bytes[j] == FILL_BYTE);
+            }
+
+            free(ptr2);
+        }
+    }
+
+    //==============================================================================================
+    // Repeated grow/shrink cycles: stress alignment and header validation.
+    //==============================================================================================
+
+    {
+        size_t cur_size = 32u;
+        void *ptr = malloc(cur_size);
+        assert(ptr != NULL);
+        memset(ptr, FILL_BYTE, cur_size);
+
+        for (size_t cycle = 0; cycle < STRESS_CYCLES; ++cycle) {
+            // Alternate: grow on even cycles, shrink on odd.
+            size_t new_size = (cycle % 2 == 0) ? cur_size * 2 : cur_size / 2;
+            if (new_size == 0) {
+                new_size = 1;
+            }
+
+            size_t check_size = (new_size < cur_size) ? new_size : cur_size;
+            void *ptr2 = realloc(ptr, new_size);
+            assert(ptr2 != NULL);
+
+            // Verify data preserved up to the smaller of old/new sizes.
+            unsigned char *bytes = (unsigned char *)ptr2;
+            for (size_t j = 0; j < check_size; ++j) {
+                assert(bytes[j] == FILL_BYTE);
+            }
+
+            // Fill the new region with the pattern.
+            memset(ptr2, FILL_BYTE, new_size);
+
+            ptr = ptr2;
+            cur_size = new_size;
+        }
+
+        free(ptr);
+    }
+
+    fprintf(stderr, "passed\n");
+}


### PR DESCRIPTION
## Summary

Fix underlying allocation alignment in `libc_stdlib` and add header sanity validation in the free path.

### Bug Fix (`block_header.rs`)

- Changed underlying allocation alignment from `align_of::<usize>()` to a fixed `UNDERLYING_ALIGNMENT = 8` so that talc's free-list nodes (`LlistNode`, 8 bytes) are always naturally aligned when placed at the base of a freed chunk.
- Round `alloc_size` up to `UNDERLYING_ALIGNMENT` to prevent misaligned access.
- Added header sanity validation in `BlockHeader::free()`: checks alignment, alloc_size, base address range, and user pointer range before deallocation. Corrupted headers are detected and the block is leaked instead of causing undefined behavior.
- Added `MAX_ALIGNMENT = 4096` constant.

### Integration Test (`realloc.c`)

Added a dedicated C integration test exercising:
- Growth realloc (malloc → realloc to larger size)
- Shrink realloc (malloc → realloc to smaller size)
- NULL-ptr realloc (behaves like malloc)
- Data preservation across realloc
- Alignment boundary sizes (1, 7, 8, 9, 15, 16, 17, 31, 32, 33 bytes)
- Repeated grow/shrink cycles (64 iterations)

### Validation

- All pre-commit hooks pass (7/9 configurations checked)
- Full build succeeds (`./z build --with-cached-options -- all`)
- All integration tests pass (`./z build --with-cached-options -- run-nanvix-tests`)