### PR TITLE
[uservm] Direct file I/O for RAMFS load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -817,7 +817,7 @@ jobs:
         env:
           MACHINE_TYPE: ${{ matrix.machine-type }}
         run: |
-          .\z.ps1 build -- all MACHINE=$env:MACHINE_TYPE RELEASE=yes LOG_LEVEL=panic
+          .\z.ps1 build -- all MACHINE=$env:MACHINE_TYPE RELEASE=yes LOG_LEVEL=panic PROFILER=yes
 
       - name: "Exclude bin/ from Windows Defender"
         shell: pwsh
@@ -1327,7 +1327,7 @@ jobs:
         env:
           MACHINE_TYPE: ${{ matrix.machine-type }}
         run: |
-          .\z.ps1 build -- all MACHINE=$env:MACHINE_TYPE RELEASE=yes LOG_LEVEL=panic
+          .\z.ps1 build -- all MACHINE=$env:MACHINE_TYPE RELEASE=yes LOG_LEVEL=panic PROFILER=yes
 
       - name: "Run Micro-Benchmarks"
         shell: pwsh

--- a/src/uservm/src/vmm/microvm/ramfs.rs
+++ b/src/uservm/src/vmm/microvm/ramfs.rs
@@ -15,8 +15,6 @@ use ::log::{
     error,
     trace,
 };
-#[cfg(target_os = "windows")]
-use ::std::io::Read;
 use ::std::{
     fs::File,
     path::{
@@ -48,21 +46,17 @@ const RAMFS_MIN_SLACK_BYTES: usize = 4 * 1024 * 1024;
 /// physical memory.
 ///
 /// On Linux, the image is file-backed (memory-mapped into guest memory via `remap_file_at`).
-/// On Windows, the image contents are read into memory and copied into guest memory.
+/// On Windows, the image file is read directly into guest memory (single I/O, no intermediate
+/// buffer).
 ///
 #[derive(Debug)]
 pub struct RamFs {
     /// Filesystem path from which the RAMFS image was loaded.
     path: PathBuf,
-    /// Size of the RAMFS image in bytes (Linux: from file metadata).
-    #[cfg(target_os = "linux")]
+    /// Size of the RAMFS image in bytes.
     size: usize,
-    /// Handle to the RAMFS image file used for memory-mapping (Linux only).
-    #[cfg(target_os = "linux")]
+    /// Handle to the RAMFS image file.
     file: File,
-    /// Contents of the RAMFS image (Windows only).
-    #[cfg(target_os = "windows")]
-    data: Vec<u8>,
 }
 
 //==================================================================================================
@@ -128,7 +122,7 @@ impl RamFs {
                     file,
                 })
             } else if #[cfg(target_os = "windows")] {
-                let mut file: File = match File::open(path) {
+                let file: File = match File::open(path) {
                     Ok(file) => file,
                     Err(error) => {
                         let reason: String = format!(
@@ -139,18 +133,32 @@ impl RamFs {
                     },
                 };
 
-                let mut data: Vec<u8> = Vec::new();
-                if let Err(error) = file.read_to_end(&mut data) {
-                    let reason: String = format!(
-                        "failed to read ramfs image (path={path:?}, error={error:?})"
-                    );
-                    error!("RamFs::open(): {reason}");
-                    anyhow::bail!(reason)
-                }
+                let size_u64: u64 = match file.metadata() {
+                    Ok(metadata) => metadata.len(),
+                    Err(error) => {
+                        let reason: String = format!(
+                            "failed retrieving ramfs metadata (path={path:?}, error={error:?})"
+                        );
+                        error!("RamFs::open(): {reason}");
+                        anyhow::bail!(reason)
+                    },
+                };
+
+                let size: usize = match usize::try_from(size_u64) {
+                    Ok(size) => size,
+                    Err(_error) => {
+                        let reason: String = format!(
+                            "ramfs image too large to fit on this platform (size={size_u64})"
+                        );
+                        error!("RamFs::open(): {reason}");
+                        anyhow::bail!(reason)
+                    },
+                };
 
                 Ok(Self {
                     path: path.to_path_buf(),
-                    data,
+                    size,
+                    file,
                 })
             }
         }
@@ -158,13 +166,7 @@ impl RamFs {
 
     /// Returns the size of the RAMFS image in bytes.
     fn ramfs_size(&self) -> usize {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "linux")] {
-                self.size
-            } else if #[cfg(target_os = "windows")] {
-                self.data.len()
-            }
-        }
+        self.size
     }
 
     ///
