### PR TITLE
[build] Fix Stale-Artifact Bugs

### DIFF
--- a/z.ps1
+++ b/z.ps1
@@ -425,7 +425,33 @@ function Build-UserVm {
 function Build-Guest {
     param([bool]$IsRelease, [bool]$UseMinimal = $true, [string[]]$ExtraMakeParams = @())
 
+    # Prevent cleanup errors from aborting the build (consistent with other functions).
+    $ErrorActionPreference = 'Continue'
+
     Write-Info "Building guest components (Docker)..."
+
+    # Remove guest artifacts from previous Docker exports. Docker's
+    # --output type=local is additive: it writes new files but never deletes
+    # files that no longer exist in the output. Without this cleanup, stale
+    # guest binaries (e.g., a removed .elf) persist across builds.
+    # This cleanup is safe here because Build-Guest always does a full guest
+    # rebuild (all-guest-staticlibs all-kernel all-guest-binaries). It must
+    # NOT be placed in Invoke-DockerBuild, which is also called for partial
+    # targets (e.g., kernel, format-check) that would not regenerate all files.
+    foreach ($dir in @($BinDir, $LibDir)) {
+        if (-not (Test-Path $dir)) { continue }
+        Get-ChildItem -Path $dir -File -Include "*.elf", "*.wasm", "*.a", "*.so", "*.img" -Recurse -ErrorAction SilentlyContinue |
+            ForEach-Object { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
+    }
+
+    # Remove the sysroot directory matching the current build profile so that
+    # stale sysroot artifacts do not survive across Docker exports.
+    $sysrootSuffix = if ($IsRelease) { "release" } else { "debug" }
+    $sysrootDir = Join-Path $RootDir "sysroot-$sysrootSuffix"
+    if (Test-Path $sysrootDir) {
+        Remove-Item $sysrootDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
     $releaseFlag = if ($IsRelease) { "RELEASE=yes" } else { "" }
     $buildParams = "all-guest-staticlibs all-kernel all-guest-binaries $releaseFlag MACHINE=microvm DEPLOYMENT_MODE=standalone"
     if ($ExtraMakeParams.Count -gt 0) {

--- a/z.ps1
+++ b/z.ps1
@@ -583,6 +583,47 @@ function Invoke-DistClean {
 }
 
 # ==================================================================================================
+# Host Binary Freshness
+# ==================================================================================================
+
+# During development, developers often run 'cargo build' directly for faster
+# iteration. Cargo outputs to target/{debug,release}/ but z.ps1 run executes
+# from bin/. This function detects when target/ has a newer host binary than
+# bin/ and copies it, preventing stale artifact issues.
+function Sync-HostBinaries {
+    if (-not (Test-Path $BinDir)) { return }
+
+    # Host binaries that are natively built on Windows and copied to bin/.
+    $hostBinaries = @("nanvixd.exe", "uservm.exe")
+
+    foreach ($binary in $hostBinaries) {
+        $dst = Join-Path $BinDir $binary
+        if (-not (Test-Path $dst)) { continue }
+        $dstTime = (Get-Item $dst).LastWriteTime
+
+        # Check both debug and release profiles for a newer build.
+        foreach ($mode in @("debug", "release")) {
+            $src = Join-Path $TargetDir (Join-Path $mode $binary)
+            if (-not (Test-Path $src)) { continue }
+            $srcTime = (Get-Item $src).LastWriteTime
+            if ($srcTime -le $dstTime) { continue }
+
+            $delta = [int]($srcTime - $dstTime).TotalSeconds
+            Write-Warn ("Stale binary: bin\$binary is ${delta}s behind" +
+                " target\$mode\$binary. Syncing...")
+            try {
+                Copy-Item $src $dst -Force -ErrorAction Stop
+                Write-Success "Updated bin\$binary from target\$mode."
+            }
+            catch {
+                Write-Err ("Failed to update bin\$binary from target\$mode: " + $_.Exception.Message)
+            }
+            break
+        }
+    }
+}
+
+# ==================================================================================================
 # Run
 # ==================================================================================================
 
@@ -609,6 +650,10 @@ function Invoke-Run {
             default { Write-Warn "Unknown run option: $($RunArgs[$i])" }
         }
     }
+
+    # Sync host binaries from target/ to bin/ in case the developer built
+    # directly with 'cargo build' instead of 'z.ps1 build'.
+    Sync-HostBinaries
 
     $nanvixdBin = Join-Path $BinDir "nanvixd.exe"
     if (-not (Test-Path $nanvixdBin)) {


### PR DESCRIPTION
## Summary

Fixes two stale-artifact bugs that affect the Windows build-run-debug cycle
with `z.ps1`.

## Changes

### Pre-clean guest artifacts before Docker build

Docker's `--output type=local,dest=.` is additive: it writes new files but
never deletes files that no longer exist in the build output. Without cleanup,
stale guest binaries (e.g., a removed `.elf`) persist across builds in `bin/`
and `lib/`.

`Build-Guest` now removes guest-produced files (`*.elf`, `*.wasm`, `*.a`,
`*.so`, `*.img`) and ephemeral sysroot directories before invoking
`Invoke-DockerBuild`. Host-built `.exe` files are preserved.

### Sync stale host binaries before run

`cargo build` writes to `target/{debug,release}/` but `z.ps1 run` launches
from `bin/`. When a developer builds with `cargo build` directly (e.g., during
an IDE debug iteration) and then runs `z.ps1 run`, the executed binary is
stale.

`Invoke-Run` now calls `Sync-HostBinaries`, which compares timestamps of
`nanvixd.exe` and `uservm.exe` between `target/` and `bin/`. If `target/`
holds a newer copy, it is automatically copied to `bin/` with a warning.

## Testing

- Reproduced Bug 1: confirmed 28 s timestamp gap between `target/debug/uservm.exe`
  and `bin/uservm.exe` after a direct `cargo build`.
- Verified `Sync-HostBinaries` detects and resolves the gap.
- Verified pre-clean removes stale `.elf`/`.wasm` files.
- Syntax-validated with `[System.Management.Automation.PSParser]`.