### PR TITLE
[sorted-vec] E: Add Verus Verification

### DIFF
--- a/src/libs/sorted-vec/Cargo.toml
+++ b/src/libs/sorted-vec/Cargo.toml
@@ -13,7 +13,11 @@ homepage.workspace = true
 [lib]
 crate-type = ["lib"]
 
+[package.metadata.verus]
+verify = true
+
 [dependencies]
+vstd = { workspace = true }
 
 [features]
 default = []

--- a/src/libs/sorted-vec/src/lib.proof.rs
+++ b/src/libs/sorted-vec/src/lib.proof.rs
@@ -1,0 +1,229 @@
+// Macro: reveals vstd's opaque ordering axioms (obeys_cmp_spec and friends).
+// Reveals are local to the calling function; a proof fn can't propagate them.
+// Use verus_proof_expr! so the macro expands inside verus! blocks.
+#[allow(unused_macros)]
+macro_rules! reveal_cmp_laws {
+    () => {
+        verus_proof_expr! {
+            {
+                reveal(::vstd::laws_cmp::obeys_cmp_spec);
+                reveal(::vstd::laws_cmp::obeys_cmp_partial_ord);
+                reveal(::vstd::laws_cmp::obeys_cmp_ord);
+                reveal(::vstd::laws_cmp::obeys_partial_cmp_spec_properties);
+                reveal(::vstd::laws_eq::obeys_eq_spec_properties);
+            }
+        }
+    };
+}
+
+verus! {
+
+proof fn lemma_insert_replace_maintains_inv<T: Ord>(old_seq: Seq<T>, idx: int, value: T)
+    requires
+        spec_strictly_sorted(old_seq),
+        0 <= idx < old_seq.len(),
+        old_seq[idx].cmp_spec(&value) is Equal,
+        obeys_cmp_spec::<T>(),
+    ensures
+        old_seq.remove(idx).insert(idx, value) =~= old_seq.update(idx, value),
+        spec_strictly_sorted(old_seq.update(idx, value)),
+        old_seq.update(idx, value).len() == old_seq.len(),
+        spec_contains(old_seq.update(idx, value), value),
+        old_seq.update(idx, value).contains(value),
+        old_seq.contains(old_seq[idx]),
+        forall|v: T| #![auto] old_seq.update(idx, value).contains(v)
+            ==> (old_seq.contains(v) || v == value),
+{
+    reveal_cmp_laws!();
+    let new_seq = old_seq.update(idx, value);
+
+    assert forall|i: int, j: int|
+        #![trigger new_seq[i], new_seq[j]]
+        0 <= i < j < new_seq.len()
+        implies new_seq[i].cmp_spec(&new_seq[j]) is Less
+    by {
+        if i == idx {
+            assert(old_seq[idx].cmp_spec(&old_seq[j]) is Less);
+        } else if j == idx {
+            assert(old_seq[i].cmp_spec(&old_seq[idx]) is Less);
+        } else {
+            assert(old_seq[i].cmp_spec(&old_seq[j]) is Less);
+        }
+    }
+
+    assert(new_seq[idx] == value);
+
+    assert forall|v: T|
+        new_seq.contains(v)
+        implies (old_seq.contains(v) || v == value)
+    by {
+        let k = choose|k: int| 0 <= k < new_seq.len() && new_seq[k] == v;
+        if k == idx {
+            assert(v == value);
+        } else {
+            assert(new_seq[k] == old_seq[k]);
+        }
+    }
+}
+
+proof fn lemma_insert_new_maintains_inv<T: Ord>(old_seq: Seq<T>, idx: int, value: T)
+    requires
+        spec_strictly_sorted(old_seq),
+        0 <= idx <= old_seq.len(),
+        !spec_contains(old_seq, value),
+        forall|k: int| #![auto] 0 <= k < idx ==> old_seq[k].cmp_spec(&value) is Less,
+        forall|k: int| #![auto] idx <= k < old_seq.len() ==> value.cmp_spec(&old_seq[k]) is Less,
+        obeys_cmp_spec::<T>(),
+    ensures
+        spec_strictly_sorted(old_seq.insert(idx, value)),
+        old_seq.insert(idx, value).len() == old_seq.len() + 1,
+        spec_contains(old_seq.insert(idx, value), value),
+        old_seq.insert(idx, value).contains(value),
+        forall|v: T| #![auto] old_seq.insert(idx, value).contains(v)
+            ==> (old_seq.contains(v) || v == value),
+{
+    reveal_cmp_laws!();
+    let new_seq = old_seq.insert(idx, value);
+
+    assert forall|i: int, j: int|
+        #![trigger new_seq[i], new_seq[j]]
+        0 <= i < j < new_seq.len()
+        implies new_seq[i].cmp_spec(&new_seq[j]) is Less
+    by {
+        if i < idx && j == idx {
+            assert(old_seq[i].cmp_spec(&value) is Less);
+        } else if i < idx && j > idx {
+            assert(old_seq[i].cmp_spec(&old_seq[j - 1]) is Less);
+        } else if i == idx && j > idx {
+            assert(value.cmp_spec(&old_seq[j - 1]) is Less);
+        } else if i > idx {
+            assert(old_seq[i - 1].cmp_spec(&old_seq[j - 1]) is Less);
+        }
+    }
+
+    assert(new_seq[idx] == value);
+
+    assert forall|v: T|
+        new_seq.contains(v)
+        implies (old_seq.contains(v) || v == value)
+    by {
+        let k = choose|k: int| 0 <= k < new_seq.len() && new_seq[k] == v;
+        if k == idx {
+            assert(v == value);
+        } else if k < idx {
+            assert(new_seq[k] == old_seq[k]);
+        } else {
+            assert(new_seq[k] == old_seq[k - 1]);
+        }
+    }
+}
+
+proof fn lemma_remove_maintains_inv<T: Ord>(old_seq: Seq<T>, idx: int, value: T)
+    requires
+        spec_strictly_sorted(old_seq),
+        0 <= idx < old_seq.len(),
+        old_seq[idx].cmp_spec(&value) is Equal,
+        obeys_cmp_spec::<T>(),
+    ensures
+        spec_strictly_sorted(old_seq.remove(idx)),
+        old_seq.remove(idx).len() == old_seq.len() - 1,
+        !spec_contains(old_seq.remove(idx), value),
+        old_seq.contains(old_seq[idx]),
+        forall|v: T| #![auto] old_seq.remove(idx).contains(v) ==> old_seq.contains(v),
+        forall|v: T| #![auto] old_seq.contains(v) && v != old_seq[idx] ==> old_seq.remove(idx).contains(v),
+{
+    reveal_cmp_laws!();
+    let rem = old_seq.remove(idx);
+
+    assert forall|i: int, j: int|
+        #![trigger rem[i], rem[j]]
+        0 <= i < j < rem.len()
+        implies rem[i].cmp_spec(&rem[j]) is Less
+    by {
+        let oi = if i < idx { i } else { i + 1 };
+        let oj = if j < idx { j } else { j + 1 };
+        assert(rem[i] == old_seq[oi]);
+        assert(rem[j] == old_seq[oj]);
+    }
+
+    assert forall|i: int| #![auto]
+        0 <= i < rem.len()
+        implies !(rem[i].cmp_spec(&value) is Equal)
+    by {
+        let oi = if i < idx { i } else { i + 1 };
+        assert(rem[i] == old_seq[oi]);
+        if oi < idx {
+            assert(old_seq[oi].cmp_spec(&old_seq[idx]) is Less);
+        } else {
+            assert(old_seq[idx].cmp_spec(&old_seq[oi]) is Less);
+        }
+    }
+
+    assert forall|v: T|
+        rem.contains(v) implies old_seq.contains(v)
+    by {
+        let k = choose|k: int| 0 <= k < rem.len() && rem[k] == v;
+        if k < idx { assert(rem[k] == old_seq[k]); }
+        else { assert(rem[k] == old_seq[k + 1]); }
+    }
+
+    assert forall|v: T|
+        old_seq.contains(v) && v != old_seq[idx] implies rem.contains(v)
+    by {
+        let k = choose|k: int| 0 <= k < old_seq.len() && old_seq[k] == v;
+        if k < idx { assert(rem[k] == v); }
+        else if k > idx { assert(rem[k - 1] == v); }
+        else { assert(false); }
+    }
+}
+
+/// get: uniqueness — strict sorting means at most one Ord-equal element.
+proof fn lemma_get_uniqueness<T: Ord>(seq: Seq<T>, index: int, value: T)
+    requires
+        spec_strictly_sorted(seq),
+        obeys_cmp_spec::<T>(),
+        0 <= index < seq.len(),
+        seq[index].cmp_spec(&value) is Equal,
+    ensures
+        forall|j: int| #![auto] 0 <= j < seq.len() && j != index
+            ==> !(seq[j].cmp_spec(&value) is Equal),
+{
+    reveal_cmp_laws!();
+    assert forall|j: int| #![auto]
+        0 <= j < seq.len() && j != index
+        implies !(seq[j].cmp_spec(&value) is Equal)
+    by {
+        if j < index {
+            assert(seq[j].cmp_spec(&seq[index]) is Less);
+        } else {
+            assert(seq[index].cmp_spec(&seq[j]) is Less);
+        }
+    }
+}
+
+/// remove_by: forward frame — non-removed elements preserved after Vec::remove.
+proof fn lemma_remove_forward_frame<T: Ord>(old_seq: Seq<T>, index: int, removed: T)
+    requires
+        0 <= index < old_seq.len(),
+        old_seq[index] == removed,
+    ensures
+        forall|v: T| #![auto]
+            old_seq.contains(v) && v != removed
+            ==> old_seq.remove(index).contains(v),
+{
+    assert forall|v: T| #![auto]
+        old_seq.contains(v) && v != removed
+        implies old_seq.remove(index).contains(v)
+    by {
+        let k = choose|k: int| 0 <= k < old_seq.len() && old_seq[k] == v;
+        if k < index {
+            assert(old_seq.remove(index)[k] == v);
+        } else if k > index {
+            assert(old_seq.remove(index)[k - 1] == v);
+        } else {
+            assert(false);
+        }
+    }
+}
+
+} // verus!

