### PR TITLE
[build] Decouple standalone/gdb features from microvm

### DIFF
--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -25,8 +25,8 @@ default = ["microvm", "multi-process"]
 # into Nanvix Daemon (nanvixd).
 single-process = ["nanvix/single-process"]
 multi-process = ["nanvix/multi-process"]
-standalone = ["gdb", "nanvix/standalone"]
-gdb = ["microvm", "nanvix/gdb"]
+standalone = ["nanvix/standalone"]
+gdb = ["nanvix/gdb"]
 hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 


### PR DESCRIPTION
## Summary

- Decouple `standalone` feature from `gdb` dependency
- Decouple `gdb` feature from `microvm` dependency
- Enables building `nanvixd` in standalone mode with the hyperlight backend (microvm and hyperlight are mutually exclusive)

## Context

Extracted from #1729 per review feedback.