### PR TITLE
[build] Ensure toolchain directory is not in repository root

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -136,6 +136,9 @@ exec $SHELL
 ln -T -s $HOME/toolchain toolchain           # Create symbolic link for toolchain for convenience.
 ```
 
+> **Note:** The toolchain directory must be located outside the repository root.
+> Use `./z setup --toolchain-dir <path>` to specify a valid location.
+
 #### Step 3: Build QEMU (Optional)
 
 To run Nanvix on QEMU, you need to build it:

--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -30,6 +30,44 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/logging.sh"
 #
 # Description
 #
+#   Resolves a path to an absolute path without assuming GNU realpath -m is available.
+#   If the path exists, it is resolved via cd + pwd -P. Otherwise, an absolute path
+#   is constructed without normalization.
+#
+# Arguments
+#
+#   $1 - The path to resolve.
+#
+# Return Value
+#
+#   - On success, prints the resolved absolute path.
+#
+# Usage Example
+#
+#   resolved=$(resolve_path "$TARGET_DIR")
+#
+resolve_path() {
+    local path="$1"
+    local resolved=""
+
+    if cd "${path}" >/dev/null 2>&1; then
+        resolved="$(pwd -P)"
+        cd - >/dev/null 2>&1 || true
+    else
+        # For non-existent paths, construct an absolute path without normalization.
+        if [[ "${path}" == /* ]]; then
+            resolved="${path}"
+        else
+            resolved="$(pwd -P)/${path}"
+        fi
+    fi
+
+    printf '%s\n' "${resolved}"
+}
+
+#
+# Description
+#
 #   Gets the current version from a Cargo.toml file.
 #
 # Arguments

--- a/z
+++ b/z
@@ -394,7 +394,7 @@ check_filesystem_support() {
 #         * Verifies the expected image (derived from current Nanvix version) is present locally.
 #         * Validates the derived tag matches the MAJOR.MINOR.x pattern expected.
 #     - When building with the local toolchain:
-#         * Ensures the version file exists and is readable.
+#         * Ensures the version file exists, is outside the repository, and is readable.
 #         * Compares its contents to the expected version string.
 #
 #   On mismatch or missing artifacts, an error is printed and the function returns non-zero.
@@ -576,6 +576,18 @@ main() {
             TOOLCHAIN_DIR="${param#TOOLCHAIN_DIR=}"
         fi
     done
+
+    # Disallow TOOLCHAIN_DIR inside the repository only for non-Docker builds.
+    if [[ "${BUILD_WITH_DOCKER:-false}" != "true" ]]; then
+        local resolved_toolchain resolved_repo
+        resolved_toolchain="$(resolve_path "$TOOLCHAIN_DIR")"
+        resolved_repo="$(cd "${REPO_ROOT_DIR}" && pwd -P)"
+        if [[ "${resolved_toolchain}" == "${resolved_repo}" || "${resolved_toolchain}" == "${resolved_repo}/"* ]]; then
+            print_error "Absolute path to the toolchain directory must not be inside the repository (${REPO_ROOT_DIR})."
+            print_info "Hint: Specify the toolchain by passing '--toolchain-dir'"
+            exit 1
+        fi
+    fi
 
     # If using cache, restore variables from cache when not overridden by command line options.
     if ${WITH_CACHED_OPTIONS}; then


### PR DESCRIPTION
Setting up the project using `./z setup` without any flags results in creating the native toolchain directly in the repository. This breaks the build process. To fix this, this PR prevents the `z` script from running if the realpath of `$TOOLCHAIN_DIR` is detected to be within the repo root.