### PR TITLE
Downgrade VFS syscall logs to warn and set release LOG_LEVEL to error

### DIFF
--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -55,7 +55,7 @@ Set these as environment variables or pass them after `--` in the `z` command:
 | `MACHINE`        | `microvm`, `hyperlight`  | `microvm`       |
 | `TARGET`         | `x86`                    | `x86`           |
 | `RELEASE`        | `yes`, `no`              | `no`            |
-| `LOG_LEVEL`      | `trace`, `debug`,        | `warn`          |
+| `LOG_LEVEL`      | `trace`, `debug`,        | `error`         |
 |                  | `info`, `warn`,          |                 |
 |                  | `error`, `panic`         |                 |
 | `PROFILER`       | `yes`, `no`              | `no`            |

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 
 # Log Level
 ifeq ($(RELEASE),yes)
-export LOG_LEVEL ?= warn
+export LOG_LEVEL ?= error
 else
 export LOG_LEVEL ?= trace
 endif

--- a/doc/build-linux.md
+++ b/doc/build-linux.md
@@ -69,7 +69,7 @@ Pass build parameters after `--`:
 ./z build -- all LOG_LEVEL=debug
 
 # Combine multiple parameters.
-./z build -- all RELEASE=yes DEPLOYMENT_MODE=multi-process LOG_LEVEL=warn
+./z build -- all RELEASE=yes DEPLOYMENT_MODE=multi-process LOG_LEVEL=error
 ```
 
 Available build parameters:
@@ -77,7 +77,7 @@ Available build parameters:
 | Parameter         | Default         | Values                                                             |
 |-------------------|-----------------|--------------------------------------------------------------------|
 | `DEPLOYMENT_MODE` | `multi-process` | `standalone`, `single-process`, `multi-process`, `l2`              |
-| `LOG_LEVEL`       | `warn`          | `trace`, `debug`, `info`, `warn`, `error`, `panic`                 |
+| `LOG_LEVEL`       | `error`         | `trace`, `debug`, `info`, `warn`, `error`, `panic`                 |
 | `MACHINE`         | `microvm`       | `hyperlight`, `microvm`, `qemu-pc`, `qemu-isapc`, `qemu-baremetal` |
 | `PROFILER`        | `no`            | `yes`, `no`                                                        |
 | `RELEASE`         | `no`            | `yes`, `no`                                                        |

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -75,7 +75,7 @@ Pass build parameters after `--`:
 .\z.ps1 build -- all LOG_LEVEL=debug
 
 # Combine multiple parameters.
-.\z.ps1 build -- all RELEASE=yes DEPLOYMENT_MODE=standalone LOG_LEVEL=warn
+.\z.ps1 build -- all RELEASE=yes DEPLOYMENT_MODE=standalone LOG_LEVEL=error
 ```
 
 Available build parameters:
@@ -83,7 +83,7 @@ Available build parameters:
 | Parameter         | Default      | Values                                             |
 |-------------------|--------------|----------------------------------------------------|
 | `DEPLOYMENT_MODE` | `standalone` | `standalone`                                       |
-| `LOG_LEVEL`       | `warn`       | `trace`, `debug`, `info`, `warn`, `error`, `panic` |
+| `LOG_LEVEL`       | `error`      | `trace`, `debug`, `info`, `warn`, `error`, `panic` |
 | `MACHINE`         | `microvm`    | `microvm`, `hyperlight`                            |
 | `MESSAGE_FORMAT`  | (none)       | `json`, `json-diagnostic-rendered-ansi`             |
 | `RELEASE`         | `no`         | `yes`, `no`                                        |

--- a/src/libs/syscall/src/fcntl/syscall/fallocate.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fallocate.rs
@@ -51,7 +51,7 @@ pub fn posix_fallocate(fd: RawFileDescriptor, offset: off_t, len: off_t) -> Resu
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_fallocate(fd, offset, len).map_err(|e| {
                 let code: ::sys::error::ErrorCode = e.into();
-                ::syslog::error!("posix_fallocate(): VFS fallocate failed (fd={fd:?}, error={e})");
+                ::syslog::warn!("posix_fallocate(): VFS fallocate failed (fd={fd:?}, error={e})");
                 Error::new(code, "vfs fallocate failed")
             });
         }

