### PR TITLE
[ci] Reduce CI matrix by splitting build types per event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ concurrency:
 env:
   SCCACHE: "/usr/local/bin/sccache"
 
+# Build-type strategy:
+#   pull_request      → debug only   (fast feedback during development)
+#   merge_group       → release only (final validation before landing on dev)
+#   push (dev)        → release only (release archives & publish pipeline)
+#   workflow_dispatch → both          (full coverage for manual runs)
+
 jobs:
   # ==========================================================================================
   # Pre-check
@@ -238,7 +244,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [debug, release]
+        # PRs run debug only (fast feedback); merge queue and dev pushes run
+        # release only (final validation + release archives); manual dispatch
+        # runs both.
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' || github.event_name == 'workflow_dispatch' && '["debug","release"]' || '["release"]') }}
         machine-type: [microvm, hyperlight]
         deployment-type: [standalone, single-process, multi-process]
         memory-size: [128]
@@ -334,7 +343,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [debug, release]
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' || github.event_name == 'workflow_dispatch' && '["debug","release"]' || '["release"]') }}
         machine-type: [microvm, hyperlight]
         deployment-type: [standalone, single-process, multi-process]
     runs-on:
@@ -432,7 +441,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [debug, release]
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' || github.event_name == 'workflow_dispatch' && '["debug","release"]' || '["release"]') }}
         machine-type: [microvm, hyperlight]
     permissions:
       contents: read
@@ -578,7 +587,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [debug, release]
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' || github.event_name == 'workflow_dispatch' && '["debug","release"]' || '["release"]') }}
         machine-type: [microvm, hyperlight]
     runs-on: windows-latest
     permissions:
@@ -656,7 +665,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [debug, release]
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' || github.event_name == 'workflow_dispatch' && '["debug","release"]' || '["release"]') }}
         machine-type: [microvm, hyperlight]
     runs-on: windows-latest
     permissions:
@@ -759,7 +768,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [debug, release]
+        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' || github.event_name == 'workflow_dispatch' && '["debug","release"]' || '["release"]') }}
         machine-type: [microvm, hyperlight]
     runs-on:
       group: Test


### PR DESCRIPTION
Previously every CI trigger (pull_request, merge_group, push, and
workflow_dispatch) ran both debug and release builds, doubling the
number of jobs.

Apply a build-type strategy that selects the matrix based on the
event that triggered the workflow:

- **pull_request** → debug only (fast feedback during development)
- **merge_group** → release only (final validation before landing)
- **push (dev)** → release only (release archives & publish)
- **workflow_dispatch** → both (full coverage for manual runs)

The strategy is applied consistently to all six job matrices: Build,
Test, Benchmark (Linux and Windows), and System-Test (Linux and
Windows).

This roughly halves the number of CI jobs for the two most common
triggers (PRs and merge-queue runs) while preserving full coverage on
manual dispatch.