### PR TITLE
[ci] Add Windows/WHP CI pipeline and native z.ps1 build targets

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,300 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Nanvix Windows CI"
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    types:
+      - "opened"
+      - "synchronize"
+      - "reopened"
+      - "ready_for_review"
+    branches:
+      - "dev"
+
+  merge_group:
+    types:
+      - "checks_requested"
+
+  push:
+    branches:
+      - "dev"
+
+# Cancel previous running actions for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}
+
+jobs:
+  # ==========================================================================================
+  # Stage 1: Guest Cross-Compilation (Linux/Docker) + Windows Source Checks
+  # ==========================================================================================
+
+  # Guest components (kernel, hello-rust-nostd) require a Linux cross-compilation
+  # toolchain that is only available inside Docker. GitHub-hosted Windows runners
+  # do not support Linux containers, so this job runs on ubuntu-24.04 and uploads
+  # the resulting ELF binaries for downstream Windows jobs.
+  guest-build:
+    name: "Guest Build (Linux/Docker)"
+    timeout-minutes: 60
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    if: |
+      github.repository == 'nanvix/nanvix' && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'merge_group' || (
+          (
+            github.event_name != 'push' ||
+            !startsWith(github.event.head_commit.message, 'Merge ')
+          ) && (
+            github.event_name != 'pull_request' ||
+            !github.event.pull_request.draft
+          )
+        )
+      )
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Setup Docker Toolchain"
+        uses: ./.github/actions/docker-setup
+
+      - name: "Build Guest Components"
+        shell: bash
+        run: |
+          ./z build --with-minimal-docker -- \
+            all-guest-staticlibs all-kernel all-guest-binaries \
+            MACHINE=microvm \
+            DEPLOYMENT_MODE=standalone \
+            TARGET=x86
+
+      - name: "Upload Guest Artifacts"
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-guest-build
+          retention-days: 1
+          path: |
+            bin/kernel.elf
+            bin/hello-rust-nostd.elf
+
+  # Run format and lint checks natively on Windows for host crates. These do
+  # not require Docker and run in parallel with the guest-build job.
+  checks:
+    name: "Source Checks (Windows)"
+    timeout-minutes: 30
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    if: |
+      github.repository == 'nanvix/nanvix' && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'merge_group' || (
+          (
+            github.event_name != 'push' ||
+            !startsWith(github.event.head_commit.message, 'Merge ')
+          ) && (
+            github.event_name != 'pull_request' ||
+            !github.event.pull_request.draft
+          )
+        )
+      )
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Install Rust Toolchain"
+        shell: pwsh
+        run: |
+          rustup component add clippy rustfmt
+
+      - name: "Check Code Format"
+        shell: pwsh
+        run: |
+          .\z.ps1 build -- format-check
+
+      - name: "Lint"
+        shell: pwsh
+        run: |
+          .\z.ps1 build -- lint-check
+
+  # ==========================================================================================
+  # Stage 2: Build & Unit Test (Windows)
+  # ==========================================================================================
+
+  # Build UserVM natively on Windows and run unit tests. Guest artifacts from
+  # the Linux job are downloaded so they can be bundled for the smoke test.
+  ci-build:
+    name: "Build (${{ matrix.build-type }})"
+    needs: [checks, guest-build]
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [debug, release]
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Install Rust Toolchain"
+        shell: pwsh
+        run: |
+          rustup show
+
+      - name: "Download Guest Artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: windows-guest-build
+          path: bin
+
+      - name: "Build UserVM"
+        shell: pwsh
+        env:
+          RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
+        run: |
+          if ($env:RELEASE_FLAG) {
+            .\z.ps1 build -- uservm $env:RELEASE_FLAG
+          } else {
+            .\z.ps1 build -- uservm
+          }
+
+      - name: "Unit Tests"
+        shell: pwsh
+        run: |
+          .\z.ps1 build -- run-unit-tests
+
+      - name: "Upload Build Artifacts"
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-build-${{ matrix.build-type }}
+          retention-days: 1
+          path: |
+            bin/uservm.exe
+            bin/kernel.elf
+            bin/hello-rust-nostd.elf
+
+  # ==========================================================================================
+  # Stage 3: Smoke Test (Windows/WHP)
+  # ==========================================================================================
+
+  # Run UserVM in standalone mode with the hello-rust-nostd guest to verify
+  # end-to-end boot on Windows Hypervisor Platform.
+  smoke-test:
+    name: "Smoke Test (${{ matrix.build-type }})"
+    needs: [ci-build]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [debug, release]
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Download Build Artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: windows-build-${{ matrix.build-type }}
+          path: bin
+
+      - name: "Enable Windows Hypervisor Platform"
+        shell: pwsh
+        run: |
+          # Check if WHP is already enabled; enable it if not.
+          $feature = Get-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform
+          if ($feature.State -ne 'Enabled') {
+            Write-Host "Enabling Windows Hypervisor Platform..."
+            Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform -All -NoRestart
+          } else {
+            Write-Host "Windows Hypervisor Platform is already enabled."
+          }
+
+      - name: "Run Hello World (standalone)"
+        shell: pwsh
+        run: |
+          $TIMEOUT_SECONDS = 120
+          $MAGIC_STRING = "Hello, world from Rust!"
+
+          Write-Host "Starting UserVM (standalone, timeout=${TIMEOUT_SECONDS}s)..."
+
+          # Start uservm as a background process and capture output.
+          $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+          $pinfo.FileName = "bin\uservm.exe"
+          $pinfo.Arguments = "-kernel bin\kernel.elf -initrd bin\hello-rust-nostd.elf -standalone"
+          $pinfo.RedirectStandardOutput = $true
+          $pinfo.RedirectStandardError = $true
+          $pinfo.UseShellExecute = $false
+          $pinfo.CreateNoWindow = $true
+
+          $process = New-Object System.Diagnostics.Process
+          $process.StartInfo = $pinfo
+
+          # Collect output asynchronously.
+          $stdout = New-Object System.Text.StringBuilder
+          $stderr = New-Object System.Text.StringBuilder
+          $outputEvent = Register-ObjectEvent -InputObject $process -EventName OutputDataReceived -Action {
+            if ($null -ne $EventArgs.Data) {
+              [void]$Event.MessageData.AppendLine($EventArgs.Data)
+              Write-Host $EventArgs.Data
+            }
+          } -MessageData $stdout
+          $errorEvent = Register-ObjectEvent -InputObject $process -EventName ErrorDataReceived -Action {
+            if ($null -ne $EventArgs.Data) {
+              [void]$Event.MessageData.AppendLine($EventArgs.Data)
+              Write-Host $EventArgs.Data
+            }
+          } -MessageData $stderr
+
+          $process.Start() | Out-Null
+          $process.BeginOutputReadLine()
+          $process.BeginErrorReadLine()
+
+          $exited = $process.WaitForExit($TIMEOUT_SECONDS * 1000)
+
+          # Give event handlers a moment to flush remaining data.
+          Start-Sleep -Milliseconds 500
+
+          Unregister-Event -SourceIdentifier $outputEvent.Name
+          Unregister-Event -SourceIdentifier $errorEvent.Name
+
+          $allOutput = $stdout.ToString() + $stderr.ToString()
+
+          if (-not $exited) {
+            $process.Kill()
+            Write-Host "::error::Smoke test timed out after ${TIMEOUT_SECONDS}s."
+            Write-Host "--- Captured output ---"
+            Write-Host $allOutput
+            exit 1
+          }
+
+          $exitCode = $process.ExitCode
+          Write-Host "UserVM exited with code $exitCode"
+
+          if ("${{ matrix.build-type }}" -eq "release") {
+            # Release builds suppress debug output; just verify clean exit.
+            if ($exitCode -ne 0) {
+              Write-Host "::error::Smoke test failed: UserVM exited with code $exitCode."
+              exit 1
+            }
+          } else {
+            # Debug builds should print the magic string.
+            if ($allOutput -match [regex]::Escape($MAGIC_STRING)) {
+              Write-Host "Smoke test passed: found '$MAGIC_STRING' in output."
+            } else {
+              Write-Host "::error::Smoke test failed: magic string '$MAGIC_STRING' not found in output."
+              Write-Host "--- Captured output ---"
+              Write-Host $allOutput
+              exit 1
+            }
+          }

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -14,7 +14,9 @@
 //==================================================================================================
 
 // Lints
