### PR TITLE
[shim] Correct JSON format for UserVmIdentifier

### DIFF
--- a/src/libs/control-plane-api/Cargo.toml
+++ b/src/libs/control-plane-api/Cargo.toml
@@ -19,6 +19,8 @@ user-vm-api = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["std"] }
 
 [features]
 default = []

--- a/src/libs/control-plane-api/src/lib.rs
+++ b/src/libs/control-plane-api/src/lib.rs
@@ -562,3 +562,453 @@ impl ControlPlaneRegistrationMessage {
         }
     }
 }
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::serde::{
+        Deserialize,
+        Serialize,
+    };
+
+    /// Mirrors the `Kill` message struct from `nanvix-http::message` so that the test suite can
+    /// verify JSON wire-format compatibility without pulling in the full HTTP crate.
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    struct Kill {
+        user_vm_id: UserVmIdentifier,
+    }
+
+    // ==================== UserVmIdentifier JSON Tests ====================
+
+    /// `UserVmIdentifier` must serialize as a nested object `{"value": N}`, not a bare integer.
+    #[test]
+    fn user_vm_identifier_serializes_as_nested_object() {
+        let id = UserVmIdentifier::new(42);
+        let result = serde_json::to_string(&id);
+        assert!(result.is_ok(), "serialize UserVmIdentifier should succeed");
+        if let Ok(json) = result {
+            assert_eq!(
+                json, r#"{"value":42}"#,
+                "UserVmIdentifier should serialize as nested object"
+            );
+        }
+    }
+
+    /// A bare integer must fail to deserialize as `UserVmIdentifier`.
+    #[test]
+    fn user_vm_identifier_rejects_bare_integer() {
+        let result = serde_json::from_str::<UserVmIdentifier>("42");
+        assert!(result.is_err(), "bare integer should not deserialize as UserVmIdentifier");
+    }
+
+    /// The nested `{{"value": N}}` format must round-trip through serde.
+    #[test]
+    fn user_vm_identifier_roundtrip() {
+        let id = UserVmIdentifier::new(4132086170);
+        let result = serde_json::to_string(&id);
+        assert!(result.is_ok(), "serialize UserVmIdentifier should succeed");
+        if let Ok(json) = result {
+            let result2 = serde_json::from_str::<UserVmIdentifier>(&json);
+            assert!(result2.is_ok(), "deserialize UserVmIdentifier should succeed");
+            if let Ok(recovered) = result2 {
+                assert_eq!(id, recovered, "UserVmIdentifier should round-trip through JSON");
+            }
+        }
+    }
+
+    /// A Kill message with `{"user_vm_id": N}` (bare integer) must fail deserialization — this is
+    /// the exact bug from issue #2017.
+    #[test]
+    fn kill_message_rejects_bare_integer_user_vm_id() {
+        let bad_json = r#"{"user_vm_id":4132086170}"#;
+        let result = serde_json::from_str::<Kill>(bad_json);
+        assert!(result.is_err(), "Kill with bare-integer user_vm_id should fail deserialization");
+    }
+
+    /// A Kill message with `{"user_vm_id": {"value": N}}` must deserialize correctly.
+    #[test]
+    fn kill_message_accepts_nested_user_vm_id() {
+        let good_json = r#"{"user_vm_id":{"value":4132086170}}"#;
+        let result = serde_json::from_str::<Kill>(good_json);
+        assert!(result.is_ok(), "Kill with nested user_vm_id should succeed");
+        if let Ok(msg) = result {
+            assert_eq!(
+                msg.user_vm_id,
+                UserVmIdentifier::new(4132086170),
+                "parsed user_vm_id should match"
+            );
+        }
+    }
+
+    /// A Kill message must round-trip through serde_json and always produce the nested format.
+    #[test]
+    fn kill_message_serialization_roundtrip() {
+        let msg = Kill {
+            user_vm_id: UserVmIdentifier::new(99),
+        };
+        let result = serde_json::to_string(&msg);
+        assert!(result.is_ok(), "serialize Kill should succeed");
+        if let Ok(json) = result {
+            assert_eq!(
+                json, r#"{"user_vm_id":{"value":99}}"#,
+                "Kill should serialize with nested user_vm_id"
+            );
+            let result2 = serde_json::from_str::<Kill>(&json);
+            assert!(result2.is_ok(), "deserialize Kill should succeed");
+            if let Ok(recovered) = result2 {
+                assert_eq!(
+                    recovered.user_vm_id, msg.user_vm_id,
+                    "Kill should round-trip through JSON"
+                );
+            }
+        }
+    }
+
+    // ==================== NanvixdControlMessage Tests ====================
+
+    /// WIRE_SIZE must equal 1 byte.
+    #[test]
+    fn nanvixd_control_message_wire_size() {
+        assert_eq!(NanvixdControlMessage::WIRE_SIZE, 1, "wire size should be 1 byte");
+    }
+
+    /// `new()` followed by `cmd()` must return the same command.
+    #[test]
+    fn nanvixd_control_message_new_and_cmd() {
+        let msg = NanvixdControlMessage::new(NanvixdCommand::Shutdown);
+        assert_eq!(msg.cmd(), NanvixdCommand::Shutdown, "cmd() should return Shutdown");
+    }
+
+    /// Shutdown command must round-trip through `to_bytes` / `try_from_bytes`.
+    #[test]
+    fn nanvixd_control_message_roundtrip_shutdown() {
+        let msg = NanvixdControlMessage::new(NanvixdCommand::Shutdown);
+        let mut buf = [0u8; NanvixdControlMessage::WIRE_SIZE];
+        msg.to_bytes(&mut buf);
+        let result = NanvixdControlMessage::try_from_bytes(&buf);
+        assert!(result.is_ok(), "deserialize Shutdown should succeed");
+        if let Ok(recovered) = result {
+            assert_eq!(
+                recovered.cmd(),
+                NanvixdCommand::Shutdown,
+                "roundtrip should preserve command"
+            );
+        }
+    }
+
+    /// An invalid command byte must be rejected by `try_from_bytes`.
+    #[test]
+    fn nanvixd_control_message_rejects_invalid_command() {
+        let buf = [0xFFu8; NanvixdControlMessage::WIRE_SIZE];
+        let result = NanvixdControlMessage::try_from_bytes(&buf);
+        assert!(result.is_err(), "invalid command byte 0xFF should be rejected");
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidData, "error kind should be InvalidData");
+        }
+    }
+
+    // ==================== LinuxdControlMessage Tests ====================
+
+    /// WIRE_SIZE must equal 5 bytes (1 command + 4 gateway_id).
+    #[test]
+    fn linuxd_control_message_wire_size() {
+        assert_eq!(LinuxdControlMessage::WIRE_SIZE, 5, "wire size should be 5 bytes");
+    }
+
+    /// `new()` followed by accessors must return the construction arguments.
+    #[test]
+    fn linuxd_control_message_new_and_accessors() {
+        let msg = LinuxdControlMessage::new(LinuxdCommand::GatewayReady, 42);
+        assert_eq!(msg.cmd(), LinuxdCommand::GatewayReady, "cmd() should return GatewayReady");
+        assert_eq!(msg.gateway_id(), 42, "gateway_id() should return 42");
+    }
+
+    /// GatewayReady command must round-trip through `to_bytes` / `try_from_bytes`.
+    #[test]
+    fn linuxd_control_message_roundtrip() {
+        let msg = LinuxdControlMessage::new(LinuxdCommand::GatewayReady, 0xDEADBEEF);
+        let mut buf = [0u8; LinuxdControlMessage::WIRE_SIZE];
+        msg.to_bytes(&mut buf);
+        let result = LinuxdControlMessage::try_from_bytes(&buf);
+        assert!(result.is_ok(), "deserialize GatewayReady should succeed");
+        if let Ok(recovered) = result {
+            assert_eq!(
+                recovered.cmd(),
+                LinuxdCommand::GatewayReady,
+                "roundtrip should preserve command"
+            );
+            assert_eq!(recovered.gateway_id(), 0xDEADBEEF, "roundtrip should preserve gateway_id");
+        }
+    }
+
+    /// Zero gateway_id round-trips correctly.
+    #[test]
+    fn linuxd_control_message_roundtrip_zero_gateway_id() {
+        let msg = LinuxdControlMessage::new(LinuxdCommand::GatewayReady, 0);
+        let mut buf = [0u8; LinuxdControlMessage::WIRE_SIZE];
+        msg.to_bytes(&mut buf);
+        let result = LinuxdControlMessage::try_from_bytes(&buf);
+        assert!(result.is_ok(), "deserialize should succeed");
+        if let Ok(recovered) = result {
+            assert_eq!(recovered.gateway_id(), 0, "zero gateway_id should round-trip");
+        }
+    }
+
+    /// u32::MAX gateway_id round-trips correctly.
+    #[test]
+    fn linuxd_control_message_roundtrip_max_gateway_id() {
+        let msg = LinuxdControlMessage::new(LinuxdCommand::GatewayReady, u32::MAX);
+        let mut buf = [0u8; LinuxdControlMessage::WIRE_SIZE];
+        msg.to_bytes(&mut buf);
+        let result = LinuxdControlMessage::try_from_bytes(&buf);
+        assert!(result.is_ok(), "deserialize should succeed");
+        if let Ok(recovered) = result {
+            assert_eq!(recovered.gateway_id(), u32::MAX, "u32::MAX gateway_id should round-trip");
+        }
+    }
+
+    /// An invalid command byte must be rejected by `try_from_bytes`.
+    #[test]
+    fn linuxd_control_message_rejects_invalid_command() {
+        let buf = [0xFFu8; LinuxdControlMessage::WIRE_SIZE];
+        let result = LinuxdControlMessage::try_from_bytes(&buf);
+        assert!(result.is_err(), "invalid command byte 0xFF should be rejected");
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidData, "error kind should be InvalidData");
+        }
+    }
+
+    // ==================== ControlPlaneRegistrationMessage Tests ====================
+
+    /// HEADER_SIZE must equal 7 bytes (1 peer_kind + 4 user_vm_id + 2 tenant_id_len).
+    #[test]
+    fn registration_header_size() {
+        assert_eq!(ControlPlaneRegistrationMessage::HEADER_SIZE, 7, "header should be 7 bytes");
+    }
+
+    /// `for_linuxd` creates a LinuxDaemon registration with the given tenant_id.
+    #[test]
+    fn registration_for_linuxd_valid() {
+        let result = ControlPlaneRegistrationMessage::for_linuxd("tenant-abc");
+        assert!(result.is_ok(), "valid tenant_id should be accepted");
+        if let Ok(msg) = result {
+            assert_eq!(msg.peer_kind(), ControlPlanePeerKind::LinuxDaemon, "should be LinuxDaemon");
+            assert_eq!(
+                msg.tenant_id(),
+                Some("tenant-abc"),
+                "tenant_id should match construction argument"
+            );
+            assert_eq!(msg.user_vm_id(), None, "LinuxDaemon should not have user_vm_id");
+        }
+    }
+
+    /// `for_linuxd` rejects an empty tenant_id.
+    #[test]
+    fn registration_for_linuxd_rejects_empty_tenant() {
+        let result = ControlPlaneRegistrationMessage::for_linuxd("");
+        assert!(result.is_err(), "empty tenant_id should be rejected");
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidInput, "error kind should be InvalidInput");
+        }
+    }
+
+    /// `for_linuxd` rejects a tenant_id that exceeds MAX_TENANT_ID_LEN.
+    #[test]
+    fn registration_for_linuxd_rejects_oversized_tenant() {
+        let long_tenant = "a".repeat(ControlPlaneRegistrationMessage::MAX_TENANT_ID_LEN + 1);
+        let result = ControlPlaneRegistrationMessage::for_linuxd(&long_tenant);
+        assert!(result.is_err(), "oversized tenant_id should be rejected");
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidInput, "error kind should be InvalidInput");
+        }
+    }
+
+    /// `for_linuxd` accepts a tenant_id at exactly MAX_TENANT_ID_LEN.
+    #[test]
+    fn registration_for_linuxd_accepts_max_len_tenant() {
+        let max_tenant = "b".repeat(ControlPlaneRegistrationMessage::MAX_TENANT_ID_LEN);
+        let result = ControlPlaneRegistrationMessage::for_linuxd(&max_tenant);
+        assert!(result.is_ok(), "max-length tenant_id should be accepted");
+        if let Ok(msg) = result {
+            assert_eq!(msg.tenant_id(), Some(max_tenant.as_str()), "tenant_id should match");
+        }
+    }
+
+    /// `for_uservm` creates a UserVm registration with the given identifier.
+    #[test]
+    fn registration_for_uservm_valid() {
+        let vm_id = UserVmIdentifier::new(777);
+        let msg = ControlPlaneRegistrationMessage::for_uservm(vm_id);
+        assert_eq!(msg.peer_kind(), ControlPlanePeerKind::UserVm, "should be UserVm");
+        assert_eq!(msg.user_vm_id(), Some(vm_id), "user_vm_id should match construction argument");
+        assert_eq!(msg.tenant_id(), None, "UserVm should not have tenant_id");
+    }
+
+    /// `wire_size` for a linuxd registration includes header + tenant_id bytes.
+    #[test]
+    fn registration_wire_size_linuxd() {
+        let result = ControlPlaneRegistrationMessage::for_linuxd("hello");
+        assert!(result.is_ok(), "valid tenant_id should be accepted");
+        if let Ok(msg) = result {
+            assert_eq!(
+                msg.wire_size(),
+                ControlPlaneRegistrationMessage::HEADER_SIZE + 5,
+                "wire_size should be HEADER_SIZE + tenant_id length"
+            );
+        }
+    }
+
+    /// `wire_size` for a uservm registration is exactly HEADER_SIZE (empty tenant_id).
+    #[test]
+    fn registration_wire_size_uservm() {
+        let msg = ControlPlaneRegistrationMessage::for_uservm(UserVmIdentifier::new(1));
+        assert_eq!(
+            msg.wire_size(),
+            ControlPlaneRegistrationMessage::HEADER_SIZE,
+            "wire_size should be HEADER_SIZE for UserVm"
+        );
+    }
+
+    /// LinuxDaemon registration must round-trip through `to_bytes` / `try_from_parts`.
+    #[test]
+    fn registration_roundtrip_linuxd() {
+        let result = ControlPlaneRegistrationMessage::for_linuxd("my-tenant");
+        assert!(result.is_ok(), "valid tenant should be accepted");
+        if let Ok(original) = result {
+            let result2 = original.to_bytes();
+            assert!(result2.is_ok(), "serialize should succeed");
+            if let Ok(bytes) = result2 {
+                let header_result: Result<&[u8; ControlPlaneRegistrationMessage::HEADER_SIZE], _> =
+                    bytes[..ControlPlaneRegistrationMessage::HEADER_SIZE].try_into();
+                assert!(header_result.is_ok(), "header slice should succeed");
+                if let Ok(header) = header_result {
+                    let tenant_payload = &bytes[ControlPlaneRegistrationMessage::HEADER_SIZE..];
+                    let result3 =
+                        ControlPlaneRegistrationMessage::try_from_parts(header, tenant_payload);
+                    assert!(result3.is_ok(), "deserialize should succeed");
+                    if let Ok(recovered) = result3 {
+                        assert_eq!(recovered, original, "linuxd registration should round-trip");
+                    }
+                }
+            }
+        }
+    }
+
+    /// UserVm registration must round-trip through `to_bytes` / `try_from_parts`.
+    #[test]
+    fn registration_roundtrip_uservm() {
+        let original =
+            ControlPlaneRegistrationMessage::for_uservm(UserVmIdentifier::new(0xCAFEBABE));
+        let result = original.to_bytes();
+        assert!(result.is_ok(), "serialize should succeed");
+        if let Ok(bytes) = result {
+            let header_result: Result<&[u8; ControlPlaneRegistrationMessage::HEADER_SIZE], _> =
+                bytes[..ControlPlaneRegistrationMessage::HEADER_SIZE].try_into();
+            assert!(header_result.is_ok(), "header slice should succeed");
+            if let Ok(header) = header_result {
+                let tenant_payload = &bytes[ControlPlaneRegistrationMessage::HEADER_SIZE..];
+                let result2 =
+                    ControlPlaneRegistrationMessage::try_from_parts(header, tenant_payload);
+                assert!(result2.is_ok(), "deserialize should succeed");
+                if let Ok(recovered) = result2 {
+                    assert_eq!(recovered, original, "uservm registration should round-trip");
+                }
+            }
+        }
+    }
+
+    /// `try_from_parts` rejects an invalid peer-kind byte.
+    #[test]
+    fn registration_rejects_invalid_peer_kind() {
+        let mut header = [0u8; ControlPlaneRegistrationMessage::HEADER_SIZE];
+        header[ControlPlaneRegistrationMessage::PEER_KIND_OFFSET] = 0xFF;
+        let result = ControlPlaneRegistrationMessage::try_from_parts(&header, &[]);
+        assert!(result.is_err(), "invalid peer kind should be rejected");
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidData, "error kind should be InvalidData");
+        }
+    }
+
+    /// `try_from_parts` rejects a LinuxDaemon registration with an empty tenant_id payload.
+    #[test]
+    fn registration_rejects_linuxd_without_tenant() {
+        let mut header = [0u8; ControlPlaneRegistrationMessage::HEADER_SIZE];
+        header[ControlPlaneRegistrationMessage::PEER_KIND_OFFSET] =
+            ControlPlanePeerKind::LinuxDaemon.into();
+        // tenant_id_len = 0, payload = empty
+        let result = ControlPlaneRegistrationMessage::try_from_parts(&header, &[]);
+        assert!(result.is_err(), "linuxd without tenant_id should be rejected");
+    }
+
+    /// `try_from_parts` rejects a UserVm registration that includes a tenant_id payload.
+    #[test]
+    fn registration_rejects_uservm_with_tenant() {
+        let tenant = b"unexpected";
+        // "unexpected" is 10 bytes — use the literal to avoid a truncating cast.
+        let tenant_len = 10u16.to_le_bytes();
+        let mut header = [0u8; ControlPlaneRegistrationMessage::HEADER_SIZE];
+        header[ControlPlaneRegistrationMessage::PEER_KIND_OFFSET] =
+            ControlPlanePeerKind::UserVm.into();
+        header[ControlPlaneRegistrationMessage::TENANT_ID_LEN_OFFSET] = tenant_len[0];
+        header[ControlPlaneRegistrationMessage::TENANT_ID_LEN_OFFSET + 1] = tenant_len[1];
+        let result = ControlPlaneRegistrationMessage::try_from_parts(&header, tenant);
+        assert!(result.is_err(), "uservm with tenant_id should be rejected");
+    }
+
+    /// `try_from_parts` rejects a header whose tenant_id_len does not match the payload length.
+    #[test]
+    fn registration_rejects_tenant_length_mismatch() {
+        let mut header = [0u8; ControlPlaneRegistrationMessage::HEADER_SIZE];
+        header[ControlPlaneRegistrationMessage::PEER_KIND_OFFSET] =
+            ControlPlanePeerKind::LinuxDaemon.into();
+        // Claim 10 bytes in the header but provide only 3 in the payload.
+        let tenant_len = 10u16.to_le_bytes();
+        header[ControlPlaneRegistrationMessage::TENANT_ID_LEN_OFFSET] = tenant_len[0];
+        header[ControlPlaneRegistrationMessage::TENANT_ID_LEN_OFFSET + 1] = tenant_len[1];
+        let result = ControlPlaneRegistrationMessage::try_from_parts(&header, b"abc");
+        assert!(result.is_err(), "length mismatch should be rejected");
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidData, "error kind should be InvalidData");
+        }
+    }
+
+    /// `try_from_parts` rejects a tenant_id_len that exceeds MAX_TENANT_ID_LEN.
+    #[test]
+    fn registration_rejects_oversized_tenant_in_header() {
+        // MAX_TENANT_ID_LEN is 256, so MAX + 1 = 257 = 0x0101.
+        let huge_len = 257u16.to_le_bytes();
+        let mut header = [0u8; ControlPlaneRegistrationMessage::HEADER_SIZE];
+        header[ControlPlaneRegistrationMessage::PEER_KIND_OFFSET] =
+            ControlPlanePeerKind::LinuxDaemon.into();
+        header[ControlPlaneRegistrationMessage::TENANT_ID_LEN_OFFSET] = huge_len[0];
+        header[ControlPlaneRegistrationMessage::TENANT_ID_LEN_OFFSET + 1] = huge_len[1];
+        let payload = vec![b'x'; ControlPlaneRegistrationMessage::MAX_TENANT_ID_LEN + 1];
+        let result = ControlPlaneRegistrationMessage::try_from_parts(&header, &payload);
+        assert!(result.is_err(), "oversized tenant_id_len in header should be rejected");
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidData, "error kind should be InvalidData");
+        }
+    }
+
+    /// `try_from_parts` rejects a tenant_id payload that is not valid UTF-8.
+    #[test]
+    fn registration_rejects_invalid_utf8_tenant() {
+        let bad_bytes: &[u8] = &[0xFF, 0xFE];
+        // bad_bytes is 2 bytes long.
+        let tenant_len = 2u16.to_le_bytes();
+        let mut header = [0u8; ControlPlaneRegistrationMessage::HEADER_SIZE];
+        header[ControlPlaneRegistrationMessage::PEER_KIND_OFFSET] =
+            ControlPlanePeerKind::LinuxDaemon.into();
+        header[ControlPlaneRegistrationMessage::TENANT_ID_LEN_OFFSET] = tenant_len[0];
+        header[ControlPlaneRegistrationMessage::TENANT_ID_LEN_OFFSET + 1] = tenant_len[1];
+        let result = ControlPlaneRegistrationMessage::try_from_parts(&header, bad_bytes);
+        assert!(result.is_err(), "invalid UTF-8 tenant_id should be rejected");
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidData, "error kind should be InvalidData");
+        }
+    }
+}

