### PR TITLE
[arch] Move x86_64 definitions to dedicated module

### DIFF
--- a/src/libs/arch/src/x86/cpu/idt.rs
+++ b/src/libs/arch/src/x86/cpu/idt.rs
@@ -2,119 +2,16 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
-// Imports
+// Re-exports
 //==================================================================================================
 
-use crate::x86::cpu::ring::PrivilegeLevel;
-
-//==================================================================================================
-// Gate Type
-//==================================================================================================
-
-/// Mask for extracting the gate type from the lower nibble of an IDT flags byte.
-const GATE_TYPE_MASK: u8 = 0x0F;
-/// Gate type value for a 32-bit task gate.
-const GATE_TYPE_TASK32: u8 = 0x5;
-/// Gate type value for a 16-bit interrupt gate.
-const GATE_TYPE_INT16: u8 = 0x6;
-/// Gate type value for a 16-bit trap gate.
-const GATE_TYPE_TRAP16: u8 = 0x7;
-/// Gate type value for a 32-bit interrupt gate.
-const GATE_TYPE_INT32: u8 = 0xe;
-/// Gate type value for a 32-bit trap gate.
-const GATE_TYPE_TRAP32: u8 = 0xf;
-
-#[repr(u8)]
-pub enum GateType {
-    Task32 = GATE_TYPE_TASK32, // 32-bit task gate.
-    Int16 = GATE_TYPE_INT16,   // 16-bit interrupt gate.
-    Trap16 = GATE_TYPE_TRAP16, // 16-bit trap gate.
-    Int32 = GATE_TYPE_INT32,   // 32-bit interrupt gate.
-    Trap32 = GATE_TYPE_TRAP32, // 32-bit trap gate.
-}
-
-impl GateType {
-    /// Decodes the gate type from the lower nibble of an IDT flags byte.
-    ///
-    /// Returns `Some(GateType)` if the nibble matches a known gate type, `None` otherwise.
-    pub fn from_u8(value: u8) -> Option<Self> {
-        match value & GATE_TYPE_MASK {
-            GATE_TYPE_TASK32 => Some(Self::Task32),
-            GATE_TYPE_INT16 => Some(Self::Int16),
-            GATE_TYPE_TRAP16 => Some(Self::Trap16),
-            GATE_TYPE_INT32 => Some(Self::Int32),
-            GATE_TYPE_TRAP32 => Some(Self::Trap32),
-            _ => None,
-        }
-    }
-}
-
-impl core::fmt::Debug for GateType {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", gate_type_str(self))
-    }
-}
-
-/// Returns a static string label for a [`GateType`] variant.
-const fn gate_type_str(gate: &GateType) -> &'static str {
-    match gate {
-        GateType::Task32 => "task32",
-        GateType::Int16 => "int16",
-        GateType::Trap16 => "trap16",
-        GateType::Int32 => "int32",
-        GateType::Trap32 => "trap32",
-    }
-}
-
-//==================================================================================================
-// Present Bit
-//==================================================================================================
-
-/// Bit position of the present flag in the IDT flags byte.
-const PRESENT_BIT_SHIFT: u8 = 7;
-
-#[repr(u8)]
-pub enum PresentBit {
-    NotPresent = 0 << PRESENT_BIT_SHIFT,
-    Present = 1 << PRESENT_BIT_SHIFT,
-}
-
-//==================================================================================================
-// Descriptor Privilege Level
-//==================================================================================================
-
-/// Bit position of the descriptor privilege level field in the IDT flags byte.
-const DPL_SHIFT: u8 = 5;
-
-#[repr(u8)]
-pub enum DescriptorPrivilegeLevel {
-    Ring0 = (PrivilegeLevel::Ring0 as u8) << DPL_SHIFT,
-    Ring1 = (PrivilegeLevel::Ring1 as u8) << DPL_SHIFT,
-    Ring2 = (PrivilegeLevel::Ring2 as u8) << DPL_SHIFT,
-    Ring3 = (PrivilegeLevel::Ring3 as u8) << DPL_SHIFT,
-}
-
-//==================================================================================================
-// Flags
-//==================================================================================================
-
-pub struct Flags {
-    present: PresentBit,
-    dpl: DescriptorPrivilegeLevel,
-    typ: GateType,
-}
-
-impl Flags {
-    pub fn new(present: PresentBit, dpl: DescriptorPrivilegeLevel, typ: GateType) -> Self {
-        Self { present, dpl, typ }
-    }
-}
-
-impl From<Flags> for u8 {
-    fn from(val: Flags) -> Self {
-        val.present as u8 | val.dpl as u8 | val.typ as u8
-    }
-}
+use super::idt_common::gate_type_str;
+pub use super::idt_common::{
+    DescriptorPrivilegeLevel,
+    Flags,
+    GateType,
+    PresentBit,
+};
 
 //==================================================================================================
 // Interrupt Descriptor Table Entry

