### PR TITLE
Enable Hyperlight backend in Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,7 +425,7 @@ jobs:
   # do not support Linux containers, so this job runs on ubuntu-24.04 and uploads
   # the resulting ELF binaries for downstream Windows jobs.
   windows-guest-build:
-    name: "Windows Guest Build (${{ matrix.build-type }})"
+    name: "Windows Guest Build (${{ matrix.machine-type }}, ${{ matrix.build-type }})"
     needs: [precheck]
     timeout-minutes: 60
     runs-on: ubuntu-24.04
@@ -433,6 +433,7 @@ jobs:
       fail-fast: false
       matrix:
         build-type: [debug, release]
+        machine-type: [microvm, hyperlight]
     permissions:
       contents: read
 
@@ -462,29 +463,32 @@ jobs:
           LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
           RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
         run: |
+          WHP_ARG=""
+          if [ "${{ matrix.machine-type }}" = "microvm" ]; then
+            WHP_ARG="WHP=yes"
+          fi
           ./z build --with-minimal-docker -- \
             all-guest-staticlibs all-kernel all-guest-binaries \
-            MACHINE=microvm \
+            MACHINE=${{ matrix.machine-type }} \
             DEPLOYMENT_MODE=standalone \
             TARGET=x86 \
-            WHP=yes \
+            ${WHP_ARG} \
             LOG_LEVEL=${LOG_LEVEL} \
             ${RELEASE_FLAG}
 
       - name: "Upload Guest Artifacts"
         uses: actions/upload-artifact@v7
         with:
