### PR TITLE
[scripts] Gate setup behind opt-in flags

### DIFF
--- a/.github/actions/native-setup/action.yml
+++ b/.github/actions/native-setup/action.yml
@@ -33,44 +33,14 @@ runs:
     - name: "Install System Dependencies"
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends \
-          codespell \
-          pkg-config \
-          python3-venv \
-          shellcheck
+        if [ "${{ inputs.install-cloud-hypervisor }}" = "true" ]; then
+          ./z setup --l2-deployment
+        else
+          ./z setup
+        fi
 
     - name: "Setup Python Environment"
       shell: bash
       run: |
         python3 -m venv .venv
         .venv/bin/pip install --quiet -r requirements.txt
-
-    - name: "Create Cloud-Hypervisor Directory"
-      shell: bash
-      run: |
-        CLH_DIR="${HOME}/toolchain"
-        mkdir -p "${CLH_DIR}/bin"
-        echo "[INFO] Created cloud-hypervisor directory at ${CLH_DIR}"
-
-    - name: "Build Cloud-Hypervisor"
-      if: inputs.install-cloud-hypervisor == 'true'
-      shell: bash
-      run: |
-        CLH_DIR="${HOME}/toolchain"
-        # Build only cloud-hypervisor (skip Linux kernel build).
-        CLOUD_HYPERVISOR_COMMIT="4681d5eba0e63fb010bf4ca962eb3c9f163d3288"
-        CLOUD_HYPERVISOR_REPO="https://github.com/nanvix/cloud-hypervisor"
-        SRC_DIR="${RUNNER_TEMP}/cloud-hypervisor-src"
-
-        git clone "${CLOUD_HYPERVISOR_REPO}" "${SRC_DIR}"
-        pushd "${SRC_DIR}"
-        git checkout "${CLOUD_HYPERVISOR_COMMIT}"
-        cargo build --release
-        cp ./target/release/cloud-hypervisor "${CLH_DIR}/bin/cloud-hypervisor"
-        cp ./target/release/ch-remote "${CLH_DIR}/bin/ch-remote"
-        # Set CAP_NET_ADMIN for TAP device creation without sudo.
-        sudo setcap cap_net_admin+ep "${CLH_DIR}/bin/cloud-hypervisor" || true
-        popd
-        rm -rf "${SRC_DIR}"
-        echo "[INFO] Cloud-hypervisor installed to ${CLH_DIR}/bin/"

--- a/.github/skills/troubleshooting/SKILL.md
+++ b/.github/skills/troubleshooting/SKILL.md
@@ -58,7 +58,7 @@ There is also a cleanup script for `nanvixd` resources:
 ```bash
 ls -la toolchain/
 # If missing, rebuild:
-./z setup --toolchain-dir $HOME/toolchain
+./z setup --nanvix-sdk --toolchain-dir $HOME/toolchain
 ln -s $HOME/toolchain toolchain
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ See [doc/setup.md](doc/setup.md) for full environment setup. The quickest path:
 
 ```bash
 git clone https://github.com/nanvix/nanvix.git && cd nanvix
-./z setup --toolchain-dir $HOME/toolchain
+./z setup --nanvix-sdk --toolchain-dir $HOME/toolchain
 ln -T -s $HOME/toolchain toolchain
 ./z build -- all
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Requires Ubuntu 24.04 with sudo privileges and
 git clone https://github.com/nanvix/nanvix.git && cd nanvix
 
 # Setup the development environment.
-./z setup --toolchain-dir $HOME/toolchain
+./z setup --nanvix-sdk --toolchain-dir $HOME/toolchain
 ln -T -s $HOME/toolchain toolchain
 
 # Build Nanvix.

