### PR TITLE
[kernel] Fix ELF segment size calculation

### DIFF
--- a/src/kernel/src/mm/elf.rs
+++ b/src/kernel/src/mm/elf.rs
@@ -178,9 +178,9 @@ fn do_elf32_load(
 
         // Allocate segment.
         let size: usize = max(phdr.p_filesz as usize, phdr.p_memsz as usize);
-        let virt_addr_range_end: usize = virt_addr_base.checked_add(size).ok_or_else(|| {
+        let virt_addr_range_end: usize = adjusted_vaddr.checked_add(size).ok_or_else(|| {
             let reason: &str = "virtual address overflow in elf segment";
-            error!("{reason} (virt_addr_base={virt_addr_base:#x}, size={size})");
+            error!("{reason} (adjusted_vaddr={adjusted_vaddr:#x}, size={size})");
             Error::new(ErrorCode::BadFile, reason)
         })?;
         let virt_addr_end: usize = ::sys::mm::align_up(virt_addr_range_end, PAGE_ALIGNMENT)


### PR DESCRIPTION
The segment end address in `do_elf32_load()` was computed from the page-aligned base (`virt_addr_base`) instead of the actual segment start address (`adjusted_vaddr`). When `p_vaddr` is not page-aligned, this drops the within-page offset from the size calculation, potentially under-allocating pages for the segment.

Currently latent because all executables (`ET_EXEC` and `ET_DYN`) have page-aligned `p_vaddr` values, but this is a correctness fix that prevents breakage if future toolchains emit segments with non-page-aligned virtual addresses.

This is the same class of bug fixed in `DynamicLibrary::open()` (#1818), applied to the kernel ELF loader.