### PR TITLE
[kernel] Replace hardcoded assembly constants

### DIFF
--- a/src/kernel/src/hal/arch/x86/asm/hooks.rs
+++ b/src/kernel/src/hal/arch/x86/asm/hooks.rs
@@ -5,64 +5,41 @@
 // x86 Exception, Interrupt, Kernel-Call Hooks and Low-Level Routines
 //==================================================================================================
 
-use core::arch::global_asm;
+use crate::hal::arch::x86::{
+    cpu::ExceptionInformation,
+    ContextInformation,
+};
+use ::arch::{
+    cpu::tss::Tss,
+    mem::WORD_SIZE,
+};
+use ::core::arch::global_asm;
 
 //==================================================================================================
 // Constants
 //==================================================================================================
 
-const WORD_SIZE: u32 = 4;
-
-/// VMM control I/O port.
-const VMM_PORT: u32 = 0x604;
-
-/// VMM shutdown command (upper 16 bits of the outl value).
-const VMM_SHUTDOWN_CMD: u32 = 0x2000;
-
-/// Exit status used by the stack overflow guard.
-/// Must match `ExitStatus::STACK_OVERFLOW_EXCEPTION` in `src/libs/sys/src/exit_status.rs`.
-const STACK_OVERFLOW_EXIT_STATUS: u32 = 200;
-
-/// Software-saved execution context size (in bytes).
-const CONTEXT_SW_SIZE: u32 = 52;
-
-// Offsets to the TSS structure.
-const TSS_ESP0: u32 = 4;
-
-// Offsets to the Context Structure.
-const CONTEXT_ESP0: u32 = 0;
-const CONTEXT_CR3: u32 = 4;
-const CONTEXT_GS: u32 = 8;
-const CONTEXT_FS: u32 = 12;
-const CONTEXT_ES: u32 = 16;
-const CONTEXT_DS: u32 = 20;
-const CONTEXT_EDI: u32 = 24;
-const CONTEXT_ESI: u32 = 28;
-const CONTEXT_EBP: u32 = 32;
-const CONTEXT_EDX: u32 = 36;
-const CONTEXT_ECX: u32 = 40;
-const CONTEXT_EBX: u32 = 44;
-const CONTEXT_EAX: u32 = 48;
-const CONTEXT_ERR: u32 = 52;
-const CONTEXT_EIP: u32 = 56;
-const CONTEXT_EFLAGS: u32 = 64;
-const CONTEXT_ESP: u32 = 68;
-
-/// Exception information size (in bytes).
-const EXCEPTION_SIZE: u32 = 16;
-
-// Offsets to the Exception Information Structure.
-const EXCEPTION_NR: u32 = 0;
-const EXCEPTION_ERR: u32 = 4;
-const EXCEPTION_DATA: u32 = 8;
-const EXCEPTION_CODE: u32 = 12;
-
 /// Offset to exception structure.
-const EXCEPTION_SKIP: i32 =
-    -(CONTEXT_SW_SIZE as i32) - EXCEPTION_SIZE as i32 + EXCEPTION_ERR as i32;
+const EXCEPTION_SKIP: i32 = -(ContextInformation::CONTEXT_SW_SIZE as i32)
+    - ExceptionInformation::EXCEPTION_SIZE as i32
+    + ExceptionInformation::EXCEPTION_ERR as i32;
 