--- a/src/libs/sorted-vec/src/lib.rs
+++ b/src/libs/sorted-vec/src/lib.rs
@@ -6,6 +6,8 @@
 //==================================================================================================
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(verus_keep_ghost, feature(proc_macro_hygiene))]
+#![cfg_attr(verus_keep_ghost, feature(allocator_api))]
 
 //==================================================================================================
 // Modules
@@ -21,8 +23,31 @@ mod test;
 extern crate alloc;
 
 use ::alloc::vec::Vec;
+use ::vstd::prelude::*;
+#[cfg(verus_keep_ghost)]
+use ::vstd::{
+    laws_cmp::{
+        obeys_cmp_ord,
+        obeys_cmp_partial_ord,
+        obeys_cmp_spec,
+        obeys_partial_cmp_spec_properties,
+    },
+    laws_eq::obeys_eq_spec_properties,
+    std_specs::{
+        cmp::*,
+        convert::FromSpecImpl,
+    },
+};
 
 //==================================================================================================
+// Include specifications.
+#[cfg(verus_keep_ghost)]
+include!("lib.spec.rs");
+
+// Include proofs.
+#[cfg(verus_keep_ghost)]
+include!("lib.proof.rs");
+
 // Structures
 //==================================================================================================
 
@@ -30,6 +55,15 @@ use ::alloc::vec::Vec;
 /// that Verus cannot verify.
 #[inline]
 #[allow(clippy::ptr_arg)]
