### PR TITLE
[kernel] Add demand-paging support for user stack

### DIFF
--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -14,6 +14,7 @@ use crate::{
         },
         Hal,
     },
+    mm::VirtMemoryManager,
     pm::{
         sync::condvar::Condvar,
         ExceptionGuard,
@@ -960,6 +961,24 @@ fn do_exception_handler(
         error!("{:?}", info);
         error!("{:?}", ctx);
         panic!("the kernel triggered an exception");
+    }
+
+    // Handle page faults: demand-page user stack pages.
+    if info.num() == ::arch::cpu::excp::Exception::PageFault as u32 {
+        // SAFETY: This is the only thread running, thus access to the managers is synchronized.
+        let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+        let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+
+        if pm
+            .handle_stack_page_fault(
+                mm,
+                info.addr() as usize,
+                ::arch::cpu::excp::ErrorCode::new(info.code()),
+            )
+            .map_err(SleepError::Generic)?
+        {
+            return Ok(());
+        }
     }
 
     // Handle FPU Exceptions.

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -170,6 +170,14 @@ use ::sys::error::Error;
 ::static_assert::assert_eq!(
     config::memory_layout::USER_STACK_TOP_RAW >= config::memory_layout::USER_BASE_RAW
 );
+// Ensure that the minimum stack size is a multiple of a page size.
+::static_assert::assert_eq!(
+    config::memory_layout::USER_STACK_MIN_SIZE.is_multiple_of(PAGE_ALIGNMENT as usize)
+);
+// Ensure that the minimum stack size does not exceed the total stack size.
+::static_assert::assert_eq!(
+    config::memory_layout::USER_STACK_MIN_SIZE <= config::memory_layout::USER_STACK_SIZE
+);
 
 //==================================================================================================
 // Standalone Functions

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -70,8 +70,15 @@ use ::alloc::{
     },
     ffi::CString,
 };
