### PR TITLE
[micropython] Add MicroPython port for NanVix

### DIFF
--- a/build/user/linker/x86/user.ld
+++ b/build/user/linker/x86/user.ld
@@ -27,6 +27,32 @@ SECTIONS
 		*(.text*)
 	}
 
+	/* C runtime init/fini (called by c_trampoline before/after main). */
+	.init : ALIGN(4)
+	{
+		KEEP(*(.init))
+	}
+
+	.fini : ALIGN(4)
+	{
+		KEEP(*(.fini))
+	}
+
+	/* C++ global constructors/destructors (called from _init/_fini). */
+	.ctors : ALIGN(4)
+	{
+		KEEP(*crtbegin*.o(.ctors))
+		KEEP(*(SORT(.ctors.*)))
+		KEEP(*(.ctors))
+	}
+
+	.dtors : ALIGN(4)
+	{
+		KEEP(*crtbegin*.o(.dtors))
+		KEEP(*(SORT(.dtors.*)))
+		KEEP(*(.dtors))
+	}
+
 	/* Initialized data section. */
 	.data : ALIGN(PAGE_SIZE)
 	{

--- a/src/ports/micropython-nanvix/Makefile
+++ b/src/ports/micropython-nanvix/Makefile
@@ -1,0 +1,87 @@
+include ../../py/mkenv.mk
+
+# Cross-compilation for NanVix (i686 bare-metal via NanVix toolchain).
+CROSS = 1
+CROSS_COMPILE ?= i686-nanvix-
+
+# qstr definitions (must come before including py.mk).
+QSTR_DEFS = qstrdefsport.h
+
+# MicroPython feature configurations.
+MICROPY_ROM_TEXT_COMPRESSION ?= 0
+
+# Include MicroPython core make definitions.
+include $(TOP)/py/py.mk
+
+# Compiler: use i686-nanvix-gcc from the NanVix toolchain.
+CC = $(CROSS_COMPILE)gcc
+LD = $(CROSS_COMPILE)gcc
+SIZE = $(CROSS_COMPILE)size
+OBJCOPY = $(CROSS_COMPILE)objcopy
+
+# Include paths.
+INC += -I.
+INC += -I$(TOP)
+INC += -I$(BUILD)
+
+# Compiler flags for NanVix target.
+CFLAGS += $(INC) -Wall -std=c99 $(COPT)
+CFLAGS += -m32 -march=pentiumpro
+CFLAGS += -fdata-sections -ffunction-sections
+
+# NanVix-specific paths (set by Docker or caller).
+NANVIX_ROOT ?= /mnt
+NANVIX_LIB_DIR ?= $(NANVIX_ROOT)/lib
+TOOLCHAIN_DIR ?= /opt/nanvix
+
+# Linker flags: use NanVix linker script and libraries.
+LDFLAGS += -z noexecstack
+LDFLAGS += -T $(NANVIX_ROOT)/build/user/linker/x86/user.ld
+LDFLAGS += -Wl,--gc-sections
+LDFLAGS += -Wl,-Map=$@.map,--cref
+
+# Libraries: NanVix POSIX + libc + libm.
+LIBS += -Wl,--start-group
+LIBS += $(NANVIX_LIB_DIR)/libposix.a
+LIBS += $(TOOLCHAIN_DIR)/i686-nanvix/lib/libc.a
+LIBS += $(TOOLCHAIN_DIR)/i686-nanvix/lib/libm.a
+LIBS += -Wl,--end-group
+
+# Optimisation.
+CSUPEROPT = -Os
+
+ifeq ($(DEBUG), 1)
+CFLAGS += -O0 -g
+else
+CFLAGS += -Os -DNDEBUG
+endif
+
+# Source files.
+SRC_C = \
+	main.c \
+	uart_core.c \
+	shared/libc/printf.c \
+	shared/readline/readline.c \
+	shared/runtime/pyexec.c \
+	shared/runtime/stdout_helpers.c \
+	$(BUILD)/_frozen_mpy.c \
+
+SRC_QSTR += shared/readline/readline.c shared/runtime/pyexec.c
+
+# Object files.
+OBJ += $(PY_CORE_O)
+OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+
+# Build target.
+all: $(BUILD)/micropython.elf
+
+$(BUILD)/_frozen_mpy.c: $(TOP)/tests/frozen/frozentest.mpy $(BUILD)/genhdr/qstrdefs.generated.h
+	$(ECHO) "MISC freezing bytecode"
+	$(Q)$(TOP)/tools/mpy-tool.py -f -q $(BUILD)/genhdr/qstrdefs.preprocessed.h -mlongint-impl=none $< > $@
+
+$(BUILD)/micropython.elf: $(OBJ)
+	$(ECHO) "LINK $@"
+	$(Q)$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(Q)$(SIZE) $@
+
+include $(TOP)/py/mkrules.mk

--- a/src/ports/micropython-nanvix/main.c
+++ b/src/ports/micropython-nanvix/main.c
@@ -1,0 +1,110 @@
+// MicroPython NanVix port — main entry point
+// Runs MicroPython inside a NanVix VM.
+// Usage: nanvixd.exe -- micropython.elf [-c "print('hello')"]
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "py/builtin.h"
+#include "py/compile.h"
+#include "py/runtime.h"
+#include "py/repl.h"
+#include "py/gc.h"
+#include "py/mperrno.h"
+#include "shared/runtime/pyexec.h"
+
+static void do_str(const char *src, mp_parse_input_kind_t input_kind) {
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
+        qstr source_name = lex->source_name;
+        mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
+        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, true);
+        mp_call_function_0(module_fun);
+        nlr_pop();
+    } else {
+        mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
+    }
+}
+
+static char *stack_top;
+static char heap[MICROPY_HEAP_SIZE];
+
+int main(int argc, char **argv) {
+    int stack_dummy;
+    stack_top = (char *)&stack_dummy;
+
+    gc_init(heap, heap + sizeof(heap));
+    mp_init();
+
+    // Check for -c "code" argument.
+    // NanVix splits arguments on spaces (no shell-style quoting), so
+    // `-c print('hello world')` arrives as argv = ["micropython", "-c", "print('hello", "world')"].
+    // Rejoin everything after `-c` into a single string for MicroPython.
+    if (argc >= 3 && strcmp(argv[1], "-c") == 0) {
+        static char code_buf[4096];
+        size_t offset = 0;
+        for (int i = 2; i < argc; i++) {
+            size_t arg_len = strlen(argv[i]);
+            size_t space = (i > 2) ? 1 : 0;
+            if (offset + space + arg_len >= sizeof(code_buf)) {
+                printf("Error: -c argument too long (max %zu bytes)\n",
+                       sizeof(code_buf) - 1);
+                mp_deinit();
+                return 1;
+            }
+            if (space) {
+                code_buf[offset++] = ' ';
+            }
+            memcpy(code_buf + offset, argv[i], arg_len);
+            offset += arg_len;
+        }
+        code_buf[offset] = '\0';
+        do_str(code_buf, MP_PARSE_FILE_INPUT);
+    } else if (argc >= 2) {
+        // Treat argument as a script to execute via do_str.
+        do_str(argv[1], MP_PARSE_FILE_INPUT);
+    } else {
+        // No arguments — run interactive REPL.
+        pyexec_friendly_repl();
+    }
+
+    mp_deinit();
+    return 0;
+}
+
+// Garbage collection: scan the stack for root pointers.
+void gc_collect(void) {
+    void *dummy;
+    gc_collect_start();
+    gc_collect_root(&dummy, ((mp_uint_t)stack_top - (mp_uint_t)&dummy) / sizeof(mp_uint_t));
+    gc_collect_end();
+}
+
+// File import — not supported yet.
+mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
+    mp_raise_OSError(MP_ENOENT);
+}
+
+mp_import_stat_t mp_import_stat(const char *path) {
+    return MP_IMPORT_STAT_NO_EXIST;
+}
+
+// Fatal error handlers.
+void nlr_jump_fail(void *val) {
+    printf("FATAL: nlr_jump_fail\n");
+    for (;;) {}
+}
+
+void NORETURN __fatal_error(const char *msg) {
+    printf("FATAL: %s\n", msg);
+    for (;;) {}
+}
+
+#ifndef NDEBUG
+void MP_WEAK __assert_func(const char *file, int line, const char *func, const char *expr) {
+    printf("Assertion '%s' failed, at file %s:%d\n", expr, file, line);
+    __fatal_error("Assertion failed");
+}
+#endif

