### PR TITLE
Migrate microvm and hyperlight MMIO regions to IoMemoryAllocator

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -27,6 +27,7 @@ use crate::{
         mem::{
             MemoryRegion,
             MemoryRegionType,
+            PageAligned,
             PhysicalAddress,
             TruncatedMemoryRegion,
         },
@@ -35,7 +36,12 @@ use crate::{
             madt::MadtInfo,
             peb::ProcessEnvironmentBlock,
             region_names::RAMFS_REGION_NAME,
-            region_tags::RAMFS_MMIO_TAG,
+            region_tags::{
+                INPUT_BUF_MMIO_TAG,
+                OUTPUT_BUF_MMIO_TAG,
+                PEB_MMIO_TAG,
+                RAMFS_MMIO_TAG,
+            },
         },
     },
     kmod::KernelModule,
@@ -530,30 +536,31 @@ pub fn init(
             error!("init(): {reason} (kernel_end_addr={kernel_end_addr:#x})");
             Error::new(ErrorCode::BadAddress, reason)
         })?;
-    let peb: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+    let peb: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new(
         "peb",
-        VirtualAddress::from_raw_value(peb_base),
+        PageAligned::from_raw_value(peb_base)?,
         PEB_SIZE,
         MemoryRegionType::Mmio,
         AccessPermission::RDWR,
     )?;
-    memory_regions.push_back(peb);
+    ioaddresses.register(PEB_MMIO_TAG, peb.clone())?;
+    mmio_regions.push_back(peb);
 
-    // Register input data buffer.
     // Register input data buffer (directly after PEB in v0.13.0+).
     let input_data_base: usize = peb_base.checked_add(PEB_SIZE).ok_or_else(|| {
         let reason: &str = "input data buffer base address overflow";
         error!("init(): {}", reason);
         Error::new(ErrorCode::OutOfMemory, reason)
     })?;
-    let input_data_buffer: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+    let input_data_buffer: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new(
         "input data buffer",
-        VirtualAddress::from_raw_value(input_data_base),
+        PageAligned::from_raw_value(input_data_base)?,
         INPUT_DATA_BUFFER_SIZE,
         MemoryRegionType::Mmio,
         AccessPermission::RDWR,
     )?;
-    memory_regions.push_back(input_data_buffer);
+    ioaddresses.register(INPUT_BUF_MMIO_TAG, input_data_buffer.clone())?;
+    mmio_regions.push_back(input_data_buffer);
 
     // Register output data buffer.
     let output_data_base: usize = input_data_base
@@ -563,14 +570,15 @@ pub fn init(
             error!("init(): {}", reason);
             Error::new(ErrorCode::OutOfMemory, reason)
         })?;
-    let output_data_buffer: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+    let output_data_buffer: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new(
         "output data buffer",
-        VirtualAddress::from_raw_value(output_data_base),
+        PageAligned::from_raw_value(output_data_base)?,
         OUTPUT_DATA_BUFFER_SIZE,
         MemoryRegionType::Mmio,
         AccessPermission::RDWR,
     )?;
-    memory_regions.push_back(output_data_buffer);
+    ioaddresses.register(OUTPUT_BUF_MMIO_TAG, output_data_buffer.clone())?;
+    mmio_regions.push_back(output_data_buffer);
 
     // Compute heap padding between output data buffer and kernel pool.
     let heap_padding_base: usize = output_data_base

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -35,7 +35,11 @@ use crate::{
             bootinfo::BootInfo,
             madt::MadtInfo,
             region_names::RAMFS_REGION_NAME,
-            region_tags::RAMFS_MMIO_TAG,
+            region_tags::{
+                MICROVM_CTRL_MMIO_TAG,
+                PVCLOCK_MMIO_TAG,
+                RAMFS_MMIO_TAG,
+            },
         },
     },
     kmod::KernelModule,
