### PR TITLE
[ci] B: Fix hyperlight update workflow

### DIFF
--- a/.github/workflows/update-hyperlight.yml
+++ b/.github/workflows/update-hyperlight.yml
@@ -35,7 +35,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bash scripts/update-hyperlight.sh | tee -a "$GITHUB_OUTPUT"
+          bash scripts/update-hyperlight.sh > /tmp/hl-output.txt
+          cat /tmp/hl-output.txt
+          cat /tmp/hl-output.txt >> "$GITHUB_OUTPUT"
 
       - name: "Create Pull Request"
         if: steps.update.outputs.UPDATED == 'true'

--- a/scripts/update-hyperlight.sh
+++ b/scripts/update-hyperlight.sh
@@ -182,7 +182,7 @@ resolve_latest_commit() {
         | awk '
             /^\[workspace\.package\]/ { in_section=1; next }
             /^\[/ && in_section { in_section=0 }
-            in_section && $1 ~ /^version[[:space:]]*=/ {
+            in_section && /^version[[:space:]]*=/ {
                 if (match($0, /"[^"]*"/)) {
                     v = substr($0, RSTART + 1, RLENGTH - 2);
                     print v;


### PR DESCRIPTION
Fix two bugs in the hyperlight update workflow that caused the nightly run to silently succeed despite failing to resolve the hyperlight workspace version.

**Bug 1 — awk pattern in `scripts/update-hyperlight.sh`:**
The awk rule used `$1 ~ /^version[[:space:]]*=/` to match the version field inside `[workspace.package]`. Since awk splits on whitespace, `$1` only contains `"version"` (without `=`), so the regex never matched. Replace `$1 ~` with a bare `/pattern/` so the match runs against the full line (`$0`).

**Bug 2 — pipeline masks exit code in `update-hyperlight.yml`:**
The step ran `bash scripts/update-hyperlight.sh | tee -a "$GITHUB_OUTPUT"`. Although the script uses `set -euo pipefail`, the runner shell does not inherit pipefail, so `tee` succeeding masked the non-zero exit from the script. Replace the pipeline with a redirect to a temp file, then cat and append, so any script failure immediately fails the step.