--- a/doc/setup-linux.md
+++ b/doc/setup-linux.md
@@ -36,8 +36,8 @@ cd nanvix                                       # Navigate to the Nanvix source 
 
 ```bash
 # Ensure you are in the project's root directory.
-cat ./scripts/setup/ubuntu.sh      # Review the installation script.
-sudo -E ./scripts/setup/ubuntu.sh  # Run the script to install dependencies.
+cat ./scripts/setup/ubuntu-core.sh      # Review the installation script.
+sudo -E ./scripts/setup/ubuntu-core.sh  # Run the script to install core dependencies.
 ```
 
 ## 4. Setup KVM
@@ -117,12 +117,18 @@ exec $SHELL
 
 ```bash
 # Ensure you are in the project's root directory.
-./z setup --toolchain-dir $HOME/toolchain    # Build the cross compiler toolchain and place it in $HOME/toolchain.
-ln -T -s $HOME/toolchain toolchain           # Create symbolic link for toolchain for convenience.
+./z setup --nanvix-sdk --toolchain-dir $HOME/toolchain    # Build the cross compiler toolchain and place it in $HOME/toolchain.
+ln -T -s $HOME/toolchain toolchain                        # Create symbolic link for toolchain for convenience.
 ```
 
 > **Note:** The toolchain directory must be located outside the repository root.
-> Use `./z setup --toolchain-dir <path>` to specify a valid location.
+> Use `./z setup --nanvix-sdk --toolchain-dir <path>` to specify a valid location.
+>
+> To also build Cloud Hypervisor for L2 deployment, add `--l2-deployment`:
+>
+> ```bash
+> ./z setup --nanvix-sdk --l2-deployment --toolchain-dir $HOME/toolchain
+> ```
 
 ## 8. Updating Your Development Tools
 

--- a/scripts/setup-nanvix.sh
+++ b/scripts/setup-nanvix.sh
@@ -10,7 +10,8 @@ echo "Using NANVIX_DIR=${NANVIX_DIR}"
 
 echo "=== Step 1: Install system dependencies ==="
 cd "${NANVIX_DIR}"
-sudo -E ./scripts/setup/ubuntu.sh
+sudo -E ./scripts/setup/ubuntu-core.sh
+sudo -E ./scripts/setup/ubuntu-sdk.sh
 
 echo "=== Step 2: Install sccache ==="
 SCCACHE_VERSION="v0.10.0"
@@ -26,7 +27,7 @@ export RUSTC_WRAPPER=sccache
 
 echo "=== Step 3: Build cross-compiler toolchain ==="
 cd "${NANVIX_DIR}"
-./z setup --toolchain-dir $HOME/toolchain
+./z setup --nanvix-sdk --toolchain-dir $HOME/toolchain
 ln -T -sf $HOME/toolchain toolchain
 
 echo "=== Step 4: Build Nanvix ==="

--- a/scripts/setup/Dockerfile
+++ b/scripts/setup/Dockerfile
@@ -37,7 +37,8 @@ RUN git clone https://github.com/nanvix/nanvix /opt/nanvix/src/nanvix && \
 
 # Install dependencies for development tools.
 RUN cd /opt/nanvix/src/nanvix && \
-    ./scripts/setup/ubuntu.sh
+    ./scripts/setup/ubuntu-core.sh && \
+    ./scripts/setup/ubuntu-sdk.sh
 
 # Install Rust.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -55,4 +56,4 @@ RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_
 
 # Build toolchain.
 RUN cd /opt/nanvix/src/nanvix && \
-    ./z setup --toolchain-dir /opt/nanvix
+    ./z setup --nanvix-sdk --l2-deployment --toolchain-dir /opt/nanvix

--- a/scripts/setup/Dockerfile.optimized
+++ b/scripts/setup/Dockerfile.optimized
@@ -22,12 +22,14 @@ USER $USER
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
-# Install runtime and build dependencies via shared setup script (keeps parity with full image).
-COPY --from=source /opt/nanvix/src/nanvix/scripts/setup/ubuntu.sh /tmp/ubuntu.sh
+# Install runtime and build dependencies via shared setup scripts (keeps parity with full image).
+COPY --from=source /opt/nanvix/src/nanvix/scripts/setup/ubuntu-core.sh /tmp/ubuntu-core.sh
+COPY --from=source /opt/nanvix/src/nanvix/scripts/setup/ubuntu-sdk.sh /tmp/ubuntu-sdk.sh
 
 RUN apt-get update && \
