### PR TITLE
[ci] Align Dependabot with cargo-upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     schedule:
       interval: "daily"
       time: "03:00"
-    versioning-strategy: auto
+    versioning-strategy: increase
     labels:
       - "enhancement"
     open-pull-requests-limit: 20
@@ -26,6 +26,9 @@ updates:
       - dependency-name: "hyperlight-host"
       - dependency-name: "hyperlight-guest"
       - dependency-name: "fatfs"
+      - dependency-name: "spin"
+      - dependency-name: "talc"
+      - dependency-name: "vstd"
 
     groups:
       kvm-stack:


### PR DESCRIPTION
Closes #1011

- Change `versioning-strategy` from `auto` to `increase` so Dependabot always updates `Cargo.toml` version requirements.
- Add `spin`, `talc`, and `vstd` to the ignore list to match the exclude list in `cargo-upgrade.yml`.