### PR TITLE
[build] Add target architecture to release

### DIFF
--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -5,6 +5,9 @@ name: "Release Package"
 description: "Package a release archive from pre-built artifacts"
 
 inputs:
+  target-arch:
+    description: "Target architecture (e.g. x86)"
+    required: true
   machine-type:
     description: "Target machine type"
     required: true
@@ -27,6 +30,7 @@ runs:
       name: "Package Release Archive"
       shell: bash
       env:
+        TARGET_ARCH: ${{ inputs.target-arch }}
         MACHINE_TYPE: ${{ inputs.machine-type }}
         DEPLOYMENT_TYPE: ${{ inputs.deployment-type }}
         MEMORY_SIZE_MB: ${{ inputs.memory-size }}
@@ -42,7 +46,7 @@ runs:
         fi
 
         commit_id="${GITHUB_SHA}"
-        archive_name="nanvix-${MACHINE_TYPE}-${DEPLOYMENT_TYPE}-release-${MEMORY_SIZE_MB}mb-${commit_id}.tar.bz2"
+        archive_name="nanvix-${TARGET_ARCH}-${MACHINE_TYPE}-${DEPLOYMENT_TYPE}-release-${MEMORY_SIZE_MB}mb-${commit_id}.tar.bz2"
 
         echo "Reusing pre-built release archive: ${archive_src} -> ${archive_name}"
         mv "${archive_src}" "${archive_name}"

--- a/.github/skills/ci-cd-pipeline/SKILL.md
+++ b/.github/skills/ci-cd-pipeline/SKILL.md
@@ -95,7 +95,7 @@ Matrix coverage in GitHub Actions:
 ./z build -- release
 
 # The archive name follows this pattern:
