### PR TITLE
[nanvix-sandbox-cache] Control Plane Acceptor Task

### DIFF
--- a/src/daemons/linuxd/src/lib.rs
+++ b/src/daemons/linuxd/src/lib.rs
@@ -35,6 +35,7 @@ use ::config::{
 };
 use ::control_plane_api::{
     self,
+    ControlPlaneRegistrationMessage,
     NanvixdControlMessage,
 };
 use ::log::{
@@ -50,6 +51,7 @@ use ::std::{
         VecDeque,
     },
     io::ErrorKind,
+    net::SocketAddr,
     str::FromStr,
     sync::Arc,
 };
@@ -80,7 +82,11 @@ use ::syscomm::{
     WriteAll,
 };
 use ::tokio::{
-    net::TcpListener,
+    io::AsyncReadExt,
+    net::{
+        TcpListener,
+        TcpStream,
+    },
     sync::{
         mpsc::{
             channel,
@@ -140,6 +146,13 @@ pub const WORKER_THREAD_CHANNEL_CAPACITY: usize = 1024;
 ///
 const USER_VM_CHANNEL_CAPACITY: usize = 1024;
 
+///
+/// # Description
+///
+/// Number of bytes used to encode the tenant identifier length in the restore-gate protocol.
+///
+const RESTORE_GATE_TENANT_ID_LEN_SIZE: usize = size_of::<u16>();
+
 //==================================================================================================
 // Structures
 //==================================================================================================
@@ -158,6 +171,7 @@ const USER_VM_CHANNEL_CAPACITY: usize = 1024;
 pub struct LinuxDaemon<T: Sync + Send + 'static> {
     syscall_table: Arc<SyscallTable<T>>,
     assembler: Arc<Mutex<RequestAssembler>>,
+    tenant_id: String,
     control_plane_sockaddr: String,
     control_plane_sockaddr_type: SocketType,
     user_vm_listener: SocketListener,
@@ -178,6 +192,7 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
     /// # Parameters
     ///
     /// - `syscall_table`: System call table.
+    /// - `tenant_id`: Unique tenant identifier.
     /// - `control_plane_sockaddr`: Control plane socket address.
     /// - `control_plane_sockaddr_type`: Control plane socket type.
     /// - `user_vm_listener`: User VM listener socket.
@@ -190,6 +205,7 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
     ///
     pub fn init(
         syscall_table: Arc<SyscallTable<T>>,
+        tenant_id: &str,
         control_plane_sockaddr: &str,
         control_plane_sockaddr_type: &str,
         user_vm_listener: SocketListener,
@@ -214,6 +230,7 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
         Ok(Self {
             syscall_table,
             assembler: Arc::new(Mutex::new(RequestAssembler::default())),
+            tenant_id: tenant_id.to_string(),
             control_plane_sockaddr: control_plane_sockaddr.to_string(),
             control_plane_sockaddr_type: control_plane_sockaddr_type_parsed,
             user_vm_listener,
@@ -222,8 +239,26 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
         })
     }
 
-    /// This helper method accepts a connection from the control-plane.
-    async fn accept_control_plane_connection(&self) -> Result<SocketStream, Error> {
+    ///
+    /// # Description
+    ///
+    /// This helper method establishes a connection with the control-plane.
+    ///
+    /// To connect to the control-plane, we first establish the raw connection, and then send our
+    /// registration key (i.e. tenant_id) so that the control-plane can identify who is connecting.
+    ///
+    /// # Arguments
+    ///
+    /// `registration_key`: the key to send to the control-plane.
+    ///
+    /// # Returns
+    ///
+    /// The control-plane stream on success, an error otherwise.
+    ///
+    async fn accept_control_plane_connection(
+        &self,
+        registration_key: &str,
+    ) -> Result<SocketStream, Error> {
         // The control-plane socket type depends on whether we are deploying linuxd in
         // an L2 VM or not.
 
@@ -234,7 +269,28 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
         )
         .await
         {
-            Ok(Ok(socket)) => {
+            Ok(Ok(mut socket)) => {
+                let registration: Vec<u8> =
+                    ControlPlaneRegistrationMessage::for_linuxd(registration_key)
+                        .and_then(|msg| msg.to_bytes())
+                        .map_err(|error| {
+                            let reason: &str = "failed to encode control-plane registration";
+                            error!(
+                                "accept_control_plane_connection(): {reason} \
+                                 (registration_key={}, error={error:?})",
+                                registration_key
+                            );
+                            Error::new(ErrorCode::InvalidArgument, reason)
+                        })?;
+                socket.write_all(&registration).await.map_err(|error| {
+                    let reason: &str = "failed to register control-plane connection";
+                    error!(
+                        "accept_control_plane_connection(): {reason} (registration_key={}, \
+                         error={error:?})",
+                        registration_key
+                    );
+                    Error::new(ErrorCode::ConnectionAborted, reason)
+                })?;
                 info!("Connected to control plane on: {:?}", self.control_plane_sockaddr);
                 Ok(socket)
             },
@@ -254,9 +310,13 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
         }
     }
 
+    ///
+    /// # Description
+    ///
     /// This helper method will trap waiting for a message in a given port if we are about to be
-    /// snapshotted.
-    async fn trap_if_pending_snapshot(&self) -> Result<()> {
+    /// snapshotted. If we are, after restore it will read the corresponding tenant ID.
+    ///
+    async fn trap_if_pending_snapshot(&self) -> Result<Option<String>> {
         if self.in_l2 {
             let trap_listener: TcpListener =
                 TcpListener::bind(restore_gate_sockaddr_builder(None)).await?;
@@ -265,11 +325,33 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
             // script.
             println!("{}", SNAPSHOT_MAGIC_STRING);
 
-            trap_listener.accept().await?;
-            trace!("linuxd unblocked from restore gate");
+            // Read the tenant ID we are restored for.
+            let (mut trap_stream, _peer_addr): (TcpStream, SocketAddr) =
+                trap_listener.accept().await?;
+            let mut tenant_id_len_bytes: [u8; RESTORE_GATE_TENANT_ID_LEN_SIZE] =
+                [0u8; RESTORE_GATE_TENANT_ID_LEN_SIZE];
+            trap_stream.read_exact(&mut tenant_id_len_bytes).await?;
+
+            let tenant_id_len: usize = usize::from(u16::from_be_bytes(tenant_id_len_bytes));
+            if tenant_id_len == 0 {
+                let reason: &str = "empty tenant identifier in restore gate payload";
+                error!("trap_if_pending_snapshot(): {reason}");
+                anyhow::bail!(reason);
+            }
+
+            let mut tenant_id_bytes: Vec<u8> = vec![0u8; tenant_id_len];
+            trap_stream.read_exact(&mut tenant_id_bytes).await?;
+            let tenant_id: String = String::from_utf8(tenant_id_bytes).map_err(|error| {
+                let reason: String =
+                    format!("invalid tenant identifier in restore gate payload (error={error:?})");
+                error!("trap_if_pending_snapshot(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+            debug!("trap_if_pending_snapshot(): linuxd unblocked from restore gate");
+            return Ok(Some(tenant_id));
         }
 
-        Ok(())
+        Ok(None)
     }
 
     /// This helper method accepts connections into the main user VM listener socket, and, if
@@ -548,10 +630,17 @@ impl<T: Sync + Send + 'static> LinuxDaemon<T> {
         // Right before entering the main loop, block if we are pending to be snapshotted, and
         // accept the control-plane stream afterwards. We are pending to be snapshotted if we are
         // in this line of code, and are deployed in an L2 VM.
-        self.trap_if_pending_snapshot().await.map_err(|_| {
-            Self::log_and_error(ErrorCode::IoErr, "error conditionally trapping on snapshot gate")
-        })?;
-        let control_plane_stream: SocketStream = self.accept_control_plane_connection().await?;
+        let restored_tenant_id: Option<String> =
+            self.trap_if_pending_snapshot().await.map_err(|_| {
+                Self::log_and_error(
+                    ErrorCode::IoErr,
+                    "error conditionally trapping on snapshot gate",
+                )
+            })?;
+        let registration_key: &str = restored_tenant_id.as_deref().unwrap_or(&self.tenant_id);
+        let control_plane_stream: SocketStream = self
+            .accept_control_plane_connection(registration_key)
+            .await?;
 
         // Split the control-plane stream so that the reader stays in the main loop and the writer
         // can be shared with gateway priming tasks to send GatewayReady notifications.

--- a/src/daemons/linuxd/src/main.rs
+++ b/src/daemons/linuxd/src/main.rs
@@ -82,7 +82,7 @@ pub async fn main() -> Result<()> {
             Some(sanitize_tenant_id(id))
         }
     });
-    ::syslog::init(args.log_to_file(), DEFAULT_LOG_LEVEL, args.log_file_dir(), tenant_id);
+    ::syslog::init(args.log_to_file(), DEFAULT_LOG_LEVEL, args.log_file_dir(), tenant_id.clone());
 
     // Work-out the socket addresses.
     let control_plane_sockaddr: &str = args.control_plane_sockaddr();
@@ -109,6 +109,7 @@ pub async fn main() -> Result<()> {
 
     let linuxd: LinuxDaemon<()> = match LinuxDaemon::init(
         Arc::new(SyscallTable::default()),
+        tenant_id.as_deref().unwrap_or_default(),
         control_plane_sockaddr,
         args.control_plane_socket_type(),
         user_vm_listener,

--- a/src/libs/control-plane-api/Cargo.toml
+++ b/src/libs/control-plane-api/Cargo.toml
@@ -15,6 +15,7 @@ config = { workspace = true }
 log = { workspace = true }
 num_enum = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+user-vm-api = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/src/libs/control-plane-api/src/lib.rs
+++ b/src/libs/control-plane-api/src/lib.rs
@@ -46,6 +46,7 @@ use ::std::{
     },
     mem,
 };
+use ::user_vm_api::UserVmIdentifier;
 
 //==================================================================================================
 // Structures
@@ -95,6 +96,32 @@ pub struct LinuxdControlMessage {
     command: LinuxdCommand,
     /// Identifier of the User VM that this message pertains to.
     gateway_id: u32,
+}
+
+///
+/// # Description
+///
+/// Kind of peer registering on the shared control-plane listener.
+///
+#[derive(Debug, Clone, Copy, IntoPrimitive, PartialEq, Eq, TryFromPrimitive)]
+#[repr(u8)]
+pub enum ControlPlanePeerKind {
+    /// Linux daemon instance.
+    LinuxDaemon,
+    /// User VM instance.
+    UserVm,
+}
+
+///
+/// # Description
+///
+/// Registration message sent immediately after a peer connects to the control-plane listener.
+///
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ControlPlaneRegistrationMessage {
+    peer_kind: ControlPlanePeerKind,
+    user_vm_id: u32,
+    tenant_id: String,
 }
 
 //==================================================================================================
@@ -163,7 +190,7 @@ impl NanvixdControlMessage {
     /// On success, this function returns the deserialized command. On failure, it returns an error.
     ///
     pub fn try_from_bytes(buffer: &[u8; Self::WIRE_SIZE]) -> Result<Self, Error> {
-        let command = NanvixdCommand::try_from(buffer[0]).map_err(|_| {
+        let command: NanvixdCommand = NanvixdCommand::try_from(buffer[0]).map_err(|_| {
             let reason: String = format!("invalid command: {}", buffer[0]);
             error!("try_from_bytes(): {reason}");
             Error::new(ErrorKind::InvalidData, reason)
@@ -252,7 +279,7 @@ impl LinuxdControlMessage {
     /// On success, this function returns the deserialized command. On failure, it returns an error.
     ///
     pub fn try_from_bytes(buffer: &[u8; Self::WIRE_SIZE]) -> Result<Self, Error> {
-        let command = LinuxdCommand::try_from(buffer[0]).map_err(|_| {
+        let command: LinuxdCommand = LinuxdCommand::try_from(buffer[0]).map_err(|_| {
             let reason: String = format!("invalid linuxd command: {}", buffer[0]);
             error!("try_from_bytes(): {reason}");
             Error::new(ErrorKind::InvalidData, reason)
@@ -262,5 +289,252 @@ impl LinuxdControlMessage {
             command,
             gateway_id,
         })
+    }
+}
+
+impl ControlPlaneRegistrationMessage {
+    /// Wire header size: 1 byte peer kind + 4 bytes user VM id + 2 bytes tenant-id length.
+    pub const HEADER_SIZE: usize = 1 + mem::size_of::<u32>() + mem::size_of::<u16>();
+
+    /// Byte offset of the peer-kind field within the wire header.
+    pub const PEER_KIND_OFFSET: usize = 0;
+
+    /// Byte offset of the user-VM-id field within the wire header.
+    pub const USER_VM_ID_OFFSET: usize = Self::PEER_KIND_OFFSET + 1;
+
+    /// Byte offset of the tenant-id-length field within the wire header.
+    pub const TENANT_ID_LEN_OFFSET: usize = Self::USER_VM_ID_OFFSET + mem::size_of::<u32>();
+
+    ///
+    /// # Description
+    ///
+    /// Creates a registration message for a Linux daemon connection.
+    ///
+    /// # Arguments
+    ///
+    /// - `tenant_id`: Tenant identifier associated with the Linux daemon instance. Must not be
+    ///   empty.
+    ///
+    /// # Returns
+    ///
+    /// Returns the newly created registration message if `tenant_id` is valid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ErrorKind::InvalidInput`] if `tenant_id` is empty.
+    ///
+    pub fn for_linuxd(tenant_id: &str) -> Result<Self, Error> {
+        if tenant_id.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "tenant_id cannot be empty for Linux daemon registration",
+            ));
+        }
+
+        Ok(Self {
+            peer_kind: ControlPlanePeerKind::LinuxDaemon,
+            user_vm_id: 0,
+            tenant_id: tenant_id.to_string(),
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Creates a registration message for a User VM connection.
+    ///
+    /// # Arguments
+    ///
+    /// - `user_vm_id`: Identifier of the User VM instance.
+    ///
+    /// # Returns
+    ///
+    /// Returns the newly created registration message.
+    ///
+    pub fn for_uservm(user_vm_id: UserVmIdentifier) -> Self {
+        Self {
+            peer_kind: ControlPlanePeerKind::UserVm,
+            user_vm_id: user_vm_id.into(),
+            tenant_id: String::new(),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the peer kind encoded in this message.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
+    ///
+    /// # Returns
+    ///
+    /// Returns the kind of the peer that emitted this registration.
+    ///
+    pub fn peer_kind(&self) -> ControlPlanePeerKind {
+        self.peer_kind
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the User VM identifier if this is a User VM registration.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
+    ///
+    /// # Returns
+    ///
+    /// Returns the registered User VM identifier when present.
+    ///
+    pub fn user_vm_id(&self) -> Option<UserVmIdentifier> {
+        if self.peer_kind == ControlPlanePeerKind::UserVm {
+            Some(UserVmIdentifier::new(self.user_vm_id))
+        } else {
+            None
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the tenant identifier if this is a Linux daemon registration.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
+    ///
+    /// # Returns
+    ///
+    /// Returns the registered tenant identifier when present.
+    ///
+    pub fn tenant_id(&self) -> Option<&str> {
+        if self.peer_kind == ControlPlanePeerKind::LinuxDaemon {
+            Some(&self.tenant_id)
+        } else {
+            None
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the exact serialized size of this message.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
+    ///
+    /// # Returns
+    ///
+    /// Returns the serialized size in bytes.
+    ///
+    pub fn wire_size(&self) -> usize {
+        Self::HEADER_SIZE + self.tenant_id.len()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Serializes this registration message.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
+    ///
+    /// # Returns
+    ///
+    /// Returns the serialized registration message bytes.
+    ///
+    pub fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        let tenant_id_bytes: &[u8] = self.tenant_id.as_bytes();
+        let tenant_id_len: u16 = tenant_id_bytes.len().try_into().map_err(|_| {
+            let reason: String = format!("tenant identifier too long: {}", tenant_id_bytes.len());
+            error!("to_bytes(): {reason}");
+            Error::new(ErrorKind::InvalidInput, reason)
+        })?;
+        let mut bytes: Vec<u8> = vec![0u8; self.wire_size()];
+        bytes[Self::PEER_KIND_OFFSET] = self.peer_kind.into();
+        bytes[Self::USER_VM_ID_OFFSET..Self::TENANT_ID_LEN_OFFSET]
+            .copy_from_slice(&self.user_vm_id.to_le_bytes());
+        bytes[Self::TENANT_ID_LEN_OFFSET..Self::HEADER_SIZE]
+            .copy_from_slice(&tenant_id_len.to_le_bytes());
+        bytes[Self::HEADER_SIZE..].copy_from_slice(tenant_id_bytes);
+        Ok(bytes)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Deserializes a registration message from its header and tenant-id payload.
+    ///
+    /// # Arguments
+    ///
+    /// - `header`: Fixed-size registration header.
+    /// - `tenant_id_bytes`: Variable-size tenant identifier payload.
+    ///
+    /// # Returns
+    ///
+    /// Returns the decoded registration message.
+    ///
+    pub fn try_from_parts(
+        header: &[u8; Self::HEADER_SIZE],
+        tenant_id_bytes: &[u8],
+    ) -> Result<Self, Error> {
+        let peer_kind: ControlPlanePeerKind =
+            ControlPlanePeerKind::try_from(header[Self::PEER_KIND_OFFSET]).map_err(|_| {
+                let reason: String =
+                    format!("invalid control-plane peer kind: {}", header[Self::PEER_KIND_OFFSET]);
+                error!("try_from_parts(): {reason}");
+                Error::new(ErrorKind::InvalidData, reason)
+            })?;
+        let user_vm_id: u32 = u32::from_le_bytes([
+            header[Self::USER_VM_ID_OFFSET],
+            header[Self::USER_VM_ID_OFFSET + 1],
+            header[Self::USER_VM_ID_OFFSET + 2],
+            header[Self::USER_VM_ID_OFFSET + 3],
+        ]);
+        let tenant_id_len: usize = usize::from(u16::from_le_bytes([
+            header[Self::TENANT_ID_LEN_OFFSET],
+            header[Self::TENANT_ID_LEN_OFFSET + 1],
+        ]));
+        if tenant_id_len != tenant_id_bytes.len() {
+            let reason: String = format!(
+                "tenant identifier length mismatch (header={tenant_id_len}, payload={})",
+                tenant_id_bytes.len()
+            );
+            error!("try_from_parts(): {reason}");
+            return Err(Error::new(ErrorKind::InvalidData, reason));
+        }
+        let tenant_id: String = String::from_utf8(tenant_id_bytes.to_vec()).map_err(|error| {
+            let reason: String = format!("invalid tenant identifier encoding (error={error:?})");
+            error!("try_from_parts(): {reason}");
+            Error::new(ErrorKind::InvalidData, reason)
+        })?;
+
+        match peer_kind {
+            ControlPlanePeerKind::LinuxDaemon if tenant_id.is_empty() => {
+                let reason: &str = "linux daemon registration missing tenant identifier";
+                error!("try_from_parts(): {reason}");
+                Err(Error::new(ErrorKind::InvalidData, reason))
+            },
+            ControlPlanePeerKind::LinuxDaemon => Ok(Self {
+                peer_kind,
+                user_vm_id: 0,
+                tenant_id,
+            }),
+            ControlPlanePeerKind::UserVm if !tenant_id.is_empty() => {
+                let reason: &str = "user VM registration should not include tenant identifier";
+                error!("try_from_parts(): {reason}");
+                Err(Error::new(ErrorKind::InvalidData, reason))
+            },
+            ControlPlanePeerKind::UserVm => Ok(Self {
+                peer_kind,
+                user_vm_id,
+                tenant_id,
+            }),
+        }
     }
 }

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -39,7 +39,10 @@ use ::log::{
 use ::nanvix_sandbox::{
     control_plane_sockaddr_builder,
     gateway_sockaddr_builder,
-    linuxd::LinuxDaemon,
+    linuxd::{
+        LinuxDaemon,
+        PendingLinuxDaemon,
+    },
     netns::{
         NetnsHandle,
         NetnsInfo,
@@ -49,11 +52,13 @@ use ::nanvix_sandbox::{
     },
     syscomm::{
         SocketListener,
+        SocketStream,
         SocketType,
         UnboundSocket,
     },
     tcp_port::TcpPort,
     user_vm_sockaddr_builder,
+    ControlPlaneAcceptor,
     InitializedSandbox,
     LinuxDaemonArgs,
     RunningSandbox,
@@ -61,6 +66,7 @@ use ::nanvix_sandbox::{
     SnapshotDirHandle,
     UninitializedSandbox,
     UserVmIdentifier,
+    CONTROL_PLANE_ACCEPT_TIMEOUT,
 };
 use ::std::{
     collections::HashMap,
@@ -68,10 +74,12 @@ use ::std::{
     path::PathBuf,
     sync::Arc,
 };
-use ::tokio::sync::{
-    Mutex,
-    MutexGuard,
-    RwLock,
+use ::tokio::{
+    sync::{
+        oneshot::Receiver,
+        RwLock,
+    },
+    time::timeout,
 };
 
 //==================================================================================================
@@ -105,8 +113,8 @@ pub struct SandboxCache<T> {
     running_sandboxes: RwLock<HashMap<UserVmIdentifier, RunningSandbox>>,
     /// Registry of all tenant's state indexed by the unique tenant ID.
     tenants: RwLock<HashMap<String, Arc<TenantState>>>,
-    /// Shared control plane listener socket (reused across sandboxes for efficiency).
-    control_plane_bind_socket: Arc<Mutex<(SocketListener, String, SocketType)>>,
+    /// Shared acceptor that routes control-plane connections to waiting children.
+    control_plane_acceptor: Arc<ControlPlaneAcceptor>,
     /// Network namespace pool for different L2 VMs.
     netns_pool: NetnsPool,
 }
@@ -234,15 +242,17 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
                 },
             };
 
+        let control_plane_acceptor: Arc<ControlPlaneAcceptor> = ControlPlaneAcceptor::new(
+            control_plane_bind_socket,
+            control_plane_bind_sockaddr,
+            control_plane_bind_socket_type,
+        );
+
         Ok(Arc::new(Self {
             config,
             running_sandboxes: RwLock::new(HashMap::new()),
             tenants: RwLock::new(HashMap::new()),
-            control_plane_bind_socket: Arc::new(Mutex::new((
-                control_plane_bind_socket,
-                control_plane_bind_sockaddr,
-                control_plane_bind_socket_type,
-            ))),
+            control_plane_acceptor,
             netns_pool: NetnsPool::new(
                 NetnsPoolConfig::new(
                     ::config::linuxd::GATEWAY_PORT_RANGE_BEGIN,
@@ -438,36 +448,62 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
             self.config.l2(),
         );
 
-        // Here we acquire a lock on the control-plane bind socket while holding the write lock
-        // on linuxd_instance. There is no risk of deadlocks because the only two other places
-        // where we try and lock this socket are:
-        //
-        // - UninitializedSandbox::initialize() - in the branch where linuxd is not initialized,
-        //   but we never hit this branch in multi-process, as we are spawning linuxd here.
-        //
-        // - InitializedSandbox::start() - when spawning a user VM. Note that a user VM whose
-        //   tenant has not been initialized will never make it to start(), so it is not possible
-        //   for two tasks to be competing on the linuxd_instance write lock and the control-plane
-        //   lock when spawning a user VM for the same tenant.
         let linuxd: Arc<LinuxDaemon> = {
-            let mut listener_and_info: MutexGuard<'_, (SocketListener, String, SocketType)> =
-                self.control_plane_bind_socket.lock().await;
-            match LinuxDaemon::spawn(
-                &linuxd_args,
-                &mut listener_and_info.0,
-                netns_handle,
-                snapshot_dir_handle,
-            )
-            .await
-            {
-                Ok(linuxd) => Arc::new(linuxd),
-                Err(error) => {
-                    let reason: String =
-                        format!("failed to spawn linuxd (tenant_id={tenant_id}, error={error:?})");
-                    error!("get_or_create_linuxd(): {reason}");
-                    anyhow::bail!(reason);
-                },
-            }
+            // Register interest in the new linuxd instance.
+            let control_plane_stream_rx: Receiver<SocketStream> = self
+                .control_plane_acceptor
+                .register_linuxd(tenant_id)
+                .await?;
+
+            // Spawn it.
+            let pending_linuxd: PendingLinuxDaemon =
+                match LinuxDaemon::spawn(&linuxd_args, netns_handle, snapshot_dir_handle).await {
+                    Ok(linuxd) => linuxd,
+                    Err(error) => {
+                        self.control_plane_acceptor
+                            .unregister_linuxd(tenant_id)
+                            .await;
+                        let reason: String = format!(
+                            "failed to spawn linuxd (tenant_id={tenant_id}, error={error:?})"
+                        );
+                        error!("get_or_create_linuxd(): {reason}");
+                        anyhow::bail!(reason);
+                    },
+                };
+
+            // Await for the linuxd instance to send a handshake message.
+            let control_plane_stream: SocketStream =
+                match timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, control_plane_stream_rx).await {
+                    Ok(Ok(stream)) => stream,
+                    Ok(Err(error)) => {
+                        self.control_plane_acceptor
+                            .unregister_linuxd(tenant_id)
+                            .await;
+                        pending_linuxd.abort().await;
+                        let reason: String = format!(
+                            "control-plane acceptor dropped before delivering linuxd stream \
+                             (tenant_id={tenant_id}, error={error:?})"
+                        );
+                        error!("get_or_create_linuxd(): {reason}");
+                        anyhow::bail!(reason);
+                    },
+                    Err(error) => {
+                        self.control_plane_acceptor
+                            .unregister_linuxd(tenant_id)
+                            .await;
+                        pending_linuxd.abort().await;
+                        let reason: String = format!(
+                            "timed-out waiting for linuxd control-plane connection \
+                             (tenant_id={tenant_id}, error={error:?})"
+                        );
+                        error!("get_or_create_linuxd(): {reason}");
+                        anyhow::bail!(reason);
+                    },
+                };
+
+            // Upgrade the pending linuxd instance to a full one by attaching the newly received
+            // control-plane stream.
+            Arc::new(pending_linuxd.attach_control_plane(control_plane_stream))
         };
 
         *linuxd_instance = Some(Arc::clone(&linuxd));
@@ -612,13 +648,11 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
             gateway_l2_port = Some(tcp_port);
         }
 
-        let control_plane_bind_socket: Arc<Mutex<(SocketListener, String, SocketType)>> =
-            self.control_plane_bind_socket.clone();
         let uninitialized_sandbox: UninitializedSandbox<T> = UninitializedSandbox::new(
             tag.program(),
             tag.program_args().cloned(),
             self.config.ramfs_filename().map(|s| s.to_string()),
-            control_plane_bind_socket,
+            self.control_plane_acceptor.clone(),
         )
         .with_netns_handle(netns_handle)
         .with_linuxd(linuxd);

--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -49,6 +49,12 @@ pub const CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
 pub const CONTROL_PLANE_ACCEPT_TIMEOUT: Duration = Duration::from_secs(60);
 
 ///
+/// Maximum number of early (unregistered) control-plane connections buffered before eviction.
+///
+#[cfg(not(feature = "standalone"))]
+pub const MAX_EARLY_CONTROL_PLANE_CONNECTIONS: usize = 64;
+
+///
 /// # Description
 ///
 /// Timeout for connecting to gateway.

--- a/src/libs/nanvix-sandbox/src/control_plane_acceptor.rs
+++ b/src/libs/nanvix-sandbox/src/control_plane_acceptor.rs
@@ -1,0 +1,589 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Shared control-plane acceptor and connection router.
+//!
+//! This module implements a daemon task that owns the control-plane listener socket and accepts
+//! incoming connections from new linuxd and uservm instances. It then notifies the tasks that
+//! spawned them and are blocked waiting for the spawn to be complete and the instance to be ready.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::config::{
+    CONTROL_PLANE_ACCEPT_TIMEOUT,
+    MAX_EARLY_CONTROL_PLANE_CONNECTIONS,
+};
+use ::anyhow::Result;
+use ::control_plane_api::ControlPlaneRegistrationMessage;
+use ::log::{
+    debug,
+    error,
+    warn,
+};
+use ::std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        Weak,
+    },
+};
+use ::syscomm::{
+    ReadExact,
+    SocketListener,
+    SocketStream,
+    SocketType,
+};
+use ::tokio::{
+    spawn,
+    sync::{
+        oneshot::{
+            channel,
+            Receiver,
+            Sender,
+        },
+        Mutex,
+        MutexGuard,
+    },
+    task::{
+        AbortHandle,
+        JoinHandle,
+    },
+    time::timeout,
+};
+use ::user_vm_api::UserVmIdentifier;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Logical identity of a peer connecting to the shared control-plane listener.
+///
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+enum ControlPlanePeer {
+    LinuxDaemon(String),
+    UserVm(UserVmIdentifier),
+}
+
+///
+/// # Description
+///
+/// Internal routing state for the control-plane acceptor.
+///
+#[derive(Default)]
+struct ControlPlaneAcceptorState {
+    /// Registered peers pending to connect to the sandbox cache.
+    pending: HashMap<ControlPlanePeer, Sender<SocketStream>>,
+    /// Peers that arrived before a request to register them.
+    early: HashMap<ControlPlanePeer, SocketStream>,
+}
+
+///
+/// # Description
+///
+/// Background acceptor that owns control-plane accepts and routes streams to waiting peers.
+///
+pub struct ControlPlaneAcceptor {
+    listener: SocketListener,
+    _listener_sockaddr: String,
+    _listener_socket_type: SocketType,
+    state: Mutex<ControlPlaneAcceptorState>,
+    accept_task: AbortHandle,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl ControlPlaneAcceptor {
+    ///
+    /// # Description
+    ///
+    /// Creates a new control-plane acceptor and spawns its background accept loop.
+    ///
+    /// # Arguments
+    ///
+    /// - `listener`: Bound listener socket.
+    /// - `listener_sockaddr`: Listener socket address used for diagnostics and resource ownership.
+    /// - `listener_socket_type`: Listener socket type metadata.
+    ///
+    /// # Returns
+    ///
+    /// Returns a shared handle to the newly created acceptor.
+    ///
+    pub fn new(
+        listener: SocketListener,
+        listener_sockaddr: String,
+        listener_socket_type: SocketType,
+    ) -> Arc<Self> {
+        // We need a new_cyclic here in order to be able to start the acceptor task as part of the
+        // call to `new`. The acceptor task requires a reference to self, hence the cyclic
+        // dependency.
+        Arc::new_cyclic(|weak_self: &Weak<Self>| {
+            let weak_self: Weak<Self> = weak_self.clone();
+            let accept_task: JoinHandle<()> = spawn(async move {
+                // Yield once so that `Arc::new_cyclic` finishes setting the strong reference
+                // count before we attempt to upgrade the weak reference. Without this yield, a
+                // worker thread may poll this future before `new_cyclic` returns, causing
+                // `upgrade()` to return `None` and the accept loop to silently never start.
+                tokio::task::yield_now().await;
+                if let Some(acceptor) = weak_self.upgrade() {
+                    acceptor.run().await;
+                }
+            });
+
+            Self {
+                listener,
+                _listener_sockaddr: listener_sockaddr,
+                _listener_socket_type: listener_socket_type,
+                state: Mutex::new(ControlPlaneAcceptorState::default()),
+                accept_task: accept_task.abort_handle(),
+            }
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Registers interest in the next control-plane connection from a specific User VM.
+    ///
+    /// # Arguments
+    ///
+    /// - `user_vm_id`: Identifier of the User VM that is expected to connect.
+    ///
+    /// # Returns
+    ///
+    /// Returns a oneshot receiver that resolves to the routed control-plane stream.
+    ///
+    pub async fn register_uservm(
+        &self,
+        user_vm_id: UserVmIdentifier,
+    ) -> Result<Receiver<SocketStream>> {
+        self.register(ControlPlanePeer::UserVm(user_vm_id)).await
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Removes any pending control-plane registration for a specific User VM.
+    ///
+    /// # Arguments
+    ///
+    /// - `user_vm_id`: Identifier of the User VM whose registration should be removed.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
+    ///
+    pub async fn unregister_uservm(&self, user_vm_id: UserVmIdentifier) {
+        self.unregister(&ControlPlanePeer::UserVm(user_vm_id)).await;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Registers interest in the next control-plane connection from a specific Linux daemon.
+    ///
+    /// # Arguments
+    ///
+    /// - `tenant_id`: Tenant identifier associated with the Linux daemon instance.
+    ///
+    /// # Returns
+    ///
+    /// Returns a oneshot receiver that resolves to the routed control-plane stream.
+    ///
+    pub async fn register_linuxd(&self, tenant_id: &str) -> Result<Receiver<SocketStream>> {
+        self.register(ControlPlanePeer::LinuxDaemon(tenant_id.to_string()))
+            .await
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Removes any pending control-plane registration for a tenant's Linux daemon.
+    ///
+    /// # Arguments
+    ///
+    /// - `tenant_id`: Tenant identifier associated with the Linux daemon instance.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
+    ///
+    pub async fn unregister_linuxd(&self, tenant_id: &str) {
+        self.unregister(&ControlPlanePeer::LinuxDaemon(tenant_id.to_string()))
+            .await;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Installs a pending waiter or immediately delivers an early-arriving buffered stream.
+    ///
+    /// # Arguments
+    ///
+    /// - `peer`: Logical identity of the peer whose control-plane stream is being awaited.
+    ///
+    /// # Returns
+    ///
+    /// Returns a oneshot receiver for the matching control-plane stream.
+    ///
+    async fn register(&self, peer: ControlPlanePeer) -> Result<Receiver<SocketStream>> {
+        let (tx, rx): (Sender<SocketStream>, Receiver<SocketStream>) = channel();
+        let mut state = self.state.lock().await;
+
+        if state.pending.contains_key(&peer) {
+            let reason: String = format!("duplicate control-plane registration ({peer:?})");
+            error!("register(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        // If the notification from the peer arrived early, still return a oneshot channel but
+        // immediately send the result.
+        if let Some(stream) = state.early.remove(&peer) {
+            if tx.send(stream).is_err() {
+                let reason: String =
+                    format!("failed to deliver buffered control-plane connection ({peer:?})");
+                error!("register(): {reason}");
+                anyhow::bail!(reason);
+            }
+            debug!("register(): delivered buffered control-plane connection ({peer:?})");
+            return Ok(rx);
+        }
+
+        state.pending.insert(peer.clone(), tx);
+        debug!("register(): installed control-plane waiter ({peer:?})");
+        Ok(rx)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Removes a pending waiter from the acceptor state.
+    ///
+    /// # Arguments
+    ///
+    /// - `peer`: Logical identity of the peer to unregister.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
+    ///
+    async fn unregister(&self, peer: &ControlPlanePeer) {
+        let mut state = self.state.lock().await;
+        if state.pending.remove(peer).is_some() {
+            debug!("unregister(): removed pending control-plane waiter ({peer:?})");
+        }
+        if state.early.remove(peer).is_some() {
+            debug!("unregister(): dropped buffered early control-plane connection ({peer:?})");
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Runs the background accept loop and routes accepted streams to pending waiters.
+    ///
+    /// # Arguments
+    ///
+    /// This function does not return under normal operation.
+    ///
+    async fn run(self: Arc<Self>) {
+        loop {
+            // Accept new connection.
+            let accept_result: Result<SocketStream, ::std::io::Error> =
+                self.listener.accept().await;
+            let mut stream: SocketStream = match accept_result {
+                Ok(stream) => stream,
+                Err(error) => {
+                    error!("run(): failed to accept control-plane connection (error={error:?})");
+                    continue;
+                },
+            };
+
+            // Read peer from connection.
+            let peer: ControlPlanePeer =
+                match timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, Self::read_registration(&mut stream))
+                    .await
+                {
+                    Ok(Ok(peer)) => peer,
+                    Ok(Err(error)) => {
+                        warn!(
+                            "run(): dropping control-plane connection with invalid registration \
+                             (error={error:?})"
+                        );
+                        continue;
+                    },
+                    Err(error) => {
+                        warn!(
+                            "run(): dropping control-plane connection after registration timeout \
+                             (error={error:?})"
+                        );
+                        continue;
+                    },
+                };
+
+            // Notify awaiting peer, or store peer in early arrivals.
+            let mut state: MutexGuard<'_, ControlPlaneAcceptorState> = self.state.lock().await;
+            if let Some(waiter) = state.pending.remove(&peer) {
+                if waiter.send(stream).is_err() {
+                    warn!("run(): waiter dropped before control-plane delivery ({peer:?})");
+                }
+                continue;
+            }
+
+            // Evict the oldest buffered connection if the early buffer is at capacity.
+            if state.early.len() >= MAX_EARLY_CONTROL_PLANE_CONNECTIONS {
+                if let Some(evicted) = state.early.keys().next().cloned() {
+                    warn!(
+                        "run(): evicting oldest early control-plane connection ({evicted:?}) to \
+                         make room"
+                    );
+                    state.early.remove(&evicted);
+                }
+            }
+            warn!("run(): buffering early control-plane connection ({peer:?})");
+            state.early.insert(peer, stream);
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reads and decodes the registration handshake from an accepted control-plane stream.
+    ///
+    /// # Arguments
+    ///
+    /// - `stream`: Newly accepted control-plane stream.
+    ///
+    /// # Returns
+    ///
+    /// Returns the logical identity of the connecting peer.
+    ///
+    async fn read_registration(stream: &mut SocketStream) -> Result<ControlPlanePeer> {
+        let mut header: [u8; ControlPlaneRegistrationMessage::HEADER_SIZE] =
+            [0u8; ControlPlaneRegistrationMessage::HEADER_SIZE];
+        stream.read_exact(&mut header).await?;
+        let tenant_id_len: usize = usize::from(u16::from_le_bytes([
+            header[ControlPlaneRegistrationMessage::TENANT_ID_LEN_OFFSET],
+            header[ControlPlaneRegistrationMessage::TENANT_ID_LEN_OFFSET + 1],
+        ]));
+        let mut tenant_id_bytes: Vec<u8> = vec![0u8; tenant_id_len];
+        if tenant_id_len > 0 {
+            stream.read_exact(&mut tenant_id_bytes).await?;
+        }
+
+        let registration: ControlPlaneRegistrationMessage =
+            ControlPlaneRegistrationMessage::try_from_parts(&header, &tenant_id_bytes)?;
+
+        match registration.user_vm_id() {
+            Some(user_vm_id) => Ok(ControlPlanePeer::UserVm(user_vm_id)),
+            None => Ok(ControlPlanePeer::LinuxDaemon(
+                registration.tenant_id().unwrap_or_default().to_string(),
+            )),
+        }
+    }
+}
+
+impl Drop for ControlPlaneAcceptor {
+    ///
+    /// # Description
+    ///
+    /// Aborts the background accept task when the acceptor is dropped.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
+    ///
+    fn drop(&mut self) {
+        self.accept_task.abort();
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::control_plane_api::ControlPlaneRegistrationMessage;
+    use ::syscomm::{
+        SocketType,
+        UnboundSocket,
+        WriteAll,
+    };
+
+    /// Helper: bind a TCP listener on localhost with an OS-assigned port and return the acceptor
+    /// together with the connect address.
+    async fn setup_acceptor() -> (Arc<ControlPlaneAcceptor>, String) {
+        let listener: SocketListener = UnboundSocket::new(SocketType::Tcp)
+            .bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind test listener");
+
+        let addr: String = match &listener {
+            SocketListener::Tcp { listener, .. } => {
+                let bound = listener.local_addr().expect("local_addr failed");
+                format!("127.0.0.1:{}", bound.port())
+            },
+            #[cfg(unix)]
+            _ => unreachable!(),
+        };
+
+        let acceptor: Arc<ControlPlaneAcceptor> =
+            ControlPlaneAcceptor::new(listener, addr.clone(), SocketType::Tcp);
+
+        (acceptor, addr)
+    }
+
+    /// Helper: connect to the acceptor and send a registration message.
+    async fn connect_and_register(addr: &str, msg: &[u8]) -> SocketStream {
+        let mut stream: SocketStream = UnboundSocket::new(SocketType::Tcp)
+            .connect(addr)
+            .await
+            .expect("failed to connect to test acceptor");
+        stream
+            .write_all(msg)
+            .await
+            .expect("failed to write registration");
+        stream
+    }
+
+    #[tokio::test]
+    async fn register_then_connect_delivers_stream() {
+        let (acceptor, addr) = setup_acceptor().await;
+
+        let user_vm_id: UserVmIdentifier = UserVmIdentifier::new(42);
+        let rx: Receiver<SocketStream> = acceptor
+            .register_uservm(user_vm_id)
+            .await
+            .expect("register failed");
+
+        let registration: Vec<u8> = ControlPlaneRegistrationMessage::for_uservm(user_vm_id)
+            .to_bytes()
+            .expect("to_bytes failed");
+        let _client: SocketStream = connect_and_register(&addr, &registration).await;
+
+        let delivered: SocketStream = timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, rx)
+            .await
+            .expect("timed out waiting for delivery")
+            .expect("channel error");
+        drop(delivered);
+    }
+
+    #[tokio::test]
+    async fn early_arrival_buffered_and_delivered() {
+        let (acceptor, addr) = setup_acceptor().await;
+
+        let tenant_id: &str = "tenant-early";
+        let registration: Vec<u8> = ControlPlaneRegistrationMessage::for_linuxd(tenant_id)
+            .expect("for_linuxd failed")
+            .to_bytes()
+            .expect("to_bytes failed");
+        let _client: SocketStream = connect_and_register(&addr, &registration).await;
+
+        // Small delay to let the acceptor loop buffer the connection.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let rx: Receiver<SocketStream> = acceptor
+            .register_linuxd(tenant_id)
+            .await
+            .expect("register failed");
+
+        let delivered: SocketStream = timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, rx)
+            .await
+            .expect("timed out waiting for delivery")
+            .expect("channel error");
+        drop(delivered);
+    }
+
+    #[tokio::test]
+    async fn duplicate_registration_returns_error() {
+        let (acceptor, _addr) = setup_acceptor().await;
+
+        let user_vm_id: UserVmIdentifier = UserVmIdentifier::new(99);
+
+        acceptor
+            .register_uservm(user_vm_id)
+            .await
+            .expect("first register should succeed");
+
+        let result = acceptor.register_uservm(user_vm_id).await;
+        assert!(result.is_err(), "duplicate registration should fail");
+    }
+
+    #[tokio::test]
+    async fn unregister_cleans_early_buffer() {
+        let (acceptor, addr) = setup_acceptor().await;
+
+        let tenant_id: &str = "tenant-unregister";
+        let registration: Vec<u8> = ControlPlaneRegistrationMessage::for_linuxd(tenant_id)
+            .expect("for_linuxd failed")
+            .to_bytes()
+            .expect("to_bytes failed");
+        let _client: SocketStream = connect_and_register(&addr, &registration).await;
+
+        // Wait for the connection to be buffered.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // Unregister should drop the buffered entry even though nothing was pending.
+        acceptor.unregister_linuxd(tenant_id).await;
+
+        // A subsequent register should NOT see a buffered stream (it was cleaned up).
+        let rx: Receiver<SocketStream> = acceptor
+            .register_linuxd(tenant_id)
+            .await
+            .expect("register after unregister should succeed");
+
+        // The channel should not resolve immediately since the early buffer was cleaned.
+        let result = tokio::time::timeout(std::time::Duration::from_millis(300), rx).await;
+        assert!(result.is_err(), "should timeout because early entry was cleaned");
+    }
+
+    #[tokio::test]
+    async fn correct_delivery_per_peer() {
+        let (acceptor, addr) = setup_acceptor().await;
+
+        let vm_a: UserVmIdentifier = UserVmIdentifier::new(1);
+        let vm_b: UserVmIdentifier = UserVmIdentifier::new(2);
+
+        let rx_a: Receiver<SocketStream> = acceptor
+            .register_uservm(vm_a)
+            .await
+            .expect("register A failed");
+        let rx_b: Receiver<SocketStream> = acceptor
+            .register_uservm(vm_b)
+            .await
+            .expect("register B failed");
+
+        // Connect B first, then A (reverse order).
+        let reg_b: Vec<u8> = ControlPlaneRegistrationMessage::for_uservm(vm_b)
+            .to_bytes()
+            .expect("to_bytes failed");
+        let _client_b: SocketStream = connect_and_register(&addr, &reg_b).await;
+
+        let reg_a: Vec<u8> = ControlPlaneRegistrationMessage::for_uservm(vm_a)
+            .to_bytes()
+            .expect("to_bytes failed");
+        let _client_a: SocketStream = connect_and_register(&addr, &reg_a).await;
+
+        // Both should be delivered to their respective receivers regardless of order.
+        let _stream_a: SocketStream = timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, rx_a)
+            .await
+            .expect("timed out A")
+            .expect("channel error A");
+        let _stream_b: SocketStream = timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, rx_b)
+            .await
+            .expect("timed out B")
+            .expect("channel error B");
+    }
+}

--- a/src/libs/nanvix-sandbox/src/initialized.rs
+++ b/src/libs/nanvix-sandbox/src/initialized.rs
@@ -11,12 +11,19 @@
 // Imports
 //==================================================================================================
 
-#[cfg(not(feature = "standalone"))]
-use crate::config::GATEWAY_CONNECT_TIMEOUT;
-#[cfg(not(feature = "standalone"))]
-use crate::linuxd::LinuxDaemon;
 #[cfg(not(any(feature = "single-process", feature = "standalone")))]
 use crate::netns::NetnsHandle;
+#[cfg(not(feature = "standalone"))]
+use crate::ControlPlaneAcceptor;
+#[cfg(not(feature = "standalone"))]
+use crate::{
+    config::{
+        CONTROL_PLANE_ACCEPT_TIMEOUT,
+        GATEWAY_CONNECT_TIMEOUT,
+    },
+    linuxd::LinuxDaemon,
+    uservm::PendingUserVm,
+};
 use crate::{
     tcp_port::TcpPort,
     uservm::UserVm,
@@ -29,14 +36,16 @@ use ::anyhow::Result;
 use ::log::error;
 #[cfg(not(any(feature = "single-process", feature = "standalone")))]
 use ::std::marker::PhantomData;
-use ::std::sync::Arc;
-use ::syscomm::{
-    SocketListener,
-    SocketType,
-};
-use ::tokio::sync::Mutex;
 #[cfg(not(feature = "standalone"))]
-use ::tokio::sync::MutexGuard;
+use ::std::sync::Arc;
+#[cfg(not(feature = "standalone"))]
+use ::syscomm::SocketStream;
+use ::syscomm::SocketType;
+#[cfg(not(feature = "standalone"))]
+use ::tokio::{
+    sync::oneshot::Receiver,
+    time::timeout,
+};
 
 //==================================================================================================
 // Structures
@@ -68,8 +77,9 @@ pub struct InitializedSandbox<T: Send + Sync + Default + 'static> {
     /// Shared handle to the Linux Daemon instance managing this sandbox.
     #[cfg(not(feature = "standalone"))]
     pub(super) linuxd: Arc<LinuxDaemon>,
-    /// Control plane listener socket, address, and socket type.
-    pub(super) control_plane_bind_socket_and_info: Arc<Mutex<(SocketListener, String, SocketType)>>,
+    /// Shared control-plane acceptor used to route child connections.
+    #[cfg(not(feature = "standalone"))]
+    pub(super) control_plane_acceptor: Arc<ControlPlaneAcceptor>,
     /// Complete configuration for the sandbox execution environment.
     pub(super) sandbox_config: SandboxConfig<T>,
     /// Handle to the network namespace (only set in L2-mode).
@@ -161,15 +171,15 @@ impl<T: Send + Sync + Default + 'static> InitializedSandbox<T> {
 
         #[cfg(not(feature = "standalone"))]
         let uservm: UserVm = {
-            let mut locked_control_plane_bind_socket_and_info: MutexGuard<
-                '_,
-                (SocketListener, String, SocketType),
-            > = self.control_plane_bind_socket_and_info.lock().await;
-            match UserVm::spawn(
+            // Register interest in the user VM we are about to spawn.
+            let control_plane_stream_rx: Receiver<SocketStream> = self
+                .control_plane_acceptor
+                .register_uservm(uservm_id)
+                .await?;
+
+            // Spawn the user VM.
+            let pending_uservm: PendingUserVm = match UserVm::spawn(
                 &uservm_args,
-                // Pass a mutable reference to the unique control-plane listener socket to accept
-                // one connection from the new user VM.
-                &mut locked_control_plane_bind_socket_and_info.0,
                 // Pass ownership of the netns RAII handle to the user VM.
                 #[cfg(not(feature = "single-process"))]
                 self.netns_handle.take(),
@@ -178,10 +188,47 @@ impl<T: Send + Sync + Default + 'static> InitializedSandbox<T> {
             {
                 Ok(uservm) => uservm,
                 Err(error) => {
+                    self.control_plane_acceptor
+                        .unregister_uservm(uservm_id)
+                        .await;
                     error!("start(): failed to spawn uservm (error={error:?})");
                     return Err(error);
                 },
-            }
+            };
+
+            // Await for the user VM to send a handshake message.
+            let control_plane_stream: SocketStream =
+                match timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, control_plane_stream_rx).await {
+                    Ok(Ok(stream)) => stream,
+                    Ok(Err(error)) => {
+                        self.control_plane_acceptor
+                            .unregister_uservm(uservm_id)
+                            .await;
+                        let reason: String = format!(
+                            "control-plane acceptor dropped before delivering uservm stream \
+                             (uservm_id={uservm_id}, error={error:?})"
+                        );
+                        error!("start(): {reason}");
+                        pending_uservm.abort().await;
+                        anyhow::bail!(reason);
+                    },
+                    Err(error) => {
+                        self.control_plane_acceptor
+                            .unregister_uservm(uservm_id)
+                            .await;
+                        let reason: String = format!(
+                            "timed-out waiting for uservm control-plane connection \
+                             (uservm_id={uservm_id}, error={error:?})"
+                        );
+                        error!("start(): {reason}");
+                        pending_uservm.abort().await;
+                        anyhow::bail!(reason);
+                    },
+                };
+
+            // Upgrade the pending user VM to a full user VM by attaching the received
+            // control-plane stream.
+            pending_uservm.attach_control_plane(control_plane_stream)
         };
 
         // Wait for linuxd to signal that the gateway listener is bound and ready for this User VM.
@@ -195,7 +242,8 @@ impl<T: Send + Sync + Default + 'static> InitializedSandbox<T> {
             uservm,
             #[cfg(not(feature = "standalone"))]
             _linuxd: self.linuxd,
-            _control_plane_socket_and_info: self.control_plane_bind_socket_and_info,
+            #[cfg(not(feature = "standalone"))]
+            _control_plane_acceptor: self.control_plane_acceptor,
             gateway_socket_info: gateway_socket_info_with_port,
         })
     }
@@ -214,19 +262,21 @@ impl<T: Send + Sync + Default + 'static> InitializedSandbox<T> {
         self.linuxd.clone()
     }
 
+    #[cfg(not(feature = "standalone"))]
     ///
     /// # Description
     ///
-    /// Returns a shared handle to the control plane socket information including the listener,
-    /// socket address, and socket type.
+    /// Returns a shared handle to the control-plane acceptor associated with this sandbox.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
     ///
     /// # Returns
     ///
-    /// A shared handle to the control plane listener socket information.
+    /// Returns the shared control-plane acceptor handle.
     ///
-    pub fn control_plane_bind_socket_info(
-        &self,
-    ) -> Arc<Mutex<(SocketListener, String, SocketType)>> {
-        self.control_plane_bind_socket_and_info.clone()
+    pub fn control_plane_acceptor(&self) -> Arc<ControlPlaneAcceptor> {
+        self.control_plane_acceptor.clone()
     }
 }

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -51,10 +51,14 @@
 //!
 //! ```rust,no_run
 //! use ::nanvix_sandbox::{UninitializedSandbox, SandboxConfig, SandboxTag};
-//! use ::syscomm::{SocketListener, SocketType, UnboundSocket};
+//! #[cfg(not(feature = "standalone"))]
+//! use ::nanvix_sandbox::ControlPlaneAcceptor;
+//! use ::syscomm::SocketType;
+//! #[cfg(not(feature = "standalone"))]
+//! use ::syscomm::UnboundSocket;
 //! use ::user_vm_api::UserVmIdentifier;
+//! #[cfg(not(feature = "standalone"))]
 //! use ::std::sync::Arc;
-//! use ::tokio::sync::Mutex;
 //!
 //! # async fn example() -> anyhow::Result<()> {
 //! // Create configuration.
@@ -80,19 +84,26 @@
 //!     Some(false),  // l2
 //! );
 //!
-//! // Create and bind control plane socket.
-//! let control_plane_bind_sockaddr: String = "/tmp/nvx:cp.socket".to_string();
-//! let control_plane_socket: SocketListener =
-//!     UnboundSocket::new(SocketType::Unix).bind(&control_plane_bind_sockaddr).await?;
-//! let control_plane_bind_socket: Arc<Mutex<(SocketListener, String, SocketType)>> =
-//!     Arc::new(Mutex::new((control_plane_socket, control_plane_bind_sockaddr, SocketType::Unix)));
+//! // Create control-plane acceptor.
+//! #[cfg(not(feature = "standalone"))]
+//! let control_plane_acceptor: Arc<ControlPlaneAcceptor> = {
+//!     let control_plane_bind_sockaddr: String = "/tmp/nvx:cp.socket".to_string();
+//!     let control_plane_listener =
+//!         UnboundSocket::new(SocketType::Unix).bind(&control_plane_bind_sockaddr).await?;
+//!     ControlPlaneAcceptor::new(
+//!         control_plane_listener,
+//!         control_plane_bind_sockaddr,
+//!         SocketType::Unix,
+//!     )
+//! };
 //!
 //! // Create and initialize sandbox.
 //! let sandbox = UninitializedSandbox::new(
 //!     "/path/to/guest.elf",
 //!     None,
 //!     None,
-//!     control_plane_bind_socket,
+//!     #[cfg(not(feature = "standalone"))]
+//!     control_plane_acceptor,
 //! )
 //!     .with_config(config)
 //!     .initialize()
@@ -130,6 +141,8 @@
 //==================================================================================================
 
 mod config;
+#[cfg(not(feature = "standalone"))]
+mod control_plane_acceptor;
 mod initialized;
 #[cfg(not(feature = "standalone"))]
 mod linuxd_args;
@@ -182,6 +195,8 @@ pub mod tcp_port;
 pub use self::snapshot_dir_handle::SnapshotDirHandle;
 
 #[cfg(not(feature = "standalone"))]
+pub use self::control_plane_acceptor::ControlPlaneAcceptor;
+#[cfg(not(feature = "standalone"))]
 pub use self::linuxd_args::LinuxDaemonArgs;
 pub use self::{
     initialized::InitializedSandbox,
@@ -194,6 +209,8 @@ pub use self::{
 pub use ::hwloc::HwLoc;
 pub use ::syscomm;
 pub use ::user_vm_api::UserVmIdentifier;
+#[cfg(not(feature = "standalone"))]
+pub use config::CONTROL_PLANE_ACCEPT_TIMEOUT;
 pub use config::{
     control_plane_sockaddr_builder,
     gateway_sockaddr_builder,

--- a/src/libs/nanvix-sandbox/src/running.rs
+++ b/src/libs/nanvix-sandbox/src/running.rs
@@ -13,20 +13,17 @@
 
 #[cfg(not(feature = "standalone"))]
 use crate::linuxd::LinuxDaemon;
+#[cfg(not(feature = "standalone"))]
+use crate::ControlPlaneAcceptor;
 use crate::{
     tcp_port::TcpPort,
     uservm::UserVm,
     SandboxTag,
 };
-use ::std::{
-    process::ExitStatus,
-    sync::Arc,
-};
-use ::syscomm::{
-    SocketListener,
-    SocketType,
-};
-use ::tokio::sync::Mutex;
+use ::std::process::ExitStatus;
+#[cfg(not(feature = "standalone"))]
+use ::std::sync::Arc;
+use ::syscomm::SocketType;
 
 //==================================================================================================
 // Structures
@@ -51,8 +48,9 @@ pub struct RunningSandbox {
     pub(super) _linuxd: Arc<LinuxDaemon>, // Keep resource.
     /// Gateway socket information (address, socket type, optional L2 TCP port).
     pub(super) gateway_socket_info: (String, SocketType, Option<TcpPort>),
-    /// Control plane listener socket, address, and socket type (kept alive for resource management).
-    pub(super) _control_plane_socket_and_info: Arc<Mutex<(SocketListener, String, SocketType)>>, // Keep resource.
+    /// Shared control-plane acceptor kept alive for resource management.
+    #[cfg(not(feature = "standalone"))]
+    pub(super) _control_plane_acceptor: Arc<ControlPlaneAcceptor>,
 }
 
 impl RunningSandbox {

--- a/src/libs/nanvix-sandbox/src/sandbox/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/multi_process/linuxd.rs
@@ -15,7 +15,6 @@ use crate::{
     config::{
         get_clh_api_socket_path,
         get_clh_bin_dir,
-        CONTROL_PLANE_ACCEPT_TIMEOUT,
         SHUTDOWN_TIMEOUT,
     },
     netns::{
@@ -57,13 +56,7 @@ use ::std::{
         Stdio,
     },
 };
-use ::syscomm::{
-    SocketListener,
-    SocketStream,
-    SocketType,
-    UnboundSocket,
-    WriteAll,
-};
+use ::syscomm::{SocketStream, SocketType, UnboundSocket, WriteAll};
 use ::tokio::{
     fs as tokio_fs,
     io::{
@@ -84,9 +77,8 @@ use ::tokio::{
     },
 };
 
-/// Single-byte that we send to unlock a linuxd instance restored from a snapshot. Anything that
-/// triggers a readable event in the receiving socket should work.
-const RESTORE_GATE_BYTES: [u8; 1] = [0];
+/// Number of bytes used to encode the tenant identifier length in the restore-gate protocol.
+const RESTORE_GATE_TENANT_ID_LEN_SIZE: usize = ::core::mem::size_of::<u16>();
 
 //==================================================================================================
 // WaitForSocketError
@@ -172,6 +164,12 @@ pub struct LinuxDaemon {
     /// RAII handle to the network namespace linuxd runs in (L2-mode only).
     netns_handle: Option<NetnsHandle>,
     /// RAII handle to the per-instance snapshot directory used in L2 mode.
+    snapshot_dir_handle: Option<SnapshotDirHandle>,
+}
+
+pub struct PendingLinuxDaemon {
+    child: Child,
+    netns_handle: Option<NetnsHandle>,
     snapshot_dir_handle: Option<SnapshotDirHandle>,
 }
 
@@ -262,6 +260,7 @@ impl LinuxDaemon {
     /// # Parameters
     ///
     /// - `netns_info`: Information about the L2 VM's network namespace.
+    /// - `tenant_id`: Tenant identifier to deliver to the restored linuxd instance.
     /// - `ch_remote_path`: Path to the ch-remote binary.
     /// - `clh_api_socket_path`: Path to the cloud-hypervisor API socket.
     /// - `clh_stderr_log_path`: Destination file where CLH stderr is captured.
@@ -272,6 +271,7 @@ impl LinuxDaemon {
     ///
     async fn resume_l2_vm(
         netns_info: &NetnsInfo,
+        tenant_id: &str,
         ch_remote_path: &str,
         clh_api_socket_path: &str,
         clh_stderr_log_path: &Path,
@@ -345,13 +345,25 @@ impl LinuxDaemon {
             anyhow::bail!(reason);
         }
 
-        // After receiving the HTTP reply, unlock the post-snapshot gate by sending a single byte.
+        // After receiving the HTTP reply, unlock the post-snapshot gate and deliver the tenant ID
+        // that the restored linuxd should use when registering its control-plane connection.
         let unbound_socket: UnboundSocket = UnboundSocket::new(SocketType::Tcp);
         let mut stream: SocketStream = unbound_socket
             .connect(&restore_gate_sockaddr_builder(Some(netns_info.veth_ns_ip())))
             .await?;
-        if let Err(e) = stream.write_all(&RESTORE_GATE_BYTES).await {
-            error!("failed to write restore gate bytes (error={e:?})");
+        let tenant_id_bytes: &[u8] = tenant_id.as_bytes();
+        let tenant_id_len: u16 = u16::try_from(tenant_id_bytes.len()).map_err(|error| {
+            let reason: String =
+                format!("tenant identifier too large for restore gate payload (error={error:?})");
+            error!("resume_l2_vm(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+        let mut payload: Vec<u8> =
+            Vec::with_capacity(RESTORE_GATE_TENANT_ID_LEN_SIZE + tenant_id_bytes.len());
+        payload.extend_from_slice(&tenant_id_len.to_be_bytes());
+        payload.extend_from_slice(tenant_id_bytes);
+        if let Err(e) = stream.write_all(&payload).await {
+            error!("failed to write restore gate payload (error={e:?})");
             return Err(e.into());
         }
 
@@ -451,10 +463,9 @@ impl LinuxDaemon {
     ///
     pub async fn spawn<T: Sync + Send + 'static>(
         args: &LinuxDaemonArgs<T>,
-        control_plane_listener: &mut SocketListener,
         netns_handle: Option<NetnsHandle>,
         snapshot_dir_handle: Option<SnapshotDirHandle>,
-    ) -> Result<Self> {
+    ) -> Result<PendingLinuxDaemon> {
         debug!(
             "spawn(): spawning linux daemon (control-plane={:?}, user-vm={:?}, l2={})",
             args.control_plane_connect_socket_info(),
@@ -555,6 +566,7 @@ impl LinuxDaemon {
                 format!("{}/ch-remote", get_clh_bin_dir(args.toolchain_binary_directory())?);
             if let Err(e) = Self::resume_l2_vm(
                 &netns_handle.netns_info()?,
+                args.tenant_id(),
                 &ch_remote_path,
                 &clh_api_socket_path,
                 &clh_stderr_log_path,
@@ -588,44 +600,8 @@ impl LinuxDaemon {
                 })?
         };
 
-        // After linuxd has started, accept the incoming connection and return the stream for
-        // further use.
-        let control_plane_stream: SocketStream =
-            match timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, control_plane_listener.accept()).await {
-                Ok(Ok(stream)) => stream,
-                Ok(Err(e)) => {
-                    // If linuxd has not accepted the control-plane connection, it means that
-                    // something went wrong during start-up. We kill the process ignoring errors,
-                    // and return an error.
-                    let reason: String =
-                        format!("error connecting control-plane to linuxd (error={e:?})");
-                    error!("spawn(): {reason}");
-
-                    // Use a SIGKILL because the process is already faulty.
-                    Self::send_sigkill_to_child(&child);
-
-                    anyhow::bail!(reason)
-                },
-                Err(e) => {
-                    let reason: String = format!(
-                        "timed-out waiting for linuxd to connect to control-plane (error={e:?})"
-                    );
-                    error!("spawn(): {reason}");
-
-                    // Use a SIGKILL because the process is already faulty.
-                    Self::send_sigkill_to_child(&child);
-
-                    anyhow::bail!(reason)
-                },
-            };
-        debug!("nanvixd received connection from linuxd's control-plane socket");
-
-        Ok(Self {
-            inner: Mutex::new(Some(LinuxDaemonInner {
-                child,
-                control_plane_stream,
-                pending_gateway_ready: HashMap::new(),
-            })),
+        Ok(PendingLinuxDaemon {
+            child,
             netns_handle,
             snapshot_dir_handle,
         })
@@ -798,6 +774,50 @@ impl LinuxDaemon {
             netns_handle: None,
             snapshot_dir_handle: None,
         }
+    }
+}
+
+impl PendingLinuxDaemon {
+    ///
+    /// # Description
+    ///
+    /// Completes Linux daemon startup by attaching the accepted control-plane stream.
+    ///
+    /// # Arguments
+    ///
+    /// - `control_plane_stream`: Accepted control-plane stream for the spawned Linux daemon.
+    ///
+    /// # Returns
+    ///
+    /// Returns the running Linux daemon handle.
+    ///
+    pub fn attach_control_plane(self, control_plane_stream: SocketStream) -> LinuxDaemon {
+        LinuxDaemon {
+            inner: Mutex::new(Some(LinuxDaemonInner {
+                child: self.child,
+                control_plane_stream,
+                pending_gateway_ready: HashMap::new(),
+            })),
+            netns_handle: self.netns_handle,
+            snapshot_dir_handle: self.snapshot_dir_handle,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Aborts a pending Linux daemon startup by forcefully terminating the child process.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
+    ///
+    pub async fn abort(self) {
+        LinuxDaemon::send_sigkill_to_child(&self.child);
     }
 }
 

--- a/src/libs/nanvix-sandbox/src/sandbox/multi_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/multi_process/uservm.rs
@@ -12,10 +12,7 @@
 //==================================================================================================
 
 use crate::{
-    config::{
-        CLEANUP_TIMEOUT,
-        CONTROL_PLANE_ACCEPT_TIMEOUT,
-    },
+    config::CLEANUP_TIMEOUT,
     UserVmArgs,
 };
 #[cfg(not(feature = "single-process"))]
@@ -35,14 +32,9 @@ use ::std::{
         Stdio,
     },
 };
-use ::syscomm::{
-    SocketListener,
-    SocketStream,
-    WriteAll,
-};
+use ::syscomm::{SocketStream, WriteAll};
 use ::log::{
     debug,
-    error,
     trace,
     warn,
 };
@@ -74,6 +66,12 @@ pub struct UserVm {
     _netns_handle: Option<NetnsHandle>,
 }
 
+pub struct PendingUserVm {
+    child: Option<Child>,
+    #[cfg(not(feature = "single-process"))]
+    netns_handle: Option<NetnsHandle>,
+}
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
@@ -97,9 +95,8 @@ impl UserVm {
     ///
     pub async fn spawn(
         args: &UserVmArgs,
-        control_plane_listener: &mut SocketListener,
         #[cfg(not(feature = "single-process"))] netns_handle: Option<NetnsHandle>,
-    ) -> Result<Self> {
+    ) -> Result<PendingUserVm> {
         trace!("spawn(): args={args:?}");
 
         let mut user_vm_args: Vec<String> = vec![
@@ -200,43 +197,10 @@ impl UserVm {
             args.console_file(),
         );
 
-        // After the user VM has started, accept the incoming connection for the control-plane.
-        // Post-condition: once the connection has been accepted, the user VM has been able to
-        // connect to the system VM (if an address is provided).
-        let control_plane_stream: SocketStream =
-            match timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, control_plane_listener.accept()).await {
-                Ok(Ok(stream)) => stream,
-                Ok(Err(e)) => {
-                    // If the user VM has not accepted the control-plane connection, it means that
-                    // something went wrong during start-up. We kill the process ignoring errors,
-                    // and return an error.
-                    let reason: String =
-                        format!("error connecting control-plane to user VM (error={e:?})");
-                    error!("{reason}");
-
-                    Self::send_sigkill_to_child(child);
-
-                    return Err(anyhow::anyhow!("{reason}"));
-                },
-                Err(e) => {
-                    let reason: String = format!(
-                        "timed-out waiting for user VM to connect the control-plane stream \
-                         (error={e:?})"
-                    );
-                    error!("{reason}");
-
-                    Self::send_sigkill_to_child(child);
-
-                    return Err(anyhow::anyhow!("{reason}"));
-                },
-            };
-        debug!("nanvixd received connection from the user VM's control-plane socket");
-
-        Ok(Self {
+        Ok(PendingUserVm {
             child: Some(child),
-            control_plane_stream,
             #[cfg(not(feature = "single-process"))]
-            _netns_handle: netns_handle,
+            netns_handle,
         })
     }
 
@@ -336,6 +300,49 @@ impl UserVm {
             }
         } else {
             false
+        }
+    }
+}
+
+impl PendingUserVm {
+    ///
+    /// # Description
+    ///
+    /// Completes User VM startup by attaching the accepted control-plane stream.
+    ///
+    /// # Arguments
+    ///
+    /// - `control_plane_stream`: Accepted control-plane stream for the spawned User VM.
+    ///
+    /// # Returns
+    ///
+    /// Returns the running User VM handle.
+    ///
+    pub fn attach_control_plane(self, control_plane_stream: SocketStream) -> UserVm {
+        UserVm {
+            child: self.child,
+            control_plane_stream,
+            #[cfg(not(feature = "single-process"))]
+            _netns_handle: self.netns_handle,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Aborts a pending User VM startup by forcefully terminating the child process.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
+    ///
+    pub async fn abort(self) {
+        if let Some(child) = self.child {
+            UserVm::send_sigkill_to_child(child);
         }
     }
 }

--- a/src/libs/nanvix-sandbox/src/sandbox/single_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/single_process/linuxd.rs
@@ -12,10 +12,7 @@
 //==================================================================================================
 
 use crate::{
-    config::{
-        CONTROL_PLANE_ACCEPT_TIMEOUT,
-        SHUTDOWN_TIMEOUT,
-    },
+    config::SHUTDOWN_TIMEOUT,
     LinuxDaemonArgs,
 };
 use ::anyhow::Result;
@@ -25,7 +22,6 @@ use ::control_plane_api::{
 };
 use ::linuxd::LinuxDaemon as EmbeddedLinuxd;
 use ::log::{
-    debug,
     error,
     trace,
     warn,
@@ -77,6 +73,10 @@ pub struct LinuxDaemon {
     inner: Mutex<Option<LinuxDaemonInner>>,
 }
 
+pub struct PendingLinuxDaemon {
+    linuxd_task: Option<JoinHandle<Result<()>>>,
+}
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
@@ -99,8 +99,7 @@ impl LinuxDaemon {
     ///
     pub async fn spawn<T: Sync + Send + Default + 'static>(
         args: &LinuxDaemonArgs<T>,
-        control_plane_listener: &mut SocketListener,
-    ) -> Result<Self> {
+    ) -> Result<PendingLinuxDaemon> {
         trace!(
             "spawn(): control_plane_connect_socket_address={:?}, user_vm_sockaddr={:?}",
             args.control_plane_connect_socket_info(),
@@ -139,6 +138,7 @@ impl LinuxDaemon {
 
         let linuxd: EmbeddedLinuxd<T> = EmbeddedLinuxd::init(
             syscall_table,
+            args.tenant_id(),
             &args.control_plane_connect_socket_info().0,
             args.control_plane_connect_socket_info().1.to_str(),
             user_vm_listener,
@@ -160,36 +160,8 @@ impl LinuxDaemon {
             })
         });
 
-        // Wait for the linuxd to connect to the control-plane socket.
-        let control_plane_stream: SocketStream =
-            match timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, control_plane_listener.accept()).await {
-                Ok(Ok(stream)) => stream,
-                Ok(Err(error)) => {
-                    linuxd_task.abort();
-                    let reason: String =
-                        format!("error connecting control-plane to linuxd (error={error:?})");
-                    error!("spawn(): {reason}");
-                    anyhow::bail!("{reason}");
-                },
-                Err(elapsed) => {
-                    linuxd_task.abort();
-                    let reason: String = format!(
-                        "timed-out waiting for linuxd to connect the control-plane stream \
-                         (elapsed={elapsed:?})"
-                    );
-                    error!("spawn(): {reason}");
-                    anyhow::bail!("{reason}");
-                },
-            };
-
-        debug!("spawn(): nanvixd received connection from linuxd control-plane socket");
-
-        Ok(Self {
-            inner: Mutex::new(Some(LinuxDaemonInner {
-                linuxd_task,
-                control_plane_stream,
-                pending_gateway_ready: HashMap::new(),
-            })),
+        Ok(PendingLinuxDaemon {
+            linuxd_task: Some(linuxd_task),
         })
     }
 
@@ -320,6 +292,50 @@ impl LinuxDaemon {
                 control_plane_stream,
                 pending_gateway_ready: HashMap::new(),
             })),
+        }
+    }
+}
+
+impl PendingLinuxDaemon {
+    ///
+    /// # Description
+    ///
+    /// Completes Linux daemon startup by attaching the accepted control-plane stream.
+    ///
+    /// # Arguments
+    ///
+    /// - `control_plane_stream`: Accepted control-plane stream for the spawned Linux daemon.
+    ///
+    /// # Returns
+    ///
+    /// Returns the running Linux daemon handle.
+    ///
+    pub fn attach_control_plane(self, control_plane_stream: SocketStream) -> LinuxDaemon {
+        LinuxDaemon {
+            inner: Mutex::new(Some(LinuxDaemonInner {
+                linuxd_task: self.linuxd_task.expect("linuxd task missing"),
+                control_plane_stream,
+                pending_gateway_ready: HashMap::new(),
+            })),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Aborts a pending Linux daemon startup by cancelling its background task.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
+    ///
+    pub async fn abort(self) {
+        if let Some(task) = self.linuxd_task {
+            task.abort();
         }
     }
 }

--- a/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
@@ -12,14 +12,12 @@
 //==================================================================================================
 
 use crate::{
-    config::{
-        CLEANUP_TIMEOUT,
-        CONTROL_PLANE_ACCEPT_TIMEOUT,
-    },
+    config::CLEANUP_TIMEOUT,
     UserVmArgs,
 };
 use ::anyhow::Result;
 use ::control_plane_api::{
+    ControlPlaneRegistrationMessage,
     NanvixdCommand,
     NanvixdControlMessage,
 };
@@ -41,7 +39,6 @@ use ::std::{
 };
 use ::sys::ipc::IkcFrame;
 use ::syscomm::{
-    SocketListener,
     SocketStream,
     SocketType,
     UnboundSocket,
@@ -90,6 +87,10 @@ pub struct UserVm {
     control_plane_stream: SocketStream,
 }
 
+pub struct PendingUserVm {
+    task: Option<JoinHandle<Result<u8>>>,
+}
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
@@ -112,8 +113,7 @@ impl UserVm {
     ///
     pub async fn spawn(
         args: &UserVmArgs,
-        control_plane_listener: &mut SocketListener,
-    ) -> Result<Self> {
+    ) -> Result<PendingUserVm> {
         trace!("spawn(): args={args:?}");
 
         // Check if CPU affinity settings were provided.
@@ -189,6 +189,12 @@ impl UserVm {
                         return Err(anyhow::anyhow!("{reason}"));
                     },
                 };
+
+                let registration: ControlPlaneRegistrationMessage =
+                    ControlPlaneRegistrationMessage::for_uservm(user_vm_id);
+                let registration_bytes: Vec<u8> = registration.to_bytes()?;
+                let mut control_plane_stream = control_plane_stream;
+                control_plane_stream.write_all(&registration_bytes).await?;
 
                 // Connect to the system VM socket.
                 let unbound_socket: UnboundSocket =
@@ -321,31 +327,8 @@ impl UserVm {
             })
         });
 
-        // Wait for the User VM task to connect to the control-plane socket.
-        let control_plane_stream: SocketStream =
-            match timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, control_plane_listener.accept()).await {
-                Ok(Ok(stream)) => stream,
-                Ok(Err(error)) => {
-                    uservm_task.abort();
-                    let reason: String =
-                        format!("error connecting control-plane to user VM (error={error:?})");
-                    error!("spawn(): {reason}");
-                    anyhow::bail!("{reason}");
-                },
-                Err(elapsed) => {
-                    uservm_task.abort();
-                    let reason: String = format!(
-                        "timed-out waiting for user VM to connect the control-plane stream \
-                         (elapsed={elapsed:?})"
-                    );
-                    error!("spawn(): {reason}");
-                    anyhow::bail!("{reason}");
-                },
-            };
-
-        Ok(Self {
+        Ok(PendingUserVm {
             task: Some(uservm_task),
-            control_plane_stream,
         })
     }
 
@@ -423,6 +406,47 @@ impl UserVm {
             !task.is_finished()
         } else {
             false
+        }
+    }
+}
+
+impl PendingUserVm {
+    ///
+    /// # Description
+    ///
+    /// Completes User VM startup by attaching the accepted control-plane stream.
+    ///
+    /// # Arguments
+    ///
+    /// - `control_plane_stream`: Accepted control-plane stream for the spawned User VM.
+    ///
+    /// # Returns
+    ///
+    /// Returns the running User VM handle.
+    ///
+    pub fn attach_control_plane(self, control_plane_stream: SocketStream) -> UserVm {
+        UserVm {
+            task: self.task,
+            control_plane_stream,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Aborts a pending User VM startup by cancelling its background task.
+    ///
+    /// # Arguments
+    ///
+    /// This function takes no arguments.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
+    ///
+    pub async fn abort(self) {
+        if let Some(task) = self.task {
+            task.abort();
         }
     }
 }

--- a/src/libs/nanvix-sandbox/src/simple_cache/mod.rs
+++ b/src/libs/nanvix-sandbox/src/simple_cache/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     control_plane_sockaddr_builder,
     gateway_sockaddr_builder,
     linuxd::LinuxDaemon,
+    ControlPlaneAcceptor,
     syscomm::{
         SocketListener,
         SocketType,
@@ -86,8 +87,8 @@ pub struct SimpleSandboxCache<T> {
     running_sandbox: Option<(UserVmIdentifier, RunningSandbox)>,
     /// Registry of Linux Daemon instances indexed by tenant ID (one per tenant).
     linuxd_instances: HashMap<String, Arc<LinuxDaemon>>,
-    /// Shared control plane listener socket (reused across sandboxes for efficiency).
-    control_plane_bind_socket: Option<Arc<Mutex<(SocketListener, String, SocketType)>>>,
+    /// Shared acceptor that routes control-plane connections to waiters.
+    control_plane_acceptor: Option<Arc<ControlPlaneAcceptor>>,
 }
 
 ///
@@ -155,15 +156,18 @@ impl<T: Sync + Send + Default + 'static> SimpleSandboxCache<T> {
                 },
             };
 
+        let control_plane_acceptor: Arc<ControlPlaneAcceptor> =
+            ControlPlaneAcceptor::new(
+                control_plane_bind_socket,
+                control_plane_bind_sockaddr,
+                control_plane_bind_socket_type,
+            );
+
         Ok(Arc::new(Mutex::new(Self {
             config,
             running_sandbox: None,
             linuxd_instances: HashMap::new(),
-            control_plane_bind_socket: Some(Arc::new(Mutex::new((
-                control_plane_bind_socket,
-                control_plane_bind_sockaddr,
-                control_plane_bind_socket_type,
-            )))),
+            control_plane_acceptor: Some(control_plane_acceptor),
         })))
     }
 
@@ -176,7 +180,7 @@ impl<T: Sync + Send + Default + 'static> SimpleSandboxCache<T> {
         SimpleSandboxCacheStateSummary {
             has_running_sandbox: self.running_sandbox.is_some(),
             linuxd_instances: self.linuxd_instances.len(),
-            has_control_plane_bind_socket: self.control_plane_bind_socket.is_some(),
+            has_control_plane_bind_socket: self.control_plane_acceptor.is_some(),
         }
     }
 
@@ -219,9 +223,11 @@ impl<T: Sync + Send + Default + 'static> SimpleSandboxCache<T> {
                 sandbox.gateway_socket_info().1,
             )),
             _ => {
-                let control_plane_bind_socket: Arc<Mutex<(SocketListener, String, SocketType)>> =
-                    self.control_plane_bind_socket.clone().ok_or_else(|| {
-                        let reason: &str = "control plane socket not initialized";
+                let control_plane_acceptor: Arc<ControlPlaneAcceptor> = self
+                    .control_plane_acceptor
+                    .clone()
+                    .ok_or_else(|| {
+                        let reason: &str = "control plane acceptor not initialized";
                         error!("get(): {reason}");
                         anyhow::anyhow!(reason)
                     })?;
@@ -230,7 +236,7 @@ impl<T: Sync + Send + Default + 'static> SimpleSandboxCache<T> {
                     tag.program(),
                     tag.program_args().cloned(),
                     self.config.ramfs_filename().map(|s| s.to_string()),
-                    control_plane_bind_socket,
+                    control_plane_acceptor,
                 );
 
                 let gateway_l2_port: Option<crate::tcp_port::TcpPort> = None;

--- a/src/libs/nanvix-sandbox/src/uninitialized.rs
+++ b/src/libs/nanvix-sandbox/src/uninitialized.rs
@@ -11,17 +11,24 @@
 // Imports
 //==================================================================================================
 
-#[cfg(not(feature = "standalone"))]
-use crate::linuxd::LinuxDaemon;
 #[cfg(not(any(feature = "single-process", feature = "standalone")))]
 use crate::netns::{
     NetnsHandle,
     NetnsInfo,
 };
 #[cfg(not(feature = "standalone"))]
-use crate::LinuxDaemonArgs;
+use crate::ControlPlaneAcceptor;
 #[cfg(not(any(feature = "single-process", feature = "standalone")))]
 use crate::SnapshotDirHandle;
+#[cfg(not(feature = "standalone"))]
+use crate::{
+    config::CONTROL_PLANE_ACCEPT_TIMEOUT,
+    linuxd::{
+        LinuxDaemon,
+        PendingLinuxDaemon,
+    },
+    LinuxDaemonArgs,
+};
 use crate::{
     InitializedSandbox,
     SandboxConfig,
@@ -30,14 +37,15 @@ use ::anyhow::Result;
 use ::log::error;
 #[cfg(not(any(feature = "single-process", feature = "standalone")))]
 use ::std::marker::PhantomData;
-use ::std::sync::Arc;
-use ::syscomm::{
-    SocketListener,
-    SocketType,
-};
-use ::tokio::sync::Mutex;
 #[cfg(not(feature = "standalone"))]
-use ::tokio::sync::MutexGuard;
+use ::std::sync::Arc;
+#[cfg(not(feature = "standalone"))]
+use ::syscomm::SocketStream;
+#[cfg(not(feature = "standalone"))]
+use ::tokio::{
+    sync::oneshot::Receiver,
+    time::timeout,
+};
 
 //==================================================================================================
 // Structures
@@ -73,8 +81,9 @@ pub struct UninitializedSandbox<T> {
     /// Optional handle to the per-instance snapshot directory. Only used in L2 deployments.
     #[cfg(not(any(feature = "single-process", feature = "standalone")))]
     snapshot_dir_handle: Option<SnapshotDirHandle>,
-    /// Optional control plane listener socket, address, and socket type.
-    control_plane_bind_socket_and_info: Option<Arc<Mutex<(SocketListener, String, SocketType)>>>,
+    /// Shared control-plane acceptor used to route child connections.
+    #[cfg(not(feature = "standalone"))]
+    control_plane_acceptor: Option<Arc<ControlPlaneAcceptor>>,
     /// Optional sandbox configuration parameters.
     config: Option<SandboxConfig<T>>,
     /// Phantom data to maintain the generic type parameter `T` in the structure.
@@ -98,8 +107,7 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
     /// - `guest_binary_path`: Path to the guest binary file to execute.
     /// - `program_args`: Optional command-line arguments for the program.
     /// - `ramfs_filename`: Optional RAM filesystem image filename to expose to the guest.
-    /// - `control_plane_bind_socket_and_info`: Shared control plane socket listener, address, and
-    ///   socket type.
+    /// - `control_plane_acceptor`: Shared control-plane acceptor.
     ///
     /// # Returns
     ///
@@ -109,7 +117,7 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
         guest_binary_path: &str,
         program_args: Option<String>,
         ramfs_filename: Option<String>,
-        control_plane_bind_socket_and_info: Arc<Mutex<(SocketListener, String, SocketType)>>,
+        #[cfg(not(feature = "standalone"))] control_plane_acceptor: Arc<ControlPlaneAcceptor>,
     ) -> Self {
         UninitializedSandbox {
             guest_binary_path: guest_binary_path.to_string(),
@@ -121,7 +129,8 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
             netns_handle: None,
             #[cfg(not(any(feature = "single-process", feature = "standalone")))]
             snapshot_dir_handle: None,
-            control_plane_bind_socket_and_info: Some(control_plane_bind_socket_and_info),
+            #[cfg(not(feature = "standalone"))]
+            control_plane_acceptor: Some(control_plane_acceptor),
             config: None,
             #[cfg(not(any(feature = "single-process", feature = "standalone")))]
             _phantom: PhantomData,
@@ -253,12 +262,12 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
             Some(config) => config,
         };
 
-        // Get the control-plane listener socket (must be provided via new()).
-        let control_plane_bind_socket_and_info: Arc<Mutex<(SocketListener, String, SocketType)>> =
-            match self.control_plane_bind_socket_and_info.take() {
-                Some(control_plane_bind_socket_and_info) => control_plane_bind_socket_and_info,
+        #[cfg(not(feature = "standalone"))]
+        let control_plane_acceptor: Arc<ControlPlaneAcceptor> =
+            match self.control_plane_acceptor.take() {
+                Some(control_plane_acceptor) => control_plane_acceptor,
                 None => {
-                    let reason: &str = "control plane listener socket not provided via new()";
+                    let reason: &str = "control plane acceptor not provided via new()";
                     error!("initialize(): {reason}");
                     anyhow::bail!(reason);
                 },
@@ -269,11 +278,6 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
         let linuxd: Arc<LinuxDaemon> = match self.linuxd.take() {
             // Linux Daemon not yet initialized.
             None => {
-                let mut locked_control_plane_bind_socket_and_info: MutexGuard<
-                    '_,
-                    (SocketListener, String, SocketType),
-                > = control_plane_bind_socket_and_info.lock().await;
-
                 // Build Linux Daemon arguments.
                 let linuxd_args: LinuxDaemonArgs<T> = {
                     // Get toolchain binary directory.
@@ -330,12 +334,15 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
                     )
                 };
 
-                // Spawn Linux Daemon.
-                match LinuxDaemon::spawn(
+                // Register interest in control-plane stream for the linuxd instance we are about
+                // to spawn.
+                let control_plane_stream_rx: Receiver<SocketStream> = control_plane_acceptor
+                    .register_linuxd(config.tenant_id())
+                    .await?;
+
+                // Spawn linuxd.
+                let pending_linuxd: PendingLinuxDaemon = match LinuxDaemon::spawn(
                     &linuxd_args,
-                    // Pass a mutable reference to the shared listener socket to accept one
-                    // incoming connection from the newly spawned linuxd instance.
-                    &mut locked_control_plane_bind_socket_and_info.0,
                     // Share ownership of netns handle with linux daemon process. The netns is
                     // provisioned upstream, if it is not but we are in L2 mode, spawn will fail.
                     #[cfg(not(any(feature = "single-process", feature = "standalone")))]
@@ -346,13 +353,53 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
                 )
                 .await
                 {
-                    Ok(linuxd) => Arc::new(linuxd),
+                    Ok(linuxd) => linuxd,
                     Err(error) => {
+                        control_plane_acceptor
+                            .unregister_linuxd(config.tenant_id())
+                            .await;
                         let reason: String = format!("failed to spawn linuxd (error={error:?})");
                         error!("initialize(): {reason}");
                         anyhow::bail!(reason);
                     },
-                }
+                };
+
+                // Await the handshake message from the newly spawned linuxd via the control-plane
+                // stream.
+                let control_plane_stream: SocketStream =
+                    match timeout(CONTROL_PLANE_ACCEPT_TIMEOUT, control_plane_stream_rx).await {
+                        Ok(Ok(stream)) => stream,
+                        Ok(Err(error)) => {
+                            control_plane_acceptor
+                                .unregister_linuxd(config.tenant_id())
+                                .await;
+                            pending_linuxd.abort().await;
+                            let reason: String = format!(
+                                "control-plane acceptor dropped before delivering linuxd stream \
+                                 (tenant_id={}, error={error:?})",
+                                config.tenant_id()
+                            );
+                            error!("initialize(): {reason}");
+                            anyhow::bail!(reason);
+                        },
+                        Err(error) => {
+                            control_plane_acceptor
+                                .unregister_linuxd(config.tenant_id())
+                                .await;
+                            pending_linuxd.abort().await;
+                            let reason: String = format!(
+                                "timed-out waiting for linuxd control-plane connection \
+                                 (tenant_id={}, error={error:?})",
+                                config.tenant_id()
+                            );
+                            error!("initialize(): {reason}");
+                            anyhow::bail!(reason);
+                        },
+                    };
+
+                // Upgrade the pending linuxd instance to a linuxd one by attaching the newly
+                // received control-plane stream.
+                Arc::new(pending_linuxd.attach_control_plane(control_plane_stream))
             },
             Some(linuxd) => linuxd,
         };
@@ -364,7 +411,8 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
             ramfs_filename: self.ramfs_filename,
             #[cfg(not(feature = "standalone"))]
             linuxd,
-            control_plane_bind_socket_and_info,
+            #[cfg(not(feature = "standalone"))]
+            control_plane_acceptor,
             sandbox_config: config,
             // Pass ownership of the network namespace to the initialized sandbox.
             #[cfg(not(any(feature = "single-process", feature = "standalone")))]

--- a/src/uservm/src/main.rs
+++ b/src/uservm/src/main.rs
@@ -17,6 +17,8 @@ extern crate kvm_bindings;
 extern crate kvm_ioctls;
 
 use ::anyhow::Result;
+#[cfg(target_os = "linux")]
+use ::control_plane_api::ControlPlaneRegistrationMessage;
 use ::log::{
     debug,
     error,
@@ -250,7 +252,10 @@ async fn run_managed(
     )
     .await
     {
-        Ok(Ok(stream)) => {
+        Ok(Ok(mut stream)) => {
+            let registration: Vec<u8> =
+                ControlPlaneRegistrationMessage::for_uservm(args.user_vm_id()).to_bytes()?;
+            stream.write_all(&registration).await?;
             info!(
                 "main(): connected to control plane (control_plane_addr={:?})",
                 args.control_plane_addr()
@@ -375,7 +380,7 @@ async fn run_managed(
         #[cfg(feature = "gdb")]
         gdb_port: None,
         #[cfg(feature = "profile-time")]
-        perf_timings: crate::perf::PerfTimings::new(),
+        perf_timings: ::uservm::perf::PerfTimings::new(),
     });
 
     let vm_exit_status: Result<u16> = vmm_handle.await?;


### PR DESCRIPTION
In this PR I address a scalability bottleneck in the current control plane that I presented in #1610.

The source of the issue is that, before, each `nanvix-sandbox` instance kept a reference to the global control plane listener socket and, whenever a new sandbox was spawned, had to acquire it with mutual exclusion. This ended up effectively serializing all linuxd and user vm creations, limiting the maximum sustainable sandbox creation throughput.

In this PR I introduce a new background task that owns the control plane listener socket, and continuously accepts in a loop. Tasks instantiating a new `nanvix-sandbox` first register interest in accepting a new connection by calling a method on the acceptor task passing a unique identifier for the new sandbox (user vm id or tenant id). Then, when the actual sandbox is spawned, when connecting to the control-plane it will include its unique identifier so that the acceptor task can disambiguate concurrent connections, and route them to the corresponding `nanvixd` task.

The only hairy aspect of the implementation is that linuxd instances restored from a snapshot of an L2 VM do not have a unique tenant identifier. One option was to add the new tenant id to the snapshot config file (which we reseed per tenant) but I saw no clear field where to add it. Instead, I pass the tenant id as part of the unblocking of linuxd via the restore gate.