### PR TITLE
[uservm] WHP snapshot/restore

### DIFF
--- a/.github/skills/benchmarking/SKILL.md
+++ b/.github/skills/benchmarking/SKILL.md
@@ -126,6 +126,7 @@ from process spawn to the first echo round-trip.
 |--------------------|---------------------------------------------------------|
 | `boot-time`        | Start a user VM (no nanvixd)                            |
 | `cold-start`       | Spawn nanvixd + VM + echo round-trip (standalone mode)  |
+| `snapshot-restore` | Measure snapshot restore latency vs boot-time           |
 | `warm-start-vmm`   | Raw round-trip latency inside the user VM               |
 
 ### Running

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,8 +741,9 @@ jobs:
   # Run micro-benchmarks on a Windows GitHub-hosted runner using WHP so that
   # Windows-specific performance data is collected alongside the Linux results.
   # Only standalone-mode benchmarks are supported (boot-time, cold-start,
-  # warm-start-vmm). GitHub-hosted Windows runners have variable WHP performance,
-  # so continue-on-error prevents flaky failures from blocking the pipeline.
+  # snapshot-restore, warm-start-vmm). GitHub-hosted Windows runners have
+  # variable WHP performance, so continue-on-error prevents flaky failures
+  # from blocking the pipeline.
   windows-benchmark-ci:
     name: "Windows Benchmark CI (${{ matrix.machine-type }})"
     needs: [precheck]
@@ -753,7 +754,7 @@ jobs:
       matrix:
         include:
           - machine-type: microvm
-            standard-benchmarks: "boot-time cold-start warm-start-vmm"
+            standard-benchmarks: "boot-time cold-start snapshot-restore warm-start-vmm"
             standard-iterations: "100"
           # NOTE (#1759, #1762): Hyperlight benchmarks are disabled until the
           # round-trip-latency failure is investigated.
@@ -1171,9 +1172,9 @@ jobs:
 
   # Build from source and run micro-benchmarks on self-hosted Windows baremetal
   # runners. Only standalone-mode benchmarks are supported (boot-time, cold-start,
-  # warm-start-vmm). The self-hosted runner is a dedicated machine with a
-  # known-functional WHP hypervisor, so the WHP probe and Defender exclusion
-  # steps used by windows-benchmark-ci are omitted.
+  # snapshot-restore, warm-start-vmm). The self-hosted runner is a dedicated
+  # machine with a known-functional WHP hypervisor, so the WHP probe and Defender
+  # exclusion steps used by windows-benchmark-ci are omitted.
   windows-benchmark:
     name: "Windows Benchmark (${{ matrix.machine-type }})"
     needs: [precheck]
@@ -1183,7 +1184,7 @@ jobs:
       matrix:
         include:
           - machine-type: microvm
-            standard-benchmarks: "boot-time cold-start warm-start-vmm"
+            standard-benchmarks: "boot-time cold-start snapshot-restore warm-start-vmm"
             standard-iterations: "100"
           # NOTE (#1759, #1762): Hyperlight benchmarks are disabled until the
           # round-trip-latency failure is investigated.
@@ -1453,7 +1454,7 @@ jobs:
       - name: "Report Benchmark Results"
         uses: ./.github/actions/benchmark-report
         with:
-          benchmarks: "boot-time,cold-start,warm-start-vmm"
+          benchmarks: "boot-time,cold-start,snapshot-restore,warm-start-vmm"
           machine-types: "microvm"
           archs: "X64"
           dev-dir: "data/windows-baremetal"
@@ -1464,7 +1465,7 @@ jobs:
         if: github.ref_name == 'dev'
         uses: ./.github/actions/benchmark-persist
         with:
-          benchmarks: "boot-time,cold-start,warm-start-vmm"
+          benchmarks: "boot-time,cold-start,snapshot-restore,warm-start-vmm"
           machine-types: "microvm"
           archs: "X64"
           target-dir: "data/windows-baremetal"
@@ -1734,7 +1735,7 @@ jobs:
         if: steps.check-results.outputs.has_results == 'true'
         uses: ./.github/actions/benchmark-report
         with:
-          benchmarks: "boot-time,cold-start,warm-start-vmm"
+          benchmarks: "boot-time,cold-start,snapshot-restore,warm-start-vmm"
           machine-types: "microvm"
           archs: "X64"
           dev-dir: "data/windows-github"
@@ -1745,7 +1746,7 @@ jobs:
         if: github.ref_name == 'dev' && steps.check-results.outputs.has_results == 'true'
         uses: ./.github/actions/benchmark-persist
         with:
-          benchmarks: "boot-time,cold-start,warm-start-vmm"
+          benchmarks: "boot-time,cold-start,snapshot-restore,warm-start-vmm"
           machine-types: "microvm"
           archs: "X64"
           target-dir: "data/windows-github"
@@ -1769,7 +1770,14 @@ jobs:
   # Create release archives for all applicable configurations.
   release-archive:
     name: "Release Archive (${{ matrix.machine-type }}, ${{ matrix.deployment-type }}, ${{ matrix.memory-size }}mb)"
-    needs: [ci-test, ci-l2, benchmark-finalize, benchmark-ci-finalize, windows-benchmark-finalize]
+    needs:
+      [
+        ci-test,
+        ci-l2,
+        benchmark-finalize,
+        benchmark-ci-finalize,
+        windows-benchmark-finalize,
+      ]
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     if: |
       !cancelled() &&