+#[verus_verify(external_body)]
+#[verus_spec(prev =>
+    requires
+        index < old(v)@.len()
+    ensures
+        prev == old(v)@[index as int],
+        v@ == old(v)@.update(index as int, value),
+        v@.len() == old(v)@.len()
+)]
 fn vec_replace<T>(v: &mut Vec<T>, index: usize, value: T) -> T {
     ::core::mem::replace(&mut v[index], value)
 }
@@ -38,6 +72,13 @@ fn vec_replace<T>(v: &mut Vec<T>, index: usize, value: T) -> T {
 /// (`&mut Vec<T>` → `&mut [T]`) that Verus cannot verify.
 #[inline]
 #[allow(clippy::ptr_arg)]
+#[verus_verify(external_body)]
+#[verus_spec(ensures
+        v@.len() == old(v)@.len(),
+        forall|val: T| v@.contains(val) <==> old(v)@.contains(val),
+        forall|i: int, j: int| #![trigger v@[i], v@[j]]
+            0 <= i < j < v@.len() ==> !(v@[j].cmp_spec(&v@[i]) is Less)
+)]
 fn vec_sort_unstable<T: Ord>(v: &mut Vec<T>) {
     v.sort_unstable();
 }
@@ -51,7 +92,8 @@ fn vec_sort_unstable<T: Ord>(v: &mut Vec<T>) {
 /// Elements must implement [`Ord`] for sorting and searching. The vector does not allow
 /// duplicate elements; inserting a value that already exists replaces the old entry.
 ///
-#[derive(Debug, Clone)]
+#[cfg_attr(not(verus_keep_ghost), derive(Debug, Clone))]
+#[verus_verify]
 pub struct SortedVec<T: Ord> {
     /// Underlying storage.
     inner: Vec<T>,
@@ -61,6 +103,7 @@ pub struct SortedVec<T: Ord> {
 // Implementations
 //==================================================================================================
 
+#[verus_verify]
 impl<T: Ord> SortedVec<T> {
     ///
     /// # Description
@@ -71,6 +114,11 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// An empty sorted vector.
     ///
+    #[verus_spec(result =>
+        ensures
+            result.inv(),
+            result@ == Seq::<T>::empty()
+    )]
     pub fn new() -> Self {
         Self { inner: Vec::new() }
     }
@@ -88,6 +136,11 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// An empty sorted vector with the given capacity.
     ///
+    #[verus_spec(result =>
+        ensures
+            result.inv(),
+            result@ == Seq::<T>::empty()
+    )]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             inner: Vec::with_capacity(capacity),
@@ -103,6 +156,10 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// The number of elements.
     ///
