### PR TITLE
[ci] Add 256MB image support for Windows

### DIFF
--- a/.github/actions/patch-memory-size/action.yml
+++ b/.github/actions/patch-memory-size/action.yml
@@ -1,0 +1,33 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: "Patch Memory Size"
+description: "Patch memory_size in the kernel configuration file"
+
+inputs:
+  memory-size:
+    description: "Memory size in megabytes"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Patch memory_size in kernel config"
+      shell: bash
+      env:
+        MEMORY_SIZE_MB: ${{ inputs.memory-size }}
+      run: |
+        memory_size_bytes=$(( MEMORY_SIZE_MB * 1048576 ))
+        sed -i "s/^memory_size = .*/memory_size = ${memory_size_bytes}/" build/kernel_config.toml
+        # Verify that exactly one memory_size line exists after patching
+        matches=$(grep -c "^memory_size = " build/kernel_config.toml || true)
+        if [ "${matches}" -ne 1 ]; then
+          echo "Error: Expected exactly one 'memory_size' entry in build/kernel_config.toml, found ${matches}." >&2
+          exit 1
+        fi
+        # Verify that the memory_size line has the expected value
+        if ! grep -q "^memory_size = ${memory_size_bytes}$" build/kernel_config.toml; then
+          echo "Error: Failed to set 'memory_size' to ${memory_size_bytes} bytes in build/kernel_config.toml." >&2
+          exit 1
+        fi
+        echo "Set memory_size to ${memory_size_bytes} bytes (${MEMORY_SIZE_MB} MB)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,24 +264,9 @@ jobs:
         uses: ./.github/actions/native-setup
 
       - name: "Patch memory_size in kernel config"
-        shell: bash
-        env:
-          MEMORY_SIZE_MB: ${{ matrix.memory-size }}
-        run: |
-          memory_size_bytes=$(( MEMORY_SIZE_MB * 1048576 ))
-          sed -i "s/^memory_size = .*/memory_size = ${memory_size_bytes}/" build/kernel_config.toml
-          # Verify that exactly one memory_size line exists after patching
-          matches=$(grep -c "^memory_size = " build/kernel_config.toml || true)
-          if [ "${matches}" -ne 1 ]; then
-            echo "Error: Expected exactly one 'memory_size' entry in build/kernel_config.toml, found ${matches}." >&2
-            exit 1
-          fi
-          # Verify that the memory_size line has the expected value
-          if ! grep -q "^memory_size = ${memory_size_bytes}$" build/kernel_config.toml; then
-            echo "Error: Failed to set 'memory_size' to ${memory_size_bytes} bytes in build/kernel_config.toml." >&2
-            exit 1
-          fi
-          echo "Set memory_size to ${memory_size_bytes} bytes (${MEMORY_SIZE_MB} MB)"
+        uses: ./.github/actions/patch-memory-size
+        with:
+          memory-size: "${{ matrix.memory-size }}"
 
       - name: "Setup sccache"
         uses: Mozilla-Actions/sccache-action@v0.0.9
@@ -565,7 +550,7 @@ jobs:
   # Build all components (guest + host) natively on Windows using the local
   # cross-compilation toolchain (GNU Make + rust-lld) and run unit tests.
   windows-ci-build:
-    name: "Windows Build (${{ matrix.machine-type }}, ${{ matrix.build-type }})"
+    name: "Windows Build (${{ matrix.machine-type }}, ${{ matrix.build-type }}, ${{ matrix.memory-size }}mb)"
     needs: [windows-format-check, windows-lint-check, windows-verify]
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     # !failure() ensures the build does not start when checks/lint/verify fail.
@@ -580,6 +565,11 @@ jobs:
       matrix:
         build-type: ${{ fromJSON(github.event_name == 'pull_request' && '["debug"]' || github.event_name == 'workflow_dispatch' && '["debug","release"]' || '["release"]') }}
         machine-type: [microvm, hyperlight]
+        memory-size: [128, 256]
+        # 256MB images are release-only; exclude them from debug builds.
+        exclude:
+          - build-type: debug
+            memory-size: 256
     runs-on: windows-latest
     permissions:
       contents: read
@@ -624,6 +614,11 @@ jobs:
           echo "CARGO_HOME=$isolatedCargo" >> $env:GITHUB_ENV
           Write-Host "Isolated CARGO_HOME to $isolatedCargo"
 
