### PR TITLE
[libs] Add sorted-vec crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
         "src/libs/profiler",
         "src/libs/raw-array",
         "src/libs/slab",
+        "src/libs/sorted-vec",
         "src/libs/static_assert",
         "src/libs/sysalloc",
         "src/libs/sysapi",
@@ -185,6 +186,7 @@ sha2 = "0.11.0"
 shell-words = "1.1"
 signal-hook = "0.4.3"
 slab = { path = "src/libs/slab", default-features = false }
+sorted-vec = { path = "src/libs/sorted-vec", default-features = false }
 spin = { git = "https://github.com/nanvix/spin-rs", package = "spin", branch = "nanvix/v0.10.0", default-features = false }
 static_assert = { path = "src/libs/static_assert", default-features = false }
 libc_stdlib = { path = "src/libs/libc_stdlib", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -314,8 +314,8 @@ export VERUS_VERIFY_CMD = RUSTC_BOOTSTRAP=1 RUSTFLAGS=$(KERNEL_RUST_FLAGS) \
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix
-ALL_GUEST_RUST_LIBS := arch bitmap config elf error fat32 type-safe nvx proc raw-array slab static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap config elf error fat32 type-safe proc raw-array slab static_assert libc_string syslog-macros syslog
+ALL_GUEST_RUST_LIBS := arch bitmap config elf error fat32 type-safe nvx proc raw-array slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap config elf error fat32 type-safe proc raw-array slab sorted-vec static_assert libc_string syslog-macros syslog
 
 ALL_GUEST_DAEMONS := memd procd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd

--- a/src/libs/sorted-vec/Cargo.toml
+++ b/src/libs/sorted-vec/Cargo.toml
@@ -1,0 +1,23 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "sorted-vec"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Sorted vector with binary search lookup"
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+
+[features]
+default = []
+std = []
+
+[lints]
+workspace = true

--- a/src/libs/sorted-vec/src/lib.rs
+++ b/src/libs/sorted-vec/src/lib.rs
@@ -1,0 +1,364 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod test;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+extern crate alloc;
+
+use ::alloc::vec::Vec;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A sorted vector that maintains its elements in ascending order and provides efficient
+/// lookup via binary search.
+///
+/// Elements must implement [`Ord`] for sorting and searching. The vector does not allow
+/// duplicate elements; inserting a value that already exists replaces the old entry.
+///
+#[derive(Debug, Clone)]
+pub struct SortedVec<T: Ord> {
+    /// Underlying storage.
+    inner: Vec<T>,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl<T: Ord> SortedVec<T> {
+    ///
+    /// # Description
+    ///
+    /// Creates an empty [`SortedVec`].
+    ///
+    /// # Returns
+    ///
+    /// An empty sorted vector.
+    ///
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Creates an empty [`SortedVec`] with the specified capacity.
+    ///
+    /// # Parameters
+    ///
+    /// - `capacity`: The number of elements the vector can hold without reallocating.
+    ///
+    /// # Returns
+    ///
+    /// An empty sorted vector with the given capacity.
+    ///
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Vec::with_capacity(capacity),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the number of elements in the sorted vector.
+    ///
+    /// # Returns
+    ///
+    /// The number of elements.
+    ///
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns `true` if the sorted vector contains no elements.
+    ///
+    /// # Returns
+    ///
+    /// `true` if empty, `false` otherwise.
+    ///
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the capacity of the sorted vector.
+    ///
+    /// # Returns
+    ///
+    /// The number of elements the vector can hold without reallocating.
+    ///
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Clears all elements from the sorted vector.
+    ///
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Inserts a value into the sorted vector, maintaining sorted order. If the value already
+    /// exists, the old value is replaced and returned.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: The value to insert.
+    ///
+    /// # Returns
+    ///
+    /// `Some(old_value)` if the value was already present, `None` otherwise.
+    ///
+    pub fn insert(&mut self, value: T) -> Option<T> {
+        match self.inner.binary_search(&value) {
+            Ok(index) => {
+                let old: T = ::core::mem::replace(&mut self.inner[index], value);
+                Some(old)
+            },
+            Err(index) => {
+                self.inner.insert(index, value);
+                None
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Removes a value from the sorted vector.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: The value to remove.
+    ///
+    /// # Returns
+    ///
+    /// `Some(removed_value)` if found, `None` otherwise.
+    ///
+    pub fn remove(&mut self, value: &T) -> Option<T> {
+        match self.inner.binary_search(value) {
+            Ok(index) => Some(self.inner.remove(index)),
+            Err(_) => None,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Removes an element by extracting a comparable key from each entry.
+    ///
+    /// The key function must extract a value whose natural ordering is consistent with the
+    /// ascending [`Ord`] order of the underlying sorted vector. The library performs the
+    /// comparison internally, so ordering correctness is enforced by construction.
+    ///
+    /// # Parameters
+    ///
+    /// - `key`: The key value to search for.
+    /// - `f`: A function that extracts a comparable key of type `K` from each element.
+    ///
+    /// # Returns
+    ///
+    /// `Some(removed_value)` if found, `None` otherwise.
+    ///
+    pub fn remove_by<K, F>(&mut self, key: &K, f: F) -> Option<T>
+    where
+        K: Ord,
+        F: FnMut(&T) -> K,
+    {
+        match self.inner.binary_search_by_key(key, f) {
+            Ok(index) => Some(self.inner.remove(index)),
+            Err(_) => None,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns `true` if the sorted vector contains the given value.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: The value to search for.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the value is found, `false` otherwise.
+    ///
+    pub fn contains(&self, value: &T) -> bool {
+        self.inner.binary_search(value).is_ok()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a reference to the element matching the given value, using binary search.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: The value to search for.
+    ///
+    /// # Returns
+    ///
+    /// `Some(&element)` if found, `None` otherwise.
+    ///
+    pub fn get(&self, value: &T) -> Option<&T> {
+        match self.inner.binary_search(value) {
+            Ok(index) => Some(&self.inner[index]),
+            Err(_) => None,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Searches the sorted vector by extracting a comparable key from each entry.
+    ///
+    /// The key function must extract a value whose natural ordering is consistent with the
+    /// ascending [`Ord`] order of the underlying sorted vector. The library performs the
+    /// comparison internally, so ordering correctness is enforced by construction.
+    ///
+    /// # Parameters
+    ///
+    /// - `key`: The key value to search for.
+    /// - `f`: A function that extracts a comparable key of type `K` from each element.
+    ///
+    /// # Returns
+    ///
+    /// `Some(&element)` if found, `None` otherwise.
+    ///
+    pub fn lookup_by<K, F>(&self, key: &K, f: F) -> Option<&T>
+    where
+        K: Ord,
+        F: FnMut(&T) -> K,
+    {
+        match self.inner.binary_search_by_key(key, f) {
+            Ok(index) => Some(&self.inner[index]),
+            Err(_) => None,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a reference to the smallest element.
+    ///
+    /// # Returns
+    ///
+    /// `Some(&element)` if non-empty, `None` otherwise.
+    ///
+    pub fn first(&self) -> Option<&T> {
+        self.inner.first()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a reference to the largest element.
+    ///
+    /// # Returns
+    ///
+    /// `Some(&element)` if non-empty, `None` otherwise.
+    ///
+    pub fn last(&self) -> Option<&T> {
+        self.inner.last()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns an iterator over the elements in sorted order.
+    ///
+    /// # Returns
+    ///
+    /// An iterator yielding references to elements in ascending order.
+    ///
+    pub fn iter(&self) -> ::core::slice::Iter<'_, T> {
+        self.inner.iter()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a slice of the underlying sorted elements.
+    ///
+    /// # Returns
+    ///
+    /// A slice of all elements in sorted order.
+    ///
+    pub fn as_slice(&self) -> &[T] {
+        self.inner.as_slice()
+    }
+}
+
+//==================================================================================================
+// Trait Implementations
+//==================================================================================================
+
+impl<T: Ord> Default for SortedVec<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Ord> From<Vec<T>> for SortedVec<T> {
+    ///
+    /// # Description
+    ///
+    /// Creates a [`SortedVec`] from an unsorted [`Vec`]. The vector is sorted and duplicates
+    /// are removed.
+    ///
+    fn from(mut vec: Vec<T>) -> Self {
+        vec.sort_unstable();
+        vec.dedup();
+        Self { inner: vec }
+    }
+}
+
+impl<T: Ord> IntoIterator for SortedVec<T> {
+    type Item = T;
+    type IntoIter = ::alloc::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
+impl<'a, T: Ord> IntoIterator for &'a SortedVec<T> {
+    type Item = &'a T;
+    type IntoIter = ::core::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.iter()
+    }
+}

--- a/src/libs/sorted-vec/src/test.rs
+++ b/src/libs/sorted-vec/src/test.rs
@@ -1,0 +1,382 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+use crate::SortedVec;
+use alloc::{
+    vec,
+    vec::Vec,
+};
+use core::cmp::Ordering;
+
+/// Helper type whose `Ord`/`Eq` compare only by `key`, carrying a separate `payload`.
+#[derive(Debug, Clone)]
+struct KeyValue {
+    key: i32,
+    payload: &'static str,
+}
+
+impl PartialEq for KeyValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+
+impl Eq for KeyValue {}
+
+impl PartialOrd for KeyValue {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for KeyValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key.cmp(&other.key)
+    }
+}
+
+//==================================================================================================
+// Creation Tests
+//==================================================================================================
+
+#[test]
+fn test_new_is_empty() {
+    let sv: SortedVec<i32> = SortedVec::new();
+    assert!(sv.is_empty());
+    assert_eq!(sv.len(), 0);
+}
+
+#[test]
+fn test_with_capacity() {
+    let sv: SortedVec<i32> = SortedVec::with_capacity(16);
+    assert!(sv.is_empty());
+    assert!(sv.capacity() >= 16);
+}
+
+#[test]
+fn test_default() {
+    let sv: SortedVec<i32> = SortedVec::default();
+    assert!(sv.is_empty());
+}
+
+//==================================================================================================
+// Insertion Tests
+//==================================================================================================
+
+#[test]
+fn test_insert_single() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    let result: Option<i32> = sv.insert(42);
+    assert!(result.is_none());
+    assert_eq!(sv.len(), 1);
+    assert_eq!(sv.get(&42), Some(&42));
+}
+
+#[test]
+fn test_insert_maintains_order() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(30);
+    sv.insert(10);
+    sv.insert(20);
+    assert_eq!(sv.as_slice(), &[10, 20, 30]);
+}
+
+#[test]
+fn test_insert_duplicate_replaces() {
+    let mut sv: SortedVec<KeyValue> = SortedVec::new();
+    sv.insert(KeyValue {
+        key: 10,
+        payload: "first",
+    });
+    let old: Option<KeyValue> = sv.insert(KeyValue {
+        key: 10,
+        payload: "second",
+    });
+    assert_eq!(sv.len(), 1);
+    let old = old.expect("duplicate insert should return the old element");
+    assert_eq!(old.payload, "first");
+    assert_eq!(
+        sv.get(&KeyValue {
+            key: 10,
+            payload: ""
+        })
+        .expect("element should exist after replacement")
+        .payload,
+        "second"
+    );
+}
+
+#[test]
+fn test_insert_ascending() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    for i in 0..10 {
+        sv.insert(i);
+    }
+    let expected: Vec<i32> = (0..10).collect();
+    assert_eq!(sv.as_slice(), expected.as_slice());
+}
+
+#[test]
+fn test_insert_descending() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    for i in (0..10).rev() {
+        sv.insert(i);
+    }
+    let expected: Vec<i32> = (0..10).collect();
+    assert_eq!(sv.as_slice(), expected.as_slice());
+}
+
+//==================================================================================================
+// Removal Tests
+//==================================================================================================
+
+#[test]
+fn test_remove_existing() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(10);
+    sv.insert(20);
+    sv.insert(30);
+    let removed: Option<i32> = sv.remove(&20);
+    assert_eq!(removed, Some(20));
+    assert_eq!(sv.len(), 2);
+    assert_eq!(sv.as_slice(), &[10, 30]);
+}
+
+#[test]
+fn test_remove_nonexistent() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(10);
+    let removed: Option<i32> = sv.remove(&99);
+    assert!(removed.is_none());
+    assert_eq!(sv.len(), 1);
+}
+
+#[test]
+fn test_remove_from_empty() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    let removed: Option<i32> = sv.remove(&1);
+    assert!(removed.is_none());
+}
+
+#[test]
+fn test_remove_by_existing() {
+    let mut sv: SortedVec<(i32, &str)> = SortedVec::new();
+    sv.insert((1, "one"));
+    sv.insert((2, "two"));
+    sv.insert((3, "three"));
+    let removed: Option<(i32, &str)> = sv.remove_by(&2, |&(k, _)| k);
+    assert_eq!(removed, Some((2, "two")));
+    assert_eq!(sv.len(), 2);
+    assert_eq!(sv.as_slice(), &[(1, "one"), (3, "three")]);
+}
+
+#[test]
+fn test_remove_by_not_found() {
+    let mut sv: SortedVec<(i32, &str)> = SortedVec::new();
+    sv.insert((1, "one"));
+    sv.insert((3, "three"));
+    let removed: Option<(i32, &str)> = sv.remove_by(&2, |&(k, _)| k);
+    assert!(removed.is_none());
+    assert_eq!(sv.len(), 2);
+}
+
+//==================================================================================================
+// Lookup Tests
+//==================================================================================================
+
+#[test]
+fn test_contains() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(5);
+    sv.insert(15);
+    assert!(sv.contains(&5));
+    assert!(sv.contains(&15));
+    assert!(!sv.contains(&10));
+}
+
+#[test]
+fn test_get_existing() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(42);
+    assert_eq!(sv.get(&42), Some(&42));
+}
+
+#[test]
+fn test_get_nonexistent() {
+    let sv: SortedVec<i32> = SortedVec::new();
+    assert_eq!(sv.get(&42), None);
+}
+
+//==================================================================================================
+// Lookup Tests (Custom Comparator)
+//==================================================================================================
+
+#[test]
+fn test_lookup() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(10);
+    sv.insert(20);
+    sv.insert(30);
+    let result: Option<&i32> = sv.lookup_by(&20, |x| *x);
+    assert_eq!(result, Some(&20));
+}
+
+#[test]
+fn test_lookup_not_found() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(10);
+    sv.insert(30);
+    let result: Option<&i32> = sv.lookup_by(&20, |x| *x);
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_lookup_by_key() {
+    let mut sv: SortedVec<(i32, &str)> = SortedVec::new();
+    sv.insert((1, "one"));
+    sv.insert((2, "two"));
+    sv.insert((3, "three"));
+    let result: Option<&(i32, &str)> = sv.lookup_by(&2, |&(k, _)| k);
+    assert_eq!(result, Some(&(2, "two")));
+}
+
+#[test]
+fn test_lookup_by_key_not_found() {
+    let mut sv: SortedVec<(i32, &str)> = SortedVec::new();
+    sv.insert((1, "one"));
+    sv.insert((3, "three"));
+    let result: Option<&(i32, &str)> = sv.lookup_by(&2, |&(k, _)| k);
+    assert!(result.is_none());
+}
+
+//==================================================================================================
+// First/Last Tests
+//==================================================================================================
+
+#[test]
+fn test_first_last() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(30);
+    sv.insert(10);
+    sv.insert(20);
+    assert_eq!(sv.first(), Some(&10));
+    assert_eq!(sv.last(), Some(&30));
+}
+
+#[test]
+fn test_first_last_empty() {
+    let sv: SortedVec<i32> = SortedVec::new();
+    assert_eq!(sv.first(), None);
+    assert_eq!(sv.last(), None);
+}
+
+//==================================================================================================
+// Clear Tests
+//==================================================================================================
+
+#[test]
+fn test_clear() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(1);
+    sv.insert(2);
+    sv.insert(3);
+    sv.clear();
+    assert!(sv.is_empty());
+    assert_eq!(sv.len(), 0);
+}
+
+//==================================================================================================
+// Conversion Tests
+//==================================================================================================
+
+#[test]
+fn test_from_vec_sorts_and_dedups() {
+    let sv: SortedVec<i32> = SortedVec::from(vec![3, 1, 2, 1, 3]);
+    assert_eq!(sv.as_slice(), &[1, 2, 3]);
+    assert_eq!(sv.len(), 3);
+}
+
+#[test]
+fn test_from_empty_vec() {
+    let sv: SortedVec<i32> = SortedVec::from(vec![]);
+    assert!(sv.is_empty());
+}
+
+//==================================================================================================
+// Iterator Tests
+//==================================================================================================
+
+#[test]
+fn test_iter() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(30);
+    sv.insert(10);
+    sv.insert(20);
+    let collected: Vec<&i32> = sv.iter().collect();
+    assert_eq!(collected, vec![&10, &20, &30]);
+}
+
+#[test]
+fn test_into_iter() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(3);
+    sv.insert(1);
+    sv.insert(2);
+    let collected: Vec<i32> = sv.into_iter().collect();
+    assert_eq!(collected, vec![1, 2, 3]);
+}
+
+#[test]
+fn test_ref_into_iter() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(3);
+    sv.insert(1);
+    sv.insert(2);
+    let collected: Vec<&i32> = (&sv).into_iter().collect();
+    assert_eq!(collected, vec![&1, &2, &3]);
+}
+
+//==================================================================================================
+// Edge Case Tests
+//==================================================================================================
+
+#[test]
+fn test_single_element() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(42);
+    assert_eq!(sv.first(), Some(&42));
+    assert_eq!(sv.last(), Some(&42));
+    assert!(sv.contains(&42));
+}
+
+#[test]
+fn test_insert_remove_reinsert() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(10);
+    sv.remove(&10);
+    assert!(sv.is_empty());
+    sv.insert(10);
+    assert_eq!(sv.len(), 1);
+    assert!(sv.contains(&10));
+}
+
+#[test]
+fn test_large_insertion() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    for i in (0..100).rev() {
+        sv.insert(i);
+    }
+    assert_eq!(sv.len(), 100);
+    for i in 0..100 {
+        assert!(sv.contains(&i));
+    }
+}
+
+#[test]
+fn test_clone() {
+    let mut sv: SortedVec<i32> = SortedVec::new();
+    sv.insert(1);
+    sv.insert(2);
+    let cloned: SortedVec<i32> = sv.clone();
+    assert_eq!(sv.as_slice(), cloned.as_slice());
+}


