### PR TITLE
Switch release publishing to nightly schedule

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -2,16 +2,12 @@
 # Licensed under the MIT License.
 
 name: "Publish Release"
-description: "Publish a versioned release to GitHub and trigger downstream dispatches"
+description: "Publish a versioned release to GitHub"
 
 inputs:
   github-token:
     description: "GitHub token for creating releases"
     required: true
-  dispatch-token:
-    description: "Token for dispatching to downstream repositories (optional)"
-    required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -371,51 +367,3 @@ runs:
               `is older than the current latest release — updating would regress the latest pointer.`
             );
           }
-
-    - name: "Trigger Nanvix Release Dispatch"
-      shell: bash
-      env:
-        DISPATCH_TOKEN: ${{ inputs.dispatch-token }}
-      run: |
-        if [[ -z "${DISPATCH_TOKEN}" ]]; then
-          echo "::warning::DISPATCH_TOKEN secret is not configured; skipping release dispatch."
-          exit 0
-        fi
-
-        repos=("bzip2" "cymem" "kiwi" "libexpat" "libffi" "murmurhash" "numpy" "openblas" "openssl" "posix-tests" "preshed" "quickjs" "rusty_v8" "sqlite" "srsly" "zlib")
-        failed=0
-
-        for repo in "${repos[@]}"; do
-          API_URL="https://api.github.com/repos/nanvix/${repo}/dispatches"
-          PAYLOAD=$(cat <<JSON
-        {
-          "event_type": "nanvix-minor-release",
-          "client_payload": {
-            "source_repo": "nanvix/nanvix",
-            "ref": "${GITHUB_REF}",
-            "sha": "${GITHUB_SHA}",
-            "component": "${repo}",
-            "reason": "sync build from nanvix/nanvix"
-          }
-        }
-        JSON
-        )
-
-          http_response=$(curl -sS -o /dev/null -w "%{http_code}" -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "$API_URL" \
-            -d "${PAYLOAD}")
-
-          if [[ "${http_response}" -ge 200 && "${http_response}" -lt 300 ]]; then
-            echo "Dispatched nanvix-minor-release event to nanvix/${repo} (HTTP ${http_response})."
-          else
-            echo "::error::Failed to dispatch nanvix-minor-release event to nanvix/${repo} (HTTP ${http_response})."
-            failed=1
-          fi
-        done
-
-        if [[ "${failed}" -eq 1 ]]; then
-          exit 1
-        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1309,7 +1309,6 @@ jobs:
         uses: ./.github/actions/publish-release
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          dispatch-token: ${{ secrets.DISPATCH_TOKEN }}
 
   # Open a GitHub issue when any job in the release pipeline fails on dev.
   notify-release-failure:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@
 name: "Nanvix CI/CD"
 
 on:
+  schedule:
+    # Nightly release: build, test, and publish a release every day at midnight UTC.
+    - cron: "0 0 * * *"
+
   workflow_dispatch:
 
   pull_request:
@@ -31,7 +35,8 @@ concurrency:
 # Build-type strategy:
 #   pull_request      → debug only   (fast feedback during development)
 #   merge_group       → release only (final validation before landing on dev)
-#   push (dev)        → release only (release archives & publish pipeline)
+#   push (dev)        → release only (CI pipeline only, no release publish)
+#   schedule          → release only (nightly release archives & publish pipeline)
 #   workflow_dispatch → both          (full coverage for manual runs)
 
 jobs:
@@ -42,8 +47,9 @@ jobs:
   precheck:
     # The merge queue already ensures the branch is up-to-date, so skip this
     # check for merge_group events to avoid false negatives from the merge
-    # commit detection in the reusable workflow.
-    if: github.event_name != 'merge_group'
+    # commit detection in the reusable workflow. Scheduled runs have no PR
+    # context, so skip them as well.
+    if: github.event_name != 'merge_group' && github.event_name != 'schedule'
     uses: nanvix/nanvix/.github/workflows/branch-up-to-date.yml@dev
     secrets: inherit
 
@@ -68,7 +74,7 @@ jobs:
     # - Non-draft PRs.
     if: |
       github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
             github.event_name != 'push' ||
             github.event.head_commit == null ||
@@ -125,7 +131,7 @@ jobs:
 
     if: |
       github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
             github.event_name != 'push' ||
             github.event.head_commit == null ||
@@ -173,7 +179,7 @@ jobs:
 
     if: |
       github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
             github.event_name != 'push' ||
             github.event.head_commit == null ||
@@ -264,7 +270,7 @@ jobs:
 
     if: |
       github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
             github.event_name != 'push' ||
             github.event.head_commit == null ||
@@ -453,7 +459,7 @@ jobs:
 
     if: |
       github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
             github.event_name != 'push' ||
             github.event.head_commit == null ||
@@ -496,7 +502,7 @@ jobs:
 
     if: |
       github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
             github.event_name != 'push' ||
             github.event.head_commit == null ||
@@ -708,7 +714,7 @@ jobs:
 
     if: |
       github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
             github.event_name != 'push' ||
             github.event.head_commit == null ||
@@ -814,7 +820,7 @@ jobs:
 
     if: |
       github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
             github.event_name != 'push' ||
             github.event.head_commit == null ||
@@ -996,7 +1002,7 @@ jobs:
 
     if: |
       github.repository == 'nanvix/nanvix' && (
-        github.event_name == 'merge_group' || (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
           needs.precheck.outputs.up_to_date == 'true' && (
             github.event_name != 'push' ||
             github.event.head_commit == null ||
@@ -1182,6 +1188,7 @@ jobs:
     if: |
       github.repository == 'nanvix/nanvix' &&
       github.ref == 'refs/heads/dev' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.ci-test.result == 'success' &&
       needs.ci-l2.result == 'success' &&
       needs.benchmark-finalize.result == 'success' &&
@@ -1236,6 +1243,7 @@ jobs:
     if: |
       github.repository == 'nanvix/nanvix' &&
       github.ref == 'refs/heads/dev' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.ci-test.result == 'success' &&
       needs.ci-l2.result == 'success' &&
       needs.benchmark-finalize.result == 'success' &&
@@ -1288,6 +1296,7 @@ jobs:
     if: |
       github.repository == 'nanvix/nanvix' &&
       github.ref == 'refs/heads/dev' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.release-archive.result == 'success' &&
       needs.windows-release-archive.result == 'success'
     runs-on:


### PR DESCRIPTION
## Summary

Move release publishing from every push-to-dev to a nightly cron schedule, and remove the downstream repository dispatch mechanism.

## Changes

### Remove downstream release dispatch
- Remove the `dispatch-token` input and the "Trigger Nanvix Release Dispatch" step from the `publish-release` composite action.
- Remove `dispatch-token` usage from the CI workflow.

### Add nightly schedule trigger
- Add a `schedule` trigger (`0 0 * * *`) to run the full CI/CD pipeline daily at midnight UTC.
- Skip the `precheck` job for scheduled runs (no PR context).
- Gate all CI jobs to run unconditionally on `schedule` events (alongside `merge_group`).
- Restrict the release pipeline (`release-archive`, `windows-release-archive`, `publish-release`) to `schedule` and `workflow_dispatch` events only — pushes to `dev` now run CI without publishing a release.