### PR TITLE
[ci] Fix nightly release transitive skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,8 @@ jobs:
   ci-test:
     name: "Test (${{ matrix.build-type }}, ${{ matrix.machine-type }}, ${{ matrix.deployment-type }})"
     needs: [ci-build]
+    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    if: ${{ !cancelled() && needs.ci-build.result == 'success' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -557,6 +559,11 @@ jobs:
   windows-ci-build:
     name: "Windows Build (${{ matrix.machine-type }}, ${{ matrix.build-type }})"
     needs: [windows-format-check, windows-lint-check]
+    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    if: |
+      !cancelled() &&
+      needs.windows-format-check.result == 'success' &&
+      needs.windows-lint-check.result == 'success'
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -634,6 +641,8 @@ jobs:
   windows-integration-test:
     name: "Windows Integration Test (${{ matrix.machine-type }}, ${{ matrix.build-type }})"
     needs: [windows-ci-build]
+    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    if: ${{ !cancelled() && needs.windows-ci-build.result == 'success' }}
     timeout-minutes: 30
     continue-on-error: true
     strategy:
@@ -1737,7 +1746,9 @@ jobs:
   release-archive:
     name: "Release Archive (${{ matrix.machine-type }}, ${{ matrix.deployment-type }}, ${{ matrix.memory-size }}mb)"
     needs: [ci-test, ci-l2, benchmark-finalize, benchmark-ci-finalize, windows-benchmark-finalize]
+    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     if: |
+      !cancelled() &&
       github.repository == 'nanvix/nanvix' &&
       github.ref == 'refs/heads/dev' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
@@ -1794,7 +1805,9 @@ jobs:
         benchmark-ci-finalize,
         windows-benchmark-finalize,
       ]
+    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     if: |
+      !cancelled() &&
       github.repository == 'nanvix/nanvix' &&
       github.ref == 'refs/heads/dev' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
@@ -1848,7 +1861,9 @@ jobs:
   publish-release:
     name: "Publish Release"
     needs: [release-archive, windows-release-archive]
+    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     if: |
+      !cancelled() &&
       github.repository == 'nanvix/nanvix' &&
       github.ref == 'refs/heads/dev' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&


### PR DESCRIPTION
## Summary

Fix the nightly release pipeline silently skipping `publish-release` due to
transitive job skipping ([actions/runner#2205](https://github.com/actions/runner/issues/2205)).

## Root Cause

`precheck` is intentionally skipped for `schedule` and `merge_group` events.
Jobs like `ci-build`, `checks`, `lint`, and `ci-l2` break the transitive skip
chain with `if: !cancelled() && ...`. Three jobs lacked this override:

- **`ci-test`** (`needs: [ci-build]`, no `if:`)
- **`windows-ci-build`** (`needs: [windows-format-check, windows-lint-check]`, no `if:`)
- **`windows-integration-test`** (`needs: [windows-ci-build]`, no `if:`)

Without `!cancelled()`, GitHub Actions applies the implicit `success()` gate,
which sees the transitive skip from `precheck` and skips the job. This cascaded
through `release-archive` → `publish-release`, silently preventing nightly releases.

## Changes

**Primary (break the transitive skip chain):**
- `ci-test`: add `if: !cancelled() && needs.ci-build.result == 'success'`
- `windows-ci-build`: add `if: !cancelled() && needs.*.result == 'success'`
- `windows-integration-test`: add `if: !cancelled() && needs.windows-ci-build.result == 'success'`

**Defensive (prevent implicit `success()` wrapping on release jobs):**
- `release-archive`, `windows-release-archive`, `publish-release`: prepend `!cancelled() &&`

## Evidence

Workflow run [#2413](https://github.com/nanvix/nanvix/actions/runs/23829440197):
all CI jobs passed but `ci-test`, `windows-ci-build`, `windows-integration-test`,
`release-archive`, `windows-release-archive`, and `publish-release` were skipped.
