### PR TITLE
perf: VFS metadata cache, ramfs madvise prefaulting, mkramfs optimizations

### DIFF
--- a/src/libs/vfs/src/cache.rs
+++ b/src/libs/vfs/src/cache.rs
@@ -1,0 +1,136 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! VFS metadata cache for accelerating repeated path lookups.
+//!
+//! CPython's import system performs hundreds of `stat()` and `open()` calls
+//! during interpreter startup. Each call traverses the FAT32 cluster chain
+//! to resolve the path. This module provides caches that eliminate redundant
+//! FAT32 traversals:
+//!
+//! - **Stat cache**: Maps absolute paths to cached `Stat` results.
+//! - **Negative cache**: Tracks paths known to not exist (ENOENT).
+//! - **Raw region cache**: Maps paths to `(ptr, size)` for zero-copy direct
+//!   read handles.
+//!
+//! # Thread Safety
+//!
+//! All caches are protected by `spin::Mutex` for safe concurrent access.
+//!
+//! # Invalidation
+//!
+//! Caches are invalidated on write operations (`mkdir`, `rmdir`, `unlink`,
+//! `rename`, `create`). For read-only filesystems (e.g., ramfs in standalone
+//! mode), invalidation never fires and the caches persist for the VM's
+//! lifetime.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::file::Stat;
+use ::alloc::{
+    collections::BTreeMap,
+    string::String,
+};
+use ::spin::Mutex;
+
+//==================================================================================================
+// Cache State
+//==================================================================================================
+
+/// Cached stat result for a path.
+struct StatCache {
+    entries: BTreeMap<String, Stat>,
+}
+
+/// Set of paths known to not exist.
+struct NegativeCache {
+    entries: BTreeMap<String, ()>,
+}
+
+/// Cached raw region pointers for zero-copy reads.
+struct RawRegionCache {
+    entries: BTreeMap<String, Option<(*const u8, usize)>>,
+}
+
+// SAFETY: The raw pointer in RawRegionCache points into the FAT image memory
+// which lives for the entire program lifetime. Access is serialized through
+// the spin::Mutex.
+unsafe impl Send for RawRegionCache {}
+
+static STAT_CACHE: Mutex<StatCache> = Mutex::new(StatCache {
+    entries: BTreeMap::new(),
+});
+
+static NEGATIVE_CACHE: Mutex<NegativeCache> = Mutex::new(NegativeCache {
+    entries: BTreeMap::new(),
+});
+
+static RAW_REGION_CACHE: Mutex<RawRegionCache> = Mutex::new(RawRegionCache {
+    entries: BTreeMap::new(),
+});
+
+//==================================================================================================
+// Public API
+//==================================================================================================
+
+/// Looks up a cached stat result.
+///
+/// Returns `Some(stat)` if the path has been cached, `None` on cache miss.
+pub fn get_stat(path: &str) -> Option<Stat> {
+    STAT_CACHE.lock().entries.get(path).copied()
+}
+
+/// Inserts a stat result into the cache.
+pub fn put_stat(path: &str, stat: Stat) {
+    STAT_CACHE.lock().entries.insert(String::from(path), stat);
+}
+
+/// Returns `true` if the path is in the negative cache (known ENOENT).
+pub fn is_negative(path: &str) -> bool {
+    NEGATIVE_CACHE.lock().entries.contains_key(path)
+}
+
+/// Adds a path to the negative cache.
+pub fn put_negative(path: &str) {
+    NEGATIVE_CACHE
+        .lock()
+        .entries
+        .insert(String::from(path), ());
+}
+
+/// Looks up a cached raw region result.
+///
+/// Returns `Some(Some((ptr, size)))` if contiguous region was cached,
+/// `Some(None)` if we cached that the file is not contiguous, or
+/// `None` on cache miss.
+pub fn get_raw_region(path: &str) -> Option<Option<(*const u8, usize)>> {
+    RAW_REGION_CACHE.lock().entries.get(path).copied()
+}
+
+/// Inserts a raw region result into the cache.
+pub fn put_raw_region(path: &str, region: Option<(*const u8, usize)>) {
+    RAW_REGION_CACHE
+        .lock()
+        .entries
+        .insert(String::from(path), region);
+}
+
+/// Invalidates all cached entries for a specific path.
+///
+/// Called when a write operation modifies the filesystem.
+pub fn invalidate_path(path: &str) {
+    STAT_CACHE.lock().entries.remove(path);
+    NEGATIVE_CACHE.lock().entries.remove(path);
+    RAW_REGION_CACHE.lock().entries.remove(path);
+}
+
+/// Invalidates the entire cache.
+///
+/// Called when a bulk filesystem modification occurs (e.g., rename across dirs).
+pub fn invalidate_all() {
+    STAT_CACHE.lock().entries.clear();
+    NEGATIVE_CACHE.lock().entries.clear();
+    RAW_REGION_CACHE.lock().entries.clear();
+}

