### PR TITLE
[slab] Fix Slab bugs found via verification

### DIFF
--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -214,6 +214,9 @@ impl Slab {
         if ptr < self.data_addr || addr >= self.end_addr {
             return Err(Error::new(ErrorCode::BadAddress, "pointer out of bounds"));
         }
+        if !addr.is_multiple_of(self.block_size) {
+            return Err(Error::new(ErrorCode::BadAddress, "pointer unaligned"));
+        }
 
         // Compute the block index.
         let index: usize = unsafe { ptr.offset_from_unsigned(self.data_addr) } / self.block_size;

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -48,8 +48,8 @@ pub struct Slab {
     index: Bitmap,
     /// Base address of data blocks.
     data_addr: *mut u8,
-    /// Number of data blocks in the slab.
-    num_data_blocks: usize,
+    /// End of data blocks.
+    end_addr: usize,
     /// Size of blocks in the slab.
     block_size: usize,
 }
@@ -87,7 +87,7 @@ impl Slab {
         block_size: usize,
     ) -> Result<Slab, Error> {
         // Check if length is invalid valid.
-        if len == 0 || len >= i32::MAX as usize {
+        if len == 0 || len >= i32::MAX as usize || len > isize::MAX as usize {
             return Err(Error::new(ErrorCode::InvalidArgument, "invalid slab length"));
         }
 
@@ -163,10 +163,11 @@ impl Slab {
             index.set(i)?;
         }
 
+        let end_addr = (addr as usize) + total_num_blocks * block_size;
         Ok(Slab {
-            num_data_blocks,
             block_size,
             data_addr,
+            end_addr,
             index,
         })
     }
@@ -208,18 +209,14 @@ impl Slab {
     /// - It dereferences the pointer `ptr`.
     ///
     pub unsafe fn deallocate(&mut self, ptr: *const u8) -> Result<(), Error> {
+        let addr = ptr as usize;
         // Return an error if the pointer is before the data blocks.
-        if ptr < self.data_addr {
+        if ptr < self.data_addr || addr >= self.end_addr {
             return Err(Error::new(ErrorCode::BadAddress, "pointer out of bounds"));
         }
 
         // Compute the block index.
         let index: usize = unsafe { ptr.offset_from_unsigned(self.data_addr) } / self.block_size;
-
-        // Return an error if the pointer is after the data blocks.
-        if index >= self.num_data_blocks {
-            return Err(Error::new(ErrorCode::BadAddress, "pointer out of bounds"));
-        }
 
         // Return an error if the block is already free.
         if !self.index.test(index)? {

--- a/src/libs/slab/src/test.rs
+++ b/src/libs/slab/src/test.rs
@@ -110,3 +110,47 @@ fn test_allocate_out_of_bounds() {
     assert!(dealloc_result.is_err());
     assert_eq!(dealloc_result.unwrap_err().code, ErrorCode::BadAddress);
 }
+
+#[test]
+fn test_deallocate_unaligned_pointer() {
+    let block_size: usize = 16;
+    let len: usize = 1024;
+    // Ensure memory is aligned to block_size.
+    let layout = std::alloc::Layout::from_size_align(len, block_size).unwrap();
+    let memory = unsafe { std::alloc::alloc_zeroed(layout) };
+    assert!(!memory.is_null());
+
+    let mut slab = unsafe { Slab::from_raw_parts(memory, len, block_size) }.unwrap();
+
+    // Allocate a valid block, then try to deallocate at an offset of 1 byte
+    // (not a block boundary).
+    let block = slab.allocate().unwrap();
+    let unaligned_ptr = unsafe { block.add(1) };
+    let result = unsafe { slab.deallocate(unaligned_ptr) };
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code, ErrorCode::BadAddress);
+
+    // The original block should still be deallocatable.
+    let result = unsafe { slab.deallocate(block) };
+    assert!(result.is_ok());
+
+    unsafe { std::alloc::dealloc(memory, layout) };
+}
+
+#[test]
+fn test_deallocate_at_end_addr() {
+    let block_size: usize = 16;
+    let len: usize = 256;
+    let layout = std::alloc::Layout::from_size_align(len, block_size).unwrap();
+    let memory = unsafe { std::alloc::alloc_zeroed(layout) };
+    assert!(!memory.is_null());
+
+    let mut slab = unsafe { Slab::from_raw_parts(memory, len, block_size) }.unwrap();
+
+    // A pointer at the very end of the memory region (at or past end_addr)
+    // should be rejected even if it's block-aligned.
+    let end_ptr = unsafe { memory.add(len) } as *const u8;
+    let result = unsafe { slab.deallocate(end_ptr) };
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code, ErrorCode::BadAddress);
+}


### PR DESCRIPTION
Through verification, I discovered two bugs in `Slab`. This PR fixes both those bugs.

First, we sometimes violated a precondition of `offset_from_unsigned`. The Rust documentation says it should only be called when you're sure the difference is `<= isize::MAX`. To ensure this, we have to (1) make sure we don't use an array bigger than that, and (2) when receiving an untrusted `ptr` input to `deallocate`, check that we haven't gone past the end of that array before calling `offset_from_unsigned` on that `ptr`.

Second, we weren't checking that the untrusted `ptr` passed to `deallocate` was aligned by block size. This could cause us to return `Ok` even though we weren't passed a valid pointer, but rather a pointer to the middle of a block.