### PR TITLE
[build] Switch to native Windows build system

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 [codespell]
 # Skip binary directories and files that don't need spell checking
-skip = .git,.venv,bin,lib,logs,build,target,toolchain,sysroot-debug,sysroot-release,*.pdf,*.png,*.jpg,*.jpeg,*.ico,*.svg,*.woff,*.woff2,*.eot,*.ttf
+skip = .git, .venv, bin, lib, logs, build, target, toolchain, sysroot-debug, sysroot-release, *.pdf, *.png, *.jpg, *.jpeg, *.ico, *.svg, *.woff, *.woff2, *.eot, *.ttf
 
 # Ignore words that are commonly used in systems programming
 # and are flagged as typos by codespell
-ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr
+ignore-words-list = crate, inout, nd, rdonly, wronly, rdwr, servent

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,8 +33,8 @@ Nanvix supports two host platforms:
 - **Linux** — Full development workflow: build, run, test, benchmark, and debug.
   Uses KVM for the microvm backend.
 - **Windows 11** — Host-side development with the Windows Hypervisor Platform (WHP)
-  backend. Guest components (kernel, user binaries) are cross-compiled inside Docker;
-  the UserVM is built natively. Only standalone interactive mode is available
+  backend. Guest components (kernel, user binaries) are cross-compiled using a local
+  toolchain; the UserVM is built natively. Only standalone interactive mode is available
   (no HTTP mode or L2 deployments). Use `z.ps1` instead of `./z`.
 
 When modifying or generating code, keep platform differences in mind:
@@ -44,8 +44,8 @@ When modifying or generating code, keep platform differences in mind:
   GDB debugging, network namespaces.
 - Windows-supported features: standalone interactive mode, benchmarking
   (`boot-time`, `cold-start`, `warm-start-vmm`).
-- Windows-only concerns: WHP enablement, Developer Mode for symlinks, Docker
-  Desktop with Linux containers, `.venv` cleanup before Docker builds.
+- Windows-only concerns: WHP enablement, Developer Mode for symlinks, GNU Make
+  on PATH.
 
 ## Repository-wide Engineering Rules
 

--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -12,7 +12,7 @@ covers all build-system operations exposed through the `z` utility.
 
 - Development environment set up per `doc/setup.md`.
 - A local cross-compilation toolchain (`toolchain/`).
-- **Windows 11:** Docker Desktop (Linux containers), Windows Hypervisor Platform enabled,
+- **Windows 11:** GNU Make on PATH, Windows Hypervisor Platform enabled,
   Developer Mode enabled, and Rust toolchain installed. See `doc/setup.md` for details.
 
 ## Windows Setup Summary
@@ -21,10 +21,10 @@ Before building on Windows, ensure:
 
 1. **Windows Hypervisor Platform** is enabled (`Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform -All`, then reboot).
 2. **Developer Mode** is on (Settings > Privacy & Security > For developers).
-3. **Docker Desktop** is installed and configured for Linux containers.
+3. **GNU Make** is on PATH (`winget install ezwinports.make`).
 4. **Rust toolchain** is installed via `winget install Rustlang.Rustup`.
 5. Repository was cloned with `git clone -c core.symlinks=true`.
-6. Docker toolchain image is pulled: `./z.ps1 setup`.
+6. Git hooks are installed: `./z.ps1 setup`.
 
 ## Building
 
@@ -84,11 +84,11 @@ Example with custom parameters:
 ### Building on Windows (using `z.ps1`)
 
 On Windows 11, the `z.ps1` PowerShell script provides the same CLI interface. Guest components are
-cross-compiled inside Docker; host binaries (`nanvixd`, `uservm`) are built natively with the
+cross-compiled using a local toolchain; host binaries (`nanvixd`, `uservm`) are built natively with the
 microvm backend (WHP on Windows).
 
 ```powershell
-# Build everything (guest via Docker + host binaries natively).
+# Build everything (guest via make + host binaries natively).
 .\z.ps1 build -- all
 
 # Build only the UserVM (native Windows build).
@@ -100,17 +100,14 @@ microvm backend (WHP on Windows).
 # Build only nanvix-bench (native Windows build).
 .\z.ps1 build -- nanvix-bench
 
-# Build only guest components (kernel + hello-rust-nostd, via Docker).
+# Build only guest components (kernel + hello-rust-nostd).
 .\z.ps1 build -- guest
 
 # Release build.
 .\z.ps1 build -- all RELEASE=yes
-
-# Use the full (non-minimal) Docker image.
-.\z.ps1 build --with-docker -- all
 ```
 
-Any unrecognized target is forwarded to `make` via Docker, just like on Linux:
+Any unrecognized target is forwarded to `make`, just like on Linux:
 
 ```powershell
 .\z.ps1 build -- kernel
@@ -193,7 +190,7 @@ machine and deployment configurations.
 
 Use the host-specific settings template. The Linux template invokes `./z`, while the Windows
 template routes Rust Analyzer through `./z.bat build -- check`, which runs native `cargo check`
-on host crates (`uservm`, `nanvixd`, `nanvix-test`, `mkramfs`) without Docker.
+on host crates (`uservm`, `nanvixd`, `nanvix-test`, `mkramfs`).
 
 **Linux:**
 
@@ -210,15 +207,13 @@ Copy-Item scripts\setup\vscode\settings-windows.json .vscode\settings.json
 ```
 
 > **Note:** The `check` target in `z.ps1` only checks host crates natively. Guest and kernel
-> crates require the Docker-based cross-toolchain and are not checked by Rust Analyzer. Run
-> `.\z.ps1 build -- check-kernel check-guest-binaries` via Docker for a full cross-target check.
+> crates require the cross-compilation toolchain. Run
+> `.\z.ps1 build -- check-kernel check-guest-binaries` for a full cross-target check.
 
 ## Troubleshooting Build Issues
 
 - If builds fail with toolchain errors, verify `toolchain/` symlink points to a valid toolchain.
 - Use `./z help` for usage information.
 - **Windows:** Use `.\z.ps1 help` for Windows-specific usage information.
-- **Windows:** If Docker builds fail with symlink errors, `z.ps1` automatically restores Git
-  symlinks as file copies. Ensure Docker Desktop is running with Linux containers enabled.
 - **Windows:** If the UserVM build fails, verify that the Windows Hypervisor Platform feature is
   enabled (`Get-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform`).

--- a/.github/skills/library-development/SKILL.md
+++ b/.github/skills/library-development/SKILL.md
@@ -119,12 +119,13 @@ libraries use `HOST_CARGO_BUILD_CMD`.
 
 ## Windows Compilation
 
-On a Windows development host, guest libraries are cross-compiled inside Docker, so they work
-identically to Linux. Host libraries that use `std` may need conditional compilation
+On a Windows development host, guest libraries are cross-compiled using a local toolchain, so
+they work identically to Linux. Host libraries that use `std` may need conditional compilation
 (`#[cfg(target_os = "...")]`) for platform-specific code paths (e.g., KVM, libc).
 
-> **Note:** There is no Windows CI job yet. Platform-independent crates should be manually
-> verified on Windows when making changes that may affect cross-platform compatibility.
+> **Note:** Windows CI jobs run as part of the main CI pipeline. Platform-independent crates
+> should still be manually verified on a Windows host when making changes that may affect
+> cross-platform compatibility or Windows-specific behavior.
 
 ## Coding Rules (Library-Specific)
 

--- a/.github/skills/test/SKILL.md
+++ b/.github/skills/test/SKILL.md
@@ -39,7 +39,7 @@ Test configurations are auto-selected based on deployment mode:
 
 ## Windows
 
-On Windows, unit tests can be run via Docker through `z.ps1`:
+On Windows, unit tests can be run natively through `z.ps1`:
 
 ```powershell
 .\z.ps1 build -- run-unit-tests

--- a/.github/skills/troubleshooting/SKILL.md
+++ b/.github/skills/troubleshooting/SKILL.md
@@ -182,24 +182,6 @@ Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform -All
 # Restart the machine.
 ```
 
-### Docker Build Fails on Windows
-
-**Symptom**: Docker build fails with symlink or file-access errors, or the Docker output exporter
-fails because a previous build left a `.venv` directory with Linux symlinks (`lib64 -> lib`) that
-Windows cannot handle.
-
-**Fix**:
-
-1. Ensure Docker Desktop is running with Linux containers enabled: `docker info`.
-2. Remove stale `.venv` directory (cmd handles broken reparse points more reliably):
-   ```powershell
-   cmd /c "rmdir /s /q .venv"
-   ```
-3. Delete build cache and retry:
-    `Remove-Item .z.cache -ErrorAction SilentlyContinue; .\z.ps1 build -- all`.
-
-> **Note:** The `z.ps1` script removes `.venv` automatically before each Docker build.
-
 ### Symlink Errors on Windows Clone
 
 **Symptom**: Build or tool errors because Git checked out symlinks as text files.
@@ -221,15 +203,4 @@ git status
 
 git config core.symlinks true
 git checkout -- .
-```
-
-### Cached Build Options Stale (Windows)
-
-**Symptom**: Build uses wrong parameters on Windows.
-
-**Fix**: Delete the cache file and rebuild:
-
-```powershell
-Remove-Item .z.cache -ErrorAction SilentlyContinue
-.\z.ps1 build -- all
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,73 +442,6 @@ jobs:
   # Windows CI (GitHub-Hosted Runners)
   # ==========================================================================================
 