-# nanvix-<ver>-<machine>-<deploy>-<mode>-<log>.tar.bz2
+# nanvix-<ver>-<target>-<machine>-<deploy>-<mode>-<log>-<memory>mb.tar.bz2
 ```
 
 Minor releases can be created with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1834,7 +1834,7 @@ jobs:
 
   # Create release archives for all applicable configurations.
   release-archive:
-    name: "Release Archive (${{ matrix.machine-type }}, ${{ matrix.deployment-type }}, ${{ matrix.memory-size }}mb)"
+    name: "Release Archive (${{ matrix.target-arch }}, ${{ matrix.machine-type }}, ${{ matrix.deployment-type }}, ${{ matrix.memory-size }}mb)"
     needs:
       [
         ci-test,
@@ -1858,6 +1858,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        target-arch: [x86]
         machine-type: [microvm, hyperlight]
         deployment-type: [standalone, single-process, multi-process]
         memory-size: [128, 256]
@@ -1878,6 +1879,7 @@ jobs:
         id: release-archive
         uses: ./.github/actions/release-package
         with:
+          target-arch: "${{ matrix.target-arch }}"
           machine-type: "${{ matrix.machine-type }}"
           deployment-type: "${{ matrix.deployment-type }}"
           memory-size: "${{ matrix.memory-size }}"
@@ -1885,14 +1887,14 @@ jobs:
       - name: "Upload Release Artifact"
         uses: actions/upload-artifact@v7
         with:
-          name: release-${{ matrix.machine-type }}-${{ matrix.deployment-type }}-${{ matrix.memory-size }}mb
+          name: release-${{ matrix.target-arch }}-${{ matrix.machine-type }}-${{ matrix.deployment-type }}-${{ matrix.memory-size }}mb
           path: ${{ steps.release-archive.outputs.archive-path }}
           overwrite: true
 
   # Package Windows standalone binaries into a release archive (.zip).
   # Windows only supports standalone deployment mode.
   windows-release-archive:
-    name: "Windows Release Archive (${{ matrix.machine-type }}, ${{ matrix.memory-size }}mb)"
+    name: "Windows Release Archive (${{ matrix.target-arch }}, ${{ matrix.machine-type }}, ${{ matrix.memory-size }}mb)"
     needs:
       [
         windows-integration-test,
@@ -1918,6 +1920,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        target-arch: [x86]
         machine-type: [microvm, hyperlight]
         memory-size: [128, 256]
     runs-on: ubuntu-24.04
@@ -1938,7 +1941,7 @@ jobs:
         shell: bash
         run: |
           commit_id="${GITHUB_SHA}"
-          archive_name="nanvix-windows-${{ matrix.machine-type }}-standalone-release-${{ matrix.memory-size }}mb-${commit_id}.zip"
+          archive_name="nanvix-windows-${{ matrix.target-arch }}-${{ matrix.machine-type }}-standalone-release-${{ matrix.memory-size }}mb-${commit_id}.zip"
 
           # Create the zip archive from the downloaded Windows binaries.
           cd windows-bin
@@ -1952,7 +1955,7 @@ jobs:
       - name: "Upload Release Artifact"
         uses: actions/upload-artifact@v7
         with:
-          name: release-windows-${{ matrix.machine-type }}-standalone-${{ matrix.memory-size }}mb
+          name: release-windows-${{ matrix.target-arch }}-${{ matrix.machine-type }}-standalone-${{ matrix.memory-size }}mb
           path: ${{ steps.package.outputs.archive-path }}
           overwrite: true
 

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ MEMORY_SIZE_MB = $(shell echo $$(($(MEMORY_SIZE_BYTES) / 1048576)))
 # VFS benchmark image filename.
 export VFS_BENCH_IMG ?= vfs-bench.img
 
-RELEASE_ARCHIVE := nanvix-$(RELEASE_VERSION)-$(MACHINE)-$(RELEASE_DEPLOYMENT_MODE)-$(RELEASE_BUILD_MODE)-$(LOG_LEVEL)-$(MEMORY_SIZE_MB)mb.tar.bz2
+RELEASE_ARCHIVE := nanvix-$(RELEASE_VERSION)-$(TARGET)-$(MACHINE)-$(RELEASE_DEPLOYMENT_MODE)-$(RELEASE_BUILD_MODE)-$(LOG_LEVEL)-$(MEMORY_SIZE_MB)mb.tar.bz2
 MANIFEST_FILE := $(SYSROOT_DIR)/manifest.json
 
 #===================================================================================================

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -29,6 +29,9 @@ pub mod system {
     /// Default system name.
     pub const DEFAULT_SYSTEM_NAME: &str = "nanvix";
 
+    /// Default target architecture name.
+    pub const DEFAULT_TARGET_NAME: &str = "x86";
+
     cfg_if::cfg_if! {
         if #[cfg(feature = "microvm")] {
             /// Default machine name.

--- a/src/libs/nanvix-registry/src/lib.rs
+++ b/src/libs/nanvix-registry/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //!     // Get a cached binary (downloads if not already cached).
 //!     let binary_path: String = registry
-//!         .get_cached_binary("microvm", "single-process", 128, "kernel.elf")
+//!         .get_cached_binary("x86", "microvm", "single-process", 128, "kernel.elf")
 //!         .await?;
 //!
 //!     println!("Binary path: {}", binary_path);
@@ -73,7 +73,7 @@
 //!     // This will automatically download openssl, zlib, and other required packages.
 //!     // Use `true` to fall back to latest version if compatible version not found.
 //!     let install_path: String = registry
-//!         .install("microvm", "single-process", 128, "python", true)
+//!         .install("x86", "microvm", "single-process", 128, "python", true)
 //!         .await?;
 //!
 //!     println!("Python installed to: {}", install_path);
@@ -96,7 +96,7 @@
 //!
 //!     // Use the registry normally - it will use the custom directory.
 //!     let binary_path: String = registry
-//!         .get_cached_binary("hyperlight", "multi-process", 128, "kernel.elf")
+//!         .get_cached_binary("x86", "hyperlight", "multi-process", 128, "kernel.elf")
 //!         .await?;
 //!
 //!     Ok(())
@@ -184,6 +184,7 @@ mod progress;
 mod rate_limiter;
 mod release;
 mod tarball;
+mod target;
 mod tempfile;
 
 //==================================================================================================
@@ -200,6 +201,7 @@ pub use crate::{
         ProgressCallback,
         SharedProgress,
     },
+    target::Target,
 };
 
 //==================================================================================================
@@ -254,6 +256,8 @@ const BINARY_DIRECTORY_NAME: &str = "bin";
 /// reducing the number of function arguments and improving code maintainability.
 ///
 struct InstallContext<'a> {
+    /// Target architecture.
+    target: Target,
     /// Target machine type.
     machine: Machine,
     /// Deployment type.
@@ -271,6 +275,11 @@ struct InstallContext<'a> {
 }
 
 impl<'a> InstallContext<'a> {
+    /// Returns the target architecture.
+    fn target(&self) -> Target {
+        self.target
+    }
+
     /// Returns the target machine type.
     fn machine(&self) -> Machine {
         self.machine
@@ -327,7 +336,7 @@ impl<'a> InstallContext<'a> {
 ///
 ///     // Get the kernel binary for microvm single-process deployment.
 ///     let kernel_path: String = registry
-///         .get_cached_binary("microvm", "single-process", 128, "kernel.elf")
+///         .get_cached_binary("x86", "microvm", "single-process", 128, "kernel.elf")
 ///         .await?;
 ///
 ///     Ok(())
@@ -386,6 +395,8 @@ impl Registry {
     ///
     /// # Parameters
     ///
+    /// - `target`: Target architecture. Supported values:
+    ///   - `"x86"`: x86 architecture.
     /// - `machine`: Target machine type. Supported values:
     ///   - `"hyperlight"`: Hyperlight machine type.
     ///   - `"microvm"`: microvm machine type.
@@ -402,6 +413,7 @@ impl Registry {
     /// # Errors
     ///
     /// This function returns an error if:
+    /// - The target architecture is not recognized.
     /// - The machine type is not recognized.
     /// - The deployment type is not recognized.
     /// - The GitHub API request fails.
@@ -420,7 +432,7 @@ impl Registry {
     ///
     ///     // Get the QuickJS binary for hyperlight multi-process deployment.
     ///     let qjs_path: String = registry
-    ///         .get_cached_binary("hyperlight", "multi-process", 128, "qjs")
+    ///         .get_cached_binary("x86", "hyperlight", "multi-process", 128, "qjs")
     ///         .await?;
     ///
     ///     println!("QuickJS binary: {}", qjs_path);
@@ -431,6 +443,7 @@ impl Registry {
     ///
     pub async fn get_cached_binary(
         &self,
+        target: &str,
         machine: &str,
         deployment: &str,
         memory_size_mb: u32,
@@ -438,6 +451,7 @@ impl Registry {
     ) -> Result<String> {
         // Use get_cached_artifact to search for the binary within the "bin" directory.
         self.get_cached_artifact(
+            target,
             machine,
             deployment,
             memory_size_mb,
@@ -458,6 +472,8 @@ impl Registry {
     ///
     /// # Parameters
     ///
+    /// - `target`: Target architecture. Supported values:
+    ///   - `"x86"`: x86 architecture.
     /// - `machine`: Target machine type. Supported values:
     ///   - `"hyperlight"`: Hyperlight machine type.
     ///   - `"microvm"`: microvm machine type.
@@ -477,6 +493,7 @@ impl Registry {
     /// # Errors
     ///
     /// This function returns an error if:
+    /// - The target architecture is not recognized.
     /// - The machine type is not recognized.
     /// - The deployment type is not recognized.
     /// - The GitHub API request fails.
@@ -495,12 +512,12 @@ impl Registry {
     ///
     ///     // Search for a configuration file from the cache directory root.
     ///     let config_path: String = registry
-    ///         .get_cached_artifact("hyperlight", "multi-process", 128, "config.json", None)
+    ///         .get_cached_artifact("x86", "hyperlight", "multi-process", 128, "config.json", None)
     ///         .await?;
     ///
     ///     // Search for a library file in a specific subdirectory.
     ///     let lib_path: String = registry
-    ///         .get_cached_artifact("microvm", "single-process", 128, "libssl.so", Some("lib"))
+    ///         .get_cached_artifact("x86", "microvm", "single-process", 128, "libssl.so", Some("lib"))
     ///         .await?;
     ///
     ///     println!("Configuration file: {}", config_path);
@@ -512,6 +529,7 @@ impl Registry {
     ///
     pub async fn get_cached_artifact(
         &self,
+        target: &str,
         machine: &str,
         deployment: &str,
         memory_size_mb: u32,
@@ -522,6 +540,9 @@ impl Registry {
 
         let cache_dir: PathBuf = self.get_cache_dir().await?;
 
+        // Convert target from string representation.
+        let target: Target = Target::try_from(target)?;
+
         // Convert machine from string representation.
         let machine: Machine = Machine::try_from(machine)?;
 
@@ -529,7 +550,8 @@ impl Registry {
         let deployment: Deployment = Deployment::try_from(deployment)?;
 
         // Create release handle for checking latest release.
-        let release: LatestRelease = LatestRelease::new(deployment, machine, memory_size_mb);
+        let release: LatestRelease =
+            LatestRelease::new(target, deployment, machine, memory_size_mb);
 
         // Get the latest release URL.
         let latest_url: String = release.get_url().await?;
@@ -547,9 +569,9 @@ impl Registry {
             },
         };
 
-        // Construct the subdirectory name: <machine>-<deployment>-<memory_size>mb-<commit_id>.
+        // Construct the subdirectory name: <target>-<machine>-<deployment>-<memory_size>mb-<commit_id>.
         let subdir_name: String =
-            format!("{}-{}-{}mb-{}", machine, deployment, memory_size_mb, commit_id);
+            format!("{}-{}-{}-{}mb-{}", target, machine, deployment, memory_size_mb, commit_id);
         let artifact_cache_dir: PathBuf = cache_dir.join(&subdir_name);
 
         // Load or create the release registry.
@@ -569,36 +591,39 @@ impl Registry {
         };
 
         // Check if we need to download this specific configuration.
-        let needs_download: bool =
-            if let Some(cached_entry) = registry.get_release(machine, deployment, memory_size_mb) {
-                if cached_entry.commit_id() != commit_id.as_str() {
-                    info!(
-                        "New release detected for {}-{}-{}mb (cached: {}, latest: {})",
-                        machine,
-                        deployment,
-                        memory_size_mb,
-                        cached_entry.commit_id(),
-                        commit_id
-                    );
-                    true
-                } else {
-                    debug!(
-                        "Using cached release for {}-{}-{}mb: {}",
-                        machine,
-                        deployment,
-                        memory_size_mb,
-                        cached_entry.commit_id()
-                    );
-                    false
-                }
-            } else {
-                // Configuration not in registry, need to download.
+        let needs_download: bool = if let Some(cached_entry) =
+            registry.get_release(target, machine, deployment, memory_size_mb)
+        {
+            if cached_entry.commit_id() != commit_id.as_str() {
                 info!(
-                    "Configuration {}-{}-{}mb not cached, downloading...",
-                    machine, deployment, memory_size_mb
+                    "New release detected for {}-{}-{}-{}mb (cached: {}, latest: {})",
+                    target,
+                    machine,
+                    deployment,
+                    memory_size_mb,
+                    cached_entry.commit_id(),
+                    commit_id
                 );
                 true
-            };
+            } else {
+                debug!(
+                    "Using cached release for {}-{}-{}-{}mb: {}",
+                    target,
+                    machine,
+                    deployment,
+                    memory_size_mb,
+                    cached_entry.commit_id()
+                );
+                false
+            }
+        } else {
+            // Configuration not in registry, need to download.
+            info!(
+                "Configuration {}-{}-{}-{}mb not cached, downloading...",
+                target, machine, deployment, memory_size_mb
+            );
+            true
+        };
 
         if needs_download {
             // Create the artifact cache directory.
@@ -612,7 +637,14 @@ impl Registry {
             let downloaded_url: String = release.download(&artifact_cache_dir).await?;
 
             // Update the registry with the new release.
-            registry.set_release(machine, deployment, memory_size_mb, downloaded_url, commit_id);
+            registry.set_release(
+                target,
+                machine,
+                deployment,
+                memory_size_mb,
+                downloaded_url,
+                commit_id,
+            );
             registry.save(&cache_dir).await?;
         }
 
@@ -646,6 +678,8 @@ impl Registry {
     ///
     /// # Parameters
     ///
+    /// - `target`: Target architecture. Supported values:
+    ///   - `"x86"`: x86 architecture.
     /// - `machine`: Target machine type. Supported values:
     ///   - `"hyperlight"`: Hyperlight machine type.
     ///   - `"microvm"`: microvm machine type.
@@ -671,6 +705,7 @@ impl Registry {
     /// # Errors
     ///
     /// This function returns an error if:
+    /// - The target architecture is not recognized.
     /// - The machine type is not recognized.
     /// - The deployment type is not recognized.
     /// - The package name is not recognized.
@@ -691,12 +726,12 @@ impl Registry {
     ///
     ///     // Install CPython and its dependencies (strict mode - requires compatible version).
     ///     let install_path: String = registry
-    ///         .install("microvm", "single-process", 128, "python", false)
+    ///         .install("x86", "microvm", "single-process", 128, "python", false)
     ///         .await?;
     ///
     ///     // Install with fallback to latest if compatible version not found.
     ///     let install_path: String = registry
-    ///         .install("microvm", "single-process", 128, "python", true)
+    ///         .install("x86", "microvm", "single-process", 128, "python", true)
     ///         .await?;
     ///
     ///     println!("Package installed to: {}", install_path);
@@ -707,6 +742,7 @@ impl Registry {
     ///
     pub async fn install(
         &self,
+        target: &str,
         machine: &str,
         deployment: &str,
         memory_size_mb: u32,
@@ -714,6 +750,7 @@ impl Registry {
         use_latest_fallback: bool,
     ) -> Result<String> {
         self.install_with_progress(
+            target,
             machine,
             deployment,
             memory_size_mb,
@@ -734,6 +771,7 @@ impl Registry {
     ///
     /// # Parameters
     ///
+    /// - `target`: Target architecture (see [`install`](Self::install) for supported values).
     /// - `machine`: Target machine type (see [`install`](Self::install) for supported values).
     /// - `deployment`: Deployment type (see [`install`](Self::install) for supported values).
     /// - `memory_size_mb`: Memory size in megabytes for selecting the correct release archive.
@@ -761,7 +799,7 @@ impl Registry {
     ///     let progress = Arc::new(LoggingProgress);
     ///
     ///     let install_path: String = registry
-    ///         .install_with_progress("microvm", "single-process", 128, "python", true, progress)
+    ///         .install_with_progress("x86", "microvm", "single-process", 128, "python", true, progress)
     ///         .await?;
     ///
     ///     println!("Package installed to: {}", install_path);
@@ -770,8 +808,11 @@ impl Registry {
     /// }
     /// ```
     ///