--- a/src/libs/arch/src/x86/cpu/idt_common.rs
+++ b/src/libs/arch/src/x86/cpu/idt_common.rs
@@ -1,0 +1,117 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::ring::PrivilegeLevel;
+
+//==================================================================================================
+// Gate Type
+//==================================================================================================
+
+/// Mask for extracting the gate type from the lower nibble of an IDT flags byte.
+pub(crate) const GATE_TYPE_MASK: u8 = 0x0F;
+/// Gate type value for a 32-bit task gate.
+pub(crate) const GATE_TYPE_TASK32: u8 = 0x5;
+/// Gate type value for a 16-bit interrupt gate.
+pub(crate) const GATE_TYPE_INT16: u8 = 0x6;
+/// Gate type value for a 16-bit trap gate.
+pub(crate) const GATE_TYPE_TRAP16: u8 = 0x7;
+/// Gate type value for a 32-bit interrupt gate.
+pub(crate) const GATE_TYPE_INT32: u8 = 0xe;
+/// Gate type value for a 32-bit trap gate.
+pub(crate) const GATE_TYPE_TRAP32: u8 = 0xf;
+
+#[repr(u8)]
+pub enum GateType {
+    Task32 = GATE_TYPE_TASK32, // 32-bit task gate.
+    Int16 = GATE_TYPE_INT16,   // 16-bit interrupt gate.
+    Trap16 = GATE_TYPE_TRAP16, // 16-bit trap gate.
+    Int32 = GATE_TYPE_INT32,   // 32-bit interrupt gate.
+    Trap32 = GATE_TYPE_TRAP32, // 32-bit trap gate.
+}
+
+impl GateType {
+    /// Decodes the gate type from the lower nibble of an IDT flags byte.
+    ///
+    /// Returns `Some(GateType)` if the nibble matches a known gate type, `None` otherwise.
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value & GATE_TYPE_MASK {
+            GATE_TYPE_TASK32 => Some(Self::Task32),
+            GATE_TYPE_INT16 => Some(Self::Int16),
+            GATE_TYPE_TRAP16 => Some(Self::Trap16),
+            GATE_TYPE_INT32 => Some(Self::Int32),
+            GATE_TYPE_TRAP32 => Some(Self::Trap32),
+            _ => None,
+        }
+    }
+}
+
+impl core::fmt::Debug for GateType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", gate_type_str(self))
+    }
+}
+
+/// Returns a static string label for a [`GateType`] variant.
+pub(crate) const fn gate_type_str(gate: &GateType) -> &'static str {
+    match gate {
+        GateType::Task32 => "task32",
+        GateType::Int16 => "int16",
+        GateType::Trap16 => "trap16",
+        GateType::Int32 => "int32",
+        GateType::Trap32 => "trap32",
+    }
+}
+
+//==================================================================================================
+// Present Bit
+//==================================================================================================
+
+/// Bit position of the present flag in the IDT flags byte.
+pub(crate) const PRESENT_BIT_SHIFT: u8 = 7;
+
+#[repr(u8)]
+pub enum PresentBit {
+    NotPresent = 0 << PRESENT_BIT_SHIFT,
+    Present = 1 << PRESENT_BIT_SHIFT,
+}
+
+//==================================================================================================
+// Descriptor Privilege Level
+//==================================================================================================
+
+/// Bit position of the descriptor privilege level field in the IDT flags byte.
+pub(crate) const DPL_SHIFT: u8 = 5;
+
+#[repr(u8)]
+pub enum DescriptorPrivilegeLevel {
+    Ring0 = (PrivilegeLevel::Ring0 as u8) << DPL_SHIFT,
+    Ring1 = (PrivilegeLevel::Ring1 as u8) << DPL_SHIFT,
+    Ring2 = (PrivilegeLevel::Ring2 as u8) << DPL_SHIFT,
+    Ring3 = (PrivilegeLevel::Ring3 as u8) << DPL_SHIFT,
+}
+
+//==================================================================================================
+// Flags
+//==================================================================================================
+
+pub struct Flags {
+    present: PresentBit,
+    dpl: DescriptorPrivilegeLevel,
+    typ: GateType,
+}
+
+impl Flags {
+    pub fn new(present: PresentBit, dpl: DescriptorPrivilegeLevel, typ: GateType) -> Self {
+        Self { present, dpl, typ }
+    }
+}
+
+impl From<Flags> for u8 {
+    fn from(val: Flags) -> Self {
+        val.present as u8 | val.dpl as u8 | val.typ as u8
+    }
+}

