### PR TITLE
[nanvixd] Add Support for Windows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,13 +34,13 @@ Nanvix supports two host platforms:
   Uses KVM for the microvm backend and QEMU for other machine types.
 - **Windows 11** — Host-side development with the Windows Hypervisor Platform (WHP)
   backend. Guest components (kernel, user binaries) are cross-compiled inside Docker;
-  the UserVM is built natively. Only standalone UserVM mode is available (no
-  `nanvixd`, HTTP mode, or L2 deployments). Use `z.ps1` instead of `./z`.
+  the UserVM is built natively. Only standalone interactive mode is available
+  (no HTTP mode or L2 deployments). Use `z.ps1` instead of `./z`.
 
 When modifying or generating code, keep platform differences in mind:
 
 - Use `z.ps1` for Windows commands and `./z` for Linux commands.
-- Linux-only features: `nanvixd`, HTTP mode, interactive mode, L2 deployments,
+- Linux-only features: HTTP mode, L2 deployments,
   GDB debugging, benchmarking, network namespaces.
 - Windows-only concerns: WHP enablement, Developer Mode for symlinks, Docker
   Desktop with Linux containers, `.venv` cleanup before Docker builds.

--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -92,15 +92,18 @@ Example with custom parameters:
 ### Building on Windows (using `z.ps1`)
 
 On Windows 11, the `z.ps1` PowerShell script provides the same CLI interface. Guest components are
-cross-compiled inside Docker; the UserVM is built natively with the microvm backend (WHP on
-Windows).
+cross-compiled inside Docker; host binaries (`nanvixd`, `uservm`) are built natively with the
+microvm backend (WHP on Windows).
 
 ```powershell
-# Build everything (guest via Docker + UserVM natively).
+# Build everything (guest via Docker + host binaries natively).
 .\z.ps1 build -- all
 
 # Build only the UserVM (native Windows build).
 .\z.ps1 build -- uservm
+
+# Build only nanvixd (native Windows build).
+.\z.ps1 build -- nanvixd
 
 # Build only guest components (kernel + hello-rust-nostd, via Docker).
 .\z.ps1 build -- guest

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -85,10 +85,8 @@ Matrix coverage in GitHub Actions:
   and `multi-process` (excluding `qemu-pc + single-process`).
 - `ci-l2`: separate L2 jobs for `microvm` and `hyperlight`.
 
-> **Note:** There is no Windows CI job yet. Windows builds must be verified manually.
-> Once a `ci-windows` job is added, it should validate that platform-independent library crates
-> compile and pass Clippy on Windows, and eventually build and test the UserVM with the WHP
-> backend.
+> **Note:** The `ci-windows` workflow validates Windows host builds (nanvixd, UserVM, source checks)
+> and runs a smoke test using nanvixd in standalone interactive mode on WHP-enabled runners.
 
 ## Release Process
 

--- a/.github/skills/user-app-development/SKILL.md
+++ b/.github/skills/user-app-development/SKILL.md
@@ -72,10 +72,12 @@ curl --silent \
 
 ### Running on Windows
 
-On Windows, only standalone UserVM mode is available. The UserVM runs natively with the WHP backend:
+On Windows, `nanvixd` supports standalone interactive mode (no HTTP mode). Both `nanvixd` and the
+UserVM are built natively with the WHP backend:
 
 ```powershell
-.\bin\uservm.exe -kernel .\bin\kernel.elf -initrd .\bin\hello-rust-nostd.elf -standalone
+# Run via nanvixd (recommended).
+.\bin\nanvixd.exe -- .\bin\hello-rust-nostd.elf
 ```
 
 You can also launch a run via `z.ps1`:
@@ -84,12 +86,18 @@ You can also launch a run via `z.ps1`:
 # Run with default options.
 .\z.ps1 run
 
-# Run with custom kernel and initrd.
-.\z.ps1 run -- -kernel bin\kernel.elf -initrd bin\hello-rust-nostd.elf
+# Run with a custom guest binary.
+.\z.ps1 run -- -program bin\hello-rust-nostd.elf
 ```
 
