### PR TITLE
[build] Verus support on Windows

### DIFF
--- a/.github/actions/verify/action.yml
+++ b/.github/actions/verify/action.yml
@@ -1,0 +1,91 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Verify"
+description: "Run Verus formal verification on annotated kernel crates"
+
+inputs:
+  machine-type:
+    description: "Machine type"
+    required: true
+    default: "microvm"
+  deployment-type:
+    description: "Deployment type"
+    required: true
+    default: "standalone"
+  github-token:
+    description: "GitHub token for authenticated Verus downloads"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Resolve Verus Version"
+      id: verus-version
+      shell: bash
+      run: echo "version=$(tr -d '[:space:]' < build/verus-version)" >> "$GITHUB_OUTPUT"
+
+    - name: "Restore Verus Archive Cache"
+      id: verus-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: .verus-cache
+        key: verus-${{ runner.os }}-${{ steps.verus-version.outputs.version }}
+
+    - name: "Pre-download Verus Archive (Linux)"
+      if: runner.os == 'Linux' && steps.verus-cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: ./scripts/setup/verus.sh --download-only
+
+    - name: "Pre-download Verus Archive (Windows)"
+      if: runner.os == 'Windows' && steps.verus-cache.outputs.cache-hit != 'true'
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: .\scripts\setup\verus.ps1 -DownloadOnly
+
+    - name: "Install Verus (Linux)"
+      if: runner.os == 'Linux'
+      shell: bash
+      run: ./scripts/setup/verus.sh "${HOME}/toolchain/verus"
+
+    - name: "Install Verus (Windows)"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: .\scripts\setup\verus.ps1 "$env:USERPROFILE\verus"
+
+    - name: "Verify (Linux)"
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        ./z build -- verify \
+          "VERUS_EXECUTABLE_DIR=${HOME}/toolchain/verus" \
+          "MACHINE=${{ inputs.machine-type }}" \
+          TARGET=x86 \
+          LOG_LEVEL=trace \
+          VERBOSE=yes \
+          BUILD_OPT=no \
+          "DEPLOYMENT_MODE=${{ inputs.deployment-type }}"
+
+    - name: "Verify (Windows)"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        .\z.ps1 verify -- `
+          "VERUS_EXECUTABLE_DIR=$env:USERPROFILE\verus" `
+          "MACHINE=${{ inputs.machine-type }}" `
+          TARGET=x86 `
+          LOG_LEVEL=trace `
+          VERBOSE=yes `
+          BUILD_OPT=no `
+          "DEPLOYMENT_MODE=${{ inputs.deployment-type }}"
+
+    - name: "Save Verus Archive Cache"
+      if: steps.verus-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: .verus-cache
+        key: verus-${{ runner.os }}-${{ steps.verus-version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,54 +206,12 @@ jobs:
       - name: "Setup"
         uses: ./.github/actions/native-setup
 
-      # Cache the Verus release archive so that verify jobs do not need to
-      # re-download it on every run. The cache is keyed on the pinned Verus
-      # version; a version bump automatically causes a single fresh download.
-      - name: "Resolve Verus Version"
-        id: verus-version
-        shell: bash
-        run: echo "version=$(tr -d '[:space:]' < build/verus-version)" >> "$GITHUB_OUTPUT"
-
-      - name: "Restore Verus Archive Cache"
-        id: verus-cache
-        uses: actions/cache/restore@v5
-        with:
-          path: .verus-cache
-          key: verus-${{ steps.verus-version.outputs.version }}
-
-      - name: "Pre-download Verus Archive"
-        if: steps.verus-cache.outputs.cache-hit != 'true'
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./scripts/setup/verus.sh --download-only
-
-      - name: "Install Verus"
-        shell: bash
-        run: |
-          ./scripts/setup/verus.sh "${HOME}/toolchain/verus"
-
       - name: "Verify"
-        shell: bash
-        run: |
-          ./z build -- verify \
-            "VERUS_EXECUTABLE_DIR=${HOME}/toolchain/verus" \
-            "MACHINE=${{ matrix.machine-type }}" \
-            TARGET=x86 \
-            LOG_LEVEL=trace \
-            VERBOSE=yes \
-            BUILD_OPT=no \
-            "DEPLOYMENT_MODE=${{ matrix.deployment-type }}"
-
-      # Save the Verus archive to the cache only when it was not already
-      # cached. The first matrix leg to reach this step wins the cache
-      # reservation; the rest skip gracefully.
-      - name: "Save Verus Archive Cache"
-        if: steps.verus-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: ./.github/actions/verify
         with:
-          path: .verus-cache
-          key: verus-${{ steps.verus-version.outputs.version }}
+          machine-type: ${{ matrix.machine-type }}
+          deployment-type: ${{ matrix.deployment-type }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # Each matrix entry builds on a GitHub-hosted runner. Integration tests run
   # in a separate ci-test job (typically on self-hosted runners) that depends
@@ -554,16 +512,64 @@ jobs:
         run: |
           .\z.ps1 build -- lint-check MACHINE=${{ matrix.machine-type }}
 
+  # Verus formal verification on Windows. Only standalone deployment is supported
+  # on Windows, so the matrix covers machine-type only.
+  windows-verify:
+    name: "Windows Verify (${{ matrix.machine-type }})"
+    needs: [precheck]
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        machine-type: [microvm, hyperlight]
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    if: |
+      !cancelled() &&
+      github.repository == 'nanvix/nanvix' && (
+        github.event_name == 'merge_group' || github.event_name == 'schedule' || (
+          needs.precheck.outputs.up_to_date == 'true' && (
+            github.event_name != 'push' ||
+            github.event.head_commit == null ||
+            !startsWith(github.event.head_commit.message, 'Merge ')
+          ) && (
+            github.event_name != 'pull_request' ||
+            !github.event.pull_request.draft
+          )
+        )
+      )
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Install Rust Toolchain"
+        shell: pwsh
+        run: |
+          $toolchain = (Get-Content rust-toolchain | Select-String '^channel\s*=').ToString() -replace '.*=\s*"([^"]+)".*','$1'
+          rustup toolchain install $toolchain
+          rustup show
+
+      - name: "Verify"
+        uses: ./.github/actions/verify
+        with:
+          machine-type: ${{ matrix.machine-type }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   # Build all components (guest + host) natively on Windows using the local
   # cross-compilation toolchain (GNU Make + rust-lld) and run unit tests.
   windows-ci-build:
     name: "Windows Build (${{ matrix.machine-type }}, ${{ matrix.build-type }})"
-    needs: [windows-format-check, windows-lint-check]
+    needs: [windows-format-check, windows-lint-check, windows-verify]
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
+    # !failure() ensures the build does not start when checks/lint/verify fail.
     if: |
-      !cancelled() &&
+      !cancelled() && !failure() &&
       needs.windows-format-check.result == 'success' &&
-      needs.windows-lint-check.result == 'success'
+      needs.windows-lint-check.result == 'success' &&
+      needs.windows-verify.result == 'success'
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -1939,6 +1945,7 @@ jobs:
         publish-release,
         windows-format-check,
         windows-lint-check,
+        windows-verify,
         windows-ci-build,
         windows-integration-test,
       ]

--- a/Makefile
+++ b/Makefile
@@ -284,10 +284,26 @@ export VERUS_EXECUTABLE_DIR ?=
 # List of crates to verify with Verus.
 VERUS_CRATES := bitmap slab
 
+# Platform-specific Verus binary name.
+ifeq ($(IS_WINDOWS),yes)
+  VERUS_BINARY := verus.exe
+else
+  VERUS_BINARY := verus
+endif
+
 # Verus verification command.
 # Uses RUSTC_BOOTSTRAP=1 because the Verus rustc wrapper identifies as a stable compiler
 # but needs to accept -Z flags passed by -Z build-std.
-export VERUS_VERIFY_CMD = RUSTC_BOOTSTRAP=1 RUSTFLAGS=$(KERNEL_RUST_FLAGS) PATH="$(VERUS_EXECUTABLE_DIR):$$PATH" \
+ifeq ($(IS_WINDOWS),yes)
+# On Windows, convert VERUS_EXECUTABLE_DIR to a Unix-style path for the MSYS2 shell
+# so that drive-letter colons (e.g., C:\) are not misinterpreted as PATH separators.
+  VERUS_PATH_PREFIX = $$(cygpath -u '$(VERUS_EXECUTABLE_DIR)')
+else
+  VERUS_PATH_PREFIX = $(VERUS_EXECUTABLE_DIR)
+endif
+
+export VERUS_VERIFY_CMD = RUSTC_BOOTSTRAP=1 RUSTFLAGS=$(KERNEL_RUST_FLAGS) \
+	PATH="$(VERUS_PATH_PREFIX):$$PATH" \
 	$(CARGO) verus verify --no-default-features
 
 #===================================================================================================
@@ -538,11 +554,20 @@ ensure-verus:
 ifeq ($(VERUS_EXECUTABLE_DIR),)
 	@echo "VERUS_EXECUTABLE_DIR is not set; skipping verification."
 else
-	@if [ ! -x "$(VERUS_EXECUTABLE_DIR)/verus" ]; then \
-		echo "Error: VERUS_EXECUTABLE_DIR is set to '$(VERUS_EXECUTABLE_DIR)' but no verus binary found there."; \
+	@verus_dir="$(VERUS_EXECUTABLE_DIR)"; \
+	if command -v cygpath >/dev/null 2>&1; then \
+		verus_dir="$$(cygpath -u "$$verus_dir")"; \
+	fi; \
+	verus_path="$$verus_dir/$(VERUS_BINARY)"; \
+	if [ ! -f "$$verus_path" ]; then \
+		echo "Error: VERUS_EXECUTABLE_DIR is set to '$(VERUS_EXECUTABLE_DIR)' but no $(VERUS_BINARY) found there."; \
 		exit 1; \
-	fi
-	@echo "Using Verus installation at $(VERUS_EXECUTABLE_DIR)."
+	fi; \
+	if [ "$(IS_WINDOWS)" != "yes" ] && [ ! -x "$$verus_path" ]; then \
+		echo "Error: $(VERUS_BINARY) at '$$verus_path' is not executable."; \
+		exit 1; \
+	fi; \
+	echo "Using Verus installation at $(VERUS_EXECUTABLE_DIR)."
 endif
 
 # Pattern rule for verifying individual crates.

--- a/doc/build-linux.md
+++ b/doc/build-linux.md
@@ -130,23 +130,26 @@ To run formal verification:
 
 ```bash
 # Verify all annotated crates.