--- a/src/libs/nanvix-shim-standalone/src/mode.rs
+++ b/src/libs/nanvix-shim-standalone/src/mode.rs
@@ -492,7 +492,7 @@ impl ExecutionMode for StandaloneMode {
             // Give the app a moment to start before sending KILL.
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-            let kill_body: String = format!(r#"{{"user_vm_id":{}}}"#, vm_id);
+            let kill_body: String = format!(r#"{{"user_vm_id":{{"value":{}}}}}"#, vm_id);
 
             // Use a simple TCP request to send KILL (replicating http_post logic).
             use tokio::io::{
@@ -557,7 +557,7 @@ impl ExecutionMode for StandaloneMode {
         let vm_id = *self.user_vm_id.lock().await;
 
         if let (Some(addr), Some(id)) = (http_addr, vm_id) {
-            let kill_body: String = format!(r#"{{"user_vm_id":{}}}"#, id);
+            let kill_body: String = format!(r#"{{"user_vm_id":{{"value":{}}}}}"#, id);
 
             match self.http_post(&addr, "KILL", &kill_body).await {
                 Ok(response) => {


### PR DESCRIPTION
## Summary

- Correct JSON format for `UserVmIdentifier` in the shim protocol.
- Add unit tests for `control-plane-api`.

## Commits

- `[shim] B: Correct JSON fmt for UserVmIdentifier`
- `[control-plane-api] E: Add unit tests`
