### PR TITLE
[kernel] Buffer kernel log output

### DIFF
--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -115,3 +115,9 @@ cond_open_max = 32
 # - This value must be smaller than a page.
 # - The kernel debug handler rejects messages larger than this limit.
 debug_buffer_size = 256
+
+# Size (in bytes) of the kernel log buffer.
+# Notes:
+# - All kernel log output is buffered here before being flushed in bulk.
+# - Set to 0 to disable all kernel logging.
+klog_buffer_size = 4096

--- a/src/kernel/src/debug.rs
+++ b/src/kernel/src/debug.rs
@@ -31,7 +31,9 @@ fn do_debug(buf: &[u8]) -> Result<(), Error> {
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         },
     };
-    unsafe { crate::klog::puts(message) }
+    // SAFETY: the standard output device is present, initialized, and accessed
+    // exclusively from a single core with interrupts disabled.
+    unsafe { crate::klog::puts(message) };
 
     Ok(())
 }

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -251,17 +251,17 @@ pub unsafe fn vmbus_read(addr: *mut u8) {
 ///
 /// # Description
 ///
-/// Shutdowns the machine.
+/// Shuts down the machine.
 ///
 /// # Parameters
 ///
 /// - `status`: The shutdown status code (low 8 bits are passed to the VMM).
 ///
-/// # Return
+/// # Returns
 ///
 /// This function never returns.
 ///
-pub fn shutdown(status: usize) -> ! {
+pub(in crate::hal::platform) fn do_shutdown(status: usize) -> ! {
     // Pass the low 8 bits of status as the exit code to the VMM.
     let code: u8 = (status & 0xFF) as u8;
     // NOTE: We use abort_with_code() for all exit codes (including 0) rather than halt() because

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -194,17 +194,17 @@ pub unsafe fn vmbus_read(addr: *mut u8) {
 ///
 /// # Description
 ///
-/// Shutdowns the machine.
+/// Shuts down the machine.
 ///
 /// # Parameters
 ///
 /// - `status`: The shutdown status code.
 ///
-/// # Return
+/// # Returns
 ///
 /// This function never returns.
 ///
-pub fn shutdown(status: usize) -> ! {
+pub(in crate::hal::platform) fn do_shutdown(status: usize) -> ! {
     unsafe {
         let status: u16 = (status & 0xffff) as u16;
         let cmd: u16 = ::config::microvm::DEFAULT_VMM_SHUTDOWN_CMD;

--- a/src/kernel/src/hal/platform/mod.rs
+++ b/src/kernel/src/hal/platform/mod.rs
@@ -39,9 +39,47 @@ pub use microvm::*;
 #[cfg(feature = "hyperlight")]
 pub use hyperlight::*;
 
+#[cfg(any(
+    feature = "qemu-pc",
+    feature = "qemu-isapc",
+    feature = "qemu-baremetal"
+))]
+use pc::do_shutdown;
+
+#[cfg(feature = "microvm")]
+use microvm::do_shutdown;
+
+#[cfg(feature = "hyperlight")]
+use hyperlight::do_shutdown;
+
 pub mod acpi;
 pub mod bootinfo;
 pub mod madt;
+
+//==================================================================================================
+// Shutdown
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Shuts down the machine. Flushes the kernel log buffer to ensure all buffered output is emitted,
+/// then delegates to the platform-specific shutdown implementation.
+///
+/// # Parameters
+///
+/// - `status`: The shutdown status code.
+///
+/// # Returns
+///
+/// This function never returns.
+///
+pub fn shutdown(status: usize) -> ! {
+    // SAFETY: the standard output device is present, initialized, and accessed exclusively from a
+    // single core with interrupts disabled.
+    unsafe { crate::klog::flush() };
+    do_shutdown(status);
+}
 
 //==================================================================================================
 // Interrupts

--- a/src/kernel/src/hal/platform/pc/baremetal.rs
+++ b/src/kernel/src/hal/platform/pc/baremetal.rs
@@ -8,17 +8,17 @@
 ///
 /// # Description
 ///
-/// Shutdowns the machine.
+/// Shuts down the machine.
 ///
 /// # Parameters
 ///
 /// - `status`: The shutdown status code.
 ///
-/// # Return
+/// # Returns
 ///
 /// This function never returns.
 ///
-pub fn shutdown(_status: usize) -> ! {
+pub(in crate::hal::platform) fn do_shutdown(_status: usize) -> ! {
     loop {
         core::hint::spin_loop();
     }

--- a/src/kernel/src/hal/platform/pc/mod.rs
+++ b/src/kernel/src/hal/platform/pc/mod.rs
@@ -70,16 +70,16 @@ pub mod mboot;
 //==================================================================================================
 
 #[cfg(any(feature = "qemu-isapc", feature = "qemu-pc"))]
-pub use qemu::{
-    putb,
-    shutdown,
-};
+pub use qemu::putb;
+
+#[cfg(any(feature = "qemu-isapc", feature = "qemu-pc"))]
+pub(in crate::hal::platform) use qemu::do_shutdown;
 
 #[cfg(feature = "qemu-baremetal")]
-pub use baremetal::{
-    putb,
-    shutdown,
-};
+pub use baremetal::putb;
+
+#[cfg(feature = "qemu-baremetal")]
+pub(in crate::hal::platform) use baremetal::do_shutdown;
 
 ///
 /// # Description

--- a/src/kernel/src/hal/platform/pc/qemu/isapc.rs
+++ b/src/kernel/src/hal/platform/pc/qemu/isapc.rs
@@ -8,17 +8,17 @@
 ///
 /// # Description
 ///
-/// Shutdowns the machine.
+/// Shuts down the machine.
 ///
 /// # Parameters
 ///
 /// - `status`: The shutdown status code.
 ///
-/// # Return
+/// # Returns
 ///
 /// This function never returns.
 ///
-pub fn shutdown(_status: usize) -> ! {
+pub(in crate::hal::platform) fn do_shutdown(_status: usize) -> ! {
     loop {
         core::hint::spin_loop();
     }

--- a/src/kernel/src/hal/platform/pc/qemu/mod.rs
+++ b/src/kernel/src/hal/platform/pc/qemu/mod.rs
@@ -16,10 +16,10 @@ mod pc;
 //==================================================================================================
 
 #[cfg(feature = "qemu-isapc")]
-pub use isapc::shutdown;
+pub(in crate::hal::platform) use isapc::do_shutdown;
 
 #[cfg(feature = "qemu-pc")]
-pub use pc::shutdown;
+pub(in crate::hal::platform) use pc::do_shutdown;
 
 //==================================================================================================
 // Standalone Functions

--- a/src/kernel/src/hal/platform/pc/qemu/pc.rs
+++ b/src/kernel/src/hal/platform/pc/qemu/pc.rs
@@ -8,17 +8,17 @@
 ///
 /// # Description
 ///
-/// Shutdowns the machine.
+/// Shuts down the machine.
 ///
 /// # Parameters
 ///
 /// - `status`: The shutdown status code.
 ///
-/// # Return
+/// # Returns
 ///
 /// This function never returns.
 ///
-pub fn shutdown(_status: usize) -> ! {
+pub(in crate::hal::platform) fn do_shutdown(_status: usize) -> ! {
     unsafe {
         ::arch::io::out16(::config::pc::DEFAULT_VMM_PORT, ::config::pc::DEFAULT_VMM_SHUTDOWN_CMD);
     };

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -99,6 +99,11 @@ pub fn kcall_handler() -> ExitStatus {
 
         // No work to do, so yield the CPU.
         if !message_received && !harvested_process {
+            // Flush the kernel log buffer.
+            // SAFETY: the standard output device is present, initialized, and accessed
+            // exclusively from a single core with interrupts disabled.
+            unsafe { crate::klog::flush() };
+
             // SAFETY: the kernel process does not hold any resources.
             if let Err(error) = unsafe { ProcessManager::giveup() } {
                 error!("context switch failed (error={:?})", error);

--- a/src/kernel/src/klog.rs
+++ b/src/kernel/src/klog.rs
@@ -1,4 +1,4 @@
-// Copyright(c) 2dThe Maintainers of Nanvix.
+// Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
 //==================================================================================================
@@ -91,6 +91,8 @@ impl Drop for Klog {
 
 impl fmt::Write for Klog {
     fn write_str(&mut self, s: &str) -> fmt::Result {
+        // SAFETY: the standard output device is present, initialized, and accessed
+        // exclusively from a single core with interrupts disabled.
         unsafe { puts(s) };
         Ok(())
     }
@@ -116,7 +118,8 @@ impl core::fmt::Debug for KlogLevel {
 ///
 /// # Description
 ///
-/// Writes the string `s` to the platform's standard debug device.
+/// Writes the string `s` directly to the platform's standard debug device, bypassing the kernel log
+/// buffer. This is used internally by the buffer's flush path.
 ///
 /// # Parameters
 ///
@@ -130,7 +133,7 @@ impl core::fmt::Debug for KlogLevel {
 /// - It assumes that the standard output device was properly initialized.
 /// - It does not prevent concurrent access to the standard output device.
 ///
-pub unsafe fn puts(s: &str) {
+unsafe fn raw_puts(s: &str) {
     cfg_if::cfg_if! {
         if #[cfg(feature = "puts")] {
             platform::puts(s);
@@ -142,3 +145,203 @@ pub unsafe fn puts(s: &str) {
         }
     }
 }
+
+///
+/// # Description
+///
+/// Writes the string `s` to the kernel log buffer. The buffered data is flushed to the platform's
+/// standard debug device in bulk when the buffer is full or when [`flush()`] is called.
+///
+/// # Parameters
+///
+/// - `s`: String to write.
+///
+/// # Safety
+///
+/// This function is unsafe for multiple reasons:
+///
+/// - It assumes that the standard output device is present.
+/// - It assumes that the standard output device was properly initialized.
+/// - It does not prevent concurrent access to the standard output device.
+///
+pub unsafe fn puts(_s: &str) {
+    #[cfg(not(feature = "smp"))]
+    {
+        // Logging is disabled when the buffer size is zero.
+        if BUFFER_SIZE == 0 {
+            return;
+        }
+
+        KLOG_BUFFER.get().append(_s);
+    }
+}
+
+///
+/// # Description
+///
+/// Flushes the kernel log buffer, writing all buffered data to the platform's standard debug device
+/// in bulk. This should be called periodically (e.g., from the kernel call handler loop) and before
+/// shutdown to ensure no output is lost.
+///
+/// # Safety
+///
+/// This function is unsafe for multiple reasons:
+///
+/// - It assumes that the standard output device is present.
+/// - It assumes that the standard output device was properly initialized.
+/// - It does not prevent concurrent access to the standard output device.
+///
+pub unsafe fn flush() {
+    #[cfg(not(feature = "smp"))]
+    {
+        // Logging is disabled when the buffer size is zero.
+        if BUFFER_SIZE == 0 {
+            return;
+        }
+
+        KLOG_BUFFER.get().flush();
+    }
+}
+
+//==================================================================================================
+// Kernel Log Buffer
+//==================================================================================================
+
+// The kernel log buffer infrastructure is only available in single-core builds. Under SMP, all
+// output is written directly to the platform device (no buffering).
+#[cfg(not(feature = "smp"))]
+mod buffer {
+    use super::*;
+    use ::core::cell::UnsafeCell;
+
+    /// Size of the kernel log buffer in bytes.
+    pub const BUFFER_SIZE: usize = config::kernel::KLOG_BUFFER_SIZE;
+
+    /// Global kernel log buffer.
+    ///
+    /// Wrapped in [`SyncUnsafeCell`] to allow safe static storage on a single-core system.
+    pub static KLOG_BUFFER: SyncUnsafeCell<KlogBuffer> = SyncUnsafeCell::new(KlogBuffer::new());
+
+    /// A thin wrapper around [`UnsafeCell`] that implements [`Sync`].
+    ///
+    /// # Safety
+    ///
+    /// This is sound because the Nanvix kernel runs on a single core with interrupts disabled
+    /// during all access to the wrapped value, so no concurrent access can occur.
+    pub struct SyncUnsafeCell<T>(UnsafeCell<T>);
+
+    impl<T> SyncUnsafeCell<T> {
+        pub const fn new(value: T) -> Self {
+            Self(UnsafeCell::new(value))
+        }
+
+        /// Returns a mutable reference to the inner value.
+        ///
+        /// # Safety
+        ///
+        /// The caller must ensure that no other reference to the inner value exists.
+        #[allow(clippy::mut_from_ref)]
+        pub unsafe fn get(&self) -> &mut T {
+            &mut *self.0.get()
+        }
+    }
+
+    // SAFETY: the kernel is single-core with interrupts disabled during access.
+    unsafe impl<T> Sync for SyncUnsafeCell<T> {}
+
+    /// A fixed-size buffer that batches kernel log output before flushing to the platform device.
+    ///
+    /// All kernel log output (from logging macros and the debug kernel call) is appended to this
+    /// buffer instead of being written directly to the output device. The buffer is flushed in bulk
+    /// when it is full or when an explicit flush is requested, reducing per-character I/O overhead.
+    pub struct KlogBuffer {
+        /// Underlying storage.
+        data: [u8; BUFFER_SIZE],
+        /// Number of valid bytes currently stored in `data`.
+        len: usize,
+    }
+
+    impl KlogBuffer {
+        /// Creates a new, empty kernel log buffer.
+        pub const fn new() -> Self {
+            Self {
+                data: [0; BUFFER_SIZE],
+                len: 0,
+            }
+        }
+
+        ///
+        /// # Description
+        ///
+        /// Appends the string `s` to the buffer. If the incoming data does not fit, the buffer is
+        /// flushed first (force-flush policy) before appending. Messages larger than the entire
+        /// buffer are flushed and then written directly to the platform output.
+        ///
+        /// # Parameters
+        ///
+        /// - `s`: String to append.
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe for multiple reasons:
+        ///
+        /// - It assumes that the standard output device is present.
+        /// - It assumes that the standard output device was properly initialized.
+        /// - It does not prevent concurrent access to the standard output device.
+        ///
+        pub unsafe fn append(&mut self, s: &str) {
+            let bytes: &[u8] = s.as_bytes();
+
+            // If the message is larger than the entire buffer, flush current contents and write
+            // directly to the platform output to avoid losing data.
+            if bytes.len() > BUFFER_SIZE {
+                self.flush();
+                raw_puts(s);
+                return;
+            }
+
+            // If the message does not fit in the remaining space, flush first.
+            if self.len + bytes.len() > BUFFER_SIZE {
+                self.flush();
+            }
+
+            // Append to buffer.
+            self.data[self.len..self.len + bytes.len()].copy_from_slice(bytes);
+            self.len += bytes.len();
+
+            // If the buffer is now exactly full, flush immediately to honor the documented policy.
+            if self.len == BUFFER_SIZE {
+                self.flush();
+            }
+        }
+
+        ///
+        /// # Description
+        ///
+        /// Flushes all buffered data to the platform's standard debug device and resets the buffer.
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe for multiple reasons:
+        ///
+        /// - It assumes that the standard output device is present.
+        /// - It assumes that the standard output device was properly initialized.
+        /// - It does not prevent concurrent access to the standard output device.
+        ///
+        pub unsafe fn flush(&mut self) {
+            // No data to flush.
+            if self.len == 0 {
+                return;
+            }
+
+            // SAFETY: the buffer only contains bytes from valid UTF-8 strings appended via
+            // `append()`.
+            let s: &str = core::str::from_utf8_unchecked(&self.data[..self.len]);
+            raw_puts(s);
+            self.len = 0;
+        }
+    }
+}
+
+#[cfg(not(feature = "smp"))]
+use buffer::*;

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -184,6 +184,12 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     );
     constants.push_str(&format!("pub const DEBUG_BUFFER_SIZE: usize = {val};\n"));
 
+    let val: usize = parse_hex_or_decimal_usize(
+        required_key(&kernel_config_toml, "klog_buffer_size"),
+        "klog_buffer_size",
+    );
+    constants.push_str(&format!("pub const KLOG_BUFFER_SIZE: usize = {val};\n"));
+
     constants.push_str("}\n");
 
     //==============================================================================================


### PR DESCRIPTION
## Summary

Buffer kernel log output to reduce the overhead of individual log writes.

## Changes

- Added kernel log buffer configuration options in `kernel_config.toml`
- Implemented log buffering in `klog.rs` with configurable buffer size
- Updated platform modules to support buffered log flushing
- Added kernel call handler support for log buffer operations
- Updated config build script to expose new configuration constants

## Files Changed

- `build/kernel_config.toml` — new config entries for log buffer
- `src/kernel/src/klog.rs` — core log buffer implementation
- `src/kernel/src/debug.rs` — debug output adjustments
- `src/kernel/src/hal/platform/` — platform-level flush support
- `src/kernel/src/kcall/handler.rs` — kernel call handler updates
- `src/libs/config/build.rs` — config build integration