--- a/src/uservm/src/vmm/whp/emulator.rs
+++ b/src/uservm/src/vmm/whp/emulator.rs
@@ -214,6 +214,9 @@ impl Emulator {
                     ::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD => {
                         return Ok(Some(::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD));
                     },
+                    ::config::microvm::DEFAULT_VMM_SNAPSHOT_CMD => {
+                        return Ok(Some(::config::microvm::DEFAULT_VMM_SNAPSHOT_CMD));
+                    },
                     cmd => anyhow::bail!("unknown virtual machine command (cmd={cmd:#06x})"),
                 },
                 // Write to an I/O port that is not emulated.

--- a/src/uservm/src/vmm/whp/guest.rs
+++ b/src/uservm/src/vmm/whp/guest.rs
@@ -22,6 +22,10 @@ use ::log::{
     error,
     trace,
 };
+use ::serde::{
+    Deserialize,
+    Serialize,
+};
 use ::std::{
     mem,
     ptr,
@@ -33,6 +37,19 @@ const PAGE_SIZE: usize = 4096;
 //==================================================================================================
 // Structures
 //==================================================================================================
+
+/// Serializable guest state for WHP snapshot/restore.
+#[derive(Serialize, Deserialize)]
+pub struct GuestState {
+    /// Kernel location and size.
+    kernel: Option<(usize, usize)>,
+    /// Initial RAM disk location and size.
+    initrd: Option<(usize, usize)>,
+    /// IKC credits counter.
+    credits: u32,
+    /// Kernel entry point address.
+    entry: usize,
+}
 
 #[derive(Debug, Default)]
 pub struct Guest {
@@ -351,5 +368,24 @@ impl Guest {
             config::microvm::DEFAULT_MICROVM_CTRL_PAUSE_REQUESTED as u64,
             &::config::microvm::RUNNING.to_le_bytes(),
         )
+    }
+
+    /// Saves the guest state for snapshot serialization.
+    pub fn save_state(&self) -> Result<GuestState> {
+        Ok(GuestState {
+            kernel: self.kernel,
+            initrd: self.initrd,
+            credits: self.credits,
+            entry: self.entry,
+        })
+    }
+
+    /// Restores the guest state from a snapshot.
+    pub fn restore_state(&mut self, state: &GuestState) -> Result<()> {
+        self.kernel = state.kernel;
+        self.initrd = state.initrd;
+        self.credits = state.credits;
+        self.entry = state.entry;
+        Ok(())
     }
 }

--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -51,9 +51,18 @@ use ::log::{
     trace,
     warn,
 };
+use ::serde::{
+    Deserialize,
+    Serialize,
+};
 use ::std::{
+    ffi::OsStr,
+    fs::File,
     io::Write,
-    path::Path,
+    path::{
+        Path,
+        PathBuf,
+    },
     sync::{
         Arc,
         atomic::{
@@ -278,6 +287,23 @@ impl IkcNotifier {
 }
 
 //==================================================================================================
+// Snapshot
+//==================================================================================================
+
+/// Serializable WHP snapshot holding guest metadata and vCPU register state.
+///
+/// Memory is saved separately via the sparse snapshot APIs
+/// [`vmem::VirtualMemory::save_snapshot_sparse`] and
+/// [`vmem::VirtualMemory::load_snapshot_sparse`].
+#[derive(Serialize, Deserialize)]
+struct WhpSnapshot {
+    /// Guest metadata (kernel/initrd locations, credits, entry point).
+    guest_state: guest::GuestState,
+    /// Full vCPU register and LAPIC state.
+    vcpu_state: vcpu::VcpuState,
+}
+
+//==================================================================================================
 // Structures
 //==================================================================================================
 
@@ -329,6 +355,10 @@ struct InteriorWhpHandle {
     control_rx: Receiver<VcpuControlCommand>,
     /// Channel to send control responses to the VMM.
     control_tx: Sender<VcpuControlResponse>,
+    /// Kernel filename used for snapshot path derivation.
+    kernel_filename: String,
+    /// When true, the next guest-initiated snapshot request is silently skipped.
+    skip_next_snapshot: bool,
 }
 
 //==================================================================================================
@@ -506,6 +536,8 @@ impl Vmm {
                 emulator,
                 control_rx: args.control_rx,
                 control_tx: args.control_tx,
+                kernel_filename: args.kernel_filename,
+                skip_next_snapshot: false,
             })),
             #[cfg(feature = "profile-time")]
             perf_timings,
@@ -737,6 +769,11 @@ impl Vmm {
                                     },
                                 }
                             }
