### PR TITLE
[syscall] Fix dlopen segment capacity

### DIFF
--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -203,20 +203,20 @@ impl DynamicLibrary {
                             }
 
                             let base: VirtualAddress = VirtualAddress::from_raw_value(base);
-                            let capacity: usize = mm::align_up(
-                                phdr.p_memsz as usize,
-                                PAGE_ALIGNMENT,
-                            )
-                            .ok_or_else(|| {
-                                let reason: &str = "align_up overflow";
-                                ::syslog::error!(
-                                    "load(): {reason} (p_memsz={}, vaddr={:#x}, base={:#x})",
-                                    phdr.p_memsz,
-                                    phdr.p_vaddr,
-                                    base.into_raw_value()
-                                );
-                                Error::new(ErrorCode::BadFile, reason)
-                            })?;
+                            let offset: usize = unaligned_base - base.into_raw_value();
+                            let capacity: usize =
+                                mm::align_up(offset + phdr.p_memsz as usize, PAGE_ALIGNMENT)
+                                    .ok_or_else(|| {
+                                        let reason: &str = "align_up overflow";
+                                        ::syslog::error!(
+                                            "load(): {reason} (p_memsz={}, vaddr={:#x}, \
+                                             base={:#x})",
+                                            phdr.p_memsz,
+                                            phdr.p_vaddr,
+                                            base.into_raw_value()
+                                        );
+                                        Error::new(ErrorCode::BadFile, reason)
+                                    })?;
                             let end_raw: usize =
                                 base.into_raw_value().checked_add(capacity).ok_or_else(|| {
                                     let reason: &str = "end_address overflow";
@@ -227,7 +227,6 @@ impl DynamicLibrary {
                                     Error::new(ErrorCode::BadFile, reason)
                                 })?;
                             end_address = VirtualAddress::from_raw_value(end_raw);
-                            let offset: usize = unaligned_base - base.into_raw_value();
                             (base, offset, capacity)
                         };
 


### PR DESCRIPTION
The segment capacity calculation in `DynamicLibrary::open()` used `align_up(p_memsz)` without accounting for the within-page offset of the segment. When `p_vaddr` is not page-aligned, the data starts at an offset within the allocated page, so the total allocation must be `align_up(offset + p_memsz)`.

This caused `dlopen()` to fail for shared libraries produced by clang, which emits 4 page-aligned LOAD segments with large within-page offsets (e.g., `.dynamic`/`.got` at VAddr `0x3f50`). The `segment.load()` bounds check rejected the write because `offset + filesz` exceeded the undersized capacity.

GCC-built libraries were unaffected because their 2-segment layout happens to keep within-page offsets small enough to fit within a single page.