### PR TITLE
[build] Split `TOOLCHAIN_DIR` into `CLH_DIR` and explicit `VERUS_EXECUTABLE_DIR`

### DIFF
--- a/.github/actions/benchmark-build/action.yml
+++ b/.github/actions/benchmark-build/action.yml
@@ -24,7 +24,6 @@ runs:
       TIMESTAMP_MSG_FLAG: ${{ inputs.timestamp-msg == 'yes' && 'TIMESTAMP_MSG=yes' || '' }}
     run: |
       ./z build \
-        --toolchain-dir "$HOME/toolchain" \
         -- \
         all \
         "MACHINE=${MACHINE_TYPE}" \

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -33,7 +33,6 @@ runs:
     shell: bash
     run: |
       ./z build \
-        --toolchain-dir "$HOME/toolchain" \
         -- \
         all \
         "MACHINE=${{ inputs.machine-type }}" \

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -33,7 +33,6 @@ runs:
     shell: bash
     run: |
       ./z build \
-        --toolchain-dir "$HOME/toolchain" \
         -- \
         lint-check \
         "MACHINE=${{ inputs.machine-type }}" \

--- a/.github/actions/native-setup/action.yml
+++ b/.github/actions/native-setup/action.yml
@@ -48,23 +48,18 @@ runs:
         python3 -m venv .venv
         .venv/bin/pip install --quiet -r requirements.txt
 
-    - name: "Create Toolchain Directory"
+    - name: "Create Cloud-Hypervisor Directory"
       shell: bash
       run: |
