### PR TITLE
[uservm] Defer pvclock timer start

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -358,6 +358,14 @@ pub(in crate::hal::platform) fn do_shutdown(status: usize) -> ! {
 ///
 /// # Description
 ///
+/// Signals the VMM that the kernel has finished booting and user-space
+/// applications are about to start. No-op on the Hyperlight platform.
+///
+pub fn signal_boot_complete() {}
+
+///
+/// # Description
+///
 /// Parses boot information.
 ///
 /// # Parameters

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -241,6 +241,23 @@ pub fn snapshot() {
 ///
 /// # Description
 ///
+/// Signals the VMM that the kernel has finished booting and user-space
+/// applications are about to start. The VMM uses this to enable
+/// host-side services (e.g., pvclock timer) that should not run during
+/// the boot phase.
+///
+pub fn signal_boot_complete() {
+    // SAFETY: The port I/O write targets the VMM control port with a well-known
+    // boot-complete command value.
+    unsafe {
+        let cmd: u16 = ::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD;
+        ::arch::io::out32(::config::microvm::DEFAULT_VMM_PORT, (cmd as u32) << 16);
+    }
+}
+
+///
+/// # Description
+///
 /// Parses boot information.
 ///
 /// # Parameters

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -66,6 +66,9 @@ pub fn kcall_handler() -> ExitStatus {
         panic!("failed to initialize event manager: {:?}", e);
     }
 
+    // Signal the VMM that kernel boot is complete and user-space is about to start.
+    crate::hal::platform::signal_boot_complete();
+
     let status: ExitStatus = loop {
         // Check if inter-kernel communication messages are available.
         let message_received: bool = poll_ikc_messages();

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -230,6 +230,9 @@ pub mod microvm {
     /// Default VMM snapshot command. Triggers a guest-initiated VM snapshot.
     pub const DEFAULT_VMM_SNAPSHOT_CMD: u16 = 0x4000;
 
+    /// Default VMM boot-complete command. Sent by the kernel after boot finishes.
+    pub const DEFAULT_VMM_BOOT_COMPLETE_CMD: u16 = 0x5000;
+
     /// Default base address for MicroVM control registers.
     pub const DEFAULT_MICROVM_CTRL_BASE: usize = 0x00000000;
 

--- a/src/uservm/src/vmm/microvm/emulator.rs
+++ b/src/uservm/src/vmm/microvm/emulator.rs
@@ -198,6 +198,9 @@ impl Emulator {
                         ::config::microvm::DEFAULT_VMM_SNAPSHOT_CMD => {
                             return Ok(Some(::config::microvm::DEFAULT_VMM_SNAPSHOT_CMD));
                         },
+                        ::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD => {
+                            return Ok(Some(::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD));
+                        },
                         cmd => anyhow::bail!("unknown virtual machine command (cmd={cmd:#06x})"),
                     }
                 },

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -616,7 +616,9 @@ impl Vmm {
                         .emulator_mut()
                         .handle_pmio_access(access)?;
                     if let Some(exit_status) = exit_status {
-                        if exit_status == ::config::microvm::DEFAULT_VMM_SNAPSHOT_CMD {
+                        if exit_status == ::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD {
+                            // Kernel finished booting; no-op on KVM backend.
+                        } else if exit_status == ::config::microvm::DEFAULT_VMM_SNAPSHOT_CMD {
                             Handle::current().block_on(self.handle_snapshot())?;
                         } else if exit_status != ::config::microvm::DEFAULT_VMM_PAUSE_CMD {
                             Handle::current().block_on(self.handle_shutdown(exit_status));

--- a/src/uservm/src/vmm/whp/emulator.rs
+++ b/src/uservm/src/vmm/whp/emulator.rs
@@ -211,6 +211,9 @@ impl Emulator {
                     ::config::microvm::DEFAULT_VMM_PAUSE_CMD => {
                         return Ok(Some(::config::microvm::DEFAULT_VMM_PAUSE_CMD));
                     },
+                    ::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD => {
+                        return Ok(Some(::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD));
+                    },
                     cmd => anyhow::bail!("unknown virtual machine command (cmd={cmd:#06x})"),
                 },
                 // Write to an I/O port that is not emulated.

--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -552,13 +552,15 @@ impl Vmm {
         // interpolates between updates using LAPIC timer tick counts
         // (1 kHz) for ~1 ms accuracy with zero VM exits per time read.
         //
-        // A low-frequency host timer (100Hz) calls
-        // WHvCancelRunVirtualProcessor to force VM exits so the VMM
-        // loop can update system_time on the pvclock page. Without these
-        // periodic exits, pvclock would freeze during CPU-bound guest
-        // execution (no I/O = no VM exits), causing condvar/sleep
-        // timeouts to malfunction.
-        self.timer.lock().unwrap().start(10_000); // 10ms = 100Hz
+        // Defer the pvclock timer until the kernel explicitly signals
+        // boot completion via DEFAULT_VMM_BOOT_COMPLETE_CMD on the VMM
+        // port. Starting the timer earlier causes
+        // WHvCancelRunVirtualProcessor to interrupt the very first
+        // WHvRunVirtualProcessor call, which carries a heavy one-time
+        // partition-setup cost inside WHP. Deferring avoids those
+        // unnecessary cancel-induced VM exits during boot while still
+        // providing pvclock updates once user-space is running.
+        let mut timer_started: bool = false;
 
         // PIT channel 2 state for LAPIC timer calibration. The guest
         // programs PIT ch2 in one-shot mode and polls port 0x61 bit 5
@@ -699,7 +701,15 @@ impl Vmm {
                         },
                     };
                     if let Some(exit_status) = exit_status {
-                        if exit_status != ::config::microvm::DEFAULT_VMM_PAUSE_CMD {
+                        if exit_status == ::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD {
+                            // The kernel signals that boot is complete and
+                            // user-space is about to start. Start the
+                            // pvclock host timer now.
+                            if !timer_started {
+                                self.timer.lock().unwrap().start(10_000); // 10ms = 100Hz
+                                timer_started = true;
+                            }
+                        } else if exit_status != ::config::microvm::DEFAULT_VMM_PAUSE_CMD {
                             warn!(
                                 "VMM exit: PMIO shutdown (exit_status={exit_status}, elapsed={:?})",
                                 loop_start.elapsed()

--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -702,12 +702,24 @@ impl Vmm {
                     };
                     if let Some(exit_status) = exit_status {
                         if exit_status == ::config::microvm::DEFAULT_VMM_BOOT_COMPLETE_CMD {
-                            // The kernel signals that boot is complete and
-                            // user-space is about to start. Start the
-                            // pvclock host timer now.
+                            // The kernel signals that boot is complete and user-space is about to
+                            // start. Start the pvclock host timer now.
                             if !timer_started {
-                                self.timer.lock().unwrap().start(10_000); // 10ms = 100Hz
-                                timer_started = true;
+                                match self.timer.lock() {
+                                    Ok(mut locked_timer) => {
+                                        locked_timer.start(10_000); // 10ms = 100Hz
+                                        trace!("pvclock timer started");
+                                        timer_started = true;
+                                    },
+                                    Err(e) => {
+                                        error!(
+                                            "Failed to acquire timer lock to start pvclock: {e:?}"
+                                        );
+                                        break Err(anyhow::anyhow!(
+                                            "Failed to acquire timer lock to start pvclock: {e:?}"
+                                        ));
+                                    },
+                                }
                             }
                         } else if exit_status != ::config::microvm::DEFAULT_VMM_PAUSE_CMD {
                             warn!(

--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -103,6 +103,13 @@ pub const KILL_SIGNAL: i32 = 0;
 /// IDT vector for IRQ 9 (IKC): PIC2 base (0x28) + (IRQ 9 - 8) = 0x29.
 const IKC_VECTOR: u32 = 0x29;
 
+/// Pvclock host timer period in microseconds (10 ms = 100 Hz). This timer
+/// forces periodic VM exits via `WHvCancelRunVirtualProcessor` so the VMM loop
+/// can update the pvclock `system_time` field. 100 Hz is high enough that the
+/// guest sees sub-10 ms clock drift between LAPIC tick interpolations, yet low
+/// enough to keep the VM-exit overhead negligible.
+const PVCLOCK_TIMER_PERIOD_US: u64 = 10_000;
+
 /// PIT oscillator frequency in Hz (1.193181 MHz).
 const PIT_FREQ_HZ: u64 = 1_193_181;
 
@@ -707,7 +714,7 @@ impl Vmm {
                             if !timer_started {
                                 match self.timer.lock() {
                                     Ok(mut locked_timer) => {
-                                        locked_timer.start(10_000); // 10ms = 100Hz
+                                        locked_timer.start(PVCLOCK_TIMER_PERIOD_US);
                                         trace!("pvclock timer started");
                                         timer_started = true;
                                     },


### PR DESCRIPTION
## Summary

Defer the 100 Hz pvclock host timer until the kernel explicitly signals boot
completion via a new `DEFAULT_VMM_BOOT_COMPLETE_CMD` (0x5000) on the VMM
control port. Starting the timer earlier causes `WHvCancelRunVirtualProcessor`
to interrupt the costly first `WHvRunVirtualProcessor` call.

The previous heuristic (first application-level I/O exit) was unreliable
because the kernel itself performs I/O (logging via stdout port 0xe9) during
boot, which would prematurely trigger the timer.

## Changes

### Add explicit boot-complete VMM command
- Add `DEFAULT_VMM_BOOT_COMPLETE_CMD` (0x5000) constant to config.
- Add `signal_boot_complete()` to kernel microvm platform (writes the command
  to the VMM port, following the existing shutdown/snapshot pattern).
- Add `signal_boot_complete()` as a no-op on the Hyperlight platform.
- Call `signal_boot_complete()` from the kcall handler before the main event
  loop — the precise kernel-to-user-space transition point.
- WHP VMM: start the pvclock timer only upon receiving the boot-complete
  command.
- KVM VMM: handle the new command as a no-op (KVM uses native pvclock).
- Both emulators: recognize the new command to avoid bailing on unknown VMM
  commands.

### Proper error handling for timer lock
- Replace `unwrap()` on the timer mutex with a `match` that logs and
  returns a descriptive error on poisoned lock instead of panicking.

### Extract pvclock timer period constant
- Replace inline magic number `10_000` with `PVCLOCK_TIMER_PERIOD_US`
  file-level constant with documentation explaining the 100 Hz trade-off.