-./z build -- verify VERUS_EXECUTABLE_DIR=~/toolchain/verus
+./z verify -- VERUS_EXECUTABLE_DIR=~/toolchain/verus
 
 # Verify a single crate (e.g., bitmap).
-./z build -- verify-bitmap VERUS_EXECUTABLE_DIR=~/toolchain/verus
+./z verify -- verify-bitmap VERUS_EXECUTABLE_DIR=~/toolchain/verus
 ```
 
 > **Note:** `VERUS_EXECUTABLE_DIR` must be set; when unset, verification is a silent no-op.
 
 Verification requires `VERUS_EXECUTABLE_DIR` to point to the directory that contains the
 `verus` executable (and required companion binaries). When the variable is unset, `make verify`
-is a no-op. The `scripts/setup/verus.sh` helper can download the pinned release:
+is a no-op. Use the setup command or the helper script to download the pinned release:
 
 ```bash
-# Install verus to a local directory and run verification.
+# Option 1: Automated install via z (installs to ~/verus).
+./z setup --verus
+
+# Option 2: Install to a custom directory.
 ./scripts/setup/verus.sh ~/toolchain/verus
-./z build -- verify VERUS_EXECUTABLE_DIR=~/toolchain/verus
+./z verify -- VERUS_EXECUTABLE_DIR=~/toolchain/verus
 
 # Or use a source-built installation.
