### PR TITLE
[vfs] Reject directory reads and update epoch timestamp

### DIFF
--- a/src/libs/vfs/src/fd.rs
+++ b/src/libs/vfs/src/fd.rs
@@ -445,6 +445,10 @@ pub fn vfs_read(fd: c_int, buf: &mut [u8]) -> Result<c_size_t, Fat32Error> {
     let mut slot: spin::MutexGuard<'_, Option<VfsEntry>> = FD_TABLE.lock(fd)?;
     let entry: &mut VfsEntry = slot.as_mut().ok_or(Fat32Error::InvalidFd)?;
 
+    if entry.handle.is_dir() {
+        return Err(Fat32Error::NotAFile);
+    }
+
     let size: u64 = entry.handle.size()?;
     if entry.virtual_pos as u64 >= size {
         return Ok(0);
@@ -527,8 +531,8 @@ pub fn vfs_lseek(fd: c_int, offset: off_t, whence: c_int) -> Result<off_t, Fat32
 /// - Timestamps set to a fixed epoch value (FAT has no sub-second precision).
 /// - Permissions: owner read+write for files, owner rwx for directories.
 fn populate_stat_fields(buf: &mut ::sysapi::sys_stat::stat, size: u64, is_dir: bool) {
-    // Fixed epoch timestamp: 2020-01-01T00:00:00Z (1577836800).
-    const FIXED_EPOCH: i64 = 1_577_836_800;
+    // Fixed epoch timestamp: 2024-01-01T00:00:00Z (1704067200).
+    const FIXED_EPOCH: i64 = 1_704_067_200;
 
     buf.st_size = size as off_t;
     buf.st_nlink = if is_dir { 2 } else { 1 };

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -61,6 +61,7 @@ program = "./bin/vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
 input = "[]"
 expect_empty_output = true
+expected_exit_code = 0
 runs_on = ["microvm"]
 
 [[tests]]
@@ -185,6 +186,7 @@ program = "./bin/vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
 input = "[]"
 expect_empty_output = true
+expected_exit_code = 0
 runs_on = ["microvm"]
 
 [[tests]]


### PR DESCRIPTION
Closes #1761

## Summary

- Reject `vfs_read()` on directory file descriptors (was causing hangs).
- Update VFS stat epoch from 2020 (`1577836800`) to 2024 (`1704067200`).

## Test runner fix (nanvix-test)

- Change `WorkloadSpec::expected_exit_code()` return type from `Option<i32>` to `i32`, defaulting to `0` when the field is omitted in the TOML config. Previously, omitting `expected_exit_code` caused the runner to skip exit-code validation entirely, silently masking non-zero exits.
- Update HTTP and terminal executor validation to use the non-`Option` return directly.
- Add vfs-test entries to `test/test-multi_process.toml` (both HTTP and terminal executors) so the VFS integration tests are actually exercised in multi-process CI runs.

## Root cause of CI gap

The vfs-test integration tests for both bugs already existed on `dev` (`test_open_directory()` and `test_stat_timestamps()`), but the test runner silently ignored non-zero exit codes because:

1. `expected_exit_code()` returned `Option<i32>` -- when the config field was absent it returned `None`, and the `let Some(expected) = ...` pattern in the executors short-circuited, skipping validation entirely.
2. The vfs-test entries were only present in `test-standalone.toml`, not in `test-multi_process.toml`, so they never ran in the default CI configuration.