### PR TITLE
[build] Speedup Build on Windows

### DIFF
--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -10,9 +10,11 @@ NANVIXD_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIXD_FEATURES := $(strip $(NANVIXD_FEATURES))
 NANVIXD_CARGO_FEATURES := $(if $(NANVIXD_FEATURES),--features "$(NANVIXD_FEATURES)")
 
-# In standalone mode, nanvixd needs mkramfs to produce the rootfs image.
+# In standalone mode, nanvixd needs mkramfs to produce the rootfs image
+# and guest binaries (which build shared libraries like libmul.so that
+# are bundled into the standalone rootfs).
 ifeq ($(DEPLOYMENT_MODE),standalone)
-all-nanvixd: all-host-binaries-mkramfs
+all-nanvixd: all-host-binaries-mkramfs all-guest-binaries
 endif
 
 all-nanvixd: init

--- a/scripts/setup/Dockerfile.build
+++ b/scripts/setup/Dockerfile.build
@@ -93,7 +93,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
         export SCCACHE_GHA_CACHE_FROM="${SCCACHE_GHA_CACHE_FROM}"; \
     fi && \
     SCCACHE_DIR=/root/.cache/sccache CONTRIB_SRC_DIR=/opt/contrib-src \
-    make TOOLCHAIN_DIR=/opt/nanvix ${SCCACHE_ARG} ${BUILD_PARAMS} && \
+    make -j"$(nproc)" TOOLCHAIN_DIR=/opt/nanvix ${SCCACHE_ARG} ${BUILD_PARAMS} && \
     if [ -x /usr/local/bin/sccache ]; then \
         echo "=== sccache statistics ===" && \
         /usr/local/bin/sccache --show-stats; \

