### PR TITLE
[kernel] Skip dry-run passes in memory operations

### DIFF
--- a/build/make/kernel.mk
+++ b/build/make/kernel.mk
@@ -3,6 +3,7 @@
 
 KERNEL_FEATURES := $(MACHINE) $(LOG_LEVEL)
 KERNEL_FEATURES += $(if $(filter yes,$(WHP)),whp,)
+KERNEL_FEATURES += $(if $(filter yes,$(RELEASE)),nightly-performance-optimizations,)
 KERNEL_FEATURES := $(strip $(KERNEL_FEATURES))
 KERNEL_CARGO_FEATURES := $(if $(KERNEL_FEATURES),--features "$(KERNEL_FEATURES)")
 

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -67,6 +67,9 @@ putb = []
 puts = []
 stdio = []
 
+# Enables latest performance optimizations.
+nightly-performance-optimizations = []
+
 # Interface Features
 kcall = []
 

--- a/src/kernel/src/mm/elf.rs
+++ b/src/kernel/src/mm/elf.rs
@@ -391,6 +391,11 @@ pub fn elf32_load(
     vmem: &mut Vmem,
     elf: &Elf32Fhdr,
 ) -> Result<(VirtualAddress, PageAligned<VirtualAddress>), Error> {
-    do_elf32_load(mm, vmem, elf, true)?;
-    do_elf32_load(mm, vmem, elf, false)
+    if cfg!(feature = "nightly-performance-optimizations") {
+        do_elf32_load(mm, vmem, elf, false)
+    } else {
+        // Two-pass: first validate with a dry run, then load.
+        do_elf32_load(mm, vmem, elf, true)?;
+        do_elf32_load(mm, vmem, elf, false)
+    }
 }

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -774,10 +774,13 @@ impl Vmem {
             Ok(())
         };
 
-        // Run in dry-run mode first to check for errors.
-        copy_from_user_unaligned_impl(true, src, dst, size)?;
-        // Run in normal mode to effectively copy data.
-        copy_from_user_unaligned_impl(false, src, dst, size)?;
+        if cfg!(feature = "nightly-performance-optimizations") {
+            copy_from_user_unaligned_impl(false, src, dst, size)?;
+        } else {
+            // Two-pass: first validate with a dry run, then copy.
+            copy_from_user_unaligned_impl(true, src, dst, size)?;
+            copy_from_user_unaligned_impl(false, src, dst, size)?;
+        }
 
         Ok(())
     }

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -977,10 +977,13 @@ impl Vmem {
         src: VirtualAddress,
         size: usize,
     ) -> Result<(), Error> {
-        // Perform a dry run first to check for errors.
-        self.copy_to_user_unaligned_unchecked(dst, src, size, true)?;
-        // Perform the actual copy, this will panic on irrecoverable errors.
-        self.copy_to_user_unaligned_unchecked(dst, src, size, false)
+        if cfg!(feature = "nightly-performance-optimizations") {
+            self.copy_to_user_unaligned_unchecked(dst, src, size, false)
+        } else {
+            // Two-pass: first validate with a dry run, then copy.
+            self.copy_to_user_unaligned_unchecked(dst, src, size, true)?;
+            self.copy_to_user_unaligned_unchecked(dst, src, size, false)
+        }
     }
 
     ///

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -1086,12 +1086,16 @@ impl Vmem {
             Ok(())
         };
 
-        // Two-pass approach: the dry run walks all page tables to verify that every source and
-        // destination page is mapped before any bytes are copied. This prevents partial transfers
-        // that would leave the destination in an inconsistent state if a page fault were
-        // encountered mid-copy.
-        copy_user_to_user_impl(true, src, dst, size)?;
-        copy_user_to_user_impl(false, src, dst, size)?;
+        if cfg!(feature = "nightly-performance-optimizations") {
+            copy_user_to_user_impl(false, src, dst, size)?;
+        } else {
+            // Two-pass: the dry run walks all page tables to verify that every source and
+            // destination page is mapped before any bytes are copied. This prevents partial
+            // transfers that would leave the destination in an inconsistent state if a page
+            // fault were encountered mid-copy.
+            copy_user_to_user_impl(true, src, dst, size)?;
+            copy_user_to_user_impl(false, src, dst, size)?;
+        }
 
         Ok(())
     }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1918,16 +1918,24 @@ impl ProcessManager {
         })?;
         let perm: AccessPermission = region.perm();
 
-        // Validate that every page can be mapped before modifying any state.
-        for raw_vaddr in (base..end).step_by(PAGE_SIZE) {
-            let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(raw_vaddr)?;
-            vmem.kctrl(vaddr, perm, true)?;
-        }
+        if cfg!(feature = "nightly-performance-optimizations") {
+            // Single pass: apply permission changes directly.
+            for raw_vaddr in (base..end).step_by(PAGE_SIZE) {
+                let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(raw_vaddr)?;
+                vmem.kctrl(vaddr, perm, false)?;
+            }
+        } else {
+            // Two-pass: validate that every page can be mapped before modifying any state.
+            for raw_vaddr in (base..end).step_by(PAGE_SIZE) {
+                let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(raw_vaddr)?;
+                vmem.kctrl(vaddr, perm, true)?;
+            }
 
-        // All validations passed — apply the permission changes for real.
-        for raw_vaddr in (base..end).step_by(PAGE_SIZE) {
-            let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(raw_vaddr)?;
-            vmem.kctrl(vaddr, perm, false)?;
+            // All validations passed — apply the permission changes for real.
+            for raw_vaddr in (base..end).step_by(PAGE_SIZE) {
+                let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(raw_vaddr)?;
+                vmem.kctrl(vaddr, perm, false)?;
+            }
         }
 
         state.add_mmio(region);


### PR DESCRIPTION
This PR skips unnecessary dry-run passes in kernel memory operations to improve performance.  ### Changes  - Skip ELF dry-run pass - Skip MMIO kctrl dry-run - Skip copy_from_user dry-run - Skip copy_to_user dry-run - Skip copy_user_to_user dry-run

## Related Issues

- #1975 — Runtime kernel boot flags for performance tuning