### PR TITLE
[nanvix-http] Add Readiness Probe

### DIFF
--- a/src/libs/nanvix-http/src/client/mod.rs
+++ b/src/libs/nanvix-http/src/client/mod.rs
@@ -32,6 +32,7 @@ use crate::message::{
 use ::http_body_util::Full;
 use ::hyper::{
     body::Bytes,
+    Request,
     Response,
     StatusCode,
 };
@@ -58,6 +59,38 @@ pub use self::standalone::{
 //==================================================================================================
 
 impl<T: Send + Sync + Default + 'static> HttpClient<T> {
+    ///
+    /// # Description
+    ///
+    /// Returns whether an incoming request is a readiness probe.
+    ///
+    /// # Parameters
+    ///
+    /// - `request`: Incoming HTTP request.
+    ///
+    /// # Returns
+    ///
+    /// `true` for `GET /ready`, `false` otherwise.
+    ///
+    fn is_ready_request<B>(request: &Request<B>) -> bool {
+        request.method() == ::hyper::Method::GET && request.uri().path() == "/ready"
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Builds a successful readiness response.
+    ///
+    /// # Returns
+    ///
+    /// An empty `204 No Content` response.
+    ///
+    fn ready_response() -> Response<Full<Bytes>> {
+        let mut response: Response<Full<Bytes>> = Response::new(Full::new(Bytes::new()));
+        *response.status_mut() = StatusCode::NO_CONTENT;
+        response
+    }
+
     ///
     /// # Description
     ///

--- a/src/libs/nanvix-http/src/client/multi_process.rs
+++ b/src/libs/nanvix-http/src/client/multi_process.rs
@@ -179,6 +179,10 @@ impl<T: Send + Sync + Default + 'static> Service<Request<Incoming>> for HttpClie
         // Clone all necessary values before moving them into the future
         let sandbox_cache = self.sandbox_cache.clone();
         let future = async move {
+            if Self::is_ready_request(&request) {
+                return Ok(Self::ready_response());
+            }
+
             // Get the request headers before consuming the body.
             let message_type: MessageType = match request
                 .headers()

--- a/src/libs/nanvix-http/src/client/single_process.rs
+++ b/src/libs/nanvix-http/src/client/single_process.rs
@@ -184,6 +184,10 @@ impl<T: Send + Sync + Default + 'static> Service<Request<Incoming>> for HttpClie
         // Clone all necessary values before moving them into the future
         let sandbox_cache = self.sandbox_cache.clone();
         let future = async move {
+            if Self::is_ready_request(&request) {
+                return Ok(Self::ready_response());
+            }
+
             // Get the request headers before consuming the body.
             let message_type: MessageType = match request
                 .headers()

--- a/src/libs/nanvix-http/src/client/standalone.rs
+++ b/src/libs/nanvix-http/src/client/standalone.rs
@@ -369,6 +369,10 @@ impl<T: Send + Sync + Default + 'static> Service<Request<Incoming>> for HttpClie
     fn call(&self, request: Request<Incoming>) -> Self::Future {
         let state: Arc<StandaloneState> = self.state.clone();
         let future = async move {
+            if Self::is_ready_request(&request) {
+                return Ok(Self::ready_response());
+            }
+
             // Get the request headers before consuming the body.
             let message_type: MessageType = match request
                 .headers()


### PR DESCRIPTION
In this commit I add a `/ready` endpoint to the nanvix HTTP server. Such an endpoint is a useful way to poll nanvixd's readiness without having to rely on other collateral measurements, like checking whether a given port is open or not.