### PR TITLE
[ci] Add Windows benchmark CI jobs and make benchmark.py cross-platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,6 +693,164 @@ jobs:
             **/*.out
             **/*.err
 
+  # Run micro-benchmarks on a Windows GitHub-hosted runner using WHP so that
+  # Windows-specific performance data is collected alongside the Linux results.
+  # Only standalone-mode benchmarks are supported (boot-time, cold-start,
+  # warm-start-vmm). GitHub-hosted Windows runners have variable WHP performance,
+  # so continue-on-error prevents flaky failures from blocking the pipeline.
+  windows-benchmark-ci:
+    name: "Windows Benchmark CI (${{ matrix.machine-type }})"
+    needs: [precheck]
+    timeout-minutes: 120
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - machine-type: microvm
+            standard-benchmarks: "boot-time cold-start warm-start-vmm"
+            standard-iterations: "100"
+          # NOTE (#1759, #1762): Hyperlight benchmarks are disabled until the
+          # round-trip-latency failure is investigated.
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    if: |
+      github.repository == 'nanvix/nanvix' && (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
+          needs.precheck.outputs.up_to_date == 'true' && (
+            github.event_name != 'push' ||
+            github.event.head_commit == null ||
+            !startsWith(github.event.head_commit.message, 'Merge ')
+          ) && (
+            github.event_name != 'pull_request' ||
+            !github.event.pull_request.draft
+          )
+        )
+      )
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Install Rust Toolchain"
+        shell: pwsh
+        run: |
+          $toolchain = (Get-Content rust-toolchain | Select-String '^channel\s*=').ToString() -replace '.*=\s*"([^"]+)".*','$1'
+          rustup toolchain install $toolchain
+          rustup show
+          rustup component add --toolchain $toolchain clippy rustfmt
+
+      - name: "Setup Prerequisites"
+        shell: pwsh
+        run: |
+          $osVersion = [System.Environment]::OSVersion.Version
+          if ($osVersion.Build -ge 22000) {
+            Write-Host "Detected Windows build $($osVersion.Build) (Windows 11 or later). Running z.ps1 setup..."
+            .\z.ps1 setup
+          }
+          else {
+            Write-Host "Detected Windows build $($osVersion.Build) (< 22000). Skipping z.ps1 setup on CI runner."
+          }
+
+      - name: "Build"
+        shell: pwsh
+        env:
+          MACHINE_TYPE: ${{ matrix.machine-type }}
+        run: |
+          .\z.ps1 build -- all MACHINE=$env:MACHINE_TYPE RELEASE=yes LOG_LEVEL=panic
+
+      - name: "Exclude bin/ from Windows Defender"
+        shell: pwsh
+        run: |
+          $binDir = Join-Path $env:GITHUB_WORKSPACE "bin"
+          Add-MpPreference -ExclusionPath $binDir
+          Write-Host "Added Defender exclusion for $binDir"
+
+      - name: "Check Windows Hypervisor Platform"
+        id: whp-check
+        shell: pwsh
+        run: |
+          $feature = Get-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform
+          if ($feature.State -ne 'Enabled') {
+            Write-Host "::warning::Windows Hypervisor Platform is not enabled — skipping benchmarks."
+            echo "whp_available=false" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+          Write-Host "HypervisorPlatform feature is enabled."
+
+          # Probe whether WHP can actually boot a guest by running hello-rust-nostd
+          # with a short timeout. GitHub-hosted runners may report the feature as
+          # enabled without functional nested virtualization.
+          Write-Host "Probing WHP with hello-rust-nostd (30s timeout)..."
+          $proc = Start-Process -FilePath ".\bin\nanvixd.exe" `
+            -ArgumentList "-- .\bin\hello-rust-nostd.elf" `
+            -PassThru -NoNewWindow -RedirectStandardOutput "whp-probe-stdout.txt" `
+            -RedirectStandardError "whp-probe-stderr.txt"
+
+          $proc | Wait-Process -Timeout 30 -ErrorAction SilentlyContinue
+          if (-not $proc.HasExited) {
+            $proc | Stop-Process -Force
+            Write-Host "::warning::WHP probe timed out — hypervisor is not functional on this runner. Skipping benchmarks."
+            echo "whp_available=false" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+
+          if ($proc.ExitCode -ne 0) {
+            Write-Host "::warning::WHP probe failed with exit code $($proc.ExitCode) — skipping benchmarks."
+            Get-Content "whp-probe-stderr.txt" -ErrorAction SilentlyContinue | Write-Host
+            echo "whp_available=false" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+
+          Write-Host "WHP probe succeeded — hypervisor is functional."
+          echo "whp_available=true" >> $env:GITHUB_OUTPUT
+
+      - name: "Run Micro-Benchmarks"
+        if: steps.whp-check.outputs.whp_available == 'true'
+        shell: pwsh
+        env:
+          BENCHMARKS: ${{ matrix.standard-benchmarks }}
+          MACHINE_TYPE: ${{ matrix.machine-type }}
+          ITERATIONS: ${{ matrix.standard-iterations }}
+        run: |
+          foreach ($bench in $env:BENCHMARKS -split ' ') {
+            Write-Host "[INFO] Running benchmark '${bench}'..."
+            python scripts/benchmark.py `
+              run `
+              --benchmark $bench `
+              --machine-type $env:MACHINE_TYPE `
+              --iterations $env:ITERATIONS `
+              --output-dir "." `
+              --commit "${{ github.sha }}"
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "Benchmark '${bench}' failed with exit code $LASTEXITCODE"
+              exit $LASTEXITCODE
+            }
+          }
+
+      - name: "Upload Benchmark Results"
+        if: always() && !cancelled() && steps.whp-check.outputs.whp_available == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-ci-windows-results-${{ matrix.machine-type }}
+          overwrite: true
+          retention-days: 1
+          path: nanvix_bench_*.csv
+
+      - name: "Upload logs in case of benchmark failures"
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nanvix-benchmark-ci-windows-logs-${{ github.event.pull_request.number || github.run_number }}-${{ matrix.machine-type }}
+          overwrite: "true"
+          path: |
+            logs/
+            **/*.log
+            **/*.out
+            **/*.err
+            bench_*.txt
+
   # ==========================================================================================
   # Stage 3: L2 and Benchmark (Self-Hosted Runners)
   # ==========================================================================================
@@ -1178,6 +1336,80 @@ jobs:
             **/*.out
             **/*.err
 
+  # Aggregate Windows CI benchmark results, post a PR comment, and persist
+  # the updated baselines on dev. Results are stored in data/windows-github/ to keep
+  # them isolated from the Linux baselines.
+  windows-benchmark-ci-finalize:
+    name: "Windows Benchmark CI Finalize"
+    needs: [windows-benchmark-ci]
+    # NOTE: windows-benchmark-ci uses continue-on-error, so its result may be
+    # 'failure' even when it ran successfully enough to produce artifacts. Run
+    # the finalize job whenever the benchmark job actually ran (not skipped).
+    if: ${{ !cancelled() && needs.windows-benchmark-ci.result != 'skipped' }}
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_PRIVATE_SSH_KEY }}
+
+      - name: "Download Benchmark Results"
+        id: download-results
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: benchmark-ci-windows-results-*
+          path: .
+          merge-multiple: true
+
+      - name: "Check for benchmark results"
+        id: check-results
+        shell: bash
+        run: |
+          if compgen -G "nanvix_bench_*.csv" > /dev/null 2>&1; then
+            echo "has_results=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No Windows benchmark CSV files found — skipping report and persist."
+            echo "has_results=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Report Benchmark Results"
+        if: steps.check-results.outputs.has_results == 'true'
+        uses: ./.github/actions/benchmark-report
+        with:
+          benchmarks: "boot-time,cold-start,warm-start-vmm"
+          machine-types: "microvm"
+          archs: "X64"
+          dev-dir: "data/windows-github"
+          runner-label: "windows-github-hosted"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Persist results on dev"
+        if: github.ref_name == 'dev' && steps.check-results.outputs.has_results == 'true'
+        uses: ./.github/actions/benchmark-persist
+        with:
+          benchmarks: "boot-time,cold-start,warm-start-vmm"
+          machine-types: "microvm"
+          archs: "X64"
+          target-dir: "data/windows-github"
+
+      - name: "Upload logs in case of finalize failures"
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nanvix-benchmark-ci-windows-finalize-logs-${{ github.event.pull_request.number || github.run_number }}
+          overwrite: "true"
+          path: |
+            logs/
+            **/*.log
+            **/*.out
+            **/*.err
+
   # ==========================================================================================
   # Stage 4: Post Actions (Conditional)
   # ==========================================================================================
@@ -1335,6 +1567,8 @@ jobs:
         benchmark-finalize,
         benchmark-ci,
         benchmark-ci-finalize,
+        windows-benchmark-ci,
+        windows-benchmark-ci-finalize,
         release-archive,
         windows-release-archive,
         publish-release,

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -11,6 +11,7 @@ import io
 import itertools
 import os
 import pathlib
+import platform
 import re
 import signal
 import subprocess
@@ -22,8 +23,9 @@ from typing import Optional
 
 HYPERLIGHT_MACHINE_TYPE = "hyperlight"
 MICROVM_MACHINE_TYPE = "microvm"
+IS_WINDOWS = platform.system() == "Windows"
 NA = "NA"
-NANVIX_BENCH_ELF = "nanvix-bench.elf"
+NANVIX_BENCH_BINARY = "nanvix-bench.exe" if IS_WINDOWS else "nanvix-bench.elf"
 PERCENTILES = ["p50", "p95", "p99"]
 ROUND_TRIP_SIZES = ["32B", "64B", "128B", "256B", "512B", "1KiB", "4KiB"]
 X86_64_ARCH = "X64"
@@ -688,17 +690,26 @@ def ci_summary(args):
         fh.write(bench_summary)
 
 
-def _kill_process_group(pid: int) -> None:
-    """Send SIGKILL to the process group led by *pid*.
+def _kill_process_tree(proc: subprocess.Popen) -> None:
+    """Forcefully terminate a process and all its descendants.
 
-    Because we launch benchmarks with ``start_new_session=True``, the child
-    becomes its own process-group leader (PGID == PID).  Killing the group
-    ensures that all grandchildren are reaped, not just the direct child.
+    On Unix, benchmarks run in their own session (``start_new_session=True``),
+    so killing the process group (PGID == PID) reaps all grandchildren.
+
+    On Windows, ``taskkill /F /T`` is used to terminate the entire process
+    tree rooted at the child PID.
     """
     try:
-        os.killpg(pid, signal.SIGKILL)
+        if IS_WINDOWS:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        else:
+            os.killpg(proc.pid, signal.SIGKILL)
     except OSError:
-        pass  # Process group may already be gone.
+        pass  # Process (group) may already be gone.
 
 
 def _run_with_timeout(
@@ -708,11 +719,14 @@ def _run_with_timeout(
     capture_output: bool = False,
     check: bool = False,
 ) -> subprocess.CompletedProcess:
-    """Run *cmd* in a new session, killing the entire process group on timeout."""
-    kwargs = {
+    """Run *cmd* in a new session, killing the entire process tree on timeout."""
+    kwargs: dict = {
         "shell": True,
-        "start_new_session": True,
     }
+    if IS_WINDOWS:
+        kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        kwargs["start_new_session"] = True
     if capture_output:
         kwargs["stdout"] = subprocess.PIPE
         kwargs["stderr"] = subprocess.PIPE
@@ -721,7 +735,7 @@ def _run_with_timeout(
     try:
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
-        _kill_process_group(proc.pid)
+        _kill_process_tree(proc)
         stdout, stderr = proc.communicate()
         raise subprocess.TimeoutExpired(
             proc.args, timeout, output=stdout, stderr=stderr
@@ -745,6 +759,11 @@ def run_benchmark(args):
         f"[BENCHMARK] Configuration: iterations={args.iterations}, "
         f"hwloc={args.hwloc}"
     )
+    # Normalize paths so that Unix-style "./" prefixes are converted to
+    # platform-native form (cmd.exe does not understand "./").
+    args.bin_dir = os.path.normpath(args.bin_dir)
+    args.toolchain_bin_dir = os.path.normpath(args.toolchain_bin_dir)
+
     print(
         f"[BENCHMARK] Paths: bin_dir={args.bin_dir}, "
         f"toolchain_bin_dir={args.toolchain_bin_dir}"
@@ -770,7 +789,8 @@ def run_benchmark(args):
 
     # Before running L2 benchmarks, wait for TCP connections from previous runs to clear.
     # This is critical when L2 benchmarks run after non-L2 benchmarks in sequence.
-    if args.benchmark.endswith(L2_SUFFIX):
+    # These cleanup steps use Linux-specific tools (ss, ip netns) and are skipped on Windows.
+    if not IS_WINDOWS and args.benchmark.endswith(L2_SUFFIX):
         print(
             "[BENCHMARK] This is an L2 benchmark, checking for lingering TCP connections..."
         )
@@ -782,8 +802,9 @@ def run_benchmark(args):
     # Clean up any stale network namespaces before running all benchmarks.
     # This prevents resource conflicts from previous runs, especially when running
     # non-L2 benchmarks after L2 benchmarks in a sequence.
-    print("[BENCHMARK] Cleaning up stale network namespaces...")
-    cleanup_stale_netns()
+    if not IS_WINDOWS:
+        print("[BENCHMARK] Cleaning up stale network namespaces...")
+        cleanup_stale_netns()
 
     # The concurrent benchmark takes slightly different command-line arguments than the other
     # benchmarks. It does not take a `-hwloc` file, and instead of `-iterations` it takes
@@ -792,7 +813,7 @@ def run_benchmark(args):
     print(f"[BENCHMARK] Is concurrent benchmark: {is_concurrent_bench}")
 
     nanvix_bench_cmd = [
-        os.path.join(args.bin_dir, NANVIX_BENCH_ELF),
+        os.path.join(args.bin_dir, NANVIX_BENCH_BINARY),
         f"-benchmark {args.benchmark}",
         f"-hwloc {args.hwloc}" if (not is_concurrent_bench and args.hwloc) else "",
         (
@@ -848,8 +869,8 @@ def run_benchmark(args):
             print("[BENCHMARK] STDERR:")
             print(result.stderr.decode("utf-8"))
 
-            # Additional diagnostics for L2 benchmarks.
-            if args.benchmark.endswith(L2_SUFFIX):
+            # Additional diagnostics for L2 benchmarks (Linux-only tools).
+            if not IS_WINDOWS and args.benchmark.endswith(L2_SUFFIX):
                 print("[BENCHMARK] Running post-failure network diagnostics...")
                 diag_result = subprocess.run(
                     ["ss", "-tan", "state", "time-wait", "sport", "9999"],
@@ -902,7 +923,7 @@ def run_benchmark(args):
     # After L2 benchmarks, wait for TCP connections in TIME_WAIT to clear.
     # L2 benchmarks create many TCP connections that linger in TIME_WAIT state,
     # which can cause connection issues for subsequent benchmarks.
-    if args.benchmark.endswith(L2_SUFFIX):
+    if not IS_WINDOWS and args.benchmark.endswith(L2_SUFFIX):
         print("[BENCHMARK] Post-benchmark: checking for lingering TCP connections...")
         cleanup_success = wait_for_tcp_cleanup()
         result_str = "success" if cleanup_success else "timeout/failure"
@@ -1092,7 +1113,7 @@ if __name__ == "__main__":
     )
     run_parser.add_argument(
         "--bin-dir",
-        help="Directory where to find nanvix-bench.elf",
+        help="Directory where to find the nanvix-bench binary",
         default="./bin",
     )
     run_parser.add_argument(


### PR DESCRIPTION
Add `windows-benchmark-ci` and `windows-benchmark-ci-finalize` jobs to the CI workflow to run standalone-mode micro-benchmarks (boot-time, cold-start, warm-start-vmm) on GitHub-hosted Windows runners using WHP.

The benchmark job probes WHP availability before running, and uses `continue-on-error: true` to prevent flaky runner failures from blocking the pipeline. Results are stored in `data/windows-github/`, isolated from the Linux baselines. The finalize job aggregates results, posts PR comments, and persists baselines on dev.

Update `scripts/benchmark.py` for Windows compatibility:
- Detect the host platform and select the correct binary name (`nanvix-bench.exe` vs `nanvix-bench.elf`).
- Use `CREATE_NEW_PROCESS_GROUP` instead of `start_new_session` on Windows, and `taskkill /F /T` instead of `os.killpg()` to kill the entire process tree on timeout.
- Skip Linux-specific cleanup steps (TCP TIME_WAIT checks, network namespace cleanup, `ss`/`ip netns` diagnostics) on Windows.

Wire both new jobs into the `ci-ok` and `ci-complete` dependency graphs.