### PR TITLE
[test] Disable dlfcn-rust.elf on Hyperlight

### DIFF
--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -115,6 +115,7 @@ executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
 expected_output = "ok"
+runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "http"
@@ -205,6 +206,7 @@ expected_output = "ok"
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
+runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "terminal"

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -114,6 +114,7 @@ executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
 expected_output = "ok"
+runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "http"
@@ -204,6 +205,7 @@ expected_output = "ok"
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
+runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "terminal"

--- a/test/test.toml
+++ b/test/test.toml
@@ -114,6 +114,7 @@ executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
 expected_output = "ok"
+runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "http"
@@ -204,6 +205,7 @@ expected_output = "ok"
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
+runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "terminal"


### PR DESCRIPTION
## Summary

Disable `dlfcn-rust.elf` on Hyperlight by adding `runs_on = ["microvm"]` to all six test entries (http + terminal) across the three test configuration files.

## Motivation

The `dlfcn-rust.elf` test triggers kernel heap exhaustion (kpanic) on Hyperlight due to heavy vmbus I/O pressure during dynamic linking. This is a known issue (#1643) unrelated to any recent changes — the 896 KB slab heap is fully consumed during `pull()` operations, causing:

```
[ERROR][kheap] alloc(): allocation failed (layout=Layout { size: 4120, align: 1 (1 << 0) })
[PANIC][kernel] kpanic(): memory allocation of 4120 bytes failed
```

## Changes

| File | Change |
|------|--------|
| `test/test.toml` | Add `runs_on = ["microvm"]` to both dlfcn entries |
| `test/test-single_process.toml` | Same |
| `test/test-multi_process.toml` | Same |

## Tracking

- Root cause: #1643
- Re-enable: #1829