### PR TITLE
[uservm] Forceful vCPU shutdown on Windows via shared flag and `WHvCancelRunVirtualProcessor`

### DIFF
--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -85,6 +85,7 @@ use crate::{
         Orchestrator,
         PauseFn,
         ResumeFn,
+        ShutdownVcpuFn,
         VcpuControlCommand,
         VcpuControlResponse,
     },
@@ -384,6 +385,7 @@ impl UserVm {
             resume_microvm(guest.clone(), vmem.clone()),
             create_snapshot_fn(microvm.clone(), filename.clone()),
             load_snapshot_fn(microvm.clone(), filename.clone()),
+            shutdown_vcpu_fn(microvm.clone()),
         );
 
         let orchestrator_thread_handle: JoinHandle<Result<()>> = orchestrator_thread.spawn();
@@ -448,6 +450,12 @@ fn resume_microvm(guest: Arc<Mutex<Guest>>, vmem: Arc<Mutex<VirtualMemory>>) -> 
             let mut vmem: MutexGuard<VirtualMemory> = vmem.lock().await;
             guest.resume_vm(&mut vmem)
         })
+    })
+}
+
+fn shutdown_vcpu_fn(vmm: Vmm) -> Box<ShutdownVcpuFn> {
+    Box::new(move || {
+        vmm.request_shutdown();
     })
 }
 

--- a/src/uservm/src/orchestrator.rs
+++ b/src/uservm/src/orchestrator.rs
@@ -58,6 +58,7 @@ pub type CreateSnapshotFn =
     dyn Fn() -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send + 'static;
 pub type LoadSnapshotFn =
     dyn Fn() -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send + 'static;
+pub type ShutdownVcpuFn = dyn Fn() + Send + 'static;
 
 //==================================================================================================
 // Structure
@@ -95,6 +96,9 @@ pub struct Orchestrator {
     _create_snapshot: Box<CreateSnapshotFn>,
     /// Callback function to load a snapshot.
     load_snapshot: Box<LoadSnapshotFn>,
+    /// Callback function to request vCPU shutdown (sets shared flag and cancels the vCPU run).
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+    shutdown_vcpu: Box<ShutdownVcpuFn>,
 }
 
 //==================================================================================================
@@ -209,6 +213,7 @@ impl Orchestrator {
         resume_microvm: Box<ResumeFn>,
         create_snapshot: Box<CreateSnapshotFn>,
         load_snapshot: Box<LoadSnapshotFn>,
+        shutdown_vcpu: Box<ShutdownVcpuFn>,
     ) -> Self {
         Self {
             state: State::PreBoot,
@@ -223,6 +228,7 @@ impl Orchestrator {
             resume_microvm,
             _create_snapshot: create_snapshot,
             load_snapshot,
+            shutdown_vcpu,
         }
     }
 
@@ -257,13 +263,10 @@ impl Orchestrator {
                             let pthread_id: libc::pthread_t = self.vcpu_tid as libc::pthread_t;
                             unsafe { ::libc::pthread_kill(pthread_id, KILL_SIGNAL) };
                         }
-                        // TODO: on Windows, implement forceful vCPU termination.
-                        // The WHP backend currently relies on cooperative shutdown
-                        // (guest writes to the VMM exit port), so if the guest hangs
-                        // this timeout path is a no-op. A possible approach is to
-                        // pass a cancellation callback into the orchestrator that
-                        // calls `WHvCancelRunVirtualProcessor` and sets the SHUTDOWN
-                        // flag, similar to the existing `pause_microvm` callback.
+                        #[cfg(target_os = "windows")]
+                        {
+                            (self.shutdown_vcpu)();
+                        }
                         break;
                     },
                 }
@@ -521,9 +524,8 @@ impl Orchestrator {
                         }
                         #[cfg(target_os = "windows")]
                         {
-                            // Forceful termination is not yet implemented; cooperative shutdown
-                            // via guest abort_with_code() is relied upon instead. See issue #1010.
-                            debug!("try_receive_from_io_thread(): cooperative shutdown for vcpu thread id: {} (issue #1010)", self.vcpu_tid);
+                            debug!("try_receive_from_io_thread(): requesting vCPU shutdown (tid={})", self.vcpu_tid);
+                            (self.shutdown_vcpu)();
                         }
                         self.state = State::ShuttingDown;
                         Ok(Continue(()))
@@ -538,12 +540,8 @@ impl Orchestrator {
                         }
                         #[cfg(target_os = "windows")]
                         {
-                            // TODO: Set shared shutdown flag so the WHP run loop exits on next
-                            // iteration.  Then cancel the blocking WHvRunVirtualProcessor call.
-                            // Currently not possible because:
-                            //   1. SHUTDOWN is thread-local, not accessible from the orchestrator
-                            //   2. The orchestrator doesn't hold the WHP partition handle
-                            // A cancellation callback (like pause_microvm) would solve both.
+                            debug!("try_receive_from_io_thread(): requesting vCPU shutdown (tid={})", self.vcpu_tid);
+                            (self.shutdown_vcpu)();
                         }
 
                         // Transition to shutting down state.
@@ -811,6 +809,7 @@ mod tests {
                     })
                 })
             },
