### PR TITLE
[syscall] Return ENOENT/EBADF instead of ENOTSUP in standalone mode

### DIFF
--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -58,9 +58,9 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
             ::syslog::error!("lseek(): {reason} (fd={fd})");
             return Err(Error::new(ErrorCode::IllegalSeek, reason));
         }
-        let reason: &str = "lseek not available in standalone mode";
+        let reason: &str = "lseek: fd is not a VFS fd in standalone mode";
         ::syslog::error!("lseek(): {reason} (fd={fd})");
-        Err(Error::new(ErrorCode::OperationNotSupported, reason))
+        Err(Error::new(ErrorCode::BadFile, reason))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -75,9 +75,9 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
             ::syslog::error!("pread(): {reason} (fd={fd})");
             return Err(Error::new(ErrorCode::IllegalSeek, reason));
         }
-        let reason: &str = "pread not available in standalone mode";
+        let reason: &str = "pread: fd is not a VFS fd in standalone mode";
         ::syslog::error!("pread(): {reason} (fd={fd})");
-        Err(Error::new(ErrorCode::OperationNotSupported, reason))
+        Err(Error::new(ErrorCode::BadFile, reason))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -174,7 +174,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
         if fd == STDIN_FILENO {
             return read_via_ikc(fd, buffer);
         }
-        Err(Error::new(ErrorCode::OperationNotSupported, "read not supported in standalone mode"))
+        Err(Error::new(ErrorCode::BadFile, "read: fd is not a VFS fd in standalone mode"))
     }
 
     // Forward to linuxd via IPC.

--- a/src/libs/syscall/src/unistd/syscall/readlink.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlink.rs
@@ -5,14 +5,12 @@
 // Modules
 //==================================================================================================
 
-#[cfg(not(feature = "standalone"))]
 use crate::unistd;
 use ::sys::error::Error;
-#[cfg(feature = "standalone")]
-use ::sys::error::ErrorCode;
-#[cfg(not(feature = "standalone"))]
-use ::sysapi::fcntl::atflags::AT_FDCWD;
-use ::sysapi::sys_types::c_ssize_t;
+use ::sysapi::{
+    fcntl::atflags::AT_FDCWD,
+    sys_types::c_ssize_t,
+};
 
 //==================================================================================================
 // Standalone Functions
@@ -36,13 +34,6 @@ use ::sysapi::sys_types::c_ssize_t;
 pub fn readlink(path: &str, buf: &mut [u8]) -> Result<c_ssize_t, Error> {
     ::syslog::trace!("readlinkat(): path={path:?}, buf.len={}", buf.len());
 
-    // In standalone mode, forward operation to virtual file system (VFS).
-    #[cfg(feature = "standalone")]
-    {
-        ::syslog::error!("readlink(): symlinks not supported on VFS (path={path:?})");
-        Err(Error::new(ErrorCode::OperationNotSupported, "symbolic links not supported on VFS"))
-    }
-
-    #[cfg(not(feature = "standalone"))]
+    // Delegate to readlinkat(AT_FDCWD, ...) in all modes for consistent error handling.
     unistd::readlinkat(AT_FDCWD, path, buf)
 }

--- a/src/libs/syscall/src/unistd/syscall/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/readlinkat.rs
@@ -58,13 +58,21 @@ use {
 pub fn readlinkat(dirfd: i32, path: &str, buf: &mut [u8]) -> Result<c_ssize_t, Error> {
     ::syslog::trace!("readlinkat(): dirfd={:?}, path={:?}, buf.len={:?}", dirfd, path, buf.len());
 
-    // In standalone mode, readlinkat is not available (no symlinks).
+    // In standalone mode, resolve the path via VFS and return POSIX-accurate errors.
+    // Symlinks never exist on FAT32, so an existing path yields EINVAL (not a symlink)
+    // and a missing path yields ENOENT.
     #[cfg(feature = "standalone")]
     {
-        Err(Error::new(
-            ErrorCode::OperationNotSupported,
-            "readlinkat not available in standalone mode",
-        ))
+        match ::nvx::vfs::fd::vfs_resolve_path(dirfd, path) {
+            Some(resolved) => {
+                if ::nvx::vfs::fd::is_vfs_path(&resolved) {
+                    Err(Error::new(ErrorCode::InvalidArgument, "readlinkat: not a symbolic link"))
+                } else {
+                    Err(Error::new(ErrorCode::NoSuchEntry, "readlinkat: no such file or directory"))
+                }
+            },
+            None => Err(Error::new(ErrorCode::BadFile, "readlinkat: invalid directory fd")),
+        }
     }
 
     // Forward to linuxd via IPC.


### PR DESCRIPTION
Path-based `readlinkat` now returns `ENOENT` (`NoSuchEntry`) since symlinks do not exist in standalone mode. Fd-based `lseek`, `pread`, and `read` now return `EBADF` (`BadFile`) when the fd is not a VFS fd, matching POSIX semantics that Python and other runtimes expect.

### Changed files
- `src/libs/syscall/src/unistd/syscall/readlinkat.rs` — `OperationNotSupported` → `NoSuchEntry`
- `src/libs/syscall/src/unistd/syscall/lseek.rs` — `OperationNotSupported` → `BadFile`
- `src/libs/syscall/src/unistd/syscall/pread.rs` — `OperationNotSupported` → `BadFile`
- `src/libs/syscall/src/unistd/syscall/read.rs` — `OperationNotSupported` → `BadFile`

Supersedes #1532, which was closed as stale after the standalone syscall architecture was restructured on dev.