-/// Compound shutdown value: (VMM_SHUTDOWN_CMD << 16) | STACK_OVERFLOW_EXIT_STATUS.
-const SHUTDOWN_VALUE: u32 = (VMM_SHUTDOWN_CMD << 16) | STACK_OVERFLOW_EXIT_STATUS;
+/// Whether the microvm feature is enabled (1) or not (0). Used by the assembly `.if` directive
+/// to conditionally compile the stack-overflow guard macro body.
+const MICROVM: u32 = if cfg!(feature = "microvm") { 1 } else { 0 };
+
+/// VMM ACPI power-management I/O port (microvm only; dummy value when disabled).
+#[cfg(feature = "microvm")]
+const VMM_PORT: u32 = ::config::microvm::DEFAULT_VMM_PORT as u32;
+#[cfg(not(feature = "microvm"))]
+const VMM_PORT: u32 = 0;
+
+/// Compound shutdown value: (SHUTDOWN_CMD << 16) | exit_status (microvm only; dummy when disabled).
+#[cfg(feature = "microvm")]
+const SHUTDOWN_VALUE: u32 = ((::config::microvm::DEFAULT_VMM_SHUTDOWN_CMD as u32) << 16)
+    | ::sys::ExitStatus::STACK_OVERFLOW_EXCEPTION.as_u32();
+#[cfg(not(feature = "microvm"))]
+const SHUTDOWN_VALUE: u32 = 0;
 
 //==================================================================================================
 // Assembly: Macros, Exception/Interrupt/Kcall Hooks, Context Switch, Leave Kernel, Physical Memory