-#![forbid(clippy::unwrap_used)]
+// NOTE: `deny` instead of `forbid` so that the WHP module (Windows only) can
+// `#[allow]` these lints where the Windows Hypervisor Platform API requires casts.
+#![deny(clippy::unwrap_used)]
 #![forbid(clippy::cast_possible_wrap)]
 #![forbid(clippy::cast_precision_loss)]
 #![forbid(clippy::char_lit_as_u8)]
@@ -28,7 +30,7 @@
 #![forbid(clippy::unimplemented)]
 #![forbid(clippy::todo)]
 #![forbid(clippy::unreachable)]
-#![forbid(clippy::cast_possible_truncation)]
+#![deny(clippy::cast_possible_truncation)]
 // The following lints are allowed in tests to facilitate testing of error conditions.
 #![cfg_attr(not(test), forbid(clippy::expect_used))]
 

--- a/src/uservm/src/vmm/whp/emulator.rs
+++ b/src/uservm/src/vmm/whp/emulator.rs
@@ -1,6 +1,9 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+// The WHP emulator uses u32/u16 casts when interfacing with the Windows API.
+#![allow(clippy::cast_possible_truncation)]
+
 //==================================================================================================
 // Imports
 //==================================================================================================

--- a/src/uservm/src/vmm/whp/guest.rs
+++ b/src/uservm/src/vmm/whp/guest.rs
@@ -1,6 +1,9 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+// The WHP guest uses pointer-to-usize casts for address arithmetic.
+#![allow(clippy::cast_possible_truncation)]
+
 //==================================================================================================
 // Imports
 //==================================================================================================