+    #[verus_spec(result =>
+        ensures
+            result as int == self@.len()
+    )]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
@@ -116,6 +173,10 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// `true` if empty, `false` otherwise.
     ///
+    #[verus_spec(result =>
+        ensures
+            result <==> self@.len() == 0
+    )]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
@@ -129,6 +190,10 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// The number of elements the vector can hold without reallocating.
     ///
+    #[verus_spec(result =>
+        ensures
+            result as int >= self@.len()
+    )]
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
     }
@@ -138,6 +203,12 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// Clears all elements from the sorted vector.
     ///
+    #[verus_spec(requires
+            old(self).inv()
+        ensures
+            self.inv(),
+            self@ == Seq::<T>::empty()
+    )]
     pub fn clear(&mut self) {
         self.inner.clear();
     }
@@ -156,14 +227,52 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// `Some(old_value)` if the value was already present, `None` otherwise.
     ///
+    #[verus_spec(result =>
+        requires
+            old(self).inv(),
+            obeys_cmp_spec::<T>()
+        ensures
+            self.inv(),
+            // Biconditional: replacement iff value was Ord-present
+            result.is_some() <==> spec_contains(old(self)@, value),
+            // Replacement case: positional update at the Ord-equal index
+            result.is_some() ==> {
+                &&& old(self)@.contains(result.unwrap())
+                &&& result.unwrap().cmp_spec(&value) is Equal
+                &&& self@.len() == old(self)@.len()
+                &&& spec_contains(self@, value)
+                // POSITIONAL frame: self@ equals old@ with exactly one position updated
+                &&& exists|idx: int| #![auto] 0 <= idx < old(self)@.len()
+                    && old(self)@[idx].cmp_spec(&value) is Equal
+                    && self@ == old(self)@.update(idx, value)
+            },
+            // New insertion case: positional insert at sorted position
+            result.is_none() ==> {
+                &&& self@.len() == old(self)@.len() + 1
+                &&& spec_contains(self@, value)
+                // POSITIONAL frame: self@ equals old@ with value inserted at sorted position
+                &&& exists|idx: int| #![auto] 0 <= idx <= old(self)@.len()
+                    && self@ == old(self)@.insert(idx, value)
+            },
+            self@.contains(value),
+            // Bidirectional frame: no spurious elements introduced
+            forall|v: T| self@.contains(v) ==> (old(self)@.contains(v) || v == value)
+    )]
     pub fn insert(&mut self, value: T) -> Option<T> {
         match self.inner.binary_search(&value) {
             Ok(index) => {
                 let old_val: T = vec_replace(&mut self.inner, index, value);
+                proof! {
+                    lemma_insert_replace_maintains_inv(old(self)@, index as int, value);
+                }
                 Some(old_val)
             },
             Err(index) => {
                 self.inner.insert(index, value);
+                proof! {
+                    let ghost _vec_len: usize = vstd::std_specs::vec::spec_vec_len(&self.inner);
+                    lemma_insert_new_maintains_inv(old(self)@, index as int, value);
+                }
                 None
             },
         }
@@ -182,9 +291,38 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// `Some(removed_value)` if found, `None` otherwise.
     ///
+    #[verus_spec(result =>
+        requires
+            old(self).inv(),
+            obeys_cmp_spec::<T>()
+        ensures
+            self.inv(),
+            result.is_some() <==> spec_contains(old(self)@, *value),
+            // Found: positional removal at the Ord-equal index
+            result.is_some() ==> {
+                &&& result.unwrap().cmp_spec(value) is Equal
+                &&& self@.len() == old(self)@.len() - 1
+                &&& !spec_contains(self@, *value)
+                &&& old(self)@.contains(result.unwrap())
+                // POSITIONAL frame: self@ equals old@ with exactly one position removed
+                &&& exists|idx: int| #![auto] 0 <= idx < old(self)@.len()
+                    && old(self)@[idx] == result.unwrap()
+                    && self@ == old(self)@.remove(idx)
+            },
+            // Not found: state completely unchanged
+            result.is_none() ==> {
+                &&& !spec_contains(old(self)@, *value)
+                &&& self@ == old(self)@
+            },
+            // Bidirectional frame: no spurious elements
+            forall|v: T| self@.contains(v) ==> old(self)@.contains(v)
+    )]
     pub fn remove(&mut self, value: &T) -> Option<T> {
         match self.inner.binary_search(value) {
-            Ok(index) => Some(self.inner.remove(index)),
+            Ok(index) => {
+                proof! { lemma_remove_maintains_inv(self@, index as int, *value); }
+                Some(self.inner.remove(index))
+            },
             Err(_) => None,
         }
     }
