### PR TITLE
[arch] Safe page-table abstractions

### DIFF
--- a/src/libs/arch/src/x86/mem/paging/mod.rs
+++ b/src/libs/arch/src/x86/mem/paging/mod.rs
@@ -31,6 +31,13 @@ pub use table::*;
 ///
 pub type PteWord = u32;
 
+///
+/// # Description
+///
+/// Log2 of the size of [`PteWord`] in bytes.
+///
+pub const PTE_WORD_SIZE_LOG2: usize = ::core::mem::size_of::<PteWord>().trailing_zeros() as usize;
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================

--- a/src/libs/arch/src/x86/mem/paging/pde.rs
+++ b/src/libs/arch/src/x86/mem/paging/pde.rs
@@ -5,19 +5,22 @@
 // Imports
 //==================================================================================================
 
-use crate::x86::mem::paging::{
-    flags::{
-        AccessedFlag,
-        DirtyFlag,
-        PageCacheDisableFlag,
-        PageSizeFlag,
-        PageWriteThroughFlag,
-        PresentFlag,
-        ReadWriteFlag,
-        UserSupervisorFlag,
+use crate::{
+    mem::paging::TableEntry,
+    x86::mem::paging::{
+        flags::{
+            AccessedFlag,
+            DirtyFlag,
+            PageCacheDisableFlag,
+            PageSizeFlag,
+            PageWriteThroughFlag,
+            PresentFlag,
+            ReadWriteFlag,
+            UserSupervisorFlag,
+        },
+        frame::FrameNumber,
+        PteWord,
     },
-    frame::FrameNumber,
-    PteWord,
 };
 
 //==================================================================================================
@@ -422,5 +425,15 @@ impl PageDirectoryEntry {
     ///
     pub fn set_user_supervisor(&mut self, user_supervisor: UserSupervisorFlag) {
         self.flags.set_user_supervisor(user_supervisor);
+    }
+}
+
+impl TableEntry for PageDirectoryEntry {
+    fn from_raw(raw: PteWord) -> Option<Self> {
+        Self::from_raw_value(raw)
+    }
+
+    fn raw(self) -> PteWord {
+        self.into_raw_value()
     }
 }

--- a/src/libs/arch/src/x86/mem/paging/pte.rs
+++ b/src/libs/arch/src/x86/mem/paging/pte.rs
@@ -6,7 +6,10 @@
 //==================================================================================================
 
 use crate::{
-    mem,
+    mem::{
+        self,
+        paging::TableEntry,
+    },
     x86::mem::paging::{
         flags::{
             AccessedFlag,
@@ -363,5 +366,15 @@ impl PageTableEntry {
     ///
     pub fn set_user_supervisor(&mut self, user_supervisor: UserSupervisorFlag) {
         self.flags.set_user_supervisor(user_supervisor);
+    }
+}
+
+impl TableEntry for PageTableEntry {
+    fn from_raw(raw: PteWord) -> Option<Self> {
+        Self::from_raw_value(raw)
+    }
+
+    fn raw(self) -> PteWord {
+        self.into_raw_value()
     }
 }

--- a/src/libs/arch/src/x86/mem/paging/table.rs
+++ b/src/libs/arch/src/x86/mem/paging/table.rs
@@ -5,7 +5,10 @@
 // Imports
 //==================================================================================================
 
-use super::PteWord;
+use super::{
+    PteWord,
+    PTE_WORD_SIZE_LOG2,
+};
 
 //==================================================================================================
 // Table Entry Trait
@@ -26,17 +29,58 @@ pub trait TableEntry: Copy {
 }
 
 //==================================================================================================
+// Table Index
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A validated index into a page table, guaranteed to be in `[0, PAGE_TABLE_LENGTH)`.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TableIndex(usize);
+
+impl TableIndex {
+    ///
+    /// # Description
+    ///
+    /// Creates a [`TableIndex`] from a raw `usize`, returning `None` if the value is out of
+    /// bounds.
+    ///
+    pub const fn new(index: usize) -> Option<Self> {
+        if index < crate::mem::PAGE_TABLE_LENGTH {
+            Some(Self(index))
+        } else {
+            None
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the underlying index value.
+    ///
+    pub const fn into_raw(self) -> usize {
+        self.0
+    }
+}
+
+//==================================================================================================
 // Virtual Address Index Extraction
 //==================================================================================================
 
-/// Extracts the PD index (bits 22-31) from a virtual address.
-pub const fn pd_index(vaddr: usize) -> usize {
-    (vaddr >> crate::mem::PGTAB_SHIFT) & (crate::mem::PGTAB_SIZE / crate::mem::PAGE_SIZE - 1)
+/// Extracts the PD index (bits 22-31) from a virtual address as a [`TableIndex`].
+pub const fn pd_index(vaddr: usize) -> TableIndex {
+    // The mask guarantees the result is always < PAGE_TABLE_LENGTH.
+    let index: usize = (vaddr >> crate::mem::PGTAB_SHIFT) & (crate::mem::PAGE_TABLE_LENGTH - 1);
+    TableIndex(index)
 }
 
-/// Extracts the PT index (bits 12-21) from a virtual address.
-pub const fn pt_index(vaddr: usize) -> usize {
-    (vaddr >> crate::mem::PAGE_SHIFT) & (crate::mem::PGTAB_SIZE / crate::mem::PAGE_SIZE - 1)
+/// Extracts the PT index (bits 12-21) from a virtual address as a [`TableIndex`].
+pub const fn pt_index(vaddr: usize) -> TableIndex {
+    // The mask guarantees the result is always < PAGE_TABLE_LENGTH.
+    let index: usize = (vaddr >> crate::mem::PAGE_SHIFT) & (crate::mem::PAGE_TABLE_LENGTH - 1);
+    TableIndex(index)
 }
 
 //==================================================================================================
@@ -52,12 +96,13 @@ pub const fn pt_index(vaddr: usize) -> usize {
 /// its own entry kind (e.g., PD tables only [`PageDirectoryEntry`], PT tables only
 /// [`PageTableEntry`]).
 ///
-/// The table is accessed via a physical base address (identity-mapped in kernel space). It does
-/// not own the backing memory — the caller is responsible for allocation and lifetime management.
+/// The table is accessed via a base address that must be valid in the current address space
+/// (i.e., a mapped virtual address). It does not own the backing memory — the caller is
+/// responsible for allocation and lifetime management.
 ///
 #[derive(Debug)]
 pub struct Table<E: TableEntry> {
-    /// Base address of the table (must be page-aligned, identity-mapped).
+    /// Base address of the table (must be page-aligned).
     base: usize,
     /// Phantom marker for the entry type.
     _marker: ::core::marker::PhantomData<E>,
@@ -71,8 +116,8 @@ impl<E: TableEntry> Table<E> {
     ///
     /// # Safety
     ///
-    /// `base` must be a valid, page-aligned, identity-mapped address with at least one page
-    /// of readable/writable memory.
+    /// `base` must be a valid, page-aligned address with at least one page of readable/writable
+    /// memory.
     ///
     pub const unsafe fn from_address(base: usize) -> Self {
         Self {
@@ -86,20 +131,16 @@ impl<E: TableEntry> Table<E> {
     ///
     /// Reads the entry at `index`.
     ///
-    /// Returns `Err(())` if `index >= PAGE_TABLE_LENGTH`, or `Ok(None)` if the raw value is
-    /// invalid according to `E::from_raw()`.
+    /// Returns `None` if the raw value is invalid according to `E::from_raw()`.
     ///
     /// # Safety
     ///
     /// The memory at `base + index * size_of::<PteWord>()` must be valid for a volatile read.
     ///
-    pub unsafe fn read(&self, index: usize) -> Result<Option<E>, ()> {
-        if index >= crate::mem::PAGE_TABLE_LENGTH {
-            return Err(());
-        }
-        let ptr: *const PteWord =
-            (self.base + index * ::core::mem::size_of::<PteWord>()) as *const PteWord;
-        Ok(E::from_raw(::core::ptr::read_volatile(ptr)))
+    pub unsafe fn read(&self, index: TableIndex) -> Option<E> {
+        let offset: usize = index.into_raw() << PTE_WORD_SIZE_LOG2;
+        let ptr: *const PteWord = (self.base + offset) as *const PteWord;
+        E::from_raw(::core::ptr::read_volatile(ptr))
     }
 
     ///
@@ -107,19 +148,13 @@ impl<E: TableEntry> Table<E> {
     ///
     /// Writes `entry` at `index`.
     ///
-    /// Returns `Err(())` if `index >= PAGE_TABLE_LENGTH`.
-    ///
     /// # Safety
     ///
     /// The memory at `base + index * size_of::<PteWord>()` must be valid for a volatile write.
     ///
-    pub unsafe fn write(&self, index: usize, entry: E) -> Result<(), ()> {
-        if index >= crate::mem::PAGE_TABLE_LENGTH {
-            return Err(());
-        }
-        let ptr: *mut PteWord =
-            (self.base + index * ::core::mem::size_of::<PteWord>()) as *mut PteWord;
+    pub unsafe fn write(&self, index: TableIndex, entry: E) {
+        let offset: usize = index.into_raw() << PTE_WORD_SIZE_LOG2;
+        let ptr: *mut PteWord = (self.base + offset) as *mut PteWord;
         ::core::ptr::write_volatile(ptr, entry.raw());
-        Ok(())
     }
 }

--- a/src/libs/arch/src/x86/mem/paging/table.rs
+++ b/src/libs/arch/src/x86/mem/paging/table.rs
@@ -38,3 +38,88 @@ pub const fn pd_index(vaddr: usize) -> usize {
 pub const fn pt_index(vaddr: usize) -> usize {
     (vaddr >> crate::mem::PAGE_SHIFT) & (crate::mem::PGTAB_SIZE / crate::mem::PAGE_SIZE - 1)
 }
+
+//==================================================================================================
+// Table
+//==================================================================================================
+
+///
+/// # Description
+///
+/// A page-table page containing [`PAGE_TABLE_LENGTH`](crate::mem::PAGE_TABLE_LENGTH) entries.
+///
+/// This type is parameterized over the entry type to enforce that each table level uses only
+/// its own entry kind (e.g., PD tables only [`PageDirectoryEntry`], PT tables only
+/// [`PageTableEntry`]).
+///
+/// The table is accessed via a physical base address (identity-mapped in kernel space). It does
+/// not own the backing memory — the caller is responsible for allocation and lifetime management.
+///
+#[derive(Debug)]
+pub struct Table<E: TableEntry> {
+    /// Base address of the table (must be page-aligned, identity-mapped).
+    base: usize,
+    /// Phantom marker for the entry type.
+    _marker: ::core::marker::PhantomData<E>,
+}
+
+impl<E: TableEntry> Table<E> {
+    ///
+    /// # Description
+    ///
+    /// Creates a table reference from a base address.
+    ///
+    /// # Safety
+    ///
+    /// `base` must be a valid, page-aligned, identity-mapped address with at least one page
+    /// of readable/writable memory.
+    ///
+    pub const unsafe fn from_address(base: usize) -> Self {
+        Self {
+            base,
+            _marker: ::core::marker::PhantomData,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reads the entry at `index`.
+    ///
+    /// Returns `Err(())` if `index >= PAGE_TABLE_LENGTH`, or `Ok(None)` if the raw value is
+    /// invalid according to `E::from_raw()`.
+    ///
+    /// # Safety
+    ///
+    /// The memory at `base + index * size_of::<PteWord>()` must be valid for a volatile read.
+    ///
+    pub unsafe fn read(&self, index: usize) -> Result<Option<E>, ()> {
+        if index >= crate::mem::PAGE_TABLE_LENGTH {
+            return Err(());
+        }
+        let ptr: *const PteWord =
+            (self.base + index * ::core::mem::size_of::<PteWord>()) as *const PteWord;
+        Ok(E::from_raw(::core::ptr::read_volatile(ptr)))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Writes `entry` at `index`.
+    ///
+    /// Returns `Err(())` if `index >= PAGE_TABLE_LENGTH`.
+    ///
+    /// # Safety
+    ///
+    /// The memory at `base + index * size_of::<PteWord>()` must be valid for a volatile write.
+    ///
+    pub unsafe fn write(&self, index: usize, entry: E) -> Result<(), ()> {
+        if index >= crate::mem::PAGE_TABLE_LENGTH {
+            return Err(());
+        }
+        let ptr: *mut PteWord =
+            (self.base + index * ::core::mem::size_of::<PteWord>()) as *mut PteWord;
+        ::core::ptr::write_volatile(ptr, entry.raw());
+        Ok(())
+    }
+}

--- a/src/libs/arch/src/x86/mem/paging/table.rs
+++ b/src/libs/arch/src/x86/mem/paging/table.rs
@@ -19,8 +19,8 @@ use super::PteWord;
 /// The raw representation uses [`PteWord`] — `u32` on x86.
 ///
 pub trait TableEntry: Copy {
-    /// Creates from a raw [`PteWord`].
-    fn from_raw(raw: PteWord) -> Self;
+    /// Creates from a raw [`PteWord`], returning `None` if the value is invalid.
+    fn from_raw(raw: PteWord) -> Option<Self>;
     /// Returns the raw [`PteWord`] representation.
     fn raw(self) -> PteWord;
 }


### PR DESCRIPTION
This pull request refactors and extends the paging table abstractions in the x86 memory management code. The changes introduce a new, type-safe `Table` abstraction for page tables, add a validated `TableIndex` type, and update the `TableEntry` trait for greater safety and flexibility. The code is also updated to use these abstractions throughout, and minor improvements are made for clarity and correctness.