### PR TITLE
[kernel] Bulk identity page table fill

### DIFF
--- a/src/kernel/src/hal/arch/x86/mem/mmu/page_table.rs
+++ b/src/kernel/src/hal/arch/x86/mem/mmu/page_table.rs
@@ -309,6 +309,105 @@ impl<T: DerefMut<Target = [u32]>> PageTable<T> {
         Ok(())
     }
 
+    ///
+    /// # Description
+    ///
+    /// Bulk-fills page table entries for contiguous identity-mapped physical memory.
+    ///
+    /// Each entry maps physical frame `base_frame + i` with the given PTE flags.
+    ///
+    /// # Parameters
+    ///
+    /// - `start_index`: First entry index to fill (0–1023).
+    /// - `count`: Number of consecutive entries to fill.
+    /// - `base_address`: Page-aligned physical address of the first frame.
+    /// - `pte_flags`: Strongly typed PTE flags.
+    /// - `skip_pte_verification`: If `true`, skip the check that all target entries are not
+    ///   present.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the number of frames mapped is returned and the page table entries are
+    /// filled. Upon failure, a tuple containing the number of frames that were successfully
+    /// mapped before the error and the error itself is returned.
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidArgument` if `start_index + count` overflows or exceeds the table length.
+    /// - `InvalidArgument` if the present bit is not set in `pte_flags`.
+    /// - `InvalidArgument` if a frame number exceeds the valid range.
+    /// - `ResourceBusy` if any target entry is already present (unless `skip_pte_verification` is
+    ///   `true`).
+    ///
+    /// # Notes
+    ///
+    /// - Entries written before a mid-fill error are not rolled back.
+    ///
+    pub fn fill(
+        &mut self,
+        start_index: usize,
+        count: usize,
+        base_address: FrameAddress,
+        pte_flags: PageTableEntryFlags,
+        skip_pte_verification: bool,
+    ) -> Result<usize, (usize, Error)> {
+        // Bounds check.
+        let end: usize = start_index.checked_add(count).ok_or_else(|| {
+            let reason: &str = "index overflow";
+            error!("fill(): {}", reason);
+            (0, Error::new(ErrorCode::InvalidArgument, reason))
+        })?;
+        if end > self.entries.len() {
+            let reason: &str = "index out of bounds";
+            error!(
+                "fill(): {} (start_index={}, count={}, entries_len={})",
+                reason,
+                start_index,
+                count,
+                self.entries.len()
+            );
+            return Err((0, Error::new(ErrorCode::InvalidArgument, reason)));
+        }
+
+        // Validate that the present bit is set.
+        if !pte_flags.is_present() {
+            let reason: &str = "present bit not set in pte_flags";
+            error!("fill(): {}", reason);
+            return Err((0, Error::new(ErrorCode::InvalidArgument, reason)));
+        }
+
+        // Verify that all target entries are not present.
+        if !skip_pte_verification {
+            for entry in &self.entries[start_index..end] {
+                if PresentFlag::is_set(*entry) {
+                    let reason: &str = "page table entry is busy";
+                    error!("fill(): {}", reason);
+                    return Err((0, Error::new(ErrorCode::ResourceBusy, reason)));
+                }
+            }
+        }
+
+        // Build and write each page table entry.
+        let base_frame: FrameNumber = base_address.into_frame_number();
+        for i in 0..count {
+            let raw_frame: usize = base_frame.into_raw_value().checked_add(i).ok_or_else(|| {
+                let reason: &str = "frame number overflow";
+                error!("fill(): {}", reason);
+                (i, Error::new(ErrorCode::InvalidArgument, reason))
+            })?;
+            let frame: FrameNumber = FrameNumber::from_raw_value(raw_frame).ok_or_else(|| {
+                let reason: &str = "frame number out of range";
+                error!("fill(): {}", reason);
+                (i, Error::new(ErrorCode::InvalidArgument, reason))
+            })?;
+            let pte: PageTableEntry = PageTableEntry::new(pte_flags, frame);
+            self.entries[start_index + i] = pte.into_raw_value();
+            self.nmapped += 1;
+        }
+
+        Ok(count)
+    }
+
     fn clean(&mut self) {
         for pte in self.entries.iter_mut() {
             *pte = 0;

--- a/src/kernel/src/mm/virt/mod.rs
+++ b/src/kernel/src/mm/virt/mod.rs
@@ -36,7 +36,17 @@ use ::alloc::{
 use ::arch::{
     mem,
     mem::{
-        paging::PageTableEntry,
+        paging::{
+            AccessedFlag,
+            DirtyFlag,
+            PageCacheDisableFlag,
+            PageTableEntry,
+            PageTableEntryFlags,
+            PageWriteThroughFlag,
+            PresentFlag,
+            ReadWriteFlag,
+            UserSupervisorFlag,
+        },
         PGTAB_ALIGNMENT,
     },
 };
@@ -332,34 +342,75 @@ pub fn init(
                     (PageTableAddress::new(page_table_addr), page_table)
                 };
 
-            // FIXME: do not be so open about permissions and caching.
-            page_table.map(
-                PageAddress::new(PageAligned::from_raw_value(raw_vaddr)?),
-                paddr,
-                true,
-                true,
-                false,
-                AccessPermission::RDWR,
-            )?;
-            root_pagetables.push_back((page_table_addr, page_table));
-            if raw_vaddr == (config::kernel::MEMORY_SIZE - mem::PAGE_SIZE) {
-                break;
-            }
-            raw_vaddr += mem::PAGE_SIZE;
-            paddr = match region.typ() {
-                MemoryRegionType::Mmio => {
+            if region.typ() != MemoryRegionType::Mmio {
+                // Bulk identity fill: map all pages in this page table at once.
+                // FIXME: do not be so open about permissions and caching.
+                let pgtab_base: usize = ::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT);
+                let start_index: usize = (raw_vaddr - pgtab_base) / mem::PAGE_SIZE;
+                let pgtab_remaining: usize = PAGE_TABLE_LENGTH - start_index;
+                let region_remaining: usize = (end - raw_vaddr) / mem::PAGE_SIZE + 1;
+                let memory_remaining: usize =
+                    config::kernel::MEMORY_SIZE.saturating_sub(raw_vaddr) / mem::PAGE_SIZE;
+                let count: usize = pgtab_remaining.min(region_remaining).min(memory_remaining);
+
+                if count == 0 {
+                    break;
+                }
+
+                let fill_count: usize = page_table
+                    .fill(
+                        start_index,
+                        count,
+                        FrameAddress::from_raw_value(raw_vaddr)?,
+                        PageTableEntryFlags::new(
+                            PresentFlag::Present,
+                            ReadWriteFlag::ReadWrite,
+                            UserSupervisorFlag::Supervisor,
+                            PageWriteThroughFlag::WriteThrough,
+                            PageCacheDisableFlag::CacheDisabled,
+                            AccessedFlag::NotAccessed,
+                            DirtyFlag::NotDirty,
+                        ),
+                        false,
+                    )
+                    .map_err(|(_count, e)| e)?;
+                debug_assert!(fill_count == count, "fill_count ({fill_count}) != count ({count})");
+
+                root_pagetables.push_back((page_table_addr, page_table));
+                // NOTE: `count` is bounded by `memory_remaining`, so this cannot overflow.
+                raw_vaddr += count
+                    .checked_mul(mem::PAGE_SIZE)
+                    .expect("count * PAGE_SIZE overflow");
+                if raw_vaddr >= config::kernel::MEMORY_SIZE {
+                    break;
+                }
+                paddr = FrameAddress::new(PageAligned::from_address(
+                    PhysicalAddress::from_raw_value(raw_vaddr)?,
+                )?);
+            } else {
+                // MMIO: per-page mapping with address translation.
+                // FIXME: do not be so open about permissions and caching.
+                page_table.map(
+                    PageAddress::new(PageAligned::from_raw_value(raw_vaddr)?),
+                    paddr,
+                    true,
+                    true,
+                    false,
+                    AccessPermission::RDWR,
+                )?;
+                root_pagetables.push_back((page_table_addr, page_table));
+                if raw_vaddr == (config::kernel::MEMORY_SIZE - mem::PAGE_SIZE) {
+                    break;
+                }
+                raw_vaddr += mem::PAGE_SIZE;
+                paddr = {
                     let mmio_addr: VirtualAddress = VirtualAddress::new(raw_vaddr);
                     let phys_addr: PhysicalAddress =
-                    // FIXME: ensure safety here.
-                    unsafe { PhysicalAddress::from_mmio_address(mmio_addr)? };
-                    let page_aligned_phys_addr: PageAligned<PhysicalAddress> =
-                        PageAligned::from_address(phys_addr)?;
-                    FrameAddress::new(page_aligned_phys_addr)
-                },
-                _ => FrameAddress::new(PageAligned::from_address(
-                    PhysicalAddress::from_raw_value(raw_vaddr)?,
-                )?),
-            };
+                        // FIXME: ensure safety here.
+                        unsafe { PhysicalAddress::from_mmio_address(mmio_addr)? };
+                    FrameAddress::new(PageAligned::from_address(phys_addr)?)
+                };
+            }
         }
     }
 

--- a/src/libs/arch/src/x86/mem/paging/flags.rs
+++ b/src/libs/arch/src/x86/mem/paging/flags.rs
@@ -10,7 +10,7 @@
 ///
 /// A type that represents the present flag of a page table entry.
 ///
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum PresentFlag {
     /// The page table entry is not present.
     NotPresent = 0,
@@ -23,7 +23,7 @@ pub enum PresentFlag {
 ///
 /// A type that represents the read/write flag of a page table entry.
 ///
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum ReadWriteFlag {
     /// The page table entry is read-only.
     ReadOnly = 0,
@@ -36,7 +36,7 @@ pub enum ReadWriteFlag {
 ///
 /// A type that represents the user/supervisor flag of a page table entry.
 ///
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum UserSupervisorFlag {
     /// The page table entry is for supervisor mode.
     Supervisor = 0,
@@ -49,7 +49,7 @@ pub enum UserSupervisorFlag {
 ///
 /// A type that represents the page write-through flag of a page table entry.
 ///
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum PageWriteThroughFlag {
     /// The page table entry is not write-through.
     NotWriteThrough = 0,
@@ -62,7 +62,7 @@ pub enum PageWriteThroughFlag {
 ///
 /// A type that represents the page cache disable flag of a page table entry.
 ///
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum PageCacheDisableFlag {
     /// The page table entry is not cache disabled.
     CacheEnabled = 0,
@@ -75,7 +75,7 @@ pub enum PageCacheDisableFlag {
 ///
 /// A type that represents the accessed flag of a page table entry.
 ///
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum AccessedFlag {
     /// The page table entry has not been accessed.
     NotAccessed = 0,
@@ -88,7 +88,7 @@ pub enum AccessedFlag {
 ///
 /// A type that represents the dirty flag of a page table entry.
 ///
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum DirtyFlag {
     /// The page table entry has not been written.
     NotDirty = 0,
@@ -115,6 +115,12 @@ impl PresentFlag {
 
     pub fn into_raw_value(self) -> u32 {
         self as u32
+    }
+
+    /// Checks if the present bit is set in a raw page table entry value.
+    #[inline(always)]
+    pub fn is_set(raw_entry: u32) -> bool {
+        raw_entry & Self::MASK != 0
     }
 }
 

--- a/src/libs/arch/src/x86/mem/paging/pte.rs
+++ b/src/libs/arch/src/x86/mem/paging/pte.rs
@@ -30,7 +30,7 @@ use crate::{
 ///
 /// A type that represents flags of a page table entry.
 ///
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct PageTableEntryFlags {
     /// Present flag.
     present: PresentFlag,
@@ -134,6 +134,23 @@ impl PageTableEntryFlags {
         value |= self.dirty.into_raw_value();
 
         value
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks if the present flag is set.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the present flag is set, `false` otherwise.
+    ///
+    #[inline(always)]
+    pub fn is_present(&self) -> bool {
+        match self.present {
+            PresentFlag::Present => true,
+            PresentFlag::NotPresent => false,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Add `PageTable::fill()` for batch PTE writes during boot-time identity mapping, replacing the per-page `map()` loop for non-MMIO memory regions.

## Changes

### `page_table.rs`

- Add `PresentFlag::is_set()` to query the present bit from a raw PTE value.
- Add `PageTableEntryFlags::is_present()` to check whether the present flag is set.
- Add `PageTable::fill()` that bulk-writes contiguous identity-mapped PTEs using strongly typed `PageTableEntryFlags`. Validates bounds, present-bit in flags, and entry availability upfront. Returns mapped count or a partial count with error on mid-fill failure (no rollback).

### `mm/virt/mod.rs`

- Split the init loop by region type: non-MMIO regions use `fill()` to map up to a full page table at once; MMIO regions keep the existing per-page `map()` path with address translation via `from_mmio_address()`.
- Compute `count` from page-table remaining slots, region remaining pages, and memory ceiling to advance `raw_vaddr` by a full batch per iteration.

## Split from

Split from PR #1861.