-    chmod +x /tmp/ubuntu.sh && \
-    /bin/bash /tmp/ubuntu.sh && \
+    chmod +x /tmp/ubuntu-core.sh /tmp/ubuntu-sdk.sh && \
+    /bin/bash /tmp/ubuntu-core.sh && \
+    /bin/bash /tmp/ubuntu-sdk.sh && \
     # Remove bulky docs/icons/themes that are unnecessary in the runtime image.
     apt-get purge -y --auto-remove man-db doc-base ubuntu-mono adwaita-icon-theme humanity-icon-theme hicolor-icon-theme fonts-dejavu-core fonts-dejavu-mono && \
     apt-get clean && \

--- a/scripts/setup/toolchain.sh
+++ b/scripts/setup/toolchain.sh
@@ -263,15 +263,6 @@ rm -rf "${CONTRIB_DIR}/cpython" || {
     print_warning "Failed to remove Python source directory '${CONTRIB_DIR}/cpython'."
 }
 
-# Clone, build and cleanup Cloud Hypervisor.
-"${SCRIPTS_DIR}/cloud-hypervisor.sh" "${PREFIX}" || {
-    print_error "Failed to build Cloud Hypervisor."
-    exit 1
-}
-rm -rf "${CONTRIB_DIR}/cloud-hypervisor*" || {
-    print_warning "Failed to remove Cloud Hypervisor source directory '${CONTRIB_DIR}/cloud-hypervisor'."
-}
-
 # Create version file as the final step.
 current_version=$(get_cargo_toml_version "$CARGO_TOML_FILE_PATH")
 major=$(echo "$current_version" | cut -d. -f1)

--- a/scripts/setup/ubuntu-core.sh
+++ b/scripts/setup/ubuntu-core.sh
@@ -12,11 +12,10 @@ apt-get update
 # Install build-essential by default.
 apt-get install -y build-essential --no-install-recommends
 
-# Install additional packages.
+# Install core development packages needed to build, run, and test Nanvix.
 # Keep the following list of packages sorted alphabetically.
 apt-get install -y        \
     bc                    \
-    bison                 \
     bridge-utils          \
     build-essential       \
     bzip2                 \
@@ -26,10 +25,7 @@ apt-get install -y        \
     curl                  \
     dosfstools            \
     doxygen               \
-    flex                  \
-    g++-multilib          \
     gawk                  \
-    gcc-multilib          \
     gdb-multiarch         \
     git                   \
     graphviz              \
@@ -37,15 +33,6 @@ apt-get install -y        \
     iproute2              \
     jq                    \
     kpartx                \
-    libelf-dev            \
-    libglib2.0-dev        \
-    libgmp-dev            \
-    libgmp3-dev           \
-    libmpc-dev            \
-    libmpfr-dev           \
-    libncurses5-dev       \
-    libpixman-1-dev       \
-    libsdl2-dev           \
     libvirt-clients       \
     libvirt-daemon-system \
     mmdebstrap            \
@@ -55,7 +42,6 @@ apt-get install -y        \
     pkg-config            \
     python3-venv          \
     shellcheck            \
-    texinfo               \
     unzip                 \
     wget                  \
     xorriso

--- a/scripts/setup/ubuntu-l2.sh
+++ b/scripts/setup/ubuntu-l2.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright(c) 2011-2024 The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Prevent debconf prompts from blocking the script (e.g., grub2 install dialog).
+export DEBIAN_FRONTEND=noninteractive
+
+# Update package repository.
+apt-get update
+
+# Install packages required to build Cloud Hypervisor and the L2 system VM
+# kernel from source.
+# Keep the following list of packages sorted alphabetically.
+apt-get install -y        \
+    bison                 \
+    flex                  \
+    libelf-dev            \
+    libssl-dev

