### PR TITLE
[build] Fix codespell skip and ignore-words-list in .codespellrc

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 [codespell]
 # Skip binary directories and files that don't need spell checking
-skip = .git, .venv, bin, lib, logs, build, target, toolchain, sysroot-debug, sysroot-release, *.pdf, *.png, *.jpg, *.jpeg, *.ico, *.svg, *.woff, *.woff2, *.eot, *.ttf
+skip = .git,.venv,bin,lib,logs,build,target,toolchain,sysroot-debug,sysroot-release,*.pdf,*.png,*.jpg,*.jpeg,*.ico,*.svg,*.woff,*.woff2,*.eot,*.ttf
 
 # Ignore words that are commonly used in systems programming
 # and are flagged as typos by codespell
-ignore-words-list = crate, inout, nd, rdonly, wronly, rdwr, servent
+ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,servent


### PR DESCRIPTION
## Problem

Codespell 2.2.x's `GlobMatch` splits the `skip` option by comma but does not strip surrounding whitespace. With spaces after commas (e.g., `.git, .venv, bin, target`), each entry except the first gets a leading space (` target`), causing `fnmatch` to never match the actual directory name (`target`). This made codespell scan build artifact directories like `target/`, causing false positives that blocked commits.

## Fix

Remove spaces after commas in both the `skip` and `ignore-words-list` options in `.codespellrc` so that all entries are matched correctly.