### PR TITLE
[slab] Prove liveness of Slab constructor

### DIFF
--- a/src/libs/raw-array/src/lib.rs
+++ b/src/libs/raw-array/src/lib.rs
@@ -293,13 +293,10 @@ impl<T> RawArray<T> {
             ptr.addr() + len * vstd::layout::size_of::<T>() + vstd::layout::align_of::<T>() - 1
                 <= usize::MAX as int,
         ensures
-            match result {
-                Ok(me) => {
-                    &&& me.inv()
-                    &&& me@.len() == len
-                    &&& forall|i: int| 0 <= i < len ==> is_zero(#[trigger] me@[i])
-                },
-                Err(e) => e.code == ErrorCode::InvalidArgument,
+            result matches Ok(me) && {
+                &&& me.inv()
+                &&& me@.len() == len
+                &&& forall|i: int| 0 <= i < len ==> is_zero(#[trigger] me@[i])
             },
     )]
     pub unsafe fn from_raw_parts(ptr: *mut T, len: usize) -> Result<RawArray<T>, Error> {

--- a/src/libs/slab/src/lib.proof.rs
+++ b/src/libs/slab/src/lib.proof.rs
@@ -48,6 +48,70 @@ impl Slab {
                 ==> self.index@.is_bit_set(i)
     }
 
+    proof fn lemma_wrapping_add_consequences(
+        addr: *mut u8,
+        len: usize
+    )
+        ensures
+            if ((addr as usize) + (len * size_of::<u8>())) % (usize::MAX + 1) < (addr as usize) {
+                (addr as usize) + len > usize::MAX
+            }
+            else {
+                (addr as usize) + len <= usize::MAX
+            },
+    {
+        assert(
+            if ((addr as usize) + (len * size_of::<u8>())) % (usize::MAX + 1) < (addr as usize) {
+                (addr as usize) + len > usize::MAX
+            }
+            else {
+                (addr as usize) + len <= usize::MAX
+            }
+        ) by (nonlinear_arith)
+            requires
+                size_of::<u8>() == 1,
+        ;
+    }
+
+    proof fn lemma_no_room_for_index(
+        len: usize,
+        block_size: usize,
+        total_num_blocks: usize,
+        num_index_blocks: usize,
+        divisor: usize,
+    )
+        requires
+            len <= isize::MAX,
+            block_size > 0,
+            total_num_blocks == len / block_size,
+            divisor == block_size * (u8::BITS as usize) + 1,
+            num_index_blocks == (total_num_blocks / divisor)
+                + if total_num_blocks % divisor == 0 {
+                      0int
+                  } else {
+                      1int
+                  },
+            num_index_blocks >= total_num_blocks,
+        ensures
+            len < block_size * 2,
+    {
+        assert(len < block_size * 2) by (nonlinear_arith)
+            requires
+                len <= isize::MAX,
+                block_size > 0,
+                total_num_blocks == len / block_size,
+                u8::BITS == 8,
+                divisor == block_size * u8::BITS + 1,
+                num_index_blocks == (total_num_blocks / divisor)
+                    + if total_num_blocks % divisor == 0 {
+                          0int
+                      } else {
+                          1int
+                      },
+                num_index_blocks >= total_num_blocks,
+        ;
+    }
+
     proof fn lemma_can_compute_data_addr(
         addr: *mut u8,
         total_num_blocks: usize,

--- a/src/libs/slab/src/lib.rs
+++ b/src/libs/slab/src/lib.rs
@@ -104,7 +104,21 @@ impl Slab {
                      &&& slab@.end_addr <= addr as usize + len
                      &&& slab@.allocated_addrs == Set::<usize>::empty()
                  },
-                 Err(e) => e.code == ErrorCode::InvalidArgument,
+                 Err(e) => {
+                     &&& e.code == ErrorCode::InvalidArgument
+                     &&& {
+                         ||| addr as usize == 0
+                         ||| len == 0
+                         ||| len >= i32::MAX
+                         ||| len > isize::MAX
+                         ||| addr as usize + len > usize::MAX
+                         ||| block_size == 0
+                         ||| block_size >= i32::MAX
+                         ||| block_size > (usize::MAX - 1) / (u8::BITS as int)
+                         ||| len < block_size * 2
+                         ||| addr as usize % block_size != 0
+                     }
+                 }
              },
     )]
     pub unsafe fn from_raw_parts(
@@ -123,6 +137,7 @@ impl Slab {
         }
 
         // Check if the memory region wraps around.
+        proof! { Self::lemma_wrapping_add_consequences(addr, len); }
         if addr.wrapping_add(len) < addr {
             return Err(Error::new(ErrorCode::InvalidArgument, "wrapping memory region"));
         }
@@ -165,10 +180,17 @@ impl Slab {
                 1
             };
         if num_index_blocks >= total_num_blocks {
+            proof! {
+                Self::lemma_no_room_for_index(len, block_size, total_num_blocks,
+                                              num_index_blocks, divisor);
+            }
             return Err(Error::new(ErrorCode::InvalidArgument, "insufficient blocks for index"));
         }
 
-        proof! { Slab::lemma_can_compute_data_addr(addr, total_num_blocks, num_index_blocks, block_size, len); }
+        proof! {
+            Slab::lemma_can_compute_data_addr(addr, total_num_blocks, num_index_blocks,
+                                              block_size, len);
+        }
         let data_addr: *mut u8 = addr.add(num_index_blocks * block_size);
 
         let num_data_blocks: usize = total_num_blocks - num_index_blocks;


### PR DESCRIPTION
This PR states a stronger liveness property about `RawArray::from_raw_parts` and uses it to prove that the constructor `Slab::from_raw_parts` is live, i.e., that it only fails if it's passed unreasonable parameters.