### PR TITLE
[kernel] Fix event manager exception resume and thread-level wakeup tracking

### DIFF
--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -67,6 +67,7 @@ static mut MANAGER: Option<EventManager> = None;
 
 struct ExceptionEventInformation {
     pid: ProcessIdentifier,
+    tid: ThreadIdentifier,
     info: ExceptionInformation,
 }
 
@@ -459,26 +460,24 @@ impl EventManagerInner {
             }
         };
 
-        // Get exception owner.
-        let pid: ProcessIdentifier = match self.exception_ownership[idx] {
-            Some(owner) => owner,
-            None => {
-                let reason: &str = "no owner for exception";
-                error!("reason={:?}", reason);
-                unimplemented!("terminate process")
-            },
-        };
+        // Check that the exception has an owner.
+        if self.exception_ownership[idx].is_none() {
+            let reason: &str = "no owner for exception";
+            error!("reason={:?}", reason);
+            unimplemented!("terminate process")
+        }
 
         // Search and remove event from pending exceptions.
         if let Some(entry) = self.pending_exceptions[idx]
             .iter()
             .position(|(evdesc, _info, _resume)| is_pending_exception(evdesc, &ev))
         {
-            let (_enventinfo, _excpinfo, resume) = self.pending_exceptions[idx].remove(entry);
+            let (_eventinfo, excpinfo, resume) = self.pending_exceptions[idx].remove(entry);
 
-            if let Err(error) = resume.notify_process(pid) {
-                warn!("{error:?}");
-                unimplemented!("terminate process")
+            if let Err(error) = resume.notify_thread(excpinfo.tid) {
+                // The faulting thread may have already been terminated by the exception owner .
+                // This is a legitimate outcome, not an error.
+                warn!("faulting thread already gone (tid={:?}, error={:?})", excpinfo.tid, error);
             }
         }
 
@@ -541,7 +540,8 @@ impl EventManagerInner {
     /// # Parameters
     ///
     /// - `exceptions`: Bit mask of exceptions.
-    /// - `pid`: Identifier of the target process.
+    /// - `pid`: Identifier of the faulting process.
+    /// - `tid`: Identifier of the faulting thread.
     /// - `info`: Exception information.
     ///
     /// # Returns
@@ -563,9 +563,10 @@ impl EventManagerInner {
         &mut self,
         exceptions: usize,
         pid: ProcessIdentifier,
+        tid: ThreadIdentifier,
         info: &ExceptionInformation,
     ) -> Result<Condvar, Error> {
-        trace!("exceptions={:#x}, pid={:?}, info={:?}", exceptions, pid, info);
+        trace!("exceptions={:#x}, pid={:?}, tid={:?}, info={:?}", exceptions, pid, tid, info);
         self.nevents += 1;
         let idx: usize = exceptions.trailing_zeros() as usize;
         let ev: Event = Event::from(ExceptionEvent::try_from(idx)?);
@@ -575,6 +576,7 @@ impl EventManagerInner {
             eventid,
             ExceptionEventInformation {
                 pid,
+                tid,
                 info: info.clone(),
             },
             resume.clone(),
@@ -963,6 +965,8 @@ fn do_exception_handler(
         panic!("the kernel triggered an exception");
     }
 
+    let tid: ThreadIdentifier = unsafe { ProcessManager::get() }.get_tid();
+
     // Handle page faults: demand-page user stack pages.
     if info.num() == ::arch::cpu::excp::Exception::PageFault as u32 {
         // SAFETY: This is the only thread running, thus access to the managers is synchronized.
@@ -998,7 +1002,7 @@ fn do_exception_handler(
             .map_err(SleepError::Generic)?
             .try_borrow_mut()
             .map_err(SleepError::Generic)?
-            .wakeup_exception(1 << info.num() as usize, pid, info)
+            .wakeup_exception(1 << info.num() as usize, pid, tid, info)
             .map_err(SleepError::Generic)?
     };
 

--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -23,7 +23,10 @@ use crate::{
         SleepError,
     },
 };
-use ::alloc::collections::LinkedList;
+use ::alloc::collections::{
+    LinkedList,
+    VecDeque,
+};
 use ::core::{
     cell::{
         RefCell,
@@ -69,6 +72,56 @@ struct ExceptionEventInformation {
     pid: ProcessIdentifier,
     tid: ThreadIdentifier,
     info: ExceptionInformation,
+}
+
+///
+/// # Description
+///
+/// RAII guard that removes a thread from the event manager's waiting list on drop.
+///
+struct WaitingThreadGuard {
+    pid: ProcessIdentifier,
+    tid: ThreadIdentifier,
+}
+
+impl WaitingThreadGuard {
+    /// Registers the thread in the event manager's waiting list and returns a guard that removes
+    /// it on drop.
+    fn register(pid: ProcessIdentifier, tid: ThreadIdentifier) -> Result<Self, Error> {
+        EventManager::get()?
+            .try_borrow_mut()?
+            .waiting_threads
+            .push_back((pid, tid));
+        Ok(Self { pid, tid })
+    }
+}
+
+impl Drop for WaitingThreadGuard {
+    fn drop(&mut self) {
+        match EventManager::get() {
+            Ok(em) => match em.try_borrow_mut() {
+                Ok(mut inner) => {
+                    inner
+                        .waiting_threads
+                        .retain(|&(p, t)| p != self.pid || t != self.tid);
+                },
+                Err(e) => {
+                    error!(
+                        "WaitingThreadGuard::drop(): failed to borrow event manager (pid={:?}, \
+                         tid={:?}, error={:?})",
+                        self.pid, self.tid, e
+                    );
+                },
+            },
+            Err(e) => {
+                error!(
+                    "WaitingThreadGuard::drop(): failed to get event manager (pid={:?}, tid={:?}, \
+                     error={:?})",
+                    self.pid, self.tid, e
+                );
+            },
+        }
+    }
 }
 
 pub struct EventOwnership {
@@ -125,6 +178,7 @@ struct EventManagerInner {
     interrupt_capable: bool,
     nevents: usize,
     wait: Option<Condvar>,
+    waiting_threads: VecDeque<(ProcessIdentifier, ThreadIdentifier)>,
     interrupt_ownership: [Option<ProcessIdentifier>; usize::BITS as usize],
     pending_interrupts: [LinkedList<EventDescriptor>; usize::BITS as usize],
     exception_ownership: [Option<ProcessIdentifier>; usize::BITS as usize],
@@ -529,7 +583,7 @@ impl EventManagerInner {
             },
         };
 
-        self.get_wait().notify_process(pid)
+        self.notify_all_process_threads(pid)
     }
 
     ///
@@ -593,7 +647,7 @@ impl EventManagerInner {
         };
 
         // Notify exception owner.
-        self.get_wait().notify_process(pid)?;
+        self.notify_all_process_threads(pid)?;
 
         Ok(resume)
     }
@@ -609,7 +663,7 @@ impl EventManagerInner {
         match receiver.as_id() {
             Ok(pid) => {
                 // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
-                unsafe { self.get_wait().notify_process(pid) }
+                unsafe { self.notify_all_process_threads(pid) }
             },
             Err(tid) => {
                 // SAFETY: the calling process does not hold mutable reference to the inner state of the process manager.
@@ -663,7 +717,7 @@ impl EventManagerInner {
             };
 
         trace!("pid={:?}, info={:?}", pid, info);
-        self.get_wait().notify_process(pid)?;
+        self.notify_all_process_threads(pid)?;
 
         Ok(())
     }
@@ -671,6 +725,46 @@ impl EventManagerInner {
     fn get_wait(&self) -> &Condvar {
         // NOTE: it is safe to unwrap because the wait field is always Some.
         self.wait.as_ref().unwrap()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Wakes up all threads of a process that are waiting on the event manager.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the target process.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, empty is returned. Otherwise, an error is returned instead.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it operates on global variables.
+    ///
+    /// This function is safe to use if and only if the following conditions are met:
+    ///
+    /// - The calling process does not hold a reference to the process manager.
+    ///
+    unsafe fn notify_all_process_threads(&self, pid: ProcessIdentifier) -> Result<(), Error> {
+        let mut first_error: Option<Error> = None;
+
+        // Wake up all threads of the target process in the waiting list.
+        for (_p, tid) in self.waiting_threads.iter().filter(|(p, _)| *p == pid) {
+            if let Err(error) = self.get_wait().notify_thread(*tid) {
+                warn!("{error:?} (pid={pid:?}, tid={tid:?})");
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+            }
+        }
+
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
     }
 }
 
@@ -791,6 +885,10 @@ impl EventManager {
             .map_err(SleepError::Generic)?
             .get_wait()
             .clone();
+
+        // Register this thread in the waiting list so producers can find it by pid.
+        let _guard: WaitingThreadGuard =
+            WaitingThreadGuard::register(pid, tid).map_err(SleepError::Generic)?;
 
         loop {
             let message: Option<Message> = EventManager::get()
@@ -1124,6 +1222,7 @@ pub fn init() -> Result<(), Error> {
         exception_ownership,
         pending_scheduling,
         scheduling_ownership,
+        waiting_threads: VecDeque::new(),
         wait: Some(Condvar::new()),
     });
 

--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -490,7 +490,7 @@ impl EventManagerInner {
     ///
     /// # Parameters
     ///
-    /// - `ev`: Exception event.
+    /// - `evdesc`: Full event descriptor (id + event type) identifying the pending exception.
     ///
     /// # Returns
     ///
@@ -504,14 +504,14 @@ impl EventManagerInner {
     ///
     /// - The calling process does not hold a reference to the process manager.
     ///
-    unsafe fn resume_exception(&mut self, ev: ExceptionEvent) -> Result<(), Error> {
-        let idx: usize = usize::from(ev);
-
-        let is_pending_exception = |evdesc: &EventDescriptor, ev: &ExceptionEvent| -> bool {
-            match evdesc.event() {
-                Event::Exception(ev2) => &ev2 == ev,
-                _ => false,
-            }
+    unsafe fn resume_exception(&mut self, evdesc: EventDescriptor) -> Result<(), Error> {
+        let idx: usize = match evdesc.event() {
+            Event::Exception(ev) => usize::from(ev),
+            other => {
+                let reason: &str = "event descriptor does not refer to an exception";
+                error!("reason={:?}, event={:?}", reason, other);
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
         };
 
         // Check that the exception has an owner.
@@ -521,10 +521,10 @@ impl EventManagerInner {
             unimplemented!("terminate process")
         }
 
-        // Search and remove event from pending exceptions.
+        // Search and remove event from pending exceptions by full descriptor (id + event).
         if let Some(entry) = self.pending_exceptions[idx]
             .iter()
-            .position(|(evdesc, _info, _resume)| is_pending_exception(evdesc, &ev))
+            .position(|(pending_evdesc, _info, _resume)| *pending_evdesc == evdesc)
         {
             let (_eventinfo, excpinfo, resume) = self.pending_exceptions[idx].remove(entry);
 
@@ -803,7 +803,9 @@ impl EventManager {
                 // No further action is required for interrupts.
                 Ok(())
             },
-            Event::Exception(ev) => EventManager::get()?.try_borrow_mut()?.resume_exception(ev),
+            Event::Exception(_ev) => EventManager::get()?
+                .try_borrow_mut()?
+                .resume_exception(evdesc),
             Event::Scheduling(_ev) => {
                 // No further action is required for scheduling events.
                 Ok(())

--- a/src/kernel/src/pm/sync/condvar.rs
+++ b/src/kernel/src/pm/sync/condvar.rs
@@ -11,7 +11,7 @@ use crate::pm::{
     ProcessManager,
 };
 use ::alloc::{
-    collections::LinkedList,
+    collections::VecDeque,
     sync::Arc,
 };
 use ::core::{
@@ -40,7 +40,7 @@ use ::sys::{
 /// Represents the inner state of a condition variable.
 ///
 struct CondvarInner {
-    sleeping: RefCell<LinkedList<(ProcessIdentifier, ThreadIdentifier)>>,
+    sleeping: RefCell<VecDeque<ThreadIdentifier>>,
 }
 
 ///
@@ -70,7 +70,7 @@ impl Condvar {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(CondvarInner {
-                sleeping: RefCell::new(LinkedList::new()),
+                sleeping: RefCell::new(VecDeque::new()),
             }),
         }
     }
@@ -116,57 +116,12 @@ impl Condvar {
         let mut awakened: u32 = 0;
 
         // Attempt to wake up the first thread in the sleeping queue.
-        if let Some((_pid, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
+        if let Some(tid) = self.inner.sleeping.borrow_mut().pop_front() {
             ProcessManager::wakeup(tid)?;
             awakened += 1;
         }
 
         Ok(awakened)
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Wakes up the first thread of a process that is waiting on the target condition variable.
-    ///
-    /// # Parameters
-    ///
-    /// - `pid`: Identifier of the target process.
-    ///
-    /// # Returns
-    ///
-    /// Upon successful completion, empty is returned. Otherwise, an error is returned instead.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe because it operates on global variables.
-    ///
-    /// This function is safe to use if and only if the following conditions are met:
-    ///
-    /// - The calling process does not hold a reference to the process manager.
-    ///
-    pub unsafe fn notify_process(&self, pid: ProcessIdentifier) -> Result<(), Error> {
-        // Find process.
-        let idx: Option<usize> = self
-            .inner
-            .sleeping
-            .borrow()
-            .iter()
-            .position(|&(p, _)| p == pid);
-
-        // Remove process from sleeping queue.
-        if let Some(at) = idx {
-            let (_notified_pid, tid) = self.inner.sleeping.borrow_mut().remove(at);
-            debug_assert!(
-                _notified_pid == pid,
-                "notify_process(): pid and tid do not match (expected: pid={:?}, got pid={:?})",
-                pid,
-                _notified_pid
-            );
-            ProcessManager::wakeup(tid)?;
-        }
-
-        Ok(())
     }
 
     ///
@@ -192,24 +147,18 @@ impl Condvar {
     ///
     pub unsafe fn notify_thread(&self, tid: ThreadIdentifier) -> Result<(), Error> {
         // Find thread.
-        let idx: Option<usize> = self
-            .inner
-            .sleeping
-            .borrow()
-            .iter()
-            .position(|&(_p, t)| t == tid);
+        let idx: Option<usize> = self.inner.sleeping.borrow().iter().position(|&t| t == tid);
 
-        // Remove thread from sleeping queue.
+        // Remove thread from sleeping queue and wake it up.
         if let Some(at) = idx {
-            let (_notified_pid, notified_tid): (ProcessIdentifier, ThreadIdentifier) =
-                self.inner.sleeping.borrow_mut().remove(at);
-            debug_assert!(
-                notified_tid == tid,
-                "notify_thread(): pid and tid do not match (expected: tid={:?}, got tid={:?})",
-                tid,
-                notified_tid
-            );
-            ProcessManager::wakeup(tid)?;
+            if let Some(notified_tid) = self.inner.sleeping.borrow_mut().remove(at) {
+                debug_assert!(
+                    notified_tid == tid,
+                    "notify_thread(): tid does not match (expected: tid={tid:?}, got \
+                     tid={notified_tid:?})",
+                );
+                ProcessManager::wakeup(tid)?;
+            }
         }
 
         Ok(())
@@ -241,11 +190,11 @@ impl Condvar {
         let mut first_error: Option<Error> = None; // First error encountered (if any).
 
         // Traverse the sleeping queue, waking up all threads.
-        while let Some((pid, tid)) = self.inner.sleeping.borrow_mut().pop_front() {
+        while let Some(tid) = self.inner.sleeping.borrow_mut().pop_front() {
             // Attempt to wake up thread and check for errors.
             if let Err(error) = ProcessManager::wakeup(tid) {
                 // Failed to wake up thread, log a warning, store the first error, and continue.
-                warn!("{error:?} (pid={pid:?}, tid={tid:?})");
+                warn!("{error:?} (tid={tid:?})");
                 if first_error.is_none() {
                     first_error = Some(error);
                 }
@@ -306,16 +255,13 @@ impl Condvar {
             }
         }
 
-        self.inner.sleeping.borrow_mut().push_back((pid, tid));
+        self.inner.sleeping.borrow_mut().push_back(tid);
 
         match ProcessManager::sleep(alarm) {
             Ok(()) => Ok(()),
             Err(error) => {
                 // Remove the thread from the sleeping queue if it was not woken up.
-                self.inner
-                    .sleeping
-                    .borrow_mut()
-                    .retain(|&mut (p, t)| p != pid || t != tid);
+                self.inner.sleeping.borrow_mut().retain(|&t| t != tid);
                 Err(error)
             },
         }


### PR DESCRIPTION
## Summary

Fix the event manager to correctly resume the faulting thread on exception handling, replace process-level condvar wakeups with thread-level tracking, and refactor the exception resume lookup to use full event descriptors.

## Commits

### `[kernel] B: Fix exception resume wakeup`

When handling an exception, the exception handler was resuming the process that owned the exception via `notify_process(pid)`. This could wake any thread of the process, not necessarily the one that faulted.

Track the faulting thread's identifier in `ExceptionEventInformation` and use `notify_thread(tid)` to resume the specific faulting thread when the exception is handled. Handle the case where the faulting thread was already terminated by the exception owner (e.g., memd killing a faulting process) by logging a warning instead of panicking.

Changes:
- Add `tid` field to `ExceptionEventInformation`.
- Add `tid` parameter to `wakeup_exception()`.
- Use `notify_thread(excpinfo.tid)` for exception resume.
- Obtain `tid` in `do_exception_handler()` and forward it.
- Refactor exception ownership check in `handle_exception()`.
- Handle `notify_thread()` failure in `resume_exception()` gracefully when the faulting thread was already terminated by the exception owner.
- Fix typo: `_enventinfo` -> `_eventinfo`.

### `[kernel] E: Track event waiters by thread`

Replace the Condvar's process-level wakeup (`notify_process`) with thread-level tracking in the EventManager. The Condvar sleeping queue now stores only `ThreadIdentifier`s instead of `(pid, tid)` pairs.

A new `waiting_threads` list in `EventManagerInner` tracks which threads are waiting on the event manager by `(pid, tid)`. When a process needs notification, the EventManager iterates `waiting_threads` to find all threads of that process and wakes each individually via `notify_thread()`.

Changes:
- Condvar: simplify sleeping queue to `VecDeque<ThreadIdentifier>`.
- Condvar: remove `notify_process()` method.
- EventManager: add `WaitingThreadGuard` RAII struct.
- EventManager: add `waiting_threads` field.
- EventManager: add `notify_all_process_threads()`.
- EventManager: replace `notify_process()` calls with `notify_all_process_threads()`.
- EventManager: register waiting threads via `WaitingThreadGuard` in `wait_event()`.

### `[kernel] E: Refactor resume_exception lookup`

Pass the full `EventDescriptor` to `resume_exception()` instead of only the `ExceptionEvent`. This eliminates the redundant event-type match between the caller (`resume`) and callee, and replaces the event-type-only pending exception lookup with a full descriptor equality check that correctly distinguishes between different instances of the same exception type.

Changes:
- Change `resume_exception()` to accept `EventDescriptor`.
- Extract `ExceptionEvent` index inline with error path.
- Match pending exceptions by full descriptor equality instead of event-type-only comparison.
- Update `resume()` to pass `evdesc` directly.

## Testing

All commits pass pre-commit hook checks (7/9 configurations, 2 excluded). No new build errors introduced beyond pre-existing ones.