### PR TITLE
[build] Fix Ephemeral Port Reuse In L2 VMs

### DIFF
--- a/build/linuxd_config.toml
+++ b/build/linuxd_config.toml
@@ -17,10 +17,15 @@ snapshot_name = "l2-sysvm-snapshot"
 control_plane_port = 9000
 user_vm_port = 9001
 
+# Ephemeral TCP source port range to configure inside the guest kernel of the L2 VM.
+# This range must not overlap with the gateway listener port range below, otherwise the guest
+# kernel may auto-select a source port that collides with a gateway listener.
+guest_ephemeral_port_range_begin = 32768
+guest_ephemeral_port_range_end = 49151
+
 # Each user VM instance gets a different gateway port, so we define the allowed port range
-# here. Note that this range limits the total number of concurrent user VMs we can have
-# at any point in time. We pick large values that are unlikely to overlap with other
-# services, and with the ephemeral port range used in Linux, readable with:
-# cat /proc/sys/net/ipv4/ip_local_port_range
+# here. Note that this range limits the total number of concurrent user VMs we can have at any
+# point in time. This range must not overlap with the guest kernel's ephemeral source port range
+# above, otherwise outbound guest connections may claim ports reserved for gateway listeners.
 gateway_port_range_begin = 49152
 gateway_port_range_end = 65535

--- a/scripts/generate-l2-initramfs.sh
+++ b/scripts/generate-l2-initramfs.sh
@@ -55,6 +55,8 @@ GUEST_TAP_IP_ADDRESS=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "guest_tap_ip
 HOST_TAP_IP_ADDRESS=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "host_tap_ip_address")
 CONTROL_PLANE_PORT=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "control_plane_port")
 USER_VM_PORT=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "user_vm_port")
+GUEST_EPHEMERAL_PORT_RANGE_BEGIN=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "guest_ephemeral_port_range_begin")
+GUEST_EPHEMERAL_PORT_RANGE_END=$(get_value_from_toml "${LINUXD_CONFIG_TOML}" "guest_ephemeral_port_range_end")
 
 CONTROL_PLANE_SOCKADDR="${HOST_TAP_IP_ADDRESS}:${CONTROL_PLANE_PORT}"
 USER_VM_SOCKADDR="${GUEST_TAP_IP_ADDRESS}:${USER_VM_PORT}"
@@ -103,6 +105,11 @@ cat >/tmp/init <<EOF
 echo "[init] Nanvix L2 System VM init wrapper started!"
 
 # Set-up any resources that linuxd needs when running in the L2-VM.
+mount -t proc proc /proc
+
+# Keep guest ephemeral source ports away from the dedicated gateway listener range.
+echo "${GUEST_EPHEMERAL_PORT_RANGE_BEGIN} ${GUEST_EPHEMERAL_PORT_RANGE_END}" > /proc/sys/net/ipv4/ip_local_port_range
+echo "[init] Configured guest ephemeral port range to ${GUEST_EPHEMERAL_PORT_RANGE_BEGIN}-${GUEST_EPHEMERAL_PORT_RANGE_END}"
 
 # We must bind to the same IP, as it is the only one available in the guest.
 echo "[init] Nanvix L2 System VM passed init gate. Starting linuxd..."

--- a/scripts/generate-l2-initramfs.sh
+++ b/scripts/generate-l2-initramfs.sh
@@ -65,7 +65,7 @@ USER_VM_SOCKADDR="${GUEST_TAP_IP_ADDRESS}:${USER_VM_PORT}"
 # Build initramfs
 #===================================================================================================
 
-UBUNTU_VERSION="jammy"
+UBUNTU_VERSION="noble"
 UBUNTU_COMPONENTS="main,restricted,universe,multiverse"
 # Robust mirror detection, and fallback to a safe default.
 UBUNTU_MIRROR="$(


### PR DESCRIPTION
In this PR I fix a bug in L2 deployments where, at very high concurrency, the ephemeral port range used by the kernel would overlap with the gateway port range assigned by nanvixd for user VM gateways.

Instead, we now control and configure both ranges by modifying the initramfs.

In the process I also bump the OS version inside the initramfs.

Closes #1859 