--- a/src/libs/syscall/src/fcntl/syscall/fcntl.rs
+++ b/src/libs/syscall/src/fcntl/syscall/fcntl.rs
@@ -40,7 +40,7 @@ pub fn fcntl(fd: i32, cmd: i32, arg: Option<c_int>) -> Result<c_int, Error> {
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_fcntl(fd, cmd).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("fcntl(): VFS fcntl failed (fd={fd}, cmd={cmd}, error={e})");
+                ::syslog::warn!("fcntl(): VFS fcntl failed (fd={fd}, cmd={cmd}, error={e})");
                 Error::new(code, "vfs fcntl failed")
             });
         }

--- a/src/libs/syscall/src/fcntl/syscall/open.rs
+++ b/src/libs/syscall/src/fcntl/syscall/open.rs
@@ -43,7 +43,7 @@ pub fn open(pathname: &str, flags: c_int, mode: mode_t) -> Result<c_int, Error> 
     {
         ::nvx::vfs::fd::vfs_open(pathname, flags).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("open(): VFS open failed (pathname={pathname:?}, error={e})");
+            ::syslog::warn!("open(): VFS open failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs open failed")
         })
     }

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -46,7 +46,7 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
     {
         ::nvx::vfs::fd::vfs_open(pathname, flags).map_err(|e| {
             let code: ErrorCode = e.into();
-            ::syslog::error!("openat(): VFS open failed (pathname={pathname:?}, error={e})");
+            ::syslog::warn!("openat(): VFS open failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs open failed")
         })
     }

--- a/src/libs/syscall/src/fcntl/syscall/rename.rs
+++ b/src/libs/syscall/src/fcntl/syscall/rename.rs
@@ -38,7 +38,7 @@ pub fn rename(oldpath: &str, newpath: &str) -> Result<(), Error> {
     {
         ::nvx::vfs::fd::vfs_rename(oldpath, newpath).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("rename(): VFS rename failed (oldpath={oldpath:?}, error={e})");
+            ::syslog::warn!("rename(): VFS rename failed (oldpath={oldpath:?}, error={e})");
             Error::new(code, "vfs rename failed")
         })
     }

--- a/src/libs/syscall/src/fcntl/syscall/renameat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/renameat.rs
@@ -64,7 +64,7 @@ pub fn renameat(
     {
         ::nvx::vfs::fd::vfs_renameat(olddirfd, oldpath, newdirfd, newpath).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("renameat(): VFS renameat failed (oldpath={oldpath:?}, error={e})");
+            ::syslog::warn!("renameat(): VFS renameat failed (oldpath={oldpath:?}, error={e})");
             Error::new(code, "vfs renameat failed")
         })
     }

--- a/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/unlinkat.rs
@@ -53,7 +53,7 @@ pub fn unlinkat(dirfd: RawFileDescriptor, pathname: &str, flags: c_int) -> Resul
     {
         ::nvx::vfs::fd::vfs_unlinkat(dirfd, pathname, flags).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("unlinkat(): VFS unlinkat failed (pathname={pathname:?}, error={e})");
+            ::syslog::warn!("unlinkat(): VFS unlinkat failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs unlinkat failed")
         })
     }

--- a/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmodat.rs
@@ -54,7 +54,7 @@ pub fn fchmodat(dirfd: c_int, path: &str, mode: mode_t, flag: c_int) -> Result<(
     {
         ::nvx::vfs::fd::vfs_fchmodat(dirfd, path, mode, flag).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("fchmodat(): VFS fchmodat failed (path={path:?}, error={e})");
+            ::syslog::warn!("fchmodat(): VFS fchmodat failed (path={path:?}, error={e})");
             ::sys::error::Error::new(code, "vfs fchmodat failed")
         })
     }

--- a/src/libs/syscall/src/sys/stat/syscall/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstat.rs
@@ -43,7 +43,7 @@ pub fn fstat(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_fstat(fd, buf).map_err(|e| {
                 let code: ::sys::error::ErrorCode = e.into();
-                ::syslog::error!("fstat(): VFS fstat failed (fd={fd}, error={e})");
+                ::syslog::warn!("fstat(): VFS fstat failed (fd={fd}, error={e})");
                 Error::new(code, "vfs fstat failed")
             });
         }

--- a/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstatat.rs
@@ -50,7 +50,7 @@ pub fn fstatat(dirfd: i32, path: &str, buf: &mut sys_stat::stat, flag: i32) -> R
     {
         ::nvx::vfs::fd::vfs_stat(path, buf).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("fstatat(): VFS stat failed (path={path:?}, error={e})");
+            ::syslog::warn!("fstatat(): VFS stat failed (path={path:?}, error={e})");
             ::sys::error::Error::new(code, "vfs stat failed")
         })
     }