--- a/src/libs/arch/src/x86/cpu/idtr.rs
+++ b/src/libs/arch/src/x86/cpu/idtr.rs
@@ -28,6 +28,10 @@ impl Idtr {
 
     /// Loads the IDT.
     pub unsafe fn load(&self) {
-        arch::asm!("lidt (%eax)", in("eax") self, options(nostack, nomem, att_syntax));
+        arch::asm!(
+            "lidt (%eax)",
+            in("eax") self,
+            options(nostack, readonly, preserves_flags, att_syntax)
+        );
     }
 }

--- a/src/libs/arch/src/x86/cpu/mod.rs
+++ b/src/libs/arch/src/x86/cpu/mod.rs
@@ -13,8 +13,15 @@ pub mod cr0;
 pub mod cr4;
 pub mod eflags;
 pub mod excp;
+#[cfg(target_arch = "x86")]
 pub mod idt;
+pub(crate) mod idt_common;
+#[cfg(target_arch = "x86_64")]
+pub use crate::x86_64::cpu::idt;
+#[cfg(target_arch = "x86")]
 pub mod idtr;
+#[cfg(target_arch = "x86_64")]
+pub use crate::x86_64::cpu::idtr;
 #[cfg(feature = "ioapic")]
 pub mod ioapic;
 #[cfg(feature = "madt")]
@@ -27,7 +34,10 @@ pub mod pic;
 #[cfg(feature = "pit")]
 pub mod pit;
 pub mod ring;
+#[cfg(target_arch = "x86")]
 pub mod tss;
+#[cfg(target_arch = "x86_64")]
+pub use crate::x86_64::cpu::tss;
 #[cfg(feature = "xapic")]
 pub mod xapic;
 

--- a/src/libs/arch/src/x86/mem/constants.rs
+++ b/src/libs/arch/src/x86/mem/constants.rs
@@ -56,6 +56,13 @@ pub const PGTAB_SIZE: usize = 1 << PGTAB_SHIFT;
 ///
 /// # Description
 ///
+/// Number of entries in a page table.
+///
+pub const PAGE_TABLE_LENGTH: usize = PGTAB_SIZE / PAGE_SIZE;
+
+///
+/// # Description
+///
 /// Mask for page table offset.
 ///
 pub const PGTAB_MASK: usize = !(PGTAB_SIZE - 1);

--- a/src/libs/arch/src/x86/mem/mod.rs
+++ b/src/libs/arch/src/x86/mem/mod.rs
@@ -12,7 +12,10 @@ mod constants;
 //==================================================================================================
 
 pub mod gdt;
+#[cfg(target_arch = "x86")]
 pub mod gdtr;
+#[cfg(target_arch = "x86_64")]
+pub use crate::x86_64::mem::gdtr;
 pub mod paging;
 
 pub use constants::*;