--- a/src/libs/vfs/src/fat32_backend.rs
+++ b/src/libs/vfs/src/fat32_backend.rs
@@ -40,6 +40,14 @@ use ::sysapi::{
 ///
 /// - `path`: Absolute or relative path to check.
 pub fn exists(path: &str) -> bool {
+    // Fast path: check negative cache.
+    if crate::cache::is_negative(path) {
+        return false;
+    }
+    // Fast path: check stat cache.
+    if crate::cache::get_stat(path).is_some() {
+        return true;
+    }
     if crate::stat(path).is_ok() {
         return true;
     }
@@ -111,7 +119,15 @@ pub fn open(path: &str, flags: c_int) -> Result<VfsFileHandle, Fat32Error> {
     let creation_flags: c_int =
         file_creation_flags::O_CREAT | file_creation_flags::O_TRUNC | file_creation_flags::O_EXCL;
     if is_read_only && (flags & creation_flags) == 0 {
-        if let Some((data_ptr, size)) = crate::file_raw_region(path) {
+        // Check raw region cache first, then fall back to VFS lookup.
+        let raw_region = if let Some(cached) = crate::cache::get_raw_region(path) {
+            cached
+        } else {
+            let region = crate::file_raw_region(path);
+            crate::cache::put_raw_region(path, region);
+            region
+        };
+        if let Some((data_ptr, size)) = raw_region {
             return Ok(VfsFileHandle::DirectRead(DirectReadHandle::new(data_ptr, size)));
         }
     }

--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -579,6 +579,11 @@ pub fn vfs_close(fd: c_int) -> Result<(), Fat32Error> {
 
 /// Gets file status for a path through the VFS.
 pub fn vfs_stat(path: &str, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fat32Error> {
+    // Fast path: check negative cache to avoid FAT32 traversal.
+    if crate::cache::is_negative(path) {
+        return Err(Fat32Error::NotFound);
+    }
+
     let info: VfsStat = fat32_backend::stat(path)?;
 
     // Zero-initialize the stat buffer.

--- a/src/libs/vfs/src/file.rs
+++ b/src/libs/vfs/src/file.rs
@@ -392,15 +392,20 @@ pub fn open(path: &str) -> Result<File, Fat32Error> {
 ///
 /// - `path`: The path to the file.
 pub fn file_raw_region(path: &str) -> Option<(*const u8, usize)> {
+    // Check cache first.
+    if let Some(cached) = crate::cache::get_raw_region(path) {
+        return cached;
+    }
+
     let (mount_idx, relative_path): (usize, String) = resolve_path(path).ok()?;
-    state::with_vfs(|vfs| {
+    let result = state::with_vfs(|vfs| {
         let mount: &crate::mount::Mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
-        mount
-            .fat()
-            .file_raw_region(&relative_path)
-            .ok_or(Fat32Error::NotFound)
+        Ok(mount.fat().file_raw_region(&relative_path))
     })
-    .ok()
+    .ok()?;
+
+    crate::cache::put_raw_region(path, result);
+    result
 }
 
 /// File metadata.
@@ -451,18 +456,50 @@ impl Stat {
 /// - [`Fat32Error::NotInitialized`] if the filesystem hasn't been initialized.
 /// - [`Fat32Error::NotFound`] if the path doesn't exist.
 pub fn stat(path: &str) -> Result<Stat, Fat32Error> {
-    let (mount_idx, relative_path) = resolve_path(path)?;
+    // Check negative cache first (known ENOENT).
+    if crate::cache::is_negative(path) {
+        return Err(Fat32Error::NotFound);
+    }
+
+    // Check stat cache.
+    if let Some(cached) = crate::cache::get_stat(path) {
+        return Ok(cached);
+    }
+
+    let result = resolve_path(path);
+    let (mount_idx, relative_path) = match result {
+        Ok(v) => v,
+        Err(Fat32Error::NotFound) => {
+            crate::cache::put_negative(path);
+            return Err(Fat32Error::NotFound);
+        },
+        Err(e) => return Err(e),
+    };
 
     // Handle root of mount specially.
     if relative_path.is_empty() {
-        return Ok(Stat::new(0, true));
+        let s = Stat::new(0, true);
+        crate::cache::put_stat(path, s);
+        return Ok(s);
     }
 
-    state::with_vfs(|vfs| {
+    let result = state::with_vfs(|vfs| {
         let mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
         let fat_stat = mount.fat().stat(&relative_path)?;
         Ok(Stat::new(fat_stat.size, fat_stat.is_dir))
-    })
+    });
+
+    match result {
+        Ok(s) => {
+            crate::cache::put_stat(path, s);
+            Ok(s)
+        },
+        Err(Fat32Error::NotFound) => {
+            crate::cache::put_negative(path);
+            Err(Fat32Error::NotFound)
+        },
+        Err(e) => Err(e),
+    }
 }
 
 /// Directory entry returned by [`read_dir()`].
@@ -521,10 +558,15 @@ impl DirEntry {
 pub fn mkdir(path: &str) -> Result<(), Fat32Error> {
     let (mount_idx, relative_path) = resolve_path(path)?;
 
-    state::with_vfs_mut(|vfs| {
+    let result = state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
         mount.fat_mut().mkdir(&relative_path)
-    })
+    });
+
+    if result.is_ok() {
+        crate::cache::invalidate_path(path);
+    }
+    result
 }
 
 /// Removes an empty directory.
@@ -542,10 +584,15 @@ pub fn mkdir(path: &str) -> Result<(), Fat32Error> {
 pub fn rmdir(path: &str) -> Result<(), Fat32Error> {
     let (mount_idx, relative_path) = resolve_path(path)?;
 
-    state::with_vfs_mut(|vfs| {
+    let result = state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
         mount.fat_mut().rmdir(&relative_path)
-    })
+    });
+
+    if result.is_ok() {
+        crate::cache::invalidate_path(path);
+    }
+    result
 }
 
 /// Deletes a file.
@@ -562,10 +609,15 @@ pub fn rmdir(path: &str) -> Result<(), Fat32Error> {
 pub fn unlink(path: &str) -> Result<(), Fat32Error> {
     let (mount_idx, relative_path) = resolve_path(path)?;
 
-    state::with_vfs_mut(|vfs| {
+    let result = state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
         mount.fat_mut().unlink(&relative_path)
-    })
+    });
+
+    if result.is_ok() {
+        crate::cache::invalidate_path(path);
+    }
+    result
 }
 
 /// Lists the contents of a directory.
@@ -630,10 +682,16 @@ pub fn rename(old_path: &str, new_path: &str) -> Result<(), Fat32Error> {
         return Err(Fat32Error::InvalidPath);
     }
 
-    state::with_vfs(|vfs| {
+    let result = state::with_vfs(|vfs| {
         let mount = vfs.get_mount(old_idx).ok_or(Fat32Error::NotFound)?;
         mount.fat().rename(&old_rel, &new_rel)
-    })
+    });
+
+    if result.is_ok() {
+        crate::cache::invalidate_path(old_path);
+        crate::cache::invalidate_path(new_path);
+    }
+    result
 }
 
 /// Gets the current working directory.

--- a/src/libs/vfs/src/lib.rs
+++ b/src/libs/vfs/src/lib.rs
@@ -59,6 +59,9 @@ extern crate alloc;
 // Modules
 //==================================================================================================
 
+/// VFS metadata cache for accelerating repeated path lookups.
+pub mod cache;
+
 /// FAT32 backend: translates VFS operations to `fat32` crate calls.
 pub mod fat32_backend;
 

--- a/src/uservm/src/pal/linux.rs
+++ b/src/uservm/src/pal/linux.rs
@@ -266,6 +266,47 @@ impl AnonymousMapping {
     ///
     /// # Description
     ///
+    /// Issues an `madvise` hint for a sub-region of the mapping.
+    ///
+    /// # Parameters
+    ///
+    /// * `start` - Byte offset from the start of the mapping (must be page-aligned).
+    /// * `len` - Size of the region in bytes.
+    /// * `advice` - madvise advice constant (e.g., `MADV_SEQUENTIAL`, `MADV_WILLNEED`).
+    ///
+    /// # Returns
+    ///
+    /// On success, returns empty. On failure, returns an error.
+    ///
+    pub fn madvise_at(&self, start: usize, len: usize, advice: i32) -> Result<()> {
+        if len == 0 {
+            return Ok(());
+        }
+
+        if start.checked_add(len).is_none_or(|end| end > self.size) {
+            anyhow::bail!(
+                "madvise region [{start:#x}, {:#x}) exceeds mapping bounds (size={:#x})",
+                start.saturating_add(len),
+                self.size
+            );
+        }
+
+        // SAFETY: `start` has been bounds-checked, so `self.ptr + start` stays within the mapping.
+        let addr: *mut ::libc::c_void = unsafe { self.ptr.cast::<u8>().add(start).cast() };
+        let ret: i32 = unsafe { ::libc::madvise(addr, len, advice) };
+        if ret != 0 {
+            anyhow::bail!(
+                "madvise failed at {addr:?} (error={})",
+                ::std::io::Error::last_os_error()
+            );
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
     /// Replaces the entire mapping with a fresh anonymous read-write mapping using `MAP_FIXED`.
     /// This is useful for restoring a neutral memory region after a failed file-backed remap.
     ///

--- a/src/uservm/src/vmm/microvm/kvm/vmem.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vmem.rs
@@ -212,6 +212,25 @@ impl VirtualMemory {
     ///
     /// # Description
     ///
+    /// Issues an `madvise` hint for a sub-region of the virtual memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `start`: Byte offset from the start of the mapping.
+    /// - `len`: Size of the region in bytes.
+    /// - `advice`: madvise advice constant (e.g., `MADV_SEQUENTIAL`, `MADV_WILLNEED`).
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns empty. Otherwise, returns an error.
+    ///
+    pub fn madvise_at(&self, start: usize, len: usize, advice: i32) -> Result<()> {
+        self.mapping.madvise_at(start, len, advice)
+    }
+
+    ///
+    /// # Description
+    ///
     /// Attaches a RAM filesystem descriptor to the virtual memory so the backing file remains
     /// alive for the VM's lifetime.
     ///

--- a/src/uservm/src/vmm/microvm/ramfs.rs
+++ b/src/uservm/src/vmm/microvm/ramfs.rs
@@ -318,6 +318,18 @@ impl RamFs {
                 anyhow::anyhow!(reason)
             })?;
 
+        // Advise the host kernel to prefault ramfs pages.  MADV_SEQUENTIAL
+        // enables aggressive readahead, and MADV_WILLNEED triggers immediate
+        // prefaulting.  This avoids page-fault stalls during guest execution.
+        vmem.madvise_at(base, length, ::libc::MADV_SEQUENTIAL)
+            .unwrap_or_else(|e| {
+                trace!("RamFs::map_file_into_guest(): madvise MADV_SEQUENTIAL failed: {e}");
+            });
+        vmem.madvise_at(base, length, ::libc::MADV_WILLNEED)
+            .unwrap_or_else(|e| {
+                trace!("RamFs::map_file_into_guest(): madvise MADV_WILLNEED failed: {e}");
+            });
+
         Ok(())
     }
 }

--- a/src/utils/mkramfs/src/main.rs
+++ b/src/utils/mkramfs/src/main.rs
@@ -29,7 +29,10 @@ const MIN_IMAGE_SIZE: u64 = 1024 * 1024;
 
 /// Extra headroom added to the computed image size to leave free space for
 /// guest-created temporary files at runtime.
-const HEADROOM_FACTOR: f64 = 2.0;
+/// Reduced from 2.0 to 1.3: standalone mode is mostly read-only, so minimal
+/// headroom suffices.  Smaller images reduce host memory pressure and improve
+/// TLB utilization.
+const HEADROOM_FACTOR: f64 = 1.3;
 
 //==================================================================================================
 // Main
@@ -123,6 +126,10 @@ fn generate_image(output: &Path, source_dir: &Path, size: u64) {
 /// Recursively copies the contents of `current` into the FAT directory `fat_dir`.
 ///
 /// `base` is the original source root, used to compute relative paths for error messages.
+///
+/// Files are sorted by size in descending order before writing to maximize
+/// contiguous cluster allocation in FAT.  This improves the hit rate of
+/// the VFS `DirectReadHandle` zero-copy path.
 fn copy_dir_recursive<IO, TP, OCC>(fat_dir: &fatfs::Dir<IO, TP, OCC>, current: &Path, base: &Path)
 where
     IO: fatfs::ReadWriteSeek,
@@ -134,6 +141,10 @@ where
         process::exit(1);
     });
 
+    // Collect and partition entries into directories and files.
+    let mut dirs: Vec<(PathBuf, String, PathBuf)> = Vec::new();
+    let mut files: Vec<(PathBuf, String, PathBuf, u64)> = Vec::new();
+
     for entry in entries {
         let entry = entry.unwrap_or_else(|e| {
             eprintln!("mkramfs: failed to read entry in {}: {e}", current.display());
@@ -144,26 +155,41 @@ where
         let rel: PathBuf = path.strip_prefix(base).unwrap_or(&path).to_path_buf();
 
         if path.is_dir() {
-            fat_dir.create_dir(&name).unwrap_or_else(|_| {
-                panic!("mkramfs: failed to create directory {}", rel.display())
-            });
-            let sub_dir = fat_dir
-                .open_dir(&name)
-                .unwrap_or_else(|_| panic!("mkramfs: failed to open directory {}", rel.display()));
-            copy_dir_recursive(&sub_dir, &path, base);
+            dirs.push((path, name, rel));
         } else if path.is_file() {
-            let data: Vec<u8> = fs::read(&path).unwrap_or_else(|e| {
-                eprintln!("mkramfs: failed to read {}: {e}", rel.display());
-                process::exit(1);
-            });
-            let mut fat_file = fat_dir
-                .create_file(&name)
-                .unwrap_or_else(|_| panic!("mkramfs: failed to create {}", rel.display()));
-            fatfs::Write::write_all(&mut fat_file, &data)
-                .unwrap_or_else(|_| panic!("mkramfs: failed to write {}", rel.display()));
-            fatfs::Write::flush(&mut fat_file)
-                .unwrap_or_else(|_| panic!("mkramfs: failed to flush {}", rel.display()));
+            let size = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+            files.push((path, name, rel, size));
         }
+    }
+
+    // Sort files largest-first so they get contiguous clusters in FAT.
+    files.sort_by(|a, b| b.3.cmp(&a.3));
+
+    // Write files first (before subdirectories) to pack them at the
+    // beginning of the FAT cluster chain.
+    for (path, name, rel, _size) in &files {
+        let data: Vec<u8> = fs::read(path).unwrap_or_else(|e| {
+            eprintln!("mkramfs: failed to read {}: {e}", rel.display());
+            process::exit(1);
+        });
+        let mut fat_file = fat_dir
+            .create_file(name)
+            .unwrap_or_else(|_| panic!("mkramfs: failed to create {}", rel.display()));
+        fatfs::Write::write_all(&mut fat_file, &data)
+            .unwrap_or_else(|_| panic!("mkramfs: failed to write {}", rel.display()));
+        fatfs::Write::flush(&mut fat_file)
+            .unwrap_or_else(|_| panic!("mkramfs: failed to flush {}", rel.display()));
+    }
+
+    // Then recurse into subdirectories.
+    for (path, name, rel) in &dirs {
+        fat_dir.create_dir(name).unwrap_or_else(|_| {
+            panic!("mkramfs: failed to create directory {}", rel.display())
+        });
+        let sub_dir = fat_dir
+            .open_dir(name)
+            .unwrap_or_else(|_| panic!("mkramfs: failed to open directory {}", rel.display()));
+        copy_dir_recursive(&sub_dir, path, base);
     }
 }
 


### PR DESCRIPTION
## Summary

Performance optimizations for standalone mode targeting CPython startup latency.

### VFS Metadata Cache (`src/libs/vfs/src/cache.rs`)
- **Stat cache**: `BTreeMap<path, Stat>` eliminates redundant FAT32 cluster traversals for repeated `stat()` calls
- **Negative cache**: `BTreeMap<path, ()>` fast-returns ENOENT for paths known not to exist (CPython probes many module paths that miss)
- **Raw region cache**: caches `file_raw_region()` results for DirectReadHandle zero-copy optimization
- Invalidated on write operations (mkdir, rmdir, unlink, rename) for correctness

### Ramfs Prefaulting (`src/uservm/src/vmm/microvm/ramfs.rs`)
- `madvise(MADV_SEQUENTIAL)` enables aggressive host readahead on the ramfs mmap
- `madvise(MADV_WILLNEED)` prefaults ramfs pages into host page cache before guest execution
- New `madvise_at()` API on `AnonymousMapping` and `VirtualMemory`

### mkramfs Optimizations (`src/utils/mkramfs/src/main.rs`)
- Reduced `HEADROOM_FACTOR` from 2.0 to 1.3 (standalone is mostly read-only)
- Files sorted by size descending before writing to maximize contiguous cluster allocation for DirectReadHandle

### Test Results
- VFS: 56/56 tests pass
- FAT32: 51/51 tests pass
- uservm: 71/71 tests pass
- Guest static libs compile clean for x86-user target with standalone feature