--- a/src/libs/syscall/src/sys/stat/syscall/lstat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/lstat.rs
@@ -45,7 +45,7 @@ pub fn lstat(pathname: &str, buf: &mut sys_stat::stat) -> Result<(), Error> {
     {
         ::nvx::vfs::fd::vfs_stat(pathname, buf).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("lstat(): VFS lstat failed (pathname={pathname:?}, error={e})");
+            ::syslog::warn!("lstat(): VFS lstat failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs lstat failed")
         })
     }

--- a/src/libs/syscall/src/sys/stat/syscall/mkdir.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mkdir.rs
@@ -39,7 +39,7 @@ pub fn mkdir(pathname: &str, mode: mode_t) -> Result<(), Error> {
     {
         ::nvx::vfs::fd::vfs_mkdir(pathname).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("mkdir(): VFS mkdir failed (pathname={pathname:?}, error={e})");
+            ::syslog::warn!("mkdir(): VFS mkdir failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs mkdir failed")
         })
     }

--- a/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/mkdirat.rs
@@ -58,7 +58,7 @@ pub fn mkdirat(dirfd: RawFileDescriptor, pathname: &str, mode: mode_t) -> Result
     {
         ::nvx::vfs::fd::vfs_mkdir(pathname).map_err(|e| {
             let code: ErrorCode = e.into();
-            ::syslog::error!("mkdirat(): VFS mkdir failed (pathname={pathname:?}, error={e})");
+            ::syslog::warn!("mkdirat(): VFS mkdir failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs mkdir failed")
         })
     }

--- a/src/libs/syscall/src/sys/stat/syscall/stat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/stat.rs
@@ -40,7 +40,7 @@ pub fn stat(pathname: &str, statbuf: &mut sys_stat::stat) -> Result<(), Error> {
     {
         ::nvx::vfs::fd::vfs_stat(pathname, statbuf).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("stat(): VFS stat failed (pathname={pathname:?}, error={e})");
+            ::syslog::warn!("stat(): VFS stat failed (pathname={pathname:?}, error={e})");
             Error::new(code, "vfs stat failed")
         })
     }

--- a/src/libs/syscall/src/unistd/bindings/rmdir.rs
+++ b/src/libs/syscall/src/unistd/bindings/rmdir.rs
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn rmdir(path: *const c_char) -> c_int {
             Ok(()) => 0,
             Err(e) => {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("rmdir(): VFS rmdir failed (path={pathname:?}, error={e})");
+                ::syslog::warn!("rmdir(): VFS rmdir failed (path={pathname:?}, error={e})");
                 *__errno_location() = code.get();
                 -1
             },

--- a/src/libs/syscall/src/unistd/syscall/chdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/chdir.rs
@@ -50,7 +50,7 @@ pub fn chdir(path: &str) -> Result<(), Error> {
     {
         ::nvx::vfs::fd::vfs_chdir(path).map_err(|e| {
             let code: ErrorCode = e.into();
-            ::syslog::error!("chdir(): VFS chdir failed (path={path:?}, error={e})");
+            ::syslog::warn!("chdir(): VFS chdir failed (path={path:?}, error={e})");
             Error::new(code, "vfs chdir failed")
         })
     }

--- a/src/libs/syscall/src/unistd/syscall/close.rs
+++ b/src/libs/syscall/src/unistd/syscall/close.rs
@@ -36,7 +36,7 @@ pub fn close(fd: i32) -> Result<(), Error> {
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_close(fd).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("close(): VFS close failed (fd={fd}, error={e})");
+                ::syslog::warn!("close(): VFS close failed (fd={fd}, error={e})");
                 Error::new(code, "vfs close failed")
             });
         }

--- a/src/libs/syscall/src/unistd/syscall/faccessat.rs
+++ b/src/libs/syscall/src/unistd/syscall/faccessat.rs
@@ -59,7 +59,7 @@ pub fn faccessat(dirfd: c_int, path: &str, mode: c_int, flag: c_int) -> Result<(
     {
         ::nvx::vfs::fd::vfs_access(path).map_err(|e| {
             let code: ErrorCode = e.into();
-            ::syslog::error!("faccessat(): VFS access failed (path={path:?}, error={e})");
+            ::syslog::warn!("faccessat(): VFS access failed (path={path:?}, error={e})");
             Error::new(code, "vfs access failed")
         })
     }

--- a/src/libs/syscall/src/unistd/syscall/fchdir.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchdir.rs
@@ -46,7 +46,7 @@ pub fn fchdir(fd: c_int) -> Result<(), Error> {
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_fchdir(fd).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("fchdir(): VFS fchdir failed (fd={fd}, error={e})");
+                ::syslog::warn!("fchdir(): VFS fchdir failed (fd={fd}, error={e})");
                 Error::new(code, "vfs fchdir failed")
             });
         }

