### PR TITLE
[build] Lint guest crates on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -573,9 +573,6 @@ lint-check: python-lint
 endif
 
 # Runs clippy.
-# On Windows, only host crates are linted (kernel and guest crates require a
-# cross-compilation toolchain that is not available natively on Windows).
-ifneq ($(IS_WINDOWS),yes)
 rust-lint-check: \
 	rust-lint-check-kernel \
 	rust-lint-check-guest-binaries \
@@ -583,7 +580,6 @@ rust-lint-check: \
 	rust-lint-check-guest-staticlibs \
 	rust-lint-check-wasmd \
 	rust-lint-check-wasm-binaries
-endif
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 rust-lint-check: rust-lint-check-host-binaries rust-lint-check-host-rlibs rust-lint-check-nanvixd rust-lint-check-uservm rust-lint-check-nanvix-test
@@ -597,7 +593,6 @@ rust-lint-check: rust-lint-check-nanvix-bench
 endif
 
 # Fixes code linting issues.
-ifneq ($(IS_WINDOWS),yes)
 rust-lint: \
 	rust-lint-kernel \
 	rust-lint-guest-binaries \
@@ -605,7 +600,6 @@ rust-lint: \
 	rust-lint-guest-staticlibs \
 	rust-lint-wasmd \
 	rust-lint-wasm-binaries
-endif
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
 rust-lint: rust-lint-host-binaries rust-lint-host-rlibs rust-lint-nanvixd rust-lint-uservm rust-lint-nanvix-test

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
@@ -302,13 +302,13 @@ impl InterruptController {
                     // they do not skew the pvclock refresh cadence.
                     if intnum == InterruptNumber::Timer {
                         let tick: u32 = EOI_COUNTER.fetch_add(1, Ordering::Relaxed);
-                        if tick % PIC_EOI_DIVISOR == 0 {
+                        if tick.is_multiple_of(PIC_EOI_DIVISOR) {
                             pic.ack(intnum as u32);
                         }
                     } else {
                         pic.ack(intnum as u32);
                     }
-                    return Ok(());
+                    Ok(())
                 }
                 #[cfg(not(all(feature = "microvm", feature = "whp")))]
                 {

--- a/src/kernel/src/hal/platform/microvm/pvclock.rs
+++ b/src/kernel/src/hal/platform/microvm/pvclock.rs
@@ -149,7 +149,7 @@ pub fn monotonic_time_ns() -> Option<u64> {
         let base_ticks: u32 = SNAP_TICKS.load(Ordering::Relaxed);
         let delta_ticks: u32 = (crate::pm::clock::ticks() as u32).wrapping_sub(base_ticks);
         const NS_PER_TICK: u64 = 1_000_000;
-        return Some(base_ns.wrapping_add(delta_ticks as u64 * NS_PER_TICK));
+        Some(base_ns.wrapping_add(delta_ticks as u64 * NS_PER_TICK))
     }
 
     // KVM/QEMU path: use TSC-based computation with the seqlock protocol.


### PR DESCRIPTION
Remove the IS_WINDOWS guard from rust-lint-check and rust-lint Make targets so that kernel, guest-binary, guest-rlib, guest-staticlib, and wasm crates are linted on Windows, matching Linux CI coverage.

Fix three pre-existing clippy warnings in kernel code that are now caught by the expanded Windows lint:
- needless_return in interrupt controller and pvclock
- manual_is_multiple_of in interrupt controller

Closes #1855