### PR TITLE
[kernel] Increase kernel stack to 256 KB

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -45,7 +45,7 @@ kpool_base = 0x00800000
 # - Must be a multiple of the page size.
 # - Must be at least two pages (one guard page + one usable page).
 # - Must not exceed the size of a page table.
-kstack_size = 65536
+kstack_size = 262144
 
 # Kernel stack guard watermark pattern (repeated 32-bit word).
 # The bottom page of each kernel stack is filled with this pattern at boot. If a stack overflow


### PR DESCRIPTION
Raise kstack_size from 64 KB to 256 KB. Debug-mode frames exceed 64 KB when timer interrupts fire during deep paths. Part of #1641.