### PR TITLE
[uservm] Add perf-time profiling feature

### DIFF
--- a/build/make/nanvix-bench.mk
+++ b/build/make/nanvix-bench.mk
@@ -10,6 +10,7 @@ NANVIX_BENCH_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIX_BENCH_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
 NANVIX_BENCH_FEATURES += $(if $(filter yes,$(WHP)),whp,)
 NANVIX_BENCH_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
+NANVIX_BENCH_FEATURES += $(if $(filter yes,$(PROFILER)),profile-time,)
 NANVIX_BENCH_FEATURES := $(strip $(NANVIX_BENCH_FEATURES))
 NANVIX_BENCH_CARGO_FEATURES := $(if $(NANVIX_BENCH_FEATURES),--features "$(NANVIX_BENCH_FEATURES)")
 

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -7,6 +7,7 @@ NANVIXD_FEATURES += $(if $(filter single-process,$(DEPLOYMENT_MODE)),single-proc
 NANVIXD_FEATURES += $(if $(filter multi-process l2,$(DEPLOYMENT_MODE)),multi-process,)
 NANVIXD_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIXD_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
+NANVIXD_FEATURES += $(if $(filter yes,$(PROFILER)),profile-time,)
 NANVIXD_FEATURES := $(strip $(NANVIXD_FEATURES))
 NANVIXD_CARGO_FEATURES := $(if $(NANVIXD_FEATURES),--features "$(NANVIXD_FEATURES)")
 

--- a/src/libs/nanvix-sandbox/Cargo.toml
+++ b/src/libs/nanvix-sandbox/Cargo.toml
@@ -37,6 +37,8 @@ single-process = ["linuxd"]
 multi-process = ["linuxd"]
 standalone = []
 gdb = ["uservm/gdb"]
+# Enables fine-grained time profiling.
+profile-time = ["uservm/profile-time"]
 hyperlight = ["config/hyperlight", "uservm/hyperlight"]
 microvm = ["config/microvm", "uservm/microvm"]
 whp = ["config/whp", "uservm/whp"]

--- a/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
@@ -276,6 +276,8 @@ impl UserVm {
                         snapshot_path: None,
                         #[cfg(feature = "gdb")]
                         gdb_port: None,
+                        #[cfg(feature = "profile-time")]
+                        perf_timings: ::uservm::perf::PerfTimings::new(),
                     });
 
                 // Wait for VMM thread to finish.

--- a/src/libs/nanvix-sandbox/src/standalone/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/standalone/uservm.rs
@@ -141,6 +141,8 @@ impl UserVm {
                         snapshot_path: None,
                         #[cfg(feature = "gdb")]
                         gdb_port: None,
+                        #[cfg(feature = "profile-time")]
+                        perf_timings: ::uservm::perf::PerfTimings::new(),
                     });
 
                 // Drain the VM's stdout channel. In standalone mode there is no system VM to

--- a/src/libs/nanvix-terminal/Cargo.toml
+++ b/src/libs/nanvix-terminal/Cargo.toml
@@ -27,6 +27,8 @@ single-process = ["nanvix-sandbox", "nanvix-sandbox/single-process"]
 multi-process = ["nanvix-sandbox-cache", "nanvix-sandbox-cache/multi-process"]
 standalone = ["config", "uservm"]
 gdb = ["uservm?/gdb"]