--- a/src/ports/micropython-nanvix/mpconfigport.h
+++ b/src/ports/micropython-nanvix/mpconfigport.h
@@ -1,0 +1,49 @@
+// MicroPython configuration for NanVix port
+// Based on ports/minimal/mpconfigport.h
+
+#include <stdint.h>
+
+// Use the minimum starting configuration.
+#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_MINIMUM)
+
+// Enable the compiler and REPL.
+#define MICROPY_ENABLE_COMPILER     (1)
+
+// Enable garbage collection.
+#define MICROPY_ENABLE_GC           (1)
+
+// Enable REPL helpers (tab completion, history).
+#define MICROPY_HELPER_REPL         (1)
+
+// Enable external imports (for frozen modules).
+#define MICROPY_ENABLE_EXTERNAL_IMPORT (1)
+
+// Frozen bytecode support.
+#define MICROPY_QSTR_EXTRA_POOL     mp_qstr_frozen_const_pool
+#define MICROPY_MODULE_FROZEN_MPY   (1)
+
+// Use stdout for I/O (NanVix provides POSIX read/write).
+#define MICROPY_MIN_USE_STDOUT      (1)
+
+// Heap size: 256KB (NanVix VMs have plenty of memory).
+#define MICROPY_HEAP_SIZE           (256 * 1024)
+
+// Path allocation limit.
+#define MICROPY_ALLOC_PATH_MAX      (256)
+
+// Minimum chunk size for parser.
+#define MICROPY_ALLOC_PARSE_CHUNK_INIT (16)
+
+// Type definitions for i686 (32-bit).
+typedef intptr_t mp_int_t;
+typedef uintptr_t mp_uint_t;
+typedef long mp_off_t;
+
+// alloca() declaration.
+#include <alloca.h>
+
+// Board identification.
+#define MICROPY_HW_BOARD_NAME       "NanVix"
+#define MICROPY_HW_MCU_NAME         "i686"
+
+#define MP_STATE_PORT               MP_STATE_VM

