### PR TITLE
[slab] Don't waste index bits on index

### DIFF
--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -113,7 +113,6 @@ impl Slab {
 
         // Compute layout of the slab allocator.
         let total_num_blocks: usize = len / block_size;
-        // info!("total number of blocks: {:?}", total_num_blocks);
 
         // The number of index blocks (`num_index_blocks`) we need is
         //  `ceil(total_num_blocks / (block_size * u8::BITS + 1))`
@@ -133,7 +132,6 @@ impl Slab {
             } else {
                 1
             };
-        // info!("number of index blocks: {:?}", num_index_blocks);
         if num_index_blocks >= total_num_blocks {
             return Err(Error::new(ErrorCode::InvalidArgument, "insufficient blocks for index"));
         }
@@ -141,14 +139,12 @@ impl Slab {
         let data_addr: *mut u8 = addr.add(num_index_blocks * block_size);
 
         let num_data_blocks: usize = total_num_blocks - num_index_blocks;
-        // info!("number of data blocks: {:?}", num_data_blocks);
         let index_len = (num_data_blocks / U8_BITS)
             + if num_data_blocks.is_multiple_of(U8_BITS) {
                 0
             } else {
                 1
             };
-        // info!("length of index in bytes: {:?}", index_len);
 
         // Instantiate index.
         let storage: RawArray<u8> = RawArray::from_raw_parts(addr, index_len)?;

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -125,8 +125,8 @@ impl Slab {
         // `num_index_blocks` blocks contain. The right-hand side of this inequality
         // is the number of blocks that aren't index blocks. So, a bitmap occupying
         // `num_index_blocks` blocks can address all the blocks outside of that bitmap.
-        let u8_bits: usize = u8::BITS as usize;
-        let divisor: usize = block_size * u8_bits + 1;
+        const U8_BITS: usize = u8::BITS as usize;
+        let divisor: usize = block_size * U8_BITS + 1;
         let num_index_blocks: usize = (total_num_blocks / divisor)
             + if total_num_blocks.is_multiple_of(divisor) {
                 0
@@ -142,8 +142,8 @@ impl Slab {
 
         let num_data_blocks: usize = total_num_blocks - num_index_blocks;
         // info!("number of data blocks: {:?}", num_data_blocks);
-        let index_len = (num_data_blocks / u8_bits)
-            + if num_data_blocks.is_multiple_of(u8_bits) {
+        let index_len = (num_data_blocks / U8_BITS)
+            + if num_data_blocks.is_multiple_of(U8_BITS) {
                 0
             } else {
                 1
@@ -164,7 +164,7 @@ impl Slab {
         // them "in use" and thereby prevent them from being
         // allocated. Note that there are at most 7 such bits we need
         // to set.
-        for i in num_data_blocks..(index_len * u8_bits) {
+        for i in num_data_blocks..(index_len * U8_BITS) {
             index.set(i)?;
         }
 

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -101,11 +101,6 @@ impl Slab {
             return Err(Error::new(ErrorCode::InvalidArgument, "invalid block size"));
         }
 
-        // Check if the `block_size` is a power of two.
-        if block_size & (block_size - 1) != 0 {
-            return Err(Error::new(ErrorCode::InvalidArgument, "block size is not a power of two"));
-        }
-
         // Check if `addr` is aligned to `block_size`.
         if !(addr as usize).is_multiple_of(block_size) {
             return Err(Error::new(ErrorCode::InvalidArgument, "unaligned start address"));

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -98,7 +98,7 @@ impl Slab {
             return Err(Error::new(ErrorCode::InvalidArgument, "wrapping memory region"));
         }
 
-        // Check if block size is valid.
+        // Check if the block size is valid.
         if block_size == 0 || block_size >= i32::MAX as usize || block_size > len {
             return Err(Error::new(ErrorCode::InvalidArgument, "invalid block size"));
         }
@@ -108,7 +108,7 @@ impl Slab {
             return Err(Error::new(ErrorCode::InvalidArgument, "block size is not a power of two"));
         }
 
-        // Check if `start_addr` is aligned to `block_size`.
+        // Check if `addr` is aligned to `block_size`.
         if !(addr as usize).is_multiple_of(block_size) {
             return Err(Error::new(ErrorCode::InvalidArgument, "unaligned start address"));
         }

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -139,7 +139,7 @@ impl Slab {
         let data_addr: *mut u8 = addr.add(num_index_blocks * block_size);
 
         let num_data_blocks: usize = total_num_blocks - num_index_blocks;
-        let index_len = (num_data_blocks / U8_BITS)
+        let index_len: usize = (num_data_blocks / U8_BITS)
             + if num_data_blocks.is_multiple_of(U8_BITS) {
                 0
             } else {

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -128,7 +128,7 @@ impl Slab {
                 1
             };
         // info!("number of index blocks: {:?}", num_index_blocks);
-        if num_index_blocks > total_num_blocks {
+        if num_index_blocks >= total_num_blocks {
             return Err(Error::new(ErrorCode::InvalidArgument, "insufficient blocks for index"));
         }
         let num_data_blocks: usize = total_num_blocks - num_index_blocks;

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -48,8 +48,6 @@ pub struct Slab {
     index: Bitmap,
     /// Base address of data blocks.
     data_addr: *mut u8,
-    /// Number of index blocks in the slab.
-    num_index_blocks: usize,
     /// Number of data blocks in the slab.
     num_data_blocks: usize,
     /// Size of blocks in the slab.
@@ -116,13 +114,21 @@ impl Slab {
         // Compute layout of the slab allocator.
         let total_num_blocks: usize = len / block_size;
         // info!("total number of blocks: {:?}", total_num_blocks);
-        if !total_num_blocks.is_multiple_of(u8::BITS as usize) {
-            return Err(Error::new(ErrorCode::InvalidArgument, "invalid number of blocks"));
-        }
-        let index_len: usize = total_num_blocks / u8::BITS as usize;
-        // info!("index length: {:?}", index_len);
-        let num_index_blocks: usize = (index_len / block_size)
-            + if index_len.is_multiple_of(block_size) {
+
+        // The number of index blocks (`num_index_blocks`) we need is
+        //  `ceil(total_num_blocks / (block_size * u8::BITS + 1))`
+        // for the following reason. This condition implies:
+        //  `num_index_blocks * (block_size * u8::BITS + 1) >= total_num_blocks`
+        // This, in turn, implies that:
+        //  `num_index_blocks * block_size * u8::BITS  >= total_num_blocks - num_index_blocks`
+        // The left-hand side of this inequality is the number of bits that
+        // `num_index_blocks` blocks contain. The right-hand side of this inequality
+        // is the number of blocks that aren't index blocks. So, a bitmap occupying
+        // `num_index_blocks` blocks can address all the blocks outside of that bitmap.
+        let u8_bits: usize = u8::BITS as usize;
+        let divisor: usize = block_size * u8_bits + 1;
+        let num_index_blocks: usize = (total_num_blocks / divisor)
+            + if total_num_blocks.is_multiple_of(divisor) {
                 0
             } else {
                 1
@@ -131,14 +137,18 @@ impl Slab {
         if num_index_blocks >= total_num_blocks {
             return Err(Error::new(ErrorCode::InvalidArgument, "insufficient blocks for index"));
         }
-        let num_data_blocks: usize = total_num_blocks - num_index_blocks;
-        // info!("number of data blocks: {:?}", num_data_blocks);
+
         let data_addr: *mut u8 = addr.add(num_index_blocks * block_size);
 
-        // Check if `data_addr` is aligned to `block_size`.
-        if !(data_addr as usize).is_multiple_of(block_size) {
-            return Err(Error::new(ErrorCode::InvalidArgument, "unaligned data address"));
-        }
+        let num_data_blocks: usize = total_num_blocks - num_index_blocks;
+        // info!("number of data blocks: {:?}", num_data_blocks);
+        let index_len = (num_data_blocks / u8_bits)
+            + if num_data_blocks.is_multiple_of(u8_bits) {
+                0
+            } else {
+                1
+            };
+        // info!("length of index in bytes: {:?}", index_len);
 
         // Instantiate index.
         let storage: RawArray<u8> = RawArray::from_raw_parts(addr, index_len)?;
@@ -148,12 +158,17 @@ impl Slab {
         // the memory region is left in a modified state.
 
         // Initialize index.
-        for i in 0..num_index_blocks {
+        //
+        // The uppermost bits of the index may point beyond the end of
+        // the allocated region. So, we need to set those bits to mark
+        // them "in use" and thereby prevent them from being
+        // allocated. Note that there are at most 7 such bits we need
+        // to set.
+        for i in num_data_blocks..(index_len * u8_bits) {
             index.set(i)?;
         }
 
         Ok(Slab {
-            num_index_blocks,
             num_data_blocks,
             block_size,
             data_addr,
@@ -174,10 +189,7 @@ impl Slab {
     pub fn allocate(&mut self) -> Result<*mut u8, Error> {
         let block: usize = self.index.alloc()?;
         // Safety: the start and resulting addresses are valid.
-        let block_addr: *mut u8 = unsafe {
-            self.data_addr
-                .add((block - self.num_index_blocks) * self.block_size)
-        };
+        let block_addr: *mut u8 = unsafe { self.data_addr.add(block * self.block_size) };
         Ok(block_addr)
     }
 
@@ -201,20 +213,20 @@ impl Slab {
     /// - It dereferences the pointer `ptr`.
     ///
     pub unsafe fn deallocate(&mut self, ptr: *const u8) -> Result<(), Error> {
-        // Check if the pointer lies in a memory region that is not managed by this allocator.
-        // Safety: the start and resulting addresses are valid.
-        if ptr < self.data_addr
-            || ptr >= unsafe { self.data_addr.add(self.num_data_blocks * self.block_size) }
-        {
+        // Return an error if the pointer is before the data blocks.
+        if ptr < self.data_addr {
             return Err(Error::new(ErrorCode::BadAddress, "pointer out of bounds"));
         }
 
         // Compute the block index.
-        // Safety: we have already checked that ptr is within the bounds of the slab.
-        let index: usize = self.num_index_blocks
-            + unsafe { ptr.offset_from_unsigned(self.data_addr) } / self.block_size;
+        let index: usize = unsafe { ptr.offset_from_unsigned(self.data_addr) } / self.block_size;
 
-        // Check if the block is already free.
+        // Return an error if the pointer is after the data blocks.
+        if index >= self.num_data_blocks {
+            return Err(Error::new(ErrorCode::BadAddress, "pointer out of bounds"));
+        }
+
+        // Return an error if the block is already free.
         if !self.index.test(index)? {
             return Err(Error::new(ErrorCode::BadAddress, "block is already free"));
         }

--- a/src/libs/slab/src/test.rs
+++ b/src/libs/slab/src/test.rs
@@ -58,16 +58,16 @@ fn test_double_deallocate() {
 
 #[test]
 fn test_slab_creation_minimal_valid_blocks() {
-    // Use a minimal valid configuration: 8 blocks of block_size=1 bytes.
+    // Use a minimal valid configuration: 2 blocks of block_size=1 bytes.
     // This exercises the smallest valid slab layout and ensures the
-    // guard against `num_index_blocks > total_num_blocks` does not
+    // guard against `num_index_blocks >= total_num_blocks` does not
     // reject a valid configuration.
     let block_size: usize = 1;
-    let total_num_blocks: usize = 8;
+    let total_num_blocks: usize = 2;
     let len: usize = total_num_blocks * block_size;
     let mut memory = vec![0u8; len];
     let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr(), len, block_size) };
-    // With block_size=1 and len=8: total=8, index_len=1, num_index=1, data=7 → should succeed.
+    // With block_size=1 and len=2: total_num_blocks=2, num_index_blocks=1 → should succeed.
     assert!(slab.is_ok());
 }
 

--- a/src/libs/slab/src/test.rs
+++ b/src/libs/slab/src/test.rs
@@ -6,14 +6,14 @@ use ::sys::error::ErrorCode;
 
 #[test]
 fn test_slab_creation() {
-    let mut memory = vec![0u32; 1024];
+    let mut memory = vec![0u8; 1024];
     let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 4) };
     assert!(slab.is_ok());
 }
 
 #[test]
 fn test_slab_creation_invalid_length() {
-    let mut memory = vec![0u32; 0];
+    let mut memory = vec![0u8; 0];
     let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 4) };
     assert!(slab.is_err());
     assert_eq!(slab.unwrap_err().code, ErrorCode::InvalidArgument);
@@ -21,7 +21,7 @@ fn test_slab_creation_invalid_length() {
 
 #[test]
 fn test_slab_creation_invalid_block_size() {
-    let mut memory = vec![0u32; 1024];
+    let mut memory = vec![0u8; 1024];
     let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 0) };
     assert!(slab.is_err());
     assert_eq!(slab.unwrap_err().code, ErrorCode::InvalidArgument);
@@ -29,7 +29,7 @@ fn test_slab_creation_invalid_block_size() {
 
 #[test]
 fn test_allocate_deallocate() {
-    let mut memory = vec![0u32; 1024];
+    let mut memory = vec![0u8; 1024];
     let mut slab =
         unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 4) }.unwrap();
 
@@ -42,7 +42,7 @@ fn test_allocate_deallocate() {
 
 #[test]
 fn test_double_deallocate() {
-    let mut memory = vec![0u32; 1024];
+    let mut memory = vec![0u8; 1024];
     let mut slab =
         unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 4) }.unwrap();
 
@@ -87,7 +87,7 @@ fn test_slab_creation_minimal_valid_blocks() {
 
 #[test]
 fn test_allocate_out_of_bounds() {
-    let mut memory = vec![0u32; 1024];
+    let mut memory = vec![0u8; 1024];
     let mut slab =
         unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 4) }.unwrap();
 

--- a/src/libs/slab/src/test.rs
+++ b/src/libs/slab/src/test.rs
@@ -86,6 +86,23 @@ fn test_slab_creation_minimal_valid_blocks() {
 }
 
 #[test]
+fn test_slab_creation_non_power_of_2() {
+    let block_size: usize = 10;
+    let total_num_blocks: usize = 15;
+    let len: usize = total_num_blocks * block_size;
+    let mut memory = vec![0u8; len + block_size];
+    let memory_offset_mod_block_size: usize = (memory.as_mut_ptr() as usize) % block_size;
+    let padding_needed = if memory_offset_mod_block_size != 0 {
+        block_size - memory_offset_mod_block_size
+    } else {
+        0
+    };
+    let slab =
+        unsafe { Slab::from_raw_parts(memory.as_mut_ptr().add(padding_needed), len, block_size) };
+    assert!(slab.is_ok());
+}
+
+#[test]
 fn test_allocate_out_of_bounds() {
     let mut memory = vec![0u8; 1024];
     let mut slab =

--- a/src/libs/slab/src/test.rs
+++ b/src/libs/slab/src/test.rs
@@ -69,6 +69,20 @@ fn test_slab_creation_minimal_valid_blocks() {
     let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr(), len, block_size) };
     // With block_size=1 and len=2: total_num_blocks=2, num_index_blocks=1 → should succeed.
     assert!(slab.is_ok());
+    let mut slab = slab.unwrap();
+
+    // It should only be possible to allocate a single block from this
+    // minimal configuration: the one block that isn't an index block.
+    // The failure to allocate more than one block tests that the
+    // current implementation correctly avoids allocating beyond the
+    // end of the valid region.
+    let block1 = slab.allocate();
+    assert!(block1.is_ok());
+    let block1 = block1.unwrap();
+    assert!(memory.as_ptr() <= block1);
+    assert!(unsafe { block1.add(block_size) <= memory.as_mut_ptr().add(len) });
+    let block2 = slab.allocate();
+    assert!(!block2.is_ok());
 }
 
 #[test]

--- a/src/libs/slab/src/test.rs
+++ b/src/libs/slab/src/test.rs
@@ -7,14 +7,14 @@ use ::sys::error::ErrorCode;
 #[test]
 fn test_slab_creation() {
     let mut memory = vec![0u8; 1024];
-    let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 4) };
+    let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr(), memory.len(), 4) };
     assert!(slab.is_ok());
 }
 
 #[test]
 fn test_slab_creation_invalid_length() {
     let mut memory = vec![0u8; 0];
-    let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 4) };
+    let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr(), memory.len(), 4) };
     assert!(slab.is_err());
     assert_eq!(slab.unwrap_err().code, ErrorCode::InvalidArgument);
 }
@@ -22,7 +22,7 @@ fn test_slab_creation_invalid_length() {
 #[test]
 fn test_slab_creation_invalid_block_size() {
     let mut memory = vec![0u8; 1024];
-    let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 0) };
+    let slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr(), memory.len(), 0) };
     assert!(slab.is_err());
     assert_eq!(slab.unwrap_err().code, ErrorCode::InvalidArgument);
 }
@@ -30,8 +30,7 @@ fn test_slab_creation_invalid_block_size() {
 #[test]
 fn test_allocate_deallocate() {
     let mut memory = vec![0u8; 1024];
-    let mut slab =
-        unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 4) }.unwrap();
+    let mut slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr(), memory.len(), 4) }.unwrap();
 
     let block = slab.allocate();
     assert!(block.is_ok());
@@ -43,8 +42,7 @@ fn test_allocate_deallocate() {
 #[test]
 fn test_double_deallocate() {
     let mut memory = vec![0u8; 1024];
-    let mut slab =
-        unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 4) }.unwrap();
+    let mut slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr(), memory.len(), 4) }.unwrap();
 
     let block = slab.allocate().unwrap();
     unsafe {
@@ -82,7 +80,7 @@ fn test_slab_creation_minimal_valid_blocks() {
     assert!(memory.as_ptr() <= block1);
     assert!(unsafe { block1.add(block_size) <= memory.as_mut_ptr().add(len) });
     let block2 = slab.allocate();
-    assert!(!block2.is_ok());
+    assert!(block2.is_err());
 }
 
 #[test]
@@ -105,8 +103,7 @@ fn test_slab_creation_non_power_of_2() {
 #[test]
 fn test_allocate_out_of_bounds() {
     let mut memory = vec![0u8; 1024];
-    let mut slab =
-        unsafe { Slab::from_raw_parts(memory.as_mut_ptr() as *mut u8, memory.len(), 4) }.unwrap();
+    let mut slab = unsafe { Slab::from_raw_parts(memory.as_mut_ptr(), memory.len(), 4) }.unwrap();
 
     let invalid_ptr = unsafe { memory.as_mut_ptr().add(2048) };
     let dealloc_result = unsafe { slab.deallocate(invalid_ptr as *const u8) };


### PR DESCRIPTION
This pull request refactors the slab allocator implementation to improve correctness and simplify block indexing logic. The main changes involve removing the explicit tracking of index blocks, updating how the number of index and data blocks is calculated, and refining allocation and deallocation logic to avoid off-by-one errors and ensure proper bounds checking.