### PR TITLE
[syscall] Cache thread ID in TDA for fast pthread_self()

### DIFF
--- a/src/libs/nvx/src/lib.rs
+++ b/src/libs/nvx/src/lib.rs
@@ -324,6 +324,7 @@ fn init() {
             if let Err(error) = ::sys::kcall::pm::set_thread_data_area(tda_ptr) {
                 panic!("init(): failed to set thread data area (error={error:?})");
             }
+            sysalloc::tda::mark_initialized();
         },
         core::prelude::v1::Ok(None) => {
             // No thread-local storage to set.

--- a/src/libs/sys/src/sys/kcall/arch/x86.rs
+++ b/src/libs/sys/src/sys/kcall/arch/x86.rs
@@ -195,3 +195,68 @@ pub unsafe fn kcall4(kcall_nr: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) 
 
     ((high_ret as i64) << 32) | (low_ret as i64)
 }
+
+//==================================================================================================
+// Thread Data Area Helpers
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads a `u32` value from the Thread Data Area (TDA) via the `%gs` segment register.
+///
+/// # Parameters
+///
+/// - `offset`: Byte offset within the TDA.
+///
+/// # Returns
+///
+/// The `u32` value stored at `gs:[offset]`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - The `%gs` segment base has been configured via `set_thread_data_area()`.
+/// - `offset` refers to a valid, properly aligned `u32` slot within the TDA.
+///
+#[inline(always)]
+pub unsafe fn read_tda_u32(offset: u32) -> u32 {
+    let val: u32;
+    unsafe {
+        arch::asm!(
+            "mov {0:e}, gs:[{1:e}]",
+            out(reg) val,
+            in(reg) offset,
+            options(nostack, readonly, preserves_flags),
+        );
+    }
+    val
+}
+
+///
+/// # Description
+///
+/// Writes a `u32` value to the Thread Data Area (TDA) via the `%gs` segment register.
+///
+/// # Parameters
+///
+/// - `offset`: Byte offset within the TDA.
+/// - `val`: The `u32` value to store at `gs:[offset]`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - The `%gs` segment base has been configured via `set_thread_data_area()`.
+/// - `offset` refers to a valid, properly aligned `u32` slot within the TDA.
+///
+#[inline(always)]
+pub unsafe fn write_tda_u32(offset: u32, val: u32) {
+    unsafe {
+        arch::asm!(
+            "mov gs:[{0:e}], {1:e}",
+            in(reg) offset,
+            in(reg) val,
+            options(nostack, preserves_flags),
+        );
+    }
+}

--- a/src/libs/sys/src/sys/kcall/arch/x86_64.rs
+++ b/src/libs/sys/src/sys/kcall/arch/x86_64.rs
@@ -1,0 +1,73 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::core::arch;
+
+//==================================================================================================
+// Thread Data Area Helpers
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Reads a `u32` value from the Thread Data Area (TDA) via the `%fs` segment register.
+///
+/// # Parameters
+///
+/// - `offset`: Byte offset within the TDA.
+///
+/// # Returns
+///
+/// The `u32` value stored at `fs:[offset]`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - The `%fs` segment base has been configured via `set_thread_data_area()`.
+/// - `offset` refers to a valid, properly aligned `u32` slot within the TDA.
+///
+#[inline(always)]
+pub unsafe fn read_tda_u32(offset: u32) -> u32 {
+    let val: u32;
+    unsafe {
+        arch::asm!(
+            "mov {0:e}, fs:[{1:e}]",
+            out(reg) val,
+            in(reg) offset,
+            options(nostack, readonly, preserves_flags),
+        );
+    }
+    val
+}
+
+///
+/// # Description
+///
+/// Writes a `u32` value to the Thread Data Area (TDA) via the `%fs` segment register.
+///
+/// # Parameters
+///
+/// - `offset`: Byte offset within the TDA.
+/// - `val`: The `u32` value to store at `fs:[offset]`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - The `%fs` segment base has been configured via `set_thread_data_area()`.
+/// - `offset` refers to a valid, properly aligned `u32` slot within the TDA.
+///
+#[inline(always)]
+pub unsafe fn write_tda_u32(offset: u32, val: u32) {
+    unsafe {
+        arch::asm!(
+            "mov fs:[{0:e}], {1:e}",
+            in(reg) offset,
+            in(reg) val,
+            options(nostack, preserves_flags),
+        );
+    }
+}