--- a/src/ports/micropython-nanvix/mphalport.h
+++ b/src/ports/micropython-nanvix/mphalport.h
@@ -1,0 +1,20 @@
+// MicroPython HAL (Hardware Abstraction Layer) for NanVix
+// Uses POSIX clock_gettime for timing, read/write for I/O.
+
+#include <time.h>
+
+static inline mp_uint_t mp_hal_ticks_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (mp_uint_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+}
+
+static inline mp_uint_t mp_hal_ticks_us(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (mp_uint_t)(ts.tv_sec * 1000000 + ts.tv_nsec / 1000);
+}
+
+static inline void mp_hal_set_interrupt_char(char c) {
+    (void)c;
+}

--- a/src/ports/micropython-nanvix/qstrdefsport.h
+++ b/src/ports/micropython-nanvix/qstrdefsport.h
@@ -1,0 +1,1 @@
+// Extra qstr definitions for NanVix port (empty — no port-specific strings).

--- a/src/ports/micropython-nanvix/uart_core.c
+++ b/src/ports/micropython-nanvix/uart_core.c
@@ -1,0 +1,20 @@
+// UART/IO core for NanVix port
+// Uses POSIX read()/write() — NanVix provides these via its POSIX layer.
+
+#include <unistd.h>
+#include "py/mpconfig.h"
+
+// Receive single character from stdin.
+int mp_hal_stdin_rx_chr(void) {
+    unsigned char c = 0;
+    int r = read(STDIN_FILENO, &c, 1);
+    (void)r;
+    return c;
+}
+
+// Send string of given length to stdout.
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
+    int r = write(STDOUT_FILENO, str, len);
+    (void)r;
+    return len;
+}


### PR DESCRIPTION
Add a MicroPython v1.24.1 port enabling Python script execution inside NanVix VMs. The port provides 6 source files based on MicroPython's minimal port template, adapted for NanVix's i686 POSIX environment.

Port files (src/ports/micropython-nanvix/):
- main.c: Entry point with -c flag support and argv-rejoin workaround for NanVix's space-based argument splitting. Uses bounded memcpy with length checking (4096-byte limit) to prevent buffer overflows.
- mpconfigport.h: Minimal config (MICROPY_CONFIG_ROM_LEVEL_MINIMUM), 256KB GC heap, i686 32-bit types, GC + compiler + REPL enabled.
- mphalport.h: HAL with real monotonic clock via clock_gettime() for mp_hal_ticks_ms/us instead of returning zero.
- uart_core.c: I/O via POSIX read()/write() on stdin/stdout.
- qstrdefsport.h: Empty (no port-specific interned strings).
- Makefile: Cross-compile with i686-nanvix-gcc, link against libposix/libc/libm, uses --gc-sections for dead code elimination.

Linker script changes (build/user/linker/x86/user.ld):
- Added .init/.fini sections with KEEP to preserve C runtime initialisation code when --gc-sections is enabled.
- Added .ctors/.dtors sections with KEEP to preserve GCC's crtbegin/crtend constructor/destructor sentinel values.

Tested: 7/7 passing (hello, Hello World, arithmetic, loops, list comprehensions, string concat, function definitions). Binary size: 800KB (with --gc-sections).