### PR TITLE
[nanvixd] Skip tmp_dir creation in standalone mode

### DIFF
--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -180,7 +180,9 @@ async fn async_main() -> Result<ExitCode> {
         ensure_all_binaries_available(&args, machine, deployment).await?;
 
     // Create temporary directory that will be automatically cleaned up on drop.
-    #[allow(unused_variables)]
+    // Standalone mode does not use the temporary directory, so skip creating it
+    // to avoid unnecessary filesystem overhead on the cold-start path.
+    #[cfg(not(feature = "standalone"))]
     let tmp_directory: TemporaryDirectory = create_tmp_dir(args.tmp_directory()).await?;
 
     #[cfg(all(feature = "single-process", not(feature = "standalone")))]
@@ -461,6 +463,7 @@ fn print_startup_info(args: &Args) {
 /// On success, returns a `TemporaryDirectory` instance that manages the lifecycle of the created
 /// directory. On failure, returns an error describing what went wrong during directory creation.
 ///
+#[cfg_attr(feature = "standalone", allow(dead_code))]
 async fn create_tmp_dir(tmp_directory: &str) -> Result<TemporaryDirectory> {
     // Get current timestamp in microseconds.
     let timestamp_micros: u128 = SystemTime::now()


### PR DESCRIPTION
## Summary

Skip creating the temporary directory in standalone mode to avoid unnecessary filesystem overhead on the cold-start path.

## Changes

- Gate `tmp_directory` creation with `#[cfg(not(feature = "standalone"))]` in `async_main()`.
- Add `#[cfg_attr(feature = "standalone", allow(dead_code))]` to `create_tmp_dir()`.

## Split from

Split from PR #1862.