### PR TITLE
[build] Update hyperlight to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,17 +124,17 @@ goblin = { version = "0.10.5", default-features = false }
 indicatif = "0.18.4"
 http = "1.4.0"
 http-body-util = "0.1.3"
-hyperlight-common = { version = "0.13.1", default-features = false, features = [
+hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "1a90040af3475da9f9bc5fdbf7eba61353678b32", default-features = false, features = [
         "nanvix-unstable",
 ] }
-hyperlight-host = { version = "0.13.1", default-features = false, features = [
+hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "1a90040af3475da9f9bc5fdbf7eba61353678b32", default-features = false, features = [
         "kvm",
         "mshv3",
         "hw-interrupts",
         "executable_heap",
         "nanvix-unstable",
 ] }
-hyperlight-guest = { version = "0.13.1", default-features = false, features = [
+hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "1a90040af3475da9f9bc5fdbf7eba61353678b32", default-features = false, features = [
         "nanvix-unstable",
 ] }
 hyper = { version = "1.9.0", default-features = false }


### PR DESCRIPTION
Automated hyperlight version bump.

| Field | Value |
|-------|-------|
| Repository | [`hyperlight-dev/hyperlight`](https://github.com/hyperlight-dev/hyperlight) |
| Version | `0.14.0` |
| Old ref | `0.13.1` |
| New rev | `1a90040af3475da9f9bc5fdbf7eba61353678b32` |

**Files changed:**
- `Cargo.toml` — updated hyperlight crate references
- `Cargo.lock` — regenerated

> Generated by the **Hyperlight Update** workflow.