### PR TITLE
[ci] Allow nightly schedule to publish releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ name: "Nanvix CI/CD"
 
 on:
   schedule:
-    # Nightly release: build, test, and publish a release every day at midnight UTC.
     - cron: "0 0 * * *"
 
   workflow_dispatch:
@@ -1656,12 +1655,19 @@ jobs:
     # Checks:
     # 1. Event is a push or schedule (not a PR or workflow_dispatch)
     # 2. Actor is not github-actions[bot] (prevents workflow-triggered runs)
-    # 3. Commit author is not github-actions[bot] (prevents runs on bot commits)
+    # 3. For push events: commit author/committer is not github-actions[bot]
+    #    For schedule events: head_commit is not available, so skip that check
     if: >-
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       github.actor != 'github-actions[bot]' &&
-      github.event.head_commit.author.username != 'github-actions[bot]' &&
-      github.event.head_commit.committer.username != 'github-actions[bot]'
+      (
+        (
+          github.event_name == 'push' &&
+          github.event.head_commit.author.username != 'github-actions[bot]' &&
+          github.event.head_commit.committer.username != 'github-actions[bot]'
+        ) ||
+        github.event_name == 'schedule'
+      )
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1651,14 +1651,14 @@ jobs:
   # merge commits while this job specifically targets them.
   create-minor-release:
     name: "Create Minor Release"
-    # Only run on merge commits to dev branch that were not made by github-actions[bot].
-    # This prevents infinite loops when the workflow commits back to dev.
+    # Publish a release on push-to-dev merges and on nightly schedule runs.
+    # Guard against infinite loops by excluding github-actions[bot] commits.
     # Checks:
-    # 1. Event is a push (not a PR or workflow_dispatch)
+    # 1. Event is a push or schedule (not a PR or workflow_dispatch)
     # 2. Actor is not github-actions[bot] (prevents workflow-triggered runs)
     # 3. Commit author is not github-actions[bot] (prevents runs on bot commits)
     if: >-
-      github.event_name == 'push' &&
+      (github.event_name == 'push' || github.event_name == 'schedule') &&
       github.actor != 'github-actions[bot]' &&
       github.event.head_commit.author.username != 'github-actions[bot]' &&
       github.event.head_commit.committer.username != 'github-actions[bot]'


### PR DESCRIPTION
The `create-minor-release` job only fires on `push` events
(`github.event_name == 'push'`), so nightly schedule runs never
publish a release — even after the transitive-skip fix in PR #1872.

**Root cause:** line 1661 of `ci.yml` gates the release job on
`github.event_name == 'push'`, which excludes `schedule` events.

**Fix:** add `github.event_name == 'schedule'` to the condition.

> **Note:** the second commit temporarily sets the cron to every 2 hours
> so the fix can be validated sooner. It must be reverted before merge.