### PR TITLE
[nanvixd] Use single-thread runtime in standalone mode

### DIFF
--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -137,6 +137,15 @@ macro_rules! log_info {
 //   `#![forbid(clippy::expect_used)]` lint configuration.
 ///
 pub fn main() -> Result<ExitCode> {
+    // Standalone mode uses a single-thread runtime to avoid the overhead of
+    // spawning worker threads at startup.  Other deployment modes keep the
+    // multi-thread runtime for higher throughput.
+    #[cfg(feature = "standalone")]
+    let rt: ::tokio::runtime::Runtime = ::tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| ::anyhow::anyhow!("failed to build tokio runtime: {e}"))?;
+    #[cfg(not(feature = "standalone"))]
     let rt: ::tokio::runtime::Runtime = ::tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()


### PR DESCRIPTION
## Summary

Use a single-threaded tokio runtime in standalone mode to avoid the overhead of spawning worker threads at startup.

## Changes

- Add `#[cfg(feature = "standalone")]` block using `new_current_thread()` in `main()`.
- Gate the existing `new_multi_thread()` builder with `#[cfg(not(feature = "standalone"))]`.

## Split from

Split from PR #1862.