### PR TITLE
[ci] Run shim integration tests sequentially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
           set -Eeuo pipefail
           echo "Running shim integration tests with NANVIX_DIR=${NANVIX_DIR}"
           cargo test --no-default-features \
-            -p containerd-shim-nanvix-v1 --test integration -- --nocapture
+            -p containerd-shim-nanvix-v1 --test integration -- --nocapture --test-threads=1
 
       - name: "Post-Cleanup Dangling Resources"
         if: always()


### PR DESCRIPTION
The `test_standalone_lifecycle_no_ramfs` test fails intermittently when it runs concurrently with `test_standalone_lifecycle_with_ramfs`. Both lifecycle tests spawn separate nanvixd processes that each initialize a Hyperlight VM backed by KVM. On CI runners, concurrent KVM VM creation causes resource contention: a nanvixd instance may pass the TCP readiness check during prepare() but crash or become unresponsive before start() can send its HTTP POST, resulting in "Connection refused".

Add `--test-threads=1` to the shim integration `cargo test` invocation so the lifecycle tests execute sequentially, eliminating the race.

Closes #2016