+    // TODO: Consolidate parameters into a config/builder struct to reduce argument count.
+    #[allow(clippy::too_many_arguments)]
     pub async fn install_with_progress(
         &self,
+        target: &str,
         machine: &str,
         deployment: &str,
         memory_size_mb: u32,
@@ -783,6 +824,9 @@ impl Registry {
 
         let cache_dir: PathBuf = self.get_cache_dir().await?;
 
+        // Convert target from string representation.
+        let target: Target = Target::try_from(target)?;
+
         // Convert machine from string representation.
         let machine: Machine = Machine::try_from(machine)?;
 
@@ -793,7 +837,8 @@ impl Registry {
         let package: Package = Package::try_from(package_name)?;
 
         // First, ensure we have the Nanvix release cached to get the commit ID.
-        let release: LatestRelease = LatestRelease::new(deployment, machine, memory_size_mb);
+        let release: LatestRelease =
+            LatestRelease::new(target, deployment, machine, memory_size_mb);
         let latest_url: String = release.get_url().await?;
 
         let commit_id: String = match Self::extract_commit_id(&latest_url) {
@@ -825,6 +870,7 @@ impl Registry {
 
         // Install the package (and dependencies) recursively.
         let context: InstallContext<'_> = InstallContext {
+            target,
             machine,
             deployment,
             memory_size_mb,
@@ -877,13 +923,15 @@ impl Registry {
 
         // Check if package is already installed for this configuration.
         if registry.is_package_installed(
+            context.target(),
             context.machine(),
             context.deployment(),
             package,
             context.commit_id(),
         ) {
             let subdir_name: String = format!(
-                "{}-{}-{}mb-{}",
+                "{}-{}-{}-{}mb-{}",
+                context.target(),
                 context.machine(),
                 context.deployment(),
                 context.memory_size_mb(),
@@ -891,8 +939,9 @@ impl Registry {
             );
             let package_dir: PathBuf = context.cache_dir().join(&subdir_name);
             info!(
-                "Package {} already installed for {}-{}-{}mb-{}",
+                "Package {} already installed for {}-{}-{}-{}mb-{}",
                 package,
+                context.target(),
                 context.machine(),
                 context.deployment(),
                 context.memory_size_mb(),
@@ -940,7 +989,8 @@ impl Registry {
 
         // Now install the package itself.
         let subdir_name: String = format!(
-            "{}-{}-{}mb-{}",
+            "{}-{}-{}-{}mb-{}",
+            context.target(),
             context.machine(),
             context.deployment(),
             context.memory_size_mb(),
@@ -956,8 +1006,9 @@ impl Registry {
         }
 
         info!(
-            "Installing package {} for {}-{}-{}mb-{}",
+            "Installing package {} for {}-{}-{}-{}mb-{}",
             package,
+            context.target(),
             context.machine(),
             context.deployment(),
             context.memory_size_mb(),
@@ -979,6 +1030,7 @@ impl Registry {
         // Update and save the registry with the installed package.
         // We save after each package to persist partial progress on failure.
         registry.set_package(
+            context.target(),
             context.machine(),
             context.deployment(),
             package,
@@ -1333,13 +1385,32 @@ mod tests {
     ///
     /// # Description
     ///
+    /// Tests that invalid target architecture returns error.
+    ///
+    #[tokio::test]
+    async fn test_invalid_target() {
+        let registry: Registry = Registry::new(None);
+        let result = registry
+            .get_cached_binary("invalid-target", "microvm", "single-process", 128, "kernel.elf")
+            .await;
+
+        assert!(result.is_err());
+        assert!(result
+            .expect_err("should fail")
+            .to_string()
+            .contains("Unknown target architecture"));
+    }
+
+    ///
+    /// # Description
+    ///
     /// Tests that invalid machine type returns error.
     ///
     #[tokio::test]
     async fn test_invalid_machine() {
         let registry: Registry = Registry::new(None);
         let result = registry
-            .get_cached_binary("invalid-machine", "single-process", 128, "kernel.elf")
+            .get_cached_binary("x86", "invalid-machine", "single-process", 128, "kernel.elf")
             .await;
 
         assert!(result.is_err());
@@ -1358,7 +1429,7 @@ mod tests {
     async fn test_invalid_deployment() {
         let registry: Registry = Registry::new(None);
         let result = registry
-            .get_cached_binary("microvm", "invalid-deployment", 128, "kernel.elf")
+            .get_cached_binary("x86", "microvm", "invalid-deployment", 128, "kernel.elf")
             .await;
 
         assert!(result.is_err());
@@ -1385,13 +1456,46 @@ mod tests {
     ///
     /// # Description
     ///
+    /// Tests that invalid target architecture returns error for get_cached_artifact.
+    ///
+    #[tokio::test]
+    async fn test_get_cached_artifact_invalid_target() {
+        let registry: Registry = Registry::new(None);
+        let result: Result<String> = registry
+            .get_cached_artifact(
+                "invalid-target",
+                "microvm",
+                "single-process",
+                128,
+                "config.json",
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(result
+            .expect_err("should fail")
+            .to_string()
+            .contains("Unknown target architecture"));
+    }
+
+    ///
+    /// # Description
+    ///
     /// Tests that invalid machine type returns error for get_cached_artifact.
     ///
     #[tokio::test]
     async fn test_get_cached_artifact_invalid_machine() {
         let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
-            .get_cached_artifact("invalid-machine", "single-process", 128, "config.json", None)
+            .get_cached_artifact(
+                "x86",
+                "invalid-machine",
+                "single-process",
+                128,
+                "config.json",
+                None,
+            )
             .await;
 
         assert!(result.is_err());
@@ -1410,7 +1514,7 @@ mod tests {
     async fn test_get_cached_artifact_invalid_deployment() {
         let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
-            .get_cached_artifact("microvm", "invalid-deployment", 128, "config.json", None)
+            .get_cached_artifact("x86", "microvm", "invalid-deployment", 128, "config.json", None)
             .await;
 
         assert!(result.is_err());
@@ -1469,13 +1573,20 @@ mod tests {
 
         // Test with None (searches from cache root) - should fail gracefully since no actual cache exists.
         let result: Result<String> = registry
-            .get_cached_artifact("microvm", "single-process", 128, "nonexistent.txt", None)
+            .get_cached_artifact("x86", "microvm", "single-process", 128, "nonexistent.txt", None)
             .await;
         assert!(result.is_err());
 
         // Test with Some custom directory - should also fail gracefully since no actual cache exists.
         let result: Result<String> = registry
-            .get_cached_artifact("microvm", "single-process", 128, "nonexistent.txt", Some("lib"))
+            .get_cached_artifact(
+                "x86",
+                "microvm",
+                "single-process",
+                128,
+                "nonexistent.txt",
+                Some("lib"),
+            )
             .await;
         assert!(result.is_err());
     }
@@ -1542,19 +1653,19 @@ mod tests {
     #[test]
     fn test_extract_commit_id() {
         // Test valid URL with commit ID and memory size.
-        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.bz2";
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-x86-hyperlight-multi-process-release-128mb-abc123def456.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
         assert_eq!(commit_id.expect("failed"), "abc123def456");
 
         // Test another valid URL format with different memory size.
-        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-microvm-single-process-release-256mb-1a2b3c4d5e6f.tar.bz2";
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-x86-microvm-single-process-release-256mb-1a2b3c4d5e6f.tar.bz2";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
         assert_eq!(commit_id.expect("failed"), "1a2b3c4d5e6f");
 
         // Test valid URL with .tar.gz extension.
-        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.gz";
+        let url: &str = "https://github.com/nanvix/nanvix/releases/download/latest/nanvix-x86-hyperlight-multi-process-release-128mb-abc123def456.tar.gz";
         let commit_id: Option<String> = Registry::extract_commit_id(url);
         assert!(commit_id.is_some());
         assert_eq!(commit_id.expect("failed"), "abc123def456");
@@ -1585,13 +1696,27 @@ mod tests {
     ///
     /// # Description
     ///
+    /// Tests that install returns error for invalid target architecture.
+    ///
+    #[tokio::test]
+    async fn test_install_invalid_target() {
+        let registry: Registry = Registry::new(None);
+        let result: Result<String> = registry
+            .install("invalid-target", "microvm", "single-process", 128, "openssl", false)
+            .await;
+        assert!(result.is_err());
+    }
+
+    ///
+    /// # Description
+    ///
     /// Tests that install returns error for invalid machine type.
     ///
     #[tokio::test]
     async fn test_install_invalid_machine() {
         let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
-            .install("invalid-machine", "single-process", 128, "openssl", false)
+            .install("x86", "invalid-machine", "single-process", 128, "openssl", false)
             .await;
         assert!(result.is_err());
     }
@@ -1605,7 +1730,7 @@ mod tests {
     async fn test_install_invalid_deployment() {
         let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
-            .install("microvm", "invalid-deployment", 128, "openssl", false)
+            .install("x86", "microvm", "invalid-deployment", 128, "openssl", false)
             .await;
         assert!(result.is_err());
     }
@@ -1619,7 +1744,7 @@ mod tests {
     async fn test_install_invalid_package() {
         let registry: Registry = Registry::new(None);
         let result: Result<String> = registry
-            .install("microvm", "single-process", 128, "invalid-package", false)
+            .install("x86", "microvm", "single-process", 128, "invalid-package", false)
             .await;
         assert!(result.is_err());
     }
@@ -1659,7 +1784,7 @@ mod tests {
 
                 // Attempt to install the package.
                 let result: Result<String> = registry
-                    .install("microvm", "single-process", 128, package_name, true)
+                    .install("x86", "microvm", "single-process", 128, package_name, true)
                     .await;
 
                 // Verify installation succeeded.

--- a/src/libs/nanvix-registry/src/metadata.rs
+++ b/src/libs/nanvix-registry/src/metadata.rs
@@ -9,6 +9,7 @@ use crate::{
     deployment::Deployment,
     machine::Machine,
     package::Package,
+    target::Target,
 };
 use ::anyhow::Result;
 use ::log::{
@@ -71,17 +72,19 @@ pub(crate) struct PackageEntry {
 ///
 /// Registry metadata tracking multiple machine-deployment configurations.
 ///
-/// This structure maintains a map where keys are in the format "<machine>-<deployment>"
-/// and values are `ReleaseEntry` instances containing the URL and commit ID of the
-/// most recent release for that configuration.
+/// This structure maintains a map where keys are in the format
+/// "<target>-<machine>-<deployment>-<memory>mb" and values are `ReleaseEntry` instances
+/// containing the URL and commit ID of the most recent release for that configuration.
 ///
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub(crate) struct ReleaseRegistry {
-    /// Map of machine-deployment configurations to their release entries.
-    /// Key format: "<machine>-<deployment>" (e.g., "microvm-single-process").
+    /// Map of target-machine-deployment configurations to their release entries.
+    /// Key format: "<target>-<machine>-<deployment>-<memory>mb"
+    /// (e.g., "x86-microvm-single-process-128mb").
     releases: HashMap<String, ReleaseEntry>,
     /// Map of installed packages to their entries.
-    /// Key format: "<machine>-<deployment>-<package>" (e.g., "microvm-single-process-openssl").
+    /// Key format: "<target>-<machine>-<deployment>-<package>"
+    /// (e.g., "x86-microvm-single-process-openssl").
     #[serde(default)]
     packages: HashMap<String, PackageEntry>,
 }
@@ -207,24 +210,27 @@ impl ReleaseRegistry {
     ///
     /// # Description
     ///
-    /// Adds or updates a release entry for a specific machine-deployment configuration.
+    /// Adds or updates a release entry for a specific target-machine-deployment configuration.
     ///
     /// # Parameters
     ///
+    /// - `target`: The target architecture.
     /// - `machine`: The target machine type.
     /// - `deployment`: The deployment type.
+    /// - `memory_size_mb`: The memory size in megabytes.
     /// - `url`: The URL of the release tarball.
     /// - `commit_id`: The commit ID extracted from the release URL.
     ///
     pub(crate) fn set_release(
         &mut self,
+        target: Target,
         machine: Machine,
         deployment: Deployment,
         memory_size_mb: u32,
         url: String,
         commit_id: String,
     ) {
-        let key: String = format!("{}-{}-{}mb", machine, deployment, memory_size_mb);
+        let key: String = format!("{}-{}-{}-{}mb", target, machine, deployment, memory_size_mb);
         let entry: ReleaseEntry = ReleaseEntry::new(url, commit_id);
         self.releases.insert(key, entry);
     }
@@ -232,12 +238,14 @@ impl ReleaseRegistry {
     ///
     /// # Description
     ///
-    /// Gets the release entry for a specific machine-deployment configuration.
+    /// Gets the release entry for a specific target-machine-deployment configuration.
     ///
     /// # Parameters
     ///
+    /// - `target`: The target architecture.
     /// - `machine`: The target machine type.
     /// - `deployment`: The deployment type.
+    /// - `memory_size_mb`: The memory size in megabytes.
     ///
     /// # Returns
     ///
@@ -245,11 +253,12 @@ impl ReleaseRegistry {
     ///
     pub(crate) fn get_release(
         &self,
+        target: Target,
         machine: Machine,
         deployment: Deployment,
         memory_size_mb: u32,
     ) -> Option<&ReleaseEntry> {
-        let key: String = format!("{}-{}-{}mb", machine, deployment, memory_size_mb);
+        let key: String = format!("{}-{}-{}-{}mb", target, machine, deployment, memory_size_mb);
         self.releases.get(&key)
     }
 
@@ -284,10 +293,12 @@ impl ReleaseRegistry {
     ///
     /// # Description
     ///
-    /// Adds or updates a package entry for a specific machine-deployment-package configuration.
+    /// Adds or updates a package entry for a specific target-machine-deployment-package
+    /// configuration.
     ///
     /// # Parameters
     ///
+    /// - `target`: The target architecture.
     /// - `machine`: The target machine type.
     /// - `deployment`: The deployment type.
     /// - `package`: The package being installed.
@@ -296,13 +307,14 @@ impl ReleaseRegistry {
     ///
     pub(crate) fn set_package(
         &mut self,
+        target: Target,
         machine: Machine,
         deployment: Deployment,
         package: Package,
         url: String,
         nanvix_commit_id: String,
     ) {
-        let key: String = format!("{}-{}-{}", machine, deployment, package);
+        let key: String = format!("{}-{}-{}-{}", target, machine, deployment, package);
         let entry: PackageEntry = PackageEntry::new(url, nanvix_commit_id);
         self.packages.insert(key, entry);
     }
@@ -310,10 +322,11 @@ impl ReleaseRegistry {
     ///
     /// # Description
     ///
-    /// Gets the package entry for a specific machine-deployment-package configuration.
+    /// Gets the package entry for a specific target-machine-deployment-package configuration.
     ///
     /// # Parameters
     ///
+    /// - `target`: The target architecture.
     /// - `machine`: The target machine type.
     /// - `deployment`: The deployment type.
     /// - `package`: The package to look up.
@@ -324,22 +337,24 @@ impl ReleaseRegistry {
     ///
     pub(crate) fn get_package(
         &self,
+        target: Target,
         machine: Machine,
         deployment: Deployment,
         package: Package,
     ) -> Option<&PackageEntry> {
-        let key: String = format!("{}-{}-{}", machine, deployment, package);
+        let key: String = format!("{}-{}-{}-{}", target, machine, deployment, package);
         self.packages.get(&key)
     }
 
     ///
     /// # Description
     ///
-    /// Checks whether a package is installed for a specific machine-deployment configuration
-    /// and matches the given Nanvix commit ID.
+    /// Checks whether a package is installed for a specific target-machine-deployment
+    /// configuration and matches the given Nanvix commit ID.
     ///
     /// # Parameters
     ///
+    /// - `target`: The target architecture.
     /// - `machine`: The target machine type.
     /// - `deployment`: The deployment type.
     /// - `package`: The package to check.
@@ -351,12 +366,13 @@ impl ReleaseRegistry {
     ///
     pub(crate) fn is_package_installed(
         &self,
+        target: Target,
         machine: Machine,
         deployment: Deployment,
         package: Package,
         nanvix_commit_id: &str,
     ) -> bool {
-        if let Some(entry) = self.get_package(machine, deployment, package) {
+        if let Some(entry) = self.get_package(target, machine, deployment, package) {
             entry.nanvix_commit_id() == nanvix_commit_id
         } else {
             false
@@ -543,6 +559,7 @@ mod tests {
 
         // Set a release.
         registry.set_release(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             128,
@@ -552,7 +569,7 @@ mod tests {
 
         // Get the release.
         let entry: Option<&ReleaseEntry> =
-            registry.get_release(Machine::Microvm, Deployment::SingleProcess, 128);
+            registry.get_release(Target::X86, Machine::Microvm, Deployment::SingleProcess, 128);
         assert!(entry.is_some());
 
         let entry: &ReleaseEntry = entry.expect("failed");
@@ -571,6 +588,7 @@ mod tests {
 
         // Add multiple configurations.
         registry.set_release(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             128,
@@ -579,6 +597,7 @@ mod tests {
         );
 
         registry.set_release(
+            Target::X86,
             Machine::Microvm,
             Deployment::MultiProcess,
             128,
@@ -587,6 +606,7 @@ mod tests {
         );
 
         registry.set_release(
+            Target::X86,
             Machine::Hyperlight,
             Deployment::SingleProcess,
             128,
@@ -599,17 +619,17 @@ mod tests {
 
         // Verify each entry.
         let entry: &ReleaseEntry = registry
-            .get_release(Machine::Microvm, Deployment::SingleProcess, 128)
+            .get_release(Target::X86, Machine::Microvm, Deployment::SingleProcess, 128)
             .expect("failed");
         assert_eq!(entry.commit_id(), "abc111def");
 
         let entry: &ReleaseEntry = registry
-            .get_release(Machine::Microvm, Deployment::MultiProcess, 128)
+            .get_release(Target::X86, Machine::Microvm, Deployment::MultiProcess, 128)
             .expect("failed");
         assert_eq!(entry.commit_id(), "abc222def");
 
         let entry: &ReleaseEntry = registry
-            .get_release(Machine::Hyperlight, Deployment::SingleProcess, 128)
+            .get_release(Target::X86, Machine::Hyperlight, Deployment::SingleProcess, 128)
             .expect("failed");
         assert_eq!(entry.commit_id(), "abc333def");
     }
@@ -625,6 +645,7 @@ mod tests {
 
         // Add initial release.
         registry.set_release(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             128,
@@ -636,6 +657,7 @@ mod tests {
 
         // Update with new release.
         registry.set_release(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             128,
@@ -647,7 +669,7 @@ mod tests {
         assert_eq!(registry.len(), 1);
 
         let entry: &ReleaseEntry = registry
-            .get_release(Machine::Microvm, Deployment::SingleProcess, 128)
+            .get_release(Target::X86, Machine::Microvm, Deployment::SingleProcess, 128)
             .expect("failed");
         assert_eq!(entry.url(), "https://test.com/new.tar.bz2");
         assert_eq!(entry.commit_id(), "abc222def");
@@ -662,6 +684,7 @@ mod tests {
     fn test_serialization() {
         let mut registry: ReleaseRegistry = ReleaseRegistry::new();
         registry.set_release(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             128,
@@ -671,7 +694,7 @@ mod tests {
 
         let json: String = serde_json::to_string(&registry).expect("failed");
         assert!(json.contains("releases"));
-        assert!(json.contains("microvm-single-process-128mb"));
+        assert!(json.contains("x86-microvm-single-process-128mb"));
         assert!(json.contains("https://example.com/release.tar.bz2"));
         assert!(json.contains("abc123def456"));
     }
@@ -683,11 +706,11 @@ mod tests {
     ///
     #[test]
     fn test_deserialization() {
-        let json: &str = r#"{"releases":{"microvm-single-process-128mb":{"url":"https://example.com/release.tar.bz2","commit_id":"abc123def456"}}}"#;
+        let json: &str = r#"{"releases":{"x86-microvm-single-process-128mb":{"url":"https://example.com/release.tar.bz2","commit_id":"abc123def456"}}}"#;
         let registry: ReleaseRegistry = serde_json::from_str(json).expect("failed");
 
         let entry: &ReleaseEntry = registry
-            .get_release(Machine::Microvm, Deployment::SingleProcess, 128)
+            .get_release(Target::X86, Machine::Microvm, Deployment::SingleProcess, 128)
             .expect("failed");
         assert_eq!(entry.url(), "https://example.com/release.tar.bz2");
         assert_eq!(entry.commit_id(), "abc123def456");
@@ -706,6 +729,7 @@ mod tests {
 
         let mut original: ReleaseRegistry = ReleaseRegistry::new();
         original.set_release(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             128,
@@ -713,6 +737,7 @@ mod tests {
             "abc111def".to_string(),
         );
         original.set_release(
+            Target::X86,
             Machine::Hyperlight,
             Deployment::MultiProcess,
             128,
@@ -732,12 +757,12 @@ mod tests {
         assert_eq!(loaded.len(), 2);
 
         let entry: &ReleaseEntry = loaded
-            .get_release(Machine::Microvm, Deployment::SingleProcess, 128)
+            .get_release(Target::X86, Machine::Microvm, Deployment::SingleProcess, 128)
             .expect("failed");
         assert_eq!(entry.commit_id(), "abc111def");
 
         let entry: &ReleaseEntry = loaded
-            .get_release(Machine::Hyperlight, Deployment::MultiProcess, 128)
+            .get_release(Target::X86, Machine::Hyperlight, Deployment::MultiProcess, 128)
             .expect("failed");
         assert_eq!(entry.commit_id(), "abc222def");
 
@@ -772,6 +797,7 @@ mod tests {
 
         let mut registry: ReleaseRegistry = ReleaseRegistry::new();
         registry.set_release(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             128,
@@ -800,6 +826,7 @@ mod tests {
 
         let mut registry: ReleaseRegistry = ReleaseRegistry::new();
         registry.set_release(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             128,
@@ -861,6 +888,7 @@ mod tests {
 
         // Set a package.
         registry.set_package(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::OpenSSL,
@@ -869,8 +897,12 @@ mod tests {
         );
 
         // Get the package.
-        let entry: Option<&PackageEntry> =
-            registry.get_package(Machine::Microvm, Deployment::SingleProcess, Package::OpenSSL);
+        let entry: Option<&PackageEntry> = registry.get_package(
+            Target::X86,
+            Machine::Microvm,
+            Deployment::SingleProcess,
+            Package::OpenSSL,
+        );
         assert!(entry.is_some());
 
         let entry: &PackageEntry = entry.expect("package entry should exist");
@@ -889,6 +921,7 @@ mod tests {
         let nanvix_commit_id: String = "abc123def456".to_string();
 
         registry.set_package(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::OpenSSL,
@@ -897,6 +930,7 @@ mod tests {
         );
 
         assert!(registry.is_package_installed(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::OpenSSL,
@@ -914,6 +948,7 @@ mod tests {
         let registry: ReleaseRegistry = ReleaseRegistry::new();
 
         assert!(!registry.is_package_installed(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::OpenSSL,
@@ -931,6 +966,7 @@ mod tests {
         let mut registry: ReleaseRegistry = ReleaseRegistry::new();
 
         registry.set_package(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::OpenSSL,
@@ -940,6 +976,7 @@ mod tests {
 
         // Check with different commit ID.
         assert!(!registry.is_package_installed(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::OpenSSL,
@@ -959,6 +996,7 @@ mod tests {
 
         // Add multiple packages.
         registry.set_package(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::OpenSSL,
@@ -967,6 +1005,7 @@ mod tests {
         );
 
         registry.set_package(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::Zlib,
@@ -975,6 +1014,7 @@ mod tests {
         );
 
         registry.set_package(
+            Target::X86,
             Machine::Hyperlight,
             Deployment::MultiProcess,
             Package::CPython,
@@ -984,6 +1024,7 @@ mod tests {
 
         // Verify all packages are installed.
         assert!(registry.is_package_installed(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::OpenSSL,
@@ -991,6 +1032,7 @@ mod tests {
         ));
 
         assert!(registry.is_package_installed(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::Zlib,
@@ -998,6 +1040,7 @@ mod tests {
         ));
 
         assert!(registry.is_package_installed(
+            Target::X86,
             Machine::Hyperlight,
             Deployment::MultiProcess,
             Package::CPython,
@@ -1006,6 +1049,7 @@ mod tests {
 
         // Verify non-installed package returns false.
         assert!(!registry.is_package_installed(
+            Target::X86,
             Machine::Microvm,
             Deployment::SingleProcess,
             Package::QuickJS,

--- a/src/libs/nanvix-registry/src/release.rs
+++ b/src/libs/nanvix-registry/src/release.rs
@@ -14,6 +14,7 @@ use crate::{
         RateLimiter,
     },
     tarball::Tarball,
+    target::Target,
     tempfile::TemporaryFile,
 };
 use ::anyhow::Result;
@@ -50,6 +51,8 @@ const GITHUB_API_URL: &str = "https://api.github.com/repos/nanvix/nanvix/release
 /// Represents the latest release from the Nanvix GitHub repository.
 ///
 pub(crate) struct LatestRelease {
+    /// Target architecture for the release.
+    target: Target,
     /// Deployment type for the release.
     deployment: Deployment,
     /// Target machine type for the release.
@@ -68,22 +71,29 @@ impl LatestRelease {
     ///
     /// # Description
     ///
-    /// Creates a new handle for a latest release for the specified deployment, machine type, and
-    /// memory size.
+    /// Creates a new handle for a latest release for the specified target architecture,
+    /// deployment, machine type, and memory size.
     ///
     /// # Parameters
     ///
+    /// - `target`: The target architecture.
     /// - `deployment`: The deployment type.
     /// - `machine`: The target machine type.
     /// - `memory_size_mb`: The memory size in megabytes.
     ///
     /// # Returns
     ///
-    /// A new handle for a latest release for the specified deployment, machine type, and memory
-    /// size.
+    /// A new handle for a latest release for the specified target architecture, deployment,
+    /// machine type, and memory size.
     ///
-    pub(crate) fn new(deployment: Deployment, machine: Machine, memory_size_mb: u32) -> Self {
+    pub(crate) fn new(
+        target: Target,
+        deployment: Deployment,
+        machine: Machine,
+        memory_size_mb: u32,
+    ) -> Self {
         Self {
+            target,
             deployment,
             machine,
             memory_size_mb,
@@ -203,8 +213,8 @@ impl LatestRelease {
         };
 
         let release_pattern: String = format!(
-            "nanvix-{}-{}-release-{}mb-",
-            self.machine, self.deployment, self.memory_size_mb
+            "nanvix-{}-{}-{}-release-{}mb-",
+            self.target, self.machine, self.deployment, self.memory_size_mb
         );
 
         // Search for the matching asset.
@@ -240,10 +250,12 @@ mod tests {
     ///
     #[test]
     fn test_new() {
+        let target: Target = Target::X86;
         let deployment: Deployment = Deployment::SingleProcess;
         let machine: Machine = Machine::Microvm;
-        let release: LatestRelease = LatestRelease::new(deployment, machine, 128);
+        let release: LatestRelease = LatestRelease::new(target, deployment, machine, 128);
 
+        assert!(matches!(release.target, Target::X86));
         assert!(matches!(release.deployment, Deployment::SingleProcess));
         assert!(matches!(release.machine, Machine::Microvm));
         assert_eq!(release.memory_size_mb, 128);
@@ -256,18 +268,22 @@ mod tests {
     ///
     #[test]
     fn test_release_pattern() {
+        let target: Target = Target::X86;
         let deployment: Deployment = Deployment::MultiProcess;
         let machine: Machine = Machine::Hyperlight;
 
-        let pattern: String = format!("nanvix-{}-{}-release-{}mb-", machine, deployment, 128);
-        assert_eq!(pattern, "nanvix-hyperlight-multi-process-release-128mb-");
+        let pattern: String =
+            format!("nanvix-{}-{}-{}-release-{}mb-", target, machine, deployment, 128);
+        assert_eq!(pattern, "nanvix-x86-hyperlight-multi-process-release-128mb-");
 
         // Verify the pattern matches the memory-size archive name format.
-        let name_128: &str = "nanvix-hyperlight-multi-process-release-128mb-abc123def456.tar.bz2";
+        let name_128: &str =
+            "nanvix-x86-hyperlight-multi-process-release-128mb-abc123def456.tar.bz2";
         assert!(name_128.contains(&pattern));
 
         // Verify the pattern does NOT match a different memory size.
-        let name_1024: &str = "nanvix-hyperlight-multi-process-release-1024mb-abc123def456.tar.bz2";
+        let name_1024: &str =
+            "nanvix-x86-hyperlight-multi-process-release-1024mb-abc123def456.tar.bz2";
         assert!(!name_1024.contains(&pattern));
     }
 
@@ -290,18 +306,23 @@ mod tests {
     ///
     #[test]
     fn test_all_release_patterns() {
+        let targets: [Target; 1] = [Target::X86];
         let deployments: [Deployment; 2] = [Deployment::SingleProcess, Deployment::MultiProcess];
         let machines: [Machine; 2] = [Machine::Hyperlight, Machine::Microvm];
         let memory_sizes: [u32; 4] = [128, 256, 512, 1024];
 
-        for deployment in &deployments {
-            for machine in &machines {
-                for memory_size_mb in &memory_sizes {
-                    let pattern: String =
-                        format!("nanvix-{}-{}-release-{}mb-", machine, deployment, memory_size_mb);
-                    assert!(pattern.contains("nanvix-"));
-                    assert!(pattern.contains("-release-"));
-                    assert!(pattern.ends_with("mb-"));
+        for target in &targets {
+            for deployment in &deployments {
+                for machine in &machines {
+                    for memory_size_mb in &memory_sizes {
+                        let pattern: String = format!(
+                            "nanvix-{}-{}-{}-release-{}mb-",
+                            target, machine, deployment, memory_size_mb
+                        );
+                        assert!(pattern.contains("nanvix-"));
+                        assert!(pattern.contains("-release-"));
+                        assert!(pattern.ends_with("mb-"));
+                    }
                 }
             }
         }

--- a/src/libs/nanvix-registry/src/target.rs
+++ b/src/libs/nanvix-registry/src/target.rs
@@ -1,0 +1,163 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::log::error;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Represents a target architecture for Nanvix releases.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Target {
+    /// x86 (32/64-bit) architecture.
+    X86,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Target {
+    /// String representation of x86 target.
+    pub const X86_STR: &'static str = "x86";
+
+    ///
+    /// # Description
+    ///
+    /// Converts the target architecture to its string representation.
+    ///
+    /// # Returns
+    ///
+    /// A string representation of the target architecture.
+    ///
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Target::X86 => Target::X86_STR,
+        }
+    }
+}
+
+impl ::std::fmt::Display for Target {
+    ///
+    /// # Description
+    ///
+    /// Converts the target architecture to its string representation.
+    ///
+    /// # Parameters
+    ///
+    /// - `f`: The formatter.
+    ///
+    /// # Returns
+    ///
+    /// On success, this function returns an empty tuple. On failure, it returns an object that
+    /// describes the error.
+    ///
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<&str> for Target {
+    type Error = anyhow::Error;
+
+    ///
+    /// # Description
+    ///
+    /// Attempts to convert a string slice to a `Target` enum variant.
+    ///
+    /// # Parameters
+    ///
+    /// - `value`: The string representation of the target architecture (case-insensitive).
+    ///
+    /// # Returns
+    ///
+    /// On success, returns the corresponding `Target` variant. On failure, it returns an object
+    /// that describes the error.
+    ///
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let value_lower: String = value.to_lowercase();
+        match value_lower.as_str() {
+            Self::X86_STR => Ok(Target::X86),
+            _ => {
+                let reason: String = format!("Unknown target architecture: {value}");
+                error!("{reason}");
+                anyhow::bail!(reason)
+            },
+        }
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `X86` target converts to correct string representation.
+    ///
+    #[test]
+    fn test_x86_as_str() {
+        let target: Target = Target::X86;
+        assert_eq!(target.as_str(), "x86");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests that `X86` display trait works correctly.
+    ///
+    #[test]
+    fn test_x86_display() {
+        let target: Target = Target::X86;
+        assert_eq!(format!("{}", target), "x86");
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests conversion from valid string.
+    ///
+    #[test]
+    fn test_try_from_valid() {
+        let target: Target = Target::try_from("x86").expect("should succeed");
+        assert!(matches!(target, Target::X86));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests case-insensitive conversion from string.
+    ///
+    #[test]
+    fn test_try_from_case_insensitive() {
+        let target: Target = Target::try_from("X86").expect("should succeed");
+        assert!(matches!(target, Target::X86));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Tests conversion from invalid string.
+    ///
+    #[test]
+    fn test_try_from_invalid() {
+        let result: Result<Target> = Target::try_from("arm64");
+        assert!(result.is_err());
+    }
+}

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -36,7 +36,10 @@ use ::nanvix::{
     config::{
         constants::MEGABYTE,
         kernel::MEMORY_SIZE,
-        system::DEFAULT_MACHINE_NAME,
+        system::{
+            DEFAULT_MACHINE_NAME,
+            DEFAULT_TARGET_NAME,
+        },
     },
     registry::Registry,
     sandbox::NAMED_RESOURCE_PREFIX,
@@ -379,7 +382,13 @@ async fn ensure_all_binaries_available(
     let memory_size_mb: u32 = (MEMORY_SIZE / MEGABYTE) as u32;
 
     let kernel_cached_path: String = registry
-        .get_cached_binary(machine, deployment, memory_size_mb, KERNEL_BINARY_NAME)
+        .get_cached_binary(
+            DEFAULT_TARGET_NAME,
+            machine,
+            deployment,
+            memory_size_mb,
+            KERNEL_BINARY_NAME,
+        )
         .await?;
     log_info!("using registry binary {}: {}", KERNEL_BINARY_NAME, kernel_cached_path);
 
@@ -389,12 +398,24 @@ async fn ensure_all_binaries_available(
     #[cfg(not(any(feature = "single-process", feature = "standalone")))]
     {
         let linuxd_cached_path: String = registry
-            .get_cached_binary(machine, deployment, memory_size_mb, LINUXD_BINARY_NAME)
+            .get_cached_binary(
+                DEFAULT_TARGET_NAME,
+                machine,
+                deployment,
+                memory_size_mb,
+                LINUXD_BINARY_NAME,
+            )
             .await?;
         log_info!("using registry binary {}: {}", LINUXD_BINARY_NAME, linuxd_cached_path);
 
         let uservm_cached_path: String = registry
-            .get_cached_binary(machine, deployment, memory_size_mb, USERVM_BINARY_NAME)
+            .get_cached_binary(
+                DEFAULT_TARGET_NAME,
+                machine,
+                deployment,
+                memory_size_mb,
+                USERVM_BINARY_NAME,
+            )
             .await?;
         log_info!("using registry binary {}: {}", USERVM_BINARY_NAME, uservm_cached_path);
 


### PR DESCRIPTION
## Summary

Add a target architecture dimension to the release pipeline, registry API, and CI workflow. This enables future support for multiple architectures (e.g., ARM) alongside the current x86 target.

## Changes

- Introduce `Target` enum in nanvix-registry with `TryFrom<&str>`, `Display`, and validation logic (`src/libs/nanvix-registry/src/target.rs`).
- Thread a `target` parameter through `get_cached_binary()`, `get_cached_artifact()`, `install()`, and `install_with_progress()` in the registry public API.
- Update `LatestRelease` to include the target in the release pattern (`nanvix-<target>-<machine>-<deployment>-release-<mem>mb-<commit>.tar.bz2`).
- Add `DEFAULT_TARGET_NAME` constant to the config crate.
- Update nanvixd to pass the default target to all registry calls.
- Add `target-arch` input to the release-package GitHub Action and propagate it into the archive filename.
- Add `target-arch: [x86]` to the CI release-archive and windows-release-archive matrices, updating job names and artifact names to include the architecture.
- Update the Makefile `RELEASE_ARCHIVE` pattern to include `$(TARGET)`.
- Add negative tests for invalid target architecture on `get_cached_binary`, `get_cached_artifact`, and `install`.
- Derive `PartialEq, Eq` on `Target` for ergonomic comparisons.
- Update ci-cd-pipeline skill doc to reflect the new naming pattern.