### PR TITLE
[kernel] Add dynamic exception stack guard

### DIFF
--- a/src/kernel/src/hal/arch/x86/asm_defs.h
+++ b/src/kernel/src/hal/arch/x86/asm_defs.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#ifndef _ASM_DEFS_H_
+#define _ASM_DEFS_H_
+
+/**
+ * @brief Hardware-saved execution context size (in bytes).
+ */
+#define CONTEXT_HW_SIZE 24
+
+#endif /* _ASM_DEFS_H_ */

--- a/src/kernel/src/hal/arch/x86/hooks.S
+++ b/src/kernel/src/hal/arch/x86/hooks.S
@@ -9,9 +9,23 @@
 #define DWORD_SIZE 8 /** Number of bytes in a double-word. */
 
 /**
- * @brief Hardware-saved execution context size (in bytes).
+ * @brief VMM control I/O port.
  */
-#define CONTEXT_HW_SIZE 24
+#define VMM_PORT 0x604
+
+/**
+ * @brief VMM shutdown command (upper 16 bits of the outl value).
+ */
+#define VMM_SHUTDOWN_CMD 0x2000
+
+/**
+ * @brief Exit status used by the stack overflow guard.
+ *
+ * Must match `ExitStatus::STACK_OVERFLOW_EXCEPTION` in `src/libs/sys/src/exit_status.rs`.
+ */
+#define STACK_OVERFLOW_EXIT_STATUS 200
+
+#include "asm_defs.h"
 
 /**
  * @brief Software-saved execution context size (in bytes).
@@ -187,6 +201,42 @@
 
 .endm
 
+/*
+ * Macro: excp_stack_guard_check
+ *
+ * Dynamic stack overflow guard.  Compares ESP against the global variable
+ * EXCP_STACK_GUARD, which holds the lowest safe ESP for the currently-active
+ * kernel stack.  Updated by Rust on every context switch and at boot.
+ *
+ * A value of 0 in EXCP_STACK_GUARD disables the check (guard not yet set).
+ *
+ * This macro performs one memory read from the kernel .bss section.  This is
+ * safe even when kpool page tables are corrupted, because the kernel data
+ * pages reside in different PDE entries than the kpool region.
+ *
+ * Clobbers: EDX, EAX (only on the overflow path which never returns).
+ *
+ * Atomicity note: on x86, aligned 32-bit loads and stores are naturally
+ * atomic, and the Total Store Order (TSO) memory model guarantees that every
+ * store is implicitly release-ordered and every load is implicitly
+ * acquire-ordered.  No LOCK prefix or fence is required for the plain
+ * cmpl instructions used here.
+ */
+.macro excp_stack_guard_check
+    cmpl $0, EXCP_STACK_GUARD
+    je   1f
+    cmpl EXCP_STACK_GUARD, %esp
+    jae  1f
+    /* Stack overflow — trigger a clean VMM shutdown. */
+    movl $(VMM_SHUTDOWN_CMD << 16 | STACK_OVERFLOW_EXIT_STATUS), %eax
+    movw $VMM_PORT, %dx
+    outl %eax, (%dx)
+    /* Fallback halt loop in case the outl does not terminate the VM. */
+2:  hlt
+    jmp 2b
+1:
+.endm
+
 /*----------------------------------------------------------------------------*
  * _do_excp()                                                                 *
  *----------------------------------------------------------------------------*/
@@ -196,6 +246,7 @@
  */
 .macro _do_excp_noerr_code, number
     _do_excp\()\number:
+        excp_stack_guard_check
         push $0
         xchg %eax, (%esp)
         xchg %eax, EXCEPTION_SKIP(%esp)
@@ -211,6 +262,7 @@
  */
 .macro _do_excp_err_code, number
     _do_excp\()\number:
+        excp_stack_guard_check
         xchg %eax, (%esp)
         xchg %eax, EXCEPTION_SKIP(%esp)
         xchg %eax, (%esp)
@@ -225,6 +277,7 @@
  */
 .macro _do_excp_err2_code, number
     _do_excp\()\number:
+        excp_stack_guard_check
         xchg %eax, (%esp)
         xchg %eax, EXCEPTION_SKIP(%esp)
         xchg %eax, (%esp)
@@ -258,12 +311,17 @@
 .section .text,"ax",@progbits
 
 /*----------------------------------------------------------------------------*
- * Exported Symbols                                                           *
+ * Imported Symbols                                                           *
  *----------------------------------------------------------------------------*/
 
 .extern do_exception
 .extern do_kcall
 .extern do_interrupt
+.extern EXCP_STACK_GUARD
+
+/*----------------------------------------------------------------------------*
+ * Exported Symbols                                                           *
+ *----------------------------------------------------------------------------*/
 
 /* Exception hooks. */
 .globl _do_excp0

