### PR TITLE
[kernel] Fix UserStack base()/top() doc semantics

### DIFF
--- a/src/kernel/src/mm/ustack.rs
+++ b/src/kernel/src/mm/ustack.rs
@@ -56,7 +56,7 @@ impl UserStack {
     ///
     /// # Notes
     ///
-    /// As sacks grow downwards, the base address is the highest address of the stack.
+    /// As stacks grow downwards, the base address is the lowest address of the stack region.
     ///
     pub fn base(&self) -> PageAligned<VirtualAddress> {
         self.base
@@ -73,7 +73,7 @@ impl UserStack {
     ///
     /// # Notes
     ///
-    /// As stacks grow downwards, the top address is the lowest address of the stack.
+    /// As stacks grow downwards, the top address is the highest address of the stack region.
     ///
     pub fn top(&self) -> PageAligned<VirtualAddress> {
         PageAligned::from_raw_value(self.base.into_raw_value() + self.size()).unwrap()


### PR DESCRIPTION
The documentation for `UserStack::base()` and `UserStack::top()` described traditional stack semantics (base = highest address, top = lowest), but the implementation uses memory-region semantics: `base()` returns the lowest address and `top()` = `base + size` returns the highest. Corrected the docs to match the code.