+                        } else if exit_status == ::config::microvm::DEFAULT_VMM_SNAPSHOT_CMD {
+                            if let Err(e) = Handle::current().block_on(self.handle_snapshot()) {
+                                error!("VMM exit: snapshot error (error={e:?})");
+                                break Err(e);
+                            }
                         } else if exit_status != ::config::microvm::DEFAULT_VMM_PAUSE_CMD {
                             warn!(
                                 "VMM exit: PMIO shutdown (exit_status={exit_status}, elapsed={:?})",
@@ -839,20 +876,131 @@ impl Vmm {
     ///
     /// # Description
     ///
-    /// Stub for snapshot creation (not supported on WHP backend).
+    /// Derives the snapshot file paths from the kernel filename.
     ///
-    pub async fn create_snapshot(&self, _filepath: String) -> Result<()> {
-        warn!("create_snapshot(): snapshots are not supported on WHP backend");
-        Ok(())
+    /// # Parameters
+    ///
+    /// - `filepath`: Path to the kernel file whose stem is used to build snapshot filenames.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns a tuple containing the virtual memory
+    /// snapshot path and the WHP state snapshot path.
+    ///
+    fn make_snapshot_paths(filepath: &str) -> (PathBuf, PathBuf) {
+        let snapshots_dir: &Path = Path::new("snapshots");
+        let stem: &OsStr = Path::new(filepath)
+            .file_stem()
+            .unwrap_or(OsStr::new("default"));
+        let vmem_filepath: PathBuf = snapshots_dir.join(stem).with_extension("vmem");
+        let whp_filepath: PathBuf = snapshots_dir.join(stem).with_extension("whp.cbor");
+        (vmem_filepath, whp_filepath)
     }
 
     ///
     /// # Description
     ///
-    /// Stub for snapshot loading (not supported on WHP backend).
+    /// Saves the virtual memory and WHP state to snapshot files.
     ///
-    pub async fn load_snapshot(&self, _filepath: String) -> Result<()> {
-        warn!("load_snapshot(): snapshots are not supported on WHP backend");
+    /// # Parameters
+    ///
+    /// - `filepath`: Path to the kernel file whose stem is used to build snapshot filenames.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, an empty result is returned. Otherwise, it returns an error.
+    ///
+    pub async fn create_snapshot(&self, filepath: String) -> Result<()> {
+        let (vmem_filepath, whp_filepath) = Self::make_snapshot_paths(&filepath);
+
+        // Ensure snapshots directory exists.
+        if let Some(parent) = vmem_filepath.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Save guest memory (sparse format: only non-zero pages).
+        if let Err(e) = self.vmem.lock().await.save_snapshot_sparse(&vmem_filepath) {
+            let reason: String = format!("failed creating virtual memory snapshot (error={e:?})");
+            error!("create_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        // Save vCPU and guest state.
+        let whp_snapshot = WhpSnapshot {
+            guest_state: self.guest.lock().await.save_state()?,
+            vcpu_state: self.vcpu.lock().await.save_state()?,
+        };
+
+        let mut file: File = File::create(&whp_filepath)?;
+        match ::serde_cbor::to_vec(&whp_snapshot) {
+            Ok(buffer) => {
+                file.write_all(&buffer)?;
+                trace!("create_snapshot(): wrote {} bytes to WHP snapshot file", buffer.len());
+                Ok(())
+            },
+            Err(e) => {
+                let reason: String = format!("failed serializing WHP snapshot (error={e:?})");
+                error!("create_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Loads the virtual memory and WHP state from snapshot files.
+    ///
+    /// # Parameters
+    ///
+    /// - `filepath`: Path to the kernel file whose stem is used to locate snapshot filenames.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, an empty result is returned. Otherwise, it returns an error.
+    ///
+    pub async fn load_snapshot(&self, filepath: String) -> Result<()> {
+        let (vmem_filepath, whp_filepath) = Self::make_snapshot_paths(&filepath);
+
+        // Load guest memory (sparse format).
+        if let Err(e) = self.vmem.lock().await.load_snapshot_sparse(&vmem_filepath) {
+            let reason: String = format!("failed loading virtual memory snapshot (error={e:?})");
+            error!("load_snapshot(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        // Load vCPU and guest state.
+        let mut file: File = match File::open(&whp_filepath) {
+            Ok(f) => f,
+            Err(e) => {
+                let reason: String = format!("failed opening WHP snapshot file (error={e:?})");
+                error!("load_snapshot(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        let whp_snapshot: WhpSnapshot =
+            match ::serde_cbor::from_reader::<WhpSnapshot, &mut File>(&mut file) {
+                Ok(snapshot) => snapshot,
+                Err(e) => {
+                    let reason: String = format!("failed decoding WHP snapshot file (error={e:?})");
+                    error!("load_snapshot(): {reason}");
+                    anyhow::bail!(reason)
+                },
+            };
+
+        // Restore guest state.
+        self.guest
+            .lock()
+            .await
+            .restore_state(&whp_snapshot.guest_state)?;
+
+        // Restore vCPU state (registers + LAPIC).
+        self.vcpu
+            .lock()
+            .await
+            .load_state(&whp_snapshot.vcpu_state)?;
+
         Ok(())
     }
 
@@ -894,6 +1042,58 @@ impl Vmm {
             .await?)
     }
 
+    /// Handles a guest-initiated snapshot request from the VMM run loop.
+    ///
+    /// WHP advances RIP before delivering port-I/O exits, so the saved
+    /// state already points past the `out` instruction. Unlike KVM, no
+    /// `skip_next_snapshot` guard is needed to prevent re-triggering.
+    async fn handle_snapshot(&self) -> Result<()> {
+        let kernel_filename: String = {
+            let mut locked_inner: MutexGuard<'_, InteriorWhpHandle> = self.inner.lock().await;
+            if locked_inner.skip_next_snapshot {
+                trace!("handle_snapshot(): skipping snapshot (restored from snapshot)");
+                locked_inner.skip_next_snapshot = false;
+                return Ok(());
+            }
+            locked_inner.kernel_filename.clone()
+        };
+        match self.create_snapshot(kernel_filename).await {
+            Ok(()) => {
+                trace!("handle_snapshot(): snapshot created successfully");
+                Ok(())
+            },
+            Err(error) => {
+                error!("handle_snapshot(): failed to create snapshot: {error:?}");
+                Err(error)
+            },
+        }
+    }
+
+    /// Creates a snapshot and sends the result to the orchestrator.
+    async fn handle_create_snapshot(&self, filepath: String) -> Result<()> {
+        match self.create_snapshot(filepath).await {
+            Ok(()) => {
+                self.inner
+                    .lock()
+                    .await
+                    .control_tx
+                    .send(VcpuControlResponse::SnapshotCreated)
+                    .await?;
+                Ok(())
+            },
+            Err(error) => {
+                self.inner
+                    .lock()
+                    .await
+                    .control_tx
+                    .send(VcpuControlResponse::SnapshotCreationFailed)
+                    .await?;
+                error!("handle_create_snapshot(): failed to create snapshot: {error:?}");
+                Err(error)
+            },
+        }
+    }
+
     ///
     /// # Description
     ///
@@ -909,9 +1109,8 @@ impl Vmm {
 
         match self.inner.lock().await.control_rx.recv().await {
             Some(VcpuControlCommand::Resume) => Ok(()),
-            Some(VcpuControlCommand::CreateSnapshot(_filepath)) => {
-                // Snapshots are not supported on Windows WHP backend.
-                warn!("handle_pause(): snapshot creation not supported on WHP backend");
+            Some(VcpuControlCommand::CreateSnapshot(filepath)) => {
+                self.handle_create_snapshot(filepath).await?;
                 Ok(())
             },
             None => {

--- a/src/uservm/src/vmm/whp/vcpu/mod.rs
+++ b/src/uservm/src/vmm/whp/vcpu/mod.rs
@@ -27,6 +27,10 @@ use ::log::{
     trace,
     warn,
 };
+use ::serde::{
+    Deserialize,
+    Serialize,
+};
 use ::std::mem;
 use windows::Win32::System::Hypervisor::{
     WHV_PARTITION_HANDLE,
@@ -65,12 +69,91 @@ const WHV_X64_REGISTER_DELIVERABILITY_NOTIFICATIONS: WHV_REGISTER_NAME =
     WHV_REGISTER_NAME(-2_147_483_644i32);
 /// Pending interruption register (inject interrupts into the vCPU).
 const WHV_X64_REGISTER_PENDING_INTERRUPTION: WHV_REGISTER_NAME = WHV_REGISTER_NAME(i32::MIN); // 0x80000000
-/// TSC register.
-const WHV_X64_REGISTER_TSC: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0x00000011);
+/// TSC register (virtual/MSR register space).
+const WHV_X64_REGISTER_TSC: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0x2000);
+
+/// Complete list of vCPU registers saved in a WHP snapshot.
+const SNAPSHOT_REGISTER_NAMES: [WHV_REGISTER_NAME; 52] = [
+    // General purpose registers.
+    WHV_REGISTER_NAME(0x00), // RAX
+    WHV_REGISTER_NAME(0x01), // RCX
+    WHV_REGISTER_NAME(0x02), // RDX
+    WHV_REGISTER_NAME(0x03), // RBX
+    WHV_REGISTER_NAME(0x04), // RSP
+    WHV_REGISTER_NAME(0x05), // RBP
+    WHV_REGISTER_NAME(0x06), // RSI
+    WHV_REGISTER_NAME(0x07), // RDI
+    WHV_REGISTER_NAME(0x08), // R8
+    WHV_REGISTER_NAME(0x09), // R9
+    WHV_REGISTER_NAME(0x0A), // R10
+    WHV_REGISTER_NAME(0x0B), // R11
+    WHV_REGISTER_NAME(0x0C), // R12
+    WHV_REGISTER_NAME(0x0D), // R13
+    WHV_REGISTER_NAME(0x0E), // R14
+    WHV_REGISTER_NAME(0x0F), // R15
+    // Instruction pointer and flags.
+    WHV_REGISTER_NAME(0x10), // RIP
+    WHV_REGISTER_NAME(0x11), // RFLAGS
+    // Segment registers.
+    WHV_REGISTER_NAME(0x12), // ES
+    WHV_REGISTER_NAME(0x13), // CS
+    WHV_REGISTER_NAME(0x14), // SS
+    WHV_REGISTER_NAME(0x15), // DS
+    WHV_REGISTER_NAME(0x16), // FS
+    WHV_REGISTER_NAME(0x17), // GS
+    WHV_REGISTER_NAME(0x18), // LDTR
+    WHV_REGISTER_NAME(0x19), // TR
+    // Table registers.
+    WHV_REGISTER_NAME(0x1A), // IDTR
+    WHV_REGISTER_NAME(0x1B), // GDTR
+    // Control registers.
+    WHV_REGISTER_NAME(0x1C), // CR0
+    WHV_REGISTER_NAME(0x1D), // CR2
+    WHV_REGISTER_NAME(0x1E), // CR3
+    WHV_REGISTER_NAME(0x1F), // CR4
+    WHV_REGISTER_NAME(0x20), // CR8
+    // Debug registers.
+    WHV_REGISTER_NAME(0x21), // DR0
+    WHV_REGISTER_NAME(0x22), // DR1
+    WHV_REGISTER_NAME(0x23), // DR2
+    WHV_REGISTER_NAME(0x24), // DR3
+    WHV_REGISTER_NAME(0x25), // DR6
+    WHV_REGISTER_NAME(0x26), // DR7
+    // Extended control register.
+    WHV_REGISTER_NAME(0x27), // XCR0
+    // Virtual / MSR registers.
+    WHV_REGISTER_NAME(0x2000), // TSC
+    WHV_REGISTER_NAME(0x2001), // EFER
+    WHV_REGISTER_NAME(0x2002), // KernelGsBase
+    WHV_REGISTER_NAME(0x2003), // ApicBase
+    WHV_REGISTER_NAME(0x2004), // PAT
+    WHV_REGISTER_NAME(0x2005), // SysenterCs
+    WHV_REGISTER_NAME(0x2006), // SysenterEip
+    WHV_REGISTER_NAME(0x2007), // SysenterEsp
+    WHV_REGISTER_NAME(0x2008), // Star
+    WHV_REGISTER_NAME(0x2009), // Lstar
+    WHV_REGISTER_NAME(0x200A), // Cstar
+    WHV_REGISTER_NAME(0x200B), // Sfmask
+];
+
+// Compile-time assertion: WHV_REGISTER_VALUE must be exactly 16 bytes for safe raw serialization.
+const _: () = assert!(mem::size_of::<WHV_REGISTER_VALUE>() == 16);
 
 //==================================================================================================
 // Structures
 //==================================================================================================
+
+/// Serializable vCPU state for WHP snapshot/restore.
+///
+/// Register values are stored as raw 16-byte arrays matching the binary layout of
+/// `WHV_REGISTER_VALUE`. The order corresponds to [`SNAPSHOT_REGISTER_NAMES`].
+#[derive(Serialize, Deserialize)]
+pub struct VcpuState {
+    /// Raw register values (each entry is a 16-byte `WHV_REGISTER_VALUE`).
+    register_values: Vec<[u8; 16]>,
+    /// LAPIC interrupt controller state (raw bytes).
+    lapic_state: Vec<u8>,
+}
 
 ///
 /// # Description
@@ -286,6 +369,78 @@ impl VirtualProcessor {
             )
             .map_err(|e| anyhow::anyhow!("failed to set LAPIC state (error={e:?})"))?;
         }
+        Ok(())
+    }
+
+    /// Saves the complete vCPU state for snapshot serialization.
+    pub fn save_state(&self) -> Result<VcpuState> {
+        let count: usize = SNAPSHOT_REGISTER_NAMES.len();
+        let mut values: Vec<WHV_REGISTER_VALUE> = vec![unsafe { mem::zeroed() }; count];
+
+        unsafe {
+            whp_get_registers(self.partition, self.index, &SNAPSHOT_REGISTER_NAMES, &mut values)
+                .map_err(|e| anyhow::anyhow!("save_state: failed to get registers ({e:?})"))?;
+        }
+
+        let register_values: Vec<[u8; 16]> = values
+            .iter()
+            .map(|v| {
+                let mut bytes = [0u8; 16];
+                // SAFETY: WHV_REGISTER_VALUE is a 16-byte C union; raw copy is valid.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        (v as *const WHV_REGISTER_VALUE).cast::<u8>(),
+                        bytes.as_mut_ptr(),
+                        16,
+                    );
+                }
+                bytes
+            })
+            .collect();
+
+        let lapic_state: Vec<u8> = self.get_lapic_state()?;
+
+        Ok(VcpuState {
+            register_values,
+            lapic_state,
+        })
+    }
+
+    /// Restores the complete vCPU state from a snapshot.
+    pub fn load_state(&mut self, state: &VcpuState) -> Result<()> {
+        if state.register_values.len() != SNAPSHOT_REGISTER_NAMES.len() {
+            anyhow::bail!(
+                "load_state: register count mismatch (expected={}, got={})",
+                SNAPSHOT_REGISTER_NAMES.len(),
+                state.register_values.len()
+            );
+        }
+
+        let values: Vec<WHV_REGISTER_VALUE> = state
+            .register_values
+            .iter()
+            .map(|bytes| {
+                let mut v: WHV_REGISTER_VALUE = unsafe { mem::zeroed() };
+                // SAFETY: WHV_REGISTER_VALUE is a 16-byte C union; raw copy is valid.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        bytes.as_ptr(),
+                        (&mut v as *mut WHV_REGISTER_VALUE).cast::<u8>(),
+                        16,
+                    );
+                }
+                v
+            })
+            .collect();
+
+        unsafe {
+            whp_set_registers(self.partition, self.index, &SNAPSHOT_REGISTER_NAMES, &values)
+                .map_err(|e| anyhow::anyhow!("load_state: failed to set registers ({e:?})"))?;
+        }
+
+        self.set_lapic_state(&state.lapic_state)?;
+        self.online = true;
+
         Ok(())
     }
 

--- a/src/uservm/src/vmm/whp/vmem.rs
+++ b/src/uservm/src/vmm/whp/vmem.rs
@@ -79,6 +79,15 @@ unsafe impl Sync for VirtualMemory {}
 
 const SIZE_OF_HEADER: usize = mem::size_of::<SnapshotHeader>();
 
+/// Page size used by the sparse snapshot format.
+const SPARSE_PAGE_SIZE: usize = ::arch::mem::PAGE_SIZE;
+
+/// Byte size of the memory-size field (`u64`) in the sparse snapshot header.
+const SPARSE_MEMORY_SIZE_FIELD: usize = mem::size_of::<u64>();
+
+/// Byte size of a page-index entry (`u32`) in the sparse snapshot format.
+const SPARSE_PAGE_INDEX_SIZE: usize = ::arch::mem::paging::PageTableEntry::SIZE;
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
@@ -338,6 +347,170 @@ impl VirtualMemory {
             error!("load_snapshot(): {reason}");
             anyhow::bail!(reason)
         }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Saves a sparse virtual memory snapshot, writing only pages with non-zero content.
+    ///
+    /// **Format:**
+    /// - `u64` — memory size in bytes (little-endian).
+    /// - `u32` — number of non-zero pages (little-endian).
+    /// - For each non-zero page: `u32` page index (LE) + PAGE_SIZE raw bytes.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: Path to the snapshot file.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn save_snapshot_sparse(&self, path: &Path) -> Result<()> {
+        trace!("save_snapshot_sparse(): writing to {:?}", path);
+
+        let page_size: usize = SPARSE_PAGE_SIZE;
+        let page_count: usize = self.size / page_size;
+        let zero_page: [u8; SPARSE_PAGE_SIZE] = [0u8; SPARSE_PAGE_SIZE];
+        let memory_slice: &[u8] = unsafe { slice::from_raw_parts(self.ptr, self.size) };
+
+        let mut file: File = File::create(path).map_err(|e| {
+            let reason: String = format!("failed creating sparse snapshot file (error={e:?})");
+            error!("save_snapshot_sparse(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        // Write placeholder header (memory_size + page_count).
+        file.write_all(&(self.size as u64).to_le_bytes())
+            .map_err(|e| {
+                let reason: String = format!("failed writing header memory_size (error={e:?})");
+                error!("save_snapshot_sparse(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        file.write_all(&0u32.to_le_bytes()).map_err(|e| {
+            let reason: String =
+                format!("failed writing header placeholder page_count (error={e:?})");
+            error!("save_snapshot_sparse(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        let mut non_zero_count: u32 = 0;
+        for i in 0..page_count {
+            let offset: usize = i * page_size;
+            let page: &[u8] = &memory_slice[offset..offset + page_size];
+            if page != zero_page {
+                file.write_all(&(i as u32).to_le_bytes()).map_err(|e| {
+                    let reason: String = format!("failed writing page index {i} (error={e:?})");
+                    error!("save_snapshot_sparse(): {reason}");
+                    anyhow::anyhow!(reason)
+                })?;
+                file.write_all(page).map_err(|e| {
+                    let reason: String =
+                        format!("failed writing page data for page {i} (error={e:?})");
+                    error!("save_snapshot_sparse(): {reason}");
+                    anyhow::anyhow!(reason)
+                })?;
+                non_zero_count += 1;
+            }
+        }
+
+        // Seek back and write actual page count.
+        use std::io::Seek;
+        file.seek(std::io::SeekFrom::Start(SPARSE_MEMORY_SIZE_FIELD as u64))
+            .map_err(|e| {
+                let reason: String =
+                    format!("failed seeking to header page_count field (error={e:?})");
+                error!("save_snapshot_sparse(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        file.write_all(&non_zero_count.to_le_bytes()).map_err(|e| {
+            let reason: String = format!("failed writing final page_count (error={e:?})");
+            error!("save_snapshot_sparse(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+        file.sync_all().map_err(|e| {
+            let reason: String = format!("failed to sync sparse snapshot file (error={e:?})");
+            error!("save_snapshot_sparse(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        trace!(
+            "save_snapshot_sparse(): saved {non_zero_count} non-zero pages ({} bytes) out of \
+             {page_count} total pages",
+            non_zero_count as usize * (SPARSE_PAGE_INDEX_SIZE + page_size),
+        );
+
+        Ok(())
+    }
+
+    /// Loads a sparse virtual memory snapshot.
+    ///
+    /// Assumes the target memory is zero-initialized (true for fresh `VirtualAlloc`).
+    /// Only non-zero pages stored in the snapshot are written.
+    pub fn load_snapshot_sparse(&mut self, path: &Path) -> Result<()> {
+        trace!("load_snapshot_sparse(): reading from {:?}", path);
+
+        let page_size: usize = SPARSE_PAGE_SIZE;
+        let mut file: File = File::open(path).map_err(|e| {
+            let reason: String = format!("failed opening sparse snapshot file (error={e:?})");
+            error!("load_snapshot_sparse(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        // Read header.
+        let mut size_buf: [u8; 8] = [0u8; 8];
+        file.read_exact(&mut size_buf).map_err(|e| {
+            let reason: String = format!("failed reading header memory_size (error={e:?})");
+            error!("load_snapshot_sparse(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+        let memory_size: usize = u64::from_le_bytes(size_buf) as usize;
+        if memory_size != self.size {
+            anyhow::bail!("memory size mismatch: expected {}, got {}", self.size, memory_size);
+        }
+
+        let mut count_buf: [u8; 4] = [0u8; 4];
+        file.read_exact(&mut count_buf).map_err(|e| {
+            let reason: String = format!("failed reading header page_count (error={e:?})");
+            error!("load_snapshot_sparse(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+        let page_count: u32 = u32::from_le_bytes(count_buf);
+
+        // Read and restore each non-zero page.
+        let mut idx_buf: [u8; 4] = [0u8; 4];
+        let mut page_buf: [u8; SPARSE_PAGE_SIZE] = [0u8; SPARSE_PAGE_SIZE];
+        for _ in 0..page_count {
+            file.read_exact(&mut idx_buf).map_err(|e| {
+                let reason: String = format!("failed reading page index (error={e:?})");
+                error!("load_snapshot_sparse(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+            let idx: usize = u32::from_le_bytes(idx_buf) as usize;
+            file.read_exact(&mut page_buf).map_err(|e| {
+                let reason: String =
+                    format!("failed reading page data for page {idx} (error={e:?})");
+                error!("load_snapshot_sparse(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+
+            let offset: usize = idx * page_size;
+            if offset + page_size > self.size {
+                anyhow::bail!("sparse page index {idx} out of bounds (memory_size={})", self.size);
+            }
+
+            unsafe {
+                ptr::copy_nonoverlapping(page_buf.as_ptr(), self.ptr.add(offset), page_size);
+            }
+        }
+
+        trace!(
+            "load_snapshot_sparse(): loaded {page_count} pages ({} bytes)",
+            page_count as usize * page_size,
+        );
 
         Ok(())
     }

--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -93,12 +93,10 @@ impl Args {
             );
         }
 
-        if cfg!(not(windows)) {
-            benchmarks.push_str(
-                "\
+        benchmarks.push_str(
+            "\
   snapshot-restore       Measure snapshot restore latency vs boot-time.\n",
-            );
-        }
+        );
 
         if cfg!(any(feature = "multi-process", feature = "single-process")) {
             benchmarks.push_str(

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/snapshot_restore.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/snapshot_restore.rs
@@ -27,12 +27,42 @@ use ::nanvix::{
         },
     },
 };
+#[cfg(feature = "profile-time")]
+use ::std::collections::HashMap;
 use ::std::time::Instant;
 use ::tokio::{
     sync::mpsc,
     task::JoinHandle,
     time::sleep,
 };
+
+/// Phase names in display order for the timing breakdown table.
+#[cfg(feature = "profile-time")]
+const PHASE_NAMES: &[&str] = &[
+    "partition_create_us",
+    "vmem_create_us",
+    "vcpu_create_us",
+    "kernel_load_us",
+    "vcpu_reset_us",
+    "thread_spawn_us",
+    "guest_exec_us",
+    "exit_handling_us",
+    "total_us",
+];
+
+/// Human-readable labels for each phase, matching [`PHASE_NAMES`] order.
+#[cfg(feature = "profile-time")]
+const PHASE_LABELS: &[&str] = &[
+    "partition_create",
+    "vmem_create",
+    "vcpu_create",
+    "kernel_load",
+    "vcpu_reset",
+    "thread_spawn",
+    "guest_exec",
+    "exit_handling",
+    "total",
+];
 
 impl Benchmark {
     ///
@@ -43,11 +73,17 @@ impl Benchmark {
     /// that snapshot, measuring the time for each restore-and-exit cycle.
     ///
     pub async fn run_snapshot_restore(&mut self) -> Result<()> {
+        if self.iterations == 0 {
+            anyhow::bail!("run_snapshot_restore(): iterations must be at least 1");
+        }
+
         let kernel_filename: String = format!("{}/bin/kernel.elf", self.workspace_root.display());
         let snapshot_program: String = self.flavour.get_program(&self.workspace_root);
 
         // Ensure snapshots directory exists.
-        let snapshots_dir: std::path::PathBuf = self.workspace_root.join("snapshots");
+        // NOTE: Uses a relative path to stay consistent with the VMM snapshot logic
+        // (`whp::WhpHandle::make_snapshot_paths`), which writes to `snapshots/` relative to CWD.
+        let snapshots_dir: std::path::PathBuf = std::path::PathBuf::from("snapshots");
         if !snapshots_dir.exists() {
             std::fs::create_dir_all(&snapshots_dir)?;
         }
@@ -129,6 +165,25 @@ impl Benchmark {
             sleep(std::time::Duration::from_millis(CLEANUP_SLEEP_DURATION)).await;
         }
 
+        // Report snapshot file sizes.
+        // NOTE: Uses the same relative path as the VMM snapshot logic above.
+        {
+            let snapshots_dir: std::path::PathBuf = std::path::PathBuf::from("snapshots");
+            if snapshots_dir.exists() {
+                println!("Snapshot files:");
+                for entry in std::fs::read_dir(&snapshots_dir)? {
+                    let entry = entry?;
+                    let size: u64 = entry.metadata()?.len();
+                    println!(
+                        "  {}: {} KB ({} bytes)",
+                        entry.file_name().to_string_lossy(),
+                        size / 1024,
+                        size
+                    );
+                }
+            }
+        }
+
         // Phase 2: Measure snapshot restore latency.
         let pb = ProgressBar::new(self.iterations.try_into().unwrap());
         pb.set_style(
@@ -140,6 +195,15 @@ impl Benchmark {
         pb.set_message("Snapshot restore:");
 
         let mut latencies: Vec<u128> = Vec::with_capacity(self.iterations);
+        #[cfg(feature = "profile-time")]
+        let mut phase_samples: HashMap<String, Vec<u64>> = {
+            let mut m: HashMap<String, Vec<u64>> = HashMap::new();
+            for name in PHASE_NAMES {
+                m.insert((*name).to_string(), Vec::with_capacity(self.iterations));
+            }
+            m
+        };
+
         for _ in 0..self.iterations {
             let (vcpu_thread_stdout_tx, mut vcpu_thread_stdout_rx) =
                 mpsc::channel::<IkcFrame>(CHANNEL_CAPACITY);
@@ -162,6 +226,11 @@ impl Benchmark {
 
             let counters: MessageCounters = MessageCounters::new();
 
+            #[cfg(feature = "profile-time")]
+            let perf_timings = ::nanvix::uservm::perf::PerfTimings::new();
+            #[cfg(feature = "profile-time")]
+            let perf_reader = perf_timings.clone();
+
             let start = Instant::now();
             let user_vm_handle = UserVm::spawn(UserVmArgs {
                 kernel_filename: kernel_filename.clone(),
@@ -178,7 +247,7 @@ impl Benchmark {
                 #[cfg(feature = "gdb")]
                 gdb_port: None,
                 #[cfg(feature = "profile-time")]
-                perf_timings: ::nanvix::uservm::perf::PerfTimings::new(),
+                perf_timings,
             });
 
             let join_result = user_vm_handle.await;
@@ -215,16 +284,71 @@ impl Benchmark {
 
             latencies.push(start.elapsed().as_micros());
 
+            // Accumulate per-phase timing samples.
+            #[cfg(feature = "profile-time")]
+            {
+                let json_str: String = perf_reader.to_json();
+                if let Ok(timings) = ::serde_json::from_str::<::serde_json::Value>(&json_str) {
+                    for name in PHASE_NAMES {
+                        if let Some(value) = timings.get(*name) {
+                            if let Some(samples) = phase_samples.get_mut(*name) {
+                                if let Some(v) = value.as_u64() {
+                                    samples.push(v);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             pb.inc(1);
 
             sleep(std::time::Duration::from_millis(CLEANUP_SLEEP_DURATION)).await;
         }
 
         pb.finish();
+        println!("First req: {} us", latencies[0]);
         latencies.sort();
-        println!("p50: {} us", latencies[(self.iterations as f32 * 0.5) as usize]);
-        println!("p95: {} us", latencies[(self.iterations as f32 * 0.95) as usize]);
-        println!("p99: {} us", latencies[(self.iterations as f32 * 0.99) as usize]);
+        let len: usize = latencies.len();
+        let p50: u128 = latencies[((len as f32 * 0.5) as usize).min(len - 1)];
+        let p95: u128 = latencies[((len as f32 * 0.95) as usize).min(len - 1)];
+        let p99: u128 = latencies[((len as f32 * 0.99) as usize).min(len - 1)];
+        let min: u128 = latencies[0];
+        let max: u128 = latencies[len - 1];
+        let mean: u128 = latencies.iter().sum::<u128>() / len as u128;
+        println!("p50: {} us", p50);
+        println!("p95: {} us", p95);
+        println!("p99: {} us", p99);
+        println!("min: {} us", min);
+        println!("max: {} us", max);
+        println!("mean: {} us", mean);
+
+        // Print per-phase timing breakdown if any phase data was collected.
+        #[cfg(feature = "profile-time")]
+        {
+            let has_phase_data: bool = phase_samples.values().any(|v| !v.is_empty());
+            if has_phase_data {
+                println!();
+                println!(
+                    "{:<22} {:>10} {:>10} {:>10}",
+                    "Phase", "p50 (us)", "p95 (us)", "p99 (us)"
+                );
+                println!("{}", "-".repeat(54));
+                for (name, label) in PHASE_NAMES.iter().zip(PHASE_LABELS.iter()) {
+                    if let Some(samples) = phase_samples.get_mut(*name) {
+                        if samples.is_empty() {
+                            continue;
+                        }
+                        samples.sort();
+                        let len: usize = samples.len();
+                        let p50: u64 = samples[((len as f32 * 0.5) as usize).min(len - 1)];
+                        let p95: u64 = samples[((len as f32 * 0.95) as usize).min(len - 1)];
+                        let p99: u64 = samples[((len as f32 * 0.99) as usize).min(len - 1)];
+                        println!("{:<22} {:>10} {:>10} {:>10}", label, p50, p95, p99);
+                    }
+                }
+            }
+        }
 
         Ok(())
     }

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -293,16 +293,7 @@ async fn main() -> Result<()> {
             }
         },
         BenchmarkFlavour::WarmStartVMM => benchmark.run_warm_start_vmm().await,
-        BenchmarkFlavour::SnapshotRestore => {
-            #[cfg(windows)]
-            {
-                anyhow::bail!("snapshot-restore is not supported on Windows/WHP");
-            }
-            #[cfg(not(windows))]
-            {
-                benchmark.run_snapshot_restore().await
-            }
-        },
+        BenchmarkFlavour::SnapshotRestore => benchmark.run_snapshot_restore().await,
     };
     match result {
         Ok(()) => {},


### PR DESCRIPTION
## Summary

Implement snapshot/restore support for the WHP (Windows Hypervisor Platform) backend and enrich the snapshot benchmark.

## Changes

- **[uservm] E: Implement WHP snapshot/restore** — add snapshot save/load for WHP partitions, including guest metadata, vCPU register/LAPIC state, and virtual memory serialization. Handles snapshot-triggered VMM exits via `DEFAULT_VMM_SNAPSHOT_CMD`.
- **[nanvix-bench] E: Enrich snapshot bench** — expand the snapshot-restore benchmark with additional metrics and remove the Windows platform gate (now supported).

## Split from

Split from PR #1852 ("Improve cold-start performance on WHP/Windows").