### PR TITLE
[kernel] Harden and Consolidate User-Page Allocation

### DIFF
--- a/src/kernel/src/mm/elf.rs
+++ b/src/kernel/src/mm/elf.rs
@@ -332,9 +332,10 @@ fn do_elf32_load(
                     // be zeroed.
                     let page_is_partially_covered: bool =
                         page_phys_addr < phys_addr_end && page_phys_addr_end > phys_addr_end;
-                    mm.alloc_upage(
+                    mm.alloc_upages(
                         vmem,
                         vaddr,
+                        1,
                         access,
                         page_lies_in_bss || page_is_partially_covered,
                     )?;

--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -32,10 +32,6 @@ impl PhysMemoryManager {
         PhysMemoryManager { kpool, upool }
     }
 
-    pub fn alloc_user_frame(&mut self) -> Result<UserFrame, Error> {
-        self.upool.alloc()
-    }
-
     pub fn alloc_many_user_frames(&mut self, nframes: usize) -> Result<Vec<UserFrame>, Error> {
         self.upool.alloc_many(nframes)
     }

--- a/src/kernel/src/mm/phys/upool.rs
+++ b/src/kernel/src/mm/phys/upool.rs
@@ -52,20 +52,6 @@ impl UpoolInner {
     ///
     /// # Description
     ///
-    /// Allocates a frame from the user frame pool.
-    ///
-    /// # Returns
-    ///
-    /// On success, the physical address of the allocated frame is returned. On failure, an error is
-    /// returned.
-    ///
-    fn alloc(&mut self) -> Result<FrameAddress, Error> {
-        self.frame_allocator.alloc()
-    }
-
-    ///
-    /// # Description
-    ///
     /// Allocates a contiguous range of frames from the user frame pool.
     ///
     /// # Parameters
@@ -185,23 +171,6 @@ impl Upool {
         Self {
             inner: Rc::new(RefCell::new(UpoolInner::new(frame_allocator))),
         }
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Allocates a frame from the user frame pool.
-    ///
-    /// # Returns
-    ///
-    /// On success, the physical address of the allocated frame is returned, with
-    /// read-only permissions and all bytes set to zero. On failure, an error is
-    /// returned instead.
-    ///
-    pub fn alloc(&mut self) -> Result<UserFrame, Error> {
-        let addr: FrameAddress = self.inner.borrow_mut().alloc()?;
-        let uframe: UserFrame = UserFrame::new(addr);
-        Ok(uframe)
     }
 
     pub fn alloc_many(&mut self, nframes: usize) -> Result<Vec<UserFrame>, Error> {

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -222,50 +222,6 @@ impl VirtMemoryManager {
         Ok(new_vmem)
     }
 
-    #[allow(dead_code)]
-    pub fn alloc_upage(
-        &mut self,
-        vmem: &mut Vmem,
-        vaddr: PageAligned<VirtualAddress>,
-        access: AccessPermission,
-        clear: bool,
-    ) -> Result<(), Error> {
-        let uframe: UserFrame = match self.physman.try_borrow_mut() {
-            Ok(mut physman) => physman.alloc_user_frame()?,
-            Err(_) => {
-                let reason: &str = "failed to borrow physical memory manager";
-                error!("{reason}");
-                return Err(Error::new(ErrorCode::ResourceBusy, reason));
-            },
-        };
-
-        let physman: Rc<RefCell<PhysMemoryManager>> = self.physman.clone();
-        let page_table_allocator = move || {
-            let kframe: KernelFrame = match physman.try_borrow_mut() {
-                Ok(mut physman) => physman.alloc_kernel_frame(true)?,
-                Err(_) => {
-                    let reason: &str = "failed to borrow physical memory manager";
-                    error!("{reason}");
-                    return Err(Error::new(ErrorCode::ResourceBusy, reason));
-                },
-            };
-            let kpage: KernelPage = KernelPage::new(kframe);
-            let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
-            let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
-            Ok(page_table)
-        };
-
-        vmem.map(uframe, vaddr, access, &page_table_allocator)?;
-
-        // Check if the page should be cleared.
-        if clear {
-            // Safety: `vaddr` points to a valid memory location.
-            vmem.memset(vaddr, 0)?;
-        }
-
-        Ok(())
-    }
-
     ///
     /// # Description
     ///

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -222,6 +222,7 @@ impl VirtMemoryManager {
         Ok(new_vmem)
     }
 
+    #[allow(dead_code)]
     pub fn alloc_upage(
         &mut self,
         vmem: &mut Vmem,

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -300,8 +300,41 @@ impl VirtMemoryManager {
         mut vaddr: PageAligned<VirtualAddress>,
         nframes: usize,
         access: AccessPermission,
+        clear: bool,
     ) -> Result<(), Error> {
         trace!("vaddr={:?}, nframes={}", vaddr, nframes);
+
+        // Validate that nframes is positive and the full range lies in user space.
+        let range_size: usize = nframes.checked_mul(mem::PAGE_SIZE).ok_or_else(|| {
+            let reason: &str = "range size overflow";
+            error!("{reason} (nframes={nframes})");
+            Error::new(ErrorCode::InvalidArgument, reason)
+        })?;
+        if !Vmem::is_user_region(vaddr.into_inner(), range_size) {
+            let reason: &str = "range is not entirely in user space";
+            error!("{reason} (vaddr={vaddr:?}, nframes={nframes})");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+
+        // Check that none of the pages in the range are already mapped.
+        let mut check_addr: PageAligned<VirtualAddress> = vaddr;
+        for _ in 0..nframes {
+            if vmem.is_user_page_mapped(check_addr)? {
+                let reason: &str = "page already mapped in range";
+                error!("{reason} (vaddr={check_addr:?})");
+                return Err(Error::new(ErrorCode::ResourceBusy, reason));
+            }
+            check_addr = PageAligned::from_raw_value(
+                check_addr
+                    .into_raw_value()
+                    .checked_add(mem::PAGE_SIZE)
+                    .ok_or_else(|| {
+                        let reason: &str = "address overflow in range check";
+                        error!("{reason} (check_addr={check_addr:?})");
+                        Error::new(ErrorCode::BadAddress, reason)
+                    })?,
+            )?;
+        }
 
         let physman: Rc<RefCell<PhysMemoryManager>> = self.physman.clone();
 
@@ -329,11 +362,48 @@ impl VirtMemoryManager {
             },
         };
 
-        // FIXME: check if range is not busy.
+        let start_vaddr: PageAligned<VirtualAddress> = vaddr;
+        let mut mapped_count: usize = 0;
+        let mut map_error: Result<(), Error> = Ok(());
 
         for uframe in uframes {
-            vmem.map(uframe, vaddr, access, &page_table_allocator)?;
-            vaddr = PageAligned::from_raw_value(vaddr.into_raw_value() + mem::PAGE_SIZE)?;
+            if let Err(e) = vmem.map(uframe, vaddr, access, &page_table_allocator) {
+                map_error = Err(e);
+                break;
+            }
+            mapped_count += 1;
+            if clear {
+                if let Err(e) = vmem.memset(vaddr, 0) {
+                    map_error = Err(e);
+                    break;
+                }
+            }
+            match PageAligned::from_raw_value(vaddr.into_raw_value() + mem::PAGE_SIZE) {
+                Ok(next) => vaddr = next,
+                Err(e) => {
+                    map_error = Err(e);
+                    break;
+                },
+            }
+        }
+
+        if let Err(e) = map_error {
+            // Rollback: unmap all pages that were successfully mapped.
+            let mut rollback_addr: PageAligned<VirtualAddress> = start_vaddr;
+            for _ in 0..mapped_count {
+                if let Err(re) = self.try_unmap_upage(vmem, rollback_addr) {
+                    warn!(
+                        "alloc_upages(): rollback failed (vaddr={rollback_addr:?}, error={re:?})"
+                    );
+                }
+                rollback_addr = match PageAligned::from_raw_value(
+                    rollback_addr.into_raw_value() + mem::PAGE_SIZE,
+                ) {
+                    Ok(next) => next,
+                    Err(_) => break,
+                };
+            }
+            return Err(e);
         }
 
         Ok(())

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -392,6 +392,29 @@ impl Vmem {
         Ok(())
     }
 
+    ///
+    /// # Description
+    ///
+    /// Checks whether a user page is currently mapped at the given virtual address.
+    ///
+    /// # Parameters
+    ///
+    /// - `vaddr`: Virtual address of the page to check.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(true)` if the page is mapped, `Ok(false)` if it is not, or `Err(_)` on
+    /// unexpected failures.
+    ///
+    pub fn is_user_page_mapped(&self, vaddr: PageAligned<VirtualAddress>) -> Result<bool, Error> {
+        // Check if the provided address lies outside user space.
+        if !Self::is_user_addr(vaddr.into_inner()) {
+            let reason: &str = "address is not in user space";
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
+        Ok(self.try_find_user_frame(vaddr)?.is_some())
+    }
+
     /// Asserts whether an address lies in the user space.
     pub fn is_user_addr(virt_addr: VirtualAddress) -> bool {
         virt_addr >= config::memory_layout::USER_BASE && virt_addr < config::memory_layout::USER_END

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -495,7 +495,7 @@ impl ProcessManager {
             error!("{reason} (cmdline.len={:?})", args.len());
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
-        mm.alloc_upage(&mut vmem, args_vaddr, AccessPermission::RDWR, true)?;
+        mm.alloc_upages(&mut vmem, args_vaddr, 1, AccessPermission::RDWR, true)?;
         vmem.copy_to_user_unaligned(
             args_vaddr.into_inner(),
             VirtualAddress::new(args.as_ptr() as usize),
@@ -513,7 +513,7 @@ impl ProcessManager {
         let envp_vaddr: PageAligned<VirtualAddress> = PageAligned::<VirtualAddress>::from_address(
             VirtualAddress::new(args_vaddr.into_raw_value() + PAGE_SIZE),
         )?;
-        mm.alloc_upage(&mut vmem, envp_vaddr, AccessPermission::RDWR, true)?;
+        mm.alloc_upages(&mut vmem, envp_vaddr, 1, AccessPermission::RDWR, true)?;
 
         // Populate the environment variable page.
         vmem.copy_to_user_unaligned(
@@ -1869,7 +1869,7 @@ impl ProcessManager {
     ) -> Result<(), Error> {
         let mut process: ProcessRefMut = self.find_process_mut(pid)?;
         let vmem: &mut Vmem = process.state_mut().vmem_mut();
-        mm.alloc_upage(vmem, vaddr, access, true)
+        mm.alloc_upages(vmem, vaddr, 1, access, true)
     }
 
     pub fn munmap(

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -556,6 +556,7 @@ impl ProcessManager {
             initial_stack_base,
             USER_STACK_MIN_SIZE / PAGE_SIZE,
             AccessPermission::RDWR,
+            true,
         )?;
 
         //==============================================================


### PR DESCRIPTION
This pull request refactors the user page allocation logic in the kernel's memory management subsystem to improve safety and consistency when allocating multiple user pages at once. The main changes involve replacing single-page allocation methods with multi-page variants, adding robust error handling and rollback for partial failures, and removing now-unnecessary single-page allocation code.