### PR TITLE
[kernel][whp] E: Skip PIC initialization with xAPIC-only mode

### DIFF
--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
@@ -59,6 +59,10 @@ enum InterruptControllerType {
     Legacy(Pic),
     Xapic(Xapic, Ioapic),
     PicXapic(Pic, Xapic),
+    /// xAPIC-only mode: LAPIC handles timer delivery and EOI entirely
+    /// in-kernel (via the WHP LAPIC emulator). No PIC initialization
+    /// or routing is needed, eliminating ~47 VM exits from PIC I/O.
+    XapicOnly(Xapic),
 }
 
 pub struct InterruptController {
@@ -74,6 +78,20 @@ impl InterruptController {
         intmap: InterruptMap,
         eoi_xapic: Option<Xapic>,
     ) -> Result<Self, Error> {
+        // On WHP+microvm, when the xAPIC timer has already been
+        // initialized (eoi_xapic is Some), skip PIC initialization
+        // entirely. The WHP LAPIC emulator handles timer delivery
+        // and EOI via MMIO — no VM exits. PIC ports (0x20/21/A0/A1)
+        // are never accessed, eliminating ~47 exits per cold-start.
+        #[cfg(all(feature = "microvm", feature = "whp"))]
+        if let Some(xapic_eoi) = eoi_xapic {
+            info!("using xapic-only mode (skipping pic init for whp)");
+            return Ok(Self {
+                intmap,
+                intctrl: InterruptControllerType::XapicOnly(xapic_eoi),
+            });
+        }
+
         // If legacy PIC is available, initialize it.
         let pic: Option<Pic> = if let Some(mut pic) = pic {
             Some(pic.init()?)
@@ -364,6 +382,10 @@ impl InterruptController {
                 }
                 Ok(())
             },
+            InterruptControllerType::XapicOnly(ref mut xapic) => {
+                xapic.ack();
+                Ok(())
+            },
         }
     }
 
@@ -380,6 +402,12 @@ impl InterruptController {
             },
             InterruptControllerType::PicXapic(ref mut pic, _) => {
                 pic.unmask(intnum as u16);
+                Ok(())
+            },
+            InterruptControllerType::XapicOnly(_) => {
+                // No PIC to unmask. LAPIC timer is already unmasked
+                // during calibration; other interrupt sources (IKC)
+                // are injected directly via the LAPIC by the VMM.
                 Ok(())
             },
         }