-> **Note:** Interactive mode, HTTP mode, and `nanvixd` are Linux-only. On Windows, all guest
-> execution goes through the standalone UserVM.
+For low-level debugging, the standalone UserVM is still available:
+
+```powershell
+.\bin\uservm.exe -kernel .\bin\kernel.elf -initrd .\bin\hello-rust-nostd.elf -standalone
+```
+
+> **Note:** HTTP mode is Linux-only. On Windows, only standalone interactive mode
+> via `nanvixd` is supported.
 
 ## Creating a New Rust Application (no_std)
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -130,8 +130,9 @@ jobs:
   # Stage 2: Build & Unit Test (Windows)
   # ==========================================================================================
 
-  # Build UserVM natively on Windows and run unit tests. Guest artifacts from
-  # the Linux job are downloaded so they can be bundled for the smoke test.
+  # Build host binaries (nanvixd, UserVM) natively on Windows and run unit
+  # tests. Guest artifacts from the Linux job are downloaded so they can be
+  # bundled for the smoke test.
   ci-build:
     name: "Build (${{ matrix.build-type }})"
     needs: [checks, guest-build]
@@ -172,6 +173,17 @@ jobs:
             .\z.ps1 build -- uservm
           }
 
+      - name: "Build Nanvixd"
+        shell: pwsh
+        env:
+          RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
+        run: |
+          if ($env:RELEASE_FLAG) {
+            .\z.ps1 build -- nanvixd $env:RELEASE_FLAG
+          } else {
+            .\z.ps1 build -- nanvixd
+          }
+
       - name: "Unit Tests"
         shell: pwsh
         run: |
@@ -183,6 +195,7 @@ jobs:
           name: windows-build-${{ matrix.build-type }}
           retention-days: 1
           path: |
+            bin/nanvixd.exe
             bin/uservm.exe
             bin/kernel.elf
             bin/hello-rust-nostd.elf
@@ -191,8 +204,8 @@ jobs:
   # Stage 3: Smoke Test (Windows/WHP)
   # ==========================================================================================
 
-  # Run UserVM in standalone mode with the hello-rust-nostd guest to verify
-  # end-to-end boot on Windows Hypervisor Platform.
+  # Run nanvixd in standalone interactive mode with the hello-rust-nostd guest
+  # to verify end-to-end boot on Windows Hypervisor Platform.
   smoke-test:
     name: "Smoke Test (${{ matrix.build-type }})"
     needs: [ci-build]
@@ -230,12 +243,12 @@ jobs:
           $TIMEOUT_SECONDS = 120
           $MAGIC_STRING = "Hello, world from Rust!"
 
-          Write-Host "Starting UserVM (standalone, timeout=${TIMEOUT_SECONDS}s)..."
+          Write-Host "Starting nanvixd (standalone, timeout=${TIMEOUT_SECONDS}s)..."
 
-          # Start uservm as a background process and capture output.
+          # Start nanvixd as a background process and capture output.
           $pinfo = New-Object System.Diagnostics.ProcessStartInfo
-          $pinfo.FileName = "bin\uservm.exe"
-          $pinfo.Arguments = "-kernel bin\kernel.elf -initrd bin\hello-rust-nostd.elf -standalone"
+          $pinfo.FileName = "bin\nanvixd.exe"
+          $pinfo.Arguments = "-- bin\hello-rust-nostd.elf"
           $pinfo.RedirectStandardOutput = $true
           $pinfo.RedirectStandardError = $true
           $pinfo.UseShellExecute = $false
@@ -247,13 +260,13 @@ jobs:
           # Collect output asynchronously.
           $stdout = New-Object System.Text.StringBuilder
           $stderr = New-Object System.Text.StringBuilder