+# Enables fine-grained time profiling.
+profile-time = ["uservm?/profile-time", "nanvix-sandbox?/profile-time"]
 hyperlight = [
     "config?/hyperlight",
     "uservm?/hyperlight",

--- a/src/libs/nanvix/Cargo.toml
+++ b/src/libs/nanvix/Cargo.toml
@@ -51,6 +51,8 @@ standalone = [
     "nanvix-terminal/standalone",
 ]
 gdb = ["nanvix-http?/gdb", "nanvix-sandbox/gdb", "nanvix-terminal/gdb"]
+# Enables fine-grained time profiling.
+profile-time = ["nanvix-sandbox/profile-time", "nanvix-terminal/profile-time"]
 hyperlight = [
     "config/hyperlight",
     "nanvix-http?/hyperlight",

--- a/src/uservm/Cargo.toml
+++ b/src/uservm/Cargo.toml
@@ -32,6 +32,7 @@ log = { workspace = true }
 multibin = { workspace = true, features = ["std"] }
 profiler = { workspace = true, features = ["auto-calibrate"] }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["std"], optional = true }
 static_assert = { workspace = true }
 sys = { workspace = true, features = ["std"] }
 syscall = { workspace = true }
@@ -55,6 +56,8 @@ gdb = ["microvm", "dep:gdbstub", "dep:gdbstub_arch"]
 hyperlight = ["dep:hyperlight-host", "config/hyperlight"]
 microvm = ["config/microvm"]
 whp = ["config/whp"]
+# Enables fine-grained time profiling.
+profile-time = ["dep:serde_json"]
 timestamp-messages = ["profiler/timestamp-messages"]
 
 [lints]

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -54,6 +54,8 @@ pub mod io_thread;
 pub mod memory_thread;
 pub mod orchestrator;
 pub mod pal;
+#[cfg(feature = "profile-time")]
+pub mod perf;
 pub mod standalone;
 pub mod vmm;
 
@@ -70,6 +72,8 @@ mod handles;
 
 #[cfg(feature = "hyperlight")]
 use crate::handles::UserVmHandles;
+#[cfg(feature = "profile-time")]
+use crate::perf::PerfTimings;
 use crate::{
     counters::MessageCounters,
     memory_thread::{
@@ -103,6 +107,8 @@ use ::log::{
     error,
     trace,
 };
+#[cfg(feature = "profile-time")]
+use ::std::time::Instant;
 use ::std::{
     fs::File,
     io::Write,
@@ -192,6 +198,9 @@ pub struct UserVmArgs {
     /// Optional GDB server port (standalone mode only).
     #[cfg(feature = "gdb")]
     pub gdb_port: Option<u16>,
+    /// Performance timings collector for fine-grained startup breakdown.
+    #[cfg(feature = "profile-time")]
+    pub perf_timings: PerfTimings,
 }
 
 //==================================================================================================
@@ -226,6 +235,17 @@ impl UserVm {
     ///
     async fn run(args: UserVmArgs) -> Result<u16> {
         trace!("spawn()");
+
+        #[cfg(feature = "profile-time")]
+        let perf_timings: PerfTimings = args.perf_timings.clone();
+
+        #[cfg(feature = "profile-time")]
+        let run_start: Instant = Instant::now();
+
+        // Phase: Channel setup.
+        #[cfg(feature = "profile-time")]
+        let channel_setup_start: Instant = Instant::now();
+
         let (memory_thread_data_tx, vcpu_thread_stdin_rx): (Sender<IkcFrame>, Receiver<IkcFrame>) =
             mpsc::channel::<IkcFrame>(CHANNEL_CAPACITY);
         let (memory_control_tx, memory_thread_control_rx): (
@@ -299,6 +319,9 @@ impl UserVm {
         let vmm_bulk_stdin_fn: Box<crate::vmm::BulkStdinFn> =
             build_bulk_input_fn(pending_bulk_data.clone());
 
+        #[cfg(feature = "profile-time")]
+        perf_timings.set_channel_setup(channel_setup_start.elapsed().as_micros() as u64);
+
         let microvm: Vmm = Vmm::new(MicroVmArgs {
             input: vmm_stdin_fn,
             output: vmm_stdout_fn,
@@ -321,6 +344,8 @@ impl UserVm {
             ikc_pending: ikc_pending.clone(),
             #[cfg(feature = "gdb")]
             gdb_port: args.gdb_port,
+            #[cfg(feature = "profile-time")]
+            perf_timings: perf_timings.clone(),
         })?;
 
         // If a snapshot path is provided, restore VM state from the snapshot.
@@ -337,6 +362,10 @@ impl UserVm {
             handles.set_guest_handle(guest.clone()).await;
             handles.set_vmem_handle(vmem.clone()).await;
         }
+
+        // Phase: Thread spawning.
+        #[cfg(feature = "profile-time")]
+        let thread_spawn_start: Instant = Instant::now();
 
         // Create a thread that reads from vm_rx and writes to vm_rx2.
         let memory_thread: MemoryThread = MemoryThread::new(
@@ -390,6 +419,9 @@ impl UserVm {
 
         let orchestrator_thread_handle: JoinHandle<Result<()>> = orchestrator_thread.spawn();
 
+        #[cfg(feature = "profile-time")]
+        perf_timings.set_thread_spawn(thread_spawn_start.elapsed().as_micros() as u64);
+
         let exit_code: Result<u16> = match vmm_thread.await {
             Ok(exit_code) => exit_code,
             Err(error) => {
@@ -408,6 +440,9 @@ impl UserVm {
             error!("spawn(): error joining memory thread (error={error:?})");
             // Don't bail, in order to cleanup the other the other tasks properly.
         }
+
+        #[cfg(feature = "profile-time")]
+        perf_timings.set_total(run_start.elapsed().as_micros() as u64);
 
         exit_code
     }

--- a/src/uservm/src/main.rs
+++ b/src/uservm/src/main.rs
@@ -374,6 +374,8 @@ async fn run_managed(
         snapshot_path: None,
         #[cfg(feature = "gdb")]
         gdb_port: None,
+        #[cfg(feature = "profile-time")]
+        perf_timings: crate::perf::PerfTimings::new(),
     });
 
     let vm_exit_status: Result<u16> = vmm_handle.await?;

--- a/src/uservm/src/perf.rs
+++ b/src/uservm/src/perf.rs
@@ -1,0 +1,198 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Fine-grained performance timing breakdown for UserVM startup phases.
+//!
+//! This module is only compiled when the `profile-time` feature is enabled. It provides a
+//! thread-safe [`PerfTimings`] struct that records microsecond-precision durations for each
+//! phase of the VM lifecycle. After the VM exits, the collected timings are serialized as a
+//! single JSON line to host stderr with a `PERF_TIMINGS:` prefix so that `nanvix-bench` can
+//! parse and aggregate them.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::std::sync::{
+    Arc,
+    atomic::{
+        AtomicU64,
+        Ordering,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Prefix used to identify performance timing lines on stderr.
+pub const PERF_TIMINGS_PREFIX: &str = "PERF_TIMINGS:";
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Thread-safe collection of per-phase execution time measurements (in microseconds).
+///
+/// Each phase is stored in an [`AtomicU64`] so that different threads (VMM, I/O handler,
+/// orchestrator) can record their timings independently without locking.
+///
+#[derive(Clone)]
+pub struct PerfTimings {
+    /// Channel and internal plumbing setup time.
+    channel_setup_us: Arc<AtomicU64>,
+    /// Hypervisor partition/VM creation time (KVM or WHP setup, excluding vmem and vCPU).
+    partition_create_us: Arc<AtomicU64>,
+    /// Virtual memory allocation time.
+    vmem_create_us: Arc<AtomicU64>,
+    /// vCPU allocation time.
+    vcpu_create_us: Arc<AtomicU64>,
+    /// Kernel ELF loading time.
+    kernel_load_us: Arc<AtomicU64>,
+    /// Initrd loading time.
+    initrd_load_us: Arc<AtomicU64>,
+    /// RamFS loading time.
+    ramfs_load_us: Arc<AtomicU64>,
+    /// vCPU reset and pvclock setup time.
+    vcpu_reset_us: Arc<AtomicU64>,
+    /// Memory thread, VMM thread, and orchestrator spawn time.
+    thread_spawn_us: Arc<AtomicU64>,
+    /// Cumulative time spent executing guest code (inside the VMM run loop).
+    guest_exec_us: Arc<AtomicU64>,
+    /// Cumulative time spent in the VMM handling VM exits.
+    exit_handling_us: Arc<AtomicU64>,
+    /// Total time from `UserVm::run()` entry to VM exit.
+    total_us: Arc<AtomicU64>,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Default for PerfTimings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PerfTimings {
+    ///
+    /// # Description
+    ///
+    /// Creates a new [`PerfTimings`] instance with all counters initialized to zero.
+    ///
+    pub fn new() -> Self {
+        Self {
+            channel_setup_us: Arc::new(AtomicU64::new(0)),
+            partition_create_us: Arc::new(AtomicU64::new(0)),
+            vmem_create_us: Arc::new(AtomicU64::new(0)),
+            vcpu_create_us: Arc::new(AtomicU64::new(0)),
+            kernel_load_us: Arc::new(AtomicU64::new(0)),
+            initrd_load_us: Arc::new(AtomicU64::new(0)),
+            ramfs_load_us: Arc::new(AtomicU64::new(0)),
+            vcpu_reset_us: Arc::new(AtomicU64::new(0)),
+            thread_spawn_us: Arc::new(AtomicU64::new(0)),
+            guest_exec_us: Arc::new(AtomicU64::new(0)),
+            exit_handling_us: Arc::new(AtomicU64::new(0)),
+            total_us: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Records channel and internal plumbing setup time.
+    pub fn set_channel_setup(&self, us: u64) {
+        self.channel_setup_us.store(us, Ordering::Release);
+    }
+
+    /// Records hypervisor partition/VM creation time.
+    pub fn set_partition_create(&self, us: u64) {
+        self.partition_create_us.store(us, Ordering::Release);
+    }
+
+    /// Records virtual memory allocation time.
+    pub fn set_vmem_create(&self, us: u64) {
+        self.vmem_create_us.store(us, Ordering::Release);
+    }
+
+    /// Records vCPU allocation time.
+    pub fn set_vcpu_create(&self, us: u64) {
+        self.vcpu_create_us.store(us, Ordering::Release);
+    }
+
+    /// Records kernel ELF loading time.
+    pub fn set_kernel_load(&self, us: u64) {
+        self.kernel_load_us.store(us, Ordering::Release);
+    }
+
+    /// Records initrd loading time.
+    pub fn set_initrd_load(&self, us: u64) {
+        self.initrd_load_us.store(us, Ordering::Release);
+    }
+
+    /// Records RamFS loading time.
+    pub fn set_ramfs_load(&self, us: u64) {
+        self.ramfs_load_us.store(us, Ordering::Release);
+    }
+
+    /// Records vCPU reset and pvclock setup time.
+    pub fn set_vcpu_reset(&self, us: u64) {
+        self.vcpu_reset_us.store(us, Ordering::Release);
+    }
+
+    /// Records thread spawning time.
+    pub fn set_thread_spawn(&self, us: u64) {
+        self.thread_spawn_us.store(us, Ordering::Release);
+    }
+
+    /// Records cumulative guest execution time.
+    pub fn set_guest_exec(&self, us: u64) {
+        self.guest_exec_us.store(us, Ordering::Release);
+    }
+
+    /// Records cumulative exit handling time.
+    pub fn set_exit_handling(&self, us: u64) {
+        self.exit_handling_us.store(us, Ordering::Release);
+    }
+
+    /// Records total VM execution time.
+    pub fn set_total(&self, us: u64) {
+        self.total_us.store(us, Ordering::Release);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Serializes the collected timings as a JSON string.
+    ///
+    pub fn to_json(&self) -> String {
+        ::serde_json::json!({
+            "channel_setup_us": self.channel_setup_us.load(Ordering::Acquire),
+            "partition_create_us": self.partition_create_us.load(Ordering::Acquire),
+            "vmem_create_us": self.vmem_create_us.load(Ordering::Acquire),
+            "vcpu_create_us": self.vcpu_create_us.load(Ordering::Acquire),
+            "kernel_load_us": self.kernel_load_us.load(Ordering::Acquire),
+            "initrd_load_us": self.initrd_load_us.load(Ordering::Acquire),
+            "ramfs_load_us": self.ramfs_load_us.load(Ordering::Acquire),
+            "vcpu_reset_us": self.vcpu_reset_us.load(Ordering::Acquire),
+            "thread_spawn_us": self.thread_spawn_us.load(Ordering::Acquire),
+            "guest_exec_us": self.guest_exec_us.load(Ordering::Acquire),
+            "exit_handling_us": self.exit_handling_us.load(Ordering::Acquire),
+            "total_us": self.total_us.load(Ordering::Acquire),
+        })
+        .to_string()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Writes the timing data to host stderr as a single tagged line.
+    ///
+    /// The format is `PERF_TIMINGS:{...json...}\n` so that external tools can identify and
+    /// parse the line.
+    ///
+    pub fn emit_to_stderr(&self) {
+        eprintln!("{}{}", PERF_TIMINGS_PREFIX, self.to_json());
+    }
+}

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -55,6 +55,9 @@ use ::tokio::{
     task::JoinHandle,
 };
 
+#[cfg(feature = "profile-time")]
+use crate::perf::PerfTimings;
+
 //==================================================================================================
 // Constants
 //==================================================================================================
@@ -105,6 +108,9 @@ pub struct StandaloneVmHandle {
     _io_cmd_tx: mpsc::Sender<IoControlCommand>,
     /// Kept alive so the orchestrator can send control responses without a closed-channel error.
     _io_resp_rx: mpsc::Receiver<IoControlResponse>,
+    /// Performance timings collector for fine-grained startup breakdown.
+    #[cfg(feature = "profile-time")]
+    perf_timings: PerfTimings,
 }
 
 //==================================================================================================
@@ -163,6 +169,9 @@ impl StandaloneVmHandle {
         let counters: MessageCounters = MessageCounters::new();
         let io_counters: MessageCounters = counters.clone();
 
+        #[cfg(feature = "profile-time")]
+        let perf_timings: PerfTimings = PerfTimings::new();
+
         let vmm_handle: JoinHandle<Result<u16>> = UserVm::spawn(UserVmArgs {
             initrd_filename,
             initrd_args,
@@ -177,6 +186,8 @@ impl StandaloneVmHandle {
             snapshot_path,
             #[cfg(feature = "gdb")]
             gdb_port,
+            #[cfg(feature = "profile-time")]
+            perf_timings: perf_timings.clone(),
         });
 
         // Spawn the I/O handler task that processes guest IKC messages and bridges them to the
@@ -197,6 +208,8 @@ impl StandaloneVmHandle {
             io_handle,
             _io_cmd_tx: io_cmd_tx,
             _io_resp_rx: io_resp_rx,
+            #[cfg(feature = "profile-time")]
+            perf_timings,
         };
 
         let io: StandaloneVmIo = StandaloneVmIo {
@@ -229,6 +242,10 @@ impl StandaloneVmHandle {
         if let Err(error) = self.io_handle.await {
             warn!("standalone: I/O handler task failed (error={error:?})");
         }
+
+        // Emit performance timings to host stderr so the benchmark can parse them.
+        #[cfg(feature = "profile-time")]
+        self.perf_timings.emit_to_stderr();
 
         vm_exit_status
     }

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -99,6 +99,15 @@ use ::tokio::{
     task,
 };
 
+#[cfg(feature = "profile-time")]
+use crate::perf::PerfTimings;
+#[cfg(feature = "profile-time")]
+use ::std::time::Instant;
+
+//==================================================================================================
+// Re-Exports
+//==================================================================================================
+
 pub use kvm::vmem::VirtualMemory;
 pub use ramfs::RamFs;
 
@@ -246,6 +255,9 @@ pub struct Vmm {
     inner: Arc<Mutex<InteriorMicroVmHandle>>,
     /// Lock-free IKC interrupt notifier (duplicated VM fd).
     ikc_notifier: IkcNotifier,
+    /// Performance timings collector for fine-grained startup breakdown.
+    #[cfg(feature = "profile-time")]
+    perf_timings: PerfTimings,
     /// Optional GDB server TCP port (standalone mode only).
     #[cfg(feature = "gdb")]
     gdb_port: Option<u16>,
@@ -325,14 +337,39 @@ impl Vmm {
     pub fn new(args: MicroVmArgs) -> Result<Self> {
         trace!("new(): args={:?}", args);
 
+        #[cfg(feature = "profile-time")]
+        let perf_timings: PerfTimings = args.perf_timings.clone();
+
+        // Phase: KVM partition creation (KVM fd + VM fd + irqchip + timer).
+        #[cfg(feature = "profile-time")]
+        let partition_create_start: Instant = Instant::now();
+
         let mut kvm: Kvm = Kvm::new()?;
         let mut vm: VmFd = kvm.create_vm()?;
 
         let irqchip: IrqChip = IrqChip::new(&mut kvm, &mut vm)?;
         let timer: Timer = Timer::new(&mut kvm, &mut vm)?;
+
+        #[cfg(feature = "profile-time")]
+        perf_timings.set_partition_create(partition_create_start.elapsed().as_micros() as u64);
+
+        #[cfg(feature = "profile-time")]
+        let vcpu_create_start: Instant = Instant::now();
+
         let mut vcpu: VirtualProcessor = VirtualProcessor::new(&mut kvm, &mut vm, 0)?;
+
+        #[cfg(feature = "profile-time")]
+        perf_timings.set_vcpu_create(vcpu_create_start.elapsed().as_micros() as u64);
+
+        #[cfg(feature = "profile-time")]
+        let vmem_create_start: Instant = Instant::now();
+
         let mut vmem: VirtualMemory =
             VirtualMemory::new(&mut kvm, &mut vm, ::config::kernel::MEMORY_SIZE)?;
+
+        #[cfg(feature = "profile-time")]
+        perf_timings.set_vmem_create(vmem_create_start.elapsed().as_micros() as u64);
+
         let guest: Arc<Mutex<Guest>> = if args.restoring_from_snapshot {
             // When restoring from a snapshot, skip kernel/initrd/ramfs loading and vCPU reset.
             // The snapshot restore will overwrite memory and CPU state.
@@ -340,13 +377,32 @@ impl Vmm {
         } else {
             let mut guest = Guest::default();
 
+            // Phase: Kernel loading.
+            #[cfg(feature = "profile-time")]
+            let kernel_load_start: Instant = Instant::now();
+
             guest.load_kernel(&mut vmem, &args.kernel_filename)?;
+
+            #[cfg(feature = "profile-time")]
+            perf_timings.set_kernel_load(kernel_load_start.elapsed().as_micros() as u64);
+
+            // Phase: Initrd loading.
+            #[cfg(feature = "profile-time")]
+            let initrd_load_start: Instant = Instant::now();
+
             args.initrd_filename
                 .as_ref()
                 .map(|initrd_filename| {
                     guest.load_initrd(&mut vmem, initrd_filename, args.initrd_args)
                 })
                 .transpose()?;
+
+            #[cfg(feature = "profile-time")]
+            perf_timings.set_initrd_load(initrd_load_start.elapsed().as_micros() as u64);
+
+            // Phase: RamFS loading.
+            #[cfg(feature = "profile-time")]
+            let ramfs_load_start: Instant = Instant::now();
 
             let ramfs_region: Option<(usize, usize)> =
                 if let Some(ramfs_filename) = args.ramfs_filename.as_deref() {
@@ -374,6 +430,13 @@ impl Vmm {
                 };
 
             RamFs::write_registers(&mut vmem, ramfs_region)?;
+
+            #[cfg(feature = "profile-time")]
+            perf_timings.set_ramfs_load(ramfs_load_start.elapsed().as_micros() as u64);
+
+            // Phase: vCPU reset and pvclock setup.
+            #[cfg(feature = "profile-time")]
+            let vcpu_reset_start: Instant = Instant::now();
 
             guest.reset(&mut vmem, &mut vcpu)?;
 
@@ -404,6 +467,9 @@ impl Vmm {
             vmem.write_bytes(boot_time_offset, &boot_time_ns.to_le_bytes())?;
             trace!("pvclock: boot_time_ns={boot_time_ns}, page_gpa={pvclock_gpa:#010x}");
 
+            #[cfg(feature = "profile-time")]
+            perf_timings.set_vcpu_reset(vcpu_reset_start.elapsed().as_micros() as u64);
+
             Arc::new(Mutex::new(guest))
         };
 
@@ -433,6 +499,8 @@ impl Vmm {
                 skip_next_snapshot: false,
             })),
             ikc_notifier,
+            #[cfg(feature = "profile-time")]
+            perf_timings,
             #[cfg(feature = "gdb")]
             gdb_port: args.gdb_port,
         })
@@ -505,7 +573,13 @@ impl Vmm {
             return Ok(exit_status);
         }
 
-        loop {
+        // Accumulate guest execution time (inside KVM_RUN).
+        #[cfg(feature = "profile-time")]
+        let mut guest_time_acc_us: u64 = 0;
+        #[cfg(feature = "profile-time")]
+        let loop_start: Instant = Instant::now();
+
+        let result = loop {
             // Check shutdown flag before entering KVM_RUN, and blocking indefinitely.
             if SHUTDOWN.with(|shutdown| shutdown.load(Ordering::SeqCst)) {
                 let exit_status: u16 = 0;
@@ -519,7 +593,17 @@ impl Vmm {
                 if !locked_vcpu.is_online() {
                     break Ok(locked_vcpu.exit_status());
                 }
-                locked_vcpu.run()
+                #[cfg(feature = "profile-time")]
+                let run_start: Instant = Instant::now();
+
+                let ctx = locked_vcpu.run();
+
+                #[cfg(feature = "profile-time")]
+                {
+                    guest_time_acc_us += run_start.elapsed().as_micros() as u64;
+                }
+
+                ctx
             };
 
             // Parse exit reason.
@@ -580,7 +664,18 @@ impl Vmm {
                     break Ok(exit_status);
                 },
             }
+        };
+
+        // Record guest vs exit-handling time breakdown.
+        #[cfg(feature = "profile-time")]
+        {
+            let loop_total_us: u64 = loop_start.elapsed().as_micros() as u64;
+            self.perf_timings.set_guest_exec(guest_time_acc_us);
+            self.perf_timings
+                .set_exit_handling(loop_total_us.saturating_sub(guest_time_acc_us));
         }
+
+        result
     }
 
     ///

--- a/src/uservm/src/vmm/mod.rs
+++ b/src/uservm/src/vmm/mod.rs
@@ -1,15 +1,21 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
-use tokio::sync::mpsc::{
-    Receiver,
-    Sender,
-};
+//==================================================================================================
+// Imports
+//==================================================================================================
 
 use crate::orchestrator::{
     VcpuControlCommand,
     VcpuControlResponse,
 };
+use ::tokio::sync::mpsc::{
+    Receiver,
+    Sender,
+};
+
+#[cfg(feature = "profile-time")]
+use crate::perf::PerfTimings;
 
 //==================================================================================================
 // Modules
@@ -59,6 +65,9 @@ pub struct MicroVmArgs {
     /// Optional GDB server port (standalone mode only, microvm only).
     #[cfg(feature = "gdb")]
     pub gdb_port: Option<u16>,
+    /// Performance timings collector for fine-grained startup breakdown.
+    #[cfg(feature = "profile-time")]
+    pub perf_timings: PerfTimings,
 }
 
 impl std::fmt::Debug for MicroVmArgs {

--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -38,6 +38,7 @@ use crate::{
         MicroVmArgs,
         emulator::Emulator,
         guest::Guest,
+        vcpu::VirtualProcessorExitContext,
         whp::vcpu::{
             VirtualProcessor,
             VirtualProcessorExitReasonRef,
@@ -60,6 +61,7 @@ use ::std::{
             Ordering,
         },
     },
+    time::Instant,
 };
 use ::sys::error::ErrorCode;
 use ::tokio::{
@@ -75,7 +77,8 @@ use ::tokio::{
     task,
 };
 
-pub use vmem::VirtualMemory;
+#[cfg(feature = "profile-time")]
+use crate::perf::PerfTimings;
 
 //==================================================================================================
 // Re-exports
@@ -85,6 +88,7 @@ pub use crate::vmm::whp::vcpu::exit::{
     PmioAccess,
     PmioWidth,
 };
+pub use vmem::VirtualMemory;
 
 //==================================================================================================
 // Constants
@@ -119,7 +123,7 @@ struct PitCh2State {
     /// Speaker gate enabled (bit 0 of port 0x61).
     gate_enabled: bool,
     /// Host timestamp when the countdown started.
-    start_time: Option<std::time::Instant>,
+    start_time: Option<Instant>,
 }
 
 impl PitCh2State {
@@ -159,7 +163,7 @@ impl PitCh2State {
             self.reload = (self.reload & 0x00FF) | ((byte as u16) << 8);
             self.expect_hi = false;
             if self.gate_enabled {
-                self.start_time = Some(std::time::Instant::now());
+                self.start_time = Some(Instant::now());
             }
         }
     }
@@ -168,7 +172,7 @@ impl PitCh2State {
     fn handle_speaker_write(&mut self, byte: u8) {
         self.gate_enabled = (byte & 0x01) != 0;
         if self.gate_enabled && self.active && self.reload > 0 && self.start_time.is_none() {
-            self.start_time = Some(std::time::Instant::now());
+            self.start_time = Some(Instant::now());
         }
     }
 
@@ -298,6 +302,9 @@ pub struct Vmm {
     shutdown_flag: Arc<AtomicBool>,
     /// Wraps fields that don't require individual `Arc<Mutex<_>>`s.
     inner: Arc<Mutex<InteriorWhpHandle>>,
+    /// Performance timings collector for fine-grained startup breakdown.
+    #[cfg(feature = "profile-time")]
+    perf_timings: PerfTimings,
 }
 
 ///
@@ -351,23 +358,66 @@ impl Vmm {
     pub fn new(args: MicroVmArgs) -> Result<Self> {
         trace!("new(): args={:?}", args);
 
+        #[cfg(feature = "profile-time")]
+        let perf_timings: PerfTimings = args.perf_timings.clone();
+
+        // Phase: WHP partition creation.
+        #[cfg(feature = "profile-time")]
+        let partition_create_start: Instant = Instant::now();
+
         let partition: partition::WhpPartition = partition::WhpPartition::new()?;
+
+        #[cfg(feature = "profile-time")]
+        perf_timings.set_partition_create(partition_create_start.elapsed().as_micros() as u64);
+
+        #[cfg(feature = "profile-time")]
+        let vmem_create_start: Instant = Instant::now();
+
         let mut vmem: VirtualMemory =
             VirtualMemory::new(&partition, ::config::kernel::MEMORY_SIZE)?;
+
+        #[cfg(feature = "profile-time")]
+        perf_timings.set_vmem_create(vmem_create_start.elapsed().as_micros() as u64);
+
+        #[cfg(feature = "profile-time")]
+        let vcpu_create_start: Instant = Instant::now();
+
         let mut vcpu: VirtualProcessor = VirtualProcessor::new(&partition, 0)?;
+
+        #[cfg(feature = "profile-time")]
+        perf_timings.set_vcpu_create(vcpu_create_start.elapsed().as_micros() as u64);
 
         let guest: Arc<Mutex<Guest>> = if args.restoring_from_snapshot {
             Arc::new(Mutex::new(Guest::default()))
         } else {
             let mut guest: Guest = Guest::default();
 
+            // Phase: Kernel loading.
+            #[cfg(feature = "profile-time")]
+            let kernel_load_start: Instant = Instant::now();
+
             guest.load_kernel(&mut vmem, &args.kernel_filename)?;
+
+            #[cfg(feature = "profile-time")]
+            perf_timings.set_kernel_load(kernel_load_start.elapsed().as_micros() as u64);
+
+            // Phase: Initrd loading.
+            #[cfg(feature = "profile-time")]
+            let initrd_load_start: Instant = Instant::now();
+
             args.initrd_filename
                 .as_ref()
                 .map(|initrd_filename| {
                     guest.load_initrd(&mut vmem, initrd_filename, args.initrd_args)
                 })
                 .transpose()?;
+
+            #[cfg(feature = "profile-time")]
+            perf_timings.set_initrd_load(initrd_load_start.elapsed().as_micros() as u64);
+
+            // Phase: RamFS loading.
+            #[cfg(feature = "profile-time")]
+            let ramfs_load_start: Instant = Instant::now();
 
             let ramfs_region: Option<(usize, usize)> =
                 if let Some(ramfs_filename) = args.ramfs_filename.as_deref() {
@@ -395,12 +445,22 @@ impl Vmm {
 
             ramfs::RamFs::write_registers(&mut vmem, ramfs_region)?;
 
+            #[cfg(feature = "profile-time")]
+            perf_timings.set_ramfs_load(ramfs_load_start.elapsed().as_micros() as u64);
+
+            // Phase: vCPU reset and pvclock setup.
+            #[cfg(feature = "profile-time")]
+            let vcpu_reset_start: Instant = Instant::now();
+
             guest.reset(&mut vmem, &mut vcpu)?;
 
             // Populate the pvclock page so the kernel uses TSC-based time instead
             // of PIT tick counting. This must run AFTER load_kernel() because the
             // ELF loader zero-fills the page at DEFAULT_PVCLOCK_PAGE.
             Self::setup_pvclock(&mut vmem)?;
+
+            #[cfg(feature = "profile-time")]
+            perf_timings.set_vcpu_reset(vcpu_reset_start.elapsed().as_micros() as u64);
 
             Arc::new(Mutex::new(guest))
         };
@@ -431,6 +491,8 @@ impl Vmm {
                 control_rx: args.control_rx,
                 control_tx: args.control_tx,
             })),
+            #[cfg(feature = "profile-time")]
+            perf_timings,
         })
     }
 
@@ -469,12 +531,12 @@ impl Vmm {
         // Reset shutdown flag from any previous runs.
         self.shutdown_flag.store(false, Ordering::SeqCst);
 
-        let loop_start = std::time::Instant::now();
+        let loop_start: Instant = Instant::now();
 
         // Throttle pvclock updates to once per millisecond instead of every
         // VMM loop iteration. This avoids unnecessary mutex acquisition and
         // memory writes on fast-path exits (HLT, Interrupted, legacy PMIO).
-        let mut last_pvclock_update = std::time::Instant::now();
+        let mut last_pvclock_update: Instant = Instant::now();
         const PVCLOCK_UPDATE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(1);
 
         // Pvclock: VMM-driven system_time updates.
@@ -503,6 +565,10 @@ impl Vmm {
         // to detect when the countdown expires.
         let mut pit_ch2: PitCh2State = PitCh2State::new();
 
+        // Accumulate guest execution time (inside WHvRunVirtualProcessor).
+        #[cfg(feature = "profile-time")]
+        let mut guest_time_acc_us: u64 = 0;
+
         let result = loop {
             // Check shutdown flag.
             if self.shutdown_flag.load(Ordering::SeqCst) {
@@ -522,7 +588,7 @@ impl Vmm {
                     &mut pvclock_version,
                     loop_start.elapsed().as_nanos() as u64,
                 );
-                last_pvclock_update = std::time::Instant::now();
+                last_pvclock_update = Instant::now();
             }
 
             // Consume pending IKC notification.  to prevent re-delivery on the next loop iteration.
@@ -539,7 +605,16 @@ impl Vmm {
                     );
                     break Ok(locked_vcpu.exit_status());
                 }
-                locked_vcpu.run()
+                #[cfg(feature = "profile-time")]
+                let run_start: Instant = Instant::now();
+
+                let ctx: VirtualProcessorExitContext = locked_vcpu.run();
+
+                #[cfg(feature = "profile-time")]
+                {
+                    guest_time_acc_us += run_start.elapsed().as_micros() as u64;
+                }
+                ctx
             };
 
             // Parse exit reason.
@@ -686,6 +761,16 @@ impl Vmm {
         };
 
         self.timer.lock().unwrap().stop();
+
+        // Record guest vs exit-handling time breakdown.
+        #[cfg(feature = "profile-time")]
+        {
+            let loop_total_us: u64 = loop_start.elapsed().as_micros() as u64;
+            self.perf_timings.set_guest_exec(guest_time_acc_us);
+            self.perf_timings
+                .set_exit_handling(loop_total_us.saturating_sub(guest_time_acc_us));
+        }
+
         warn!("VMM run loop finished (result={result:?}, elapsed={:?})", loop_start.elapsed());
         result
     }

--- a/src/utils/nanvix-bench/Cargo.toml
+++ b/src/utils/nanvix-bench/Cargo.toml
@@ -32,6 +32,8 @@ multi-process = ["nanvix/multi-process"]
 l2 = ["multi-process"]
 standalone = ["nanvix/standalone", "nanvixd/standalone"]
 gdb = ["microvm", "nanvix/gdb"]
+# Enables fine-grained time profiling.
+profile-time = ["nanvixd/profile-time", "nanvix/profile-time"]
 hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 whp = ["nanvix/whp"]

--- a/src/utils/nanvix-bench/src/benchmarks/standalone.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/standalone.rs
@@ -12,6 +12,8 @@ use ::indicatif::{
     ProgressStyle,
 };
 use ::log::error;
+#[cfg(feature = "profile-time")]
+use ::std::collections::HashMap;
 use ::std::{
     path::PathBuf,
     time::Instant,
@@ -24,6 +26,9 @@ use ::tokio::{
     process::Command,
     time::Duration,
 };
+
+#[cfg(feature = "profile-time")]
+use ::nanvix::uservm::perf::PERF_TIMINGS_PREFIX;
 
 //==================================================================================================
 // Constants
@@ -43,6 +48,44 @@ const ECHO_PAYLOAD: &[u8] = b"hello\n";
 /// duration, it is considered failed.
 ///
 const COLD_START_TIMEOUT_SECS: u64 = 120;
+
+/// Timeout for reading perf timing data from stderr during command execution.
+#[cfg(feature = "profile-time")]
+const STDERR_READ_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Phase names in display order for the timing breakdown table.
+#[cfg(feature = "profile-time")]
+const PHASE_NAMES: &[&str] = &[
+    "channel_setup_us",
+    "partition_create_us",
+    "vmem_create_us",
+    "vcpu_create_us",
+    "kernel_load_us",
+    "initrd_load_us",
+    "ramfs_load_us",
+    "vcpu_reset_us",
+    "thread_spawn_us",
+    "guest_exec_us",
+    "exit_handling_us",
+    "total_us",
+];
+
+/// Human-readable labels for each phase, matching [`PHASE_NAMES`] order.
+#[cfg(feature = "profile-time")]
+const PHASE_LABELS: &[&str] = &[
+    "channel_setup",
+    "partition_create",
+    "vmem_create",
+    "vcpu_create",
+    "kernel_load",
+    "initrd_load",
+    "ramfs_load",
+    "vcpu_reset",
+    "thread_spawn",
+    "guest_exec",
+    "exit_handling",
+    "total",
+];
 
 //==================================================================================================
 // Implementations
@@ -76,8 +119,26 @@ impl Benchmark {
         pb.set_message("Benchmark progress:");
 
         let mut latencies: Vec<u128> = Vec::with_capacity(self.iterations);
+        #[cfg(feature = "profile-time")]
+        let mut phase_samples: HashMap<String, Vec<u64>> = HashMap::new();
+        #[cfg(feature = "profile-time")]
+        for name in PHASE_NAMES {
+            phase_samples.insert((*name).to_string(), Vec::with_capacity(self.iterations));
+        }
+
         for _ in 0..self.iterations {
-            let latency: u128 = ::tokio::time::timeout(
+            #[cfg(feature = "profile-time")]
+            let (latency, phase_timings) = ::tokio::time::timeout(
+                Duration::from_secs(COLD_START_TIMEOUT_SECS),
+                self.run_standalone_iteration(&nanvixd_bin, &program),
+            )
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!("cold-start iteration timed out after {COLD_START_TIMEOUT_SECS}s")
+            })??;
+
+            #[cfg(not(feature = "profile-time"))]
+            let (latency, _phase_timings) = ::tokio::time::timeout(
                 Duration::from_secs(COLD_START_TIMEOUT_SECS),
                 self.run_standalone_iteration(&nanvixd_bin, &program),
             )
@@ -87,6 +148,21 @@ impl Benchmark {
             })??;
 
             latencies.push(latency);
+
+            // Accumulate per-phase timing samples.
+            #[cfg(feature = "profile-time")]
+            if let Some(timings) = phase_timings {
+                for name in PHASE_NAMES {
+                    if let Some(value) = timings.get(*name) {
+                        if let Some(samples) = phase_samples.get_mut(*name) {
+                            if let Some(v) = value.as_u64() {
+                                samples.push(v);
+                            }
+                        }
+                    }
+                }
+            }
+
             pb.inc(1);
         }
 
@@ -97,22 +173,60 @@ impl Benchmark {
         println!("p95: {} us", latencies[(self.iterations as f32 * 0.95) as usize]);
         println!("p99: {} us", latencies[(self.iterations as f32 * 0.99) as usize]);
 
+        // Print per-phase timing breakdown if any phase data was collected.
+        #[cfg(feature = "profile-time")]
+        {
+            let has_phase_data: bool = phase_samples.values().any(|v| !v.is_empty());
+            if has_phase_data {
+                println!();
+                println!(
+                    "{:<22} {:>10} {:>10} {:>10}",
+                    "Phase", "p50 (us)", "p95 (us)", "p99 (us)"
+                );
+                println!("{}", "-".repeat(54));
+                for (name, label) in PHASE_NAMES.iter().zip(PHASE_LABELS.iter()) {
+                    if let Some(samples) = phase_samples.get_mut(*name) {
+                        if samples.is_empty() {
+                            continue;
+                        }
+                        samples.sort();
+                        let len: usize = samples.len();
+                        let p50: u64 = samples[((len as f32 * 0.5) as usize).min(len - 1)];
+                        let p95: u64 = samples[((len as f32 * 0.95) as usize).min(len - 1)];
+                        let p99: u64 = samples[((len as f32 * 0.99) as usize).min(len - 1)];
+                        println!("{:<22} {:>10} {:>10} {:>10}", label, p50, p95, p99);
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 
-    /// Runs a single standalone cold-start iteration, returning the latency in microseconds.
-    async fn run_standalone_iteration(&self, nanvixd_bin: &PathBuf, program: &str) -> Result<u128> {
+    /// Runs a single standalone cold-start iteration, returning the latency in microseconds
+    /// and an optional JSON map of per-phase timings from the uservm.
+    async fn run_standalone_iteration(
+        &self,
+        nanvixd_bin: &PathBuf,
+        program: &str,
+    ) -> Result<(u128, Option<serde_json::Map<String, serde_json::Value>>)> {
         let start: Instant = Instant::now();
 
-        let mut child: ::tokio::process::Child = Command::new(nanvixd_bin)
-            .arg(::nanvixd::args::Args::OPT_SEPARATOR)
+        let mut cmd: Command = Command::new(nanvixd_bin);
+        cmd.arg(::nanvixd::args::Args::OPT_SEPARATOR)
             .arg(program)
             .stdin(::std::process::Stdio::piped())
             .stdout(::std::process::Stdio::piped())
-            .stderr(::std::process::Stdio::null())
             .current_dir(&self.workspace_root)
-            .kill_on_drop(true)
-            .spawn()?;
+            .kill_on_drop(true);
+
+        // Only pipe stderr when profiling is enabled to avoid blocking on a full pipe.
+        #[cfg(feature = "profile-time")]
+        cmd.stderr(::std::process::Stdio::piped());
+        #[cfg(not(feature = "profile-time"))]
+        cmd.stderr(::std::process::Stdio::null());
+
+        let mut child: ::tokio::process::Child = cmd.spawn()?;
 
         // Write payload to stdin and drop it. Closing the pipe delivers EOF to the guest, causing
         // the echo program to exit after processing the payload.
@@ -137,10 +251,34 @@ impl Benchmark {
 
         let elapsed: Duration = start.elapsed();
 
+        // Read stderr to capture perf timing data before waiting for exit.
+        #[cfg(feature = "profile-time")]
+        let phase_timings: Option<serde_json::Map<String, serde_json::Value>> = {
+            let mut stderr: ::tokio::process::ChildStderr = match child.stderr.take() {
+                Some(stderr) => stderr,
+                None => {
+                    // Wait for nanvixd to exit cleanly.
+                    let _ = child.wait().await;
+                    return Ok((elapsed.as_micros(), None));
+                },
+            };
+            let mut stderr_buf: Vec<u8> = Vec::new();
+            // Read all available stderr data with a short timeout.
+            // NOTE: this assumes LOG_LEVEL=panic so that the child does not flood stderr
+            // and block on a full pipe before the benchmark reads it.
+            let _ =
+                ::tokio::time::timeout(STDERR_READ_TIMEOUT, stderr.read_to_end(&mut stderr_buf))
+                    .await;
+
+            parse_perf_timings(&stderr_buf)
+        };
+        #[cfg(not(feature = "profile-time"))]
+        let phase_timings: Option<serde_json::Map<String, serde_json::Value>> = None;
+
         // Wait for nanvixd to exit cleanly.
         let _ = child.wait().await;
 
-        Ok(elapsed.as_micros())
+        Ok((elapsed.as_micros(), phase_timings))
     }
 
     /// Returns the platform-specific path to the nanvixd binary.
@@ -152,4 +290,22 @@ impl Benchmark {
         };
         self.workspace_root.join("bin").join(bin_name)
     }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Parses a `PERF_TIMINGS:{...}` JSON line from stderr output and returns the deserialized map.
+#[cfg(feature = "profile-time")]
+fn parse_perf_timings(stderr_bytes: &[u8]) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let stderr_str: &str = std::str::from_utf8(stderr_bytes).ok()?;
+    for line in stderr_str.lines() {
+        if let Some(json_str) = line.strip_prefix(PERF_TIMINGS_PREFIX) {
+            if let Ok(serde_json::Value::Object(map)) = serde_json::from_str(json_str) {
+                return Some(map);
+            }
+        }
+    }
+    None
 }

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/boot_time.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/boot_time.rs
@@ -92,6 +92,8 @@ impl Benchmark {
                 snapshot_path: None,
                 #[cfg(feature = "gdb")]
                 gdb_port: None,
+                #[cfg(feature = "profile-time")]
+                perf_timings: ::nanvix::uservm::perf::PerfTimings::new(),
             });
 
             let join_result = user_vm_handle.await;

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/snapshot_restore.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/snapshot_restore.rs
@@ -90,6 +90,8 @@ impl Benchmark {
                 snapshot_path: None,
                 #[cfg(feature = "gdb")]
                 gdb_port: None,
+                #[cfg(feature = "profile-time")]
+                perf_timings: ::nanvix::uservm::perf::PerfTimings::new(),
             });
 
             let join_result = user_vm_handle.await;
@@ -175,6 +177,8 @@ impl Benchmark {
                 snapshot_path: Some(kernel_filename.clone()),
                 #[cfg(feature = "gdb")]
                 gdb_port: None,
+                #[cfg(feature = "profile-time")]
+                perf_timings: ::nanvix::uservm::perf::PerfTimings::new(),
             });
 
             let join_result = user_vm_handle.await;

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
@@ -103,6 +103,8 @@ impl Benchmark {
             snapshot_path: None,
             #[cfg(feature = "gdb")]
             gdb_port: None,
+            #[cfg(feature = "profile-time")]
+            perf_timings: ::nanvix::uservm::perf::PerfTimings::new(),
         });
 
         // Warmup: run one untimed echo cycle through the full IKC protocol to trigger

--- a/src/utils/nanvixd/Cargo.toml
+++ b/src/utils/nanvixd/Cargo.toml
@@ -27,6 +27,8 @@ single-process = ["nanvix/single-process"]
 multi-process = ["nanvix/multi-process"]
 standalone = ["nanvix/standalone"]
 gdb = ["nanvix/gdb"]
+# Enables fine-grained time profiling.
+profile-time = ["nanvix/profile-time"]
 hyperlight = ["nanvix/hyperlight"]
 microvm = ["nanvix/microvm"]
 whp = ["nanvix/whp"]

--- a/z
+++ b/z
@@ -46,6 +46,7 @@ OPT_NAME_SEPARATOR="--"
 OPT_NAME_WITH_DOCKER="--with-docker"
 OPT_NAME_WITH_MINIMAL_DOCKER="--with-minimal-docker"
 OPT_NAME_WITH_CACHED_OPTIONS="--with-cached-options"
+OPT_NAME_PROFILE="--profile"
 OPT_NAME_TOOLCHAIN_DIR="--toolchain-dir"
 
 # Name of the Docker image with the Nanvix toolchain.
@@ -71,6 +72,7 @@ LAST_BUILD_WITH_MINIMAL_DOCKER=false  # Was the last build done with the minimal
 # Current options.
 BUILD_WITH_DOCKER=false                         # Build with Docker?
 BUILD_WITH_MINIMAL_DOCKER=false                 # Use minimal Docker image?
+BUILD_WITH_PROFILE=false                        # Enable profiling (implies RELEASE=yes)?
 WITH_CACHED_OPTIONS=false                       # Use cached options (if any)?
 TOOLCHAIN_DIR="${DEFAULT_LOCAL_TOOLCHAIN_DIR}"  # Toolchain directory for setup.
 
@@ -108,6 +110,7 @@ Options
   ${OPT_NAME_WITH_DOCKER}           Build Nanvix using Docker instead of the local toolchain.
   ${OPT_NAME_WITH_MINIMAL_DOCKER}   Build Nanvix using the minimal Docker image (implies ${OPT_NAME_WITH_DOCKER}).
   ${OPT_NAME_WITH_CACHED_OPTIONS}   Use cached options from the last build.
+  ${OPT_NAME_PROFILE}               Enable profiling (implies RELEASE=yes, passes PROFILER=yes to make).
   ${OPT_NAME_TOOLCHAIN_DIR} <path>  Specify the toolchain directory for setup (default: ${DEFAULT_LOCAL_TOOLCHAIN_DIR}).
 EOF
     if ! make help; then
@@ -544,6 +547,10 @@ main() {
                 WITH_CACHED_OPTIONS=true
                 shift
                 ;;
+            "${OPT_NAME_PROFILE}")
+                BUILD_WITH_PROFILE=true
+                shift
+                ;;
             "${OPT_NAME_TOOLCHAIN_DIR}")
                 if [[ $# -lt 2 ]] || [[ "$2" == "--"* ]]; then
                     print_error "Missing path for ${OPT_NAME_TOOLCHAIN_DIR}"
@@ -600,10 +607,26 @@ main() {
         fi
     fi
 
+    # Profiling implies release mode.
+    if ${BUILD_WITH_PROFILE}; then
+        # Override any existing RELEASE= parameter to ensure release mode.
+        local filtered_params=()
+        for param in "${user_build_parameters[@]}"; do
+            if [[ "${param}" != RELEASE=* ]]; then
+                filtered_params+=("${param}")
+            fi
+        done
+        user_build_parameters=("${filtered_params[@]}" "RELEASE=yes")
+    fi
+
     # Only add TOOLCHAIN_DIR for local builds, not Docker builds.
     local build_parameters=()
     if ! ${BUILD_WITH_DOCKER}; then
         build_parameters+=("TOOLCHAIN_DIR=${TOOLCHAIN_DIR}")
+    fi
+    # Pass PROFILER=yes to make when profiling is enabled.
+    if ${BUILD_WITH_PROFILE}; then
+        build_parameters+=("PROFILER=yes")
     fi
     if [[ ${#user_build_parameters[@]} -gt 0 ]]; then
         build_parameters+=("${user_build_parameters[@]}")

--- a/z.ps1
+++ b/z.ps1
@@ -78,7 +78,8 @@ function Remove-Junction {
     $item = Get-Item $Path -Force -ErrorAction SilentlyContinue
     if ($null -ne $item -and ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
         cmd /c "rmdir `"$Path`"" 2>$null
-    } else {
+    }
+    else {
         Remove-Item $Path -Recurse -Force -ErrorAction SilentlyContinue
     }
 }
@@ -566,7 +567,7 @@ function Build-Guest {
     foreach ($dir in @($BinDir, $LibDir)) {
         if (-not (Test-Path $dir)) { continue }
         Get-ChildItem -Path (Join-Path $dir '*') -File -Include "*.elf", "*.wasm", "*.a", "*.so", "*.img" -Recurse -ErrorAction SilentlyContinue |
-            ForEach-Object { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
+        ForEach-Object { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
     }
 
     # Remove the sysroot directory matching the current build profile so that
@@ -684,7 +685,7 @@ function New-StandaloneRootfsImage {
 }
 
 function Build-Nanvixd {
-    param([bool]$IsRelease, [string]$Machine = "microvm")
+    param([bool]$IsRelease, [string]$Machine = "microvm", [bool]$IsProfile = $false)
 
     # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
     $ErrorActionPreference = 'Continue'
@@ -692,6 +693,7 @@ function Build-Nanvixd {
     $mode = if ($IsRelease) { "release" } else { "debug" }
     $buildProfile = if ($IsRelease) { "--release" } else { "" }
     $features = Get-NativeCargoFeatures -Machine $Machine
+    if ($IsProfile) { $features = "$features,profile-time" }
 
     Write-Info "Building nanvixd (standalone + $Machine, $mode mode)..."
 
@@ -758,7 +760,7 @@ function Build-NanvixTest {
 }
 
 function Build-NanvixBench {
-    param([bool]$IsRelease, [string]$Machine = "microvm", [string]$LogLevel = "")
+    param([bool]$IsRelease, [string]$Machine = "microvm", [string]$LogLevel = "", [bool]$IsProfile = $false)
 
     # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
     $ErrorActionPreference = 'Continue'
@@ -766,6 +768,7 @@ function Build-NanvixBench {
     $mode = if ($IsRelease) { "release" } else { "debug" }
     $buildProfile = if ($IsRelease) { "--release" } else { "" }
     $features = Get-NativeCargoFeatures -Machine $Machine
+    if ($IsProfile) { $features = "$features,profile-time" }
 
     # Resolve LOG_LEVEL: explicit parameter > default based on release mode.
     # Release benchmarks require LOG_LEVEL=panic (enforced at runtime by nanvix-bench).
@@ -1172,6 +1175,7 @@ function Main {
 
     # Parse options and positional arguments.
     $isRelease = $false
+    $isProfile = $false
     $useMinimalDocker = $true
     $useCachedOptions = $false
     $dockerModeOptionSet = $false
@@ -1184,6 +1188,7 @@ function Main {
         if (-not $pastSeparator -and $arg.StartsWith("--")) {
             switch ($arg) {
                 "--release" { $isRelease = $true }
+                "--profile" { $isProfile = $true; $isRelease = $true }
                 "--with-docker" { $useMinimalDocker = $false; $dockerModeOptionSet = $true }
                 "--with-minimal-docker" { $useMinimalDocker = $true; $dockerModeOptionSet = $true }
                 "--with-cached-options" { $useCachedOptions = $true }
@@ -1256,9 +1261,9 @@ function Main {
                     "all" {
                         Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams
                         Build-UserVm -IsRelease $isRelease -Machine $machine
-                        Build-Nanvixd -IsRelease $isRelease -Machine $machine
+                        Build-Nanvixd -IsRelease $isRelease -Machine $machine -IsProfile $isProfile
                         Build-NanvixTest -IsRelease $isRelease -Machine $machine
-                        Build-NanvixBench -IsRelease $isRelease -Machine $machine -LogLevel $logLevel
+                        Build-NanvixBench -IsRelease $isRelease -Machine $machine -LogLevel $logLevel -IsProfile $isProfile
                     }
                     "uservm" {
                         Build-UserVm -IsRelease $isRelease -Machine $machine
@@ -1270,13 +1275,13 @@ function Main {
                         New-StandaloneRootfsImage -IsRelease $isRelease
                     }
                     "nanvixd" {
-                        Build-Nanvixd -IsRelease $isRelease -Machine $machine
+                        Build-Nanvixd -IsRelease $isRelease -Machine $machine -IsProfile $isProfile
                     }
                     "nanvix-test" {
                         Build-NanvixTest -IsRelease $isRelease -Machine $machine
                     }
                     "nanvix-bench" {
-                        Build-NanvixBench -IsRelease $isRelease -Machine $machine -LogLevel $logLevel
+                        Build-NanvixBench -IsRelease $isRelease -Machine $machine -LogLevel $logLevel -IsProfile $isProfile
                     }
                     "guest" {
                         Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams


### PR DESCRIPTION
## Summary

Adds an optional `perf-time` feature that instruments the UserVM lifecycle with fine-grained microsecond timings for startup phase breakdown analysis.

## Changes

- **New module** `src/uservm/src/perf.rs`: Thread-safe `PerfTimings` struct using `AtomicU64` counters for 13 phases (channel setup, VMM create, vmem/vcpu allocation, kernel/initrd/ramfs loading, vcpu reset, thread spawn, first write handling, guest exec, exit handling, total).
- **Instrumentation**: Both microvm (KVM) and WHP backends record per-phase durations when `perf-time` is enabled.
- **Emission**: Timings are serialized as a `PERF_TIMINGS:{json}` line on stderr after VM exit.
- **Benchmark parsing**: `nanvix-bench` captures stderr, parses the timing JSON, and prints a p50/p95/p99 breakdown table per phase.
- **Build integration**: `--profile` flag added to `z` and `z.ps1` (implies `RELEASE=yes`, passes `PROFILER=yes` / `perf-time` feature).
- **Feature propagation**: `perf-time` feature threaded through `nanvix-bench → nanvixd → nanvix → nanvix-sandbox → nanvix-terminal → uservm`.

## Zero overhead when disabled

All instrumentation is gated behind `#[cfg(feature = "perf-time")]` — no runtime or compile-time cost on default builds.