### PR TITLE
[syscall] Fix readlink buffer bugs

### DIFF
--- a/src/libs/syscall/src/safe/fs/mod.rs
+++ b/src/libs/syscall/src/safe/fs/mod.rs
@@ -40,6 +40,7 @@ use crate::{
 };
 use ::alloc::{
     string::String,
+    vec,
     vec::Vec,
 };
 use ::sys::error::{
@@ -357,7 +358,7 @@ pub fn open(
 /// an error.
 ///
 pub fn readlink(path: &FileSystemPath) -> Result<FileSystemPath, Error> {
-    let mut buf: Vec<u8> = Vec::with_capacity(PATH_MAX);
+    let mut buf: Vec<u8> = vec![0u8; PATH_MAX];
 
     let num_bytes_read: c_ssize_t = unistd::readlink(path.as_str(), &mut buf)?;
 
@@ -366,7 +367,17 @@ pub fn readlink(path: &FileSystemPath) -> Result<FileSystemPath, Error> {
         Err(_) => return Err(Error::new(ErrorCode::TooBig, "path too long")),
     };
 
-    FileSystemPath::try_from_bytes(&buf[..num_bytes_read])
+    // readlink() indicates truncation by returning a byte count equal to the buffer length.
+    if num_bytes_read == buf.len() {
+        return Err(Error::new(ErrorCode::TooBig, "readlink: path too long (truncated)"));
+    }
+
+    // readlink() does not NUL-terminate, so convert from raw UTF-8 bytes.
+    let target: &str = core::str::from_utf8(&buf[..num_bytes_read]).map_err(|_| {
+        Error::new(ErrorCode::InvalidArgument, "readlink: invalid UTF-8 in target path")
+    })?;
+
+    FileSystemPath::new(target)
 }
 
 ///


### PR DESCRIPTION
## Summary

`safe::fs::readlink()` had two bugs that caused IPC corruption in nanvixd, making subsequent VM tests hang (5-minute timeout).

## Bug 1: Zero-length buffer

`Vec::with_capacity(PATH_MAX)` creates a buffer with **length 0** but capacity 1024. When passed as `&mut [u8]`, the slice has length 0, causing `bufsiz=0` in the IPC request to linuxd. The daemon ignores bufsiz, returns the full readlink result, and the guest receives data it has no space for — corrupting IPC state.


## Bug 2: Missing NUL-terminator handling

`FileSystemPath::try_from_bytes()` calls `CString::from_vec_with_nul()`, which expects a trailing NUL byte. POSIX `readlink()` **never** NUL-terminates its output, so this always fails.

**Fix:** Convert via `core::str::from_utf8()` + `FileSystemPath::new()`.

## Testing

- Built and ran full integration test suite (`make test MACHINE=microvm DEPLOYMENT_TYPE=multi-process`) — all tests pass.
- Previously verified the fix resolves the `thread-rust.elf` 300s timeout that occurred when running after `file-rust.elf` (which exercises readlink via the symlink test).