### PR TITLE
[scripts] Remove outdated VS Code settings

### DIFF
--- a/scripts/setup/vscode/settings-linux.json
+++ b/scripts/setup/vscode/settings-linux.json
@@ -3,8 +3,6 @@
 // How to use:
 // 1. Create a folder named '.vscode' in the root of your Nanvix workspace.
 // 2. Copy this file into the '.vscode' folder as 'settings.json'.
-// 3. Ensure the "C_Cpp.default.compilerPath" setting below points to the GCC binary of your Nanvix
-//    toolchain.
 {
     //==============================================================================================
     // Editor Settings
@@ -26,10 +24,7 @@
     "files.exclude": {
         "**/__pycache__/**": true,
         "target/**": true,
-        "**/*.d": true,
-        "**/*.elf": true,
-        "**/*.o": true,
-        "**/*.out": true
+        "**/*.elf": true
     },
     //==============================================================================================
     // Rust Analyzer Settings
@@ -39,26 +34,7 @@
     "rust-analyzer.check.overrideCommand": [
         "./z",
         "build",
-        "--with-cached-options",
         "--",
         "check"
-    ],
-    //==============================================================================================
-    // C/C++ Settings
-    //==============================================================================================
-    "C_Cpp.default.compilerPath": "${workspaceFolder}/toolchain/bin/i686-nanvix-gcc",
-    "C_Cpp.files.exclude": {
-        "sysroot-*/**": true
-    },
-    //==============================================================================================
-    // Assembly Settings
-    //==============================================================================================
-    "[asm-intel-x86-generic]": {
-        "vim.textwidth": 80,
-        "editor.rulers": [
-            80
-        ],
-        "editor.tabSize": 4,
-        "editor.insertSpaces": true
-    }
+    ]
 }

--- a/scripts/setup/vscode/settings-windows.json
+++ b/scripts/setup/vscode/settings-windows.json
@@ -16,8 +16,6 @@
 //   nanvixd, nanvix-test, and mkramfs.
 //   Guest and kernel crates are checked via cross-compilation targets like 'check-kernel' and
 //   'check-guest-binaries'; invoke them manually with 'z.ps1 build -- <target>' when needed.
-// - 'C_Cpp.default.compilerPath' is intentionally omitted here because the guest cross-toolchain is not
-//   installed natively on Windows by default.
 {
     //==============================================================================================
     // Editor Settings
@@ -42,10 +40,7 @@
     "files.exclude": {
         "**/__pycache__/**": true,
         "target/**": true,
-        "**/*.d": true,
-        "**/*.elf": true,
-        "**/*.o": true,
-        "**/*.out": true
+        "**/*.elf": true
     },
     //==============================================================================================
     // Rust Analyzer Settings
@@ -74,16 +69,5 @@
     ],
     "rust-analyzer.cargo.features": [
         "standalone"
-    ],
-    //==============================================================================================
-    // Assembly Settings
-    //==============================================================================================
-    "[asm-intel-x86-generic]": {
-        "vim.textwidth": 80,
-        "editor.rulers": [
-            80
-        ],
-        "editor.tabSize": 4,
-        "editor.insertSpaces": true
-    }
+    ]
 }


### PR DESCRIPTION
## Summary

Remove outdated C/C++, assembly, and build-tool settings from VS Code configuration templates. The codebase is now fully Rust, so these entries no longer apply.

## Changes

### `settings-linux.json`
- Remove `--with-cached-options` from `rust-analyzer.check.overrideCommand` (no longer supported by `z`).
- Remove `C_Cpp.default.compilerPath` and `C_Cpp.files.exclude` settings.
- Remove `[asm-intel-x86-generic]` language-specific overrides.
- Remove C build artifact patterns (`*.d`, `*.o`, `*.out`) from `files.exclude`.
- Remove header comment referencing GCC compiler path setup.

### `settings-windows.json`
- Remove comment about `C_Cpp.default.compilerPath` being intentionally omitted.
- Remove `[asm-intel-x86-generic]` language-specific overrides.
- Remove C build artifact patterns (`*.d`, `*.o`, `*.out`) from `files.exclude`.