### PR TITLE
[kernel] Use no_fail! macro to enforce infallible code paths in ProcessManager

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -20,6 +20,7 @@ bitmap = { workspace = true }
 cfg-if = { workspace = true }
 config = { workspace = true, optional = true }
 elf = { workspace = true }
+no_fail = { workspace = true }
 type-safe = { workspace = true }
 raw-array = { workspace = true }
 slab = { workspace = true }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -72,7 +72,7 @@ use ::alloc::{
 };
 use ::arch::mem::PAGE_SIZE;
 use ::config::memory_layout::USER_STACK_TOP_RAW;
-
+use ::no_fail::no_fail;
 use ::sys::{
     error::{
         Error,
@@ -287,40 +287,39 @@ impl ProcessManager {
         // Reserve the next thread identifier early, before any resource allocation.
         let (tid, next_tid): (ThreadIdentifier, ThreadIdentifier) = self.tm.try_next_tid()?;
 
-        let ready_thread: ReadyThread = {
-            let enable_interrupts: bool = self.interrupt_capable;
+        let enable_interrupts: bool = self.interrupt_capable;
 
-            // Create a kernel context.
-            let (kernel_stack, context): (KernelStack, ContextInformation) =
-                Self::forge_user_context(
-                    mm,
-                    self.get_running_mut().state_mut().vmem_mut(),
-                    thread_create_args,
-                    enable_interrupts,
-                )?;
+        // Create a kernel context.
+        let (kernel_stack, context): (KernelStack, ContextInformation) = Self::forge_user_context(
+            mm,
+            self.get_running_mut().state_mut().vmem_mut(),
+            thread_create_args,
+            enable_interrupts,
+        )?;
 
-            //==============================================================
-            // NOTE: if we fail beyond this point we need to page mappings.
-            //==============================================================
+        //==============================================================
+        // NOTE: if we fail beyond this point we need to page mappings.
+        //==============================================================
 
+        Ok(no_fail!(ThreadIdentifier, {
             // Create a new thread.
-            self.tm.create_thread(
+            let ready_thread: ReadyThread = self.tm.create_thread(
                 tid,
                 Some(kernel_stack),
                 None,
                 thread_create_args.user_tda,
                 context,
-            )
-        };
+            );
 
-        // Commit the next thread identifier now that all fallible operations have succeeded.
-        self.tm.commit_next_tid(next_tid);
+            // Commit the next thread identifier now that all fallible operations have succeeded.
+            self.tm.commit_next_tid(next_tid);
 
-        // Add the new thread to the running process.
-        let tid: ThreadIdentifier = ready_thread.id();
-        self.get_running_mut().add_thread(ready_thread);
+            // Add the new thread to the running process.
+            let tid: ThreadIdentifier = ready_thread.id();
+            self.get_running_mut().add_thread(ready_thread);
 
-        Ok(tid)
+            Ok(tid)
+        }))
     }
 
     ///
@@ -553,23 +552,25 @@ impl ProcessManager {
         // NOTE: if we fail beyond this point we need to page mappings.
         //==============================================================
 
-        let thread: ReadyThread = self.tm.create_thread(
-            tid,
-            Some(kernel_stack),
-            Some(user_stack),
-            args.user_tda,
-            context,
-        );
+        Ok(no_fail!(ProcessIdentifier, {
+            let thread: ReadyThread = self.tm.create_thread(
+                tid,
+                Some(kernel_stack),
+                Some(user_stack),
+                args.user_tda,
+                context,
+            );
 
-        // Commit the next process and thread identifiers now that all fallible operations have succeeded.
-        self.next_pid = next_pid;
-        self.tm.commit_next_tid(next_tid);
-        let process: RunnableProcess = RunnableProcess::new(pid, thread, vmem);
+            // Commit the next process and thread identifiers now that all fallible operations have succeeded.
+            self.next_pid = next_pid;
+            self.tm.commit_next_tid(next_tid);
+            let process: RunnableProcess = RunnableProcess::new(pid, thread, vmem);
 
-        // Add process to the queue of ready processes.
-        self.ready.push_back(process);
+            // Add process to the queue of ready processes.
+            self.ready.push_back(process);
 
-        Ok(pid)
+            Ok(pid)
+        }))
     }
 
     ///


### PR DESCRIPTION
## Summary

Use the `no_fail!` macro to enforce at compile time that no fallible operations occur after critical resource allocation points in the process manager, replacing ad-hoc `// NOTE: if we fail beyond this point...` comments with a machine-enforced contract.

## Changes

### Kernel — Process Manager
- Import `no_fail` crate.
- Wrap the infallible tails of `create_thread()` and `create_process()` in `no_fail!()`.

## Deferred

The remaining locations identified in #1443 have pre-existing bugs — actual failure points after the marked commit boundaries — that need to be fixed before `no_fail!` can be applied. Tracked separately:

### Virtual Memory Manager
- #1674 — `map_kpage()` has fallible operations after page-table commit point
- #1675 — `map()` has fallible operations after page-table commit point
- #1676 — `unmap()` has fallible `pgdir.unmap()` after page-unmap commit point

### Slab Allocator
Deferred pending further analysis of the `Bitmap::set()` failure modes.

### Dynamic Library Loader
The `dynlib.rs` location from the issue no longer contains the target comment pattern; skipped.

## Validation

- Build, lint, and format checks all pass.

Partially addresses #1443.
