### PR TITLE
[kernel] Optimize `__phys_memset`

### DIFF
--- a/src/kernel/src/hal/arch/x86/asm/hooks.rs
+++ b/src/kernel/src/hal/arch/x86/asm/hooks.rs
@@ -114,7 +114,7 @@ global_asm!(
     ".global __leave_kernel_to_user_mode",
     ".global __phys_memcpy",
     ".global __phys_memcpy32",
-    ".global __phys_memset",
+    ".global __phys_memset32",
 
     // =================================================================
     // Macros
@@ -557,36 +557,52 @@ global_asm!(
     "    ret",
 
     // =================================================================
-    // __phys_memset()
+    // __phys_memset32()
     // =================================================================
     //
-    // Fills a physical memory region with a given value.
+    // Fills a physical memory region with a given value using 32-bit
+    // stores. Size must be a multiple of 4 bytes.
     //
-    "__phys_memset:",
+    "__phys_memset32:",
     "    pushl %edi",
 
     // Get parameters.
     "    movl 8(%esp), %edi",  // dest
-    "    movl 12(%esp), %edx", // value
-    "    movl 16(%esp), %ecx", // size
+    "    movl 12(%esp), %eax", // value (byte)
+    "    movl 16(%esp), %ecx", // size in bytes
+
+    // Replicate byte value across all 4 bytes of %eax.
+    "    movzbl %al, %eax",
+    "    imull $0x01010101, %eax, %eax",
+
+    // Convert size in bytes to number of 32-bit words.
+    "    shrl $2, %ecx",
+
+    // If size is zero, skip.
+    "    test %ecx, %ecx",
+    "    jz __phys_memset32.done",
+
+    // Preserve flags before paging is disabled.
+    "    pushf",
 
     // Disable paging.
-    "    movl %cr0, %eax",
-    "    andl $0x80000000 - 1, %eax",
-    "    movl %eax, %cr0",
+    "    movl %cr0, %edx",
+    "    andl $0x80000000 - 1, %edx",
+    "    movl %edx, %cr0",
 
-    // We cannot use rep stosb because we would use segment registers
-    // and therefore the GDT, which is only accessible when paging is enabled.
-    "__phys_memset.loop:",
-    "    movb %dl, (%edi)",
-    "    inc %edi",
-    "    dec %ecx",
-    "    jnz __phys_memset.loop",
+    // Fill 32-bit words using fast-string microcode.
+    "    cld",
+    "    rep stosl",
 
     // Re-enable paging.
-    "    movl %cr0, %eax",
-    "    orl $0x80000000, %eax",
-    "    movl %eax, %cr0",
+    "    movl %cr0, %edx",
+    "    orl $0x80000000, %edx",
+    "    movl %edx, %cr0",
+
+    // Restore flags.
+    "    popf",
+
+    "__phys_memset32.done:",
 
     "    popl %edi",
 

--- a/src/kernel/src/hal/arch/x86_64/asm/hooks.rs
+++ b/src/kernel/src/hal/arch/x86_64/asm/hooks.rs
@@ -96,7 +96,7 @@ global_asm!(
     ".global __leave_kernel_to_user_mode",
     ".global __phys_memcpy",
     ".global __phys_memcpy32",
-    ".global __phys_memset",
+    ".global __phys_memset32",
 
     // =================================================================
     // Macros
@@ -477,20 +477,28 @@ global_asm!(
     "    ret",
 
     // =================================================================
-    // __phys_memset()
+    // __phys_memset32()
     // =================================================================
     //
-    // Fills a physical memory region with a given value
-    // (identity mapped).
+    // Fills a physical memory region with a given value using 32-bit
+    // stores. Region must be identity mapped. Size must be a multiple
+    // of 4 bytes.
     //
-    // void __phys_memset(void *dest, int value, size_t size);
-    // RDI = dest, RSI = value, RDX = size
+    // void __phys_memset32(void *dest, int value, size_t size);
+    // RDI = dest, RSI = value, RDX = size (in bytes)
     //
-    "__phys_memset:",
-    "    movq %rsi, %rax", // value
-    "    movq %rdx, %rcx", // count
+    "__phys_memset32:",
+    // Replicate byte value across all 4 bytes of %eax.
+    "    movzbl %sil, %eax",
+    "    imull $0x01010101, %eax, %eax",
+    // Convert size in bytes to dword count.
+    "    movq %rdx, %rcx",
+    "    shrq $2, %rcx",
+    "    test %rcx, %rcx",
+    "    jz __phys_memset32.done",
     "    cld",
-    "    rep stosb",
+    "    rep stosl",
+    "__phys_memset32.done:",
     "    ret",
 
     // =================================================================

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -113,20 +113,31 @@ unsafe extern "C" {
     ///
     /// # Description
     ///
-    /// This function disables paging and fills the memory region with the provided value.
+    /// Fills a physical memory region with the provided byte value using 32-bit stores. The byte
+    /// value is replicated across all four bytes of each 32-bit word.
+    ///
+    /// - **x86**: temporarily disables paging to access physical memory directly.
+    /// - **x86_64**: requires the target region to be identity-mapped.
+    ///
+    /// If the size is zero, this function does nothing.
     ///
     /// # Parameters
     ///
-    /// - `base`: Base address of the memory region.
-    /// - `value`: Value to fill the memory region with.
-    /// - `size`: Size of the memory region.
+    /// - `base`: Base physical address of the memory region.
+    /// - `value`: Byte value to fill the memory region with.
+    /// - `size`: Size of the memory region in bytes.
     ///
     /// # Safety
     ///
-    /// This function may lead to undefined behavior if the provided base address is not
-    /// correct.
+    /// This function is marked as unsafe because it performs a raw physical memory write (x86:
+    /// temporarily disables paging; x86_64: requires identity-mapped physical addresses).
     ///
-    fn __phys_memset(base: *mut u8, value: u8, size: usize);
+    /// It is safe to call this function if and only if all the following conditions are met:
+    /// - `base` points to a physical memory address that is valid and safe to write to.
+    /// - `base` is 4-byte aligned.
+    /// - `size` is a multiple of 4 bytes.
+    ///
+    fn __phys_memset32(base: *mut u8, value: u8, size: usize);
 }
 
 /// A type that represents a virtual memory space.
@@ -1064,10 +1075,13 @@ impl Vmem {
         let dst: PageAligned<PhysicalAddress> = uframe.into_physical_address();
         let base: *mut u8 = dst.into_raw_value() as *mut u8;
 
-        // Safety: `base` points to a valid memory location and `mem::PAGE_SIZE` bytes are
-        // writable.
+        // Safety:
+        // - `base` is obtained from `find_user_frame()`, which resolves a mapped user page,
+        //   so it points to a valid, writable physical memory location.
+        // - `base` is page-aligned, which satisfies the 4-byte alignment requirement.
+        // - `mem::PAGE_SIZE` is a multiple of 4 bytes, satisfying the size requirement.
         unsafe {
-            __phys_memset(base, value as u8, mem::PAGE_SIZE);
+            __phys_memset32(base, value as u8, mem::PAGE_SIZE);
         }
 
         Ok(())


### PR DESCRIPTION
Rename `__phys_memset` to `__phys_memset32` and replace the byte-at-a-time loop (x86) / `rep stosb` (x86_64) with `rep stosl`, which writes 32-bit words and can leverage fast-string microcode on modern processors.

## Key Changes

- Replicate the byte value across all 4 bytes of `%eax` with `imull ` before writing, so the semantics stay memset-like.
- Convert the byte count to a dword count (`shr `) and use `rep stosl`.
- x86: save/restore flags around the paging-disable window; skip the entire routine early when size is zero.
- x86_64: add an early-exit check for zero size.
- Update the extern declaration, safety comments, and alignment/size preconditions in `vmem.rs` to reflect the new 4-byte alignment and size-multiple-of-4 requirements.