--- a/src/libs/arch/src/x86_64/cpu/idt.rs
+++ b/src/libs/arch/src/x86_64/cpu/idt.rs
@@ -1,0 +1,56 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Re-exports
+//==================================================================================================
+
+pub use crate::x86::cpu::idt_common::{
+    DescriptorPrivilegeLevel,
+    Flags,
+    GateType,
+    PresentBit,
+};
+
+//==================================================================================================
+// Interrupt Descriptor Table Entry (64-bit)
+//==================================================================================================
+
+/// Interrupt descriptor table entry (IDTE) for 64-bit x86_64.
+#[repr(C, packed)]
+pub struct Idte {
+    pub handler_low: u16,  // Handler bits [0:15].
+    pub selector: u16,     // GDT selector.
+    pub ist: u8,           // IST index (bits [0:2]), rest zero.
+    pub flags: u8,         // Gate type and flags.
+    pub handler_mid: u16,  // Handler bits [16:31].
+    pub handler_high: u32, // Handler bits [32:63].
+    pub reserved: u32,     // Must be zero.
+}
+
+// `Idte` must be 16 bytes long. This must match the hardware specification.
+::static_assert::assert_eq_size!(Idte, 16);
+
+/// Bit position of the middle 16 bits of a 64-bit handler address.
+const HANDLER_MID_SHIFT: u32 = 16;
+/// Bit position of the upper 32 bits of a 64-bit handler address.
+const HANDLER_HIGH_SHIFT: u32 = 32;
+
+impl Idte {
+    /// Creates a new IDT entry.
+    pub fn new(handler: u64, selector: u16, flags: Flags) -> Self {
+        let handler_low = handler as u16;
+        let handler_mid = (handler >> HANDLER_MID_SHIFT) as u16;
+        let handler_high = (handler >> HANDLER_HIGH_SHIFT) as u32;
+
+        Self {
+            handler_low,
+            selector,
+            ist: 0,
+            flags: flags.into(),
+            handler_mid,
+            handler_high,
+            reserved: 0,
+        }
+    }
+}

--- a/src/libs/arch/src/x86_64/cpu/idtr.rs
+++ b/src/libs/arch/src/x86_64/cpu/idtr.rs
@@ -1,0 +1,37 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::arch;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Interrupt descriptor table pointer (IDTR) for 64-bit x86_64.
+#[repr(C, packed)]
+pub struct Idtr {
+    pub size: u16, // IDT size.
+    pub ptr: u64,  // IDT virtual address.
+}
+::static_assert::assert_eq_size!(Idtr, 10);
+
+impl Idtr {
+    /// Initializes an IDT register.
+    pub unsafe fn init(&mut self, ptr: u64, size: u16) {
+        self.size = size - 1;
+        self.ptr = ptr;
+    }
+
+    /// Loads the IDT.
+    pub unsafe fn load(&self) {
+        arch::asm!(
+            "lidt (%rax)",
+            in("rax") self,
+            options(nostack, readonly, preserves_flags, att_syntax)
+        );
+    }
+}

--- a/src/libs/arch/src/x86_64/cpu/mod.rs
+++ b/src/libs/arch/src/x86_64/cpu/mod.rs
@@ -1,18 +1,10 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
-#![no_std]
-#![allow(clippy::all)]
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-mod x86;
-
-#[cfg(target_arch = "x86_64")]
-mod x86_64;
-
 //==================================================================================================
 // Exports
 //==================================================================================================
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub use x86::*;
+pub mod idt;
+pub mod idtr;
+pub mod tss;

