### PR TITLE
[ci] Pin self-hosted jobs to Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,7 @@ jobs:
         deployment-type: [standalone, single-process, multi-process]
     runs-on:
       group: Test
+      labels: [self-hosted, Linux]
     permissions:
       contents: read
 
@@ -886,6 +887,7 @@ jobs:
         machine-type: [microvm, hyperlight]
     runs-on:
       group: Test
+      labels: [self-hosted, Linux]
     permissions:
       contents: read
 
@@ -995,6 +997,7 @@ jobs:
           # round-trip-latency failure is investigated.
     runs-on:
       group: Benchmark
+      labels: [self-hosted, Linux]
     permissions:
       contents: read
 
@@ -1559,6 +1562,7 @@ jobs:
       needs.windows-release-archive.result == 'success'
     runs-on:
       group: Test
+      labels: [self-hosted, Linux]
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary

Self-hosted runner groups (`Test`, `Benchmark`) did not filter by OS, allowing Windows runners to
pick up Linux-only jobs. This caused the **Benchmark (microvm)** job in
[run #23776560530](https://github.com/nanvix/nanvix/actions/runs/23776560530) to fail immediately
with `bash: command not found` because a Windows runner in the Benchmark group claimed the job.

## Changes

Add `labels: [self-hosted, Linux]` to all four self-hosted `runs-on` blocks so that only Linux
runners can pick up these jobs:

| Job | Runner Group |
|-----|-------------|
| `ci-test` | Test |
| `ci-l2` | Test |
| `benchmark` | Benchmark |
| `nightly-release` | Test |

## Testing

No functional changes to build or test logic — only runner selection is affected.