### PR TITLE
[build] Remove Docker from Linux z/docs

### DIFF
--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -11,7 +11,7 @@ covers all build-system operations exposed through the `z` utility.
 ## Prerequisites
 
 - Development environment set up per `doc/setup.md`.
-- Either a local cross-compilation toolchain (`toolchain/`) or Docker installed.
+- A local cross-compilation toolchain (`toolchain/`).
 - **Windows 11:** Docker Desktop (Linux containers), Windows Hypervisor Platform enabled,
   Developer Mode enabled, and Rust toolchain installed. See `doc/setup.md` for details.
 
@@ -31,12 +31,6 @@ Before building on Windows, ensure:
 ### Preferred Build Commands (using `z` utility)
 
 ```bash
-# Build everything with previously cached build options.
-./z build --with-cached-options -- all
-
-# Build everything with Docker.
-./z build --with-docker -- all
-
 # Build everything with the local toolchain.
 ./z build -- all
 ```
@@ -45,11 +39,11 @@ Before building on Windows, ensure:
 
 ```bash
 # Kernel only.
-./z build --with-cached-options -- kernel
+./z build -- kernel
 # Nanvixd only.
-./z build --with-cached-options -- all-nanvixd
+./z build -- all-nanvixd
 # UserVM only.
-./z build --with-cached-options -- all-uservm
+./z build -- all-uservm
 ```
 
 ### Build Parameters
@@ -130,27 +124,27 @@ Any unrecognized target is forwarded to `make` via Docker, just like on Linux:
 
 ```bash
 # Check formatting issues.
-./z build --with-cached-options -- format-check
+./z build -- format-check
 # Auto-fix formatting issues.
-./z build --with-cached-options -- format
+./z build -- format
 ```
 
 ### Linting
 
 ```bash
 # Check linting issues.
-./z build --with-cached-options -- lint-check
+./z build -- lint-check
 # Auto-fix linting issues.
-./z build --with-cached-options -- lint
+./z build -- lint
 ```
 
 ### Spell Checking
 
 ```bash
 # Check spelling errors.
-./z build --with-cached-options -- spellcheck
+./z build -- spellcheck
 # Fix spelling errors.
-./z build --with-cached-options -- spellcheck-fix
+./z build -- spellcheck-fix
 ```
 
 ## Formal Verification
@@ -159,10 +153,10 @@ Nanvix uses Verus for formal verification of selected kernel crates. The expecte
 
 ```bash
 # Verify all annotated crates.
-./z build --with-cached-options -- verify
+./z build -- verify
 
 # Verify a single crate.
-./z build --with-cached-options -- verify-bitmap
+./z build -- verify-bitmap
 ```
 
 - The `ensure-verus` prerequisite downloads the correct Verus release automatically.
@@ -222,9 +216,7 @@ Copy-Item scripts\setup\vscode\settings-windows.json .vscode\settings.json
 ## Troubleshooting Build Issues
 
 - If builds fail with toolchain errors, verify `toolchain/` symlink points to a valid toolchain.
-- If Docker builds fail, ensure Docker is running and the image is available.
 - Use `./z help` for usage information.
-- Cached build options are stored in `.z.cache` — delete this file to reset.
 - **Windows:** Use `.\z.ps1 help` for Windows-specific usage information.
 - **Windows:** If Docker builds fail with symlink errors, `z.ps1` automatically restores Git
   symlinks as file copies. Ensure Docker Desktop is running with Linux containers enabled.

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -56,19 +56,19 @@ steps for `microvm` and `hyperlight`.
 
 ```bash
 # Spell check.
-./z build --with-cached-options -- spellcheck
+./z build -- spellcheck
 
 # Format check.
-./z build --with-cached-options -- format-check
+./z build -- format-check
 
 # Lint check.
-./z build --with-cached-options -- lint-check
+./z build -- lint-check
 
 # Formal verification.
-./z build --with-cached-options -- verify
+./z build -- verify
 
 # Unit tests.
-./z build --with-cached-options -- run-unit-tests
+./z build -- run-unit-tests
 ```
 
 ## GitHub Actions Workflows

--- a/.github/skills/daemon-development/SKILL.md
+++ b/.github/skills/daemon-development/SKILL.md
@@ -52,7 +52,7 @@ events/messages.
 
 ```bash
 # Build all daemons as part of the full build.
-./z build --with-cached-options -- all
+./z build -- all
 
 # Guest daemons: GUEST_CARGO_BUILD_CMD.
 # Host daemons (linuxd): HOST_CARGO_BUILD_CMD.

--- a/.github/skills/gdb-debugging/SKILL.md
+++ b/.github/skills/gdb-debugging/SKILL.md
@@ -18,7 +18,7 @@ Refer to `doc/gdb.md` for the user-facing documentation.
 ## Build
 
 ```bash
-./z build --with-cached-options -- all DEPLOYMENT_MODE=standalone
+./z build -- all DEPLOYMENT_MODE=standalone
 ```
 
 ## Launch

--- a/.github/skills/kernel-development/SKILL.md
+++ b/.github/skills/kernel-development/SKILL.md
@@ -52,7 +52,7 @@ feature flags:
 ## Building the Kernel
 
 ```bash
-./z build --with-cached-options -- kernel
+./z build -- kernel
 ```
 
 The kernel uses a custom Cargo target

--- a/.github/skills/library-development/SKILL.md
+++ b/.github/skills/library-development/SKILL.md
@@ -108,10 +108,10 @@ These run on the host system and are compiled with the host Rust build command
 
 ```bash
 # Build all guest libraries.
-./z build --with-cached-options -- all
+./z build -- all
 
 # Run unit tests for host libraries.
-./z build --with-cached-options -- run-unit-tests
+./z build -- run-unit-tests
 ```
 
 Guest libraries use `GUEST_CARGO_BUILD_CMD` (cross-compiled with `cargo`). Host

--- a/.github/skills/test-development/SKILL.md
+++ b/.github/skills/test-development/SKILL.md
@@ -16,7 +16,7 @@ Unit tests are `#[cfg(test)]` modules within library crates. They run on the hos
 `cargo test`.
 
 ```bash
-./z build --with-cached-options -- run-unit-tests
+./z build -- run-unit-tests
 ```
 
 Libraries with unit tests are listed in
@@ -54,7 +54,7 @@ System tests run the full Nanvix stack (`nanvixd` + kernel + guest) and are avai
 `microvm` and `hyperlight` machines.
 
 ```bash
-./z build --with-cached-options -- run-nanvix-tests
+./z build -- run-nanvix-tests
 ```
 
 Test configurations:
