### PR TITLE
[build] Skip dlfcn-rust build script when LIBRARIES_DIR is unset

### DIFF
--- a/src/tests/dlfcn-rust/build.rs
+++ b/src/tests/dlfcn-rust/build.rs
@@ -86,8 +86,13 @@ fn main() {
     let mul_c: PathBuf = Path::new(&manifest_dir).join("libs/mul.c");
     println!("cargo:rerun-if-changed=libs/mul.c");
 
-    let libraries_dir: String = env::var("LIBRARIES_DIR")
-        .unwrap_or_else(|_| panic!("LIBRARIES_DIR not set — required to place libmul.so"));
+    // When rust-analyzer (or plain `cargo check`) runs without the full build
+    // environment, these variables are absent.  Skip the shared-library build
+    // and linker configuration so the IDE can still provide diagnostics.
+    let libraries_dir: String = match env::var("LIBRARIES_DIR") {
+        Ok(v) => v,
+        Err(_) => return,
+    };
     let lib_dir = Path::new(&libraries_dir);
 
     // Ensure the output directory exists (it may not in a fresh CI checkout).


### PR DESCRIPTION
## Summary

Skip the dlfcn-rust build script when `LIBRARIES_DIR` is not set, so rust-analyzer and plain `cargo check` no longer crash.

## Motivation

When rust-analyzer runs `cargo check` outside the full Nanvix build environment, `LIBRARIES_DIR`, `NANVIX_CC`, and `NANVIX_CFLAGS` are absent. The build script panicked on the missing variable, crashing the language server:

```
thread 'main' panicked at src/tests/dlfcn-rust/build.rs:90:29:
LIBRARIES_DIR not set — required to place libmul.so
```

## Changes

| File | Change |
| ---- | ------ |
| `src/tests/dlfcn-rust/build.rs` | Return early instead of panicking when `LIBRARIES_DIR` is unset |