### PR TITLE
[uservm] Dump memory info

### DIFF
--- a/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -102,6 +102,85 @@ const MSR_IA32_TSC: u32 = 0x10;
 ///
 /// # Description
 ///
+/// Hypervisor-independent segment register descriptor for diagnostic dumps.
+///
+pub struct SegmentRegister {
+    /// Segment selector.
+    pub selector: u16,
+    /// Segment base address.
+    pub base: u64,
+    /// Segment limit.
+    pub limit: u32,
+}
+
+///
+/// # Description
+///
+/// Hypervisor-independent descriptor table register for diagnostic dumps.
+///
+pub struct DescriptorTable {
+    /// Table base address.
+    pub base: u64,
+    /// Table limit.
+    pub limit: u16,
+}
+
+///
+/// # Description
+///
+/// Hypervisor-independent snapshot of virtual processor register state for diagnostic dumps.
+///
+pub struct VirtualProcessorDumpInfo {
+    /// Instruction pointer.
+    pub rip: u64,
+    /// Flags register.
+    pub rflags: u64,
+    /// General-purpose registers.
+    pub rax: u64,
+    pub rbx: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rsi: u64,
+    pub rdi: u64,
+    /// Stack pointer.
+    pub rsp: u64,
+    /// Base (frame) pointer.
+    pub rbp: u64,
+    pub r8: u64,
+    pub r9: u64,
+    pub r10: u64,
+    pub r11: u64,
+    pub r12: u64,
+    pub r13: u64,
+    pub r14: u64,
+    pub r15: u64,
+    /// Control registers.
+    pub cr0: u64,
+    pub cr2: u64,
+    pub cr3: u64,
+    pub cr4: u64,
+    pub cr8: u64,
+    /// Extended feature enable register.
+    pub efer: u64,
+    /// Segment registers.
+    pub cs: SegmentRegister,
+    pub ds: SegmentRegister,
+    pub ss: SegmentRegister,
+    pub es: SegmentRegister,
+    pub fs: SegmentRegister,
+    pub gs: SegmentRegister,
+    /// Descriptor table registers.
+    pub gdt: DescriptorTable,
+    pub idt: DescriptorTable,
+    /// Task register.
+    pub tr: SegmentRegister,
+    /// Local descriptor table register.
+    pub ldt: SegmentRegister,
+}
+
+///
+/// # Description
+///
 /// A structure that represents a virtual processor.
 ///
 pub struct VirtualProcessor {
@@ -464,6 +543,105 @@ impl VirtualProcessor {
     ///
     /// # Description
     ///
+    /// Returns a hypervisor-independent snapshot of the virtual processor's register state for
+    /// diagnostic dumps.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns a [`VirtualProcessorDumpInfo`]. Otherwise,
+    /// it returns an error.
+    ///
+    pub fn get_dump_info(&self) -> Result<VirtualProcessorDumpInfo> {
+        let regs: kvm_regs = self.fd.get_regs().map_err(|e| {
+            let reason: String = format!("failed to get registers (error={e:?})");
+            error!("get_dump_info(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+        let sregs: kvm_sregs = self.fd.get_sregs().map_err(|e| {
+            let reason: String = format!("failed to get special registers (error={e:?})");
+            error!("get_dump_info(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        Ok(VirtualProcessorDumpInfo {
+            rip: regs.rip,
+            rflags: regs.rflags,
+            rax: regs.rax,
+            rbx: regs.rbx,
+            rcx: regs.rcx,
+            rdx: regs.rdx,
+            rsi: regs.rsi,
+            rdi: regs.rdi,
+            rsp: regs.rsp,
+            rbp: regs.rbp,
+            r8: regs.r8,
+            r9: regs.r9,
+            r10: regs.r10,
+            r11: regs.r11,
+            r12: regs.r12,
+            r13: regs.r13,
+            r14: regs.r14,
+            r15: regs.r15,
+            cr0: sregs.cr0,
+            cr2: sregs.cr2,
+            cr3: sregs.cr3,
+            cr4: sregs.cr4,
+            cr8: sregs.cr8,
+            efer: sregs.efer,
+            cs: SegmentRegister {
+                selector: sregs.cs.selector,
+                base: sregs.cs.base,
+                limit: sregs.cs.limit,
+            },
+            ds: SegmentRegister {
+                selector: sregs.ds.selector,
+                base: sregs.ds.base,
+                limit: sregs.ds.limit,
+            },
+            ss: SegmentRegister {
+                selector: sregs.ss.selector,
+                base: sregs.ss.base,
+                limit: sregs.ss.limit,
+            },
+            es: SegmentRegister {
+                selector: sregs.es.selector,
+                base: sregs.es.base,
+                limit: sregs.es.limit,
+            },
+            fs: SegmentRegister {
+                selector: sregs.fs.selector,
+                base: sregs.fs.base,
+                limit: sregs.fs.limit,
+            },
+            gs: SegmentRegister {
+                selector: sregs.gs.selector,
+                base: sregs.gs.base,
+                limit: sregs.gs.limit,
+            },
+            gdt: DescriptorTable {
+                base: sregs.gdt.base,
+                limit: sregs.gdt.limit,
+            },
+            idt: DescriptorTable {
+                base: sregs.idt.base,
+                limit: sregs.idt.limit,
+            },
+            tr: SegmentRegister {
+                selector: sregs.tr.selector,
+                base: sregs.tr.base,
+                limit: sregs.tr.limit,
+            },
+            ldt: SegmentRegister {
+                selector: sregs.ldt.selector,
+                base: sregs.ldt.base,
+                limit: sregs.ldt.limit,
+            },
+        })
+    }
+
+    ///
+    /// # Description
+    ///
     /// Runs the virtual processor until it exits.
     ///
     /// # Returns
@@ -473,7 +651,6 @@ impl VirtualProcessor {
     ///
     pub fn run(&mut self) -> VirtualProcessorExitContext {
         // Run the virtual processor and parse exit reason.
-        let mut should_dump: bool = false;
         let ctx: VirtualProcessorExitContext = match self.fd.run() {
             Ok(vcpu_exit) => match vcpu_exit {
                 // Read from an I/O port.
@@ -509,60 +686,50 @@ impl VirtualProcessor {
                 },
                 // Halt the virtual processor.
                 VcpuExit::Hlt => VirtualProcessorExitContext::Halt,
-                // All other exit reasons trigger a machine state dump.
                 // Exception occurred.
                 VcpuExit::Exception => {
                     warn!("run(): exception");
-                    should_dump = true;
                     VirtualProcessorExitContext::Unknown
                 },
                 // Hypervisor call invoked.
                 VcpuExit::Hypercall(_) => {
                     warn!("run(): hypercall");
-                    should_dump = true;
                     VirtualProcessorExitContext::Unknown
                 },
                 // Debugging event occurred.
                 VcpuExit::Debug(_) => {
                     warn!("run(): debug");
-                    should_dump = true;
                     VirtualProcessorExitContext::Unknown
                 },
                 // Shutdown the virtual processor (e.g., triple fault).
                 VcpuExit::Shutdown => {
                     warn!("run(): shutdown");
-                    should_dump = true;
                     VirtualProcessorExitContext::Shutdown
                 },
                 // Fail to run the virtual processor.
                 VcpuExit::FailEntry(reason, cpud) => {
                     warn!("run(): fail entry (reason={reason:?}, cpud={cpud})");
-                    should_dump = true;
                     VirtualProcessorExitContext::Unknown
                 },
                 // Non-maskable interrupt occurred.
                 VcpuExit::Nmi => {
                     warn!("run(): nmi");
-                    should_dump = true;
                     VirtualProcessorExitContext::Unknown
                 },
                 // Internal error occurred.
                 VcpuExit::InternalError => {
                     warn!("run(): internal error");
-                    should_dump = true;
                     VirtualProcessorExitContext::Unknown
                 },
                 // Unsupported exit reason.
                 VcpuExit::Unsupported(reason) => {
                     warn!("run(): unsupported exit reason ({reason:?})");
-                    should_dump = true;
                     VirtualProcessorExitContext::Unknown
                 },
                 // Unknown exit reason.
                 // NOTE: we do not parse all exit reasons, so it is worthy checking what happened.
                 _ => {
                     warn!("run(): unknown exit reason");
-                    should_dump = true;
                     VirtualProcessorExitContext::Unknown
                 },
             },
@@ -575,100 +742,11 @@ impl VirtualProcessor {
             },
             Err(error) => {
                 error!("run(): error running vCPU (error={error:?})");
-                should_dump = true;
                 VirtualProcessorExitContext::Unknown
             },
         };
 
-        if should_dump {
-            self.dump_state();
-        }
-
         ctx
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Dumps the machine state for debugging purposes, including general purpose registers,
-    /// special registers (control registers, segment registers), and descriptor table pointers.
-    ///
-    fn dump_state(&self) {
-        // Dump general purpose registers.
-        match self.fd.get_regs() {
-            Ok(regs) => {
-                error!("=== General Purpose Registers ===");
-                error!("  RIP={:#018x}  RFLAGS={:#018x}", regs.rip, regs.rflags);
-                error!(
-                    "  RAX={:#018x}  RBX={:#018x}  RCX={:#018x}  RDX={:#018x}",
-                    regs.rax, regs.rbx, regs.rcx, regs.rdx
-                );
-                error!(
-                    "  RSI={:#018x}  RDI={:#018x}  RSP={:#018x}  RBP={:#018x}",
-                    regs.rsi, regs.rdi, regs.rsp, regs.rbp
-                );
-                error!(
-                    "  R8 ={:#018x}  R9 ={:#018x}  R10={:#018x}  R11={:#018x}",
-                    regs.r8, regs.r9, regs.r10, regs.r11
-                );
-                error!(
-                    "  R12={:#018x}  R13={:#018x}  R14={:#018x}  R15={:#018x}",
-                    regs.r12, regs.r13, regs.r14, regs.r15
-                );
-            },
-            Err(e) => {
-                error!("dump_state(): failed to read registers (error={e:?})");
-            },
-        }
-
-        // Dump special registers and descriptor table pointers.
-        match self.fd.get_sregs() {
-            Ok(sregs) => {
-                error!("=== Control Registers ===");
-                error!(
-                    "  CR0={:#018x}  CR2={:#018x}  CR3={:#018x}  CR4={:#018x}  CR8={:#018x}  \
-                     EFER={:#018x}",
-                    sregs.cr0, sregs.cr2, sregs.cr3, sregs.cr4, sregs.cr8, sregs.efer
-                );
-                error!("=== Segment Registers ===");
-                error!(
-                    "  CS:  selector={:#06x}  base={:#018x}  limit={:#010x}",
-                    sregs.cs.selector, sregs.cs.base, sregs.cs.limit
-                );
-                error!(
-                    "  DS:  selector={:#06x}  base={:#018x}  limit={:#010x}",
-                    sregs.ds.selector, sregs.ds.base, sregs.ds.limit
-                );
-                error!(
-                    "  SS:  selector={:#06x}  base={:#018x}  limit={:#010x}",
-                    sregs.ss.selector, sregs.ss.base, sregs.ss.limit
-                );
-                error!(
-                    "  ES:  selector={:#06x}  base={:#018x}  limit={:#010x}",
-                    sregs.es.selector, sregs.es.base, sregs.es.limit
-                );
-                error!(
-                    "  FS:  selector={:#06x}  base={:#018x}  limit={:#010x}",
-                    sregs.fs.selector, sregs.fs.base, sregs.fs.limit
-                );
-                error!(
-                    "  GS:  selector={:#06x}  base={:#018x}  limit={:#010x}",
-                    sregs.gs.selector, sregs.gs.base, sregs.gs.limit
-                );
-                error!("=== Descriptor Tables ===");
-                error!("  GDT: base={:#018x}  limit={:#06x}", sregs.gdt.base, sregs.gdt.limit);
-                error!("  IDT: base={:#018x}  limit={:#06x}", sregs.idt.base, sregs.idt.limit);
-                error!(
-                    "  TR:  selector={:#06x}  base={:#018x}  limit={:#010x}",
-                    sregs.tr.selector, sregs.tr.base, sregs.tr.limit
-                );
-                error!(
-                    "  LDT: selector={:#06x}  base={:#018x}  limit={:#010x}",
-                    sregs.ldt.selector, sregs.ldt.base, sregs.ldt.limit
-                );
-            },
-            Err(e) => error!("dump_state(): failed to read special registers (error={e:?})"),
-        }
     }
 
     ///

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -38,6 +38,7 @@ use crate::{
     vmm::emulator::Emulator,
     vmm::microvm::kvm::vcpu::{
         VirtualProcessor,
+        VirtualProcessorDumpInfo,
         VirtualProcessorExitContext,
         VirtualProcessorExitReasonRef,
     },
@@ -528,6 +529,7 @@ impl Vmm {
                 // The guest was shutdown (triple fault).
                 VirtualProcessorExitReasonRef::Shutdown => {
                     error!("run(): guest shutdown (triple fault)");
+                    self.dump_vm_info();
                     let exit_status: u16 = ErrorCode::IllegalByteSequence.into();
                     Handle::current().block_on(self.handle_shutdown(exit_status));
                     break Ok(exit_status);
@@ -536,6 +538,7 @@ impl Vmm {
                 // Virtual machine exited due to an unknown reason.
                 VirtualProcessorExitReasonRef::Unknown => {
                     error!("run(): guest exited due to an unknown reason");
+                    self.dump_vm_info();
                     let exit_status: u16 = ErrorCode::IllegalByteSequence.into();
                     Handle::current().block_on(self.handle_shutdown(exit_status));
                     break Ok(exit_status);
@@ -906,5 +909,109 @@ impl Vmm {
         locked_inner.skip_next_snapshot = true;
 
         Ok(())
+    }
+
+    //==============================================================================================
+    // Diagnostic Dump Helpers
+    //==============================================================================================
+
+    ///
+    /// # Description
+    ///
+    /// Dumps the virtual machine state for diagnostic purposes.
+    ///
+    /// This method reads the vCPU registers and logs general-purpose registers, control
+    /// registers, segment registers, and descriptor tables.
+    ///
+    /// Failures to read registers are logged but do not propagate — this method
+    /// is best-effort diagnostics.
+    ///
+    fn dump_vm_info(&self) {
+        // Read vCPU registers.
+        let info: VirtualProcessorDumpInfo = {
+            let vcpu: MutexGuard<'_, VirtualProcessor> = self.vcpu.blocking_lock();
+            match vcpu.get_dump_info() {
+                Ok(i) => i,
+                Err(e) => {
+                    error!("dump_vm_info(): failed to read registers (error={e:?})");
+                    return;
+                },
+            }
+        };
+
+        // Dump register state.
+        Self::dump_registers(&info);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Dumps general-purpose registers, control registers, segment registers, and descriptor
+    /// table pointers from a hypervisor-independent register snapshot.
+    ///
+    /// # Parameters
+    ///
+    /// - `info`: Register snapshot to dump.
+    ///
+    fn dump_registers(info: &VirtualProcessorDumpInfo) {
+        error!("=== General Purpose Registers ===");
+        error!("  RIP={:#018x}  RFLAGS={:#018x}", info.rip, info.rflags);
+        error!(
+            "  RAX={:#018x}  RBX={:#018x}  RCX={:#018x}  RDX={:#018x}",
+            info.rax, info.rbx, info.rcx, info.rdx
+        );
+        error!(
+            "  RSI={:#018x}  RDI={:#018x}  RSP={:#018x}  RBP={:#018x}",
+            info.rsi, info.rdi, info.rsp, info.rbp
+        );
+        error!(
+            "  R8 ={:#018x}  R9 ={:#018x}  R10={:#018x}  R11={:#018x}",
+            info.r8, info.r9, info.r10, info.r11
+        );
+        error!(
+            "  R12={:#018x}  R13={:#018x}  R14={:#018x}  R15={:#018x}",
+            info.r12, info.r13, info.r14, info.r15
+        );
+        error!("=== Control Registers ===");
+        error!(
+            "  CR0={:#018x}  CR2={:#018x}  CR3={:#018x}  CR4={:#018x}  CR8={:#018x}  EFER={:#018x}",
+            info.cr0, info.cr2, info.cr3, info.cr4, info.cr8, info.efer
+        );
+        error!("=== Segment Registers ===");
+        error!(
+            "  CS:  selector={:#06x}  base={:#018x}  limit={:#010x}",
+            info.cs.selector, info.cs.base, info.cs.limit
+        );
+        error!(
+            "  DS:  selector={:#06x}  base={:#018x}  limit={:#010x}",
+            info.ds.selector, info.ds.base, info.ds.limit
+        );
+        error!(
+            "  SS:  selector={:#06x}  base={:#018x}  limit={:#010x}",
+            info.ss.selector, info.ss.base, info.ss.limit
+        );
+        error!(
+            "  ES:  selector={:#06x}  base={:#018x}  limit={:#010x}",
+            info.es.selector, info.es.base, info.es.limit
+        );
+        error!(
+            "  FS:  selector={:#06x}  base={:#018x}  limit={:#010x}",
+            info.fs.selector, info.fs.base, info.fs.limit
+        );
+        error!(
+            "  GS:  selector={:#06x}  base={:#018x}  limit={:#010x}",
+            info.gs.selector, info.gs.base, info.gs.limit
+        );
+        error!("=== Descriptor Tables ===");
+        error!("  GDT: base={:#018x}  limit={:#06x}", info.gdt.base, info.gdt.limit);
+        error!("  IDT: base={:#018x}  limit={:#06x}", info.idt.base, info.idt.limit);
+        error!(
+            "  TR:  selector={:#06x}  base={:#018x}  limit={:#010x}",
+            info.tr.selector, info.tr.base, info.tr.limit
+        );
+        error!(
+            "  LDT: selector={:#06x}  base={:#018x}  limit={:#010x}",
+            info.ldt.selector, info.ldt.base, info.ldt.limit
+        );
     }
 }

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -915,19 +915,32 @@ impl Vmm {
     // Diagnostic Dump Helpers
     //==============================================================================================
 
+    /// Number of bytes to dump around RIP (instruction pointer).
+    const CODE_DUMP_RADIUS: u64 = 32;
+    /// Number of bytes to dump around RSP (stack pointer).
+    const STACK_DUMP_RADIUS: u64 = 64;
+    /// Maximum number of stack frames to walk via the RBP chain.
+    const MAX_STACK_FRAMES: usize = 32;
+
     ///
     /// # Description
     ///
     /// Dumps the virtual machine state for diagnostic purposes.
     ///
-    /// This method reads the vCPU registers and logs general-purpose registers, control
-    /// registers, segment registers, and descriptor tables.
+    /// This method reads the vCPU registers and guest memory, then logs:
+    /// - General-purpose registers, control registers, segment registers, and descriptor tables.
+    /// - Code bytes around RIP (instruction vicinity).
+    /// - Stack bytes around RSP (stack vicinity).
+    /// - Stack trace by walking the RBP frame-pointer chain.
     ///
-    /// Failures to read registers are logged but do not propagate — this method
+    /// All memory reads use guest physical addresses. This is correct because the Nanvix kernel
+    /// identity-maps its virtual address space.
+    ///
+    /// Failures to read registers or memory are logged but do not propagate — this method
     /// is best-effort diagnostics.
     ///
     fn dump_vm_info(&self) {
-        // Read vCPU registers.
+        // Read vCPU registers (narrow scope releases the lock before acquiring vmem).
         let info: VirtualProcessorDumpInfo = {
             let vcpu: MutexGuard<'_, VirtualProcessor> = self.vcpu.blocking_lock();
             match vcpu.get_dump_info() {
@@ -941,6 +954,21 @@ impl Vmm {
 
         // Dump register state.
         Self::dump_registers(&info);
+
+        // Dump memory context (narrow scope releases the lock at the end).
+        {
+            let vmem: MutexGuard<'_, VirtualMemory> = self.vmem.blocking_lock();
+            let mem_size: u64 = vmem.get_size() as u64;
+
+            // Dump code bytes around RIP.
+            Self::dump_region(&vmem, mem_size, "Code", info.rip, Self::CODE_DUMP_RADIUS);
+
+            // Dump stack bytes around RSP.
+            Self::dump_region(&vmem, mem_size, "Stack", info.rsp, Self::STACK_DUMP_RADIUS);
+
+            // Walk the RBP frame-pointer chain to produce a stack trace.
+            Self::dump_stack_trace(&vmem, mem_size, info.rip, info.rbp);
+        }
     }
 
     ///
@@ -1013,5 +1041,121 @@ impl Vmm {
             "  LDT: selector={:#06x}  base={:#018x}  limit={:#010x}",
             info.ldt.selector, info.ldt.base, info.ldt.limit
         );
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Dumps a region of guest memory around a given address.
+    ///
+    /// # Parameters
+    ///
+    /// - `vmem`: Handle to the guest virtual memory.
+    /// - `mem_size`: Total size of guest memory in bytes.
+    /// - `label`: Human-readable label for the region (e.g., "Code", "Stack").
+    /// - `center`: Address around which to dump.
+    /// - `radius`: Number of bytes to dump before and after `center`.
+    ///
+    fn dump_region(vmem: &VirtualMemory, mem_size: u64, label: &str, center: u64, radius: u64) {
+        let start: u64 = center.saturating_sub(radius);
+        let end: u64 = center.saturating_add(radius).min(mem_size);
+
+        if start >= mem_size || start >= end {
+            error!("=== {label} Dump (addr={center:#018x}) ===");
+            error!("  address outside guest memory");
+            return;
+        }
+
+        let len: usize = match usize::try_from(end - start) {
+            Ok(v) => v,
+            Err(_) => {
+                error!("=== {label} Dump (addr={center:#018x}) ===");
+                error!("  region too large to dump");
+                return;
+            },
+        };
+        let mut buf: Vec<u8> = vec![0u8; len];
+        if let Err(e) = vmem.read_bytes(start, &mut buf) {
+            error!("=== {label} Dump (addr={center:#018x}) ===");
+            error!("  failed to read memory (error={e:?})");
+            return;
+        }
+
+        error!("=== {label} Dump ({center:#018x}, {start:#018x}..{end:#018x}) ===");
+        for (i, chunk) in buf.chunks(16).enumerate() {
+            let addr: u64 = start + (i as u64) * 16;
+            let hex: String = chunk
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            error!("  {addr:#018x}: {hex}");
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Walks the RBP frame-pointer chain and logs a stack trace.
+    ///
+    /// Each x86-64 stack frame (with frame pointers) stores the caller's RBP at [RBP] and the
+    /// return address at [RBP+8]. The walk terminates when RBP is zero, points outside guest
+    /// memory, or the maximum frame depth is reached.
+    ///
+    /// # Parameters
+    ///
+    /// - `vmem`: Handle to the guest virtual memory.
+    /// - `mem_size`: Total size of guest memory in bytes.
+    /// - `rip`: Current instruction pointer (frame 0 return address).
+    /// - `rbp`: Current base pointer (start of the frame chain).
+    ///
+    fn dump_stack_trace(vmem: &VirtualMemory, mem_size: u64, rip: u64, rbp: u64) {
+        error!("=== Stack Trace ===");
+        error!("  #{:<3} RIP={rip:#018x}", 0);
+
+        let mut current_rbp: u64 = rbp;
+
+        for frame in 1..Self::MAX_STACK_FRAMES {
+            // Each frame requires 16 bytes: saved_rbp (8) + return_addr (8).
+            if current_rbp == 0 || current_rbp.checked_add(16).is_none_or(|end| end > mem_size) {
+                break;
+            }
+
+            let mut frame_data: [u8; 16] = [0u8; 16];
+            if vmem.read_bytes(current_rbp, &mut frame_data).is_err() {
+                error!("  #{frame:<3} <unreadable frame at RBP={current_rbp:#018x}>");
+                break;
+            }
+
+            let saved_rbp: u64 = u64::from_le_bytes([
+                frame_data[0],
+                frame_data[1],
+                frame_data[2],
+                frame_data[3],
+                frame_data[4],
+                frame_data[5],
+                frame_data[6],
+                frame_data[7],
+            ]);
+            let ret_addr: u64 = u64::from_le_bytes([
+                frame_data[8],
+                frame_data[9],
+                frame_data[10],
+                frame_data[11],
+                frame_data[12],
+                frame_data[13],
+                frame_data[14],
+                frame_data[15],
+            ]);
+
+            error!("  #{frame:<3} RIP={ret_addr:#018x}  (RBP={current_rbp:#018x})");
+
+            // Detect cycles or backward frame-pointer movement.
+            if saved_rbp == 0 || saved_rbp <= current_rbp {
+                break;
+            }
+
+            current_rbp = saved_rbp;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Move the VM state dump from the vCPU layer to the VMM layer and extend it to include guest memory context.

### Commit 1: Move VM state dump from vCPU to VMM

Lift the register dump out of `VirtualProcessor::run()` and into the VMM layer so that diagnostic output can be extended with guest memory context alongside CPU state.

- Introduce `VirtualProcessorDumpInfo`, `SegmentRegister`, and `DescriptorTable` structs that capture the full register snapshot without exposing KVM-specific types.
- Add `VirtualProcessor::get_dump_info()` to produce this snapshot from KVM's `kvm_regs` and `kvm_sregs`.
- Move all diagnostic formatting into `Vmm::dump_vm_info()` and `Vmm::dump_registers()`.
- Invoke `dump_vm_info()` from the VMM run loop on Shutdown (triple fault) and Unknown exit reasons.

### Commit 2: Dump memory information on unexpected VM exit

Extend `Vmm::dump_vm_info()` to also dump guest memory context:

- Code bytes around RIP (±32 bytes).
- Stack bytes around RSP (±64 bytes).
- Stack trace by walking the RBP frame-pointer chain (up to 32 frames).

All memory reads use guest physical addresses (correct because the Nanvix kernel identity-maps its virtual address space). Narrow scoping releases the vCPU lock before acquiring the vmem lock to avoid potential deadlocks.