@@ -500,7 +504,7 @@ fn register_pit_ports(ioports: &mut IoPortAllocator) -> Result<(), Error> {
 pub fn init(
     ioports: &mut IoPortAllocator,
     ioaddresses: &mut IoMemoryAllocator,
-    memory_regions: &mut LinkedList<MemoryRegion<VirtualAddress>>,
+    _memory_regions: &mut LinkedList<MemoryRegion<VirtualAddress>>,
     mmio_regions: &mut LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
     madt: &Option<MadtInfo>,
     _mem_lower: Option<usize>,
@@ -516,24 +520,26 @@ pub fn init(
     register_pic_ioports(ioports)?;
 
     // Register MicroVM control registers.
-    let scratch_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+    let scratch_region: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new(
         "microvm-ctrl-registers",
-        VirtualAddress::from_raw_value(::config::microvm::DEFAULT_MICROVM_CTRL_BASE),
+        PageAligned::from_raw_value(::config::microvm::DEFAULT_MICROVM_CTRL_BASE)?,
         mem::PAGE_SIZE,
         MemoryRegionType::Mmio,
         AccessPermission::RDONLY,
     )?;
-    memory_regions.push_back(scratch_region);
+    ioaddresses.register(MICROVM_CTRL_MMIO_TAG, scratch_region.clone())?;
+    mmio_regions.push_back(scratch_region);
 
     // Register pvclock page so the kernel can read TSC calibration data.
-    let pvclock_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+    let pvclock_region: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new(
         "pvclock-page",
-        VirtualAddress::from_raw_value(::config::microvm::DEFAULT_PVCLOCK_PAGE),
+        PageAligned::from_raw_value(::config::microvm::DEFAULT_PVCLOCK_PAGE)?,
         mem::PAGE_SIZE,
         MemoryRegionType::Mmio,
         AccessPermission::RDONLY,
     )?;
-    memory_regions.push_back(pvclock_region);
+    ioaddresses.register(PVCLOCK_MMIO_TAG, pvclock_region.clone())?;
+    mmio_regions.push_back(pvclock_region);
 
     // Register the LAPIC MMIO page only for the WHP microvm backend.
     // The guest uses this page to enable LAPIC software delivery and to

--- a/src/kernel/src/hal/platform/region_tags.rs
+++ b/src/kernel/src/hal/platform/region_tags.rs
@@ -28,3 +28,15 @@ pub const PVCLOCK_MMIO_TAG: MmioTag = MmioTag::new(*b"PVCLOCK ");
 /// Tag used to identify the RAMFS MMIO region.
 #[cfg(any(feature = "microvm", feature = "hyperlight"))]
 pub const RAMFS_MMIO_TAG: MmioTag = MmioTag::new(*b"RAMFS   ");
+
+/// Tag used to identify the Hyperlight PEB MMIO region.
+#[cfg(feature = "hyperlight")]
+pub const PEB_MMIO_TAG: MmioTag = MmioTag::new(*b"PEB     ");
+
+/// Tag used to identify the Hyperlight input data buffer MMIO region.
+#[cfg(feature = "hyperlight")]
+pub const INPUT_BUF_MMIO_TAG: MmioTag = MmioTag::new(*b"INPUTBUF");
+
+/// Tag used to identify the Hyperlight output data buffer MMIO region.
+#[cfg(feature = "hyperlight")]
+pub const OUTPUT_BUF_MMIO_TAG: MmioTag = MmioTag::new(*b"OUTPUTBF");

--- a/src/kernel/src/hal/platform/region_tags.rs
+++ b/src/kernel/src/hal/platform/region_tags.rs
@@ -17,6 +17,14 @@ pub const IOAPIC_MMIO_TAG: MmioTag = MmioTag::new(*b"IOAPIC  ");
 /// Tag used to identify the Local APIC MMIO region.
 pub const LAPIC_MMIO_TAG: MmioTag = MmioTag::new(*b"LAPIC   ");
 
+/// Tag used to identify the MicroVM control registers MMIO region.
+#[cfg(feature = "microvm")]
+pub const MICROVM_CTRL_MMIO_TAG: MmioTag = MmioTag::new(*b"MVMCTRL ");
+
+/// Tag used to identify the pvclock MMIO region.
+#[cfg(feature = "microvm")]
+pub const PVCLOCK_MMIO_TAG: MmioTag = MmioTag::new(*b"PVCLOCK ");
+
 /// Tag used to identify the RAMFS MMIO region.
 #[cfg(any(feature = "microvm", feature = "hyperlight"))]
 pub const RAMFS_MMIO_TAG: MmioTag = MmioTag::new(*b"RAMFS   ");


### PR DESCRIPTION
## Summary

Migrate platform-specific MMIO regions (microvm and Hyperlight) from raw `MemoryRegion` entries in `memory_regions` to `TruncatedMemoryRegion` entries registered through the `IoMemoryAllocator` with dedicated MMIO tags.

## Changes

### Commit 1: Migrate microvm MMIO regions
- Add `MICROVM_CTRL_MMIO_TAG` and `PVCLOCK_MMIO_TAG` constants in `region_tags.rs`.
- Convert microvm control registers and pvclock page to `TruncatedMemoryRegion` with `PageAligned` addresses.
- Register both regions in `IoMemoryAllocator` and push into `mmio_regions`.

### Commit 2: Migrate hyperlight MMIO regions
- Add `PEB_MMIO_TAG`, `INPUT_BUF_MMIO_TAG`, and `OUTPUT_BUF_MMIO_TAG` constants in `region_tags.rs`.
- Convert the Hyperlight PEB, input data buffer, and output data buffer to `TruncatedMemoryRegion` with `PageAligned` addresses.
- Register all three regions in `IoMemoryAllocator` and push into `mmio_regions`.

## Testing
- [ ] CI passes