-          name: windows-guest-build-${{ matrix.build-type }}
+          name: windows-guest-build-${{ matrix.machine-type }}-${{ matrix.build-type }}
           retention-days: 1
           path: |
             bin/*.elf
             bin/*.img
             lib/*.so
 
-  # Run format and lint checks natively on Windows for host crates. These do
-  # not require Docker and run in parallel with the guest-build job.
-  windows-checks:
-    name: "Windows Source Checks"
+  # Format check is machine-type independent, so it runs once.
+  windows-format-check:
+    name: "Windows Format Check"
     needs: [precheck]
     timeout-minutes: 30
     runs-on: windows-latest
@@ -514,32 +518,73 @@ jobs:
           $toolchain = (Get-Content rust-toolchain | Select-String '^channel\s*=').ToString() -replace '.*=\s*"([^"]+)".*','$1'
           rustup toolchain install $toolchain
           rustup show
-          rustup component add --toolchain $toolchain clippy rustfmt
+          rustup component add --toolchain $toolchain rustfmt
 
       - name: "Check Code Format"
         shell: pwsh
         run: |
           .\z.ps1 build -- format-check
 
+  # Lint check varies by machine-type (different Cargo features), so it runs per backend.
+  windows-lint-check:
+    name: "Windows Lint Check (${{ matrix.machine-type }})"
+    needs: [precheck]
+    timeout-minutes: 30
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        machine-type: [microvm, hyperlight]
+
+    if: |
+      github.repository == 'nanvix/nanvix' && (
+        github.event_name == 'merge_group' || (
+          needs.precheck.outputs.up_to_date == 'true' && (
+            github.event_name != 'push' ||
+            github.event.head_commit == null ||
+            !startsWith(github.event.head_commit.message, 'Merge ')
+          ) && (
+            github.event_name != 'pull_request' ||
+            !github.event.pull_request.draft
+          )
+        )
+      )
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Install Rust Toolchain"
+        shell: pwsh
+        run: |
+          $toolchain = (Get-Content rust-toolchain | Select-String '^channel\s*=').ToString() -replace '.*=\s*"([^"]+)".*','$1'
+          rustup toolchain install $toolchain
+          rustup show
+          rustup component add --toolchain $toolchain clippy
+
       - name: "Lint"
         shell: pwsh
         run: |
-          .\z.ps1 build -- lint-check
+          .\z.ps1 build -- lint-check MACHINE=${{ matrix.machine-type }}
 
   # Build host binaries (nanvixd, UserVM, nanvix-test) natively on Windows and
   # run unit tests. Guest artifacts from the Linux job are downloaded and
   # bundled with the standalone rootfs for the integration test stage.
   windows-ci-build:
-    name: "Windows Build (${{ matrix.build-type }})"
-    needs: [windows-checks, windows-guest-build]
+    name: "Windows Build (${{ matrix.machine-type }}, ${{ matrix.build-type }})"
+    needs: [windows-format-check, windows-lint-check, windows-guest-build]
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         build-type: [debug, release]
+        machine-type: [microvm, hyperlight]
     runs-on: windows-latest
     permissions:
       contents: read
+    env:
+      MACHINE_TYPE: ${{ matrix.machine-type }}
 
     steps:
       - uses: actions/checkout@v6
@@ -555,7 +600,7 @@ jobs:
       - name: "Download Guest Artifacts"
         uses: actions/download-artifact@v8
         with:
-          name: windows-guest-build-${{ matrix.build-type }}
+          name: windows-guest-build-${{ matrix.machine-type }}-${{ matrix.build-type }}
           path: .
 
       - name: "Build UserVM"
@@ -564,7 +609,7 @@ jobs:
           LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
           RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
         run: |
-          .\z.ps1 build -- uservm $env:RELEASE_FLAG LOG_LEVEL=$env:LOG_LEVEL
+          .\z.ps1 build -- uservm $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL
 
       - name: "Build Nanvixd"
         shell: pwsh
@@ -572,7 +617,7 @@ jobs:
           LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
           RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
         run: |
-          .\z.ps1 build -- nanvixd $env:RELEASE_FLAG LOG_LEVEL=$env:LOG_LEVEL
+          .\z.ps1 build -- nanvixd $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL
 
       - name: "Build Nanvix Test Runner"
         shell: pwsh
@@ -580,17 +625,17 @@ jobs:
           LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
           RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
         run: |
-          .\z.ps1 build -- nanvix-test $env:RELEASE_FLAG LOG_LEVEL=$env:LOG_LEVEL
+          .\z.ps1 build -- nanvix-test $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL
 
       - name: "Unit Tests"
         shell: pwsh
         run: |
-          .\z.ps1 build -- run-unit-tests
+          .\z.ps1 build -- run-unit-tests MACHINE=$env:MACHINE_TYPE
 
       - name: "Upload Build Artifacts"
         uses: actions/upload-artifact@v7
         with:
-          name: windows-build-${{ matrix.build-type }}
+          name: windows-build-${{ matrix.machine-type }}-${{ matrix.build-type }}
           retention-days: 1
           path: |
             bin/*.exe
@@ -604,7 +649,7 @@ jobs:
   # due to slow nested virtualization. continue-on-error prevents flaky
   # failures from blocking the pipeline.
   windows-integration-test:
-    name: "Windows Integration Test (${{ matrix.build-type }})"
+    name: "Windows Integration Test (${{ matrix.machine-type }}, ${{ matrix.build-type }})"
     needs: [windows-ci-build]
     timeout-minutes: 30
     continue-on-error: true
@@ -612,6 +657,7 @@ jobs:
       fail-fast: false
       matrix:
         build-type: [debug, release]
+        machine-type: [microvm, hyperlight]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -622,7 +668,7 @@ jobs:
       - name: "Download Build Artifacts"
         uses: actions/download-artifact@v8
         with:
-          name: windows-build-${{ matrix.build-type }}
+          name: windows-build-${{ matrix.machine-type }}-${{ matrix.build-type }}
           path: bin
 
       - name: "Exclude bin/ from Windows Defender"
@@ -692,7 +738,7 @@ jobs:
         if: failure() || cancelled()
         uses: actions/upload-artifact@v7
         with:
-          name: nanvix-windows-integration-logs-${{ github.event.pull_request.number || github.run_number }}-${{ matrix.build-type }}
+          name: nanvix-windows-integration-logs-${{ github.event.pull_request.number || github.run_number }}-${{ matrix.machine-type }}-${{ matrix.build-type }}
           overwrite: "true"
           path: |
             logs/

--- a/src/uservm/src/orchestrator.rs
+++ b/src/uservm/src/orchestrator.rs
@@ -513,9 +513,18 @@ impl Orchestrator {
                         // before sending SIGKILL. See issue #1010 for context.
                         debug!("try_receive_from_io_thread(): waiting {:?} before killing vcpu thread", crate::vmm::SHUTDOWN_GRACE_PERIOD);
                         ::std::thread::sleep(crate::vmm::SHUTDOWN_GRACE_PERIOD);
-                        debug!("try_receive_from_io_thread(): killing vcpu thread id: {}", self.vcpu_tid);
-                        let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
-                        unsafe { ::libc::pthread_kill(pthread_id, KILL_SIGNAL) };
+                        #[cfg(target_os = "linux")]
+                        {
+                            debug!("try_receive_from_io_thread(): killing vcpu thread id: {}", self.vcpu_tid);
+                            let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
+                            unsafe { ::libc::pthread_kill(pthread_id, KILL_SIGNAL) };
+                        }
+                        #[cfg(target_os = "windows")]
+                        {
+                            // Forceful termination is not yet implemented; cooperative shutdown
+                            // via guest abort_with_code() is relied upon instead. See issue #1010.
+                            debug!("try_receive_from_io_thread(): cooperative shutdown for vcpu thread id: {} (issue #1010)", self.vcpu_tid);
+                        }
                         self.state = State::ShuttingDown;
                         Ok(Continue(()))
                     } else {

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -31,17 +31,22 @@ use ::hyperlight_host::{
         },
     },
 };
+#[cfg(target_os = "windows")]
+use ::log::warn;
 use ::log::{
     debug,
     error,
 };
+#[cfg(target_os = "linux")]
 use ::std::{
     fs::File,
-    io::Write,
     os::{
         raw::c_int,
         unix::io::AsRawFd,
     },
+};
+use ::std::{
+    io::Write,
     path::Path,
     sync::Arc,
     time::Duration,
@@ -61,9 +66,11 @@ use ::tokio::{
 //==================================================================================================
 
 /// Signal used to interrupt the vCPU thread.
+#[cfg(target_os = "linux")]
 pub const INTERRUPT_SIGNAL: c_int = libc::SIGUSR1;
 
 /// Signal used to kill the vCPU thread.
+#[cfg(target_os = "linux")]
 pub const KILL_SIGNAL: c_int = libc::SIGKILL;
 
 /// Grace period before sending SIGKILL to the vCPU thread during shutdown.
@@ -98,10 +105,12 @@ pub type StderrFn = dyn Write + Send;
 //==================================================================================================
 
 /// RAII guard that redirects process stderr to a file and restores the original fd on drop.
+#[cfg(target_os = "linux")]
 struct StderrRedirect {
     saved_fd: c_int,
 }
 
+#[cfg(target_os = "linux")]
 impl StderrRedirect {
     /// Redirects process stderr to `path`, returning a guard that restores it on drop.
     fn new(path: &str) -> Result<Self> {
@@ -136,6 +145,7 @@ impl StderrRedirect {
     }
 }
 
+#[cfg(target_os = "linux")]
 impl Drop for StderrRedirect {
     fn drop(&mut self) {
         // SAFETY: saved_fd was obtained from dup() in new() and has not been closed.
@@ -143,6 +153,24 @@ impl Drop for StderrRedirect {
             libc::dup2(self.saved_fd, libc::STDERR_FILENO);
             libc::close(self.saved_fd);
         }
+    }
+}
+
+/// No-op stderr redirect on Windows — hyperlight DebugPrint output goes to default stderr.
+#[cfg(target_os = "windows")]
+struct StderrRedirect;
+
+#[cfg(target_os = "windows")]
+impl StderrRedirect {
+    fn new(path: &str) -> Result<Self> {
+        if !path.is_empty() {
+            warn!(
+                "stderr redirection to '{}' is not supported on Windows; output goes to default \
+                 stderr",
+                path
+            );
+        }
+        Ok(Self)
     }
 }
 
@@ -390,8 +418,12 @@ impl Vmm {
 
     pub fn spawn(mut self) -> tokio::task::JoinHandle<Result<u16>> {
         task::spawn_blocking(move || {
-            let pthread_id: libc::pthread_t = unsafe { libc::pthread_self() };
-            Handle::current().block_on(self.send_tid(pthread_id))?;
+            #[cfg(target_os = "linux")]
+            let thread_id: u64 = unsafe { libc::pthread_self() } as u64;
+            #[cfg(target_os = "windows")]
+            let thread_id: u64 =
+                unsafe { windows::Win32::System::Threading::GetCurrentThreadId() as u64 };
+            Handle::current().block_on(self.send_tid(thread_id))?;
             self.run()
         })
     }
@@ -462,7 +494,7 @@ impl Vmm {
                     Ok(code as u16)
                 },
                 None => {
-                    error!("run(): vmm aborted (error={error:?})");
+                    error!("run(): vmm aborted (debug={error:?}, display={error})");
                     Ok(ErrorCode::ConnectionReset.into())
                 },
             },
@@ -484,7 +516,14 @@ impl Vmm {
         // For Initialize path, parse the Debug representation.
         // Format: ...GuestAborted { code: N, message: "..." }...
         let debug_str = format!("{error:?}");
-        Self::parse_guest_aborted_from_debug(&debug_str)
+        if let Some(result) = Self::parse_guest_aborted_from_debug(&debug_str) {
+            return Some(result);
+        }
+
+        // Fallback: parse the Display representation.
+        // Format: ...Guest aborted: error code N, message: ...
+        let display_str = format!("{error}");
+        Self::parse_guest_aborted_from_display(&display_str)
     }
 
     /// Parses a `GuestAborted { code: N, message: "..." }` fragment from a `Debug` string.
@@ -511,6 +550,22 @@ impl Vmm {
         Some((code, message))
     }
 
+    /// Parses a `Guest aborted: error code N, message: M` fragment from a `Display` string.
+    fn parse_guest_aborted_from_display(display_str: &str) -> Option<(u8, String)> {
+        const PREFIX: &str = "Guest aborted: error code ";
+
+        let rest = &display_str[display_str.find(PREFIX)? + PREFIX.len()..];
+        let code_end = rest.find(',')?;
+        let code = rest[..code_end].trim().parse::<u8>().ok()?;
+
+        let message = rest
+            .find("message: ")
+            .map(|pos| rest[pos + "message: ".len()..].trim().to_string())
+            .unwrap_or_default();
+
+        Some((code, message))
+    }
+
     ///
     /// # Description
     ///
@@ -524,7 +579,7 @@ impl Vmm {
     ///
     /// Upon success, returns empty. Otherwise, returns an error.
     ///
-    async fn send_tid(&self, tid: libc::pthread_t) -> Result<()> {
+    async fn send_tid(&self, tid: u64) -> Result<()> {
         Ok(self
             .inner
             .lock()
@@ -639,6 +694,41 @@ mod tests {
     fn parse_guest_aborted_invalid_code() {
         let input = r#"GuestAborted { code: 999, message: "overflow" }"#;
         let result = Vmm::parse_guest_aborted_from_debug(input);
+        assert_eq!(result, None); // 999 doesn't fit u8
+    }
+
+    #[test]
+    fn parse_guest_aborted_from_display_typical() {
+        let input = "Guest aborted: error code 13, message: kernel exited";
+        let result = Vmm::parse_guest_aborted_from_display(input);
+        assert_eq!(result, Some((13, "kernel exited".to_string())));
+    }
+
+    #[test]
+    fn parse_guest_aborted_from_display_empty_message() {
+        let input = "Guest aborted: error code 1, message: ";
+        let result = Vmm::parse_guest_aborted_from_display(input);
+        assert_eq!(result, Some((1, String::new())));
+    }
+
+    #[test]
+    fn parse_guest_aborted_from_display_nested() {
+        let input = "initialize sandbox: Guest aborted: error code 42, message: test panic";
+        let result = Vmm::parse_guest_aborted_from_display(input);
+        assert_eq!(result, Some((42, "test panic".to_string())));
+    }
+
+    #[test]
+    fn parse_guest_aborted_from_display_missing() {
+        let input = "some unrelated error occurred";
+        let result = Vmm::parse_guest_aborted_from_display(input);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn parse_guest_aborted_from_display_invalid_code() {
+        let input = "Guest aborted: error code 999, message: overflow";
+        let result = Vmm::parse_guest_aborted_from_display(input);
         assert_eq!(result, None); // 999 doesn't fit u8
     }
 }

--- a/test/test-standalone-windows.toml
+++ b/test/test-standalone-windows.toml
@@ -57,6 +57,7 @@ extra_nanvixd_args = "-ramfs README.md"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
+runs_on = ["microvm"]
 
 [[tests]]
 executor = "terminal"
@@ -139,9 +140,11 @@ executor = "terminal"
 program = "./bin/dlfcn-c.elf"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
 expected_output = "ok"
+runs_on = ["microvm"]
 
 [[tests]]
 executor = "terminal"
 program = "./bin/dlfcn-pie-c.elf"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
 expected_output = "ok"
+runs_on = ["microvm"]

--- a/z.ps1
+++ b/z.ps1
@@ -7,8 +7,8 @@
 
 .DESCRIPTION
     Windows counterpart of the './z' bash script. Mirrors the same CLI interface.
-    Builds the UserVM natively on Windows with the microvm backend, and builds guest
-    components (kernel, hello-rust-nostd) via Docker.
+    Builds the UserVM natively on Windows with the microvm or hyperlight backend,
+    and builds guest components (kernel, hello-rust-nostd) via Docker.
 
 .EXAMPLE
     .\z.ps1 help
@@ -81,7 +81,7 @@ Options
 
 Build Targets (after --)
   all                     Build everything (guest + host).
-  uservm                  Build UserVM only (native Windows, microvm backend).
+  uservm                  Build UserVM only (native Windows).
   mkramfs                 Build mkramfs only (native Windows).
   guest                   Build guest components only (kernel + hello-rust-nostd).
   format-check            Check code formatting (native for host crates).
@@ -102,7 +102,7 @@ Run Options (after --)
 
 Build Parameters (after --)
   RELEASE=yes             Enable release mode.
-  MACHINE=microvm         Target machine (default: microvm).
+  MACHINE=microvm         Target machine: microvm (default) or hyperlight.
   WHP=yes                 Enable WHP-specific guest kernel code for microvm builds.
   LOG_LEVEL=<level>       Log level (default: trace for debug, warn for release).
 
@@ -408,22 +408,38 @@ function Add-GuestMachineDefaults {
 # Build Functions
 # ==================================================================================================
 
+function Get-NativeCargoFeatures {
+    param([string]$Machine = "microvm")
+    $normalized = $Machine.Trim().ToLowerInvariant()
+    if ($normalized -eq "hyperlight") {
+        return "hyperlight"
+    }
+    elseif ($normalized -eq "microvm") {
+        return "microvm,whp"
+    }
+    else {
+        Write-Err "Unsupported machine type '$Machine'. Supported values are: microvm, hyperlight."
+        exit 1
+    }
+}
+
 function Build-UserVm {
-    param([bool]$IsRelease)
+    param([bool]$IsRelease, [string]$Machine = "microvm")
 
     # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
     $ErrorActionPreference = 'Continue'
 
     $mode = if ($IsRelease) { "release" } else { "debug" }
     $buildProfile = if ($IsRelease) { "--release" } else { "" }
+    $features = Get-NativeCargoFeatures -Machine $Machine
 
-    Write-Info "Building UserVM (microvm backend, $mode mode)..."
+    Write-Info "Building UserVM ($Machine backend, $mode mode)..."
 
     if (-not (Test-Path $BinDir)) {
         New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
     }
 
-    $cmd = "cargo build --no-default-features --features `"microvm,whp`" -p uservm $buildProfile"
+    $cmd = "cargo build --no-default-features --features `"$features`" -p uservm $buildProfile"
     Write-Host "  $cmd" -ForegroundColor DarkGray
     Invoke-Expression $cmd
     if ($LASTEXITCODE -ne 0) {
@@ -545,21 +561,22 @@ function New-StandaloneRootfsImage {
 }
 
 function Build-Nanvixd {
-    param([bool]$IsRelease)
+    param([bool]$IsRelease, [string]$Machine = "microvm")
 
     # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
     $ErrorActionPreference = 'Continue'
 
     $mode = if ($IsRelease) { "release" } else { "debug" }
     $buildProfile = if ($IsRelease) { "--release" } else { "" }
+    $features = Get-NativeCargoFeatures -Machine $Machine
 
-    Write-Info "Building nanvixd (standalone + microvm, $mode mode)..."
+    Write-Info "Building nanvixd (standalone + $Machine, $mode mode)..."
 
     if (-not (Test-Path $BinDir)) {
         New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
     }
 
-    $cmd = "cargo build --no-default-features --features `"standalone,microvm,whp`" -p nanvixd $buildProfile"
+    $cmd = "cargo build --no-default-features --features `"standalone,$features`" -p nanvixd $buildProfile"
     Write-Host "  $cmd" -ForegroundColor DarkGray
     Invoke-Expression $cmd
     if ($LASTEXITCODE -ne 0) {
@@ -580,23 +597,24 @@ function Build-Nanvixd {
 }
 
 function Build-NanvixTest {
-    param([bool]$IsRelease)
+    param([bool]$IsRelease, [string]$Machine = "microvm")
 
     # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
     $ErrorActionPreference = 'Continue'
 
     $mode = if ($IsRelease) { "release" } else { "debug" }
     $buildProfile = if ($IsRelease) { "--release" } else { "" }
+    $features = Get-NativeCargoFeatures -Machine $Machine
 
     New-StandaloneRootfsImage -IsRelease $IsRelease
 
-    Write-Info "Building nanvix-test (standalone + microvm, $mode mode)..."
+    Write-Info "Building nanvix-test (standalone + $Machine, $mode mode)..."
 
     if (-not (Test-Path $BinDir)) {
         New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
     }
 
-    $cmd = "cargo build --no-default-features --features `"standalone,microvm,whp`" -p nanvix-test $buildProfile"
+    $cmd = "cargo build --no-default-features --features `"standalone,$features`" -p nanvix-test $buildProfile"
     Write-Host "  $cmd" -ForegroundColor DarkGray
     Invoke-Expression $cmd
     if ($LASTEXITCODE -ne 0) {
@@ -856,16 +874,20 @@ function Main {
                 }
             }
 
+            # Extract MACHINE parameter for native builds.
+            $machineParam = $makeParams | Where-Object { $_ -match '^MACHINE=' } | Select-Object -Last 1
+            $machine = if ($machineParam) { $machineParam -replace '^MACHINE=', '' } else { 'microvm' }
+
             foreach ($target in $targets) {
                 switch ($target) {
                     "all" {
                         Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams
-                        Build-UserVm -IsRelease $isRelease
-                        Build-Nanvixd -IsRelease $isRelease
-                        Build-NanvixTest -IsRelease $isRelease
+                        Build-UserVm -IsRelease $isRelease -Machine $machine
+                        Build-Nanvixd -IsRelease $isRelease -Machine $machine
+                        Build-NanvixTest -IsRelease $isRelease -Machine $machine
                     }
                     "uservm" {
-                        Build-UserVm -IsRelease $isRelease
+                        Build-UserVm -IsRelease $isRelease -Machine $machine
                     }
                     "mkramfs" {
                         Build-Mkramfs -IsRelease $isRelease
@@ -874,10 +896,10 @@ function Main {
                         New-StandaloneRootfsImage -IsRelease $isRelease
                     }
                     "nanvixd" {
-                        Build-Nanvixd -IsRelease $isRelease
+                        Build-Nanvixd -IsRelease $isRelease -Machine $machine
                     }
                     "nanvix-test" {
-                        Build-NanvixTest -IsRelease $isRelease
+                        Build-NanvixTest -IsRelease $isRelease -Machine $machine
                     }
                     "guest" {
                         Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams
@@ -895,9 +917,10 @@ function Main {
                     }
                     "lint-check" {
                         # Native lint check for host crates that compile on Windows.
-                        Write-Info "Linting host crates (native)..."
+                        $features = Get-NativeCargoFeatures -Machine $machine
+                        Write-Info "Linting host crates (native, $machine backend)..."
                         $ErrorActionPreference = 'Continue'
-                        cargo clippy --no-default-features --features "microvm,whp" -p uservm -- -D warnings
+                        cargo clippy --no-default-features --features "$features" -p uservm -- -D warnings
                         if ($LASTEXITCODE -ne 0) {
                             Write-Err "Lint check failed for uservm."
                             exit 1
@@ -911,9 +934,10 @@ function Main {
                     }
                     "run-unit-tests" {
                         # Native unit tests for host crates (no Docker required).
-                        Write-Info "Running unit tests (native)..."
+                        $features = Get-NativeCargoFeatures -Machine $machine
+                        Write-Info "Running unit tests (native, $machine backend)..."
                         $ErrorActionPreference = 'Continue'
-                        cargo test --no-default-features --features "microvm,whp" -p uservm
+                        cargo test --no-default-features --features "$features" -p uservm
                         if ($LASTEXITCODE -ne 0) {
                             Write-Err "Unit tests failed for uservm."
                             exit 1


### PR DESCRIPTION
## Summary
- Add Hyperlight as a second machine backend (alongside microvm/WHP) to the Windows CI pipeline
- `z.ps1`: New `Get-NativeCargoFeatures` helper and `-Machine` parameter threaded through `Build-UserVm`, `Build-Nanvixd`, `Build-NanvixTest`, `lint-check`, and `run-unit-tests` — selects `--features "hyperlight"` vs `--features "microvm,whp"` based on `MACHINE=`
- `ci-windows.yml`: Added `machine-type: [microvm, hyperlight]` matrix dimension to all jobs (guest-build, checks, ci-build, smoke-test) with machine-type-qualified artifact names