@@ -114,7 +114,7 @@ Guest integration tests are `#![no_std]` binaries that run inside Nanvix:
 
 ```bash
 # Unit tests + system tests (if applicable).
-./z build --with-cached-options -- test
+./z build -- test
 # Full CI pipeline (includes all test types).
 ./scripts/pipeline.sh
 ```

--- a/.github/skills/test/SKILL.md
+++ b/.github/skills/test/SKILL.md
@@ -16,13 +16,13 @@ integration tests, and the combined test suite exposed through the `z` utility.
 ## Unit Tests
 
 ```bash
-./z build --with-cached-options -- run-unit-tests
+./z build -- run-unit-tests
 ```
 
 ## System Integration Tests (microvm and hyperlight only)
 
 ```bash
-./z build --with-cached-options -- run-nanvix-tests
+./z build -- run-nanvix-tests
 ```
 
 Test configurations are auto-selected based on deployment mode:
@@ -34,7 +34,7 @@ Test configurations are auto-selected based on deployment mode:
 ## All Tests
 
 ```bash
-./z build --with-cached-options -- test
+./z build -- test
 ```
 
 ## Windows

--- a/.github/skills/troubleshooting/SKILL.md
+++ b/.github/skills/troubleshooting/SKILL.md
@@ -62,27 +62,14 @@ ls -la toolchain/
 ln -s $HOME/toolchain toolchain
 ```
 
-### Cached Build Options Stale
-
-**Symptom**: Build behaves unexpectedly or uses wrong parameters.
-
-**Fix**: Delete the cache file and rebuild:
-
-```bash
-rm -f .z.cache
-./z build -- all
-```
-
 ### Full Reset (Last Resort)
 
-**Symptom**: Build or test issues persist after normal cleanup and cache reset.
+**Symptom**: Build or test issues persist after normal cleanup.
 
 **Fix**: Perform a full cleanup, then rebuild:
 
 ```bash
 ./z distclean
-# If building with Docker:
-./z distclean --with-docker
 
 ./z build -- all
 ```
@@ -96,16 +83,6 @@ rm -f .z.cache
 ```bash
 ./z build -- all SCCACHE=
 ```
-
-### Docker Build Failures
-
-**Symptom**: Docker-based builds fail with permission or image errors.
-
-**Fix**:
-
-1. Check Docker is running: `docker info`.
-2. Verify image availability: `docker images | grep nanvix`.
-3. Rebuild with: `./z build --with-docker -- all`.
 
 ## Runtime Failures
 
@@ -183,7 +160,7 @@ RUST_LOG=debug ./bin/uservm.elf \
 
 ```bash
 # Rust check with JSON output for IDE integration.
-./z build --with-cached-options -- check
+./z build -- check
 ```
 
 ### Log Files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,9 @@ See [doc/setup.md](doc/setup.md) for full environment setup. The quickest path:
 
 ```bash
 git clone https://github.com/nanvix/nanvix.git && cd nanvix
-./z setup --with-minimal-docker
-./z build --with-minimal-docker -- all
+./z setup --toolchain-dir $HOME/toolchain
+ln -T -s $HOME/toolchain toolchain
+./z build -- all
 ```
 
 On Windows, run `./z.ps1 setup --with-minimal-docker` to pull the Docker image and install the
@@ -125,11 +126,11 @@ and use `set -euo pipefail` where appropriate.
 Run these before submitting a pull request:
 
 ```bash
-./z build --with-cached-options -- format-check    # Formatting.
-./z build --with-cached-options -- lint-check      # Linting.
-./z build --with-cached-options -- spellcheck      # Spelling.
-./z build --with-cached-options -- verify          # Formal verification (Verus).
-./z build --with-cached-options -- test            # Unit + system tests.
+./z build -- format-check    # Formatting.
+./z build -- lint-check      # Linting.
+./z build -- spellcheck      # Spelling.
+./z build -- verify          # Formal verification (Verus).
+./z build -- test            # Unit + system tests.
 ```
 
 Or run the full CI pipeline locally:

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@ Nanvix is a microkernel-based research operating system.
 
 ### Linux
 
-Requires Ubuntu 24.04 with sudo privileges, [Docker](doc/setup-linux.md#5-setup-docker-optional), and
+Requires Ubuntu 24.04 with sudo privileges and
 [KVM](doc/setup-linux.md#4-setup-kvm) enabled.
 
 ```bash
 # Clone this source code.
 git clone https://github.com/nanvix/nanvix.git && cd nanvix
 
-# Setup a minimal development environment.
-./z setup --with-minimal-docker
+# Setup the development environment.
+./z setup --toolchain-dir $HOME/toolchain
+ln -T -s $HOME/toolchain toolchain
 
 # Build Nanvix.
-./z build --with-minimal-docker -- all
+./z build -- all
 
 # Run an example application.
 ./bin/nanvixd.elf -console-file /dev/stdout -- ./bin/hello-rust-nostd.elf