-./z build -- verify VERUS_EXECUTABLE_DIR=~/verus/target-verus/release
+./z verify -- VERUS_EXECUTABLE_DIR=~/verus/target-verus/release
 ```

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -16,6 +16,7 @@ while guest components are cross-compiled using a local toolchain.
 - [Building Individual Components](#building-individual-components)
 - [Build Parameters](#build-parameters)
 - [Code Quality Checks](#code-quality-checks)
+- [Formal Verification with Verus](#formal-verification-with-verus)
 - [Cleaning](#cleaning)
 
 ---
@@ -118,6 +119,33 @@ Available build parameters:
 # Run standalone integration tests on Windows.
 .\z.ps1 test -- MACHINE=microvm
 ```
+
+## Formal Verification with Verus
+
+Nanvix uses [Verus](https://github.com/verus-lang/verus) for formal verification of selected
+kernel crates. The correct Verus version is pinned in `build/verus-version`.
+
+To install Verus on Windows, use the setup command or the PowerShell setup script:
+
+```powershell
+# Option 1: Automated install via z.ps1 (installs to %USERPROFILE%\verus).
+.\z.ps1 setup --verus
+
+# Option 2: Manual install to a custom directory.
+.\scripts\setup\verus.ps1 C:\verus
+```
+
+To run formal verification:
+
+```powershell
+# Verify all annotated crates.
+.\z.ps1 verify -- VERUS_EXECUTABLE_DIR=C:\verus
+
+# Verify a single crate (e.g., bitmap).
+.\z.ps1 verify -- verify-bitmap VERUS_EXECUTABLE_DIR=C:\verus
+```
+
+> **Note:** `VERUS_EXECUTABLE_DIR` must be set; when unset, verification is skipped.
 
 ## Cleaning
 

--- a/doc/setup-linux.md
+++ b/doc/setup-linux.md
@@ -157,12 +157,22 @@ compatibility. Follow these steps to update your environment:
 
 Verification requires `VERUS_EXECUTABLE_DIR` to point to the directory containing the `verus`
 binary. When unset, `make verify` is a no-op. The expected version is pinned in
-`build/verus-version`; use `scripts/setup/verus.sh` to download it:
+`build/verus-version`.
+
+The easiest way to install Verus is via the setup command:
+
+```bash
+./z setup --verus
+```
+
+This installs the pinned Verus release to `~/verus` (or `<toolchain-dir>/verus` when
+`--toolchain-dir` is provided). You can also invoke the setup script directly to choose a
+custom install directory:
 
 ```bash
 # Download the pinned release and run verification.
 ./scripts/setup/verus.sh ~/toolchain/verus
-./z build -- verify VERUS_EXECUTABLE_DIR=~/toolchain/verus
+./z verify -- VERUS_EXECUTABLE_DIR=~/toolchain/verus
 ```
 
 ### Using a Custom Verus Installation
@@ -178,7 +188,7 @@ cd ~/verus-src/source
 
 # 2. From the Nanvix repo root, run verification pointing at the verus binary directory.
 cd /path/to/nanvix
-./z build -- verify VERUS_EXECUTABLE_DIR=~/verus-src/source/target-verus/release
+./z verify -- VERUS_EXECUTABLE_DIR=~/verus-src/source/target-verus/release
 ```
 
 > **Note:** The build validates that a `verus` binary exists at the given path (the directory

--- a/doc/setup-windows.md
+++ b/doc/setup-windows.md
@@ -9,7 +9,8 @@ This guide will help you set up your development environment to build and run Na
 - [3. Clone This Repository](#3-clone-this-repository)
 - [4. Enable Windows Hypervisor Platform](#4-enable-windows-hypervisor-platform)
 - [5. Run Setup](#5-run-setup)
-- [6. Setup Your IDE (Optional)](#6-setup-your-ide-optional)
+- [6. Verus (Formal Verification, Optional)](#6-verus-formal-verification-optional)
+- [7. Setup Your IDE (Optional)](#7-setup-your-ide-optional)
   - [Visual Studio Code](#visual-studio-code)
 
 ---
@@ -94,7 +95,38 @@ This command validates prerequisites and configures the development environment:
 
 ---
 
-## 6. Setup Your IDE (Optional)
+## 6. Verus (Formal Verification, Optional)
+
+Verus formal verification is optional. When `VERUS_EXECUTABLE_DIR` is not set, verification
+is skipped.
+
+The easiest way to install Verus is via the setup command:
+
+```powershell
+.\z.ps1 setup --verus
+```
+
+This installs the pinned Verus release to `%USERPROFILE%\verus`. You can also invoke the
+setup script directly to choose a custom install directory:
+
+```powershell
+.\scripts\setup\verus.ps1 C:\verus
+```
+
+The script downloads the prebuilt Windows binary from the Verus GitHub releases page,
+validates the archive, and installs it to the given directory. Use `VERUS_EXECUTABLE_DIR`
+to point the build system at the installation:
+
+```powershell
+.\z.ps1 verify -- VERUS_EXECUTABLE_DIR=C:\verus
+```
+
+> **Note:** The expected version is pinned in `build/verus-version`. Re-run `setup --verus`
+> or the setup script after version bumps to update the installation.
+
+---
+
+## 7. Setup Your IDE (Optional)
 
 Choose one of the following options to set up your IDE for Nanvix development.
 

--- a/scripts/setup/verus.ps1
+++ b/scripts/setup/verus.ps1
@@ -1,0 +1,292 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Ensures the correct version of Verus is installed on Windows.
+
+.DESCRIPTION
+    Reads the expected version from build/verus-version, checks whether Verus is
+    already present at that version in the target directory, and downloads/installs
+    it when missing or outdated. Downloads the prebuilt Windows binary from GitHub
+    releases.
+
+.PARAMETER InstallDir
+    Directory where Verus will be installed. Defaults to $env:USERPROFILE\verus.
+
+.PARAMETER DownloadOnly
+    Download the Verus archive to the local cache and exit without installing.
+    Useful for CI pre-warming.
+
+.EXAMPLE
+    .\scripts\setup\verus.ps1 C:\verus
+    .\scripts\setup\verus.ps1 -DownloadOnly C:\verus
+
+.NOTES
+    Environment Variables:
+      GITHUB_TOKEN        GitHub token for authenticated downloads (optional).
+      GH_TOKEN            Alternative to GITHUB_TOKEN (GitHub CLI convention).
+      VERUS_ZIP_CACHE_DIR Override the default cache directory (.verus-cache).
+#>
+
+param(
+    [Parameter(Position = 0)]
+    [string]$InstallDir = "$env:USERPROFILE\verus",
+
+    [switch]$DownloadOnly
+)
+
+# Fail fast on errors.
+$ErrorActionPreference = "Stop"
+
+# ==================================================================================================
+# Constants
+# ==================================================================================================
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = (git rev-parse --show-toplevel 2>$null)
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..\..")).Path
+}
+
+$VerusVersionFile = Join-Path $RepoRoot "build\verus-version"
+$VerusReleaseUrl = "https://github.com/verus-lang/verus/releases/download/release"
+$VerusZipSubdir = "verus-x86-win"
+
+if ($env:VERUS_ZIP_CACHE_DIR) {
+    $CacheDir = $env:VERUS_ZIP_CACHE_DIR
+} else {
+    $CacheDir = Join-Path $RepoRoot ".verus-cache"
+}
+
+# ==================================================================================================
+# Helper Functions
+# ==================================================================================================
+
+function Write-Info { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundColor Cyan }
+function Write-Ok   { param([string]$Msg) Write-Host "[OK]   $Msg" -ForegroundColor Green }
+function Write-Warn { param([string]$Msg) Write-Host "[WARN] $Msg" -ForegroundColor Yellow }
+function Write-Err  { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red }
+
+function Get-ExpectedVersion {
+    if (-not (Test-Path $VerusVersionFile)) {
+        Write-Err "Verus version file not found: $VerusVersionFile"
+        exit 1
+    }
+    $version = (Get-Content $VerusVersionFile -Raw).Trim()
+    if (-not $version) {
+        Write-Err "Verus version file is empty: $VerusVersionFile"
+        exit 1
+    }
+    return $version
+}
+
+function Get-InstalledVersion {
+    param([string]$Dir)
+    $versionFile = Join-Path $Dir "version.txt"
+    if (Test-Path $versionFile) {
+        return (Get-Content $versionFile -Raw).Trim()
+    }
+    return ""
+}
+
+function Get-AuthHeaders {
+    $token = if ($env:GITHUB_TOKEN) { $env:GITHUB_TOKEN } elseif ($env:GH_TOKEN) { $env:GH_TOKEN } else { "" }
+    if ($token) {
+        return @{ Authorization = "Bearer $token" }
+    }
+    return @{}
+}
+
+function Test-ZipArchive {
+    param([string]$ZipPath)
+    try {
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+        $zip.Dispose()
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Get-VerusArchive {
+    param(
+        [string]$DestPath,
+        [string]$Version
+    )
+
+    $zipName = "verus-${Version}-x86-win.zip"
+    $downloadUrl = "${VerusReleaseUrl}/${Version}/${zipName}"
+
+    # Try the local zip cache first.
+    if ($CacheDir) {
+        $cachedZip = Join-Path $CacheDir $zipName
+        if ((Test-Path $cachedZip) -and (Get-Item $cachedZip).Length -gt 0) {
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+            if (Test-ZipArchive $cachedZip) {
+                Write-Info "Using cached Verus archive from $cachedZip"
+                Copy-Item $cachedZip $DestPath -Force
+                return
+            } else {
+                Write-Warn "Cached Verus archive at $cachedZip is corrupted; deleting and re-downloading."
+                Remove-Item $cachedZip -Force
+            }
+        }
+    }
+
+    Write-Info "Downloading Verus $Version from $downloadUrl ..."
+    $headers = Get-AuthHeaders
+
+    $maxRetries = 5
+    $retryDelay = 10
+    for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
+        try {
+            $webArgs = @{
+                Uri     = $downloadUrl
+                OutFile = $DestPath
+            }
+            if ($headers.Count -gt 0) { $webArgs.Headers = $headers }
+            Invoke-WebRequest @webArgs
+            break
+        } catch {
+            if ($attempt -eq $maxRetries) {
+                Write-Err "Failed to download Verus from $downloadUrl after $maxRetries attempts."
+                Write-Err $_.Exception.Message
+                exit 1
+            }
+            Write-Warn "Download attempt $attempt failed; retrying in ${retryDelay}s..."
+            Start-Sleep -Seconds $retryDelay
+        }
+    }
+
+    # Persist the downloaded archive for future runs.
+    if ($CacheDir) {
+        if (-not (Test-Path $CacheDir)) {
+            New-Item -ItemType Directory -Path $CacheDir -Force | Out-Null
+        }
+        Copy-Item $DestPath (Join-Path $CacheDir $zipName) -Force
+    }
+}
+
+function Install-Verus {
+    param(
+        [string]$Dir,
+        [string]$Version
+    )
+
+    $zipName = "verus-${Version}-x86-win.zip"
+
+    # Validate that the install directory looks reasonable.
+    if ($Dir -notmatch "verus") {
+        Write-Err "Install directory '$Dir' does not contain 'verus'. Aborting for safety."
+        exit 1
+    }
+
+    # Create a temporary directory for the download.
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "verus-install-$([guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+
+    try {
+        $zipPath = Join-Path $tmpDir $zipName
+        Get-VerusArchive -DestPath $zipPath -Version $Version
+
+        Write-Info "Extracting Verus to $Dir ..."
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $extractDir = Join-Path $tmpDir "extract"
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $extractDir)
+
+        # Verify the expected subdirectory exists in the archive.
+        $subDir = Join-Path $extractDir $VerusZipSubdir
+        if (-not (Test-Path $subDir)) {
+            Write-Err "Expected directory '$VerusZipSubdir' not found in archive."
+            exit 1
+        }
+
+        # Replace the install directory contents.
+        if (-not (Test-Path $Dir)) {
+            New-Item -ItemType Directory -Path $Dir -Force | Out-Null
+        } else {
+            Get-ChildItem $Dir | Remove-Item -Recurse -Force
+        }
+        Get-ChildItem $subDir | Copy-Item -Destination $Dir -Recurse -Force
+
+        Write-Ok "Verus $Version installed to $Dir."
+    } finally {
+        if (Test-Path $tmpDir) {
+            Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Confirm-VerusToolchain {
+    param([string]$Dir)
+
+    $versionJson = Join-Path $Dir "version.json"
+    if (-not (Test-Path $versionJson)) { return }
+    if (-not (Get-Command rustup -ErrorAction SilentlyContinue)) { return }
+
+    try {
+        $data = Get-Content $versionJson -Raw | ConvertFrom-Json
+        $toolchain = $data.verus.toolchain
+        if (-not $toolchain) { return }
+
+        $null = rustup run $toolchain rustc --version 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Info "Installing Rust toolchain '$toolchain' required by Verus..."
+            rustup toolchain install $toolchain --profile minimal --component rust-src
+        }
+    } catch {
+        Write-Warn "Failed to parse $versionJson; skipping toolchain check."
+    }
+}
+
+# ==================================================================================================
+# Main
+# ==================================================================================================
+
+$expectedVersion = Get-ExpectedVersion
+
+if ($DownloadOnly) {
+    $zipName = "verus-${expectedVersion}-x86-win.zip"
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "verus-dl-$([guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+    try {
+        Get-VerusArchive -DestPath (Join-Path $tmpDir $zipName) -Version $expectedVersion
+
+        # Validate the cached archive.
+        $cachedZip = Join-Path $CacheDir $zipName
+        if ((Test-Path $cachedZip) -and (Get-Item $cachedZip).Length -gt 0) {
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+            if (-not (Test-ZipArchive $cachedZip)) {
+                Write-Err "Downloaded Verus archive failed validation: $cachedZip"
+                Remove-Item $cachedZip -Force
+                exit 1
+            }
+        } else {
+            Write-Err "Verus archive not found in cache after download: $cachedZip"
+            exit 1
+        }
+
+        Write-Ok "Verus $expectedVersion archive cached in $CacheDir."
+    } finally {
+        if (Test-Path $tmpDir) { Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+    exit 0
+}
+
+$installedVersion = Get-InstalledVersion -Dir $InstallDir
+
+if ($installedVersion -eq $expectedVersion) {
+    Write-Info "Verus $expectedVersion is already installed in $InstallDir."
+    Confirm-VerusToolchain -Dir $InstallDir
+    exit 0
+}
+
+if ($installedVersion) {
+    Write-Info "Verus version mismatch (found '$installedVersion', expected '$expectedVersion'). Updating..."
+} else {
+    Write-Info "Verus not found in $InstallDir. Installing..."
+}
+
+Install-Verus -Dir $InstallDir -Version $expectedVersion
+Confirm-VerusToolchain -Dir $InstallDir

--- a/tests/test_z.py
+++ b/tests/test_z.py
@@ -93,6 +93,11 @@ class TestParseCli(unittest.TestCase):
         cmd, _ = zmod.parse_cli(["run"])
         self.assertEqual(cmd, "run")
 
+    def test_subcommand_verify(self) -> None:
+        """Parsing ['verify'] extracts 'verify' as the subcommand."""
+        cmd, _ = zmod.parse_cli(["verify"])
+        self.assertEqual(cmd, "verify")
+
     def test_subcommand_bench(self) -> None:
         """Parsing ['bench'] extracts 'bench' as the subcommand."""
         cmd, _ = zmod.parse_cli(["bench"])
@@ -158,6 +163,11 @@ class TestParseCli(unittest.TestCase):
         """The --l2-deployment flag enables the l2_deployment config field."""
         _, cfg = zmod.parse_cli(["setup", "--l2-deployment"])
         self.assertTrue(cfg.l2_deployment)
+
+    def test_verus_flag(self) -> None:
+        """The --verus flag enables the verus config field."""
+        _, cfg = zmod.parse_cli(["setup", "--verus"])
+        self.assertTrue(cfg.verus)
 
     # --- -- separator behaviour ---
 
@@ -1336,6 +1346,7 @@ class TestCommands(unittest.TestCase):
         expected = {
             "build",
             "test",
+            "verify",
             "clean",
             "distclean",
             "setup",

--- a/z.ps1
+++ b/z.ps1
@@ -15,6 +15,7 @@
     .\z.ps1 build -- uservm
     .\z.ps1 build -- guest
     .\z.ps1 build -- lint-check
+    .\z.ps1 verify -- VERUS_EXECUTABLE_DIR=C:\verus
     .\z.ps1 clean
     .\z.ps1 distclean
     .\z.ps1 run

--- a/z.py
+++ b/z.py
@@ -255,6 +255,7 @@ class BuildConfig:
 
     nanvix_sdk: bool = False
     l2_deployment: bool = False
+    verus: bool = False
     _user_set_toolchain_dir: bool = False
 
     toolchain_dir: str = ""
@@ -395,6 +396,8 @@ def parse_cli(argv: Sequence[str]) -> tuple[str, BuildConfig]:
             config.nanvix_sdk = True
         elif arg == "--l2-deployment":
             config.l2_deployment = True
+        elif arg == "--verus":
+            config.verus = True
         elif arg == "--toolchain-dir":
             i += 1
             if i >= len(argv_list):
@@ -845,6 +848,41 @@ def cmd_test(plat: PlatformInfo, config: BuildConfig) -> int:
 
 
 # ==================================================================================================
+# Subcommand: verify
+# ==================================================================================================
+
+
+def cmd_verify(plat: PlatformInfo, config: BuildConfig) -> int:
+    """Execute the verify subcommand (Verus formal verification)."""
+    if plat.is_windows:
+        restore_git_symlinks(plat.repo_root)
+
+    injected, user_args = _assemble_build_make_args(plat, config)
+
+    # If the user did not supply explicit Make goals after `--`, default to the
+    # top-level `verify` target. Otherwise, rely solely on the user-specified
+    # goals and do not prepend `verify`.  Variable assignments (KEY=VALUE) are
+    # not Make goals, so they must not suppress the default target.
+    has_goals = any("=" not in a for a in user_args)
+    targets: list[str] = ["verify"] if not has_goals else []
+
+    rc = invoke_make(
+        plat,
+        injected_vars=injected,
+        raw_args=user_args,
+        targets=targets,
+        verbose=config.verbose,
+    )
+
+    if rc == 0:
+        print_success("Verification complete.")
+    else:
+        print_error("Verification failed.")
+
+    return rc
+
+
+# ==================================================================================================
 # Subcommand: run
 # ==================================================================================================
 
@@ -923,6 +961,7 @@ Usage:
 Commands:
   build       Build Nanvix components.
   test        Run tests.
+  verify      Run Verus formal verification on annotated crates.
   clean       Remove build artifacts (quick clean).
   distclean   Remove everything (full clean).
   setup       Install development prerequisites.
@@ -957,6 +996,8 @@ Examples:
   z.ps1 build -- all                      Build everything (Windows).
   z.ps1 build -- guest                    Cross-compile guest only.
   ./z test                                Run all tests.
+  ./z verify -- VERUS_EXECUTABLE_DIR=~/toolchain/verus   Verify all annotated crates.
+  z.ps1 verify -- VERUS_EXECUTABLE_DIR=C:\\verus          Verify on Windows.
   ./z clean                               Clean build artifacts.
   ./z setup                                Install core dev prerequisites.
   ./z setup --nanvix-sdk                   Also build the cross-compilation toolchain.
@@ -1174,6 +1215,21 @@ def cmd_setup_linux(plat: PlatformInfo, config: BuildConfig) -> int:
         if rc != 0:
             die("Cloud Hypervisor setup failed.")
 
+    # Verus formal verification toolchain (optional).
+    if config.verus:
+        verus_script = plat.repo_root / "scripts" / "setup" / "verus.sh"
+        if not verus_script.exists():
+            die(f"Verus setup script not found: {verus_script}")
+        verus_dir = (
+            Path(config.toolchain_dir) / "verus"
+            if config.toolchain_dir
+            else Path.home() / "verus"
+        )
+        print_info(f"Installing Verus to {verus_dir} ...")
+        rc = subprocess.run([str(verus_script), str(verus_dir)]).returncode
+        if rc != 0:
+            die("Verus setup failed.")
+
     _install_git_hooks(plat.repo_root)
     print_success("Setup complete.")
     return 0
@@ -1290,6 +1346,30 @@ def cmd_setup_windows(plat: PlatformInfo, config: BuildConfig) -> int:
                 )
     print_success("Rust toolchain: OK")
 
+    # Verus (optional).
+    if config.verus:
+        verus_script = plat.repo_root / "scripts" / "setup" / "verus.ps1"
+        if not verus_script.exists():
+            die(f"Verus setup script not found: {verus_script}")
+        if config.toolchain_dir:
+            verus_dir = Path(config.toolchain_dir) / "verus"
+        else:
+            verus_dir = Path(os.environ.get("USERPROFILE", "")) / "verus"
+        print_info(f"Installing Verus to {verus_dir} ...")
+        rc = subprocess.run(
+            [
+                "powershell",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(verus_script),
+                str(verus_dir),
+            ]
+        ).returncode
+        if rc != 0:
+            die("Verus setup failed.")
+        print_success("Verus: OK")
+
     _install_git_hooks(plat.repo_root)
     print_success("Windows setup complete.")
     return 0
@@ -1312,6 +1392,7 @@ def cmd_setup(plat: PlatformInfo, config: BuildConfig) -> int:
 COMMANDS = {
     "build": cmd_build,
     "test": cmd_test,
+    "verify": cmd_verify,
     "clean": cmd_clean,
     "distclean": cmd_distclean,
     "setup": cmd_setup,


### PR DESCRIPTION
## Summary

Adds cross-platform support for Verus formal verification on Windows.

Closes #1847

## Changes

- **z.py**: Add `verify` subcommand that delegates to `make verify` with appropriate environment setup
- **Makefile**: Add `VERUS_BINARY` variable (`verus.exe` on Windows, `verus` on Linux); adapt `VERUS_VERIFY_CMD` to convert paths via `cygpath` on Windows; update `ensure-verus` to check for the platform-specific binary name
- **scripts/setup/verus.ps1**: New Windows Verus setup script — downloads prebuilt `x86-win` binary from GitHub releases with caching, version pinning, and Rust toolchain validation
- **z.ps1**: Add `verify` example to header
- **Documentation**: Add Verus sections to `build-windows.md` and `setup-windows.md`; update `build-linux.md` and `setup-linux.md` to use the new `./z verify` subcommand

## Testing

- Verified `z.py verify` correctly delegates to `make verify` (no-op when `VERUS_EXECUTABLE_DIR` is unset)
- Verified `z.py help` lists the new `verify` command
- Pre-commit checks pass (2/2 configurations)