### PR TITLE
[kernel] E: Kernel boot optimizations for WHP

### DIFF
--- a/src/kernel/src/hal/arch/x86/asm/start.rs
+++ b/src/kernel/src/hal/arch/x86/asm/start.rs
@@ -15,9 +15,9 @@ use ::core::arch::global_asm;
 //==================================================================================================
 
 // _do_start2 (entered from 16-bit trampoline, already in protected mode).
+// Part 1: Protected-mode entry — load data segments and save boot info registers.
 global_asm!(
     r#".section .bootstrap,"ax",@progbits"#,
-
     ".align 4",
     ".globl _do_start2",
     "_do_start2:",
@@ -27,17 +27,32 @@ global_asm!(
     "    mov %dx, %fs",
     "    mov %dx, %gs",
     "    mov %dx, %ss",
-
     // EAX and EBX registers store boot information.
-
-    // Fill BSS section with zeros.
     "    movl %eax, %edx",
+    options(att_syntax),
+);
+
+// Part 2: Fill BSS section with zeros.
+//
+// On WHP the host has already zeroed guest memory (VirtualAlloc + ELF loader write_bytes), so every
+// BSS page is guaranteed to contain zeros before the vCPU starts.  Skipping the guest-side `rep
+// stosb` avoids touching every BSS page from inside the VM, which would otherwise trigger expensive
+// EPT-violation faults (~70 µs each on WHP) for pages the kernel never actually reads during boot.
+#[cfg(not(feature = "whp"))]
+global_asm!(
+    r#".section .bootstrap,"ax",@progbits"#,
     "    movl $__BSS_START, %edi",
     "    movl $__BSS_END, %ecx",
     "    subl %edi, %ecx",
     "    xorl %eax, %eax",
     "    cld",
     "    rep stosb",
+    options(att_syntax),
+);
+
+// Part 3: Stack guard, stack setup, and jump to kmain.
+global_asm!(
+    r#".section .bootstrap,"ax",@progbits"#,
 
     // Fill the boot stack guard page with a watermark pattern.
     "    movl $kstack_guard, %edi",

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
@@ -144,10 +144,7 @@ impl InterruptController {
             // handled by the WHP LAPIC emulator (not guest RAM).
             #[cfg(all(feature = "microvm", feature = "whp"))]
             {
-                use ::arch::cpu::{
-                    pit,
-                    xapic,
-                };
+                use ::arch::cpu::xapic;
                 let lapic_base: usize = ::config::microvm::DEFAULT_LAPIC_BASE;
                 let lapic: xapic::Xapic = xapic::Xapic::new(lapic_base as *mut u32);
                 // SAFETY: The LAPIC MMIO page is identity-mapped during
@@ -159,24 +156,23 @@ impl InterruptController {
                 }
                 info!("lapic svr enabled for whp interrupt delivery");
 
-                // PIT-based LAPIC timer calibration.
+                // RDTSC-based LAPIC timer calibration.
                 //
-                // We use PIT channel 2 in one-shot mode to measure how
-                // many LAPIC timer ticks elapse in a known duration.
-                // PIT I/O (ports 0x40-0x43, 0x61) causes PMIO VM exits,
-                // which returns control to the VMM loop and allows
-                // pvclock to advance during calibration. At runtime,
-                // PIC EOI is skipped; pvclock is updated via guest-
-                // driven refresh and a 100 Hz host timer fallback.
-                const CALIBRATION_MS: u32 = 1;
-                let pit_reload: u16 = ((pit::PIT_MAX_FREQUENCY as u64 * CALIBRATION_MS as u64
-                    / 1000)
-                    & 0xFFFF) as u16;
+                // On WHP, every I/O port access (PIT polling) causes a
+                // VM exit. During the very first WHvRunVirtualProcessor
+                // call these exits are extremely expensive because WHP
+                // lazily initialises internal partition state. Replacing
+                // PIT-based calibration with an RDTSC spin loop
+                // eliminates ~100 VM exits and saves significant time.
+                //
+                // The TSC frequency is obtained from CPUID leaf 0x16
+                // (processor frequency information, EAX = base freq in
+                // MHz). If the leaf is unavailable a 2 GHz default is
+                // used; the correction step (target / actual) cancels
+                // most of the error.
 
-                // SAFETY: All I/O port accesses below target the PIT and
-                // speaker gate, which are emulated by the VMM. The LAPIC
-                // registers are accessed through the identity-mapped MMIO
-                // page handled by the WHP LAPIC emulator.
+                // SAFETY: LAPIC registers go through the WHP emulator.
+                // CPUID and RDTSC do not cause VM exits.
                 unsafe {
                     // 1. Mask the LAPIC timer during calibration.
                     lapic.write(
@@ -187,45 +183,35 @@ impl InterruptController {
                     // 2. Set LAPIC timer divide-by-128.
                     lapic.write(xapic::XAPIC_TDCR, 0x0A);
 
-                    // 3. Program PIT channel 2 in one-shot mode.
-                    // Enable speaker gate for channel 2 and clear output bit.
-                    let speaker: u8 = (::arch::io::in8(0x61) & 0xFC) | 0x01;
-                    ::arch::io::out8(0x61, speaker);
-                    // Channel 2, lobyte/hibyte, mode 0 (one-shot), binary.
-                    ::arch::io::out8(
-                        pit::PIT_CTRL,
-                        pit::PIT_SEL2 | pit::PIT_ACC_LOHI | pit::PIT_MODE_TCOUNT | pit::PIT_BINARY,
-                    );
-                    ::arch::io::out8(pit::PIT_DATA + 2, (pit_reload & 0xFF) as u8);
-                    ::arch::io::out8(pit::PIT_DATA + 2, (pit_reload >> 8) as u8);
+                    // 3. Obtain TSC frequency from CPUID leaf 0x16.
+                    let cpuid16 = core::arch::x86::__cpuid(0x16);
+                    let tsc_freq_mhz: u64 = if cpuid16.eax > 0 {
+                        cpuid16.eax as u64
+                    } else {
+                        2_000 // 2 GHz fallback.
+                    };
+                    let tsc_ticks_per_ms: u64 = tsc_freq_mhz * 1_000;
 
                     // 4. Start the LAPIC timer counting from max value.
                     lapic.write(xapic::XAPIC_TICR, 0xFFFF_FFFF);
 
-                    // 5. Wait for PIT channel 2 output (bit 5 of port 0x61),
-                    //    but avoid an unbounded busy-wait in case OUT2 never
-                    //    transitions due to misconfigured PIT emulation.
-                    const PIT_CALIBRATION_MAX_ITERS: u32 = 10_000_000;
-                    let mut pit_iters: u32 = 0;
-                    while (::arch::io::in8(0x61) & 0x20) == 0 {
+                    // 5. Spin for ~1 ms using RDTSC (zero VM exits).
+                    let tsc_start: u64 = ::arch::cpu::rdtsc();
+                    while (::arch::cpu::rdtsc() - tsc_start) < tsc_ticks_per_ms {
                         core::hint::spin_loop();
-                        pit_iters = pit_iters.wrapping_add(1);
-                        if pit_iters >= PIT_CALIBRATION_MAX_ITERS {
-                            warn!(
-                                "PIT calibration timeout: OUT2 did not assert after {} iterations",
-                                PIT_CALIBRATION_MAX_ITERS
-                            );
-                            break;
-                        }
                     }
 
-                    // 6. Read remaining LAPIC timer count.
+                    // 6. Read remaining LAPIC count and actual TSC delta
+                    //    to correct for TSC frequency inaccuracy.
                     let current_count: u32 = lapic.read(xapic::XAPIC_TCCR);
-                    let elapsed_ticks: u32 = 0xFFFF_FFFF - current_count;
-                    let mut ticks_per_ms: u32 = elapsed_ticks / CALIBRATION_MS;
+                    let elapsed_ticks: u32 = 0xFFFF_FFFF_u32.wrapping_sub(current_count);
+                    let tsc_elapsed: u64 = ::arch::cpu::rdtsc() - tsc_start;
+
+                    // ticks_per_ms = elapsed × (target / actual) so the
+                    // result is independent of TSC frequency errors.
+                    let mut ticks_per_ms: u32 =
+                        ((elapsed_ticks as u64 * tsc_ticks_per_ms) / tsc_elapsed) as u32;
                     if ticks_per_ms == 0 {
-                        // Calibration underflow: use minimal non-zero fallback
-                        // to avoid programming LAPIC TICR with 0.
                         warn!(
                             "lapic timer calibration underflow: elapsed_ticks={elapsed_ticks}, \
                              using fallback ticks_per_ms=1"
@@ -234,12 +220,13 @@ impl InterruptController {
                     }
 
                     info!(
-                        "lapic timer calibration: elapsed_ticks={}, ticks_per_ms={}",
-                        elapsed_ticks, ticks_per_ms
+                        "lapic timer calibration (rdtsc): elapsed_ticks={}, ticks_per_ms={}, \
+                         tsc_freq_mhz={}",
+                        elapsed_ticks, ticks_per_ms, tsc_freq_mhz
                     );
 
                     // 7. Program LAPIC timer in periodic mode with vector
-                    //    0x20, initial count = ticks_per_ms (1kHz).
+                    //    0x20, initial count = ticks_per_ms (1 kHz).
                     lapic.write(
                         xapic::XAPIC_TIMER,
                         xapic::XapicTimer::new(0x20, false, false, 1).to_u32(),

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
@@ -168,7 +168,7 @@ impl InterruptController {
                 // pvclock to advance during calibration. At runtime,
                 // PIC EOI is skipped; pvclock is updated via guest-
                 // driven refresh and a 100 Hz host timer fallback.
-                const CALIBRATION_MS: u32 = 10;
+                const CALIBRATION_MS: u32 = 1;
                 let pit_reload: u16 = ((pit::PIT_MAX_FREQUENCY as u64 * CALIBRATION_MS as u64
                     / 1000)
                     & 0xFFFF) as u16;

--- a/src/kernel/src/hal/arch/x86/mem/mmu/page_table.rs
+++ b/src/kernel/src/hal/arch/x86/mem/mmu/page_table.rs
@@ -309,6 +309,37 @@ impl<T: DerefMut<Target = [u32]>> PageTable<T> {
         Ok(())
     }
 
+    ///
+    /// # Description
+    ///
+    /// Bulk-fills page table entries for contiguous identity-mapped physical memory.
+    ///
+    /// Each entry maps physical frame `base_frame + i` with the given raw PTE flags. This bypasses
+    /// per-entry validation and PTE struct construction for maximum performance during boot-time
+    /// identity mapping.
+    ///
+    /// # Parameters
+    ///
+    /// - `start_index`: First entry index to fill (0–1023).
+    /// - `count`: Number of consecutive entries to fill.
+    /// - `base_frame`: Frame number of the first page (physical address >> PAGE_SHIFT).
+    /// - `pte_flags`: Raw PTE flag bits (e.g., Present | ReadWrite | WriteThrough | CacheDisable).
+    ///
+    pub fn fill_identity(
+        &mut self,
+        start_index: usize,
+        count: usize,
+        base_frame: u32,
+        pte_flags: u32,
+    ) {
+        let mut raw_pte: u32 = (base_frame << ::arch::mem::FRAME_SHIFT as u32) | pte_flags;
+        for entry in &mut self.entries[start_index..start_index + count] {
+            *entry = raw_pte;
+            raw_pte += ::arch::mem::PAGE_SIZE as u32;
+        }
+        self.nmapped += count;
+    }
+
     fn clean(&mut self) {
         for pte in self.entries.iter_mut() {
             *pte = 0;

--- a/src/kernel/src/mm/virt/mod.rs
+++ b/src/kernel/src/mm/virt/mod.rs
@@ -332,34 +332,55 @@ pub fn init(
                     (PageTableAddress::new(page_table_addr), page_table)
                 };
 
-            // FIXME: do not be so open about permissions and caching.
-            page_table.map(
-                PageAddress::new(PageAligned::from_raw_value(raw_vaddr)?),
-                paddr,
-                true,
-                true,
-                false,
-                AccessPermission::RDWR,
-            )?;
-            root_pagetables.push_back((page_table_addr, page_table));
-            if raw_vaddr == (config::kernel::MEMORY_SIZE - mem::PAGE_SIZE) {
-                break;
-            }
-            raw_vaddr += mem::PAGE_SIZE;
-            paddr = match region.typ() {
-                MemoryRegionType::Mmio => {
+            if region.typ() != MemoryRegionType::Mmio {
+                // Bulk identity fill: map all pages in this page table at once.
+                let pgtab_base: usize = ::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT);
+                let start_index: usize = (raw_vaddr - pgtab_base) / mem::PAGE_SIZE;
+                let pgtab_remaining: usize = PAGE_TABLE_LENGTH - start_index;
+                let region_remaining: usize = (end + 1 - raw_vaddr) / mem::PAGE_SIZE;
+                let memory_remaining: usize =
+                    config::kernel::MEMORY_SIZE.saturating_sub(raw_vaddr) / mem::PAGE_SIZE;
+                let count: usize = pgtab_remaining.min(region_remaining).min(memory_remaining);
+
+                if count > 0 {
+                    // Present | ReadWrite | WriteThrough | CacheDisable.
+                    const IDENTITY_PTE_FLAGS: u32 = 0x1B;
+                    let base_frame: u32 = (raw_vaddr >> mem::PAGE_SHIFT) as u32;
+                    page_table.fill_identity(start_index, count, base_frame, IDENTITY_PTE_FLAGS);
+                }
+
+                root_pagetables.push_back((page_table_addr, page_table));
+                raw_vaddr += count * mem::PAGE_SIZE;
+                if raw_vaddr >= config::kernel::MEMORY_SIZE {
+                    break;
+                }
+                paddr = FrameAddress::new(PageAligned::from_address(
+                    PhysicalAddress::from_raw_value(raw_vaddr)?,
+                )?);
+            } else {
+                // MMIO: per-page mapping with address translation.
+                // FIXME: do not be so open about permissions and caching.
+                page_table.map(
+                    PageAddress::new(PageAligned::from_raw_value(raw_vaddr)?),
+                    paddr,
+                    true,
+                    true,
+                    false,
+                    AccessPermission::RDWR,
+                )?;
+                root_pagetables.push_back((page_table_addr, page_table));
+                if raw_vaddr == (config::kernel::MEMORY_SIZE - mem::PAGE_SIZE) {
+                    break;
+                }
+                raw_vaddr += mem::PAGE_SIZE;
+                paddr = {
                     let mmio_addr: VirtualAddress = VirtualAddress::new(raw_vaddr);
                     let phys_addr: PhysicalAddress =
-                    // FIXME: ensure safety here.
-                    unsafe { PhysicalAddress::from_mmio_address(mmio_addr)? };
-                    let page_aligned_phys_addr: PageAligned<PhysicalAddress> =
-                        PageAligned::from_address(phys_addr)?;
-                    FrameAddress::new(page_aligned_phys_addr)
-                },
-                _ => FrameAddress::new(PageAligned::from_address(
-                    PhysicalAddress::from_raw_value(raw_vaddr)?,
-                )?),
-            };
+                        // FIXME: ensure safety here.
+                        unsafe { PhysicalAddress::from_mmio_address(mmio_addr)? };
+                    FrameAddress::new(PageAligned::from_address(phys_addr)?)
+                };
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Optimize the kernel boot path for WHP/Windows, reducing cold-start latency.

## Changes

### LAPIC Calibration
- **[kernel] E: Reduce LAPIC calibration delay** — reduce PIT-based calibration window from 10 ms to 1 ms (~9 ms saving).
- **[kernel] E: RDTSC LAPIC calibration on WHP** — replace PIT-based LAPIC timer calibration with an RDTSC spin loop, eliminating ~100 PIT-polling VM exits during boot.

### Memory Initialization
- **[kernel] E: Skip BSS clear on WHP** — WHP already zeroes guest memory via VirtualAlloc; skip redundant guest-side `rep stosb` to avoid EPT-violation faults (~2 ms saving).
- **[kernel] E: Bulk identity page table fill** — add `fill_identity()` to `PageTable` for batch PTE writes in `virt::init()`.

## Split from

Split from PR #1852 ("Improve cold-start performance on WHP/Windows").