--- a/src/libs/syscall/src/unistd/syscall/fdatasync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fdatasync.rs
@@ -49,7 +49,7 @@ pub fn fdatasync(fd: RawFileDescriptor) -> Result<(), Error> {
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_fsync(fd).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("fdatasync(): VFS fdatasync failed (fd={fd}, error={e})");
+                ::syslog::warn!("fdatasync(): VFS fdatasync failed (fd={fd}, error={e})");
                 Error::new(code, "vfs fdatasync failed")
             });
         }

--- a/src/libs/syscall/src/unistd/syscall/fsync.rs
+++ b/src/libs/syscall/src/unistd/syscall/fsync.rs
@@ -47,7 +47,7 @@ pub fn fsync(fd: c_int) -> Result<(), Error> {
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_fsync(fd).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("fsync(): VFS fsync failed (fd={fd}, error={e})");
+                ::syslog::warn!("fsync(): VFS fsync failed (fd={fd}, error={e})");
                 Error::new(code, "vfs fsync failed")
             });
         }

--- a/src/libs/syscall/src/unistd/syscall/ftruncate.rs
+++ b/src/libs/syscall/src/unistd/syscall/ftruncate.rs
@@ -53,7 +53,7 @@ pub fn ftruncate(fd: c_int, length: off_t) -> Result<(), Error> {
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_ftruncate(fd, length).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("ftruncate(): VFS ftruncate failed (fd={fd}, error={e})");
+                ::syslog::warn!("ftruncate(): VFS ftruncate failed (fd={fd}, error={e})");
                 Error::new(code, "vfs ftruncate failed")
             });
         }

--- a/src/libs/syscall/src/unistd/syscall/getcwd.rs
+++ b/src/libs/syscall/src/unistd/syscall/getcwd.rs
@@ -41,7 +41,7 @@ pub fn getcwd() -> Result<String, Error> {
     {
         ::nvx::vfs::fd::vfs_getcwd().map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("getcwd(): VFS getcwd failed (error={e})");
+            ::syslog::warn!("getcwd(): VFS getcwd failed (error={e})");
             Error::new(code, "vfs getcwd failed")
         })
     }

--- a/src/libs/syscall/src/unistd/syscall/link.rs
+++ b/src/libs/syscall/src/unistd/syscall/link.rs
@@ -37,7 +37,7 @@ pub fn link(oldpath: &str, newpath: &str) -> Result<(), Error> {
     // In standalone mode, forward operation to virtual file system (VFS).
     #[cfg(feature = "standalone")]
     {
-        ::syslog::error!("link(): hard links not supported on VFS (oldpath={oldpath:?})");
+        ::syslog::warn!("link(): hard links not supported on VFS (oldpath={oldpath:?})");
         Err(Error::new(ErrorCode::OperationNotSupported, "hard links not supported on VFS"))
     }
 

--- a/src/libs/syscall/src/unistd/syscall/linkat.rs
+++ b/src/libs/syscall/src/unistd/syscall/linkat.rs
@@ -69,7 +69,7 @@ pub fn linkat(
     {
         ::nvx::vfs::fd::vfs_linkat(olddirfd, oldpath, newdirfd, newpath, flags).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("linkat(): VFS linkat failed (oldpath={oldpath:?}, error={e})");
+            ::syslog::warn!("linkat(): VFS linkat failed (oldpath={oldpath:?}, error={e})");
             Error::new(code, "vfs linkat failed")
         })
     }

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -49,7 +49,7 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_lseek(fd, offset, whence).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("lseek(): VFS lseek failed (fd={fd}, error={e})");
+                ::syslog::warn!("lseek(): VFS lseek failed (fd={fd}, error={e})");
                 Error::new(code, "vfs lseek failed")
             });
         }

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -66,7 +66,7 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_pread(fd, buffer, offset).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("pread(): VFS pread failed (fd={fd}, error={e})");
+                ::syslog::warn!("pread(): VFS pread failed (fd={fd}, error={e})");
                 Error::new(code, "vfs pread failed")
             });
         }

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -66,7 +66,7 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             return ::nvx::vfs::fd::vfs_pwrite(fd, buffer, offset).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("pwrite(): VFS pwrite failed (fd={fd}, error={e})");
+                ::syslog::warn!("pwrite(): VFS pwrite failed (fd={fd}, error={e})");
                 Error::new(code, "vfs pwrite failed")
             });
         }

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -166,7 +166,7 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             let n: c_size_t = ::nvx::vfs::fd::vfs_read(fd, buffer).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("read(): VFS read failed (fd={fd}, error={e})");
+                ::syslog::warn!("read(): VFS read failed (fd={fd}, error={e})");
                 Error::new(code, "vfs read failed")
             })?;
             return Ok(n);