-  # Guest components (kernel, hello-rust-nostd) are cross-compiled on a Linux
-  # runner using the default Rust nightly toolchain. GitHub-hosted Windows
-  # runners do not support the required Rust nightly targets, so this job runs
-  # on ubuntu-24.04 and uploads the resulting ELF binaries for downstream
-  # Windows jobs.
-  windows-guest-build:
-    name: "Windows Guest Build (${{ matrix.machine-type }}, ${{ matrix.build-type }})"
-    needs: [precheck]
-    timeout-minutes: 60
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' || github.event_name == 'workflow_dispatch' && '["debug","release"]' || '["release"]') }}
-        machine-type: [microvm, hyperlight]
-    permissions:
-      contents: read
-
-    if: |
-      github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || (
-          needs.precheck.outputs.up_to_date == 'true' && (
-            github.event_name != 'push' ||
-            github.event.head_commit == null ||
-            !startsWith(github.event.head_commit.message, 'Merge ')
-          ) && (
-            github.event_name != 'pull_request' ||
-            !github.event.pull_request.draft
-          )
-        )
-      )
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: "Setup"
-        uses: ./.github/actions/native-setup
-
-      - name: "Build Guest Components"
-        shell: bash
-        env:
-          LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
-          RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
-        run: |
-          WHP_ARG=""
-          if [ "${{ matrix.machine-type }}" = "microvm" ]; then
-            WHP_ARG="WHP=yes"
-          fi
-          ./z build --toolchain-dir "${RUNNER_TEMP}/toolchain" -- \
-            all-guest-staticlibs all-kernel all-guest-binaries \
-            MACHINE=${{ matrix.machine-type }} \
-            DEPLOYMENT_MODE=standalone \
-            TARGET=x86 \
-            ${WHP_ARG} \
-            LOG_LEVEL=${LOG_LEVEL} \
-            ${RELEASE_FLAG}
-
-      - name: "Upload Guest Artifacts"
-        uses: actions/upload-artifact@v7
-        with:
-          name: windows-guest-build-${{ matrix.machine-type }}-${{ matrix.build-type }}
-          retention-days: 1
-          path: |
-            bin/*.elf
-            bin/*.img
-            lib/*.so
-
   # Format check is machine-type independent, so it runs once.
   windows-format-check:
     name: "Windows Format Check"
@@ -591,12 +524,11 @@ jobs:
         run: |
           .\z.ps1 build -- lint-check MACHINE=${{ matrix.machine-type }}
 
-  # Build host binaries (nanvixd, UserVM, nanvix-test) natively on Windows and
-  # run unit tests. Guest artifacts from the Linux job are downloaded and
-  # bundled with the standalone rootfs for the integration test stage.
+  # Build all components (guest + host) natively on Windows using the local
+  # cross-compilation toolchain (GNU Make + rust-lld + clang) and run unit tests.
   windows-ci-build:
     name: "Windows Build (${{ matrix.machine-type }}, ${{ matrix.build-type }})"
-    needs: [windows-format-check, windows-lint-check, windows-guest-build]
+    needs: [windows-format-check, windows-lint-check]
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -620,40 +552,25 @@ jobs:
           rustup show
           rustup component add --toolchain $toolchain clippy rustfmt
 
-      - name: "Download Guest Artifacts"
-        uses: actions/download-artifact@v8
-        with:
-          name: windows-guest-build-${{ matrix.machine-type }}-${{ matrix.build-type }}
-          path: .
+      - name: "Setup Prerequisites"
+        shell: pwsh
+        run: |
+          $osVersion = [System.Environment]::OSVersion.Version
+          if ($osVersion.Build -ge 22000) {
+            Write-Host "Detected Windows build $($osVersion.Build) (Windows 11 or later). Running z.ps1 setup..."
+            .\z.ps1 setup
+          }
+          else {
+            Write-Host "Detected Windows build $($osVersion.Build) (< 22000). Skipping z.ps1 setup on CI runner."
+          }
 
-      - name: "Build UserVM"
+      - name: "Build & Unit Test"
         shell: pwsh
         env:
           LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
           RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
         run: |
-          .\z.ps1 build -- uservm $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL
-
-      - name: "Build Nanvixd"
-        shell: pwsh
-        env:
-          LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
-          RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
-        run: |
-          .\z.ps1 build -- nanvixd $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL
-
-      - name: "Build Nanvix Test Runner"
-        shell: pwsh
-        env:
-          LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
-          RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
-        run: |
-          .\z.ps1 build -- nanvix-test $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL
-
-      - name: "Unit Tests"
-        shell: pwsh
-        run: |
-          .\z.ps1 build -- run-unit-tests MACHINE=$env:MACHINE_TYPE
+          .\z.ps1 build -- all run-unit-tests $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL
 
       - name: "Upload Build Artifacts"
         uses: actions/upload-artifact@v7
@@ -1412,7 +1329,6 @@ jobs:
         release-archive,
         windows-release-archive,
         publish-release,
-        windows-guest-build,
         windows-format-check,
         windows-lint-check,
         windows-ci-build,

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ sysroot
 *.obj
 *.wasm
 .z.cache
+.z.shims/
 Cargo.lock
 linuxd.stdout
 linuxd.stderr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,7 @@ ln -T -s $HOME/toolchain toolchain
 ./z build -- all
 ```
 
-On Windows, run `./z.ps1 setup --with-minimal-docker` to pull the Docker image and install the
-repository Git hooks from `.githooks`.
+On Windows, run `.\z.ps1 setup` to install the repository Git hooks from `.githooks`.
 
 Further reading: [Building](doc/build.md) | [Running](doc/run.md) | [Testing](doc/test.md) |
 [Benchmarking](doc/benchmark.md) | [Troubleshooting](doc/troubleshooting.md)

--- a/Makefile
+++ b/Makefile
@@ -93,16 +93,24 @@ export OBJECTS_DIR   := $(ROOT_DIR)/target
 # passed on the command line (e.g., from Dockerfile.build).
 NO_SCCACHE_GOALS := check format format-check lint lint-check spellcheck spellcheck-fix verify help clean distclean
 
+# On Windows (MSYS/Git-for-Windows sh), `which` returns POSIX paths (e.g.
+# /c/Users/...) that native Windows tools cannot resolve.  Pipe through
+# `cygpath -w` when available to convert them to Windows paths.
+WHICH_SCCACHE = $(shell p=$$(which sccache 2>/dev/null) && \
+	if command -v cygpath >/dev/null 2>&1 && [ -n "$$p" ]; then \
+		cygpath -w "$$p"; \
+	else echo "$$p"; fi)
+
 ifeq ($(MAKECMDGOALS),)
 # Default target ('all') produces artifacts — enable sccache.
-export SCCACHE ?= $(shell which sccache 2>/dev/null)
+export SCCACHE ?= $(WHICH_SCCACHE)
 else ifeq ($(filter-out $(NO_SCCACHE_GOALS),$(MAKECMDGOALS)),)
 # All command-line goals are check-only — disable sccache.
 override SCCACHE :=
 export SCCACHE
 else
 # At least one goal produces artifacts — enable sccache.
-export SCCACHE ?= $(shell which sccache 2>/dev/null)
+export SCCACHE ?= $(WHICH_SCCACHE)
 endif
 
 #===================================================================================================
@@ -111,7 +119,7 @@ endif
 
 RELEASE_DEPLOYMENT_MODE := $(subst -,_,$(DEPLOYMENT_MODE))
 RELEASE_BUILD_MODE := $(if $(filter yes,$(RELEASE)),release,debug)
-RELEASE_VERSION := $(strip $(shell cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.packages[0].version'))
+RELEASE_VERSION := $(strip $(shell cargo metadata --no-deps --format-version 1 2>/dev/null | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' | head -n1))
 
 # Extract memory_size (bytes) from kernel config and convert to megabytes.
 MEMORY_SIZE_BYTES = $(strip $(shell sed -nE 's/^[[:space:]]*memory_size[[:space:]]*=[[:space:]]*(0x[0-9a-fA-F]+|[0-9]+).*/\1/p' $(BUILD_DIR)/kernel_config.toml | head -n1))
@@ -294,7 +302,12 @@ ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 
 ALL_HOST_RUST_LIBS := control-plane-api hwloc multibin profiler nanvix nanvix-http nanvix-registry nanvix-sandbox nanvix-sandbox-cache nanvix-terminal syscomm user-vm-api
 ALL_HOST_UTILS := echo-client mkimage mkramfs strace
+# linuxd is only needed for multi-process and L2 deployments (Linux-only).
+ifeq ($(filter standalone single-process,$(DEPLOYMENT_MODE)),)
 ALL_HOST_DAEMONS := linuxd
+else
+ALL_HOST_DAEMONS :=
+endif
 ALL_HOST_BINARIES := $(ALL_HOST_UTILS) $(ALL_HOST_DAEMONS)
 
 #===================================================================================================
@@ -349,7 +362,11 @@ all-nanvix: \
 	all-snapshot
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-all-nanvix: all-host-binaries all-nanvixd all-uservm all-nanvix-test all-nanvix-shim
+all-nanvix: all-host-binaries all-nanvixd all-uservm all-nanvix-test
+# The containerd shim is not needed in standalone mode.
+ifneq ($(DEPLOYMENT_MODE),standalone)
+all-nanvix: all-nanvix-shim
+endif
 endif
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
@@ -560,15 +577,20 @@ endif
 PYTHON_FILES := $(shell git ls-files -- "*.py" 2>/dev/null || find . -name "*.py" -not -path "*/venv/*" -not -path "*/.venv/*" -not -path "*/__pycache__/*" -not -path "*/toolchain/*" -not -path "*/target/*" -not -path "*/.cargo/*")
 C_CPP_FILES := $(shell git ls-files -- "*.c" "*.cpp" "*.h" "*.hpp" 2>/dev/null || find . -type f \( -name "*.c" -o -name "*.cpp" -o -name "*.h" -o -name "*.hpp" \) -not -path "*/toolchain/*" -not -path "*/target/*" -not -path "*/.cargo/*")
 SHELL_FILES := $(shell git ls-files -- "*.sh" 2>/dev/null || find . -name "*.sh" -not -path "*/toolchain/*" -not -path "*/target/*" -not -path "*/.cargo/*")
-ALL_SOURCE_FILES := $(shell git ls-files 2>/dev/null || find . -type f -not -path "*/target/*" -not -path "*/toolchain/*" -not -path "*/venv/*" -not -path "*/.venv/*" -not -path "*/.git/*" -not -path "*/__pycache__/*" -not -path "*/.cargo/*")
 
 # Fixes spelling errors in source code and documentation.
+# Codespell reads .codespellrc for skip patterns and options.
+# Avoid passing $(ALL_SOURCE_FILES) to prevent exceeding the Windows
+# command-line length limit.
 spellcheck-fix:
-	codespell --write-changes $(ALL_SOURCE_FILES)
+	codespell --write-changes .
 
 # Checks for spelling errors in source code and documentation.
+# Codespell reads .codespellrc for skip patterns and options.
+# Avoid passing $(ALL_SOURCE_FILES) to prevent exceeding the Windows
+# command-line length limit.
 spellcheck:
-	codespell $(ALL_SOURCE_FILES)
+	codespell .
 
 # Fixes code formatting issues.
 format: \
@@ -715,7 +737,11 @@ endif
 run-unit-tests: all-nanvix test-guest-rlibs
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-run-unit-tests: test-host-rlibs test-nanvix-shim
+run-unit-tests: test-host-rlibs
+# The containerd shim tests are not needed in standalone mode.
+ifneq ($(DEPLOYMENT_MODE),standalone)
+run-unit-tests: test-nanvix-shim
+endif
 endif
 
 # Determine the test configuration file based on deployment mode.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ln -T -s $HOME/toolchain toolchain
 
 ### Windows
 