@@ -207,13 +345,50 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// `Some(removed_value)` if found, `None` otherwise.
     ///
+    #[verus_spec(result =>
+        requires
+            old(self).inv(),
+            obeys_cmp_spec::<K>(),
+            // Key extraction is consistent with sorted order
+            forall|i: int, j: int, x: K, y: K| {
+                &&& 0 <= i < j < old(self)@.len()
+                &&& f.ensures((&old(self)@[i], ), x)
+                &&& f.ensures((&old(self)@[j], ), y)
+            } ==> !(x.cmp_spec(&y) is Greater)
+        ensures
+            self.inv(),
+            // Found: element removed, key matched
+            result.is_some() ==> {
+                &&& old(self)@.contains(result.unwrap())
+                &&& maps_to_key(f, &result.unwrap(), key)
+                &&& self@.len() == old(self)@.len() - 1
+                // Positional frame
+                &&& exists|idx: int| #![auto] 0 <= idx < old(self)@.len()
+                    && old(self)@[idx] == result.unwrap()
+                    && self@ == old(self)@.remove(idx)
+            },
+            // Not found: state unchanged
+            result.is_none() ==> self@ == old(self)@,
+            // Bidirectional frame
+            forall|v: T| self@.contains(v) ==> old(self)@.contains(v),
+            // Forward frame: non-removed elements preserved
+            result.is_some() ==> forall|v: T|
+                old(self)@.contains(v) && v != result.unwrap() ==> self@.contains(v)
+    )]
     pub fn remove_by<K, F>(&mut self, key: &K, f: F) -> Option<T>
     where
         K: Ord,
         F: FnMut(&T) -> K,
     {
         match self.inner.binary_search_by_key(key, f) {
-            Ok(index) => Some(self.inner.remove(index)),
+            Ok(index) => {
+                proof_decl! { let ghost old_seq = old(self)@; }
+                let removed = self.inner.remove(index);
+                proof! {
+                    lemma_remove_forward_frame(old_seq, index as int, removed);
+                }
+                Some(removed)
+            },
             Err(_) => None,
         }
     }
@@ -231,6 +406,13 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// `true` if the value is found, `false` otherwise.
     ///
+    #[verus_spec(result =>
+        requires
+            self.inv(),
+            obeys_cmp_spec::<T>()
+        ensures
+            result <==> spec_contains(self@, *value)
+    )]
     pub fn contains(&self, value: &T) -> bool {
         self.inner.binary_search(value).is_ok()
     }
@@ -248,9 +430,30 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// `Some(&element)` if found, `None` otherwise.
     ///
+    #[verus_spec(result =>
+        requires
+            self.inv(),
+            obeys_cmp_spec::<T>()
+        ensures
+            result.is_some() <==> spec_contains(self@, *value),
+            result.is_some() ==> {
+                &&& (*result.unwrap()).cmp_spec(value) is Equal
+                // Exact position: the returned element is at binary_search's index
+                &&& exists|i: int| #![auto] 0 <= i < self@.len()
+                    && self@[i] == *result.unwrap()
+                    && self@[i].cmp_spec(value) is Equal
+                    // Uniqueness: this is the ONLY Ord-equal element
+                    && forall|j: int| #![auto] 0 <= j < self@.len() && j != i ==> !(self@[j].cmp_spec(value) is Equal)
+            }
+    )]
     pub fn get(&self, value: &T) -> Option<&T> {
         match self.inner.binary_search(value) {
-            Ok(index) => Some(&self.inner[index]),
+            Ok(index) => {
+                proof! {
+                    lemma_get_uniqueness(self@, index as int, *value);
+                }
+                Some(&self.inner[index])
+            },
             Err(_) => None,
         }
     }
@@ -273,6 +476,30 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// `Some(&element)` if found, `None` otherwise.
     ///
