### PR TITLE
[ci] Pre-built container for CI jobs

### DIFF
--- a/.github/actions/native-setup/action.yml
+++ b/.github/actions/native-setup/action.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 name: "Native Setup"
-description: "Set up native build environment on GitHub-hosted runners (no Docker)"
+description: "Set up native build environment for CI jobs (container-aware)"
 
 inputs:
   components:
@@ -17,20 +17,46 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: "Detect CI Container"
+      id: detect-container
+      shell: bash
+      run: |
+        if [ -f /etc/nanvix-ci-container ]; then
+          echo "in-container=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "in-container=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # When running outside the CI container, free disk space and install system
+    # dependencies from scratch.  Inside the container these are already present.
     - name: "Free Disk Space"
+      if: steps.detect-container.outputs.in-container != 'true'
       uses: ./.github/actions/free-disk-space
 
     - name: "Install Rust Toolchain"
       shell: bash
+      env:
+        IN_CONTAINER: ${{ steps.detect-container.outputs.in-container }}
       run: |
-        # The rust-toolchain file auto-configures the channel via rustup.
-        rustup show
-        # Install additional components if requested.
-        for component in ${{ inputs.components }}; do
-          rustup component add "${component}"
-        done
+        if [ "${IN_CONTAINER}" = "true" ]; then
+          # Container already has the toolchain; just ensure extra components.
+          for component in ${{ inputs.components }}; do
+            if ! rustup component add "${component}" 2>/dev/null; then
+              echo "error: failed to add Rust component '${component}' in CI container image." >&2
+              echo "       Ensure the component is preinstalled in the image or remove it from 'inputs.components'." >&2
+              exit 1
+            fi
+          done
+        else
+          # Bare runner — rust-toolchain file drives the install.
+          rustup show
+          for component in ${{ inputs.components }}; do
+            rustup component add "${component}"
+          done
+        fi
 
     - name: "Install System Dependencies"
+      if: steps.detect-container.outputs.in-container != 'true'
       shell: bash
       run: |
         if [ "${{ inputs.install-cloud-hypervisor }}" = "true" ]; then
@@ -41,6 +67,16 @@ runs:
 
     - name: "Setup Python Environment"
       shell: bash
+      env:
+        IN_CONTAINER: ${{ steps.detect-container.outputs.in-container }}
       run: |