-Requires Windows 11 with [Docker Desktop](doc/setup-windows.md#5-install-docker-desktop) (Linux containers), [Windows
+Requires Windows 11 with [GNU Make](doc/setup-windows.md#5-run-setup) on PATH, [Windows
 Hypervisor Platform](doc/setup-windows.md#4-enable-windows-hypervisor-platform) enabled, [Developer
 Mode](doc/setup-windows.md#2-enable-developer-mode) turned on, and a Rust toolchain installed via
 [rustup](https://rustup.rs).
@@ -40,7 +40,7 @@ Mode](doc/setup-windows.md#2-enable-developer-mode) turned on, and a Rust toolch
 # Clone this source code (symlinks require Developer Mode).
 git clone -c core.symlinks=true https://github.com/nanvix/nanvix.git; cd nanvix
 
-# Setup the development environment (pulls Docker image).
+# Setup the development environment.
 .\z.ps1 setup
 
 # Build Nanvix.

--- a/build/make/generic-guest-binaries.mk
+++ b/build/make/generic-guest-binaries.mk
@@ -93,6 +93,12 @@ endif
 	@for pkg in $(ALL_GUEST_BINARIES); do \
 		$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/$$pkg.elf $(BINARIES_DIR)/$$pkg.elf; \
 	done
+# Copy side-artifact images produced by guest build scripts (e.g., vfs-test.img).
+# The build script may be cached, so the copy it performs at build time is
+# unreliable after a bin/ clean. Re-copy from the build output directory.
+	@for img in $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/build/vfs-test-*/out/test.img; do \
+		if [ -f "$$img" ]; then $(CP_CMD) "$$img" $(BINARIES_DIR)/vfs-test.img; break; fi; \
+	done
 
 check-guest-binaries:
 ifneq ($(_GUEST_BINS_REGULAR_PKGS),)

--- a/build/make/generic-host-rlibs.mk
+++ b/build/make/generic-host-rlibs.mk
@@ -11,6 +11,7 @@ MULTI_PROCESS_ONLY_RLIBS := nanvix-sandbox-cache
 MACHINE_FEATURES :=
 MACHINE_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 MACHINE_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
+MACHINE_FEATURES += $(if $(filter yes,$(WHP)),whp,)
 MACHINE_FEATURES := $(strip $(MACHINE_FEATURES))
 
 # Deployment-mode feature flags for host rlibs that depend on uservm.

--- a/build/make/nanvix-test.mk
+++ b/build/make/nanvix-test.mk
@@ -7,6 +7,7 @@ NANVIX_TEST_FEATURES += $(if $(filter single-process,$(DEPLOYMENT_MODE)),single-
 NANVIX_TEST_FEATURES += $(if $(filter multi-process l2,$(DEPLOYMENT_MODE)),multi-process,)
 NANVIX_TEST_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIX_TEST_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
+NANVIX_TEST_FEATURES += $(if $(filter yes,$(WHP)),whp,)
 NANVIX_TEST_FEATURES := $(strip $(NANVIX_TEST_FEATURES))
 NANVIX_TEST_CARGO_FEATURES := $(if $(NANVIX_TEST_FEATURES),--features "$(NANVIX_TEST_FEATURES)")
 

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -7,6 +7,7 @@ NANVIXD_FEATURES += $(if $(filter single-process,$(DEPLOYMENT_MODE)),single-proc
 NANVIXD_FEATURES += $(if $(filter multi-process l2,$(DEPLOYMENT_MODE)),multi-process,)
 NANVIXD_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 NANVIXD_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
+NANVIXD_FEATURES += $(if $(filter yes,$(WHP)),whp,)
 NANVIXD_FEATURES += $(if $(filter yes,$(PROFILER)),profile-time,)
 NANVIXD_FEATURES := $(strip $(NANVIXD_FEATURES))
 NANVIXD_CARGO_FEATURES := $(if $(NANVIXD_FEATURES),--features "$(NANVIXD_FEATURES)")

--- a/build/make/uservm.mk
+++ b/build/make/uservm.mk
@@ -6,6 +6,7 @@ USERVM_FEATURES += $(if $(filter yes,$(PROFILER)),profiler,)
 USERVM_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
 USERVM_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 USERVM_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)
+USERVM_FEATURES += $(if $(filter yes,$(WHP)),whp,)
 USERVM_FEATURES := $(strip $(USERVM_FEATURES))
 USERVM_CARGO_FEATURES := $(if $(USERVM_FEATURES),--features "$(USERVM_FEATURES)")
 

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -6,7 +6,7 @@ your development environment, please refer to the [Windows setup](setup-windows.
 
 This document guides you through building Nanvix on Windows. On Windows, the `z.ps1` PowerShell
 script provides the same interface as the Linux `z` utility. Host-side components are built natively,
-while guest components are cross-compiled inside Docker.
+while guest components are cross-compiled using a local toolchain.
 
 ## Table of Contents
 
@@ -23,7 +23,7 @@ while guest components are cross-compiled inside Docker.
 ## Building Nanvix with `z.ps1`
 
 `z.ps1` is a utility for building Nanvix on Windows. It provides you with a simplified interface
-for building Nanvix either using Docker or your local toolchain.
+for building Nanvix using your local toolchain.
 
 ### Getting Started with `z.ps1`
 
@@ -93,7 +93,7 @@ Available build parameters:
 ## Code Quality Checks
 
 ```powershell
-# Run cargo check on host crates (native, no Docker).
+# Run cargo check on host crates.
 .\z.ps1 build -- check
 
 # Check formatting.

--- a/doc/build.md
+++ b/doc/build.md
@@ -11,5 +11,5 @@ environment:
   built natively or via Docker. Uses `./z` as the build utility.
 
 - **[Windows Build](build-windows.md)** — Full build workflow on Windows 11. Host components are
-  built natively; guest components are cross-compiled inside Docker. Uses `z.ps1` as the build
-  utility.
+  built natively; guest components are cross-compiled using a local toolchain. Uses `z.ps1` as the
+  build utility.

--- a/doc/setup-windows.md
+++ b/doc/setup-windows.md
@@ -8,10 +8,8 @@ This guide will help you set up your development environment to build and run Na
 - [2. Enable Developer Mode](#2-enable-developer-mode)
 - [3. Clone This Repository](#3-clone-this-repository)
 - [4. Enable Windows Hypervisor Platform](#4-enable-windows-hypervisor-platform)
-- [5. Install Docker Desktop](#5-install-docker-desktop)
-- [6. Install the Rust Toolchain](#6-install-the-rust-toolchain)
-- [7. Pull the Docker Toolchain Image](#7-pull-the-docker-toolchain-image)
-- [8. Setup Your IDE (Optional)](#8-setup-your-ide-optional)
+- [5. Run Setup](#5-run-setup)
+- [6. Setup Your IDE (Optional)](#6-setup-your-ide-optional)
   - [Visual Studio Code](#visual-studio-code)
 
 ---
@@ -69,58 +67,38 @@ Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform -All
 
 Restart your machine after enabling the feature.
 
-## 5. Install Docker Desktop
-
-Install [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop/) and ensure
-it is configured to use **Linux containers** (the default).
-
-Verify Docker is working:
-
-```powershell
-docker info
-```
-
-## 6. Install the Rust Toolchain
-
-Install Rust via [rustup](https://rustup.rs):
-
-```powershell
-# Download and run the rustup installer.
-winget install Rustlang.Rustup
-```
-
-After installation, restart your terminal and verify:
-
-```powershell
-rustc --version
-cargo --version
-```
-
-## 7. Pull the Docker Toolchain Image
+## 5. Run Setup
 
 ```powershell
 .\z.ps1 setup
 ```
 
-This pulls the pre-built minimal Docker toolchain image required for cross-compiling guest
-components. To use the full (non-minimal) image instead:
+This command validates prerequisites and configures the development environment:
 
-```powershell
-.\z.ps1 setup --with-docker
-```
+1. Verifies you are running Windows 11.
+2. Verifies Developer Mode is enabled.
+3. Verifies the Windows Hypervisor Platform is active.
+4. Installs GNU Make via winget (if not already installed).
+5. Installs LLVM/Clang via winget (if not already installed).
+6. Installs the Rust toolchain via winget (if not already installed).
+7. Configures the repository Git hooks from `.githooks`.
+
+> **Note:** If winget is not available, install the prerequisites manually before running setup:
+>
+> - GNU Make: `winget install ezwinports.make`
+> - LLVM/Clang: `winget install LLVM.LLVM`
+> - Rust: `winget install Rustlang.Rustup` (see [rustup.rs](https://rustup.rs))
 
 ---
 
-## 8. Setup Your IDE (Optional)
+## 6. Setup Your IDE (Optional)
 
 Choose one of the following options to set up your IDE for Nanvix development.
 
 ### Visual Studio Code
 
-Use the host-specific settings template below. The Windows template invokes `./z.bat` and also
-routes Rust Analyzer build-script discovery through the Windows Docker workflow. Without the
-Windows override, Rust Analyzer falls back to native `cargo` for build-script metadata and guest
-crates such as `kernel` fail because cross-compilation tools are not available on the host `PATH`.
+Use the host-specific settings template below. The Windows template invokes `./z.bat` and routes
+Rust Analyzer build-script discovery through the Windows build workflow.
 
 ```powershell
 New-Item -ItemType Directory -Path .vscode -Force

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -7,5 +7,5 @@ guide that matches your host operating system:
   are built natively. Uses KVM as the virtualization backend.
 
 - **[Windows Setup](setup-windows.md)** — Full development workflow on Windows 11. Host components
-  are built natively; guest components are cross-compiled inside Docker. Uses the Windows Hypervisor
-  Platform (WHP) as the virtualization backend.
+  are built natively; guest components are cross-compiled using a local toolchain. Uses the Windows
+  Hypervisor Platform (WHP) as the virtualization backend.

--- a/doc/troubleshooting-windows.md
+++ b/doc/troubleshooting-windows.md
@@ -6,8 +6,6 @@ developing, building, or running Nanvix on Windows 11.
 ## Table of Contents
 
 - [Windows Hypervisor Platform Not Enabled](#windows-hypervisor-platform-not-enabled)
-- [Docker Build Fails with Symlink Errors](#docker-build-fails-with-symlink-errors)
-- [Stale `.venv` Directory Blocks Docker Build](#stale-venv-directory-blocks-docker-build)
 - [Cleaning on Windows](#cleaning-on-windows)
 
 ---
@@ -31,41 +29,6 @@ Verify it is enabled:
 ```powershell
 Get-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform
 ```
-
-## Docker Build Fails with Symlink Errors
-
-**Description:** The repository uses symbolic links. If cloned without `core.symlinks=true` or
-without Developer Mode enabled, Git checks out symlinks as small text files. The `z.ps1` script
-attempts to restore these as file copies before Docker builds, but issues may arise if the
-restoration fails.
-
-**Fix:** Re-clone with symlinks enabled (requires [Developer Mode](setup-windows.md#2-enable-developer-mode)):
-
-```powershell
-git clone -c core.symlinks=true https://github.com/nanvix/nanvix.git
-```
-
-If you must repair an existing clone, back up or stash any local changes first because refreshing
-the worktree will overwrite unstaged files:
-
-```powershell
-git config core.symlinks true
-git checkout -- .
-```
-
-## Stale `.venv` Directory Blocks Docker Build
-
-**Description:** A previous Docker build may leave a broken `.venv` directory with Linux symlinks
-(e.g., `lib64 -> lib`) that Windows cannot handle, causing the Docker output exporter to fail.
-
-**Fix:** Remove the `.venv` directory before building:
-
-```powershell
-# cmd handles broken reparse points more reliably.
-cmd /c "rmdir /s /q .venv"
-```
-
-> **Note:** The `z.ps1` script performs this cleanup automatically before each Docker build.
 
 ## Cleaning on Windows
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -7,5 +7,5 @@ environment:
 - **[Linux Troubleshooting](troubleshooting-linux.md)** — Resource leak cleanup, stale build
   cache, CI/CD failures, and TIME_WAIT socket issues on Linux.
 
-- **[Windows Troubleshooting](troubleshooting-windows.md)** — WHP enablement, Docker symlink
-  errors, stale `.venv` cleanup, and build artifact cleanup on Windows 11.
+- **[Windows Troubleshooting](troubleshooting-windows.md)** — WHP enablement, symlink errors,
+  and build artifact cleanup on Windows 11.

--- a/scripts/setup/vscode/settings-windows.json
+++ b/scripts/setup/vscode/settings-windows.json
@@ -5,18 +5,16 @@
 // 2. Copy this file into the '.vscode' folder as 'settings.json'.
 // 3. For fast host-only Rust checks (uservm, nanvixd, nanvix-test, mkramfs), run:
 //      z.ps1 build -- check
-//    This matches the Rust Analyzer configuration below and runs natively without Docker.
-// 4. To check guest/kernel crates inside Docker, use the dedicated targets, for example:
+//    This matches the Rust Analyzer configuration below and runs natively.
+// 4. To check guest/kernel crates, use the dedicated targets, for example:
 //      z.ps1 build -- check-kernel
 //      z.ps1 build -- check-guest-binaries
 //
 // Notes:
 // - Rust Analyzer routes check-on-save and build-script discovery through './z.bat build -- check'.
 //   The 'check' target is intentionally host-only and runs natively on crates such as uservm,
-//   nanvixd, nanvix-test, and mkramfs without Docker, avoiding the infinite rebuild loop that
-//   occurred when 'check' was forwarded to Docker (symlink mutations + file output triggered
-//   rust-analyzer to re-check endlessly).
-//   Guest and kernel crates are checked via Docker-only targets like 'check-kernel' and
+//   nanvixd, nanvix-test, and mkramfs.
+//   Guest and kernel crates are checked via cross-compilation targets like 'check-kernel' and
 //   'check-guest-binaries'; invoke them manually with 'z.ps1 build -- <target>' when needed.
 // - 'C_Cpp.default.compilerPath' is intentionally omitted here because the guest cross-toolchain is not
 //   installed natively on Windows by default.

--- a/src/kernel/src/event/manager.rs
+++ b/src/kernel/src/event/manager.rs
@@ -562,7 +562,7 @@ impl EventManagerInner {
     unsafe fn wakeup_interrupt(&mut self, interrupts: usize) -> Result<(), Error> {
         // Check if an spurious interrupt was received.
         if self.interrupt_capable {
-            let reason: &str = "interrupt manager is not capable of handlin ginterrupts";
+            let reason: &str = "interrupt manager is not capable of handling ginterrupts";
             error!("reason={:?}", reason);
             return Err(Error::new(ErrorCode::OperationNotSupported, reason));
         }
@@ -923,7 +923,7 @@ impl EventManager {
             Event::Interrupt(interrupt_event) => {
                 // Check if the interrupt manager is capable of handling interrupts.
                 if !em.try_borrow_mut()?.interrupt_capable {
-                    let reason: &str = "interrupt manager is not capable of handlin ginterrupts";
+                    let reason: &str = "interrupt manager is not capable of handling ginterrupts";
                     error!("{:?} (reason={:?})", reason, req);
                     return Err(Error::new(ErrorCode::OperationNotSupported, reason));
                 }

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 //! This file implements the logic to load `.toml` files in the `build/` directory so that they can
-//! be re-used as constants in rust source, and also in shell scripts.
+//! be reused as constants in rust source, and also in shell scripts.
 
 //==================================================================================================
 // Imports

--- a/src/tests/dlfcn-rust/build.rs
+++ b/src/tests/dlfcn-rust/build.rs
@@ -29,6 +29,10 @@ use std::{
 /// Compiles `libs/mul.c` into a shared library using the cross-compiler
 /// specified by NANVIX_CC with the cross-compilation flags from NANVIX_CFLAGS.
 ///
+/// The build is split into compile + link steps so that the linker can be
+/// invoked directly (via `ld` on PATH), avoiding clang's linker-driver
+/// which tries to call `gcc` for bare-metal targets and fails on Windows.
+///
 /// - `output` — absolute path to the output `.so` file.
 /// - `source` — absolute path to the `mul.c` source file.
 fn build_shared_lib(output: &Path, source: &Path) {
@@ -37,19 +41,40 @@ fn build_shared_lib(output: &Path, source: &Path) {
     let cflags = env::var("NANVIX_CFLAGS").unwrap_or_else(|_| {
         panic!("NANVIX_CFLAGS not set — required to cross-compile shared libs")
     });
+
+    // Step 1: Compile to object file.
+    let obj = output.with_extension("o");
     let mut parts = cc.split_whitespace();
     let program = parts.next().unwrap_or_else(|| panic!("NANVIX_CC is empty"));
     let mut cmd = Command::new(program);
     cmd.args(parts);
-    cmd.args(cflags.split_whitespace());
-    cmd.args(["-shared", "-fPIC"]);
+    // Filter out linker-only flags (e.g. -fuse-ld=lld) that are invalid for -c.
+    cmd.args(
+        cflags
+            .split_whitespace()
+            .filter(|f| !f.starts_with("-fuse-ld")),
+    );
+    cmd.args(["-fPIC", "-c"]);
     cmd.arg(source);
     cmd.arg("-o");
-    cmd.arg(output);
+    cmd.arg(&obj);
     let status = cmd
         .status()
         .unwrap_or_else(|e| panic!("failed to run {cc}: {e}"));
-    assert!(status.success(), "failed to build {}", output.display());
+    assert!(status.success(), "failed to compile {}", source.display());
+
+    // Step 2: Link the object file into a shared library using ld directly.
+    // Use -z notext to allow text relocations (R_386_PC32 from inline asm
+    // call instructions) which lld rejects by default but GNU ld allows.
+    let mut link = Command::new("ld");
+    link.args(["-shared", "-melf_i386", "-z", "notext"]);
+    link.arg(&obj);
+    link.arg("-o");
+    link.arg(output);
+    let status = link
+        .status()
+        .unwrap_or_else(|e| panic!("failed to run ld: {e}"));
+    assert!(status.success(), "failed to link {}", output.display());
 }
 
 //==================================================================================================
@@ -132,4 +157,14 @@ fn main() {
 
     // Suppress PT_INTERP — Nanvix has no system dynamic linker.
     println!("cargo::rustc-link-arg=--no-dynamic-linker");
+
+    // Allow text relocations (R_386_32 against local symbols from Rust
+    // libraries compiled without -fPIC).  GNU ld allows these by default
+    // but lld rejects them unless explicitly permitted.
+    println!("cargo::rustc-link-arg=-z");
+    println!("cargo::rustc-link-arg=notext");
+
+    // Use legacy SysV hash style to avoid .gnu.hash / .hash section type
+    // mismatch when lld merges sections specified by the linker script.
+    println!("cargo::rustc-link-arg=--hash-style=sysv");
 }

--- a/src/tests/file-rust/src/safe/file/advise.rs
+++ b/src/tests/file-rust/src/safe/file/advise.rs
@@ -18,7 +18,7 @@ use ::syscall::safe::{
 // Standalone Functions
 //==================================================================================================
 
-/// Tests whether we can provide advices about the use of a regular file.
+/// Tests whether we can provide advice about the use of a regular file.
 pub fn test() {
     let pathname: FileSystemPath = match FileSystemPath::new("README.md") {
         Ok(pathname) => pathname,

--- a/z.ps1
+++ b/z.ps1
@@ -8,7 +8,7 @@
 .DESCRIPTION
     Windows counterpart of the './z' bash script. Mirrors the same CLI interface.
     Builds the UserVM natively on Windows with the microvm or hyperlight backend,
-    and builds guest components (kernel, hello-rust-nostd) via Docker.
+    and builds guest components using a local cross-compilation toolchain.
 
 .EXAMPLE
     .\z.ps1 help
@@ -37,39 +37,6 @@ $CargoLock = Join-Path $RootDir "Cargo.lock"
 $VenvDir = Join-Path $RootDir ".venv"
 $SysImage = Join-Path $RootDir "nanvix.img"
 $SysrootLink = Join-Path $RootDir "sysroot"
-$ZCacheFile = Join-Path $RootDir ".z.cache"
-Set-Variable -Scope Script -Name DockerfileRelativePath -Value "scripts/setup/Dockerfile.build" -Option Constant
-
-# ==================================================================================================
-# Build Option Cache
-# ==================================================================================================
-
-function Write-ZCache {
-    param([string[]]$Options)
-    [System.IO.File]::WriteAllLines($ZCacheFile, $Options)
-}
-
-function Read-ZCache {
-    if (-not (Test-Path $ZCacheFile)) {
-        Write-Warn "No cached options found. Run a build first."
-        return @()
-    }
-    $lines = @(Get-Content -Path $ZCacheFile -Encoding UTF8 | Where-Object { $_.Trim() -ne "" })
-    if ($lines.Count -eq 0) {
-        Write-Warn "Cache file is empty."
-        return @()
-    }
-    # Extract only docker mode flags (stop at -- separator), matching Linux read_cache.
-    $result = @()
-    foreach ($line in $lines) {
-        if ($line -eq "--") { break }
-        switch ($line) {
-            "--with-docker" { $result += $line }
-            "--with-minimal-docker" { $result += $line }
-        }
-    }
-    return $result
-}
 
 # Remove a directory junction (or plain directory) without following into the target.
 function Remove-Junction {
@@ -123,10 +90,7 @@ Commands
   help        Prints this help message.
 
 Options
-  --release               Build in release mode.
-  --with-docker           Use the full Docker toolchain image.
-  --with-minimal-docker   Use the minimal Docker toolchain image (default).
-  --with-cached-options   Replay Docker build mode from the last successful build.
+  --release                Build in release mode.
 
 Build Targets (after --)
   all                     Build everything (guest + host).
@@ -137,16 +101,16 @@ Build Targets (after --)
   format-check            Check code formatting (native for host crates).
   lint-check              Check for linting issues (native for uservm).
   run-unit-tests          Run unit tests (native for uservm).
-  format                  Fix code formatting (via Docker).
-  lint                    Fix linting issues (via Docker).
-  spellcheck              Check spelling (via Docker).
-  spellcheck-fix          Fix spelling errors (via Docker).
-  check                   Run cargo check on host crates (native, no Docker).
-  check-uservm            Run cargo check on uservm only (native, no Docker).
-  run-nanvix-tests        Run system integration tests (via Docker).
-  test                    Run all tests (via Docker).
-  verify                  Run Verus formal verification (via Docker).
-  <any-make-target>       Any other target is forwarded to make via Docker.
+  format                  Fix code formatting.
+  lint                    Fix linting issues.
+  spellcheck              Check spelling.
+  spellcheck-fix          Fix spelling errors.
+  check                   Run cargo check on host crates (native).
+  check-uservm            Run cargo check on uservm only (native).
+  run-nanvix-tests        Run system integration tests.
+  test                    Run all tests.
+  verify                  Run Verus formal verification.
+  <any-make-target>       Any other target is forwarded to make.
 
 Run Options (after --)
   -program <path>         Path to guest binary (default: bin/hello-rust-nostd.elf).
@@ -163,137 +127,11 @@ Test Parameters (after --)
   LOG_LEVEL=<level>       Set RUST_LOG for test execution.
 
 Prerequisites
-  - Docker Desktop for Windows (with Linux containers enabled).
+  - GNU Make on PATH (for cross-compiling guest components).
   - Windows Hypervisor Platform enabled (for running the UserVM).
   - Rust toolchain on Windows (via rustup).
 
 "@
-}
-
-# ==================================================================================================
-# Symlink Helpers
-# ==================================================================================================
-
-# On Windows with core.symlinks=false, Git checks out symlinks as missing files (or small text files
-# containing the target path). This function detects such entries and materializes them as copies of
-# the target so that the Docker build context includes the correct file content.
-function Restore-GitSymlinks {
-    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
-    $ErrorActionPreference = 'Continue'
-
-    Write-Info "Restoring Git symlinks as file copies (Windows workaround)..."
-    $restored = 0
-    # List all git symlinks (mode 120000).
-    $symlinkLines = git ls-files -s 2>$null | Where-Object { $_ -match '^120000' }
-    foreach ($line in $symlinkLines) {
-        # Format: "120000 <hash> <stage>\t<path>"
-        $parts = $line -split '\t', 2
-        if ($parts.Count -lt 2) { continue }
-        $filePath = $parts[1].Trim()
-        if (-not $filePath) { continue }
-
-        # Extract the blob hash from the metadata portion.
-        $metaParts = $parts[0] -split '\s+'
-        if ($metaParts.Count -lt 2) { continue }
-        $blobHash = $metaParts[1]
-
-        $absPath = Join-Path $RootDir $filePath
-
-        # If Git already checked out a native symlink, leave it alone. Docker can
-        # consume the real symlink directly and overwriting it races with tools
-        # like rust-analyzer that may have the path open.
-        if (Test-Path $absPath) {
-            $item = Get-Item $absPath -Force -ErrorAction SilentlyContinue
-            if ($null -ne $item -and (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
-                continue
-            }
-        }
-
-        # Read the raw symlink target from the blob object.
-        # For mode 120000, the blob content is the relative target path.
-        # NOTE: Do NOT use 'git show HEAD:<path>' - it follows symlinks
-        # and returns the resolved file content instead of the target path.
-        $target = (git cat-file blob $blobHash 2>$null)
-        if (-not $target) { continue }
-        # cat-file may return an array of lines; join them first.
-        if ($target -is [array]) { $target = $target -join "`n" }
-        $target = $target.Trim()
-
-        # Sanity check: symlink targets are short relative paths (e.g.
-        # "../../shared/build.rs"). If the blob content looks like source
-        # code (multi-line or very long), the entry is not a real symlink
-        # or has already been resolved - skip it.
-        if ($target.Contains("`n") -or $target.Length -gt 500) {
-            continue
-        }
-
-        # Resolve the target relative to the symlink's directory.
-        $fileDir = Split-Path $absPath -Parent
-        $targetAbsPath = Join-Path $fileDir $target
-        $targetAbsPath = [System.IO.Path]::GetFullPath($targetAbsPath)
-
-        if (-not (Test-Path $targetAbsPath)) {
-            Write-Warn "Symlink target not found: $filePath -> $target"
-            continue
-        }
-
-        # Create parent directory if needed.
-        $parentDir = Split-Path $absPath -Parent
-        if (-not (Test-Path $parentDir)) {
-            New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
-        }
-
-        # Copy the target content as the symlink file.
-        if (Test-Path $targetAbsPath -PathType Container) {
-            # Target is a directory; copy as directory.
-            if (Test-Path $absPath) { Remove-Item $absPath -Recurse -Force }
-            Copy-Item -Path $targetAbsPath -Destination $absPath -Recurse -Force
-        }
-        else {
-            Copy-Item -Path $targetAbsPath -Destination $absPath -Force
-        }
-        $restored++
-    }
-    if ($restored -gt 0) {
-        Write-Info "Restored $restored symlink(s) as file copies."
-    }
-    else {
-        Write-Info "No symlinks needed restoring."
-    }
-}
-
-# Removes the materialized symlink copies and restores the original Git symlink
-# text files so they don't pollute the working tree.
-function Remove-RestoredSymlinks {
-    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
-    $ErrorActionPreference = 'Continue'
-
-    $symlinkPaths = @()
-    $symlinkLines = git ls-files -s 2>$null | Where-Object { $_ -match '^120000' }
-    foreach ($line in $symlinkLines) {
-        $parts = $line -split '\t', 2
-        if ($parts.Count -lt 2) { continue }
-        $filePath = $parts[1].Trim()
-        if (-not $filePath) { continue }
-        $absPath = Join-Path $RootDir $filePath
-        if (Test-Path $absPath) {
-            $item = Get-Item $absPath -Force -ErrorAction SilentlyContinue
-            if ($null -eq $item) {
-                Write-Warn "Cannot read attributes for '$filePath'; skipping removal."
-            }
-            elseif (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0) {
-                Remove-Item $absPath -Recurse -Force -ErrorAction SilentlyContinue
-            }
-        }
-        $symlinkPaths += $filePath
-    }
-
-    # Restore the original symlink text files from Git so the working tree stays clean.
-    if ($symlinkPaths.Count -gt 0) {
-        foreach ($sp in $symlinkPaths) {
-            git checkout -- $sp 2>$null
-        }
-    }
 }
 
 # ==================================================================================================
@@ -328,148 +166,223 @@ function Install-GitHooks {
 }
 
 # ==================================================================================================
-# Docker
+# Symlink Helpers
 # ==================================================================================================
 
-function Assert-DockerAvailable {
-    $dockerAvailable = Get-Command docker -ErrorAction SilentlyContinue
-    if (-not $dockerAvailable) {
-        Write-Err "Docker is not available. Install Docker Desktop for Windows."
+# On Windows without Developer Mode, Git cannot create native symlinks and
+# checks them out as small text files containing the target path. This function
+# detects such entries and copies the target content in-place so that Rust and
+# Make can find the real files.
+function Restore-GitSymlinks {
+    $ErrorActionPreference = 'Continue'
+
+    $restored = 0
+    $symlinkLines = git ls-files -s 2>$null | Where-Object { $_ -match '^120000' }
+    foreach ($line in $symlinkLines) {
+        $parts = $line -split '\t', 2
+        if ($parts.Count -lt 2) { continue }
+        $filePath = $parts[1].Trim()
+        if (-not $filePath) { continue }
+
+        $absPath = Join-Path $RootDir $filePath
+
+        # Skip if the entry is already a real symlink or directory junction.
+        if (Test-Path $absPath) {
+            $item = Get-Item $absPath -Force -ErrorAction SilentlyContinue
+            if ($null -ne $item -and (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+                continue
+            }
+        }
+
+        # Read the first line; if it looks like a short relative path, it is a
+        # broken symlink text stub.
+        $content = Get-Content $absPath -Raw -ErrorAction SilentlyContinue
+        if (-not $content) { continue }
+        $target = $content.Trim()
+        if ($target.Contains("`n") -or $target.Length -gt 500) { continue }
+
+        # Resolve the target relative to the symlink's parent directory.
+        $fileDir = Split-Path $absPath -Parent
+        $targetAbs = [System.IO.Path]::GetFullPath((Join-Path $fileDir $target))
+        if (-not (Test-Path $targetAbs)) { continue }
+
+        # Replace the text stub with a copy of the target.
+        if (Test-Path $targetAbs -PathType Container) {
+            if (Test-Path $absPath) { Remove-Item $absPath -Recurse -Force }
+            Copy-Item -Path $targetAbs -Destination $absPath -Recurse -Force
+        }
+        else {
+            Copy-Item -Path $targetAbs -Destination $absPath -Force
+        }
+        $restored++
+    }
+    if ($restored -gt 0) {
+        Write-Info "Restored $restored symlink(s) as file copies (Developer Mode not enabled)."
+    }
+}
+
+# ==================================================================================================
+# Make
+# ==================================================================================================
+
+# Creates an ld.exe shim from rust-lld so that the kernel and guest linker
+# ("linker": "ld" in target specs) works on Windows. rust-lld auto-detects
+# GNU ld flavor when its executable name is 'ld' or 'ld.lld'.
+function Ensure-LdShim {
+    $shimDir = Join-Path $RootDir ".z.shims"
+    $shimExe = Join-Path $shimDir "ld.exe"
+
+    # Check whether an existing ld.exe on PATH supports ELF linking.
+    # Some Windows environments (e.g., CI runners) ship an ld.exe that
+    # only supports PE formats (i386pep, i386pe). We need one that
+    # supports ELF cross-linking for guest binaries. rust-lld (LLD)
+    # supports both ELF and PE, so we check for "LLD" in the version
+    # string to detect a capable linker.
+    $existingLd = Get-Command ld.exe -ErrorAction SilentlyContinue
+    if ($existingLd) {
+        $ldVersion = & $existingLd.Source -V 2>&1 | Out-String
+        if ($ldVersion -match 'LLD') {
+            # Existing ld is LLD-based (supports ELF) — no shim needed.
+            return
+        }
+        # Existing ld does not support ELF; fall through to create the shim
+        # and prepend it to PATH so it takes precedence.
+    }
+
+    # Only recreate if missing.
+    if (Test-Path $shimExe) {
+        if ($env:Path -notlike "*$shimDir*") {
+            $env:Path = "$shimDir;$env:Path"
+        }
+        return
+    }
+
+    # Locate rust-lld inside the active Rust toolchain.
+    $rustcPath = Get-Command rustc -ErrorAction SilentlyContinue
+    if (-not $rustcPath) {
+        Write-Err "rustc not found. Install the Rust toolchain."
         exit 1
     }
-}
-
-function Assert-DockerImageAvailable {
-    param([string]$ImageName)
-    # Temporarily suppress errors from native commands so that Docker stderr
-    # does not trigger a terminating error under $ErrorActionPreference = "Stop".
-    $ErrorActionPreference = 'SilentlyContinue'
-    docker image inspect $ImageName >$null 2>&1
-    $exitCode = $LASTEXITCODE
-    $ErrorActionPreference = 'Stop'
-    if ($exitCode -ne 0) {
-        Write-Err "Docker image '$ImageName' not found locally. Run '.\z setup' to pull it."
+    $sysroot = (& rustc --print sysroot 2>$null)
+    if (-not $sysroot -or -not (Test-Path $sysroot)) {
+        Write-Err "Could not determine Rust sysroot."
         exit 1
     }
+    # Derive the active host triple from rustc -vV instead of hardcoding MSVC.
+    $rustcVersionInfo = (& rustc -vV 2>$null)
+    if (-not $rustcVersionInfo) {
+        Write-Err "Could not query rustc version info to determine host triple."
+        exit 1
+    }
+    $hostTriple = $null
+    foreach ($line in ($rustcVersionInfo -split "`n")) {
+        if ($line -like "host:*") {
+            $hostTriple = $line.Split(":", 2)[1].Trim()
+            break
+        }
+    }
+    if (-not $hostTriple) {
+        Write-Err "Could not determine Rust host triple from 'rustc -vV' output."
+        exit 1
+    }
+
+    $lldPath = Join-Path $sysroot ("lib\rustlib\{0}\bin\rust-lld.exe" -f $hostTriple)
+    if (-not (Test-Path $lldPath)) {
+        Write-Err "rust-lld not found at $lldPath. Cannot cross-link guest ELF binaries."
+        exit 1
+    }
+
+    # Copy rust-lld.exe as ld.exe and ld.lld.exe. rust-lld detects GNU linker
+    # flavor from its executable name (ld, ld.lld), so no wrapper is needed.
+    # ld.exe is needed by cargo (target spec "linker": "ld").
+    # ld.lld.exe is needed by clang -fuse-ld=lld for C cross-compilation.
+    if (-not (Test-Path $shimDir)) {
+        New-Item -ItemType Directory -Path $shimDir -Force | Out-Null
+    }
+    Copy-Item -Path $lldPath -Destination $shimExe -Force
+    $shimLld = Join-Path $shimDir "ld.lld.exe"
+    if (-not (Test-Path $shimLld)) {
+        Copy-Item -Path $lldPath -Destination $shimLld -Force
+    }
+
+    if ($env:Path -notlike "*$shimDir*") {
+        $env:Path = "$shimDir;$env:Path"
+    }
 }
 
-function Get-DockerImageName {
-    param([bool]$UseMinimal = $true)
-    $cargoToml = Join-Path $RootDir "Cargo.toml"
-    $versionLine = Select-String -Path $cargoToml -Pattern '^version\s*=\s*"([^"]+)"' | Select-Object -First 1
-    if ($versionLine -and $versionLine.Matches[0].Groups[1].Value) {
-        $v = $versionLine.Matches[0].Groups[1].Value -split '\.'
-        $imageTag = "v$($v[0]).$($v[1]).x"
-    }
-    else {
-        $imageTag = "latest"
-        Write-Warn "Could not parse version from Cargo.toml, using '$imageTag'."
-    }
-    $suffix = if ($UseMinimal) { "-minimal" } else { "" }
-    return "nanvix/toolchain:$imageTag$suffix"
-}
-
-function Get-SccacheArgs {
-    $result = @()
-    if ($env:SCCACHE_GHA_ENABLED) {
-        $result += "--build-arg"
-        $result += "SCCACHE_GHA_ENABLED=$env:SCCACHE_GHA_ENABLED"
-    }
-    if ($env:SCCACHE_GHA_CACHE_TO) {
-        $result += "--build-arg"
-        $result += "SCCACHE_GHA_CACHE_TO=$env:SCCACHE_GHA_CACHE_TO"
-    }
-    if ($env:SCCACHE_GHA_CACHE_FROM) {
-        $result += "--build-arg"
-        $result += "SCCACHE_GHA_CACHE_FROM=$env:SCCACHE_GHA_CACHE_FROM"
-    }
-    if ($env:ACTIONS_RESULTS_URL) {
-        $result += "--secret"
-        $result += "id=actions_results_url,env=ACTIONS_RESULTS_URL"
-    }
-    if ($env:ACTIONS_RUNTIME_TOKEN) {
-        $result += "--secret"
-        $result += "id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN"
-    }
-    return $result
-}
-
-function Invoke-DockerBuild {
-    param([string]$BuildParams, [bool]$IsRelease = $false, [bool]$UseMinimal = $true)
+function Invoke-Make {
+    param([string[]]$MakeParams = @())
 
     # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
     $ErrorActionPreference = 'Continue'
 
-    Assert-DockerAvailable
-
-    $imageName = Get-DockerImageName -UseMinimal $UseMinimal
-
-    # Validate that the Docker image exists locally before attempting the build.
-    Assert-DockerImageAvailable -ImageName $imageName
-
-    # Restore Git symlinks as file copies so the Docker build context is complete.
-    Restore-GitSymlinks
-
-    Write-Host "  Image: $imageName" -ForegroundColor DarkGray
-
-    $sysrootSuffix = if ($IsRelease) { "release" } else { "debug" }
-
-    $dockerfilePath = Join-Path $RootDir $DockerfileRelativePath
-    if (-not (Test-Path $dockerfilePath)) {
-        Remove-RestoredSymlinks
-        Write-Err "Build Dockerfile not found at $dockerfilePath"
+    $makeCmd = Get-Command make -ErrorAction SilentlyContinue
+    if (-not $makeCmd) {
+        # Auto-discover make from common winget install locations.
+        $wingetMake = Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\*make*\bin\make.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($wingetMake) {
+            $env:Path = "$($wingetMake.DirectoryName);$env:Path"
+            $makeCmd = Get-Command make -ErrorAction SilentlyContinue
+        }
+    }
+    if (-not $makeCmd) {
+        Write-Err "GNU Make is not available. Install it (winget install ezwinports.make) and restart your terminal."
         exit 1
     }
 
-    $env:DOCKER_BUILDKIT = "1"
-    Write-Host "  docker build (params: $BuildParams)" -ForegroundColor DarkGray
-
-    $ghaSccacheArgs = Get-SccacheArgs
-
-    # Remove the local .venv directory if it exists. Docker builds may create a
-    # .venv inside the container with a lib64 -> lib symlink (standard Linux Python
-    # venv). If a previous Docker export left a broken reparse point at .venv\lib64
-    # on Windows, the output exporter fails with "The file cannot be accessed by
-    # the system." Removing it beforehand prevents this.
-    if (Test-Path $VenvDir) {
-        # Use cmd to remove in case of broken reparse points that PowerShell can't handle.
-        cmd /c "rmdir /s /q `"$VenvDir`"" 2>$null
-        if (Test-Path $VenvDir) {
-            Remove-Item $VenvDir -Recurse -Force -ErrorAction SilentlyContinue
+    # Auto-discover clang from the default LLVM install location.
+    if (-not (Get-Command clang -ErrorAction SilentlyContinue)) {
+        $llvmBin = "C:\Program Files\LLVM\bin"
+        if (Test-Path "$llvmBin\clang.exe") {
+            $env:Path = "$llvmBin;$env:Path"
         }
     }
 
-    # Use the repository directory directly as the Docker build context.
-    # The .dockerignore file handles exclusions (mirroring the old robocopy filter).
-    # Restore-GitSymlinks (called above) already materialized symlinks in-place,
-    # so the context is complete. Symlinks are restored after the build via the
-    # finally block below.
-    $dockerArgs = @(
-        "build",
-        "--build-arg", "BASE_IMAGE=$imageName",
-        "--build-arg", "BUILD_PARAMS=$BuildParams",
-        "--build-arg", "SYSROOT_SUFFIX=$sysrootSuffix",
-        "--build-arg", "WORKSPACE_PATH=/mnt",
-        "--output", "type=local,dest=.",
-        "--progress=plain",
-        "-f", $dockerfilePath
-    )
-    if ($ghaSccacheArgs.Count -gt 0) {
-        $dockerArgs += $ghaSccacheArgs
-    }
-    $dockerArgs += $RootDir
-
-    $buildExitCode = 1
-    try {
-        & docker @dockerArgs
-        $buildExitCode = $LASTEXITCODE
-    }
-    finally {
-        Remove-RestoredSymlinks
+    # The Makefile uses $(HOME)/.cargo/bin/cargo. On Windows, HOME is not set
+    # by default so the path resolves to /.cargo/bin/cargo. Set it from
+    # USERPROFILE with forward slashes so that MSYS sh does not interpret
+    # backslashes as escape characters.
+    if (-not $env:HOME) {
+        $env:HOME = $env:USERPROFILE -replace '\\', '/'
     }
 
-    if ($buildExitCode -ne 0) {
-        Write-Err "Docker build failed (params: $BuildParams)."
+    # GNU Make needs a POSIX shell (sh) for recipe lines that use Unix syntax
+    # (rm, cp, mkdir -p, env-var prefixes). Git for Windows ships sh.exe and
+    # the required coreutils in its usr/bin directory. Add it to PATH so that
+    # make auto-detects sh.exe as its shell.
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($gitCmd) {
+        $gitUsrBin = Join-Path (Split-Path (Split-Path $gitCmd.Source)) "usr\bin"
+        if ((Test-Path $gitUsrBin) -and ($env:Path -notlike "*$gitUsrBin*")) {
+            $env:Path = "$gitUsrBin;$env:Path"
+        }
+    }
+
+    # Ensure Python Scripts directory (codespell, etc.) is on PATH for make.
+    # Get-Command may return the WindowsApps stub; ask Python for its real
+    # scripts directory instead.
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if ($pythonCmd) {
+        $pythonScripts = & python -c "import sysconfig; print(sysconfig.get_path('scripts'))" 2>$null
+        if ($pythonScripts -and (Test-Path $pythonScripts) -and ($env:Path -notlike "*$pythonScripts*")) {
+            $env:Path = "$pythonScripts;$env:Path"
+        }
+    }
+
+    # Guest target specs use "linker": "ld" (GNU ld for ELF linking). On
+    # Windows there is no system ld, but the Rust toolchain ships rust-lld
+    # which is compatible with GNU ld. Create an ld.exe shim.
+    Ensure-LdShim
+
+    # If symlinks are checked out as text stubs (Developer Mode not enabled),
+    # restore them as file copies so that cargo and make find real content.
+    Restore-GitSymlinks
+
+    Write-Host "  make $($MakeParams -join ' ')" -ForegroundColor DarkGray
+
+    & make @MakeParams
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "make failed (params: $($MakeParams -join ' '))."
         exit 1
     }
 }
@@ -488,6 +401,11 @@ function Add-GuestMachineDefaults {
 
     if ($machine -eq 'microvm' -and -not ($resolvedParams | Where-Object { $_ -match '^WHP=' })) {
         $resolvedParams += "WHP=yes"
+    }
+
+    # Windows only supports standalone deployment mode.
+    if (-not ($resolvedParams | Where-Object { $_ -match '^DEPLOYMENT_MODE=' })) {
+        $resolvedParams += "DEPLOYMENT_MODE=standalone"
     }
 
     return , $resolvedParams
@@ -549,21 +467,15 @@ function Build-UserVm {
 }
 
 function Build-Guest {
-    param([bool]$IsRelease, [bool]$UseMinimal = $true, [string[]]$ExtraMakeParams = @())
+    param([bool]$IsRelease, [string[]]$ExtraMakeParams = @())
 
     # Prevent cleanup errors from aborting the build (consistent with other functions).
     $ErrorActionPreference = 'Continue'
 
-    Write-Info "Building guest components (Docker)..."
+    Write-Info "Building guest components..."
 
-    # Remove guest artifacts from previous Docker exports. Docker's
-    # --output type=local is additive: it writes new files but never deletes
-    # files that no longer exist in the output. Without this cleanup, stale
-    # guest binaries (e.g., a removed .elf) persist across builds.
-    # This cleanup is safe here because Build-Guest always does a full guest
-    # rebuild (all-guest-staticlibs all-kernel all-guest-binaries). It must
-    # NOT be placed in Invoke-DockerBuild, which is also called for partial
-    # targets (e.g., kernel, format-check) that would not regenerate all files.
+    # Remove guest artifacts from previous builds. This cleanup ensures stale
+    # guest binaries (e.g., a removed .elf) do not persist across builds.
     foreach ($dir in @($BinDir, $LibDir)) {
         if (-not (Test-Path $dir)) { continue }
         Get-ChildItem -Path (Join-Path $dir '*') -File -Include "*.elf", "*.wasm", "*.a", "*.so", "*.img" -Recurse -ErrorAction SilentlyContinue |
@@ -571,7 +483,7 @@ function Build-Guest {
     }
 
     # Remove the sysroot directory matching the current build profile so that
-    # stale sysroot artifacts do not survive across Docker exports.
+    # stale sysroot artifacts do not survive across builds.
     $sysrootSuffix = if ($IsRelease) { "release" } else { "debug" }
     $sysrootDir = Join-Path $RootDir "sysroot-$sysrootSuffix"
     if (Test-Path $sysrootDir) {
@@ -587,9 +499,9 @@ function Build-Guest {
         $buildParams += $ExtraMakeParams
     }
     $buildParams = Add-GuestMachineDefaults -MakeParams $buildParams
-    Invoke-DockerBuild -BuildParams ($buildParams -join ' ') -IsRelease $IsRelease -UseMinimal $UseMinimal
+    Invoke-Make -MakeParams $buildParams
 
-    # Create sysroot junction after Docker build (parity with Linux ln -sfn).
+    # Create sysroot junction after build (parity with Linux ln -sfn).
     $sysrootTarget = Join-Path $RootDir "sysroot-$sysrootSuffix"
     if (Test-Path $sysrootTarget) {
         Remove-Junction -Path $SysrootLink
@@ -885,13 +797,12 @@ function Invoke-DistClean {
     # Remove bin/.
     if (Test-Path $BinDir) { Remove-Item $BinDir -Recurse -Force }
 
-    # Remove .venv/. Use cmd rmdir first because Docker builds on Windows can
-    # leave broken reparse points (e.g., lib64 -> lib) that PowerShell's
-    # Remove-Item cannot handle.
+    # Remove .venv/.
     if (Test-Path $VenvDir) {
-        cmd /c "rmdir /s /q `"$VenvDir`"" 2>$null
+        Remove-Item $VenvDir -Recurse -Force -ErrorAction SilentlyContinue
         if (Test-Path $VenvDir) {
-            Remove-Item $VenvDir -Recurse -Force -ErrorAction SilentlyContinue
+            # Fallback for broken reparse points from older Docker-based workflows.
+            & cmd /c "rmdir /s /q `"$VenvDir`"" *> $null
         }
     }
 
@@ -903,18 +814,9 @@ function Invoke-DistClean {
 
     # Sysroot junction and images/ already removed by Invoke-Clean above.
 
-    # Remove build option cache.
-    if (Test-Path $ZCacheFile) { Remove-Item $ZCacheFile -Force }
-
-    # Clean up Docker build cache for Nanvix.
-    $dockerAvailable = Get-Command docker -ErrorAction SilentlyContinue
-    if ($dockerAvailable) {
-        Write-Info "Pruning Docker build cache..."
-        docker builder prune --force
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warn "Docker build cache prune failed with exit code $LASTEXITCODE."
-        }
-    }
+    # Remove linker shim directory.
+    $shimDir = Join-Path $RootDir ".z.shims"
+    if (Test-Path $shimDir) { Remove-Item $shimDir -Recurse -Force }
 
     Write-Success "Full cleanup complete."
 }
@@ -1123,27 +1025,196 @@ function Invoke-Bench {
 # Setup
 # ==================================================================================================
 
-function Invoke-Setup {
-    param([bool]$UseMinimal = $true)
+function Assert-WindowsVersion {
+    $build = [System.Environment]::OSVersion.Version.Build
+    if ($build -lt 22000) {
+        Write-Warn "Windows 11 (build 22000+) is recommended. Current build: $build."
+        Write-Warn "Some features (e.g., WHP-backed UserVM workflows) may not be available on this host."
+        return
+    }
+    Write-Success "Windows 11 detected (build $build)."
+}
 
+function Assert-DeveloperMode {
+    $regPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock"
+    $val = Get-ItemProperty -Path $regPath -Name AllowDevelopmentWithoutDevLicense -ErrorAction SilentlyContinue
+    if (-not $val -or $val.AllowDevelopmentWithoutDevLicense -ne 1) {
+        Write-Warn "Developer Mode is not enabled. Symlinks will be restored as file copies."
+        Write-Warn "  Enable it in Settings > Privacy & Security > For developers."
+        return
+    }
+    Write-Success "Developer Mode is enabled."
+}
+
+function Assert-HypervisorEnabled {
+    $cs = Get-CimInstance Win32_ComputerSystem
+    if (-not $cs.HypervisorPresent) {
+        Write-Warn "No hypervisor detected. The UserVM will not run without WHP."
+        Write-Warn "  Enable it in an elevated PowerShell prompt and restart:"
+        Write-Warn "  Enable-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform -All"
+        return
+    }
+    Write-Success "Hypervisor is active."
+}
+
+function Install-GnuMake {
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    if (Get-Command make -ErrorAction SilentlyContinue) {
+        Write-Success "GNU Make is already installed."
+        return
+    }
+
+    # Check winget package directory (portable zip — not on PATH by default).
+    $wingetMake = Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\*make*\bin\make.exe" `
+        -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($wingetMake) {
+        $env:Path = "$($wingetMake.DirectoryName);$env:Path"
+        Write-Success "GNU Make found at $($wingetMake.FullName)."
+        return
+    }
+
+    $wingetCmd = Get-Command winget -ErrorAction SilentlyContinue
+    if (-not $wingetCmd) {
+        Write-Err "winget is not available. Install GNU Make manually: https://sourceforge.net/projects/ezwinports/files/"
+        exit 1
+    }
+
+    Write-Info "Installing GNU Make via winget..."
+    winget install ezwinports.make --accept-source-agreements --accept-package-agreements
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Failed to install GNU Make. Install it manually: winget install ezwinports.make"
+        exit 1
+    }
+
+    # Refresh discovery after installation.
+    $wingetMake = Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\*make*\bin\make.exe" `
+        -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($wingetMake) {
+        $env:Path = "$($wingetMake.DirectoryName);$env:Path"
+    }
+
+    if (-not (Get-Command make -ErrorAction SilentlyContinue)) {
+        Write-Warn "GNU Make installed but not on PATH. Restart your terminal and re-run setup."
+        exit 1
+    }
+    Write-Success "GNU Make installed."
+}
+
+function Install-Llvm {
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    if (Get-Command clang -ErrorAction SilentlyContinue) {
+        Write-Success "LLVM/Clang is already installed."
+        return
+    }
+
+    # Check default LLVM install location.
+    $llvmBin = "C:\Program Files\LLVM\bin"
+    if (Test-Path "$llvmBin\clang.exe") {
+        $env:Path = "$llvmBin;$env:Path"
+        Write-Success "LLVM/Clang found at $llvmBin."
+        return
+    }
+
+    $wingetCmd = Get-Command winget -ErrorAction SilentlyContinue
+    if (-not $wingetCmd) {
+        Write-Err "winget is not available. Install LLVM manually: https://releases.llvm.org/"
+        exit 1
+    }
+
+    Write-Info "Installing LLVM/Clang via winget..."
+    winget install LLVM.LLVM --accept-source-agreements --accept-package-agreements --silent
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Failed to install LLVM. Install it manually: winget install LLVM.LLVM"
+        exit 1
+    }
+
+    # Refresh PATH after installation.
+    if ((Test-Path $llvmBin) -and ($env:Path -notlike "*$llvmBin*")) {
+        $env:Path = "$llvmBin;$env:Path"
+    }
+
+    if (-not (Get-Command clang -ErrorAction SilentlyContinue)) {
+        Write-Warn "LLVM installed but not on PATH. Restart your terminal and re-run setup."
+        exit 1
+    }
+    Write-Success "LLVM/Clang installed."
+}
+
+function Install-RustToolchain {
+    # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
+    $ErrorActionPreference = 'Continue'
+
+    if (Get-Command rustc -ErrorAction SilentlyContinue) {
+        Write-Success "Rust toolchain is already installed."
+        return
+    }
+
+    # Check if cargo bin exists but is not on PATH.
+    $cargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
+    if (Test-Path (Join-Path $cargoBin "rustc.exe")) {
+        if ($env:Path -notlike "*$cargoBin*") {
+            $env:Path = "$cargoBin;$env:Path"
+        }
+        Write-Success "Rust toolchain is already installed."
+        return
+    }
+
+    $wingetCmd = Get-Command winget -ErrorAction SilentlyContinue
+    if (-not $wingetCmd) {
+        Write-Err "winget is not available. Install Rust manually: https://rustup.rs"
+        exit 1
+    }
+
+    Write-Info "Installing Rust toolchain via winget..."
+    winget install Rustlang.Rustup --accept-source-agreements --accept-package-agreements
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Failed to install Rust. Install it manually: https://rustup.rs"
+        exit 1
+    }
+
+    # Add cargo bin to PATH for the current session.
+    if ((Test-Path $cargoBin) -and ($env:Path -notlike "*$cargoBin*")) {
+        $env:Path = "$cargoBin;$env:Path"
+    }
+
+    if (-not (Get-Command rustc -ErrorAction SilentlyContinue)) {
+        Write-Warn "Rust installed but not on PATH. Restart your terminal and re-run setup."
+        exit 1
+    }
+    Write-Success "Rust toolchain installed."
+}
+
+function Invoke-Setup {
     # Prevent native command stderr from triggering $ErrorActionPreference = "Stop".
     $ErrorActionPreference = 'Continue'
 
     Write-Info "Setting up Nanvix development environment..."
 
-    Assert-DockerAvailable
+    # Step 1: Verify Windows version.
+    Assert-WindowsVersion
 
-    $imageName = Get-DockerImageName -UseMinimal $UseMinimal
-    Write-Info "Pulling Docker image: $imageName"
-    docker pull $imageName
+    # Step 2: Verify Developer Mode.
+    Assert-DeveloperMode
 
-    if ($LASTEXITCODE -ne 0) {
-        Write-Err "Failed to pull Docker image '$imageName'."
-        exit 1
-    }
+    # Step 3: Verify Windows Hypervisor Platform.
+    Assert-HypervisorEnabled
 
-    Write-Success "Docker image '$imageName' downloaded successfully."
+    # Step 4: Install GNU Make if missing.
+    Install-GnuMake
+
+    # Step 5: Install LLVM/Clang if missing.
+    Install-Llvm
+
+    # Step 6: Install Rust toolchain if missing.
+    Install-RustToolchain
+
+    # Step 7: Configure Git hooks.
     Install-GitHooks
+
     Write-Success "Setup complete."
 }
 
@@ -1176,22 +1247,17 @@ function Main {
     # Parse options and positional arguments.
     $isRelease = $false
     $isProfile = $false
-    $useMinimalDocker = $true
-    $useCachedOptions = $false
-    $dockerModeOptionSet = $false
     $buildParams = @()
 
     $pastSeparator = $false
 
-    foreach ($arg in $remaining) {
+    for ($i = 0; $i -lt $remaining.Count; $i++) {
+        $arg = $remaining[$i]
         if ($arg -eq "--") { $pastSeparator = $true; continue }
         if (-not $pastSeparator -and $arg.StartsWith("--")) {
             switch ($arg) {
                 "--release" { $isRelease = $true }
                 "--profile" { $isProfile = $true; $isRelease = $true }
-                "--with-docker" { $useMinimalDocker = $false; $dockerModeOptionSet = $true }
-                "--with-minimal-docker" { $useMinimalDocker = $true; $dockerModeOptionSet = $true }
-                "--with-cached-options" { $useCachedOptions = $true }
                 default {
                     Write-Err "Unknown option: $arg"
                     exit 1
@@ -1201,18 +1267,6 @@ function Main {
         else {
             if ($arg -ne '') {
                 $buildParams += $arg
-            }
-        }
-    }
-
-    # Apply cached options only when no docker mode flag was explicitly set on
-    # the command line. This matches Linux z behavior: explicit flags always win.
-    if ($useCachedOptions -and -not $dockerModeOptionSet) {
-        $cached = Read-ZCache
-        foreach ($opt in $cached) {
-            switch ($opt) {
-                "--with-docker" { $useMinimalDocker = $false }
-                "--with-minimal-docker" { $useMinimalDocker = $true }
             }
         }
     }
@@ -1232,7 +1286,6 @@ function Main {
 
             Write-Info "Command:  build"
             Write-Info "Release:  $isRelease"
-            Write-Info "Minimal:  $useMinimalDocker"
             Write-Info "Targets:  $($buildParams -join ' ')"
             Write-Host ""
 
@@ -1259,7 +1312,7 @@ function Main {
             foreach ($target in $targets) {
                 switch ($target) {
                     "all" {
-                        Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams
+                        Build-Guest -IsRelease $isRelease -ExtraMakeParams $makeParams
                         Build-UserVm -IsRelease $isRelease -Machine $machine
                         Build-Nanvixd -IsRelease $isRelease -Machine $machine -IsProfile $isProfile
                         Build-NanvixTest -IsRelease $isRelease -Machine $machine
@@ -1284,10 +1337,10 @@ function Main {
                         Build-NanvixBench -IsRelease $isRelease -Machine $machine -LogLevel $logLevel -IsProfile $isProfile
                     }
                     "guest" {
-                        Build-Guest -IsRelease $isRelease -UseMinimal $useMinimalDocker -ExtraMakeParams $makeParams
+                        Build-Guest -IsRelease $isRelease -ExtraMakeParams $makeParams
                     }
                     "format-check" {
-                        # Native format check for host crates (no Docker required).
+                        # Format check for host crates.
                         Write-Info "Checking code formatting (native)..."
                         $ErrorActionPreference = 'Continue'
                         cargo fmt -p uservm -p nanvixd -p mkramfs --check
@@ -1315,7 +1368,7 @@ function Main {
                         Write-Success "Lint check passed."
                     }
                     "run-unit-tests" {
-                        # Native unit tests for host crates (no Docker required).
+                        # Unit tests for host crates.
                         $features = Get-NativeCargoFeatures -Machine $machine
                         Write-Info "Running unit tests (native, $machine backend)..."
                         $ErrorActionPreference = 'Continue'
@@ -1327,7 +1380,7 @@ function Main {
                         Write-Success "Unit tests passed."
                     }
                     "check-uservm" {
-                        # Native cargo check for uservm only (no Docker required).
+                        # Cargo check for uservm only.
                         $features = Get-NativeCargoFeatures -Machine $machine
                         Write-Info "Checking uservm (native, $machine backend)..."
                         $ErrorActionPreference = 'Continue'
@@ -1357,10 +1410,8 @@ function Main {
                         Write-Success "Check passed (uservm)."
                     }
                     "check" {
-                        # Native cargo check for host crates (no Docker required).
-                        # This avoids the infinite rebuild loop caused by Docker's
-                        # symlink manipulation and file output when used with
-                        # rust-analyzer. Pass MESSAGE_FORMAT=json for RA integration.
+                        # Cargo check for host crates.
+                        # Pass MESSAGE_FORMAT=json for Rust Analyzer integration.
                         $features = Get-NativeCargoFeatures -Machine $machine
                         Write-Info "Checking host crates (native, $machine backend)..."
                         $ErrorActionPreference = 'Continue'
@@ -1406,50 +1457,50 @@ function Main {
                         Write-Success "Check passed."
                     }
                     "spellcheck" {
-                        # Spellcheck requires pyspelling which is only available inside
-                        # Docker. When Docker is not available or not running, skip gracefully.
+                        $spellParams = Add-GuestMachineDefaults `
+                            -MakeParams (@("spellcheck") + $makeParams)
+                        Write-Info "Running spellcheck..."
+                        Invoke-Make -MakeParams $spellParams
+                    }
+                    "test" {
+                        # Build everything and run unit tests (Windows standalone).
+                        Build-Guest -IsRelease $isRelease -ExtraMakeParams $makeParams
+                        Build-UserVm -IsRelease $isRelease -Machine $machine
+                        Build-Nanvixd -IsRelease $isRelease -Machine $machine -IsProfile $isProfile
+                        Build-NanvixTest -IsRelease $isRelease -Machine $machine
+                        Build-NanvixBench -IsRelease $isRelease -Machine $machine -LogLevel $logLevel -IsProfile $isProfile
+
+                        # Run unit tests for host crates that compile on Windows.
+                        $features = Get-NativeCargoFeatures -Machine $machine
+                        Write-Info "Running unit tests (native, $machine backend)..."
                         $ErrorActionPreference = 'Continue'
-                        $dockerCmd = Get-Command docker -ErrorAction SilentlyContinue
-                        $dockerRunning = $false
-                        if ($dockerCmd) {
-                            docker info >$null 2>&1
-                            $dockerRunning = ($LASTEXITCODE -eq 0)
+                        cargo test --no-default-features --features "$features" -p uservm
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Err "Unit tests failed for uservm."
+                            exit 1
                         }
-                        if (-not $dockerRunning) {
-                            Write-Warn "Skipping spellcheck (Docker not available or not running). Run with Docker to enable."
-                        }
-                        else {
-                            $dockerParams = Add-GuestMachineDefaults `
-                                -MakeParams (@("spellcheck") + $makeParams)
-                            Write-Info "Running spellcheck via Docker..."
-                            Invoke-DockerBuild -BuildParams ($dockerParams -join ' ') -IsRelease $isRelease -UseMinimal $useMinimalDocker
-                        }
+                        Write-Success "Unit tests passed."
+
+                        # Run guest rlib unit tests via make.
+                        $guestTestParams = Add-GuestMachineDefaults -MakeParams (@("test-guest-rlibs") + $makeParams)
+                        Write-Info "Running guest rlib tests..."
+                        Invoke-Make -MakeParams $guestTestParams
+                    }
+                    "run-nanvix-tests" {
+                        # Run integration tests using the Windows-specific config.
+                        Invoke-Test -IsRelease $isRelease -TestArgs $makeParams
                     }
                     default {
-                        # Forward any other target to Docker make (mirrors bash z behavior).
-                        $dockerParams = Add-GuestMachineDefaults -MakeParams (@($target) + $makeParams)
-                        Write-Info "Forwarding '$target' to Docker..."
-                        Invoke-DockerBuild -BuildParams ($dockerParams -join ' ') -IsRelease $isRelease -UseMinimal $useMinimalDocker
+                        # Forward any other target to make (mirrors bash z behavior).
+                        $fwdParams = Add-GuestMachineDefaults -MakeParams (@($target) + $makeParams)
+                        Write-Info "Forwarding '$target' to make..."
+                        Invoke-Make -MakeParams $fwdParams
                     }
                 }
             }
 
             Write-Host ""
             Write-Success "Build complete."
-
-            # Cache build options for --with-cached-options.
-            # Write the full command line (matching Linux write_cache behavior).
-            $cacheOpts = @("build")
-            if ($isRelease) { $cacheOpts += "--release" }
-            if ($useMinimalDocker) { $cacheOpts += "--with-minimal-docker" } else { $cacheOpts += "--with-docker" }
-            $cacheOpts += "--"
-            $cacheOpts += $buildParams
-            try {
-                Write-ZCache -Options $cacheOpts
-            }
-            catch {
-                Write-Warn "Failed to write .z.cache: $($_.Exception.Message)"
-            }
         }
 
         "clean" {
@@ -1469,7 +1520,7 @@ function Main {
         }
 
         "setup" {
-            Invoke-Setup -UseMinimal $useMinimalDocker
+            Invoke-Setup
         }
 
         "test" {


### PR DESCRIPTION
## Summary

Update the CI/CD pipeline to leverage the native Windows build system introduced by this branch, removing the dependency on a separate Linux runner for guest cross-compilation.

## Changes

- **Remove \windows-guest-build\ job**: Guest components (kernel, user binaries) are now cross-compiled natively on Windows using GNU Make + rust-lld + clang, eliminating the need for a separate Linux runner.
- **Simplify \windows-ci-build\**: Replace the multi-step build (download guest artifacts + build host components individually) with a single \z.ps1 build -- all run-unit-tests\ invocation.
- **Add \Setup Prerequisites\ step**: Runs \z.ps1 setup\ to install GNU Make and LLVM/Clang on the Windows runner.
- **Update \
otify-release-failure\**: Remove \windows-guest-build\ from the dependency list.

## Motivation

The \nhancement-build-windows\ branch replaces the Docker-based Windows build workflow with a native cross-compilation toolchain (\z.ps1\). The CI pipeline still used the old split architecture (Linux for guests, Windows for host), which is no longer necessary. This PR aligns the CI with the new unified native build.