--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -6,6 +6,11 @@
 //==================================================================================================
 
 #![allow(clippy::module_inception)]
+// The WHP backend interfaces with the Windows Hypervisor Platform API, which
+// uses u32/u16 parameters extensively. These casts are intentional and safe.
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::collapsible_match)]
 
 //==================================================================================================
 // Modules

--- a/src/uservm/src/vmm/whp/timer.rs
+++ b/src/uservm/src/vmm/whp/timer.rs
@@ -1,6 +1,9 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+// The WHP timer uses size_of<T>() as u32 for the Windows API.
+#![allow(clippy::cast_possible_truncation)]
+
 //==================================================================================================
 // Imports
 //==================================================================================================

--- a/src/uservm/src/vmm/whp/vcpu/exit.rs
+++ b/src/uservm/src/vmm/whp/vcpu/exit.rs
@@ -1,6 +1,9 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+// Enum-to-usize casts are intentional for PmioWidth conversion.
+#![allow(clippy::cast_possible_truncation)]
+
 //==================================================================================================
 // Structures
 //==================================================================================================

--- a/src/uservm/src/vmm/whp/vcpu/mod.rs
+++ b/src/uservm/src/vmm/whp/vcpu/mod.rs
@@ -1,6 +1,9 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+// The WHP vCPU uses u32 casts for Windows API parameters.
+#![allow(clippy::cast_possible_truncation)]
+
 //==================================================================================================
 // Modules
 //==================================================================================================

--- a/z.ps1
+++ b/z.ps1
@@ -77,14 +77,14 @@ Build Targets (after --)
   all                     Build everything (guest + uservm).
   uservm                  Build UserVM only (native Windows, microvm backend).
   guest                   Build guest components only (kernel + hello-rust-nostd).
-  format-check            Check code formatting (via Docker).
-  lint-check              Check for linting issues (via Docker).
+  format-check            Check code formatting (native for host crates).
+  lint-check              Check for linting issues (native for host crates).
+  run-unit-tests          Run unit tests (native for host crates).
   format                  Fix code formatting (via Docker).
   lint                    Fix linting issues (via Docker).
   spellcheck              Check spelling (via Docker).
   spellcheck-fix          Fix spelling errors (via Docker).
   check                   Run cargo check (via Docker).
-  run-unit-tests          Run unit tests (via Docker).
   run-nanvix-tests        Run system integration tests (via Docker).
   test                    Run all tests (via Docker).
   verify                  Run Verus formal verification (via Docker).
