### PR TITLE
[ci] Skip x86_64 sync for forks

### DIFF
--- a/.github/workflows/sync-x64-branch.yml
+++ b/.github/workflows/sync-x64-branch.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   sync:
     name: "Merge dev into feature-kernel-x64"
+    if: github.repository == 'nanvix/nanvix'
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
Add a check to skip the workflow in `sync-x64-branch.yml` from running for forks.

Forks generally do not clone all branches of the upstream repository, and this workflow fails every hour on trying to locate the feature-kernel-x64 branch.