### PR TITLE
[ci] Remove unsupported --type flag from gh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1934,7 +1934,6 @@ jobs:
             --title "CI/CD pipeline failure on dev (Run #${{ github.run_number }})" \
             --label "devops:ci" \
             --assignee "ppenna" \
-            --type "Bug" \
             --body "## CI/CD Release Pipeline Failure
 
           The CI/CD pipeline failed on a push to \`dev\`.


### PR DESCRIPTION
## Summary

Remove the --type Bug argument from the gh issue create command in the Notify Release Failure job.

## Problem

The --type flag was introduced in gh CLI v2.72.0, but the ubuntu-24.04 runner image ships an older version that does not recognize it. This causes the step to fail with: unknown flag: --type

Example failure: job 69544585446 in workflow run 23852195683 (https://github.com/nanvix/nanvix/actions/runs/23852195683/job/69544585446).

## Fix

Remove the unsupported flag so that issue creation works with any gh CLI version available on GitHub-hosted runners. The issue type can be set manually after creation if needed.