### PR TITLE
[uservm/nanvixd] E: VMM startup optimizations

### DIFF
--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -552,13 +552,15 @@ impl Vmm {
         // interpolates between updates using LAPIC timer tick counts
         // (1 kHz) for ~1 ms accuracy with zero VM exits per time read.
         //
-        // A low-frequency host timer (100Hz) calls
-        // WHvCancelRunVirtualProcessor to force VM exits so the VMM
-        // loop can update system_time on the pvclock page. Without these
-        // periodic exits, pvclock would freeze during CPU-bound guest
-        // execution (no I/O = no VM exits), causing condvar/sleep
-        // timeouts to malfunction.
-        self.timer.lock().unwrap().start(10_000); // 10ms = 100Hz
+        // Defer the pvclock timer until after the kernel finishes
+        // booting (first application-level I/O exit).  Starting the
+        // timer earlier causes WHvCancelRunVirtualProcessor to
+        // interrupt the very first WHvRunVirtualProcessor call, which
+        // carries a heavy one-time partition-setup cost inside WHP.
+        // Deferring avoids those unnecessary cancel-induced VM exits
+        // during boot while still providing pvclock updates once the
+        // guest application is running.
+        let mut timer_started: bool = false;
 
         // PIT channel 2 state for LAPIC timer calibration. The guest
         // programs PIT ch2 in one-shot mode and polls port 0x61 bit 5
@@ -685,6 +687,14 @@ impl Vmm {
                     }
 
                     // Slow path: application-level I/O (stdout, stdin, VMM port).
+
+                    // Start the pvclock timer on the first application-
+                    // level I/O, which signals that the kernel has
+                    // finished booting and guest apps are running.
+                    if !timer_started {
+                        self.timer.lock().unwrap().start(10_000); // 10ms = 100Hz
+                        timer_started = true;
+                    }
 
                     let exit_status: Option<u16> = match self
                         .inner

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -137,6 +137,15 @@ macro_rules! log_info {
 //   `#![forbid(clippy::expect_used)]` lint configuration.
 ///
 pub fn main() -> Result<ExitCode> {
+    // Standalone mode uses a single-thread runtime to avoid the overhead of
+    // spawning worker threads at startup.  Other deployment modes keep the
+    // multi-thread runtime for higher throughput.
+    #[cfg(feature = "standalone")]
+    let rt: ::tokio::runtime::Runtime = ::tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| ::anyhow::anyhow!("failed to build tokio runtime: {e}"))?;
+    #[cfg(not(feature = "standalone"))]
     let rt: ::tokio::runtime::Runtime = ::tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -180,6 +189,9 @@ async fn async_main() -> Result<ExitCode> {
         ensure_all_binaries_available(&args, machine, deployment).await?;
 
     // Create temporary directory that will be automatically cleaned up on drop.
+    // Standalone mode does not use the temporary directory, so skip creating it
+    // to avoid unnecessary filesystem overhead on the cold-start path.
+    #[cfg(not(feature = "standalone"))]
     #[allow(unused_variables)]
     let tmp_directory: TemporaryDirectory = create_tmp_dir(args.tmp_directory()).await?;
 
@@ -461,6 +473,7 @@ fn print_startup_info(args: &Args) {
 /// On success, returns a `TemporaryDirectory` instance that manages the lifecycle of the created
 /// directory. On failure, returns an error describing what went wrong during directory creation.
 ///
+#[cfg_attr(feature = "standalone", allow(dead_code))]
 async fn create_tmp_dir(tmp_directory: &str) -> Result<TemporaryDirectory> {
     // Get current timestamp in microseconds.
     let timestamp_micros: u128 = SystemTime::now()


### PR DESCRIPTION
## Summary

Reduce VMM and host startup overhead for WHP/Windows standalone mode.

## Changes

- **[uservm] E: Defer pvclock timer start** — delay the 100 Hz pvclock timer until the first application-level I/O exit, avoiding timer interrupts during the costly first `WHvRunVirtualProcessor` call (~6 ms saving on boot-time).
- **[nanvixd] E: Reduce standalone startup cost** — use single-threaded tokio runtime and skip temporary directory creation in standalone mode.

## Split from

Split from PR #1852 ("Improve cold-start performance on WHP/Windows").