--- a/doc/build-linux.md
+++ b/doc/build-linux.md
@@ -11,8 +11,6 @@ script for a simplified build process or do it manually.
 
 - [Building Nanvix with `z`](#building-nanvix-with-z)
   - [Getting Started with `z`](#getting-started-with-z)
-  - [Using `z` to Build Nanvix with Docker](#using-z-to-build-nanvix-with-docker)
-  - [Using `z` to Build Nanvix with a Local Toolchain](#using-z-to-build-nanvix-with-a-local-toolchain)
 - [Building Individual Components](#building-individual-components)
 - [Build Parameters](#build-parameters)
 - [Code Quality Checks](#code-quality-checks)
@@ -24,7 +22,7 @@ script for a simplified build process or do it manually.
 ## Building Nanvix with `z`
 
 `z` is a utility for building Nanvix. It provides you with a simplified interface for building
-Nanvix either using Docker or your local toolchain.
+Nanvix using your local toolchain.
 
 ### Getting Started with `z`
 
@@ -34,17 +32,7 @@ For more information on how to use the `z` utility, you can run:
 ./z help
 ```
 
-### Using `z` to Build Nanvix with Docker
-
-To build Nanvix using the latest Docker image and default build parameters, run:
-
-```bash
-./z build --with-docker -- all
-```
-
-### Using `z` to Build Nanvix with a Local Toolchain
-
-To build Nanvix using your local toolchain and default build parameters, run:
+To build Nanvix with default build parameters, run:
 
 ```bash
 ./z build -- all
@@ -142,10 +130,10 @@ To run formal verification:
 
 ```bash
 # Verify all annotated crates.
-./z build --with-cached-options -- verify
+./z build -- verify
 
 # Verify a single crate (e.g., bitmap).
-./z build --with-cached-options -- verify-bitmap
+./z build -- verify-bitmap
 ```
 
 Verus is installed to `$(TOOLCHAIN_DIR)/verus` by default. When `VERUS_EXECUTABLE_DIR` points
@@ -157,5 +145,5 @@ executable (and required companion binaries), not just the Verus source tree.
 ```bash
 # Use a custom Verus installation (pre-built or source-built).
 # VERUS_EXECUTABLE_DIR must be the directory that contains the verus binary.
-./z build --with-cached-options -- verify VERUS_EXECUTABLE_DIR=~/verus/target-verus/release
+./z build -- verify VERUS_EXECUTABLE_DIR=~/verus/target-verus/release
 ```

--- a/doc/gdb.md
+++ b/doc/gdb.md
@@ -20,7 +20,7 @@ Build Nanvix in standalone mode. The `standalone` feature automatically enables 
 feature in `nanvixd` and `nanvix-bench`:
 
 ```bash
-./z build --with-cached-options -- all DEPLOYMENT_MODE=standalone
+./z build -- all DEPLOYMENT_MODE=standalone
 ```
 
 You also need a GDB client with x86_64 target support (`gdb-multiarch` or `x86_64-elf-gdb`).

--- a/doc/setup-linux.md
+++ b/doc/setup-linux.md
@@ -8,16 +8,12 @@ This guide will help you set up your development environment to build and run Na
 - [2. Clone This Repository](#2-clone-this-repository)
 - [3. Install Dependencies for Development Tools](#3-install-dependencies-for-development-tools)
 - [4. Setup KVM](#4-setup-kvm)
-- [5. Setup Docker (Optional)](#5-setup-docker-optional)
-- [6. Setup SCCACHE (Optional)](#6-setup-sccache-optional)
-- [7. Set Up GDB Debugging (Optional)](#7-set-up-gdb-debugging-optional)
-- [8. Setting Up Development Tools for the First Time](#8-setting-up-development-tools-for-the-first-time)
-  - [Option 1: Build Development Tools Locally (Preferred Method)](#option-1-build-development-tools-locally-preferred-method)
-  - [Option 2: Use a Pre-Built Docker Image](#option-2-use-a-pre-built-docker-image)
-  - [Option 3: Build a Docker Image](#option-3-build-a-docker-image)
-- [9. Updating Your Development Tools](#9-updating-your-development-tools)
-- [10. Verus (Formal Verification)](#10-verus-formal-verification)
-- [11. Setup Your IDE (Optional)](#11-setup-your-ide-optional)
+- [5. Setup SCCACHE (Optional)](#5-setup-sccache-optional)
+- [6. Set Up GDB Debugging (Optional)](#6-set-up-gdb-debugging-optional)
+- [7. Setting Up Development Tools for the First Time](#7-setting-up-development-tools-for-the-first-time)
+- [8. Updating Your Development Tools](#8-updating-your-development-tools)
+- [9. Verus (Formal Verification)](#9-verus-formal-verification)
+- [10. Setup Your IDE (Optional)](#10-setup-your-ide-optional)
   - [Visual Studio Code](#visual-studio-code)
 
 ---
@@ -59,21 +55,7 @@ newgrp kvm
 groups
 ```
 
-## 5. Setup Docker (Optional)
-
-```bash
-# Install Docker.
-curl -fsSL https://get.docker.com | sh
-
-# Add user to Docker group.
-sudo usermod -aG docker $USER
-
-# Re-login and check if groups changed.
-newgrp docker
-groups
-```
-
-## 6. Setup SCCACHE (Optional)
+## 5. Setup SCCACHE (Optional)
 
 Install `sccache` to enable caching of compilation artifacts, which can significantly speed up
 builds.
@@ -100,7 +82,7 @@ echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-## 7. Set Up GDB Debugging (Optional)
+## 6. Set Up GDB Debugging (Optional)
 
 The repository includes a `.gdbinit` file that automatically configures GDB for debugging. By
 default, GDB refuses to auto-load `.gdbinit` files from arbitrary directories. To allow it for
@@ -117,21 +99,11 @@ For full debugging instructions with GDB, see [doc/gdb.md](gdb.md).
 
 ---
 
-## 8. Setting Up Development Tools for the First Time
+## 7. Setting Up Development Tools for the First Time
 
 > ⚠️ **Note:** This process may take some time to complete.
 
-Choose one of the following methods to set up the development tools for Nanvix.
-
-> **Tip:** If you plan to actively contribute to Nanvix, building the tools locally (Option 1) is
-> recommended. It provides the fastest edit-build-test cycle and full access to debugging and
-> profiling tools.
-
-### Option 1: Build Development Tools Locally (Preferred Method)
-
-To build the tools directly on your system, follow these steps.
-
-#### Step 1: Install the Rust Toolchain
+### Step 1: Install the Rust Toolchain
 
 ```bash
 # Install Rust.
@@ -141,7 +113,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 exec $SHELL
 ```
 
-#### Step 2: Build Cross Compiler Toolchain
+### Step 2: Build Cross Compiler Toolchain
 
 ```bash
 # Ensure you are in the project's root directory.
@@ -152,35 +124,17 @@ ln -T -s $HOME/toolchain toolchain           # Create symbolic link for toolchai
 > **Note:** The toolchain directory must be located outside the repository root.
 > Use `./z setup --toolchain-dir <path>` to specify a valid location.
 
-### Option 2: Use a Pre-Built Docker Image
-
-This is the easiest and fastest way to get started:
-
-```bash
-# Ensure you are in the project's root directory.
-./z setup --with-docker
-```
-
-### Option 3: Build a Docker Image
-
-To build a Docker image with the required tools:
-
-```bash
-# Ensure you are in the project's root directory.
-./scripts/setup/docker.sh
-```
-
-## 9. Updating Your Development Tools
+## 8. Updating Your Development Tools
 
 When a new major release of Nanvix is available, you must update your development tools to ensure
 compatibility. Follow these steps to update your environment:
 
 1. **Update system dependencies**: [Re-install dependencies for development tools](#3-install-dependencies-for-development-tools).
-2. **Rebuild development tools**: [Re-build the development tools](#option-1-build-development-tools-locally-preferred-method).
+2. **Rebuild development tools**: [Re-build the development tools](#7-setting-up-development-tools-for-the-first-time).
 
 > **Note:** This update process is only required for major releases, not for minor updates or patches.
 
-## 10. Verus (Formal Verification)
+## 9. Verus (Formal Verification)
 
 Verus is installed automatically when you run `make verify`. The expected version is pinned in
 `build/verus-version` and installed to `toolchain/verus`. No manual setup is required.
@@ -207,7 +161,7 @@ make verify VERUS_EXECUTABLE_DIR=~/verus-src/source/target-verus/release
 
 ---
 
-## 11. Setup Your IDE (Optional)
+## 10. Setup Your IDE (Optional)
 
 Choose one of the following options to set up your IDE for Nanvix development.
 

--- a/doc/test.md
+++ b/doc/test.md
@@ -28,7 +28,7 @@ This document guides you through testing Nanvix.
 build parameters.
 
 ```bash
-./z build --with-cached-options -- run-unit-tests
+./z build -- run-unit-tests
 ```
 
 ## Running System Integration Tests (MicroVM and Hyperlight Only)
@@ -40,7 +40,7 @@ the Nanvix Daemon.
 The system integration tests can be run directly using:
 
 ```bash
-./z build --with-cached-options -- run-nanvix-tests
+./z build -- run-nanvix-tests
 ```
 
 The appropriate test configuration is automatically selected based on the
@@ -70,9 +70,9 @@ The `nanvix-test.elf` utility supports two execution modes:
 > ℹ️ This target sequentially invokes each underlying test suite.
 
 ```bash
-./z build --with-cached-options -- test
+./z build -- test
 ```
 
 On `microvm` and `hyperlight` machines,
-`./z build --with-cached-options -- test` runs both unit tests and system
+`./z build -- test` runs both unit tests and system
 integration tests. On other machines, only unit tests are executed.

--- a/doc/troubleshooting-linux.md
+++ b/doc/troubleshooting-linux.md
@@ -137,22 +137,6 @@ done
 echo "Cleanup complete."
 ```
 
-## Cross-Platform Issues
-
-### Cached Build Options Stale (`./z`)
-
-**Description:** Build behaves unexpectedly or uses wrong parameters due to stale cached options.
-
-**Fix:** Delete the `.z.cache` file used by the `./z` wrapper script and rebuild:
-
-```bash
-rm -f .z.cache
-./z build -- all
-```
-
-This applies to the Linux/macOS `./z` wrapper script. The Windows `z.ps1` workflow does not use
-`.z.cache`.
-
 ## CI/CD Failures
 
 ### Stale Resources Causing Test Failures

--- a/z
+++ b/z
@@ -43,20 +43,11 @@ CMD_NAME_HELP="help"
 
 # Option names.
 OPT_NAME_SEPARATOR="--"
-OPT_NAME_WITH_DOCKER="--with-docker"
-OPT_NAME_WITH_MINIMAL_DOCKER="--with-minimal-docker"
-OPT_NAME_WITH_CACHED_OPTIONS="--with-cached-options"
 OPT_NAME_PROFILE="--profile"
 OPT_NAME_TOOLCHAIN_DIR="--toolchain-dir"
 
-# Name of the Docker image with the Nanvix toolchain.
-DOCKER_IMAGE_BASE_NAME="nanvix/toolchain"
-
-# Cache file to store the last build command and options.
-Z_CACHE_FILE=".z.cache"
-
 # Default toolchain directory for setup.
-DEFAULT_LOCAL_TOOLCHAIN_DIR="${PWD}/toolchain"
+DEFAULT_LOCAL_TOOLCHAIN_DIR="${HOME:-${PWD}}/toolchain"
 
 # Location of ubuntu setup script.
 UBUNTU_SETUP_SCRIPT="${REPO_ROOT_DIR}/scripts/setup/ubuntu.sh"
@@ -65,15 +56,7 @@ UBUNTU_SETUP_SCRIPT="${REPO_ROOT_DIR}/scripts/setup/ubuntu.sh"
 # Global Variables
 #==================================================================================================
 
-# Options from cache.
-LAST_BUILD_WITH_DOCKER=false          # Was the last build done with Docker?
-LAST_BUILD_WITH_MINIMAL_DOCKER=false  # Was the last build done with the minimal Docker image?
-
-# Current options.
-BUILD_WITH_DOCKER=false                         # Build with Docker?
-BUILD_WITH_MINIMAL_DOCKER=false                 # Use minimal Docker image?
 BUILD_WITH_PROFILE=false                        # Enable profiling (implies RELEASE=yes)?
-WITH_CACHED_OPTIONS=false                       # Use cached options (if any)?
 TOOLCHAIN_DIR="${DEFAULT_LOCAL_TOOLCHAIN_DIR}"  # Toolchain directory for setup.
 
 #==================================================================================================
@@ -93,10 +76,10 @@ Utility for building Nanvix.
 
 Usage:
   ./z COMMAND [OPTIONS] [${OPT_NAME_SEPARATOR} BUILD_TARGET BUILD_PARAMETERS]
-  ./z ${CMD_NAME_BUILD} [${OPT_NAME_WITH_DOCKER}] [${OPT_NAME_WITH_CACHED_OPTIONS}] [${OPT_NAME_SEPARATOR} BUILD_TARGET BUILD_PARAMETERS]
-  ./z ${CMD_NAME_CLEAN} [${OPT_NAME_WITH_DOCKER}]
-  ./z ${CMD_NAME_DISTCLEAN} [${OPT_NAME_WITH_DOCKER}]
-  ./z ${CMD_NAME_SETUP} [${OPT_NAME_WITH_DOCKER}] [${OPT_NAME_TOOLCHAIN_DIR} <path>]
+  ./z ${CMD_NAME_BUILD} [${OPT_NAME_SEPARATOR} BUILD_TARGET BUILD_PARAMETERS]
+  ./z ${CMD_NAME_CLEAN}
+  ./z ${CMD_NAME_DISTCLEAN}
+  ./z ${CMD_NAME_SETUP} [${OPT_NAME_TOOLCHAIN_DIR} <path>]
   ./z ${CMD_NAME_HELP}
 
 Commands
@@ -107,210 +90,12 @@ Commands
   help      Prints the help information.
 
 Options
-  ${OPT_NAME_WITH_DOCKER}           Build Nanvix using Docker instead of the local toolchain.
-  ${OPT_NAME_WITH_MINIMAL_DOCKER}   Build Nanvix using the minimal Docker image (implies ${OPT_NAME_WITH_DOCKER}).
-  ${OPT_NAME_WITH_CACHED_OPTIONS}   Use cached options from the last build.
   ${OPT_NAME_PROFILE}               Enable profiling (implies RELEASE=yes, passes PROFILER=yes to make).
   ${OPT_NAME_TOOLCHAIN_DIR} <path>  Specify the toolchain directory for setup (default: ${DEFAULT_LOCAL_TOOLCHAIN_DIR}).
 EOF
     if ! make help; then
         print_error "Failed to get help on build targets and parameters."
         exit 1
-    fi
-}
-
-#
-# Description
-#
-#   Checks if Docker is installed and aborts if it is not.
-#
-# Usage Example
-#   check_docker_installed
-#
-check_docker_installed() {
-    if ! command -v docker >/dev/null 2>&1; then
-        print_error "Docker is not installed. Please install Docker to build with Docker."
-        exit 1
-    fi
-}
-
-#
-# Description
-#
-#   Checks if the Docker image is available locally and aborts if it is not.
-#
-# Arguments
-#   $1 - The name of the Docker image to check.
-#
-# Usage Example
-#   check_docker_image_available "nanvix/toolchain:v1.0.x"
-#
-check_docker_image_available() {
-    local image_name="$1"
-    if ! docker image inspect "${image_name}" >/dev/null 2>&1; then
-        print_error "Docker image '${image_name}' not found. Please pull it first."
-        exit 1
-    fi
-}
-
-#
-# Description
-#
-#   Returns the name of the Docker image to use for building Nanvix.
-#
-# Arguments
-#  $1 - The version of the Docker image to use.
-#  $2 - (Optional, default: false) Set to true to use the minimal Docker image.
-#
-# Usage Example
-#   get_docker_image_name "v1.0.0"
-#
-get_docker_image_name() {
-    # Build image tag version by replacing patch with "x".
-    local image_tag_version
-    local use_minimal=${2:-false}
-    image_tag_version="${1%.*}.x"
-
-    local suffix=""
-    if ${use_minimal}; then
-        suffix="-minimal"
-    fi
-
-    echo "${DOCKER_IMAGE_BASE_NAME}:v${image_tag_version}${suffix}"
-}
-
-#
-# Description
-#   Builds Nanvix using Docker with BuildKit cache mounts.
-#   Uses 'docker build' with --mount=type=cache for efficient caching.
-#
-# Arguments
-#   $* - The build parameters to pass to make.
-#
-# Return
-#   0 on success, non-zero on failure.
-#
-# Usage Example
-#   run_docker_build "all"
-#
-run_docker_build() {
-    local build_parameters="${*}"
-
-    # Check if Docker is installed.
-    check_docker_installed
-
-    local current_version
-    current_version=$(get_cargo_toml_version "$CARGO_TOML_FILE_PATH")
-
-    # Get the Docker image name.
-    local image_name
-    image_name=$(get_docker_image_name "${current_version}" "${BUILD_WITH_MINIMAL_DOCKER}")
-
-    # Check if the Docker image is available.
-    check_docker_image_available "${image_name}"
-
-    # Path to the build Dockerfile.
-    local dockerfile_path="${REPO_ROOT_DIR}/scripts/setup/Dockerfile.build"
-
-    # Check if the Dockerfile exists.
-    if [[ ! -f "${dockerfile_path}" ]]; then
-        print_error "Build Dockerfile not found: ${dockerfile_path}"
-        return 1
-    fi
-
-    # Extract RELEASE value from build parameters to determine sysroot suffix.
-    local sysroot_suffix="debug"
-    if [[ "${build_parameters}" =~ RELEASE=yes ]]; then
-        sysroot_suffix="release"
-    fi
-
-    # Get the absolute workspace path. This is passed to Docker so that Python
-    # and other binaries with embedded absolute paths can find their libraries
-    # at runtime without requiring symlinks on the host filesystem.
-    local workspace_path
-    workspace_path="$(pwd -P)"
-
-    # Run the build with BuildKit using the external Dockerfile.
-    # Forward GitHub Actions sccache cache backend variables when available.
-    # SCCACHE_GHA_ENABLED, SCCACHE_GHA_CACHE_TO, and SCCACHE_GHA_CACHE_FROM
-    # are passed as build args.
-    # ACTIONS_RESULTS_URL and ACTIONS_RUNTIME_TOKEN are injected as Docker secrets
-    # so that their per-run values do not bust the BuildKit layer cache.
-    local gha_sccache_args=()
-    if [[ -n "${SCCACHE_GHA_ENABLED:-}" ]]; then
-        gha_sccache_args+=(--build-arg "SCCACHE_GHA_ENABLED=${SCCACHE_GHA_ENABLED}")
-    fi
-    if [[ -n "${SCCACHE_GHA_CACHE_TO:-}" ]]; then
-        gha_sccache_args+=(--build-arg "SCCACHE_GHA_CACHE_TO=${SCCACHE_GHA_CACHE_TO}")
-    fi
-    if [[ -n "${SCCACHE_GHA_CACHE_FROM:-}" ]]; then
-        gha_sccache_args+=(--build-arg "SCCACHE_GHA_CACHE_FROM=${SCCACHE_GHA_CACHE_FROM}")
-    fi
-    if [[ -n "${ACTIONS_RESULTS_URL:-}" ]]; then
-        gha_sccache_args+=(--secret "id=actions_results_url,env=ACTIONS_RESULTS_URL")
-    fi
-    if [[ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
-        gha_sccache_args+=(--secret "id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN")
-    fi
-
-    DOCKER_BUILDKIT=1 docker build \
-        --build-arg BASE_IMAGE="${image_name}" \
-        --build-arg BUILD_PARAMS="${build_parameters}" \
-        --build-arg SYSROOT_SUFFIX="${sysroot_suffix}" \
-        --build-arg WORKSPACE_PATH="${workspace_path}" \
-        ${gha_sccache_args[@]+"${gha_sccache_args[@]}"} \
-        --output type=local,dest=. \
-        --progress=plain \
-        -f "${dockerfile_path}" \
-        .
-}
-
-#
-# Description
-#   Writes the last build command and options to the cache file.
-#   Each argument is written on a separate line.
-#
-# Arguments
-#   $@ - The full command line arguments.
-#
-# Usage Example
-#   write_cache "build" "--with-docker" "--" "all"
-#
-write_cache() {
-    printf '%s\n' "${@}" > "${Z_CACHE_FILE}"
-}
-
-#
-# Description
-#   Reads the last build command and options from the cache file.
-#   Sets the following global variables based on whether the cache contains the Docker option:
-#   - LAST_BUILD_WITH_DOCKER: true if the last build was done with Docker, false otherwise.
-#
-# Usage Example
-#   read_cache
-#
-read_cache() {
-    LAST_BUILD_WITH_DOCKER=false
-    LAST_BUILD_WITH_MINIMAL_DOCKER=false
-
-    if [[ -f "${Z_CACHE_FILE}" ]]; then
-        local cache_lines
-        mapfile -t cache_lines < "${Z_CACHE_FILE}"
-        # Check if the cache file is empty.
-        if [[ ${#cache_lines[@]} -eq 0 ]]; then
-            return
-        fi
-        # Process the cache lines to determine the last build options.
-        for arg in "${cache_lines[@]}"; do
-            if [[ "$arg" == "${OPT_NAME_WITH_MINIMAL_DOCKER}" ]]; then
-                LAST_BUILD_WITH_DOCKER=true
-                LAST_BUILD_WITH_MINIMAL_DOCKER=true
-            elif [[ "$arg" == "${OPT_NAME_WITH_DOCKER}" ]]; then
-                LAST_BUILD_WITH_DOCKER=true
-            elif [[ "$arg" == "${OPT_NAME_SEPARATOR}" ]]; then
-                break
-            fi
-        done
     fi
 }
 
@@ -375,7 +160,7 @@ check_filesystem_support() {
         *)
             print_warning "Unsupported file system '${fs_type}' detected for toolchain directory '${target_dir}'"
             print_warning "Only ext3/ext4/overlay are supported because extended attributes (xattr) are required for setcap commands."
-            print_warning "Consider moving the toolchain directory to a partition formatted with ext3, ext4, or using Docker."
+            print_warning "Consider moving the toolchain directory to a partition formatted with ext3, ext4, or overlay."
             return 4
             ;;
     esac
@@ -384,22 +169,12 @@ check_filesystem_support() {
 #
 # Description
 #
-#   Checks whether the currently selected toolchain (Docker image or local installation)
-#   matches the Nanvix version required by the workspace. The Nanvix version is read
-#   from the root `Cargo.toml` (via `get_cargo_toml_version`). The expected toolchain
-#   version string format is:
-#     - Docker image tag:   vMAJOR.MINOR.x (e.g., v1.2.x)
-#     - Local version file: nanvix-toolchain-vMAJOR.MINOR.x (single line in TOOLCHAIN_DIR/version)
+#   Checks whether the local toolchain matches the Nanvix version required by the workspace.
+#   The Nanvix version is read from the root `Cargo.toml` (via `get_cargo_toml_version`).
+#   The expected toolchain version string format is:
+#     nanvix-toolchain-vMAJOR.MINOR.x (single line in TOOLCHAIN_DIR/version)
 #
-#   Behavior:
-#     - When building with Docker (`BUILD_WITH_DOCKER=true`):
-#         * Verifies Docker is installed.
-#         * Verifies the expected image (derived from current Nanvix version) is present locally.
-#         * Validates the derived tag matches the MAJOR.MINOR.x pattern expected.
-#     - When building with the local toolchain:
-#         * Ensures the version file exists, is outside the repository, and is readable.
-#         * Compares its contents to the expected version string.
-#
+#   Ensures the version file exists, is readable, and its contents match the expected version.
 #   On mismatch or missing artifacts, an error is printed and the function returns non-zero.
 #   On success, returns zero.
 #
@@ -418,78 +193,41 @@ check_toolchain() {
     local expected_tag
     expected_tag="${current_version%.*}.x"
 
-    local expected_image_tag="${expected_tag}"
-    if ${BUILD_WITH_MINIMAL_DOCKER}; then
-        expected_image_tag="${expected_image_tag}-minimal"
+    local version_file
+    version_file="${TOOLCHAIN_DIR}/version"
+    local expected_version_string
+    expected_version_string="nanvix-toolchain-v${expected_tag}"
+
+    # Check if version file exists (follows symbolic links).
+    if [[ ! -e "${version_file}" ]]; then
+        print_error "Toolchain version file '${version_file}' not found. Run './z setup' to build the local toolchain."
+        return 1
     fi
 
-    if ${BUILD_WITH_DOCKER}; then
-        # Docker-based toolchain validation.
-        check_docker_installed
-
-        local image_name
-        image_name=$(get_docker_image_name "${current_version}" "${BUILD_WITH_MINIMAL_DOCKER}")
-
-        # Check image availability.
-        if ! docker image inspect "${image_name}" >/dev/null 2>&1; then
-            local setup_cmd="./z setup --with-docker"
-            if ${BUILD_WITH_MINIMAL_DOCKER}; then
-                setup_cmd="./z setup --with-minimal-docker"
-            fi
-            print_error "Required Docker toolchain image '${image_name}' not found. Run '${setup_cmd}' to fetch it."
-            return 1
-        fi
-
-        # Expected image tag extracted from the computed image name.
-        local image_tag
-        image_tag="${image_name##*:v}"
-
-        # Sanity check on tag consistency (defensive; should always match expected_image_tag).
-        if [[ "${image_tag}" != "${expected_image_tag}" ]]; then
-            print_error "Docker toolchain version mismatch (found tag '${image_tag}', expected '${expected_image_tag}'). Run './z setup --with-docker' or './z setup --with-minimal-docker' to update the toolchain image."
-            return 1
-        fi
-
-        print_info "Docker toolchain version '${image_tag}' matches expected '${expected_image_tag}'."
-    else
-        # Local toolchain validation.
-        local version_file
-        version_file="${TOOLCHAIN_DIR}/version"
-        local expected_version_string
-        expected_version_string="nanvix-toolchain-v${expected_tag}"
-
-        # Check if version file exists (follows symbolic links).
-        if [[ ! -e "${version_file}" ]]; then
-            print_error "Toolchain version file '${version_file}' not found. Run './z setup' to build the local toolchain."
-            return 1
-        fi
-
-        # Check if version file is readable (follows symbolic links).
-        if [[ ! -r "${version_file}" ]]; then
-            print_error "Toolchain version file '${version_file}' is not readable."
-            return 1
-        fi
-
-        local found_version
-        if ! read -r found_version < "${version_file}"; then
-            print_error "Failed to read toolchain version file '${version_file}'."
-            return 1
-        fi
-        found_version="$(echo "${found_version}" | tr -d '[:space:]')"
-
-        if [[ -z "${found_version}" ]]; then
-            print_error "Toolchain version file '${version_file}' is empty. Run './z setup' to (re)install the toolchain."
-            return 1
-        fi
-
-        if [[ "${found_version}" != "${expected_version_string}" ]]; then
-            print_error "Local toolchain version mismatch (found '${found_version}', expected '${expected_version_string}'). Run './z setup' to update the toolchain."
-            return 1
-        fi
-
-        print_info "Local toolchain version '${found_version}' matches expected '${expected_version_string}'."
+    # Check if version file is readable (follows symbolic links).
+    if [[ ! -r "${version_file}" ]]; then
+        print_error "Toolchain version file '${version_file}' is not readable."
+        return 1
     fi
 
+    local found_version
+    if ! read -r found_version < "${version_file}"; then
+        print_error "Failed to read toolchain version file '${version_file}'."
+        return 1
+    fi
+    found_version="$(echo "${found_version}" | tr -d '[:space:]')"
+
+    if [[ -z "${found_version}" ]]; then
+        print_error "Toolchain version file '${version_file}' is empty. Run './z setup' to (re)install the toolchain."
+        return 1
+    fi
+
+    if [[ "${found_version}" != "${expected_version_string}" ]]; then
+        print_error "Local toolchain version mismatch (found '${found_version}', expected '${expected_version_string}'). Run './z setup' to update the toolchain."
+        return 1
+    fi
+
+    print_info "Local toolchain version '${found_version}' matches expected '${expected_version_string}'."
     return 0
 }
 
@@ -522,31 +260,9 @@ main() {
     command="$1"
     shift
 
-    # Read last build info from cache
-    read_cache
-
-    local docker_option_set=false
-    local minimal_option_set=false
-
     # Parse command options.
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            "${OPT_NAME_WITH_DOCKER}")
-                BUILD_WITH_DOCKER=true
-                docker_option_set=true
-                shift
-                ;;
-            "${OPT_NAME_WITH_MINIMAL_DOCKER}")
-                BUILD_WITH_DOCKER=true
-                BUILD_WITH_MINIMAL_DOCKER=true
-                docker_option_set=true
-                minimal_option_set=true
-                shift
-                ;;
-            "${OPT_NAME_WITH_CACHED_OPTIONS}")
-                WITH_CACHED_OPTIONS=true
-                shift
-                ;;
             "${OPT_NAME_PROFILE}")
                 BUILD_WITH_PROFILE=true
                 shift
@@ -584,8 +300,14 @@ main() {
         fi
     done
 
-    # Disallow TOOLCHAIN_DIR inside the repository only for non-Docker builds.
-    if [[ "${BUILD_WITH_DOCKER:-false}" != "true" ]]; then
+    # Build parameters always include TOOLCHAIN_DIR.
+    local build_parameters=("TOOLCHAIN_DIR=${TOOLCHAIN_DIR}")
+    if [[ ${#user_build_parameters[@]} -gt 0 ]]; then
+        build_parameters+=("${user_build_parameters[@]}")
+    fi
+
+    # Disallow TOOLCHAIN_DIR inside the repository for commands that require a toolchain.
+    if [[ "${command}" == "${CMD_NAME_BUILD}" || "${command}" == "${CMD_NAME_SETUP}" ]]; then
         local resolved_toolchain resolved_repo
         resolved_toolchain="$(resolve_path "$TOOLCHAIN_DIR")"
         resolved_repo="$(cd "${REPO_ROOT_DIR}" && pwd -P)"
@@ -593,17 +315,6 @@ main() {
             print_error "Absolute path to the toolchain directory must not be inside the repository (${REPO_ROOT_DIR})."
             print_info "Hint: Specify the toolchain by passing '--toolchain-dir'"
             exit 1
-        fi
-    fi
-
-    # If using cache, restore variables from cache when not overridden by command line options.
-    if ${WITH_CACHED_OPTIONS}; then
-        print_info "Using cached build options."
-        if ! ${minimal_option_set} && ${LAST_BUILD_WITH_MINIMAL_DOCKER}; then
-            BUILD_WITH_MINIMAL_DOCKER=true
-            BUILD_WITH_DOCKER=true
-        elif ! ${docker_option_set} && ${LAST_BUILD_WITH_DOCKER}; then
-            BUILD_WITH_DOCKER=true
         fi
     fi
 
@@ -619,37 +330,15 @@ main() {
         user_build_parameters=("${filtered_params[@]}" "RELEASE=yes")
     fi
 
-    # Only add TOOLCHAIN_DIR for local builds, not Docker builds.
-    local build_parameters=()
-    if ! ${BUILD_WITH_DOCKER}; then
-        build_parameters+=("TOOLCHAIN_DIR=${TOOLCHAIN_DIR}")
-    fi
     # Pass PROFILER=yes to make when profiling is enabled.
     if ${BUILD_WITH_PROFILE}; then
         build_parameters+=("PROFILER=yes")
-    fi
-    if [[ ${#user_build_parameters[@]} -gt 0 ]]; then
-        build_parameters+=("${user_build_parameters[@]}")
     fi
 
     case "${command}" in
         "${CMD_NAME_BUILD}")
             print_info "Command: ${command}"
-            print_info "Build with Docker: ${BUILD_WITH_DOCKER}"
             print_info "Build Parameters: ${build_parameters[*]}"
-
-            # Check if we are switching build modes.
-            # Note: When switching TO Docker, we don't need to clean because Docker builds
-            # use isolated cache mounts. We only need to clean local artifacts when switching
-            # FROM Docker to local toolchain.
-            if ! ${BUILD_WITH_DOCKER} && ${LAST_BUILD_WITH_DOCKER}; then
-                print_warning "Switching to local toolchain build, forcing cleanup."
-                # Force a cleanup.
-                if ! make distclean ; then
-                    print_error "Cleanup failed with local toolchain."
-                    exit 1
-                fi
-            fi
 
             # Validate toolchain compatibility before building.
             if ! check_toolchain; then
@@ -658,84 +347,29 @@ main() {
             fi
 
             # Build Nanvix.
-            if ${BUILD_WITH_DOCKER}; then
-                print_info "Building with Docker (using BuildKit cache)..."
-                if ! run_docker_build "${build_parameters[@]}"; then
-                    print_error "Build failed with Docker."
-                    exit 1
-                fi
-                # Create sysroot symlink after Docker build.
-                # Docker COPY cannot preserve symlinks across the export boundary,
-                # so we create the symlink here to point to the correct sysroot.
-                local sysroot_suffix="debug"
-                if [[ "${build_parameters[*]}" =~ RELEASE=yes ]]; then
-                    sysroot_suffix="release"
-                fi
-                ln -sfn "sysroot-${sysroot_suffix}" sysroot
-            else
-                print_info "Building with local toolchain..."
-                if ! make "${build_parameters[@]}"; then
-                    print_error "Build failed."
-                    exit 1
-                fi
+            if ! make "${build_parameters[@]}"; then
+                print_error "Build failed."
+                exit 1
             fi
-
-            # Save current build command and options to cache.
-            cache_args=("${command}")
-            if ${BUILD_WITH_MINIMAL_DOCKER}; then
-                cache_args+=("${OPT_NAME_WITH_MINIMAL_DOCKER}")
-            elif ${BUILD_WITH_DOCKER}; then
-                cache_args+=("${OPT_NAME_WITH_DOCKER}")
-            fi
-            cache_args+=("${OPT_NAME_SEPARATOR}" "${build_parameters[@]}")
-            write_cache "${cache_args[@]}"
 
             print_success "Build complete."
             ;;
 
         "${CMD_NAME_CLEAN}")
-            if ${BUILD_WITH_DOCKER}; then
-                print_info "Running quick cleanup with Docker..."
-                if ! run_docker_build clean; then
-                    print_error "Quick clean failed with Docker."
-                    exit 1
-                fi
-            else
-                print_info "Running quick cleanup with local toolchain..."
-                if ! make clean; then
-                    print_error "Quick clean failed."
-                    exit 1
-                fi
-            fi
-
-            # Remove cache file (same behavior as legacy 'cleanup').
-            if [[ -f "${Z_CACHE_FILE}" ]]; then
-                rm -f "${Z_CACHE_FILE}"
-                print_success "Cache file removed."
+            print_info "Running quick cleanup..."
+            if ! make clean; then
+                print_error "Quick clean failed."
+                exit 1
             fi
 
             print_success "Quick clean complete."
             ;;
 
         "${CMD_NAME_DISTCLEAN}")
-            if ${BUILD_WITH_DOCKER}; then
-                print_info "Running full cleanup with Docker..."
-                if ! run_docker_build distclean; then
-                    print_error "Full cleanup failed with Docker."
-                    exit 1
-                fi
-            else
-                print_info "Running full cleanup with local toolchain..."
-                if ! make distclean; then
-                    print_error "Full cleanup failed."
-                    exit 1
-                fi
-            fi
-
-            # Remove cache file.
-            if [[ -f "${Z_CACHE_FILE}" ]]; then
-                rm -f "${Z_CACHE_FILE}"
-                print_success "Cache file removed."
+            print_info "Running full cleanup..."
+            if ! make distclean; then
+                print_error "Full cleanup failed."
+                exit 1
             fi
 
             print_success "Full cleanup complete."
@@ -754,73 +388,48 @@ main() {
                 fi
             fi
 
-            # If Docker is requested, download the Docker image.
-            if ${BUILD_WITH_DOCKER}; then
-                print_info "Docker setup requested, downloading Docker image..."
+            print_info "Toolchain directory: ${TOOLCHAIN_DIR}"
 
-                # Check if Docker is installed.
-                check_docker_installed
-
-                # Get the Docker image name using the same logic as run_docker_build.
-                local current_version
-                current_version=$(get_cargo_toml_version "$CARGO_TOML_FILE_PATH")
-
-                # Get the Docker image name.
-                local image_name
-                image_name=$(get_docker_image_name "${current_version}" "${BUILD_WITH_MINIMAL_DOCKER}")
-
-                # Pull the Docker image.
-                print_info "Pulling Docker image: ${image_name}"
-                if ! docker pull "${image_name}"; then
-                    print_error "Failed to pull Docker image '${image_name}'."
+            # Ensure the toolchain directory exists; create it if it does not.
+            if [[ ! -d "${TOOLCHAIN_DIR}" ]]; then
+                print_info "Toolchain directory '${TOOLCHAIN_DIR}' does not exist. Creating it..."
+                if ! mkdir -p "${TOOLCHAIN_DIR}"; then
+                    print_error "Failed to create toolchain directory '${TOOLCHAIN_DIR}'. Please check your permissions or specify another directory."
                     exit 1
                 fi
+            fi
 
-                print_success "Docker image '${image_name}' downloaded successfully."
-            else
-                print_info "Toolchain directory: ${TOOLCHAIN_DIR}"
+            # Check if user has write permissions to the toolchain directory.
+            if [[ ! -w "${TOOLCHAIN_DIR}" ]]; then
+                print_error "No write permissions to: ${TOOLCHAIN_DIR}. Run with appropriate permissions or specify another directory."
+                exit 1
+            fi
 
-                # Ensure the toolchain directory exists; create it if it does not.
-                if [[ ! -d "${TOOLCHAIN_DIR}" ]]; then
-                    print_info "Toolchain directory '${TOOLCHAIN_DIR}' does not exist. Creating it..."
-                    if ! mkdir -p "${TOOLCHAIN_DIR}"; then
-                        print_error "Failed to create toolchain directory '${TOOLCHAIN_DIR}'. Please check your permissions or specify another directory."
-                        exit 1
-                    fi
-                fi
+            # Check if the toolchain directory is on a supported file system.
+            check_filesystem_support "${TOOLCHAIN_DIR}" || {
+                print_error "Toolchain directory '${TOOLCHAIN_DIR}' is not on a supported file system (ext3/ext4/overlay)."
+                exit 1
+            }
 
-                # Check if user has write permissions to the toolchain directory.
-                if [[ ! -w "${TOOLCHAIN_DIR}" ]]; then
-                    print_error "No write permissions to: ${TOOLCHAIN_DIR}. Run with appropriate permissions or specify another directory."
-                    exit 1
-                fi
+            # Warn if toolchain directory is not empty.
+            if [ "$(ls -A "${TOOLCHAIN_DIR}" 2>/dev/null)" ]; then
+                print_warning "Toolchain directory is not empty: ${TOOLCHAIN_DIR}. Existing files may be overwritten."
+            fi
 
-                # Check if the toolchain directory is on a supported file system.
-                check_filesystem_support "${TOOLCHAIN_DIR}" || {
-                    print_error "Toolchain directory '${TOOLCHAIN_DIR}' is not on a supported file system (ext3/ext4)."
-                    exit 1
-                }
+            # Path to the main setup script
+            local setup_script="${REPO_ROOT_DIR}/scripts/setup/toolchain.sh"
 
-                # Warn if toolchain directory is not empty.
-                if [ "$(ls -A "${TOOLCHAIN_DIR}" 2>/dev/null)" ]; then
-                    print_warning "Toolchain directory is not empty: ${TOOLCHAIN_DIR}. Existing files may be overwritten."
-                fi
+            # Check if setup script exists
+            if [[ ! -f "${setup_script}" ]]; then
+                print_error "Setup script not found: ${setup_script}"
+                exit 1
+            fi
 
-                # Path to the main setup script
-                local setup_script="${REPO_ROOT_DIR}/scripts/setup/toolchain.sh"
-
-                # Check if setup script exists
-                if [[ ! -f "${setup_script}" ]]; then
-                    print_error "Setup script not found: ${setup_script}"
-                    exit 1
-                fi
-
-                # Run the setup script
-                print_info "Running setup script: ${setup_script}"
-                if ! "${setup_script}" "${TOOLCHAIN_DIR}"; then
-                    print_error "Setup failed."
-                    exit 1
-                fi
+            # Run the setup script
+            print_info "Running setup script: ${setup_script}"
+            if ! "${setup_script}" "${TOOLCHAIN_DIR}"; then
+                print_error "Setup failed."
+                exit 1
             fi
 
             print_success "Setup complete."


### PR DESCRIPTION
Remove Docker-based build options (`--with-docker`, `--with-minimal-docker`,
`--with-cached-options`) from the z bash script and all Linux documentation.
All components are now built locally using a cross-compilation toolchain.

- Refactor z script: remove Docker functions, cache logic, and Docker
  option parsing. Add `--toolchain-dir` option. (578 → 423 lines)
- Update doc/build-linux.md, doc/setup-linux.md, doc/test.md,
  doc/troubleshooting-linux.md, doc/gdb.md.
- Update README.md Linux section, CONTRIBUTING.md Linux commands.
- Update .github/skills/ SKILL.md files (Linux references).