--- a/src/libs/syscall/src/unistd/syscall/symlink.rs
+++ b/src/libs/syscall/src/unistd/syscall/symlink.rs
@@ -51,7 +51,7 @@ pub fn symlink(target: &str, linkpath: &str) -> Result<(), Error> {
     // In standalone mode, forward operation to virtual file system (VFS).
     #[cfg(feature = "standalone")]
     {
-        ::syslog::error!("symlink(): symlinks not supported on VFS (linkpath={linkpath:?})");
+        ::syslog::warn!("symlink(): symlinks not supported on VFS (linkpath={linkpath:?})");
         Err(Error::new(ErrorCode::OperationNotSupported, "symbolic links not supported on VFS"))
     }
 

--- a/src/libs/syscall/src/unistd/syscall/unlink.rs
+++ b/src/libs/syscall/src/unistd/syscall/unlink.rs
@@ -46,7 +46,7 @@ pub fn unlink(path: &str) -> Result<(), Error> {
     {
         ::nvx::vfs::fd::vfs_unlink(path).map_err(|e| {
             let code: ::sys::error::ErrorCode = e.into();
-            ::syslog::error!("unlink(): VFS unlink failed (path={path:?}, error={e})");
+            ::syslog::warn!("unlink(): VFS unlink failed (path={path:?}, error={e})");
             Error::new(code, "vfs unlink failed")
         })
     }

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -136,7 +136,7 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
         if ::nvx::vfs::fd::is_vfs_fd(fd) {
             let n: c_size_t = ::nvx::vfs::fd::vfs_write(fd, buffer).map_err(|e| {
                 let code: ErrorCode = e.into();
-                ::syslog::error!("write(): VFS write failed (fd={fd}, error={e})");
+                ::syslog::warn!("write(): VFS write failed (fd={fd}, error={e})");
                 Error::new(code, "vfs write failed")
             })?;
             return Ok(n);

--- a/z.ps1
+++ b/z.ps1
@@ -119,7 +119,7 @@ Build Parameters (after --)
   RELEASE=yes             Enable release mode.
   MACHINE=microvm         Target machine: microvm (default) or hyperlight.
   WHP=yes                 Enable WHP-specific guest kernel code for microvm builds.
-  LOG_LEVEL=<level>       Log level (default: trace for debug, warn for release).
+  LOG_LEVEL=<level>       Log level (default: trace for debug, error for release).
 
 Test Parameters (after --)
   RELEASE=yes             Build nanvix-test in release mode if auto-build is needed.


### PR DESCRIPTION
## Summary

Reduces log noise from expected VFS failures (e.g., Python probing for missing files during startup) and tightens the default release log level.

## Changes

### 1. Downgrade VFS failure logs from `error!` to `warn!`
All 32 `syslog::error!` calls in the `syscall` crate that log VFS operation failures are now `syslog::warn!`. These are normal syscall return paths (e.g., `ENOENT`), not true error conditions. Non-VFS errors (null-pointer checks, IPC/linuxd failures) remain as `error!`.

### 2. Change default release `LOG_LEVEL` from `warn` to `error`
Release builds and artifacts now compile with `LOG_LEVEL=error`, which means VFS warnings are compiled out entirely in release binaries. Debug builds continue to use `LOG_LEVEL=trace`.

> **Note:** CI already used `LOG_LEVEL=error` for release builds — no workflow changes needed.

### Motivation

When running Python on Nanvix, normal startup file probing (`pybuilddir.txt`, `.so` extensions, `pyvenv.cfg`, etc.) produced `Error:` log lines interleaved with program output. These are expected POSIX behavior — not actual errors.

### Files Changed
- **`Makefile`** — Release default `warn` → `error`
- **`z.ps1`** — Help text updated
- **`doc/build-linux.md`, `doc/build-windows.md`** — Examples and tables updated
- **`.github/skills/build/SKILL.md`** — Parameter table updated
- **32 files in `src/libs/syscall/src/`** — `syslog::error!` → `syslog::warn!` for VFS failures