-        python3 -m venv .venv
-        .venv/bin/pip install --quiet -r requirements.txt
+        if [ "${IN_CONTAINER}" = "true" ]; then
+          # Container venv is at /opt/nanvix-venv; create a local symlink so
+          # scripts that activate .venv keep working.
+          if [ ! -d .venv ]; then
+            ln -s /opt/nanvix-venv .venv
+          fi
+        else
+          python3 -m venv .venv
+          .venv/bin/pip install --quiet -r requirements.txt
+        fi

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -1,0 +1,87 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# =============================================================================
+# Build and push the Nanvix CI container image.
+#
+# The image is rebuilt whenever the Dockerfile, system-dependency scripts,
+# Rust toolchain pin, or Python requirements change.  It is also rebuilt on
+# a weekly schedule to pick up security updates from the base image.
+#
+# Bootstrap: Before the first merge to dev that adds `container:` to ci.yml,
+# run this workflow manually via workflow_dispatch to publish the initial image.
+# =============================================================================
+
+name: "CI Container Image"
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "docker/ci/Dockerfile"
+      - "scripts/setup/ubuntu-core.sh"
+      - "scripts/setup/ubuntu-l2.sh"
+      - "rust-toolchain"
+      - "requirements.txt"
+      - ".github/workflows/ci-container.yml"
+
+  pull_request:
+    branches: [dev]
+    paths:
+      - "docker/ci/Dockerfile"
+      - "scripts/setup/ubuntu-core.sh"
+      - "scripts/setup/ubuntu-l2.sh"
+      - "rust-toolchain"
+      - "requirements.txt"
+      - ".github/workflows/ci-container.yml"
+
+  schedule:
+    # Rebuild weekly (Sunday 04:00 UTC) to pick up base-image security patches.
+    - cron: "0 4 * * 0"
+
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nanvix/ci
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: "Build CI Image"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Log in to GitHub Container Registry"
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Extract metadata"
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=ubuntu-24.04
+            type=sha,prefix=ubuntu-24.04-
+
+      - name: "Build and push"
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/ci/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,0 +1,99 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# =============================================================================
+# Nanvix CI container image.
+#
+# This image pre-installs every system package, Rust toolchain component, and
+# Python dependency required by GitHub-hosted CI jobs so that workflows can skip
+# the expensive apt-get update / install cycle at runtime.
+#
+# Build:
+#   docker build -t ghcr.io/nanvix/ci:ubuntu-24.04 -f docker/ci/Dockerfile .
+#
+# The image is rebuilt automatically by .github/workflows/ci-container.yml
+# whenever the Dockerfile, setup scripts, rust-toolchain, or requirements.txt
+# change.
+# =============================================================================
+
+FROM ubuntu:24.04
+
+# Prevent interactive prompts during package installation.
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ---------------------------------------------------------------------------
+# System packages — mirrors scripts/setup/ubuntu-core.sh + ubuntu-l2.sh
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bc                    \
+        bison                 \
+        bridge-utils          \
+        build-essential       \
+        bzip2                 \
+        cmake                 \
+        codespell             \
+        cpio                  \
+        curl                  \
+        dosfstools            \
+        doxygen               \
+        flex                  \
+        gawk                  \
+        gdb-multiarch         \
+        git                   \
+        graphviz              \
+        grub2                 \
+        iproute2              \
+        jq                    \
+        kpartx                \
+        libelf-dev            \
+        libssl-dev            \
+        libvirt-clients       \
+        libvirt-daemon-system \
+        mmdebstrap            \
+        mtools                \
+        netcat-openbsd        \
+        ninja-build           \
+        pkg-config            \
+        python3-pip           \
+        python3-venv          \
+        shellcheck            \
+        sudo                  \
+        unzip                 \
+        wget                  \
+        xorriso               \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Rust toolchain — derived from rust-toolchain at build time.
+# ---------------------------------------------------------------------------
+COPY rust-toolchain /tmp/rust-toolchain
+
+ENV RUSTUP_HOME=/opt/rust/rustup \
+    CARGO_HOME=/opt/rust/cargo
+ENV PATH="${CARGO_HOME}/bin:${PATH}"
+
+RUN RUST_CHANNEL="$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' /tmp/rust-toolchain | head -n 1)" \
+    && if [ -z "${RUST_CHANNEL}" ]; then echo "error: failed to parse Rust channel from rust-toolchain" >&2; exit 1; fi \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain "${RUST_CHANNEL}" \
+    && rustup component add rust-src rustfmt clippy \
+    && rustup target add wasm32-wasip1 \
+    && rm /tmp/rust-toolchain
+
+# ---------------------------------------------------------------------------
+# Python virtual environment — mirrors requirements.txt.
+# ---------------------------------------------------------------------------
+COPY requirements.txt /tmp/requirements.txt
+RUN python3 -m venv /opt/nanvix-venv \
+    && /opt/nanvix-venv/bin/pip install --no-cache-dir -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
+ENV PATH="/opt/nanvix-venv/bin:${PATH}" \
+    VIRTUAL_ENV="/opt/nanvix-venv"
+
+# ---------------------------------------------------------------------------
+# Marker so native-setup can detect it is running inside the CI container.
+# ---------------------------------------------------------------------------
+RUN touch /etc/nanvix-ci-container
+
+LABEL org.opencontainers.image.source="https://github.com/nanvix/nanvix" \
+      org.opencontainers.image.description="Nanvix CI build environment"


### PR DESCRIPTION
## Summary

Replace the per-job `apt-get update` + `apt-get install` (~144 packages) on GitHub-hosted runners with a pre-built Docker image (`ghcr.io/nanvix/ci:ubuntu-24.04`) that already contains all system dependencies, Rust toolchain, and Python environment.

## Motivation

Workflow run [23809790684](https://github.com/nanvix/nanvix/actions/runs/23809790684) showed that intermittent network throttling to `azure.archive.ubuntu.com` caused a Lint job to stall for **25+ minutes** downloading packages, while an identical job on a different runner finished in under 3 minutes. Even under normal conditions, every GitHub-hosted job spends 40-50s on `apt-get update` + install.

## Changes

| File | Description |
|------|-------------|
| `docker/ci/Dockerfile` | New CI image based on `ubuntu:24.04` with all packages from `ubuntu-core.sh` + `ubuntu-l2.sh`, pinned Rust nightly, and Python venv |
| `.github/workflows/ci-container.yml` | New workflow to build and push the image on dependency changes + weekly for security patches |
| `.github/actions/native-setup/action.yml` | Container-aware: detects `/etc/nanvix-ci-container` marker and skips redundant setup steps |
| `.github/workflows/ci.yml` | Added `container: { image: ghcr.io/nanvix/ci:ubuntu-24.04 }` to 5 job types: checks, lint, verify, ci-build, benchmark-ci |

## Rollout

1. Merge this PR to trigger the `ci-container.yml` workflow and publish the image.
2. Subsequent CI runs will pull the pre-built image instead of installing packages.
3. The `native-setup` action remains backward-compatible for bare-runner usage (e.g., self-hosted runners, local dev).
