### PR TITLE
[build] Add x86_64 target support to the build system

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,4 @@ skip = .git,.venv,bin,lib,logs,build,target,toolchain,sysroot-debug,sysroot-rele
 
 # Ignore words that are commonly used in systems programming
 # and are flagged as typos by codespell
-ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,servent
+ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,12 @@ ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap config elf error fat32 type-safe pr
 ALL_GUEST_DAEMONS := memd procd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd
 ALL_GUEST_APPLICATIONS := hello-rust-nostd
-ALL_GUEST_TESTS := testd file-rust thread-rust stress-rust test-kernel test-mmio-fault linux-app arch-rust vfs-test misc-rust memory-rust network-rust dlfcn-rust c-bindings-rust
+ALL_GUEST_TESTS := testd file-rust thread-rust stress-rust test-kernel test-mmio-fault linux-app arch-rust vfs-test misc-rust memory-rust network-rust c-bindings-rust
+# dlfcn-rust requires PIE linking for dlopen/dlsym; the x86_64 static
+# relocation model produces R_X86_64_32 relocations incompatible with PIE.
+ifneq ($(TARGET),x86_64)
+ALL_GUEST_TESTS += dlfcn-rust
+endif
 ALL_GUEST_BINARIES := $(ALL_GUEST_DAEMONS) $(ALL_GUEST_BENCHMARKS) $(ALL_GUEST_APPLICATIONS)
 ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 
@@ -539,7 +544,7 @@ help:
 	@echo "Parameter Values"
 	@echo "  DEPLOYMENT_MODE standalone, single-process, multi-process, l2"
 	@echo "  MACHINE         hyperlight, microvm"
-	@echo "  TARGET          x86"
+	@echo "  TARGET          x86, x86_64"
 	@echo "  RELEASE         yes, no"
 	@echo "  LOG_LEVEL       trace, debug, info, warn, error, panic"
 	@echo "  PROFILER        yes, no"
@@ -843,7 +848,7 @@ endif
 endif
 endif
 
-# Determine the test configuration file based on deployment mode.
+# Determine the test configuration file based on deployment mode and architecture.
 ifeq ($(IS_WINDOWS),yes)
 ifeq ($(DEPLOYMENT_MODE),standalone)
 NANVIX_TEST_CONFIG := test/test-standalone-windows.toml
@@ -853,13 +858,25 @@ NANVIX_TEST_CONFIG := test/test-standalone-windows.toml
 endif
 else
 ifeq ($(DEPLOYMENT_MODE),standalone)
+ifeq ($(TARGET),x86_64)
+NANVIX_TEST_CONFIG := test/test-standalone-x86_64.toml
+else
 NANVIX_TEST_CONFIG := test/test-standalone.toml
+endif
 else ifneq ($(filter single-process,$(DEPLOYMENT_MODE)),)
+ifeq ($(TARGET),x86_64)
+NANVIX_TEST_CONFIG := test/test-standalone-x86_64.toml
+else
 NANVIX_TEST_CONFIG := test/test-single_process.toml
+endif
 else ifeq ($(DEPLOYMENT_MODE),l2)
 NANVIX_TEST_CONFIG := test/test-l2.toml
 else
+ifeq ($(TARGET),x86_64)
+NANVIX_TEST_CONFIG := test/test-standalone-x86_64.toml
+else
 NANVIX_TEST_CONFIG := test/test-multi_process.toml
+endif
 endif
 endif
 