+    #[verus_spec(result =>
+        requires
+            self.inv(),
+            obeys_cmp_spec::<K>(),
+            // Key extraction is deterministic (one output per input)
+            forall|i: int, x1: K, x2: K|
+                0 <= i < self@.len()
+                && f.ensures((&self@[i], ), x1)
+                && f.ensures((&self@[i], ), x2)
+                ==> x1 == x2,
+            // Key extraction is consistent with sorted order
+            forall|i: int, j: int, x: K, y: K| {
+                &&& 0 <= i < j < self@.len()
+                &&& f.ensures((&self@[i], ), x)
+                &&& f.ensures((&self@[j], ), y)
+            } ==> !(x.cmp_spec(&y) is Greater)
+        ensures
+            result.is_some() ==> {
+                &&& exists|i: int| #![auto] 0 <= i < self@.len() && self@[i] == *result.unwrap()
+                &&& maps_to_key(f, result.unwrap(), key)
+            },
+            result.is_none() ==> forall|i: int| #![auto]
+                0 <= i < self@.len() ==> !maps_to_key(f, &self@[i], key)
+    )]
     pub fn lookup_by<K, F>(&self, key: &K, f: F) -> Option<&T>
     where
         K: Ord,
@@ -280,7 +507,12 @@ impl<T: Ord> SortedVec<T> {
     {
         match self.inner.binary_search_by_key(key, f) {
             Ok(index) => Some(&self.inner[index]),
-            Err(_) => None,
+            Err(_) => {
+                proof! {
+                    reveal_cmp_laws!();
+                }
+                None
+            },
         }
     }
 
@@ -293,6 +525,15 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// `Some(&element)` if non-empty, `None` otherwise.
     ///
+    #[verus_spec(result =>
+        requires
+            self.inv()
+        ensures
+            result.is_some() <==> self@.len() > 0,
+            result.is_some() ==> *result.unwrap() == self@[0],
+            result.is_some() ==> forall|i: int| 0 < i < self@.len()
+                ==> (#[trigger] self@[0]).cmp_spec(&self@[i]) is Less
+    )]
     pub fn first(&self) -> Option<&T> {
         self.inner.first()
     }
@@ -306,6 +547,15 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// `Some(&element)` if non-empty, `None` otherwise.
     ///
+    #[verus_spec(result =>
+        requires
+            self.inv()
+        ensures
+            result.is_some() <==> self@.len() > 0,
+            result.is_some() ==> *result.unwrap() == self@[self@.len() - 1],
+            result.is_some() ==> forall|i: int| 0 <= i < self@.len() - 1
+                ==> (#[trigger] self@[i]).cmp_spec(&self@[self@.len() - 1]) is Less
+    )]
     pub fn last(&self) -> Option<&T> {
         self.inner.last()
     }
@@ -319,6 +569,14 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// An iterator yielding references to elements in ascending order.
     ///
+    #[verus_spec(iter =>
+        ensures
+            ({
+            let (index, seq) = iter@;
+            &&& index == 0
+            &&& seq == self@
+        })
+    )]
     pub fn iter(&self) -> ::core::slice::Iter<'_, T> {
         self.inner.iter()
     }
@@ -332,6 +590,12 @@ impl<T: Ord> SortedVec<T> {
     ///
     /// A slice of all elements in sorted order.
     ///
+    #[verus_spec(result =>
+        requires
+            self.inv()
+        ensures
+            result@ == self@
+    )]
     pub fn as_slice(&self) -> &[T] {
         self.inner.as_slice()
     }
@@ -341,12 +605,19 @@ impl<T: Ord> SortedVec<T> {
 // Trait Implementations
 //==================================================================================================
 
+#[verus_verify]
 impl<T: Ord> Default for SortedVec<T> {
+    #[verus_spec(result =>
+        ensures
+            result.inv(),
+            result@ == Seq::<T>::empty()
+    )]
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[verus_verify]
 impl<T: Ord> From<Vec<T>> for SortedVec<T> {
     ///
     /// # Description
@@ -354,27 +625,47 @@ impl<T: Ord> From<Vec<T>> for SortedVec<T> {
     /// Creates a [`SortedVec`] from an unsorted [`Vec`]. The vector is sorted and duplicates
     /// are removed.
     ///
+    #[verus_spec(result =>
+        ensures
+            obeys_cmp_spec::<T>() ==> result.inv(),
+            result@.len() <= vec@.len(),
+            forall|v: T| result@.contains(v) ==> vec@.contains(v)
+    )]
     fn from(vec: Vec<T>) -> Self {
         let mut vec = vec;
+        proof! { let ghost _len: usize = vstd::std_specs::vec::spec_vec_len(&vec); }
         vec_sort_unstable(&mut vec);
         vec.dedup();
+        proof! {
+            reveal_cmp_laws!();
+        }
         Self { inner: vec }
     }
 }
 
