### PR TITLE
[build] Add native check target to z.ps1

### DIFF
--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -195,8 +195,8 @@ machine and deployment configurations.
 ### Visual Studio Code
 
 Use the host-specific settings template. The Linux template invokes `./z`, while the Windows
-template routes Rust Analyzer build-script discovery through the Windows Docker workflow so that
-guest crates build correctly.
+template routes Rust Analyzer through `./z.bat build -- check`, which runs native `cargo check`
+on host crates (`uservm`, `nanvixd`, `nanvix-test`, `mkramfs`) without Docker.
 
 **Linux:**
 
@@ -212,8 +212,9 @@ New-Item -ItemType Directory -Path .vscode -Force
 Copy-Item scripts\setup\vscode\settings-windows.json .vscode\settings.json
 ```
 
-> **Note:** Without the Windows override, Rust Analyzer falls back to native `cargo` for
-> build-script metadata and guest crates fail because `gcc`/`ar` are not on the host `PATH`.
+> **Note:** The `check` target in `z.ps1` only checks host crates natively. Guest and kernel
+> crates require the Docker-based cross-toolchain and are not checked by Rust Analyzer. Run
+> `.\z.ps1 build -- check-kernel check-guest-binaries` via Docker for a full cross-target check.
 
 ## Troubleshooting Build Issues
 

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -81,7 +81,8 @@ Available build parameters:
 |-------------------|--------------|----------------------------------------------------|
 | `DEPLOYMENT_MODE` | `standalone` | `standalone`                                       |
 | `LOG_LEVEL`       | `warn`       | `trace`, `debug`, `info`, `warn`, `error`, `panic` |
-| `MACHINE`         | `microvm`    | `microvm`                                          |
+| `MACHINE`         | `microvm`    | `microvm`, `hyperlight`                            |
+| `MESSAGE_FORMAT`  | (none)       | `json`, `json-diagnostic-rendered-ansi`             |
 | `RELEASE`         | `no`         | `yes`, `no`                                        |
 | `TARGET`          | `x86`        | `x86`                                              |
 | `TIMEOUT`         | `600`        | Execution timeout in seconds                       |
@@ -89,6 +90,9 @@ Available build parameters:
 ## Code Quality Checks
 
 ```powershell
+# Run cargo check on host crates (native, no Docker).
+.\z.ps1 build -- check
+
 # Check formatting.
 .\z.ps1 build -- format-check
 

--- a/scripts/setup/vscode/settings-windows.json
+++ b/scripts/setup/vscode/settings-windows.json
@@ -3,12 +3,21 @@
 // How to use:
 // 1. Create a folder named '.vscode' in the root of your Nanvix workspace.
 // 2. Copy this file into the '.vscode' folder as 'settings.json'.
-// 3. Ensure Docker Desktop is running before relying on Rust Analyzer diagnostics for guest crates.
+// 3. For fast host-only Rust checks (uservm, nanvixd, nanvix-test, mkramfs), run:
+//      z.ps1 build -- check
+//    This matches the Rust Analyzer configuration below and runs natively without Docker.
+// 4. To check guest/kernel crates inside Docker, use the dedicated targets, for example:
+//      z.ps1 build -- check-kernel
+//      z.ps1 build -- check-guest-binaries
 //
 // Notes:
-// - Rust Analyzer must route both check-on-save and build-script discovery through './z.bat'.
-//   A native 'cargo check' on Windows cannot build guest crates because the required guest GCC/binutils
-//   live inside Docker rather than on the host PATH.
+// - Rust Analyzer routes check-on-save and build-script discovery through './z.bat build -- check'.
+//   The 'check' target is intentionally host-only and runs natively on crates such as uservm,
+//   nanvixd, nanvix-test, and mkramfs without Docker, avoiding the infinite rebuild loop that
+//   occurred when 'check' was forwarded to Docker (symlink mutations + file output triggered
+//   rust-analyzer to re-check endlessly).
+//   Guest and kernel crates are checked via Docker-only targets like 'check-kernel' and
+//   'check-guest-binaries'; invoke them manually with 'z.ps1 build -- <target>' when needed.
 // - 'C_Cpp.default.compilerPath' is intentionally omitted here because the guest cross-toolchain is not
 //   installed natively on Windows by default.
 {
@@ -26,6 +35,9 @@
         "**/__pycache__/**": true,
         "**/.git/**": true,
         "**/.hg/**": true,
+        "bin/**": true,
+        "images/**": true,
+        "lib/**": true,
         "sysroot-*/**": true,
         "target/**": true
     },
@@ -52,13 +64,15 @@
         "./z.bat",
         "build",
         "--",
