### PR TITLE
[build] Harden Python discovery to skip Windows Store stubs

### DIFF
--- a/z.ps1
+++ b/z.ps1
@@ -25,25 +25,76 @@
 # Configuration
 # ==================================================================================================
 
+# Minimum major and minor Python versions required to run z.py. This should be kept in sync with the
+# minimum version specified in pyproject.toml.
+$MinPythonMajor = 3
+$MinPythonMinor = 10
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 if (-not $ScriptDir) { $ScriptDir = Get-Location }
 $ZPy = Join-Path $ScriptDir "z.py"
 
-# Find Python.
-$Python = $null
-foreach ($name in @("python", "python3")) {
-    $Python = Get-Command $name -ErrorAction SilentlyContinue | Select-Object -First 1
-    if ($Python) { break }
+# Return $true when the executable at $Path reports Python >= $MinPythonMajor.$MinPythonMinor.
+function Test-PythonMinVersion {
+    param([string]$Path)
+    try {
+        $output = & $Path --version 2>&1
+        if ($LASTEXITCODE -ne 0) { return $false }
+        # Expected format: "Python 3.x.y"
+        if ($output -match 'Python\s+(\d+)\.(\d+)') {
+            $major = [int]$Matches[1]
+            $minor = [int]$Matches[2]
+            return ($major -gt $MinPythonMajor -or ($major -eq $MinPythonMajor -and $minor -ge $MinPythonMinor))
+        }
+        return $false
+    } catch {
+        return $false
+    }
 }
 
-if (-not $Python) {
-    Write-Host "[ERROR] Python 3.10+ is required but was not found on PATH." -ForegroundColor Red
-    Write-Host "        Install Python 3.10+ (e.g., via winget or the official installer), then re-run this command." -ForegroundColor Red
+# Find Python — verify the candidate actually runs (filters out Windows Store stubs).
+function Find-Python {
+    # 1. Try names on PATH.
+    foreach ($name in @("python", "python3")) {
+        $cmd = Get-Command $name -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($cmd -and (Test-PythonMinVersion $cmd.Source)) {
+            return $cmd.Source
+        }
+    }
+
+    # 2. Fall back to common install locations (3.10+).
+    $locations = @(
+        "$env:LOCALAPPDATA\Programs\Python\Python31*\python.exe",
+        "$env:LOCALAPPDATA\Programs\Python\Python32*\python.exe",
+        "$env:ProgramFiles\Python31*\python.exe",
+        "$env:ProgramFiles\Python32*\python.exe",
+        "${env:ProgramFiles(x86)}\Python31*\python.exe",
+        "${env:ProgramFiles(x86)}\Python32*\python.exe",
+        "C:\Python31*\python.exe",
+        "C:\Python32*\python.exe"
+    )
+    foreach ($pattern in $locations) {
+        $found = Get-Item $pattern -ErrorAction SilentlyContinue |
+                 Sort-Object FullName -Descending |
+                 Select-Object -First 1
+        if ($found -and (Test-PythonMinVersion $found.FullName)) {
+            return $found.FullName
+        }
+    }
+
+    return $null
+}
+
+$PythonExe = Find-Python
+if (-not $PythonExe) {
+    Write-Host "[ERROR] Python $MinPythonMajor.$MinPythonMinor+ is required but was not found." -ForegroundColor Red
+    Write-Host "        Install Python $MinPythonMajor.$MinPythonMinor+ (e.g., via winget or the official installer)" -ForegroundColor Red
+    Write-Host "        and make sure it is on PATH, then re-run this command." -ForegroundColor Red
     exit 1
 }
 
 # Use Continue so that stderr output from native commands (e.g., rustfmt
 # warnings) is not treated as a terminating error by PowerShell.
 $ErrorActionPreference = "Continue"
-& $Python.Source $ZPy @args
+& $PythonExe $ZPy @args
 exit $LASTEXITCODE


### PR DESCRIPTION
The previous Get-Command lookup could resolve the Windows Store `python` stub, which is not a real interpreter and causes z.ps1 to fail with a cryptic error.

Replace the inline lookup with a Find-Python function that:
- Validates each PATH candidate by running `--version` and checking `0`, skipping stubs and broken installs.
- Falls back to common install locations when no valid PATH entry is found, restricting globs to Python 3.10+ (Python31*, Python32*).
- Runs the same `--version` validation on fallback candidates.

Also improves the error message to remind users to add Python to PATH.