+      - name: "Patch memory_size in kernel config"
+        uses: ./.github/actions/patch-memory-size
+        with:
+          memory-size: "${{ matrix.memory-size }}"
+
       - name: "Build & Unit Test"
         shell: pwsh
         env:
@@ -635,7 +630,7 @@ jobs:
       - name: "Upload Build Artifacts"
         uses: actions/upload-artifact@v7
         with:
-          name: windows-build-${{ matrix.machine-type }}-${{ matrix.build-type }}
+          name: windows-build-${{ matrix.machine-type }}-${{ matrix.build-type }}-${{ matrix.memory-size }}mb
           retention-days: 1
           path: |
             bin/*.exe
@@ -665,7 +660,7 @@ jobs:
       - name: "Download Build Artifacts"
         uses: actions/download-artifact@v8
         with:
-          name: windows-build-${{ matrix.machine-type }}-${{ matrix.build-type }}
+          name: windows-build-${{ matrix.machine-type }}-${{ matrix.build-type }}-128mb
           path: bin
 
       - name: "Exclude bin/ from Windows Defender"
@@ -1885,7 +1880,7 @@ jobs:
   # Package Windows standalone binaries into a release archive (.zip).
   # Windows only supports standalone deployment mode.
   windows-release-archive:
-    name: "Windows Release Archive (${{ matrix.machine-type }})"
+    name: "Windows Release Archive (${{ matrix.machine-type }}, ${{ matrix.memory-size }}mb)"
     needs:
       [
         windows-integration-test,
@@ -1912,6 +1907,7 @@ jobs:
       fail-fast: false
       matrix:
         machine-type: [microvm, hyperlight]
+        memory-size: [128, 256]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -1922,7 +1918,7 @@ jobs:
       - name: "Download Windows Build Artifacts"
         uses: actions/download-artifact@v8
         with:
-          name: windows-build-${{ matrix.machine-type }}-release
+          name: windows-build-${{ matrix.machine-type }}-release-${{ matrix.memory-size }}mb
           path: windows-bin
 
       - name: "Package Windows Release Archive"
@@ -1930,7 +1926,7 @@ jobs:
         shell: bash
         run: |
           commit_id="${GITHUB_SHA}"
-          archive_name="nanvix-windows-${{ matrix.machine-type }}-standalone-release-128mb-${commit_id}.zip"
+          archive_name="nanvix-windows-${{ matrix.machine-type }}-standalone-release-${{ matrix.memory-size }}mb-${commit_id}.zip"
 
           # Create the zip archive from the downloaded Windows binaries.
           cd windows-bin
@@ -1944,7 +1940,7 @@ jobs:
       - name: "Upload Release Artifact"
         uses: actions/upload-artifact@v7
         with:
-          name: release-windows-${{ matrix.machine-type }}-standalone-128mb
+          name: release-windows-${{ matrix.machine-type }}-standalone-${{ matrix.memory-size }}mb
           path: ${{ steps.package.outputs.archive-path }}
           overwrite: true
 


### PR DESCRIPTION
## Summary

Add `memory-size` matrix dimension to Windows CI build and release archive jobs so that 256MB standalone images are built and published for Windows, matching the existing Linux pipeline behavior.

## Problem

The Linux CI pipeline builds and publishes both 128MB and 256MB standalone images via its `memory-size: [128, 256]` matrix. The Windows pipeline lacked this dimension entirely — it only built with the default 128MB config and hardcoded `128mb` in release archive names.

## Changes

### `windows-ci-build`
- Add `memory-size: [128, 256]` to matrix (256MB excluded from debug builds, matching Linux).
- Add `Patch memory_size in kernel config` step identical to the Linux `ci-build` job.
- Update artifact naming to include memory size suffix.

### `windows-integration-test`
- Pin artifact download to `128mb` (matching Linux `ci-test`, which only tests the default 128MB).

### `windows-release-archive`
- Add `memory-size: [128, 256]` to matrix.
- Replace hardcoded `128mb` in archive and artifact names with `${{ matrix.memory-size }}mb`.

### No changes needed
- **`publish-release`** action already discovers all `release-*` artifacts via glob.
- **Windows benchmark jobs** build from source and are unaffected.