@@ -203,9 +180,14 @@ global_asm!(
     // Dynamic stack overflow guard. Compares ESP against the global
     // variable EXCP_STACK_GUARD. A value of 0 disables the check.
     //
+    // On microvm, a stack overflow triggers a clean VMM shutdown via
+    // the ACPI power-management port. On hyperlight, the macro is a
+    // no-op because that mechanism is not available.
+    //
     // Clobbers: EDX, EAX (only on the overflow path which never returns).
     //
     ".macro excp_stack_guard_check",
+    ".if {MICROVM}",
     "    cmpl $0, EXCP_STACK_GUARD",
     "    je 1f",
     "    cmpl EXCP_STACK_GUARD, %esp",
@@ -218,6 +200,7 @@ global_asm!(
     "2:  hlt",
     "    jmp 2b",
     "1:",
+    ".endif",
     ".endm",
 
     // -----------------------------------------------------------------
@@ -613,31 +596,32 @@ global_asm!(
     // Const Operands
     // =================================================================
     WORD_SIZE = const WORD_SIZE,
-    CONTEXT_SW_SIZE = const CONTEXT_SW_SIZE,
-    CONTEXT_ESP0 = const CONTEXT_ESP0,
-    CONTEXT_CR3 = const CONTEXT_CR3,
-    CONTEXT_GS = const CONTEXT_GS,
-    CONTEXT_FS = const CONTEXT_FS,
-    CONTEXT_ES = const CONTEXT_ES,
-    CONTEXT_DS = const CONTEXT_DS,
-    CONTEXT_EDI = const CONTEXT_EDI,
-    CONTEXT_ESI = const CONTEXT_ESI,
-    CONTEXT_EBP = const CONTEXT_EBP,
-    CONTEXT_EDX = const CONTEXT_EDX,
-    CONTEXT_ECX = const CONTEXT_ECX,
-    CONTEXT_EBX = const CONTEXT_EBX,
-    CONTEXT_EAX = const CONTEXT_EAX,
-    CONTEXT_ERR = const CONTEXT_ERR,
-    CONTEXT_EIP = const CONTEXT_EIP,
-    CONTEXT_EFLAGS = const CONTEXT_EFLAGS,
-    CONTEXT_ESP = const CONTEXT_ESP,
-    EXCEPTION_SIZE = const EXCEPTION_SIZE,
-    EXCEPTION_NR = const EXCEPTION_NR,
-    EXCEPTION_ERR = const EXCEPTION_ERR,
-    EXCEPTION_DATA = const EXCEPTION_DATA,
-    EXCEPTION_CODE = const EXCEPTION_CODE,
+    CONTEXT_SW_SIZE = const ContextInformation::CONTEXT_SW_SIZE,
+    CONTEXT_ESP0 = const ContextInformation::CONTEXT_ESP0,
+    CONTEXT_CR3 = const ContextInformation::CONTEXT_CR3,
+    CONTEXT_GS = const ContextInformation::CONTEXT_GS,
+    CONTEXT_FS = const ContextInformation::CONTEXT_FS,
+    CONTEXT_ES = const ContextInformation::CONTEXT_ES,
+    CONTEXT_DS = const ContextInformation::CONTEXT_DS,
+    CONTEXT_EDI = const ContextInformation::CONTEXT_EDI,
+    CONTEXT_ESI = const ContextInformation::CONTEXT_ESI,
+    CONTEXT_EBP = const ContextInformation::CONTEXT_EBP,
+    CONTEXT_EDX = const ContextInformation::CONTEXT_EDX,
+    CONTEXT_ECX = const ContextInformation::CONTEXT_ECX,
+    CONTEXT_EBX = const ContextInformation::CONTEXT_EBX,
+    CONTEXT_EAX = const ContextInformation::CONTEXT_EAX,
+    CONTEXT_ERR = const ContextInformation::CONTEXT_ERR,
+    CONTEXT_EIP = const ContextInformation::CONTEXT_EIP,
+    CONTEXT_EFLAGS = const ContextInformation::CONTEXT_EFLAGS,
+    CONTEXT_ESP = const ContextInformation::CONTEXT_ESP,
+    EXCEPTION_SIZE = const ExceptionInformation::EXCEPTION_SIZE,
+    EXCEPTION_NR = const ExceptionInformation::EXCEPTION_NR,
+    EXCEPTION_ERR = const ExceptionInformation::EXCEPTION_ERR,
+    EXCEPTION_DATA = const ExceptionInformation::EXCEPTION_DATA,
+    EXCEPTION_CODE = const ExceptionInformation::EXCEPTION_CODE,
     EXCEPTION_SKIP = const EXCEPTION_SKIP,
-    TSS_ESP0 = const TSS_ESP0,
+    TSS_ESP0 = const Tss::TSS_ESP0,
+    MICROVM = const MICROVM,
     SHUTDOWN_VALUE = const SHUTDOWN_VALUE,
     VMM_PORT = const VMM_PORT,
     options(att_syntax),

--- a/src/kernel/src/hal/arch/x86/asm/start.rs
+++ b/src/kernel/src/hal/arch/x86/asm/start.rs
@@ -6,16 +6,9 @@
 //==================================================================================================
 
 use super::constants;
-use core::arch::global_asm;
-
-//==================================================================================================
-// Constants
-//==================================================================================================
-
-const PAGE_SIZE: u32 = 4096;
-
-/// Hardware-saved execution context size (in bytes).
-const CONTEXT_HW_SIZE: u32 = 24;
+use crate::hal::arch::x86::cpu::ContextInformation;
+use ::arch::mem::PAGE_SIZE;
+use ::core::arch::global_asm;
 
 //==================================================================================================
 // Bootstrap Section — BSP Entry Point
@@ -86,7 +79,7 @@ global_asm!(
     "    jmp 1b",
 
     PAGE_SIZE = const PAGE_SIZE,
-    CONTEXT_HW_SIZE = const CONTEXT_HW_SIZE,
+    CONTEXT_HW_SIZE = const ContextInformation::CONTEXT_HW_SIZE,
     KSTACK_GUARD_PATTERN = const constants::KSTACK_GUARD_PATTERN,
     options(att_syntax),
 );

--- a/src/kernel/src/hal/arch/x86/cpu/context.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/context.rs
@@ -48,7 +48,7 @@ pub struct ContextInformation {
     ss: u32,
 }
 
-// `Context` must be 72 bytes long. This must match low-level assembly dispatcher code.
+// `ContextInformation` must be 76 bytes long. This must match low-level assembly dispatcher code.
 ::static_assert::assert_eq_size!(ContextInformation, 76);
 
 //==================================================================================================
@@ -56,6 +56,47 @@ pub struct ContextInformation {
 //==================================================================================================
 
 impl ContextInformation {
+    /// Byte offset of the `esp0` field within the structure.
+    pub const CONTEXT_ESP0: u32 = core::mem::offset_of!(Self, esp0) as u32;
+    /// Byte offset of the `cr3` field within the structure.
+    pub const CONTEXT_CR3: u32 = core::mem::offset_of!(Self, cr3) as u32;
+    /// Byte offset of the `gs` field within the structure.
+    pub const CONTEXT_GS: u32 = core::mem::offset_of!(Self, gs) as u32;
+    /// Byte offset of the `fs` field within the structure.
+    pub const CONTEXT_FS: u32 = core::mem::offset_of!(Self, fs) as u32;
+    /// Byte offset of the `es` field within the structure.
+    pub const CONTEXT_ES: u32 = core::mem::offset_of!(Self, es) as u32;
+    /// Byte offset of the `ds` field within the structure.
+    pub const CONTEXT_DS: u32 = core::mem::offset_of!(Self, ds) as u32;
+    /// Byte offset of the `edi` field within the structure.
+    pub const CONTEXT_EDI: u32 = core::mem::offset_of!(Self, edi) as u32;
+    /// Byte offset of the `esi` field within the structure.
+    pub const CONTEXT_ESI: u32 = core::mem::offset_of!(Self, esi) as u32;
+    /// Byte offset of the `ebp` field within the structure.
+    pub const CONTEXT_EBP: u32 = core::mem::offset_of!(Self, ebp) as u32;
+    /// Byte offset of the `edx` field within the structure.
+    pub const CONTEXT_EDX: u32 = core::mem::offset_of!(Self, edx) as u32;
+    /// Byte offset of the `ecx` field within the structure.
+    pub const CONTEXT_ECX: u32 = core::mem::offset_of!(Self, ecx) as u32;
+    /// Byte offset of the `ebx` field within the structure.
+    pub const CONTEXT_EBX: u32 = core::mem::offset_of!(Self, ebx) as u32;
+    /// Byte offset of the `eax` field within the structure.
+    pub const CONTEXT_EAX: u32 = core::mem::offset_of!(Self, eax) as u32;
+    /// Byte offset of the `err` field within the structure.
+    pub const CONTEXT_ERR: u32 = core::mem::offset_of!(Self, err) as u32;
+    /// Byte offset of the `eip` field within the structure.
+    pub const CONTEXT_EIP: u32 = core::mem::offset_of!(Self, eip) as u32;
+    /// Byte offset of the `eflags` field within the structure.
+    pub const CONTEXT_EFLAGS: u32 = core::mem::offset_of!(Self, eflags) as u32;
+    /// Byte offset of the `esp` field within the structure.
+    pub const CONTEXT_ESP: u32 = core::mem::offset_of!(Self, esp) as u32;
+
+    /// Size of the software-saved portion of the context (bytes before `err`).
+    pub const CONTEXT_SW_SIZE: u32 = Self::CONTEXT_ERR;
+
+    /// Size of the hardware-saved portion of the context (bytes from `err` onward).
+    pub const CONTEXT_HW_SIZE: u32 = core::mem::size_of::<Self>() as u32 - Self::CONTEXT_ERR;
+
     pub fn new(cr3: u32, esp: u32, esp0: u32) -> Self {
         Self {
             esp0,

--- a/src/kernel/src/hal/arch/x86/cpu/exception/info.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/exception/info.rs
@@ -37,6 +37,18 @@ pub struct ExceptionInformation {
 //==================================================================================================
 
 impl ExceptionInformation {
+    /// Byte offset of the exception number field within the structure.
+    pub const EXCEPTION_NR: u32 = core::mem::offset_of!(Self, num) as u32;
+    /// Byte offset of the error code field within the structure.
+    pub const EXCEPTION_ERR: u32 = core::mem::offset_of!(Self, code) as u32;
+    /// Byte offset of the faulting address field within the structure.
+    pub const EXCEPTION_DATA: u32 = core::mem::offset_of!(Self, addr) as u32;
+    /// Byte offset of the faulting instruction field within the structure.
+    pub const EXCEPTION_CODE: u32 = core::mem::offset_of!(Self, instruction) as u32;
+
+    /// Total size of the exception information structure (in bytes).
+    pub const EXCEPTION_SIZE: u32 = core::mem::size_of::<Self>() as u32;
+
     pub fn num(&self) -> u32 {
         self.num
     }

--- a/src/libs/arch/src/x86/cpu/tss.rs
+++ b/src/libs/arch/src/x86/cpu/tss.rs
@@ -33,3 +33,8 @@ pub struct Tss {
 }
 // `Tss` must be 104 bytes long. This must match the hardware specification.
 ::static_assert::assert_eq_size!(Tss, 104);
+
+impl Tss {
+    /// Byte offset of the `esp0` field within the structure.
+    pub const TSS_ESP0: u32 = core::mem::offset_of!(Self, esp0) as u32;
+}

--- a/src/libs/arch/src/x86/mem/constants.rs
+++ b/src/libs/arch/src/x86/mem/constants.rs
@@ -14,6 +14,13 @@ use sys::mm::Alignment;
 ///
 /// # Description
 ///
+/// Number of bytes in a word.
+///
+pub const WORD_SIZE: usize = ::core::mem::size_of::<u32>();
+
+///
+/// # Description
+///
 /// Log2 PAGE_SIZE
 ///
 pub const PAGE_SHIFT: usize = 12;

--- a/src/libs/sys/src/exit_status.rs
+++ b/src/libs/sys/src/exit_status.rs
@@ -38,10 +38,12 @@ pub struct ExitStatus(u32);
 
 impl ExitStatus {
     /// Stack overflow detected at exception entry (assembly guard).
-    ///
-    /// The assembly macro `excp_stack_guard_check` in `hooks.S` mirrors this value as
-    /// `STACK_OVERFLOW_EXIT_STATUS`. Both constants must be kept in sync manually.
     pub const STACK_OVERFLOW_EXCEPTION: Self = Self(200);
+
+    /// Returns the raw `u32` value of the exit status.
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
 
     /// Stack overflow detected at a scheduling checkpoint (Rust guard watermark).
     pub const STACK_OVERFLOW_WATERMARK: Self = Self(201);

--- a/src/tests/dlfcn-rust/build.rs
+++ b/src/tests/dlfcn-rust/build.rs
@@ -89,9 +89,19 @@ fn main() {
     // When rust-analyzer (or plain `cargo check`) runs without the full build
     // environment, these variables are absent.  Skip the shared-library build
     // and linker configuration so the IDE can still provide diagnostics.
+    println!("cargo:rerun-if-env-changed=LIBRARIES_DIR");
+    println!("cargo:rerun-if-env-changed=NANVIX_CC");
+    println!("cargo:rerun-if-env-changed=NANVIX_CFLAGS");
     let libraries_dir: String = match env::var("LIBRARIES_DIR") {
         Ok(v) => v,
-        Err(_) => return,
+        Err(_) => {
+            println!(
+                "cargo:warning=Skipping dlfcn shared library build and linker configuration: \
+                 LIBRARIES_DIR is not set; set LIBRARIES_DIR (and NANVIX_CC/NANVIX_CFLAGS) to \
+                 enable dlopen() tests."
+            );
+            return;
+        },
     };
     let lib_dir = Path::new(&libraries_dir);
 


### PR DESCRIPTION
## Summary


## Changes

| Commit | Description |
|--------|-------------|
| `[build] E: Warning when skipping dlfcn-rust build` | Emit `cargo:warning` and add `rerun-if-env-changed` for dlfcn-rust build.rs |
| `[sys] E: Add ExitStatus::as_u32() accessor` | Add `const fn as_u32()` to `ExitStatus` so assembly can reference it |
| `[arch] E: Add WORD_SIZE constant for x86` | Add `WORD_SIZE` to `arch::mem` |
| `[kernel] E: Replace hardcoded assembly constants` | Rewrite hooks.rs and start.rs to use struct-derived constants; extract `excp_stack_guard_check` behind `cfg(feature = "microvm")` |

## Motivation

The x86 assembly in `hooks.rs` and `start.rs` duplicated byte offsets for `ContextInformation`, `ExceptionInformation`, and `Tss` as raw integer constants. Any struct layout change required manually updating these values — a mismatch would produce silent, hard-to-debug corruption at runtime.


Additionally, the `excp_stack_guard_check` macro is now conditionally compiled: on `microvm` it triggers ACPI shutdown, on `hyperlight` it compiles as a no-op — removing dead VMM port/shutdown constants from the hyperlight build.