### PR TITLE
[nanvix-sandbox] Fix acceptor startup race

### DIFF
--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -55,13 +55,6 @@ pub const CONTROL_PLANE_ACCEPT_TIMEOUT: Duration = Duration::from_secs(60);
 pub const MAX_EARLY_CONTROL_PLANE_CONNECTIONS: usize = 64;
 
 ///
-/// Maximum number of `yield_now()` retries when upgrading the weak self-reference during acceptor
-/// startup.
-///
-#[cfg(not(feature = "standalone"))]
-pub const MAX_WEAK_UPGRADE_RETRIES: u32 = 100;
-
-///
 /// Maximum number of concurrent in-flight connection handler tasks in the control-plane acceptor.
 ///
 #[cfg(not(feature = "standalone"))]

--- a/src/libs/nanvix-sandbox/src/control_plane_acceptor.rs
+++ b/src/libs/nanvix-sandbox/src/control_plane_acceptor.rs
@@ -15,7 +15,6 @@ use crate::config::{
     CONTROL_PLANE_ACCEPT_TIMEOUT,
     MAX_CONCURRENT_CONTROL_PLANE_HANDLERS,
     MAX_EARLY_CONTROL_PLANE_CONNECTIONS,
-    MAX_WEAK_UPGRADE_RETRIES,
 };
 use ::anyhow::Result;
 use ::control_plane_api::ControlPlaneRegistrationMessage;
@@ -96,7 +95,7 @@ pub struct ControlPlaneAcceptor {
     _listener_sockaddr: String,
     _listener_socket_type: SocketType,
     state: Mutex<ControlPlaneAcceptorState>,
-    accept_task: AbortHandle,
+    accept_task: std::sync::OnceLock<AbortHandle>,
     /// Limits the number of concurrent in-flight connection handler tasks.
     handler_semaphore: Arc<Semaphore>,
 }
@@ -126,45 +125,34 @@ impl ControlPlaneAcceptor {
         listener_sockaddr: String,
         listener_socket_type: SocketType,
     ) -> Arc<Self> {
-        // We need a new_cyclic here in order to be able to start the acceptor task as part of the
-        // call to `new`. The acceptor task requires a reference to self, hence the cyclic
-        // dependency.
-        Arc::new_cyclic(|weak_self: &Weak<Self>| {
-            let weak_self: Weak<Self> = weak_self.clone();
-            let accept_task: JoinHandle<()> = spawn(async move {
-                // Try to upgrade immediately in case `Arc::new_cyclic` already finished
-                // setting the strong reference count before this task was first polled.
-                if let Some(acceptor) = weak_self.upgrade() {
-                    acceptor.run().await;
-                    return;
-                }
+        // Build the Arc first so that the strong reference count is non-zero before spawning the
+        // accept loop. The previous `Arc::new_cyclic` approach had a race: the spawned task could
+        // be polled on another worker thread before `new_cyclic` finished setting the strong count,
+        // causing `Weak::upgrade()` to return `None` and the accept loop to never start.
+        let acceptor: Arc<Self> = Arc::new(Self {
+            listener,
+            _listener_sockaddr: listener_sockaddr,
+            _listener_socket_type: listener_socket_type,
+            state: Mutex::new(ControlPlaneAcceptorState::default()),
+            accept_task: std::sync::OnceLock::new(),
+            handler_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_CONTROL_PLANE_HANDLERS)),
+        });
 
-                // Yield until `Arc::new_cyclic` finishes setting the strong reference count. A
-                // single yield is not enough: in a multi-threaded runtime a different worker
-                // thread can re-poll this future before the originating thread completes
-                // `new_cyclic`, causing `upgrade()` to return `None`.
-                for _ in 0..MAX_WEAK_UPGRADE_RETRIES {
-                    tokio::task::yield_now().await;
-                    if let Some(acceptor) = weak_self.upgrade() {
-                        acceptor.run().await;
-                        return;
-                    }
-                }
-                error!(
-                    "accept loop failed to start: could not upgrade weak reference after \
-                     {MAX_WEAK_UPGRADE_RETRIES} yield cycles"
-                );
-            });
-
-            Self {
-                listener,
-                _listener_sockaddr: listener_sockaddr,
-                _listener_socket_type: listener_socket_type,
-                state: Mutex::new(ControlPlaneAcceptorState::default()),
-                accept_task: accept_task.abort_handle(),
-                handler_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_CONTROL_PLANE_HANDLERS)),
+        // Spawn the accept loop now that the Arc is fully constructed.
+        let weak_self: Weak<Self> = Arc::downgrade(&acceptor);
+        let accept_task: JoinHandle<()> = spawn(async move {
+            if let Some(acceptor) = weak_self.upgrade() {
+                acceptor.run().await;
+            } else {
+                debug!("accept loop did not start: acceptor was dropped before task was polled");
             }
-        })
+        });
+        acceptor
+            .accept_task
+            .set(accept_task.abort_handle())
+            .expect("control-plane acceptor abort handle must be initialized exactly once");
+
+        acceptor
     }
 
     ///
@@ -472,7 +460,9 @@ impl Drop for ControlPlaneAcceptor {
     /// This function does not return a value.
     ///
     fn drop(&mut self) {
-        self.accept_task.abort();
+        if let Some(handle) = self.accept_task.get() {
+            handle.abort();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fix intermittent `timed-out waiting for linuxd control-plane connection` failures in single-process and multi-process modes.

## Root Cause

`ControlPlaneAcceptor::new()` used `Arc::new_cyclic` to spawn the background accept loop task. Inside the `new_cyclic` closure, the Arc's strong reference count is still 0, so a `Weak::upgrade()` in the spawned task can return `None` if the task is polled on another tokio worker thread before `new_cyclic` finishes. The retry loop (`MAX_WEAK_UPGRADE_RETRIES = 100` yields) mitigated but did not eliminate this race — on loaded systems all 100 retries can exhaust before the originating thread completes `new_cyclic`.

When the accept loop fails to start, linuxd/uservm connections sit in the kernel backlog unprocessed, causing the 60-second timeout to fire.

## Fix

Replace `Arc::new_cyclic` with plain `Arc::new` followed by a post-construction `tokio::spawn`. The `Weak::upgrade()` is now guaranteed to succeed because the Arc is fully constructed before the task is spawned.

### Changes
- **`control_plane_acceptor.rs`**: Two-phase construction — `Arc::new(Self{..})` first, then `Arc::downgrade` + `tokio::spawn`. Changed `accept_task` field from `AbortHandle` to `OnceLock<AbortHandle>`.
- **`config.rs`**: Removed `MAX_WEAK_UPGRADE_RETRIES` constant (no longer needed).

## Testing

- All pre-commit checks passed (6/6 configurations)
- Unit tests passed
- Integration tests passed (`run-nanvix-tests`)

## Related

- Introduced by: 5b21fae554583dfccbd50af5d3fd02c559d2f432 (PR #1836)
- Previous fix attempts: PR #1997, PR #1998
- Downstream failures: usr/bin/quickjs PR #47, usr/lib/bzip2 PR #88