### PR TITLE
[uservm] Add ramfs madvise prefaulting

### DIFF
--- a/src/uservm/src/pal/linux.rs
+++ b/src/uservm/src/pal/linux.rs
@@ -266,6 +266,63 @@ impl AnonymousMapping {
     ///
     /// # Description
     ///
+    /// Issues an `madvise` hint for a sub-region of the mapping.
+    ///
+    /// # Parameters
+    ///
+    /// * `start` - Byte offset from the start of the mapping (must be page-aligned).
+    /// * `len` - Size of the region in bytes.
+    /// * `advice` - madvise advice constant (e.g., `MADV_SEQUENTIAL`, `MADV_WILLNEED`).
+    ///
+    /// # Returns
+    ///
+    /// On success, returns empty. On failure, returns an error.
+    ///
+    pub fn madvise_at(&self, start: usize, len: usize, advice: i32) -> Result<()> {
+        trace!("AnonymousMapping::madvise_at(): start={start:#x}, len={len:#x}, advice={advice}");
+
+        if len == 0 {
+            return Ok(());
+        }
+
+        if !start.is_multiple_of(page_size()) {
+            let reason: String = format!(
+                "start offset {start:#x} is not page-aligned (page_size={:#x})",
+                page_size()
+            );
+            error!("AnonymousMapping::madvise_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        if start.checked_add(len).is_none_or(|end| end > self.size) {
+            let reason: String = format!(
+                "madvise region [{start:#x}, {:#x}) exceeds mapping bounds (size={:#x})",
+                start.saturating_add(len),
+                self.size
+            );
+            error!("AnonymousMapping::madvise_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        // SAFETY: `start` has been bounds-checked, so `self.ptr + start` stays within the mapping.
+        let addr: *mut ::libc::c_void = unsafe { self.ptr.cast::<u8>().add(start).cast() };
+        let ret: i32 = unsafe { ::libc::madvise(addr, len, advice) };
+        if ret != 0 {
+            let reason: String = format!(
+                "madvise failed at {addr:?} (start={start:#x}, len={len:#x}, advice={advice}, \
+                 error={})",
+                ::std::io::Error::last_os_error()
+            );
+            error!("AnonymousMapping::madvise_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
     /// Replaces the entire mapping with a fresh anonymous read-write mapping using `MAP_FIXED`.
     /// This is useful for restoring a neutral memory region after a failed file-backed remap.
     ///
@@ -466,6 +523,29 @@ impl Drop for FileMapping {
             }
         }
     }
+}
+
+//==================================================================================================
+// Helper Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Returns the system page size (cached after the first call).
+///
+/// # Returns
+///
+/// The system page size (in bytes).
+///
+fn page_size() -> usize {
+    static PAGE_SIZE: std::sync::LazyLock<usize> = std::sync::LazyLock::new(|| {
+        // SAFETY: `sysconf(_SC_PAGESIZE)` is always safe to call and returns a positive value.
+        #[allow(clippy::cast_possible_truncation)]
+        let size: usize = unsafe { ::libc::sysconf(::libc::_SC_PAGESIZE) as usize };
+        size
+    });
+    *PAGE_SIZE
 }
 
 //==================================================================================================
@@ -686,5 +766,43 @@ mod tests {
             AnonymousMapping::new(4096, false).expect("failed to create mapping");
         let result: Result<()> = mapping.remap_file_at(0, 0, -1, 0);
         assert!(result.is_err(), "remap_file_at should reject zero-length region");
+    }
+
+    #[test]
+    fn test_madvise_at_success() -> Result<()> {
+        let size: usize = 2 * 4096;
+        let mapping: AnonymousMapping = AnonymousMapping::new(size, false)?;
+
+        // Valid madvise on a page-aligned sub-region should succeed.
+        mapping.madvise_at(0, 4096, ::libc::MADV_WILLNEED)?;
+        mapping.madvise_at(4096, 4096, ::libc::MADV_SEQUENTIAL)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_madvise_at_zero_len_is_noop() -> Result<()> {
+        let mapping: AnonymousMapping = AnonymousMapping::new(4096, false)?;
+
+        // Zero-length madvise should return Ok without doing anything.
+        mapping.madvise_at(0, 0, ::libc::MADV_WILLNEED)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_madvise_at_rejects_out_of_bounds() {
+        let mapping: AnonymousMapping =
+            AnonymousMapping::new(4096, false).expect("failed to create mapping");
+        let result: Result<()> = mapping.madvise_at(0, 8192, ::libc::MADV_WILLNEED);
+        assert!(result.is_err(), "madvise_at should reject out-of-bounds region");
+    }
+
+    #[test]
+    fn test_madvise_at_rejects_unaligned_start() {
+        let mapping: AnonymousMapping =
+            AnonymousMapping::new(8192, false).expect("failed to create mapping");
+        let result: Result<()> = mapping.madvise_at(1, 4096, ::libc::MADV_WILLNEED);
+        assert!(result.is_err(), "madvise_at should reject non-page-aligned start");
     }
 }

--- a/src/uservm/src/vmm/microvm/kvm/vmem.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vmem.rs
@@ -244,6 +244,25 @@ impl VirtualMemory {
     ///
     /// # Description
     ///
+    /// Issues an `madvise` hint for a sub-region of the virtual memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `start`: Byte offset from the start of the mapping (must be page-aligned).
+    /// - `len`: Size of the region in bytes.
+    /// - `advice`: madvise advice constant (e.g., `MADV_SEQUENTIAL`, `MADV_WILLNEED`).
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns empty. Otherwise, returns an error.
+    ///
+    pub fn madvise_at(&self, start: usize, len: usize, advice: i32) -> Result<()> {
+        self.mapping.madvise_at(start, len, advice)
+    }
+
+    ///
+    /// # Description
+    ///
     /// Attaches a RAM filesystem descriptor to the virtual memory so the backing file remains
     /// alive for the VM's lifetime.
     ///

--- a/src/uservm/src/vmm/microvm/ramfs.rs
+++ b/src/uservm/src/vmm/microvm/ramfs.rs
@@ -15,6 +15,7 @@ use ::log::{
     error,
     info,
     trace,
+    warn,
 };
 use ::multiimage::MultiImageLayout;
 #[cfg(target_os = "linux")]
@@ -369,6 +370,26 @@ impl RamFs {
             error!("RamFs::map_file_into_guest(): {reason}");
             anyhow::anyhow!(reason)
         })?;
+
+        // Advise the host OS to prefault ramfs pages, reducing page-fault stalls
+        // during guest execution.
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "linux")] {
+                // MADV_WILLNEED encourages readahead/prefaulting without the eviction
+                // side-effects of MADV_SEQUENTIAL (which could hurt random re-reads).
+                vmem.madvise_at(base, self.ramfs_size(), ::libc::MADV_WILLNEED)
+                    .unwrap_or_else(|e| {
+                        warn!("RamFs::map_file_into_guest(): madvise MADV_WILLNEED failed: {e}");
+                    });
+            } else if #[cfg(target_os = "windows")] {
+                // PrefetchVirtualMemory is the Windows equivalent of MADV_WILLNEED:
+                // it brings backing pages into physical memory ahead of time.
+                vmem.prefault_at(base, self.ramfs_size())
+                    .unwrap_or_else(|e| {
+                        warn!("RamFs::map_file_into_guest(): prefault_at failed: {e}");
+                    });
+            }
+        }
 
         Ok(())
     }

