### PR TITLE
[ci] Add 256MB memory-size images to release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,11 @@ jobs:
         build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' || github.event_name == 'workflow_dispatch' && '["debug","release"]' || '["release"]') }}
         machine-type: [microvm, hyperlight]
         deployment-type: [standalone, single-process, multi-process]
-        memory-size: [128]
+        memory-size: [128, 256]
+        # 256MB images are release-only; exclude them from debug builds.
+        exclude:
+          - build-type: debug
+            memory-size: 256
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -1789,7 +1793,7 @@ jobs:
       matrix:
         machine-type: [microvm, hyperlight]
         deployment-type: [standalone, single-process, multi-process]
-        memory-size: [128]
+        memory-size: [128, 256]
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
Add 256MB to the ci-build and release-archive matrix memory-size
dimension so that release pipelines produce images for both 128MB
and 256MB configurations.

A matrix exclude rule keeps 256MB out of debug (PR) builds to avoid
doubling the PR feedback loop; only release builds (merge-queue, dev
pushes, and manual dispatch) produce the larger images.

Downstream jobs are unaffected:
- ci-test defaults to 128MB via prepare-test-artifacts and does not
  need a matrix change.
- The Makefile already embeds MEMORY_SIZE_MB in release archive
  filenames, so 128MB and 256MB artifacts coexist without collision.