### PR TITLE
[doc] Add Documentation for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Nanvix is a microkernel-based research operating system.
 
 ## Quick Start
 
+### Linux
+
 Requires Ubuntu 24.04 with sudo privileges, [Docker](doc/setup.md#5-setup-docker-optional), and
 [KVM](doc/setup.md#4-setup-kvm) enabled.
 
@@ -24,6 +26,27 @@ git clone https://github.com/nanvix/nanvix.git && cd nanvix
 
 # Run an example application.
 ./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/hello-rust-nostd.elf
+```
+
+### Windows
+
+Requires Windows 11 with [Docker Desktop](doc/setup.md#windows-setup) (Linux containers), [Windows
+Hypervisor Platform](doc/setup.md#1-enable-windows-hypervisor-platform) enabled, [Developer
+Mode](doc/setup.md#2-enable-developer-mode) turned on, and a Rust toolchain installed via
+[rustup](https://rustup.rs).
+
+```powershell
+# Clone this source code (symlinks require Developer Mode).
+git clone -c core.symlinks=true https://github.com/nanvix/nanvix.git; cd nanvix
+
+# Setup the development environment (pulls Docker image).
+.\z.ps1 setup
+
+# Build Nanvix.
+.\z.ps1 build -- all
+
+# Run an example application.
+.\bin\uservm.exe -kernel .\bin\kernel.elf -initrd .\bin\hello-rust-nostd.elf -standalone
 ```
 
 > For more details, see the full [setup](doc/setup.md), [build](doc/build.md), and

--- a/doc/build.md
+++ b/doc/build.md
@@ -9,20 +9,27 @@ simplified build process or do it manually.
 
 ## Table of Contents
 
-- [Building Nanvix with `z` (Preferred Method)](#building-nanvix-with-z-preferred-method)
-  - [Getting Started with `z`](#getting-started-with-z)
-  - [Using `z` to Build Nanvix with Docker](#using-z-to-build-nanvix-with-docker)
-  - [Using `z` to Build Nanvix with a Local Toolchain](#using-z-to-build-nanvix-with-a-local-toolchain)
-- [Building Nanvix Manually](#building-nanvix-manually)
-  - [Manually Building Nanvix with Docker](#manually-building-nanvix-with-docker)
-  - [Manually Building Nanvix with a Local Toolchain](#manually-building-nanvix-with-a-local-toolchain)
+- [Building Nanvix on Linux](#building-nanvix-on-linux)
+  - [Building Nanvix with `z` (Preferred Method)](#building-nanvix-with-z-preferred-method)
+  - [Building Nanvix Manually](#building-nanvix-manually)
+  - [Formal Verification with Verus](#formal-verification-with-verus)
+- [Building Nanvix on Windows](#building-nanvix-on-windows)
+  - [Building Everything](#building-everything)
+  - [Building Individual Components](#building-individual-components)
+  - [Build Parameters (Windows)](#build-parameters-windows)
+  - [Code Quality Checks (Windows)](#code-quality-checks-windows)
+  - [Cleaning (Windows)](#cleaning-windows)
 
-## Building Nanvix with `z` (Preferred Method)
+## Building Nanvix on Linux
+
+> ℹ️ Ensure you have completed the [Linux setup](setup.md#linux-setup) before proceeding.
+
+### Building Nanvix with `z` (Preferred Method)
 
 `z` is a utility for building Nanvix. It provides you with a simplified interface for building
 Nanvix either using Docker or your local toolchain.
 
-### Getting Started with `z`
+#### Getting Started with `z`
 
 For more information on how to use the `z` utility, you can run:
 
@@ -30,7 +37,7 @@ For more information on how to use the `z` utility, you can run:
 ./z help
 ```
 
-### Using `z` to Build Nanvix with Docker
+#### Using `z` to Build Nanvix with Docker
 
 To build Nanvix using the latest Docker image and default build parameters, run:
 
@@ -38,7 +45,7 @@ To build Nanvix using the latest Docker image and default build parameters, run:
 ./z build --with-docker -- all
 ```
 
-### Using `z` to Build Nanvix with a Local Toolchain
+#### Using `z` to Build Nanvix with a Local Toolchain
 
 To build Nanvix using your local toolchain and default build parameters, run:
 
@@ -46,11 +53,11 @@ To build Nanvix using your local toolchain and default build parameters, run:
 ./z build -- all
 ```
 
-## Building Nanvix Manually
+### Building Nanvix Manually
 
 Instead of using the `z` utility, you can build Nanvix manually.
 
-### Manually Building Nanvix with Docker
+#### Manually Building Nanvix with Docker
 
 To build Nanvix using the latest Docker image and default build parameters, run:
 
@@ -71,7 +78,7 @@ DOCKER_BUILDKIT=1 docker build \
 > to `/mnt`, but should be set to `$(pwd -P)` so that Python and other binaries with
 > embedded absolute paths can find their libraries at runtime.
 
-### Manually Building Nanvix with a Local Toolchain
+#### Manually Building Nanvix with a Local Toolchain
 
 To build Nanvix using your local toolchain and default build parameters, run:
 
@@ -86,7 +93,7 @@ local in-memory VFS layer and kernel debug serial port:
 make all DEPLOYMENT_MODE=standalone
 ```
 
-## Formal Verification with Verus
+### Formal Verification with Verus
 
 Nanvix uses [Verus](https://github.com/verus-lang/verus) for formal verification of selected
 kernel crates. The correct Verus version is pinned in `build/verus-version` and is automatically
@@ -112,4 +119,85 @@ executable (and required companion binaries), not just the Verus source tree.
 # Use a custom Verus installation (pre-built or source-built).
 # VERUS_EXECUTABLE_DIR must be the directory that contains the verus binary.
 ./z build --with-cached-options -- verify VERUS_EXECUTABLE_DIR=~/verus/target-verus/release
+```
+
+## Building Nanvix on Windows
+
+On Windows, the `z.ps1` PowerShell script provides the same interface as the Linux `z` utility.
+Guest components (kernel, user binaries) are cross-compiled inside Docker, while the UserVM is
+built natively using the Windows Hypervisor Platform (WHP) backend. The WHP backend is
+automatically selected when building with the `microvm` feature on Windows.
+
+> ℹ️ Ensure you have completed the [Windows setup](setup.md#windows-setup) before proceeding.
+
+### Building Everything
+
+Build all components:
+
+```powershell
+.\z.ps1 build -- all
+```
+
+### Building Individual Components
+
+```powershell
+# Build only the UserVM.
+.\z.ps1 build -- uservm
+
+# Build only guest components.
+.\z.ps1 build -- guest
+```
+
+### Build Parameters (Windows)
+
+Pass build parameters after `--`, just like on Linux:
+
+```powershell
+# Release build.
+.\z.ps1 build -- all RELEASE=yes
+
+# Use the full (non-minimal) Docker image.
+.\z.ps1 build --with-docker -- all
+```
+
+Any make target not handled by `z.ps1` directly is forwarded to `make` via Docker:
+
+```powershell
+# Forward a custom make target to Docker.
+.\z.ps1 build -- kernel
+```
+
+### Code Quality Checks (Windows)
+
+Code quality checks run inside Docker and work the same as on Linux:
+
+```powershell
+# Check formatting.
+.\z.ps1 build -- format-check
+
+# Fix formatting.
+.\z.ps1 build -- format
+
+# Check linting.
+.\z.ps1 build -- lint-check
+
+# Fix linting.
+.\z.ps1 build -- lint
+
+# Spell checking.
+.\z.ps1 build -- spellcheck
+.\z.ps1 build -- spellcheck-fix
+
+# Run unit tests.
+.\z.ps1 build -- run-unit-tests
+```
+
+### Cleaning (Windows)
+
+```powershell
+# Quick clean (removes build artifacts and cache).
+.\z.ps1 clean
+
+# Full clean (removes everything).
+.\z.ps1 distclean
 ```

--- a/doc/run.md
+++ b/doc/run.md
@@ -5,13 +5,18 @@
 
 ## Overview
 
-Nanvix instances are launched and managed through `nanvixd`, which operates in one
-of two mutually exclusive modes:
+On Linux, Nanvix instances are launched and managed through `nanvixd`, which operates in one of
+two mutually exclusive modes:
 
 - **Interactive Mode**: runs a single application, waits for it to exit, and forwards its exit code.
 - **HTTP Mode**: starts a REST server that spawns and kills applications on demand.
 
+On Windows, the supported host workflow is standalone UserVM execution; see
+[`Running on Windows`](#running-on-windows).
+
 ## Quick Start
+
+### Linux
 
 Run a hello-world application and see its output on the terminal:
 
@@ -19,7 +24,13 @@ Run a hello-world application and see its output on the terminal:
 ./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/hello-rust-nostd.elf
 ```
 
-> **Tip:** Run `./bin/nanvixd.elf -help` for the full list of command-line options.
+### Windows
+
+On Windows, you can run the UserVM in standalone mode directly:
+
+```powershell
+.\bin\uservm.exe -kernel .\bin\kernel.elf -initrd .\bin\hello-rust-nostd.elf -standalone
+```
 
 ## Table of Contents
 
@@ -34,6 +45,7 @@ Run a hello-world application and see its output on the terminal:
   - [HTTP Error Codes](#http-error-codes)
 - [Logging](#logging)
 - [Expert Mode: Standalone User VM](#expert-mode-standalone-user-vm)
+- [Running on Windows](#running-on-windows)
 
 ## Interactive Mode
 
@@ -253,4 +265,44 @@ Enable verbose logging with `RUST_LOG`:
 ```bash
 RUST_LOG=debug ./bin/uservm.elf -kernel ./bin/kernel.elf \
     -initrd ./bin/hello-rust-nostd.elf -standalone
+```
+
+## Running on Windows
+
+On Windows, the UserVM is built natively with the WHP (Windows Hypervisor Platform) backend and
+can be run in **standalone mode** using `z.ps1`. Interactive and HTTP modes via `nanvixd` are not
+available on Windows.
+
+### Using `z.ps1 run`
+
+The simplest way to run the UserVM on Windows:
+
+```powershell
+.\z.ps1 run
+```
+
+This uses default paths (`bin/kernel.elf` and `bin/hello-rust-nostd.elf`). You can override them:
+
+```powershell
+.\z.ps1 run -- -kernel bin\kernel.elf -initrd bin\hello-rust-nostd.elf
+```
+
+| Option             | Default                       | Description                |
+| ------------------ | ----------------------------- | -------------------------- |
+| `-kernel <path>`   | `bin/kernel.elf`              | Path to the kernel binary. |
+| `-initrd <path>`   | `bin/hello-rust-nostd.elf`    | Path to the guest binary.  |
+
+### Running the UserVM Directly
+
+You can also invoke `uservm.exe` directly:
+
+```powershell
+.\bin\uservm.exe -kernel .\bin\kernel.elf -initrd .\bin\hello-rust-nostd.elf -standalone
+```
+
+Enable verbose logging with the `RUST_LOG` environment variable:
+
+```powershell
+$env:RUST_LOG = "debug"
+.\bin\uservm.exe -kernel .\bin\kernel.elf -initrd .\bin\hello-rust-nostd.elf -standalone
 ```

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -4,26 +4,33 @@ This guide will help you set up your development environment to build and run Na
 
 ## Table of Contents
 
-- [Setting Up Your System](#setting-up-your-system)
+- [Linux Setup](#linux-setup)
   - [1. Check Your System and Permissions](#1-check-your-system-and-permissions)
   - [2. Clone This Repository](#2-clone-this-repository)
   - [3. Install Dependencies for Development Tools](#3-install-dependencies-for-development-tools)
   - [4. Setup KVM](#4-setup-kvm)
   - [5. Setup Docker (Optional)](#5-setup-docker-optional)
   - [6. Setup SCCACHE (Optional)](#6-setup-sccache-optional)
+  - [7. Set Up GDB Debugging (Optional)](#7-set-up-gdb-debugging-optional)
 - [Setting Up Development Tools for the First Time](#setting-up-development-tools-for-the-first-time)
   - [Option 1: Build Development Tools Locally (Preferred Method)](#option-1-build-development-tools-locally-preferred-method)
   - [Option 2: Use a Pre-Built Docker Image](#option-2-use-a-pre-built-docker-image)
   - [Option 3: Build a Docker Image](#option-3-build-a-docker-image)
 - [Updating Your Development Tools](#updating-your-development-tools)
   - [Verus (Formal Verification)](#verus-formal-verification)
+- [Windows Setup](#windows-setup)
+  - [1. Enable Windows Hypervisor Platform](#1-enable-windows-hypervisor-platform)
+  - [2. Enable Developer Mode](#2-enable-developer-mode)
+  - [3. Install Docker Desktop](#3-install-docker-desktop)
+  - [4. Install the Rust Toolchain](#4-install-the-rust-toolchain)
+  - [5. Clone This Repository](#5-clone-this-repository)
+  - [6. Pull the Docker Toolchain Image](#6-pull-the-docker-toolchain-image)
 - [Setup Your IDE (Optional)](#setup-your-ide-optional)
   - [Visual Studio Code](#visual-studio-code)
-- [Setting Up GDB Debugging (Optional)](#setting-up-gdb-debugging-optional)
 
 ---
 
-## Setting Up Your System
+## Linux Setup
 
 ### 1. Check Your System and Permissions
 
@@ -101,6 +108,21 @@ rm -rf "${SCCACHE_TAR}" "${SCCACHE_FILENAME}"
 echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 ```
+
+### 7. Set Up GDB Debugging (Optional)
+
+The repository includes a `.gdbinit` file that automatically configures GDB for debugging. By
+default, GDB refuses to auto-load `.gdbinit` files from arbitrary directories. To allow it for
+this project, add the repository path to your GDB auto-load safe-path:
+
+```bash
+echo "add-auto-load-safe-path $(pwd)/.gdbinit" >> ~/.gdbinit
+```
+
+After this, launching `gdb-multiarch` from the project root will automatically pick up the
+project's `.gdbinit`.
+
+For full debugging instructions, see [doc/gdb.md](gdb.md).
 
 ---
 
@@ -202,28 +224,117 @@ make verify VERUS_EXECUTABLE_DIR=~/verus-src/source/target-verus/release
 > read-only; nothing is written to it). You are responsible for ensuring the Verus version is
 > compatible with the `vstd` crate version pinned in `Cargo.toml`.
 
+## Windows Setup
+
+Nanvix currently supports Windows 11 on the host side. On Windows 11, guest components (kernel,
+user binaries) are cross-compiled inside Docker while the UserVM is built natively using the
+Windows Hypervisor Platform (WHP) backend. The `z.ps1` PowerShell script mirrors the Linux `z`
+utility interface.
+
+### 1. Enable Windows Hypervisor Platform
+
+The Windows Hypervisor Platform (WHP) feature is required to run the UserVM natively. This step
+requires an elevated PowerShell session.
+
+```powershell
+# Run in an elevated PowerShell prompt.
+Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform -All
+```
+
+Restart your machine after enabling the feature.
+
+### 2. Enable Developer Mode
+
+This repository uses symbolic links. On Windows, Git needs Developer Mode enabled to create native
+symlinks during clone. Without it, symlinks are checked out as small text files and tools that
+expect real files may fail.
+
+1. Open **Settings > Privacy & Security > For developers**.
+2. Turn on **Developer Mode**.
+
+Using the Settings app may prompt for approval, but it does not require you to manually open an
+elevated PowerShell session.
+
+Alternatively, enable it from PowerShell. This command does require an elevated PowerShell
+session:
+
+```powershell
+reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v AllowDevelopmentWithoutDevLicense /d 1
+```
+
+### 3. Install Docker Desktop
+
+Install [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop/) and ensure
+it is configured to use **Linux containers** (the default).
+
+Verify Docker is working:
+
+```powershell
+docker info
+```
+
+### 4. Install the Rust Toolchain
+
+Install Rust via [rustup](https://rustup.rs):
+
+```powershell
+# Download and run the rustup installer.
+winget install Rustlang.Rustup
+```
+
+After installation, restart your terminal and verify:
+
+```powershell
+rustc --version
+cargo --version
+```
+
+### 5. Clone This Repository
+
+```powershell
+git clone -c core.symlinks=true https://github.com/nanvix/nanvix.git
+cd nanvix
+```
+
+> **Note:** The `-c core.symlinks=true` flag ensures Git creates native symlinks instead of text
+> stub files. This requires [Developer Mode](#2-enable-developer-mode) to be enabled. If you
+> already cloned without this flag, prefer re-cloning after enabling Developer Mode so your
+> existing worktree is not overwritten.
+>
+> **Note:** Cloning the repository does not require an elevated PowerShell session once Developer
+> Mode is enabled.
+
+### 6. Pull the Docker Toolchain Image
+
+```powershell
+.\z.ps1 setup
+```
+
+This pulls the pre-built minimal Docker toolchain image required for cross-compiling guest
+components. To use the full (non-minimal) image instead:
+
+```powershell
+.\z.ps1 setup --with-docker
+```
+
+---
+
 ## Setup Your IDE (Optional)
 
 Choose one of the following options to set up your IDE for Nanvix development.
 
 ### Visual Studio Code
 
+**Linux:**
+
 ```bash
 mkdir -p .vscode && cd .vscode
 ln -s ../scripts/setup/vscode/settings.json settings.json
 ```
 
-## Setting Up GDB Debugging (Optional)
+**Windows (PowerShell):**
 
-The repository includes a `.gdbinit` file that automatically configures GDB for debugging.  By
-default, GDB refuses to auto-load `.gdbinit` files from arbitrary directories. To allow it for this
-project, add the repository path to your GDB auto-load safe-path:
-
-```bash
-echo "add-auto-load-safe-path $(pwd)/.gdbinit" >> ~/.gdbinit
+```powershell
+New-Item -ItemType Directory -Path .vscode -Force
+Copy-Item scripts\setup\vscode\settings.json .vscode\settings.json
 ```
-
-After this, launching `gdb-multiarch` from the project root will automatically pick up the
-project's `.gdbinit`.
-
-For full debugging instructions, see [doc/gdb.md](gdb.md).

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -120,6 +120,91 @@ done
 echo "Cleanup complete."
 ```
 
+## Windows-Specific Issues
+
+The Windows host-side workflow is currently supported on Windows 11 hosts.
+
+### Windows Hypervisor Platform Not Enabled
+
+**Description:** The UserVM fails to start because WHP is not enabled.
+
+**Symptom:** Error messages mentioning WHP or hypervisor platform when running `uservm.exe`.
+
+**Fix:**
+
+```powershell
+# Run in an elevated PowerShell prompt.
+Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform -All
+# Restart your machine after enabling the feature.
+```
+
+Verify it is enabled:
+
+```powershell
+Get-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform
+```
+
+### Docker Build Fails with Symlink Errors
+
+**Description:** The repository uses symbolic links. If cloned without `core.symlinks=true` or
+without Developer Mode enabled, Git checks out symlinks as small text files. The `z.ps1` script
+attempts to restore these as file copies before Docker builds, but issues may arise if the
+restoration fails.
+
+**Fix:** Re-clone with symlinks enabled (requires [Developer Mode](setup.md#2-enable-developer-mode)):
+
+```powershell
+git clone -c core.symlinks=true https://github.com/nanvix/nanvix.git
+```
+
+If you must repair an existing clone, back up or stash any local changes first because refreshing
+the worktree will overwrite unstaged files:
+
+```powershell
+git config core.symlinks true
+git checkout -- .
+```
+
+### Stale `.venv` Directory Blocks Docker Build
+
+**Description:** A previous Docker build may leave a broken `.venv` directory with Linux symlinks
+(e.g., `lib64 -> lib`) that Windows cannot handle, causing the Docker output exporter to fail.
+
+**Fix:** Remove the `.venv` directory before building:
+
+```powershell
+# cmd handles broken reparse points more reliably.
+cmd /c "rmdir /s /q .venv"
+```
+
+> **Note:** The `z.ps1` script performs this cleanup automatically before each Docker build.
+
+### Cleaning on Windows
+
+```powershell
+# Quick clean (removes UserVM build artifacts and cache).
+.\z.ps1 clean
+
+# Full clean (cargo clean + remove all build artifacts).
+.\z.ps1 distclean
+```
+
+## Cross-Platform Issues
+
+### Cached Build Options Stale (`./z` on Linux/macOS)
+
+**Description:** Build behaves unexpectedly or uses wrong parameters due to stale cached options.
+
+**Fix:** Delete the `.z.cache` file used by the `./z` wrapper script and rebuild:
+
+```bash
+rm -f .z.cache
+./z build -- all
+```
+
+This applies to the Linux/macOS `./z` wrapper script. The Windows `z.ps1` workflow does not use
+`.z.cache`.
+
 ## CI/CD Failures
 
 ### Stale Resources Causing Test Failures

--- a/z.ps1
+++ b/z.ps1
@@ -18,8 +18,8 @@
     .\z.ps1 build -- lint-check
     .\z.ps1 clean
     .\z.ps1 distclean
-    .\z.ps1 setup
     .\z.ps1 run
+    .\z.ps1 setup
 #>
 
 # ==================================================================================================
@@ -73,10 +73,8 @@ Options
   --with-minimal-docker   Use the minimal Docker toolchain image (default).
 
 Build Targets (after --)
-  all                     Build everything (guest + uservm + nanvixd).
+  all                     Build everything (guest + uservm).
   uservm                  Build UserVM only (native Windows, microvm backend).
-  nanvixd                 Build nanvixd only (native Windows, standalone + microvm).
-  nanvix-test             Build nanvix-test only (native Windows, standalone + microvm).
   guest                   Build guest components only (kernel + hello-rust-nostd).
   format-check            Check code formatting (via Docker).
   lint-check              Check for linting issues (via Docker).
@@ -94,7 +92,6 @@ Build Targets (after --)
 Run Options (after --)
   -kernel <path>          Path to kernel binary (default: bin/kernel.elf).
   -initrd <path>          Path to guest binary (default: bin/hello-rust-nostd.elf).
-  -memory <size>          Memory size with suffix K/M/G (default: 32M).
 
 Build Parameters (after --)
   RELEASE=yes             Enable release mode.
@@ -370,7 +367,7 @@ function Build-Guest {
 
     Write-Info "Building guest components (Docker)..."
     $releaseFlag = if ($IsRelease) { "RELEASE=yes" } else { "" }
-    $buildParams = "all-guest-staticlibs all-kernel all-guest-binaries all-nanvixd $releaseFlag MACHINE=microvm DEPLOYMENT_MODE=standalone"
+    $buildParams = "all-guest-staticlibs all-kernel all-guest-binaries $releaseFlag MACHINE=microvm DEPLOYMENT_MODE=standalone"
     if ($ExtraMakeParams.Count -gt 0) {
         $buildParams += " " + ($ExtraMakeParams -join ' ')
     }
@@ -412,6 +409,60 @@ function Invoke-DistClean {
         if (Test-Path $nanvixdBin) { Remove-Item $nanvixdBin -Force }
     }
     Write-Success "Full cleanup complete."
+}
+
+# ==================================================================================================
+# Run
+# ==================================================================================================
+
+function Invoke-Run {
+    param([string[]]$RunArgs = @())
+
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    # Default values.
+    $kernel = Join-Path $BinDir "kernel.elf"
+    $initrd = Join-Path $BinDir "hello-rust-nostd.elf"
+
+    # Parse run options.
+    for ($i = 0; $i -lt $RunArgs.Count; $i++) {
+        switch ($RunArgs[$i]) {
+            "-kernel"  {
+                if ($i + 1 -ge $RunArgs.Count) {
+                    Write-Err "Missing value for -kernel. Usage: .\z.ps1 run -- -kernel <path> [-initrd <path>]"
+                    exit 1
+                }
+                $i++
+                $kernel = $RunArgs[$i]
+            }
+            "-initrd"  {
+                if ($i + 1 -ge $RunArgs.Count) {
+                    Write-Err "Missing value for -initrd. Usage: .\z.ps1 run -- [-kernel <path>] -initrd <path>"
+                    exit 1
+                }
+                $i++
+                $initrd = $RunArgs[$i]
+            }
+            default    { Write-Warn "Unknown run option: $($RunArgs[$i])" }
+        }
+    }
+
+    $uvmBin = Join-Path $BinDir "uservm.exe"
+    if (-not (Test-Path $uvmBin)) {
+        Write-Err "UserVM binary not found at $uvmBin. Build it first with: .\z.ps1 build -- uservm"
+        exit 1
+    }
+
+    Write-Info "Running UserVM in standalone mode..."
+    Write-Host "  Kernel: $kernel" -ForegroundColor DarkGray
+    Write-Host "  Initrd: $initrd" -ForegroundColor DarkGray
+
+    & $uvmBin -kernel $kernel -initrd $initrd -standalone
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "UserVM exited with code $LASTEXITCODE."
+        exit $LASTEXITCODE
+    }
 }
 
 # ==================================================================================================
@@ -461,7 +512,7 @@ function Main {
 
     # If the first argument looks like a build target (not a known command),
     # treat it as an implicit "build <target>" for convenience.
-    $knownCommands = @("build", "clean", "distclean", "setup", "help")
+    $knownCommands = @("build", "clean", "distclean", "setup", "run", "help")
     if ($command -notin $knownCommands) {
         $remaining = @($command) + $remaining
         $command = "build"
@@ -556,6 +607,10 @@ function Main {
 
         "distclean" {
             Invoke-DistClean
+        }
+
+        "run" {
+            Invoke-Run -RunArgs $buildParams
         }
 
         "setup" {


### PR DESCRIPTION
## Summary
- add a Windows un subcommand to z.ps1 for standalone UserVM execution
- document the Windows host workflow across setup, build, run, README quick start, and troubleshooting guides
- clarify Windows-specific prerequisites and recovery steps for symlink and build issues

## Testing
- not run (documentation and helper-script workflow changes only)
