### PR TITLE
[build] Fix profiler feature in uservm.mk

### DIFF
--- a/build/make/uservm.mk
+++ b/build/make/uservm.mk
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 USERVM_FEATURES :=
-USERVM_FEATURES += $(if $(filter yes,$(PROFILER)),profiler,)
+USERVM_FEATURES += $(if $(filter yes,$(PROFILER)),profile-time,)
 USERVM_FEATURES += $(if $(filter yes,$(TIMESTAMP_MSG)),timestamp-messages,)
 USERVM_FEATURES += $(if $(filter hyperlight,$(MACHINE)),hyperlight,)
 USERVM_FEATURES += $(if $(filter microvm,$(MACHINE)),microvm,)


### PR DESCRIPTION
## Summary

Fix the Cargo feature name in `build/make/uservm.mk` from `profiler` to `profile-time`.

## Changes

- **[build] F: Fix profiler feature in uservm.mk** — corrected the feature flag so that `PROFILER=yes` correctly enables the `profile-time` Cargo feature for the uservm crate.

## Split from

Split from PR #1852 ("Improve cold-start performance on WHP/Windows").