--- a/scripts/setup/ubuntu-sdk.sh
+++ b/scripts/setup/ubuntu-sdk.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright(c) 2011-2024 The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Prevent debconf prompts from blocking the script (e.g., grub2 install dialog).
+export DEBIAN_FRONTEND=noninteractive
+
+# Update package repository.
+apt-get update
+
+# Install packages required to build the Nanvix cross-compilation toolchain
+# (Binutils, GCC, Newlib, LLVM, custom Rust, CPython) from source.
+# Keep the following list of packages sorted alphabetically.
+apt-get install -y        \
+    bison                 \
+    flex                  \
+    g++-multilib          \
+    gcc-multilib          \
+    libelf-dev            \
+    libglib2.0-dev        \
+    libgmp-dev            \
+    libgmp3-dev           \
+    libmpc-dev            \
+    libmpfr-dev           \
+    libncurses5-dev       \
+    libpixman-1-dev       \
+    libsdl2-dev           \
+    texinfo

--- a/z.py
+++ b/z.py
@@ -233,6 +233,10 @@ class BuildConfig:
     timestamp_msg: bool = False
     whp: bool = False
 
+    nanvix_sdk: bool = False
+    l2_deployment: bool = False
+    _user_set_toolchain_dir: bool = False
+
     toolchain_dir: str = ""
     sysroot_dir: str = ""
     host_cpu: str = ""
@@ -367,11 +371,16 @@ def parse_cli(argv: Sequence[str]) -> tuple[str, BuildConfig]:
             config.profiler = True
         elif arg == "--release":
             config.release = True
+        elif arg == "--nanvix-sdk":
+            config.nanvix_sdk = True
+        elif arg == "--l2-deployment":
+            config.l2_deployment = True
         elif arg == "--toolchain-dir":
             i += 1
             if i >= len(argv_list):
                 die("--toolchain-dir requires a path argument.")
             config.toolchain_dir = argv_list[i]
+            config._user_set_toolchain_dir = True
         elif arg.startswith("--"):
             die(f"Unknown option: {arg}")
         else:
@@ -904,6 +913,8 @@ Commands:
 Options:
   --profile             Enable profiling (implies --release, passes PROFILER=yes).
   --release             Build in release mode.
+  --nanvix-sdk          Build the Nanvix cross-compilation toolchain (setup only, Linux).
+  --l2-deployment       Build Cloud Hypervisor for L2 deployment (setup only, Linux).
   --toolchain-dir DIR   Toolchain directory (setup only, Linux, default: ~/toolchain).
 
 Build Parameters (after --):
@@ -927,7 +938,10 @@ Examples:
   z.ps1 build -- guest                    Cross-compile guest only.
   ./z test                                Run all tests.
   ./z clean                               Clean build artifacts.