--- a/src/libs/arch/src/x86_64/cpu/tss.rs
+++ b/src/libs/arch/src/x86_64/cpu/tss.rs
@@ -1,0 +1,42 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+/// Task state segment (TSS) for 64-bit x86_64.
+#[repr(C, packed)]
+pub struct Tss {
+    pub reserved0: u32,  // Reserved.
+    pub rsp0_low: u32,   // Ring 0 stack pointer (low 32 bits).
+    pub rsp0_high: u32,  // Ring 0 stack pointer (high 32 bits).
+    pub rsp1_low: u32,   // Ring 1 stack pointer (low 32 bits).
+    pub rsp1_high: u32,  // Ring 1 stack pointer (high 32 bits).
+    pub rsp2_low: u32,   // Ring 2 stack pointer (low 32 bits).
+    pub rsp2_high: u32,  // Ring 2 stack pointer (high 32 bits).
+    pub reserved1: u32,  // Reserved.
+    pub reserved2: u32,  // Reserved.
+    pub ist1_low: u32,   // IST1 (low 32 bits).
+    pub ist1_high: u32,  // IST1 (high 32 bits).
+    pub ist2_low: u32,   // IST2 (low 32 bits).
+    pub ist2_high: u32,  // IST2 (high 32 bits).
+    pub ist3_low: u32,   // IST3 (low 32 bits).
+    pub ist3_high: u32,  // IST3 (high 32 bits).
+    pub ist4_low: u32,   // IST4 (low 32 bits).
+    pub ist4_high: u32,  // IST4 (high 32 bits).
+    pub ist5_low: u32,   // IST5 (low 32 bits).
+    pub ist5_high: u32,  // IST5 (high 32 bits).
+    pub ist6_low: u32,   // IST6 (low 32 bits).
+    pub ist6_high: u32,  // IST6 (high 32 bits).
+    pub ist7_low: u32,   // IST7 (low 32 bits).
+    pub ist7_high: u32,  // IST7 (high 32 bits).
+    pub reserved3: u32,  // Reserved.
+    pub reserved4: u32,  // Reserved.
+    pub reserved5: u16,  // Reserved.
+    pub iomap_base: u16, // I/O map base address.
+}
+
+// `Tss` must be 104 bytes long. This must match the hardware specification.
+::static_assert::assert_eq_size!(Tss, 104);
+
+impl Tss {
+    /// Byte offset of the `rsp0_low` field within the structure.
+    pub const TSS_RSP0: u32 = core::mem::offset_of!(Self, rsp0_low) as u32;
+}

--- a/src/libs/arch/src/x86_64/mem/gdtr.rs
+++ b/src/libs/arch/src/x86_64/mem/gdtr.rs
@@ -1,0 +1,26 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Global Descriptor Table Register (GDTR) — 64-bit
+//==================================================================================================
+
+/// Global descriptor table register (GDTR) for 64-bit x86_64.
+#[derive(Default)]
+#[repr(C, packed)]
+pub struct Gdtr {
+    limit: u16,
+    base: u64,
+}
+
+// `Gdtr` must be 10 bytes long. This must match the hardware specification.
+::static_assert::assert_eq_size!(Gdtr, 10);
+
+impl Gdtr {
+    pub fn new(base: u64, size: u16) -> Self {
+        Self {
+            base,
+            limit: size - 1,
+        }
+    }
+}

--- a/src/libs/arch/src/x86_64/mem/mod.rs
+++ b/src/libs/arch/src/x86_64/mem/mod.rs
@@ -1,18 +1,8 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
-#![no_std]
-#![allow(clippy::all)]
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-mod x86;
-
-#[cfg(target_arch = "x86_64")]
-mod x86_64;
-
 //==================================================================================================
 // Exports
 //==================================================================================================
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub use x86::*;
+pub mod gdtr;

--- a/src/libs/arch/src/x86_64/mod.rs
+++ b/src/libs/arch/src/x86_64/mod.rs
@@ -1,18 +1,9 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
-#![no_std]
-#![allow(clippy::all)]
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-mod x86;
-
-#[cfg(target_arch = "x86_64")]
-mod x86_64;
-
 //==================================================================================================
 // Exports
 //==================================================================================================
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub use x86::*;
+pub mod cpu;
+pub mod mem;


### PR DESCRIPTION
Move the four 64-bit-specific files from `x86/cpu/` and `x86/mem/` into a new top-level `x86_64` module under `libs/arch/src/`:

- `x86/cpu/idt_x86_64.rs` → `x86_64/cpu/idt.rs`
- `x86/cpu/idtr_x86_64.rs` → `x86_64/cpu/idtr.rs`
- `x86/cpu/tss_x86_64.rs` → `x86_64/cpu/tss.rs`
- `x86/mem/gdtr_x86_64.rs` → `x86_64/mem/gdtr.rs`

The conditional `#[path]` directives in `x86/cpu/mod.rs` and `x86/mem/mod.rs` are replaced with `pub use` re-exports, preserving the existing public API so downstream consumers require no changes.

Additionally, IDT types shared between both architectures (`GateType`, `PresentBit`, `DescriptorPrivilegeLevel`, `Flags`) are extracted into a new `idt_common` module compiled unconditionally. Both arch-specific `idt.rs` files now re-export from `idt_common` instead of duplicating definitions.

Also adds a `PAGE_TABLE_LENGTH` constant derived from existing `PGTAB_SIZE` and `PAGE_SIZE`.