--- a/src/kernel/src/hal/arch/x86/start.S
+++ b/src/kernel/src/hal/arch/x86/start.S
@@ -16,6 +16,8 @@
 
 /* KSTACK_GUARD_PATTERN is defined via -DKSTACK_GUARD_PATTERN=<value> from build.rs. */
 
+#include "asm_defs.h"
+
 /* Multiboot2 magic constant */
 #define MBOOT2_HEADER_MAGIC 0xe85250d6
 
@@ -39,6 +41,7 @@
 .extern __BSS_START
 .extern __BSS_END
 .extern do_ap_start
+.extern EXCP_STACK_GUARD
 
 /*============================================================================*
  * Bootstrap Section                                                          *
@@ -132,6 +135,16 @@ _do_start2:
     /* Reset stack. */
     movl $kstack, %esp /* Stack pointer. */
     movl %esp, %ebp    /* Frame pointer. */
+
+    /*
+     * Initialize the dynamic stack overflow guard for the boot stack.
+     * CONTEXT_HW_SIZE (24) accounts for the maximum hardware-pushed exception
+     * frame: EIP + CS + EFLAGS + ESP + SS + error code.
+     *
+     * No LOCK prefix needed: aligned 32-bit stores are naturally atomic on
+     * x86, and at this point only the BSP is running with interrupts disabled.
+     */
+    movl $(kstack_guard + CONTEXT_HW_SIZE), EXCP_STACK_GUARD
 
     /* Save boot information on the stack. */
     push %ebx

--- a/src/kernel/src/kpanic.rs
+++ b/src/kernel/src/kpanic.rs
@@ -19,10 +19,7 @@ use ::core::{
         PanicMessage,
     },
 };
-use ::sys::{
-    error::ErrorCode,
-    ExitStatus,
-};
+use ::sys::ExitStatus;
 
 //==================================================================================================
 // Standalone Functions
@@ -53,5 +50,5 @@ pub fn kpanic(info: &PanicInfo) -> ! {
         let _ = write!(klog, "file='{file}', line={line} :: {m}");
     }
 
-    platform::shutdown(ExitStatus::from(ErrorCode::UnrecoverableState).into());
+    platform::shutdown(ExitStatus::KERNEL_PANIC.into());
 }

--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -16,7 +16,13 @@ use ::alloc::vec::Vec;
 use ::arch::mem::PAGE_ALIGNMENT;
 #[cfg(debug_assertions)]
 use ::config::kernel::KSTACK_GUARD_PATTERN;
-use ::core::fmt;
+use ::core::{
+    fmt,
+    sync::atomic::{
+        AtomicU32,
+        Ordering,
+    },
+};
 #[cfg(debug_assertions)]
 use ::sys::error::ErrorCode;
 use ::sys::{
@@ -26,6 +32,26 @@ use ::sys::{
         VirtualAddress,
     },
 };
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+use ::arch::cpu::excp::Exception;
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Dynamic stack overflow guard threshold, read by the assembly `excp_stack_guard_check` macro.
+///
+/// Holds the lowest safe ESP value for the currently-active kernel stack. Updated on every context
+/// switch and at boot. A value of 0 disables the guard check.
+///
+/// TODO (#1665): this is a single global, so it is only correct on uniprocessor builds. For SMP,
+/// replace with a per-core variable (e.g., indexed by APIC ID or stored in per-core data).
+#[unsafe(no_mangle)]
+pub static EXCP_STACK_GUARD: AtomicU32 = AtomicU32::new(0);
 
 //==================================================================================================
 // Structures
