### PR TITLE
[nanvix-test] Simplify Exit Code Validation

### DIFF
--- a/src/utils/nanvix-test/src/executor/http.rs
+++ b/src/utils/nanvix-test/src/executor/http.rs
@@ -195,13 +195,11 @@ pub(crate) async fn test_with_http_executor(
                 },
             };
 
-            // Validate exit code if expected_exit_code is specified and validation is not skipped.
+            // Validate exit code unless skip_exit_code_validation() is set.
             // FIXME (#1010): Remove skip_exit_code_validation() once graceful hyperlight interrupt
             // is implemented. Currently hyperlight uses SIGKILL which prevents clean exit.
-            if !workload.skip_exit_code_validation()
-                && let Some(expected) = workload.expected_exit_code()
-                && exit_code != expected
-            {
+            if !workload.skip_exit_code_validation() && exit_code != workload.expected_exit_code() {
+                let expected: i32 = workload.expected_exit_code();
                 let reason: String = format!(
                     "exit code mismatch (expected={}, actual={}, program={}, iteration={})",
                     expected, exit_code, program_path, iteration
@@ -210,12 +208,14 @@ pub(crate) async fn test_with_http_executor(
                 return Err(::anyhow::anyhow!(reason));
             }
 
-            // When termination succeeds on hyperlight, still validate the exit code.
+            // When termination succeeds on hyperlight, still validate the exit code
+            // — but only if the test explicitly declared an expected exit code.
             if workload.skip_exit_code_validation()
                 && exit_code != DEFAULT_EXIT_CODE_SKIP_VALIDATION
-                && let Some(expected) = workload.expected_exit_code()
-                && exit_code != expected
+                && workload.has_explicit_expected_exit_code()
+                && exit_code != workload.expected_exit_code()
             {
+                let expected: i32 = workload.expected_exit_code();
                 let reason: String = format!(
                     "exit code mismatch (expected={}, actual={}, program={}, iteration={})",
                     expected, exit_code, program_path, iteration

--- a/src/utils/nanvix-test/src/executor/mod.rs
+++ b/src/utils/nanvix-test/src/executor/mod.rs
@@ -188,14 +188,30 @@ impl<'a> WorkloadSpec<'a> {
     ///
     /// # Description
     ///
-    /// Retrieves the optional expected exit code that the workload must produce.
+    /// Retrieves the expected exit code that the workload must produce.
     ///
     /// # Return Value
     ///
-    /// Returns the expected exit code when specified; otherwise returns `None`.
+    /// Returns the expected exit code when specified; defaults to `0` (success) when not set.
     ///
-    pub const fn expected_exit_code(&self) -> Option<i32> {
-        self.expected_exit_code
+    pub const fn expected_exit_code(&self) -> i32 {
+        match self.expected_exit_code {
+            Some(code) => code,
+            None => 0,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns `true` when the test explicitly declared an expected exit code.
+    ///
+    /// # Return Value
+    ///
+    /// Returns `true` if `expected_exit_code` was set in the test configuration; otherwise `false`.
+    ///
+    pub const fn has_explicit_expected_exit_code(&self) -> bool {
+        self.expected_exit_code.is_some()
     }
 
     ///
@@ -280,21 +296,21 @@ mod tests {
     fn workload_spec_expected_exit_code_some() {
         let spec: WorkloadSpec =
             WorkloadSpec::new("./bin/test.elf", None, None, None, true, Some(0), false);
-        assert_eq!(spec.expected_exit_code(), Some(0));
+        assert_eq!(spec.expected_exit_code(), 0);
     }
 
     #[test]
     fn workload_spec_expected_exit_code_none() {
         let spec: WorkloadSpec =
             WorkloadSpec::new("./bin/test.elf", None, None, None, false, None, false);
-        assert_eq!(spec.expected_exit_code(), None);
+        assert_eq!(spec.expected_exit_code(), 0);
     }
 
     #[test]
     fn workload_spec_expected_exit_code_nonzero() {
         let spec: WorkloadSpec =
             WorkloadSpec::new("./bin/test.elf", None, None, None, true, Some(13), false);
-        assert_eq!(spec.expected_exit_code(), Some(13));
+        assert_eq!(spec.expected_exit_code(), 13);
     }
 
     #[test]
@@ -302,13 +318,27 @@ mod tests {
         let spec: WorkloadSpec =
             WorkloadSpec::new("./bin/test.elf", None, None, None, true, Some(0), true);
         assert!(spec.skip_exit_code_validation());
-        assert_eq!(spec.expected_exit_code(), Some(0));
+        assert_eq!(spec.expected_exit_code(), 0);
     }
 
     #[test]
     fn workload_spec_expected_exit_code_negative() {
         let spec: WorkloadSpec =
             WorkloadSpec::new("./bin/test.elf", None, None, None, false, Some(-1), false);
-        assert_eq!(spec.expected_exit_code(), Some(-1));
+        assert_eq!(spec.expected_exit_code(), -1);
+    }
+
+    #[test]
+    fn workload_spec_has_explicit_expected_exit_code_some() {
+        let spec: WorkloadSpec =
+            WorkloadSpec::new("./bin/test.elf", None, None, None, false, Some(0), false);
+        assert!(spec.has_explicit_expected_exit_code());
+    }
+
+    #[test]
+    fn workload_spec_has_explicit_expected_exit_code_none() {
+        let spec: WorkloadSpec =
+            WorkloadSpec::new("./bin/test.elf", None, None, None, false, None, false);
+        assert!(!spec.has_explicit_expected_exit_code());
     }
 }

--- a/src/utils/nanvix-test/src/executor/terminal.rs
+++ b/src/utils/nanvix-test/src/executor/terminal.rs
@@ -275,13 +275,11 @@ pub async fn test_with_terminal_executor(
             return Err(::anyhow::anyhow!(reason));
         }
 
-        // Validate exit code if expected_exit_code is specified and validation is not skipped.
+        // Validate exit code unless skip_exit_code_validation() is set.
         // FIXME (#1010): Remove skip_exit_code_validation() once graceful hyperlight interrupt
         // is implemented. Currently hyperlight uses SIGKILL which prevents clean exit.
-        if !workload.skip_exit_code_validation()
-            && let Some(expected) = workload.expected_exit_code()
-            && exit_code != expected
-        {
+        if !workload.skip_exit_code_validation() && exit_code != workload.expected_exit_code() {
+            let expected: i32 = workload.expected_exit_code();
             let reason: String = format!(
                 "exit code mismatch (expected={}, actual={}, program={}, iteration={})",
                 expected,
@@ -293,12 +291,14 @@ pub async fn test_with_terminal_executor(
             return Err(::anyhow::anyhow!(reason));
         }
 
-        // When wait_exit_code succeeds on hyperlight, still validate the exit code.
+        // When wait_exit_code succeeds on hyperlight, still validate the exit code
+        // — but only if the test explicitly declared an expected exit code.
         if workload.skip_exit_code_validation()
             && exit_code != DEFAULT_EXIT_CODE_SKIP_VALIDATION
-            && let Some(expected) = workload.expected_exit_code()
-            && exit_code != expected
+            && workload.has_explicit_expected_exit_code()
+            && exit_code != workload.expected_exit_code()
         {
+            let expected: i32 = workload.expected_exit_code();
             let reason: String = format!(
                 "exit code mismatch (expected={}, actual={}, program={}, iteration={})",
                 expected,

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -61,7 +61,6 @@ program = "./bin/vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
 input = "[]"
 expect_empty_output = true
-expected_exit_code = 0
 runs_on = ["microvm"]
 
 [[tests]]
@@ -186,7 +185,6 @@ program = "./bin/vfs-test.elf"
 extra_nanvixd_args = "-ramfs ./bin/vfs-test.img"
 input = "[]"
 expect_empty_output = true
-expected_exit_code = 0
 runs_on = ["microvm"]
 
 [[tests]]


### PR DESCRIPTION
[nanvix-test] E: Simplify Exit Code Validation

Change `WorkloadSpec::expected_exit_code()` return type from
`Option<i32>` to `i32`, defaulting to `0` (success) when no explicit
exit code is specified.

This eliminates redundant `Option` unwrapping at every call site
in both the HTTP and terminal executors. Exit code comparison
in validation branches now uses direct equality checks instead
of let-binding pattern matches on `Option` variants.

Updated unit tests to assert against plain `i32` values.

[nanvix-test] F: Rm Redundant expected_exit_code

Remove explicit `expected_exit_code = 0` entries from two VFS test
workloads in `test-standalone.toml`.

Since the previous commit changed `expected_exit_code()` to default
to `0` when unspecified, these entries are now redundant. Dropping
them keeps the test configuration consistent with the new convention:
only specify `expected_exit_code` when a non-zero exit code is expected.