-        "check"
+        "check",
+        "MESSAGE_FORMAT=json"
     ],
     "rust-analyzer.check.overrideCommand": [
         "./z.bat",
         "build",
         "--",
-        "check"
+        "check",
+        "MESSAGE_FORMAT=json"
     ],
     "rust-analyzer.cargo.features": [
         "standalone"

--- a/z.ps1
+++ b/z.ps1
@@ -91,7 +91,8 @@ Build Targets (after --)
   lint                    Fix linting issues (via Docker).
   spellcheck              Check spelling (via Docker).
   spellcheck-fix          Fix spelling errors (via Docker).
-  check                   Run cargo check (via Docker).
+  check                   Run cargo check on host crates (native, no Docker).
+  check-uservm            Run cargo check on uservm only (native, no Docker).
   run-nanvix-tests        Run system integration tests (via Docker).
   test                    Run all tests (via Docker).
   verify                  Run Verus formal verification (via Docker).
@@ -943,6 +944,36 @@ function Main {
                             exit 1
                         }
                         Write-Success "Unit tests passed."
+                    }
+                    "check-uservm" {
+                        # Native cargo check for uservm only (no Docker required).
+                        $features = Get-NativeCargoFeatures -Machine $machine
+                        Write-Info "Checking uservm (native, $machine backend)..."
+                        $ErrorActionPreference = 'Continue'
+
+                        $fmtParam = $makeParams | Where-Object { $_ -match '^MESSAGE_FORMAT=' } | Select-Object -Last 1
+                        $msgFmt = @()
+                        if ($fmtParam) {
+                            $fmt = ($fmtParam -replace '^MESSAGE_FORMAT=', '').Trim()
+                            $allowedFormats = @('json', 'json-diagnostic-rendered-ansi')
+                            if ([string]::IsNullOrWhiteSpace($fmt)) {
+                                Write-Err "Invalid MESSAGE_FORMAT: value is empty. Allowed values: $($allowedFormats -join ', ')."
+                                exit 1
+                            }
+                            if ($allowedFormats -notcontains $fmt) {
+                                Write-Err "Invalid MESSAGE_FORMAT: '$fmt'. Allowed values: $($allowedFormats -join ', ')."
+                                exit 1
+                            }
+                            $msgFmt = @("--message-format=$fmt")
+                        }
+
+                        cargo check --no-default-features --features "$features" -p uservm @msgFmt
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Err "Check failed for uservm."
+                            exit 1
+                        }
+
+                        Write-Success "Check passed (uservm)."
                     }
                     "check" {
                         # Native cargo check for host crates (no Docker required).

--- a/z.ps1
+++ b/z.ps1
@@ -944,6 +944,55 @@ function Main {
                         }
                         Write-Success "Unit tests passed."
                     }
+                    "check" {
+                        # Native cargo check for host crates (no Docker required).
+                        # This avoids the infinite rebuild loop caused by Docker's
+                        # symlink manipulation and file output when used with
+                        # rust-analyzer. Pass MESSAGE_FORMAT=json for RA integration.
+                        $features = Get-NativeCargoFeatures -Machine $machine
+                        Write-Info "Checking host crates (native, $machine backend)..."
+                        $ErrorActionPreference = 'Continue'
+
+                        # Detect MESSAGE_FORMAT parameter (used by rust-analyzer).
+                        $fmtParam = $makeParams | Where-Object { $_ -match '^MESSAGE_FORMAT=' } | Select-Object -Last 1
+                        $msgFmt = @()
+                        if ($fmtParam) {
+                            $fmt = ($fmtParam -replace '^MESSAGE_FORMAT=', '').Trim()
+                            $allowedFormats = @('json', 'json-diagnostic-rendered-ansi')
+                            if ([string]::IsNullOrWhiteSpace($fmt)) {
+                                Write-Err "Invalid MESSAGE_FORMAT: value is empty. Allowed values: $($allowedFormats -join ', ')."
+                                exit 1
+                            }
+                            if ($allowedFormats -notcontains $fmt) {
+                                Write-Err "Invalid MESSAGE_FORMAT: '$fmt'. Allowed values: $($allowedFormats -join ', ')."
+                                exit 1
+                            }
+                            $msgFmt = @("--message-format=$fmt")
+                        }
+
+                        # Check uservm (machine features, no standalone).
+                        cargo check --no-default-features --features "$features" -p uservm @msgFmt
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Err "Check failed for uservm."
+                            exit 1
+                        }
+
+                        # Check mkramfs (no features).
+                        cargo check -p mkramfs @msgFmt
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Err "Check failed for mkramfs."
+                            exit 1
+                        }
+
+                        # Check nanvixd and nanvix-test (standalone + machine features).
+                        cargo check --no-default-features --features "standalone,$features" -p nanvixd -p nanvix-test @msgFmt
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Err "Check failed for nanvixd/nanvix-test."
+                            exit 1
+                        }
+
+                        Write-Success "Check passed."
+                    }
                     "spellcheck" {
                         # Spellcheck requires pyspelling which is only available inside
                         # Docker. When Docker is not available or not running, skip gracefully.


### PR DESCRIPTION
## Summary

Rust Analyzer's `overrideCommand` previously forwarded `check` to the Docker-based build via `Invoke-DockerBuild`. Every invocation mutated the workspace in two ways:

1. `Restore-GitSymlinks` / `Remove-RestoredSymlinks` overwrote and reverted 13 symlinked `build.rs` files across `src/benchmarks`, `src/daemons`, `src/tests`, and `src/user`.
2. Docker's `--output type=local,dest=.` wrote artifacts back into `bin/`, `lib/`, `sysroot-*`, and `images/`.

Rust Analyzer detected these file changes and re-triggered the check, creating an infinite feedback loop.

## Changes

- **z.ps1**: Add explicit `check` case that runs `cargo check` natively on host crates (`uservm`, `mkramfs`, `nanvixd`, `nanvix-test`) without Docker. Three separate calls needed due to incompatible feature sets.
- **z.ps1**: Add `MESSAGE_FORMAT=json` build parameter support for rust-analyzer integration.
- **settings-windows.json**: Update override commands to pass `MESSAGE_FORMAT=json`, add `bin/**`, `images/**`, `lib/**` to watcher exclusions.
- **build-windows.md**: Document `check` target and `MESSAGE_FORMAT` parameter.
- **build/SKILL.md**: Update IDE setup section to reflect native check behavior.