+            Box::new(|| {}),
         );
 
         Harness {

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -610,6 +610,9 @@ impl Vmm {
         Err(anyhow::anyhow!(reason))
     }
 
+    /// No-op on the Hyperlight backend. Shutdown is handled via cooperative guest exit.
+    pub fn request_shutdown(&self) {}
+
     ///
     /// # Description
     ///

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -947,6 +947,9 @@ impl Vmm {
         Ok(())
     }
 
+    /// No-op on the KVM/microvm backend. Shutdown is handled via `pthread_kill`.
+    pub fn request_shutdown(&self) {}
+
     //==============================================================================================
     // Diagnostic Dump Helpers
     //==============================================================================================

--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -267,15 +267,6 @@ impl IkcNotifier {
 }
 
 //==================================================================================================
-// Thread-Local Variables
-//==================================================================================================
-
-thread_local! {
-    /// Shutdown flag, set to true when the vCPU thread should stop running.
-    static SHUTDOWN: AtomicBool = const { AtomicBool::new(false) };
-}
-
-//==================================================================================================
 // Structures
 //==================================================================================================
 
@@ -302,6 +293,9 @@ pub struct Vmm {
     /// handles actual 1kHz scheduling inside the WHP emulator (zero
     /// VM exits for timer delivery).
     timer: Arc<std::sync::Mutex<timer::Timer>>,
+    /// Shared shutdown flag. When set to `true` from any thread, the VMM
+    /// run loop will break on the next iteration.
+    shutdown_flag: Arc<AtomicBool>,
     /// Wraps fields that don't require individual `Arc<Mutex<_>>`s.
     inner: Arc<Mutex<InteriorWhpHandle>>,
 }
@@ -418,6 +412,7 @@ impl Vmm {
         let vcpu: Arc<Mutex<VirtualProcessor>> = Arc::new(Mutex::new(vcpu));
 
         let ikc_notifier: IkcNotifier = IkcNotifier::new(partition_handle);
+        let shutdown_flag: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
         let emulator: Emulator =
             Emulator::new(guest.clone(), vmem.clone(), args.input, args.output, args.stderr)?;
@@ -429,6 +424,7 @@ impl Vmm {
             ikc_notifier,
             partition_handle,
             timer,
+            shutdown_flag,
             inner: Arc::new(Mutex::new(InteriorWhpHandle {
                 _partition: partition,
                 emulator,
@@ -471,7 +467,7 @@ impl Vmm {
         trace!("run()");
 
         // Reset shutdown flag from any previous runs.
-        SHUTDOWN.with(|shutdown| shutdown.store(false, Ordering::SeqCst));
+        self.shutdown_flag.store(false, Ordering::SeqCst);
 
         let loop_start = std::time::Instant::now();
 
@@ -509,7 +505,7 @@ impl Vmm {
 
         let result = loop {
             // Check shutdown flag.
-            if SHUTDOWN.with(|shutdown| shutdown.load(Ordering::SeqCst)) {
+            if self.shutdown_flag.load(Ordering::SeqCst) {
                 let exit_status: u16 = 0;
                 warn!("VMM exit: SHUTDOWN flag (elapsed={:?})", loop_start.elapsed());
                 Handle::current().block_on(self.handle_shutdown(exit_status));
@@ -735,6 +731,29 @@ impl Vmm {
     pub async fn load_snapshot(&self, _filepath: String) -> Result<()> {
         warn!("load_snapshot(): snapshots are not supported on WHP backend");
         Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Requests a graceful shutdown of the vCPU run loop from any thread.
+    /// Sets the shared shutdown flag and cancels the current
+    /// `WHvRunVirtualProcessor` call so the VMM loop can observe the flag
+    /// on its next iteration.
+    ///
+    pub fn request_shutdown(&self) {
+        self.shutdown_flag.store(true, Ordering::SeqCst);
+        // SAFETY: `partition_handle` is a valid WHP partition handle that outlives this call.
+        unsafe {
+            let hr = windows::Win32::System::Hypervisor::WHvCancelRunVirtualProcessor(
+                self.partition_handle,
+                0,
+                0,
+            );
+            if hr.is_err() {
+                warn!("WHvCancelRunVirtualProcessor(0) failed during request_shutdown(): {hr:?}");
+            }
+        }
     }
 
     ///


### PR DESCRIPTION
Replace the thread-local SHUTDOWN flag in the WHP backend with a shared`nArc<AtomicBool> accessible from any thread. Add a request_shutdown()`nmethod that sets this flag and calls WHvCancelRunVirtualProcessor to`ncancel the blocking vCPU run, allowing the VMM loop to observe the flag`non its next iteration.`n`nIntroduce a ShutdownVcpuFn callback type in the orchestrator and wire it`nthrough UserVm construction so the orchestrator can request vCPU`ntermination from outside the vCPU thread. Use this callback in all three`nWindows shutdown paths (timeout, abort, kill) where cooperative guest`nexit was previously the only mechanism.`n`nAdd no-op request_shutdown() stubs to the microvm and Hyperlight backends`nfor API uniformity (those backends use pthread_kill and cooperative exit`nrespectively).`n`nResolves the TODOs referencing issue #1010 for forceful vCPU termination`non Windows.