+#[verus_verify]
 impl<T: Ord> IntoIterator for SortedVec<T> {
     type Item = T;
     type IntoIter = ::alloc::vec::IntoIter<T>;
 
+    #[verus_spec(iter =>
+        ensures
+            iter@ == (0int, self@)
+    )]
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter()
     }
 }
 
+#[verus_verify]
 impl<'a, T: Ord> IntoIterator for &'a SortedVec<T> {
     type Item = &'a T;
     type IntoIter = ::core::slice::Iter<'a, T>;
 
+    #[verus_spec(iter =>
+        ensures
+            iter@ == (0int, self@)
+    )]
     fn into_iter(self) -> Self::IntoIter {
         self.inner.iter()
     }

--- a/src/libs/sorted-vec/src/lib.spec.rs
+++ b/src/libs/sorted-vec/src/lib.spec.rs
@@ -1,0 +1,151 @@
+verus! {
+
+// ===========================================================================
+// View
+// ===========================================================================
+
+impl<T: Ord> View for SortedVec<T> {
+    type V = Seq<T>;
+
+    closed spec fn view(&self) -> Seq<T> {
+        self.inner@
+    }
+}
+
+// ===========================================================================
+// Spec Helpers — built on vstd's OrdSpec::cmp_spec
+// ===========================================================================
+
+
+/// Strict sorted: all pairs in ascending order via cmp_spec.
+pub open spec fn spec_strictly_sorted<T: Ord>(s: Seq<T>) -> bool {
+    forall|i: int, j: int| #![trigger s[i], s[j]]
+        0 <= i < j < s.len() ==> s[i].cmp_spec(&s[j]) is Less
+}
+
+/// Membership via Ord-equality.
+pub open spec fn spec_contains<T: Ord>(s: Seq<T>, v: T) -> bool {
+    exists|i: int| #![auto] 0 <= i < s.len() && s[i].cmp_spec(&v) is Equal
+}
+
+// ===========================================================================
+// Invariant
+// ===========================================================================
+
+impl<T: Ord> SortedVec<T> {
+    pub open spec fn inv(&self) -> bool {
+        &&& spec_strictly_sorted(self@)
+        &&& self@.len() <= usize::MAX as int
+    }
+}
+
+// ===========================================================================
+// Assume Specifications
+// ===========================================================================
+
+// binary_search: requires obeys_cmp_spec (vstd ordering laws).
+// No more axiom-bundling in ensures — axioms come from vstd.
+pub assume_specification<T: Ord>[ <[T]>::binary_search ](
+    slice: &[T],
+    value: &T,
+) -> (result: Result<usize, usize>)
+    requires
+        spec_strictly_sorted(slice@),
+        obeys_cmp_spec::<T>(),
+    ensures
+        match result {
+            Ok(idx) => {
+                &&& (idx as int) < slice@.len()
+                &&& slice@[idx as int].cmp_spec(value) is Equal
+            },
+            Err(idx) => {
+                &&& (idx as int) <= slice@.len()
+                &&& !spec_contains(slice@, *value)
+                &&& forall|k: int| #![auto] 0 <= k < idx as int
+                    ==> slice@[k].cmp_spec(value) is Less
+                &&& forall|k: int| #![auto] idx as int <= k < slice@.len()
+                    ==> value.cmp_spec(&slice@[k]) is Less
+            },
+        },
+;
+
+// binary_search_by_key
+pub open spec fn maps_to_key<'a, T, B: Eq, F: FnMut(&'a T) -> B>(f: F, n: &'a T, key: &B) -> bool
+{
+    exists|x: B| #[trigger] f.ensures((n,), x) && x.eq_spec(key)
+}
+
+pub open spec fn map_key_cmp<'a, T, B: Ord, F: FnMut(&'a T) -> B>(
+    f: F, n: &'a T, key: &B, order: core::cmp::Ordering,
+) -> bool
+{
+    exists|x: B| #[trigger] f.ensures((n,), x) && x.cmp_spec(key) == order
+}
+
+pub assume_specification<'a, T, B: Ord, F: FnMut(&'a T) -> B>[ <[T]>::binary_search_by_key ](
+    slice: &'a [T],
+    key: &B,
+    f: F,
+) -> (result: Result<usize, usize>)
+    requires
+        obeys_cmp_spec::<B>(),
+        forall|i: int, j: int, x: B, y: B| {
+            &&& 0 <= i < j < slice@.len()
+            &&& f.ensures((&slice[i], ), x)
+            &&& f.ensures((&slice[j], ), y)
+        } ==> !(x.cmp_spec(&y) is Greater),
+    ensures
+        match result {
+            Ok(index) => {
+                &&& 0 <= index < slice@.len()
+                &&& maps_to_key(f, &slice[index as int], key)
+            },
+            Err(index) => {
+                &&& 0 <= index <= slice@.len()
+                &&& forall|i: int| #![trigger slice[i]]
+                    0 <= i < index ==> map_key_cmp(f, &slice[i], key, core::cmp::Ordering::Less)
+                &&& forall|i: int| #![trigger slice[i]]
+                    index <= i < slice@.len() ==> map_key_cmp(f, &slice[i], key, core::cmp::Ordering::Greater)
+            },
+        },
+;
+
+// sort_unstable
+pub assume_specification<T: Ord>[ <[T]>::sort_unstable ](slice: &mut [T])
+    ensures
+        slice@.len() == old(slice)@.len(),
+        forall|v: T| slice@.contains(v) <==> old(slice)@.contains(v),
+        forall|i: int, j: int| #![trigger slice@[i], slice@[j]]
+            0 <= i < j < slice@.len() ==> !(slice@[j].cmp_spec(&slice@[i]) is Less),
+;
+
+// dedup: preserves order (subsequence property) + no consecutive eq_spec equal
+pub assume_specification<T: PartialEq, A: core::alloc::Allocator>[ Vec::<T, A>::dedup ](vec: &mut Vec<T, A>)
+    ensures
+        vec@.len() <= old(vec)@.len(),
+        forall|v: T| vec@.contains(v) ==> old(vec)@.contains(v),
+        forall|i: int| 0 <= i < vec@.len() - 1
+            ==> !(#[trigger] vec@[i]).eq_spec(&vec@[i + 1]),
+        // Order preservation: pairwise
+        forall|i: int, j: int| #![trigger vec@[i], vec@[j]]
+            0 <= i < j < vec@.len() ==> (
+            exists|ki: int, kj: int|
+                0 <= ki < kj < old(vec)@.len()
+                && vec@[i] == old(vec)@[ki]
+                && vec@[j] == old(vec)@[kj]),
+;
+
+// Vec::capacity
+pub assume_specification<T, A: core::alloc::Allocator>[ Vec::<T, A>::capacity ](vec: &Vec<T, A>) -> (result: usize)
+    ensures
+        result as int >= vec@.len(),
+;
+
+// FromSpec: vacuously satisfies vstd trait postcondition.
+impl<T: Ord> FromSpecImpl<Vec<T>> for SortedVec<T> {
+    open spec fn obeys_from_spec() -> bool { false }
+    open spec fn from_spec(v: Vec<T>) -> Self { arbitrary() }
+}
+
+} // verus!
+


