### PR TITLE
[uservm] Zero-copy RAMFS mapping via MapViewOfFile3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,8 @@ vstd = { version = "=0.0.0-2026-04-05-0114", default-features = false }
 vmm-sys-util = { version = "0.15.0", default-features = false }
 wasmi = { version = "1.0.9", default-features = false }
 windows = { version = "0.62", features = [
+        "Win32_Foundation",
+        "Win32_Security",
         "Win32_System_Hypervisor",
         "Win32_System_Memory",
         "Win32_System_Threading",

--- a/src/uservm/src/pal/windows.rs
+++ b/src/uservm/src/pal/windows.rs
@@ -14,22 +14,49 @@ use ::anyhow::Result;
 use ::log::{
     error,
     trace,
+    warn,
 };
 use ::std::{
-    fs,
+    fs::{
+        self,
+        File,
+    },
+    os::windows::io::AsRawHandle,
     path::Path,
+};
+use ::windows::Win32::{
+    Foundation::{
+        CloseHandle,
+        HANDLE,
+    },
+    System::Memory::{
+        CreateFileMappingW,
+        FILE_MAP_READ,
+        MEMORY_MAPPED_VIEW_ADDRESS,
+        MapViewOfFile,
+        PAGE_READONLY,
+        UnmapViewOfFile,
+    },
 };
 
 //==================================================================================================
 // Structures
 //==================================================================================================
 
-/// A file loaded into memory.
-#[derive(Debug)]
+/// A memory-mapped file.
 pub struct FileMapping {
-    /// Contents of the file.
-    data: Vec<u8>,
+    /// Section handle returned by `CreateFileMappingW`.
+    section_handle: HANDLE,
+    /// File view mapped into host address space by `MapViewOfFile`.
+    view: MEMORY_MAPPED_VIEW_ADDRESS,
+    /// Size of the mapped region (in bytes).
+    size: usize,
 }
+
+// SAFETY: `FileMapping` owns OS handles (section handle, mapped view) that have no thread
+// affinity. All mutation requires `&mut self`, and resources are released exactly once in `Drop`.
+unsafe impl Send for FileMapping {}
+unsafe impl Sync for FileMapping {}
 
 //==================================================================================================
 // Implementations
@@ -39,7 +66,7 @@ impl FileMapping {
     ///
     /// # Description
     ///
-    /// Reads a file into memory.
+    /// Maps a file into memory (read-only).
     ///
     /// # Parameters
     ///
@@ -47,7 +74,7 @@ impl FileMapping {
     ///
     /// # Returns
     ///
-    /// On success, this function returns an object representing the loaded file. On failure,
+    /// On success, this function returns an object representing the memory-mapped file. On failure,
     /// an error object that describes the error is returned instead.
     ///
     pub fn open(filename: &str) -> Result<Self> {
@@ -55,42 +82,125 @@ impl FileMapping {
 
         let path: &Path = Path::new(filename);
 
-        let data: Vec<u8> = match fs::read(path) {
-            Ok(data) => data,
-            Err(e) => {
-                let reason: String = format!("failed to read file (error={e})");
+        let file: File = fs::File::open(path).map_err(|e| {
+            let reason: String = format!("failed to open file (error={e})");
+            error!("open(): {reason} (filename={filename})");
+            anyhow::anyhow!(reason)
+        })?;
+
+        let size: usize = usize::try_from(
+            file.metadata()
+                .map_err(|e| {
+                    let reason: String = format!("failed to get file metadata (error={e})");
+                    error!("open(): {reason} (filename={filename})");
+                    anyhow::anyhow!(reason)
+                })?
+                .len(),
+        )
+        .map_err(|_| {
+            let reason: &str = "file size exceeds addressable range";
+            error!("open(): {reason} (filename={filename})");
+            anyhow::anyhow!(reason)
+        })?;
+
+        if size == 0 {
+            let reason: &str = "cannot map zero-sized file";
+            error!("open(): {reason} (filename={filename})");
+            anyhow::bail!(reason);
+        }
+
+        let file_handle: HANDLE = HANDLE(file.as_raw_handle());
+
+        // NOTE: `file` is dropped at the end of this function, but the section handle created below
+        // keeps an internal kernel reference to the underlying file object.  The OS file handle can
+        // therefore be closed safely; the mapping stays valid until `section_handle` itself is
+        // closed in `Drop`.
+        //
+        // SAFETY: `file_handle` is a valid OS handle obtained from the `File` opened above.
+        // Passing `None` for security attributes and name is permitted. Size parameters of
+        // (0, 0) tell the OS to use the file's actual size.
+        let section_handle: HANDLE = unsafe {
+            CreateFileMappingW(file_handle, None, PAGE_READONLY, 0, 0, None).map_err(|e| {
+                let reason: String = format!("failed to create file mapping (error={e:?})");
                 error!("open(): {reason} (filename={filename})");
-                anyhow::bail!(reason);
-            },
+                anyhow::anyhow!(reason)
+            })?
         };
 
-        Ok(Self { data })
+        // SAFETY: `section_handle` is a valid section handle from the successful
+        // `CreateFileMappingW` call above. `size` equals the file size obtained from metadata.
+        let view: MEMORY_MAPPED_VIEW_ADDRESS =
+            unsafe { MapViewOfFile(section_handle, FILE_MAP_READ, 0, 0, size) };
+
+        if view.Value.is_null() {
+            // SAFETY: `section_handle` is a valid handle from `CreateFileMappingW`; it must be
+            // closed before returning, since the view creation failed.
+            unsafe {
+                if CloseHandle(section_handle).is_err() {
+                    warn!("open(): CloseHandle() failed while cleaning up section handle");
+                }
+            }
+            let reason: &str = "MapViewOfFile returned null";
+            error!("open(): {reason} (filename={filename})");
+            anyhow::bail!(reason);
+        }
+
+        Ok(Self {
+            section_handle,
+            view,
+            size,
+        })
     }
 
     ///
     /// # Description
     ///
-    /// Returns a pointer to the loaded file data.
+    /// Returns a pointer to the mapped file data.
     ///
     /// # Returns
     ///
     /// A pointer to the file data.
     ///
     pub fn ptr(&self) -> *const u8 {
-        self.data.as_ptr()
+        self.view.Value as *const u8
     }
 
     ///
     /// # Description
     ///
-    /// Returns the size of the loaded file (in bytes).
+    /// Returns the size of the mapped file (in bytes).
     ///
     /// # Returns
     ///
     /// The size of the file (in bytes).
     ///
     pub fn size(&self) -> usize {
-        self.data.len()
+        self.size
+    }
+}
+
+impl ::std::fmt::Debug for FileMapping {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        f.debug_struct("FileMapping")
+            .field("view", &self.view.Value)
+            .field("size", &self.size)
+            .finish()
+    }
+}
+
+impl Drop for FileMapping {
+    fn drop(&mut self) {
+        trace!("drop(): FileMapping (size={})", self.size);
+        // SAFETY: `self.view` and `self.section_handle` are valid OS resources created in
+        // `open()`. They are released exactly once here and not used after this point.
+        unsafe {
+            if let Err(e) = UnmapViewOfFile(self.view) {
+                error!("drop(): UnmapViewOfFile failed (error={e:?})");
+            }
+            if let Err(e) = CloseHandle(self.section_handle) {
+                error!("drop(): CloseHandle failed on section handle (error={e:?})");
+            }
+        }
     }
 }
 
@@ -139,6 +249,8 @@ mod tests {
         let loaded: &[u8] = unsafe { ::std::slice::from_raw_parts(mapping.ptr(), mapping.size()) };
         assert_eq!(loaded, payload);
 
+        // Drop the mapping before deleting the file; the section handle keeps the file open.
+        drop(mapping);
         fs::remove_file(path_buf).ok();
         Ok(())
     }

--- a/src/uservm/src/vmm/microvm/kvm/vmem.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vmem.rs
@@ -25,10 +25,7 @@ use ::std::{
         Write,
     },
     mem,
-    os::unix::io::{
-        AsRawFd,
-        RawFd,
-    },
+    os::unix::io::AsRawFd,
     path::Path,
 };
 use kvm_ioctls::{
@@ -193,20 +190,13 @@ impl VirtualMemory {
     /// - `start`: Byte offset into guest memory (must be page-aligned).
     /// - `len`: Size of the region to remap.
     /// - `fd`: File descriptor of the backing file.
-    /// - `file_offset`: Byte offset into the file.
     ///
     /// # Returns
     ///
     /// Upon success, returns empty. Otherwise, returns an error.
     ///
-    pub fn remap_file_at(
-        &self,
-        start: usize,
-        len: usize,
-        fd: RawFd,
-        file_offset: ::libc::off_t,
-    ) -> Result<()> {
-        self.mapping.remap_file_at(start, len, fd, file_offset)
+    pub fn remap_file_at(&mut self, start: usize, len: usize, file: &File) -> Result<()> {
+        self.mapping.remap_file_at(start, len, file.as_raw_fd(), 0)
     }
 
     ///

--- a/src/uservm/src/vmm/microvm/ramfs.rs
+++ b/src/uservm/src/vmm/microvm/ramfs.rs
@@ -15,17 +15,14 @@ use ::log::{
     error,
     trace,
 };
+#[cfg(target_os = "linux")]
+use ::std::fs::Metadata;
 use ::std::{
     fs::File,
     path::{
         Path,
         PathBuf,
     },
-};
-#[cfg(target_os = "linux")]
-use ::std::{
-    fs::Metadata,
-    os::fd::AsRawFd,
 };
 
 //==================================================================================================
@@ -46,8 +43,8 @@ const RAMFS_MIN_SLACK_BYTES: usize = 4 * 1024 * 1024;
 /// physical memory.
 ///
 /// On Linux, the image is file-backed (memory-mapped into guest memory via `remap_file_at`).
-/// On Windows, the image file is read directly into guest memory (single I/O, no intermediate
-/// buffer).
+/// On Windows, the image is zero-copy file-backed via `MapViewOfFile3` with
+/// `MEM_REPLACE_PLACEHOLDER`, mapping the file directly into the guest memory region.
 ///
 #[derive(Debug)]
 pub struct RamFs {
@@ -175,8 +172,8 @@ impl RamFs {
     /// Loads this RAMFS image near the end of the provided virtual memory while maintaining the
     /// alignment and slack guarantees required by the initrd.
     ///
-    /// On Linux, the file is memory-mapped directly into guest memory (zero-copy). On Windows,
-    /// the file contents are copied into guest memory.
+    /// On both Linux and Windows, the file is memory-mapped directly into guest memory
+    /// (zero-copy).
     ///
     /// # Parameters
     ///
@@ -261,21 +258,7 @@ impl RamFs {
         }
 
         // Transfer RAMFS data into guest memory.
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "linux")] {
-                self.map_file_into_guest(vmem, ramfs_base, ramfs_size)?;
-            } else if #[cfg(target_os = "windows")] {
-                vmem.load_from_file(ramfs_base as u64, &self.file, ramfs_size)
-                    .map_err(|e| {
-                        let reason: String = format!(
-                            "failed to load ramfs image into guest memory (path={:?}, error={e})",
-                            self.path
-                        );
-                        error!("RamFs::load_into_virtual_memory(): {reason}");
-                        anyhow::anyhow!(reason)
-                    })?;
-            }
-        }
+        self.map_file_into_guest(vmem, ramfs_base, ramfs_size)?;
 
         trace!(
             "RamFs::load_into_virtual_memory(): loaded ramfs (path={:?}, base={:#010x}, \
@@ -354,10 +337,17 @@ impl RamFs {
     ///
     /// # Description
     ///
-    /// Maps the RAMFS file directly into the provided guest memory region (Linux only).
+    /// Maps the RAMFS file directly into the provided guest memory region (zero-copy).
     ///
-    #[cfg(target_os = "linux")]
-    fn map_file_into_guest(&self, vmem: &VirtualMemory, base: usize, length: usize) -> Result<()> {
+    /// On Linux, the file is remapped via `mmap(MAP_FIXED)`.
+    /// On Windows, the file is mapped via `MapViewOfFile3` with `MEM_REPLACE_PLACEHOLDER`.
+    ///
+    fn map_file_into_guest(
+        &self,
+        vmem: &mut VirtualMemory,
+        base: usize,
+        length: usize,
+    ) -> Result<()> {
         trace!(
             "RamFs::map_file_into_guest(): path={:?}, base={:#010x}, length={length}",
             self.path, base
@@ -372,17 +362,16 @@ impl RamFs {
             anyhow::bail!(reason)
         }
 
-        // Remaps [base, base + length) of guest memory to be file-backed by the RAMFS image,
+        // Remap [base, base + length) of guest memory to be file-backed by the RAMFS image,
         // replacing the anonymous pages covering that range while leaving the rest untouched.
-        vmem.remap_file_at(base, length, self.file.as_raw_fd(), 0)
-            .map_err(|e| {
-                let reason: String = format!(
-                    "failed to map ramfs image into guest memory (path={:?}, error={e})",
-                    self.path
-                );
-                error!("RamFs::map_file_into_guest(): {reason}");
-                anyhow::anyhow!(reason)
-            })?;
+        vmem.remap_file_at(base, length, &self.file).map_err(|e| {
+            let reason: String = format!(
+                "failed to map ramfs image into guest memory (path={:?}, error={e})",
+                self.path
+            );
+            error!("RamFs::map_file_into_guest(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
 
         Ok(())
     }

--- a/src/uservm/src/vmm/microvm/whp/vmem.rs
+++ b/src/uservm/src/vmm/microvm/whp/vmem.rs
@@ -8,32 +8,60 @@
 use crate::vmm::microvm::whp::partition::WhpPartition;
 use ::anyhow::Result;
 use ::log::{
+    debug,
     error,
     trace,
+    warn,
 };
 use ::std::{
     fs::File,
     io::{
         Read,
+        Seek,
+        SeekFrom,
         Write,
     },
     mem,
+    os::windows::io::AsRawHandle,
     path::Path,
     ptr,
     slice,
 };
-use windows::Win32::System::{
-    Hypervisor::{
-        WHV_MAP_GPA_RANGE_FLAGS,
-        WHvMapGpaRange,
+use ::windows::Win32::{
+    Foundation::{
+        CloseHandle,
+        HANDLE,
     },
-    Memory::{
-        MEM_COMMIT,
-        MEM_RELEASE,
-        MEM_RESERVE,
-        PAGE_READWRITE,
-        VirtualAlloc,
-        VirtualFree,
+    System::{
+        Hypervisor::{
+            WHV_MAP_GPA_RANGE_FLAGS,
+            WHV_PARTITION_HANDLE,
+            WHvMapGpaRange,
+            WHvMapGpaRangeFlagExecute,
+            WHvMapGpaRangeFlagRead,
+            WHvMapGpaRangeFlagWrite,
+            WHvUnmapGpaRange,
+        },
+        Memory::{
+            CreateFileMappingW,
+            MEM_COMMIT,
+            MEM_PRESERVE_PLACEHOLDER,
+            MEM_RELEASE,
+            MEM_REPLACE_PLACEHOLDER,
+            MEM_RESERVE,
+            MEM_RESERVE_PLACEHOLDER,
+            MEMORY_MAPPED_VIEW_ADDRESS,
+            MapViewOfFile3,
+            PAGE_NOACCESS,
+            PAGE_READWRITE,
+            PAGE_WRITECOPY,
+            UNMAP_VIEW_OF_FILE_FLAGS,
+            UnmapViewOfFileEx,
+            VIRTUAL_FREE_TYPE,
+            VirtualAlloc2,
+            VirtualFree,
+        },
+        Threading::GetCurrentProcess,
     },
 };
 
@@ -51,6 +79,31 @@ pub struct VirtualMemory {
     ptr: *mut u8,
     /// Size of the virtual memory.
     size: usize,
+    /// WHP partition handle for GPA (un)mapping operations.
+    partition_handle: WHV_PARTITION_HANDLE,
+    /// File-backed remap info for placeholder-split cleanup, or `None` when the region is a
+    /// single committed block.
+    file_remap: Option<FileRemap>,
+}
+
+///
+/// # Description
+///
+/// Tracks the coordinates of a remap performed by `remap_file_at()`. The middle segment
+/// is either file-backed (via `MapViewOfFile3` with `MEM_REPLACE_PLACEHOLDER`) when the file
+/// is page-aligned, or committed (via `VirtualAlloc2` with `MEM_REPLACE_PLACEHOLDER`) when
+/// the file is not page-aligned. Used by `Drop` to correctly tear down the split region.
+///
+struct FileRemap {
+    /// Byte offset of the remapped view within the guest memory region.
+    start: usize,
+    /// Page-aligned size of the remapped view.
+    aligned_len: usize,
+    /// Section handle returned by `CreateFileMappingW`. Set to `HANDLE::default()` (null) when
+    /// the middle segment uses the commit+read fallback (non-page-aligned file) instead of a
+    /// file-backed view. `Drop` uses this to select between `UnmapViewOfFileEx` (file-backed)
+    /// and `VirtualFree` (committed) for cleanup.
+    section_handle: HANDLE,
 }
 
 ///
@@ -64,12 +117,13 @@ struct SnapshotHeader {
     memory_size: usize,
 }
 
-// SAFETY: `VirtualMemory` is a thin owner of a contiguous region of virtual memory allocated
-// with `VirtualAlloc` and released in `Drop` via `VirtualFree`. The fields (`ptr: *mut u8` and
-// `size: usize`) are plain data without thread-affine state. All operations that mutate or
-// deallocate the region require exclusive access (`&mut self`), and the allocation is released
-// exactly once during `Drop`. Synchronisation of concurrent access to the pointed-to memory is
-// the responsibility of higher-level code.
+// SAFETY: `VirtualMemory` owns a contiguous region of virtual memory allocated with
+// `VirtualAlloc2` and released in `Drop` (via `VirtualFree` and, when a file remap is active,
+// `UnmapViewOfFileEx` + `CloseHandle`), a WHP partition handle (an opaque OS handle safe to use
+// from any thread), and an optional `FileRemap` containing OS handles with no thread affinity.
+// All operations that mutate or deallocate the region require exclusive access (`&mut self`),
+// and resources are released exactly once during `Drop`. Synchronisation of concurrent access to
+// the pointed-to memory is the responsibility of higher-level code.
 unsafe impl Send for VirtualMemory {}
 unsafe impl Sync for VirtualMemory {}
 
@@ -87,6 +141,15 @@ const SPARSE_MEMORY_SIZE_FIELD: usize = mem::size_of::<u64>();
 
 /// Byte size of a page-index entry (`u32`) in the sparse snapshot format.
 const SPARSE_PAGE_INDEX_SIZE: usize = ::arch::mem::paging::PageTableEntry::SIZE;
+
+/// WHP GPA mapping flags: Read | Write | Execute.
+const GPA_RWX: WHV_MAP_GPA_RANGE_FLAGS = WHV_MAP_GPA_RANGE_FLAGS(
+    WHvMapGpaRangeFlagRead.0 | WHvMapGpaRangeFlagWrite.0 | WHvMapGpaRangeFlagExecute.0,
+);
+
+/// WHP GPA mapping flags: Read | Write (no Execute).
+const GPA_RW: WHV_MAP_GPA_RANGE_FLAGS =
+    WHV_MAP_GPA_RANGE_FLAGS(WHvMapGpaRangeFlagRead.0 | WHvMapGpaRangeFlagWrite.0);
 
 //==================================================================================================
 // Implementations
@@ -111,29 +174,79 @@ impl VirtualMemory {
     pub fn new(partition: &WhpPartition, size: usize) -> Result<Self> {
         trace!("VirtualMemory::new(): size={size}");
 
-        // Allocate memory using VirtualAlloc.
+        // Reserve the entire address space as a placeholder so that sub-regions can later be
+        // split and replaced with file-backed views via MapViewOfFile3.
+        // SAFETY: `GetCurrentProcess()` returns a pseudo-handle that is always valid.
+        let current_process: HANDLE = unsafe { GetCurrentProcess() };
+        // SAFETY: Allocates a new placeholder region from the OS with no pre-existing pointer
+        // dependency.  All parameters are valid constants; `None` base address lets the OS choose.
+        let placeholder: *mut u8 = unsafe {
+            VirtualAlloc2(
+                Some(current_process),
+                None,
+                size,
+                MEM_RESERVE | MEM_RESERVE_PLACEHOLDER,
+                PAGE_NOACCESS.0,
+                None,
+            )
+            .cast::<u8>()
+        };
+
+        if placeholder.is_null() {
+            let reason: String =
+                "failed to reserve placeholder for the virtual machine".to_string();
+            error!("VirtualMemory::new(): {reason} (memory_size={size:?})");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        // Replace the placeholder with committed memory. This allocation can later be freed
+        // back to a placeholder with VirtualFree(MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER).
+        // SAFETY: `placeholder` is a valid placeholder region returned by the `VirtualAlloc2`
+        // call above.  `MEM_REPLACE_PLACEHOLDER` atomically replaces it with committed memory.
         let ptr: *mut u8 = unsafe {
-            VirtualAlloc(Some(ptr::null()), size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE)
-                .cast::<u8>()
+            VirtualAlloc2(
+                Some(current_process),
+                Some(placeholder.cast()),
+                size,
+                MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
+                PAGE_READWRITE.0,
+                None,
+            )
+            .cast::<u8>()
         };
 
         if ptr.is_null() {
-            let reason: String = "failed to allocate memory for the virtual machine".to_string();
+            // Release the placeholder before returning.
+            // SAFETY: `placeholder` is a valid reserved region from the earlier `VirtualAlloc2`;
+            // `MEM_RELEASE` with size 0 releases the entire allocation.
+            unsafe {
+                if VirtualFree(placeholder.cast(), 0, MEM_RELEASE).is_err() {
+                    warn!("VirtualMemory::new(): VirtualFree() failed while releasing placeholder");
+                }
+            }
+            let reason: String = "failed to commit memory for the virtual machine".to_string();
             error!("VirtualMemory::new(): {reason} (memory_size={size:?})");
             return Err(anyhow::anyhow!(reason));
         }
 
         // Create the VirtualMemory instance (destructor will free memory on error).
-        let vmem: Self = Self { ptr, size };
+        let vmem: Self = Self {
+            ptr,
+            size,
+            partition_handle: partition.handle(),
+            file_remap: None,
+        };
 
         // Map the memory into the WHP partition at guest physical address 0.
+        // SAFETY: `ptr` is a valid committed region of `size` bytes from `VirtualAlloc2`.
+        // `partition.handle()` is a valid WHP partition handle.
         unsafe {
             WHvMapGpaRange(
                 partition.handle(),
                 ptr as *const std::ffi::c_void,
                 0, // Guest physical address.
                 size as u64,
-                WHV_MAP_GPA_RANGE_FLAGS(7), // Read | Write | Execute.
+                GPA_RWX,
             )
             .map_err(|e| {
                 let reason: String =
@@ -152,6 +265,424 @@ impl VirtualMemory {
 
     pub fn get_size(&self) -> usize {
         self.size
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Replaces a sub-region of guest memory with a zero-copy, file-backed mapping using
+    /// Windows placeholder APIs.
+    ///
+    /// Only the tail of the committed region (from `start` onward) is freed back to a
+    /// placeholder via `MEM_PRESERVE_PLACEHOLDER`, which splits the committed region in place
+    /// without disturbing preceding memory (kernel, initrd). The file is then mapped directly
+    /// at `self.ptr.add(start)` via `MapViewOfFile3` with `MEM_REPLACE_PLACEHOLDER`, and the
+    /// affected GPA segments are re-registered with the WHP partition.
+    ///
+    /// # Parameters
+    ///
+    /// - `start`: Byte offset from the start of guest memory (must be page-aligned).
+    /// - `len`: Size of the region to remap (in bytes).
+    /// - `file`: File to map from.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns empty. On failure, returns an error.
+    ///
+    /// # Note
+    ///
+    /// If this method fails partway through, the guest memory region may be left in an
+    /// inconsistent state (partially unmapped from WHP, partially split). This mirrors the
+    /// Linux `mmap(MAP_FIXED)` semantics where the previous mapping is destroyed before the
+    /// new one is established. Callers should treat a failure as fatal for the VM instance.
+    ///
+    pub fn remap_file_at(&mut self, start: usize, len: usize, file: &File) -> Result<()> {
+        trace!("remap_file_at(): start={start:#x}, len={len:#x}");
+
+        if self.file_remap.is_some() {
+            let reason: &str = "remap_file_at() has already been called on this VirtualMemory";
+            error!("remap_file_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        if len == 0 {
+            let reason: &str = "cannot remap zero-sized region";
+            error!("remap_file_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        if start.checked_add(len).is_none_or(|end| end > self.size) {
+            let reason: String = format!(
+                "remap region [{start:#x}, {:#x}) exceeds memory bounds (size={:#x})",
+                start.saturating_add(len),
+                self.size
+            );
+            error!("remap_file_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        let page_size: usize = ::arch::mem::PAGE_SIZE;
+        if !start.is_multiple_of(page_size) {
+            let reason: String = format!(
+                "start address is not page-aligned (start={start:#x}, page_size={page_size:#x})"
+            );
+            error!("remap_file_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        let aligned_len: usize = (len + page_size - 1) & !(page_size - 1);
+        if start + aligned_len > self.size {
+            let reason: String = format!(
+                "page-aligned remap [{start:#x}, {:#x}) exceeds memory bounds (size={:#x})",
+                start + aligned_len,
+                self.size
+            );
+            error!("remap_file_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        // SAFETY: `GetCurrentProcess()` returns a pseudo-handle that is always valid.
+        let current_process: HANDLE = unsafe { GetCurrentProcess() };
+
+        // Phase 1: Unmap the GPA tail from WHP and split the committed region into
+        //          placeholders: [start..start+aligned_len) and [start+aligned_len..size).
+        self.prepare_placeholders(start, aligned_len)?;
+
+        // Record the split immediately so `Drop` can clean up the placeholders if a later
+        // phase fails.  The section handle starts as null (placeholder / committed fallback)
+        // and is updated to the real handle after a successful zero-copy map.
+        self.file_remap = Some(FileRemap {
+            start,
+            aligned_len,
+            section_handle: HANDLE::default(),
+        });
+
+        // Phase 2: Replace the middle placeholder [start..start+aligned_len) with a
+        //          file-backed view (zero-copy) or committed memory (fallback).
+        let section_handle: HANDLE =
+            self.replace_placeholder_with_file(start, len, aligned_len, file, current_process)?;
+
+        // Update the section handle now that the file view is established.
+        self.file_remap.as_mut().unwrap().section_handle = section_handle;
+
+        // Phase 3: Re-commit the tail placeholder and re-register all affected GPA segments
+        //          with the WHP partition.
+        self.commit_and_map_tail(start, aligned_len, current_process)?;
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Unmaps the GPA range `[start..size)` from the WHP partition and converts the committed
+    /// host memory in that range back to placeholders, splitting the region into up to two
+    /// placeholders: `[start..start+aligned_len)` for the file view and
+    /// `[start+aligned_len..size)` for the tail.
+    ///
+    fn prepare_placeholders(&mut self, start: usize, aligned_len: usize) -> Result<()> {
+        let tail_start: usize = start + aligned_len;
+
+        // ── 1. Unmap [start..size) from the WHP partition ──────────────────────────────────
+        //
+        // The head [0..start) stays mapped and its committed memory is untouched, avoiding
+        // the cost of backing up and restoring kernel/initrd data.
+        let unmap_size: u64 = (self.size - start) as u64;
+        // SAFETY: `self.partition_handle` is a valid WHP handle from `new()`. The GPA range
+        // [start..size) was mapped in `new()` and has not yet been unmapped.
+        unsafe {
+            WHvUnmapGpaRange(self.partition_handle, start as u64, unmap_size).map_err(|e| {
+                let reason: String = format!(
+                    "failed to unmap GPA range for file remap (start={start:#x}, \
+                     size={unmap_size:#x}, error={e:?})"
+                );
+                error!("prepare_placeholders(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        }
+
+        // ── 2. Free [start..size) back to a placeholder ────────────────────────────────────
+        //
+        // `VirtualFree(addr, size, MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)` splits the
+        // committed region in place: [0..start) stays committed, [start..size) becomes a
+        // placeholder. No data is destroyed in the head.
+        const MEM_RELEASE_PRESERVE: VIRTUAL_FREE_TYPE =
+            VIRTUAL_FREE_TYPE(MEM_RELEASE.0 | MEM_PRESERVE_PLACEHOLDER.0);
+        // SAFETY: `self.ptr.add(start)` points within the committed region (bounds checked
+        // by the caller). `MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER` splits the committed
+        // allocation: [0..start) stays committed, [start..size) becomes a placeholder.
+        unsafe {
+            VirtualFree(self.ptr.add(start).cast(), self.size - start, MEM_RELEASE_PRESERVE)
+                .map_err(|e| {
+                    let reason: String = format!(
+                        "failed to free tail to placeholder (start={start:#x}, error={e:?})"
+                    );
+                    error!("prepare_placeholders(): {reason}");
+                    anyhow::anyhow!(reason)
+                })?;
+        }
+
+        // ── 3. Split the tail placeholder if there is memory after the file region ─────────
+        //
+        // After step 2, [start..size) is a single placeholder. If `tail_start < size`, split
+        // it into [start..tail_start) and [tail_start..size).
+        if tail_start < self.size {
+            // SAFETY: After step 2, [start..size) is a single placeholder.
+            // `self.ptr.add(start)` is the base of that placeholder, and `aligned_len` is
+            // within it.  This splits it into [start..tail_start) and [tail_start..size).
+            unsafe {
+                VirtualFree(self.ptr.add(start).cast(), aligned_len, MEM_RELEASE_PRESERVE)
+                    .map_err(|e| {
+                        let reason: String = format!(
+                            "failed to split file placeholder (start={start:#x}, \
+                             aligned_len={aligned_len:#x}, error={e:?})"
+                        );
+                        error!("prepare_placeholders(): {reason}");
+                        anyhow::anyhow!(reason)
+                    })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Replaces the placeholder at `[start..start+aligned_len)` with a file-backed view.
+    ///
+    /// When the file size (`len`) is page-aligned, a true zero-copy `PAGE_WRITECOPY` section
+    /// is created and mapped via `MapViewOfFile3`. When the file size is NOT page-aligned,
+    /// the placeholder is committed via `VirtualAlloc2` and the file content is read into it.
+    ///
+    /// Returns the section handle for the file-backed path, or `HANDLE::default()` for the
+    /// commit+read fallback (used by `Drop` to choose the correct cleanup).
+    ///
+    fn replace_placeholder_with_file(
+        &mut self,
+        start: usize,
+        len: usize,
+        aligned_len: usize,
+        file: &File,
+        current_process: HANDLE,
+    ) -> Result<HANDLE> {
+        let page_size: usize = ::arch::mem::PAGE_SIZE;
+        let file_handle: HANDLE = HANDLE(file.as_raw_handle());
+
+        if len.is_multiple_of(page_size) {
+            self.map_file_view_zero_copy(start, aligned_len, file_handle, current_process)
+        } else {
+            self.map_file_view_commit_read(start, len, aligned_len, file, current_process)
+        }
+    }
+
+    /// Zero-copy path: creates a `PAGE_WRITECOPY` section backed by the file and maps it into
+    /// the placeholder at `[start..start+aligned_len)` via `MapViewOfFile3`.
+    ///
+    /// Returns the section handle on success.
+    fn map_file_view_zero_copy(
+        &mut self,
+        start: usize,
+        aligned_len: usize,
+        file_handle: HANDLE,
+        current_process: HANDLE,
+    ) -> Result<HANDLE> {
+        let size_high: u32 = (aligned_len >> 32) as u32;
+        let size_low: u32 = aligned_len as u32;
+
+        // SAFETY: `file_handle` comes from a valid open `File`. Size parameters are
+        // derived from `aligned_len` which does not exceed the region bounds.
+        let section: HANDLE = unsafe {
+            CreateFileMappingW(file_handle, None, PAGE_WRITECOPY, size_high, size_low, None)
+                .map_err(|e| {
+                    let reason: String =
+                        format!("failed to create file mapping section (error={e:?})");
+                    error!("map_file_view_zero_copy(): {reason}");
+                    anyhow::anyhow!(reason)
+                })?
+        };
+
+        // SAFETY: `section` is a valid handle from `CreateFileMappingW`.
+        // `self.ptr.add(start)` targets a placeholder of exactly `aligned_len` bytes
+        // created by `prepare_placeholders()`.  `MEM_REPLACE_PLACEHOLDER` atomically
+        // replaces it with a file-backed view.
+        let view: MEMORY_MAPPED_VIEW_ADDRESS = unsafe {
+            MapViewOfFile3(
+                section,
+                Some(current_process),
+                Some(self.ptr.add(start).cast()),
+                0,
+                aligned_len,
+                MEM_REPLACE_PLACEHOLDER,
+                PAGE_WRITECOPY.0,
+                None,
+            )
+        };
+
+        if view.Value.is_null() {
+            // SAFETY: `GetLastError` has no preconditions.
+            let win_err: u32 = unsafe { ::windows::Win32::Foundation::GetLastError().0 };
+            // SAFETY: `section` is a valid handle that must be closed on this error path.
+            unsafe {
+                if CloseHandle(section).is_err() {
+                    warn!(
+                        "map_file_view_zero_copy(): CloseHandle() failed while cleaning up section"
+                    );
+                }
+            }
+            let reason: String = format!(
+                "MapViewOfFile3 returned null (start={start:#x}, aligned_len={aligned_len:#x}, \
+                 win32_error={win_err})"
+            );
+            error!("map_file_view_zero_copy(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        // The file-backed view uses PAGE_WRITECOPY: reads are served from the OS page
+        // cache (zero-copy), while writes trigger copy-on-write, creating private pages.
+        Ok(section)
+    }
+
+    /// Fallback path for non-page-aligned files: commits the placeholder at
+    /// `[start..start+aligned_len)` and reads the file content directly into it.
+    ///
+    /// Returns `HANDLE::default()` to signal this is a committed region, not file-mapped.
+    fn map_file_view_commit_read(
+        &mut self,
+        start: usize,
+        len: usize,
+        aligned_len: usize,
+        file: &File,
+        current_process: HANDLE,
+    ) -> Result<HANDLE> {
+        debug!(
+            "map_file_view_commit_read(): file size ({len:#x}) is not page-aligned, using \
+             commit+read fallback"
+        );
+
+        // SAFETY: `self.ptr.add(start)` targets a placeholder of `aligned_len` bytes.
+        // `MEM_REPLACE_PLACEHOLDER` replaces it with committed memory.
+        let committed: *mut std::ffi::c_void = unsafe {
+            VirtualAlloc2(
+                Some(current_process),
+                Some(self.ptr.add(start).cast()),
+                aligned_len,
+                MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
+                PAGE_READWRITE.0,
+                None,
+            )
+        };
+        if committed.is_null() {
+            let reason: String = format!(
+                "failed to commit file placeholder [{start:#x}..{:#x})",
+                start + aligned_len
+            );
+            error!("map_file_view_commit_read(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        // Read the file content directly into the committed guest memory.
+        // Seek to the start of the file in case a previous operation advanced the cursor.
+        (&*file).seek(SeekFrom::Start(0)).map_err(|e| {
+            let reason: String = format!("failed to seek to start of file (error={e:?})");
+            error!("map_file_view_commit_read(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        // SAFETY: The `VirtualAlloc2` above succeeded, so `self.ptr.add(start)` points to
+        // `aligned_len` bytes of committed memory. `len <= aligned_len` (checked by caller).
+        let dest: &mut [u8] = unsafe { slice::from_raw_parts_mut(self.ptr.add(start), len) };
+        (&*file).read_exact(dest).map_err(|e| {
+            let reason: String = format!("failed to read file into committed region (error={e:?})");
+            error!("map_file_view_commit_read(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        Ok(HANDLE::default())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Re-commits the tail placeholder `[start+aligned_len..size)` (if any) and re-registers
+    /// the file-backed middle segment and the tail committed segment with the WHP partition.
+    ///
+    fn commit_and_map_tail(
+        &mut self,
+        start: usize,
+        aligned_len: usize,
+        current_process: HANDLE,
+    ) -> Result<()> {
+        let tail_start: usize = start + aligned_len;
+
+        // Re-commit the tail placeholder (if any).
+        if tail_start < self.size {
+            let tail_size: usize = self.size - tail_start;
+            // SAFETY: `self.ptr.add(tail_start)` targets the tail placeholder created by
+            // `prepare_placeholders()`.  `tail_size` spans [tail_start..size).
+            let committed: *mut std::ffi::c_void = unsafe {
+                VirtualAlloc2(
+                    Some(current_process),
+                    Some(self.ptr.add(tail_start).cast()),
+                    tail_size,
+                    MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
+                    PAGE_READWRITE.0,
+                    None,
+                )
+            };
+            if committed.is_null() {
+                let reason: String =
+                    format!("failed to re-commit tail segment [{tail_start:#x}..{:#x})", self.size);
+                error!("commit_and_map_tail(): {reason}");
+                anyhow::bail!(reason);
+            }
+        }
+
+        // Re-map the file-backed (or committed) middle segment into the WHP partition.
+        // The head [0..start) was never unmapped — skip it.
+        // Use RW-only permissions: RAMFS data does not contain executable code.
+        // SAFETY: `self.ptr.add(start)` points to the file-backed (or committed) view of
+        // `aligned_len` bytes established by `replace_placeholder_with_file()`.
+        unsafe {
+            WHvMapGpaRange(
+                self.partition_handle,
+                self.ptr.add(start) as *const std::ffi::c_void,
+                start as u64,
+                aligned_len as u64,
+                GPA_RW,
+            )
+            .map_err(|e| {
+                let reason: String = format!(
+                    "failed to map file-backed GPA range (start={start:#x}, len={aligned_len:#x}, \
+                     error={e:?})"
+                );
+                error!("commit_and_map_tail(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        }
+
+        // Re-map the tail committed segment (if any).
+        if tail_start < self.size {
+            let tail_size: usize = self.size - tail_start;
+            // SAFETY: `self.ptr.add(tail_start)` points to the re-committed tail segment.
+            // `tail_size` spans [tail_start..size). The WHP handle is valid.
+            unsafe {
+                WHvMapGpaRange(
+                    self.partition_handle,
+                    self.ptr.add(tail_start) as *const std::ffi::c_void,
+                    tail_start as u64,
+                    tail_size as u64,
+                    GPA_RWX,
+                )
+                .map_err(|e| {
+                    let reason: String = format!("failed to re-map tail GPA range (error={e:?})");
+                    error!("commit_and_map_tail(): {reason}");
+                    anyhow::anyhow!(reason)
+                })?;
+            }
+        }
+
+        Ok(())
     }
 
     ///
@@ -195,65 +726,6 @@ impl VirtualMemory {
         unsafe {
             ptr::copy_nonoverlapping(data.as_ptr(), self.ptr.add(addr), data.len());
         }
-
-        Ok(())
-    }
-
-    ///
-    /// # Description
-    ///
-    /// Reads `len` bytes from a file directly into the virtual memory at the given guest address,
-    /// bypassing any intermediate heap buffer.
-    ///
-    /// # Parameters
-    ///
-    /// - `addr`: Destination address in the virtual memory.
-    /// - `file`: File to read from (starting at its current seek position).
-    /// - `len`: Number of bytes to read.
-    ///
-    /// # Returns
-    ///
-    /// Upon successful completion, this method returns empty. Otherwise, it returns an error.
-    ///
-    pub fn load_from_file(&mut self, addr: u64, file: &File, len: usize) -> Result<()> {
-        let addr: usize = match usize::try_from(addr) {
-            Ok(v) => v,
-            Err(_) => {
-                let reason: String = format!("invalid address (addr={addr:#010x})");
-                error!("load_from_file(): {reason}");
-                return Err(anyhow::anyhow!(reason));
-            },
-        };
-
-        // Check if region lies within the virtual memory (overflow-safe).
-        match addr.checked_add(len) {
-            Some(end) if end <= self.size => {},
-            _ => {
-                let reason: String = format!(
-                    "invalid memory access (addr={addr:#010x}, len={len:#x}, size={:#x})",
-                    self.size
-                );
-                error!("load_from_file(): {reason}");
-                return Err(anyhow::anyhow!(reason));
-            },
-        }
-
-        // SAFETY: `self.ptr` is a valid, committed allocation of `self.size` bytes (from
-        // `VirtualAlloc`). The checked range validation above guarantees that
-        // `[addr, addr + len)` lies within this region.
-        let dest: &mut [u8] = unsafe { slice::from_raw_parts_mut(self.ptr.add(addr), len) };
-
-        // Read from `&File` (shared reference) — Rust's std provides `impl Read for &File`,
-        // which calls `ReadFile` on the underlying OS handle.
-        let mut reader: &File = file;
-        reader.read_exact(dest).map_err(|e| {
-            let reason: String = format!(
-                "failed to read file into virtual memory (addr={addr:#010x}, len={len}, \
-                 error={e:?})"
-            );
-            error!("load_from_file(): {reason}");
-            anyhow::anyhow!(reason)
-        })?;
 
         Ok(())
     }
@@ -591,10 +1063,92 @@ impl VirtualMemory {
 
 impl Drop for VirtualMemory {
     fn drop(&mut self) {
+        // Unmap the entire GPA range from the WHP partition before releasing host memory.
+        // SAFETY: `self.partition_handle` is a valid WHP handle from `new()`. The GPA range
+        // [0..size) was mapped during construction and has not been freed.
         unsafe {
-            if VirtualFree(self.ptr.cast(), 0, MEM_RELEASE).is_err() {
-                error!("VirtualFree() failed");
+            if let Err(e) = WHvUnmapGpaRange(self.partition_handle, 0, self.size as u64) {
+                error!("WHvUnmapGpaRange() failed in Drop (error={e:?})");
             }
+        }
+
+        match self.file_remap.take() {
+            Some(remap) => {
+                // The region was split into up to three segments by `remap_file_at()`.
+                // Free each segment individually: committed segments via VirtualFree,
+                // the file view via UnmapViewOfFileEx (or VirtualFree if committed), and
+                // the section handle via CloseHandle (when file-mapped).
+                //
+                // This also handles partial-failure states: if `remap_file_at()` failed
+                // after `prepare_placeholders()` but before completing all phases, some
+                // segments may still be placeholders. `VirtualFree(MEM_RELEASE)` releases
+                // both committed regions and placeholders, so cleanup is safe either way.
+                let tail_start: usize = remap.start + remap.aligned_len;
+
+                // Free the head committed segment.
+                if remap.start > 0 {
+                    // SAFETY: `self.ptr` is the base of the original allocation.  After
+                    // `remap_file_at()`, [0..start) is a standalone committed region.
+                    unsafe {
+                        if VirtualFree(self.ptr.cast(), 0, MEM_RELEASE).is_err() {
+                            error!("VirtualFree() failed for head segment");
+                        }
+                    }
+                }
+
+                // Release the middle segment.
+                if remap.section_handle == HANDLE::default() {
+                    // Middle is committed memory, a placeholder (partial failure), or
+                    // the commit+read fallback (non-page-aligned file). VirtualFree
+                    // handles all three cases.
+                    // SAFETY: `self.ptr.add(remap.start)` is the base of a standalone
+                    // region created during `remap_file_at()`.
+                    unsafe {
+                        if VirtualFree(self.ptr.add(remap.start).cast(), 0, MEM_RELEASE).is_err() {
+                            error!("VirtualFree() failed for committed middle segment");
+                        }
+                    }
+                } else {
+                    // Middle is a file-backed view — unmap and close the section handle.
+                    // SAFETY: `self.ptr.add(remap.start)` is the address of the file-backed
+                    // view created by `MapViewOfFile3` in `remap_file_at()` and
+                    // `remap.section_handle` is the corresponding section handle.  Both are
+                    // released exactly once here.
+                    unsafe {
+                        let view: MEMORY_MAPPED_VIEW_ADDRESS = MEMORY_MAPPED_VIEW_ADDRESS {
+                            Value: self.ptr.add(remap.start).cast(),
+                        };
+                        if UnmapViewOfFileEx(view, UNMAP_VIEW_OF_FILE_FLAGS(0)).is_err() {
+                            error!("UnmapViewOfFileEx() failed for file view");
+                        }
+                        if CloseHandle(remap.section_handle).is_err() {
+                            error!("CloseHandle() failed for section handle");
+                        }
+                    }
+                }
+
+                // Free the tail committed segment (or placeholder if Phase 3a failed).
+                if tail_start < self.size {
+                    // SAFETY: `self.ptr.add(tail_start)` is the base of either the
+                    // re-committed tail segment or a placeholder (if `commit_and_map_tail()`
+                    // failed before re-committing). `VirtualFree(MEM_RELEASE)` handles both.
+                    unsafe {
+                        if VirtualFree(self.ptr.add(tail_start).cast(), 0, MEM_RELEASE).is_err() {
+                            error!("VirtualFree() failed for tail segment");
+                        }
+                    }
+                }
+            },
+            None => {
+                // No remap: the region is a single committed block.
+                // SAFETY: `self.ptr` is a valid committed allocation from `VirtualAlloc2`
+                // in `new()` and is released exactly once here.
+                unsafe {
+                    if VirtualFree(self.ptr.cast(), 0, MEM_RELEASE).is_err() {
+                        error!("VirtualFree() failed");
+                    }
+                }
+            },
         }
     }
 }


### PR DESCRIPTION
This pull request refactors the way RAMFS images are loaded into guest memory on Windows, switching from a read/copy approach to a true zero-copy, file-backed memory mapping using Windows APIs. It introduces a new `FileMapping` abstraction that manages OS handles and memory-mapped views safely, and updates the `RamFs` logic to use this for efficient guest memory mapping. This brings the Windows implementation in line with Linux, improving performance and resource usage.

**Windows file mapping and zero-copy improvements:**

* Replaced the previous file read/copy logic with a new `FileMapping` struct in `pal/windows.rs` that uses Windows APIs (`CreateFileMappingW`, `MapViewOfFile`, and friends) for read-only memory-mapped files, managing OS handles safely and supporting zero-copy access. [[1]](diffhunk://#diff-eefdcb89a2f2858bbdc0e7449db83cdc792e72805473aac439d9c3a28b84ffa8L19-R59) [[2]](diffhunk://#diff-eefdcb89a2f2858bbdc0e7449db83cdc792e72805473aac439d9c3a28b84ffa8L42-R186)
* Updated the `RamFs` implementation to use `map_file_into_guest` on Windows, which now uses `MapViewOfFile3` with `MEM_REPLACE_PLACEHOLDER` for direct, zero-copy mapping of the RAMFS image into guest memory. [[1]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4L49-R50) [[2]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4L178-R179) [[3]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4L264-L278) [[4]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4R375-R415)

**Code and documentation consistency:**

* Updated documentation and comments in `ramfs.rs` to accurately describe the new zero-copy, file-backed approach for Windows, matching the Linux implementation. [[1]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4L49-R50) [[2]](diffhunk://#diff-047a151efc040588daf87c2cddc2f9a0d6e167b696c8d9df11dd5470fd9a9fa4L178-R179)

**Testing and resource management:**

* Improved test cleanup in `pal/windows.rs` to ensure the file mapping is dropped before deleting the test file, preventing file handle leaks.

**Dependency updates:**

* Added required Windows API feature flags to the `windows` crate in `Cargo.toml` to support the new memory-mapping logic.