### PR TITLE
[build] Harden Windows build system with Docker cache parity

### DIFF
--- a/z.ps1
+++ b/z.ps1
@@ -37,7 +37,51 @@ $CargoLock = Join-Path $RootDir "Cargo.lock"
 $VenvDir = Join-Path $RootDir ".venv"
 $SysImage = Join-Path $RootDir "nanvix.img"
 $SysrootLink = Join-Path $RootDir "sysroot"
+$ZCacheFile = Join-Path $RootDir ".z.cache"
 Set-Variable -Scope Script -Name DockerfileRelativePath -Value "scripts/setup/Dockerfile.build" -Option Constant
+
+# ==================================================================================================
+# Build Option Cache
+# ==================================================================================================
+
+function Write-ZCache {
+    param([string[]]$Options)
+    [System.IO.File]::WriteAllLines($ZCacheFile, $Options)
+}
+
+function Read-ZCache {
+    if (-not (Test-Path $ZCacheFile)) {
+        Write-Warn "No cached options found. Run a build first."
+        return @()
+    }
+    $lines = @(Get-Content -Path $ZCacheFile -Encoding UTF8 | Where-Object { $_.Trim() -ne "" })
+    if ($lines.Count -eq 0) {
+        Write-Warn "Cache file is empty."
+        return @()
+    }
+    # Extract only docker mode flags (stop at -- separator), matching Linux read_cache.
+    $result = @()
+    foreach ($line in $lines) {
+        if ($line -eq "--") { break }
+        switch ($line) {
+            "--with-docker" { $result += $line }
+            "--with-minimal-docker" { $result += $line }
+        }
+    }
+    return $result
+}
+
+# Remove a directory junction (or plain directory) without following into the target.
+function Remove-Junction {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return }
+    $item = Get-Item $Path -Force -ErrorAction SilentlyContinue
+    if ($null -ne $item -and ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+        cmd /c "rmdir `"$Path`"" 2>$null
+    } else {
+        Remove-Item $Path -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
 
 # ==================================================================================================
 # Logging
@@ -80,6 +124,7 @@ Options
   --release               Build in release mode.
   --with-docker           Use the full Docker toolchain image.
   --with-minimal-docker   Use the minimal Docker toolchain image (default).
+  --with-cached-options   Replay Docker build mode from the last successful build.
 
 Build Targets (after --)
   all                     Build everything (guest + host).
@@ -321,6 +366,31 @@ function Get-DockerImageName {
     return "nanvix/toolchain:$imageTag$suffix"
 }
 
+function Get-SccacheArgs {
+    $result = @()
+    if ($env:SCCACHE_GHA_ENABLED) {
+        $result += "--build-arg"
+        $result += "SCCACHE_GHA_ENABLED=$env:SCCACHE_GHA_ENABLED"
+    }
+    if ($env:SCCACHE_GHA_CACHE_TO) {
+        $result += "--build-arg"
+        $result += "SCCACHE_GHA_CACHE_TO=$env:SCCACHE_GHA_CACHE_TO"
+    }
+    if ($env:SCCACHE_GHA_CACHE_FROM) {
+        $result += "--build-arg"
+        $result += "SCCACHE_GHA_CACHE_FROM=$env:SCCACHE_GHA_CACHE_FROM"
+    }
+    if ($env:ACTIONS_RESULTS_URL) {
+        $result += "--secret"
+        $result += "id=actions_results_url,env=ACTIONS_RESULTS_URL"
+    }
+    if ($env:ACTIONS_RUNTIME_TOKEN) {
+        $result += "--secret"
+        $result += "id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN"
+    }
+    return $result
+}
+
 function Invoke-DockerBuild {
     param([string]$BuildParams, [bool]$IsRelease = $false, [bool]$UseMinimal = $true)
 
@@ -351,6 +421,8 @@ function Invoke-DockerBuild {
     $env:DOCKER_BUILDKIT = "1"
     Write-Host "  docker build (params: $BuildParams)" -ForegroundColor DarkGray
 
+    $ghaSccacheArgs = Get-SccacheArgs
+
     # Remove the local .venv directory if it exists. Docker builds may create a
     # .venv inside the container with a lib64 -> lib symlink (standard Linux Python
     # venv). If a previous Docker export left a broken reparse point at .venv\lib64
@@ -369,18 +441,24 @@ function Invoke-DockerBuild {
     # Restore-GitSymlinks (called above) already materialized symlinks in-place,
     # so the context is complete. Symlinks are restored after the build via the
     # finally block below.
+    $dockerArgs = @(
+        "build",
+        "--build-arg", "BASE_IMAGE=$imageName",
+        "--build-arg", "BUILD_PARAMS=$BuildParams",
+        "--build-arg", "SYSROOT_SUFFIX=$sysrootSuffix",
+        "--build-arg", "WORKSPACE_PATH=/mnt",
+        "--output", "type=local,dest=.",
+        "--progress=plain",
+        "-f", $dockerfilePath
+    )
+    if ($ghaSccacheArgs.Count -gt 0) {
+        $dockerArgs += $ghaSccacheArgs
+    }
+    $dockerArgs += $RootDir
+
     $buildExitCode = 1
     try {
-        docker build `
-            --build-arg "BASE_IMAGE=$imageName" `
-            --build-arg "BUILD_PARAMS=$BuildParams" `
-            --build-arg "SYSROOT_SUFFIX=$sysrootSuffix" `
-            --build-arg "WORKSPACE_PATH=/mnt" `
-            --output "type=local,dest=." `
-            --progress=plain `
-            -f $dockerfilePath `
-            $RootDir
-
+        & docker @dockerArgs
         $buildExitCode = $LASTEXITCODE
     }
     finally {
@@ -485,7 +563,7 @@ function Build-Guest {
     # targets (e.g., kernel, format-check) that would not regenerate all files.
     foreach ($dir in @($BinDir, $LibDir)) {
         if (-not (Test-Path $dir)) { continue }
-        Get-ChildItem -Path $dir -File -Include "*.elf", "*.wasm", "*.a", "*.so", "*.img" -Recurse -ErrorAction SilentlyContinue |
+        Get-ChildItem -Path (Join-Path $dir '*') -File -Include "*.elf", "*.wasm", "*.a", "*.so", "*.img" -Recurse -ErrorAction SilentlyContinue |
             ForEach-Object { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
     }
 
@@ -507,6 +585,15 @@ function Build-Guest {
     }
     $buildParams = Add-GuestMachineDefaults -MakeParams $buildParams
     Invoke-DockerBuild -BuildParams ($buildParams -join ' ') -IsRelease $IsRelease -UseMinimal $UseMinimal
+
+    # Create sysroot junction after Docker build (parity with Linux ln -sfn).
+    $sysrootTarget = Join-Path $RootDir "sysroot-$sysrootSuffix"
+    if (Test-Path $sysrootTarget) {
+        Remove-Junction -Path $SysrootLink
+        New-Item -ItemType Junction -Path $SysrootLink -Target $sysrootTarget | Out-Null
+        Write-Info "Sysroot junction: sysroot -> sysroot-$sysrootSuffix"
+    }
+
     Write-Info "Guest components built successfully."
 }
 
@@ -685,18 +772,25 @@ function Invoke-Clean {
 
     # Remove all guest binaries in bin/
     if (Test-Path $BinDir) {
-        Get-ChildItem -Path $BinDir -File -Include "*.elf", "*.wasm" -Recurse |
+        Get-ChildItem -Path (Join-Path $BinDir '*') -File -Include "*.elf", "*.wasm" -Recurse |
         Remove-Item -Force -ErrorAction SilentlyContinue
     }
 
     # Remove all guest libraries in lib/.
     if (Test-Path $LibDir) {
-        Get-ChildItem -Path $LibDir -File -Include "*.a", "*.so" -Recurse |
+        Get-ChildItem -Path (Join-Path $LibDir '*') -File -Include "*.a", "*.so" -Recurse |
         Remove-Item -Force -ErrorAction SilentlyContinue
     }
 
     # Remove system image.
     if (Test-Path $SysImage) { Remove-Item $SysImage -Force }
+
+    # Remove sysroot junction (without following into the target directory).
+    Remove-Junction -Path $SysrootLink
+
+    # Remove images directory.
+    $imagesDir = Join-Path $RootDir "images"
+    if (Test-Path $imagesDir) { Remove-Item $imagesDir -Recurse -Force }
 
     Write-Success "Quick clean complete."
 }
@@ -709,6 +803,15 @@ function Invoke-DistClean {
     Invoke-Clean
 
     Write-Info "Removing everything (full clean)..."
+
+    # Clean all Rust build artifacts.
+    $cargoAvailable = Get-Command cargo -ErrorAction SilentlyContinue
+    if ($cargoAvailable) {
+        cargo clean 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "cargo clean failed with exit code $LASTEXITCODE."
+        }
+    }
 
     # Remove Cargo.lock.
     if (Test-Path $CargoLock) { Remove-Item $CargoLock -Force }
@@ -738,8 +841,10 @@ function Invoke-DistClean {
         if (Test-Path $sysrootDir) { Remove-Item $sysrootDir -Recurse -Force }
     }
 
-    # Remove sysroot symlink (SYSROOT_LINK).
-    if (Test-Path $SysrootLink) { Remove-Item $SysrootLink -Force }
+    # Sysroot junction and images/ already removed by Invoke-Clean above.
+
+    # Remove build option cache.
+    if (Test-Path $ZCacheFile) { Remove-Item $ZCacheFile -Force }
 
     # Clean up Docker build cache for Nanvix.
     $dockerAvailable = Get-Command docker -ErrorAction SilentlyContinue
@@ -985,15 +1090,20 @@ function Main {
     # Parse options and positional arguments.
     $isRelease = $false
     $useMinimalDocker = $true
+    $useCachedOptions = $false
+    $dockerModeOptionSet = $false
     $buildParams = @()
 
+    $pastSeparator = $false
+
     foreach ($arg in $remaining) {
-        if ($arg -eq "--") { continue }
-        if ($arg.StartsWith("--")) {
+        if ($arg -eq "--") { $pastSeparator = $true; continue }
+        if (-not $pastSeparator -and $arg.StartsWith("--")) {
             switch ($arg) {
                 "--release" { $isRelease = $true }
-                "--with-docker" { $useMinimalDocker = $false }
-                "--with-minimal-docker" { $useMinimalDocker = $true }
+                "--with-docker" { $useMinimalDocker = $false; $dockerModeOptionSet = $true }
+                "--with-minimal-docker" { $useMinimalDocker = $true; $dockerModeOptionSet = $true }
+                "--with-cached-options" { $useCachedOptions = $true }
                 default {
                     Write-Err "Unknown option: $arg"
                     exit 1
@@ -1003,6 +1113,18 @@ function Main {
         else {
             if ($arg -ne '') {
                 $buildParams += $arg
+            }
+        }
+    }
+
+    # Apply cached options only when no docker mode flag was explicitly set on
+    # the command line. This matches Linux z behavior: explicit flags always win.
+    if ($useCachedOptions -and -not $dockerModeOptionSet) {
+        $cached = Read-ZCache
+        foreach ($opt in $cached) {
+            switch ($opt) {
+                "--with-docker" { $useMinimalDocker = $false }
+                "--with-minimal-docker" { $useMinimalDocker = $true }
             }
         }
     }
@@ -1218,6 +1340,20 @@ function Main {
 
             Write-Host ""
             Write-Success "Build complete."
+
+            # Cache build options for --with-cached-options.
+            # Write the full command line (matching Linux write_cache behavior).
+            $cacheOpts = @("build")
+            if ($isRelease) { $cacheOpts += "--release" }
+            if ($useMinimalDocker) { $cacheOpts += "--with-minimal-docker" } else { $cacheOpts += "--with-docker" }
+            $cacheOpts += "--"
+            $cacheOpts += $buildParams
+            try {
+                Write-ZCache -Options $cacheOpts
+            }
+            catch {
+                Write-Warn "Failed to write .z.cache: $($_.Exception.Message)"
+            }
         }
 
         "clean" {

--- a/z.ps1
+++ b/z.ps1
@@ -470,7 +470,33 @@ function Build-UserVm {
 function Build-Guest {
     param([bool]$IsRelease, [bool]$UseMinimal = $true, [string[]]$ExtraMakeParams = @())
 
+    # Prevent cleanup errors from aborting the build (consistent with other functions).
+    $ErrorActionPreference = 'Continue'
+
     Write-Info "Building guest components (Docker)..."
+
+    # Remove guest artifacts from previous Docker exports. Docker's
+    # --output type=local is additive: it writes new files but never deletes
+    # files that no longer exist in the output. Without this cleanup, stale
+    # guest binaries (e.g., a removed .elf) persist across builds.
+    # This cleanup is safe here because Build-Guest always does a full guest
+    # rebuild (all-guest-staticlibs all-kernel all-guest-binaries). It must
+    # NOT be placed in Invoke-DockerBuild, which is also called for partial
+    # targets (e.g., kernel, format-check) that would not regenerate all files.
+    foreach ($dir in @($BinDir, $LibDir)) {
+        if (-not (Test-Path $dir)) { continue }
+        Get-ChildItem -Path $dir -File -Include "*.elf", "*.wasm", "*.a", "*.so", "*.img" -Recurse -ErrorAction SilentlyContinue |
+            ForEach-Object { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
+    }
+
+    # Remove the sysroot directory matching the current build profile so that
+    # stale sysroot artifacts do not survive across Docker exports.
+    $sysrootSuffix = if ($IsRelease) { "release" } else { "debug" }
+    $sysrootDir = Join-Path $RootDir "sysroot-$sysrootSuffix"
+    if (Test-Path $sysrootDir) {
+        Remove-Item $sysrootDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
     $releaseFlag = if ($IsRelease) { "RELEASE=yes" } else { "" }
     $buildParams = @("all-guest-staticlibs", "all-kernel", "all-guest-binaries", "DEPLOYMENT_MODE=standalone")
     if ($releaseFlag) {

--- a/z.ps1
+++ b/z.ps1
@@ -755,6 +755,47 @@ function Invoke-DistClean {
 }
 
 # ==================================================================================================
+# Host Binary Freshness
+# ==================================================================================================
+
+# During development, developers often run 'cargo build' directly for faster
+# iteration. Cargo outputs to target/{debug,release}/ but z.ps1 run executes
+# from bin/. This function detects when target/ has a newer host binary than
+# bin/ and copies it, preventing stale artifact issues.
+function Sync-HostBinaries {
+    if (-not (Test-Path $BinDir)) { return }
+
+    # Host binaries that are natively built on Windows and copied to bin/.
+    $hostBinaries = @("nanvixd.exe", "uservm.exe")
+
+    foreach ($binary in $hostBinaries) {
+        $dst = Join-Path $BinDir $binary
+        if (-not (Test-Path $dst)) { continue }
+        $dstTime = (Get-Item $dst).LastWriteTime
+
+        # Check both debug and release profiles for a newer build.
+        foreach ($mode in @("debug", "release")) {
+            $src = Join-Path $TargetDir (Join-Path $mode $binary)
+            if (-not (Test-Path $src)) { continue }
+            $srcTime = (Get-Item $src).LastWriteTime
+            if ($srcTime -le $dstTime) { continue }
+
+            $delta = [int]($srcTime - $dstTime).TotalSeconds
+            Write-Warn ("Stale binary: bin\$binary is ${delta}s behind" +
+                " target\${mode}\$binary. Syncing...")
+            try {
+                Copy-Item $src $dst -Force -ErrorAction Stop
+                Write-Success "Updated bin\$binary from target\${mode}."
+            }
+            catch {
+                Write-Err ("Failed to update bin\$binary from target\${mode}: " + $_.Exception.Message)
+            }
+            break
+        }
+    }
+}
+
+# ==================================================================================================
 # Run
 # ==================================================================================================
 
@@ -781,6 +822,10 @@ function Invoke-Run {
             default { Write-Warn "Unknown run option: $($RunArgs[$i])" }
         }
     }
+
+    # Sync host binaries from target/ to bin/ in case the developer built
+    # directly with 'cargo build' instead of 'z.ps1 build'.
+    Sync-HostBinaries
 
     $nanvixdBin = Join-Path $BinDir "nanvixd.exe"
     if (-not (Test-Path $nanvixdBin)) {


### PR DESCRIPTION
Closes #1714

Hardens the Windows build system (`z.ps1`) to close gaps with the Linux `z` script.

## Changes (z.ps1: +149/-19)

- **Build option cache** (`--with-cached-options`): Write/read `.z.cache` matching Linux `write_cache`/`read_cache`. Explicit CLI flags always override cached values.
- **sccache CI forwarding**: Forward `SCCACHE_GHA_*` build-args and `ACTIONS_*` secrets to Docker when running in GitHub Actions.
- **Sysroot junction**: Create `sysroot -> sysroot-{debug|release}` junction after Docker guest builds (parity with Linux `ln -sfn`).
- **Expanded clean/distclean**: Remove sysroot junction, images/, .z.cache, and run `cargo clean` in distclean. Extract `Remove-Junction` helper for safe junction removal.
- **Pre-clean stale guest artifacts**: Remove .elf/.wasm/.a/.so/.img before Docker export to prevent orphaned files.
- **Sync stale host binaries**: Detect when `target/` has newer host binaries than `bin/` and copy them before run.
- **-- separator fix**: Args after `--` are now treated as build parameters, not parsed as script options.

## PowerShell compatibility fixes

- `Get-ChildItem -Include` with `-Recurse`: Use `Join-Path` with wildcard to match top-level files on PS 5.1 (fixes known PS 5.1 quirk).
- BOM-free cache: Use `[System.IO.File]::WriteAllLines()` instead of `Set-Content -Encoding UTF8` to avoid UTF-8 BOM.
- Array-safe reads: Wrap `Get-Content` pipeline in `@()` for reliable `.Count` on all PS versions.

## Cherry-picked from #1763

This branch includes two commits from #1763 (rebased on `origin/dev`):
- `68f8b2b3b` [build] B: Pre-clean guest artifacts
- `52d490aae` [build] B: Sync stale host binaries before run

## Build timing (Windows, Docker BuildKit cache mounts)

| Scenario | Time |
|----------|------|
| First build (cold cache) | ~5m08s |
| second build (warm cache, no changes) | ~29s |
| Incremental rebuild (guest source change) | ~58s |
| UserVM-only rebuild (host source change) | ~57s |

I didn't see a difference between `dev` and this change. it seems like most of the caching was already in place.  

No changes to `Dockerfile.build` -- all 7 BuildKit cache mounts are already in place.