### PR DESCRIPTION
## Summary
Formal verification of all 23 public functions in `sorted-vec`.
25 verified, 0 errors, 0 `assume()` calls.

## New Files
- `lib.spec.rs`: View trait, invariant, spec helpers, assume_specifications for binary_search, binary_search_by_key, sort_unstable, dedup, capacity
- `lib.proof.rs`: 5 proof lemmas + `reveal_cmp_laws!` macro

## Annotations in lib.rs
- `#[verus_verify]` on struct and impl blocks
- `#[verus_spec]` on all functions (requires/ensures)
- `proof!` blocks for insert, remove, get, remove_by, lookup_by, from

## Trust Boundary
| Type | Count | Details |
|------|-------|---------|
| external_body | 2 | vec_replace (reborrowing), vec_sort_unstable (DerefMut) |
| assume_specification | 5 | binary_search, binary_search_by_key, sort_unstable, dedup, capacity |
| assume() | 0 | Eliminated via conditional ensures (`obeys_cmp_spec ==> inv()`) |

## Key Design Decisions
- **Dedup spec**: pairwise order preservation (`∀i<j ∃ki<kj`) instead of eq_spec, enabling composition with sort's cmp_spec postcondition
- **Conditional ensures on From**: `obeys_cmp_spec::<T>() ==> result.inv()` (vstd BTreeMap pattern, avoids assume for generic T)
- **FromSpecImpl**: `obeys_from_spec() = false` (sort_unstable is nondeterministic, cannot write precise from_spec)

## Cargo.toml
Added `vstd` dependency and `[package.metadata.verus]` section.

---
*Depends on #2027*