### PR TITLE
[ci] Restrict image sizes to 128 MB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,17 +241,7 @@ jobs:
         build-type: [debug, release]
         machine-type: [microvm, hyperlight]
         deployment-type: [standalone, single-process, multi-process]
-        # Build all memory sizes only on dev pushes (for release archives);
-        # PRs and merge-queue runs build 128 MB only to reduce CI load.
-        memory-size: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/dev') && fromJSON('[128, 256, 512, 1024]') || fromJSON('[128]') }}
-        exclude:
-          # Debug builds only run at the default memory size (128 MB).
-          - build-type: debug
-            memory-size: 256
-          - build-type: debug
-            memory-size: 512
-          - build-type: debug
-            memory-size: 1024
+        memory-size: [128]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -874,7 +864,7 @@ jobs:
   # Stage 4: Post Actions (Conditional)
   # ==========================================================================================
 
-  # Create release archives for all applicable configurations and memory sizes.
+  # Create release archives for all applicable configurations.
   release-archive:
     name: "Release Archive (${{ matrix.machine-type }}, ${{ matrix.deployment-type }}, ${{ matrix.memory-size }}mb)"
     needs: [ci-test, ci-l2, benchmark-finalize, benchmark-ci-finalize]
@@ -891,7 +881,7 @@ jobs:
       matrix:
         machine-type: [microvm, hyperlight]
         deployment-type: [standalone, single-process, multi-process]
-        memory-size: [128, 256, 512, 1024]
+        memory-size: [128]
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Restrict CI build and release-archive matrices to only produce the 128 MB memory-size variant, dropping the 256, 512, and 1024 MB sizes.

## Changes

- **`ci-build` matrix**: Replaced the conditional `fromJSON` expression (which expanded to all four sizes on dev pushes) with a static `[128]`. Removed the three debug-build exclude entries for 256/512/1024 that are no longer needed.
- **`release-archive` matrix**: Narrowed `memory-size` from `[128, 256, 512, 1024]` to `[128]`.

## Notes

- The `publish-release` action discovers release artifacts via a glob pattern (`release-*`), so it adapts automatically — no action-level changes are needed.
- The `release-package` action receives `memory-size` as a matrix input, so it also adapts automatically.