-use ::arch::mem::PAGE_SIZE;
-use ::config::memory_layout::USER_STACK_TOP_RAW;
+use ::arch::{
+    cpu::excp,
+    mem::PAGE_SIZE,
+};
+use ::config::memory_layout::{
+    USER_STACK_MIN_SIZE,
+    USER_STACK_SIZE,
+    USER_STACK_TOP_RAW,
+};
 use ::no_fail::no_fail;
 use ::sys::{
     error::{
@@ -538,13 +545,16 @@ impl ProcessManager {
         let (kernel_stack, context): (KernelStack, ContextInformation) =
             Self::forge_user_context(mm, &mut vmem, &args, self.interrupt_capable)?;
 
-        // Alloc user stack and map it.
+        // Map only the minimum number of stack pages near the stack top (where ESP starts).
+        // Additional pages up to USER_STACK_SIZE are demand-paged on stack growth faults.
         // NOTE: if we fail beyond this point we must unmap kernel pages from `vmem`, otherwise we
         // will leak underlying pages.
+        let initial_stack_base: PageAligned<VirtualAddress> =
+            PageAligned::from_raw_value(user_stack.top().into_raw_value() - USER_STACK_MIN_SIZE)?;
         mm.alloc_upages(
             &mut vmem,
-            user_stack.base(),
-            user_stack.size() / PAGE_SIZE,
+            initial_stack_base,
+            USER_STACK_MIN_SIZE / PAGE_SIZE,
             AccessPermission::RDWR,
         )?;
 
@@ -2044,5 +2054,54 @@ impl ProcessManager {
         self.get_running_mut().state_mut().remove_event(ev);
 
         Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Handles a page fault that may be caused by user-space stack growth.
+    /// If the faulting address falls within the user stack region and the page is not present,
+    /// a new page is demand-allocated and mapped.
+    ///
+    /// # Parameters
+    ///
+    /// - `mm`: Virtual memory manager.
+    /// - `fault_addr`: Faulting virtual address.
+    /// - `error_code`: Typed x86 page-fault error code.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if the fault was resolved by mapping a new stack page.
+    /// - `Ok(false)` if the fault address is not within the user stack region or the fault is not
+    ///   a page-not-present fault from user mode.
+    /// - `Err(...)` if page allocation failed.
+    ///
+    pub fn handle_stack_page_fault(
+        &mut self,
+        mm: &mut VirtMemoryManager,
+        fault_addr: usize,
+        error_code: excp::ErrorCode,
+    ) -> Result<bool, Error> {
+        // Only handle page-not-present faults from user mode.
+        if error_code.is_present() || !error_code.is_user() {
+            return Ok(false);
+        }
+
+        // Check if the faulting address falls within the main-thread user stack region.
+        // The stack occupies [USER_STACK_TOP_RAW, USER_STACK_TOP_RAW + USER_STACK_SIZE).
+        const STACK_REGION_START: usize = USER_STACK_TOP_RAW;
+        const STACK_REGION_END: usize = STACK_REGION_START + USER_STACK_SIZE;
+        if !(STACK_REGION_START..STACK_REGION_END).contains(&fault_addr) {
+            return Ok(false);
+        }
+
+        // Page-align the faulting address and map the page.
+        let page_addr: usize = fault_addr & !(PAGE_SIZE - 1);
+        let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(page_addr)?;
+        let pid: ProcessIdentifier = self.get_pid();
+        debug!("demand-paging stack page (pid={pid:?}, vaddr={vaddr:?})");
+        self.mmap(mm, pid, vaddr, AccessPermission::RDWR)?;
+
+        Ok(true)
     }
 }

--- a/src/libs/arch/src/x86/cpu/excp.rs
+++ b/src/libs/arch/src/x86/cpu/excp.rs
@@ -2,6 +2,88 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Wraps the hardware error code pushed by the CPU for exceptions that include one
+/// (Double Fault, Invalid TSS, Segment Not Present, Stack Segment Fault,
+/// General Protection Fault, Page Fault, Alignment Check, and Security).
+///
+/// For page faults the individual bits carry specific meaning defined by the x86 ISA.
+/// For selector-based exceptions (GP, SS, NP, TSS) the low 16 bits encode the
+/// offending segment selector.
+///
+#[derive(Clone, Copy)]
+#[must_use]
+pub struct ErrorCode(u32);
+
+impl ErrorCode {
+    /// Creates a new [`ErrorCode`] from a raw 32-bit value.
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw 32-bit value.
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    /// Page-fault bit 0 — *Present*.
+    ///
+    /// `true` when the fault was caused by a page-level protection violation.
+    /// `false` when the fault was caused by a non-present page.
+    pub const fn is_present(self) -> bool {
+        (self.0 & (1 << 0)) != 0
+    }
+
+    /// Page-fault bit 1 — *Write*.
+    ///
+    /// `true` when the access that caused the fault was a write.
+    pub const fn is_write(self) -> bool {
+        (self.0 & (1 << 1)) != 0
+    }
+
+    /// Page-fault bit 2 — *User*.
+    ///
+    /// `true` when the fault occurred while the CPU was in user mode (CPL = 3).
+    pub const fn is_user(self) -> bool {
+        (self.0 & (1 << 2)) != 0
+    }
+
+    /// Page-fault bit 3 — *Reserved-bit violation*.
+    ///
+    /// `true` when a reserved bit was set in a page-structure entry.
+    pub const fn is_reserved_bit_violation(self) -> bool {
+        (self.0 & (1 << 3)) != 0
+    }
+
+    /// Page-fault bit 4 — *Instruction fetch*.
+    ///
+    /// `true` when the fault was caused by an instruction fetch (requires NX support).
+    pub const fn is_instruction_fetch(self) -> bool {
+        (self.0 & (1 << 4)) != 0
+    }
+}
+
+impl core::fmt::Debug for ErrorCode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "ErrorCode({:#x} [P={}, W={}, U={}, RSVD={}, I/D={}])",
+            self.0,
+            self.is_present() as u8,
+            self.is_write() as u8,
+            self.is_user() as u8,
+            self.is_reserved_bit_violation() as u8,
+            self.is_instruction_fetch() as u8,
+        )
+    }
+}
+
+//==================================================================================================
 // Enumerations
 //==================================================================================================
 

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -142,6 +142,18 @@ pub mod memory_layout {
     ///
     /// # Description
     ///
+    /// Minimum number of stack bytes mapped at process creation.
+    /// Additional pages up to [`USER_STACK_SIZE`] are demand-paged on stack growth faults.
+    ///
+    /// # Notes:
+    ///
+    /// - This size should be a multiple of a page size.
+    ///
+    pub const USER_STACK_MIN_SIZE: usize = 32 * crate::constants::KILOBYTE;
+
+    ///
+    /// # Description
+    ///
     /// Number of entries in the user stack. This should be a multiple of 8.
     ///
     pub const NUM_USER_STACK_ENTRIES: usize = 8;

--- a/src/tests/test-kernel/Cargo.toml
+++ b/src/tests/test-kernel/Cargo.toml
@@ -15,8 +15,10 @@ name = "test-kernel"
 
 [dependencies]
 arch = { workspace = true }
+config = { workspace = true }
 libc_string = { workspace = true }
 nvx = { workspace = true }
+static_assert = { workspace = true }
 sys = { workspace = true, features = ["kcall"] }
 syslog = { workspace = true, default-features = true }
 

--- a/src/tests/test-kernel/src/demand_paging.rs
+++ b/src/tests/test-kernel/src/demand_paging.rs
@@ -1,0 +1,221 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! # Demand Paging Regression Tests
+//!
+//! This module verifies that the kernel correctly demand-pages the user stack beyond the initially
+//! mapped region.  At process creation the kernel maps only
+//! [`USER_STACK_MIN_SIZE`](config::memory_layout::USER_STACK_MIN_SIZE) bytes of the total
+//! [`USER_STACK_SIZE`](config::memory_layout::USER_STACK_SIZE)-byte stack.  Accessing addresses
+//! deeper than the initial mapping triggers a page fault that the kernel resolves transparently by
+//! mapping a new page.  If demand paging is broken the process will triple-fault instead.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::config::memory_layout::{
+    USER_STACK_MIN_SIZE,
+    USER_STACK_SIZE,
+};
+use ::sys::error::Error;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Page size in bytes.
+const PAGE_SIZE: usize = ::arch::mem::PAGE_SIZE;
+
+/// Size of the basic demand-paging buffer — 1.5× the initial mapping so it always crosses into
+/// demand-paged territory regardless of the configured [`USER_STACK_MIN_SIZE`].
+const BASIC_BUF_SIZE: usize = USER_STACK_MIN_SIZE + USER_STACK_MIN_SIZE / 2;
+
+/// Number of pages to touch in the incremental test — 2× the initial mapping.
+const INCREMENTAL_PAGES: usize = (USER_STACK_MIN_SIZE * 2) / PAGE_SIZE;
+
+/// Size of the large integrity buffer — 4× the initial mapping, capped at half the total stack
+/// size.  This exercises demand paging across many pages beyond the initial mapping.
+const INTEGRITY_BUF_SIZE: usize = if USER_STACK_MIN_SIZE * 4 < USER_STACK_SIZE {
+    USER_STACK_MIN_SIZE * 4
+} else {
+    USER_STACK_SIZE / 2
+};
+
+/// Size of the per-frame local buffer in the recursion test.
+const RECURSION_FRAME_SIZE: usize = PAGE_SIZE;
+
+/// Recursion depth for the deep-recursion test.  Each frame uses [`RECURSION_FRAME_SIZE`] bytes,
+/// and we recurse deep enough to exceed [`USER_STACK_MIN_SIZE`] by at least 50%.
+const RECURSION_DEPTH: usize =
+    (USER_STACK_MIN_SIZE + USER_STACK_MIN_SIZE / 2) / RECURSION_FRAME_SIZE;
+
+// The basic buffer must be larger than the initially mapped region so that writing to it triggers
+// at least one demand-paged page fault.
+static_assert::assert_eq!(BASIC_BUF_SIZE > USER_STACK_MIN_SIZE);
+// The basic buffer must fit within the total stack so it does not overflow into unmappable space.
+static_assert::assert_eq!(BASIC_BUF_SIZE <= USER_STACK_SIZE);
+// The incremental test must span more bytes than the initial mapping to guarantee that some of the
+// per-page touches land on demand-paged pages.
+static_assert::assert_eq!(INCREMENTAL_PAGES * PAGE_SIZE > USER_STACK_MIN_SIZE);
+// The incremental test must not exceed the total stack capacity.
+static_assert::assert_eq!(INCREMENTAL_PAGES * PAGE_SIZE <= USER_STACK_SIZE);
+// The integrity buffer must exceed the initial mapping to exercise demand paging across many pages.
+static_assert::assert_eq!(INTEGRITY_BUF_SIZE > USER_STACK_MIN_SIZE);
+// The integrity buffer must remain within the total stack limit.
+static_assert::assert_eq!(INTEGRITY_BUF_SIZE <= USER_STACK_SIZE);
+// The total stack consumed by recursion must exceed the initial mapping so that deeper frames
+// trigger demand-paged faults.
+static_assert::assert_eq!(RECURSION_DEPTH * RECURSION_FRAME_SIZE > USER_STACK_MIN_SIZE);
+// The total stack consumed by recursion must not overflow the maximum stack size.
+static_assert::assert_eq!(RECURSION_DEPTH * RECURSION_FRAME_SIZE <= USER_STACK_SIZE);
+// Sanity: the initial mapping must be strictly smaller than the total stack; otherwise there is
+// nothing to demand-page and these tests are meaningless.
+static_assert::assert_eq!(USER_STACK_MIN_SIZE < USER_STACK_SIZE);
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+/// Fills `buf` with a deterministic, position-dependent pattern.
+fn fill_pattern(buf: &mut [u8]) {
+    for (i, byte) in buf.iter_mut().enumerate() {
+        *byte = ((i.wrapping_mul(37).wrapping_add(7)) & 0xFF) as u8;
+    }
+}
+
+/// Verifies that `buf` matches the deterministic pattern produced by [`fill_pattern`].
+///
+/// Returns `true` if and only if every byte matches.
+fn verify_pattern(buf: &[u8]) -> bool {
+    for (i, &byte) in buf.iter().enumerate() {
+        let expected: u8 = ((i.wrapping_mul(37).wrapping_add(7)) & 0xFF) as u8;
+        if byte != expected {
+            return false;
+        }
+    }
+    true
+}
+
+//==================================================================================================
+// Test Cases
+//==================================================================================================
+
+/// Allocate a [`BASIC_BUF_SIZE`]-byte buffer on the stack (exceeds [`USER_STACK_MIN_SIZE`]), fill
+/// it with a deterministic pattern, and verify the contents.  If demand paging is not working the
+/// write to the unmapped region will cause a fatal page fault.
+fn test_basic_demand_paging() -> Result<(), Error> {
+    let mut buf: [u8; BASIC_BUF_SIZE] = [0u8; BASIC_BUF_SIZE];
+    // Prevent the compiler from eliding the stack allocation.
+    let buf: &mut [u8; BASIC_BUF_SIZE] = core::hint::black_box(&mut buf);
+    fill_pattern(buf);
+    assert!(verify_pattern(buf), "basic demand-paging buffer mismatch");
+    Ok(())
+}
+
+/// Touch one byte on every page across [`INCREMENTAL_PAGES`] pages of stack depth, verifying each
+/// write/read.  Pages are touched individually in reverse order (toward the stack-growth direction)
+/// so that demand faults are triggered one page at a time.
+fn test_incremental_page_touch() -> Result<(), Error> {
+    // Create a buffer large enough to span INCREMENTAL_PAGES pages.
+    let mut buf: [u8; INCREMENTAL_PAGES * PAGE_SIZE] = [0u8; INCREMENTAL_PAGES * PAGE_SIZE];
+    let buf: &mut [u8; INCREMENTAL_PAGES * PAGE_SIZE] = core::hint::black_box(&mut buf);
+
+    // Touch one byte per page in reverse order (toward stack growth direction).
+    for page in (0..INCREMENTAL_PAGES).rev() {
+        let offset: usize = page * PAGE_SIZE;
+        let canary: u8 = (page & 0xFF) as u8;
+        buf[offset] = canary;
+    }
+
+    // Verify all written canaries.
+    for page in 0..INCREMENTAL_PAGES {
+        let offset: usize = page * PAGE_SIZE;
+        let expected: u8 = (page & 0xFF) as u8;
+        assert!(buf[offset] == expected, "incremental page touch mismatch at page {}", page);
+    }
+
+    Ok(())
+}
+
+/// Recursive function that consumes [`RECURSION_FRAME_SIZE`] bytes of stack per frame.  At each
+/// level a local buffer is filled with a canary value and verified after the recursive call
+/// returns, ensuring that demand-paged pages remain valid across nested calls.
+#[inline(never)]
+fn recurse(depth: usize) -> Result<(), Error> {
+    if depth == 0 {
+        return Ok(());
+    }
+
+    let mut frame_buf: [u8; RECURSION_FRAME_SIZE] = [0u8; RECURSION_FRAME_SIZE];
+    let frame_buf: &mut [u8; RECURSION_FRAME_SIZE] = core::hint::black_box(&mut frame_buf);
+
+    // Write a canary pattern unique to this recursion level.
+    let canary: u8 = (depth & 0xFF) as u8;
+    for byte in frame_buf.iter_mut() {
+        *byte = canary;
+    }
+
+    // Recurse deeper.
+    recurse(depth - 1)?;
+
+    // Verify the canary is still intact after returning from the deeper call — this catches
+    // corruption from incorrectly mapped pages.
+    for (i, &byte) in frame_buf.iter().enumerate() {
+        assert!(byte == canary, "recursion canary corrupted at depth {} byte {}", depth, i);
+        // Prevent the loop from being optimized away.
+        core::hint::black_box(i);
+    }
+
+    Ok(())
+}
+
+/// Exercise demand paging via natural call-stack growth by recursing [`RECURSION_DEPTH`] levels
+/// deep with [`RECURSION_FRAME_SIZE`]-byte frames, exceeding [`USER_STACK_MIN_SIZE`].
+fn test_deep_recursion() -> Result<(), Error> {
+    recurse(RECURSION_DEPTH)
+}
+
+/// Allocate an [`INTEGRITY_BUF_SIZE`]-byte buffer on the stack, fill it with a deterministic
+/// pattern, and verify the entire contents.  This exercises demand paging across many pages beyond
+/// the initial [`USER_STACK_MIN_SIZE`] mapping.
+fn test_stack_write_read_integrity() -> Result<(), Error> {
+    let mut buf: [u8; INTEGRITY_BUF_SIZE] = [0u8; INTEGRITY_BUF_SIZE];
+    let buf: &mut [u8; INTEGRITY_BUF_SIZE] = core::hint::black_box(&mut buf);
+    fill_pattern(buf);
+    assert!(verify_pattern(buf), "large stack integrity buffer mismatch");
+    Ok(())
+}
+
+//==================================================================================================
+// Public Entry Point
+//==================================================================================================
+
+/// Runs all demand-paging regression tests.
+///
+/// # Returns
+///
+/// `Ok(())` if all tests pass.
+///
+/// # Errors
+///
+/// Returns the first error encountered by any test case.
+pub fn run() -> Result<(), Error> {
+    ::syslog::info!("test-kernel: demand_paging: starting demand-paging regression tests");
+
+    test_basic_demand_paging()?;
+    ::syslog::info!("test-kernel: demand_paging: PASS - basic_demand_paging");
+
+    test_incremental_page_touch()?;
+    ::syslog::info!("test-kernel: demand_paging: PASS - incremental_page_touch");
+
+    test_deep_recursion()?;
+    ::syslog::info!("test-kernel: demand_paging: PASS - deep_recursion");
+
+    test_stack_write_read_integrity()?;
+    ::syslog::info!("test-kernel: demand_paging: PASS - stack_write_read_integrity");
+
+    ::syslog::info!("test-kernel: demand_paging: all tests passed");
+
+    Ok(())
+}