@@ -38,6 +64,8 @@ use ::sys::{
 ///
 pub struct KernelStack {
     kpages: Vec<KernelPage>,
+    /// Lowest safe ESP value for this stack (base + CONTEXT_HW_SIZE).
+    guard_threshold: u32,
 }
 
 //==================================================================================================
@@ -66,13 +94,34 @@ impl KernelStack {
         let kpages: Vec<KernelPage> =
             mm.alloc_kpages(true, config::kernel::KSTACK_SIZE / ::arch::mem::PAGE_SIZE)?;
 
-        let stack: Self = Self { kpages };
+        let guard_threshold: u32 =
+            (kpages[0].base().into_raw_value() + Exception::CONTEXT_HW_SIZE) as u32;
+
+        let stack: Self = Self {
+            kpages,
+            guard_threshold,
+        };
 
         // Fill the bottom page of the stack with the watermark pattern.
         #[cfg(debug_assertions)]
         stack.fill_guard_watermark();
 
         Ok(stack)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the guard threshold for this kernel stack. This is the lowest safe ESP value:
+    /// the stack base address plus the maximum hardware-pushed exception frame size.
+    ///
+    /// # Returns
+    ///
+    /// The guard threshold value.
+    ///
+    #[allow(dead_code)]
+    pub fn guard_threshold(&self) -> u32 {
+        self.guard_threshold
     }
 
     ///
@@ -236,6 +285,21 @@ pub fn check_boot_stack_guard() -> Result<(), Error> {
     }
 }
 
+///
+/// # Description
+///
+/// Sets the active stack overflow guard threshold. Called on every context switch to update the
+/// assembly-level guard to the currently-active kernel stack.
+///
+/// # Parameters
+///
+/// - `threshold`: The guard threshold (lowest safe ESP) for the new active stack.
+///
+#[allow(dead_code)]
+pub fn set_active_guard(threshold: u32) {
+    EXCP_STACK_GUARD.store(threshold, Ordering::Release);
+}
+
 //==================================================================================================
 // Trait Implementations
 //==================================================================================================
@@ -255,6 +319,16 @@ impl fmt::Debug for KernelStack {
 impl Drop for KernelStack {
     fn drop(&mut self) {
         debug!("{:?}", &self);
+
+        // If this stack was the active one, clear the guard so a stale threshold is never
+        // checked against a freed stack region.
+        let _ = EXCP_STACK_GUARD.compare_exchange(
+            self.guard_threshold,
+            0,
+            Ordering::Release,
+            Ordering::Relaxed,
+        );
+
         while let Some(kpage) = self.kpages.pop() {
             drop(kpage);
         }

--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -119,7 +119,6 @@ impl KernelStack {
     ///
     /// The guard threshold value.
     ///
-    #[allow(dead_code)]
     pub fn guard_threshold(&self) -> u32 {
         self.guard_threshold
     }
@@ -295,7 +294,6 @@ pub fn check_boot_stack_guard() -> Result<(), Error> {
 ///
 /// - `threshold`: The guard threshold (lowest safe ESP) for the new active stack.
 ///
-#[allow(dead_code)]
 pub fn set_active_guard(threshold: u32) {
     EXCP_STACK_GUARD.store(threshold, Ordering::Release);
 }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -626,6 +626,7 @@ impl ProcessManager {
         let next_tid: ThreadIdentifier = next_process.get_tid();
         self.interrupt_reason = reason;
         self.running = Some(next_process);
+        self.update_active_stack_guard();
         (next_pid, next_tid, previous_context, next_context, user_tda)
     }
 
@@ -722,6 +723,7 @@ impl ProcessManager {
         let next_tid: ThreadIdentifier = next_process.get_tid();
         self.interrupt_reason = reason;
         self.running = Some(next_process);
+        self.update_active_stack_guard();
         (next_pid, next_tid, previous_context, next_context, user_tda)
     }
 
@@ -904,6 +906,7 @@ impl ProcessManager {
         let next_tid: ThreadIdentifier = next_process.get_tid();
         self.interrupt_reason = reason;
         self.running = Some(next_process);
+        self.update_active_stack_guard();
         (next_pid, next_tid, previous_context, next_context, user_tda)
     }
 
@@ -995,6 +998,7 @@ impl ProcessManager {
         let next_tid: ThreadIdentifier = next_process.get_tid();
         self.interrupt_reason = reason;
         self.running = Some(next_process);
+        self.update_active_stack_guard();
         (next_pid, next_tid, join_cond, previous_context, next_context, user_tda)
     }
 
@@ -1402,9 +1406,28 @@ impl ProcessManager {
                     running.get_tid(),
                     running.state().pid(),
                 );
-                platform::shutdown(ExitStatus::from(ErrorCode::UnrecoverableState).into());
+                platform::shutdown(ExitStatus::STACK_OVERFLOW_WATERMARK.into());
             }
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Updates the assembly-level stack overflow guard to match the currently-active kernel stack.
+    /// Called after setting `self.running` in every scheduling path.
+    ///
+    fn update_active_stack_guard(&self) {
+        if let Some(ref running) = self.running {
+            if let Some(threshold) = running.guard_threshold() {
+                crate::mm::kstack::set_active_guard(threshold);
+                return;
+            }
+        }
+
+        // When there is no running process or no guard threshold, clear the guard so that
+        // a stale threshold from a previous stack does not trigger a false overflow.
+        crate::mm::kstack::set_active_guard(0);
     }
 
     ///

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -334,6 +334,20 @@ impl RunningProcess {
     ///
     /// # Description
     ///
+    /// Returns the guard threshold of the running thread's kernel stack, if any.
+    ///
+    /// # Returns
+    ///
+    /// The guard threshold value, or `None` if the running thread has no kernel stack.
+    ///
+    #[inline]
+    pub fn guard_threshold(&self) -> Option<u32> {
+        self.running.guard_threshold()
+    }
+
+    ///
+    /// # Description
+    ///
     /// Adds a ready thread to the running process.
     ///
     /// # Parameters

--- a/src/kernel/src/pm/thread/running.rs
+++ b/src/kernel/src/pm/thread/running.rs
@@ -224,6 +224,20 @@ impl RunningThread {
     ///
     /// # Description
     ///
+    /// Returns the guard threshold of the running thread's kernel stack, if any.
+    ///
+    /// # Returns
+    ///
+    /// The guard threshold value, or `None` if the thread has no kernel stack.
+    ///
+    #[inline]
+    pub fn guard_threshold(&self) -> Option<u32> {
+        self.state.guard_threshold()
+    }
+
+    ///
+    /// # Description
+    ///
     /// Sets the base address for the user-space thread data area for the target thread.
     ///
     /// # Parameters

--- a/src/kernel/src/pm/thread/state.rs
+++ b/src/kernel/src/pm/thread/state.rs
@@ -253,6 +253,19 @@ impl ThreadState {
     ///
     /// # Description
     ///
+    /// Returns the guard threshold of the kernel stack, if any.
+    ///
+    /// # Returns
+    ///
+    /// The guard threshold value, or `None` if this thread has no kernel stack.
+    ///
+    pub(super) fn guard_threshold(&self) -> Option<u32> {
+        self.kernel_stack.as_ref().map(|ks| ks.guard_threshold())
+    }
+
+    ///
+    /// # Description
+    ///
     /// Returns the user stack of the thread, if any.
     ///
     /// # Returns

--- a/src/libs/arch/src/x86/cpu/excp.rs
+++ b/src/libs/arch/src/x86/cpu/excp.rs
@@ -100,6 +100,11 @@ impl TryFrom<u32> for Exception {
 }
 
 impl Exception {
+    /// Maximum number of bytes the CPU pushes onto the stack when an exception happens (with a
+    /// privilege-level change): EIP (4) + CS (4) + EFLAGS (4) + ESP (4) + SS (4) + error code (4) =
+    /// 24 bytes.
+    pub const CONTEXT_HW_SIZE: usize = 24;
+
     /// Converts an exception vector number into an [`Exception`], returning `None` for
     /// invalid or unrecognized vector numbers.
     pub fn try_from_vector(vector: usize) -> Option<Self> {

--- a/src/libs/sys/src/exit_status.rs
+++ b/src/libs/sys/src/exit_status.rs
@@ -37,6 +37,18 @@ pub struct ExitStatus(u32);
 //==================================================================================================
 
 impl ExitStatus {
+    /// Stack overflow detected at exception entry (assembly guard).
+    ///
+    /// The assembly macro `excp_stack_guard_check` in `hooks.S` mirrors this value as
+    /// `STACK_OVERFLOW_EXIT_STATUS`. Both constants must be kept in sync manually.
+    pub const STACK_OVERFLOW_EXCEPTION: Self = Self(200);
+
+    /// Stack overflow detected at a scheduling checkpoint (Rust guard watermark).
+    pub const STACK_OVERFLOW_WATERMARK: Self = Self(201);
+
+    /// Kernel panic handler invoked.
+    pub const KERNEL_PANIC: Self = Self(202);
+
     ///
     /// # Description
     ///


### PR DESCRIPTION
## Summary

Add a dynamic stack overflow guard that detects kernel stack overflow at exception entry, before the CPU touches potentially unmapped memory.

## Changes

1. **`[libs]` Add `ExitStatus` and `Exception` constants** — new `ExitStatus::STACK_OVERFLOW_EXCEPTION` (200), `STACK_OVERFLOW_WATERMARK` (201), `KERNEL_PANIC` (202), and `Exception::CONTEXT_HW_SIZE`.

2. **`[kernel]` Use `ExitStatus::KERNEL_PANIC` in kpanic handler** — replace ad-hoc `ErrorCode::UnrecoverableState` conversion with the dedicated constant.

3. **`[kernel]` Add dynamic stack guard infrastructure in kstack** — `EXCP_STACK_GUARD` global (`AtomicU32`), `guard_threshold` field on `KernelStack`, `set_active_guard()`, and guard clearing on `Drop`.

4. **`[kernel]` Plumb guard threshold through thread/process** — expose `guard_threshold()` through `ThreadState → RunningThread → RunningProcess → ProcessManager` and call `update_active_stack_guard()` on every context switch.

5. **`[kernel]` Add assembly-level exception stack guard check** — `excp_stack_guard_check` macro in `hooks.S` compares ESP against `EXCP_STACK_GUARD`; on overflow triggers a clean VMM shutdown. Boot initialization in `start.S` and shared `asm_defs.h` header.