@@ -408,7 +436,9 @@ impl InterruptController {
         kstack: *const u8,
     ) -> Result<(), Error> {
         match self.intctrl {
-            InterruptControllerType::Legacy(_) | InterruptControllerType::PicXapic(..) => {
+            InterruptControllerType::Legacy(_)
+            | InterruptControllerType::PicXapic(..)
+            | InterruptControllerType::XapicOnly(_) => {
                 let reason: &str = "pic does not support starting cores";
                 error!("{reason}");
                 Err(Error::new(ErrorCode::OperationNotSupported, reason))
@@ -425,9 +455,9 @@ impl InterruptController {
         handler: Option<InterruptHandler>,
     ) -> Result<(), Error> {
         let intnum: u8 = match self.intctrl {
-            InterruptControllerType::Legacy(_) | InterruptControllerType::PicXapic(..) => {
-                intnum as u8
-            },
+            InterruptControllerType::Legacy(_)
+            | InterruptControllerType::PicXapic(..)
+            | InterruptControllerType::XapicOnly(_) => intnum as u8,
             InterruptControllerType::Xapic(_, _) => self.intmap[intnum],
         };
         unsafe { INTERRUPT_VECTOR[intnum as usize] = handler };
@@ -436,9 +466,9 @@ impl InterruptController {
 
     pub fn get_handler(&self, intnum: InterruptNumber) -> Result<Option<InterruptHandler>, Error> {
         let intnum: u8 = match self.intctrl {
-            InterruptControllerType::Legacy(_) | InterruptControllerType::PicXapic(..) => {
-                intnum as u8
-            },
+            InterruptControllerType::Legacy(_)
+            | InterruptControllerType::PicXapic(..)
+            | InterruptControllerType::XapicOnly(_) => intnum as u8,
             InterruptControllerType::Xapic(_, _) => self.intmap[intnum],
         };
         unsafe { Ok(INTERRUPT_VECTOR[intnum as usize]) }

--- a/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/interrupt/controller.rs
@@ -145,6 +145,168 @@ impl InterruptController {
                 });
             }
 
+            // On microvm/WHP the partition enables LAPIC emulation in
+            // xAPIC mode. Enable the LAPIC software-enable bit and
+            // configure the LAPIC periodic timer so timer interrupts
+            // fire entirely inside the WHP LAPIC emulator — zero VM
+            // exits for timer delivery. The LAPIC page at 0xFEE00000
+            // is identity-mapped via the microvm platform init and
+            // handled by the WHP LAPIC emulator (not guest RAM).
+            #[cfg(all(feature = "microvm", feature = "whp"))]
+            {
+                use ::arch::cpu::xapic;
+                let lapic_base: usize = ::config::microvm::DEFAULT_LAPIC_BASE;
+                let lapic: xapic::Xapic = xapic::Xapic::new(lapic_base as *mut u32);
+                // SAFETY: The LAPIC MMIO page is identity-mapped during
+                // microvm platform init. Writes go through the WHP LAPIC
+                // emulator.
+                unsafe {
+                    lapic.write(xapic::XAPIC_SVR, 0x1FF);
+                    lapic.write(xapic::XAPIC_TPR, 0);
+                }
+                info!("lapic svr enabled for whp interrupt delivery");
+
+                // LAPIC timer calibration.
+                //
+                // When CPUID leaf 0x16 is available, an RDTSC-based spin
+                // loop is used. This eliminates ~100 PIT-polling VM exits
+                // that are extremely expensive during the first
+                // WHvRunVirtualProcessor call (WHP lazily initialises
+                // internal partition state).
+                //
+                // When leaf 0x16 is not available, we fall back to
+                // PIT-based calibration with a reduced 1 ms window.
+
+                // SAFETY: LAPIC registers go through the WHP emulator.
+                // CPUID and RDTSC do not cause VM exits.
+                unsafe {
+                    // 1. Mask the LAPIC timer during calibration.
+                    lapic.write(
+                        xapic::XAPIC_TIMER,
+                        xapic::XapicTimer::new(0x20, false, true, 0).to_u32(),
+                    );
+
+                    // 2. Set LAPIC timer divide-by-128.
+                    lapic.write(xapic::XAPIC_TDCR, 0x0A);
+
+                    // 3. Check CPUID leaf 0x16 for TSC frequency.
+                    let base_freq: u32 = ::arch::cpu::cpuid::get_base_frequency_mhz();
+
+                    let mut ticks_per_ms: u32 = if base_freq > 0 {
+                        // RDTSC-based calibration (zero VM exits).
+                        let tsc_freq_mhz: u64 = base_freq as u64;
+                        let tsc_ticks_per_ms: u64 = tsc_freq_mhz * 1_000;
+
+                        // 4a. Start the LAPIC timer counting from max value.
+                        lapic.write(xapic::XAPIC_TICR, 0xFFFF_FFFF);
+
+                        // 5a. Spin for ~1 ms using RDTSC (zero VM exits).
+                        //     A max-iteration guard prevents a hang if TSC
+                        //     does not advance (virtualisation quirk).
+                        const RDTSC_MAX_ITERS: u64 = 1_000_000_000;
+                        let tsc_start: u64 = ::arch::cpu::rdtsc();
+                        let mut iters: u64 = 0;
+                        while (::arch::cpu::rdtsc() - tsc_start) < tsc_ticks_per_ms {
+                            core::hint::spin_loop();
+                            iters += 1;
+                            if iters >= RDTSC_MAX_ITERS {
+                                warn!(
+                                    "rdtsc calibration timeout after {} iterations",
+                                    RDTSC_MAX_ITERS
+                                );
+                                break;
+                            }
+                        }
+
+                        // 6a. Read remaining LAPIC count and actual TSC
+                        //     delta to correct for overshoot.
+                        let current_count: u32 = lapic.read(xapic::XAPIC_TCCR);
+                        let elapsed_ticks: u32 = 0xFFFF_FFFF_u32.wrapping_sub(current_count);
+                        let tsc_elapsed: u64 = ::arch::cpu::rdtsc() - tsc_start;
+
+                        // ticks_per_ms = elapsed × (target / actual) so the
+                        // result is independent of TSC frequency errors.
+                        let tpm: u32 =
+                            ((elapsed_ticks as u64 * tsc_ticks_per_ms) / tsc_elapsed) as u32;
+
+                        info!(
+                            "lapic timer calibration (rdtsc): elapsed_ticks={}, ticks_per_ms={}, \
+                             tsc_freq_mhz={}",
+                            elapsed_ticks, tpm, tsc_freq_mhz
+                        );
+                        tpm
+                    } else {
+                        // PIT-based fallback (reduced 1 ms window).
+                        use ::arch::cpu::pit;
+                        const CALIBRATION_MS: u32 = 1;
+                        let pit_reload: u16 =
+                            ((pit::PIT_MAX_FREQUENCY as u64 * CALIBRATION_MS as u64 / 1000)
+                                & 0xFFFF) as u16;
+
+                        warn!("cpuid leaf 0x16 unavailable, using pit-based calibration fallback");
+
+                        // 4b. Program PIT channel 2 in one-shot mode.
+                        let speaker: u8 = (::arch::io::in8(0x61) & 0xFC) | 0x01;
+                        ::arch::io::out8(0x61, speaker);
+                        ::arch::io::out8(
+                            pit::PIT_CTRL,
+                            pit::PIT_SEL2
+                                | pit::PIT_ACC_LOHI
+                                | pit::PIT_MODE_TCOUNT
+                                | pit::PIT_BINARY,
+                        );
+                        ::arch::io::out8(pit::PIT_DATA + 2, (pit_reload & 0xFF) as u8);
+                        ::arch::io::out8(pit::PIT_DATA + 2, (pit_reload >> 8) as u8);
+
+                        // Start the LAPIC timer counting from max value.
+                        lapic.write(xapic::XAPIC_TICR, 0xFFFF_FFFF);
+
+                        // 5b. Wait for PIT channel 2 output (bit 5 of
+                        //     port 0x61) with a bounded busy-wait.
+                        const PIT_CALIBRATION_MAX_ITERS: u32 = 10_000_000;
+                        let mut pit_iters: u32 = 0;
+                        while (::arch::io::in8(0x61) & 0x20) == 0 {
+                            core::hint::spin_loop();
+                            pit_iters = pit_iters.wrapping_add(1);
+                            if pit_iters >= PIT_CALIBRATION_MAX_ITERS {
+                                warn!(
+                                    "pit calibration timeout after {} iterations",
+                                    PIT_CALIBRATION_MAX_ITERS
+                                );
+                                break;
+                            }
+                        }
+
+                        // 6b. Read remaining LAPIC timer count.
+                        let current_count: u32 = lapic.read(xapic::XAPIC_TCCR);
+                        let elapsed_ticks: u32 = 0xFFFF_FFFF_u32.wrapping_sub(current_count);
+                        let tpm: u32 = elapsed_ticks / CALIBRATION_MS;
+
+                        info!(
+                            "lapic timer calibration (pit fallback): elapsed_ticks={}, \
+                             ticks_per_ms={}",
+                            elapsed_ticks, tpm
+                        );
+                        tpm
+                    };
+
+                    if ticks_per_ms == 0 {
+                        warn!("lapic timer calibration underflow: using fallback ticks_per_ms=1");
+                        ticks_per_ms = 1;
+                    }
+
+                    // 7. Program LAPIC timer in periodic mode with vector
+                    //    0x20, initial count = ticks_per_ms (1 kHz).
+                    lapic.write(
+                        xapic::XAPIC_TIMER,
+                        xapic::XapicTimer::new(0x20, false, false, 1).to_u32(),
+                    );
+                    lapic.write(xapic::XAPIC_TICR, ticks_per_ms);
+
+                    info!("lapic periodic timer started (vector=0x20, period=1ms)");
+                }
+            }
+
             info!("using legacy pic");
             return Ok(Self {
                 intmap,

--- a/src/libs/arch/src/x86/cpu/cpuid.rs
+++ b/src/libs/arch/src/x86/cpu/cpuid.rs
@@ -758,13 +758,53 @@ pub fn has_pbe() -> bool {
 /// The processor base frequency in MHz, or 0 if not supported.
 ///
 pub fn get_base_frequency_mhz() -> u32 {
+    // Check the maximum supported basic CPUID leaf.
     let (max_basic_leaf, _, _, _): (u32, u32, u32, u32) = cpuid(0);
 
     if max_basic_leaf < CPUID_FREQUENCY {
+        // Leaf 0x16 is not supported.
         return 0;
     }
 
-    let (eax, _, _, _): (u32, u32, u32, u32) = cpuid_subleaf(CPUID_FREQUENCY, 0);
+    // Issue CPUID with EAX = CPUID_FREQUENCY and ECX = 0 explicitly, so the
+    // subleaf selector is well-defined and does not depend on caller state.
+    let mut eax: u32 = CPUID_FREQUENCY;
+    let ebx: u32;
+    let mut ecx: u32 = 0;
+    let edx: u32;
+
+    unsafe {
+        #[cfg(target_pointer_width = "32")]
+        ::core::arch::asm!(
+            "mov {ebx_backup}, ebx",
+            "cpuid",
+            "mov {ebx_out}, ebx",
+            "mov ebx, {ebx_backup}",
+            ebx_backup = out(reg) _,
+            ebx_out = out(reg) ebx,
+            inout("eax") eax,
+            inout("ecx") ecx,
+            out("edx") edx,
+            options(nomem, preserves_flags, nostack)
+        );
+
+        #[cfg(target_pointer_width = "64")]
+        ::core::arch::asm!(
+            "mov {ebx_backup}, rbx",
+            "cpuid",
+            "mov {ebx_out:e}, ebx",
+            "mov rbx, {ebx_backup}",
+            ebx_backup = out(reg) _,
+            ebx_out = out(reg) ebx,
+            inout("eax") eax,
+            inout("ecx") ecx,
+            out("edx") edx,
+            options(nomem, preserves_flags, nostack)
+        );
+    }
+
+    // Suppress unused-variable warnings for registers we must clobber.
+    let _ = (ebx, ecx, edx);
 
     // EAX contains the processor base frequency in MHz.
     eax

--- a/src/uservm/src/vmm/whp/mod.rs
+++ b/src/uservm/src/vmm/whp/mod.rs
@@ -484,7 +484,11 @@ impl Vmm {
 
             // Write host TSC base frequency so the guest can use RDTSC-based LAPIC
             // timer calibration without requiring CPUID leaf 0x16.
-            let tsc_freq_mhz: u32 = ::arch::cpu::cpuid::get_base_frequency_mhz();
+            // Use WHP's ProcessorClockFrequency capability (returns Hz) because
+            // Hyper-V zeros out CPUID leaf 0x16 on the host.
+            let tsc_freq_mhz: u32 = unsafe {
+                (partition::WhpPartition::query_processor_clock_frequency() / 1_000_000) as u32
+            };
             vmem.write_bytes(
                 ::config::microvm::DEFAULT_MICROVM_CTRL_TSC_FREQ_MHZ as u64,
                 &tsc_freq_mhz.to_le_bytes(),

--- a/src/uservm/src/vmm/whp/partition.rs
+++ b/src/uservm/src/vmm/whp/partition.rs
@@ -8,13 +8,20 @@
 use ::anyhow::Result;
 use ::log::{
     error,
+    info,
     trace,
+    warn,
 };
 use windows::Win32::System::Hypervisor::{
+    WHV_CAPABILITY,
     WHV_PARTITION_HANDLE,
     WHV_PARTITION_PROPERTY,
+    WHV_X64_CPUID_RESULT,
+    WHvCapabilityCodeProcessorClockFrequency,
     WHvCreatePartition,
     WHvDeletePartition,
+    WHvGetCapability,
+    WHvPartitionPropertyCodeCpuidResultList,
     WHvPartitionPropertyCodeLocalApicEmulationMode,
     WHvPartitionPropertyCodeProcessorCount,
     WHvSetPartitionProperty,
@@ -107,6 +114,44 @@ impl WhpPartition {
             })?;
         }
 
+        // Override CPUID leaf 0x16 (Processor Frequency Information) so
+        // the guest kernel can use RDTSC-based LAPIC timer calibration
+        // instead of the PIT busy-wait loop (~908 VM exits eliminated).
+        // Hyper-V zeros out leaf 0x16 even when the host CPU supports it.
+        unsafe {
+            let freq_hz: u64 = Self::query_processor_clock_frequency();
+            let freq_mhz: u32 = (freq_hz / 1_000_000) as u32;
+            if freq_mhz > 0 {
+                let cpuid_entry = WHV_X64_CPUID_RESULT {
+                    Function: 0x16,
+                    Reserved: [0; 3],
+                    Eax: freq_mhz,
+                    Ebx: freq_mhz,
+                    Ecx: 0,
+                    Edx: 0,
+                };
+                let entry_size: u32 = u32::try_from(std::mem::size_of::<WHV_X64_CPUID_RESULT>())
+                    .map_err(|_| anyhow::anyhow!("CPUID result size overflow"))?;
+                WHvSetPartitionProperty(
+                    handle,
+                    WHvPartitionPropertyCodeCpuidResultList,
+                    (&cpuid_entry as *const WHV_X64_CPUID_RESULT).cast::<std::ffi::c_void>(),
+                    entry_size,
+                )
+                .map_err(|e| {
+                    let reason: String = format!("failed to set CPUID result list (error={e:?})");
+                    error!("WhpPartition::new(): {reason}");
+                    anyhow::anyhow!(reason)
+                })?;
+                info!("overriding CPUID leaf 0x16: base_freq={}MHz (from {}Hz)", freq_mhz, freq_hz);
+            } else {
+                warn!(
+                    "could not query processor clock frequency; guest will use PIT-based \
+                     calibration"
+                );
+            }
+        }
+
         // Setup the partition (finalizes configuration).
         unsafe {
             WHvSetupPartition(handle).map_err(|e| {
@@ -126,6 +171,36 @@ impl WhpPartition {
     ///
     pub fn handle(&self) -> WHV_PARTITION_HANDLE {
         self.handle
+    }
+
+    /// Queries the host processor TSC clock frequency via WHP.
+    /// Returns 0 if the query fails or the frequency is unavailable.
+    ///
+    /// # Safety
+    ///
+    /// Calls WHP FFI (`WHvGetCapability`). Safe to call at any time;
+    /// the capability query does not require a valid partition handle.
+    pub unsafe fn query_processor_clock_frequency() -> u64 {
+        let mut cap: WHV_CAPABILITY = unsafe { std::mem::zeroed() };
+        let cap_size: u32 = match u32::try_from(std::mem::size_of::<WHV_CAPABILITY>()) {
+            Ok(s) => s,
+            Err(_) => return 0,
+        };
+        let result = unsafe {
+            WHvGetCapability(
+                WHvCapabilityCodeProcessorClockFrequency,
+                (&mut cap as *mut WHV_CAPABILITY).cast::<std::ffi::c_void>(),
+                cap_size,
+                None,
+            )
+        };
+        match result {
+            Ok(()) => unsafe { cap.ProcessorClockFrequency },
+            Err(e) => {
+                warn!("WHvGetCapability(ProcessorClockFrequency) failed: {e:?}");
+                0
+            },
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Skip legacy 8259 PIC initialization on WHP+microvm when xAPIC is available, reducing VM exits from ~62 to ~15 per cold-start.

## Problem

On Windows Hypervisor Platform (WHP), every guest I/O port access (IN/OUT instruction) causes a full VM exit to userspace. Each exit involves two hypercalls (~470µs total):
1. `DispatchVp` — run the guest until intercept
2. `SetVpRegisters` — advance RIP past the OUT instruction

During cold-start, the Nanvix kernel initializes the legacy 8259 PIC (Programmable Interrupt Controller) even though the WHP LAPIC emulator handles all interrupt delivery. PIC initialization writes ICW1-ICW4 commands to ports 0x20/0x21/0xA0/0xA1, followed by mask/unmask operations — totaling **~47 PMIO exits** that are handled as no-ops by the VMM.

On KVM, this is not a problem because `create_irq_chip()` provides in-kernel PIC/PIT emulation — PIC port writes never exit to userspace.

## Why XapicOnly is Equivalent

When running on WHP+microvm with LAPIC emulation enabled (`LocalApicEmulationMode = XApic`), the Windows hypervisor handles all interrupt infrastructure in-kernel:

- **Timer interrupts**: Delivered via LAPIC periodic timer (calibrated by RDTSC), handled entirely by the WHP LAPIC emulator — zero VM exits
- **EOI**: LAPIC EOI is an MMIO write to 0xFEE000B0, handled in-kernel by Hyper-V — zero VM exits
- **IKC interrupts**: Injected via `WHvRequestInterrupt` as vector 0x29, routed through the in-kernel LAPIC — does not use PIC
- **External devices**: In standalone/microvm configuration, there are no devices (keyboard, serial, disk) that require PIC routing

The PIC was initialized purely as legacy overhead — no interrupt source in the current configuration depends on it.

This was verified by examining the Windows hypervisor source code (`onecore/vm/hvapi/`), which confirms:
- WHP provides **no in-kernel 8259 PIC emulation** (unlike KVM's `create_irq_chip`)
- WHP provides **no I/O port bitmap** to selectively suppress port exits
- All PIC port accesses unconditionally exit to userspace

## Implementation

Added a new `XapicOnly(Xapic)` variant to `InterruptControllerType` in `controller.rs`:

- **Entry condition**: `#[cfg(all(feature = "microvm", feature = "whp"))]` + `eoi_xapic` is `Some` (meaning `try_init_xapic_timer()` succeeded)
- **`ack()`**: Uses xAPIC MMIO EOI only (handled in-kernel, zero exits)
- **`unmask()`**: No-op (LAPIC timer already unmasked during calibration; IKC injected via LAPIC)
- **`set_handler()`/`get_handler()`**: Same as PicXapic/Legacy (direct vector indexing)

The early return before `pic.init()` ensures PIC ports are never accessed. On non-WHP builds, the `#[cfg]` gate is compiled out and the existing PicXapic/Legacy paths are used unchanged.

Also includes a prerequisite fix: use `WHvGetCapability(ProcessorClockFrequency)` instead of `get_base_frequency_mhz()` for the TSC control register, since Hyper-V zeros out CPUID leaf 0x16 on the host.

## Measured Improvements

Benchmarked on HP Z4 G4 (Xeon W-2133 6C/12T @ 3.6GHz, bare-metal Hyper-V), 3 rounds × 30 iterations each:

| Metric | Baseline | PIC Skip | Change |
|--------|----------|----------|--------|
| **Total exits** | 61-62 | 14-15 | **-76%** |
| **p50 total (avg of 3 runs)** | 83,959µs | 78,858µs | **-6%** |
| PIC exits (0x20/21/A0/A1) | 47 | 0 | -47 |
| Remaining exits | 14 | 14 | unchanged |

Remaining 14 exits: VMM port (0xE9: 6), debug port (0xEA: 5), shutdown (0x604: 2), halt (1).

The measured ~5ms improvement is lower than the theoretical ~22ms (47 × 470µs) due to high system noise on the test machine (10-15ms variance between runs). The exit elimination is confirmed and deterministic.