--- a/build/kernel/linker/x86_64/kernel.ld.in
+++ b/build/kernel/linker/x86_64/kernel.ld.in
@@ -1,0 +1,98 @@
+/*
+ * Copyright(c) 2011-2026 The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+OUTPUT_FORMAT("elf64-x86-64")
+ENTRY(_do_start)
+
+/*
+ * Page Size (4 KB)
+ */
+PAGE_SIZE = 0x1000;
+
+/*
+ * Boot Address
+ */
+BOOT_ADDR = 0x00100000;
+
+/*
+ * Kernel Pool Base Address
+ *
+ * This value is set by build.rs from kpool_base in build/kernel_config.toml,
+ * ensuring consistency with config::memory_layout::KPOOL_BASE_RAW.
+ */
+KPOOL_BASE = @KPOOL_BASE@;
+
+/*
+ * Machine Reserved Space
+ *
+ * Space reserved after __KERNEL_END for machine-specific structures.
+ * This value is set by build.rs based on the target machine.
+ */
+MACHINE_RESERVED = @MACHINE_RESERVED@;
+
+SECTIONS
+{
+	. = BOOT_ADDR;
+
+	__KERNEL_START = .;
+	__TEXT_START = .;
+
+	/* Bootstrap section. */
+	.bootstrap :
+	{
+		__BOOTSTRAP_START = .;
+		KEEP(*(.bootstrap))
+		__BOOTSTRAP_END = .;
+	}
+
+	/* Text section. */
+	.text : ALIGN(PAGE_SIZE)
+	{
+		*(.text*)
+	}
+
+	__TEXT_END = .;
+
+	/* Initialized data section. */
+	.data : ALIGN(PAGE_SIZE)
+	{
+		__DATA_START = .;
+		*(.data*)
+		__DATA_END = .;
+	}
+
+	/* Read-only data section. */
+	.rodata : ALIGN(PAGE_SIZE)
+	{
+		__RODATA_START = .;
+		*(.rodata*)
+		__RODATA_END = .;
+	}
+
+	/* Uninitialized data section. */
+	.bss : ALIGN(PAGE_SIZE)
+	{
+		__BSS_START = .;
+		*(.bss*)
+		__BSS_END = .;
+	}
+
+	. = ALIGN(PAGE_SIZE);
+
+	__KERNEL_END = .;
+
+	/*
+	 * Ensure the kernel image plus machine-reserved space fits before KPOOL_BASE.
+	 */
+	ASSERT(__KERNEL_END + MACHINE_RESERVED < KPOOL_BASE,
+		"Kernel too large: __KERNEL_END + MACHINE_RESERVED must be < KPOOL_BASE")
+
+	/* Discarded. */
+	/DISCARD/ :
+	{
+		*(.comment)
+		*(.note)
+	}
+}

--- a/build/targets/x86_64-kernel.json
+++ b/build/targets/x86_64-kernel.json
@@ -1,0 +1,35 @@
+{
+	"cpu": "x86-64",
+	"data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+	"llvm-target": "x86_64-unknown-none",
+	"target-endian": "little",
+	"target-pointer-width": 64,
+	"target-c-int-width": 32,
+	"max-atomic-width": 64,
+	"features": "-mmx,-avx,-avx2,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,+soft-float",
+	"rustc-abi": "x86-softfloat",
+	"os": "nanvix",
+	"target-family": [
+		"unix"
+	],
+	"arch": "x86_64",
+	"linker-flavor": "gnu-lld",
+	"linker": "rust-lld",
+	"pre-link-args": {
+		"gnu-lld": [
+			"-nostdlib",
+			"--entry=_do_start",
+			"-melf_x86_64"
+		]
+	},
+	"executables": true,
+	"code-model": "small",
+	"exe-suffix": ".elf",
+	"panic-strategy": "abort",
+	"disable-redzone": true,
+	"stack-probes": {
+		"kind": "inline"
+	},
+	"relocation-model": "static",
+	"has-thread-local": false
+}

--- a/build/targets/x86_64-user.json
+++ b/build/targets/x86_64-user.json
@@ -1,0 +1,33 @@
+{
+	"cpu": "x86-64",
+	"data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+	"llvm-target": "x86_64-unknown-none",
+	"target-endian": "little",
+	"target-pointer-width": 64,
+	"target-c-int-width": 32,
+	"max-atomic-width": 64,
+	"os": "nanvix",
+	"target-family": [
+		"unix"
+	],
+	"arch": "x86_64",
+	"linker-flavor": "gnu-lld",
+	"linker": "rust-lld",
+	"pre-link-args": {
+		"gnu-lld": [
+			"-nostdlib",
+			"--entry=_do_start",
+			"-melf_x86_64"
+		]
+	},
+	"executables": true,
+	"code-model": "small",
+	"exe-suffix": ".elf",
+	"panic-strategy": "abort",
+	"disable-redzone": true,
+	"stack-probes": {
+		"kind": "inline"
+	},
+	"relocation-model": "static",
+	"has-thread-local": false
+}