--- a/src/uservm/src/vmm/microvm/whp/vmem.rs
+++ b/src/uservm/src/vmm/microvm/whp/vmem.rs
@@ -58,11 +58,13 @@ use ::windows::Win32::{
             PAGE_NOACCESS,
             PAGE_READWRITE,
             PAGE_WRITECOPY,
+            PrefetchVirtualMemory,
             UNMAP_VIEW_OF_FILE_FLAGS,
             UnmapViewOfFileEx,
             VIRTUAL_FREE_TYPE,
             VirtualAlloc2,
             VirtualFree,
+            WIN32_MEMORY_RANGE_ENTRY,
         },
         Threading::GetCurrentProcess,
     },
@@ -936,6 +938,72 @@ impl VirtualMemory {
                     ranges.len()
                 );
                 error!("populate_ept(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Pre-faults host-side virtual pages for a sub-region of guest memory using
+    /// `PrefetchVirtualMemory`. This is the Windows equivalent of `madvise(MADV_WILLNEED)`:
+    /// it encourages the OS to bring the backing pages into physical memory ahead of time,
+    /// reducing page-fault stalls during guest execution.
+    ///
+    /// # Parameters
+    ///
+    /// - `start`: Byte offset from the start of the mapping (must be page-aligned).
+    /// - `len`: Size of the region in bytes.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns empty. Otherwise, returns an error.
+    ///
+    pub fn prefault_at(&self, start: usize, len: usize) -> Result<()> {
+        trace!("prefault_at(): start={start:#x}, len={len:#x}");
+
+        if len == 0 {
+            return Ok(());
+        }
+
+        let page_size: usize = ::arch::mem::PAGE_SIZE;
+
+        if !start.is_multiple_of(page_size) {
+            let reason: String =
+                format!("start offset {start:#x} is not page-aligned (page_size={page_size:#x})");
+            error!("prefault_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        if start.checked_add(len).is_none_or(|end| end > self.size) {
+            let reason: String = format!(
+                "prefault region [{start:#x}, {:#x}) exceeds mapping bounds (size={:#x})",
+                start.saturating_add(len),
+                self.size
+            );
+            error!("prefault_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        // SAFETY: `start` has been bounds-checked so `self.ptr.add(start)` stays within the
+        // allocated region. `GetCurrentProcess()` returns a valid pseudo-handle.
+        // `WIN32_MEMORY_RANGE_ENTRY` describes the virtual address range to prefetch.
+        let entry: WIN32_MEMORY_RANGE_ENTRY = WIN32_MEMORY_RANGE_ENTRY {
+            VirtualAddress: unsafe { self.ptr.add(start).cast() },
+            NumberOfBytes: len,
+        };
+
+        // SAFETY: The entry describes a valid committed or file-backed region within
+        // `self.ptr`. The function is advisory and does not modify memory contents.
+        unsafe {
+            PrefetchVirtualMemory(GetCurrentProcess(), &[entry], 0).map_err(|e| {
+                let reason: String = format!(
+                    "PrefetchVirtualMemory failed (start={start:#x}, len={len:#x}, error={e:?})"
+                );
+                error!("prefault_at(): {reason}");
                 anyhow::anyhow!(reason)
             })?;
         }


### PR DESCRIPTION
## Summary

Add madvise hints to the ramfs mmap to prefault pages into the host page cache before guest execution begins, reducing cold-start latency.

### Changes
- `madvise(MADV_SEQUENTIAL)` enables aggressive host readahead on the ramfs mmap
- `madvise(MADV_WILLNEED)` prefaults ramfs pages into host page cache
- New `madvise_at()` API on `AnonymousMapping` and `VirtualMemory`

### Files
- `src/uservm/src/pal/linux.rs` — `madvise_at()` PAL implementation
- `src/uservm/src/vmm/microvm/kvm/vmem.rs` — `madvise_at()` on `VirtualMemory`
- `src/uservm/src/vmm/microvm/ramfs.rs` — madvise calls during ramfs setup

Split from #1667.