--- a/src/tests/test-kernel/src/main.rs
+++ b/src/tests/test-kernel/src/main.rs
@@ -21,6 +21,7 @@ use ::sys::error::{
 // Modules
 //==================================================================================================
 
+mod demand_paging;
 mod direction_flag;
 #[cfg(not(feature = "hyperlight"))]
 mod mmio_ramfs;
@@ -58,6 +59,8 @@ pub fn main() -> Result<(), Error> {
     tls::run()?;
 
     direction_flag::run()?;
+
+    demand_paging::run()?;
 
     #[cfg(not(feature = "hyperlight"))]
     rendezvous::run()?;


### PR DESCRIPTION
Add a new demand_paging module to test-kernel that verifies the kernel
correctly demand-pages the user stack beyond the initially mapped
USER_STACK_MIN_SIZE region.

Four test cases exercise different access patterns that cross into
unmapped stack pages:

- basic_demand_paging: allocates a buffer 1.5x the initial mapping,
  fills it with a deterministic pattern, and verifies contents.
- incremental_page_touch: touches one byte per page in reverse order
  across 2x the initial mapping to trigger faults one page at a time.
- deep_recursion: recurses with PAGE_SIZE-byte frames deep enough to
  exceed the initial mapping by 50%, verifying per-frame canaries
  survive across nested calls.
- stack_write_read_integrity: allocates a buffer 4x the initial mapping
  (capped at half the total stack) and verifies full read-write
  integrity.

Compile-time static assertions guarantee that all buffer sizes and
recursion depths exceed USER_STACK_MIN_SIZE while remaining within
USER_STACK_SIZE, ensuring the tests are meaningful regardless of
configuration changes.