### PR TITLE
[ci] Isolate Cargo home in Windows benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1231,6 +1231,23 @@ jobs:
           # runner with a pre-installed toolchain.
           echo "CARGO_HOME=C:\Users\Administrator\.cargo" >> $env:GITHUB_ENV
 
+      - name: "Isolate Cargo Home"
+        shell: pwsh
+        run: |
+          # Isolate Cargo home per job to prevent git-cache corruption on
+          # Windows runners that may share the same filesystem across runs.
+          # Use an NTFS junction for the toolchain bin/ directory so that
+          # the Makefile can still resolve $env:CARGO_HOME/bin/cargo
+          # without requiring symlink privileges.
+          $cargoTarget = Join-Path $env:CARGO_HOME "bin"
+          $isolatedCargo = Join-Path $env:RUNNER_TEMP ".cargo"
+          New-Item -ItemType Directory -Force -Path $isolatedCargo | Out-Null
+          $cargoBin = Join-Path $isolatedCargo "bin"
+          if (Test-Path $cargoBin) { Remove-Item $cargoBin -Force -Recurse }
+          cmd /c "mklink /J `"$cargoBin`" `"$cargoTarget`"" | Out-Null
+          echo "CARGO_HOME=$isolatedCargo" >> $env:GITHUB_ENV
+          Write-Host "Isolated CARGO_HOME to $isolatedCargo"
+
       - name: "Verify Rust Toolchain"
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary

Add the **Isolate Cargo Home** step to the Windows Benchmark job, matching the pattern already used by other Windows and Linux CI jobs.

## Problem

The Windows Benchmark job sets \CARGO_HOME\ to the shared \C:\Users\Administrator\.cargo\ directory. When concurrent or back-to-back runs share the same runner filesystem, Cargo's git cache can become corrupted, causing build failures with OS error 183 (*Cannot create a file when that file already exists*).

**Example failure:** workflow run [23852195683](https://github.com/nanvix/nanvix/actions/runs/23852195683/job/69535172985) — \atfs\ git dependency fetch failed due to a stale cache entry.

## Fix

Create a per-job temporary \CARGO_HOME\ under \RUNNER_TEMP\, symlink the toolchain \in/\ directory so that \cargo\ is still resolved, and override the environment variable for all subsequent steps. This is the same isolation strategy used by every other CI job.