### PR TITLE
[uservm] Use `DebugPrint` in Hyperlight

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/peb.rs
+++ b/src/kernel/src/hal/platform/hyperlight/peb.rs
@@ -37,12 +37,6 @@ use ::sys::error::{
 
 pub(crate) static mut GUEST_HANDLE: GuestHandle = GuestHandle::new();
 
-/// Buffer used to store messages before the PEB is initialized.
-static mut OUTPUT_BUFFER: Buffer = Buffer {
-    data: [0; Buffer::CAPACITY],
-    len: 0,
-};
-
 //==================================================================================================
 // Process Environment Block
 //==================================================================================================
@@ -62,7 +56,6 @@ impl ProcessEnvironmentBlock {
             Err(Error::new(ErrorCode::ResourceBusy, reason))
         } else {
             GUEST_HANDLE = GuestHandle::init(peb_base);
-            OUTPUT_BUFFER.flush(&mut |s: &str| Self::host_print(s))?;
             Ok(())
         }
     }
@@ -90,13 +83,7 @@ impl ProcessEnvironmentBlock {
     /// # Safety
     /// This function is unsafe because it uses raw asm under the hood.
     pub unsafe fn puts(message: &str) -> Result<(), Error> {
-        // Check if PEB is not initialized to decide whether to buffer the message.
-        if GUEST_HANDLE.peb().is_none() {
-            return OUTPUT_BUFFER.append(message);
-        }
-
         Self::host_print(message);
-
         Ok(())
     }
 
@@ -192,96 +179,5 @@ impl ProcessEnvironmentBlock {
             Some(Vec::from(&[ParameterValue::String(message.to_string())])),
             ReturnType::Int,
         );
-    }
-}
-
-//==================================================================================================
-// Buffer
-//==================================================================================================
-
-/// A fixed-size buffer for storing output messages.
-struct Buffer {
-    /// Underlying data.
-    data: [u8; Self::CAPACITY],
-    /// Current length.
-    len: usize,
-}
-
-impl Buffer {
-    /// Buffer capacity.
-    const CAPACITY: usize = 512;
-
-    ///
-    /// # Description
-    ///
-    /// Appends a message to the buffer.
-    ///
-    /// # Parameters
-    ///
-    /// - `message`: Message to append.
-    ///
-    /// # Return Value
-    ///
-    /// On success, this function returns an empty tuple. On failure, it returns an object that
-    /// describes the error.
-    ///
-    /// # Notes
-    ///
-    /// - This function intentionally does not write to the log to avoid recursive calls.
-    ///
-    fn append(&mut self, message: &str) -> Result<(), Error> {
-        let message_bytes: &[u8] = message.as_bytes();
-
-        // Check if the message does not fit in the buffer.
-        if message_bytes.len() > Self::CAPACITY {
-            return Err(Error::new(ErrorCode::MessageTooLong, "message too long"));
-        }
-
-        // Check if there is not enough space in the buffer.
-        if self.len + message_bytes.len() > Self::CAPACITY {
-            return Err(Error::new(ErrorCode::NoSpaceOnDevice, "buffer full"));
-        }
-
-        self.data[self.len..self.len + message_bytes.len()].copy_from_slice(message_bytes);
-        self.len += message_bytes.len();
-
-        Ok(())
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Flushes the buffer using the provided write function.
-    ///
-    /// # Parameters
-    ///
-    /// - `write_fn`: Function used to write the buffered data.
-    ///
-    /// # Return Value
-    ///
-    /// On success, this function returns an empty tuple. On failure, it returns an object that
-    /// describes the error.
-    ///
-    /// # Notes
-    ///
-    /// - This function intentionally does not write to the log to avoid recursive calls.
-    ///
-    fn flush(&mut self, write_fn: &mut dyn FnMut(&str)) -> Result<(), Error> {
-        // Check if there is nothing to flush.
-        if self.len == 0 {
-            return Ok(());
-        }
-
-        // Convert the buffered data to a string.
-        let buffered_message: &str =
-            ::core::str::from_utf8(&self.data[..self.len]).map_err(|_| {
-                Error::new(ErrorCode::InvalidArgument, "puts: buffered data is not valid UTF-8")
-            })?;
-
-        // Write the buffered message using the provided function.
-        write_fn(buffered_message);
-        self.len = 0;
-
-        Ok(())
     }
 }

--- a/src/kernel/src/hal/platform/hyperlight/peb.rs
+++ b/src/kernel/src/hal/platform/hyperlight/peb.rs
@@ -14,10 +14,7 @@
 // Imports
 //==================================================================================================
 
-use ::alloc::{
-    string::ToString,
-    vec::Vec,
-};
+use ::alloc::vec::Vec;
 use ::hyperlight_common::{
     flatbuffer_wrappers::function_types::{
         ParameterValue,
@@ -78,12 +75,22 @@ impl ProcessEnvironmentBlock {
         }
     }
 
-    /// Writes a string to the guest's standard output.
+    ///
+    /// # Description
+    ///
+    /// Writes a string to the guest's standard debug output.
+    ///
+    /// # Note
+    ///
+    /// `debug_print()` is infallible (it uses inline `out` instructions), so this method always
+    /// returns `Ok(())`. The `Result` return type is preserved for API compatibility.
     ///
     /// # Safety
+    ///
     /// This function is unsafe because it uses raw asm under the hood.
+    ///
     pub unsafe fn puts(message: &str) -> Result<(), Error> {
-        Self::host_print(message);
+        ::hyperlight_guest::exit::debug_print(message);
         Ok(())
     }
 
@@ -166,18 +173,5 @@ impl ProcessEnvironmentBlock {
         GUEST_HANDLE
             .call_host_function::<Vec<u8>>("VmbusRead", None, ReturnType::VecBytes)
             .map_err(|_| Error::new(ErrorCode::IoErr, failure_reason))
-    }
-
-    /// Writes a string to the host's standard output.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe because it uses a static mutable variable.
-    unsafe fn host_print(message: &str) {
-        let _ = GUEST_HANDLE.call_host_function::<i32>(
-            "HostPrint",
-            Some(Vec::from(&[ParameterValue::String(message.to_string())])),
-            ReturnType::Int,
-        );
     }
 }

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -236,6 +236,7 @@ impl UserVm {
             Receiver<VcpuControlResponse>,
         ) = mpsc::channel::<VcpuControlResponse>(CHANNEL_CAPACITY);
 
+        #[cfg(not(feature = "hyperlight"))]
         let vmm_stderr_fn: Box<dyn Write + Send> = match get_stderr_writer(args.stderr.clone()) {
             Ok(vmm_stderr_fn) => vmm_stderr_fn,
             Err(e) => {
@@ -280,7 +281,10 @@ impl UserVm {
             output: vmm_stdout_fn,
             #[cfg(feature = "hyperlight")]
             bulk_output: vmm_bulk_stdout_fn,
+            #[cfg(not(feature = "hyperlight"))]
             stderr: vmm_stderr_fn,
+            #[cfg(feature = "hyperlight")]
+            stderr_path: args.stderr.clone(),
             control_rx: vcpu_thread_control_rx,
             control_tx: vcpu_thread_control_tx,
             kernel_filename: args.kernel_filename,

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -40,8 +40,12 @@ use ::log::{
     error,
 };
 use ::std::{
+    fs::File,
     io::Write,
-    os::raw::c_int,
+    os::{
+        raw::c_int,
+        unix::io::AsRawFd,
+    },
     path::Path,
     sync::Arc,
     time::Duration,
@@ -85,6 +89,59 @@ pub type StdoutFn = dyn FnMut(Vec<u8>) -> Result<i32, HyperlightError> + Send;
 pub type BulkStdoutFn = dyn FnMut(Vec<u8>) -> Result<i32, HyperlightError> + Send;
 
 pub type StderrFn = dyn Write + Send;
+
+//==================================================================================================
+// StderrRedirect
+//==================================================================================================
+
+/// RAII guard that redirects process stderr to a file and restores the original fd on drop.
+struct StderrRedirect {
+    saved_fd: c_int,
+}
+
+impl StderrRedirect {
+    /// Redirects process stderr to `path`, returning a guard that restores it on drop.
+    fn new(path: &str) -> Result<Self> {
+        // SAFETY: STDERR_FILENO is always valid. `dup` returns a new fd or -1 on failure.
+        let saved_fd: c_int = unsafe { libc::dup(libc::STDERR_FILENO) };
+        if saved_fd == -1 {
+            return Err(anyhow::anyhow!(
+                "failed to save stderr fd: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        let file: File = File::options()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)
+            .map_err(|e| {
+                // SAFETY: saved_fd was just obtained from dup() and is valid.
+                unsafe { libc::close(saved_fd) };
+                anyhow::anyhow!("failed to open stderr file {path:?}: {e}")
+            })?;
+        // SAFETY: both fds are valid — file was just opened and STDERR_FILENO is always
+        // present. On success dup2 returns the new fd; on failure it returns -1.
+        if unsafe { libc::dup2(file.as_raw_fd(), libc::STDERR_FILENO) } == -1 {
+            let err: std::io::Error = std::io::Error::last_os_error();
+            // SAFETY: saved_fd was obtained from dup() and is valid.
+            unsafe { libc::close(saved_fd) };
+            return Err(anyhow::anyhow!("failed to redirect stderr to {path:?}: {err}"));
+        }
+        // After dup2, STDERR_FILENO holds a copy of the fd. The original File is dropped here.
+        Ok(Self { saved_fd })
+    }
+}
+
+impl Drop for StderrRedirect {
+    fn drop(&mut self) {
+        // SAFETY: saved_fd was obtained from dup() in new() and has not been closed.
+        unsafe {
+            libc::dup2(self.saved_fd, libc::STDERR_FILENO);
+            libc::close(self.saved_fd);
+        }
+    }
+}
 
 //==================================================================================================
 // Structure
@@ -171,6 +228,8 @@ pub struct Vmm {
 
 struct InnerVmm {
     control_tx: Sender<VcpuControlResponse>,
+    /// RAII guard that restores the original stderr fd when dropped.
+    _stderr_redirect: Option<StderrRedirect>,
 }
 
 //==================================================================================================
@@ -385,18 +444,14 @@ impl Vmm {
 
         let guest: Arc<Mutex<Guest>> = Arc::new(Mutex::new(guest));
 
-        // Create a closure that takes a String and writes it to stderr.
-        // NOTE: underlying writer implements `Write` and requires mutable access.
-        let mut stderr_writer: Box<StderrFn> = args.stderr;
-        sandbox.register_print(move |s: String| -> i32 {
-            if stderr_writer.write_all(s.as_bytes()).is_err() {
-                return -1;
-            }
-            if stderr_writer.flush().is_err() {
-                return -1;
-            }
-            0
-        })?;
+        // Redirect process stderr to the custom file when configured, so that DebugPrint VM-exit
+        // output (sent via `eprint!` in the hyperlight SDK) reaches the intended destination.
+        // The guard restores the original stderr when the Vmm is dropped.
+        let stderr_redirect: Option<StderrRedirect> = args
+            .stderr_path
+            .as_deref()
+            .map(StderrRedirect::new)
+            .transpose()?;
 
         // Create a closure for VmbusWrite that matches the expected signature
         // NOTE: output function is FnMut, so we must keep it mutable when captured.
@@ -423,6 +478,7 @@ impl Vmm {
             guest,
             inner: Arc::new(Mutex::new(InnerVmm {
                 control_tx: args.control_tx,
+                _stderr_redirect: stderr_redirect,
             })),
         })
     }
@@ -466,6 +522,9 @@ impl Vmm {
 
         // Run the sandbox.
         let result: Result<MultiUseSandbox, HyperlightError> = uninit.evolve();
+
+        // Drop the stderr redirect guard to restore the original stderr fd.
+        self.inner.blocking_lock()._stderr_redirect.take();
 
         // Communicate shutdown to orchestrator.
         if let Err(error) = self

--- a/src/uservm/src/vmm/mod.rs
+++ b/src/uservm/src/vmm/mod.rs
@@ -38,7 +38,13 @@ pub struct MicroVmArgs {
     pub output: Box<StdoutFn>,
     #[cfg(feature = "hyperlight")]
     pub bulk_output: Box<BulkStdoutFn>,
+    #[cfg(not(feature = "hyperlight"))]
     pub stderr: Box<StderrFn>,
+    /// Optional file path for guest stderr redirection (hyperlight only).
+    /// When set, process stderr is redirected to this file via `dup2` so that
+    /// `DebugPrint` VM-exit output reaches the custom destination.
+    #[cfg(feature = "hyperlight")]
+    pub stderr_path: Option<String>,
     /// When true, skip kernel/initrd/ramfs loading and vCPU reset because the VM state will be
     /// restored from a snapshot.
     pub restoring_from_snapshot: bool,


### PR DESCRIPTION
This pull request refactors the guest output handling for the Hyperlight platform, removing the previous buffering logic and improving how guest standard output and error streams are managed. It introduces direct use of the `DebugPrint` VM exit for output, eliminates heap allocations and buffering, and adds support for redirecting guest stderr to a custom file via `dup2`. These changes streamline output handling and provide more flexible logging for guest processes.

Closes #1668.
Superseeds #1669.