### PR TITLE
[build] Unmount Pseudo-FS Before chown and Cleanup

### DIFF
--- a/scripts/cleanup-nanvixd.sh
+++ b/scripts/cleanup-nanvixd.sh
@@ -312,6 +312,10 @@ cleanup_images() {
     local repo_root
     repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
     if [ -n "${repo_root}" ] && [ -d "${repo_root}/images" ]; then
+        # Unmount any leftover pseudo-filesystems before deletion.
+        for mp in sys proc dev; do
+            sudo umount -lf "${repo_root}/images/l2-sysvm-rootfs/${mp}" 2>/dev/null || true
+        done
         sudo rm -rf "${repo_root}/images" 2>/dev/null || true
         log_verbose "Removed ${repo_root}/images."
     else

--- a/scripts/generate-l2-initramfs.sh
+++ b/scripts/generate-l2-initramfs.sh
@@ -83,6 +83,11 @@ build_initramfs() {
             --components="${UBUNTU_COMPONENTS}" \
             --include=busybox-static,iputils-arping,libc6,libgcc-s1,libstdc++6,iproute2,jq \
             "${UBUNTU_VERSION}" "${INITRAMFS_DIR}" "${UBUNTU_MIRROR}"
+        # After mmdebstrap and before chown, ensure /sys (and any other pseudo-fs) is
+        # unmounted. mmdebstrap may leave these mounted on teardown failure.
+        for mp in sys proc dev; do
+            sudo umount -lf "${INITRAMFS_DIR}/${mp}" 2>/dev/null || true
+        done
         sudo chown -R "$(id -u):$(id -g)" "${INITRAMFS_DIR}"
 
         print_info "Creating /dev and /proc mount points..."


### PR DESCRIPTION
## Summary

Fixes #1825.

The L2 build can fail when `mmdebstrap` leaves `/sys` (or other pseudo-filesystems) mounted inside the rootfs directory on teardown. The subsequent `chown -R` walks read-only sysfs entries and fails under `set -euo pipefail`.

## Changes

- **`scripts/generate-l2-initramfs.sh`** — After `mmdebstrap` completes and before `chown -R`, unmount `/sys`, `/proc`, and `/dev` from the rootfs (lazy + force, errors suppressed).
- **`scripts/cleanup-nanvixd.sh`** — In `cleanup_images()`, unmount the same pseudo-filesystems before `rm -rf` to prevent stale mounts from persisting across CI runs.

## Testing

Both changes are defensive (unmount with `|| true`); they are no-ops when nothing is mounted and fix the flake when `mmdebstrap` leaves mounts behind.