### PR TITLE
[kernel] Refactor LAPIC timer types

### DIFF
--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
@@ -58,6 +58,7 @@ static mut INTERRUPT_VECTOR: [Option<InterruptHandler>; INTERRUPT_VECTOR_LENGTH]
 enum InterruptControllerType {
     Legacy(Pic),
     Xapic(Xapic, Ioapic),
+    PicXapic(Pic, Xapic),
 }
 
 pub struct InterruptController {
@@ -71,6 +72,7 @@ impl InterruptController {
         xapic: Option<UninitXapic>,
         ioapic: Option<UninitIoapic>,
         intmap: InterruptMap,
+        eoi_xapic: Option<Xapic>,
     ) -> Result<Self, Error> {
         // If legacy PIC is available, initialize it.
         let pic: Option<Pic> = if let Some(mut pic) = pic {
@@ -133,123 +135,17 @@ impl InterruptController {
 
         // If legacy PIC is available, use it.
         if let Some(pic) = pic {
-            info!("using legacy pic");
-
-            // On microvm/WHP the partition enables LAPIC emulation in
-            // xAPIC mode. Enable the LAPIC software-enable bit and
-            // configure the LAPIC periodic timer so timer interrupts
-            // fire entirely inside the WHP LAPIC emulator — zero VM
-            // exits for timer delivery. The LAPIC page at 0xFEE00000
-            // is identity-mapped via the microvm platform init and
-            // handled by the WHP LAPIC emulator (not guest RAM).
-            #[cfg(all(feature = "microvm", feature = "whp"))]
-            {
-                use ::arch::cpu::{
-                    pit,
-                    xapic,
-                };
-                let lapic_base: usize = ::config::microvm::DEFAULT_LAPIC_BASE;
-                let lapic: xapic::Xapic = xapic::Xapic::new(lapic_base as *mut u32);
-                // SAFETY: The LAPIC MMIO page is identity-mapped during
-                // microvm platform init. Writes go through the WHP LAPIC
-                // emulator.
-                unsafe {
-                    lapic.write(xapic::XAPIC_SVR, 0x1FF);
-                    lapic.write(xapic::XAPIC_TPR, 0);
-                }
-                info!("lapic svr enabled for whp interrupt delivery");
-
-                // PIT-based LAPIC timer calibration.
-                //
-                // We use PIT channel 2 in one-shot mode to measure how
-                // many LAPIC timer ticks elapse in a known duration.
-                // PIT I/O (ports 0x40-0x43, 0x61) causes PMIO VM exits,
-                // which returns control to the VMM loop and allows
-                // pvclock to advance during calibration. At runtime,
-                // PIC EOI is skipped; pvclock is updated via guest-
-                // driven refresh and a 100 Hz host timer fallback.
-                const CALIBRATION_MS: u32 = 10;
-                let pit_reload: u16 = ((pit::PIT_MAX_FREQUENCY as u64 * CALIBRATION_MS as u64
-                    / 1000)
-                    & 0xFFFF) as u16;
-
-                // SAFETY: All I/O port accesses below target the PIT and
-                // speaker gate, which are emulated by the VMM. The LAPIC
-                // registers are accessed through the identity-mapped MMIO
-                // page handled by the WHP LAPIC emulator.
-                unsafe {
-                    // 1. Mask the LAPIC timer during calibration.
-                    lapic.write(
-                        xapic::XAPIC_TIMER,
-                        xapic::XapicTimer::new(0x20, false, true, 0).to_u32(),
-                    );
-
-                    // 2. Set LAPIC timer divide-by-128.
-                    lapic.write(xapic::XAPIC_TDCR, 0x0A);
-
-                    // 3. Program PIT channel 2 in one-shot mode.
-                    // Enable speaker gate for channel 2 and clear output bit.
-                    let speaker: u8 = (::arch::io::in8(0x61) & 0xFC) | 0x01;
-                    ::arch::io::out8(0x61, speaker);
-                    // Channel 2, lobyte/hibyte, mode 0 (one-shot), binary.
-                    ::arch::io::out8(
-                        pit::PIT_CTRL,
-                        pit::PIT_SEL2 | pit::PIT_ACC_LOHI | pit::PIT_MODE_TCOUNT | pit::PIT_BINARY,
-                    );
-                    ::arch::io::out8(pit::PIT_DATA + 2, (pit_reload & 0xFF) as u8);
-                    ::arch::io::out8(pit::PIT_DATA + 2, (pit_reload >> 8) as u8);
-
-                    // 4. Start the LAPIC timer counting from max value.
-                    lapic.write(xapic::XAPIC_TICR, 0xFFFF_FFFF);
-
-                    // 5. Wait for PIT channel 2 output (bit 5 of port 0x61),
-                    //    but avoid an unbounded busy-wait in case OUT2 never
-                    //    transitions due to misconfigured PIT emulation.
-                    const PIT_CALIBRATION_MAX_ITERS: u32 = 10_000_000;
-                    let mut pit_iters: u32 = 0;
-                    while (::arch::io::in8(0x61) & 0x20) == 0 {
-                        core::hint::spin_loop();
-                        pit_iters = pit_iters.wrapping_add(1);
-                        if pit_iters >= PIT_CALIBRATION_MAX_ITERS {
-                            warn!(
-                                "PIT calibration timeout: OUT2 did not assert after {} iterations",
-                                PIT_CALIBRATION_MAX_ITERS
-                            );
-                            break;
-                        }
-                    }
-
-                    // 6. Read remaining LAPIC timer count.
-                    let current_count: u32 = lapic.read(xapic::XAPIC_TCCR);
-                    let elapsed_ticks: u32 = 0xFFFF_FFFF - current_count;
-                    let mut ticks_per_ms: u32 = elapsed_ticks / CALIBRATION_MS;
-                    if ticks_per_ms == 0 {
-                        // Calibration underflow: use minimal non-zero fallback
-                        // to avoid programming LAPIC TICR with 0.
-                        warn!(
-                            "lapic timer calibration underflow: elapsed_ticks={elapsed_ticks}, \
-                             using fallback ticks_per_ms=1"
-                        );
-                        ticks_per_ms = 1;
-                    }
-
-                    info!(
-                        "lapic timer calibration: elapsed_ticks={}, ticks_per_ms={}",
-                        elapsed_ticks, ticks_per_ms
-                    );
-
-                    // 7. Program LAPIC timer in periodic mode with vector
-                    //    0x20, initial count = ticks_per_ms (1kHz).
-                    lapic.write(
-                        xapic::XAPIC_TIMER,
-                        xapic::XapicTimer::new(0x20, false, false, 1).to_u32(),
-                    );
-                    lapic.write(xapic::XAPIC_TICR, ticks_per_ms);
-
-                    info!("lapic periodic timer started (vector=0x20, period=1ms)");
-                }
+            // If an xAPIC EOI handle was provided (by the xAPIC timer init path),
+            // use PIC for external IRQ routing and the xAPIC for EOI acknowledgement.
+            if let Some(xapic_eoi) = eoi_xapic {
+                info!("using pic with xapic for eoi");
+                return Ok(Self {
+                    intmap,
+                    intctrl: InterruptControllerType::PicXapic(pic, xapic_eoi),
+                });
             }
 
+            info!("using legacy pic");
             return Ok(Self {
                 intmap,
                 intctrl: InterruptControllerType::Legacy(pic),
@@ -264,22 +160,29 @@ impl InterruptController {
     pub fn ack(&mut self, intnum: InterruptNumber) -> Result<(), Error> {
         match self.intctrl {
             InterruptControllerType::Legacy(ref mut pic) => {
-                // On microvm/WHP the LAPIC periodic timer delivers
-                // interrupts through the LAPIC emulator.
-                //
-                // **LAPIC EOI** (MMIO write to 0xFEE000B0) runs every
+                pic.ack(intnum as u32);
+                Ok(())
+            },
+            InterruptControllerType::Xapic(ref mut xapic, _) => {
+                xapic.ack();
+                Ok(())
+            },
+            InterruptControllerType::PicXapic(ref mut pic, ref mut xapic) => {
+                // xAPIC EOI (MMIO write to 0xFEE000B0) runs every
                 // tick to clear the ISR bit so the LAPIC can accept the
                 // next periodic interrupt.
-                //
-                // **PIC EOI** (PMIO write to port 0x20) runs every
-                // N-th tick to cause a VM exit for pvclock updates.
-                // Between PIC EOI exits, the guest uses tick
-                // interpolation in monotonic_time_ns() for zero-cost
-                // clock::now() calls. N=10 gives ~100 Hz pvclock
-                // refresh rate with ~1 ms interpolation accuracy.
-                #[cfg(all(feature = "microvm", feature = "whp"))]
-                {
-                    use ::arch::cpu::xapic;
+                xapic.ack();
+
+                // PIC EOI (PMIO write to port 0x20) is throttled for
+                // timer interrupts: only every N-th tick causes a VM
+                // exit for pvclock updates. Between PIC EOI exits the
+                // guest uses tick interpolation in monotonic_time_ns()
+                // for zero-cost clock::now() calls. N=10 gives ~100 Hz
+                // pvclock refresh rate with ~1 ms interpolation accuracy.
+                // Non-timer IRQs (e.g., IKC) always send PIC EOI
+                // immediately so they do not skew the pvclock refresh
+                // cadence.
+                if intnum == InterruptNumber::Timer {
                     use ::core::sync::atomic::{
                         AtomicU32,
                         Ordering,
@@ -290,34 +193,13 @@ impl InterruptController {
 
                     static EOI_COUNTER: AtomicU32 = AtomicU32::new(0);
 
-                    let lapic_base: usize = ::config::microvm::DEFAULT_LAPIC_BASE;
-                    let lapic: xapic::Xapic = xapic::Xapic::new(lapic_base as *mut u32);
-                    // SAFETY: LAPIC MMIO page is identity-mapped.
-                    unsafe {
-                        lapic.write(xapic::XAPIC_EOI, 0);
-                    }
-
-                    // Only throttle PIC EOI for timer interrupts. Non-timer
-                    // IRQs (e.g., IKC) always send PIC EOI immediately so
-                    // they do not skew the pvclock refresh cadence.
-                    if intnum == InterruptNumber::Timer {
-                        let tick: u32 = EOI_COUNTER.fetch_add(1, Ordering::Relaxed);
-                        if tick.is_multiple_of(PIC_EOI_DIVISOR) {
-                            pic.ack(intnum as u32);
-                        }
-                    } else {
+                    let tick: u32 = EOI_COUNTER.fetch_add(1, Ordering::Relaxed);
+                    if tick.is_multiple_of(PIC_EOI_DIVISOR) {
                         pic.ack(intnum as u32);
                     }
-                    Ok(())
-                }
-                #[cfg(not(all(feature = "microvm", feature = "whp")))]
-                {
+                } else {
                     pic.ack(intnum as u32);
-                    Ok(())
                 }
-            },
-            InterruptControllerType::Xapic(ref mut xapic, _) => {
-                xapic.ack();
                 Ok(())
             },
         }
@@ -333,6 +215,10 @@ impl InterruptController {
             InterruptControllerType::Xapic(_, ref mut ioapic) => {
                 let intnum: u8 = self.intmap[intnum];
                 ioapic.enable(intnum, 0)
+            },
+            InterruptControllerType::PicXapic(ref mut pic, _) => {
+                pic.unmask(intnum as u16);
+                Ok(())
             },
         }
     }
@@ -360,8 +246,8 @@ impl InterruptController {
         kstack: *const u8,
     ) -> Result<(), Error> {
         match self.intctrl {
-            InterruptControllerType::Legacy(_) => {
-                let reason: &str = "legacy pic does not support starting cores";
+            InterruptControllerType::Legacy(_) | InterruptControllerType::PicXapic(..) => {
+                let reason: &str = "pic does not support starting cores";
                 error!("{reason}");
                 Err(Error::new(ErrorCode::OperationNotSupported, reason))
             },
@@ -377,7 +263,9 @@ impl InterruptController {
         handler: Option<InterruptHandler>,
     ) -> Result<(), Error> {
         let intnum: u8 = match self.intctrl {
-            InterruptControllerType::Legacy(_) => intnum as u8,
+            InterruptControllerType::Legacy(_) | InterruptControllerType::PicXapic(..) => {
+                intnum as u8
+            },
             InterruptControllerType::Xapic(_, _) => self.intmap[intnum],
         };
         unsafe { INTERRUPT_VECTOR[intnum as usize] = handler };
@@ -386,7 +274,9 @@ impl InterruptController {
 
     pub fn get_handler(&self, intnum: InterruptNumber) -> Result<Option<InterruptHandler>, Error> {
         let intnum: u8 = match self.intctrl {
-            InterruptControllerType::Legacy(_) => intnum as u8,
+            InterruptControllerType::Legacy(_) | InterruptControllerType::PicXapic(..) => {
+                intnum as u8
+            },
             InterruptControllerType::Xapic(_, _) => self.intmap[intnum],
         };
         unsafe { Ok(INTERRUPT_VECTOR[intnum as usize]) }

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/mod.rs
@@ -66,6 +66,10 @@ pub use controller::{
     InterruptHandler,
 };
 pub use number::InterruptNumber;
+pub use xapic::{
+    Xapic,
+    XapicTimer,
+};
 
 //==================================================================================================
 // Standalone Functions
@@ -171,11 +175,16 @@ fn build_interrupt_map(madt: &MadtInfo) -> InterruptMap {
 }
 
 /// Initializes the interrupt controller.
+///
+/// If the platform registered a LAPIC MMIO region (via [`LAPIC_MMIO_TAG`]) and no MADT xAPIC
+/// consumed it, this function creates an [`XapicTimer`] (calibrated via PIT channel 2) and
+/// returns it alongside the interrupt controller. The controller receives an EOI handle extracted
+/// from the timer.
 pub fn init(
     ioports: &mut IoPortAllocator,
     ioaddresses: &mut IoMemoryAllocator,
     madt: &Option<MadtInfo>,
-) -> Result<InterruptController, Error> {
+) -> Result<(InterruptController, Option<XapicTimer>), Error> {
     info!("initializing interrupt controller...");
     match madt {
         // MADT is present.
@@ -270,22 +279,90 @@ pub fn init(
             };
 
             let intmap: InterruptMap = build_interrupt_map(madt);
-            InterruptController::new(pic, xapic, ioapic, intmap)
+
+            let (eoi_xapic, xapic_timer) = if xapic.is_some() {
+                // MADT xAPIC path already consumed the LAPIC MMIO region; skip timer probe.
+                (None, None)
+            } else {
+                // Try to create an xAPIC timer from a platform-registered LAPIC MMIO region.
+                // This succeeds only when the MADT xAPIC path did not consume the region
+                // (e.g., no xAPIC in MADT but platform registered the region for timer use).
+                try_init_xapic_timer(ioports, ioaddresses)?
+            };
+
+            let controller = InterruptController::new(pic, xapic, ioapic, intmap, eoi_xapic)?;
+            Ok((controller, xapic_timer))
         },
 
         // MADT is not present.
         None => {
             info!("madt not present, falling back to 8259 pic");
+
             match UninitPic::new(ioports, idt::INT_OFF) {
                 Ok(pic) => {
                     let intmap: InterruptMap = InterruptMap::new();
-                    Ok(InterruptController::new(Some(pic), None, None, intmap)?)
+                    // Try to create an xAPIC timer from a platform-registered LAPIC MMIO region.
+                    let (eoi_xapic, xapic_timer) = try_init_xapic_timer(ioports, ioaddresses)?;
+                    let controller =
+                        InterruptController::new(Some(pic), None, None, intmap, eoi_xapic)?;
+                    Ok((controller, xapic_timer))
                 },
                 Err(e) => {
                     warn!("failed to initialize 8259 pic (error={:?})", e);
-                    Ok(InterruptController::new(None, None, None, InterruptMap::new())?)
+                    let controller =
+                        InterruptController::new(None, None, None, InterruptMap::new(), None)?;
+                    Ok((controller, None))
                 },
             }
         },
+    }
+}
+
+/// Tries to allocate a LAPIC MMIO region for xAPIC timer use. If the platform registered
+/// [`LAPIC_MMIO_TAG`], this creates an [`UninitXapicTimer`], calibrates it via PIT, and returns
+/// the initialized [`XapicTimer`] along with an EOI handle for the interrupt controller.
+///
+/// Returns `(None, None)` if the LAPIC MMIO region is not available or the current configuration
+/// does not support PIT-based LAPIC calibration.
+fn try_init_xapic_timer(
+    _ioports: &mut IoPortAllocator,
+    ioaddresses: &mut IoMemoryAllocator,
+) -> Result<(Option<Xapic>, Option<XapicTimer>), Error> {
+    // For the WHP + PIT + microvm configuration, we attempt to allocate the LAPIC MMIO
+    // region and initialize an xAPIC timer. In other configurations, we avoid touching
+    // the allocator so we don't emit spurious error logs when LAPIC_MMIO_TAG is absent.
+    #[cfg(all(feature = "pit", feature = "microvm", feature = "whp"))]
+    {
+        use self::xapic::UninitXapicTimer;
+
+        let lapic_region: IoMemoryRegion = match ioaddresses.allocate(LAPIC_MMIO_TAG) {
+            Ok(region) => region,
+            Err(_) => return Ok((None, None)),
+        };
+
+        info!("lapic mmio region available for xapic timer");
+
+        let uninit_timer: UninitXapicTimer = UninitXapicTimer::new(lapic_region);
+
+        // Calibrate the LAPIC timer using PIT channel 2 and program it in periodic mode.
+        use crate::hal::platform::pit::Pit;
+
+        const LAPIC_CALIBRATION_MS: u32 = 10;
+
+        let mut pit: Pit = Pit::new(_ioports, ::config::kernel::TIMER_FREQ)?;
+        let xapic_timer: XapicTimer = uninit_timer.init(&mut pit, LAPIC_CALIBRATION_MS);
+
+        // SAFETY: Single-core system; the Xapic handle shares the same LAPIC MMIO page.
+        let eoi_xapic: Xapic = unsafe { xapic_timer.create_eoi_handle() };
+        Ok((Some(eoi_xapic), Some(xapic_timer)))
+    }
+
+    #[cfg(not(all(feature = "pit", feature = "microvm", feature = "whp")))]
+    {
+        // In configurations without PIT-based LAPIC calibration support, we cannot
+        // initialize the xAPIC timer. Avoid probing the LAPIC MMIO region so we don't
+        // trigger allocator error logging on platforms that don't register LAPIC_MMIO_TAG.
+        let _ = ioaddresses;
+        Ok((None, None))
     }
 }

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/xapic.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/xapic.rs
@@ -9,8 +9,8 @@ use crate::hal::{
     io::IoMemoryRegion,
     mem::Address,
 };
-use ::arch::cpu::xapic;
-use ::sys::error::{
+use arch::cpu::xapic;
+use sys::error::{
     Error,
     ErrorCode,
 };
@@ -19,7 +19,7 @@ use ::sys::error::{
 #[path = ""]
 mod smp_feature_imports {
     pub use crate::mm::kredzone;
-    pub use ::sys::mm::VirtualAddress;
+    pub use sys::mm::VirtualAddress;
 }
 
 #[cfg(feature = "smp")]
@@ -59,10 +59,8 @@ impl UninitXapic {
     pub fn init(&mut self) -> Result<Xapic, Error> {
         info!("initializing xapic (id={}, base={:?})", self.id, self.base);
 
-        let mut xapic: Xapic = Xapic {
-            id: self.id,
-            ptr: xapic::Xapic::new(self.base.base().into_raw_value() as *mut u32),
-        };
+        let mut xapic: Xapic =
+            Xapic::new(self.id, xapic::Xapic::new(self.base.base().into_raw_value() as *mut u32));
 
         // Check ID matches the one in the APIC.
         let apic_id: xapic::XapicId = xapic::XapicId::from_u32(xapic.read(xapic::XAPIC_ID));
@@ -217,6 +215,11 @@ pub struct Xapic {
 }
 
 impl Xapic {
+    /// Creates a new xAPIC handle.
+    fn new(id: u8, ptr: xapic::Xapic) -> Self {
+        Self { id, ptr }
+    }
+
     ///
     /// # Description
     ///
@@ -368,5 +371,208 @@ impl Xapic {
         let reason: &str = "maximum number of retries exceeded";
         error!("{reason}");
         Err(Error::new(ErrorCode::TimerExpired, reason))
+    }
+}
+
+//==================================================================================================
+// Uninitialized xAPIC Timer
+//==================================================================================================
+
+///
+/// # Description
+///
+/// An uninitialized xAPIC timer. Holds an allocated LAPIC MMIO region and can be initialized
+/// into an [`XapicTimer`] via PIT-based calibration, following the same Uninit pattern used
+/// by [`UninitPic`] and [`UninitXapic`].
+///
+#[allow(dead_code)]
+pub struct UninitXapicTimer {
+    /// LAPIC MMIO region handle.
+    region: IoMemoryRegion,
+    /// Low-level LAPIC MMIO handle.
+    ptr: xapic::Xapic,
+}
+
+#[allow(dead_code)]
+impl UninitXapicTimer {
+    ///
+    /// # Description
+    ///
+    /// Creates a new uninitialized xAPIC timer from an allocated MMIO region.
+    ///
+    /// # Parameters
+    ///
+    /// - `region`: Allocated LAPIC MMIO region (must be identity-mapped).
+    ///
+    pub fn new(region: IoMemoryRegion) -> Self {
+        let base: usize = region.base().into_raw_value();
+        Self {
+            region,
+            ptr: xapic::Xapic::new(base as *mut u32),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Performs a safe write on the target xAPIC.
+    ///
+    /// # Parameters
+    ///
+    /// - `reg`: Register.
+    /// - `value`: Value.
+    ///
+    fn write(&mut self, reg: u32, value: u32) {
+        unsafe { self.ptr.write(reg, value) };
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Performs a safe read on the target xAPIC.
+    ///
+    /// # Parameters
+    ///
+    /// - `reg`: Register.
+    ///
+    /// # Return Values
+    ///
+    /// The value read.
+    ///
+    fn read(&mut self, reg: u32) -> u32 {
+        unsafe { self.ptr.read(reg) }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Calibrates the LAPIC timer using a PIT-provided delay and programs it in periodic mode.
+    /// Consumes this uninitialized handle and returns an initialized [`XapicTimer`].
+    ///
+    /// # Parameters
+    ///
+    /// - `pit`: PIT handle with one-shot delay capability.
+    /// - `calibration_ms`: Duration of the measurement window in milliseconds.
+    ///
+    /// # Returns
+    ///
+    /// An initialized [`XapicTimer`] with the LAPIC periodic timer running.
+    ///
+    /// # Safety
+    ///
+    /// The LAPIC MMIO page must be identity-mapped and accessible.
+    ///
+    #[cfg(all(feature = "pit", feature = "microvm", feature = "whp"))]
+    pub fn init(
+        mut self,
+        pit: &mut crate::hal::platform::pit::Pit,
+        calibration_ms: u32,
+    ) -> XapicTimer {
+        // Validate calibration_ms before touching PIT/LAPIC hardware. A zero value
+        // would arm the PIT with reload 0 (interpreted as max interval by the PIT)
+        // and cause a division by zero when computing ticks_per_ms.
+        debug_assert!(
+            calibration_ms != 0,
+            "lapic timer calibration called with calibration_ms == 0"
+        );
+        let calibration_ms: u32 = if calibration_ms == 0 {
+            warn!("lapic timer calibration called with calibration_ms=0, clamping to 1ms");
+            1
+        } else {
+            calibration_ms
+        };
+
+        info!("calibrating lapic timer via pit channel 2 ({}ms window)", calibration_ms);
+
+        // Timer vector = IDT hardware interrupt base + Timer IRQ 0.
+        let timer_vector: u32 = crate::hal::arch::x86::cpu::idt::INT_OFF as u32;
+
+        // Mask the LAPIC timer during calibration.
+        self.write(
+            xapic::XAPIC_TIMER,
+            xapic::XapicTimer::new(timer_vector, false, true, 0).to_u32(),
+        );
+
+        // Set LAPIC timer divide-by-128.
+        self.write(xapic::XAPIC_TDCR, 0x0A);
+
+        // Arm the PIT one-shot — countdown starts on return.
+        pit.arm_oneshot(calibration_ms);
+
+        // Start the LAPIC timer counting down from max value.
+        self.write(xapic::XAPIC_TICR, 0xFFFF_FFFF);
+
+        // Wait for PIT delay to elapse.
+        pit.wait_oneshot();
+
+        // Read remaining LAPIC timer count and compute ticks per millisecond.
+        let current_count: u32 = self.read(xapic::XAPIC_TCCR);
+        let elapsed_ticks: u32 = 0xFFFF_FFFF - current_count;
+        let mut ticks_per_ms: u32 = elapsed_ticks / calibration_ms;
+        if ticks_per_ms == 0 {
+            warn!(
+                "lapic timer calibration underflow: elapsed_ticks={elapsed_ticks}, using fallback \
+                 ticks_per_ms=1"
+            );
+            ticks_per_ms = 1;
+        }
+
+        info!(
+            "lapic timer calibration: elapsed_ticks={}, ticks_per_ms={}",
+            elapsed_ticks, ticks_per_ms
+        );
+
+        // Enable LAPIC via spurious interrupt vector register.
+        self.write(xapic::XAPIC_SVR, 0x1FF);
+        self.write(xapic::XAPIC_TPR, 0);
+        info!("lapic svr enabled for interrupt delivery");
+
+        // Program LAPIC timer in periodic mode.
+        self.write(
+            xapic::XAPIC_TIMER,
+            xapic::XapicTimer::new(timer_vector, false, false, 1).to_u32(),
+        );
+        self.write(xapic::XAPIC_TICR, ticks_per_ms);
+
+        info!("lapic periodic timer started (vector={:#x}, period=1ms)", timer_vector);
+
+        XapicTimer {
+            region: self.region,
+        }
+    }
+}
+
+//==================================================================================================
+// xAPIC Timer
+//==================================================================================================
+
+///
+/// # Description
+///
+/// An initialized xAPIC periodic timer. Owns the LAPIC MMIO region and keeps the timer running.
+/// The interrupt controller handles EOI via a separate [`Xapic`] handle obtained from
+/// [`Self::create_eoi_handle()`].
+///
+#[allow(dead_code)]
+pub struct XapicTimer {
+    /// LAPIC MMIO region handle (kept alive to prevent reallocation).
+    region: IoMemoryRegion,
+}
+
+#[allow(dead_code)]
+impl XapicTimer {
+    ///
+    /// # Description
+    ///
+    /// Creates an [`Xapic`] handle that shares this timer's LAPIC MMIO page. The returned handle
+    /// is intended for EOI writes only and is passed to the interrupt controller.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the returned `Xapic` handle is only used on a single core and
+    /// does not outlive this `XapicTimer`.
+    ///
+    pub unsafe fn create_eoi_handle(&self) -> Xapic {
+        Xapic::new(0, xapic::Xapic::new(self.region.base().into_raw_value() as *mut u32))
     }
 }

--- a/src/kernel/src/hal/arch/x86/cpu/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/mod.rs
@@ -53,6 +53,7 @@ pub use interrupt::{
     InterruptController,
     InterruptHandler,
     InterruptNumber,
+    XapicTimer,
 };
 pub mod tss;
 pub use fpu::FpuState;
@@ -65,7 +66,7 @@ pub fn init(
     ioports: &mut IoPortAllocator,
     ioaddresses: &mut IoMemoryAllocator,
     madt: &Option<MadtInfo>,
-) -> Result<(GdtPtr, TssRef, Option<InterruptController>), Error> {
+) -> Result<(GdtPtr, TssRef, Option<InterruptController>, Option<XapicTimer>), Error> {
     unsafe extern "C" {
         static kstack: u8;
     }
@@ -122,16 +123,16 @@ pub fn init(
     let (gdtr, tss): (GdtPtr, TssRef) = unsafe { Gdt::init(&kstack)? };
     unsafe { idt::init() };
 
-    let controller: Option<InterruptController> = match interrupt::init(ioports, ioaddresses, madt)
-    {
-        Ok(controller) => Some(controller),
-        Err(e) => {
-            warn!("failed to initialize interrupt controller (error={:?})", e);
-            None
-        },
-    };
+    let (controller, xapic_timer): (Option<InterruptController>, Option<XapicTimer>) =
+        match interrupt::init(ioports, ioaddresses, madt) {
+            Ok((controller, xapic_timer)) => (Some(controller), xapic_timer),
+            Err(e) => {
+                warn!("failed to initialize interrupt controller (error={:?})", e);
+                (None, None)
+            },
+        };
 
-    Ok((gdtr, tss, controller))
+    Ok((gdtr, tss, controller, xapic_timer))
 }
 
 #[cfg(feature = "smp")]

--- a/src/kernel/src/hal/arch/x86/mod.rs
+++ b/src/kernel/src/hal/arch/x86/mod.rs
@@ -15,7 +15,10 @@ pub mod mem;
 
 use crate::hal::{
     arch::x86::{
-        cpu::tss::TssRef,
+        cpu::{
+            tss::TssRef,
+            XapicTimer,
+        },
         mem::gdt::GdtPtr,
     },
     io::{
@@ -59,6 +62,8 @@ pub struct Arch {
     pub _tss: Option<TssRef>,
     /// Interrupt controller.
     pub controller: Option<InterruptController>,
+    /// xAPIC timer (platform-owned, used only in PIC + xAPIC timer mode).
+    pub _xapic_timer: Option<XapicTimer>,
 }
 
 //==================================================================================================
@@ -110,13 +115,14 @@ pub fn init(
 ) -> Result<Arch, Error> {
     info!("initializing architecture-specific components...");
 
-    // Initialize interrupt controller.
-    let (gdtr, tss, controller) = cpu::init(ioports, ioaddresses, madt)?;
+    // Initialize CPU subsystem (GDT, IDT, interrupt controller, xAPIC timer).
+    let (gdtr, tss, controller, xapic_timer) = cpu::init(ioports, ioaddresses, madt)?;
 
     Ok(Arch {
         _gdtr: Some(gdtr),
         _tss: Some(tss),
         controller,
+        _xapic_timer: xapic_timer,
     })
 }
 
@@ -128,5 +134,6 @@ pub fn initialize_application_core(kstack: *const u8) -> Result<Arch, Error> {
         _gdtr: Some(gdtr),
         _tss: Some(tss),
         controller: None,
+        _xapic_timer: None,
     })
 }

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -56,7 +56,7 @@ use ::sys::error::{
 #[cfg(feature = "whp")]
 use crate::hal::platform::region_tags::LAPIC_MMIO_TAG;
 
-#[cfg(feature = "pit")]
+#[cfg(all(feature = "pit", not(feature = "whp")))]
 use crate::hal::platform::pit::Pit;
 
 //==================================================================================================
@@ -65,7 +65,7 @@ use crate::hal::platform::pit::Pit;
 
 pub struct Platform {
     pub arch: Arch,
-    #[cfg(feature = "pit")]
+    #[cfg(all(feature = "pit", not(feature = "whp")))]
     pub _pit: Pit,
 }
 
@@ -462,7 +462,7 @@ fn register_pic_ioports(ioports: &mut IoPortAllocator) -> Result<(), Error> {
     Ok(())
 }
 
-#[cfg(feature = "pit")]
+#[cfg(all(feature = "pit", not(feature = "whp")))]
 fn register_pit(ioports: &mut IoPortAllocator) -> Result<Pit, Error> {
     // Register ports for the PIT.
 
@@ -470,6 +470,16 @@ fn register_pit(ioports: &mut IoPortAllocator) -> Result<Pit, Error> {
     ioports.register_read_write(::arch::cpu::pit::PIT_DATA)?;
 
     Pit::new(ioports, ::config::kernel::TIMER_FREQ)
+}
+
+/// Registers PIT calibration ports (channel 2 + speaker gate) so the interrupt controller can
+/// allocate them during LAPIC timer calibration.
+#[cfg(all(feature = "pit", feature = "whp"))]
+fn register_pit_ports(ioports: &mut IoPortAllocator) -> Result<(), Error> {
+    ioports.register_read_write(::arch::cpu::pit::PIT_CTRL)?;
+    ioports.register_read_write(::arch::cpu::pit::PIT_DATA_CH2)?;
+    ioports.register_read_write(::arch::cpu::pit::PIT_SPEAKER_GATE)?;
+    Ok(())
 }
 
 pub fn init(
@@ -529,9 +539,16 @@ pub fn init(
     log_control_registers();
     register_ramfs_mmio_region(ioaddresses, mmio_regions)?;
 
+    // On WHP, register PIT calibration ports before arch init so the interrupt
+    // controller can allocate them during LAPIC timer calibration.
+    #[cfg(all(feature = "pit", feature = "whp"))]
+    register_pit_ports(ioports)?;
+
+    let arch = x86::init(ioports, ioaddresses, madt)?;
+
     Ok(Platform {
-        arch: x86::init(ioports, ioaddresses, madt)?,
-        #[cfg(feature = "pit")]
+        arch,
+        #[cfg(all(feature = "pit", not(feature = "whp")))]
         _pit: register_pit(ioports)?,
     })
 }

--- a/src/kernel/src/hal/platform/pit.rs
+++ b/src/kernel/src/hal/platform/pit.rs
@@ -14,10 +14,9 @@ use ::core::sync::atomic::{
     AtomicU32,
     Ordering,
 };
-use ::sys::error::{
-    Error,
-    ErrorCode,
-};
+use ::sys::error::Error;
+#[cfg(not(all(feature = "microvm", feature = "whp")))]
+use ::sys::error::ErrorCode;
 
 //==================================================================================================
 // Frequency
@@ -38,16 +37,29 @@ static TIMER_FREQUENCY: AtomicU32 = AtomicU32::new(pit::PIT_MAX_FREQUENCY);
 ///
 /// Represents the Programmable Interval Timer (PIT) device.
 ///
+/// On non-WHP platforms the PIT operates as a periodic timer using channel 0. On WHP the PIT is
+/// used exclusively as a calibration source for the LAPIC timer via channel 2.
+///
 pub struct Pit {
+    /// PIT command register (port 0x43).
     ctrl: ReadWriteIoPort,
+    /// Channel 0 data port (port 0x40). Used for periodic timer on non-WHP platforms.
+    #[cfg(not(all(feature = "microvm", feature = "whp")))]
     data: ReadWriteIoPort,
+    /// Channel 2 data port (port 0x42). Used for LAPIC timer calibration on WHP.
+    #[cfg(all(feature = "microvm", feature = "whp"))]
+    data_ch2: ReadWriteIoPort,
+    /// Speaker gate port (port 0x61). Used for LAPIC timer calibration on WHP.
+    #[cfg(all(feature = "microvm", feature = "whp"))]
+    speaker_gate: ReadWriteIoPort,
 }
 
+#[cfg(not(all(feature = "microvm", feature = "whp")))]
 impl Pit {
     ///
     /// # Description
     ///
-    /// Initializes the PIT device.
+    /// Initializes the PIT device as a periodic timer on channel 0.
     ///
     /// # Parameters
     ///
@@ -102,6 +114,122 @@ impl Pit {
         info!("pit set to {} Hz", actual_freq);
 
         Ok(pit)
+    }
+}
+
+#[cfg(all(feature = "microvm", feature = "whp"))]
+impl Pit {
+    ///
+    /// # Description
+    ///
+    /// Initializes the PIT device for LAPIC timer calibration using channel 2.
+    ///
+    /// Channel 0 is not programmed. The PIT is used only as a reference clock source to measure
+    /// LAPIC timer ticks. The timer frequency is set from the requested value so that other
+    /// kernel subsystems report the correct tick rate.
+    ///
+    /// # Parameters
+    ///
+    /// - `ioports`: I/O port allocator.
+    /// - `freq`: Timer frequency in Hz (used by the LAPIC periodic timer, not the PIT).
+    ///
+    /// # Returns
+    ///
+    /// If successful, returns a `Pit` instance. Otherwise, returns an error.
+    ///
+    pub fn new(ioports: &mut IoPortAllocator, freq: u32) -> Result<Self, Error> {
+        info!("initializing pit for lapic calibration...");
+
+        // Validate frequency to prevent divide-by-zero in downstream time conversions.
+        if freq == 0 {
+            error!("invalid frequency for pit (freq=0)");
+            return Err(Error::new(::sys::error::ErrorCode::InvalidArgument, "invalid frequency"));
+        }
+
+        // Allocate I/O ports for calibration.
+        let ctrl: ReadWriteIoPort = ioports.allocate_read_write(pit::PIT_CTRL)?;
+        let data_ch2: ReadWriteIoPort = ioports.allocate_read_write(pit::PIT_DATA_CH2)?;
+        let speaker_gate: ReadWriteIoPort = ioports.allocate_read_write(pit::PIT_SPEAKER_GATE)?;
+
+        // Set timer frequency. On WHP, the LAPIC timer is the actual timer source.
+        TIMER_FREQUENCY.store(freq, Ordering::SeqCst);
+
+        info!("pit calibration ports allocated (timer freq set to {} Hz)", freq);
+
+        Ok(Self {
+            ctrl,
+            data_ch2,
+            speaker_gate,
+        })
+    }
+
+    /// Maximum supported one-shot duration in milliseconds (~54ms for 1.193 MHz PIT).
+    pub const MAX_ONESHOT_MS: u32 = (0xFFFF_u64 * 1000 / pit::PIT_MAX_FREQUENCY as u64) as u32;
+
+    ///
+    /// # Description
+    ///
+    /// Arms PIT channel 2 in one-shot mode for the given duration. The countdown starts as soon
+    /// as the reload value is written. Call [`Self::wait_oneshot()`] to block until the delay
+    /// elapses.
+    ///
+    /// Durations of 0 ms are clamped to 1 ms (a PIT reload of 0 is interpreted as 65536).
+    /// Durations exceeding [`Self::MAX_ONESHOT_MS`] (~54 ms) are clamped to that maximum.
+    ///
+    /// # Parameters
+    ///
+    /// - `ms`: Duration in milliseconds.
+    ///
+    pub fn arm_oneshot(&mut self, ms: u32) {
+        // Clamp to valid PIT one-shot range. A reload of 0 is interpreted by the PIT
+        // as 65536 (maximum interval), so treat ms=0 as 1ms to avoid surprising behavior.
+        let clamped_ms: u32 = if ms == 0 {
+            warn!("pit oneshot duration 0ms invalid, clamping to 1ms");
+            1
+        } else if ms > Self::MAX_ONESHOT_MS {
+            warn!("pit oneshot duration {}ms exceeds max {}ms, clamping", ms, Self::MAX_ONESHOT_MS);
+            Self::MAX_ONESHOT_MS
+        } else {
+            ms
+        };
+        let pit_reload: u16 =
+            ((pit::PIT_MAX_FREQUENCY as u64 * clamped_ms as u64 / 1000) & 0xFFFF) as u16;
+
+        // Enable speaker gate for channel 2 and clear output bit.
+        let speaker: u8 = (self.speaker_gate.read8() & pit::PIT_SPEAKER_GATE_CH2_CLEAR)
+            | pit::PIT_SPEAKER_GATE_CH2_ENABLE;
+        self.speaker_gate.write8(speaker);
+
+        // Channel 2, lobyte/hibyte, mode 0 (one-shot), binary.
+        self.ctrl
+            .write8(pit::PIT_SEL2 | pit::PIT_ACC_LOHI | pit::PIT_MODE_TCOUNT | pit::PIT_BINARY);
+
+        // Write reload value — countdown starts here.
+        self.data_ch2.write8((pit_reload & 0xFF) as u8);
+        self.data_ch2.write8((pit_reload >> 8) as u8);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Busy-waits until the PIT channel 2 one-shot completes. The method polls the OUT2 bit on
+    /// the speaker gate port and returns when it asserts. A fixed iteration limit prevents an
+    /// unbounded spin if the hardware never signals completion.
+    ///
+    pub fn wait_oneshot(&self) {
+        const PIT_CALIBRATION_MAX_ITERS: u32 = 10_000_000;
+        let mut pit_iters: u32 = 0;
+        while (self.speaker_gate.read8() & pit::PIT_SPEAKER_GATE_OUT2) == 0 {
+            core::hint::spin_loop();
+            pit_iters = pit_iters.wrapping_add(1);
+            if pit_iters >= PIT_CALIBRATION_MAX_ITERS {
+                warn!(
+                    "pit oneshot timeout: out2 did not assert after {} iterations",
+                    PIT_CALIBRATION_MAX_ITERS
+                );
+                break;
+            }
+        }
     }
 }
 

--- a/src/libs/arch/src/x86/cpu/pit.rs
+++ b/src/libs/arch/src/x86/cpu/pit.rs
@@ -20,7 +20,14 @@ pub const PIT_MAX_FREQUENCY: u32 = 1193181;
 
 // Registers
 pub const PIT_CTRL: u16 = 0x43; // Control
-pub const PIT_DATA: u16 = 0x40; // Data
+pub const PIT_DATA: u16 = 0x40; // Data (channel 0)
+pub const PIT_DATA_CH2: u16 = 0x42; // Data (channel 2)
+
+// Speaker Gate (port 0x61) bits used for PIT channel 2 calibration.
+pub const PIT_SPEAKER_GATE: u16 = 0x61; // Speaker gate I/O port
+pub const PIT_SPEAKER_GATE_CH2_ENABLE: u8 = 0x01; // Enable channel 2 gate
+pub const PIT_SPEAKER_GATE_CH2_CLEAR: u8 = 0xFC; // Mask to clear gate and speaker bits
+pub const PIT_SPEAKER_GATE_OUT2: u8 = 0x20; // Channel 2 output status (bit 5)
 
 // Select Channels
 pub const PIT_SEL0: u8 = 0x00; // Channel 0


### PR DESCRIPTION
## Summary

Refactor LAPIC timer types and add RDTSC-based LAPIC timer calibration to eliminate expensive PIT-polling VM exits during early boot, especially on the WHP backend where the first `WHvRunVirtualProcessor` call triggers lazy partition initialization.

The VMM now passes the host TSC base frequency to the guest via a new microvm control register. When the frequency is available, the kernel calibrates the LAPIC timer using an RDTSC spin loop (~1 ms, zero VM exits) instead of PIT channel 2. PIT-based calibration is retained as a fallback when the TSC frequency register is zero.

## Changes

### LAPIC Timer Type Refactoring
- **`xapic.rs`**: Add `UninitXapicTimer` and `XapicTimer` types with PIT-based calibration and EOI handle creation.
- **`controller.rs`**: Introduce `PicXapic` interrupt controller variant (PIC for IRQ routing, xAPIC for EOI). Remove inline `#[cfg]`-gated LAPIC calibration code.
- **`interrupt/mod.rs`**: Add `try_init_xapic_timer()` for LAPIC MMIO region allocation and timer initialization. Return `(InterruptController, Option<XapicTimer>)` from `init()`. Reduce PIT calibration window from 10 ms to 1 ms.
- **`pit.rs` (kernel)**: Split `Pit` into two `cfg`-gated implementations: channel 0 periodic timer (non-WHP) and channel 2 one-shot calibration (WHP) with `arm_oneshot`/`wait_oneshot`.
- **`pit.rs` (arch)**: Add `PIT_DATA_CH2`, `PIT_SPEAKER_GATE`, and related constants.
- **`cpu/mod.rs`, `x86/mod.rs`**: Thread `XapicTimer` through `cpu::init()` and `Arch` struct.
- **`microvm/mod.rs` (kernel)**: Register PIT calibration ports before arch init on WHP; move platform PIT ownership to non-WHP only.

### RDTSC-Based LAPIC Timer Calibration
- **`xapic.rs`**: When `tsc_base_frequency_mhz() > 0`, calibrate the LAPIC timer via an RDTSC spin loop (~1 ms) instead of PIT channel 2. Apply overshoot correction by scaling elapsed LAPIC ticks with `(target / actual)` TSC ticks. Add max-iteration guard to prevent hangs. Use `wrapping_sub` for remaining-count subtraction.
- **`microvm/mod.rs` (kernel)**: Add `tsc_base_frequency_mhz()` platform accessor that reads the VMM-provided control register.
- **`hyperlight/mod.rs`**: Add `tsc_base_frequency_mhz()` stub returning `0` (forces PIT fallback).

### VMM: Pass Host TSC Frequency to Guest
- **`config/src/lib.rs`**: Add `DEFAULT_MICROVM_CTRL_TSC_FREQ_MHZ` control register constant at offset `0x14`.
- **`vmm/microvm/mod.rs`**: Query host TSC base frequency via CPUID leaf `0x16` and write it to the new control register before guest boot.
- **`vmm/whp/mod.rs`**: Same as microvm VMM backend.

### CPUID Subleaf Support
- **`cpuid.rs`**: Rename `cpuid()` to `cpuid_subleaf()` with an explicit ECX subleaf parameter. Re-introduce `cpuid()` as a thin wrapper with subleaf 0. Fix ECX from output-only to `inout` in inline assembly. Add `CPUID_FREQUENCY` (leaf `0x16`) constant and `get_base_frequency_mhz()` helper.