### PR TITLE
[libc] Rust no_std C standard library with C headers

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,4 @@ skip = .git,.venv,bin,lib,logs,build,target,toolchain,sysroot-debug,sysroot-rele
 
 # Ignore words that are commonly used in systems programming
 # and are flagged as typos by codespell
-ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas,statics,numer
+ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas,statics,numer,pendin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen-headers"
+version = "0.16.111"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "syn 2.0.118",
+ "toml",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ members = [
         "src/uservm",
         "src/user/hello-rust-nostd",
         "src/utils/echo-client",
+        "src/utils/gen-headers",
         "src/utils/mkimage",
         "src/utils/mkramfs",
         "src/utils/nanvix-bench",

--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ ifeq ($(IS_WINDOWS),yes)
 WINDOWS_EXCLUDED_HOST_RLIBS := nanvix-http nanvix-sandbox-cache syscomm
 ALL_HOST_RUST_LIBS := $(filter-out $(WINDOWS_EXCLUDED_HOST_RLIBS),$(ALL_HOST_RUST_LIBS))
 endif
-ALL_HOST_UTILS := echo-client mkimage mkramfs strace
+ALL_HOST_UTILS := echo-client gen-headers mkimage mkramfs strace
 # linuxd is only needed for multi-process and L2 deployments (Linux-only).
 ifeq ($(filter standalone single-process,$(DEPLOYMENT_MODE)),)
 ALL_HOST_DAEMONS := linuxd
@@ -430,7 +430,12 @@ all-nanvix: all-nanvix-bench
 endif
 
 # Performs local initialization.
-init: init-repo
+#
+# Regenerate the bundled C headers from the libc_* Rust crate sources so that
+# include/*.h stays in sync with every build. gen-headers only rewrites a
+# header when its rendered contents change, so this is a no-op on incremental
+# builds where the libc sources are unchanged.
+init: init-repo gen-headers
 
 init-repo:
 	$(MKDIR_CMD) $(BINARIES_DIR)
@@ -714,6 +719,7 @@ format: \
 
 # Checks for code formatting issues.
 format-check: \
+	gen-headers-check \
 	rust-format-check \
 	python-format-check
 
@@ -798,6 +804,16 @@ python-lint: python-init
 # Runs Python unit tests for the build backend (z.py).
 test-python: python-init
 	@$(PYTHON_VENV_PYTHON) -m unittest discover -s tests -p "test_*.py" $(PY_VERBOSE)
+
+# Generates C headers from Rust libc crate sources.
+.PHONY: gen-headers
+gen-headers:
+	@$(CARGO) run --locked --quiet -p gen-headers
+
+# Checks that generated C headers are up to date.
+.PHONY: gen-headers-check
+gen-headers-check:
+	@$(CARGO) run --locked --quiet -p gen-headers -- --check
 
 # Checks for linting issues in shell scripts.
 shell-lint-check:

--- a/include/alloca.h
+++ b/include/alloca.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_ALLOCA_H
+#define _NANVIX_ALLOCA_H
+
+/**
+ * @file alloca.h
+ * @brief Stack allocation.
+ *
+ * `alloca()` allocates memory in the caller's stack frame; the storage is freed
+ * automatically when the calling function returns. It maps directly to the
+ * compiler builtin.
+ */
+
+#include <stddef.h>
+
+#ifndef alloca
+#define alloca(size) __builtin_alloca(size)
+#endif
+
+#endif /* _NANVIX_ALLOCA_H */

--- a/include/arpa/inet.h
+++ b/include/arpa/inet.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_ARPA_INET_H
+#define _NANVIX_ARPA_INET_H
+
+/**
+ * @file arpa/inet.h
+ * @brief Internet address manipulation.
+ *
+ * Declares the byte-order conversion helpers and the textual IPv4 address
+ * conversion interfaces. The byte-order helpers are provided as static inlines
+ * (the target is little-endian, so they are simple byte swaps); the inet_*
+ * prototypes are generated from the posix crate.
+ */
+
+#include <netinet/in.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Byte Order
+ *==================================================================================================*/
+
+/*
+ * Host/network byte-order conversion. The Nanvix user target is little-endian,
+ * so host-to-network (big-endian) conversions are byte swaps. Provided as static
+ * inlines because the in-tree C library exposes no htonl/htons symbols, matching
+ * the common C-library practice of defining these in the header.
+ */
+static inline uint16_t htons(uint16_t __hostshort)
+{
+    return __builtin_bswap16(__hostshort);
+}
+
+static inline uint32_t htonl(uint32_t __hostlong)
+{
+    return __builtin_bswap32(__hostlong);
+}
+
+static inline uint16_t ntohs(uint16_t __netshort)
+{
+    return __builtin_bswap16(__netshort);
+}
+
+static inline uint32_t ntohl(uint32_t __netlong)
+{
+    return __builtin_bswap32(__netlong);
+}
+
+/*==================================================================================================
+ * Address Conversion
+ *==================================================================================================*/
+
+extern in_addr_t inet_addr(const char *cp);
+extern char *inet_ntoa(struct in_addr in);
+extern const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
+extern int inet_pton(int af, const char *src, void *dst);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_ARPA_INET_H */

--- a/include/assert.h
+++ b/include/assert.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_ASSERT_H
+#define _NANVIX_ASSERT_H
+
+/**
+ * @file assert.h
+ * @brief Diagnostics.
+ *
+ * Provides the assert() macro for runtime assertions. The underlying
+ * __assert_func() is implemented by the libc_assert Rust crate and matches
+ * the signature expected by NewLib's <assert.h>.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Internal Functions (do not call directly)
+ *==================================================================================================*/
+
+extern void __assert_func(const char *file, int line, const char *function, const char *expression);
+extern void __assert(const char *file, int line, const char *expression);
+
+#ifdef __cplusplus
+}
+#endif
+
+/*==================================================================================================
+ * assert Macro
+ *==================================================================================================*/
+
+/* The assert macro must be redefinable, so it lives outside the include guard. */
+#undef assert
+
+#ifdef NDEBUG
+#define assert(expr) ((void)0)
+#else
+#define assert(expr) ((expr) ? (void)0 : __assert_func(__FILE__, __LINE__, __func__, #expr))
+#endif
+
+#endif /* _NANVIX_ASSERT_H */

