### PR TITLE
[kernel] Replace panic with graceful halt on stack guard corruption

### DIFF
--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     pm::{
         sync::condvar::Condvar,
+        ExceptionGuard,
         InterruptReason,
         ProcessManager,
         SleepError,
@@ -987,6 +988,7 @@ fn do_exception_handler(
 }
 
 fn exception_handler(info: &ExceptionInformation, ctx: &ContextInformation) {
+    let _guard: ExceptionGuard = ProcessManager::enter_exception_handler();
     if let Err(sleep_error) = do_exception_handler(info, ctx) {
         let status: ErrorCode = match sleep_error {
             SleepError::Generic(generic_error) => {

--- a/src/kernel/src/pm/mod.rs
+++ b/src/kernel/src/pm/mod.rs
@@ -50,6 +50,7 @@ const ORDER: Ordering = Ordering::Relaxed;
 pub use clock::ticks;
 pub use kcall::*;
 pub use process::{
+    ExceptionGuard,
     ProcessManager,
     SleepError,
 };

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -24,6 +24,7 @@ use crate::{
             PageAligned,
             VirtualAddress,
         },
+        platform,
     },
     mm::{
         elf::Elf32Fhdr,
@@ -94,6 +95,12 @@ use ::sys::{
     ExitStatus,
 };
 use ::type_safe::NonEmptyVecDeque;
+
+//==================================================================================================
+// Exports
+//==================================================================================================
+
+pub use self::r#unsafe::ExceptionGuard;
 
 //==================================================================================================
 // Sleep Error
@@ -1371,20 +1378,31 @@ impl ProcessManager {
     /// # Description
     ///
     /// Checks the running thread's kernel stack guard watermark for corruption.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the watermark has been corrupted, indicating a stack overflow.
+    /// If corrupted, logs an error and halts the VM immediately.
     ///
     fn check_running_stack_guard(&self) {
+        // Skip when serving an exception: the stack may already be overflowed and
+        // the halt path would aggravate the situation by consuming more stack.
+        if Self::is_serving_exception() {
+            return;
+        }
+
         if let Some(ref running) = self.running {
-            if let Err(e) = running.check_guard_watermark() {
-                panic!(
-                    "stack overflow detected for thread {:?} in process {:?}: {:?}",
+            if let Err(_e) = running.check_guard_watermark() {
+                // Do NOT panic here. A panic formats debug information via core::fmt, which
+                // allocates a large stack frame. When this function is called from do_schedule
+                // (invoked by the timer interrupt handler), the kernel stack is already near its
+                // limit. The additional stack consumed by panic formatting can corrupt page
+                // directory entries, triggering a recursive exception cascade (triple fault).
+                //
+                // Instead, log a fixed-size message and halt immediately. The error! macro and
+                // platform::shutdown use minimal stack compared to panic! formatting.
+                error!(
+                    "stack overflow detected: tid={:?}, pid={:?}",
                     running.get_tid(),
                     running.state().pid(),
-                    e
                 );
+                platform::shutdown(ExitStatus::from(ErrorCode::UnrecoverableState).into());
             }
         }
     }

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -98,6 +98,9 @@ static REMAINING_QUANTUM: AtomicUsize = AtomicUsize::new(SCHEDULER_FREQ);
 /// ID of thread that owns the FPU.
 pub(super) static FPU_OWNER_TID: AtomicI32 = AtomicI32::new(ThreadIdentifier::KERNEL_RAW);
 
+/// Nesting depth of exception handlers currently being served.
+static SERVING_EXCEPTION: AtomicUsize = AtomicUsize::new(0);
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
@@ -806,5 +809,47 @@ impl ProcessManager {
                 // Interrupts are automatically disabled when we leave this scope.
             }
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Marks the CPU as serving an exception and returns an RAII guard that decrements the nesting
+    /// depth on drop. Supports nesting: each call increments a depth counter and the corresponding
+    /// guard decrements it, so the flag remains set until all guards have been dropped.
+    ///
+    /// # Returns
+    ///
+    /// An [`ExceptionGuard`] that decrements the nesting depth when dropped.
+    ///
+    pub fn enter_exception_handler() -> ExceptionGuard {
+        SERVING_EXCEPTION.fetch_add(1, ORDER);
+        ExceptionGuard(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns whether the CPU is currently serving an exception.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the exception handler flag is set, `false` otherwise.
+    ///
+    pub(super) fn is_serving_exception() -> bool {
+        SERVING_EXCEPTION.load(ORDER) > 0
+    }
+}
+
+/// RAII guard that decrements the `SERVING_EXCEPTION` nesting depth on drop.
+///
+/// Cannot be constructed outside this module — only [`ProcessManager::enter_exception_handler`]
+/// produces instances.
+#[must_use = "guard must be held for the duration of the exception handler"]
+pub struct ExceptionGuard(());
+
+impl Drop for ExceptionGuard {
+    fn drop(&mut self) {
+        SERVING_EXCEPTION.fetch_sub(1, ORDER);
     }
 }

--- a/src/kernel/src/pm/process/mod.rs
+++ b/src/kernel/src/pm/process/mod.rs
@@ -14,6 +14,7 @@ mod state;
 //==================================================================================================
 
 pub use manager::{
+    ExceptionGuard,
     ProcessManager,
     SleepError,
 };


### PR DESCRIPTION
## Summary

Replace `panic!()` with a graceful `platform::shutdown()` when `check_running_stack_guard()` detects a corrupted stack guard watermark, and wire the `SERVING_EXCEPTION` counter so the guard check is skipped inside exception handlers.

## Changes

- **Replace panic with graceful halt** — The panic handler invokes `core::fmt` formatting, which pushes a large stack frame. Since the check runs during `do_schedule` (called from the timer interrupt handler), the kernel stack is already near its limit. The extra frames can corrupt page directory entries, triggering a triple fault. Now uses `error!()` + `platform::shutdown()` with minimal stack usage.

- **Implement `SERVING_EXCEPTION` counter** — Adds `SERVING_EXCEPTION` atomic counter, `ExceptionGuard` RAII type, and `ProcessManager::enter_exception_handler()` factory so `is_serving_exception()` correctly reports when the CPU is inside an exception handler. The guard is acquired at the top of `event::manager::exception_handler()`.

- **Skip guard check during exceptions** — When `is_serving_exception()` returns true, the watermark check is bypassed since the stack may already be overflowed and the halt path would aggravate the situation.