-          $outputEvent = Register-ObjectEvent -InputObject $process -EventName OutputDataReceived -SourceIdentifier 'UserVM-StdOut' -Action {
+          $outputEvent = Register-ObjectEvent -InputObject $process -EventName OutputDataReceived -SourceIdentifier 'Nanvixd-StdOut' -Action {
             if ($null -ne $EventArgs.Data) {
               [void]$Event.MessageData.AppendLine($EventArgs.Data)
               Write-Host $EventArgs.Data
             }
           } -MessageData $stdout
-          $errorEvent = Register-ObjectEvent -InputObject $process -EventName ErrorDataReceived -SourceIdentifier 'UserVM-StdErr' -Action {
+          $errorEvent = Register-ObjectEvent -InputObject $process -EventName ErrorDataReceived -SourceIdentifier 'Nanvixd-StdErr' -Action {
             if ($null -ne $EventArgs.Data) {
               [void]$Event.MessageData.AppendLine($EventArgs.Data)
               Write-Host $EventArgs.Data
@@ -269,8 +282,8 @@ jobs:
           # Give event handlers a moment to flush remaining data.
           Start-Sleep -Milliseconds 500
 
-          Unregister-Event -SourceIdentifier 'UserVM-StdOut'
-          Unregister-Event -SourceIdentifier 'UserVM-StdErr'
+          Unregister-Event -SourceIdentifier 'Nanvixd-StdOut'
+          Unregister-Event -SourceIdentifier 'Nanvixd-StdErr'
           Remove-Job -Id $outputEvent.Id -Force
           Remove-Job -Id $errorEvent.Id -Force
 
@@ -285,12 +298,12 @@ jobs:
           }
 
           $exitCode = $process.ExitCode
-          Write-Host "UserVM exited with code $exitCode"
+          Write-Host "nanvixd exited with code $exitCode"
 
           if ("${{ matrix.build-type }}" -eq "release") {
             # Release builds suppress debug output; just verify clean exit.
             if ($exitCode -ne 0) {
-              Write-Host "::error::Smoke test failed: UserVM exited with code $exitCode."
+              Write-Host "::error::Smoke test failed: nanvixd exited with code $exitCode."
               exit 1
             }
           } else {

--- a/doc/build.md
+++ b/doc/build.md
@@ -124,9 +124,9 @@ executable (and required companion binaries), not just the Verus source tree.
 ## Building Nanvix on Windows
 
 On Windows, the `z.ps1` PowerShell script provides the same interface as the Linux `z` utility.
-Guest components (kernel, user binaries) are cross-compiled inside Docker, while the UserVM is
-built natively using the Windows Hypervisor Platform (WHP) backend. The WHP backend is
-automatically selected when building with the `microvm` feature on Windows.
+Guest components (kernel, user binaries) are cross-compiled inside Docker, while host binaries
+(`nanvixd`, `uservm`) are built natively using the Windows Hypervisor Platform (WHP) backend.
+The WHP backend is automatically selected when building with the `microvm` feature on Windows.
 
 > ℹ️ Ensure you have completed the [Windows setup](setup.md#windows-setup) before proceeding.
 
@@ -143,6 +143,9 @@ Build all components:
 ```powershell
 # Build only the UserVM.
 .\z.ps1 build -- uservm
+
+# Build only nanvixd.
+.\z.ps1 build -- nanvixd
 
 # Build only guest components.
 .\z.ps1 build -- guest

--- a/doc/run.md
+++ b/doc/run.md
@@ -11,7 +11,7 @@ two mutually exclusive modes:
 - **Interactive Mode**: runs a single application, waits for it to exit, and forwards its exit code.
 - **HTTP Mode**: starts a REST server that spawns and kills applications on demand.
 
-On Windows, the supported host workflow is standalone UserVM execution; see
+On Windows, `nanvixd` supports standalone interactive mode only (no HTTP mode); see
 [`Running on Windows`](#running-on-windows).
 
 ## Quick Start
@@ -26,10 +26,10 @@ Run a hello-world application and see its output on the terminal:
 
 ### Windows
 
-On Windows, you can run the UserVM in standalone mode directly:
+On Windows, run a guest application via `nanvixd` in standalone interactive mode:
 
 ```powershell
-.\bin\uservm.exe -kernel .\bin\kernel.elf -initrd .\bin\hello-rust-nostd.elf -standalone
+.\bin\nanvixd.exe -- .\bin\hello-rust-nostd.elf
 ```
 
 ## Table of Contents
@@ -304,40 +304,47 @@ RUST_LOG=debug ./bin/uservm.elf -kernel ./bin/kernel.elf \
 
 ## Running on Windows
 
-On Windows, the UserVM is built natively with the WHP (Windows Hypervisor Platform) backend and
-can be run in **standalone mode** using `z.ps1`. Interactive and HTTP modes via `nanvixd` are not
-available on Windows.
+On Windows, `nanvixd` supports **standalone interactive mode** only (no HTTP mode). Both
+`nanvixd` and the UserVM are built natively with the WHP (Windows Hypervisor Platform) backend.
 
 ### Using `z.ps1 run`
 
-The simplest way to run the UserVM on Windows:
+The simplest way to run on Windows:
 
 ```powershell
 .\z.ps1 run
 ```
 
-This uses default paths (`bin/kernel.elf` and `bin/hello-rust-nostd.elf`). You can override them:
+This launches `nanvixd.exe` with the default guest binary (`bin/hello-rust-nostd.elf`). You can
+override it:
 
 ```powershell
-.\z.ps1 run -- -kernel bin\kernel.elf -initrd bin\hello-rust-nostd.elf
+.\z.ps1 run -- -program bin\hello-rust-nostd.elf
 ```
 
-| Option             | Default                       | Description                |
-| ------------------ | ----------------------------- | -------------------------- |
-| `-kernel <path>`   | `bin/kernel.elf`              | Path to the kernel binary. |
-| `-initrd <path>`   | `bin/hello-rust-nostd.elf`    | Path to the guest binary.  |
+| Option              | Default                       | Description                |
+| ------------------- | ----------------------------- | -------------------------- |
+| `-program <path>`   | `bin/hello-rust-nostd.elf`    | Path to the guest binary.  |
 
-### Running the UserVM Directly
+### Running nanvixd Directly
 
-You can also invoke `uservm.exe` directly:
+You can also invoke `nanvixd.exe` directly:
 
 ```powershell
-.\bin\uservm.exe -kernel .\bin\kernel.elf -initrd .\bin\hello-rust-nostd.elf -standalone
+.\bin\nanvixd.exe -- .\bin\hello-rust-nostd.elf
 ```
 
 Enable verbose logging with the `RUST_LOG` environment variable:
 
 ```powershell
 $env:RUST_LOG = "debug"
+.\bin\nanvixd.exe -- .\bin\hello-rust-nostd.elf
+```
+
+### Expert Mode: Standalone UserVM (Windows)
+
+For low-level debugging, you can bypass `nanvixd` and run the UserVM directly:
+
+```powershell
 .\bin\uservm.exe -kernel .\bin\kernel.elf -initrd .\bin\hello-rust-nostd.elf -standalone
 ```

--- a/src/libs/nanvix/Cargo.toml
+++ b/src/libs/nanvix/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 config = { workspace = true }
 hwloc = { workspace = true }
 linuxd = { workspace = true, optional = true }
-nanvix-http = { workspace = true }
+nanvix-http = { workspace = true, optional = true }
 nanvix-registry = { workspace = true }
 nanvix-sandbox = { workspace = true }
 nanvix-sandbox-cache = { workspace = true, optional = true }
@@ -26,31 +26,34 @@ syscomm = { workspace = true }
 syslog = { workspace = true, features = ["std"] }
 uservm = { workspace = true, optional = true }
 
+[target.'cfg(unix)'.dependencies]
+nanvix-http = { workspace = true }
+
 [features]
 default = ["microvm", "multi-process"]
 internal-api = ["sys", "syscall", "uservm"]
 single-process = [
     "linuxd",
-    "nanvix-http/single-process",
+    "nanvix-http?/single-process",
     "nanvix-sandbox/single-process",
     "nanvix-terminal/single-process",
 ]
 multi-process = [
     "nanvix-sandbox-cache",
-    "nanvix-http/multi-process",
+    "nanvix-http?/multi-process",
     "nanvix-sandbox/multi-process",
     "nanvix-sandbox-cache/multi-process",
     "nanvix-terminal/multi-process",
 ]
 standalone = [
-    "nanvix-http/standalone",
+    "nanvix-http?/standalone",
     "nanvix-sandbox/standalone",
     "nanvix-terminal/standalone",
 ]
-gdb = ["nanvix-http/gdb", "nanvix-sandbox/gdb", "nanvix-terminal/gdb"]
+gdb = ["nanvix-http?/gdb", "nanvix-sandbox/gdb", "nanvix-terminal/gdb"]
 hyperlight = [
     "config/hyperlight",
-    "nanvix-http/hyperlight",
+    "nanvix-http?/hyperlight",
     "nanvix-sandbox/hyperlight",
     "nanvix-sandbox-cache?/hyperlight",
     "nanvix-terminal/hyperlight",
@@ -58,7 +61,7 @@ hyperlight = [
 ]
 microvm = [
     "config/microvm",
-    "nanvix-http/microvm",
+    "nanvix-http?/microvm",
     "nanvix-sandbox/microvm",
     "nanvix-sandbox-cache?/microvm",
     "nanvix-terminal/microvm",

--- a/src/libs/nanvix/src/lib.rs
+++ b/src/libs/nanvix/src/lib.rs
@@ -85,6 +85,7 @@
 
 pub use config;
 pub use hwloc;
+#[cfg(unix)]
 pub use nanvix_http as http;
 pub use nanvix_registry as registry;
 pub use nanvix_sandbox as sandbox;

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -46,6 +46,7 @@ use ::std::{
 #[derive(Debug, Clone)]
 pub struct Args {
     /// Optional HTTP server socket address (host:port). If present, enables HTTP mode.
+    #[cfg(unix)]
     http_sockaddr: Option<String>,
     /// Directory path containing Nanvix binaries.
     binary_directory: String,
@@ -90,6 +91,7 @@ impl Args {
     /// Command-line flag that prints usage information.
     pub const OPT_HELP: &'static str = "-help";
     /// Command-line option that sets the HTTP socket address.
+    #[cfg(unix)]
     pub const OPT_HTTP_SOCKADDR: &'static str = "-http-addr";
     /// Command-line option that sets the binary directory path.
     pub const OPT_BIN_DIRECTORY: &'static str = "-bin-dir";
@@ -144,6 +146,7 @@ impl Args {
     /// the parsing issue or validation failure.
     ///
     pub fn parse(args: Vec<String>) -> Result<Self> {
+        #[cfg(unix)]
         let mut http_sockaddr: Option<String> = None;
         let mut binary_directory: String = config::DEFAULT_BIN_DIRECTORY.to_string();
         let mut toolchain_binary_directory: String =
@@ -194,6 +197,7 @@ impl Args {
                     Self::usage(args[0].as_str());
                     return Err(anyhow::anyhow!("wrong usage"));
                 },
+                #[cfg(unix)]
                 Self::OPT_HTTP_SOCKADDR => {
                     i += 1;
                     http_sockaddr = Some(args[i].clone());
@@ -321,10 +325,12 @@ impl Args {
 
         // Determine operation mode: HTTP mode is active if -http-addr is provided,
         // interactive mode is active if `--` separator with program name is provided.
+        #[cfg(unix)]
         let http_mode: bool = http_sockaddr.is_some();
         let interactive_mode: bool = program_name.is_some();
 
         // Ensure exactly one mode is active.
+        #[cfg(unix)]
         if http_mode && interactive_mode {
             anyhow::bail!(
                 "cannot use both HTTP mode ({}) and interactive mode ({}) simultaneously",
@@ -333,6 +339,7 @@ impl Args {
             );
         }
 
+        #[cfg(unix)]
         if !http_mode && !interactive_mode {
             anyhow::bail!(
                 "must specify either HTTP mode ({} <sockaddr>) or interactive mode ({} <program> \
@@ -342,7 +349,18 @@ impl Args {
             );
         }
 
+        // On Windows, only interactive mode is supported.
+        #[cfg(windows)]
+        if !interactive_mode {
+            anyhow::bail!(
+                "must specify interactive mode ({} <program> [<args>...]) (HTTP mode is not \
+                 supported on Windows)",
+                Self::OPT_SEPARATOR
+            );
+        }
+
         Ok(Self {
+            #[cfg(unix)]
             http_sockaddr,
             binary_directory,
             toolchain_binary_directory,
@@ -374,13 +392,18 @@ impl Args {
     /// - `program_name`: Name of the program executable.
     ///
     pub fn usage(program_name: &str) {
+        #[cfg(unix)]
+        let http_usage: String = format!(
+            "\nUsage (HTTP mode):\n  {program_name} {} <sockaddr> [OPTIONS]\n",
+            Self::OPT_HTTP_SOCKADDR,
+        );
+        #[cfg(windows)]
+        let http_usage: &str = "";
+
         println!(
             "\
 Nanvix Daemon - System-level service and VM orchestration daemon for Nanvix OS.
-
-Usage (HTTP mode):
-  {program_name} {http_addr} <sockaddr> [OPTIONS]
-
+{http_usage}
 Usage (Interactive mode):
   {program_name} [OPTIONS] {separator} <program> [<args>...]
 
@@ -407,8 +430,8 @@ Options:
   {tmp_dir} <tmp_dir>                       Base directory for temporary files (Default: \
              {DEFAULT_TMP_DIRECTORY}).{gdb_port_line}
 ",
+            http_usage = http_usage,
             program_name = program_name,
-            http_addr = Self::OPT_HTTP_SOCKADDR,
             separator = Self::OPT_SEPARATOR,
             console_file = Self::OPT_CONSOLE_FILE,
             ramfs_filename = Self::OPT_RAMFS_FILENAME,
@@ -442,6 +465,7 @@ Options:
     ///
     /// The HTTP socket address if present; `None` otherwise.
     ///
+    #[cfg(unix)]
     pub fn http_sockaddr(&self) -> Option<&str> {
         self.http_sockaddr.as_deref()
     }

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -22,7 +22,9 @@
 
 use ::anyhow::Result;
 use ::log::error;
-#[cfg(feature = "standalone")]
+#[cfg(unix)]
+use ::nanvix::http::HttpServer;
+#[cfg(all(unix, feature = "standalone"))]
 use ::nanvix::http::StandaloneConfig;
 #[cfg(feature = "multi-process")]
 use ::nanvix::sandbox_cache::SandboxCacheConfig;
@@ -36,7 +38,6 @@ use ::nanvix::{
         kernel::MEMORY_SIZE,
         system::DEFAULT_MACHINE_NAME,
     },
-    http::HttpServer,
     registry::Registry,
     sandbox::NAMED_RESOURCE_PREFIX,
     terminal::Terminal,
@@ -201,7 +202,7 @@ async fn async_main() -> Result<ExitCode> {
         })?,
     );
 
-    #[cfg(feature = "standalone")]
+    #[cfg(all(unix, feature = "standalone"))]
     let config: StandaloneConfig = StandaloneConfig::new(
         kernel_binary_path.clone(),
         args.ramfs_filename().map(|s| s.to_string()),
@@ -281,6 +282,7 @@ async fn async_main() -> Result<ExitCode> {
         return Ok(ExitCode::from(clamped_exit_code));
     }
 
+    #[cfg(unix)]
     {
         let http_sockaddr: &str = match args.http_sockaddr() {
             None => {
@@ -297,6 +299,13 @@ async fn async_main() -> Result<ExitCode> {
         }
 
         Ok(ExitCode::SUCCESS)
+    }
+
+    #[cfg(windows)]
+    {
+        let reason: &str = "HTTP mode is not supported on Windows";
+        error!("{reason}");
+        anyhow::bail!(reason);
     }
 }
 

--- a/z.ps1
+++ b/z.ps1
@@ -436,6 +436,41 @@ function Build-Guest {
     Write-Info "Guest components built successfully."
 }
 
+function Build-Nanvixd {
+    param([bool]$IsRelease)
+
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    $mode = if ($IsRelease) { "release" } else { "debug" }
+    $buildProfile = if ($IsRelease) { "--release" } else { "" }
+
+    Write-Info "Building nanvixd (standalone + microvm, $mode mode)..."
+
+    if (-not (Test-Path $BinDir)) {
+        New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+    }
+
+    $cmd = "cargo build --no-default-features --features `"standalone,microvm`" -p nanvixd $buildProfile"
+    Write-Host "  $cmd" -ForegroundColor DarkGray
+    Invoke-Expression $cmd
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Failed to build nanvixd."
+        exit 1
+    }
+
+    $src = Join-Path (Join-Path (Join-Path $RootDir "target") $mode) "nanvixd.exe"
+    $dst = Join-Path $BinDir "nanvixd.exe"
+    if (Test-Path $src) {
+        Copy-Item $src $dst -Force
+        Write-Info "Output: $dst"
+    }
+    else {
+        Write-Err "nanvixd binary not found at $src"
+        exit 1
+    }
+}
+
 # ==================================================================================================
 # Clean
 # ==================================================================================================
@@ -689,9 +724,13 @@ function Main {
                     "all" {
                         Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams
                         Build-UserVm -IsRelease $isRelease
+                        Build-Nanvixd -IsRelease $isRelease
                     }
                     "uservm" {
                         Build-UserVm -IsRelease $isRelease
+                    }
+                    "nanvixd" {
+                        Build-Nanvixd -IsRelease $isRelease
                     }
                     "guest" {
                         Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams

--- a/z.ps1
+++ b/z.ps1
@@ -71,7 +71,7 @@ Commands
   clean       Removes build artifacts (quick clean).
   distclean   Removes everything (full clean).
   setup       Sets up the development environment and installs Git hooks.
-  run         Runs UserVM in standalone mode.
+  run         Runs nanvixd in standalone mode.
   help        Prints this help message.
 
 Options
@@ -97,8 +97,7 @@ Build Targets (after --)
   <any-make-target>       Any other target is forwarded to make via Docker.
 
 Run Options (after --)
-  -kernel <path>          Path to kernel binary (default: bin/kernel.elf).
-  -initrd <path>          Path to guest binary (default: bin/hello-rust-nostd.elf).
+  -program <path>         Path to guest binary (default: bin/hello-rust-nostd.elf).
 
 Build Parameters (after --)
   RELEASE=yes             Enable release mode.
@@ -567,46 +566,36 @@ function Invoke-Run {
     # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
     $ErrorActionPreference = 'Continue'
 
-    # Default values.
-    $kernel = Join-Path $BinDir "kernel.elf"
-    $initrd = Join-Path $BinDir "hello-rust-nostd.elf"
+    # Default value.
+    $program = Join-Path $BinDir "hello-rust-nostd.elf"
 
     # Parse run options.
     for ($i = 0; $i -lt $RunArgs.Count; $i++) {
         switch ($RunArgs[$i]) {
-            "-kernel" {
+            "-program" {
                 if ($i + 1 -ge $RunArgs.Count) {
-                    Write-Err "Missing value for -kernel. Usage: .\z.ps1 run -- -kernel <path> [-initrd <path>]"
+                    Write-Err "Missing value for -program. Usage: .\z.ps1 run -- -program <path>"
                     exit 1
                 }
                 $i++
-                $kernel = $RunArgs[$i]
-            }
-            "-initrd" {
-                if ($i + 1 -ge $RunArgs.Count) {
-                    Write-Err "Missing value for -initrd. Usage: .\z.ps1 run -- [-kernel <path>] -initrd <path>"
-                    exit 1
-                }
-                $i++
-                $initrd = $RunArgs[$i]
+                $program = $RunArgs[$i]
             }
             default { Write-Warn "Unknown run option: $($RunArgs[$i])" }
         }
     }
 
-    $uvmBin = Join-Path $BinDir "uservm.exe"
-    if (-not (Test-Path $uvmBin)) {
-        Write-Err "UserVM binary not found at $uvmBin. Build it first with: .\z.ps1 build -- uservm"
+    $nanvixdBin = Join-Path $BinDir "nanvixd.exe"
+    if (-not (Test-Path $nanvixdBin)) {
+        Write-Err "nanvixd binary not found at $nanvixdBin. Build it first with: .\z.ps1 build -- nanvixd"
         exit 1
     }
 
-    Write-Info "Running UserVM in standalone mode..."
-    Write-Host "  Kernel: $kernel" -ForegroundColor DarkGray
-    Write-Host "  Initrd: $initrd" -ForegroundColor DarkGray
+    Write-Info "Running nanvixd in standalone mode..."
+    Write-Host "  Program: $program" -ForegroundColor DarkGray
 
-    & $uvmBin -kernel $kernel -initrd $initrd -standalone
+    & $nanvixdBin -- $program
     if ($LASTEXITCODE -ne 0) {
-        Write-Err "UserVM exited with code $LASTEXITCODE."
+        Write-Err "nanvixd exited with code $LASTEXITCODE."
         exit $LASTEXITCODE
     }
 }


### PR DESCRIPTION
This pull request updates Windows support and documentation for the Nanvix project, clarifying that `nanvixd` (not just the UserVM) is now the primary entry point for running guest applications on Windows in standalone interactive mode. It also ensures that HTTP mode is Linux-only, updates the Windows CI workflow to build and test `nanvixd`, and improves conditional compilation and dependency management for platform-specific features.