### PR TITLE
[kernel] LAPIC calibration optimizations for WHP

### DIFF
--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/mod.rs
@@ -344,7 +344,8 @@ fn try_init_xapic_timer(
 
         let uninit_timer: UninitXapicTimer = UninitXapicTimer::new(lapic_region);
 
-        // Calibrate the LAPIC timer using PIT channel 2 and program it in periodic mode.
+        // Calibrate the LAPIC timer (RDTSC-based when TSC frequency is available,
+        // PIT channel 2 fallback otherwise) and program it in periodic mode.
         use crate::hal::platform::pit::Pit;
 
         const LAPIC_CALIBRATION_MS: u32 = 10;

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/mod.rs
@@ -348,7 +348,7 @@ fn try_init_xapic_timer(
         // PIT channel 2 fallback otherwise) and program it in periodic mode.
         use crate::hal::platform::pit::Pit;
 
-        const LAPIC_CALIBRATION_MS: u32 = 10;
+        const LAPIC_CALIBRATION_MS: u32 = 1;
 
         let mut pit: Pit = Pit::new(_ioports, ::config::kernel::TIMER_FREQ)?;
         let xapic_timer: XapicTimer = uninit_timer.init(&mut pit, LAPIC_CALIBRATION_MS);

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/xapic.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/xapic.rs
@@ -482,8 +482,6 @@ impl UninitXapicTimer {
             calibration_ms
         };
 
-        info!("calibrating lapic timer via pit channel 2 ({}ms window)", calibration_ms);
-
         // Timer vector = IDT hardware interrupt base + Timer IRQ 0.
         let timer_vector: u32 = crate::hal::arch::x86::cpu::idt::INT_OFF as u32;
 
@@ -496,31 +494,98 @@ impl UninitXapicTimer {
         // Set LAPIC timer divide-by-128.
         self.write(xapic::XAPIC_TDCR, 0x0A);
 
-        // Arm the PIT one-shot — countdown starts on return.
-        pit.arm_oneshot(calibration_ms);
+        // LAPIC timer calibration.
+        //
+        // The platform provides the host TSC base frequency (in MHz). When
+        // non-zero, an RDTSC-based spin loop is used. This eliminates ~100
+        // PIT-polling VM exits that are expensive during the first
+        // WHvRunVirtualProcessor call (WHP lazily initialises internal partition
+        // state) and removes the dependency on CPUID leaf 0x16 (unavailable on
+        // i686 guests).
+        //
+        // When the value is zero (platform does not provide it), we fall back
+        // to PIT-based calibration.
+        let base_freq: u32 = crate::hal::platform::tsc_base_frequency_mhz();
 
-        // Start the LAPIC timer counting down from max value.
-        self.write(xapic::XAPIC_TICR, 0xFFFF_FFFF);
+        // NOTE: the RDTSC path always calibrates for ~1 ms regardless of
+        // `calibration_ms`; only the PIT fallback uses that parameter.
+        let mut ticks_per_ms: u32 = if base_freq > 0 {
+            // RDTSC-based calibration (zero VM exits).
+            let tsc_freq_mhz: u64 = base_freq as u64;
+            let tsc_ticks_per_ms: u64 = tsc_freq_mhz * 1_000;
 
-        // Wait for PIT delay to elapse.
-        pit.wait_oneshot();
+            info!("calibrating lapic timer via rdtsc (tsc_freq={}mhz)", tsc_freq_mhz);
 
-        // Read remaining LAPIC timer count and compute ticks per millisecond.
-        let current_count: u32 = self.read(xapic::XAPIC_TCCR);
-        let elapsed_ticks: u32 = 0xFFFF_FFFF - current_count;
-        let mut ticks_per_ms: u32 = elapsed_ticks / calibration_ms;
-        if ticks_per_ms == 0 {
-            warn!(
-                "lapic timer calibration underflow: elapsed_ticks={elapsed_ticks}, using fallback \
-                 ticks_per_ms=1"
+            // Start the LAPIC timer counting down from max value.
+            self.write(xapic::XAPIC_TICR, 0xFFFF_FFFF);
+
+            // Spin for ~1 ms using RDTSC (zero VM exits). A max-iteration
+            // guard prevents a hang if TSC does not advance.
+            const RDTSC_MAX_ITERS: u64 = 1_000_000_000;
+            let tsc_start: u64 = ::arch::cpu::rdtsc();
+            let mut iters: u64 = 0;
+            while (::arch::cpu::rdtsc() - tsc_start) < tsc_ticks_per_ms {
+                core::hint::spin_loop();
+                iters += 1;
+                if iters >= RDTSC_MAX_ITERS {
+                    warn!("rdtsc calibration timeout after {} iterations", RDTSC_MAX_ITERS);
+                    break;
+                }
+            }
+
+            // Read remaining LAPIC count and actual TSC delta to correct for overshoot.
+            let current_count: u32 = self.read(xapic::XAPIC_TCCR);
+            let elapsed_ticks: u32 = 0xFFFF_FFFF_u32.wrapping_sub(current_count);
+            let tsc_elapsed: u64 = ::arch::cpu::rdtsc() - tsc_start;
+
+            // ticks_per_ms = elapsed × (target / actual) so the result is independent
+            // of TSC frequency errors. Guard against tsc_elapsed == 0 (TSC did not
+            // advance); the ticks_per_ms == 0 fallback below handles the result.
+            let tpm: u32 = if tsc_elapsed > 0 {
+                ((elapsed_ticks as u64 * tsc_ticks_per_ms) / tsc_elapsed) as u32
+            } else {
+                0
+            };
+
+            info!(
+                "lapic timer calibration (rdtsc): elapsed_ticks={}, ticks_per_ms={}, \
+                 tsc_freq_mhz={}",
+                elapsed_ticks, tpm, tsc_freq_mhz
             );
+            tpm
+        } else {
+            // PIT-based fallback.
+            info!(
+                "vmm tsc_freq_mhz register is zero, calibrating lapic timer via pit channel 2 \
+                 ({}ms window)",
+                calibration_ms
+            );
+
+            // Arm the PIT one-shot — countdown starts on return.
+            pit.arm_oneshot(calibration_ms);
+
+            // Start the LAPIC timer counting down from max value.
+            self.write(xapic::XAPIC_TICR, 0xFFFF_FFFF);
+
+            // Wait for PIT delay to elapse.
+            pit.wait_oneshot();
+
+            // Read remaining LAPIC timer count and compute ticks per millisecond.
+            let current_count: u32 = self.read(xapic::XAPIC_TCCR);
+            let elapsed_ticks: u32 = 0xFFFF_FFFF_u32.wrapping_sub(current_count);
+            let tpm: u32 = elapsed_ticks / calibration_ms;
+
+            info!(
+                "lapic timer calibration (pit fallback): elapsed_ticks={}, ticks_per_ms={}",
+                elapsed_ticks, tpm
+            );
+            tpm
+        };
+
+        if ticks_per_ms == 0 {
+            warn!("lapic timer calibration underflow: using fallback ticks_per_ms=1");
             ticks_per_ms = 1;
         }
-
-        info!(
-            "lapic timer calibration: elapsed_ticks={}, ticks_per_ms={}",
-            elapsed_ticks, ticks_per_ms
-        );
 
         // Enable LAPIC via spurious interrupt vector register.
         self.write(xapic::XAPIC_SVR, 0x1FF);

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -366,6 +366,18 @@ pub fn signal_boot_complete() {}
 ///
 /// # Description
 ///
+/// Returns the TSC base frequency in MHz. On hyperlight the VMM does not
+/// provide this value, so `0` is returned (callers should use a fallback
+/// calibration path).
+///
+#[allow(dead_code)]
+pub fn tsc_base_frequency_mhz() -> u32 {
+    0
+}
+
+///
+/// # Description
+///
 /// Parses boot information.
 ///
 /// # Parameters

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -453,6 +453,21 @@ unsafe fn read_control_register(offset: usize) -> u32 {
     core::ptr::read_volatile(addr)
 }
 
+///
+/// # Description
+///
+/// Returns the TSC base frequency in MHz as provided by the VMM via a
+/// microvm control register. Returns `0` when the VMM did not populate
+/// the register.
+///
+#[cfg(feature = "whp")]
+pub fn tsc_base_frequency_mhz() -> u32 {
+    // SAFETY: The control register is memory-mapped at a fixed address
+    // inside the kernel's identity-mapped region and is guaranteed to be
+    // valid on the microvm platform after ELF load.
+    unsafe { read_control_register(::config::microvm::DEFAULT_MICROVM_CTRL_TSC_FREQ_MHZ) }
+}
+
 fn register_pic_ioports(ioports: &mut IoPortAllocator) -> Result<(), Error> {
     // Register I/O ports for 8259 PIC.
     ioports.register_read_write(pic::PIC_CTRL_MASTER as u16)?;

--- a/src/libs/arch/src/x86/cpu/cpuid.rs
+++ b/src/libs/arch/src/x86/cpu/cpuid.rs
@@ -12,6 +12,8 @@
 //==================================================================================================
 
 pub const CPUID_FEATURES: u32 = 1;
+/// CPUID Leaf for Processor Frequency Information.
+pub const CPUID_FREQUENCY: u32 = 0x16;
 
 //==================================================================================================
 //  Structures
@@ -113,21 +115,22 @@ pub enum EdxFeature {
 ///
 /// # Description
 ///
-/// Executes the CPUID instruction.
+/// Executes the CPUID instruction with an explicit subleaf (ECX).
 ///
 /// # Parameters
 ///
-/// - `eax`: The value to set in the EAX register.
+/// - `eax`: The leaf to query (input EAX).
+/// - `ecx`: The subleaf selector (input ECX).
 ///
 /// # Return Values
 ///
 /// A tuple containing the values of the EAX, EBX, ECX, and EDX registers is returned.
 ///
-fn cpuid(eax: u32) -> (u32, u32, u32, u32) {
+fn cpuid_subleaf(eax: u32, ecx: u32) -> (u32, u32, u32, u32) {
     let mut eax: u32 = eax;
-    let mut ebx: u32;
-    let mut ecx: u32;
-    let mut edx: u32;
+    let ebx: u32;
+    let mut ecx: u32 = ecx;
+    let edx: u32;
 
     unsafe {
         #[cfg(target_pointer_width = "32")]
@@ -138,8 +141,8 @@ fn cpuid(eax: u32) -> (u32, u32, u32, u32) {
             "mov ebx, {ebx_backup}", // Restore ebx
             ebx_backup = out(reg) _,
             ebx_out = out(reg) ebx,
-            inout("eax") eax => eax,
-            out("ecx") ecx,
+            inout("eax") eax,
+            inout("ecx") ecx,
             out("edx") edx,
             options(nomem, preserves_flags, nostack)
         );
@@ -152,14 +155,31 @@ fn cpuid(eax: u32) -> (u32, u32, u32, u32) {
             "mov rbx, {ebx_backup}", // Restore rbx
             ebx_backup = out(reg) _,
             ebx_out = out(reg) ebx,
-            inout("eax") eax => eax,
-            out("ecx") ecx,
+            inout("eax") eax,
+            inout("ecx") ecx,
             out("edx") edx,
             options(nomem, preserves_flags, nostack)
         );
     }
 
     (eax, ebx, ecx, edx)
+}
+
+///
+/// # Description
+///
+/// Executes the CPUID instruction with subleaf 0.
+///
+/// # Parameters
+///
+/// - `eax`: The leaf to query (input EAX).
+///
+/// # Return Values
+///
+/// A tuple containing the values of the EAX, EBX, ECX, and EDX registers is returned.
+///
+fn cpuid(eax: u32) -> (u32, u32, u32, u32) {
+    cpuid_subleaf(eax, 0)
 }
 
 ///
@@ -726,4 +746,26 @@ pub fn has_pbe() -> bool {
     let (_, _, _, edx): (u32, u32, u32, u32) = cpuid(CPUID_FEATURES);
 
     (edx & EdxFeature::Pbe as u32) != 0
+}
+
+///
+/// # Description
+///
+/// Gets the processor base frequency from CPUID leaf 0x16.
+///
+/// # Return Values
+///
+/// The processor base frequency in MHz, or 0 if not supported.
+///
+pub fn get_base_frequency_mhz() -> u32 {
+    let (max_basic_leaf, _, _, _): (u32, u32, u32, u32) = cpuid(0);
+
+    if max_basic_leaf < CPUID_FREQUENCY {
+        return 0;
+    }
+
+    let (eax, _, _, _): (u32, u32, u32, u32) = cpuid_subleaf(CPUID_FREQUENCY, 0);
+
+    // EAX contains the processor base frequency in MHz.
+    eax
 }

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -251,6 +251,11 @@ pub mod microvm {
     /// Default base address for RAMFS size register (32-bit wide read-only register)
     pub const DEFAULT_MICROVM_CTRL_RAMFS_SIZE: usize = 0x00000010;
 
+    /// Default base address for TSC base frequency register (32-bit wide read-only register).
+    /// The VMM writes the host TSC base frequency (in MHz) here before boot so the kernel
+    /// can use RDTSC-based LAPIC timer calibration without requiring CPUID leaf 0x16.
+    pub const DEFAULT_MICROVM_CTRL_TSC_FREQ_MHZ: usize = 0x00000014;
+
     /// Magic value that identifies the running state in the pause-requested register.
     pub const RUNNING: u32 = 0x00000000;
 

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -431,6 +431,15 @@ impl Vmm {
 
             RamFs::write_registers(&mut vmem, ramfs_region)?;
 
+            // Write host TSC base frequency so the guest can use RDTSC-based LAPIC
+            // timer calibration without requiring CPUID leaf 0x16.
+            let tsc_freq_mhz: u32 = ::arch::cpu::cpuid::get_base_frequency_mhz();
+            vmem.write_bytes(
+                ::config::microvm::DEFAULT_MICROVM_CTRL_TSC_FREQ_MHZ as u64,
+                &tsc_freq_mhz.to_le_bytes(),
+            )?;
+            trace!("ctrl: tsc_freq_mhz={tsc_freq_mhz}");
+
             #[cfg(feature = "profile-time")]
             perf_timings.set_ramfs_load(ramfs_load_start.elapsed().as_micros() as u64);
 

--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -452,6 +452,15 @@ impl Vmm {
 
             ramfs::RamFs::write_registers(&mut vmem, ramfs_region)?;
 
+            // Write host TSC base frequency so the guest can use RDTSC-based LAPIC
+            // timer calibration without requiring CPUID leaf 0x16.
+            let tsc_freq_mhz: u32 = ::arch::cpu::cpuid::get_base_frequency_mhz();
+            vmem.write_bytes(
+                ::config::microvm::DEFAULT_MICROVM_CTRL_TSC_FREQ_MHZ as u64,
+                &tsc_freq_mhz.to_le_bytes(),
+            )?;
+            trace!("ctrl: tsc_freq_mhz={tsc_freq_mhz}");
+
             #[cfg(feature = "profile-time")]
             perf_timings.set_ramfs_load(ramfs_load_start.elapsed().as_micros() as u64);
 


### PR DESCRIPTION
## Summary
Optimize LAPIC timer calibration on WHP to reduce cold-start latency.

## Changes
- **Reduce LAPIC calibration delay** — reduce PIT-based calibration window from 10 ms to 1 ms (~9 ms saving).
- **RDTSC LAPIC calibration on WHP** — replace PIT-based calibration with an RDTSC spin loop, eliminating ~100 PIT-polling VM exits during boot. Uses project cpuid helper (`get_base_frequency_mhz()`) for leaf 0x16.

## Split from
Split from PR #1861.