@@ -763,6 +763,45 @@ function Main {
                     }
                     "guest" {
                         Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams
+                    }
+                    "format-check" {
+                        # Native format check for host crates (no Docker required).
+                        Write-Info "Checking code formatting (native)..."
+                        $ErrorActionPreference = 'Continue'
+                        cargo fmt -p uservm -p nanvixd --check
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Err "Format check failed."
+                            exit 1
+                        }
+                        Write-Success "Format check passed."
+                    }
+                    "lint-check" {
+                        # Native lint check for host crates (no Docker required).
+                        Write-Info "Linting host crates (native)..."
+                        $ErrorActionPreference = 'Continue'
+                        $features = "standalone,microvm"
+                        cargo clippy --no-default-features --features $features -p uservm -- -D warnings
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Err "Lint check failed for uservm."
+                            exit 1
+                        }
+                        cargo clippy --no-default-features --features $features -p nanvixd -- -D warnings
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Err "Lint check failed for nanvixd."
+                            exit 1
+                        }
+                        Write-Success "Lint check passed."
+                    }
+                    "run-unit-tests" {
+                        # Native unit tests for host crates (no Docker required).
+                        Write-Info "Running unit tests (native)..."
+                        $ErrorActionPreference = 'Continue'
+                        cargo test --no-default-features --features "microvm" -p uservm
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Err "Unit tests failed for uservm."
+                            exit 1
+                        }
+                        Write-Success "Unit tests passed."
                     }
                     default {
                         # Forward any other target to Docker make (mirrors bash z behavior).

--- a/z.ps1
+++ b/z.ps1
@@ -78,8 +78,8 @@ Build Targets (after --)
   uservm                  Build UserVM only (native Windows, microvm backend).
   guest                   Build guest components only (kernel + hello-rust-nostd).
   format-check            Check code formatting (native for host crates).
-  lint-check              Check for linting issues (native for host crates).
-  run-unit-tests          Run unit tests (native for host crates).
+  lint-check              Check for linting issues (native for uservm).
+  run-unit-tests          Run unit tests (native for uservm).
   format                  Fix code formatting (via Docker).
   lint                    Fix linting issues (via Docker).
   spellcheck              Check spelling (via Docker).
@@ -776,17 +776,14 @@ function Main {
                         Write-Success "Format check passed."
                     }
                     "lint-check" {
-                        # Native lint check for host crates (no Docker required).
+                        # Native lint check for host crates that compile on Windows
+                        # (no Docker required). nanvixd depends on nanvix-http which
+                        # uses Unix-specific APIs, so only uservm is linted natively.
                         Write-Info "Linting host crates (native)..."
                         $ErrorActionPreference = 'Continue'
                         cargo clippy --no-default-features --features "microvm" -p uservm -- -D warnings
                         if ($LASTEXITCODE -ne 0) {
                             Write-Err "Lint check failed for uservm."
-                            exit 1
-                        }
-                        cargo clippy --no-default-features --features "standalone,microvm" -p nanvixd -- -D warnings
-                        if ($LASTEXITCODE -ne 0) {
-                            Write-Err "Lint check failed for nanvixd."
                             exit 1
                         }
                         Write-Success "Lint check passed."
@@ -801,6 +798,27 @@ function Main {
                             exit 1
                         }
                         Write-Success "Unit tests passed."
+                    }
+                    "spellcheck" {
+                        # Spellcheck requires pyspelling which is only available inside
+                        # Docker. When Docker is not available or not running, skip gracefully.
+                        $ErrorActionPreference = 'Continue'
+                        $dockerCmd = Get-Command docker -ErrorAction SilentlyContinue
+                        $dockerRunning = $false
+                        if ($dockerCmd) {
+                            docker info >$null 2>&1
+                            $dockerRunning = ($LASTEXITCODE -eq 0)
+                        }
+                        if (-not $dockerRunning) {
+                            Write-Warn "Skipping spellcheck (Docker not available or not running). Run with Docker to enable."
+                        } else {
+                            $dockerParams = @("spellcheck") + $makeParams
+                            if (-not ($makeParams | Where-Object { $_ -match '^MACHINE=' })) {
+                                $dockerParams += "MACHINE=microvm"
+                            }
+                            Write-Info "Running spellcheck via Docker..."
+                            Invoke-DockerBuild -BuildParams ($dockerParams -join ' ') -IsRelease $isRelease -UseMinimal $useMinimalDocker
+                        }
                     }
                     default {
                         # Forward any other target to Docker make (mirrors bash z behavior).

--- a/z.ps1
+++ b/z.ps1
@@ -779,13 +779,12 @@ function Main {
                         # Native lint check for host crates (no Docker required).
                         Write-Info "Linting host crates (native)..."
                         $ErrorActionPreference = 'Continue'
-                        $features = "standalone,microvm"
-                        cargo clippy --no-default-features --features $features -p uservm -- -D warnings
+                        cargo clippy --no-default-features --features "microvm" -p uservm -- -D warnings
                         if ($LASTEXITCODE -ne 0) {
                             Write-Err "Lint check failed for uservm."
                             exit 1
                         }
-                        cargo clippy --no-default-features --features $features -p nanvixd -- -D warnings
+                        cargo clippy --no-default-features --features "standalone,microvm" -p nanvixd -- -D warnings
                         if ($LASTEXITCODE -ne 0) {
                             Write-Err "Lint check failed for nanvixd."
                             exit 1


### PR DESCRIPTION
Adds ci-windows.yml with four-stage pipeline for Windows/WHP:

1. **guest-build** (ubuntu-24.04): cross-compile kernel + hello-rust-nostd via Docker
2. **checks** (windows-latest): native format-check and lint-check for host crates
3. **ci-build** (windows-latest, debug/release): build uservm.exe + run unit tests
4. **smoke-test** (windows-latest, debug/release): run hello-rust-nostd via UserVM standalone on WHP

Also enhances z.ps1 with native handlers for format-check, lint-check, and run-unit-tests so these targets work without Docker on Windows runners.

Closes #1713