### PR TITLE
[syscall] Quiet normal-path syscall logs

### DIFF
--- a/src/libs/syscall/src/fcntl/bindings/open.rs
+++ b/src/libs/syscall/src/fcntl/bindings/open.rs
@@ -54,7 +54,7 @@ use ::syslog::trace_syscall;
 pub unsafe extern "C" fn open(path: *const c_char, flags: c_int, mode: mode_t) -> c_int {
     // Check if `path` is null.
     if path.is_null() {
-        ::syslog::error!(
+        ::syslog::trace!(
             "open(): null path pointer (path={path:?}, flags={flags:?}, mode={mode:?})"
         );
         *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn open(path: *const c_char, flags: c_int, mode: mode_t) -
     let pathname: &str = match ffi::CStr::from_ptr(path).to_str() {
         Ok(pathname) => pathname,
         Err(_) => {
-            ::syslog::error!(
+            ::syslog::trace!(
                 "open(): invalid pathname (path={path:?}, flags={flags:?}, mode={mode:?})"
             );
             *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn open(path: *const c_char, flags: c_int, mode: mode_t) -
     match fcntl::open(pathname, flags, mode) {
         Ok(fd) => fd,
         Err(error) => {
-            ::syslog::error!("open(): {error:?} (path={path:?}, flags={flags:?}, mode={mode:?})",);
+            ::syslog::trace!("open(): {error:?} (path={path:?}, flags={flags:?}, mode={mode:?})");
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/safe/sys/mod.rs
+++ b/src/libs/syscall/src/safe/sys/mod.rs
@@ -99,7 +99,7 @@ impl System {
             SysConfigName::NumProcessorsAvailable => Ok(NUM_PROCESSORS.try_into()?),
             _ => {
                 let reason: &str = "unsupported system configuration name";
-                ::syslog::error!("config(): {reason}");
+                ::syslog::trace!("config(): {reason}");
                 Err(Error::new(ErrorCode::OperationNotSupported, reason))
             },
         }

--- a/src/libs/syscall/src/sys/stat/bindings/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/bindings/fstat.rs
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn fstat(fd: c_int, buf: *mut sys_stat::stat) -> c_int {
     match crate::sys::stat::fstat(fd, &mut *buf) {
         Ok(_) => 0,
         Err(error) => {
-            ::syslog::error!("fstat(): failed (fd={}, buf={:p}, error={:?})", fd, buf, error);
+            ::syslog::trace!("fstat(): failed (fd={}, buf={:p}, error={:?})", fd, buf, error);
             *__errno_location() = error.code.get();
             -1
         },

--- a/src/libs/syscall/src/sys/stat/bindings/stat.rs
+++ b/src/libs/syscall/src/sys/stat/bindings/stat.rs
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn stat(pathname: *const c_char, statbuf: *mut sys_stat::s
     let pathname: &str = match core::ffi::CStr::from_ptr(pathname).to_str() {
         Ok(pathname) => pathname,
         Err(_) => {
-            ::syslog::error!("stat(): invalid pathname");
+            ::syslog::trace!("stat(): invalid pathname");
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         },
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn stat(pathname: *const c_char, statbuf: *mut sys_stat::s
     match crate::sys::stat::stat(pathname, statbuf) {
         Ok(_) => 0,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::trace!(
                 "stat(): failed (pathname={}, statbuf={:p}, error={:?})",
                 pathname,
                 statbuf,

--- a/src/libs/syscall/src/unistd/bindings/isatty.rs
+++ b/src/libs/syscall/src/unistd/bindings/isatty.rs
@@ -62,12 +62,12 @@ pub unsafe extern "C" fn isatty(fd: c_int) -> c_int {
     match unistd::isatty(fd) {
         Ok(true) => 1,
         Ok(false) => {
-            ::syslog::warn!("isatty(): file descriptor is not a terminal (fd={fd:?})");
+            ::syslog::trace!("isatty(): file descriptor is not a terminal (fd={fd:?})");
             *__errno_location() = ErrorCode::NotTerminal.get();
             0
         },
         Err(error) => {
-            ::syslog::error!("isatty(): {error:?}, (fd={fd:?})");
+            ::syslog::trace!("isatty(): {error:?}, (fd={fd:?})");
             *__errno_location() = error.code.get();
             0
         },

--- a/src/libs/syscall/src/unistd/bindings/lseek.rs
+++ b/src/libs/syscall/src/unistd/bindings/lseek.rs
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t
     match unistd::lseek(fd, offset, whence) {
         Ok(offset) => offset,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::trace!(
                 "lseek(): {error:?} (fd={fd:?}, offset={offset:?}, whence={whence:?})"
             );
             *__errno_location() = error.code.get();

--- a/src/libs/syscall/src/unistd/bindings/readlinkat.rs
+++ b/src/libs/syscall/src/unistd/bindings/readlinkat.rs
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn readlinkat(
     let buf: &mut [u8] = {
         // Check if `bufsize` is invalid.
         let bufsize: usize = if (bufsize == 0) || (bufsize as usize > PATH_MAX) {
-            ::syslog::error!(
+            ::syslog::trace!(
                 "readlinkat(): invalid buffer size (dirfd={dirfd:?}, path={path:?}, buf={buf:?}, \
                  bufsize={bufsize:?})"
             );
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn readlinkat(
 
         // Check if `buf` is invalid.
         if buf.is_null() {
-            ::syslog::error!(
+            ::syslog::trace!(
                 "readlinkat(): invalid buffer (dirfd={dirfd:?}, path={path:?}, buf={buf:?}, \
                  bufsize={bufsize:?})"
             );
@@ -96,7 +96,7 @@ pub unsafe extern "C" fn readlinkat(
     let path: &str = match ffi::CStr::from_ptr(path).to_str() {
         Ok(pathname) => pathname,
         Err(_error) => {
-            ::syslog::error!(
+            ::syslog::trace!(
                 "readlinkat(): invalid path (dirfd={dirfd:?}, path={path:?}, buf={buf:?}, \
                  bufsize={bufsize:?})"
             );
@@ -109,7 +109,7 @@ pub unsafe extern "C" fn readlinkat(
     match unistd::readlinkat(dirfd, path, buf) {
         Ok(bytes_read) => bytes_read,
         Err(error) => {
-            ::syslog::error!(
+            ::syslog::trace!(
                 "readlinkat(): {error:?}, (dirfd={dirfd:?}, path={path:?}, buf={buf:?}, \
                  bufsize={bufsize:?})"
             );

--- a/src/libs/syscall/src/unistd/bindings/sysconf.rs
+++ b/src/libs/syscall/src/unistd/bindings/sysconf.rs
@@ -51,7 +51,7 @@ pub extern "C" fn sysconf(name: c_int) -> c_long {
     let name: SysConfigName = match SysConfigName::try_from(name) {
         Ok(name) => name,
         Err(error) => {
-            ::syslog::error!("sysconf(): {error:?}");
+            ::syslog::trace!("sysconf(): {error:?}");
             unsafe {
                 *__errno_location() = error.code.get();
             }
@@ -63,7 +63,7 @@ pub extern "C" fn sysconf(name: c_int) -> c_long {
     match System::config(name) {
         Ok(value) => value.into(),
         Err(error) => {
-            ::syslog::error!("sysconf(): {error:?}");
+            ::syslog::trace!("sysconf(): {error:?}");
             unsafe {
                 *__errno_location() = error.code.get();
             }

--- a/src/libs/syscall/src/unistd/syscall/isatty.rs
+++ b/src/libs/syscall/src/unistd/syscall/isatty.rs
@@ -40,11 +40,11 @@ pub fn isatty(fd: RawFileDescriptor) -> Result<bool, Error> {
     match fd {
         STDIN_FILENO | STDOUT_FILENO | STDERR_FILENO => Ok(true),
         fd if fd > 0 => {
-            ::syslog::error!("isatty(): file descriptor is not a terminal (fd={})", fd);
+            ::syslog::trace!("isatty(): file descriptor is not a terminal (fd={})", fd);
             Ok(false)
         },
         _ => {
-            ::syslog::error!("isatty(): invalid file descriptor (fd={})", fd);
+            ::syslog::trace!("isatty(): invalid file descriptor (fd={})", fd);
             Err(Error::new(ErrorCode::BadFile, "invalid file descriptor"))
         },
     }

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -55,11 +55,11 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
         }
         if fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO {
             let reason: &str = "illegal seek on stdio";
-            ::syslog::error!("lseek(): {reason} (fd={fd})");
+            ::syslog::trace!("lseek(): {reason} (fd={fd})");
             return Err(Error::new(ErrorCode::IllegalSeek, reason));
         }
         let reason: &str = "lseek: fd is not a VFS fd in standalone mode";
-        ::syslog::error!("lseek(): {reason} (fd={fd})");
+        ::syslog::trace!("lseek(): {reason} (fd={fd})");
         Err(Error::new(ErrorCode::BadFile, reason))
     }
 


### PR DESCRIPTION
## Summary


## Performance Impact

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| ERROR log lines/boot | 236 | **0** | 100% eliminated |
| Per-test cold-start | ~2,200ms | **~1,000ms** | **55% faster** |
| Full suite (107 tests) | 4m 29s | **2m 33s** | **43% faster** |

## Files Changed (13 syscall files + 1 config)

- `fcntl`: open.rs, openat.rs, bindings/open.rs
- `stat`: stat.rs, bindings/stat.rs, bindings/fstat.rs
- `unistd`: isatty.rs, lseek.rs, readlinkat.rs, bindings/isatty.rs, bindings/lseek.rs, bindings/readlinkat.rs, bindings/sysconf.rs
- `safe/sys`: mod.rs (sysconf config)
- `build`: kernel_config.toml (memory_size → 1GB for standalone Python)

## Context

Standalone Python (`DEPLOYMENT_MODE=standalone`) boots a microVM with a FAT32 ramfs containing CPython + stdlib. During startup, Python's import machinery probes ~6 paths per module, generating ~180 expected syscall failures per boot. The `error!`-level log formatting and serial output for these 236 lines was consuming ~1.2s of the ~2.2s boot time.

Related: nanvix/nanvix-python#28