--- a/include/ctype.h
+++ b/include/ctype.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_CTYPE_H
+#define _NANVIX_CTYPE_H
+
+/**
+ * @file ctype.h
+ * @brief Character classification and conversion.
+ *
+ * Declares functions for testing and mapping characters. All functions operate
+ * on values representable as unsigned char or the value EOF. Implemented by
+ * the libc_ctype Rust crate.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Classification
+ *==================================================================================================*/
+
+extern int isalpha(int c);
+extern int isdigit(int c);
+extern int isalnum(int c);
+extern int isspace(int c);
+extern int isblank(int c);
+extern int isupper(int c);
+extern int islower(int c);
+extern int isprint(int c);
+extern int isgraph(int c);
+extern int ispunct(int c);
+extern int iscntrl(int c);
+extern int isxdigit(int c);
+extern int isascii(int c);
+
+/*==================================================================================================
+ * Conversion
+ *==================================================================================================*/
+
+extern int toupper(int c);
+extern int tolower(int c);
+extern int toascii(int c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_CTYPE_H */

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_DIRENT_H
+#define _NANVIX_DIRENT_H
+
+/**
+ * @file dirent.h
+ * @brief Directory entries.
+ *
+ * Declares the directory-stream type, the directory-entry structures, and the
+ * directory-traversal interfaces. The layouts mirror the Rust definitions in the
+ * sysapi crate (dirent.rs).
+ */
+
+#include <sys/types.h>
+#include <limits.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define DT_UNKNOWN 0 /**< Unknown file type. */
+#define DT_FIFO 1 /**< FIFO. */
+#define DT_CHR 2 /**< Character device. */
+#define DT_DIR 4 /**< Directory. */
+#define DT_BLK 6 /**< Block device. */
+#define DT_REG 8 /**< Regular file. */
+#define DT_LNK 10 /**< Symbolic link. */
+#define DT_SOCK 12 /**< Socket. */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Directory stream type. */
+typedef struct __dirstream DIR;
+
+/** @brief Directory entry. */
+struct dirent {
+    ino_t d_ino;                /**< File serial number.                  */
+    char d_name[NAME_MAX + 1];  /**< Null-terminated file name.           */
+};
+
+/** @brief Extended (Nanvix) directory entry. */
+struct posix_dent {
+    ino_t d_ino;                /**< File serial number.                  */
+    reclen_t d_reclen;          /**< Length of this entry.                */
+    unsigned char d_type;       /**< File type.                           */
+    char d_name[NAME_MAX + 1];  /**< Null-terminated file name.           */
+    char d_pad[1];              /**< Padding.                             */
+};
+
+/*==================================================================================================
+ * Directory Operations
+ *==================================================================================================*/
+
+extern DIR *opendir(const char *dirname);
+extern struct dirent *readdir(DIR *dirp);
+extern int closedir(DIR *dirp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_DIRENT_H */

--- a/include/dlfcn.h
+++ b/include/dlfcn.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_DLFCN_H
+#define _NANVIX_DLFCN_H
+
+/**
+ * @file dlfcn.h
+ * @brief Dynamic linking.
+ *
+ * Declares the dynamic-linking-loader constants, the symbol-information structure,
+ * and the dlopen()-family interfaces. The constants and layout mirror the Rust
+ * definitions in the posix and syscall crates (dlfcn).
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define RTLD_LAZY 0x1 /**< Relocations are performed at an implementation-defined time. */
+#define RTLD_NOW 0x2 /**< Relocations are performed when the object is loaded. */
+#define RTLD_GLOBAL 0x4 /**< Symbols are available for relocation processing of other objects. */
+#define RTLD_LOCAL 0x0 /**< Symbols are not made available to other objects. */
+#define RTLD_DEFAULT ((void *)0) /**< Pseudo-handle: search the global (default) symbol scope. */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Symbol information returned by dladdr(). */
+typedef struct {
+    const char *dli_fname; /**< Pathname of the mapped object.       */
+    void *dli_fbase;       /**< Base address of the mapped object.   */
+    const char *dli_sname; /**< Name of the nearest symbol.          */
+    void *dli_saddr;       /**< Exact address of the symbol.         */
+} Dl_info_t;
+
+/*==================================================================================================
+ * Dynamic Linking
+ *==================================================================================================*/
+
+extern void *dlopen(const char *filename, int mode);
+extern void *dlsym(void *handle, const char *symbol);
+extern int32_t dlclose(void *handle);
+extern char *dlerror(void);
+extern int32_t dladdr(const void *addr, Dl_info_t *dlip);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_DLFCN_H */

--- a/include/errno.h
+++ b/include/errno.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_ERRNO_H
+#define _NANVIX_ERRNO_H
+
+/**
+ * @file errno.h
+ * @brief System error numbers.
+ *
+ * Declares the system error numbers and the errno lvalue. The numbers mirror the
+ * Rust definitions in the sysapi crate (errno.rs).
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define EPERM 1
+#define ENOENT 2
+#define ESRCH 3
+#define EINTR 4
+#define EIO 5
+#define ENXIO 6
+#define E2BIG 7
+#define ENOEXEC 8
+#define EBADF 9
+#define ECHILD 10
+#define EAGAIN 11
+#define EWOULDBLOCK EAGAIN
+#define ENOMEM 12
+#define EACCES 13
+#define EFAULT 14
+#define ENOTBLK 15
+#define EBUSY 16
+#define EEXIST 17
+#define EXDEV 18
+#define ENODEV 19
+#define ENOTDIR 20
+#define EISDIR 21
+#define EINVAL 22
+#define ENFILE 23
+#define EMFILE 24
+#define ENOTTY 25
+#define ETXTBSY 26
+#define EFBIG 27
+#define ENOSPC 28
+#define ESPIPE 29
+#define EROFS 30
+#define EMLINK 31
+#define EPIPE 32
+#define EDOM 33
+#define ERANGE 34
+#define ENOMSG 35
+#define EIDRM 36
+#define ECHRNG 37
+#define EL2NSYNC 38
+#define EL3HLT 39
+#define EL3RST 40
+#define ELNRNG 41
+#define EUNATCH 42
+#define ENOCSI 43
+#define EL2HLT 44
+#define EDEADLK 45
+#define ENOLCK 46
+#define EBADE 50
+#define EBADR 51
+#define EXFULL 52
+#define ENOANO 53
+#define EBADRQC 54
+#define EBADSLT 55
+#define EDEADLOCK 56
+#define EBFONT 57
+#define ENOSTR 60
+#define ENODATA 61
+#define ETIME 62
+#define ENOSR 63
+#define ENONET 64
+#define ENOPKG 65
+#define EREMOTE 66
+#define ENOLINK 67
+#define EADV 68
+#define ESRMNT 69
+#define ECOMM 70
+#define EPROTO 71
+#define EMULTIHOP 74
+#define ELBIN 75
+#define EDOTDOT 76
+#define EBADMSG 77
+#define EFTYPE 79
+#define ENOTUNIQ 80
+#define EBADFD 81
+#define EREMCHG 82
+#define ELIBACC 83
+#define ELIBBAD 84
+#define ELIBSCN 85
+#define ELIBMAX 86
+#define ELIBEXEC 87
+#define ENOSYS 88
+#define ENOTEMPTY 90
+#define ENAMETOOLONG 91
+#define ELOOP 92
+#define EOPNOTSUPP 95
+#define EPFNOSUPPORT 96
+#define ECONNRESET 104
+#define ENOBUFS 105
+#define EAFNOSUPPORT 106
+#define EPROTOTYPE 107
+#define ENOTSOCK 108
+#define ENOPROTOOPT 109
+#define ESHUTDOWN 110
+#define ECONNREFUSED 111
+#define EADDRINUSE 112
+#define ECONNABORTED 113
+#define ENETUNREACH 114
+#define ENETDOWN 115
+#define ETIMEDOUT 116
+#define EHOSTDOWN 117
+#define EHOSTUNREACH 118
+#define EINPROGRESS 119
+#define EALREADY 120
+#define EDESTADDRREQ 121
+#define EMSGSIZE 122
+#define EPROTONOSUPPORT 123
+#define ESOCKTNOSUPPORT 124
+#define EADDRNOTAVAIL 125
+#define ENETRESET 126
+#define EISCONN 127
+#define ENOTCONN 128
+#define ETOOMANYREFS 129
+#define EUSERS 131
+#define EDQUOT 132
+#define ESTALE 133
+#define ENOTSUP 134
+#define ENOMEDIUM 135
+#define EILSEQ 138
+#define EOVERFLOW 139
+#define ECANCELED 140
+#define ENOTRECOVERABLE 141
+#define EOWNERDEAD 142
+#define ESTRPIPE 143
+
+/*==================================================================================================
+ * Error Location
+ *==================================================================================================*/
+
+extern int *__errno_location(void);
+
+/** @brief The error number set by failing library calls. */
+#define errno (*__errno_location())
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_ERRNO_H */

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_FCNTL_H
+#define _NANVIX_FCNTL_H
+
+/**
+ * @file fcntl.h
+ * @brief File control options.
+ *
+ * Declares the file-control flags and the open()/fcntl()-family interfaces. The
+ * constants mirror the Rust definitions in the sysapi crate (fcntl.rs).
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define O_ACCMODE 0x3 /**< Mask for file access mode. */
+#define O_RDONLY 0 /**< Open for reading only. */
+#define O_WRONLY 1 /**< Open for writing only. */
+#define O_RDWR 2 /**< Open for reading and writing. */
+#define O_APPEND 0x0008 /**< Set append mode. */
+#define O_CREAT 0x0200 /**< Create file if it does not exist. */
+#define O_TRUNC 0x0400 /**< Truncate file to size zero. */
+#define O_EXCL 0x0800 /**< Fail if file already exists. */
+#define O_SYNC 0x2000 /**< Synchronized I/O data integrity. */
+#define O_NONBLOCK 0x4000 /**< Non-blocking mode. */
+#define O_NOCTTY 0x8000 /**< Do not assign controlling terminal. */
+#define O_CLOEXEC 0x40000 /**< Close-on-exec. */
+#define O_NOFOLLOW 0x100000 /**< Do not follow symbolic links. */
+#define O_DIRECTORY 0x200000 /**< Fail if not a directory. */
+#define AT_FDCWD -100 /**< Use the current working directory. */
+#define AT_EACCESS 1 /**< Check access using effective IDs. */
+#define AT_SYMLINK_NOFOLLOW 2 /**< Do not follow symbolic links. */
+#define AT_REMOVEDIR 8 /**< Remove a directory instead of a file. */
+#define POSIX_FADV_NORMAL 0 /**< No advice. */
+#define POSIX_FADV_SEQUENTIAL 1 /**< Sequential access. */
+#define POSIX_FADV_RANDOM 2 /**< Random access. */
+#define POSIX_FADV_WILLNEED 3 /**< Will be accessed soon. */
+#define POSIX_FADV_DONTNEED 4 /**< Will not be accessed soon. */
+#define POSIX_FADV_NOREUSE 5 /**< Accessed once. */
+
+/*==================================================================================================
+ * File Control
+ *==================================================================================================*/
+
+/* fcntl() commands. */
+#define F_DUPFD 0
+#define F_GETFD 1
+#define F_SETFD 2
+#define F_GETFL 3
+#define F_SETFL 4
+#define F_GETLK 5
+#define F_SETLK 6
+#define F_SETLKW 7
+
+/* File-descriptor flags (F_GETFD/F_SETFD). */
+#define FD_CLOEXEC 1
+
+/* Lock types (struct flock l_type). */
+#define F_RDLCK 0
+#define F_WRLCK 1
+#define F_UNLCK 2
+
+/** @brief Advisory record lock. */
+struct flock {
+    short l_type;   /**< Lock type: F_RDLCK, F_WRLCK, F_UNLCK. */
+    short l_whence; /**< How to interpret l_start.            */
+    off_t l_start;  /**< Starting offset for the lock.        */
+    off_t l_len;    /**< Number of bytes to lock.             */
+    pid_t l_pid;    /**< PID of the process holding the lock. */
+};
+
+extern int open(const char *path, int flags, ...);
+extern int openat(int dirfd, const char *path, int flags, ...);
+extern int fcntl(int fd, int cmd, ...);
+extern int posix_fadvise(int fd, off_t offset, off_t len, int advice);
+extern int posix_fallocate(int fd, off_t offset, off_t len);
+extern int renameat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_FCNTL_H */

--- a/include/fenv.h
+++ b/include/fenv.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_FENV_H
+#define _NANVIX_FENV_H
+
+/**
+ * @file fenv.h
+ * @brief Floating-point environment.
+ *
+ * Declares the floating-point rounding-mode and exception interfaces. The
+ * rounding-mode constants follow the x86 control-word layout.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Floating-point environment. */
+typedef int fenv_t;
+
+/** @brief Floating-point exception flags. */
+typedef int fexcept_t;
+
+/*==================================================================================================
+ * Rounding modes
+ *==================================================================================================*/
+
+#define FE_TONEAREST 0x0000
+#define FE_DOWNWARD 0x0400
+#define FE_UPWARD 0x0800
+#define FE_TOWARDZERO 0x0c00
+
+/*==================================================================================================
+ * Exception flags
+ *==================================================================================================*/
+
+#define FE_INVALID 0x01
+#define FE_DENORMAL 0x02
+#define FE_DIVBYZERO 0x04
+#define FE_OVERFLOW 0x08
+#define FE_UNDERFLOW 0x10
+#define FE_INEXACT 0x20
+#define FE_ALL_EXCEPT                                                                              \
+    (FE_INVALID | FE_DENORMAL | FE_DIVBYZERO | FE_OVERFLOW | FE_UNDERFLOW | FE_INEXACT)
+
+/** @brief Default floating-point environment. */
+#define FE_DFL_ENV ((const fenv_t *)-1)
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern int fegetround(void);
+extern int fesetround(int mode);
+extern int feclearexcept(int excepts);
+extern int feraiseexcept(int excepts);
+extern int fetestexcept(int excepts);
+extern int fegetenv(fenv_t *envp);
+extern int fesetenv(const fenv_t *envp);
+extern int feholdexcept(fenv_t *envp);
+extern int feupdateenv(const fenv_t *envp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_FENV_H */

--- a/include/ftw.h
+++ b/include/ftw.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_FTW_H
+#define _NANVIX_FTW_H
+
+/**
+ * @file ftw.h
+ * @brief File-tree-walk interface.
+ */
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Type-flag values passed to the callback
+ *==================================================================================================*/
+
+#define FTW_F 0   /**< Regular file.                 */
+#define FTW_D 1   /**< Directory.                    */
+#define FTW_DNR 2 /**< Directory that cannot be read. */
+#define FTW_NS 3  /**< Stat failed.                  */
+#define FTW_SL 4  /**< Symbolic link.                */
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+/**
+ * @brief Walks the file tree rooted at @p path, invoking @p fn for each entry.
+ *
+ * @param path    Root of the tree to walk.
+ * @param fn      Callback invoked per entry with its path, stat data, and a type flag.
+ * @param nopenfd Maximum number of directory streams kept open simultaneously.
+ *
+ * @returns Zero on success, the callback's non-zero return, or -1 on error.
+ */
+extern int ftw(
+    const char *path, int (*fn)(const char *fpath, const struct stat *sb, int typeflag),
+    int nopenfd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_FTW_H */

--- a/include/iconv.h
+++ b/include/iconv.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_ICONV_H
+#define _NANVIX_ICONV_H
+
+/**
+ * @file iconv.h
+ * @brief Codeset conversion.
+ *
+ * Nanvix provides an identity-passthrough `iconv` (sufficient for ASCII/UTF-8
+ * workloads); it does not perform real codeset conversion.
+ */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Conversion descriptor. */
+typedef void *iconv_t;
+
+extern iconv_t iconv_open(const char *tocode, const char *fromcode);
+extern size_t iconv(
+    iconv_t cd, char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft);
+extern int iconv_close(iconv_t cd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_ICONV_H */

--- a/include/ieeefp.h
+++ b/include/ieeefp.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_IEEEFP_H
+#define _NANVIX_IEEEFP_H
+
+/**
+ * @file ieeefp.h
+ * @brief Legacy IEEE floating-point predicates.
+ *
+ * Provides the historical `finite()` predicates in terms of the C99
+ * `isfinite` classification macro from <math.h>.
+ */
+
+#include <math.h>
+
+#ifndef finite
+#define finite(x) isfinite(x)
+#endif
+
+#ifndef finitef
+#define finitef(x) isfinite(x)
+#endif
+
+#endif /* _NANVIX_IEEEFP_H */

--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_INTTYPES_H
+#define _NANVIX_INTTYPES_H
+
+/**
+ * @file inttypes.h
+ * @brief Fixed-width integer types — format conversion.
+ *
+ * Declares functions for greatest-width integer arithmetic and conversion,
+ * plus format macros for printf/scanf with fixed-width types. Implemented by
+ * the libc_inttypes Rust crate.
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+#ifndef _INTMAX_T_DEFINED
+#define _INTMAX_T_DEFINED
+typedef int64_t intmax_t;
+typedef uint64_t uintmax_t;
+#endif
+
+/** @brief Return type for imaxdiv(). */
+typedef struct {
+    intmax_t quot; /**< Quotient.  */
+    intmax_t rem;  /**< Remainder. */
+} imaxdiv_t;
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern intmax_t imaxabs(intmax_t n);
+extern imaxdiv_t imaxdiv(intmax_t numer, intmax_t denom);
+extern intmax_t strtoimax(const char *nptr, char **endptr, int base);
+extern uintmax_t strtoumax(const char *nptr, char **endptr, int base);
+
+#ifdef __cplusplus
+}
+#endif
+
+/*==================================================================================================
+ * printf Format Macros
+ *==================================================================================================*/
+
+/* Signed */
+#define PRId8 "d"
+#define PRId16 "d"
+#define PRId32 "d"
+#define PRId64 "lld"
+#define PRIdMAX "lld"
+#define PRIdPTR "d"
+
+#define PRIi8 "i"
+#define PRIi16 "i"
+#define PRIi32 "i"
+#define PRIi64 "lli"
+#define PRIiMAX "lli"
+#define PRIiPTR "i"
+
+/* Unsigned */
+#define PRIo8 "o"
+#define PRIo16 "o"
+#define PRIo32 "o"
+#define PRIo64 "llo"
+#define PRIoMAX "llo"
+#define PRIoPTR "o"
+
+#define PRIu8 "u"
+#define PRIu16 "u"
+#define PRIu32 "u"
+#define PRIu64 "llu"
+#define PRIuMAX "llu"
+#define PRIuPTR "u"
+
+#define PRIx8 "x"
+#define PRIx16 "x"
+#define PRIx32 "x"
+#define PRIx64 "llx"
+#define PRIxMAX "llx"
+#define PRIxPTR "x"
+
+#define PRIX8 "X"
+#define PRIX16 "X"
+#define PRIX32 "X"
+#define PRIX64 "llX"
+#define PRIXMAX "llX"
+#define PRIXPTR "X"
+
+/*==================================================================================================
+ * scanf Format Macros
+ *==================================================================================================*/
+
+#define SCNd8 "hhd"
+#define SCNd16 "hd"
+#define SCNd32 "d"
+#define SCNd64 "lld"
+#define SCNdMAX "lld"
+#define SCNdPTR "d"
+
+#define SCNi8 "hhi"
+#define SCNi16 "hi"
+#define SCNi32 "i"
+#define SCNi64 "lli"
+#define SCNiMAX "lli"
+#define SCNiPTR "i"
+
+#define SCNo8 "hho"
+#define SCNo16 "ho"
+#define SCNo32 "o"
+#define SCNo64 "llo"
+#define SCNoMAX "llo"
+#define SCNoPTR "o"
+
+#define SCNu8 "hhu"
+#define SCNu16 "hu"
+#define SCNu32 "u"
+#define SCNu64 "llu"
+#define SCNuMAX "llu"
+#define SCNuPTR "u"
+
+#define SCNx8 "hhx"
+#define SCNx16 "hx"
+#define SCNx32 "x"
+#define SCNx64 "llx"
+#define SCNxMAX "llx"
+#define SCNxPTR "x"
+
+#endif /* _NANVIX_INTTYPES_H */

--- a/include/langinfo.h
+++ b/include/langinfo.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_LANGINFO_H
+#define _NANVIX_LANGINFO_H
+
+/**
+ * @file langinfo.h
+ * @brief Language information constants.
+ *
+ * Declares nl_langinfo() and the nl_item constants used to query locale-specific
+ * data. Only the C/POSIX locale is supported. Implemented by the libc_langinfo
+ * Rust crate.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define CODESET 0
+#define D_T_FMT 1
+#define D_FMT 2
+#define T_FMT 3
+#define T_FMT_AMPM 4
+#define AM_STR 5
+#define PM_STR 6
+#define DAY_1 7
+#define DAY_2 8
+#define DAY_3 9
+#define DAY_4 10
+#define DAY_5 11
+#define DAY_6 12
+#define DAY_7 13
+#define ABDAY_1 14
+#define ABDAY_2 15
+#define ABDAY_3 16
+#define ABDAY_4 17
+#define ABDAY_5 18
+#define ABDAY_6 19
+#define ABDAY_7 20
+#define MON_1 21
+#define MON_2 22
+#define MON_3 23
+#define MON_4 24
+#define MON_5 25
+#define MON_6 26
+#define MON_7 27
+#define MON_8 28
+#define MON_9 29
+#define MON_10 30
+#define MON_11 31
+#define MON_12 32
+#define ABMON_1 33
+#define ABMON_2 34
+#define ABMON_3 35
+#define ABMON_4 36
+#define ABMON_5 37
+#define ABMON_6 38
+#define ABMON_7 39
+#define ABMON_8 40
+#define ABMON_9 41
+#define ABMON_10 42
+#define ABMON_11 43
+#define ABMON_12 44
+#define RADIXCHAR 45
+#define THOUSEP 46
+#define YESEXPR 47
+#define NOEXPR 48
+#define CRNCYSTR 49
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+#ifndef _NL_ITEM_DEFINED
+#define _NL_ITEM_DEFINED
+/** @brief Identifier for an item of locale-specific data. */
+typedef int nl_item;
+#endif
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern char *nl_langinfo(nl_item item);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_LANGINFO_H */

--- a/include/limits.h
+++ b/include/limits.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_LIMITS_H
+#define _NANVIX_LIMITS_H
+
+/**
+ * @file limits.h
+ * @brief Implementation-defined constants.
+ *
+ * Declares the numerical limits of the standard integer types (via compiler
+ * builtins) and the POSIX path/name/resource limits. The POSIX limits mirror the
+ * Rust definitions in the sysapi crate (limits.rs).
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+/* Numerical limits of the standard integer types (compiler-defined). */
+#define CHAR_BIT 8
+#define MB_LEN_MAX 4
+
+#define SCHAR_MIN (-__SCHAR_MAX__ - 1)
+#define SCHAR_MAX __SCHAR_MAX__
+#define UCHAR_MAX (__SCHAR_MAX__ * 2 + 1)
+
+/* char is signed on the i686 target. */
+#define CHAR_MIN SCHAR_MIN
+#define CHAR_MAX SCHAR_MAX
+
+#define SHRT_MIN (-__SHRT_MAX__ - 1)
+#define SHRT_MAX __SHRT_MAX__
+#define USHRT_MAX (__SHRT_MAX__ * 2 + 1)
+
+#define INT_MIN (-__INT_MAX__ - 1)
+#define INT_MAX __INT_MAX__
+#define UINT_MAX (__INT_MAX__ * 2U + 1U)
+
+#define LONG_MIN (-__LONG_MAX__ - 1L)
+#define LONG_MAX __LONG_MAX__
+#define ULONG_MAX (__LONG_MAX__ * 2UL + 1UL)
+
+#define LLONG_MIN (-__LONG_LONG_MAX__ - 1LL)
+#define LLONG_MAX __LONG_LONG_MAX__
+#define ULLONG_MAX (__LONG_LONG_MAX__ * 2ULL + 1ULL)
+
+/* POSIX path, name, and resource limits (sysapi/limits.rs). */
+#define HOST_NAME_MAX 255
+#define IOV_MAX 16
+#define NAME_MAX 255
+#define OPEN_MAX 64
+#define PATH_MAX 1024
+#define PTHREAD_KEYS_MAX 128
+#define SSIZE_MAX INT_MAX
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_LIMITS_H */

--- a/include/locale.h
+++ b/include/locale.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_LOCALE_H
+#define _NANVIX_LOCALE_H
+
+/**
+ * @file locale.h
+ * @brief Localization.
+ *
+ * Declares functions and types for locale-specific formatting. Only the
+ * C/POSIX locale is supported. Implemented by the libc_locale Rust crate.
+ */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define LC_CTYPE 0
+#define LC_NUMERIC 1
+#define LC_TIME 2
+#define LC_COLLATE 3
+#define LC_MONETARY 4
+#define LC_MESSAGES 5
+#define LC_ALL 6
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+#ifndef _LOCALE_T_DEFINED
+#define _LOCALE_T_DEFINED
+typedef void *locale_t;
+#endif
+
+/** @brief Locale-specific numeric formatting information. */
+struct lconv {
+    char *decimal_point;     /**< Decimal point character.            */
+    char *thousands_sep;     /**< Thousands separator.                */
+    char *grouping;          /**< Digit grouping.                     */
+    char *int_curr_symbol;   /**< International currency symbol.      */
+    char *currency_symbol;   /**< Local currency symbol.              */
+    char *mon_decimal_point; /**< Monetary decimal point.             */
+    char *mon_thousands_sep; /**< Monetary thousands separator.       */
+    char *mon_grouping;      /**< Monetary digit grouping.            */
+    char *positive_sign;     /**< Positive sign string.               */
+    char *negative_sign;     /**< Negative sign string.               */
+    char int_frac_digits;    /**< International fractional digits.    */
+    char frac_digits;        /**< Local fractional digits.            */
+    char p_cs_precedes;      /**< Currency symbol precedes positive.  */
+    char p_sep_by_space;     /**< Space separates symbol and positive.*/
+    char n_cs_precedes;      /**< Currency symbol precedes negative.  */
+    char n_sep_by_space;     /**< Space separates symbol and negative.*/
+    char p_sign_posn;        /**< Positive sign position.             */
+    char n_sign_posn;        /**< Negative sign position.             */
+};
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern char *setlocale(int category, const char *locale);
+extern struct lconv *localeconv(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_LOCALE_H */

--- a/include/malloc.h
+++ b/include/malloc.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_MALLOC_H
+#define _NANVIX_MALLOC_H
+
+/**
+ * @file malloc.h
+ * @brief Memory allocation.
+ *
+ * Declares the memory-allocation interfaces, including the malloc_usable_size()
+ * extension. The prototypes are generated from the libc_stdlib Rust crate.
+ */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Memory Allocation
+ *==================================================================================================*/
+
+extern void *malloc(size_t size);
+extern void free(void *ptr);
+extern void *calloc(size_t nmemb, size_t size);
+extern void *realloc(void *ptr, size_t size);
+extern void *aligned_alloc(size_t alignment, size_t size);
+extern size_t malloc_usable_size(void *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_MALLOC_H */

--- a/include/math.h
+++ b/include/math.h
@@ -1,0 +1,244 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_MATH_H
+#define _NANVIX_MATH_H
+
+/**
+ * @file math.h
+ * @brief Mathematical functions.
+ *
+ * Declares software floating-point math functions covering trigonometric,
+ * exponential, logarithmic, rounding, and classification operations.
+ * Implemented by the libc_math Rust crate.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Real-Floating Types
+ *==================================================================================================*/
+
+typedef float float_t;
+typedef double double_t;
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#ifndef HUGE_VAL
+#define HUGE_VAL (__builtin_huge_val())
+#endif
+
+#ifndef HUGE_VALF
+#define HUGE_VALF (__builtin_huge_valf())
+#endif
+
+#ifndef HUGE_VALL
+#define HUGE_VALL (__builtin_huge_vall())
+#endif
+
+#ifndef INFINITY
+#define INFINITY (__builtin_inff())
+#endif
+
+#ifndef NAN
+#define NAN (__builtin_nanf(""))
+#endif
+
+/*==================================================================================================
+ * Floating-Point Classification Constants
+ *==================================================================================================*/
+
+#define FP_NAN 0
+#define FP_INFINITE 1
+#define FP_ZERO 2
+#define FP_SUBNORMAL 3
+#define FP_NORMAL 4
+
+/* Values returned by ilogb() for a zero or NaN argument. */
+#define FP_ILOGB0 (-2147483647 - 1)
+#define FP_ILOGBNAN 2147483647
+
+/*==================================================================================================
+ * Error Handling
+ *==================================================================================================*/
+
+#define MATH_ERRNO 1
+#define MATH_ERREXCEPT 2
+#define math_errhandling 0
+
+/*==================================================================================================
+ * Classification Functions (internal)
+ *==================================================================================================*/
+
+extern int __fpclassifyf(float x);
+extern int __fpclassifyd(double x);
+extern int __isnanf(float x);
+extern int __isnand(double x);
+extern int __isinff(float x);
+extern int __isinfd(double x);
+extern int __signbitf(float x);
+extern int __signbitd(double x);
+
+/*==================================================================================================
+ * Classification Macros
+ *==================================================================================================*/
+
+#define fpclassify(x) (sizeof(x) == sizeof(float) ? __fpclassifyf(x) : __fpclassifyd(x))
+
+#define isnan(x) (sizeof(x) == sizeof(float) ? __isnanf(x) : __isnand(x))
+
+#define isinf(x) (sizeof(x) == sizeof(float) ? __isinff(x) : __isinfd(x))
+
+#define signbit(x) (sizeof(x) == sizeof(float) ? __signbitf(x) : __signbitd(x))
+
+#define isfinite(x) __builtin_isfinite(x)
+#define isnormal(x) __builtin_isnormal(x)
+
+/*==================================================================================================
+ * Comparison Macros
+ *==================================================================================================*/
+
+#define isgreater(x, y) __builtin_isgreater(x, y)
+#define isgreaterequal(x, y) __builtin_isgreaterequal(x, y)
+#define isless(x, y) __builtin_isless(x, y)
+#define islessequal(x, y) __builtin_islessequal(x, y)
+#define islessgreater(x, y) __builtin_islessgreater(x, y)
+#define isunordered(x, y) __builtin_isunordered(x, y)
+
+/*==================================================================================================
+ * Trigonometric Functions
+ *==================================================================================================*/
+
+extern double sin(double x);
+extern double cos(double x);
+extern double tan(double x);
+extern float sinf(float x);
+extern float cosf(float x);
+extern float tanf(float x);
+
+/*==================================================================================================
+ * Hyperbolic Functions
+ *==================================================================================================*/
+
+extern double sinh(double x);
+extern double cosh(double x);
+extern double tanh(double x);
+extern double asinh(double x);
+extern double acosh(double x);
+extern double atanh(double x);
+
+/*==================================================================================================
+ * Inverse Trigonometric Functions
+ *==================================================================================================*/
+
+extern double asin(double x);
+extern double acos(double x);
+extern double atan(double x);
+extern double atan2(double y, double x);
+extern float asinf(float x);
+extern float acosf(float x);
+extern float atanf(float x);
+extern float atan2f(float y, float x);
+
+/*==================================================================================================
+ * Exponential and Logarithmic Functions
+ *==================================================================================================*/
+
+extern double exp(double x);
+extern double exp2(double x);
+extern double log(double x);
+extern double log2(double x);
+extern double log10(double x);
+extern double pow(double x, double y);
+extern double expm1(double x);
+extern double log1p(double x);
+extern long lrint(double x);
+extern double erf(double x);
+extern double erfc(double x);
+extern double lgamma(double x);
+extern double tgamma(double x);
+extern double gamma(double x);
+extern double nextafter(double x, double y);
+extern double remainder(double x, double y);
+extern float expf(float x);
+extern float exp2f(float x);
+extern float logf(float x);
+extern float log2f(float x);
+extern float log10f(float x);
+extern float powf(float x, float y);
+
+/*==================================================================================================
+ * Square Root and Cube Root
+ *==================================================================================================*/
+
+extern double sqrt(double x);
+extern double cbrt(double x);
+extern double hypot(double x, double y);
+extern float sqrtf(float x);
+extern float cbrtf(float x);
+extern float hypotf(float x, float y);
+
+/*==================================================================================================
+ * Rounding and Truncation
+ *==================================================================================================*/
+
+extern double ceil(double x);
+extern double floor(double x);
+extern double round(double x);
+extern double trunc(double x);
+extern float ceilf(float x);
+extern float floorf(float x);
+extern float roundf(float x);
+extern float truncf(float x);
+
+/*==================================================================================================
+ * Absolute Value and Remainder
+ *==================================================================================================*/
+
+extern double fabs(double x);
+extern double fmod(double x, double y);
+extern float fabsf(float x);
+extern float fmodf(float x, float y);
+
+/*==================================================================================================
+ * Floating-Point Manipulation
+ *==================================================================================================*/
+
+extern double copysign(double x, double y);
+extern double ldexp(double x, int exp);
+extern double scalbn(double x, int n);
+extern double frexp(double x, int *exp);
+extern double modf(double x, double *iptr);
+extern float copysignf(float x, float y);
+extern float ldexpf(float x, int exp);
+extern float scalbnf(float x, int n);
+extern float frexpf(float x, int *exp);
+extern float modff(float x, float *iptr);
+
+/*==================================================================================================
+ * Min / Max
+ *==================================================================================================*/
+
+extern double fmin(double x, double y);
+extern double fmax(double x, double y);
+extern float fminf(float x, float y);
+extern float fmaxf(float x, float y);
+
+/*==================================================================================================
+ * Fused Multiply-Add
+ *==================================================================================================*/
+
+extern double fma(double x, double y, double z);
+extern float fmaf(float x, float y, float z);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_MATH_H */

--- a/include/memory.h
+++ b/include/memory.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_MEMORY_H
+#define _NANVIX_MEMORY_H
+
+/**
+ * @file memory.h
+ * @brief Legacy alias for <string.h>.
+ */
+
+#include <string.h>
+
+#endif /* _NANVIX_MEMORY_H */

--- a/include/netdb.h
+++ b/include/netdb.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_NETDB_H
+#define _NANVIX_NETDB_H
+
+/**
+ * @file netdb.h
+ * @brief Network database operations.
+ *
+ * The structure layouts mirror the Rust definitions in the sysapi crate
+ * (netdb.rs).
+ */
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Structures
+ *==================================================================================================*/
+
+/** @brief Host database entry. */
+struct hostent {
+    char *h_name;        /**< Official host name.        */
+    char **h_aliases;    /**< Alias list.                */
+    int h_addrtype;      /**< Host address type.         */
+    int h_length;        /**< Length of address.         */
+    char **h_addr_list;  /**< List of addresses.         */
+};
+#define h_addr h_addr_list[0]
+
+/** @brief Service database entry. */
+struct servent {
+    char *s_name;     /**< Official service name. */
+    char **s_aliases; /**< Alias list.            */
+    int s_port;       /**< Port number.           */
+    char *s_proto;    /**< Protocol to use.       */
+};
+
+/** @brief Protocol database entry. */
+struct protoent {
+    char *p_name;     /**< Official protocol name. */
+    char **p_aliases; /**< Alias list.             */
+    int p_proto;      /**< Protocol number.        */
+};
+
+/** @brief Address information. */
+struct addrinfo {
+    int ai_flags;             /**< Input flags.                 */
+    int ai_family;            /**< Address family.              */
+    int ai_socktype;          /**< Socket type.                 */
+    int ai_protocol;          /**< Protocol.                    */
+    socklen_t ai_addrlen;     /**< Length of ai_addr.           */
+    char *ai_canonname;       /**< Canonical name for the host. */
+    struct sockaddr *ai_addr; /**< Socket address.              */
+    struct addrinfo *ai_next; /**< Next structure in the list.  */
+};
+
+/*==================================================================================================
+ * Flags and error codes
+ *==================================================================================================*/
+
+#define AI_PASSIVE 0x0001
+#define AI_CANONNAME 0x0002
+#define AI_NUMERICHOST 0x0004
+#define AI_NUMERICSERV 0x0008
+#define AI_V4MAPPED 0x0800
+#define AI_ALL 0x0100
+#define AI_ADDRCONFIG 0x0400
+
+#define NI_NUMERICHOST 0x0001
+#define NI_NUMERICSERV 0x0002
+#define NI_NOFQDN 0x0004
+#define NI_NAMEREQD 0x0008
+#define NI_DGRAM 0x0010
+#define NI_MAXHOST 1025
+#define NI_MAXSERV 32
+
+#define EAI_BADFLAGS (-1)
+#define EAI_NONAME (-2)
+#define EAI_AGAIN (-3)
+#define EAI_FAIL (-4)
+#define EAI_FAMILY (-6)
+#define EAI_SOCKTYPE (-7)
+#define EAI_SERVICE (-8)
+#define EAI_MEMORY (-10)
+#define EAI_SYSTEM (-11)
+#define EAI_OVERFLOW (-12)
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern int getaddrinfo(
+    const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res);
+extern void freeaddrinfo(struct addrinfo *res);
+extern const char *gai_strerror(int errcode);
+extern int getnameinfo(
+    const struct sockaddr *sa, socklen_t salen, char *host, socklen_t hostlen, char *serv,
+    socklen_t servlen, int flags);
+extern struct hostent *gethostbyname(const char *name);
+extern struct servent *getservbyname(const char *name, const char *proto);
+
+/** @brief Error code set by the legacy host-lookup functions. */
+extern int h_errno;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_NETDB_H */

--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_NETINET_IN_H
+#define _NANVIX_NETINET_IN_H
+
+/**
+ * @file netinet/in.h
+ * @brief Internet address family.
+ *
+ * Declares the IPv4 address types and structures and the IP protocol constants.
+ * The types and layouts mirror the Rust definitions in the sysapi crate
+ * (netinet_in.rs).
+ */
+
+#include <sys/socket.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define IPPROTO_IP 0 /**< Internet protocol. */
+#define IPPROTO_ICMP 1 /**< Control message protocol. */
+#define IPPROTO_TCP 6 /**< Transmission control protocol. */
+#define IPPROTO_UDP 17 /**< User datagram protocol. */
+#define IPPROTO_IPV6 41 /**< Internet protocol version 6. */
+#define IPPROTO_RAW 255 /**< Raw IP packets protocol. */
+#define INADDR_ANY ((in_addr_t)0x00000000) /**< Address to accept any incoming messages. */
+#define INADDR_LOOPBACK ((in_addr_t)0x7f000001) /**< Loopback address (127.0.0.1). */
+#define INADDR_BROADCAST ((in_addr_t)0xffffffff) /**< Address to send to all hosts. */
+#define INADDR_NONE ((in_addr_t)0xffffffff) /**< Invalid address. */
+
+#define INET_ADDRSTRLEN 16 /**< Max length of an IPv4 address string. */
+#define INET6_ADDRSTRLEN 46 /**< Max length of an IPv6 address string. */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Internet address (IPv4). */
+typedef uint32_t in_addr_t;
+
+/** @brief Internet port. */
+typedef uint16_t in_port_t;
+
+/** @brief Internet address structure. */
+struct in_addr {
+    in_addr_t s_addr; /**< IPv4 address. */
+};
+
+/** @brief Internet socket address (IPv4). */
+struct sockaddr_in {
+    unsigned char sin_len;   /**< Total length.   */
+    sa_family_t sin_family;  /**< Address family. */
+    in_port_t sin_port;      /**< Port number.    */
+    struct in_addr sin_addr; /**< IPv4 address.   */
+    unsigned char sin_zero[8]; /**< Padding.      */
+};
+
+/** @brief IPv6 address. */
+struct in6_addr {
+    union {
+        uint8_t __u6_addr8[16];
+        uint16_t __u6_addr16[8];
+        uint32_t __u6_addr32[4];
+    } __in6_union;
+};
+#define s6_addr __in6_union.__u6_addr8
+#define s6_addr16 __in6_union.__u6_addr16
+#define s6_addr32 __in6_union.__u6_addr32
+
+/** @brief Internet socket address (IPv6). */
+struct sockaddr_in6 {
+    unsigned char sin6_len;     /**< Total length.        */
+    sa_family_t sin6_family;    /**< Address family.      */
+    in_port_t sin6_port;        /**< Port number.         */
+    uint32_t sin6_flowinfo;     /**< Traffic class/flow.  */
+    struct in6_addr sin6_addr;  /**< IPv6 address.        */
+    uint32_t sin6_scope_id;     /**< Scope ID.            */
+};
+
+#define IN6ADDR_ANY_INIT                                                                           \
+    {                                                                                              \
+        {                                                                                          \
+            {                                                                                      \
+                0                                                                                  \
+            }                                                                                      \
+        }                                                                                          \
+    }
+#define IN6ADDR_LOOPBACK_INIT                                                                      \
+    {                                                                                              \
+        {                                                                                          \
+            {                                                                                      \
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1                                     \
+            }                                                                                      \
+        }                                                                                          \
+    }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_NETINET_IN_H */

--- a/include/netinet/tcp.h
+++ b/include/netinet/tcp.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_NETINET_TCP_H
+#define _NANVIX_NETINET_TCP_H
+
+/**
+ * @file netinet/tcp.h
+ * @brief TCP protocol definitions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TCP_NODELAY 1
+#define TCP_MAXSEG 2
+#define TCP_CORK 3
+#define TCP_KEEPIDLE 4
+#define TCP_KEEPINTVL 5
+#define TCP_KEEPCNT 6
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_NETINET_TCP_H */

--- a/include/nl_types.h
+++ b/include/nl_types.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_NL_TYPES_H
+#define _NANVIX_NL_TYPES_H
+
+/**
+ * @file nl_types.h
+ * @brief Message catalog and language information types.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Type used by nl_langinfo() to identify a locale item. */
+typedef int nl_item;
+
+/** @brief Message catalog descriptor. */
+typedef void *nl_catd;
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define NL_SETD 1
+#define NL_CAT_LOCALE 1
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_NL_TYPES_H */

--- a/include/poll.h
+++ b/include/poll.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_POLL_H
+#define _NANVIX_POLL_H
+
+/**
+ * @file poll.h
+ * @brief Synchronous I/O multiplexing via poll().
+ *
+ * The `pollfd` layout mirrors the Rust definition in the sysapi crate
+ * (poll.rs).
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+typedef unsigned int nfds_t;
+
+/** @brief A descriptor to be polled. */
+struct pollfd {
+    int fd;        /**< File descriptor.        */
+    short events;  /**< Requested events.       */
+    short revents; /**< Returned events.        */
+};
+
+/*==================================================================================================
+ * Event flags
+ *==================================================================================================*/
+
+#define POLLIN 0x0001
+#define POLLPRI 0x0002
+#define POLLOUT 0x0004
+#define POLLERR 0x0008
+#define POLLHUP 0x0010
+#define POLLNVAL 0x0020
+#define POLLRDNORM POLLIN
+#define POLLWRNORM POLLOUT
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern int poll(struct pollfd *fds, nfds_t nfds, int timeout);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_POLL_H */

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_PTHREAD_H
+#define _NANVIX_PTHREAD_H
+
+/**
+ * @file pthread.h
+ * @brief Threads.
+ *
+ * Declares the POSIX threads constants and attribute types. The scalar thread
+ * identifiers are declared in <sys/types.h>; the layouts mirror the Rust
+ * definitions in the sysapi crate (pthread.rs, sys_types.rs).
+ */
+
+#include <sched.h>
+#include <sys/types.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define PTHREAD_MUTEX_NORMAL 0 /**< Mutex that does not detect deadlock. */
+#define PTHREAD_MUTEX_RECURSIVE 1 /**< Mutex that allows recursive locking. */
+#define PTHREAD_MUTEX_ERRORCHECK 2 /**< Mutex that provides error checking. */
+#define PTHREAD_MUTEX_DEFAULT 3 /**< Default mutex type. */
+#define PTHREAD_MUTEX_INITIALIZER 0xffffffff /**< Static mutex initializer. */
+#define PTHREAD_COND_INITIALIZER 0xffffffff /**< Static condition variable initializer. */
+#define PTHREAD_RWLOCK_INITIALIZER 0xffffffff /**< Static read-write lock initializer. */
+#define PTHREAD_NULL 0 /**< Null thread identifier. */
+#define PTHREAD_CREATE_JOINABLE 0 /**< Thread is created joinable. */
+#define PTHREAD_CREATE_DETACHED 1 /**< Thread is created detached. */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Thread attributes. */
+typedef struct {
+    int is_initialized;            /**< Whether the attributes are initialized. */
+    void *stackaddr;               /**< Stack base address.                     */
+    size_t stacksize;              /**< Stack size.                             */
+    int contentionscope;           /**< Contention scope.                       */
+    int inheritsched;              /**< Inherit-scheduler attribute.            */
+    int schedpolicy;               /**< Scheduling policy.                      */
+    struct sched_param schedparam; /**< Scheduling parameters.                  */
+    int cputime_clock_allowed;     /**< Whether a CPU-time clock is allowed.    */
+    int detachstate;               /**< Detach state.                           */
+} pthread_attr_t;
+
+/** @brief Condition variable attributes. */
+typedef struct {
+    int is_initialized; /**< Whether the attributes are initialized. */
+    clock_t clock;      /**< Clock used for timeouts.                */
+} pthread_condattr_t;
+
+/** @brief Mutex attributes. */
+typedef struct {
+    int is_initialized; /**< Whether the attributes are initialized. */
+    int type;           /**< Type of mutex.                          */
+    int recursive;      /**< Whether the mutex is recursive.         */
+} pthread_mutexattr_t;
+
+/** @brief Read-write lock attributes. */
+typedef struct {
+    int is_initialized; /**< Whether the attributes are initialized. */
+} pthread_rwlockattr_t;
+
+/** @brief One-time initialization control. */
+typedef struct {
+    int is_initialized; /**< Whether the control is initialized. */
+    int init_executed;  /**< Whether the initializer has run.    */
+} pthread_once_t;
+
+/** @brief Static initializer for a pthread_once_t control variable. */
+#define PTHREAD_ONCE_INIT                                                                          \
+    {                                                                                              \
+        1, 0                                                                                       \
+    }
+
+/*==================================================================================================
+ * Threads
+ *==================================================================================================*/
+
+extern int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg);
+extern int pthread_join(pthread_t thread, void **retval_ptr);
+extern int pthread_detach(pthread_t thread);
+extern int pthread_kill(pthread_t thread, int sig);
+extern void pthread_exit(void *retval);
+extern pthread_t pthread_self(void);
+extern int pthread_equal(pthread_t thread1, pthread_t thread2);
+
+/*==================================================================================================
+ * Thread Attributes
+ *==================================================================================================*/
+
+extern int pthread_attr_init(pthread_attr_t *attr);
+extern int pthread_attr_destroy(pthread_attr_t *attr);
+extern int pthread_attr_getdetachstate(const pthread_attr_t *attr, int *detachstate);
+extern int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate);
+extern int pthread_attr_getstack(const pthread_attr_t *attr, void **stackaddr, size_t *stacksize);
+extern int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr, size_t stacksize);
+extern int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize);
+extern int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize);
+extern int pthread_attr_getstackaddr(const pthread_attr_t *attr, void **stackaddr);
+extern int pthread_attr_setstackaddr(pthread_attr_t *attr, void *stackaddr);
+extern int pthread_getattr_np(pthread_t thread, pthread_attr_t *attr);
+
+/*==================================================================================================
+ * Mutexes
+ *==================================================================================================*/
+
+extern int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr);
+extern int pthread_mutex_destroy(pthread_mutex_t *mutex);
+extern int pthread_mutex_lock(pthread_mutex_t *mutex);
+extern int pthread_mutex_unlock(pthread_mutex_t *mutex);
+extern int pthread_mutex_trylock(pthread_mutex_t *mutex);
+extern int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *abstime);
+extern int pthread_mutexattr_init(pthread_mutexattr_t *attr);
+extern int pthread_mutexattr_destroy(pthread_mutexattr_t *attr);
+
+/*==================================================================================================
+ * Condition Variables
+ *==================================================================================================*/
+
+extern int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr);
+extern int pthread_cond_destroy(pthread_cond_t *cond);
+extern int pthread_cond_signal(const pthread_cond_t *cond);
+extern int pthread_cond_broadcast(const pthread_cond_t *cond);
+extern int pthread_cond_wait(const pthread_cond_t *cond, pthread_mutex_t *mutex);
+extern int pthread_cond_timedwait(const pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime);
+extern int pthread_condattr_init(pthread_condattr_t *attr);
+extern int pthread_condattr_setclock(pthread_condattr_t *attr, clockid_t clock_id);
+
+/*==================================================================================================
+ * Read-Write Locks
+ *==================================================================================================*/
+
+extern int pthread_rwlock_init(pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attr);
+extern int pthread_rwlock_destroy(pthread_rwlock_t *rwlock);
+extern int pthread_rwlock_rdlock(pthread_rwlock_t *rwlock);
+extern int pthread_rwlock_wrlock(pthread_rwlock_t *rwlock);
+extern int pthread_rwlock_unlock(pthread_rwlock_t *rwlock);
+
+/*==================================================================================================
+ * Thread-Specific Data
+ *==================================================================================================*/
+
+extern int pthread_key_create(pthread_key_t *key_ptr, void (*destructor)(void *));
+extern int pthread_key_delete(pthread_key_t key);
+extern void *pthread_getspecific(pthread_key_t key);
+extern int pthread_setspecific(pthread_key_t key, const void *value);
+extern int pthread_once(pthread_once_t *once_control, void (*init_routine)(void));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_PTHREAD_H */