--- a/z.ps1
+++ b/z.ps1
@@ -459,7 +459,7 @@ function Invoke-DistClean {
     Write-Info "Removing everything (full clean)..."
     $targetDir = Join-Path $RootDir "target"
     if (Test-Path $targetDir) {
-        cargo clean
+        cargo clean --manifest-path (Join-Path $RootDir 'Cargo.toml')
     }
     if (Test-Path $BinDir) {
         $uvmBin = Join-Path $BinDir "uservm.exe"

--- a/z.ps1
+++ b/z.ps1
@@ -580,7 +580,10 @@ function Invoke-DistClean {
     $ErrorActionPreference = 'Continue'
 
     Write-Info "Removing everything (full clean)..."
-    cargo clean
+    $targetDir = Join-Path $RootDir "target"
+    if (Test-Path $targetDir) {
+        cargo clean
+    }
     if (Test-Path $BinDir) {
         $uvmBin = Join-Path $BinDir "uservm.exe"
         if (Test-Path $uvmBin) { Remove-Item $uvmBin -Force }

--- a/z.ps1
+++ b/z.ps1
@@ -390,7 +390,7 @@ function Build-UserVm {
     $ErrorActionPreference = 'Continue'
 
     $mode = if ($IsRelease) { "release" } else { "debug" }
-    $profile = if ($IsRelease) { "--release" } else { "" }
+    $buildProfile = if ($IsRelease) { "--release" } else { "" }
 
     Write-Info "Building UserVM (microvm backend, $mode mode)..."
 
@@ -398,7 +398,7 @@ function Build-UserVm {
         New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
     }
 
-    $cmd = "cargo build --no-default-features --features `"microvm`" -p uservm $profile"
+    $cmd = "cargo build --no-default-features --features `"microvm`" -p uservm $buildProfile"
     Write-Host "  $cmd" -ForegroundColor DarkGray
     Invoke-Expression $cmd
     if ($LASTEXITCODE -ne 0) {

--- a/z.ps1
+++ b/z.ps1
@@ -305,117 +305,6 @@ function Get-DockerImageName {
     return "nanvix/toolchain:$imageTag$suffix"
 }
 
-function Convert-FileToLf {
-    param([string]$FilePath)
-
-    if (-not (Test-Path $FilePath -PathType Leaf)) {
-        return
-    }
-
-    $bytes = [System.IO.File]::ReadAllBytes($FilePath)
-    if (-not ($bytes -contains 13)) {
-        return
-    }
-
-    $normalized = New-Object 'System.Collections.Generic.List[byte]'
-    for ($i = 0; $i -lt $bytes.Length; $i++) {
-        if ($bytes[$i] -eq 13 -and ($i + 1) -lt $bytes.Length -and $bytes[$i + 1] -eq 10) {
-            continue
-        }
-        $normalized.Add($bytes[$i])
-    }
-
-    if ($normalized.Count -ne $bytes.Length) {
-        [System.IO.File]::WriteAllBytes($FilePath, $normalized.ToArray())
-    }
-}
-
-function New-DockerBuildContext {
-    $tempContextDir = Join-Path ([System.IO.Path]::GetTempPath()) ("nanvix-docker-context-" + [guid]::NewGuid())
-    New-Item -ItemType Directory -Path $tempContextDir -Force | Out-Null
-
-    $excludedDirs = @(
-        ".git",
-        ".github",
-        ".githooks",
-        ".idea",
-        ".vscode",
-        ".cargo",
-        "bin",
-        "doc",
-        "env",
-        "home",
-        "images",
-        "lib",
-        "logs",
-        "mnt",
-        "target",
-        "temp",
-        "test",
-        "tmp",
-        "toolchain",
-        "venv",
-        ".venv"
-    )
-
-    $excludedFiles = @(
-        "*.a",
-        "*.dylib",
-        "*.iso",
-        "*.log",
-        "*.o",
-        "*.so",
-        "*.tar",
-        "*.tar.bz2",
-        "*.tar.gz"
-    )
-
-    $robocopyArgs = @(
-        $RootDir,
-        $tempContextDir,
-        "/E",
-        "/R:1",
-        "/W:1",
-        "/NFL",
-        "/NDL",
-        "/NJH",
-        "/NJS",
-        "/NP",
-        "/XD"
-    ) + $excludedDirs + @("/XF") + $excludedFiles
-
-    & robocopy @robocopyArgs | Out-Null
-    $robocopyExitCode = $LASTEXITCODE
-    if ($robocopyExitCode -gt 7) {
-        Remove-Item $tempContextDir -Recurse -Force -ErrorAction SilentlyContinue
-        Write-Err "Failed to create temporary Docker build context."
-        exit 1
-    }
-
-    try {
-        $eolLines = git ls-files --eol
-        foreach ($line in $eolLines) {
-            if ($line -notmatch 'attr/.*eol=lf\s+(?<Path>.+)$') {
-                continue
-            }
-
-            $relativePath = $Matches['Path'].Trim()
-            if (-not $relativePath) {
-                continue
-            }
-
-            $contextFilePath = Join-Path $tempContextDir $relativePath
-            Convert-FileToLf -FilePath $contextFilePath
-        }
-    }
-    catch {
-        Remove-Item $tempContextDir -Recurse -Force -ErrorAction SilentlyContinue
-        throw
-    }
-
-    return $tempContextDir
-}
-
 function Invoke-DockerBuild {
     param([string]$BuildParams, [bool]$IsRelease = $false, [bool]$UseMinimal = $true)
 
@@ -431,8 +320,6 @@ function Invoke-DockerBuild {
 
     # Restore Git symlinks as file copies so the Docker build context is complete.
     Restore-GitSymlinks
-
-    $dockerContextPath = $null
 
     Write-Host "  Image: $imageName" -ForegroundColor DarkGray
 
@@ -462,38 +349,27 @@ function Invoke-DockerBuild {
         }
     }
 
-    # Create the Docker build context by copying the repository files to a temporary directory,
-    # excluding files that are not needed for the build. This avoids issues with Git symlinks on
-    # Windows and ensures a clean context for Docker. The context is cleaned up after the build.
+    # Use the repository directory directly as the Docker build context.
+    # The .dockerignore file handles exclusions (mirroring the old robocopy filter).
+    # Restore-GitSymlinks (called above) already materialized symlinks in-place,
+    # so the context is complete. Symlinks are restored after the build via the
+    # finally block below.
+    $buildExitCode = 1
     try {
-        $dockerContextPath = New-DockerBuildContext
+        docker build `
+            --build-arg "BASE_IMAGE=$imageName" `
+            --build-arg "BUILD_PARAMS=$BuildParams" `
+            --build-arg "SYSROOT_SUFFIX=$sysrootSuffix" `
+            --build-arg "WORKSPACE_PATH=/mnt" `
+            --output "type=local,dest=." `
+            --progress=plain `
+            -f $dockerfilePath `
+            $RootDir
+
+        $buildExitCode = $LASTEXITCODE
     }
     finally {
         Remove-RestoredSymlinks
-    }
-
-    $dockerfileContextPath = Join-Path $dockerContextPath $DockerfileRelativePath
-    if (-not (Test-Path $dockerfileContextPath)) {
-        Remove-Item $dockerContextPath -Recurse -Force -ErrorAction SilentlyContinue
-        Write-Err "Build Dockerfile not found in temporary Docker context at $dockerfileContextPath"
-        exit 1
-    }
-
-    docker build `
-        --build-arg "BASE_IMAGE=$imageName" `
-        --build-arg "BUILD_PARAMS=$BuildParams" `
-        --build-arg "SYSROOT_SUFFIX=$sysrootSuffix" `
-        --build-arg "WORKSPACE_PATH=/mnt" `
-        --output "type=local,dest=." `
-        --progress=plain `
-        -f $dockerfileContextPath `
-        $dockerContextPath
-
-    $buildExitCode = $LASTEXITCODE
-
-    # Clean up the temporary Docker context directory.
-    if ($null -ne $dockerContextPath -and (Test-Path $dockerContextPath)) {
-        Remove-Item $dockerContextPath -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     if ($buildExitCode -ne 0) {

--- a/z.ps1
+++ b/z.ps1
@@ -217,7 +217,8 @@ function Remove-RestoredSymlinks {
             $item = Get-Item $absPath -Force -ErrorAction SilentlyContinue
             if ($null -eq $item) {
                 Write-Warn "Cannot read attributes for '$filePath'; skipping removal."
-            } elseif (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0) {
+            }
+            elseif (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0) {
                 Remove-Item $absPath -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
@@ -494,7 +495,7 @@ function Invoke-Run {
     # Parse run options.
     for ($i = 0; $i -lt $RunArgs.Count; $i++) {
         switch ($RunArgs[$i]) {
-            "-kernel"  {
+            "-kernel" {
                 if ($i + 1 -ge $RunArgs.Count) {
                     Write-Err "Missing value for -kernel. Usage: .\z.ps1 run -- -kernel <path> [-initrd <path>]"
                     exit 1
@@ -502,7 +503,7 @@ function Invoke-Run {
                 $i++
                 $kernel = $RunArgs[$i]
             }
-            "-initrd"  {
+            "-initrd" {
                 if ($i + 1 -ge $RunArgs.Count) {
                     Write-Err "Missing value for -initrd. Usage: .\z.ps1 run -- [-kernel <path>] -initrd <path>"
                     exit 1
@@ -510,7 +511,7 @@ function Invoke-Run {
                 $i++
                 $initrd = $RunArgs[$i]
             }
-            default    { Write-Warn "Unknown run option: $($RunArgs[$i])" }
+            default { Write-Warn "Unknown run option: $($RunArgs[$i])" }
         }
     }
 
@@ -698,7 +699,8 @@ function Main {
                         }
                         if (-not $dockerRunning) {
                             Write-Warn "Skipping spellcheck (Docker not available or not running). Run with Docker to enable."
-                        } else {
+                        }
+                        else {
                             $dockerParams = @("spellcheck") + $makeParams
                             if (-not ($makeParams | Where-Object { $_ -match '^MACHINE=' })) {
                                 $dockerParams += "MACHINE=microvm"

--- a/z.ps1
+++ b/z.ps1
@@ -587,6 +587,14 @@ function Invoke-DistClean {
         $nanvixdBin = Join-Path $BinDir "nanvixd.exe"
         if (Test-Path $nanvixdBin) { Remove-Item $nanvixdBin -Force }
     }
+
+    # Clean up Docker build cache for Nanvix.
+    $dockerAvailable = Get-Command docker -ErrorAction SilentlyContinue
+    if ($dockerAvailable) {
+        Write-Info "Pruning Docker build cache..."
+        docker builder prune --force 2>$null
+    }
+
     Write-Success "Full cleanup complete."
 }
 

--- a/z.ps1
+++ b/z.ps1
@@ -580,7 +580,7 @@ function Invoke-DistClean {
     $ErrorActionPreference = 'Continue'
 
     Write-Info "Removing everything (full clean)..."
-    cargo clean 2>$null
+    cargo clean
     if (Test-Path $BinDir) {
         $uvmBin = Join-Path $BinDir "uservm.exe"
         if (Test-Path $uvmBin) { Remove-Item $uvmBin -Force }
@@ -592,7 +592,7 @@ function Invoke-DistClean {
     $dockerAvailable = Get-Command docker -ErrorAction SilentlyContinue
     if ($dockerAvailable) {
         Write-Info "Pruning Docker build cache..."
-        docker builder prune --force 2>$null
+        docker builder prune --force
     }
 
     Write-Success "Full cleanup complete."

--- a/z.ps1
+++ b/z.ps1
@@ -473,6 +473,9 @@ function Invoke-DistClean {
     if ($dockerAvailable) {
         Write-Info "Pruning Docker build cache..."
         docker builder prune --force
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "Docker build cache prune failed with exit code $LASTEXITCODE."
+        }
     }
 
     Write-Success "Full cleanup complete."


### PR DESCRIPTION
## Summary
This PR speeds up the build workflow on Windows by:

- Cleaning up Docker build cache during distclean on Windows
- Adding verbose output for distclean on Windows
- Speeding up distclean on Windows
- Enabling parallel make (`-j$(nproc)`) in Docker builds
- Using the repo directory as Docker context directly instead of copying

## Changes

- **z.ps1** — Simplified and optimized Windows build/clean scripts
- **scripts/setup/Dockerfile.build** — Enabled parallel make in Docker builds

## Testing

- Validated build and distclean on Windows