### PR DESCRIPTION
## Description

Introduce a new `no_std` utility library (`sorted-vec`) that wraps `Vec<T>` and maintains elements in ascending sorted order. All lookups use binary search for O(log n) performance. Duplicate elements are not allowed; inserting an existing value replaces the old entry.

## Public API

- `new()`, `with_capacity()`, `len()`, `is_empty()`, `capacity()`, `clear()`
- `insert()`: maintains sorted order, returns replaced element if any
- `remove()`: removes by value using binary search
- `remove_by()`: removes by extracting a comparable key from each entry
- `contains()`, `get()`: binary search lookups by value
- `lookup_by()`: binary search with a key-extraction closure
- `first()`, `last()`: access smallest/largest elements
- `iter()`, `as_slice()`: sorted-order traversal
- `From<Vec<T>>`: sort and deduplicate an unsorted vector
- `Default`, `IntoIterator`, `Clone`, `Debug` trait implementations

## Testing

30 unit tests covering creation, insertion ordering, duplicate handling (using a custom `KeyValue` type to verify payload replacement), removal, lookups, custom key-based searches, iteration, conversions, and edge cases.

## Notes

- The crate is `no_std`-compatible with an optional `std` feature gate (requires only `alloc`).
- Workspace registration in `Cargo.toml` and `Makefile` (guest Rust lib build/test lists) is included.