--- a/include/pwd.h
+++ b/include/pwd.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_PWD_H
+#define _NANVIX_PWD_H
+
+/**
+ * @file pwd.h
+ * @brief Password database.
+ *
+ * The `passwd` layout mirrors the Rust definition in the sysapi crate (pwd.rs).
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Password database entry. */
+struct passwd {
+    char *pw_name;   /**< User name.            */
+    char *pw_passwd; /**< Encrypted password.   */
+    uid_t pw_uid;    /**< User ID.              */
+    gid_t pw_gid;    /**< Group ID.             */
+    char *pw_gecos;  /**< Real name / comment.  */
+    char *pw_dir;    /**< Home directory.       */
+    char *pw_shell;  /**< Login shell.          */
+};
+
+extern struct passwd *getpwuid(uid_t uid);
+extern struct passwd *getpwnam(const char *name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_PWD_H */

--- a/include/sched.h
+++ b/include/sched.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SCHED_H
+#define _NANVIX_SCHED_H
+
+/**
+ * @file sched.h
+ * @brief Execution scheduling.
+ *
+ * Declares the scheduling policy constants and the sched_param structure used to
+ * get and set scheduling parameters. Mirrors the Rust definitions in the sysapi
+ * crate (sched.rs).
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define SCHED_OTHER 0 /**< Another scheduling policy. */
+#define SCHED_FIFO 1 /**< First in-first out scheduling policy. */
+#define SCHED_RR 2 /**< Round-robin scheduling policy. */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Scheduling parameters. */
+struct sched_param {
+    int sched_priority; /**< Process or thread execution scheduling priority. */
+};
+
+/*==================================================================================================
+ * Scheduling
+ *==================================================================================================*/
+
+extern int sched_yield(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SCHED_H */

--- a/include/setjmp.h
+++ b/include/setjmp.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SETJMP_H
+#define _NANVIX_SETJMP_H
+
+/**
+ * @file setjmp.h
+ * @brief Non-local jumps.
+ *
+ * Declares setjmp()/longjmp() and the POSIX sigsetjmp()/siglongjmp() functions
+ * for non-local control flow. jmp_buf and sigjmp_buf store the x86-32 callee-saved
+ * registers (EBX, ESI, EDI, EBP, ESP, EIP); sigjmp_buf additionally records a
+ * savemask flag. The guest does not yet maintain a signal mask, so the saved mask
+ * is currently empty. Implemented by the libc_setjmp Rust crate using global_asm.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Buffer type for saving and restoring execution context. */
+typedef struct {
+    int regs[6]; /**< Saved registers: EBX, ESI, EDI, EBP, ESP, EIP. */
+} jmp_buf[1];
+
+/** @brief Buffer type for sigsetjmp()/siglongjmp() execution context. */
+typedef struct {
+    int regs[6];  /**< Saved registers: EBX, ESI, EDI, EBP, ESP, EIP.    */
+    int savemask; /**< Nonzero if sigsetjmp() was asked to save the mask. */
+} sigjmp_buf[1];
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern int setjmp(jmp_buf env);
+extern void longjmp(jmp_buf env, int val) __attribute__((__noreturn__));
+
+/*==================================================================================================
+ * Signal Jumps (POSIX)
+ *==================================================================================================*/
+
+extern int sigsetjmp(sigjmp_buf env, int savemask);
+extern void siglongjmp(sigjmp_buf env, int val) __attribute__((__noreturn__));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SETJMP_H */

--- a/include/signal.h
+++ b/include/signal.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SIGNAL_H
+#define _NANVIX_SIGNAL_H
+
+/**
+ * @file signal.h
+ * @brief Signal handling.
+ *
+ * Declares functions and types for signal delivery and management.
+ * Implemented by the libc_signal Rust crate.
+ */
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Signal handler function pointer. */
+typedef void (*sighandler_t)(int);
+
+/** @brief Signal set type. */
+typedef uint64_t sigset_t;
+
+/** @brief Type that can be accessed atomically with respect to signals. */
+typedef int sig_atomic_t;
+
+/** @brief Value that accompanies a signal (used by SA_SIGINFO handlers). */
+union sigval {
+    int sival_int;   /**< Integer signal value. */
+    void *sival_ptr; /**< Pointer signal value. */
+};
+
+/**
+ * @brief Information passed to an SA_SIGINFO signal handler.
+ *
+ * Minimal POSIX subset: only the members common to every signal are provided.
+ * The guest does not yet populate this structure because asynchronous signal
+ * delivery is not implemented.
+ */
+typedef struct {
+    int si_signo;          /**< Signal number.                        */
+    int si_code;           /**< Signal code (one of the SI_* values). */
+    int si_errno;          /**< errno value associated with signal.   */
+    union sigval si_value; /**< Signal value.                         */
+} siginfo_t;
+
+/** @brief Structure for sigaction(). */
+struct sigaction {
+    sighandler_t sa_handler; /**< Signal handler.              */
+    sigset_t sa_mask;        /**< Signals to block in handler. */
+    int sa_flags;            /**< Action flags.                */
+    void (*sa_sigaction)(int, siginfo_t *, void *); /**< Handler used with SA_SIGINFO. */
+};
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define SIG_DFL ((sighandler_t)0)
+#define SIG_IGN ((sighandler_t)1)
+#define SIG_ERR ((sighandler_t) - 1)
+
+/* `how` argument values for sigprocmask(). */
+#define SIG_BLOCK 0
+#define SIG_UNBLOCK 1
+#define SIG_SETMASK 2
+
+/* Flags for sigaction(). */
+#define SA_NOCLDSTOP 0x00000001
+#define SA_NOCLDWAIT 0x00000002
+#define SA_SIGINFO 0x00000004
+#define SA_ONSTACK 0x08000000
+#define SA_RESTART 0x10000000
+#define SA_NODEFER 0x40000000
+#define SA_RESETHAND 0x80000000
+
+/* `si_code` values carried by siginfo_t. */
+#define SI_USER 0
+#define SI_QUEUE (-1)
+#define SI_TIMER (-2)
+#define SI_MESGQ (-3)
+#define SI_ASYNCIO (-4)
+
+/*==================================================================================================
+ * Signal Numbers
+ *==================================================================================================*/
+
+/* Standard signal numbers. */
+#ifndef SIGHUP
+#define SIGHUP 1
+#define SIGINT 2
+#define SIGQUIT 3
+#define SIGILL 4
+#define SIGTRAP 5
+#define SIGABRT 6
+#define SIGBUS 7
+#define SIGFPE 8
+#define SIGKILL 9
+#define SIGUSR1 10
+#define SIGSEGV 11
+#define SIGUSR2 12
+#define SIGPIPE 13
+#define SIGALRM 14
+#define SIGTERM 15
+#define SIGCHLD 17
+#define SIGCONT 18
+#define SIGSTOP 19
+#define SIGTSTP 20
+#define SIGTTIN 21
+#define SIGTTOU 22
+#define SIGURG 23
+#define SIGXCPU 24
+#define SIGXFSZ 25
+#define SIGVTALRM 26
+#define SIGPROF 27
+#define SIGWINCH 28
+#define SIGIO 29
+#define SIGSYS 31
+#define _NSIG 65
+#endif
+
+/*==================================================================================================
+ * Signal Functions
+ *==================================================================================================*/
+
+extern sighandler_t signal(int signum, sighandler_t handler);
+extern int raise(int sig);
+extern int kill(pid_t pid, int sig);
+
+/*==================================================================================================
+ * Signal Set Functions
+ *==================================================================================================*/
+
+extern int sigemptyset(sigset_t *set);
+extern int sigfillset(sigset_t *set);
+extern int sigaddset(sigset_t *set, int signum);
+extern int sigdelset(sigset_t *set, int signum);
+extern int sigismember(const sigset_t *set, int signum);
+extern int sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
+extern int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact);
+extern int pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SIGNAL_H */

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_STDIO_H
+#define _NANVIX_STDIO_H
+
+/**
+ * @file stdio.h
+ * @brief Standard input/output.
+ *
+ * Declares functions for formatted and unformatted I/O, stream management,
+ * and error reporting. Implemented by the libc_stdio Rust crate.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#ifndef EOF
+#define EOF (-1)
+#endif
+
+#ifndef SEEK_SET
+#define SEEK_SET 0
+#endif
+
+#ifndef SEEK_CUR
+#define SEEK_CUR 1
+#endif
+
+#ifndef SEEK_END
+#define SEEK_END 2
+#endif
+
+#ifndef NULL
+#define NULL ((void *)0)
+#endif
+
+#ifndef BUFSIZ
+#define BUFSIZ 8192
+#endif
+
+#ifndef FOPEN_MAX
+#define FOPEN_MAX 256
+#endif
+
+#ifndef FILENAME_MAX
+#define FILENAME_MAX 4096
+#endif
+
+#ifndef L_tmpnam
+#define L_tmpnam 20
+#endif
+
+#ifndef TMP_MAX
+#define TMP_MAX 10000
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/**
+ * @brief Opaque file stream type.
+ *
+ * The internal layout matches the Rust FILE struct in libc_stdio::streams.
+ * Fields should not be accessed directly; use the accessor functions below.
+ */
+typedef struct {
+    int fd;         /**< Underlying file descriptor. */
+    int eof;        /**< End-of-file indicator.      */
+    int error;      /**< Error indicator.             */
+    int ungetc_buf; /**< Push-back character buffer.  */
+} FILE;
+
+/*==================================================================================================
+ * Standard Streams
+ *==================================================================================================*/
+
+extern FILE *stdin(void);
+extern FILE *stdout(void);
+extern FILE *stderr(void);
+
+/* Convenience macros matching common usage. */
+#define stdin (stdin())
+#define stdout (stdout())
+#define stderr (stderr())
+
+/*==================================================================================================
+ * Stream Operations
+ *==================================================================================================*/
+
+extern FILE *fopen(const char *pathname, const char *mode);
+extern FILE *fdopen(int fd, const char *mode);
+extern int fclose(FILE *stream);
+extern int fflush(FILE *stream);
+extern void clearerr(FILE *stream);
+extern int ferror(FILE *stream);
+extern int feof(FILE *stream);
+extern int fileno(FILE *stream);
+extern int remove(const char *pathname);
+extern int rename(const char *old, const char *new);
+extern FILE *tmpfile(void);
+extern int sscanf(const char *s, const char *format, ...);
+extern int vsscanf(const char *s, const char *format, __builtin_va_list ap);
+
+/* Stream buffering modes (Nanvix streams are unbuffered). */
+#define _IOFBF 0
+#define _IOLBF 1
+#define _IONBF 2
+extern void setbuf(FILE *stream, char *buf);
+extern int setvbuf(FILE *stream, char *buf, int mode, size_t size);
+
+/*==================================================================================================
+ * Positioning
+ *==================================================================================================*/
+
+extern int fseek(FILE *stream, long offset, int whence);
+extern long ftell(FILE *stream);
+extern void rewind(FILE *stream);
+
+/*==================================================================================================
+ * Character I/O
+ *==================================================================================================*/
+
+extern int fgetc(FILE *stream);
+extern int getc(FILE *stream);
+extern int getchar(void);
+extern int fputc(int c, FILE *stream);
+extern int putchar(int c);
+extern int ungetc(int c, FILE *stream);
+
+/* putc is equivalent to fputc. */
+#ifndef putc
+#define putc(c, stream) fputc((c), (stream))
+#endif
+
+/*==================================================================================================
+ * String I/O
+ *==================================================================================================*/
+
+extern char *fgets(char *s, int size, FILE *stream);
+extern int fputs(const char *s, FILE *stream);
+extern int puts(const char *s);
+
+/*==================================================================================================
+ * Block I/O
+ *==================================================================================================*/
+
+extern size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
+extern size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
+
+/*==================================================================================================
+ * Formatted I/O
+ *==================================================================================================*/
+
+extern int printf(const char *fmt, ...);
+extern int fprintf(FILE *stream, const char *fmt, ...);
+extern int sprintf(char *buf, const char *fmt, ...);
+extern int snprintf(char *buf, size_t size, const char *fmt, ...);
+extern int vprintf(const char *fmt, va_list ap);
+extern int vfprintf(FILE *stream, const char *fmt, va_list ap);
+extern int vsprintf(char *buf, const char *fmt, va_list ap);
+extern int vsnprintf(char *buf, size_t size, const char *fmt, va_list ap);
+
+/*==================================================================================================
+ * Error Reporting
+ *==================================================================================================*/
+
+extern void perror(const char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_STDIO_H */

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_STDLIB_H
+#define _NANVIX_STDLIB_H
+
+/**
+ * @file stdlib.h
+ * @brief General utilities.
+ *
+ * Declares memory allocation and environment interfaces implemented by the
+ * libc_stdlib Rust crate.
+ */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Memory Allocation
+ *==================================================================================================*/
+
+extern void *malloc(size_t size);
+extern void free(void *ptr);
+extern void *calloc(size_t nmemb, size_t size);
+extern void *realloc(void *ptr, size_t size);
+extern void *aligned_alloc(size_t alignment, size_t size);
+extern int posix_memalign(void **memptr, size_t alignment, size_t size);
+
+/*==================================================================================================
+ * Environment
+ *==================================================================================================*/
+
+extern char *getenv(const char *name);
+extern int setenv(const char *name, const char *value, int overwrite);
+extern int unsetenv(const char *name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_STDLIB_H */

--- a/include/string.h
+++ b/include/string.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_STRING_H
+#define _NANVIX_STRING_H
+
+/**
+ * @file string.h
+ * @brief String and memory operations.
+ *
+ * Declares byte-string length and memory manipulation routines implemented by
+ * the libc_string Rust crate.
+ */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Memory Operations
+ *==================================================================================================*/
+
+extern void *memcpy(void *dest, const void *src, size_t len);
+extern void *memmove(void *dest, const void *src, size_t len);
+extern void *memset(void *ptr, int val, size_t len);
+extern int memcmp(const void *ptr1, const void *ptr2, size_t len);
+
+/*==================================================================================================
+ * String Operations
+ *==================================================================================================*/
+
+extern size_t strlen(const char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_STRING_H */

--- a/include/strings.h
+++ b/include/strings.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_STRINGS_H
+#define _NANVIX_STRINGS_H
+
+/**
+ * @file strings.h
+ * @brief Legacy BSD string operations.
+ */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int strcasecmp(const char *s1, const char *s2);
+extern int strncasecmp(const char *s1, const char *s2, size_t n);
+extern int bcmp(const void *s1, const void *s2, size_t n);
+extern void bcopy(const void *src, void *dest, size_t n);
+extern void bzero(void *s, size_t n);
+extern int ffs(int i);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_STRINGS_H */

--- a/include/sys/_stdint.h
+++ b/include/sys/_stdint.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS__STDINT_H
+#define _NANVIX_SYS__STDINT_H
+
+/**
+ * @file sys/_stdint.h
+ * @brief Compatibility shim for newlib's internal `<sys/_stdint.h>`.
+ *
+ * Some ports (e.g. QuickJS) include the newlib-internal `<sys/_stdint.h>`
+ * directly to obtain the fixed-width integer types. Nanvix declares those types
+ * in `<stdint.h>`, so forward to it.
+ */
+
+#include <stdint.h>
+
+#endif /* _NANVIX_SYS__STDINT_H */

--- a/include/sys/ioctl.h
+++ b/include/sys/ioctl.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_IOCTL_H
+#define _NANVIX_SYS_IOCTL_H
+
+/**
+ * @file sys/ioctl.h
+ * @brief Device control operations.
+ *
+ * Declares `ioctl()` and the terminal window-size request used by interactive
+ * ports. Nanvix has no interactive terminal in standalone mode, so the
+ * terminal requests fail; the definitions exist so such ports compile and link.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Structures
+ *==================================================================================================*/
+
+/** @brief Terminal window size. */
+struct winsize {
+    unsigned short ws_row;    /**< Rows, in characters.    */
+    unsigned short ws_col;    /**< Columns, in characters. */
+    unsigned short ws_xpixel; /**< Horizontal size, pixels. */
+    unsigned short ws_ypixel; /**< Vertical size, pixels.   */
+};
+
+/*==================================================================================================
+ * Requests
+ *==================================================================================================*/
+
+#define TIOCGWINSZ 0x5413
+#define TIOCSWINSZ 0x5414
+#define FIONREAD 0x541b
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern int ioctl(int fd, unsigned long request, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_IOCTL_H */

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_MMAN_H
+#define _NANVIX_SYS_MMAN_H
+
+/**
+ * @file sys/mman.h
+ * @brief Memory management declarations.
+ *
+ * Declares the memory-mapping protection and flag constants and the mmap/munmap
+ * interfaces. Constants mirror the Rust definitions in the sysapi crate
+ * (sys_mman.rs).
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define PROT_NONE 0x0 /**< Page cannot be accessed. */
+#define PROT_READ 0x1 /**< Page can be read. */
+#define PROT_WRITE 0x2 /**< Page can be written. */
+#define PROT_EXEC 0x4 /**< Page can be executed. */
+#define MAP_SHARED 0x01 /**< Share changes. */
+#define MAP_PRIVATE 0x02 /**< Changes are private. */
+#define MAP_FIXED 0x10 /**< Interpret the address exactly. */
+#define MAP_ANONYMOUS 0x20 /**< Anonymous mapping (not backed by a file). */
+
+/** @brief Returned by mmap() on failure. */
+#define MAP_FAILED ((void *)-1)
+
+/*==================================================================================================
+ * Memory Mapping
+ *==================================================================================================*/
+
+extern void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+extern int munmap(void *addr, size_t length);
+
+/*==================================================================================================
+ * Memory Protection
+ *==================================================================================================*/
+
+extern int mprotect(void *addr, size_t length, int prot);
+
+/*==================================================================================================
+ * Memory Locking
+ *==================================================================================================*/
+
+extern int mlock(const void *addr, size_t len);
+extern int munlock(const void *addr, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_MMAN_H */

--- a/include/sys/param.h
+++ b/include/sys/param.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_PARAM_H
+#define _NANVIX_SYS_PARAM_H
+
+/**
+ * @file sys/param.h
+ * @brief Legacy system parameters and helper macros.
+ */
+
+#include <limits.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Limits
+ *==================================================================================================*/
+
+#ifndef MAXPATHLEN
+#ifdef PATH_MAX
+#define MAXPATHLEN PATH_MAX
+#else
+#define MAXPATHLEN 4096
+#endif
+#endif
+
+#ifndef NBBY
+#define NBBY 8 /**< Number of bits in a byte. */
+#endif
+
+/*==================================================================================================
+ * Helper macros
+ *==================================================================================================*/
+
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#define howmany(x, y) (((x) + ((y) - 1)) / (y))
+#define roundup(x, y) ((((x) + ((y) - 1)) / (y)) * (y))
+#define powerof2(x) ((((x) - 1) & (x)) == 0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_PARAM_H */

--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_SELECT_H
+#define _NANVIX_SYS_SELECT_H
+
+/**
+ * @file sys/select.h
+ * @brief Synchronous I/O multiplexing.
+ *
+ * Declares `fd_set`, the `FD_*` manipulation macros, and `select()`. The
+ * `fd_set` layout mirrors the Rust definition in the sysapi crate
+ * (sys_select.rs).
+ */
+
+#include <sys/time.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+#define FD_SETSIZE 64
+
+#define _NANVIX_NFDBITS (8 * (int)sizeof(unsigned long))
+
+/** @brief A set of file descriptors. */
+typedef struct {
+    unsigned long fds_bits[FD_SETSIZE / (8 * sizeof(unsigned long))];
+} fd_set;
+
+/*==================================================================================================
+ * Manipulation macros
+ *==================================================================================================*/
+
+#define FD_ZERO(set)                                                                               \
+    do {                                                                                           \
+        unsigned int _i;                                                                           \
+        for (_i = 0; _i < sizeof(fd_set) / sizeof(unsigned long); _i++)                            \
+            ((fd_set *)(set))->fds_bits[_i] = 0;                                                   \
+    } while (0)
+#define FD_SET(fd, set)                                                                            \
+    ((set)->fds_bits[(fd) / _NANVIX_NFDBITS] |= (1UL << ((fd) % _NANVIX_NFDBITS)))
+#define FD_CLR(fd, set)                                                                            \
+    ((set)->fds_bits[(fd) / _NANVIX_NFDBITS] &= ~(1UL << ((fd) % _NANVIX_NFDBITS)))
+#define FD_ISSET(fd, set)                                                                          \
+    (((set)->fds_bits[(fd) / _NANVIX_NFDBITS] & (1UL << ((fd) % _NANVIX_NFDBITS))) != 0)
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern int select(
+    int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_SELECT_H */

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_SOCKET_H
+#define _NANVIX_SYS_SOCKET_H
+
+/**
+ * @file sys/socket.h
+ * @brief Main sockets header.
+ *
+ * Declares the socket address structures, the address-family and socket-type
+ * constants, and the core socket interfaces. The constants and layouts mirror the
+ * Rust definitions in the sysapi crate (sys_socket.rs).
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define AF_UNSPEC 0 /**< Unspecified address family. */
+#define AF_UNIX 1 /**< UNIX domain sockets. */
+#define AF_INET 2 /**< Internet domain sockets (IPv4). */
+#define AF_INET6 10 /**< Internet domain sockets (IPv6). */
+#define SOCK_STREAM 1 /**< Sequenced, reliable, connection-mode byte streams. */
+#define SOCK_DGRAM 2 /**< Connectionless, unreliable datagrams. */
+#define SOCK_RAW 3 /**< Raw protocol interface. */
+#define SOCK_SEQPACKET 5 /**< Sequenced, reliable, connection-mode records. */
+#define SOL_SOCKET 0xffff /**< Options at the socket level. */
+#define SO_REUSEADDR 0x0004 /**< Reuse of local addresses is supported. */
+#define SO_KEEPALIVE 0x0008 /**< Connections are kept alive. */
+#define SO_BROADCAST 0x0020 /**< Broadcast messages are supported. */
+#define SO_LINGER 0x0080 /**< Socket lingers on close. */
+#define SO_SNDBUF 0x1001 /**< Send buffer size. */
+#define SO_RCVBUF 0x1002 /**< Receive buffer size. */
+#define SO_ERROR 0x1007 /**< Socket error status. */
+#define SO_TYPE 0x1008 /**< Socket type. */
+#define SHUT_RD 0 /**< Disable further receives. */
+#define SHUT_WR 1 /**< Disable further sends. */
+#define MSG_OOB 0x0001 /**< Out-of-band data. */
+#define MSG_PEEK 0x0002 /**< Leave received data in queue. */
+#define MSG_DONTROUTE 0x0004 /**< Send without using routing tables. */
+#define MSG_TRUNC 0x0020 /**< Normal data truncated. */
+#define MSG_DONTWAIT 0x0040 /**< Nonblocking I/O. */
+#define MSG_WAITALL 0x0100 /**< Wait for full request or error. */
+#define MSG_NOSIGNAL 0x4000 /**< Do not generate SIGPIPE. */
+#define SHUT_RDWR 2 /**< Disable further sends and receives. */
+#define SOMAXCONN 128 /**< Maximum listen backlog. */
+#define _SS_PADSIZE 14 /**< Size of the sockaddr_storage padding field. */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Socket address family type. */
+typedef unsigned char sa_family_t;
+
+/** @brief Socket address length type. */
+typedef unsigned int socklen_t;
+
+/** @brief Generic socket address. */
+struct sockaddr {
+    unsigned char sa_len;    /**< Total length.   */
+    sa_family_t sa_family;   /**< Address family. */
+    char sa_data[14];        /**< Address data.   */
+};
+
+/** @brief Socket address storage, large enough for any address family. */
+struct sockaddr_storage {
+    unsigned char ss_len;    /**< Total length.   */
+    sa_family_t ss_family;   /**< Address family. */
+    char __ss_pad1[14];      /**< Padding.        */
+};
+
+/** @brief Linger option for SO_LINGER. */
+struct linger {
+    int l_onoff;  /**< Whether linger is enabled. */
+    int l_linger; /**< Linger time, in seconds.   */
+};
+
+/*==================================================================================================
+ * Sockets
+ *==================================================================================================*/
+
+extern int socket(int domain, int typ, int protocol);
+extern int socketpair(int domain, int typ, int protocol, int *socket_fds);
+extern int bind(int sockfd, const struct sockaddr *sockaddr, socklen_t len);
+extern int listen(int sockfd, int backlog);
+extern int accept(int sockfd, struct sockaddr *sockaddr, socklen_t *len);
+extern int connect(int sockfd, const struct sockaddr *sockaddr, socklen_t len);
+extern int getsockname(int sockfd, struct sockaddr *sockaddr, socklen_t *len);
+extern int getpeername(int sockfd, struct sockaddr *sockaddr, socklen_t *len);
+extern ssize_t send(int sockfd, const void *buf, size_t len, int flags);
+extern ssize_t recv(int sockfd, void *buf, size_t len, int flags);
+extern ssize_t sendto(int sockfd, const void *buf, size_t len, int flags, const struct sockaddr *sockaddr, socklen_t addrlen);
+extern ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags, struct sockaddr *sockaddr, socklen_t *addrlen);
+extern int setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen);
+extern int getsockopt(int sockfd, int level, int optname, void *optval, socklen_t *optlen);
+extern int shutdown(int sockfd, int how);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_SOCKET_H */

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_STAT_H
+#define _NANVIX_SYS_STAT_H
+
+/**
+ * @file sys/stat.h
+ * @brief File status.
+ *
+ * Declares the file-mode constants and the stat structure used to report file
+ * status. The layout mirrors the Rust definition in the sysapi crate
+ * (sys_stat.rs).
+ */
+
+#include <sys/types.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define S_IRWXU 0700 /**< Read, write, execute by owner. */
+#define S_IRUSR 0400 /**< Read by owner. */
+#define S_IWUSR 0200 /**< Write by owner. */
+#define S_IXUSR 0100 /**< Execute by owner. */
+#define S_IRWXG 0070 /**< Read, write, execute by group. */
+#define S_IRGRP 0040 /**< Read by group. */
+#define S_IWGRP 0020 /**< Write by group. */
+#define S_IXGRP 0010 /**< Execute by group. */
+#define S_IRWXO 0007 /**< Read, write, execute by others. */
+#define S_IROTH 0004 /**< Read by others. */
+#define S_IWOTH 0002 /**< Write by others. */
+#define S_IXOTH 0001 /**< Execute by others. */
+#define S_IFMT 0170000 /**< Mask for the file-type bit fields. */
+#define S_IFIFO 0010000 /**< FIFO. */
+#define S_IFCHR 0020000 /**< Character device. */
+#define S_IFDIR 0040000 /**< Directory. */
+#define S_IFBLK 0060000 /**< Block device. */
+#define S_IFREG 0100000 /**< Regular file. */
+#define S_IFLNK 0120000 /**< Symbolic link. */
+#define S_IFSOCK 0140000 /**< Socket. */
+#define S_ISUID 04000 /**< Set-user-ID on execution. */
+#define S_ISGID 02000 /**< Set-group-ID on execution. */
+#define S_ISVTX 01000 /**< Sticky bit. */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief File status. */
+struct stat {
+    dev_t st_dev;             /**< Device ID.                      */
+    ino_t st_ino;             /**< File serial number.             */
+    mode_t st_mode;           /**< File mode.                      */
+    nlink_t st_nlink;         /**< Link count.                     */
+    uid_t st_uid;             /**< User ID of file.                */
+    gid_t st_gid;             /**< Group ID of file.               */
+    dev_t st_rdev;            /**< Device ID (if special file).    */
+    off_t st_size;            /**< File size in bytes.             */
+    struct timespec st_atim;  /**< Last data access timestamp.     */
+    struct timespec st_mtim;  /**< Last data modification timestamp.*/
+    struct timespec st_ctim;  /**< Last status change timestamp.   */
+    blksize_t st_blksize;     /**< Preferred I/O block size.       */
+    blkcnt_t st_blocks;       /**< Number of blocks allocated.     */
+};
+
+/* POSIX timestamp field shorthands. */
+#define st_atime st_atim.tv_sec
+#define st_mtime st_mtim.tv_sec
+#define st_ctime st_ctim.tv_sec
+
+/* File-type test macros. */
+#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
+#define S_ISCHR(m)  (((m) & S_IFMT) == S_IFCHR)
+#define S_ISDIR(m)  (((m) & S_IFMT) == S_IFDIR)
+#define S_ISBLK(m)  (((m) & S_IFMT) == S_IFBLK)
+#define S_ISREG(m)  (((m) & S_IFMT) == S_IFREG)
+#define S_ISLNK(m)  (((m) & S_IFMT) == S_IFLNK)
+#define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)
+
+/*==================================================================================================
+ * File Status
+ *==================================================================================================*/
+
+extern int stat(const char *pathname, struct stat *statbuf);
+extern int fstat(int fd, struct stat *buf);
+extern int lstat(const char *pathname, struct stat *statbuf);
+extern int mkdir(const char *pathname, mode_t mode);
+extern int mkdirat(int dirfd, const char *pathname, mode_t mode);
+extern mode_t umask(mode_t mask);
+extern int fchmodat(int dirfd, const char *pathname, mode_t mode, int flags);
+extern int lchmod(const char *pathname, mode_t mode);
+extern int futimens(int fd, const struct timespec times[2]);
+extern int utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags);
+extern int chmod(const char *path, mode_t mode);
+extern int fchmod(int fd, mode_t mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_STAT_H */

--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_TIME_H
+#define _NANVIX_SYS_TIME_H
+
+/**
+ * @file sys/time.h
+ * @brief Time-of-day types and interfaces.
+ *
+ * Declares `struct timeval`, `struct timezone`, and the `gettimeofday`/`utimes`
+ * interfaces. The `timeval` layout mirrors the Rust definition in the sysapi
+ * crate (sys_select.rs).
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Structures
+ *==================================================================================================*/
+
+/**
+ * @brief Time interval expressed in seconds and microseconds.
+ */
+struct timeval {
+    time_t tv_sec;       /**< Seconds.      */
+    suseconds_t tv_usec; /**< Microseconds. */
+};
+
+/**
+ * @brief Time-zone information (obsolete; retained for compatibility).
+ */
+struct timezone {
+    int tz_minuteswest; /**< Minutes west of Greenwich. */
+    int tz_dsttime;     /**< Type of DST correction.    */
+};
+
+/*==================================================================================================
+ * Convenience macros
+ *==================================================================================================*/
+
+#define timerisset(tvp) ((tvp)->tv_sec || (tvp)->tv_usec)
+#define timerclear(tvp) ((tvp)->tv_sec = (tvp)->tv_usec = 0)
+#define timercmp(a, b, CMP)                                                                        \
+    (((a)->tv_sec == (b)->tv_sec) ? ((a)->tv_usec CMP(b)->tv_usec) : ((a)->tv_sec CMP(b)->tv_sec))
+#define timeradd(a, b, result)                                                                     \
+    do {                                                                                           \
+        (result)->tv_sec = (a)->tv_sec + (b)->tv_sec;                                              \
+        (result)->tv_usec = (a)->tv_usec + (b)->tv_usec;                                           \
+        if ((result)->tv_usec >= 1000000) {                                                        \
+            ++(result)->tv_sec;                                                                     \
+            (result)->tv_usec -= 1000000;                                                          \
+        }                                                                                          \
+    } while (0)
+#define timersub(a, b, result)                                                                     \
+    do {                                                                                           \
+        (result)->tv_sec = (a)->tv_sec - (b)->tv_sec;                                              \
+        (result)->tv_usec = (a)->tv_usec - (b)->tv_usec;                                           \
+        if ((result)->tv_usec < 0) {                                                               \
+            --(result)->tv_sec;                                                                     \
+            (result)->tv_usec += 1000000;                                                          \
+        }                                                                                          \
+    } while (0)
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+/**
+ * @brief Retrieves the current time of day.
+ *
+ * @param tv Buffer that receives the current time.
+ * @param tz Time-zone buffer (obsolete; should be NULL).
+ *
+ * @returns Zero on success, or -1 on failure with `errno` set.
+ */
+extern int gettimeofday(struct timeval *tv, void *tz);
+
+/**
+ * @brief Sets the access and modification times of a file.
+ *
+ * @param filename Path of the target file.
+ * @param times    Two-element array of access and modification times.
+ *
+ * @returns Zero on success, or -1 on failure with `errno` set.
+ */
+extern int utimes(const char *filename, const struct timeval times[2]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_TIME_H */

--- a/include/sys/times.h
+++ b/include/sys/times.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_TIMES_H
+#define _NANVIX_SYS_TIMES_H
+
+/**
+ * @file sys/times.h
+ * @brief Process times.
+ *
+ * Declares the tms structure and the times() interface. The layout mirrors the
+ * Rust definition in the sysapi crate (sys_times.rs).
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief Process and waited-for-children CPU times, in clock ticks. */
+struct tms {
+    clock_t tms_utime;  /**< User CPU time.                    */
+    clock_t tms_stime;  /**< System CPU time.                  */
+    clock_t tms_cutime; /**< User CPU time of terminated children.  */
+    clock_t tms_cstime; /**< System CPU time of terminated children.*/
+};
+
+/*==================================================================================================
+ * Process Times
+ *==================================================================================================*/
+
+extern clock_t times(struct tms *buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_TIMES_H */

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_TYPES_H
+#define _NANVIX_SYS_TYPES_H
+
+/**
+ * @file sys/types.h
+ * @brief System data types.
+ *
+ * Declares the primitive system data types. The layouts mirror the Rust
+ * definitions in the sysapi crate (sys_types.rs).
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/* Time types — guarded to coexist with <time.h>. */
+#ifndef _TIME_T_DEFINED
+#define _TIME_T_DEFINED
+typedef long long time_t;
+#endif
+
+#ifndef _CLOCK_T_DEFINED
+#define _CLOCK_T_DEFINED
+typedef long long clock_t;
+#endif
+
+#ifndef _CLOCKID_T_DEFINED
+#define _CLOCKID_T_DEFINED
+typedef int clockid_t;
+#endif
+
+/* A count of bytes or an error indication (companion of size_t). */
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
+typedef int ssize_t;
+#endif
+
+/* File-system and process types. */
+typedef long long blkcnt_t;          /**< File block counts.              */
+typedef long long blksize_t;         /**< Block sizes.                    */
+typedef unsigned long long dev_t;    /**< Device IDs.                     */
+typedef unsigned int gid_t;          /**< Group IDs.                      */
+typedef unsigned long long ino_t;    /**< File serial numbers.            */
+typedef unsigned int mode_t;         /**< File attributes.                */
+typedef unsigned long long nlink_t;  /**< Link counts.                    */
+typedef long long off_t;             /**< File sizes and offsets.         */
+typedef int pid_t;                   /**< Process and process group IDs.  */
+typedef unsigned short reclen_t;     /**< Directory entry lengths.        */
+typedef unsigned int uid_t;          /**< User IDs.                       */
+typedef long suseconds_t;            /**< Time in microseconds.           */
+
+/* POSIX threads scalar types (opaque identifiers). */
+typedef unsigned int pthread_t;        /**< Thread identifier.            */
+typedef unsigned int pthread_cond_t;   /**< Condition variable.           */
+typedef unsigned int pthread_key_t;    /**< Thread-specific data key.     */
+typedef unsigned int pthread_mutex_t;  /**< Mutex.                        */
+typedef unsigned int pthread_rwlock_t; /**< Read-write lock.              */
+
+#ifdef __cplusplus
+}
+#endif
+
+/* Expose fd_set / select() transitively, as common platforms do. Placed after
+ * the type definitions; the include guard makes the back-reference a no-op. */
+#include <sys/select.h>
+
+#endif /* _NANVIX_SYS_TYPES_H */

--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_UIO_H
+#define _NANVIX_SYS_UIO_H
+
+/**
+ * @file sys/uio.h
+ * @brief Vectored I/O.
+ *
+ * Declares the iovec structure and the scatter/gather I/O interfaces. The layout
+ * mirrors the Rust definition in the sysapi crate (sys_uio.rs).
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief An I/O vector. */
+struct iovec {
+    void *iov_base; /**< Base address of the buffer.  */
+    size_t iov_len; /**< Length of the buffer.        */
+};
+
+/*==================================================================================================
+ * Vectored I/O
+ *==================================================================================================*/
+
+extern ssize_t readv(int32_t fd, const struct iovec *iov, int32_t iovcnt);
+extern ssize_t writev(int fd, const struct iovec *iov, int iovcnt);
+extern ssize_t preadv(int32_t fd, const struct iovec *iov, int32_t iovcnt, off_t offset);
+extern ssize_t pwritev(int32_t fd, const struct iovec *iov, int iovcnt, off_t offset);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_UIO_H */

--- a/include/sys/un.h
+++ b/include/sys/un.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_UN_H
+#define _NANVIX_SYS_UN_H
+
+/**
+ * @file sys/un.h
+ * @brief UNIX domain socket address.
+ *
+ * Declares the UNIX-domain socket address structure. The layout mirrors the Rust
+ * definition in the sysapi crate (sys_un.rs).
+ */
+
+#include <sys/socket.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define SUNPATHLEN 14 /**< Size of the sun_path field. */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief UNIX domain socket address. */
+struct sockaddr_un {
+    unsigned char sun_len;     /**< Total length.   */
+    sa_family_t sun_family;    /**< Address family. */
+    char sun_path[SUNPATHLEN]; /**< Socket path.    */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_UN_H */

--- a/include/sys/utsname.h
+++ b/include/sys/utsname.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_UTSNAME_H
+#define _NANVIX_SYS_UTSNAME_H
+
+/**
+ * @file sys/utsname.h
+ * @brief System name structure.
+ *
+ * Declares the utsname structure and the uname() interface. The layout mirrors
+ * the Rust definition in the syscall crate (sys/utsname).
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#define _UTSNAME_LENGTH 64 /**< Length of each utsname field. */
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+/** @brief System name structure. */
+struct utsname {
+    char sysname[_UTSNAME_LENGTH];  /**< Operating system name.   */
+    char nodename[_UTSNAME_LENGTH]; /**< Network node name.       */
+    char release[_UTSNAME_LENGTH];  /**< Operating system release.*/
+    char version[_UTSNAME_LENGTH];  /**< Operating system version.*/
+    char machine[_UTSNAME_LENGTH];  /**< Hardware identifier.     */
+};
+
+/*==================================================================================================
+ * System Information
+ *==================================================================================================*/
+
+extern int uname(struct utsname *name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_UTSNAME_H */

--- a/include/sys/wait.h
+++ b/include/sys/wait.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYS_WAIT_H
+#define _NANVIX_SYS_WAIT_H
+
+/**
+ * @file sys/wait.h
+ * @brief Process-termination wait interface.
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Options
+ *==================================================================================================*/
+
+#define WNOHANG 1
+#define WUNTRACED 2
+
+/*==================================================================================================
+ * Status-decoding macros
+ *==================================================================================================*/
+
+#define WIFEXITED(status) (((status) & 0x7f) == 0)
+#define WEXITSTATUS(status) (((status) >> 8) & 0xff)
+#define WIFSIGNALED(status) (((status) & 0x7f) != 0 && ((status) & 0x7f) != 0x7f)
+#define WTERMSIG(status) ((status) & 0x7f)
+#define WIFSTOPPED(status) (((status) & 0xff) == 0x7f)
+#define WSTOPSIG(status) WEXITSTATUS(status)
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern pid_t waitpid(pid_t pid, int *status, int options);
+extern pid_t wait(int *status);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYS_WAIT_H */

--- a/include/syslog.h
+++ b/include/syslog.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_SYSLOG_H
+#define _NANVIX_SYSLOG_H
+
+/**
+ * @file syslog.h
+ * @brief System logging interface.
+ *
+ * Nanvix has no system log daemon in standalone mode, so these routines are
+ * no-ops; the definitions exist so that ports referencing them compile and link.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Options (openlog)
+ *==================================================================================================*/
+
+#define LOG_PID 0x01
+#define LOG_CONS 0x02
+#define LOG_ODELAY 0x04
+#define LOG_NDELAY 0x08
+#define LOG_NOWAIT 0x10
+#define LOG_PERROR 0x20
+
+/*==================================================================================================
+ * Facilities
+ *==================================================================================================*/
+
+#define LOG_KERN (0 << 3)
+#define LOG_USER (1 << 3)
+#define LOG_MAIL (2 << 3)
+#define LOG_DAEMON (3 << 3)
+#define LOG_AUTH (4 << 3)
+#define LOG_SYSLOG (5 << 3)
+#define LOG_LPR (6 << 3)
+#define LOG_LOCAL0 (16 << 3)
+
+/*==================================================================================================
+ * Priorities
+ *==================================================================================================*/
+
+#define LOG_EMERG 0
+#define LOG_ALERT 1
+#define LOG_CRIT 2
+#define LOG_ERR 3
+#define LOG_WARNING 4
+#define LOG_NOTICE 5
+#define LOG_INFO 6
+#define LOG_DEBUG 7
+
+#define LOG_MASK(pri) (1 << (pri))
+#define LOG_UPTO(pri) ((1 << ((pri) + 1)) - 1)
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern void openlog(const char *ident, int option, int facility);
+extern void closelog(void);
+extern void syslog(int priority, const char *format, ...);
+extern int setlogmask(int mask);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_SYSLOG_H */

--- a/include/termios.h
+++ b/include/termios.h
@@ -1,0 +1,248 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_TERMIOS_H
+#define _NANVIX_TERMIOS_H
+
+/**
+ * @file termios.h
+ * @brief General terminal interface.
+ *
+ * Declares `struct termios` and the terminal-attribute interfaces. Nanvix has
+ * no interactive terminal device in standalone mode, so `tcgetattr`/`tcsetattr`
+ * report that the descriptor is not a terminal; the definitions exist so that
+ * ports with an interactive mode (e.g. the QuickJS REPL) compile and link.
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+typedef unsigned int tcflag_t;
+typedef unsigned char cc_t;
+typedef unsigned int speed_t;
+
+#define NCCS 32
+
+struct termios {
+    tcflag_t c_iflag; /**< Input modes.   */
+    tcflag_t c_oflag; /**< Output modes.  */
+    tcflag_t c_cflag; /**< Control modes. */
+    tcflag_t c_lflag; /**< Local modes.   */
+    cc_t c_line;      /**< Line discipline. */
+    cc_t c_cc[NCCS];  /**< Control characters. */
+    speed_t c_ispeed; /**< Input speed.   */
+    speed_t c_ospeed; /**< Output speed.  */
+};
+
+/*==================================================================================================
+ * Input flags (c_iflag)
+ *==================================================================================================*/
+
+#define IGNBRK 0x0001
+#define BRKINT 0x0002
+#define IGNPAR 0x0004
+#define PARMRK 0x0008
+#define INPCK 0x0010
+#define ISTRIP 0x0020
+#define INLCR 0x0040
+#define IGNCR 0x0080
+#define ICRNL 0x0100
+#define IUCLC 0x0200
+#define IXON 0x0400
+#define IXANY 0x0800
+#define IXOFF 0x1000
+#define IMAXBEL 0x2000
+#define IUTF8 0x4000
+
+/*==================================================================================================
+ * Output flags (c_oflag)
+ *==================================================================================================*/
+
+#define OPOST 0x0001
+#define OLCUC 0x0002
+#define ONLCR 0x0004
+#define OCRNL 0x0008
+#define ONOCR 0x0010
+#define ONLRET 0x0020
+#define OFILL 0x0040
+#define OFDEL 0x0080
+#define NLDLY 0x0100
+#define NL0 0x0000
+#define NL1 0x0100
+#define CRDLY 0x0600
+#define CR0 0x0000
+#define CR1 0x0200
+#define CR2 0x0400
+#define CR3 0x0600
+#define TABDLY 0x1800
+#define TAB0 0x0000
+#define TAB1 0x0800
+#define TAB2 0x1000
+#define TAB3 0x1800
+#define XTABS 0x1800
+#define BSDLY 0x2000
+#define BS0 0x0000
+#define BS1 0x2000
+#define VTDLY 0x4000
+#define VT0 0x0000
+#define VT1 0x4000
+#define FFDLY 0x8000
+#define FF0 0x0000
+#define FF1 0x8000
+
+/*==================================================================================================
+ * Baud rates (c_cflag)
+ *==================================================================================================*/
+
+#define CBAUD 0x100f
+#define B0 0x0000
+#define B50 0x0001
+#define B75 0x0002
+#define B110 0x0003
+#define B134 0x0004
+#define B150 0x0005
+#define B200 0x0006
+#define B300 0x0007
+#define B600 0x0008
+#define B1200 0x0009
+#define B1800 0x000a
+#define B2400 0x000b
+#define B4800 0x000c
+#define B9600 0x000d
+#define B19200 0x000e
+#define B38400 0x000f
+#define EXTA B19200
+#define EXTB B38400
+#define CBAUDEX 0x1000
+#define B57600 0x1001
+#define B115200 0x1002
+#define B230400 0x1003
+#define B460800 0x1004
+#define B500000 0x1005
+#define B576000 0x1006
+#define B921600 0x1007
+#define B1000000 0x1008
+#define B1152000 0x1009
+#define B1500000 0x100a
+#define B2000000 0x100b
+#define B2500000 0x100c
+#define B3000000 0x100d
+#define B3500000 0x100e
+#define B4000000 0x100f
+
+/*==================================================================================================
+ * Control flags (c_cflag)
+ *==================================================================================================*/
+
+#define CSIZE 0x0030
+#define CS5 0x0000
+#define CS6 0x0010
+#define CS7 0x0020
+#define CS8 0x0030
+#define CSTOPB 0x0040
+#define CREAD 0x0080
+#define PARENB 0x0100
+#define PARODD 0x0200
+#define HUPCL 0x0400
+#define CLOCAL 0x0800
+#define CIBAUD 0x100f0000
+#define CMSPAR 0x40000000
+#define CRTSCTS 0x80000000
+
+/*==================================================================================================
+ * Local flags (c_lflag)
+ *==================================================================================================*/
+
+#define ISIG 0x0001
+#define ICANON 0x0002
+#define XCASE 0x0004
+#define ECHO 0x0008
+#define ECHOE 0x0010
+#define ECHOK 0x0020
+#define ECHONL 0x0040
+#define NOFLSH 0x0080
+#define TOSTOP 0x0100
+#define ECHOCTL 0x0200
+#define ECHOPRT 0x0400
+#define ECHOKE 0x0800
+#define FLUSHO 0x1000
+#define PENDIN 0x4000
+#define IEXTEN 0x8000
+#define EXTPROC 0x10000
+
+/*==================================================================================================
+ * Control-character indices (c_cc)
+ *==================================================================================================*/
+
+#define VINTR 0
+#define VQUIT 1
+#define VERASE 2
+#define VKILL 3
+#define VEOF 4
+#define VTIME 5
+#define VMIN 6
+#define VSWTC 7
+#define VSTART 8
+#define VSTOP 9
+#define VSUSP 10
+#define VEOL 11
+#define VREPRINT 12
+#define VDISCARD 13
+#define VWERASE 14
+#define VLNEXT 15
+#define VEOL2 16
+
+/*==================================================================================================
+ * Optional actions for tcsetattr()
+ *==================================================================================================*/
+
+#define TCSANOW 0
+#define TCSADRAIN 1
+#define TCSAFLUSH 2
+
+/*==================================================================================================
+ * Queue selectors for tcflush()
+ *==================================================================================================*/
+
+#define TCIFLUSH 0
+#define TCOFLUSH 1
+#define TCIOFLUSH 2
+
+/*==================================================================================================
+ * Actions for tcflow()
+ *==================================================================================================*/
+
+#define TCOOFF 0
+#define TCOON 1
+#define TCIOFF 2
+#define TCION 3
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+extern int tcgetattr(int fd, struct termios *termios_p);
+extern int tcsetattr(int fd, int optional_actions, const struct termios *termios_p);
+extern int tcsendbreak(int fd, int duration);
+extern int tcdrain(int fd);
+extern int tcflush(int fd, int queue_selector);
+extern int tcflow(int fd, int action);
+extern speed_t cfgetispeed(const struct termios *termios_p);
+extern speed_t cfgetospeed(const struct termios *termios_p);
+extern int cfsetispeed(struct termios *termios_p, speed_t speed);
+extern int cfsetospeed(struct termios *termios_p, speed_t speed);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_TERMIOS_H */

--- a/include/time.h
+++ b/include/time.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_TIME_H
+#define _NANVIX_TIME_H
+
+/**
+ * @file time.h
+ * @brief Date and time.
+ *
+ * Declares functions for calendar time manipulation and conversion.
+ * Implemented by the libc_time Rust crate.
+ */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+#ifndef _TIME_T_DEFINED
+#define _TIME_T_DEFINED
+typedef long long time_t;
+#endif
+
+#ifndef _CLOCK_T_DEFINED
+#define _CLOCK_T_DEFINED
+typedef long long clock_t;
+#endif
+
+#ifndef _CLOCKID_T_DEFINED
+#define _CLOCKID_T_DEFINED
+typedef int clockid_t;
+#endif
+
+#ifndef CLOCKS_PER_SEC
+#define CLOCKS_PER_SEC 1000000
+#endif
+
+#ifndef CLOCK_REALTIME
+#define CLOCK_REALTIME 1
+#endif
+
+#ifndef CLOCK_PROCESS_CPUTIME_ID
+#define CLOCK_PROCESS_CPUTIME_ID 2
+#endif
+
+#ifndef CLOCK_THREAD_CPUTIME_ID
+#define CLOCK_THREAD_CPUTIME_ID 3
+#endif
+
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC 4
+#endif
+
+/** @brief Broken-down time representation. */
+struct tm {
+    int tm_sec;   /**< Seconds [0, 60].            */
+    int tm_min;   /**< Minutes [0, 59].             */
+    int tm_hour;  /**< Hours [0, 23].               */
+    int tm_mday;  /**< Day of month [1, 31].        */
+    int tm_mon;   /**< Months since January [0, 11].*/
+    int tm_year;  /**< Years since 1900.            */
+    int tm_wday;  /**< Days since Sunday [0, 6].    */
+    int tm_yday;  /**< Days since Jan 1 [0, 365].   */
+    int tm_isdst; /**< Daylight Saving Time flag.   */
+};
+
+/** @brief Time specification for clock_gettime(). */
+struct timespec {
+    time_t tv_sec; /**< Seconds.     */
+    long tv_nsec;  /**< Nanoseconds. */
+};
+
+/*==================================================================================================
+ * Calendar Time
+ *==================================================================================================*/
+
+extern time_t time(time_t *tloc);
+extern clock_t clock(void);
+extern double difftime(time_t time1, time_t time0);
+extern time_t mktime(struct tm *timeptr);
+
+/*==================================================================================================
+ * Time Conversion
+ *==================================================================================================*/
+
+extern struct tm *gmtime(const time_t *timep);
+extern struct tm *gmtime_r(const time_t *timep, struct tm *result);
+extern struct tm *localtime(const time_t *timep);
+extern struct tm *localtime_r(const time_t *timep, struct tm *result);
+
+/*==================================================================================================
+ * Time Formatting
+ *==================================================================================================*/
+
+extern char *asctime(const struct tm *timeptr);
+extern char *asctime_r(const struct tm *timeptr, char *buf);
+extern char *ctime(const time_t *timep);
+extern char *ctime_r(const time_t *timep, char *buf);
+
+/*==================================================================================================
+ * Clocks
+ *==================================================================================================*/
+
+extern int clock_gettime(clockid_t clock_id, struct timespec *tp);
+extern int clock_getres(clockid_t clock_id, struct timespec *res);
+extern int nanosleep(const struct timespec *req, struct timespec *rem);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_TIME_H */

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_UNISTD_H
+#define _NANVIX_UNISTD_H
+
+/**
+ * @file unistd.h
+ * @brief Standard symbolic constants and types.
+ *
+ * Declares miscellaneous standard constants and the core POSIX process and I/O
+ * interfaces. Constants mirror the Rust definitions in the sysapi crate
+ * (unistd.rs); prototypes are generated from the syscall and posix crates.
+ */
+
+#include <stddef.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+/* POSIX feature-test macros. */
+#ifndef _POSIX_VERSION
+#define _POSIX_VERSION 200809L
+#endif
+#ifndef _POSIX_THREADS
+#define _POSIX_THREADS 200809L
+#endif
+
+#define STDIN_FILENO 0 /**< File descriptor of standard input. */
+#define STDOUT_FILENO 1 /**< File descriptor of standard output. */
+#define STDERR_FILENO 2 /**< File descriptor of standard error. */
+#ifndef SEEK_SET
+#define SEEK_SET 0 /**< Seek relative to start-of-file. */
+#endif
+
+#ifndef SEEK_CUR
+#define SEEK_CUR 1 /**< Seek relative to current position. */
+#endif
+
+#ifndef SEEK_END
+#define SEEK_END 2 /**< Seek relative to end-of-file. */
+#endif
+
+#define _SC_ARG_MAX 0 /**< Maximum length of arguments to exec(). */
+#define _SC_CHILD_MAX 1 /**< Maximum number of processes per user. */
+#define _SC_CLK_TCK 2 /**< Number of clock ticks per second. */
+#define _SC_NGROUPS_MAX 3 /**< Maximum number of supplementary group IDs. */
+#define _SC_OPEN_MAX 4 /**< Maximum number of open files per process. */
+#define _SC_VERSION 7 /**< POSIX.1 version. */
+#define _SC_PAGESIZE 8 /**< Size of a page in bytes. */
+#define _SC_PAGE_SIZE 8 /**< Size of a page in bytes (alias of _SC_PAGESIZE). */
+#define _SC_NPROCESSORS_CONF 9 /**< Number of configured processors. */
+#define _SC_NPROCESSORS_ONLN 10 /**< Number of online processors. */
+#define _SC_PHYS_PAGES 11 /**< Total number of physical pages. */
+#define _SC_AVPHYS_PAGES 12 /**< Number of available physical pages. */
+
+/*==================================================================================================
+ * File and Process Operations
+ *==================================================================================================*/
+
+extern ssize_t read(int fd, void *buffer, size_t count);
+extern ssize_t write(int fd, const void *buffer, size_t count);
+extern int close(int fd);
+extern void _exit(int status) __attribute__((__noreturn__));
+extern int pipe(int pipefd[2]);
+extern int dup(int oldfd);
+extern int dup2(int oldfd, int newfd);
+extern pid_t fork(void);
+extern int execve(const char *path, char *const argv[], char *const envp[]);
+extern int execvp(const char *file, char *const argv[]);
+extern int execv(const char *path, char *const argv[]);
+extern pid_t getppid(void);
+extern int faccessat(int dirfd, const char *pathname, int mode, int flags);
+extern int fchownat(int dirfd, const char *pathname, uid_t owner, gid_t group, int flags);
+extern int lchown(const char *pathname, uid_t owner, gid_t group);
+extern int linkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, int flags);
+extern int symlinkat(const char *target, int newdirfd, const char *linkpath);
+extern ssize_t readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz);
+extern int truncate(const char *path, off_t length);
+extern long fpathconf(int fd, int name);
+extern long pathconf(const char *path, int name);
+
+extern char **environ;
+extern off_t lseek(int fd, off_t offset, int whence);
+extern int unlink(const char *path);
+extern int rmdir(const char *path);
+extern long sysconf(int name);
+
+/*==================================================================================================
+ * User and Group Identification
+ *==================================================================================================*/
+
+extern pid_t getpid(void);
+extern uid_t getuid(void);
+extern uid_t geteuid(void);
+extern gid_t getgid(void);
+extern gid_t getegid(void);
+extern int setuid(uid_t uid);
+extern int seteuid(uid_t uid);
+extern int setgid(gid_t gid);
+extern int setegid(gid_t gid);
+extern int gethostname(char *name, size_t namelen);
+extern int chown(const char *path, uid_t owner, gid_t group);
+extern int fchown(int fd, uid_t owner, gid_t group);
+
+/*==================================================================================================
+ * File System Operations
+ *==================================================================================================*/
+
+extern ssize_t pread(int fd, void *buffer, size_t count, off_t offset);
+extern ssize_t pwrite(int fd, const void *buffer, size_t count, off_t offset);
+extern int ftruncate(int fd, off_t length);
+extern int fsync(int fd);
+extern int fdatasync(int fd);
+extern char *getcwd(char *buf, size_t size);
+extern int chdir(const char *path);
+extern int fchdir(int fd);
+
+/* access() mode bits. */
+#define F_OK 0
+#define X_OK 1
+#define W_OK 2
+#define R_OK 4
+extern int access(const char *path, int amode);
+extern unsigned int sleep(unsigned int seconds);
+extern int usleep(unsigned int usec);
+extern int unlinkat(int dirfd, const char *pathname, int flags);
+extern int isatty(int fd);
+extern ssize_t readlink(const char *path, char *buf, size_t bufsize);
+extern int getentropy(void *buffer, size_t length);
+extern int symlink(const char *target, const char *linkpath);
+
+/*==================================================================================================
+ * Command-Line Option Parsing
+ *==================================================================================================*/
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+extern int getopt(int argc, char *const argv[], const char *optstring);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_UNISTD_H */

--- a/include/utime.h
+++ b/include/utime.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_UTIME_H
+#define _NANVIX_UTIME_H
+
+/**
+ * @file utime.h
+ * @brief File access and modification times.
+ *
+ * Declares the legacy `utime()` interface and its `utimbuf` structure. The
+ * layout mirrors the Rust definition in the sysapi crate (utime.rs).
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Structures
+ *==================================================================================================*/
+
+/**
+ * @brief File access and modification times.
+ */
+struct utimbuf {
+    time_t actime;  /**< Access time.       */
+    time_t modtime; /**< Modification time. */
+};
+
+/*==================================================================================================
+ * Functions
+ *==================================================================================================*/
+
+/**
+ * @brief Sets the access and modification times of a file.
+ *
+ * @param filename Path of the target file.
+ * @param times    Desired access and modification times, or NULL for the
+ *                 current time.
+ *
+ * @returns Zero on success, or -1 on failure with `errno` set.
+ */
+extern int utime(const char *filename, const struct utimbuf *times);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_UTIME_H */

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_WCHAR_H
+#define _NANVIX_WCHAR_H
+
+/**
+ * @file wchar.h
+ * @brief Wide character strings.
+ *
+ * Declares functions for wide character string manipulation and memory
+ * operations. Implemented by the libc_wchar Rust crate.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <locale.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+#ifndef _WCHAR_T_DEFINED
+#define _WCHAR_T_DEFINED
+#ifndef __cplusplus
+typedef int wchar_t;
+#endif
+#endif
+
+#ifndef _WINT_T_DEFINED
+#define _WINT_T_DEFINED
+typedef int wint_t;
+#endif
+
+#ifndef _MBSTATE_T_DEFINED
+#define _MBSTATE_T_DEFINED
+/** @brief Conversion state for the restartable multibyte functions. */
+typedef struct {
+    int __count;       /**< Number of pending bytes.            */
+    unsigned char __buf[4]; /**< Buffered bytes of an incomplete seq. */
+} mbstate_t;
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#ifndef WEOF
+#define WEOF ((wint_t)(-1))
+#endif
+
+#ifndef WCHAR_MAX
+#define WCHAR_MAX 0x7fffffff
+#endif
+
+#ifndef WCHAR_MIN
+#define WCHAR_MIN (-WCHAR_MAX - 1)
+#endif
+
+#ifndef NULL
+#define NULL ((void *)0)
+#endif
+
+/*==================================================================================================
+ * String Operations
+ *==================================================================================================*/
+
+extern size_t wcslen(const wchar_t *s);
+extern wchar_t *wcscpy(wchar_t *dest, const wchar_t *src);
+extern wchar_t *wcsncpy(wchar_t *dest, const wchar_t *src, size_t n);
+extern wchar_t *wcscat(wchar_t *dest, const wchar_t *src);
+
+/*==================================================================================================
+ * Comparison
+ *==================================================================================================*/
+
+extern int wcscmp(const wchar_t *s1, const wchar_t *s2);
+extern int wcsncmp(const wchar_t *s1, const wchar_t *s2, size_t n);
+extern int wcscoll(const wchar_t *s1, const wchar_t *s2);
+extern size_t wcsxfrm(wchar_t *dest, const wchar_t *src, size_t n);
+
+/*==================================================================================================
+ * Search
+ *==================================================================================================*/
+
+extern wchar_t *wcschr(const wchar_t *s, wchar_t c);
+extern wchar_t *wcsrchr(const wchar_t *s, wchar_t c);
+extern wchar_t *wcsstr(const wchar_t *haystack, const wchar_t *needle);
+extern wchar_t *wcstok(wchar_t *ws, const wchar_t *delim, wchar_t **ptr);
+
+/*==================================================================================================
+ * Numeric Conversions
+ *==================================================================================================*/
+
+extern long wcstol(const wchar_t *nptr, wchar_t **endptr, int base);
+extern unsigned long wcstoul(const wchar_t *nptr, wchar_t **endptr, int base);
+extern long long wcstoll(const wchar_t *nptr, wchar_t **endptr, int base);
+extern unsigned long long wcstoull(const wchar_t *nptr, wchar_t **endptr, int base);
+extern double wcstod(const wchar_t *nptr, wchar_t **endptr);
+
+/*==================================================================================================
+ * Wide Memory Operations
+ *==================================================================================================*/
+
+extern wchar_t *wmemcpy(wchar_t *dest, const wchar_t *src, size_t n);
+extern wchar_t *wmemmove(wchar_t *dest, const wchar_t *src, size_t n);
+extern wchar_t *wmemset(wchar_t *s, wchar_t c, size_t n);
+extern int wmemcmp(const wchar_t *s1, const wchar_t *s2, size_t n);
+extern wchar_t *wmemchr(const wchar_t *s, wchar_t c, size_t n);
+
+/*==================================================================================================
+ * Byte / Wide Conversion
+ *==================================================================================================*/
+
+extern wint_t btowc(int c);
+extern int wctob(wint_t c);
+
+/*==================================================================================================
+ * Wide Character Formatted Output
+ *==================================================================================================*/
+
+extern int swprintf(wchar_t *ws, size_t n, const wchar_t *format, ...);
+extern int vswprintf(wchar_t *ws, size_t n, const wchar_t *format, va_list ap);
+
+/*==================================================================================================
+ * Restartable Multibyte / Wide Conversion
+ *==================================================================================================*/
+
+extern size_t mbrtowc(wchar_t *pwc, const char *s, size_t n, mbstate_t *ps);
+extern size_t wcrtomb(char *s, wchar_t wc, mbstate_t *ps);
+extern size_t mbrlen(const char *s, size_t n, mbstate_t *ps);
+extern int mbsinit(const mbstate_t *ps);
+extern size_t mbsrtowcs(wchar_t *dest, const char **src, size_t n, mbstate_t *ps);
+extern size_t wcsrtombs(char *dest, const wchar_t **src, size_t n, mbstate_t *ps);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_WCHAR_H */

--- a/include/wctype.h
+++ b/include/wctype.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _NANVIX_WCTYPE_H
+#define _NANVIX_WCTYPE_H
+
+/**
+ * @file wctype.h
+ * @brief Wide character classification and conversion.
+ *
+ * Declares functions for testing and mapping wide characters. Implemented by
+ * the libc_wctype Rust crate.
+ */
+
+#include <locale.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+ * Types
+ *==================================================================================================*/
+
+#ifndef _WINT_T_DEFINED
+#define _WINT_T_DEFINED
+typedef int wint_t;
+#endif
+
+#ifndef _WCTRANS_T_DEFINED
+#define _WCTRANS_T_DEFINED
+typedef int wctrans_t;
+#endif
+
+#ifndef _WCTYPE_T_DEFINED
+#define _WCTYPE_T_DEFINED
+typedef int wctype_t;
+#endif
+
+/*==================================================================================================
+ * Constants
+ *==================================================================================================*/
+
+#ifndef WEOF
+#define WEOF ((wint_t)(-1))
+#endif
+
+/*==================================================================================================
+ * Classification
+ *==================================================================================================*/
+
+extern int iswalpha(wint_t wc);
+extern int iswalpha_l(wint_t wc, locale_t locale);
+extern int iswdigit(wint_t wc);
+extern int iswdigit_l(wint_t wc, locale_t locale);
+extern int iswalnum(wint_t wc);
+extern int iswalnum_l(wint_t wc, locale_t locale);
+extern int iswspace(wint_t wc);
+extern int iswspace_l(wint_t wc, locale_t locale);
+extern int iswblank(wint_t wc);
+extern int iswblank_l(wint_t wc, locale_t locale);
+extern int iswupper(wint_t wc);
+extern int iswupper_l(wint_t wc, locale_t locale);
+extern int iswlower(wint_t wc);
+extern int iswlower_l(wint_t wc, locale_t locale);
+extern int iswprint(wint_t wc);
+extern int iswprint_l(wint_t wc, locale_t locale);
+extern int iswgraph(wint_t wc);
+extern int iswgraph_l(wint_t wc, locale_t locale);
+extern int iswpunct(wint_t wc);
+extern int iswpunct_l(wint_t wc, locale_t locale);
+extern int iswcntrl(wint_t wc);
+extern int iswcntrl_l(wint_t wc, locale_t locale);
+extern int iswxdigit(wint_t wc);
+extern int iswxdigit_l(wint_t wc, locale_t locale);
+extern int iswctype(wint_t wc, wctype_t charclass);
+extern int iswctype_l(wint_t wc, wctype_t charclass, locale_t locale);
+
+/*==================================================================================================
+ * Conversion
+ *==================================================================================================*/
+
+extern wint_t towupper(wint_t wc);
+extern wint_t towupper_l(wint_t wc, locale_t locale);
+extern wint_t towlower(wint_t wc);
+extern wint_t towlower_l(wint_t wc, locale_t locale);
+extern wint_t towctrans(wint_t wc, wctrans_t desc);
+extern wint_t towctrans_l(wint_t wc, wctrans_t desc, locale_t locale);
+
+/*==================================================================================================
+ * Descriptors
+ *==================================================================================================*/
+
+extern wctrans_t wctrans(const char *charclass);
+extern wctrans_t wctrans_l(const char *charclass, locale_t locale);
+extern wctype_t wctype(const char *property);
+extern wctype_t wctype_l(const char *property, locale_t locale);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NANVIX_WCTYPE_H */

--- a/src/libs/libc_stdlib/header.toml
+++ b/src/libs/libc_stdlib/header.toml
@@ -1,0 +1,29 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for stdlib.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/stdlib.h.
+
+file = "stdlib.h"
+brief = "General utilities."
+description = """
+Declares memory allocation and environment interfaces implemented by the
+libc_stdlib Rust crate."""
+includes = ["stddef.h"]
+guard = "_NANVIX_STDLIB_H"
+
+[[sections]]
+title = "Memory Allocation"
+functions = [
+    "malloc",
+    "free",
+    "calloc",
+    "realloc",
+    "aligned_alloc",
+    "posix_memalign",
+]
+
+[[sections]]
+title = "Environment"
+functions = ["getenv", "setenv", "unsetenv"]

--- a/src/libs/libc_string/header.toml
+++ b/src/libs/libc_string/header.toml
@@ -1,0 +1,22 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for string.h.
+# The gen-headers tool combines this with the extern "C" signatures parsed
+# from this crate's sources to produce include/string.h.
+
+file = "string.h"
+brief = "String and memory operations."
+description = """
+Declares byte-string length and memory manipulation routines implemented by
+the libc_string Rust crate."""
+includes = ["stddef.h"]
+guard = "_NANVIX_STRING_H"
+
+[[sections]]
+title = "Memory Operations"
+functions = ["memcpy", "memmove", "memset", "memcmp"]
+
+[[sections]]
+title = "String Operations"
+functions = ["strlen"]

--- a/src/libs/sysapi/headers/alloca.toml
+++ b/src/libs/sysapi/headers/alloca.toml
@@ -1,0 +1,24 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for alloca.h.
+
+file = "alloca.h"
+brief = "Stack allocation."
+description = '''
+`alloca()` allocates memory in the caller's stack frame; the storage is freed
+automatically when the calling function returns. It maps directly to the
+compiler builtin.'''
+includes = ["stddef.h"]
+guard = "_NANVIX_ALLOCA_H"
+extern_c = false
+content_order = [
+    "raw:0",
+]
+
+[[raw_sections]]
+title = ""
+text = '''
+#ifndef alloca
+#define alloca(size) __builtin_alloca(size)
+#endif'''

--- a/src/libs/sysapi/headers/arpa_inet.toml
+++ b/src/libs/sysapi/headers/arpa_inet.toml
@@ -1,0 +1,56 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for arpa/inet.h.
+
+file = "arpa/inet.h"
+brief = "Internet address manipulation."
+description = '''
+Declares the byte-order conversion helpers and the textual IPv4 address
+conversion interfaces. The byte-order helpers are provided as static inlines
+(the target is little-endian, so they are simple byte swaps); the inet_*
+prototypes are generated from the posix crate.'''
+includes = ["netinet/in.h", "stdint.h"]
+guard = "_NANVIX_ARPA_INET_H"
+scan_crates = ["posix"]
+content_order = [
+    "raw:0",
+    "section:0",
+]
+
+[[raw_sections]]
+title = "Byte Order"
+text = '''
+/*
+ * Host/network byte-order conversion. The Nanvix user target is little-endian,
+ * so host-to-network (big-endian) conversions are byte swaps. Provided as static
+ * inlines because the in-tree C library exposes no htonl/htons symbols, matching
+ * the common C-library practice of defining these in the header.
+ */
+static inline uint16_t htons(uint16_t __hostshort)
+{
+    return __builtin_bswap16(__hostshort);
+}
+
+static inline uint32_t htonl(uint32_t __hostlong)
+{
+    return __builtin_bswap32(__hostlong);
+}
+
+static inline uint16_t ntohs(uint16_t __netshort)
+{
+    return __builtin_bswap16(__netshort);
+}
+
+static inline uint32_t ntohl(uint32_t __netlong)
+{
+    return __builtin_bswap32(__netlong);
+}'''
+
+[[sections]]
+title = "Address Conversion"
+functions = ["inet_addr", "inet_ntoa", "inet_ntop", "inet_pton"]
+
+[overrides]
+inet_ntoa = '''
+extern char *inet_ntoa(struct in_addr in);'''

--- a/src/libs/sysapi/headers/dirent.toml
+++ b/src/libs/sysapi/headers/dirent.toml
@@ -1,0 +1,87 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for dirent.h.
+# Constants and layouts mirror src/libs/sysapi/src/dirent.rs; prototypes are
+# generated from the syscall crate.
+
+file = "dirent.h"
+brief = "Directory entries."
+description = """
+Declares the directory-stream type, the directory-entry structures, and the
+directory-traversal interfaces. The layouts mirror the Rust definitions in the
+sysapi crate (dirent.rs)."""
+includes = ["sys/types.h", "limits.h"]
+guard = "_NANVIX_DIRENT_H"
+scan_crates = ["syscall"]
+content_order = ["macros", "types:0", "section:0"]
+
+[[macros]]
+name = "DT_UNKNOWN"
+value = "0"
+comment = "Unknown file type."
+
+[[macros]]
+name = "DT_FIFO"
+value = "1"
+comment = "FIFO."
+
+[[macros]]
+name = "DT_CHR"
+value = "2"
+comment = "Character device."
+
+[[macros]]
+name = "DT_DIR"
+value = "4"
+comment = "Directory."
+
+[[macros]]
+name = "DT_BLK"
+value = "6"
+comment = "Block device."
+
+[[macros]]
+name = "DT_REG"
+value = "8"
+comment = "Regular file."
+
+[[macros]]
+name = "DT_LNK"
+value = "10"
+comment = "Symbolic link."
+
+[[macros]]
+name = "DT_SOCK"
+value = "12"
+comment = "Socket."
+
+[[types]]
+text = """
+/** @brief Directory stream type. */
+typedef struct __dirstream DIR;
+
+/** @brief Directory entry. */
+struct dirent {
+    ino_t d_ino;                /**< File serial number.                  */
+    char d_name[NAME_MAX + 1];  /**< Null-terminated file name.           */
+};
+
+/** @brief Extended (Nanvix) directory entry. */
+struct posix_dent {
+    ino_t d_ino;                /**< File serial number.                  */
+    reclen_t d_reclen;          /**< Length of this entry.                */
+    unsigned char d_type;       /**< File type.                           */
+    char d_name[NAME_MAX + 1];  /**< Null-terminated file name.           */
+    char d_pad[1];              /**< Padding.                             */
+};
+"""
+
+[[sections]]
+title = "Directory Operations"
+functions = ["opendir", "readdir", "closedir"]
+
+# opendir's Rust binding spells its path argument `*const i8`; declare the
+# standard POSIX prototype so C callers can pass a `const char *`.
+[overrides]
+opendir = "extern DIR *opendir(const char *dirname);"

--- a/src/libs/sysapi/headers/dlfcn.toml
+++ b/src/libs/sysapi/headers/dlfcn.toml
@@ -1,0 +1,58 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for dlfcn.h.
+# Constants and the Dl_info_t layout mirror src/libs/posix/src/dlfcn/mod.rs and
+# src/libs/syscall/src/dlfcn/mod.rs; prototypes are generated from the posix
+# crate.
+
+file = "dlfcn.h"
+brief = "Dynamic linking."
+description = """
+Declares the dynamic-linking-loader constants, the symbol-information structure,
+and the dlopen()-family interfaces. The constants and layout mirror the Rust
+definitions in the posix and syscall crates (dlfcn)."""
+includes = ["stdint.h"]
+guard = "_NANVIX_DLFCN_H"
+scan_crates = ["posix"]
+content_order = ["macros", "types:0", "section:0"]
+
+[[macros]]
+name = "RTLD_LAZY"
+value = "0x1"
+comment = "Relocations are performed at an implementation-defined time."
+
+[[macros]]
+name = "RTLD_NOW"
+value = "0x2"
+comment = "Relocations are performed when the object is loaded."
+
+[[macros]]
+name = "RTLD_GLOBAL"
+value = "0x4"
+comment = "Symbols are available for relocation processing of other objects."
+
+[[macros]]
+name = "RTLD_LOCAL"
+value = "0x0"
+comment = "Symbols are not made available to other objects."
+
+[[macros]]
+name = "RTLD_DEFAULT"
+value = "((void *)0)"
+comment = "Pseudo-handle: search the global (default) symbol scope."
+
+[[types]]
+text = """
+/** @brief Symbol information returned by dladdr(). */
+typedef struct {
+    const char *dli_fname; /**< Pathname of the mapped object.       */
+    void *dli_fbase;       /**< Base address of the mapped object.   */
+    const char *dli_sname; /**< Name of the nearest symbol.          */
+    void *dli_saddr;       /**< Exact address of the symbol.         */
+} Dl_info_t;
+"""
+
+[[sections]]
+title = "Dynamic Linking"
+functions = ["dlopen", "dlsym", "dlclose", "dlerror", "dladdr"]

--- a/src/libs/sysapi/headers/errno.toml
+++ b/src/libs/sysapi/headers/errno.toml
@@ -1,0 +1,150 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for errno.h.
+
+file = "errno.h"
+brief = "System error numbers."
+description = '''
+Declares the system error numbers and the errno lvalue. The numbers mirror the
+Rust definitions in the sysapi crate (errno.rs).'''
+guard = "_NANVIX_ERRNO_H"
+content_order = [
+    "raw:0",
+    "raw:1",
+]
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+#define EPERM 1
+#define ENOENT 2
+#define ESRCH 3
+#define EINTR 4
+#define EIO 5
+#define ENXIO 6
+#define E2BIG 7
+#define ENOEXEC 8
+#define EBADF 9
+#define ECHILD 10
+#define EAGAIN 11
+#define EWOULDBLOCK EAGAIN
+#define ENOMEM 12
+#define EACCES 13
+#define EFAULT 14
+#define ENOTBLK 15
+#define EBUSY 16
+#define EEXIST 17
+#define EXDEV 18
+#define ENODEV 19
+#define ENOTDIR 20
+#define EISDIR 21
+#define EINVAL 22
+#define ENFILE 23
+#define EMFILE 24
+#define ENOTTY 25
+#define ETXTBSY 26
+#define EFBIG 27
+#define ENOSPC 28
+#define ESPIPE 29
+#define EROFS 30
+#define EMLINK 31
+#define EPIPE 32
+#define EDOM 33
+#define ERANGE 34
+#define ENOMSG 35
+#define EIDRM 36
+#define ECHRNG 37
+#define EL2NSYNC 38
+#define EL3HLT 39
+#define EL3RST 40
+#define ELNRNG 41
+#define EUNATCH 42
+#define ENOCSI 43
+#define EL2HLT 44
+#define EDEADLK 45
+#define ENOLCK 46
+#define EBADE 50
+#define EBADR 51
+#define EXFULL 52
+#define ENOANO 53
+#define EBADRQC 54
+#define EBADSLT 55
+#define EDEADLOCK 56
+#define EBFONT 57
+#define ENOSTR 60
+#define ENODATA 61
+#define ETIME 62
+#define ENOSR 63
+#define ENONET 64
+#define ENOPKG 65
+#define EREMOTE 66
+#define ENOLINK 67
+#define EADV 68
+#define ESRMNT 69
+#define ECOMM 70
+#define EPROTO 71
+#define EMULTIHOP 74
+#define ELBIN 75
+#define EDOTDOT 76
+#define EBADMSG 77
+#define EFTYPE 79
+#define ENOTUNIQ 80
+#define EBADFD 81
+#define EREMCHG 82
+#define ELIBACC 83
+#define ELIBBAD 84
+#define ELIBSCN 85
+#define ELIBMAX 86
+#define ELIBEXEC 87
+#define ENOSYS 88
+#define ENOTEMPTY 90
+#define ENAMETOOLONG 91
+#define ELOOP 92
+#define EOPNOTSUPP 95
+#define EPFNOSUPPORT 96
+#define ECONNRESET 104
+#define ENOBUFS 105
+#define EAFNOSUPPORT 106
+#define EPROTOTYPE 107
+#define ENOTSOCK 108
+#define ENOPROTOOPT 109
+#define ESHUTDOWN 110
+#define ECONNREFUSED 111
+#define EADDRINUSE 112
+#define ECONNABORTED 113
+#define ENETUNREACH 114
+#define ENETDOWN 115
+#define ETIMEDOUT 116
+#define EHOSTDOWN 117
+#define EHOSTUNREACH 118
+#define EINPROGRESS 119
+#define EALREADY 120
+#define EDESTADDRREQ 121
+#define EMSGSIZE 122
+#define EPROTONOSUPPORT 123
+#define ESOCKTNOSUPPORT 124
+#define EADDRNOTAVAIL 125
+#define ENETRESET 126
+#define EISCONN 127
+#define ENOTCONN 128
+#define ETOOMANYREFS 129
+#define EUSERS 131
+#define EDQUOT 132
+#define ESTALE 133
+#define ENOTSUP 134
+#define ENOMEDIUM 135
+#define EILSEQ 138
+#define EOVERFLOW 139
+#define ECANCELED 140
+#define ENOTRECOVERABLE 141
+#define EOWNERDEAD 142
+#define ESTRPIPE 143'''
+
+[[raw_sections]]
+title = "Error Location"
+text = '''
+extern int *__errno_location(void);
+
+/** @brief The error number set by failing library calls. */
+#define errno (*__errno_location())'''

--- a/src/libs/sysapi/headers/fcntl.toml
+++ b/src/libs/sysapi/headers/fcntl.toml
@@ -1,0 +1,86 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for fcntl.h.
+
+file = "fcntl.h"
+brief = "File control options."
+description = '''
+Declares the file-control flags and the open()/fcntl()-family interfaces. The
+constants mirror the Rust definitions in the sysapi crate (fcntl.rs).'''
+includes = ["sys/types.h", "sys/stat.h"]
+guard = "_NANVIX_FCNTL_H"
+scan_crates = ["syscall"]
+content_order = [
+    "raw:0",
+    "raw:1",
+    "section:0",
+]
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+#define O_ACCMODE 0x3 /**< Mask for file access mode. */
+#define O_RDONLY 0 /**< Open for reading only. */
+#define O_WRONLY 1 /**< Open for writing only. */
+#define O_RDWR 2 /**< Open for reading and writing. */
+#define O_APPEND 0x0008 /**< Set append mode. */
+#define O_CREAT 0x0200 /**< Create file if it does not exist. */
+#define O_TRUNC 0x0400 /**< Truncate file to size zero. */
+#define O_EXCL 0x0800 /**< Fail if file already exists. */
+#define O_SYNC 0x2000 /**< Synchronized I/O data integrity. */
+#define O_NONBLOCK 0x4000 /**< Non-blocking mode. */
+#define O_NOCTTY 0x8000 /**< Do not assign controlling terminal. */
+#define O_CLOEXEC 0x40000 /**< Close-on-exec. */
+#define O_NOFOLLOW 0x100000 /**< Do not follow symbolic links. */
+#define O_DIRECTORY 0x200000 /**< Fail if not a directory. */
+#define AT_FDCWD -100 /**< Use the current working directory. */
+#define AT_EACCESS 1 /**< Check access using effective IDs. */
+#define AT_SYMLINK_NOFOLLOW 2 /**< Do not follow symbolic links. */
+#define AT_REMOVEDIR 8 /**< Remove a directory instead of a file. */
+#define POSIX_FADV_NORMAL 0 /**< No advice. */
+#define POSIX_FADV_SEQUENTIAL 1 /**< Sequential access. */
+#define POSIX_FADV_RANDOM 2 /**< Random access. */
+#define POSIX_FADV_WILLNEED 3 /**< Will be accessed soon. */
+#define POSIX_FADV_DONTNEED 4 /**< Will not be accessed soon. */
+#define POSIX_FADV_NOREUSE 5 /**< Accessed once. */'''
+
+[[raw_sections]]
+title = "File Control"
+text = '''
+/* fcntl() commands. */
+#define F_DUPFD 0
+#define F_GETFD 1
+#define F_SETFD 2
+#define F_GETFL 3
+#define F_SETFL 4
+#define F_GETLK 5
+#define F_SETLK 6
+#define F_SETLKW 7
+
+/* File-descriptor flags (F_GETFD/F_SETFD). */
+#define FD_CLOEXEC 1
+
+/* Lock types (struct flock l_type). */
+#define F_RDLCK 0
+#define F_WRLCK 1
+#define F_UNLCK 2
+
+/** @brief Advisory record lock. */
+struct flock {
+    short l_type;   /**< Lock type: F_RDLCK, F_WRLCK, F_UNLCK. */
+    short l_whence; /**< How to interpret l_start.            */
+    off_t l_start;  /**< Starting offset for the lock.        */
+    off_t l_len;    /**< Number of bytes to lock.             */
+    pid_t l_pid;    /**< PID of the process holding the lock. */
+};'''
+
+[[sections]]
+title = ""
+functions = ["open", "openat", "fcntl", "posix_fadvise", "posix_fallocate", "renameat"]
+
+[overrides]
+open = '''
+extern int open(const char *path, int flags, ...);'''
+openat = '''
+extern int openat(int dirfd, const char *path, int flags, ...);'''

--- a/src/libs/sysapi/headers/fenv.toml
+++ b/src/libs/sysapi/headers/fenv.toml
@@ -1,0 +1,63 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for fenv.h.
+
+file = "fenv.h"
+brief = "Floating-point environment."
+description = '''
+Declares the floating-point rounding-mode and exception interfaces. The
+rounding-mode constants follow the x86 control-word layout.'''
+guard = "_NANVIX_FENV_H"
+scan_crates = ["libc_math"]
+content_order = [
+    "types",
+    "raw:0",
+    "raw:1",
+    "section:0",
+]
+
+[[types]]
+text = '''
+/** @brief Floating-point environment. */
+typedef int fenv_t;
+
+/** @brief Floating-point exception flags. */
+typedef int fexcept_t;'''
+
+[[raw_sections]]
+title = "Rounding modes"
+text = '''
+#define FE_TONEAREST 0x0000
+#define FE_DOWNWARD 0x0400
+#define FE_UPWARD 0x0800
+#define FE_TOWARDZERO 0x0c00'''
+
+[[raw_sections]]
+title = "Exception flags"
+text = '''
+#define FE_INVALID 0x01
+#define FE_DENORMAL 0x02
+#define FE_DIVBYZERO 0x04
+#define FE_OVERFLOW 0x08
+#define FE_UNDERFLOW 0x10
+#define FE_INEXACT 0x20
+#define FE_ALL_EXCEPT                                                                              \
+    (FE_INVALID | FE_DENORMAL | FE_DIVBYZERO | FE_OVERFLOW | FE_UNDERFLOW | FE_INEXACT)
+
+/** @brief Default floating-point environment. */
+#define FE_DFL_ENV ((const fenv_t *)-1)'''
+
+[[sections]]
+title = "Functions"
+functions = ["fegetround", "fesetround", "feclearexcept", "feraiseexcept", "fetestexcept", "fegetenv", "fesetenv", "feholdexcept", "feupdateenv"]
+
+[overrides]
+fegetenv = '''
+extern int fegetenv(fenv_t *envp);'''
+fesetenv = '''
+extern int fesetenv(const fenv_t *envp);'''
+feholdexcept = '''
+extern int feholdexcept(fenv_t *envp);'''
+feupdateenv = '''
+extern int feupdateenv(const fenv_t *envp);'''

--- a/src/libs/sysapi/headers/ftw.toml
+++ b/src/libs/sysapi/headers/ftw.toml
@@ -1,0 +1,40 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for ftw.h.
+
+file = "ftw.h"
+brief = "File-tree-walk interface."
+description = '''
+'''
+includes = ["sys/stat.h", "sys/types.h"]
+guard = "_NANVIX_FTW_H"
+content_order = [
+    "raw:0",
+    "raw:1",
+]
+
+[[raw_sections]]
+title = "Type-flag values passed to the callback"
+text = '''
+#define FTW_F 0   /**< Regular file.                 */
+#define FTW_D 1   /**< Directory.                    */
+#define FTW_DNR 2 /**< Directory that cannot be read. */
+#define FTW_NS 3  /**< Stat failed.                  */
+#define FTW_SL 4  /**< Symbolic link.                */'''
+
+[[raw_sections]]
+title = "Functions"
+text = '''
+/**
+ * @brief Walks the file tree rooted at @p path, invoking @p fn for each entry.
+ *
+ * @param path    Root of the tree to walk.
+ * @param fn      Callback invoked per entry with its path, stat data, and a type flag.
+ * @param nopenfd Maximum number of directory streams kept open simultaneously.
+ *
+ * @returns Zero on success, the callback's non-zero return, or -1 on error.
+ */
+extern int ftw(
+    const char *path, int (*fn)(const char *fpath, const struct stat *sb, int typeflag),
+    int nopenfd);'''

--- a/src/libs/sysapi/headers/iconv.toml
+++ b/src/libs/sysapi/headers/iconv.toml
@@ -1,0 +1,36 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for iconv.h.
+
+file = "iconv.h"
+brief = "Codeset conversion."
+description = '''
+Nanvix provides an identity-passthrough `iconv` (sufficient for ASCII/UTF-8
+workloads); it does not perform real codeset conversion.'''
+includes = ["stddef.h"]
+guard = "_NANVIX_ICONV_H"
+scan_crates = ["nanvix_libc"]
+content_order = [
+    "raw:0",
+    "section:0",
+]
+
+[[raw_sections]]
+title = ""
+text = '''
+/** @brief Conversion descriptor. */
+typedef void *iconv_t;'''
+
+[[sections]]
+title = ""
+functions = ["iconv_open", "iconv", "iconv_close"]
+
+[overrides]
+iconv_open = '''
+extern iconv_t iconv_open(const char *tocode, const char *fromcode);'''
+iconv = '''
+extern size_t iconv(
+    iconv_t cd, char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft);'''
+iconv_close = '''
+extern int iconv_close(iconv_t cd);'''

--- a/src/libs/sysapi/headers/ieeefp.toml
+++ b/src/libs/sysapi/headers/ieeefp.toml
@@ -1,0 +1,27 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for ieeefp.h.
+
+file = "ieeefp.h"
+brief = "Legacy IEEE floating-point predicates."
+description = '''
+Provides the historical `finite()` predicates in terms of the C99
+`isfinite` classification macro from <math.h>.'''
+includes = ["math.h"]
+guard = "_NANVIX_IEEEFP_H"
+extern_c = false
+content_order = [
+    "raw:0",
+]
+
+[[raw_sections]]
+title = ""
+text = '''
+#ifndef finite
+#define finite(x) isfinite(x)
+#endif
+
+#ifndef finitef
+#define finitef(x) isfinite(x)
+#endif'''

--- a/src/libs/sysapi/headers/limits.toml
+++ b/src/libs/sysapi/headers/limits.toml
@@ -1,0 +1,56 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for limits.h.
+# The C integer limits are compiler-defined; the POSIX limits mirror
+# src/libs/sysapi/src/limits.rs.
+
+file = "limits.h"
+brief = "Implementation-defined constants."
+description = """
+Declares the numerical limits of the standard integer types (via compiler
+builtins) and the POSIX path/name/resource limits. The POSIX limits mirror the
+Rust definitions in the sysapi crate (limits.rs)."""
+guard = "_NANVIX_LIMITS_H"
+content_order = ["raw:0"]
+
+[[raw_sections]]
+title = "Constants"
+text = """
+/* Numerical limits of the standard integer types (compiler-defined). */
+#define CHAR_BIT 8
+#define MB_LEN_MAX 4
+
+#define SCHAR_MIN (-__SCHAR_MAX__ - 1)
+#define SCHAR_MAX __SCHAR_MAX__
+#define UCHAR_MAX (__SCHAR_MAX__ * 2 + 1)
+
+/* char is signed on the i686 target. */
+#define CHAR_MIN SCHAR_MIN
+#define CHAR_MAX SCHAR_MAX
+
+#define SHRT_MIN (-__SHRT_MAX__ - 1)
+#define SHRT_MAX __SHRT_MAX__
+#define USHRT_MAX (__SHRT_MAX__ * 2 + 1)
+
+#define INT_MIN (-__INT_MAX__ - 1)
+#define INT_MAX __INT_MAX__
+#define UINT_MAX (__INT_MAX__ * 2U + 1U)
+
+#define LONG_MIN (-__LONG_MAX__ - 1L)
+#define LONG_MAX __LONG_MAX__
+#define ULONG_MAX (__LONG_MAX__ * 2UL + 1UL)
+
+#define LLONG_MIN (-__LONG_LONG_MAX__ - 1LL)
+#define LLONG_MAX __LONG_LONG_MAX__
+#define ULLONG_MAX (__LONG_LONG_MAX__ * 2ULL + 1ULL)
+
+/* POSIX path, name, and resource limits (sysapi/limits.rs). */
+#define HOST_NAME_MAX 255
+#define IOV_MAX 16
+#define NAME_MAX 255
+#define OPEN_MAX 64
+#define PATH_MAX 1024
+#define PTHREAD_KEYS_MAX 128
+#define SSIZE_MAX INT_MAX
+"""

--- a/src/libs/sysapi/headers/malloc.toml
+++ b/src/libs/sysapi/headers/malloc.toml
@@ -1,0 +1,27 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for malloc.h.
+# Prototypes are generated from the extern "C" signatures in the libc_stdlib
+# crate (the same definitions that back <stdlib.h>).
+
+file = "malloc.h"
+brief = "Memory allocation."
+description = """
+Declares the memory-allocation interfaces, including the malloc_usable_size()
+extension. The prototypes are generated from the libc_stdlib Rust crate."""
+includes = ["stddef.h"]
+guard = "_NANVIX_MALLOC_H"
+scan_crates = ["libc_stdlib"]
+content_order = ["section:0"]
+
+[[sections]]
+title = "Memory Allocation"
+functions = [
+    "malloc",
+    "free",
+    "calloc",
+    "realloc",
+    "aligned_alloc",
+    "malloc_usable_size",
+]

--- a/src/libs/sysapi/headers/memory.toml
+++ b/src/libs/sysapi/headers/memory.toml
@@ -1,0 +1,12 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for memory.h.
+
+file = "memory.h"
+brief = "Legacy alias for <string.h>."
+description = '''
+'''
+includes = ["string.h"]
+guard = "_NANVIX_MEMORY_H"
+extern_c = false

--- a/src/libs/sysapi/headers/netdb.toml
+++ b/src/libs/sysapi/headers/netdb.toml
@@ -1,0 +1,103 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for netdb.h.
+
+file = "netdb.h"
+brief = "Network database operations."
+description = '''
+The structure layouts mirror the Rust definitions in the sysapi crate
+(netdb.rs).'''
+includes = ["netinet/in.h", "sys/socket.h"]
+guard = "_NANVIX_NETDB_H"
+content_order = [
+    "raw:0",
+    "raw:1",
+    "raw:2",
+]
+
+[[raw_sections]]
+title = "Structures"
+text = '''
+/** @brief Host database entry. */
+struct hostent {
+    char *h_name;        /**< Official host name.        */
+    char **h_aliases;    /**< Alias list.                */
+    int h_addrtype;      /**< Host address type.         */
+    int h_length;        /**< Length of address.         */
+    char **h_addr_list;  /**< List of addresses.         */
+};
+#define h_addr h_addr_list[0]
+
+/** @brief Service database entry. */
+struct servent {
+    char *s_name;     /**< Official service name. */
+    char **s_aliases; /**< Alias list.            */
+    int s_port;       /**< Port number.           */
+    char *s_proto;    /**< Protocol to use.       */
+};
+
+/** @brief Protocol database entry. */
+struct protoent {
+    char *p_name;     /**< Official protocol name. */
+    char **p_aliases; /**< Alias list.             */
+    int p_proto;      /**< Protocol number.        */
+};
+
+/** @brief Address information. */
+struct addrinfo {
+    int ai_flags;             /**< Input flags.                 */
+    int ai_family;            /**< Address family.              */
+    int ai_socktype;          /**< Socket type.                 */
+    int ai_protocol;          /**< Protocol.                    */
+    socklen_t ai_addrlen;     /**< Length of ai_addr.           */
+    char *ai_canonname;       /**< Canonical name for the host. */
+    struct sockaddr *ai_addr; /**< Socket address.              */
+    struct addrinfo *ai_next; /**< Next structure in the list.  */
+};'''
+
+[[raw_sections]]
+title = "Flags and error codes"
+text = '''
+#define AI_PASSIVE 0x0001
+#define AI_CANONNAME 0x0002
+#define AI_NUMERICHOST 0x0004
+#define AI_NUMERICSERV 0x0008
+#define AI_V4MAPPED 0x0800
+#define AI_ALL 0x0100
+#define AI_ADDRCONFIG 0x0400
+
+#define NI_NUMERICHOST 0x0001
+#define NI_NUMERICSERV 0x0002
+#define NI_NOFQDN 0x0004
+#define NI_NAMEREQD 0x0008
+#define NI_DGRAM 0x0010
+#define NI_MAXHOST 1025
+#define NI_MAXSERV 32
+
+#define EAI_BADFLAGS (-1)
+#define EAI_NONAME (-2)
+#define EAI_AGAIN (-3)
+#define EAI_FAIL (-4)
+#define EAI_FAMILY (-6)
+#define EAI_SOCKTYPE (-7)
+#define EAI_SERVICE (-8)
+#define EAI_MEMORY (-10)
+#define EAI_SYSTEM (-11)
+#define EAI_OVERFLOW (-12)'''
+
+[[raw_sections]]
+title = "Functions"
+text = '''
+extern int getaddrinfo(
+    const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res);
+extern void freeaddrinfo(struct addrinfo *res);
+extern const char *gai_strerror(int errcode);
+extern int getnameinfo(
+    const struct sockaddr *sa, socklen_t salen, char *host, socklen_t hostlen, char *serv,
+    socklen_t servlen, int flags);
+extern struct hostent *gethostbyname(const char *name);
+extern struct servent *getservbyname(const char *name, const char *proto);
+
+/** @brief Error code set by the legacy host-lookup functions. */
+extern int h_errno;'''

--- a/src/libs/sysapi/headers/netinet_in.toml
+++ b/src/libs/sysapi/headers/netinet_in.toml
@@ -1,0 +1,95 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for netinet/in.h.
+
+file = "netinet/in.h"
+brief = "Internet address family."
+description = '''
+Declares the IPv4 address types and structures and the IP protocol constants.
+The types and layouts mirror the Rust definitions in the sysapi crate
+(netinet_in.rs).'''
+includes = ["sys/socket.h", "stdint.h"]
+guard = "_NANVIX_NETINET_IN_H"
+content_order = [
+    "raw:0",
+    "types",
+]
+
+[[types]]
+text = '''
+/** @brief Internet address (IPv4). */
+typedef uint32_t in_addr_t;
+
+/** @brief Internet port. */
+typedef uint16_t in_port_t;
+
+/** @brief Internet address structure. */
+struct in_addr {
+    in_addr_t s_addr; /**< IPv4 address. */
+};
+
+/** @brief Internet socket address (IPv4). */
+struct sockaddr_in {
+    unsigned char sin_len;   /**< Total length.   */
+    sa_family_t sin_family;  /**< Address family. */
+    in_port_t sin_port;      /**< Port number.    */
+    struct in_addr sin_addr; /**< IPv4 address.   */
+    unsigned char sin_zero[8]; /**< Padding.      */
+};
+
+/** @brief IPv6 address. */
+struct in6_addr {
+    union {
+        uint8_t __u6_addr8[16];
+        uint16_t __u6_addr16[8];
+        uint32_t __u6_addr32[4];
+    } __in6_union;
+};
+#define s6_addr __in6_union.__u6_addr8
+#define s6_addr16 __in6_union.__u6_addr16
+#define s6_addr32 __in6_union.__u6_addr32
+
+/** @brief Internet socket address (IPv6). */
+struct sockaddr_in6 {
+    unsigned char sin6_len;     /**< Total length.        */
+    sa_family_t sin6_family;    /**< Address family.      */
+    in_port_t sin6_port;        /**< Port number.         */
+    uint32_t sin6_flowinfo;     /**< Traffic class/flow.  */
+    struct in6_addr sin6_addr;  /**< IPv6 address.        */
+    uint32_t sin6_scope_id;     /**< Scope ID.            */
+};
+
+#define IN6ADDR_ANY_INIT                                                                           \
+    {                                                                                              \
+        {                                                                                          \
+            {                                                                                      \
+                0                                                                                  \
+            }                                                                                      \
+        }                                                                                          \
+    }
+#define IN6ADDR_LOOPBACK_INIT                                                                      \
+    {                                                                                              \
+        {                                                                                          \
+            {                                                                                      \
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1                                     \
+            }                                                                                      \
+        }                                                                                          \
+    }'''
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+#define IPPROTO_IP 0 /**< Internet protocol. */
+#define IPPROTO_ICMP 1 /**< Control message protocol. */
+#define IPPROTO_TCP 6 /**< Transmission control protocol. */
+#define IPPROTO_UDP 17 /**< User datagram protocol. */
+#define IPPROTO_IPV6 41 /**< Internet protocol version 6. */
+#define IPPROTO_RAW 255 /**< Raw IP packets protocol. */
+#define INADDR_ANY ((in_addr_t)0x00000000) /**< Address to accept any incoming messages. */
+#define INADDR_LOOPBACK ((in_addr_t)0x7f000001) /**< Loopback address (127.0.0.1). */
+#define INADDR_BROADCAST ((in_addr_t)0xffffffff) /**< Address to send to all hosts. */
+#define INADDR_NONE ((in_addr_t)0xffffffff) /**< Invalid address. */
+
+#define INET_ADDRSTRLEN 16 /**< Max length of an IPv4 address string. */
+#define INET6_ADDRSTRLEN 46 /**< Max length of an IPv6 address string. */'''

--- a/src/libs/sysapi/headers/netinet_tcp.toml
+++ b/src/libs/sysapi/headers/netinet_tcp.toml
@@ -1,0 +1,23 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for netinet/tcp.h.
+
+file = "netinet/tcp.h"
+brief = "TCP protocol definitions."
+description = '''
+'''
+guard = "_NANVIX_NETINET_TCP_H"
+content_order = [
+    "raw:0",
+]
+
+[[raw_sections]]
+title = ""
+text = '''
+#define TCP_NODELAY 1
+#define TCP_MAXSEG 2
+#define TCP_CORK 3
+#define TCP_KEEPIDLE 4
+#define TCP_KEEPINTVL 5
+#define TCP_KEEPCNT 6'''

--- a/src/libs/sysapi/headers/nl_types.toml
+++ b/src/libs/sysapi/headers/nl_types.toml
@@ -1,0 +1,28 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for nl_types.h.
+
+file = "nl_types.h"
+brief = "Message catalog and language information types."
+description = '''
+'''
+guard = "_NANVIX_NL_TYPES_H"
+content_order = [
+    "types",
+    "raw:0",
+]
+
+[[types]]
+text = '''
+/** @brief Type used by nl_langinfo() to identify a locale item. */
+typedef int nl_item;
+
+/** @brief Message catalog descriptor. */
+typedef void *nl_catd;'''
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+#define NL_SETD 1
+#define NL_CAT_LOCALE 1'''

--- a/src/libs/sysapi/headers/poll.toml
+++ b/src/libs/sysapi/headers/poll.toml
@@ -1,0 +1,48 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for poll.h.
+
+file = "poll.h"
+brief = "Synchronous I/O multiplexing via poll()."
+description = '''
+The `pollfd` layout mirrors the Rust definition in the sysapi crate
+(poll.rs).'''
+guard = "_NANVIX_POLL_H"
+scan_crates = ["syscall"]
+content_order = [
+    "types",
+    "raw:0",
+    "section:0",
+]
+
+[[types]]
+text = '''
+typedef unsigned int nfds_t;
+
+/** @brief A descriptor to be polled. */
+struct pollfd {
+    int fd;        /**< File descriptor.        */
+    short events;  /**< Requested events.       */
+    short revents; /**< Returned events.        */
+};'''
+
+[[raw_sections]]
+title = "Event flags"
+text = '''
+#define POLLIN 0x0001
+#define POLLPRI 0x0002
+#define POLLOUT 0x0004
+#define POLLERR 0x0008
+#define POLLHUP 0x0010
+#define POLLNVAL 0x0020
+#define POLLRDNORM POLLIN
+#define POLLWRNORM POLLOUT'''
+
+[[sections]]
+title = "Functions"
+functions = ["poll"]
+
+[overrides]
+poll = '''
+extern int poll(struct pollfd *fds, nfds_t nfds, int timeout);'''

--- a/src/libs/sysapi/headers/pthread.toml
+++ b/src/libs/sysapi/headers/pthread.toml
@@ -1,0 +1,111 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for pthread.h.
+
+file = "pthread.h"
+brief = "Threads."
+description = '''
+Declares the POSIX threads constants and attribute types. The scalar thread
+identifiers are declared in <sys/types.h>; the layouts mirror the Rust
+definitions in the sysapi crate (pthread.rs, sys_types.rs).'''
+includes = ["sched.h", "sys/types.h", "time.h"]
+guard = "_NANVIX_PTHREAD_H"
+scan_crates = ["posix", "syscall"]
+content_order = [
+    "raw:0",
+    "types",
+    "section:0",
+    "section:1",
+    "section:2",
+    "section:3",
+    "section:4",
+    "section:5",
+]
+
+[[types]]
+text = '''
+/** @brief Thread attributes. */
+typedef struct {
+    int is_initialized;            /**< Whether the attributes are initialized. */
+    void *stackaddr;               /**< Stack base address.                     */
+    size_t stacksize;              /**< Stack size.                             */
+    int contentionscope;           /**< Contention scope.                       */
+    int inheritsched;              /**< Inherit-scheduler attribute.            */
+    int schedpolicy;               /**< Scheduling policy.                      */
+    struct sched_param schedparam; /**< Scheduling parameters.                  */
+    int cputime_clock_allowed;     /**< Whether a CPU-time clock is allowed.    */
+    int detachstate;               /**< Detach state.                           */
+} pthread_attr_t;
+
+/** @brief Condition variable attributes. */
+typedef struct {
+    int is_initialized; /**< Whether the attributes are initialized. */
+    clock_t clock;      /**< Clock used for timeouts.                */
+} pthread_condattr_t;
+
+/** @brief Mutex attributes. */
+typedef struct {
+    int is_initialized; /**< Whether the attributes are initialized. */
+    int type;           /**< Type of mutex.                          */
+    int recursive;      /**< Whether the mutex is recursive.         */
+} pthread_mutexattr_t;
+
+/** @brief Read-write lock attributes. */
+typedef struct {
+    int is_initialized; /**< Whether the attributes are initialized. */
+} pthread_rwlockattr_t;
+
+/** @brief One-time initialization control. */
+typedef struct {
+    int is_initialized; /**< Whether the control is initialized. */
+    int init_executed;  /**< Whether the initializer has run.    */
+} pthread_once_t;
+
+/** @brief Static initializer for a pthread_once_t control variable. */
+#define PTHREAD_ONCE_INIT                                                                          \
+    {                                                                                              \
+        1, 0                                                                                       \
+    }'''
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+#define PTHREAD_MUTEX_NORMAL 0 /**< Mutex that does not detect deadlock. */
+#define PTHREAD_MUTEX_RECURSIVE 1 /**< Mutex that allows recursive locking. */
+#define PTHREAD_MUTEX_ERRORCHECK 2 /**< Mutex that provides error checking. */
+#define PTHREAD_MUTEX_DEFAULT 3 /**< Default mutex type. */
+#define PTHREAD_MUTEX_INITIALIZER 0xffffffff /**< Static mutex initializer. */
+#define PTHREAD_COND_INITIALIZER 0xffffffff /**< Static condition variable initializer. */
+#define PTHREAD_RWLOCK_INITIALIZER 0xffffffff /**< Static read-write lock initializer. */
+#define PTHREAD_NULL 0 /**< Null thread identifier. */
+#define PTHREAD_CREATE_JOINABLE 0 /**< Thread is created joinable. */
+#define PTHREAD_CREATE_DETACHED 1 /**< Thread is created detached. */'''
+
+[[sections]]
+title = "Threads"
+functions = ["pthread_create", "pthread_join", "pthread_detach", "pthread_kill", "pthread_exit", "pthread_self", "pthread_equal"]
+
+[[sections]]
+title = "Thread Attributes"
+functions = ["pthread_attr_init", "pthread_attr_destroy", "pthread_attr_getdetachstate", "pthread_attr_setdetachstate", "pthread_attr_getstack", "pthread_attr_setstack", "pthread_attr_getstacksize", "pthread_attr_setstacksize", "pthread_attr_getstackaddr", "pthread_attr_setstackaddr", "pthread_getattr_np"]
+
+[[sections]]
+title = "Mutexes"
+functions = ["pthread_mutex_init", "pthread_mutex_destroy", "pthread_mutex_lock", "pthread_mutex_unlock", "pthread_mutex_trylock", "pthread_mutex_timedlock", "pthread_mutexattr_init", "pthread_mutexattr_destroy"]
+
+[[sections]]
+title = "Condition Variables"
+functions = ["pthread_cond_init", "pthread_cond_destroy", "pthread_cond_signal", "pthread_cond_broadcast", "pthread_cond_wait", "pthread_cond_timedwait", "pthread_condattr_init", "pthread_condattr_setclock"]
+
+[[sections]]
+title = "Read-Write Locks"
+functions = ["pthread_rwlock_init", "pthread_rwlock_destroy", "pthread_rwlock_rdlock", "pthread_rwlock_wrlock", "pthread_rwlock_unlock"]
+
+[[sections]]
+title = "Thread-Specific Data"
+functions = ["pthread_key_create", "pthread_key_delete", "pthread_getspecific", "pthread_setspecific", "pthread_once"]
+
+[overrides]
+pthread_create = '''
+extern int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg);'''

--- a/src/libs/sysapi/headers/pwd.toml
+++ b/src/libs/sysapi/headers/pwd.toml
@@ -1,0 +1,40 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for pwd.h.
+
+file = "pwd.h"
+brief = "Password database."
+description = '''
+The `passwd` layout mirrors the Rust definition in the sysapi crate (pwd.rs).'''
+includes = ["sys/types.h"]
+guard = "_NANVIX_PWD_H"
+scan_crates = ["posix"]
+content_order = [
+    "raw:0",
+    "section:0",
+]
+
+[[raw_sections]]
+title = ""
+text = '''
+/** @brief Password database entry. */
+struct passwd {
+    char *pw_name;   /**< User name.            */
+    char *pw_passwd; /**< Encrypted password.   */
+    uid_t pw_uid;    /**< User ID.              */
+    gid_t pw_gid;    /**< Group ID.             */
+    char *pw_gecos;  /**< Real name / comment.  */
+    char *pw_dir;    /**< Home directory.       */
+    char *pw_shell;  /**< Login shell.          */
+};'''
+
+[[sections]]
+title = ""
+functions = ["getpwuid", "getpwnam"]
+
+[overrides]
+getpwuid = '''
+extern struct passwd *getpwuid(uid_t uid);'''
+getpwnam = '''
+extern struct passwd *getpwnam(const char *name);'''

--- a/src/libs/sysapi/headers/sched.toml
+++ b/src/libs/sysapi/headers/sched.toml
@@ -1,0 +1,42 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sched.h.
+# Constants and the sched_param layout mirror src/libs/sysapi/src/sched.rs.
+
+file = "sched.h"
+brief = "Execution scheduling."
+description = """
+Declares the scheduling policy constants and the sched_param structure used to
+get and set scheduling parameters. Mirrors the Rust definitions in the sysapi
+crate (sched.rs)."""
+guard = "_NANVIX_SCHED_H"
+scan_crates = ["syscall"]
+content_order = ["macros", "types:0", "section:0"]
+
+[[macros]]
+name = "SCHED_OTHER"
+value = "0"
+comment = "Another scheduling policy."
+
+[[macros]]
+name = "SCHED_FIFO"
+value = "1"
+comment = "First in-first out scheduling policy."
+
+[[macros]]
+name = "SCHED_RR"
+value = "2"
+comment = "Round-robin scheduling policy."
+
+[[types]]
+text = """
+/** @brief Scheduling parameters. */
+struct sched_param {
+    int sched_priority; /**< Process or thread execution scheduling priority. */
+};
+"""
+
+[[sections]]
+title = "Scheduling"
+functions = ["sched_yield"]

--- a/src/libs/sysapi/headers/strings.toml
+++ b/src/libs/sysapi/headers/strings.toml
@@ -1,0 +1,25 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for strings.h.
+
+file = "strings.h"
+brief = "Legacy BSD string operations."
+description = '''
+'''
+includes = ["stddef.h"]
+guard = "_NANVIX_STRINGS_H"
+scan_crates = ["libc_string"]
+content_order = ["section:0"]
+
+[[sections]]
+title = ""
+functions = ["strcasecmp", "strncasecmp", "bcmp", "bcopy", "bzero", "ffs"]
+
+[overrides]
+strcasecmp = "extern int strcasecmp(const char *s1, const char *s2);"
+strncasecmp = "extern int strncasecmp(const char *s1, const char *s2, size_t n);"
+bcmp = "extern int bcmp(const void *s1, const void *s2, size_t n);"
+bcopy = "extern void bcopy(const void *src, void *dest, size_t n);"
+bzero = "extern void bzero(void *s, size_t n);"
+ffs = "extern int ffs(int i);"

--- a/src/libs/sysapi/headers/sys__stdint.toml
+++ b/src/libs/sysapi/headers/sys__stdint.toml
@@ -1,0 +1,14 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/_stdint.h.
+
+file = "sys/_stdint.h"
+brief = "Compatibility shim for newlib's internal `<sys/_stdint.h>`."
+description = '''
+Some ports (e.g. QuickJS) include the newlib-internal `<sys/_stdint.h>`
+directly to obtain the fixed-width integer types. Nanvix declares those types
+in `<stdint.h>`, so forward to it.'''
+includes = ["stdint.h"]
+guard = "_NANVIX_SYS__STDINT_H"
+extern_c = false

--- a/src/libs/sysapi/headers/sys_ioctl.toml
+++ b/src/libs/sysapi/headers/sys_ioctl.toml
@@ -1,0 +1,44 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/ioctl.h.
+
+file = "sys/ioctl.h"
+brief = "Device control operations."
+description = '''
+Declares `ioctl()` and the terminal window-size request used by interactive
+ports. Nanvix has no interactive terminal in standalone mode, so the
+terminal requests fail; the definitions exist so such ports compile and link.'''
+guard = "_NANVIX_SYS_IOCTL_H"
+scan_crates = ["posix"]
+content_order = [
+    "raw:0",
+    "raw:1",
+    "section:0",
+]
+
+[[raw_sections]]
+title = "Structures"
+text = '''
+/** @brief Terminal window size. */
+struct winsize {
+    unsigned short ws_row;    /**< Rows, in characters.    */
+    unsigned short ws_col;    /**< Columns, in characters. */
+    unsigned short ws_xpixel; /**< Horizontal size, pixels. */
+    unsigned short ws_ypixel; /**< Vertical size, pixels.   */
+};'''
+
+[[raw_sections]]
+title = "Requests"
+text = '''
+#define TIOCGWINSZ 0x5413
+#define TIOCSWINSZ 0x5414
+#define FIONREAD 0x541b'''
+
+[[sections]]
+title = "Functions"
+functions = ["ioctl"]
+
+[overrides]
+ioctl = '''
+extern int ioctl(int fd, unsigned long request, ...);'''

--- a/src/libs/sysapi/headers/sys_mman.toml
+++ b/src/libs/sysapi/headers/sys_mman.toml
@@ -1,0 +1,83 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/mman.h.
+# Constants mirror src/libs/sysapi/src/sys_mman.rs; the function prototypes are
+# generated from the extern "C" signatures in the syscall crate.
+
+file = "sys/mman.h"
+brief = "Memory management declarations."
+description = """
+Declares the memory-mapping protection and flag constants and the mmap/munmap
+interfaces. Constants mirror the Rust definitions in the sysapi crate
+(sys_mman.rs)."""
+includes = ["sys/types.h"]
+guard = "_NANVIX_SYS_MMAN_H"
+scan_crates = ["syscall"]
+content_order = ["macros", "raw:0", "section:0", "section:1", "section:2"]
+
+[[macros]]
+name = "PROT_NONE"
+value = "0x0"
+comment = "Page cannot be accessed."
+
+[[macros]]
+name = "PROT_READ"
+value = "0x1"
+comment = "Page can be read."
+
+[[macros]]
+name = "PROT_WRITE"
+value = "0x2"
+comment = "Page can be written."
+
+[[macros]]
+name = "PROT_EXEC"
+value = "0x4"
+comment = "Page can be executed."
+
+[[macros]]
+name = "MAP_SHARED"
+value = "0x01"
+comment = "Share changes."
+
+[[macros]]
+name = "MAP_PRIVATE"
+value = "0x02"
+comment = "Changes are private."
+
+[[macros]]
+name = "MAP_FIXED"
+value = "0x10"
+comment = "Interpret the address exactly."
+
+[[macros]]
+name = "MAP_ANONYMOUS"
+value = "0x20"
+comment = "Anonymous mapping (not backed by a file)."
+
+[[raw_sections]]
+title = ""
+text = """
+/** @brief Returned by mmap() on failure. */
+#define MAP_FAILED ((void *)-1)
+"""
+
+[[sections]]
+title = "Memory Mapping"
+functions = ["mmap", "munmap"]
+
+[overrides]
+mmap = "extern void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);"
+munmap = "extern int munmap(void *addr, size_t length);"
+mprotect = "extern int mprotect(void *addr, size_t length, int prot);"
+mlock = "extern int mlock(const void *addr, size_t len);"
+munlock = "extern int munlock(const void *addr, size_t len);"
+
+[[sections]]
+title = "Memory Protection"
+functions = ["mprotect"]
+
+[[sections]]
+title = "Memory Locking"
+functions = ["mlock", "munlock"]

--- a/src/libs/sysapi/headers/sys_param.toml
+++ b/src/libs/sysapi/headers/sys_param.toml
@@ -1,0 +1,44 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/param.h.
+
+file = "sys/param.h"
+brief = "Legacy system parameters and helper macros."
+description = '''
+'''
+includes = ["limits.h", "sys/types.h"]
+guard = "_NANVIX_SYS_PARAM_H"
+content_order = [
+    "raw:0",
+    "raw:1",
+]
+
+[[raw_sections]]
+title = "Limits"
+text = '''
+#ifndef MAXPATHLEN
+#ifdef PATH_MAX
+#define MAXPATHLEN PATH_MAX
+#else
+#define MAXPATHLEN 4096
+#endif
+#endif
+
+#ifndef NBBY
+#define NBBY 8 /**< Number of bits in a byte. */
+#endif'''
+
+[[raw_sections]]
+title = "Helper macros"
+text = '''
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#define howmany(x, y) (((x) + ((y) - 1)) / (y))
+#define roundup(x, y) ((((x) + ((y) - 1)) / (y)) * (y))
+#define powerof2(x) ((((x) - 1) & (x)) == 0)'''

--- a/src/libs/sysapi/headers/sys_select.toml
+++ b/src/libs/sysapi/headers/sys_select.toml
@@ -1,0 +1,55 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/select.h.
+
+file = "sys/select.h"
+brief = "Synchronous I/O multiplexing."
+description = '''
+Declares `fd_set`, the `FD_*` manipulation macros, and `select()`. The
+`fd_set` layout mirrors the Rust definition in the sysapi crate
+(sys_select.rs).'''
+includes = ["sys/time.h", "sys/types.h"]
+guard = "_NANVIX_SYS_SELECT_H"
+scan_crates = ["syscall"]
+content_order = [
+    "types",
+    "raw:0",
+    "section:0",
+]
+
+[[types]]
+text = '''
+#define FD_SETSIZE 64
+
+#define _NANVIX_NFDBITS (8 * (int)sizeof(unsigned long))
+
+/** @brief A set of file descriptors. */
+typedef struct {
+    unsigned long fds_bits[FD_SETSIZE / (8 * sizeof(unsigned long))];
+} fd_set;'''
+
+[[raw_sections]]
+title = "Manipulation macros"
+text = '''
+#define FD_ZERO(set)                                                                               \
+    do {                                                                                           \
+        unsigned int _i;                                                                           \
+        for (_i = 0; _i < sizeof(fd_set) / sizeof(unsigned long); _i++)                            \
+            ((fd_set *)(set))->fds_bits[_i] = 0;                                                   \
+    } while (0)
+#define FD_SET(fd, set)                                                                            \
+    ((set)->fds_bits[(fd) / _NANVIX_NFDBITS] |= (1UL << ((fd) % _NANVIX_NFDBITS)))
+#define FD_CLR(fd, set)                                                                            \
+    ((set)->fds_bits[(fd) / _NANVIX_NFDBITS] &= ~(1UL << ((fd) % _NANVIX_NFDBITS)))
+#define FD_ISSET(fd, set)                                                                          \
+    (((set)->fds_bits[(fd) / _NANVIX_NFDBITS] & (1UL << ((fd) % _NANVIX_NFDBITS))) != 0)'''
+
+[[sections]]
+title = "Functions"
+functions = ["select"]
+
+[overrides]
+select = '''
+extern int select(
+    int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);'''

--- a/src/libs/sysapi/headers/sys_socket.toml
+++ b/src/libs/sysapi/headers/sys_socket.toml
@@ -1,0 +1,84 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/socket.h.
+
+file = "sys/socket.h"
+brief = "Main sockets header."
+description = '''
+Declares the socket address structures, the address-family and socket-type
+constants, and the core socket interfaces. The constants and layouts mirror the
+Rust definitions in the sysapi crate (sys_socket.rs).'''
+includes = ["sys/types.h"]
+guard = "_NANVIX_SYS_SOCKET_H"
+scan_crates = ["syscall"]
+content_order = [
+    "raw:0",
+    "types",
+    "section:0",
+]
+
+[[types]]
+text = '''
+/** @brief Socket address family type. */
+typedef unsigned char sa_family_t;
+
+/** @brief Socket address length type. */
+typedef unsigned int socklen_t;
+
+/** @brief Generic socket address. */
+struct sockaddr {
+    unsigned char sa_len;    /**< Total length.   */
+    sa_family_t sa_family;   /**< Address family. */
+    char sa_data[14];        /**< Address data.   */
+};
+
+/** @brief Socket address storage, large enough for any address family. */
+struct sockaddr_storage {
+    unsigned char ss_len;    /**< Total length.   */
+    sa_family_t ss_family;   /**< Address family. */
+    char __ss_pad1[14];      /**< Padding.        */
+};
+
+/** @brief Linger option for SO_LINGER. */
+struct linger {
+    int l_onoff;  /**< Whether linger is enabled. */
+    int l_linger; /**< Linger time, in seconds.   */
+};'''
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+#define AF_UNSPEC 0 /**< Unspecified address family. */
+#define AF_UNIX 1 /**< UNIX domain sockets. */
+#define AF_INET 2 /**< Internet domain sockets (IPv4). */
+#define AF_INET6 10 /**< Internet domain sockets (IPv6). */
+#define SOCK_STREAM 1 /**< Sequenced, reliable, connection-mode byte streams. */
+#define SOCK_DGRAM 2 /**< Connectionless, unreliable datagrams. */
+#define SOCK_RAW 3 /**< Raw protocol interface. */
+#define SOCK_SEQPACKET 5 /**< Sequenced, reliable, connection-mode records. */
+#define SOL_SOCKET 0xffff /**< Options at the socket level. */
+#define SO_REUSEADDR 0x0004 /**< Reuse of local addresses is supported. */
+#define SO_KEEPALIVE 0x0008 /**< Connections are kept alive. */
+#define SO_BROADCAST 0x0020 /**< Broadcast messages are supported. */
+#define SO_LINGER 0x0080 /**< Socket lingers on close. */
+#define SO_SNDBUF 0x1001 /**< Send buffer size. */
+#define SO_RCVBUF 0x1002 /**< Receive buffer size. */
+#define SO_ERROR 0x1007 /**< Socket error status. */
+#define SO_TYPE 0x1008 /**< Socket type. */
+#define SHUT_RD 0 /**< Disable further receives. */
+#define SHUT_WR 1 /**< Disable further sends. */
+#define MSG_OOB 0x0001 /**< Out-of-band data. */
+#define MSG_PEEK 0x0002 /**< Leave received data in queue. */
+#define MSG_DONTROUTE 0x0004 /**< Send without using routing tables. */
+#define MSG_TRUNC 0x0020 /**< Normal data truncated. */
+#define MSG_DONTWAIT 0x0040 /**< Nonblocking I/O. */
+#define MSG_WAITALL 0x0100 /**< Wait for full request or error. */
+#define MSG_NOSIGNAL 0x4000 /**< Do not generate SIGPIPE. */
+#define SHUT_RDWR 2 /**< Disable further sends and receives. */
+#define SOMAXCONN 128 /**< Maximum listen backlog. */
+#define _SS_PADSIZE 14 /**< Size of the sockaddr_storage padding field. */'''
+
+[[sections]]
+title = "Sockets"
+functions = ["socket", "socketpair", "bind", "listen", "accept", "connect", "getsockname", "getpeername", "send", "recv", "sendto", "recvfrom", "setsockopt", "getsockopt", "shutdown"]

--- a/src/libs/sysapi/headers/sys_stat.toml
+++ b/src/libs/sysapi/headers/sys_stat.toml
@@ -1,0 +1,95 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/stat.h.
+
+file = "sys/stat.h"
+brief = "File status."
+description = '''
+Declares the file-mode constants and the stat structure used to report file
+status. The layout mirrors the Rust definition in the sysapi crate
+(sys_stat.rs).'''
+includes = ["sys/types.h", "time.h"]
+guard = "_NANVIX_SYS_STAT_H"
+scan_crates = ["posix", "syscall"]
+content_order = [
+    "raw:0",
+    "types",
+    "section:0",
+]
+
+[[types]]
+text = '''
+/** @brief File status. */
+struct stat {
+    dev_t st_dev;             /**< Device ID.                      */
+    ino_t st_ino;             /**< File serial number.             */
+    mode_t st_mode;           /**< File mode.                      */
+    nlink_t st_nlink;         /**< Link count.                     */
+    uid_t st_uid;             /**< User ID of file.                */
+    gid_t st_gid;             /**< Group ID of file.               */
+    dev_t st_rdev;            /**< Device ID (if special file).    */
+    off_t st_size;            /**< File size in bytes.             */
+    struct timespec st_atim;  /**< Last data access timestamp.     */
+    struct timespec st_mtim;  /**< Last data modification timestamp.*/
+    struct timespec st_ctim;  /**< Last status change timestamp.   */
+    blksize_t st_blksize;     /**< Preferred I/O block size.       */
+    blkcnt_t st_blocks;       /**< Number of blocks allocated.     */
+};
+
+/* POSIX timestamp field shorthands. */
+#define st_atime st_atim.tv_sec
+#define st_mtime st_mtim.tv_sec
+#define st_ctime st_ctim.tv_sec
+
+/* File-type test macros. */
+#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
+#define S_ISCHR(m)  (((m) & S_IFMT) == S_IFCHR)
+#define S_ISDIR(m)  (((m) & S_IFMT) == S_IFDIR)
+#define S_ISBLK(m)  (((m) & S_IFMT) == S_IFBLK)
+#define S_ISREG(m)  (((m) & S_IFMT) == S_IFREG)
+#define S_ISLNK(m)  (((m) & S_IFMT) == S_IFLNK)
+#define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)'''
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+#define S_IRWXU 0700 /**< Read, write, execute by owner. */
+#define S_IRUSR 0400 /**< Read by owner. */
+#define S_IWUSR 0200 /**< Write by owner. */
+#define S_IXUSR 0100 /**< Execute by owner. */
+#define S_IRWXG 0070 /**< Read, write, execute by group. */
+#define S_IRGRP 0040 /**< Read by group. */
+#define S_IWGRP 0020 /**< Write by group. */
+#define S_IXGRP 0010 /**< Execute by group. */
+#define S_IRWXO 0007 /**< Read, write, execute by others. */
+#define S_IROTH 0004 /**< Read by others. */
+#define S_IWOTH 0002 /**< Write by others. */
+#define S_IXOTH 0001 /**< Execute by others. */
+#define S_IFMT 0170000 /**< Mask for the file-type bit fields. */
+#define S_IFIFO 0010000 /**< FIFO. */
+#define S_IFCHR 0020000 /**< Character device. */
+#define S_IFDIR 0040000 /**< Directory. */
+#define S_IFBLK 0060000 /**< Block device. */
+#define S_IFREG 0100000 /**< Regular file. */
+#define S_IFLNK 0120000 /**< Symbolic link. */
+#define S_IFSOCK 0140000 /**< Socket. */
+#define S_ISUID 04000 /**< Set-user-ID on execution. */
+#define S_ISGID 02000 /**< Set-group-ID on execution. */
+#define S_ISVTX 01000 /**< Sticky bit. */'''
+
+[[sections]]
+title = "File Status"
+functions = ["stat", "fstat", "lstat", "mkdir", "mkdirat", "umask", "fchmodat", "lchmod", "futimens", "utimensat", "chmod", "fchmod"]
+
+[overrides]
+umask = '''
+extern mode_t umask(mode_t mask);'''
+fchmodat = '''
+extern int fchmodat(int dirfd, const char *pathname, mode_t mode, int flags);'''
+lchmod = '''
+extern int lchmod(const char *pathname, mode_t mode);'''
+futimens = '''
+extern int futimens(int fd, const struct timespec times[2]);'''
+utimensat = '''
+extern int utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags);'''

--- a/src/libs/sysapi/headers/sys_time.toml
+++ b/src/libs/sysapi/headers/sys_time.toml
@@ -1,0 +1,86 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/time.h.
+
+file = "sys/time.h"
+brief = "Time-of-day types and interfaces."
+description = '''
+Declares `struct timeval`, `struct timezone`, and the `gettimeofday`/`utimes`
+interfaces. The `timeval` layout mirrors the Rust definition in the sysapi
+crate (sys_select.rs).'''
+includes = ["sys/types.h"]
+guard = "_NANVIX_SYS_TIME_H"
+content_order = [
+    "raw:0",
+    "raw:1",
+    "raw:2",
+]
+
+[[raw_sections]]
+title = "Structures"
+text = '''
+/**
+ * @brief Time interval expressed in seconds and microseconds.
+ */
+struct timeval {
+    time_t tv_sec;       /**< Seconds.      */
+    suseconds_t tv_usec; /**< Microseconds. */
+};
+
+/**
+ * @brief Time-zone information (obsolete; retained for compatibility).
+ */
+struct timezone {
+    int tz_minuteswest; /**< Minutes west of Greenwich. */
+    int tz_dsttime;     /**< Type of DST correction.    */
+};'''
+
+[[raw_sections]]
+title = "Convenience macros"
+text = '''
+#define timerisset(tvp) ((tvp)->tv_sec || (tvp)->tv_usec)
+#define timerclear(tvp) ((tvp)->tv_sec = (tvp)->tv_usec = 0)
+#define timercmp(a, b, CMP)                                                                        \
+    (((a)->tv_sec == (b)->tv_sec) ? ((a)->tv_usec CMP(b)->tv_usec) : ((a)->tv_sec CMP(b)->tv_sec))
+#define timeradd(a, b, result)                                                                     \
+    do {                                                                                           \
+        (result)->tv_sec = (a)->tv_sec + (b)->tv_sec;                                              \
+        (result)->tv_usec = (a)->tv_usec + (b)->tv_usec;                                           \
+        if ((result)->tv_usec >= 1000000) {                                                        \
+            ++(result)->tv_sec;                                                                     \
+            (result)->tv_usec -= 1000000;                                                          \
+        }                                                                                          \
+    } while (0)
+#define timersub(a, b, result)                                                                     \
+    do {                                                                                           \
+        (result)->tv_sec = (a)->tv_sec - (b)->tv_sec;                                              \
+        (result)->tv_usec = (a)->tv_usec - (b)->tv_usec;                                           \
+        if ((result)->tv_usec < 0) {                                                               \
+            --(result)->tv_sec;                                                                     \
+            (result)->tv_usec += 1000000;                                                          \
+        }                                                                                          \
+    } while (0)'''
+
+[[raw_sections]]
+title = "Functions"
+text = '''
+/**
+ * @brief Retrieves the current time of day.
+ *
+ * @param tv Buffer that receives the current time.
+ * @param tz Time-zone buffer (obsolete; should be NULL).
+ *
+ * @returns Zero on success, or -1 on failure with `errno` set.
+ */
+extern int gettimeofday(struct timeval *tv, void *tz);
+
+/**
+ * @brief Sets the access and modification times of a file.
+ *
+ * @param filename Path of the target file.
+ * @param times    Two-element array of access and modification times.
+ *
+ * @returns Zero on success, or -1 on failure with `errno` set.
+ */
+extern int utimes(const char *filename, const struct timeval times[2]);'''

--- a/src/libs/sysapi/headers/sys_times.toml
+++ b/src/libs/sysapi/headers/sys_times.toml
@@ -1,0 +1,31 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/times.h.
+# The tms layout mirrors src/libs/sysapi/src/sys_times.rs; times() is generated
+# from the posix crate.
+
+file = "sys/times.h"
+brief = "Process times."
+description = """
+Declares the tms structure and the times() interface. The layout mirrors the
+Rust definition in the sysapi crate (sys_times.rs)."""
+includes = ["sys/types.h"]
+guard = "_NANVIX_SYS_TIMES_H"
+scan_crates = ["posix"]
+content_order = ["types:0", "section:0"]
+
+[[types]]
+text = """
+/** @brief Process and waited-for-children CPU times, in clock ticks. */
+struct tms {
+    clock_t tms_utime;  /**< User CPU time.                    */
+    clock_t tms_stime;  /**< System CPU time.                  */
+    clock_t tms_cutime; /**< User CPU time of terminated children.  */
+    clock_t tms_cstime; /**< System CPU time of terminated children.*/
+};
+"""
+
+[[sections]]
+title = "Process Times"
+functions = ["times"]

--- a/src/libs/sysapi/headers/sys_types.toml
+++ b/src/libs/sysapi/headers/sys_types.toml
@@ -1,0 +1,66 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/types.h.
+
+file = "sys/types.h"
+brief = "System data types."
+description = '''
+Declares the primitive system data types. The layouts mirror the Rust
+definitions in the sysapi crate (sys_types.rs).'''
+includes = ["stddef.h", "stdint.h"]
+guard = "_NANVIX_SYS_TYPES_H"
+content_order = [
+    "types",
+]
+
+[[types]]
+text = '''
+/* Time types — guarded to coexist with <time.h>. */
+#ifndef _TIME_T_DEFINED
+#define _TIME_T_DEFINED
+typedef long long time_t;
+#endif
+
+#ifndef _CLOCK_T_DEFINED
+#define _CLOCK_T_DEFINED
+typedef long long clock_t;
+#endif
+
+#ifndef _CLOCKID_T_DEFINED
+#define _CLOCKID_T_DEFINED
+typedef int clockid_t;
+#endif
+
+/* A count of bytes or an error indication (companion of size_t). */
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
+typedef int ssize_t;
+#endif
+
+/* File-system and process types. */
+typedef long long blkcnt_t;          /**< File block counts.              */
+typedef long long blksize_t;         /**< Block sizes.                    */
+typedef unsigned long long dev_t;    /**< Device IDs.                     */
+typedef unsigned int gid_t;          /**< Group IDs.                      */
+typedef unsigned long long ino_t;    /**< File serial numbers.            */
+typedef unsigned int mode_t;         /**< File attributes.                */
+typedef unsigned long long nlink_t;  /**< Link counts.                    */
+typedef long long off_t;             /**< File sizes and offsets.         */
+typedef int pid_t;                   /**< Process and process group IDs.  */
+typedef unsigned short reclen_t;     /**< Directory entry lengths.        */
+typedef unsigned int uid_t;          /**< User IDs.                       */
+typedef long suseconds_t;            /**< Time in microseconds.           */
+
+/* POSIX threads scalar types (opaque identifiers). */
+typedef unsigned int pthread_t;        /**< Thread identifier.            */
+typedef unsigned int pthread_cond_t;   /**< Condition variable.           */
+typedef unsigned int pthread_key_t;    /**< Thread-specific data key.     */
+typedef unsigned int pthread_mutex_t;  /**< Mutex.                        */
+typedef unsigned int pthread_rwlock_t; /**< Read-write lock.              */'''
+
+[trailer]
+text = '''
+/* Expose fd_set / select() transitively, as common platforms do. Placed after
+ * the type definitions; the include guard makes the back-reference a no-op. */
+#include <sys/select.h>'''

--- a/src/libs/sysapi/headers/sys_uio.toml
+++ b/src/libs/sysapi/headers/sys_uio.toml
@@ -1,0 +1,29 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/uio.h.
+# The iovec layout mirrors src/libs/sysapi/src/sys_uio.rs; prototypes are
+# generated from the posix crate.
+
+file = "sys/uio.h"
+brief = "Vectored I/O."
+description = """
+Declares the iovec structure and the scatter/gather I/O interfaces. The layout
+mirrors the Rust definition in the sysapi crate (sys_uio.rs)."""
+includes = ["sys/types.h"]
+guard = "_NANVIX_SYS_UIO_H"
+scan_crates = ["posix"]
+content_order = ["types:0", "section:0"]
+
+[[types]]
+text = """
+/** @brief An I/O vector. */
+struct iovec {
+    void *iov_base; /**< Base address of the buffer.  */
+    size_t iov_len; /**< Length of the buffer.        */
+};
+"""
+
+[[sections]]
+title = "Vectored I/O"
+functions = ["readv", "writev", "preadv", "pwritev"]

--- a/src/libs/sysapi/headers/sys_un.toml
+++ b/src/libs/sysapi/headers/sys_un.toml
@@ -1,0 +1,29 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/un.h.
+# The sockaddr_un layout mirrors src/libs/sysapi/src/sys_un.rs.
+
+file = "sys/un.h"
+brief = "UNIX domain socket address."
+description = """
+Declares the UNIX-domain socket address structure. The layout mirrors the Rust
+definition in the sysapi crate (sys_un.rs)."""
+includes = ["sys/socket.h"]
+guard = "_NANVIX_SYS_UN_H"
+content_order = ["macros", "types:0"]
+
+[[macros]]
+name = "SUNPATHLEN"
+value = "14"
+comment = "Size of the sun_path field."
+
+[[types]]
+text = """
+/** @brief UNIX domain socket address. */
+struct sockaddr_un {
+    unsigned char sun_len;     /**< Total length.   */
+    sa_family_t sun_family;    /**< Address family. */
+    char sun_path[SUNPATHLEN]; /**< Socket path.    */
+};
+"""

--- a/src/libs/sysapi/headers/sys_utsname.toml
+++ b/src/libs/sysapi/headers/sys_utsname.toml
@@ -1,0 +1,36 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/utsname.h.
+# The utsname layout mirrors src/libs/syscall/src/sys/utsname/mod.rs; uname() is
+# generated from the posix crate.
+
+file = "sys/utsname.h"
+brief = "System name structure."
+description = """
+Declares the utsname structure and the uname() interface. The layout mirrors
+the Rust definition in the syscall crate (sys/utsname)."""
+guard = "_NANVIX_SYS_UTSNAME_H"
+scan_crates = ["posix"]
+content_order = ["macros", "types:0", "section:0"]
+
+[[macros]]
+name = "_UTSNAME_LENGTH"
+value = "64"
+comment = "Length of each utsname field."
+
+[[types]]
+text = """
+/** @brief System name structure. */
+struct utsname {
+    char sysname[_UTSNAME_LENGTH];  /**< Operating system name.   */
+    char nodename[_UTSNAME_LENGTH]; /**< Network node name.       */
+    char release[_UTSNAME_LENGTH];  /**< Operating system release.*/
+    char version[_UTSNAME_LENGTH];  /**< Operating system version.*/
+    char machine[_UTSNAME_LENGTH];  /**< Hardware identifier.     */
+};
+"""
+
+[[sections]]
+title = "System Information"
+functions = ["uname"]

--- a/src/libs/sysapi/headers/sys_wait.toml
+++ b/src/libs/sysapi/headers/sys_wait.toml
@@ -1,0 +1,41 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for sys/wait.h.
+
+file = "sys/wait.h"
+brief = "Process-termination wait interface."
+description = '''
+'''
+includes = ["sys/types.h"]
+guard = "_NANVIX_SYS_WAIT_H"
+scan_crates = ["syscall"]
+content_order = [
+    "raw:0",
+    "raw:1",
+    "section:0",
+]
+
+[[raw_sections]]
+title = "Options"
+text = '''
+#define WNOHANG 1
+#define WUNTRACED 2'''
+
+[[raw_sections]]
+title = "Status-decoding macros"
+text = '''
+#define WIFEXITED(status) (((status) & 0x7f) == 0)
+#define WEXITSTATUS(status) (((status) >> 8) & 0xff)
+#define WIFSIGNALED(status) (((status) & 0x7f) != 0 && ((status) & 0x7f) != 0x7f)
+#define WTERMSIG(status) ((status) & 0x7f)
+#define WIFSTOPPED(status) (((status) & 0xff) == 0x7f)
+#define WSTOPSIG(status) WEXITSTATUS(status)'''
+
+[[sections]]
+title = "Functions"
+functions = ["waitpid", "wait"]
+
+[overrides]
+wait = '''
+extern pid_t wait(int *status);'''

--- a/src/libs/sysapi/headers/syslog.toml
+++ b/src/libs/sysapi/headers/syslog.toml
@@ -1,0 +1,64 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for syslog.h.
+
+file = "syslog.h"
+brief = "System logging interface."
+description = '''
+Nanvix has no system log daemon in standalone mode, so these routines are
+no-ops; the definitions exist so that ports referencing them compile and link.'''
+guard = "_NANVIX_SYSLOG_H"
+scan_crates = ["nanvix_libc"]
+content_order = ["raw:0", "raw:1", "raw:2", "section:0"]
+
+[[raw_sections]]
+title = "Options (openlog)"
+text = '''
+#define LOG_PID 0x01
+#define LOG_CONS 0x02
+#define LOG_ODELAY 0x04
+#define LOG_NDELAY 0x08
+#define LOG_NOWAIT 0x10
+#define LOG_PERROR 0x20'''
+
+[[raw_sections]]
+title = "Facilities"
+text = '''
+#define LOG_KERN (0 << 3)
+#define LOG_USER (1 << 3)
+#define LOG_MAIL (2 << 3)
+#define LOG_DAEMON (3 << 3)
+#define LOG_AUTH (4 << 3)
+#define LOG_SYSLOG (5 << 3)
+#define LOG_LPR (6 << 3)
+#define LOG_LOCAL0 (16 << 3)'''
+
+[[raw_sections]]
+title = "Priorities"
+text = '''
+#define LOG_EMERG 0
+#define LOG_ALERT 1
+#define LOG_CRIT 2
+#define LOG_ERR 3
+#define LOG_WARNING 4
+#define LOG_NOTICE 5
+#define LOG_INFO 6
+#define LOG_DEBUG 7
+
+#define LOG_MASK(pri) (1 << (pri))
+#define LOG_UPTO(pri) ((1 << ((pri) + 1)) - 1)'''
+
+[[sections]]
+title = "Functions"
+functions = ["openlog", "closelog", "syslog", "setlogmask"]
+
+[overrides]
+openlog = '''
+extern void openlog(const char *ident, int option, int facility);'''
+closelog = '''
+extern void closelog(void);'''
+syslog = '''
+extern void syslog(int priority, const char *format, ...);'''
+setlogmask = '''
+extern int setlogmask(int mask);'''

--- a/src/libs/sysapi/headers/termios.toml
+++ b/src/libs/sysapi/headers/termios.toml
@@ -1,0 +1,258 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for termios.h.
+
+file = "termios.h"
+brief = "General terminal interface."
+description = '''
+Declares `struct termios` and the terminal-attribute interfaces. Nanvix has
+no interactive terminal device in standalone mode, so `tcgetattr`/`tcsetattr`
+report that the descriptor is not a terminal; the definitions exist so that
+ports with an interactive mode (e.g. the QuickJS REPL) compile and link.'''
+includes = ["sys/types.h"]
+guard = "_NANVIX_TERMIOS_H"
+scan_crates = ["nanvix_libc", "posix"]
+content_order = [
+    "types",
+    "raw:0",
+    "raw:1",
+    "raw:2",
+    "raw:3",
+    "raw:4",
+    "raw:5",
+    "raw:6",
+    "raw:7",
+    "raw:8",
+    "section:0",
+]
+
+[[types]]
+text = '''
+typedef unsigned int tcflag_t;
+typedef unsigned char cc_t;
+typedef unsigned int speed_t;
+
+#define NCCS 32
+
+struct termios {
+    tcflag_t c_iflag; /**< Input modes.   */
+    tcflag_t c_oflag; /**< Output modes.  */
+    tcflag_t c_cflag; /**< Control modes. */
+    tcflag_t c_lflag; /**< Local modes.   */
+    cc_t c_line;      /**< Line discipline. */
+    cc_t c_cc[NCCS];  /**< Control characters. */
+    speed_t c_ispeed; /**< Input speed.   */
+    speed_t c_ospeed; /**< Output speed.  */
+};'''
+
+[[raw_sections]]
+title = "Input flags (c_iflag)"
+text = '''
+#define IGNBRK 0x0001
+#define BRKINT 0x0002
+#define IGNPAR 0x0004
+#define PARMRK 0x0008
+#define INPCK 0x0010
+#define ISTRIP 0x0020
+#define INLCR 0x0040
+#define IGNCR 0x0080
+#define ICRNL 0x0100
+#define IUCLC 0x0200
+#define IXON 0x0400
+#define IXANY 0x0800
+#define IXOFF 0x1000
+#define IMAXBEL 0x2000
+#define IUTF8 0x4000'''
+
+[[raw_sections]]
+title = "Output flags (c_oflag)"
+text = '''
+#define OPOST 0x0001
+#define OLCUC 0x0002
+#define ONLCR 0x0004
+#define OCRNL 0x0008
+#define ONOCR 0x0010
+#define ONLRET 0x0020
+#define OFILL 0x0040
+#define OFDEL 0x0080
+#define NLDLY 0x0100
+#define NL0 0x0000
+#define NL1 0x0100
+#define CRDLY 0x0600
+#define CR0 0x0000
+#define CR1 0x0200
+#define CR2 0x0400
+#define CR3 0x0600
+#define TABDLY 0x1800
+#define TAB0 0x0000
+#define TAB1 0x0800
+#define TAB2 0x1000
+#define TAB3 0x1800
+#define XTABS 0x1800
+#define BSDLY 0x2000
+#define BS0 0x0000
+#define BS1 0x2000
+#define VTDLY 0x4000
+#define VT0 0x0000
+#define VT1 0x4000
+#define FFDLY 0x8000
+#define FF0 0x0000
+#define FF1 0x8000'''
+
+[[raw_sections]]
+title = "Baud rates (c_cflag)"
+text = '''
+#define CBAUD 0x100f
+#define B0 0x0000
+#define B50 0x0001
+#define B75 0x0002
+#define B110 0x0003
+#define B134 0x0004
+#define B150 0x0005
+#define B200 0x0006
+#define B300 0x0007
+#define B600 0x0008
+#define B1200 0x0009
+#define B1800 0x000a
+#define B2400 0x000b
+#define B4800 0x000c
+#define B9600 0x000d
+#define B19200 0x000e
+#define B38400 0x000f
+#define EXTA B19200
+#define EXTB B38400
+#define CBAUDEX 0x1000
+#define B57600 0x1001
+#define B115200 0x1002
+#define B230400 0x1003
+#define B460800 0x1004
+#define B500000 0x1005
+#define B576000 0x1006
+#define B921600 0x1007
+#define B1000000 0x1008
+#define B1152000 0x1009
+#define B1500000 0x100a
+#define B2000000 0x100b
+#define B2500000 0x100c
+#define B3000000 0x100d
+#define B3500000 0x100e
+#define B4000000 0x100f'''
+
+[[raw_sections]]
+title = "Control flags (c_cflag)"
+text = '''
+#define CSIZE 0x0030
+#define CS5 0x0000
+#define CS6 0x0010
+#define CS7 0x0020
+#define CS8 0x0030
+#define CSTOPB 0x0040
+#define CREAD 0x0080
+#define PARENB 0x0100
+#define PARODD 0x0200
+#define HUPCL 0x0400
+#define CLOCAL 0x0800
+#define CIBAUD 0x100f0000
+#define CMSPAR 0x40000000
+#define CRTSCTS 0x80000000'''
+
+[[raw_sections]]
+title = "Local flags (c_lflag)"
+text = '''
+#define ISIG 0x0001
+#define ICANON 0x0002
+#define XCASE 0x0004
+#define ECHO 0x0008
+#define ECHOE 0x0010
+#define ECHOK 0x0020
+#define ECHONL 0x0040
+#define NOFLSH 0x0080
+#define TOSTOP 0x0100
+#define ECHOCTL 0x0200
+#define ECHOPRT 0x0400
+#define ECHOKE 0x0800
+#define FLUSHO 0x1000
+#define PENDIN 0x4000
+#define IEXTEN 0x8000
+#define EXTPROC 0x10000'''
+
+[[raw_sections]]
+title = "Control-character indices (c_cc)"
+text = '''
+#define VINTR 0
+#define VQUIT 1
+#define VERASE 2
+#define VKILL 3
+#define VEOF 4
+#define VTIME 5
+#define VMIN 6
+#define VSWTC 7
+#define VSTART 8
+#define VSTOP 9
+#define VSUSP 10
+#define VEOL 11
+#define VREPRINT 12
+#define VDISCARD 13
+#define VWERASE 14
+#define VLNEXT 15
+#define VEOL2 16'''
+
+[[raw_sections]]
+title = "Optional actions for tcsetattr()"
+text = '''
+#define TCSANOW 0
+#define TCSADRAIN 1
+#define TCSAFLUSH 2'''
+
+[[raw_sections]]
+title = "Queue selectors for tcflush()"
+text = '''
+#define TCIFLUSH 0
+#define TCOFLUSH 1
+#define TCIOFLUSH 2'''
+
+[[raw_sections]]
+title = "Actions for tcflow()"
+text = '''
+#define TCOOFF 0
+#define TCOON 1
+#define TCIOFF 2
+#define TCION 3'''
+
+[[sections]]
+title = "Functions"
+functions = [
+    "tcgetattr",
+    "tcsetattr",
+    "tcsendbreak",
+    "tcdrain",
+    "tcflush",
+    "tcflow",
+    "cfgetispeed",
+    "cfgetospeed",
+    "cfsetispeed",
+    "cfsetospeed",
+]
+
+[overrides]
+tcgetattr = '''
+extern int tcgetattr(int fd, struct termios *termios_p);'''
+tcsetattr = '''
+extern int tcsetattr(int fd, int optional_actions, const struct termios *termios_p);'''
+tcsendbreak = '''
+extern int tcsendbreak(int fd, int duration);'''
+tcdrain = '''
+extern int tcdrain(int fd);'''
+tcflush = '''
+extern int tcflush(int fd, int queue_selector);'''
+tcflow = '''
+extern int tcflow(int fd, int action);'''
+cfgetispeed = '''
+extern speed_t cfgetispeed(const struct termios *termios_p);'''
+cfgetospeed = '''
+extern speed_t cfgetospeed(const struct termios *termios_p);'''
+cfsetispeed = '''
+extern int cfsetispeed(struct termios *termios_p, speed_t speed);'''
+cfsetospeed = '''
+extern int cfsetospeed(struct termios *termios_p, speed_t speed);'''

--- a/src/libs/sysapi/headers/unistd.toml
+++ b/src/libs/sysapi/headers/unistd.toml
@@ -1,0 +1,130 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for unistd.h.
+
+file = "unistd.h"
+brief = "Standard symbolic constants and types."
+description = '''
+Declares miscellaneous standard constants and the core POSIX process and I/O
+interfaces. Constants mirror the Rust definitions in the sysapi crate
+(unistd.rs); prototypes are generated from the syscall and posix crates.'''
+includes = ["stddef.h", "sys/types.h"]
+guard = "_NANVIX_UNISTD_H"
+scan_crates = ["syscall"]
+content_order = [
+    "raw:0",
+    "raw:1",
+    "section:0",
+    "raw:2",
+    "raw:3",
+]
+
+[[raw_sections]]
+title = "Constants"
+text = '''
+/* POSIX feature-test macros. */
+#ifndef _POSIX_VERSION
+#define _POSIX_VERSION 200809L
+#endif
+#ifndef _POSIX_THREADS
+#define _POSIX_THREADS 200809L
+#endif
+
+#define STDIN_FILENO 0 /**< File descriptor of standard input. */
+#define STDOUT_FILENO 1 /**< File descriptor of standard output. */
+#define STDERR_FILENO 2 /**< File descriptor of standard error. */
+#ifndef SEEK_SET
+#define SEEK_SET 0 /**< Seek relative to start-of-file. */
+#endif
+
+#ifndef SEEK_CUR
+#define SEEK_CUR 1 /**< Seek relative to current position. */
+#endif
+
+#ifndef SEEK_END
+#define SEEK_END 2 /**< Seek relative to end-of-file. */
+#endif
+
+#define _SC_ARG_MAX 0 /**< Maximum length of arguments to exec(). */
+#define _SC_CHILD_MAX 1 /**< Maximum number of processes per user. */
+#define _SC_CLK_TCK 2 /**< Number of clock ticks per second. */
+#define _SC_NGROUPS_MAX 3 /**< Maximum number of supplementary group IDs. */
+#define _SC_OPEN_MAX 4 /**< Maximum number of open files per process. */
+#define _SC_VERSION 7 /**< POSIX.1 version. */
+#define _SC_PAGESIZE 8 /**< Size of a page in bytes. */
+#define _SC_PAGE_SIZE 8 /**< Size of a page in bytes (alias of _SC_PAGESIZE). */
+#define _SC_NPROCESSORS_CONF 9 /**< Number of configured processors. */
+#define _SC_NPROCESSORS_ONLN 10 /**< Number of online processors. */
+#define _SC_PHYS_PAGES 11 /**< Total number of physical pages. */
+#define _SC_AVPHYS_PAGES 12 /**< Number of available physical pages. */'''
+
+[[raw_sections]]
+title = "File and Process Operations"
+text = '''
+extern ssize_t read(int fd, void *buffer, size_t count);
+extern ssize_t write(int fd, const void *buffer, size_t count);
+extern int close(int fd);
+extern void _exit(int status) __attribute__((__noreturn__));
+extern int pipe(int pipefd[2]);
+extern int dup(int oldfd);
+extern int dup2(int oldfd, int newfd);
+extern pid_t fork(void);
+extern int execve(const char *path, char *const argv[], char *const envp[]);
+extern int execvp(const char *file, char *const argv[]);
+extern int execv(const char *path, char *const argv[]);
+extern pid_t getppid(void);
+extern int faccessat(int dirfd, const char *pathname, int mode, int flags);
+extern int fchownat(int dirfd, const char *pathname, uid_t owner, gid_t group, int flags);
+extern int lchown(const char *pathname, uid_t owner, gid_t group);
+extern int linkat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, int flags);
+extern int symlinkat(const char *target, int newdirfd, const char *linkpath);
+extern ssize_t readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz);
+extern int truncate(const char *path, off_t length);
+extern long fpathconf(int fd, int name);
+extern long pathconf(const char *path, int name);
+
+extern char **environ;
+extern off_t lseek(int fd, off_t offset, int whence);
+extern int unlink(const char *path);
+extern int rmdir(const char *path);
+extern long sysconf(int name);'''
+
+[[raw_sections]]
+title = "File System Operations"
+text = '''
+extern ssize_t pread(int fd, void *buffer, size_t count, off_t offset);
+extern ssize_t pwrite(int fd, const void *buffer, size_t count, off_t offset);
+extern int ftruncate(int fd, off_t length);
+extern int fsync(int fd);
+extern int fdatasync(int fd);
+extern char *getcwd(char *buf, size_t size);
+extern int chdir(const char *path);
+extern int fchdir(int fd);
+
+/* access() mode bits. */
+#define F_OK 0
+#define X_OK 1
+#define W_OK 2
+#define R_OK 4
+extern int access(const char *path, int amode);
+extern unsigned int sleep(unsigned int seconds);
+extern int usleep(unsigned int usec);
+extern int unlinkat(int dirfd, const char *pathname, int flags);
+extern int isatty(int fd);
+extern ssize_t readlink(const char *path, char *buf, size_t bufsize);
+extern int getentropy(void *buffer, size_t length);
+extern int symlink(const char *target, const char *linkpath);'''
+
+[[raw_sections]]
+title = "Command-Line Option Parsing"
+text = '''
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+extern int getopt(int argc, char *const argv[], const char *optstring);'''
+
+[[sections]]
+title = "User and Group Identification"
+functions = ["getpid", "getuid", "geteuid", "getgid", "getegid", "setuid", "seteuid", "setgid", "setegid", "gethostname", "chown", "fchown"]

--- a/src/libs/sysapi/headers/utime.toml
+++ b/src/libs/sysapi/headers/utime.toml
@@ -1,0 +1,41 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# C header specification for utime.h.
+
+file = "utime.h"
+brief = "File access and modification times."
+description = '''
+Declares the legacy `utime()` interface and its `utimbuf` structure. The
+layout mirrors the Rust definition in the sysapi crate (utime.rs).'''
+includes = ["sys/types.h"]
+guard = "_NANVIX_UTIME_H"
+content_order = [
+    "raw:0",
+    "raw:1",
+]
+
+[[raw_sections]]
+title = "Structures"
+text = '''
+/**
+ * @brief File access and modification times.
+ */
+struct utimbuf {
+    time_t actime;  /**< Access time.       */
+    time_t modtime; /**< Modification time. */
+};'''
+
+[[raw_sections]]
+title = "Functions"
+text = '''
+/**
+ * @brief Sets the access and modification times of a file.
+ *
+ * @param filename Path of the target file.
+ * @param times    Desired access and modification times, or NULL for the
+ *                 current time.
+ *
+ * @returns Zero on success, or -1 on failure with `errno` set.
+ */
+extern int utime(const char *filename, const struct utimbuf *times);'''

--- a/src/utils/gen-headers/Cargo.toml
+++ b/src/utils/gen-headers/Cargo.toml
@@ -1,0 +1,22 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "gen-headers"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Generates C headers from Nanvix libc_* Rust crate sources"
+homepage.workspace = true
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true, features = ["derive", "std"] }
+syn = { version = "2", features = ["full"] }
+toml = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/utils/gen-headers/src/main.rs
+++ b/src/utils/gen-headers/src/main.rs
@@ -1,0 +1,935 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+//! Generates C headers from Nanvix `libc_*` Rust crate sources.
+//!
+//! Each `libc_*` crate that carries a `header.toml` specification owns exactly one C header under
+//! `include/`. This tool parses the crate's `extern "C"` function signatures with `syn`, combines
+//! them with the specification (macros, includes, section layout), and renders the header. The
+//! output is byte-for-byte identical to the committed `include/*.h` files.
+//==================================================================================================
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::{
+    bail,
+    Context,
+    Result,
+};
+use ::clap::Parser;
+use ::serde::Deserialize;
+use ::std::{
+    collections::{
+        BTreeMap,
+        HashMap,
+    },
+    fs,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+//==================================================================================================
+// CLI Definition
+//==================================================================================================
+
+/// Command-line flags accepted by the header generator.
+#[derive(Debug, Parser)]
+#[command(
+    author,
+    version,
+    about = "Generate C headers from Nanvix libc_* Rust crate sources",
+    long_about = None
+)]
+struct Cli {
+    /// # Description
+    /// Check that committed headers are up to date instead of writing them.
+    #[arg(long)]
+    check: bool,
+
+    /// # Description
+    /// Generate only the named header (e.g. `stdio.h`).
+    #[arg(long, value_name = "NAME")]
+    header: Option<String>,
+}
+
+fn default_extern_c() -> bool {
+    true
+}
+
+//==================================================================================================
+// Specification Data Structures
+//==================================================================================================
+
+/// Complete specification for a single generated header.
+#[derive(Debug, Deserialize)]
+struct HeaderSpec {
+    /// Output header path, relative to `include/`.
+    file: String,
+    /// One-line `@brief` for the `@file` documentation block.
+    brief: String,
+    /// Multi-line `@file` description.
+    description: String,
+    /// System headers to `#include`.
+    #[serde(default)]
+    includes: Vec<String>,
+    /// Include guard macro name.
+    guard: String,
+    /// Whether to wrap declarations in an `extern "C"` block.
+    #[serde(default = "default_extern_c")]
+    extern_c: bool,
+    /// Explicit ordering of content blocks. Defaults when absent.
+    #[serde(default)]
+    content_order: Option<Vec<String>>,
+    /// `#define` constants.
+    #[serde(default)]
+    macros: Vec<Macro>,
+    /// Raw C type definitions.
+    #[serde(default)]
+    types: Vec<RawText>,
+    /// Titled groups of function declarations.
+    #[serde(default)]
+    sections: Vec<Section>,
+    /// Titled blocks of raw C text.
+    #[serde(default)]
+    raw_sections: Vec<RawSection>,
+    /// Manual declaration overrides, keyed by function name.
+    #[serde(default)]
+    overrides: HashMap<String, String>,
+    /// Raw block emitted outside the include guard.
+    #[serde(default)]
+    trailer: Option<RawText>,
+    /// Extra crates (directory names under `src/libs`) whose `src/**` trees are
+    /// scanned *recursively* for the `extern "C"` signatures this header
+    /// declares. Used by the POSIX headers, whose functions live in the
+    /// `syscall`, `posix`, and `libc_*` crates rather than next to the spec.
+    /// When empty, the spec's own crate `src/` directory is scanned (the
+    /// `libc_*` convention).
+    #[serde(default)]
+    scan_crates: Vec<String>,
+}
+
+/// A single `#define` constant.
+#[derive(Debug, Deserialize)]
+struct Macro {
+    /// Macro name.
+    name: String,
+    /// Macro replacement value.
+    value: String,
+    /// Optional documentation comment.
+    #[serde(default)]
+    comment: Option<String>,
+    /// Optional `#ifndef` redefinition guard.
+    #[serde(default)]
+    guard: Option<String>,
+}
+
+/// A block of raw C text.
+#[derive(Debug, Deserialize)]
+struct RawText {
+    /// Verbatim C text.
+    text: String,
+}
+
+/// A titled group of function declarations.
+#[derive(Debug, Deserialize)]
+struct Section {
+    /// Section bar title.
+    title: String,
+    /// Functions declared in this section, in order.
+    functions: Vec<String>,
+}
+
+/// A titled block of raw C text.
+#[derive(Debug, Deserialize)]
+struct RawSection {
+    /// Section bar title. An empty title suppresses the bar.
+    #[serde(default)]
+    title: String,
+    /// Verbatim C text.
+    text: String,
+}
+
+//==================================================================================================
+// Parsed Function Signatures
+//==================================================================================================
+
+/// A parsed C function signature.
+#[derive(Debug)]
+struct FuncSig {
+    /// Function name.
+    name: String,
+    /// Parameters as `(c_type, name)` pairs.
+    params: Vec<(String, String)>,
+    /// C return type.
+    return_type: String,
+    /// Whether the function is variadic.
+    is_variadic: bool,
+}
+
+//==================================================================================================
+// Rust-to-C Type Mapping
+//==================================================================================================
+
+/// Maps a Rust type identifier to its C equivalent, if known.
+fn map_ident_to_c(ident: &str) -> Option<&'static str> {
+    Some(match ident {
+        // Core FFI types (sysapi).
+        "c_char" => "char",
+        "c_schar" => "signed char",
+        "c_uchar" => "unsigned char",
+        "c_short" => "short",
+        "c_ushort" => "unsigned short",
+        "c_int" => "int",
+        "c_uint" => "unsigned int",
+        "c_long" => "long",
+        "c_ulong" => "unsigned long",
+        "c_longlong" => "long long",
+        "c_ulonglong" => "unsigned long long",
+        "c_void" => "void",
+        "c_size_t" => "size_t",
+        "c_ssize_t" => "ssize_t",
+        // Rust primitives that appear in extern "C" signatures.
+        "i8" => "int8_t",
+        "i16" => "int16_t",
+        "i32" => "int32_t",
+        "i64" => "int64_t",
+        "u8" => "uint8_t",
+        "u16" => "uint16_t",
+        "u32" => "uint32_t",
+        "u64" => "uint64_t",
+        "f32" => "float",
+        "f64" => "double",
+        "bool" => "bool",
+        "usize" => "size_t",
+        "isize" => "ssize_t",
+        // Domain-specific aliases (sysapi/sys_types.rs).
+        "time_t" => "time_t",
+        "clock_t" => "clock_t",
+        "clockid_t" => "clockid_t",
+        "off_t" => "off_t",
+        "pid_t" => "pid_t",
+        "mode_t" => "mode_t",
+        "intmax_t" => "intmax_t",
+        "uintmax_t" => "uintmax_t",
+        "sigset_t" => "sigset_t",
+        "wchar_t" => "wchar_t",
+        "wint_t" => "wint_t",
+        "wctype_t" => "wctype_t",
+        "wctrans_t" => "wctrans_t",
+        "locale_t" => "locale_t",
+        "nl_item" => "nl_item",
+        // Struct types.
+        "tm" => "struct tm",
+        "FILE" => "FILE",
+        "lconv" => "struct lconv",
+        "div_t" => "div_t",
+        "ldiv_t" => "ldiv_t",
+        "lldiv_t" => "lldiv_t",
+        "imaxdiv_t" => "imaxdiv_t",
+        "jmp_buf" => "jmp_buf",
+        "sigaction" => "struct sigaction",
+        "timespec" => "struct timespec",
+        // Function pointer aliases.
+        "SignalHandler" => "sighandler_t",
+        // VaList -> va_list.
+        "VaList" => "va_list",
+        // POSIX scalar type aliases (sysapi/sys_types.rs et al.). The C typedefs
+        // live in the generated headers' type blocks; these map the Rust alias
+        // name to the identical C typedef name.
+        "ssize_t" => "ssize_t",
+        "uid_t" => "uid_t",
+        "gid_t" => "gid_t",
+        "dev_t" => "dev_t",
+        "ino_t" => "ino_t",
+        "nlink_t" => "nlink_t",
+        "blkcnt_t" => "blkcnt_t",
+        "blksize_t" => "blksize_t",
+        "suseconds_t" => "suseconds_t",
+        "useconds_t" => "useconds_t",
+        "socklen_t" => "socklen_t",
+        "sa_family_t" => "sa_family_t",
+        "in_port_t" => "in_port_t",
+        "in_addr_t" => "in_addr_t",
+        "nfds_t" => "nfds_t",
+        "id_t" => "id_t",
+        "key_t" => "key_t",
+        // POSIX thread type aliases (sysapi/sys_types.rs, pthread.rs).
+        "pthread_t" => "pthread_t",
+        "pthread_attr_t" => "pthread_attr_t",
+        "pthread_mutex_t" => "pthread_mutex_t",
+        "pthread_mutexattr_t" => "pthread_mutexattr_t",
+        "pthread_cond_t" => "pthread_cond_t",
+        "pthread_condattr_t" => "pthread_condattr_t",
+        "pthread_rwlock_t" => "pthread_rwlock_t",
+        "pthread_rwlockattr_t" => "pthread_rwlockattr_t",
+        "pthread_barrier_t" => "pthread_barrier_t",
+        "pthread_barrierattr_t" => "pthread_barrierattr_t",
+        "pthread_spinlock_t" => "pthread_spinlock_t",
+        "pthread_key_t" => "pthread_key_t",
+        "pthread_once_t" => "pthread_once_t",
+        // POSIX struct types (the C side spells these `struct X`; the Rust side
+        // refers to them by the bare struct name, possibly module-qualified —
+        // `map_type_path` already reduces a path to its last segment).
+        "stat" => "struct stat",
+        "utsname" => "struct utsname",
+        "sockaddr" => "struct sockaddr",
+        "sockaddr_storage" => "struct sockaddr_storage",
+        "sockaddr_in" => "struct sockaddr_in",
+        "sockaddr_un" => "struct sockaddr_un",
+        "in_addr" => "struct in_addr",
+        "iovec" => "struct iovec",
+        "timeval" => "struct timeval",
+        "tms" => "struct tms",
+        "sched_param" => "struct sched_param",
+        "rlimit" => "struct rlimit",
+        "rusage" => "struct rusage",
+        "dirent" => "struct dirent",
+        "DIR" => "DIR",
+        // The Nanvix directory-stream handle is the POSIX `DIR`.
+        "DirectoryStream" => "DIR",
+        // The dynamic-linker symbol-info struct is spelled `Dl_info_t` in C.
+        "DlInfo" => "Dl_info_t",
+        _ => return None,
+    })
+}
+
+/// Converts a `syn` type to its C equivalent.
+fn map_type(ty: &syn::Type) -> String {
+    match ty {
+        syn::Type::Ptr(ptr) => {
+            let is_const: bool = ptr.const_token.is_some();
+            let inner: String = map_type(&ptr.elem);
+            if inner == "void" {
+                return if is_const {
+                    "const void *".to_string()
+                } else {
+                    "void *".to_string()
+                };
+            }
+            // Pointer to pointer.
+            if inner.ends_with('*') {
+                return if is_const {
+                    format!("const {inner}*")
+                } else {
+                    format!("{inner}*")
+                };
+            }
+            if is_const {
+                format!("const {inner} *")
+            } else {
+                format!("{inner} *")
+            }
+        },
+        syn::Type::Never(_) => "void".to_string(),
+        syn::Type::BareFn(bare) => map_bare_fn(bare),
+        syn::Type::Path(path) => map_type_path(path),
+        // Strip a redundant outer parenthesis or group, then map the inner type.
+        syn::Type::Paren(inner) => map_type(&inner.elem),
+        syn::Type::Group(inner) => map_type(&inner.elem),
+        _ => "/* UNMAPPED */".to_string(),
+    }
+}
+
+/// Maps a path type, handling `VaList`, `Option<fn>`, and named aliases.
+fn map_type_path(path: &syn::TypePath) -> String {
+    let Some(seg) = path.path.segments.last() else {
+        return "/* UNMAPPED */".to_string();
+    };
+    let ident: String = seg.ident.to_string();
+
+    // VaList<'_, '_> and VaListImpl<'_> -> va_list.
+    if ident == "VaList" || ident == "VaListImpl" {
+        return "va_list".to_string();
+    }
+
+    // Option<unsafe extern "C" fn(...) -> T> (function pointer).
+    if ident == "Option" {
+        if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+            if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                return map_type(inner);
+            }
+        }
+    }
+
+    match map_ident_to_c(&ident) {
+        Some(c) => c.to_string(),
+        None => format!("/* UNMAPPED: {ident} */"),
+    }
+}
+
+/// Maps a bare function pointer type to a C function pointer placeholder.
+fn map_bare_fn(bare: &syn::TypeBareFn) -> String {
+    let ret: String = match &bare.output {
+        syn::ReturnType::Default => "void".to_string(),
+        syn::ReturnType::Type(_, ty) => map_type(ty),
+    };
+    let params: Vec<String> = bare.inputs.iter().map(|arg| map_type(&arg.ty)).collect();
+    let params_str: String = if params.is_empty() {
+        "void".to_string()
+    } else {
+        params.join(", ")
+    };
+    format!("{ret} (*)({params_str})")
+}
+
+//==================================================================================================
+// Rust Source Parsing
+//==================================================================================================
+
+/// Extracts the C name of a parameter pattern, stripping leading underscores.
+fn pat_name(pat: &syn::Pat) -> String {
+    let raw: String = match pat {
+        syn::Pat::Ident(ident) => ident.ident.to_string(),
+        _ => String::new(),
+    };
+    let trimmed: &str = raw.trim_start_matches('_');
+    if trimmed.is_empty() {
+        "arg".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Parses a single Rust source file, returning its `pub extern "C"` signatures.
+fn parse_rust_file(path: &Path) -> Result<Vec<FuncSig>> {
+    let content: String =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let file: syn::File =
+        syn::parse_file(&content).with_context(|| format!("failed to parse {}", path.display()))?;
+
+    let mut results: Vec<FuncSig> = Vec::new();
+    collect_extern_c_fns(&file.items, &mut results);
+    Ok(results)
+}
+
+/// Collects `pub extern "C"` signatures from a list of items, descending into
+/// inline modules (e.g. the `pub mod bindings { ... }` blocks the syscall crate
+/// uses to group its C entry points).
+fn collect_extern_c_fns(items: &[syn::Item], results: &mut Vec<FuncSig>) {
+    for item in items {
+        match item {
+            syn::Item::Mod(module) => {
+                if let Some((_, inner)) = &module.content {
+                    collect_extern_c_fns(inner, results);
+                }
+            },
+            syn::Item::Fn(func) => {
+                if let Some(sig) = parse_extern_c_fn(func) {
+                    results.push(sig);
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+/// Returns the parsed signature of a function item iff it is `pub extern "C"`.
+fn parse_extern_c_fn(func: &syn::ItemFn) -> Option<FuncSig> {
+    if !matches!(func.vis, syn::Visibility::Public(_)) {
+        return None;
+    }
+    // Require an explicit `extern "C"` ABI.
+    let abi = func.sig.abi.as_ref()?;
+    if !matches!(&abi.name, Some(name) if name.value() == "C") {
+        return None;
+    }
+
+    let mut params: Vec<(String, String)> = Vec::new();
+    for input in &func.sig.inputs {
+        if let syn::FnArg::Typed(arg) = input {
+            params.push((map_type(&arg.ty), pat_name(&arg.pat)));
+        }
+    }
+    let return_type: String = match &func.sig.output {
+        syn::ReturnType::Default => "void".to_string(),
+        syn::ReturnType::Type(_, ty) => map_type(ty),
+    };
+
+    Some(FuncSig {
+        name: func.sig.ident.to_string(),
+        params,
+        return_type,
+        is_variadic: func.sig.variadic.is_some(),
+    })
+}
+
+/// Scans a crate's `src/*.rs` files, returning a name-to-signature map.
+fn scan_crate(crate_dir: &Path) -> Result<BTreeMap<String, FuncSig>> {
+    let src_dir: PathBuf = crate_dir.join("src");
+    let mut funcs: BTreeMap<String, FuncSig> = BTreeMap::new();
+    if !src_dir.is_dir() {
+        return Ok(funcs);
+    }
+
+    let mut rs_files: Vec<PathBuf> = fs::read_dir(&src_dir)
+        .with_context(|| format!("failed to read {}", src_dir.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.is_file() && path.extension().is_some_and(|ext| ext == "rs"))
+        .collect();
+    rs_files.sort();
+
+    for rs_file in &rs_files {
+        for sig in parse_rust_file(rs_file)? {
+            funcs.insert(sig.name.clone(), sig);
+        }
+    }
+    Ok(funcs)
+}
+
+/// Recursively scans a directory's `*.rs` files, merging signatures into `funcs`.
+fn scan_dir_recursive(dir: &Path, funcs: &mut BTreeMap<String, FuncSig>) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    let mut entries: Vec<PathBuf> = fs::read_dir(dir)
+        .with_context(|| format!("failed to read {}", dir.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .collect();
+    entries.sort();
+    for path in &entries {
+        if path.is_dir() {
+            scan_dir_recursive(path, funcs)?;
+        } else if path.is_file() && path.extension().is_some_and(|ext| ext == "rs") {
+            for sig in parse_rust_file(path)? {
+                funcs.insert(sig.name.clone(), sig);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Scans each named crate's `src/` tree recursively, returning a merged map.
+///
+/// Crate names are directory names under `libs_dir` (e.g. `syscall`, `posix`).
+fn scan_named_crates(libs_dir: &Path, crates: &[String]) -> Result<BTreeMap<String, FuncSig>> {
+    let mut funcs: BTreeMap<String, FuncSig> = BTreeMap::new();
+    for crate_name in crates {
+        let src_dir: PathBuf = libs_dir.join(crate_name).join("src");
+        scan_dir_recursive(&src_dir, &mut funcs)?;
+    }
+    Ok(funcs)
+}
+
+//==================================================================================================
+// C Declaration Formatting
+//==================================================================================================
+
+/// Formats a parsed signature as a C function declaration.
+fn format_c_declaration(sig: &FuncSig) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for (ptype, pname) in &sig.params {
+        // Function pointer parameters: "ret (*)(args)" -> "ret (*name)(args)".
+        if let Some(pos) = ptype.find("(*)(") {
+            let prefix: &str = &ptype[..pos];
+            let suffix: &str = &ptype[pos + 3..];
+            parts.push(format!("{prefix}(*{pname}){suffix}"));
+        } else if ptype.ends_with('*') {
+            parts.push(format!("{ptype}{pname}"));
+        } else {
+            parts.push(format!("{ptype} {pname}"));
+        }
+    }
+    if sig.is_variadic {
+        parts.push("...".to_string());
+    }
+    let params_str: String = if parts.is_empty() {
+        "void".to_string()
+    } else {
+        parts.join(", ")
+    };
+
+    // Keep the pointer star attached to the return type.
+    if sig.return_type.ends_with(" *") {
+        format!("extern {}{}({params_str});", sig.return_type, sig.name)
+    } else {
+        format!("extern {} {}({params_str});", sig.return_type, sig.name)
+    }
+}
+
+//==================================================================================================
+// Header Rendering
+//==================================================================================================
+
+/// Copyright block emitted at the top of every header.
+const COPYRIGHT: &str =
+    "/*\n * Copyright(c) The Maintainers of Nanvix.\n * Licensed under the MIT License.\n */";
+
+/// Renders a section bar with the given title.
+fn section_bar(title: &str) -> String {
+    let rule: String = "=".repeat(98);
+    format!("/*{rule}\n * {title}\n *{rule}*/")
+}
+
+/// Emits a `Constants` section of `#define` entries.
+fn emit_macros(lines: &mut Vec<String>, macros: &[Macro]) {
+    if macros.is_empty() {
+        return;
+    }
+    lines.push(section_bar("Constants"));
+    lines.push(String::new());
+    for macro_def in macros {
+        if let Some(guard) = &macro_def.guard {
+            lines.push(format!("#ifndef {guard}"));
+        }
+        match &macro_def.comment {
+            Some(comment) => lines.push(format!(
+                "#define {} {} /**< {} */",
+                macro_def.name, macro_def.value, comment
+            )),
+            None => lines.push(format!("#define {} {}", macro_def.name, macro_def.value)),
+        }
+        if macro_def.guard.is_some() {
+            lines.push("#endif".to_string());
+            lines.push(String::new());
+        }
+    }
+    if lines.last().map(String::as_str) != Some("") {
+        lines.push(String::new());
+    }
+}
+
+/// Emits a titled section of function declarations.
+fn emit_section(
+    lines: &mut Vec<String>,
+    section: &Section,
+    funcs: &BTreeMap<String, FuncSig>,
+    overrides: &HashMap<String, String>,
+) {
+    if !section.title.is_empty() {
+        lines.push(section_bar(&section.title));
+        lines.push(String::new());
+    }
+    for fn_name in &section.functions {
+        if let Some(override_decl) = overrides.get(fn_name) {
+            lines.push(override_decl.clone());
+        } else if let Some(sig) = funcs.get(fn_name) {
+            lines.push(format_c_declaration(sig));
+        } else {
+            lines.push(format!("/* TODO: {fn_name} — not found in Rust source */"));
+        }
+    }
+    lines.push(String::new());
+}
+
+/// Emits a titled block of raw C text.
+fn emit_raw_section(lines: &mut Vec<String>, raw: &RawSection) {
+    if !raw.title.is_empty() {
+        lines.push(section_bar(&raw.title));
+        lines.push(String::new());
+    }
+    lines.push(raw.text.trim().to_string());
+    lines.push(String::new());
+}
+
+/// Builds the default content ordering when a spec omits `content_order`.
+fn default_content_order(spec: &HeaderSpec) -> Vec<String> {
+    let mut order: Vec<String> = Vec::new();
+    if !spec.macros.is_empty() {
+        order.push("macros".to_string());
+    }
+    for index in 0..spec.types.len() {
+        order.push(format!("types:{index}"));
+    }
+    let count: usize = spec.sections.len().max(spec.raw_sections.len());
+    for index in 0..count {
+        if index < spec.sections.len() {
+            order.push(format!("section:{index}"));
+        }
+        if index < spec.raw_sections.len() {
+            order.push(format!("raw:{index}"));
+        }
+    }
+    order
+}
+
+/// Emits a `Types` block for an explicit `types:N` ordering entry.
+fn emit_indexed_type(lines: &mut Vec<String>, spec: &HeaderSpec, index: usize) {
+    if index == 0 {
+        lines.push(section_bar("Types"));
+        lines.push(String::new());
+    }
+    if index < spec.types.len() {
+        lines.push(spec.types[index].text.trim().to_string());
+        lines.push(String::new());
+    }
+}
+
+/// Renders a complete C header from a spec and parsed functions.
+fn generate_header(spec: &HeaderSpec, funcs: &BTreeMap<String, FuncSig>) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    lines.push(COPYRIGHT.to_string());
+    lines.push(String::new());
+
+    lines.push(format!("#ifndef {}", spec.guard));
+    lines.push(format!("#define {}", spec.guard));
+    lines.push(String::new());
+
+    // @file block.
+    lines.push("/**".to_string());
+    lines.push(format!(" * @file {}", spec.file));
+    lines.push(format!(" * @brief {}", spec.brief));
+    if !spec.description.trim().is_empty() {
+        lines.push(" *".to_string());
+        for desc_line in spec.description.trim().split('\n') {
+            let desc_line: &str = desc_line.trim();
+            if desc_line.is_empty() {
+                lines.push(" *".to_string());
+            } else {
+                lines.push(format!(" * {desc_line}"));
+            }
+        }
+    }
+    lines.push(" */".to_string());
+    lines.push(String::new());
+
+    // Includes.
+    for include in &spec.includes {
+        lines.push(format!("#include <{include}>"));
+    }
+    if !spec.includes.is_empty() {
+        lines.push(String::new());
+    }
+
+    // extern "C" open.
+    if spec.extern_c {
+        lines.push("#ifdef __cplusplus".to_string());
+        lines.push("extern \"C\" {".to_string());
+        lines.push("#endif".to_string());
+        lines.push(String::new());
+    }
+
+    // Content blocks.
+    let content_order: Vec<String> = spec
+        .content_order
+        .clone()
+        .unwrap_or_else(|| default_content_order(spec));
+    for entry in &content_order {
+        if entry == "macros" {
+            emit_macros(&mut lines, &spec.macros);
+        } else if entry == "types" {
+            if !spec.types.is_empty() {
+                lines.push(section_bar("Types"));
+                lines.push(String::new());
+                for type_def in &spec.types {
+                    lines.push(type_def.text.trim().to_string());
+                    lines.push(String::new());
+                }
+            }
+        } else if let Some(index) = entry.strip_prefix("types:") {
+            if let Ok(index) = index.parse::<usize>() {
+                emit_indexed_type(&mut lines, spec, index);
+            }
+        } else if let Some(index) = entry.strip_prefix("section:") {
+            if let Ok(index) = index.parse::<usize>() {
+                if index < spec.sections.len() {
+                    emit_section(&mut lines, &spec.sections[index], funcs, &spec.overrides);
+                }
+            }
+        } else if let Some(index) = entry.strip_prefix("raw:") {
+            if let Ok(index) = index.parse::<usize>() {
+                if index < spec.raw_sections.len() {
+                    emit_raw_section(&mut lines, &spec.raw_sections[index]);
+                }
+            }
+        }
+    }
+
+    // extern "C" close.
+    if spec.extern_c {
+        lines.push("#ifdef __cplusplus".to_string());
+        lines.push("}".to_string());
+        lines.push("#endif".to_string());
+        lines.push(String::new());
+    }
+
+    // Trailer (outside the include guard, e.g. the assert macro).
+    if let Some(trailer) = &spec.trailer {
+        lines.push(trailer.text.trim().to_string());
+        lines.push(String::new());
+    }
+
+    lines.push(format!("#endif /* {} */", spec.guard));
+    lines.push(String::new());
+
+    lines.join("\n")
+}
+
+//==================================================================================================
+// Discovery and Entry Point
+//==================================================================================================
+
+/// Discovers `libc_*` crates under `libs_dir` that carry a `header.toml`.
+fn discover_specs(libs_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut crates: Vec<PathBuf> = fs::read_dir(libs_dir)
+        .with_context(|| format!("failed to read {}", libs_dir.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| {
+            path.is_dir()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("libc_"))
+                && path.join("header.toml").is_file()
+        })
+        .collect();
+    crates.sort();
+    Ok(crates)
+}
+
+/// Discovers POSIX header specs under `src/libs/sysapi/headers/*.toml`.
+///
+/// These specs emit the POSIX C headers from the existing Rust definitions in
+/// the `sysapi`/`syscall`/`posix` crates (the C ABI's single source of truth).
+/// Each one names the crates to scan for its function signatures via the spec's
+/// `scan_crates` field; its types and constants are carried as raw text.
+fn discover_posix_specs(libs_dir: &Path) -> Result<Vec<PathBuf>> {
+    let dir: PathBuf = libs_dir.join("sysapi").join("headers");
+    if !dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut specs: Vec<PathBuf> = fs::read_dir(&dir)
+        .with_context(|| format!("failed to read {}", dir.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.is_file() && path.extension().is_some_and(|ext| ext == "toml"))
+        .collect();
+    specs.sort();
+    Ok(specs)
+}
+
+/// Loads, parses, and renders the header for a single `libc_*` crate.
+///
+/// Scans the crate's own `src/` plus any `scan_crates` declared in the spec
+/// (so a `libc_*` header can also pull in prototypes whose implementations live
+/// in another crate, e.g. the `clock_*` syscalls behind `<time.h>`).
+fn render_crate(crate_dir: &Path, libs_dir: &Path) -> Result<(String, String)> {
+    let spec_path: PathBuf = crate_dir.join("header.toml");
+    let spec_text: String = fs::read_to_string(&spec_path)
+        .with_context(|| format!("failed to read {}", spec_path.display()))?;
+    let spec: HeaderSpec = toml::from_str(&spec_text)
+        .with_context(|| format!("failed to parse {}", spec_path.display()))?;
+    // Start from any extra scanned crates, then overlay the crate's own
+    // definitions so a locally-defined name wins over an imported one.
+    let mut funcs: BTreeMap<String, FuncSig> = scan_named_crates(libs_dir, &spec.scan_crates)?;
+    funcs.extend(scan_crate(crate_dir)?);
+    let rendered: String = generate_header(&spec, &funcs);
+    Ok((spec.file, rendered))
+}
+
+/// Loads, parses, and renders a POSIX header spec, scanning its `scan_crates`.
+fn render_posix_spec(spec_path: &Path, libs_dir: &Path) -> Result<(String, String)> {
+    let spec_text: String = fs::read_to_string(spec_path)
+        .with_context(|| format!("failed to read {}", spec_path.display()))?;
+    let spec: HeaderSpec = toml::from_str(&spec_text)
+        .with_context(|| format!("failed to parse {}", spec_path.display()))?;
+    let funcs: BTreeMap<String, FuncSig> = scan_named_crates(libs_dir, &spec.scan_crates)?;
+    let rendered: String = generate_header(&spec, &funcs);
+    Ok((spec.file, rendered))
+}
+
+/// Scans rendered header text for unresolved generator placeholders.
+///
+/// A non-empty result means a spec referenced a Rust type the generator cannot
+/// map (`UNMAPPED`) or a function missing from the scanned sources (`TODO`).
+/// Both emit broken or incomplete C, so generation must never ship them.
+fn find_placeholders(rendered: &str) -> Vec<String> {
+    rendered
+        .lines()
+        .filter(|line| line.contains("UNMAPPED") || line.contains("not found in Rust source"))
+        .map(|line| line.trim().to_string())
+        .collect()
+}
+
+fn main() -> Result<()> {
+    let cli: Cli = Cli::parse();
+
+    // Resolve the repository root from this crate's compile-time location:
+    // <root>/src/utils/gen-headers -> <root>.
+    let root: &Path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .context("failed to locate repository root")?;
+    let libs_dir: PathBuf = root.join("src").join("libs");
+    let include_dir: PathBuf = root.join("include");
+
+    // Render every header: the per-crate `libc_*` specs, then the POSIX specs.
+    let mut headers: Vec<(String, String)> = Vec::new();
+    for crate_dir in &discover_specs(&libs_dir)? {
+        headers.push(render_crate(crate_dir, &libs_dir)?);
+    }
+    for spec_path in &discover_posix_specs(&libs_dir)? {
+        headers.push(render_posix_spec(spec_path, &libs_dir)?);
+    }
+
+    // Fail fast on any unresolved placeholder before touching the tree: a spec
+    // referenced a type the generator cannot map or a function missing from the
+    // scanned sources, either of which yields broken or incomplete C.
+    let mut placeholders: Vec<String> = Vec::new();
+    for (file, rendered) in &headers {
+        for line in find_placeholders(rendered) {
+            placeholders.push(format!("{file}: {line}"));
+        }
+    }
+    if !placeholders.is_empty() {
+        for placeholder in &placeholders {
+            eprintln!("unresolved placeholder: {placeholder}");
+        }
+        bail!(
+            "header generation produced {} unresolved placeholder(s); add the missing type \
+             mapping or function override",
+            placeholders.len()
+        );
+    }
+
+    let mut stale: Vec<String> = Vec::new();
+    let mut generated: usize = 0;
+
+    for (file, rendered) in &headers {
+        if let Some(only) = &cli.header {
+            if file != only {
+                continue;
+            }
+        }
+
+        let out_path: PathBuf = include_dir.join(file);
+        if cli.check {
+            let existing: String = fs::read_to_string(&out_path).unwrap_or_default();
+            if &existing != rendered {
+                stale.push(file.clone());
+            }
+        } else {
+            if let Some(parent) = out_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            // Only rewrite when the contents actually change so that the
+            // header's mtime is preserved on no-op builds. This keeps the
+            // generator safe to drive on every build without churning
+            // timestamps and forcing dependent C sources to recompile.
+            let existing: String = fs::read_to_string(&out_path).unwrap_or_default();
+            if existing != *rendered {
+                fs::write(&out_path, rendered)
+                    .with_context(|| format!("failed to write {}", out_path.display()))?;
+                generated += 1;
+            }
+        }
+    }
+
+    if cli.check {
+        if !stale.is_empty() {
+            for file in &stale {
+                eprintln!("out of date: {file}");
+            }
+            bail!("headers are out of date; run `cargo run -p gen-headers` to regenerate");
+        }
+        eprintln!("all headers up to date");
+    } else {
+        eprintln!("generated {generated} header(s)");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements a comprehensive POSIX-compatible C standard library in Rust `no_std`, organized as one crate per C header module, designed to gradually replace NewLib.

## New Crates (11)

| Crate | Functions | Description |
|-------|-----------|-------------|
| `libc_stdio` | 32 | printf/fprintf/snprintf/fopen/fread/fgets/fseek and more |
| `libc_assert` | 2 | `__assert_func`/`__assert` matching NewLib's assert.h |
| `libc_ctype` | 16 | Character classification and conversion |
| `libc_math` | 60 | Software floating-point math (trig, exp, log, sqrt, etc.) |
| `libc_time` | 11 | time/gmtime/mktime/asctime/ctime |
| `libc_signal` | 7 | signal/raise/sigset operations |
| `libc_locale` | 2 | C/POSIX locale stubs |
| `libc_setjmp` | 2 | setjmp/longjmp with x86-32 assembly |
| `libc_wchar` | 15 | Wide character string functions |
| `libc_wctype` | 14 | Wide character classification |
| `libc_inttypes` | 4 | strtoimax/strtoumax/imaxabs/imaxdiv |

## Extended Crates (2)

| Crate | New Functions | Examples |
|-------|--------------|---------|
| `libc_string` | +27 | strcmp, strchr, strstr, strdup, memchr, strtok, strnlen |
| `libc_stdlib` | +23 | atoi, strtol, rand, qsort, bsearch, getenv, exit, strtod |

## C Headers (13)

Standard C headers under `include/`: string.h, stdlib.h, stdio.h, assert.h, ctype.h, math.h, time.h, signal.h, locale.h, setjmp.h, wchar.h, wctype.h, inttypes.h

## Validation

- ✅ Full build (`./z build -- all`)
- ✅ Lint clean (`./z build -- lint-check`)
- ✅ Format clean (`./z build -- format-check`)
- ✅ 515+ unit tests passing
- ✅ All integration tests pass (`run-nanvix-tests`)
- ✅ Headers compile with toolchain GCC (`-Wall -Wextra -Werror -pedantic-errors`)

## Stats

- **238** Rust source files
- **13** C header files
- **~16,400** lines added