--- a/src/libs/sys/src/sys/kcall/mod.rs
+++ b/src/libs/sys/src/sys/kcall/mod.rs
@@ -10,6 +10,11 @@
 #[path = "arch/x86.rs"]
 pub mod arch;
 
+/// Architecture-specific symbols.
+#[cfg(target_arch = "x86_64")]
+#[path = "arch/x86_64.rs"]
+pub mod arch;
+
 /// Debug facilities.
 pub mod debug;
 

--- a/src/libs/sysalloc/src/tda.rs
+++ b/src/libs/sysalloc/src/tda.rs
@@ -9,6 +9,10 @@ use ::arch::mem::PAGE_ALIGNMENT;
 use ::core::{
     alloc::Layout,
     cmp::max,
+    sync::atomic::{
+        AtomicBool,
+        Ordering,
+    },
 };
 use ::sys::{
     error::{
@@ -19,8 +23,60 @@ use ::sys::{
 };
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Offset of the cached thread ID within the TDA header, in bytes.
+pub const TDA_TID_OFFSET: usize = core::mem::size_of::<*mut u8>();
+
+/// Size of the cached thread ID field in the TDA header, in bytes.
+pub const TDA_TID_SIZE: usize = core::mem::size_of::<u32>();
+
+/// Total size of the TDA header (self-pointer + cached thread ID), in bytes.
+const TDA_HEADER_SIZE: usize = TDA_TID_OFFSET + TDA_TID_SIZE;
+
+/// Sentinel value indicating the cached thread ID has not been populated yet.
+pub const TDA_TID_UNSET: u32 = 0;
+
+//==================================================================================================
 // Global Variables
 //==================================================================================================
+
+/// Tracks whether the calling thread's TDA has been fully initialized.
+///
+/// # Safety Invariant
+///
+/// This flag is set to `true` by [`mark_initialized`] after `set_thread_data_area()` succeeds
+/// during runtime init, and reset to `false` by [`mark_uninitialized`] in [`cleanup`] before the
+/// segment base is cleared. Code that reads the TDA via a segment register (e.g., the
+/// `pthread_self()` fast path) must check this flag first.
+///
+/// The flag is process-wide, which is sound because:
+/// - The main thread sets it once during `init()`, before any child thread is created.
+/// - Child threads inherit a valid TDA from the kernel (configured via `FS_BASE`/GDT on context
+///   switch) and never run user code without one.
+/// - `cleanup()` resets the flag and then diverges via `exit_thread()`, so no subsequent
+///   `pthread_self()` call can observe a stale `true`.
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+/// Marks the TDA subsystem as initialized.
+///
+/// Must be called after `set_thread_data_area()` succeeds during runtime init.
+pub fn mark_initialized() {
+    INITIALIZED.store(true, Ordering::Release);
+}
+
+/// Marks the TDA subsystem as uninitialized.
+///
+/// Must be called before clearing the segment base in [`cleanup`].
+pub fn mark_uninitialized() {
+    INITIALIZED.store(false, Ordering::Release);
+}
+
+/// Returns `true` if [`mark_initialized`] has been called and [`mark_uninitialized`] has not.
+pub fn is_initialized() -> bool {
+    INITIALIZED.load(Ordering::Acquire)
+}
 
 extern "C" {
     /// Linker symbol that marks the beginning of the TLS segment.
@@ -56,12 +112,17 @@ extern "C" {
 /// ```text
 /// High Address
 ///     ↑
-/// +---------------------+ <- tda_ptr + size_of::<*mut u8>() (end of allocation)
+/// +---------------------+ <- tda_ptr + tda_header_size (end of allocation)
+/// |                     |
+/// | Cached Thread ID    | u32 slot for fast pthread_self()
+/// |                     | Zero-initialized; lazily populated by pthread_self()
+/// |                     | Read via segment register at TDA_TID_OFFSET
+/// +---------------------+ <- tda_ptr + size_of::<*mut u8>()
 /// |                     |
 /// | Self-Reference      | Pointer to Thread Data Area (TDA)
 /// | Pointer             | Value: tda_ptr (points to itself)
-/// |                     |
-/// +---------------------+ <- tda_ptr (returned to caller)
+/// |                     |                (size_of::<*mut u8>() bytes)
+/// +---------------------+ <- tda_ptr (returned to caller, segment base)
 /// |                     |
 /// | Padding (optional)  | Padding to meet alignment requirements between TLS and TDA pointer
 /// |                     |
@@ -79,7 +140,8 @@ extern "C" {
 /// Low Address
 ///
 /// Where:
-/// - allocation_size = allocation_padding_size + size_of::<*mut u8>()
+/// - TDA_HEADER_SIZE = TDA_TID_OFFSET + TDA_TID_SIZE
+/// - allocation_size = allocation_padding_size + TDA_HEADER_SIZE
 /// - allocation_padding_size = align_up(tls_size, max(PAGE_ALIGNMENT, align_of::<*mut u8>()))
 /// - tda_ptr = allocation + allocation_padding_size
 /// ```
@@ -89,7 +151,6 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
     let tls_end_addr: usize = unsafe { &__TLS_END as *const u8 as usize };
     let tls_size: usize = tls_end_addr - tls_start_addr;
     let tls_alignment: usize = PAGE_ALIGNMENT.into();
-    let tda_ptr_size: usize = core::mem::size_of::<*mut u8>();
     let allocation_alignment: usize = max(tls_alignment, core::mem::align_of::<*mut u8>());
     let allocation_padding_size: usize = align_up(tls_size, allocation_alignment.try_into()?)
         .ok_or_else(|| {
@@ -99,11 +160,11 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
             );
             Error::new(ErrorCode::OutOfMemory, "align_up overflow")
         })?;
-    let allocation_size: usize = allocation_padding_size + tda_ptr_size;
+    let allocation_size: usize = allocation_padding_size + TDA_HEADER_SIZE;
 
     ::syslog::trace!(
         "alloc(): tls_start_addr={tls_start_addr:x?}, tls_end_addr={tls_end_addr:x?}, \
-         tls_size={tls_size}, tls_alignment={tls_alignment}, tda_ptr_size={tda_ptr_size}, \
+         tls_size={tls_size}, tls_alignment={tls_alignment}, tda_header_size={TDA_HEADER_SIZE}, \
          allocation_alignment={allocation_alignment}, \
          allocation_padding_size={allocation_padding_size}, allocation_size={allocation_size}",
     );
@@ -155,6 +216,12 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
         *self_ptr = tda_ptr;
     }
 
+    // Zero-initialize the cached thread ID at TDA_TID_OFFSET. The actual TID is populated lazily.
+    let tid_ptr: *mut u32 = unsafe { tda_ptr.add(TDA_TID_OFFSET) as *mut u32 };
+    unsafe {
+        *tid_ptr = TDA_TID_UNSET;
+    }
+
     // Compute pointer to thread-local storage.
     // SAFETY: `tda_ptr` is non-null and pointer arithmetic is within bounds.
     let tls_aligned_size: usize = align_up(tls_size, PAGE_ALIGNMENT).ok_or_else(|| {
@@ -200,6 +267,10 @@ pub fn cleanup() -> Result<(), sys::error::Error> {
     // Deallocate thread-local storage.
     dealloc(tcb_ptr)?;
 
+    // Mark TDA as uninitialized before clearing the segment base so that no subsequent
+    // segment-relative access (e.g., pthread_self() fast path) can observe a stale flag.
+    mark_uninitialized();
+
     // Clear the thread-local storage pointer first to avoid dangling pointers.
     match sys::kcall::pm::set_thread_data_area(core::ptr::null_mut()) {
         Ok(()) => Ok(()),
@@ -235,7 +306,6 @@ fn dealloc(tda_ptr: *mut u8) -> Result<(), Error> {
     let tls_end_addr: usize = unsafe { &__TLS_END as *const u8 as usize };
     let tls_size: usize = tls_end_addr - tls_start_addr;
     let tls_alignment: usize = PAGE_ALIGNMENT.into();
-    let tda_ptr_size: usize = core::mem::size_of::<*mut u8>();
     let allocation_alignment: usize = max(tls_alignment, core::mem::align_of::<*mut u8>());
     let allocation_padding_size: usize = align_up(tls_size, allocation_alignment.try_into()?)
         .ok_or_else(|| {
@@ -245,14 +315,14 @@ fn dealloc(tda_ptr: *mut u8) -> Result<(), Error> {
             );
             Error::new(ErrorCode::OutOfMemory, "align_up overflow")
         })?;
-    let allocation_size: usize = allocation_padding_size + tda_ptr_size;
+    let allocation_size: usize = allocation_padding_size + TDA_HEADER_SIZE;
 
     ::syslog::trace!(
         "cleanup(): tls_start_addr={tls_start_addr:x?}, tls_end_addr={tls_end_addr:x?}, \
-         tls_size={tls_size}, tls_alignment={tls_alignment}, tcb_size={tda_ptr_size}, \
+         tls_size={tls_size}, tls_alignment={tls_alignment}, tda_header_size={TDA_HEADER_SIZE}, \
          allocation_alignment={allocation_alignment}, \
          allocation_padding_size={allocation_padding_size}, allocation_size={allocation_size}, \
-         tcb_ptr={tda_ptr:p}",
+         tda_ptr={tda_ptr:p}",
     );
 
     // Compute allocation layout.

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -42,10 +42,14 @@ use ::spin::{
 };
 use ::sys::{
     error::Error,
-    kcall::pm::{
-        create_thread,
-        exit_thread,
-        join_thread,
+    kcall::{
+        arch,
+        pm::{
+            create_thread,
+            exit_thread,
+            gettid,
+            join_thread,
+        },
     },
     mm::VirtualAddress,
     pm::{
@@ -53,12 +57,16 @@ use ::sys::{
         ThreadIdentifier,
     },
 };
+use ::sysalloc::tda::{
+    TDA_TID_OFFSET,
+    TDA_TID_UNSET,
+};
+use ::sysapi::sys_types::pthread_t;
 
 //==================================================================================================
 // Exports
 //==================================================================================================
 
-use ::sysapi::sys_types::pthread_t;
 pub use cond::*;
 pub use mutex::*;
 pub use pthread_attr_destroy::*;
@@ -204,8 +212,38 @@ pub fn pthread_exit(retval: usize) -> Result<!, Error> {
 /// - The thread identifier returned by the kernel is not valid.
 ///
 pub fn pthread_self() -> pthread_t {
-    ::sys::kcall::pm::gettid()
-        .expect("a thread must be able to get its own identifier")
+    // Fast path: read the cached thread ID from the TDA via segment register.
+    //
+    // Safety: `is_initialized()` is process-wide but sound here because:
+    // - It is set only after `set_thread_data_area()` succeeds (main thread init).
+    // - Child threads always have a valid TDA configured by the kernel before first execution.
+    // - `cleanup()` resets the flag before clearing the segment base and then diverges.
+    if ::sysalloc::tda::is_initialized() {
+        let tid: u32 = unsafe { arch::read_tda_u32(TDA_TID_OFFSET as u32) };
+
+        // Check if the TDA slot contains a valid thread ID.
+        if tid != TDA_TID_UNSET {
+            return tid as pthread_t;
+        }
+
+        // Cache miss: the TDA slot still holds the TDA_TID_UNSET sentinel because tda::alloc()
+        // cannot know the child's TID at allocation time. Resolve via kcall and cache for future
+        // calls.
+        let real_tid: pthread_t = gettid()
+            .expect("pthread_self(): gettid kcall failed (TDA cache-miss path)")
+            .try_into()
+            .expect("pthread_self(): invalid thread identifier from kernel (TDA cache-miss path)");
+
+        unsafe {
+            arch::write_tda_u32(TDA_TID_OFFSET as u32, real_tid);
+        }
+
+        return real_tid;
+    }
+
+    // Fallback: TDA not yet initialized (early startup).
+    gettid()
+        .expect("pthread_self(): gettid kcall failed (early-startup path)")
         .try_into()
-        .expect("thread identifiers returned by the kernel must be valid")
+        .expect("pthread_self(): invalid thread identifier from kernel (early-startup path)")
 }


### PR DESCRIPTION
This pull request introduces a fast path for retrieving the current thread's ID (`pthread_self`) by caching it in the Thread Data Area (TDA), reducing the need for repeated kernel calls. It also adds architecture-specific helpers for reading and writing values in the TDA via segment registers, and refactors the TDA layout and initialization logic for clarity and efficiency.