--- a/build/user/build.rs
+++ b/build/user/build.rs
@@ -50,7 +50,8 @@ fn main() {
     // Link Archive
     //==============================================================================================
 
-    println!("cargo::rustc-link-arg=-Tbuild/user/linker/x86/user.ld");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
 
     //==============================================================================================
 

--- a/build/user/linker/x86_64/user.ld
+++ b/build/user/linker/x86_64/user.ld
@@ -1,0 +1,121 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+OUTPUT_FORMAT("elf64-x86-64")
+ENTRY(_do_start)
+
+/*
+ * Page Size (4 KB)
+ */
+PAGE_SIZE = 0x1000;
+
+/*
+ * Base Address
+ */
+BASE_ADDR = 0x40000000;
+
+SECTIONS
+{
+	. = BASE_ADDR;
+
+	/* Text section. */
+	.text : ALIGN(PAGE_SIZE)
+	{
+		*(.crt0*)
+		*(.text*)
+	}
+
+	/* Initialized data section. */
+	.data : ALIGN(PAGE_SIZE)
+	{
+		*(.data*)
+	}
+
+	/* Uninitialized data section. */
+	.bss :
+	{
+		*(.bss*)
+	}
+
+	/* Read-only data section. */
+	.rodata : ALIGN(PAGE_SIZE)
+	{
+		*(.rodata*)
+	}
+
+	/* Dynamic symbol table (populated by --export-dynamic). */
+	.dynsym : ALIGN(8)
+	{
+		PROVIDE(__dynsym_start = .);
+		*(.dynsym)
+		PROVIDE(__dynsym_end = .);
+	}
+
+	/* Dynamic string table (symbol names for .dynsym). */
+	.dynstr : ALIGN(8)
+	{
+		PROVIDE(__dynstr_start = .);
+		*(.dynstr)
+		PROVIDE(__dynstr_end = .);
+	}
+
+	/* Symbol hash table. */
+	.hash : ALIGN(8)
+	{
+		*(.hash)
+		*(.gnu.hash)
+	}
+
+	/* Exception handling frame header */
+	.eh_frame_hdr : ALIGN(8)
+	{
+		PROVIDE(__eh_frame_hdr_start = .);
+		KEEP(*(.eh_frame_hdr))
+		PROVIDE(__eh_frame_hdr_end = .);
+	}
+
+	/* Exception handling frames */
+	.eh_frame : ALIGN(8)
+	{
+		PROVIDE(__eh_frame_start = .);
+		KEEP(*(.eh_frame))
+		PROVIDE(__eh_frame_end = .);
+	}
+
+	/*
+	 * Thread-local storage.
+	 *
+	 * Must appear after all PROGBITS sections (.eh_frame, etc.) so that the NOBITS .tbss
+	 * sub-section does not cause virtual-address (VMA) overlap with subsequent PROGBITS sections.
+	 */
+	.tls : ALIGN(PAGE_SIZE)
+	{
+		__TLS_START = .;
+		*(.tdata)
+		*(.tbss)
+		__TLS_END = .;
+	}
+
+	/*
+	 * PROGBITS companion for .tls.
+	 *
+	 * Because .tbss is NOBITS it does not produce a LOAD segment.  The TDA allocator (tda.rs)
+	 * copies __TLS_START..__TLS_END into each new thread, so the kernel must have allocated and
+	 * zero-filled the pages backing that range.  This zero-filled PROGBITS section creates a LOAD
+	 * segment that covers the .tbss region, causing the ELF loader to map and clear those pages.
+	 */
+	.tls_init ADDR(.tls) : AT(ADDR(.tls))
+	{
+		FILL(0x0000000000000000);
+		. = __TLS_END;
+	}
+
+	/* Discarded. */
+	/DISCARD/ :
+	{
+		*(.comment)
+		*(.note)
+	}
+}

--- a/src/benchmarks/snapshot-rust-nostd/build.rs
+++ b/src/benchmarks/snapshot-rust-nostd/build.rs
@@ -50,7 +50,8 @@ fn main() {
     // Link Archive
     //==============================================================================================
 
-    println!("cargo::rustc-link-arg=-Tbuild/user/linker/x86/user.ld");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
 
     //==============================================================================================
 }

--- a/src/benchmarks/vfs-bench-nostd/build.rs
+++ b/src/benchmarks/vfs-bench-nostd/build.rs
@@ -106,7 +106,8 @@ fn main() {
     // Link Archive
     //==============================================================================================
 
-    println!("cargo::rustc-link-arg=-Tbuild/user/linker/x86/user.ld");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
 
     //==============================================================================================
     // Generate Dense FAT Image

--- a/src/kernel/build.rs
+++ b/src/kernel/build.rs
@@ -272,7 +272,15 @@ fn main() {
     // page of heap_padding exists.
     //
     // For non-Hyperlight targets, no reserved space is needed.
-    let linker_template_path: PathBuf = workspace_dir.join("build/kernel/linker/x86/kernel.ld.in");
+    let target_arch: String =
+        env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    let linker_subdir: &str = if target_arch == "x86_64" {
+        "x86_64"
+    } else {
+        "x86"
+    };
+    let linker_template_path: PathBuf =
+        workspace_dir.join(format!("build/kernel/linker/{}/kernel.ld.in", linker_subdir));
     let linker_output_path: PathBuf = Path::new(&out_dir).join("kernel.ld");
 
     let machine_reserved: String = if cfg!(feature = "hyperlight") {

--- a/src/tests/dlfcn-rust/build.rs
+++ b/src/tests/dlfcn-rust/build.rs
@@ -196,7 +196,8 @@ fn main() {
     // Linker Configuration
     //==============================================================================================
 
-    println!("cargo::rustc-link-arg=-Tbuild/user/linker/x86/user.ld");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
 
     // Build as a position-independent executable so the linker emits .dynsym,
     // .dynstr, .dynamic, and .hash sections.  Without -pie the binary is fully

--- a/src/tests/stress-rust/build.rs
+++ b/src/tests/stress-rust/build.rs
@@ -50,7 +50,8 @@ fn main() {
     // Link Archive
     //==============================================================================================
 
-    println!("cargo::rustc-link-arg=-Tbuild/user/linker/x86/user.ld");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
 
     //==============================================================================================
 

--- a/src/tests/vfs-test/build.rs
+++ b/src/tests/vfs-test/build.rs
@@ -25,7 +25,8 @@ fn main() {
     // Link Archive
     //==============================================================================================
 
-    println!("cargo::rustc-link-arg=-Tbuild/user/linker/x86/user.ld");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
 
     //==============================================================================================
     // Generate FAT Image

--- a/z.py
+++ b/z.py
@@ -36,7 +36,7 @@ VALID_DEPLOYMENT_MODES: tuple[str, ...] = (
     "l2",
 )
 VALID_LOG_LEVELS: tuple[str, ...] = ("trace", "debug", "info", "warn", "error", "panic")
-VALID_TARGETS: tuple[str, ...] = ("x86",)
+VALID_TARGETS: tuple[str, ...] = ("x86", "x86_64")
 VALID_MESSAGE_FORMATS: tuple[str, ...] = ("json", "json-diagnostic-rendered-ansi")
 
 DEFAULT_MACHINE = "microvm"


### PR DESCRIPTION
## Summary

Introduce build infrastructure for the x86_64 architecture, enabling kernel and user-space compilation for 64-bit x86 targets.

## New Files

- `build/targets/x86_64-kernel.json` — custom Rust target spec for the kernel (soft-float, no-SSE, static relocation, gnu-lld linker).
- `build/targets/x86_64-user.json` — custom Rust target spec for user-space binaries (static relocation, gnu-lld linker).
- `build/kernel/linker/x86_64/kernel.ld.in` — ELF64 kernel linker script with KPOOL_BASE overflow assertion.
- `build/user/linker/x86_64/user.ld` — ELF64 user linker script with TLS, dynamic symbol, and exception handling sections.
- `test/test-standalone-x86_64.toml` — standalone test configuration for x86_64.

## Build System Changes

- `Makefile`: accept `TARGET=x86_64`, select architecture-specific test config, and exclude `dlfcn-rust` on x86_64 (static relocation model emits `R_X86_64_32` relocations incompatible with PIE).
- `z.py`: add `x86_64` to `VALID_TARGETS`.
- `build.rs` (kernel, user, benchmarks, tests): resolve linker script path from `CARGO_CFG_TARGET_ARCH` instead of hardcoding x86.
- `.codespellrc`: add `ist` (Interrupt Stack Table) to ignore list.