-  ./z setup --toolchain-dir ~/toolchain   Install dev prerequisites.
+  ./z setup                                Install core dev prerequisites.
+  ./z setup --nanvix-sdk                   Also build the cross-compilation toolchain.
+  ./z setup --l2-deployment                Also build Cloud Hypervisor for L2.
+  ./z setup --nanvix-sdk --l2-deployment   Full setup including SDK and L2 support.
 """
 
 
@@ -977,48 +991,95 @@ def cmd_setup_linux(plat: PlatformInfo, config: BuildConfig) -> int:
     """Set up the development environment on Linux."""
     print_info("Setting up Nanvix development environment...")
 
-    # Install system dependencies.
-    ubuntu_script = plat.repo_root / "scripts" / "setup" / "ubuntu.sh"
-    if ubuntu_script.exists():
-        print_info("Installing development dependencies (requires sudo)...")
-        rc = subprocess.run(["sudo", str(ubuntu_script)]).returncode
-        if rc != 0:
-            die("Failed to install development dependencies.")
-    else:
-        print_warning(f"Setup script not found: {ubuntu_script}")
-
-    # Validate toolchain directory.
-    print_info(f"Toolchain directory: {config.toolchain_dir}")
-    validate_toolchain_dir_location(config.toolchain_dir, plat.repo_root)
-
-    tc_dir = Path(config.toolchain_dir)
-    if not tc_dir.exists():
-        print_info(f"Creating toolchain directory: {tc_dir}")
-        tc_dir.mkdir(parents=True, exist_ok=True)
-
-    if not os.access(str(tc_dir), os.W_OK):
-        die(f"No write permissions to: {tc_dir}")
-
-    if not check_filesystem_support(str(tc_dir)):
-        die(
-            f"Toolchain directory '{tc_dir}' is not on a supported file system"
-            " (ext3/ext4/overlay)."
-        )
-
-    if any(tc_dir.iterdir()):
+    # Warn if --toolchain-dir is provided without an opt-in flag.
+    if (
+        config._user_set_toolchain_dir
+        and not config.nanvix_sdk
+        and not config.l2_deployment
+    ):
         print_warning(
-            f"Toolchain directory is not empty: {tc_dir}. Existing files may be overwritten."
+            "--toolchain-dir has no effect without --nanvix-sdk or --l2-deployment."
         )
 
-    # Run toolchain setup.
-    toolchain_script = plat.repo_root / "scripts" / "setup" / "toolchain.sh"
-    if not toolchain_script.exists():
-        die(f"Toolchain setup script not found: {toolchain_script}")
+    # Always install core system dependencies.
+    core_script = plat.repo_root / "scripts" / "setup" / "ubuntu-core.sh"
+    if core_script.exists():
+        print_info("Installing core development dependencies (requires sudo)...")
+        rc = subprocess.run(["sudo", str(core_script)]).returncode
+        if rc != 0:
+            die("Failed to install core development dependencies.")
+    else:
+        print_warning(f"Setup script not found: {core_script}")
 
-    print_info(f"Running setup script: {toolchain_script}")
-    rc = subprocess.run([str(toolchain_script), str(tc_dir)]).returncode
-    if rc != 0:
-        die("Toolchain setup failed.")
+    # Install SDK-specific packages when building the cross-compilation toolchain.
+    if config.nanvix_sdk:
+        sdk_script = plat.repo_root / "scripts" / "setup" / "ubuntu-sdk.sh"
+        if sdk_script.exists():
+            print_info("Installing SDK development dependencies (requires sudo)...")
+            rc = subprocess.run(["sudo", str(sdk_script)]).returncode
+            if rc != 0:
+                die("Failed to install SDK development dependencies.")
+        else:
+            print_warning(f"Setup script not found: {sdk_script}")
+
+    # Install L2 deployment build dependencies (kernel build needs bison, flex, etc.).
+    if config.l2_deployment:
+        l2_script = plat.repo_root / "scripts" / "setup" / "ubuntu-l2.sh"
+        if l2_script.exists():
+            print_info("Installing L2 deployment dependencies (requires sudo)...")
+            rc = subprocess.run(["sudo", str(l2_script)]).returncode
+            if rc != 0:
+                die("Failed to install L2 deployment dependencies.")
+        else:
+            print_warning(f"Setup script not found: {l2_script}")
+
+    # Validate and prepare toolchain directory when needed.
+    if config.nanvix_sdk or config.l2_deployment:
+        print_info(f"Toolchain directory: {config.toolchain_dir}")
+        validate_toolchain_dir_location(config.toolchain_dir, plat.repo_root)
+
+        tc_dir = Path(config.toolchain_dir)
+        if not tc_dir.exists():
+            print_info(f"Creating toolchain directory: {tc_dir}")
+            tc_dir.mkdir(parents=True, exist_ok=True)
+
+        if not os.access(str(tc_dir), os.W_OK):
+            die(f"No write permissions to: {tc_dir}")
+
+        if not check_filesystem_support(str(tc_dir)):
+            die(
+                f"Toolchain directory '{tc_dir}' is not on a supported file system"
+                " (ext3/ext4/overlay)."
+            )
+
+        if any(tc_dir.iterdir()):
+            print_warning(
+                f"Toolchain directory is not empty: {tc_dir}. Existing files may be overwritten."
+            )
+
+    # Build the cross-compilation toolchain.
+    if config.nanvix_sdk:
+        toolchain_script = plat.repo_root / "scripts" / "setup" / "toolchain.sh"
+        if not toolchain_script.exists():
+            die(f"Toolchain setup script not found: {toolchain_script}")
+
+        print_info(f"Running toolchain setup: {toolchain_script}")
+        rc = subprocess.run(
+            [str(toolchain_script), str(config.toolchain_dir)]
+        ).returncode
+        if rc != 0:
+            die("Toolchain setup failed.")
+
+    # Build Cloud Hypervisor for L2 deployment.
+    if config.l2_deployment:
+        clh_script = plat.repo_root / "scripts" / "setup" / "cloud-hypervisor.sh"
+        if not clh_script.exists():
+            die(f"Cloud Hypervisor setup script not found: {clh_script}")
+
+        print_info(f"Running Cloud Hypervisor setup: {clh_script}")
+        rc = subprocess.run([str(clh_script), str(config.toolchain_dir)]).returncode
+        if rc != 0:
+            die("Cloud Hypervisor setup failed.")
 
     _install_git_hooks(plat.repo_root)
     print_success("Setup complete.")


### PR DESCRIPTION
## Summary

Gate optional setup steps behind two new opt-in CLI flags so that `./z setup` only installs core Ubuntu packages and git hooks by default.

### New flags

- `--nanvix-sdk` — installs SDK Ubuntu packages and builds the full cross-compilation toolchain (Binutils, GCC, Newlib, LLVM, custom Rust, CPython).
- `--l2-deployment` — installs L2 build dependencies and builds Cloud Hypervisor plus the L2 kernel for L2 deployment mode.

The flags are fully independent. Toolchain directory validation (permissions, filesystem checks) is skipped when neither flag is passed. A warning is emitted if `--toolchain-dir` is provided without either opt-in flag.

### Changes

**Setup scripts:**
- Split `scripts/setup/ubuntu.sh` into `ubuntu-core.sh` (always installed) and `ubuntu-sdk.sh` (only with `--nanvix-sdk`).
- Add `scripts/setup/ubuntu-l2.sh` with build dependencies needed by `--l2-deployment` (bison, flex, libelf-dev, libssl-dev).
- Remove Cloud Hypervisor invocation from `toolchain.sh`; `z.py` now calls `cloud-hypervisor.sh` independently with `--l2-deployment`.
- Add `apt-get update` to `ubuntu-sdk.sh` and `ubuntu-l2.sh` so they work standalone.

**z.py:**
- Add `nanvix_sdk` and `l2_deployment` fields to `BuildConfig`.
- Recognize `--nanvix-sdk` and `--l2-deployment` in `parse_cli()`.
- Restructure `cmd_setup_linux()` into gated phases.
- Warn when `--toolchain-dir` is passed without `--nanvix-sdk` or `--l2-deployment`.
- Install L2 build dependencies via `ubuntu-l2.sh` when `--l2-deployment` is set.
- Update help text with new flags and examples.

**CI:**
- Replace manual apt-get and cloud-hypervisor build steps in `native-setup` composite action with `./z setup` (or `./z setup --l2-deployment` when CLH is needed), making `scripts/setup/` the single source of truth.

**Documentation:**
- Update `doc/setup-linux.md`, `CONTRIBUTING.md`, `README.md`, and `.github/skills/troubleshooting/SKILL.md` to reflect the new flags.

### Behavior

| Command | What runs |
|---|---|
| `./z setup` | Core Ubuntu packages + git hooks |
| `./z setup --nanvix-sdk` | + SDK packages + full toolchain build |
| `./z setup --l2-deployment` | + L2 packages + Cloud Hypervisor + L2 kernel |
| `./z setup --nanvix-sdk --l2-deployment` | Everything |