@@ -263,10 +265,10 @@ impl RamFs {
             if #[cfg(target_os = "linux")] {
                 self.map_file_into_guest(vmem, ramfs_base, ramfs_size)?;
             } else if #[cfg(target_os = "windows")] {
-                vmem.write_bytes(ramfs_base as u64, &self.data)
+                vmem.load_from_file(ramfs_base as u64, &self.file, ramfs_size)
                     .map_err(|e| {
                         let reason: String = format!(
-                            "failed to write ramfs image into guest memory (path={:?}, error={e})",
+                            "failed to load ramfs image into guest memory (path={:?}, error={e})",
                             self.path
                         );
                         error!("RamFs::load_into_virtual_memory(): {reason}");

--- a/src/uservm/src/vmm/microvm/whp/vmem.rs
+++ b/src/uservm/src/vmm/microvm/whp/vmem.rs
@@ -178,16 +178,82 @@ impl VirtualMemory {
             },
         };
 
-        // Check if region lies within the virtual memory.
-        if addr + data.len() > self.size {
-            let reason: String = format!("invalid memory access (addr={addr:#010x})");
-            error!("write_bytes(): {reason}");
-            return Err(anyhow::anyhow!(reason));
+        // Check if region lies within the virtual memory (overflow-safe).
+        match addr.checked_add(data.len()) {
+            Some(end) if end <= self.size => {},
+            _ => {
+                let reason: String = format!(
+                    "invalid memory access (addr={addr:#010x}, len={:#x}, size={:#x})",
+                    data.len(),
+                    self.size
+                );
+                error!("write_bytes(): {reason}");
+                return Err(anyhow::anyhow!(reason));
+            },
         }
 
         unsafe {
             ptr::copy_nonoverlapping(data.as_ptr(), self.ptr.add(addr), data.len());
         }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reads `len` bytes from a file directly into the virtual memory at the given guest address,
+    /// bypassing any intermediate heap buffer.
+    ///
+    /// # Parameters
+    ///
+    /// - `addr`: Destination address in the virtual memory.
+    /// - `file`: File to read from (starting at its current seek position).
+    /// - `len`: Number of bytes to read.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, this method returns empty. Otherwise, it returns an error.
+    ///
+    pub fn load_from_file(&mut self, addr: u64, file: &File, len: usize) -> Result<()> {
+        let addr: usize = match usize::try_from(addr) {
+            Ok(v) => v,
+            Err(_) => {
+                let reason: String = format!("invalid address (addr={addr:#010x})");
+                error!("load_from_file(): {reason}");
+                return Err(anyhow::anyhow!(reason));
+            },
+        };
+
+        // Check if region lies within the virtual memory (overflow-safe).
+        match addr.checked_add(len) {
+            Some(end) if end <= self.size => {},
+            _ => {
+                let reason: String = format!(
+                    "invalid memory access (addr={addr:#010x}, len={len:#x}, size={:#x})",
+                    self.size
+                );
+                error!("load_from_file(): {reason}");
+                return Err(anyhow::anyhow!(reason));
+            },
+        }
+
+        // SAFETY: `self.ptr` is a valid, committed allocation of `self.size` bytes (from
+        // `VirtualAlloc`). The checked range validation above guarantees that
+        // `[addr, addr + len)` lies within this region.
+        let dest: &mut [u8] = unsafe { slice::from_raw_parts_mut(self.ptr.add(addr), len) };
+
+        // Read from `&File` (shared reference) — Rust's std provides `impl Read for &File`,
+        // which calls `ReadFile` on the underlying OS handle.
+        let mut reader: &File = file;
+        reader.read_exact(dest).map_err(|e| {
+            let reason: String = format!(
+                "failed to read file into virtual memory (addr={addr:#010x}, len={len}, \
+                 error={e:?})"
+            );
+            error!("load_from_file(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
 
         Ok(())
     }
@@ -216,11 +282,18 @@ impl VirtualMemory {
             },
         };
 
-        // Check if region lies within the virtual memory.
-        if addr + data.len() > self.size {
-            let reason: String = format!("invalid memory access (addr={addr:#010x})");
-            error!("read_bytes(): {reason}");
-            return Err(anyhow::anyhow!(reason));
+        // Check if region lies within the virtual memory (overflow-safe).
+        match addr.checked_add(data.len()) {
+            Some(end) if end <= self.size => {},
+            _ => {
+                let reason: String = format!(
+                    "invalid memory access (addr={addr:#010x}, len={:#x}, size={:#x})",
+                    data.len(),
+                    self.size
+                );
+                error!("read_bytes(): {reason}");
+                return Err(anyhow::anyhow!(reason));
+            },
         }
 
         unsafe {

--- a/src/utils/nanvix-bench/src/benchmarks/standalone_vfs.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/standalone_vfs.rs
@@ -12,6 +12,8 @@ use ::indicatif::{
     ProgressStyle,
 };
 use ::log::error;
+#[cfg(feature = "profile-time")]
+use ::nanvix::uservm::perf::PERF_TIMINGS_PREFIX;
 use ::rand::{
     RngExt,
     SeedableRng,
@@ -23,6 +25,11 @@ use ::std::{
         PathBuf,
     },
     time::Instant,
+};
+#[cfg(feature = "profile-time")]
+use ::tokio::io::{
+    AsyncBufReadExt,
+    BufReader,
 };
 use ::tokio::{
     io::{
@@ -45,6 +52,10 @@ use ::vfs_bench_common::{
 
 /// Timeout (in seconds) for the VFS benchmark guest application.
 const VFS_BENCH_TIMEOUT_SECS: u64 = 300;
+
+/// Timeout for reading perf timing data from stderr during teardown.
+#[cfg(feature = "profile-time")]
+const STDERR_READ_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Fixed seed for the host-side RNG that picks random files/dirs per iteration.
 const HOST_RNG_SEED: u64 = 0xCAFE_BABE;
@@ -316,6 +327,8 @@ impl Benchmark {
 
         // Measure the NOOP (protocol overhead) first.
         let noop_latencies: Vec<u128>;
+        #[cfg(feature = "profile-time")]
+        let mut ramfs_load_samples: Vec<u64> = Vec::new();
         {
             let (mut child, mut stdin, mut stdout) =
                 Self::spawn_nanvixd(nanvixd_bin, ramfs, program, &self.workspace_root)?;
@@ -332,7 +345,13 @@ impl Benchmark {
             )
             .await?;
 
-            Self::teardown_nanvixd(&mut child, stdin).await?;
+            let _teardown_timings = Self::teardown_nanvixd(&mut child, stdin).await?;
+            #[cfg(feature = "profile-time")]
+            if let Some(timings) = _teardown_timings {
+                if let Some(v) = timings.get("ramfs_load_us").and_then(|v| v.as_u64()) {
+                    ramfs_load_samples.push(v);
+                }
+            }
         }
 
         // Paired decomposition (one VM per pair, back-to-back measurement).
@@ -365,10 +384,25 @@ impl Benchmark {
             .await?;
             paired_deltas.push((label, deltas));
 
-            Self::teardown_nanvixd(&mut child, stdin).await?;
+            let _teardown_timings = Self::teardown_nanvixd(&mut child, stdin).await?;
+            #[cfg(feature = "profile-time")]
+            if let Some(timings) = _teardown_timings {
+                if let Some(v) = timings.get("ramfs_load_us").and_then(|v| v.as_u64()) {
+                    ramfs_load_samples.push(v);
+                }
+            }
         }
 
         pb.finish();
+
+        // Print VM setup timing breakdown (RAMFS load) when profiling is enabled.
+        #[cfg(feature = "profile-time")]
+        if !ramfs_load_samples.is_empty() {
+            let mut setup_data: Vec<(&str, Vec<u128>)> =
+                vec![("ramfs_load", ramfs_load_samples.into_iter().map(u128::from).collect())];
+            Self::print_latency_table("VM setup", &mut setup_data);
+        }
+
         Ok(paired_deltas)
     }
 
@@ -536,20 +570,57 @@ impl Benchmark {
         Ok((child, stdin, stdout))
     }
 
-    /// Tears down a nanvixd process by closing stdin and waiting for exit.
+    /// Tears down a nanvixd process by closing stdin and waiting for exit. Returns optional
+    /// per-phase timing data parsed from stderr when the `profile-time` feature is enabled.
     async fn teardown_nanvixd(
         child: &mut ::tokio::process::Child,
         stdin: ::tokio::process::ChildStdin,
-    ) -> Result<()> {
+    ) -> Result<Option<serde_json::Map<String, serde_json::Value>>> {
         // Close stdin to signal the guest to exit.
         drop(stdin);
 
         // Read any stderr output for diagnostics before waiting for exit.
+        let mut stderr: ::tokio::process::ChildStderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("failed to take nanvixd stderr"))?;
+
+        // When profiling, read stderr line-by-line looking for the PERF_TIMINGS line.
+        // This avoids relying on read_to_end() which only completes on EOF.
+        #[cfg(feature = "profile-time")]
+        let phase_timings: Option<serde_json::Map<String, serde_json::Value>> = {
+            let mut reader = BufReader::new(&mut stderr);
+            let mut timings = None;
+            let deadline = ::tokio::time::Instant::now() + STDERR_READ_TIMEOUT;
+            loop {
+                let mut line = String::new();
+                let remaining = deadline.saturating_duration_since(::tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                match ::tokio::time::timeout(remaining, reader.read_line(&mut line)).await {
+                    Ok(Ok(0)) => break, // EOF
+                    Ok(Ok(_)) => {
+                        let line = line.trim();
+                        if let Some(json_str) = line.strip_prefix(PERF_TIMINGS_PREFIX) {
+                            if let Ok(serde_json::Value::Object(map)) =
+                                serde_json::from_str(json_str)
+                            {
+                                timings = Some(map);
+                            }
+                            break;
+                        }
+                    },
+                    _ => break, // timeout or error
+                }
+            }
+            timings
+        };
+        #[cfg(not(feature = "profile-time"))]
+        let phase_timings: Option<serde_json::Map<String, serde_json::Value>> = None;
+
+        // Drain remaining stderr for diagnostics.
         let stderr_output: String = {
-            let mut stderr: ::tokio::process::ChildStderr = child
-                .stderr
-                .take()
-                .ok_or_else(|| anyhow::anyhow!("failed to take nanvixd stderr"))?;
             let mut buf: Vec<u8> = Vec::new();
             let _ = stderr.read_to_end(&mut buf).await;
             String::from_utf8_lossy(&buf).to_string()
@@ -563,7 +634,7 @@ impl Benchmark {
             anyhow::bail!("nanvixd exited with {status}");
         }
 
-        Ok(())
+        Ok(phase_timings)
     }
 
     /// Sends the mount configuration byte and waits for the guest's mount-complete ACK.


### PR DESCRIPTION
## Summary

Eliminate the intermediate `Vec<u8>` heap buffer when loading the RAMFS image into WHP guest memory on Windows.

## Problem

The `vfs-bench-nostd` benchmark exposed >1s RAMFS mount times on Windows. The root cause was a **double-copy** path: the 64 MB image was first read into a heap-allocated `Vec<u8>`, then `memcpy`'d into the guest's `VirtualAlloc`'d memory. This triggered ~32K demand-zero page faults (16K for the Vec + 16K for the guest region).

Linux (KVM) avoids this entirely via a single zero-copy `mmap(MAP_FIXED)` call.

## Fix

Read the file **directly** into the guest memory region, bypassing the heap buffer:
- **`ramfs.rs`**: Unify `RamFs` struct across platforms (`File` + `size` instead of `Vec<u8>`). `open()` on Windows now captures file metadata without reading contents.
- **`whp/vmem.rs`**: Add `load_from_file()` that creates a `&mut [u8]` slice into guest memory and calls `read_exact` on `&File`.

## Benchmark Results (64 MB RAMFS, release build, 5 runs)

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| `ramfs_load` avg | 35,622 µs | 22,828 µs | **-36%** |
| `ramfs_load` best | 34,452 µs | 22,015 µs | **-36%** |

## Validation

- [x] `z.ps1 build -- all-uservm` passes
- [x] `z.ps1 build -- format-check` passes
- [x] `z.ps1 build -- lint-check` passes
- [x] Pre-commit hooks pass (2/2 configurations)