### PR TITLE
[nanvixd] E: Snapshot restore support

### DIFF
--- a/src/libs/nanvix-terminal/src/standalone.rs
+++ b/src/libs/nanvix-terminal/src/standalone.rs
@@ -47,7 +47,7 @@ const IO_BUFFER_SIZE: usize = 4096;
 const STDIN_CHANNEL_CAPACITY: usize = 4096;
 
 /// Maximum time to wait for the input task to shut down gracefully before aborting it.
-const INPUT_SHUTDOWN_TIMEOUT: ::std::time::Duration = ::std::time::Duration::from_secs(1);
+const INPUT_SHUTDOWN_TIMEOUT: ::std::time::Duration = ::std::time::Duration::from_millis(10);
 
 //==================================================================================================
 // Structures
@@ -68,6 +68,8 @@ pub struct TerminalConfig {
     ramfs_filename: Option<String>,
     /// Optional file path for capturing guest stderr output.
     console_file: Option<String>,
+    /// Optional snapshot path for restoring VM state instead of cold-booting.
+    snapshot_path: Option<String>,
     /// Optional GDB server port for debugging the guest.
     #[cfg(feature = "gdb")]
     gdb_port: Option<u16>,
@@ -90,12 +92,14 @@ impl TerminalConfig {
         kernel_binary_path: String,
         ramfs_filename: Option<String>,
         console_file: Option<String>,
+        snapshot_path: Option<String>,
         #[cfg(feature = "gdb")] gdb_port: Option<u16>,
     ) -> Self {
         Self {
             kernel_binary_path,
             ramfs_filename,
             console_file,
+            snapshot_path,
             #[cfg(feature = "gdb")]
             gdb_port,
         }
@@ -171,7 +175,7 @@ impl Terminal {
             initrd_args,
             self.config.ramfs_filename.clone(),
             self.config.console_file.clone(),
-            None,
+            self.config.snapshot_path.clone(),
             #[cfg(feature = "gdb")]
             self.config.gdb_port,
         );

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -81,6 +81,8 @@ pub struct Args {
     /// Optional GDB server port: when set, the uservm starts a GDB RSP server on this TCP port.
     #[cfg(feature = "gdb")]
     gdb_port: Option<u16>,
+    /// Optional snapshot path: when set, restore VM from snapshot instead of cold-booting.
+    snapshot_path: Option<String>,
 }
 
 //==================================================================================================
@@ -126,6 +128,8 @@ impl Args {
     /// Command-line option for GDB server port (standalone mode only).
     #[cfg(feature = "gdb")]
     pub const OPT_GDB_PORT: &'static str = "-gdb-port";
+    /// Command-line option for snapshot restore path (standalone mode only).
+    pub const OPT_SNAPSHOT: &'static str = "-snapshot";
 
     ///
     /// # Description
@@ -174,6 +178,7 @@ impl Args {
         let mut tmp_directory: String = DEFAULT_TMP_DIRECTORY.to_string();
         #[cfg(feature = "gdb")]
         let mut gdb_port: Option<u16> = None;
+        let mut snapshot_path: Option<String> = None;
 
         let mut i: usize = 1;
         while i < args.len() {
@@ -280,6 +285,15 @@ impl Args {
                         anyhow::anyhow!("invalid GDB port (arg={}, error={e:?})", args[i])
                     })?);
                 },
+                // Set snapshot restore path (standalone mode only).
+                Self::OPT_SNAPSHOT => {
+                    i += 1;
+                    if i >= args.len() {
+                        Self::usage(args[0].as_str());
+                        return Err(anyhow::anyhow!("missing value for: {}", Self::OPT_SNAPSHOT));
+                    }
+                    snapshot_path = Some(args[i].clone());
+                },
                 arg => {
                     return Err(anyhow::anyhow!("invalid argument: {arg}"));
                 },
@@ -379,6 +393,7 @@ impl Args {
             tmp_directory,
             #[cfg(feature = "gdb")]
             gdb_port,
+            snapshot_path,
         })
     }
 
@@ -533,6 +548,11 @@ Options:
     ///
     pub fn ramfs_filename(&self) -> Option<&str> {
         self.ramfs_filename.as_deref()
+    }
+
+    /// Returns the optional snapshot path for VM restore.
+    pub fn snapshot_path(&self) -> Option<&str> {
+        self.snapshot_path.as_deref()
     }
 
     ///

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -273,6 +273,7 @@ async fn async_main() -> Result<ExitCode> {
             kernel_binary_path.clone(),
             args.ramfs_filename().map(|s| s.to_string()),
             args.console_file().clone(),
+            args.snapshot_path().map(|s| s.to_string()),
             #[cfg(feature = "gdb")]
             args.gdb_port(),
         ));


### PR DESCRIPTION
## Summary

Add `-snapshot` CLI flag to nanvixd standalone mode for VM snapshot restore, enabling CPython warm boot in **172ms (p50)**.

## Changes

### nanvixd args (`src/utils/nanvixd/src/args.rs`)
- Add `-snapshot` CLI option with path argument
- Add `snapshot_path()` accessor method

### nanvixd main (`src/utils/nanvixd/src/main.rs`)
- Pass `snapshot_path` to `TerminalConfig::new()`

### nanvix-terminal (`src/libs/nanvix-terminal/src/standalone.rs`)
- Add `snapshot_path: Option<String>` to `TerminalConfig`
- Thread snapshot path through to `StandaloneVmHandle::spawn()`
- **Fix**: Reduce `INPUT_SHUTDOWN_TIMEOUT` from 1s to 10ms — the previous 1s timeout added ~1 second of latency to every non-interactive execution because the stdin thread blocks on `read()` and can never exit gracefully when the VM terminates without consuming stdin

## Usage

```powershell
# Cold boot (creates snapshot):
nanvixd.exe -bin-dir bin -- bin\python.elf "-S -c pass;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1"

# Warm boot (restores from snapshot):
nanvixd.exe -bin-dir bin -snapshot snapshots\kernel -- bin\python.elf "-S -c pass;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1"
```

## Performance

| Configuration | p50 | p95 |
|---|---|---|
| Baseline (47MB, ramfs) | 1998 ms | 5256 ms |
| Optimized cold (12MB, frozen) | 825 ms | 860 ms |
| **Snapshot restore** | **172 ms** | **193 ms** |

Companion PR: nanvix/cpython#314
