### PR TITLE
[libs] Use stored field in `index()` check for bitmap

### DIFF
--- a/src/libs/bitmap/src/lib.rs
+++ b/src/libs/bitmap/src/lib.rs
@@ -673,7 +673,7 @@ impl Bitmap {
     )]
     fn index(&self, index: usize) -> Result<(usize, usize), Error> {
         // Check if the index is out of bounds.
-        if index >= self.bits.len() * u8::BITS as usize {
+        if index >= self.number_of_bits {
             let reason: &str = "index out of bounds";
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }


### PR DESCRIPTION
The `index()` function recomputed the total bit count as `bits.len() * u8::BITS` for its bounds check. Replace this with the pre-stored `number_of_bits` field, which already holds the same value and avoids a redundant multiplication.
