### PR TITLE
[kernel] Unmap of Never Demanded-Paged Pages

### DIFF
--- a/src/kernel/src/hal/arch/x86/mem/mmu/page_table.rs
+++ b/src/kernel/src/hal/arch/x86/mem/mmu/page_table.rs
@@ -234,6 +234,32 @@ impl<T: DerefMut<Target = [u32]>> PageTable<T> {
         Ok(paddr)
     }
 
+    ///
+    /// # Description
+    ///
+    /// Checks whether a page is present in the target page table.
+    ///
+    /// # Parameters
+    ///
+    /// - `page_address`: Page address to check.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if the page is present.
+    /// - `Ok(false)` if the page is not present.
+    /// - `Err(_)` if the page table entry could not be read.
+    ///
+    pub fn is_page_present(&self, page_address: PageAddress) -> Result<bool, Error> {
+        match self.read_pte(page_address) {
+            Some(pte) => Ok(pte.is_present()),
+            None => {
+                let reason: &str = "failed to read page table entry";
+                error!("{reason} (page_address={page_address:?})");
+                Err(Error::new(ErrorCode::TryAgain, reason))
+            },
+        }
+    }
+
     /// Changes access permissions on a page.
     pub fn ctrl(
         &mut self,

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -268,7 +268,7 @@ impl VirtMemoryManager {
     ///
     /// # Description
     ///
-    /// Unmaps a user page from the target virtual memory space.
+    /// Attempts to unmap a user page from the target virtual memory space.
     ///
     /// # Parameters
     ///
@@ -277,15 +277,21 @@ impl VirtMemoryManager {
     ///
     /// # Return Values
     ///
-    /// Upon success, empty is returned. Upon failure, an error is returned instead.
+    /// - `Ok(true)` if the page was present and has been unmapped.
+    /// - `Ok(false)` if the page was not present.
+    /// - `Err(_)` on unexpected failures.
     ///
-    pub fn unmap_upage(
+    pub fn try_unmap_upage(
         &mut self,
         vmem: &mut Vmem,
         vaddr: PageAligned<VirtualAddress>,
-    ) -> Result<(), Error> {
-        let uframe: UserFrame = vmem.unmap(vaddr)?;
-        self.physman.borrow_mut().free_user_frame(uframe)
+    ) -> Result<bool, Error> {
+        if let Some(uframe) = vmem.unmap(vaddr)? {
+            self.physman.borrow_mut().free_user_frame(uframe)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     pub fn alloc_upages(

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -572,6 +572,43 @@ impl Vmem {
     ///
     /// # Description
     ///
+    /// Attempts to find a user frame in the target virtual memory space.
+    ///
+    /// # Parameters
+    ///
+    /// - `vaddr`: Virtual address of the target page.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Some(addr))` if the page is present.
+    /// - `Ok(None)` if the page table or page is not present.
+    /// - `Err(_)` on unexpected failures.
+    ///
+    fn try_find_user_frame(
+        &self,
+        vaddr: PageAligned<VirtualAddress>,
+    ) -> Result<Option<FrameAddress>, Error> {
+        let page_addr: PageAddress = PageAddress::new(vaddr);
+        let pgtab_addr: PageTableAddress = PageTableAddress::new(PageTableAligned::from_raw_value(
+            ::sys::mm::align_down(vaddr.into_raw_value(), PGTAB_ALIGNMENT),
+        )?);
+
+        for (lookup_pgtable_addr, page_table) in self.user_page_tables.iter() {
+            if lookup_pgtable_addr == &pgtab_addr {
+                if page_table.is_page_present(page_addr)? {
+                    return Ok(Some(page_table.lookup(page_addr)?));
+                } else {
+                    return Ok(None);
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    ///
+    /// # Description
+    ///
     /// Translates a user-space virtual address to a guest physical address by walking the page
     /// tables. The returned physical address includes the intra-page offset from the original
     /// virtual address.
@@ -1041,16 +1078,24 @@ impl Vmem {
     ///
     /// Unmaps a page from the target virtual address space.
     ///
+    /// If the page is not present (e.g., was never demand-paged), `Ok(None)` is returned without
+    /// logging any errors. This makes the method suitable for cleaning up lazily-allocated regions
+    /// such as user stacks.
+    ///
     /// # Parameters
     ///
     /// - `vaddr`: Virtual address of the target page.
     ///
     /// # Returns
     ///
-    /// Upon success, the user frame that was unmapped is returned. Upon failure, an error code is
-    /// returned instead.
+    /// - `Ok(Some(frame))` if the page was present and has been unmapped.
+    /// - `Ok(None)` if the page was not present.
+    /// - `Err(_)` on unexpected failures.
     ///
-    pub fn unmap(&mut self, vaddr: PageAligned<VirtualAddress>) -> Result<UserFrame, Error> {
+    pub fn unmap(
+        &mut self,
+        vaddr: PageAligned<VirtualAddress>,
+    ) -> Result<Option<UserFrame>, Error> {
         // Check if the provided address lies outside the user space.
         if !Self::is_user_addr(vaddr.into_inner()) {
             let reason: &str = "address is not in user space";
@@ -1058,8 +1103,11 @@ impl Vmem {
             return Err(Error::new(ErrorCode::BadAddress, reason));
         }
 
-        // Find the corresponding frame address.
-        let frame_address: FrameAddress = self.find_user_frame(vaddr)?;
+        // Find the corresponding frame address, returning None if the page is not present.
+        let frame_address: FrameAddress = match self.try_find_user_frame(vaddr)? {
+            Some(addr) => addr,
+            None => return Ok(None),
+        };
 
         let (pgtable_vaddr, unmap_pgtable): (PageTableAddress, bool) = {
             // Get corresponding page table.
@@ -1121,7 +1169,7 @@ impl Vmem {
             self.pgdir.unmap(pgtable_vaddr)?;
         }
 
-        Ok(UserFrame::new(frame_address))
+        Ok(Some(UserFrame::new(frame_address)))
     }
 
     /// Changes access permissions on a page.

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1835,11 +1835,19 @@ impl ProcessManager {
                                 unreachable!("address conversion should succeed")
                             },
                         };
-                    // Attempt to unmap page
-                    if let Err(error) = mm.unmap_upage(state.vmem_mut(), vaddr) {
-                        // We failed, but this is not too bad, as we will free all pages
-                        // when wiping out the address space anyways.
-                        warn!("failed to unmap page (vaddr={:?}, error={:?})", vaddr, error);
+                    // Attempt to unmap page.
+                    match mm.try_unmap_upage(state.vmem_mut(), vaddr) {
+                        Ok(true) => {
+                            // Page was present and has been successfully unmapped.
+                        },
+                        Ok(false) => {
+                            // Page was never mapped (not demand-paged). Skip silently.
+                        },
+                        Err(error) => {
+                            // Unexpected failure — log but continue since the
+                            // address space will be reclaimed when it is destroyed.
+                            warn!("failed to unmap page (vaddr={:?}, error={:?})", vaddr, error);
+                        },
                     }
                 }
 
@@ -1871,7 +1879,13 @@ impl ProcessManager {
     ) -> Result<(), Error> {
         let mut process: ProcessRefMut = self.find_process_mut(pid)?;
         let vmem: &mut Vmem = process.state_mut().vmem_mut();
-        mm.unmap_upage(vmem, vaddr)
+        if mm.try_unmap_upage(vmem, vaddr)? {
+            Ok(())
+        } else {
+            let reason: &str = "page is not mapped";
+            error!("munmap(): {reason} (pid={pid:?}, vaddr={vaddr:?})");
+            Err(Error::new(ErrorCode::NoSuchEntry, reason))
+        }
     }
 
     pub fn mctrl(

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -361,8 +361,8 @@ impl ProcessManager {
                                         unreachable!("address conversion should succeed")
                                     },
                                 };
-                            // Attempt to unmap page
-                            if let Err(error) = VirtMemoryManager::get_mut().unmap_upage(
+                            // Attempt to unmap page.
+                            match VirtMemoryManager::get_mut().try_unmap_upage(
                                 Self::get_mut()
                                     .find_process_mut(pid)
                                     .map_err(SleepError::Generic)?
@@ -370,13 +370,21 @@ impl ProcessManager {
                                     .vmem_mut(),
                                 vaddr,
                             ) {
-                                // We failed, but this is not too bad, as we will free all pages
-                                // when wiping out the address space anyways.
-                                warn!(
-                                    "harvest_zombies(): failed to unmap page (vaddr={:?}, \
-                                     error={:?})",
-                                    vaddr, error
-                                );
+                                Ok(true) => {
+                                    // Page was present and has been successfully unmapped.
+                                },
+                                Ok(false) => {
+                                    // Page was never mapped (not demand-paged). Skip silently.
+                                },
+                                Err(error) => {
+                                    // Unexpected failure — log but continue since the
+                                    // address space will be reclaimed when it is destroyed.
+                                    warn!(
+                                        "harvest_zombies(): failed to unmap page (vaddr={:?}, \
+                                         error={:?})",
+                                        vaddr, error
+                                    );
+                                },
                             }
                         }
 


### PR DESCRIPTION
Pages in lazily-allocated regions (e.g., user stacks) may never be
demand-paged in before their owning process exits or their mapping
is torn down. The previous implementation treated unmapping a
non-present page as a hard error, which produced spurious warnings
during process cleanup and zombie harvesting.

Introduce a `try_find_user_frame()` helper in `Vmem` that returns
`Ok(None)` when the page or its page table is not present, and
thread its result through:

- `Vmem::unmap()` now returns `Ok(None)` instead of `Err` for
  non-present pages.
- `VirtMemoryManager::unmap_upage()` is renamed to
  `try_unmap_upage()` and returns `Result<bool, Error>` to
  distinguish "unmapped" (true) from "was not present" (false).
- `PageTable::is_page_present()` is added to query page presence
  without triggering a full lookup error path.

Callers are updated accordingly:

- Process exit and zombie harvesting silently skip non-present
  pages instead of logging warnings.
- The `munmap` kernel-call path returns `NoSuchEntry` when the
  page is genuinely not mapped, preserving its existing error
  contract.