### PR TITLE
[ci] Add Windows support to AI skills

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -161,6 +161,19 @@ get_release_flag() {
 #===================================================================================================
 
 main() {
+    # The bash pre-commit checks rely on ./z which is Linux-only.  On Windows
+    # (Git Bash / MSYS), skip the hook and remind the user to validate via z.ps1.
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*)
+            print_warning "(pre-commit) Skipping pre-commit checks on Windows."
+            print_info "(pre-commit) Run quality checks manually with z.ps1:"
+            print_info "  .\\z.ps1 build -- format-check"
+            print_info "  .\\z.ps1 build -- lint-check"
+            print_info "  .\\z.ps1 build -- spellcheck"
+            exit 0
+            ;;
+    esac
+
     # Check if we are not running inside a Git repository.
     if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         print_error "(pre-commit) This script must be run inside a Git repository."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,8 +23,27 @@ Use the corresponding skill when the user request matches the topic:
 - `kernel-development` → kernel internals and kernel-call paths.
 - `library-development` → crates under `src/libs` and related architecture.
 - `test-development` → writing and debugging tests.
-- `troubleshooting` → diagnosis of build/runtime/test failures.
-- `user-app-development` → user-space app implementation and execution.
+- `troubleshooting` → diagnosis of build/runtime/test failures (includes Windows-specific issues).
+- `user-app-development` → user-space app implementation and execution (includes Windows standalone mode).
+
+## Platform Support
+
+Nanvix supports two host platforms:
+
+- **Linux** — Full development workflow: build, run, test, benchmark, and debug.
+  Uses KVM for the microvm backend and QEMU for other machine types.
+- **Windows 11** — Host-side development with the Windows Hypervisor Platform (WHP)
+  backend. Guest components (kernel, user binaries) are cross-compiled inside Docker;
+  the UserVM is built natively. Only standalone UserVM mode is available (no
+  `nanvixd`, HTTP mode, or L2 deployments). Use `z.ps1` instead of `./z`.
+
+When modifying or generating code, keep platform differences in mind:
+
+- Use `z.ps1` for Windows commands and `./z` for Linux commands.
+- Linux-only features: `nanvixd`, HTTP mode, interactive mode, L2 deployments,
+  GDB debugging, benchmarking, network namespaces.
+- Windows-only concerns: WHP enablement, Developer Mode for symlinks, Docker
+  Desktop with Linux containers, `.venv` cleanup before Docker builds.
 
 ## Repository-wide Engineering Rules
 

--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -12,6 +12,19 @@ covers all build-system operations exposed through the `z` utility.
 
 - Development environment set up per `doc/setup.md`.
 - Either a local cross-compilation toolchain (`toolchain/`) or Docker installed.
+- **Windows 11:** Docker Desktop (Linux containers), Windows Hypervisor Platform enabled,
+  Developer Mode enabled, and Rust toolchain installed. See `doc/setup.md` for details.
+
+## Windows Setup Summary
+
+Before building on Windows, ensure:
+
+1. **Windows Hypervisor Platform** is enabled (`Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform -All`, then reboot).
+2. **Developer Mode** is on (Settings > Privacy & Security > For developers).
+3. **Docker Desktop** is installed and configured for Linux containers.
+4. **Rust toolchain** is installed via `winget install Rustlang.Rustup`.
+5. Repository was cloned with `git clone -c core.symlinks=true`.
+6. Docker toolchain image is pulled: `./z.ps1 setup`.
 
 ## Building
 
@@ -76,6 +89,37 @@ Example with custom parameters:
 ./z build -- all RELEASE=yes LOG_LEVEL=panic TIMESTAMP_MSG=yes
 ```
 
+### Building on Windows (using `z.ps1`)
+
+On Windows 11, the `z.ps1` PowerShell script provides the same CLI interface. Guest components are
+cross-compiled inside Docker; the UserVM is built natively with the microvm backend (WHP on
+Windows).
+
+```powershell
+# Build everything (guest via Docker + UserVM natively).
+.\z.ps1 build -- all
+
+# Build only the UserVM (native Windows build).
+.\z.ps1 build -- uservm
+
+# Build only guest components (kernel + hello-rust-nostd, via Docker).
+.\z.ps1 build -- guest
+
+# Release build.
+.\z.ps1 build -- all RELEASE=yes
+
+# Use the full (non-minimal) Docker image.
+.\z.ps1 build --with-docker -- all
+```
+
+Any unrecognized target is forwarded to `make` via Docker, just like on Linux:
+
+```powershell
+.\z.ps1 build -- kernel
+.\z.ps1 build -- format-check
+.\z.ps1 build -- lint-check
+```
+
 ## Code Quality
 
 ### Formatting
@@ -128,6 +172,13 @@ Nanvix uses Verus for formal verification of selected kernel crates. The expecte
 ./z distclean    # Remove all generated files.
 ```
 
+### Cleaning on Windows
+
+```powershell
+.\z.ps1 clean        # Quick clean (UserVM artifacts + cache).
+.\z.ps1 distclean    # Full clean (cargo clean + all artifacts).
+```
+
 ## CI/CD Pipeline
 
 ```bash
@@ -138,9 +189,39 @@ Nanvix uses Verus for formal verification of selected kernel crates. The expecte
 The pipeline covers: spell checking, formatting, linting, building, and testing across multiple
 machine and deployment configurations.
 
+## IDE Setup (Optional)
+
+### Visual Studio Code
+
+Use the host-specific settings template. The Linux template invokes `./z`, while the Windows
+template routes Rust Analyzer build-script discovery through the Windows Docker workflow so that
+guest crates build correctly.
+
+**Linux:**
+
+```bash
+mkdir -p .vscode && cd .vscode
+ln -s ../scripts/setup/vscode/settings-linux.json settings.json
+```
+
+**Windows (PowerShell):**
+
+```powershell
+New-Item -ItemType Directory -Path .vscode -Force
+Copy-Item scripts\setup\vscode\settings-windows.json .vscode\settings.json
+```
+
+> **Note:** Without the Windows override, Rust Analyzer falls back to native `cargo` for
+> build-script metadata and guest crates fail because `gcc`/`ar` are not on the host `PATH`.
+
 ## Troubleshooting Build Issues
 
 - If builds fail with toolchain errors, verify `toolchain/` symlink points to a valid toolchain.
 - If Docker builds fail, ensure Docker is running and the image is available.
 - Use `./z help` for usage information.
 - Cached build options are stored in `.z.cache` — delete this file to reset.
+- **Windows:** Use `.\z.ps1 help` for Windows-specific usage information.
+- **Windows:** If Docker builds fail with symlink errors, `z.ps1` automatically restores Git
+  symlinks as file copies. Ensure Docker Desktop is running with Linux containers enabled.
+- **Windows:** If the UserVM build fails, verify that the Windows Hypervisor Platform feature is
+  enabled (`Get-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform`).

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -85,6 +85,11 @@ Matrix coverage in GitHub Actions:
   and `multi-process` (excluding `qemu-pc + single-process`).
 - `ci-l2`: separate L2 jobs for `microvm` and `hyperlight`.
 
+> **Note:** There is no Windows CI job yet. Windows builds must be verified manually.
+> Once a `ci-windows` job is added, it should validate that platform-independent library crates
+> compile and pass Clippy on Windows, and eventually build and test the UserVM with the WHP
+> backend.
+
 ## Release Process
 
 ```bash

--- a/.github/skills/gdb-debugging/SKILL.md
+++ b/.github/skills/gdb-debugging/SKILL.md
@@ -107,6 +107,8 @@ launched from the project directory.
 
 ## Limitations
 
+- **Linux only.** GDB debugging requires the `microvm` machine type with KVM, which is not
+  available on Windows. The WHP backend does not expose a GDB server.
 - **Standalone mode only.** `-gdb-port` requires `DEPLOYMENT_MODE=standalone`.
 - **Physical addresses only.** The kernel uses identity mapping (GVA == GPA).
 - **No hardware breakpoints.** Only software breakpoints (`INT3`).

--- a/.github/skills/library-development/SKILL.md
+++ b/.github/skills/library-development/SKILL.md
@@ -117,6 +117,15 @@ These run on the host system and are compiled with the host Rust build command
 Guest libraries use `GUEST_CARGO_BUILD_CMD` (cross-compiled with `cargo +nanvix-x86`). Host
 libraries use `HOST_CARGO_BUILD_CMD`.
 
+## Windows Compilation
+
+On a Windows development host, guest libraries are cross-compiled inside Docker, so they work
+identically to Linux. Host libraries that use `std` may need conditional compilation
+(`#[cfg(target_os = "...")]`) for platform-specific code paths (e.g., KVM, libc).
+
+> **Note:** There is no Windows CI job yet. Platform-independent crates should be manually
+> verified on Windows when making changes that may affect cross-platform compatibility.
+
 ## Coding Rules (Library-Specific)
 
 - Guest libraries must support `#![no_std]` with optional `std` feature gate.

--- a/.github/skills/test/SKILL.md
+++ b/.github/skills/test/SKILL.md
@@ -37,6 +37,18 @@ Test configurations are auto-selected based on deployment mode:
 ./z build --with-cached-options -- test
 ```
 
+## Windows
+
+On Windows, unit tests can be run via Docker through `z.ps1`:
+
+```powershell
+.\z.ps1 build -- run-unit-tests
+```
+
+System integration tests (`run-nanvix-tests`) and `nanvixd`-based tests are **Linux-only**.
+The standalone UserVM can be launched on Windows for manual verification, but the automated
+test harness (`nanvix-test`) requires `nanvixd`, which is not available on Windows.
+
 ## Troubleshooting Test Failures
 
 - Ensure the project builds successfully before running tests (see the `build` skill).

--- a/.github/skills/troubleshooting/SKILL.md
+++ b/.github/skills/troubleshooting/SKILL.md
@@ -190,3 +190,69 @@ RUST_LOG=debug ./bin/uservm.elf \
 
 Runtime logs are stored under `logs/` with timestamped
 directory names (e.g., `logs/2026_02_24_13_04_54/`).
+
+## Windows-Specific Issues
+
+### WHP Not Enabled
+
+**Symptom**: UserVM fails to start with hypervisor-related errors.
+
+**Fix**:
+
+```powershell
+# Run in an elevated PowerShell prompt.
+Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform -All
+# Restart the machine.
+```
+
+### Docker Build Fails on Windows
+
+**Symptom**: Docker build fails with symlink or file-access errors, or the Docker output exporter
+fails because a previous build left a `.venv` directory with Linux symlinks (`lib64 -> lib`) that
+Windows cannot handle.
+
+**Fix**:
+
+1. Ensure Docker Desktop is running with Linux containers enabled: `docker info`.
+2. Remove stale `.venv` directory (cmd handles broken reparse points more reliably):
+   ```powershell
+   cmd /c "rmdir /s /q .venv"
+   ```
+3. Delete build cache and retry:
+    `Remove-Item .z.cache -ErrorAction SilentlyContinue; .\z.ps1 build -- all`.
+
+> **Note:** The `z.ps1` script removes `.venv` automatically before each Docker build.
+
+### Symlink Errors on Windows Clone
+
+**Symptom**: Build or tool errors because Git checked out symlinks as text files.
+
+**Fix**: Re-clone with Developer Mode enabled and symlinks flag:
+
+```powershell
+git clone -c core.symlinks=true https://github.com/nanvix/nanvix.git
+```
+
+To repair an existing clone (including an optional backup of local changes):
+
+```powershell
+# Optional: back up any local changes before resetting the working tree.
+git status
+# Either commit your work-in-progress, or stash it:
+# git commit -am "WIP backup"
+# git stash -u
+
+git config core.symlinks true
+git checkout -- .
+```
+
+### Cached Build Options Stale (Windows)
+
+**Symptom**: Build uses wrong parameters on Windows.
+
+**Fix**: Delete the cache file and rebuild:
+
+```powershell
+Remove-Item .z.cache -ErrorAction SilentlyContinue
+.\z.ps1 build -- all
+```

--- a/.github/skills/user-app-development/SKILL.md
+++ b/.github/skills/user-app-development/SKILL.md
@@ -70,6 +70,27 @@ curl --silent \
     -standalone
 ```
 
+### Running on Windows
+
+On Windows, only standalone UserVM mode is available. The UserVM runs natively with the WHP backend:
+
+```powershell
+.\bin\uservm.exe -kernel .\bin\kernel.elf -initrd .\bin\hello-rust-nostd.elf -standalone
+```
+
+You can also launch a run via `z.ps1`:
+
+```powershell
+# Run with default options.
+.\z.ps1 run
+
+# Run with custom kernel and initrd.
+.\z.ps1 run -- -kernel bin\kernel.elf -initrd bin\hello-rust-nostd.elf
+```
+
+> **Note:** Interactive mode, HTTP mode, and `nanvixd` are Linux-only. On Windows, all guest
+> execution goes through the standalone UserVM.
+
 ## Creating a New Rust Application (no_std)
 
 1. Create directory at `src/user/<name>/`.


### PR DESCRIPTION
Add Windows platform documentation to copilot instructions and AI skills.

## Changes

- **copilot-instructions.md**: Add Platform Support section with Linux/Windows differences and skill routing annotations for Windows.
- **build/SKILL.md**: Add Windows setup summary, z.ps1 build commands, Windows cleaning, IDE setup (VS Code settings), and Windows troubleshooting tips.
- **ci-cd-pipeline/SKILL.md**: Note that no Windows CI job exists yet.
- **gdb-debugging/SKILL.md**: Mark GDB debugging as Linux-only.
- **library-development/SKILL.md**: Add Windows compilation guidance for host crates.
- **test/SKILL.md**: Add Windows unit test command and note system tests are Linux-only.
- **troubleshooting/SKILL.md**: Add Windows-specific troubleshooting entries (WHP, Docker, symlinks, cache).
- **user-app-development/SKILL.md**: Add Windows standalone UserVM running instructions.
- **.githooks/pre-commit**: Skip pre-commit checks on Windows (bash z script is Linux-only) with guidance to validate manually via z.ps1.