-        TOOLCHAIN_DIR="${RUNNER_TEMP}/toolchain"
-        mkdir -p "${TOOLCHAIN_DIR}/bin"
-        mkdir -p "${TOOLCHAIN_DIR}/verus"
-        # Create version file matching the format expected by the z script.
-        version=$(grep -m 1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-        expected_tag="${version%.*}.x"
-        echo "nanvix-toolchain-v${expected_tag}" > "${TOOLCHAIN_DIR}/version"
-        echo "[INFO] Created toolchain directory at ${TOOLCHAIN_DIR}"
+        CLH_DIR="${HOME}/toolchain"
+        mkdir -p "${CLH_DIR}/bin"
+        echo "[INFO] Created cloud-hypervisor directory at ${CLH_DIR}"
 
     - name: "Build Cloud-Hypervisor"
       if: inputs.install-cloud-hypervisor == 'true'
       shell: bash
       run: |
-        TOOLCHAIN_DIR="${RUNNER_TEMP}/toolchain"
+        CLH_DIR="${HOME}/toolchain"
         # Build only cloud-hypervisor (skip Linux kernel build).
         CLOUD_HYPERVISOR_COMMIT="4681d5eba0e63fb010bf4ca962eb3c9f163d3288"
         CLOUD_HYPERVISOR_REPO="https://github.com/nanvix/cloud-hypervisor"
@@ -74,10 +69,10 @@ runs:
         pushd "${SRC_DIR}"
         git checkout "${CLOUD_HYPERVISOR_COMMIT}"
         cargo build --release
-        cp ./target/release/cloud-hypervisor "${TOOLCHAIN_DIR}/bin/cloud-hypervisor"
-        cp ./target/release/ch-remote "${TOOLCHAIN_DIR}/bin/ch-remote"
+        cp ./target/release/cloud-hypervisor "${CLH_DIR}/bin/cloud-hypervisor"
+        cp ./target/release/ch-remote "${CLH_DIR}/bin/ch-remote"
         # Set CAP_NET_ADMIN for TAP device creation without sudo.
-        sudo setcap cap_net_admin+ep "${TOOLCHAIN_DIR}/bin/cloud-hypervisor" || true
+        sudo setcap cap_net_admin+ep "${CLH_DIR}/bin/cloud-hypervisor" || true
         popd
         rm -rf "${SRC_DIR}"
-        echo "[INFO] Cloud-hypervisor installed to ${TOOLCHAIN_DIR}/bin/"
+        echo "[INFO] Cloud-hypervisor installed to ${CLH_DIR}/bin/"

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -34,7 +34,6 @@ runs:
     shell: bash
     run: |
       ./z build \
-        --toolchain-dir "$HOME/toolchain" \
         -- \
         run-unit-tests \
         "MACHINE=${{ inputs.machine-type }}" \
@@ -48,7 +47,6 @@ runs:
     shell: bash
     run: |
       ./z build \
-        --toolchain-dir "$HOME/toolchain" \
         -- \
         run-nanvix-tests \
         "MACHINE=${{ inputs.machine-type }}" \

--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -146,18 +146,19 @@ Any unrecognized target is forwarded to `make`, just like on Linux:
 
 ## Formal Verification
 
-Nanvix uses Verus for formal verification of selected kernel crates. The expected Verus version is pinned in `build/verus-version` and auto-installed to `$(TOOLCHAIN_DIR)/verus` on the first run.
+Nanvix uses Verus for formal verification of selected kernel crates. The expected Verus version is pinned in `build/verus-version`. Verification requires `VERUS_EXECUTABLE_DIR` to be set; when unset, `make verify` is a no-op.
 
 ```bash
-# Verify all annotated crates.
-./z build -- verify
+# Install verus and run verification.
+./scripts/setup/verus.sh ~/toolchain/verus
+./z build -- verify VERUS_EXECUTABLE_DIR=~/toolchain/verus
 
 # Verify a single crate.
-./z build -- verify-bitmap
+./z build -- verify-bitmap VERUS_EXECUTABLE_DIR=~/toolchain/verus
 ```
 
-- The `ensure-verus` prerequisite downloads the correct Verus release automatically.
-- Override the install location with `VERUS_EXECUTABLE_DIR=/path/to/verus`.
+- Set `VERUS_EXECUTABLE_DIR` to the directory containing the `verus` binary.
+- Use `scripts/setup/verus.sh <dir>` to download the pinned release.
 - The `vstd` crate version in `Cargo.toml` is exact-pinned (`=`) to match the Verus binary.
 
 ## Cleaning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,12 +97,12 @@ jobs:
       - name: "Check Code Format"
         shell: bash
         run: |
-          ./z build --toolchain-dir "${RUNNER_TEMP}/toolchain" -- format-check
+          ./z build -- format-check
 
       - name: "Spellcheck"
         shell: bash
         run: |
-          ./z build --toolchain-dir "${RUNNER_TEMP}/toolchain" -- spellcheck
+          ./z build -- spellcheck
 
   # ==========================================================================================
   # Stage 1 (parallel): Config-Dependent Source Checks (GitHub-Hosted Runners)
@@ -154,7 +154,7 @@ jobs:
       - name: "Lint"
         shell: bash
         run: |
-          ./z build --toolchain-dir "${RUNNER_TEMP}/toolchain" -- lint-check \
+          ./z build -- lint-check \
             "MACHINE=${{ matrix.machine-type }}" \
             TARGET=x86 \
             LOG_LEVEL=trace \
@@ -222,12 +222,13 @@ jobs:
       - name: "Install Verus"
         shell: bash
         run: |
-          ./scripts/setup/verus.sh "${RUNNER_TEMP}/toolchain/verus"
+          ./scripts/setup/verus.sh "${HOME}/toolchain/verus"
 
       - name: "Verify"
         shell: bash
         run: |
-          ./z build --toolchain-dir "${RUNNER_TEMP}/toolchain" -- verify \
+          ./z build -- verify \
+            "VERUS_EXECUTABLE_DIR=${HOME}/toolchain/verus" \
             "MACHINE=${{ matrix.machine-type }}" \
             TARGET=x86 \
             LOG_LEVEL=trace \
@@ -321,7 +322,7 @@ jobs:
           RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
           BUILD_TARGETS: ${{ matrix.build-type == 'release' && 'all run-unit-tests release' || 'all run-unit-tests' }}
         run: |
-          ./z build --toolchain-dir "${RUNNER_TEMP}/toolchain" -- ${BUILD_TARGETS} \
+          ./z build -- ${BUILD_TARGETS} \
             "MACHINE=${MACHINE_TYPE}" \
             TARGET=x86 \
             "LOG_LEVEL=${LOG_LEVEL}" \
@@ -1032,7 +1033,7 @@ jobs:
         env:
           MACHINE_TYPE: ${{ matrix.machine-type }}
         run: |
-          ./z build --toolchain-dir "${RUNNER_TEMP}/toolchain" -- all \
+          ./z build -- all \
             "MACHINE=${MACHINE_TYPE}" \
             TARGET=x86 \
             LOG_LEVEL=panic \
@@ -1056,7 +1057,7 @@ jobs:
               --benchmark "${bench}" \
               --machine-type "${MACHINE_TYPE}" \
               --iterations "${ITERATIONS}" \
-              --toolchain-bin-dir "${RUNNER_TEMP}/toolchain/bin" \
+              --toolchain-bin-dir "${HOME}/toolchain/bin" \
               --output-dir "$(pwd)" \
               --commit "${{ github.sha }}"
           done
@@ -1067,7 +1068,7 @@ jobs:
         env:
           MACHINE_TYPE: ${{ matrix.machine-type }}
         run: |
-          ./z build --toolchain-dir "${RUNNER_TEMP}/toolchain" -- all \
+          ./z build -- all \
             "MACHINE=${MACHINE_TYPE}" \
             TARGET=x86 \
             LOG_LEVEL=panic \
@@ -1090,7 +1091,7 @@ jobs:
               --benchmark "${bench}" \
               --machine-type "${MACHINE_TYPE}" \
               --iterations "${ITERATIONS}" \
-              --toolchain-bin-dir "${RUNNER_TEMP}/toolchain/bin" \
+              --toolchain-bin-dir "${HOME}/toolchain/bin" \
               --output-dir "$(pwd)" \
               --commit "${{ github.sha }}"
           done

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ export SNAPSHOT_DIR  := $(ROOT_DIR)/images
 export LOGS_DIR      := $(ROOT_DIR)/logs
 export SCRIPTS_DIR   := $(ROOT_DIR)/scripts
 export SOURCES_DIR   := $(ROOT_DIR)/src
-export TOOLCHAIN_DIR ?= $(ROOT_DIR)/toolchain
+export CLH_DIR       ?= $(ROOT_DIR)/toolchain
 export SYSROOT_DIR   ?= $(ROOT_DIR)/sysroot$(if $(filter yes,$(RELEASE)),-release,-debug)
 export SYSROOT_LINK  := $(ROOT_DIR)/sysroot
 export TARGETS_DIR   := $(BUILD_DIR)/targets
@@ -290,12 +290,8 @@ endif
 # Verus Formal Verification
 #===================================================================================================
 
-# Path to the directory containing the Verus executable.
-export VERUS_EXECUTABLE_DIR ?= $(TOOLCHAIN_DIR)/verus
-
-# Default Verus directory (used to detect custom VERUS_EXECUTABLE_DIR overrides).
-# patsubst strips trailing slashes so `toolchain/verus/` is not treated as custom.
-VERUS_DEFAULT_EXECUTABLE_DIR := $(patsubst %/,%,$(TOOLCHAIN_DIR)/verus)
+# Path to the directory containing the Verus executable (no default; skip verification when unset).
+export VERUS_EXECUTABLE_DIR ?=
 
 # List of crates to verify with Verus.
 VERUS_CRATES := bitmap
@@ -530,8 +526,8 @@ help:
 	@echo "  SYSROOT_DIR      Sysroot directory (default: $(SYSROOT_DIR))"
 	@echo "  TARGET           Target architecture (default: $(TARGET))"
 	@echo "  TIMEOUT          Execution timeout in seconds (default: $(TIMEOUT))"
-	@echo "  TOOLCHAIN_DIR    Toolchain location (default: $(TOOLCHAIN_DIR))"
-	@echo "  VERUS_EXECUTABLE_DIR  Path to directory containing the verus binary (default: $(VERUS_EXECUTABLE_DIR))"
+	@echo "  CLH_DIR          Cloud-hypervisor installation directory (default: $(CLH_DIR))"
+	@echo "  VERUS_EXECUTABLE_DIR  Path to directory containing the verus binary (unset: skip verification)"
 	@echo ""
 	@echo "Parameter Values"
 	@echo "  DEPLOYMENT_MODE standalone, single-process, multi-process, l2"
@@ -547,24 +543,28 @@ help:
 verify: $(addprefix verify-,$(VERUS_CRATES))
 
 # Ensures the correct Verus version is installed before verification.
-# When VERUS_EXECUTABLE_DIR points to a custom location, we assume the user has pre-built or
-# pre-downloaded Verus there and just validate the binary exists (read-only; no writes to that
-# directory).  Otherwise the prebuilt release is downloaded into the default location.
+# When VERUS_EXECUTABLE_DIR is unset, verification is skipped.
+# When set, validates that the verus binary exists at the given path.
 .PHONY: ensure-verus
 ensure-verus:
-ifneq ($(patsubst %/,%,$(VERUS_EXECUTABLE_DIR)),$(VERUS_DEFAULT_EXECUTABLE_DIR))
+ifeq ($(VERUS_EXECUTABLE_DIR),)
+	@echo "VERUS_EXECUTABLE_DIR is not set; skipping verification."
+else
 	@if [ ! -x "$(VERUS_EXECUTABLE_DIR)/verus" ]; then \
 		echo "Error: VERUS_EXECUTABLE_DIR is set to '$(VERUS_EXECUTABLE_DIR)' but no verus binary found there."; \
 		exit 1; \
 	fi
-	@echo "Using custom Verus installation at $(VERUS_EXECUTABLE_DIR)."
-else
-	@$(SCRIPTS_DIR)/setup/verus.sh "$(VERUS_EXECUTABLE_DIR)"
+	@echo "Using Verus installation at $(VERUS_EXECUTABLE_DIR)."
 endif
 
 # Pattern rule for verifying individual crates.
+# Verification is skipped when VERUS_EXECUTABLE_DIR is unset.
 $(addprefix verify-,$(VERUS_CRATES)): verify-%: ensure-verus
+ifeq ($(VERUS_EXECUTABLE_DIR),)
+	@true
+else
 	$(VERUS_VERIFY_CMD) -p $* $(KERNEL_CARGO_FLAGS) $(KERNEL_CARGO_TARGET)
+endif
 
 # Fixes code linting issues.
 ifeq ($(IS_WINDOWS),yes)
@@ -780,11 +780,11 @@ endif
 
 # Runs system in release mode.
 run: image
-	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -toolchain-bin-dir $(TOOLCHAIN_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
+	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -toolchain-bin-dir $(CLH_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
 
 # Runs system in debug mode.
 debug: image
-	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -toolchain-bin-dir $(TOOLCHAIN_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
+	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -toolchain-bin-dir $(CLH_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
 
 #===================================================================================================
 # Build Rules for System Image

--- a/build/make/snapshot.mk
+++ b/build/make/snapshot.mk
@@ -6,7 +6,7 @@ all-snapshot: all-host-binaries
 # Snapshots are only generated for microvm/hyperlight machines in L2 deployment mode.
 ifneq (,$(and $(filter l2,$(DEPLOYMENT_MODE)),$(filter $(MACHINE),microvm hyperlight)))
 	bash $(SCRIPTS_DIR)/generate-l2-initramfs.sh
-	bash $(SCRIPTS_DIR)/generate-l2-snapshot.sh $(TOOLCHAIN_DIR)
+	bash $(SCRIPTS_DIR)/generate-l2-snapshot.sh $(CLH_DIR)
 endif
 
 clean-snapshot:

--- a/doc/build-linux.md
+++ b/doc/build-linux.md
@@ -130,20 +130,23 @@ To run formal verification:
 
 ```bash
 # Verify all annotated crates.
-./z build -- verify
+./z build -- verify VERUS_EXECUTABLE_DIR=~/toolchain/verus
 
 # Verify a single crate (e.g., bitmap).
-./z build -- verify-bitmap
+./z build -- verify-bitmap VERUS_EXECUTABLE_DIR=~/toolchain/verus
 ```
 
-Verus is installed to `$(TOOLCHAIN_DIR)/verus` by default. When `VERUS_EXECUTABLE_DIR` points
-to a custom location, the build assumes pre-built or locally compiled Verus binaries are already
-present there and skips the automatic download (the directory is used read-only; nothing is
-written to it). `VERUS_EXECUTABLE_DIR` must point to the directory that contains the `verus`
-executable (and required companion binaries), not just the Verus source tree.
+> **Note:** `VERUS_EXECUTABLE_DIR` must be set; when unset, verification is a silent no-op.
+
+Verification requires `VERUS_EXECUTABLE_DIR` to point to the directory that contains the
+`verus` executable (and required companion binaries). When the variable is unset, `make verify`
+is a no-op. The `scripts/setup/verus.sh` helper can download the pinned release:
 
 ```bash
-# Use a custom Verus installation (pre-built or source-built).
-# VERUS_EXECUTABLE_DIR must be the directory that contains the verus binary.
+# Install verus to a local directory and run verification.
+./scripts/setup/verus.sh ~/toolchain/verus
+./z build -- verify VERUS_EXECUTABLE_DIR=~/toolchain/verus
+
+# Or use a source-built installation.
 ./z build -- verify VERUS_EXECUTABLE_DIR=~/verus/target-verus/release
 ```

--- a/doc/setup-linux.md
+++ b/doc/setup-linux.md
@@ -136,8 +136,15 @@ compatibility. Follow these steps to update your environment:
 
 ## 9. Verus (Formal Verification)
 
-Verus is installed automatically when you run `make verify`. The expected version is pinned in
-`build/verus-version` and installed to `toolchain/verus`. No manual setup is required.
+Verification requires `VERUS_EXECUTABLE_DIR` to point to the directory containing the `verus`
+binary. When unset, `make verify` is a no-op. The expected version is pinned in
+`build/verus-version`; use `scripts/setup/verus.sh` to download it:
+
+```bash
+# Download the pinned release and run verification.
+./scripts/setup/verus.sh ~/toolchain/verus
+./z build -- verify VERUS_EXECUTABLE_DIR=~/toolchain/verus
+```
 
 ### Using a Custom Verus Installation
 
@@ -150,14 +157,14 @@ git clone https://github.com/verus-lang/verus.git ~/verus-src
 cd ~/verus-src/source
 # Follow the Verus build instructions to produce binaries.
 
-# 2. Point VERUS_EXECUTABLE_DIR at the directory containing the verus binary.
-make verify VERUS_EXECUTABLE_DIR=~/verus-src/source/target-verus/release
+# 2. From the Nanvix repo root, run verification pointing at the verus binary directory.
+cd /path/to/nanvix
+./z build -- verify VERUS_EXECUTABLE_DIR=~/verus-src/source/target-verus/release
 ```
 
-> **Note:** When `VERUS_EXECUTABLE_DIR` is overridden, the automatic download is skipped and
-> the build validates that a `verus` binary exists at the given path (the directory is used
-> read-only; nothing is written to it). You are responsible for ensuring the Verus version is
-> compatible with the `vstd` crate version pinned in `Cargo.toml`.
+> **Note:** The build validates that a `verus` binary exists at the given path (the directory
+> is used read-only; nothing is written to it). You are responsible for ensuring the Verus
+> version is compatible with the `vstd` crate version pinned in `Cargo.toml`.
 
 ---
 

--- a/z.py
+++ b/z.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import os
 import platform
-import re
 import shutil
 import subprocess
 import sys
@@ -63,7 +62,7 @@ KNOWN_MAKE_VARS: frozenset[str] = frozenset(
         "TIMESTAMP_MSG",
         "WHP",
         "IMAGE",
-        "TOOLCHAIN_DIR",
+        "CLH_DIR",
         "HOST_CPU",
         "WASM_BINARY",
         "WASM_BINARY_ARGS",
@@ -324,13 +323,11 @@ def _parse_make_var(config: BuildConfig, key: str, val: str) -> None:
                     f"Invalid MESSAGE_FORMAT={val}. Valid: {', '.join(VALID_MESSAGE_FORMATS)}"
                 )
             config.message_format = val
-        case "TOOLCHAIN_DIR":
-            config.toolchain_dir = val
         case "SYSROOT_DIR":
             config.sysroot_dir = val
         case "VERBOSE":
             config.verbose = val.lower() == "yes"
-        case "SCCACHE" | "MAKE_NO_PRINT" | "VERUS_EXECUTABLE_DIR":
+        case "SCCACHE" | "MAKE_NO_PRINT" | "VERUS_EXECUTABLE_DIR" | "CLH_DIR":
             pass  # Passed through to Make verbatim; no z.py-side effect.
 
 
@@ -443,65 +440,6 @@ def validate_git_context() -> Path:
         die(f"Must run from repo root ({repo_root}), not {cwd}.")
 
     return repo_root
-
-
-def _get_cargo_toml_version(repo_root: Path) -> str:
-    """Extract workspace version from Cargo.toml."""
-    cargo_toml = repo_root / "Cargo.toml"
-    if not cargo_toml.exists():
-        die("Cargo.toml not found at repo root.")
-    content = cargo_toml.read_text(encoding="utf-8")
-    # Search within [workspace.package] to avoid matching dependency versions.
-    section_match = re.search(
-        r"^\[workspace\.package\]\s*\n(.*?)(?=^\[|\Z)",
-        content,
-        re.MULTILINE | re.DOTALL,
-    )
-    if not section_match:
-        die("Could not find [workspace.package] section in Cargo.toml.")
-    section = section_match.group(1)
-    match = re.search(r'^version\s*=\s*"([^"]+)"', section, re.MULTILINE)
-    if not match:
-        die("Could not extract version from [workspace.package] in Cargo.toml.")
-    return match.group(1)
-
-
-def check_toolchain_version(toolchain_dir: str, repo_root: Path) -> None:
-    """Validate toolchain version matches Cargo.toml (Linux only)."""
-    version = _get_cargo_toml_version(repo_root)
-    parts = version.split(".")
-    if len(parts) < 2:
-        die(f"Invalid version in Cargo.toml: {version}")
-    expected_tag = f"{parts[0]}.{parts[1]}.x"
-    expected_version_string = f"nanvix-toolchain-v{expected_tag}"
-
-    version_file = Path(toolchain_dir) / "version"
-    if not version_file.exists():
-        die(
-            f"Toolchain version file not found: {version_file}\n"
-            f"Run './z setup --toolchain-dir {toolchain_dir}' to install the toolchain."
-        )
-    if not os.access(str(version_file), os.R_OK):
-        die(f"Toolchain version file is not readable: {version_file}")
-
-    found_version = version_file.read_text(encoding="utf-8").strip()
-    if not found_version:
-        die(
-            f"Toolchain version file is empty: {version_file}\n"
-            f"Run './z setup' to (re)install the toolchain."
-        )
-
-    if found_version != expected_version_string:
-        die(
-            f"Toolchain version mismatch.\n"
-            f"  Expected: {expected_version_string}\n"
-            f"  Found:    {found_version}\n"
-            f"Run './z setup' to update the toolchain."
-        )
-
-    print_info(
-        f"Toolchain version '{found_version}' matches expected '{expected_version_string}'."
-    )
 
 
 def check_filesystem_support(directory: str) -> bool:
@@ -779,7 +717,7 @@ def invoke_make(
 
     Args:
         plat: Platform information.
-        injected_vars: VAR=VALUE strings z.py injects (e.g., TOOLCHAIN_DIR, RELEASE).
+        injected_vars: VAR=VALUE strings z.py injects (e.g., RELEASE).
         raw_args: Raw user arguments from after -- (targets and KEY=VALUE pairs).
         targets: Explicit Make targets to append.
         verbose: Print the full command line.
@@ -826,10 +764,6 @@ def _assemble_build_make_args(
     injected: list[str] = []
     user_args = list(config.make_args)
 
-    # On Linux, always inject TOOLCHAIN_DIR.
-    if plat.is_linux:
-        injected.append(f"TOOLCHAIN_DIR={config.toolchain_dir}")
-
     # --profile: force RELEASE=yes, add PROFILER=yes, strip user-provided RELEASE=.
     if config.profile:
         user_args = [a for a in user_args if not a.startswith("RELEASE=")]
@@ -858,11 +792,6 @@ def _assemble_build_make_args(
 
 def cmd_build(plat: PlatformInfo, config: BuildConfig) -> int:
     """Execute the build subcommand."""
-    # Linux pre-build validation.
-    if plat.is_linux:
-        validate_toolchain_dir_location(config.toolchain_dir, plat.repo_root)
-        check_toolchain_version(config.toolchain_dir, plat.repo_root)
-
     # Windows pre-build steps.
     if plat.is_windows:
         ensure_ld_shim(plat.repo_root)
@@ -1054,7 +983,7 @@ Commands:
 Options:
   --profile             Enable profiling (implies --release, passes PROFILER=yes).
   --release             Build in release mode.
-  --toolchain-dir DIR   Toolchain directory (Linux only, default: ~/toolchain).
+  --toolchain-dir DIR   Toolchain directory (setup only, Linux, default: ~/toolchain).
 
 Build Parameters (after --):
   MACHINE=microvm|hyperlight     Target machine (default: microvm).


### PR DESCRIPTION
The monolithic `TOOLCHAIN_DIR` variable served two unrelated purposes: hosting the cloud-hypervisor binaries and locating the Verus verifier. This made the build interface confusing and forced `z.py` to inject and validate a directory that most targets never used.

## Changes

**Makefile / build system**
- Rename `TOOLCHAIN_DIR` to `CLH_DIR` (cloud-hypervisor only).
- Default `VERUS_EXECUTABLE_DIR` to empty; `make verify` is a no-op when unset.
- Remove auto-download logic from `ensure-verus`; users install via `scripts/setup/verus.sh`.

**z.py**
- Stop injecting `TOOLCHAIN_DIR` into Make on Linux builds.
- Remove `check_toolchain_version()` and `_get_cargo_toml_version()` entirely; toolchain location validation remains in `cmd_setup_linux()`.
- Add `CLH_DIR` and `VERUS_EXECUTABLE_DIR` to the Make pass-through list.
- Update `--toolchain-dir` help text to reflect setup-only scope.

**CI (.github/)**
- Drop `--toolchain-dir` from all `./z build` invocations.
- Switch `native-setup` from `RUNNER_TEMP` to `HOME/toolchain`; remove version file.
- Add explicit `VERUS_EXECUTABLE_DIR` to the verification job.
- Align benchmark `--toolchain-bin-dir` paths with the new location.

**Documentation**
- Update `build-linux.md`, `setup-linux.md`, and build `SKILL.md` for opt-in verification.