### PR TITLE
[test] Use dedicated mkramfs image for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -402,7 +402,7 @@ all-nanvix: \
 	all-snapshot
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-all-nanvix: all-host-binaries all-nanvixd all-uservm all-nanvix-test
+all-nanvix: all-host-binaries all-nanvixd all-uservm all-nanvix-test all-test-kernel-ramfs
 # The containerd shim is not needed in standalone mode.
 ifneq ($(DEPLOYMENT_MODE),standalone)
 all-nanvix: all-nanvix-shim
@@ -433,7 +433,7 @@ clean: \
 	image-clean
 
 ifneq ($(strip $(filter $(MACHINE),microvm hyperlight)),)
-clean: clean-host-binaries clean-nanvixd clean-uservm clean-nanvix-test
+clean: clean-host-binaries clean-nanvixd clean-uservm clean-nanvix-test clean-test-kernel-ramfs
 ifneq ($(IS_WINDOWS),yes)
 clean: clean-nanvix-shim
 endif
@@ -826,6 +826,30 @@ run: image
 # Runs system in debug mode.
 debug: image
 	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -toolchain-bin-dir $(CLH_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
+
+#===================================================================================================
+# Build Rules for Test Kernel RAMFS Image
+#===================================================================================================
+
+# Seed directory used to build the test-kernel-ramfs.img.
+TEST_KERNEL_RAMFS_SEED := $(BINARIES_DIR)/test-kernel-ramfs-seed
+TEST_KERNEL_RAMFS_IMG  := $(BINARIES_DIR)/test-kernel-ramfs.img
+
+# Generates a FAT32 RAMFS image for the test-kernel and test-mmio-fault regression tests.
+# The image is created from a small seed directory using mkramfs.
+.PHONY: all-test-kernel-ramfs clean-test-kernel-ramfs
+all-test-kernel-ramfs: $(TEST_KERNEL_RAMFS_IMG)
+
+$(TEST_KERNEL_RAMFS_IMG): $(TEST_KERNEL_RAMFS_SEED)/marker.txt all-host-binaries-mkramfs
+	$(MKRAMFS) -o $(TEST_KERNEL_RAMFS_IMG) $(TEST_KERNEL_RAMFS_SEED)
+
+$(TEST_KERNEL_RAMFS_SEED)/marker.txt:
+	@$(MKDIR_CMD) $(TEST_KERNEL_RAMFS_SEED)
+	@echo "test-kernel ramfs marker" > $@
+
+clean-test-kernel-ramfs:
+	$(FORCE_RM_CMD) $(TEST_KERNEL_RAMFS_SEED)
+	$(RM_CMD) $(TEST_KERNEL_RAMFS_IMG)
 
 #===================================================================================================
 # Build Rules for System Image

--- a/test/test-l2.toml
+++ b/test/test-l2.toml
@@ -42,7 +42,7 @@ iterations = 2
 [[tests]]
 executor = "http"
 program = "./bin/test-kernel.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
@@ -50,7 +50,7 @@ expected_exit_code = 13
 [[tests]]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -42,7 +42,7 @@ iterations = 2
 [[tests]]
 executor = "http"
 program = "./bin/test-kernel.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
@@ -50,7 +50,7 @@ expected_exit_code = 13
 [[tests]]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
@@ -142,7 +142,7 @@ expected_output = "Hello, world!"
 [[tests]]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
@@ -150,7 +150,7 @@ expected_exit_code = 13
 [[tests]]
 executor = "terminal"
 program = "./bin/test-mmio-fault.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -41,7 +41,7 @@ iterations = 2
 [[tests]]
 executor = "http"
 program = "./bin/test-kernel.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
@@ -49,7 +49,7 @@ expected_exit_code = 13
 [[tests]]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
@@ -141,7 +141,7 @@ expected_output = "Hello, world!"
 [[tests]]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
@@ -149,7 +149,7 @@ expected_exit_code = 13
 [[tests]]
 executor = "terminal"
 program = "./bin/test-mmio-fault.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3

--- a/test/test-standalone-windows.toml
+++ b/test/test-standalone-windows.toml
@@ -53,7 +53,7 @@ iterations = 2
 [[tests]]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
@@ -62,7 +62,7 @@ runs_on = ["microvm"]
 [[tests]]
 executor = "terminal"
 program = "./bin/test-mmio-fault.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -41,7 +41,7 @@ iterations = 2
 [[tests]]
 executor = "http"
 program = "./bin/test-kernel.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
@@ -49,7 +49,7 @@ expected_exit_code = 13
 [[tests]]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
@@ -101,7 +101,7 @@ expected_output = "ok"
 [[tests]]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
@@ -109,7 +109,7 @@ expected_exit_code = 13
 [[tests]]
 executor = "terminal"
 program = "./bin/test-mmio-fault.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3

--- a/test/test.toml
+++ b/test/test.toml
@@ -41,7 +41,7 @@ iterations = 2
 [[tests]]
 executor = "http"
 program = "./bin/test-kernel.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
@@ -49,7 +49,7 @@ expected_exit_code = 13
 [[tests]]
 executor = "http"
 program = "./bin/test-mmio-fault.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
@@ -141,7 +141,7 @@ expected_output = "Hello, world!"
 [[tests]]
 executor = "terminal"
 program = "./bin/test-kernel.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 13
@@ -149,7 +149,7 @@ expected_exit_code = 13
 [[tests]]
 executor = "terminal"
 program = "./bin/test-mmio-fault.elf"
-extra_nanvixd_args = "-ramfs README.md"
+extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3


### PR DESCRIPTION
Replace the ad-hoc RAMFS input used by test-kernel and test-mmio-fault with a proper page-aligned FAT32 image generated by mkramfs.

This change adds a dedicated build flow for a test RAMFS image and updates test configs to consume that image consistently across standalone, multi-process, single-process, and L2 suites.

Key changes:
- Wire test RAMFS into top-level build/clean for microvm/hyperlight.
- Add explicit targets for test-kernel-ramfs image generation.
- Create seed marker target and build image from it with mkramfs.
- Keep cleanup of generated seed directory and image.
- Use file-based dependencies so RAMFS generation is incremental.
- Replace RAMFS argument in test manifests from README to ./bin/test-kernel-ramfs.img.

Rationale:
README.md was a placeholder RAMFS argument and not an explicit aligned RAMFS image for these fault-oriented tests. Building a dedicated mkramfs image makes setup reproducible and semantically correct.