### PR TITLE
[vfs] Add metadata cache for standalone mode

### DIFF
--- a/src/libs/cache/src/lib.rs
+++ b/src/libs/cache/src/lib.rs
@@ -39,9 +39,12 @@
 extern crate alloc;
 
 use ::alloc::collections::BTreeMap;
-use ::core::ops::{
-    Deref,
-    DerefMut,
+use ::core::{
+    borrow::Borrow,
+    ops::{
+        Deref,
+        DerefMut,
+    },
 };
 
 //==================================================================================================
@@ -136,13 +139,18 @@ impl<K: Ord + Clone, V> Cache<K, V> {
     ///
     /// # Parameters
     ///
-    /// - `key`: The cache key to look up.
+    /// - `key`: The cache key to look up. Accepts borrowed forms of the key
+    ///   (e.g., `&str` for `String` keys) to avoid allocation on lookups.
     ///
     /// # Returns
     ///
     /// An RAII guard providing access to the cached value, or `None` on cache miss.
     ///
-    pub fn get(&mut self, key: &K) -> Option<CacheGuard<'_, V>> {
+    pub fn get<Q>(&mut self, key: &Q) -> Option<CacheGuard<'_, V>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
         if let Some(entry) = self.entries.get_mut(key) {
             self.counter += 1;
             entry.last_used = self.counter;
@@ -200,9 +208,14 @@ impl<K: Ord + Clone, V> Cache<K, V> {
     ///
     /// # Parameters
     ///
-    /// - `key`: The cache key to remove.
+    /// - `key`: The cache key to remove. Accepts borrowed forms of the key
+    ///   (e.g., `&str` for `String` keys) to avoid allocation.
     ///
-    pub fn remove(&mut self, key: &K) {
+    pub fn remove<Q>(&mut self, key: &Q)
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
         self.entries.remove(key);
     }
 
@@ -330,5 +343,22 @@ mod tests {
         cache.put("a", 10);
         assert_eq!(*cache.get(&"a").unwrap(), 10);
         assert_eq!(*cache.get(&"b").unwrap(), 2);
+    }
+
+    #[test]
+    fn get_with_borrowed_key() {
+        let mut cache: Cache<String, i32> = Cache::new(4);
+        cache.put(String::from("hello"), 42);
+        // Look up with &str — avoids String allocation.
+        assert_eq!(*cache.get("hello").unwrap(), 42);
+    }
+
+    #[test]
+    fn remove_with_borrowed_key() {
+        let mut cache: Cache<String, i32> = Cache::new(4);
+        cache.put(String::from("hello"), 42);
+        // Remove with &str — avoids String allocation.
+        cache.remove("hello");
+        assert!(cache.get("hello").is_none());
     }
 }

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -269,6 +269,18 @@ pub mod microvm {
     pub const DEFAULT_LAPIC_BASE: usize = 0xFEE0_0000;
 }
 
+//==================================================================================================
+// VFS
+//==================================================================================================
+
+pub mod vfs {
+    /// Maximum number of entries in each VFS metadata cache (stat, negative, raw region).
+    ///
+    /// When a cache reaches this capacity, the least-recently-used entry is evicted before
+    /// inserting a new one.
+    pub const CACHE_CAPACITY: usize = 64;
+}
+
 // Hyperlight build-time constants are generated from hyperlight_config.toml.
 #[cfg(feature = "hyperlight")]
 include!(concat!(env!("OUT_DIR"), "/hyperlight_config.rs"));

--- a/src/libs/vfs/Cargo.toml
+++ b/src/libs/vfs/Cargo.toml
@@ -14,9 +14,11 @@ homepage.workspace = true
 crate-type = ["lib"]
 
 [dependencies]
+config = { workspace = true }
 error = { workspace = true }
 fat32 = { workspace = true }
 fatfs = { workspace = true, features = ["alloc", "lfn"] }
+cache = { workspace = true }
 spin = { workspace = true, features = ["lazy", "spin_mutex"] }
 sysapi = { workspace = true }
 

--- a/src/libs/vfs/src/cache.rs
+++ b/src/libs/vfs/src/cache.rs
@@ -1,0 +1,178 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! VFS metadata cache for accelerating repeated path lookups.
+//!
+//! CPython's import system performs hundreds of `stat()` and `open()` calls
+//! during interpreter startup. Each call traverses the FAT32 cluster chain
+//! to resolve the path. This module provides caches that eliminate redundant
+//! FAT32 traversals:
+//!
+//! - **Stat cache**: Maps absolute paths to cached `Stat` results.
+//! - **Raw region cache**: Maps paths to `(ptr, size)` for zero-copy direct
+//!   read handles.
+//!
+//! # Capacity
+//!
+//! Each cache is bounded to [`config::vfs::CACHE_CAPACITY`] entries. When
+//! full, the least-recently-used entry (approximated by access counter) is
+//! evicted before inserting a new one.
+//!
+//! # Thread Safety
+//!
+//! All caches are protected by `spin::Mutex` for safe concurrent access.
+//!
+//! # Invalidation
+//!
+//! Caches are invalidated when the directory structure changes (`mkdir`,
+//! `rmdir`, `unlink`, `rename`). File creations, truncations, and writes do
+//! not currently trigger automatic invalidation of cached entries, so this
+//! cache is intended primarily for read-only or read-mostly workloads unless
+//! callers perform explicit invalidation on such write paths. For read-only
+//! filesystems (e.g., ramfs in standalone mode), invalidation never fires and
+//! the caches persist for the VM's lifetime. All caches are also bulk-
+//! invalidated on mount and unmount operations.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::file::Stat;
+use ::alloc::string::String;
+use ::cache::Cache;
+use ::config::vfs::CACHE_CAPACITY;
+use ::spin::Mutex;
+
+//==================================================================================================
+// Raw Region Pointer Wrapper
+//==================================================================================================
+
+/// A `Copy` wrapper around an optional `(*const u8, usize)` pair.
+///
+/// This exists solely to confine the `unsafe impl Send` to the raw-pointer
+/// type rather than applying a blanket impl over all `Cache<V>`.
+#[derive(Clone, Copy)]
+pub(crate) struct RawRegion(pub Option<(*const u8, usize)>);
+
+// SAFETY: The wrapped pointers reference FAT image memory that either lives
+// for the program lifetime (host-provided mounts) or is invalidated via
+// `cache::invalidate_all()` before deallocation (guest-created mounts via
+// `state::unmount`). Access is serialized through `spin::Mutex`.
+//
+// NOTE: A TOCTOU window exists between reading a cached pointer and a
+// concurrent `unmount` that frees the underlying memory. This is the same
+// class of risk that `DirectReadHandle` already carries (it holds a raw
+// pointer outside the VFS lock). The `unmount` path mitigates this by
+// checking `has_open_files()` and returning `FileLocked` if any FDs remain
+// open, which prevents deallocation while the data is still reachable.
+unsafe impl Send for RawRegion {}
+
+//==================================================================================================
+// Cache State
+//==================================================================================================
+
+/// Cached stat results for paths.
+static STAT_CACHE: Mutex<Cache<String, Stat>> = Mutex::new(Cache::new(CACHE_CAPACITY));
+
+/// Cached raw region pointers for zero-copy reads.
+static RAW_REGION_CACHE: Mutex<Cache<String, RawRegion>> = Mutex::new(Cache::new(CACHE_CAPACITY));
+
+//==================================================================================================
+// Public API
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Looks up a cached stat result.
+///
+/// # Parameters
+///
+/// - `path`: The normalized absolute path to look up.
+///
+/// # Returns
+///
+/// `Some(stat)` if the path has been cached, `None` on cache miss.
+///
+pub(crate) fn get_stat(path: &str) -> Option<Stat> {
+    STAT_CACHE.lock().get(path).map(|g| *g)
+}
+
+///
+/// # Description
+///
+/// Inserts a stat result into the cache.
+///
+/// # Parameters
+///
+/// - `path`: The normalized absolute path to cache.
+/// - `stat`: The metadata to store.
+///
+pub(crate) fn put_stat(path: &str, stat: Stat) {
+    STAT_CACHE.lock().put(String::from(path), stat);
+}
+
+///
+/// # Description
+///
+/// Looks up a cached raw region result.
+///
+/// Only positive results are cached; negative lookups always go to FAT.
+///
+/// # Parameters
+///
+/// - `path`: The normalized absolute path to look up.
+///
+/// # Returns
+///
+/// `Some((ptr, size))` on cache hit, or `None` on cache miss.
+///
+pub(crate) fn get_raw_region(path: &str) -> Option<(*const u8, usize)> {
+    RAW_REGION_CACHE.lock().get(path).and_then(|g| g.0)
+}
+
+///
+/// # Description
+///
+/// Inserts a raw region result into the cache.
+///
+/// # Parameters
+///
+/// - `path`: The normalized absolute path to cache.
+/// - `region`: The raw pointer and size pair, or `None` if no contiguous
+///   region exists.
+///
+pub(crate) fn put_raw_region(path: &str, region: Option<(*const u8, usize)>) {
+    RAW_REGION_CACHE
+        .lock()
+        .put(String::from(path), RawRegion(region));
+}
+
+///
+/// # Description
+///
+/// Invalidates all cached entries for a specific path.
+///
+/// Called when a write operation modifies the filesystem (e.g., `mkdir`,
+/// `rmdir`, `unlink`, `rename`).
+///
+/// # Parameters
+///
+/// - `path`: The normalized absolute path to invalidate.
+///
+pub(crate) fn invalidate_path(path: &str) {
+    STAT_CACHE.lock().remove(path);
+    RAW_REGION_CACHE.lock().remove(path);
+}
+
+///
+/// # Description
+///
+/// Invalidates the entire cache.
+///
+/// Called when a bulk filesystem modification occurs (e.g., mount/unmount).
+///
+pub(crate) fn invalidate_all() {
+    STAT_CACHE.lock().clear();
+    RAW_REGION_CACHE.lock().clear();
+}

--- a/src/libs/vfs/src/file.rs
+++ b/src/libs/vfs/src/file.rs
@@ -26,6 +26,22 @@ use ::fat32::{
 use ::sysapi::unistd::file_seek;
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Path component separator.
+const VFS_PATH_SEPARATOR: char = '/';
+
+/// Current directory name.
+const VFS_CURRENT_DIRECTORY: &str = ".";
+
+/// Parent directory name.
+const VFS_PARENT_DIRECTORY: &str = "..";
+
+/// Root directory path.
+const VFS_ROOT_DIRECTORY: &str = "/";
+
+//==================================================================================================
 // OpenOptions
 //==================================================================================================
 
@@ -391,16 +407,33 @@ pub fn open(path: &str) -> Result<File, Fat32Error> {
 /// # Parameters
 ///
 /// - `path`: The path to the file.
+///
+/// # TODOs
+///
+/// - TODO (#2065): Cache negative results for read-only mounts.
+///
 pub fn file_raw_region(path: &str) -> Option<(*const u8, usize)> {
-    let (mount_idx, relative_path): (usize, String) = resolve_path(path).ok()?;
-    state::with_vfs(|vfs| {
+    // Normalize the path so the cache key is stable across cwd changes and different spellings.
+    let normalized_path: String = normalize_for_cache(path).ok()?;
+
+    // Check cache first, using the normalized path as the key.
+    if let Some(cached) = crate::cache::get_raw_region(&normalized_path) {
+        return Some(cached);
+    }
+
+    let (mount_idx, relative_path): (usize, String) = resolve_path(&normalized_path).ok()?;
+    let result = state::with_vfs(|vfs| {
         let mount: &crate::mount::Mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
-        mount
-            .fat()
-            .file_raw_region(&relative_path)
-            .ok_or(Fat32Error::NotFound)
+        Ok(mount.fat().file_raw_region(&relative_path))
     })
-    .ok()
+    .ok()?;
+
+    // Only cache positive results.
+    if result.is_some() {
+        crate::cache::put_raw_region(&normalized_path, result);
+    }
+
+    result
 }
 
 /// File metadata.
@@ -450,19 +483,50 @@ impl Stat {
 ///
 /// - [`Fat32Error::NotInitialized`] if the filesystem hasn't been initialized.
 /// - [`Fat32Error::NotFound`] if the path doesn't exist.
+///
+/// # TODOs
+///
+/// - TODO (#2065): Cache negative results for read-only mounts.
+///
 pub fn stat(path: &str) -> Result<Stat, Fat32Error> {
-    let (mount_idx, relative_path) = resolve_path(path)?;
+    // Normalize the path so the cache key is stable across cwd changes and different spellings.
+    let normalized_path: String = normalize_for_cache(path)?;
+
+    // Check stat cache.
+    if let Some(cached) = crate::cache::get_stat(&normalized_path) {
+        return Ok(cached);
+    }
+
+    let result: Result<(usize, String), Fat32Error> = resolve_path(&normalized_path);
+    let (mount_idx, relative_path) = match result {
+        Ok(v) => v,
+        // NotFound from resolve_path means no mount matches this path,
+        // not that the file is missing. Do not negative-cache here.
+        Err(Fat32Error::NotFound) => return Err(Fat32Error::NotFound),
+        Err(e) => return Err(e),
+    };
 
     // Handle root of mount specially.
     if relative_path.is_empty() {
-        return Ok(Stat::new(0, true));
+        let s = Stat::new(0, true);
+        crate::cache::put_stat(&normalized_path, s);
+        return Ok(s);
     }
 
-    state::with_vfs(|vfs| {
+    let result: Result<Stat, Fat32Error> = state::with_vfs(|vfs| {
         let mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
         let fat_stat = mount.fat().stat(&relative_path)?;
         Ok(Stat::new(fat_stat.size, fat_stat.is_dir))
-    })
+    });
+
+    match result {
+        Ok(s) => {
+            crate::cache::put_stat(&normalized_path, s);
+            Ok(s)
+        },
+        Err(Fat32Error::NotFound) => Err(Fat32Error::NotFound),
+        Err(e) => Err(e),
+    }
 }
 
 /// Directory entry returned by [`read_dir()`].
@@ -529,10 +593,17 @@ pub fn mkdir(path: &str) -> Result<(), Fat32Error> {
 
     check_writable(mount_idx)?;
 
-    state::with_vfs_mut(|vfs| {
+    let result = state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
         mount.fat_mut().mkdir(&relative_path)
-    })
+    });
+
+    if result.is_ok() {
+        if let Ok(normalized) = crate::normalize(path) {
+            crate::cache::invalidate_path(&normalized);
+        }
+    }
+    result
 }
 
 /// Removes an empty directory.
@@ -558,10 +629,17 @@ pub fn rmdir(path: &str) -> Result<(), Fat32Error> {
 
     check_writable(mount_idx)?;
 
-    state::with_vfs_mut(|vfs| {
+    let result = state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
         mount.fat_mut().rmdir(&relative_path)
-    })
+    });
+
+    if result.is_ok() {
+        if let Ok(normalized) = crate::normalize(path) {
+            crate::cache::invalidate_path(&normalized);
+        }
+    }
+    result
 }
 
 /// Deletes a file.
@@ -586,10 +664,17 @@ pub fn unlink(path: &str) -> Result<(), Fat32Error> {
 
     check_writable(mount_idx)?;
 
-    state::with_vfs_mut(|vfs| {
+    let result = state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
         mount.fat_mut().unlink(&relative_path)
-    })
+    });
+
+    if result.is_ok() {
+        if let Ok(normalized) = crate::normalize(path) {
+            crate::cache::invalidate_path(&normalized);
+        }
+    }
+    result
 }
 
 /// Lists the contents of a directory.
@@ -614,7 +699,7 @@ pub fn read_dir(path: &str) -> Result<Vec<DirEntry>, Fat32Error> {
         let mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
 
         let fat_path: &str = if relative_path.is_empty() {
-            "."
+            VFS_CURRENT_DIRECTORY
         } else {
             &relative_path
         };
@@ -661,10 +746,20 @@ pub fn rename(old_path: &str, new_path: &str) -> Result<(), Fat32Error> {
 
     check_writable(old_idx)?;
 
-    state::with_vfs(|vfs| {
+    let result: Result<(), Fat32Error> = state::with_vfs(|vfs| {
         let mount = vfs.get_mount(old_idx).ok_or(Fat32Error::NotFound)?;
         mount.fat().rename(&old_rel, &new_rel)
-    })
+    });
+
+    if result.is_ok() {
+        if let Ok(old_normalized) = crate::normalize(old_path) {
+            crate::cache::invalidate_path(&old_normalized);
+        }
+        if let Ok(new_normalized) = crate::normalize(new_path) {
+            crate::cache::invalidate_path(&new_normalized);
+        }
+    }
+    result
 }
 
 /// Gets the current working directory.
@@ -716,6 +811,100 @@ pub fn normalize(path: &str) -> Result<String, Fat32Error> {
 //==================================================================================================
 // Internal Functions
 //==================================================================================================
+
+///
+/// # Description
+///
+/// Normalizes a path for use as a cache key, avoiding the VFS lock for
+/// absolute paths.
+///
+/// Absolute paths are normalized in-place without VFS state. Relative paths
+/// fall back to [`normalize()`], which requires the CWD (and thus the VFS
+/// lock).
+///
+/// # Parameters
+///
+/// - `path`: The path to normalize.
+///
+/// # Returns
+///
+/// The normalized absolute path.
+///
+/// # Errors
+///
+/// - [`Fat32Error::NotInitialized`] if the filesystem hasn't been initialized
+///   and the path is relative.
+/// - [`Fat32Error::InvalidPath`] if the path is malformed.
+fn normalize_for_cache(path: &str) -> Result<String, Fat32Error> {
+    if path.starts_with(VFS_PATH_SEPARATOR) {
+        normalize_absolute(path)
+    } else {
+        normalize(path)
+    }
+}
+
+///
+/// # Description
+///
+/// Resolves `.` and `..` components in an absolute path without VFS state.
+///
+/// # Parameters
+///
+/// - `path`: The absolute path to normalize (must start with `/`).
+///
+/// # Returns
+///
+/// The normalized absolute path.
+///
+/// # Errors
+///
+/// - [`Fat32Error::InvalidPath`] if the path is empty, has too many `..`
+///   components, or contains empty components (e.g., consecutive separators
+///   like `//`).
+fn normalize_absolute(path: &str) -> Result<String, Fat32Error> {
+    if path.is_empty() {
+        return Err(Fat32Error::InvalidPath);
+    }
+
+    // Strip the leading separator (guaranteed by caller) and any trailing
+    // separators so they do not produce spurious empty components.
+    let inner: &str = path
+        .strip_prefix(VFS_PATH_SEPARATOR)
+        .unwrap_or(path)
+        .trim_end_matches(VFS_PATH_SEPARATOR);
+
+    // Root path: only separators.
+    if inner.is_empty() {
+        return Ok(String::from(VFS_ROOT_DIRECTORY));
+    }
+
+    let mut components: Vec<&str> = Vec::new();
+    for component in inner.split(VFS_PATH_SEPARATOR) {
+        match component {
+            "" => return Err(Fat32Error::InvalidPath),
+            VFS_CURRENT_DIRECTORY => {},
+            VFS_PARENT_DIRECTORY => {
+                if components.pop().is_none() {
+                    return Err(Fat32Error::InvalidPath);
+                }
+            },
+            other => {
+                components.push(other);
+            },
+        }
+    }
+
+    if components.is_empty() {
+        Err(Fat32Error::InvalidPath)
+    } else {
+        let mut result: String = String::new();
+        for component in components {
+            result.push(VFS_PATH_SEPARATOR);
+            result.push_str(component);
+        }
+        Ok(result)
+    }
+}
 
 /// Resolves a path through the VFS to determine which mount handles it.
 ///
@@ -769,10 +958,10 @@ fn open_with_options(
     }
 
     // Reject write/create/truncate on read-only mounts.
-    // NOTE: This gate is also what keeps the negative cache consistent —
-    // negative entries are only populated for read-only mounts, so any
-    // O_CREAT that could create a file is blocked here before it reaches
-    // the FAT layer, preventing stale negative-cache entries.
+    // NOTE: This gate also preserves cache consistency — cached entries are
+    // only populated for read-only mounts' paths, so any O_CREAT that could
+    // create a file is blocked here before it reaches the FAT layer,
+    // preventing stale cache entries.
     if write || create || create_new || truncate {
         check_writable(mount_idx)?;
     }

--- a/src/libs/vfs/src/lib.rs
+++ b/src/libs/vfs/src/lib.rs
@@ -59,6 +59,9 @@ extern crate alloc;
 // Modules
 //==================================================================================================
 
+/// VFS metadata cache for accelerating repeated path lookups.
+pub(crate) mod cache;
+
 /// FAT32 backend: translates VFS operations to `fat32` crate calls.
 pub mod fat32_backend;
 

--- a/src/libs/vfs/src/state.rs
+++ b/src/libs/vfs/src/state.rs
@@ -265,6 +265,9 @@ pub fn create_mount(mount_path: &str, size: usize) -> Result<(), Fat32Error> {
     // Mount succeeded — disarm the guard so memory is not freed.
     guard.disarm();
 
+    // A new mount may shadow previously-resolved paths, so invalidate all cached entries.
+    crate::cache::invalidate_all();
+
     // Track this as a guest-created mount (separate lock).
     GUEST_MOUNTS.lock().push(GuestMountInfo {
         path: String::from(mount_path),
@@ -352,9 +355,13 @@ pub fn unmount(mount_path: &str) -> Result<(), Fat32Error> {
         return Err(e);
     }
 
+    // Invalidate all caches before freeing the mount's memory to prevent dangling pointers in the
+    // raw region cache.
+    crate::cache::invalidate_all();
+
     // Free the memory.
-    // SAFETY: info.memory_ptr was created from Box::into_raw in
-    // create_mount().
+    // SAFETY: info.memory_ptr was created from Box::into_raw in create_mount(). All cached raw
+    // pointers into this memory have been invalidated above.
     unsafe {
         let _ =
             Box::from_raw(core::ptr::slice_from_raw_parts_mut(info.memory_ptr, info.memory_size));


### PR DESCRIPTION
## Summary

Add VFS-level caching to accelerate repeated path lookups during CPython startup in standalone mode. The import system performs hundreds of `stat()` and `open()` calls, each traversing FAT32 cluster chains from scratch.

### VFS Metadata Cache (`src/libs/vfs/src/cache.rs`)
- **Stat cache**: `BTreeMap<path, Stat>` eliminates redundant FAT32 cluster traversals for repeated `stat()` calls
- **Negative cache**: `BTreeMap<path, ()>` fast-returns ENOENT for paths known not to exist (CPython probes many module paths that miss)
- **Raw region cache**: caches `file_raw_region()` results for DirectReadHandle zero-copy optimization
- Invalidated on write operations (mkdir, rmdir, unlink, rename) for correctness

### Cache Integration
- `file.rs`: `stat()`, `file_raw_region()` check cache before FAT32 traversal; `mkdir`/`rmdir`/`unlink`/`rename` invalidate affected paths
- `fat32_backend.rs`: `exists()` and `open()` use cache fast-paths
- `fd.rs`: `vfs_stat()` checks negative cache for early ENOENT

Split from #1667.