### PR TITLE
[slab] Minor improvements to `Slab`

### DIFF
--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -214,10 +214,12 @@ impl Slab {
     /// - It dereferences the pointer `ptr`.
     ///
     pub unsafe fn deallocate(&mut self, ptr: *const u8) -> Result<(), Error> {
-        // Return an error if the pointer is before the data blocks.
+        // Return an error if the pointer is before or after the data blocks.
         if ptr < self.data_addr as *const u8 || ptr >= self.end_addr {
             return Err(Error::new(ErrorCode::BadAddress, "pointer out of bounds"));
         }
+
+        // Return an error if the pointer isn't at a block boundary.
         if !(ptr as usize).is_multiple_of(self.block_size) {
             return Err(Error::new(ErrorCode::BadAddress, "pointer unaligned"));
         }

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -170,10 +170,10 @@ impl Slab {
 
         let end_addr = addr.add(total_num_blocks * block_size);
         Ok(Slab {
-            block_size,
+            index,
             data_addr,
             end_addr,
-            index,
+            block_size,
         })
     }
 

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -49,7 +49,7 @@ pub struct Slab {
     /// Base address of data blocks.
     data_addr: *mut u8,
     /// End of data blocks.
-    end_addr: usize,
+    end_addr: *const u8,
     /// Size of blocks in the slab.
     block_size: usize,
 }
@@ -163,7 +163,7 @@ impl Slab {
             index.set(i)?;
         }
 
-        let end_addr = (addr as usize) + total_num_blocks * block_size;
+        let end_addr = addr.add(total_num_blocks * block_size);
         Ok(Slab {
             block_size,
             data_addr,
@@ -209,12 +209,11 @@ impl Slab {
     /// - It dereferences the pointer `ptr`.
     ///
     pub unsafe fn deallocate(&mut self, ptr: *const u8) -> Result<(), Error> {
-        let addr = ptr as usize;
         // Return an error if the pointer is before the data blocks.
-        if ptr < self.data_addr || addr >= self.end_addr {
+        if ptr < self.data_addr || ptr >= self.end_addr {
             return Err(Error::new(ErrorCode::BadAddress, "pointer out of bounds"));
         }
-        if !addr.is_multiple_of(self.block_size) {
+        if !(ptr as usize).is_multiple_of(self.block_size) {
             return Err(Error::new(ErrorCode::BadAddress, "pointer unaligned"));
         }
 

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -86,6 +86,11 @@ impl Slab {
         len: usize,
         block_size: usize,
     ) -> Result<Slab, Error> {
+        // Make sure the address isn't null, e.g., from a failed allocation.
+        if addr.is_null() {
+            return Err(Error::new(ErrorCode::InvalidArgument, "null pointer"));
+        }
+
         // Check if length is invalid valid.
         if len == 0 || len >= i32::MAX as usize || len > isize::MAX as usize {
             return Err(Error::new(ErrorCode::InvalidArgument, "invalid slab length"));

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -215,7 +215,7 @@ impl Slab {
     ///
     pub unsafe fn deallocate(&mut self, ptr: *const u8) -> Result<(), Error> {
         // Return an error if the pointer is before the data blocks.
-        if ptr < self.data_addr || ptr >= self.end_addr {
+        if ptr < self.data_addr as *const u8 || ptr >= self.end_addr {
             return Err(Error::new(ErrorCode::BadAddress, "pointer out of bounds"));
         }
         if !(ptr as usize).is_multiple_of(self.block_size) {

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -91,7 +91,7 @@ impl Slab {
             return Err(Error::new(ErrorCode::InvalidArgument, "null pointer"));
         }
 
-        // Check if length is invalid valid.
+        // Check if length is invalid.
         if len == 0 || len >= i32::MAX as usize || len > isize::MAX as usize {
             return Err(Error::new(ErrorCode::InvalidArgument, "invalid slab length"));
         }
@@ -211,7 +211,7 @@ impl Slab {
     ///
     /// This function is unsafe for the following reasons:
     ///
-    /// - It dereferences the pointer `ptr`.
+    /// - It uses `offset_from_unsigned`.
     ///
     pub unsafe fn deallocate(&mut self, ptr: *const u8) -> Result<(), Error> {
         // Return an error if the pointer is before or after the data blocks.


### PR DESCRIPTION
* Avoid unnecessary pointer casts to usize
* Check for null pointer
* Match constructor argument order to struct order
* Make implicit pointer cast explicit
* Fix comments
