### PR TITLE
[ci] Use pre-built CI container for Linux jobs

### DIFF
--- a/.github/actions/native-setup/action.yml
+++ b/.github/actions/native-setup/action.yml
@@ -27,6 +27,14 @@ runs:
           echo "in-container=false" >> "$GITHUB_OUTPUT"
         fi
 
+    # actions/checkout sets safe.directory via a temporary HOME override that
+    # is invisible to later steps running inside the container.  Re-add it
+    # under the real HOME so git commands in ./z (and make) work correctly.
+    - name: "Mark Workspace Safe for Git"
+      if: steps.detect-container.outputs.in-container == 'true'
+      shell: bash
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
     # When running outside the CI container, free disk space and install system
     # dependencies from scratch.  Inside the container these are already present.
     - name: "Free Disk Space"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,11 @@ jobs:
     needs: precheck
     timeout-minutes: 60
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/nanvix/ci:ubuntu-24.04
     permissions:
       contents: read
+      packages: read
 
     # Only run the CI for:
     # - Merge queue validation runs.
@@ -131,8 +134,11 @@ jobs:
         machine-type: [microvm, hyperlight]
         deployment-type: [standalone, single-process, multi-process]
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/nanvix/ci:ubuntu-24.04
     permissions:
       contents: read
+      packages: read
 
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     if: |
@@ -181,8 +187,11 @@ jobs:
         machine-type: [microvm, hyperlight]
         deployment-type: [standalone, single-process, multi-process]
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/nanvix/ci:ubuntu-24.04
     permissions:
       contents: read
+      packages: read
 
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     if: |
@@ -237,8 +246,11 @@ jobs:
           - build-type: debug
             memory-size: 256
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/nanvix/ci:ubuntu-24.04
     permissions:
       contents: read
+      packages: read
 
     # NOTE: !cancelled() — see comment on 'checks' job (actions/runner#2205).
     # !failure() ensures the build does not start when checks/lint/verify fail.


### PR DESCRIPTION
## Summary

Run `checks`, `lint`, `verify`, `ci-build`, and `benchmark-ci` jobs inside the
`ghcr.io/nanvix/ci:ubuntu-24.04` container image instead of bare `ubuntu-24.04` runners.

## Problem

All Linux CI jobs on GitHub-hosted runners execute a full `apt-get update + install` (~25 packages)
on every run via `ubuntu-core.sh`. This takes ~3-5 min normally but can spike to 25+ min when a
runner gets a slow apt mirror — as seen in workflow run #24085867728 where the Setup step on
`Build (release, hyperlight, multi-process, 256mb)` stalled for over 26 minutes.

## Fix

The CI container image (`ghcr.io/nanvix/ci:ubuntu-24.04`) already pre-bakes all system packages,
the Rust toolchain, and the Python venv. The `native-setup` composite action already detects the
container via `/etc/nanvix-ci-container` and skips `apt-get`, `free-disk-space`, and full toolchain
installation. This PR simply adds `container: image: ghcr.io/nanvix/ci:ubuntu-24.04` to the 5
Linux jobs that use `native-setup`, activating the existing fast path.

## Expected Impact

- **~3-5 min saved per job** (no more apt-get update/install)
- **Eliminates runner-lottery slowness** (no dependency on apt mirrors)
- **No behavioral changes** — the container-aware code paths in `native-setup` were already implemented and tested