### PR TITLE
[vfs] Add read-only mount support to VFS benchmark

### DIFF
--- a/src/benchmarks/vfs-bench-nostd/src/main.rs
+++ b/src/benchmarks/vfs-bench-nostd/src/main.rs
@@ -37,6 +37,8 @@ use ::vfs_bench_common::{
     ACK_ERR,
     ACK_OK,
     MAX_PATH_LEN,
+    MOUNT_READONLY,
+    MOUNT_WRITABLE,
 };
 
 //==================================================================================================
@@ -83,8 +85,26 @@ pub fn main() -> Result<(), Error> {
     // Initialize VFS.
     vfs::init().map_err(|e| fat_err(e, "vfs init failed"))?;
 
+    // Read mount configuration byte from host (writable or read-only).
+    let mut config_buf: [u8; 1] = [0u8; 1];
+    read_exact(STDIN_FILENO, &mut config_buf)?;
+    let readonly: bool = match config_buf[0] {
+        MOUNT_WRITABLE => false,
+        MOUNT_READONLY => true,
+        _unknown => {
+            let _ = unistd::write(STDOUT_FILENO, &[ACK_ERR]);
+            return Err(Error::new(ErrorCode::InvalidArgument, "unknown mount config byte"));
+        },
+    };
+
     // Mount RAMFS image from MMIO.
-    mount_ramfs()?;
+    if let Err(e) = mount_ramfs(readonly) {
+        let _ = unistd::write(STDOUT_FILENO, &[ACK_ERR]);
+        return Err(e);
+    }
+
+    // Acknowledge mount complete.
+    let _ = unistd::write(STDOUT_FILENO, &[ACK_OK]);
 
     // Enter command loop: read [opcode][path_len][path] from stdin, execute, write ack to stdout.
     let mut cmd_buf: [u8; 1] = [0u8; 1];
@@ -145,7 +165,12 @@ pub fn main() -> Result<(), Error> {
 /// On MicroVM the MMIO region is mapped read-write in guest physical memory,
 /// so we mount it in place without copying to the heap.  The MMIO allocation
 /// is intentionally kept alive for the lifetime of the process.
-fn mount_ramfs() -> Result<(), Error> {
+///
+/// # Parameters
+///
+/// - `readonly`: If `true`, the mount is registered as read-only, enabling
+///   negative caching and blocking write operations on the mount.
+fn mount_ramfs(readonly: bool) -> Result<(), Error> {
     // Acquire IO management capability.
     pm::capctl(Capability::IoManagement, true)?;
 
@@ -156,9 +181,9 @@ fn mount_ramfs() -> Result<(), Error> {
     let info: ::sys::mm::MmioRegionInfo = mm::mmio_info(RAMFS_MMIO_TAG)?;
     let total_size: usize = info.size();
 
-    // Mount the FAT image directly from the MMIO region (writable on MicroVM).
+    // Mount the FAT image directly from the MMIO region.
     unsafe {
-        vfs::mount_image("/", info.base().as_ptr() as *mut u8, total_size, false)
+        vfs::mount_image("/", info.base().as_ptr() as *mut u8, total_size, readonly)
             .map_err(|e| fat_err(e, "mount ramfs failed"))?;
     }
 

--- a/src/benchmarks/vfs-bench-nostd/src/main.rs
+++ b/src/benchmarks/vfs-bench-nostd/src/main.rs
@@ -158,7 +158,7 @@ fn mount_ramfs() -> Result<(), Error> {
 
     // Mount the FAT image directly from the MMIO region (writable on MicroVM).
     unsafe {
-        vfs::mount_image("/", info.base().as_ptr() as *mut u8, total_size)
+        vfs::mount_image("/", info.base().as_ptr() as *mut u8, total_size, false)
             .map_err(|e| fat_err(e, "mount ramfs failed"))?;
     }
 

--- a/src/libs/nvx/src/lib.rs
+++ b/src/libs/nvx/src/lib.rs
@@ -430,7 +430,7 @@ fn vfs_init_ramfs() {
             (base_ptr, false)
         };
 
-        if unsafe { ::vfs::mount_image(RAMFS_MOUNT_PATH, mount_ptr, total_size) }.is_err() {
+        if unsafe { ::vfs::mount_image(RAMFS_MOUNT_PATH, mount_ptr, total_size, false) }.is_err() {
             ::syslog::warn!("vfs_init_ramfs(): failed to mount RAMFS image");
             if !free_mmio_early {
                 let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);

--- a/src/libs/vfs-bench-common/src/lib.rs
+++ b/src/libs/vfs-bench-common/src/lib.rs
@@ -110,6 +110,22 @@ pub const ACK_ERR: u8 = 0xFF;
 pub const MAX_PATH_LEN: usize = 255;
 
 //==================================================================================================
+// Mount Configuration
+//==================================================================================================
+
+/// Mount configuration byte: mount the ramfs as writable.
+///
+/// Uses a dedicated magic value so mount configuration bytes cannot be confused with operation
+/// opcodes or acknowledgment bytes during protocol mismatches.
+pub const MOUNT_WRITABLE: u8 = 0xA5;
+
+/// Mount configuration byte: mount the ramfs as read-only.
+///
+/// Enforces the read-only gate on write operations.
+/// Uses a distinct magic value to avoid overlapping other one-byte protocol fields.
+pub const MOUNT_READONLY: u8 = 0x5A;
+
+//==================================================================================================
 // Image Filename
 //==================================================================================================
 

--- a/src/libs/vfs/src/file.rs
+++ b/src/libs/vfs/src/file.rs
@@ -516,10 +516,12 @@ impl DirEntry {
 /// # Errors
 ///
 /// - [`Fat32Error::NotInitialized`] if the filesystem hasn't been initialized.
+/// - [`Fat32Error::ReadOnly`] if the mount is read-only.
 /// - [`Fat32Error::AlreadyExists`] if directory already exists.
 /// - [`Fat32Error::NotFound`] if parent directory doesn't exist.
 pub fn mkdir(path: &str) -> Result<(), Fat32Error> {
     let (mount_idx, relative_path) = resolve_path(path)?;
+    check_writable(mount_idx)?;
 
     state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
@@ -536,11 +538,13 @@ pub fn mkdir(path: &str) -> Result<(), Fat32Error> {
 /// # Errors
 ///
 /// - [`Fat32Error::NotInitialized`] if the filesystem hasn't been initialized.
+/// - [`Fat32Error::ReadOnly`] if the mount is read-only.
 /// - [`Fat32Error::NotFound`] if directory doesn't exist.
 /// - [`Fat32Error::NotEmpty`] if directory is not empty.
 /// - [`Fat32Error::NotADirectory`] if path is a file.
 pub fn rmdir(path: &str) -> Result<(), Fat32Error> {
     let (mount_idx, relative_path) = resolve_path(path)?;
+    check_writable(mount_idx)?;
 
     state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
@@ -557,10 +561,12 @@ pub fn rmdir(path: &str) -> Result<(), Fat32Error> {
 /// # Errors
 ///
 /// - [`Fat32Error::NotInitialized`] if the filesystem hasn't been initialized.
+/// - [`Fat32Error::ReadOnly`] if the mount is read-only.
 /// - [`Fat32Error::NotFound`] if file doesn't exist.
 /// - [`Fat32Error::NotAFile`] if path is a directory.
 pub fn unlink(path: &str) -> Result<(), Fat32Error> {
     let (mount_idx, relative_path) = resolve_path(path)?;
+    check_writable(mount_idx)?;
 
     state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
@@ -629,6 +635,8 @@ pub fn rename(old_path: &str, new_path: &str) -> Result<(), Fat32Error> {
     if old_idx != new_idx {
         return Err(Fat32Error::InvalidPath);
     }
+
+    check_writable(old_idx)?;
 
     state::with_vfs(|vfs| {
         let mount = vfs.get_mount(old_idx).ok_or(Fat32Error::NotFound)?;
@@ -699,6 +707,19 @@ fn resolve_path(path: &str) -> Result<(usize, String), Fat32Error> {
     state::with_vfs(|vfs| vfs.resolve(path))
 }
 
+/// Returns [`Fat32Error::ReadOnly`] if the mount at `mount_idx` is read-only.
+/// Used to gate mutating operations.
+fn check_writable(mount_idx: usize) -> Result<(), Fat32Error> {
+    let readonly: bool = state::with_vfs(|vfs| {
+        let mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
+        Ok(mount.readonly())
+    })?;
+    if readonly {
+        return Err(Fat32Error::ReadOnly);
+    }
+    Ok(())
+}
+
 /// Opens a file with specific options.
 ///
 /// # Parameters
@@ -718,6 +739,15 @@ fn open_with_options(
     truncate: bool,
 ) -> Result<File, Fat32Error> {
     let (mount_idx, relative_path) = resolve_path(path)?;
+
+    // Reject write/create/truncate on read-only mounts.
+    // NOTE: This gate is also what keeps the negative cache consistent —
+    // negative entries are only populated for read-only mounts, so any
+    // O_CREAT that could create a file is blocked here before it reaches
+    // the FAT layer, preventing stale negative-cache entries.
+    if write || create || create_new || truncate {
+        check_writable(mount_idx)?;
+    }
 
     // Open the file under a single VFS lock scope, resolving both the
     // mount path and file handle together. This avoids aliased &/&mut

--- a/src/libs/vfs/src/mount.rs
+++ b/src/libs/vfs/src/mount.rs
@@ -40,6 +40,12 @@ pub struct Mount {
     path: String,
     /// The FAT filesystem backend for this mount.
     fat: Fat,
+    /// Whether this mount is read-only.
+    ///
+    /// When `true`, mutating operations (`mkdir`, `rmdir`, `unlink`,
+    /// `rename`, `open` with write/create/truncate) are rejected for paths
+    /// under this mount.
+    readonly: bool,
 }
 
 //==================================================================================================
@@ -53,16 +59,22 @@ impl Mount {
     ///
     /// - `path`: Absolute mount path (must start with "/").
     /// - `fat`: The FAT filesystem backend.
+    /// - `readonly`: If `true`, mutating operations (`mkdir`, `rmdir`, `unlink`,
+    ///   `rename`, `open` with write/create/truncate) are rejected on this mount.
     ///
     /// # Returns
     ///
     /// A new [`Mount`], or [`Fat32Error::InvalidPath`] if `path` doesn't start
     /// with "/".
-    pub fn new(path: String, fat: Fat) -> Result<Self, Fat32Error> {
+    pub fn new(path: String, fat: Fat, readonly: bool) -> Result<Self, Fat32Error> {
         if !path.starts_with('/') {
             return Err(Fat32Error::InvalidPath);
         }
-        Ok(Self { path, fat })
+        Ok(Self {
+            path,
+            fat,
+            readonly,
+        })
     }
 
     /// Returns the mount path.
@@ -81,6 +93,12 @@ impl Mount {
     #[inline]
     pub fn fat_mut(&mut self) -> &mut Fat {
         &mut self.fat
+    }
+
+    /// Returns whether this mount is read-only.
+    #[inline]
+    pub fn readonly(&self) -> bool {
+        self.readonly
     }
 
     /// Checks if the given path is under this mount point.
@@ -455,7 +473,7 @@ mod tests {
 
         // Create a Fat from the formatted buffer.
         let fat: Fat = unsafe { Fat::from_memory(ptr, size).expect("valid fat") };
-        let mount: Mount = Mount::new(String::from(mount_path), fat).expect("valid mount");
+        let mount: Mount = Mount::new(String::from(mount_path), fat, false).expect("valid mount");
         (mount, buf)
     }
 
@@ -516,7 +534,7 @@ mod tests {
             .expect("format should succeed");
         let fat: ::fat32::Fat = unsafe { ::fat32::Fat::from_memory(ptr, size).expect("valid fat") };
 
-        let result = Mount::new(String::from("relative"), fat);
+        let result = Mount::new(String::from("relative"), fat, false);
         match result {
             Err(e) => assert_eq!(e, Fat32Error::InvalidPath, "relative path should be rejected"),
             Ok(_) => panic!("Mount::new should reject relative paths"),
@@ -649,5 +667,42 @@ mod tests {
         let vfs: Vfs = Vfs::default();
         assert_eq!(vfs.cwd(), "/");
         assert_eq!(vfs.mount_count(), 0);
+    }
+
+    // -- Read-only mount tests ---------------------------------------------------
+
+    /// Helper: creates a Fat image and returns a read-only Mount.
+    fn make_readonly_mount(mount_path: &str) -> (Mount, Vec<u8>) {
+        use ::fat32::{
+            Fat,
+            RawMemoryStorage,
+        };
+
+        let size: usize = 64 * 1024;
+        let mut buf: Vec<u8> = alloc::vec![0u8; size];
+        let ptr: *mut u8 = buf.as_mut_ptr();
+
+        let mut storage: RawMemoryStorage =
+            unsafe { RawMemoryStorage::new(ptr, size).expect("valid storage") };
+        let options = ::fatfs::FormatVolumeOptions::new();
+        ::fatfs::format_volume(&mut storage, options).expect("format should succeed");
+
+        let fat: Fat = unsafe { Fat::from_memory(ptr, size).expect("valid fat") };
+        let mount: Mount = Mount::new(String::from(mount_path), fat, true).expect("valid mount");
+        (mount, buf)
+    }
+
+    /// Tests that a writable mount returns readonly() == false.
+    #[test]
+    fn mount_writable_flag() {
+        let (mount, _buf) = make_mount("/data");
+        assert!(!mount.readonly(), "writable mount should return false");
+    }
+
+    /// Tests that a read-only mount returns readonly() == true.
+    #[test]
+    fn mount_readonly_flag() {
+        let (mount, _buf) = make_readonly_mount("/data");
+        assert!(mount.readonly(), "read-only mount should return true");
     }
 }

--- a/src/libs/vfs/src/state.rs
+++ b/src/libs/vfs/src/state.rs
@@ -162,6 +162,7 @@ pub fn is_initialized() -> bool {
 ///   (e.g., "/data"). Must start with "/".
 /// - `ptr`: Pointer to the FAT image in memory.
 /// - `size`: Size of the memory region in bytes.
+/// - `readonly`: If `true`, the mount is marked read-only.
 ///
 /// # Errors
 ///
@@ -177,14 +178,19 @@ pub fn is_initialized() -> bool {
 /// - `ptr` points to valid memory containing a FAT filesystem image.
 /// - The memory remains valid for the lifetime of the mount.
 /// - The memory region is at least `size` bytes.
-pub unsafe fn mount_image(mount_path: &str, ptr: *mut u8, size: usize) -> Result<(), Fat32Error> {
+pub unsafe fn mount_image(
+    mount_path: &str,
+    ptr: *mut u8,
+    size: usize,
+    readonly: bool,
+) -> Result<(), Fat32Error> {
     if !mount_path.starts_with('/') {
         return Err(Fat32Error::InvalidPath);
     }
 
     // SAFETY: Caller guarantees memory region validity.
     let fat: Fat = unsafe { Fat::from_memory(ptr, size)? };
-    let mount: Mount = Mount::new(String::from(mount_path), fat)?;
+    let mount: Mount = Mount::new(String::from(mount_path), fat, readonly)?;
 
     let mut state = VFS_STATE.lock();
     let vfs: &mut Vfs = state.as_mut().ok_or(Fat32Error::NotInitialized)?;
@@ -247,7 +253,7 @@ pub fn create_mount(mount_path: &str, size: usize) -> Result<(), Fat32Error> {
     // SAFETY: memory_ptr points to valid FAT image of `size` bytes.
     let fat: Fat = unsafe { Fat::from_memory(memory_ptr, size)? };
 
-    let mount: Mount = Mount::new(String::from(mount_path), fat)?;
+    let mount: Mount = Mount::new(String::from(mount_path), fat, false)?;
 
     // Add to VFS (lock held).
     {

--- a/src/tests/vfs-test/src/main.rs
+++ b/src/tests/vfs-test/src/main.rs
@@ -151,7 +151,7 @@ fn test_ramfs_mount() -> Result<(), Error> {
 
         // Mount the FAT image.
         unsafe {
-            vfs::mount_image("/ramfs", leaked.as_mut_ptr(), leaked.len())
+            vfs::mount_image("/ramfs", leaked.as_mut_ptr(), leaked.len(), false)
                 .map_err(|e| fat_err(e, "vfs mount failed"))?;
         }
 

--- a/src/utils/nanvix-bench/src/benchmarks/standalone_vfs.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/standalone_vfs.rs
@@ -34,6 +34,8 @@ use ::tokio::{
 };
 use ::vfs_bench_common::{
     ACK_OK,
+    MOUNT_READONLY,
+    MOUNT_WRITABLE,
     VfsOp,
 };
 
@@ -70,6 +72,18 @@ const DECOMPOSED_OPS: &[(&str, VfsOp, Option<VfsOp>)] = &[
     // Level 3 — subtract a level-2 operation.
     ("write+flush", VfsOp::SeqWrite, Some(VfsOp::CreateUnlink)),
 ];
+
+/// Returns `true` if the given operation mutates the filesystem.
+fn is_write_op(op: VfsOp) -> bool {
+    matches!(
+        op,
+        VfsOp::CreateScratch
+            | VfsOp::CreateUnlink
+            | VfsOp::MkdirRmdir
+            | VfsOp::Rename
+            | VfsOp::SeqWrite
+    )
+}
 
 //==================================================================================================
 // FAT Image Manifest
@@ -171,11 +185,15 @@ impl Benchmark {
     ///
     /// # Description
     ///
-    /// Runs the standalone VFS benchmark. For each VFS operation, spawns a fresh nanvixd process
-    /// in interactive mode with the VFS benchmark guest and a ramfs image. The host scans the FAT
-    /// image to discover available files and directories, then drives each operation by sending
-    /// `[opcode][path_len][path]` on stdin and reading a one-byte acknowledgement from stdout,
-    /// measuring the round-trip latency with `Instant::now()`.
+    /// Runs the standalone VFS benchmark in two phases:
+    ///
+    /// 1. **Writable mount** — the guest mounts ramfs without the read-only flag, so write
+    ///    operations on the ramfs are permitted.
+    /// 2. **Read-only mount** — the guest mounts ramfs as read-only, enforcing the write gate.
+    ///
+    /// Each phase measures all VFS operations via paired decomposition and prints a percentile
+    /// latency table. The host controls the mount mode by sending a configuration byte immediately
+    /// after spawning each nanvixd process.
     ///
     pub async fn run_vfs_bench_standalone(&mut self) -> Result<()> {
         let nanvixd_bin: PathBuf = self.standalone_nanvixd_path();
@@ -223,13 +241,69 @@ impl Benchmark {
         println!("  Min file size: {} bytes", manifest.min_file_size());
         println!("  Max file size: {} bytes", manifest.max_file_size());
 
+        // Phase 1: writable mount.
+        let mut writable_deltas: Vec<(&str, Vec<u128>)> = self
+            .run_vfs_bench_section(
+                false,
+                "VFS (writable):",
+                &manifest,
+                &nanvixd_bin,
+                &ramfs,
+                &program,
+            )
+            .await?;
+        Self::print_latency_table("Writable mount", &mut writable_deltas);
+
+        // Phase 2: read-only mount.
+        let mut readonly_deltas: Vec<(&str, Vec<u128>)> = self
+            .run_vfs_bench_section(
+                true,
+                "VFS (readonly):",
+                &manifest,
+                &nanvixd_bin,
+                &ramfs,
+                &program,
+            )
+            .await?;
+        Self::print_latency_table("Read-only mount", &mut readonly_deltas);
+
+        Ok(())
+    }
+
+    /// Runs one full benchmark section (all applicable decomposed operations) with the given mount
+    /// mode. Write operations are excluded when `readonly` is `true`.
+    ///
+    /// Each VM is spawned fresh, configured with the mount mode, and measured. Returns the
+    /// per-operation paired deltas for printing.
+    async fn run_vfs_bench_section(
+        &self,
+        readonly: bool,
+        progress_label: &str,
+        manifest: &FatManifest,
+        nanvixd_bin: &Path,
+        ramfs: &str,
+        program: &str,
+    ) -> Result<Vec<(&'static str, Vec<u128>)>> {
+        let mount_config: u8 = if readonly {
+            MOUNT_READONLY
+        } else {
+            MOUNT_WRITABLE
+        };
+
+        // Reseed RNG for reproducibility across sections.
         let mut rng: StdRng = StdRng::seed_from_u64(HOST_RNG_SEED);
 
-        // Progress bar: NOOP (1) + paired entries (those with a subtrahend).
-        let paired_count: usize = DECOMPOSED_OPS
+        // Filter out write operations when running in read-only mode.
+        let ops: Vec<(&str, VfsOp, Option<VfsOp>)> = DECOMPOSED_OPS
             .iter()
-            .filter(|(_, _, sub)| sub.is_some())
-            .count();
+            .copied()
+            .filter(|&(_, min, sub)| {
+                !readonly || (!is_write_op(min) && sub.is_none_or(|s| !is_write_op(s)))
+            })
+            .collect();
+
+        // Progress bar: NOOP (1) + paired entries (those with a subtrahend).
+        let paired_count: usize = ops.iter().filter(|(_, _, sub)| sub.is_some()).count();
         let total_steps: u64 = ((1 + paired_count) * self.iterations) as u64;
         let pb: ProgressBar = ProgressBar::new(total_steps);
         pb.set_style(
@@ -238,20 +312,20 @@ impl Benchmark {
                 .expect("error creating progress bar")
                 .progress_chars("#>-"),
         );
-        pb.set_message("VFS benchmark:");
+        pb.set_message(progress_label.to_string());
 
-        // Measure the NOOP (protocol overhead) first — it is the only operation without a
-        // subtrahend and serves as the baseline for all decomposed measurements.
+        // Measure the NOOP (protocol overhead) first.
         let noop_latencies: Vec<u128>;
         {
             let (mut child, mut stdin, mut stdout) =
-                Self::spawn_nanvixd(&nanvixd_bin, &ramfs, &program, &self.workspace_root)?;
+                Self::spawn_nanvixd(nanvixd_bin, ramfs, program, &self.workspace_root)?;
+            Self::send_mount_config(&mut stdin, &mut stdout, mount_config).await?;
 
             noop_latencies = Self::measure_iterations(
                 &mut stdin,
                 &mut stdout,
                 VfsOp::Noop,
-                &manifest,
+                manifest,
                 &mut rng,
                 self.iterations,
                 &pb,
@@ -262,9 +336,9 @@ impl Benchmark {
         }
 
         // Paired decomposition (one VM per pair, back-to-back measurement).
-        let mut paired_deltas: Vec<(&str, Vec<u128>)> = Vec::with_capacity(DECOMPOSED_OPS.len());
+        let mut paired_deltas: Vec<(&str, Vec<u128>)> = Vec::with_capacity(ops.len());
 
-        for &(label, minuend, subtrahend) in DECOMPOSED_OPS {
+        for &(label, minuend, subtrahend) in &ops {
             let sub_op: VfsOp = match subtrahend {
                 Some(op) => op,
                 None => {
@@ -275,14 +349,15 @@ impl Benchmark {
             };
 
             let (mut child, mut stdin, mut stdout) =
-                Self::spawn_nanvixd(&nanvixd_bin, &ramfs, &program, &self.workspace_root)?;
+                Self::spawn_nanvixd(nanvixd_bin, ramfs, program, &self.workspace_root)?;
+            Self::send_mount_config(&mut stdin, &mut stdout, mount_config).await?;
 
             let deltas: Vec<u128> = Self::measure_paired_iterations(
                 &mut stdin,
                 &mut stdout,
                 minuend,
                 sub_op,
-                &manifest,
+                manifest,
                 &mut rng,
                 self.iterations,
                 &pb,
@@ -294,11 +369,7 @@ impl Benchmark {
         }
 
         pb.finish();
-
-        // Print decomposed latency table.
-        Self::print_latency_table("Decomposed (paired)", &mut paired_deltas);
-
-        Ok(())
+        Ok(paired_deltas)
     }
 
     /// Picks a random file or directory path appropriate for the given operation.
@@ -492,6 +563,30 @@ impl Benchmark {
             anyhow::bail!("nanvixd exited with {status}");
         }
 
+        Ok(())
+    }
+
+    /// Sends the mount configuration byte and waits for the guest's mount-complete ACK.
+    ///
+    /// This must be called immediately after [`spawn_nanvixd()`] and before any
+    /// operation opcodes. The guest reads one byte to decide whether to mount the
+    /// ramfs as read-only or writable, then sends `ACK_OK` once the mount succeeds.
+    async fn send_mount_config(
+        stdin: &mut ::tokio::process::ChildStdin,
+        stdout: &mut ::tokio::process::ChildStdout,
+        config: u8,
+    ) -> Result<()> {
+        stdin.write_all(&[config]).await?;
+        stdin.flush().await?;
+        let mut ack: [u8; 1] = [0u8; 1];
+        ::tokio::time::timeout(Duration::from_secs(VFS_BENCH_TIMEOUT_SECS), async {
+            stdout.read_exact(&mut ack).await
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("guest mount timed out after {VFS_BENCH_TIMEOUT_SECS}s"))??;
+        if ack[0] != ACK_OK {
+            anyhow::bail!("guest reported mount error (config={config:#04x})");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Add support for benchmarking VFS operations under both writable and read-only mount modes.

## Changes

### Guest (vfs-bench-nostd)
- Read a mount configuration byte from stdin before mounting ramfs (writable vs read-only).
- Send ACK after mount completes so the host can detect failures before sending opcodes.
- Forward the readonly flag to `vfs::mount_image()`.

### Host (nanvix-bench)
- Split `run_vfs_bench_standalone()` into two phases: writable mount (baseline) and read-only mount (with negative cache), each printing its own latency table.
- Extract `run_vfs_bench_section()` for a full measurement pass with a given mount mode.
- Add `send_mount_config()` to transmit the config byte and await the guest's mount ACK.

### Shared protocol (vfs-bench-common)
- Add `MOUNT_WRITABLE` and `MOUNT_READONLY` constants for the mount configuration byte.