### PR TITLE
[build] Drop Pure Debug Builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,15 +212,15 @@ windows = { version = "0.62", features = [
 ] }
 
 [profile.dev]
-opt-level = 0
-debug = true
+opt-level = 3
+debug = 2
 strip = false
 debug-assertions = true
 overflow-checks = true
 lto = false
 panic = 'unwind'
 incremental = true
-codegen-units = 256
+codegen-units = 1
 rpath = false
 
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,11 @@ $(error Invalid DEPLOYMENT_MODE '$(DEPLOYMENT_MODE)'. Valid values: $(VALID_DEPL
 endif
 
 # Log Level
+ifeq ($(RELEASE),yes)
 export LOG_LEVEL ?= warn
+else
+export LOG_LEVEL ?= trace
+endif
 
 # Wasm binary to embed in the WASM Daemon
 export WASM_BINARY ?= $(BINARIES_DIR)/hello-wasm.wasm
@@ -215,9 +219,10 @@ export NANVIX_CXXFLAGS += -O3
 export NANVIX_CFLAGS += -D__RELEASE
 export NANVIX_CXXFLAGS += -D__RELEASE
 else
-export NANVIX_CFLAGS += -O0
+export NANVIX_CFLAGS += -O3
 export NANVIX_CFLAGS += -g
-export NANVIX_CXXFLAGS += -O0
+export NANVIX_CXXFLAGS += -O3
+export NANVIX_CXXFLAGS += -g
 export NANVIX_CFLAGS += -D__DEBUG
 export NANVIX_CXXFLAGS += -D__DEBUG
 endif

--- a/doc/build.md
+++ b/doc/build.md
@@ -7,8 +7,26 @@ your development environment, please refer to the [setup.md](setup.md) document.
 This document guides you through building Nanvix. You can either use the `z` utility script for a
 simplified build process or do it manually.
 
+## Build Profiles
+
+Nanvix provides two build profiles controlled by the `RELEASE` variable:
+
+| Setting | Debug (`RELEASE=no`, default) | Release (`RELEASE=yes`) |
+|---|---|---|
+| Rust `opt-level` | `3` | `3` |
+| Rust `codegen-units` | `1` | `1` |
+| Rust debug info | Full (`debuginfo = 2`) | None (stripped) |
+| Rust `debug-assertions` | Enabled | Disabled |
+| C/C++ optimization | `-O3 -g` | `-O3` |
+| Default `LOG_LEVEL` | `trace` | `warn` |
+
+Both profiles generate optimized code. The debug profile additionally emits debug symbols (so that
+GDB and other debuggers remain fully usable) and defaults to trace-level logging for verbose output
+during development.
+
 ## Table of Contents
 
+- [Build Profiles](#build-profiles)
 - [Building Nanvix on Linux](#building-nanvix-on-linux)
   - [Building Nanvix with `z` (Preferred Method)](#building-nanvix-with-z-preferred-method)
   - [Building Nanvix Manually](#building-nanvix-manually)

--- a/z.ps1
+++ b/z.ps1
@@ -104,7 +104,7 @@ Build Parameters (after --)
   RELEASE=yes             Enable release mode.
   MACHINE=microvm         Target machine (default: microvm).
   WHP=yes                 Enable WHP-specific guest kernel code for microvm builds.
-  LOG_LEVEL=warn          Log level (default: warn).
+  LOG_LEVEL=<level>       Log level (default: trace for debug, warn for release).
 
 Prerequisites
   - Docker Desktop for Windows (with Linux containers enabled).


### PR DESCRIPTION
## Summary

Drop support for pure (unoptimized) debug builds. The debug Cargo profile now uses the same `opt-level` and `codegen-units` as the release profile while preserving debug symbols and trace-level logging.

## Changes

- **`Cargo.toml`**: Updated `[profile.dev]` — `opt-level` 0→3, `codegen-units` 256→1, `debug` true→2 (explicit full debuginfo).
- **`Makefile`**: Changed C/C++ debug flags from `-O0` to `-O3` (kept `-g` for debug symbols, added `-g` to `CXXFLAGS`). Made `LOG_LEVEL` conditional on `RELEASE` — defaults to `trace` for debug builds, `warn` for release.
- **`z.ps1`**: Updated help text to reflect the new conditional `LOG_LEVEL` defaults.
- **`doc/build.md`**: Added Build Profiles section documenting the new debug/release distinction.

## Motivation

Pure debug builds are too slow for the growing test matrix — individual tests can run for hours, especially on CI runners using nested virtualization. Both profiles now generate optimized code; the debug profile additionally emits debug symbols (for GDB) and defaults to trace-level logging.

## Unchanged in `[profile.dev]`

- `lto = false`, `panic = unwind`, `incremental = true` — preserved for faster compile times during development.
- `debug-assertions` and `overflow-checks` — remain enabled for safety checks.

Closes #1767