### PR TITLE
[build] Make memory_size a build-time parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,11 +275,6 @@ jobs:
       - name: "Setup"
         uses: ./.github/actions/native-setup
 
-      - name: "Patch memory_size in kernel config"
-        uses: ./.github/actions/patch-memory-size
-        with:
-          memory-size: "${{ matrix.memory-size }}"
-
       - name: "Setup sccache"
         uses: Mozilla-Actions/sccache-action@v0.0.9
         with:
@@ -300,7 +295,8 @@ jobs:
             VERBOSE=yes \
             BUILD_OPT=yes \
             ${RELEASE_FLAG} \
-            "DEPLOYMENT_MODE=${{ matrix.deployment-type }}"
+            "DEPLOYMENT_MODE=${{ matrix.deployment-type }}" \
+            "MEMORY_SIZE=${{ matrix.memory-size }}"
 
       - name: "Upload Build Artifacts"
         uses: actions/upload-artifact@v7
@@ -626,18 +622,13 @@ jobs:
           echo "CARGO_HOME=$isolatedCargo" >> $env:GITHUB_ENV
           Write-Host "Isolated CARGO_HOME to $isolatedCargo"
 
-      - name: "Patch memory_size in kernel config"
-        uses: ./.github/actions/patch-memory-size
-        with:
-          memory-size: "${{ matrix.memory-size }}"
-
       - name: "Build & Unit Test"
         shell: pwsh
         env:
           LOG_LEVEL: ${{ matrix.build-type == 'release' && 'error' || 'trace' }}
           RELEASE_FLAG: ${{ matrix.build-type == 'release' && 'RELEASE=yes' || '' }}
         run: |
-          .\z.ps1 build -- all run-unit-tests $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL
+          .\z.ps1 build -- all run-unit-tests $env:RELEASE_FLAG MACHINE=$env:MACHINE_TYPE LOG_LEVEL=$env:LOG_LEVEL MEMORY_SIZE=${{ matrix.memory-size }}
 
       - name: "Upload Build Artifacts"
         uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ export IMAGE ?= nanvix.img
 # Enable WHP backend?
 export WHP ?= no
 
+# Memory size in megabytes. Exported as MEMORY_SIZE_BYTES for build.rs scripts.
+# Example: make all MEMORY_SIZE=256
+export MEMORY_SIZE ?= 128
+
 #===================================================================================================
 # OS Detection
 #===================================================================================================
@@ -138,9 +142,18 @@ RELEASE_DEPLOYMENT_MODE := $(subst -,_,$(DEPLOYMENT_MODE))
 RELEASE_BUILD_MODE := $(if $(filter yes,$(RELEASE)),release,debug)
 RELEASE_VERSION := $(strip $(shell cargo metadata --no-deps --format-version 1 2>/dev/null | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' | head -n1))
 
-# Extract memory_size (bytes) from kernel config and convert to megabytes.
-MEMORY_SIZE_BYTES = $(strip $(shell sed -nE 's/^[[:space:]]*memory_size[[:space:]]*=[[:space:]]*(0x[0-9a-fA-F]+|[0-9]+).*/\1/p' $(BUILD_DIR)/kernel_config.toml | head -n1))
-MEMORY_SIZE_MB = $(shell echo $$(($(MEMORY_SIZE_BYTES) / 1048576)))
+# Validate MEMORY_SIZE.
+MEMORY_SIZE_MB := $(strip $(MEMORY_SIZE))
+ifeq ($(MEMORY_SIZE_MB),)
+$(error Invalid MEMORY_SIZE '$(MEMORY_SIZE)'. Expected a positive integer value in MB)
+endif
+ifneq ($(shell printf '%s\n' '$(MEMORY_SIZE_MB)' | grep -E '^[1-9][0-9]*$$'),$(MEMORY_SIZE_MB))
+$(error Invalid MEMORY_SIZE '$(MEMORY_SIZE)'. Expected a positive integer value in MB)
+endif
+
+# Derive memory size in bytes and megabytes from MEMORY_SIZE (MB).
+# Exported so that build.rs scripts read it via the MEMORY_SIZE_BYTES env var.
+export MEMORY_SIZE_BYTES := $(shell echo $$(($(MEMORY_SIZE_MB) * 1048576)))
 
 # VFS benchmark image filename.
 export VFS_BENCH_IMG ?= vfs-bench.img
@@ -485,13 +498,15 @@ endif
 # Generates a JSON manifest with build metadata and git info.
 .PHONY: release-generate-manifest
 release-generate-manifest:
+	@test -n "$(MEMORY_SIZE_MB)" || { echo "ERROR: MEMORY_SIZE is not set"; exit 1; }
+	@test -n "$(MEMORY_SIZE_BYTES)" || { echo "ERROR: MEMORY_SIZE_BYTES is not set"; exit 1; }
 	@echo "Generating manifest $(MANIFEST_FILE)..."
-	@bash $(SCRIPTS_DIR)/generate-manifest.sh $(MANIFEST_FILE) \
-		$(RELEASE_VERSION) $(MACHINE) $(TARGET) $(DEPLOYMENT_MODE) $(RELEASE_BUILD_MODE) $(LOG_LEVEL) \
-		$(BUILD_DIR)/kernel_config.toml
+	@MEMORY_SIZE_MB="$(MEMORY_SIZE_MB)" MEMORY_SIZE_BYTES="$(MEMORY_SIZE_BYTES)" \
+		bash $(SCRIPTS_DIR)/generate-manifest.sh $(MANIFEST_FILE) \
+		$(RELEASE_VERSION) $(MACHINE) $(TARGET) $(DEPLOYMENT_MODE) $(RELEASE_BUILD_MODE) $(LOG_LEVEL)
 
 release: all install release-generate-manifest
-	@test -n "$(MEMORY_SIZE_MB)" || { echo "ERROR: Failed to extract memory_size from kernel_config.toml"; exit 1; }
+	@test -n "$(MEMORY_SIZE_MB)" || { echo "ERROR: MEMORY_SIZE is not set"; exit 1; }
 	@echo "Creating release archive ${RELEASE_ARCHIVE} from ${SYSROOT_DIR}..."
 	@$(RM_CMD) ${RELEASE_ARCHIVE}
 	@tar -cjf ${RELEASE_ARCHIVE} --exclude=./src -C ${SYSROOT_DIR} .
@@ -539,6 +554,7 @@ help:
 	@echo "  TARGET           Target architecture (default: $(TARGET))"
 	@echo "  TIMEOUT          Execution timeout in seconds (default: $(TIMEOUT))"
 	@echo "  CLH_DIR          Cloud-hypervisor installation directory (default: $(CLH_DIR))"
+	@echo "  MEMORY_SIZE      Memory size in megabytes (default: $(MEMORY_SIZE))"
 	@echo "  VERUS_EXECUTABLE_DIR  Path to directory containing the verus binary (unset: skip verification)"
 	@echo ""
 	@echo "Parameter Values"

--- a/build/kernel_config.toml
+++ b/build/kernel_config.toml
@@ -15,11 +15,6 @@
 # Memory Layout
 #==================================================================================================
 
-# Total size of physical memory (in bytes).
-# Constraints
-# - Must be large enough to hold the kernel image plus the kernel pool.
-memory_size = 134217728
-
 # Number of processors.
 num_processors = 1
 

--- a/scripts/generate-manifest.sh
+++ b/scripts/generate-manifest.sh
@@ -8,6 +8,9 @@
 #
 # Run './generate-manifest.sh --help' for usage information.
 #
+# Environment Variables:
+#   MEMORY_SIZE_BYTES - Memory size in bytes (required, exported by the Makefile).
+#
 # Arguments:
 #   $1 - output-file      Path to the manifest JSON file to generate.
 #   $2 - version          Release version string.
@@ -16,7 +19,6 @@
 #   $5 - deployment_mode  Deployment mode.
 #   $6 - build_mode       Build mode (debug or release).
 #   $7 - log_level        Log level.
-#   $8 - kernel-config    Path to the kernel configuration TOML file.
 #
 
 #===================================================================================================
@@ -51,7 +53,10 @@ print_help() {
     cat << EOF
 Generates a JSON manifest file with build metadata and git information.
 
-Usage: $0 <output-file> <version> <machine> <target> <deployment_mode> <build_mode> <log_level> <kernel-config>
+Usage: $0 <output-file> <version> <machine> <target> <deployment_mode> <build_mode> <log_level>
+
+Environment Variables:
+  MEMORY_SIZE_BYTES  Memory size in bytes (required, exported by the Makefile).
 
 Arguments:
   output-file      Path to the manifest JSON file to generate.
@@ -61,7 +66,6 @@ Arguments:
   deployment_mode  Deployment mode.
   build_mode       Build mode (debug or release).
   log_level        Log level.
-  kernel-config    Path to the kernel configuration TOML file.
 EOF
 }
 
@@ -82,9 +86,14 @@ if [[ "${1:-}" == "--help" ]]; then
     exit 0
 fi
 
-if [[ $# -ne 8 ]]; then
-    print_error "Expected 8 arguments, got $#."
+if [[ $# -ne 7 ]]; then
+    print_error "Expected 7 arguments, got $#."
     print_help >&2
+    exit 1
+fi
+
+if [[ -z "${MEMORY_SIZE_BYTES:-}" ]]; then
+    print_error "MEMORY_SIZE_BYTES environment variable is required but not set."
     exit 1
 fi
 
@@ -95,7 +104,6 @@ TARGET="$4"
 DEPLOYMENT_MODE="$5"
 BUILD_MODE="$6"
 LOG_LEVEL="$7"
-KERNEL_CONFIG="$8"
 
 TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # Get git commit hash, or "unknown" if we're not in a git repository.
@@ -108,8 +116,8 @@ fi
 # Ensure the output directory exists.
 mkdir -p "$(dirname "${OUTPUT_FILE}")"
 
-# Extract memory_size from the kernel configuration.
-MEMORY_SIZE="$(get_value_from_toml "${KERNEL_CONFIG}" "memory_size")"
+# Use MEMORY_SIZE_BYTES from the environment.
+MEMORY_SIZE="${MEMORY_SIZE_BYTES}"
 
 # Generate the manifest using jq to safely escape all values.
 # Write to a temporary file and move into place for an atomic update. If jq fails unexpectedly, we

--- a/src/benchmarks/vfs-bench-nostd/build.rs
+++ b/src/benchmarks/vfs-bench-nostd/build.rs
@@ -119,7 +119,7 @@ fn main() {
     generate_dense_fat_image(&img_path, build_utils::memory_size() / 2);
 
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=build/kernel_config.toml");
+    println!("cargo:rerun-if-env-changed=MEMORY_SIZE_BYTES");
 }
 
 //==================================================================================================

--- a/src/kernel/build.rs
+++ b/src/kernel/build.rs
@@ -125,9 +125,6 @@ fn main() {
             .as_str()
     }
 
-    // Page size (architectural constant).
-    const PAGE_SIZE: usize = 4096;
-
     // Extract kstack_size from config.
     let kstack_size: usize =
         parse_hex_or_decimal(required_key(&kernel_config, "kstack_size"), "kstack_size");
@@ -135,10 +132,6 @@ fn main() {
     // Extract kpool_base from config.
     let kpool_base: usize =
         parse_hex_or_decimal(required_key(&kernel_config, "kpool_base"), "kpool_base");
-
-    // Extract kpool_size from config.
-    let kpool_size: usize =
-        parse_hex_or_decimal(required_key(&kernel_config, "kpool_size"), "kpool_size");
 
     // Extract kredzone_size from config.
     let kredzone_size: usize =
@@ -150,97 +143,7 @@ fn main() {
         "kstack_guard_pattern",
     );
 
-    //==============================================================================================
-    // Build-Time Assertions
-    //==============================================================================================
-
-    const PAGE_TABLE_SIZE: usize = 4 * 1024 * 1024;
-
-    // kstack_size must be a multiple of the page size.
-    assert!(
-        kstack_size.is_multiple_of(PAGE_SIZE),
-        "kstack_size ({}) must be a multiple of PAGE_SIZE ({})",
-        kstack_size,
-        PAGE_SIZE,
-    );
-
-    // kstack_size must be at least two pages (one guard page + one usable page).
-    assert!(
-        kstack_size >= 2 * PAGE_SIZE,
-        "kstack_size ({}) must be at least 2 * PAGE_SIZE ({})",
-        kstack_size,
-        2 * PAGE_SIZE,
-    );
-
-    // kstack_size must not exceed the size of a page table.
-    assert!(
-        kstack_size <= PAGE_TABLE_SIZE,
-        "kstack_size ({}) must not exceed PAGE_TABLE_SIZE ({})",
-        kstack_size,
-        PAGE_TABLE_SIZE,
-    );
-
-    // kpool_size must be a multiple of the page size.
-    assert!(
-        kpool_size.is_multiple_of(PAGE_SIZE),
-        "kpool_size ({}) must be a multiple of PAGE_SIZE ({})",
-        kpool_size,
-        PAGE_SIZE,
-    );
-
-    // kpool_size must not exceed the size of a page table.
-    assert!(
-        kpool_size <= PAGE_TABLE_SIZE,
-        "kpool_size ({}) must not exceed PAGE_TABLE_SIZE ({})",
-        kpool_size,
-        PAGE_TABLE_SIZE,
-    );
-
-    // kpool_base + kpool_size must fit within physical memory.
-    let memory_size: usize =
-        parse_hex_or_decimal(required_key(&kernel_config, "memory_size"), "memory_size");
-    let kpool_end: usize = match kpool_base.checked_add(kpool_size) {
-        Some(sum) => sum,
-        None => panic!(
-            "kpool_base ({:#x}) + kpool_size ({:#x}) overflows usize",
-            kpool_base, kpool_size,
-        ),
-    };
-    assert!(
-        kpool_end <= memory_size,
-        "kpool_base ({:#x}) + kpool_size ({:#x}) = {:#x} exceeds memory_size ({:#x})",
-        kpool_base,
-        kpool_size,
-        kpool_end,
-        memory_size,
-    );
-
-    // kpool_base must be aligned to a page table boundary (4 MB).
-    assert!(
-        kpool_base.is_multiple_of(PAGE_TABLE_SIZE),
-        "kpool_base ({:#x}) must be aligned to a page table boundary ({:#x})",
-        kpool_base,
-        PAGE_TABLE_SIZE,
-    );
-
-    // kstack_guard_pattern must fit in a 32-bit word.
-    assert!(
-        kstack_guard_pattern <= u32::MAX as usize,
-        "kstack_guard_pattern ({:#x}) must fit in a 32-bit word",
-        kstack_guard_pattern,
-    );
-
-    // kredzone_size must be a multiple of the word size so that usize-indexed loads/stores
-    // in kredzone.rs never silently truncate the usable slot count.
-    const WORD_SIZE: usize = core::mem::size_of::<u32>();
-    assert!(
-        kredzone_size.is_multiple_of(WORD_SIZE),
-        "kredzone_size ({}) must be a multiple of the word size ({})",
-        kredzone_size,
-        WORD_SIZE,
-    );
-
-    // Tell Cargo to rerun build script if config changes
+    // Tell Cargo to rerun build script if config changes.
     println!("cargo::rerun-if-changed={}", kernel_config_path.display());
 
     //==============================================================================================

--- a/src/libs/build-utils/src/lib.rs
+++ b/src/libs/build-utils/src/lib.rs
@@ -56,38 +56,18 @@ pub fn find_workspace_root() -> PathBuf {
 ///
 /// # Description
 ///
-/// Returns the `memory_size` value (in bytes) from `build/kernel_config.toml`.
-/// The file is located relative to the workspace root. Both decimal and `0x`-prefixed hexadecimal
-/// values are accepted.
+/// Returns the `memory_size` value (in bytes) from the `MEMORY_SIZE_BYTES` environment variable
+/// exported by the Makefile.
 ///
 /// # Returns
 ///
 /// The memory size in bytes.
 ///
 pub fn memory_size() -> usize {
-    let root = find_workspace_root();
-    let toml_path = root.join("build/kernel_config.toml");
-    let contents = fs::read_to_string(&toml_path)
-        .unwrap_or_else(|e| panic!("failed to read {}: {e}", toml_path.display()));
-    for line in contents.lines() {
-        let line = line.trim();
-        if line.starts_with('#') || line.is_empty() {
-            continue;
-        }
-        if let Some(rest) = line.strip_prefix("memory_size") {
-            let rest = rest
-                .trim()
-                .strip_prefix('=')
-                .expect("malformed memory_size line")
-                .trim();
-            return if let Some(hex) = rest.strip_prefix("0x").or_else(|| rest.strip_prefix("0X")) {
-                usize::from_str_radix(hex, 16).expect("bad hex memory_size")
-            } else {
-                rest.parse().expect("bad decimal memory_size")
-            };
-        }
-    }
-    panic!("memory_size not found in {}", toml_path.display());
+    let val: String = ::std::env::var("MEMORY_SIZE_BYTES")
+        .expect("MEMORY_SIZE_BYTES env var is required (set MEMORY_SIZE in the Makefile)");
+    val.parse()
+        .unwrap_or_else(|_| panic!("Invalid MEMORY_SIZE_BYTES value: '{val}'"))
 }
 
 //==================================================================================================

--- a/src/libs/config/build.rs
+++ b/src/libs/config/build.rs
@@ -79,6 +79,8 @@ fn load_toml(toml_path: &Path) -> HashMap<String, String> {
 fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_path: &Path) {
     let kernel_config_toml: HashMap<String, String> = load_toml(kernel_config_toml_path);
 
+    let memory_size_bytes: usize = build_utils::memory_size();
+
     /// Helper to retrieve a required key from the kernel config, panicking with a clear message if
     /// missing.
     fn required_key<'a>(config: &'a HashMap<String, String>, key: &str) -> &'a String {
@@ -91,20 +93,17 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     let mut constants = String::new();
     constants.push_str("pub mod kernel {\n");
 
-    let val: usize =
-        parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "memory_size"), "memory_size");
     // Hyperlight imposes a hard 1 GiB guest-memory ceiling. Fail the build if the configured
     // memory_size exceeds the hyperlight sandbox budget so the mismatch is caught immediately.
     if env::var("CARGO_FEATURE_HYPERLIGHT").is_ok() {
         const HYPERLIGHT_MEMORY_CEILING: usize = 1024 * 1024 * 1024;
         assert!(
-            val <= HYPERLIGHT_MEMORY_CEILING,
-            "memory_size ({val}) exceeds the Hyperlight guest-memory ceiling \
-             ({HYPERLIGHT_MEMORY_CEILING}). Reduce memory_size in kernel_config.toml for \
-             hyperlight builds.",
+            memory_size_bytes <= HYPERLIGHT_MEMORY_CEILING,
+            "memory_size ({memory_size_bytes}) exceeds the Hyperlight guest-memory ceiling \
+             ({HYPERLIGHT_MEMORY_CEILING}). Reduce MEMORY_SIZE for hyperlight builds.",
         );
     }
-    constants.push_str(&format!("pub const MEMORY_SIZE: usize = {val};\n"));
+    constants.push_str(&format!("pub const MEMORY_SIZE: usize = {memory_size_bytes};\n"));
 
     let val: usize = parse_hex_or_decimal_usize(
         required_key(&kernel_config_toml, "num_processors"),
@@ -196,9 +195,6 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
     // Build-Time Assertions
     //==============================================================================================
 
-    // Re-read constants needed for cross-validation.
-    let memory_size: usize =
-        parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "memory_size"), "memory_size");
     let kpool_base: usize =
         parse_hex_or_decimal_usize(required_key(&kernel_config_toml, "kpool_base"), "kpool_base");
     let kpool_size: usize =
@@ -224,12 +220,12 @@ fn generate_kernel_config(kernel_config_toml_path: &Path, kernel_config_output_p
         ),
     };
     assert!(
-        kpool_end <= memory_size,
+        kpool_end <= memory_size_bytes,
         "kpool_base ({:#x}) + kpool_size ({:#x}) = {:#x} exceeds memory_size ({:#x})",
         kpool_base,
         kpool_size,
         kpool_end,
-        memory_size,
+        memory_size_bytes,
     );
 
     // kpool_base must be page-table aligned (4 MB boundary).
@@ -574,6 +570,7 @@ fn main() {
     println!("cargo::rerun-if-changed=build/linuxd_config.toml");
     println!("cargo::rerun-if-changed=build/hyperlight_constants.toml");
     println!("cargo::rerun-if-changed=build/hyperlight_config.rs.template");
+    println!("cargo::rerun-if-env-changed=MEMORY_SIZE_BYTES");
 }
 
 //==================================================================================================

--- a/z.py
+++ b/z.py
@@ -46,6 +46,7 @@ DEFAULT_DEPLOYMENT_MODE_WINDOWS = "standalone"
 DEFAULT_LOG_LEVEL_DEBUG = "trace"
 DEFAULT_LOG_LEVEL_RELEASE = "warn"
 DEFAULT_TIMEOUT = 600
+DEFAULT_MEMORY_SIZE = 128
 DEFAULT_IMAGE = "nanvix.img"
 DEFAULT_RUN_PROGRAM = "bin/hello-rust-nostd.elf"
 
@@ -68,6 +69,7 @@ KNOWN_MAKE_VARS: frozenset[str] = frozenset(
         "WASM_BINARY_ARGS",
         "WASMD_SOCKADDR",
         "MAKE_NO_PRINT",
+        "MEMORY_SIZE",
         "MESSAGE_FORMAT",
         "VERBOSE",
         "SCCACHE",
@@ -267,6 +269,7 @@ class BuildConfig:
     wasmd_sockaddr: str = ""
 
     image: str = ""
+    memory_size: str = ""
     message_format: str = ""
     verbose: bool = False
 
@@ -342,6 +345,18 @@ def _parse_make_var(config: BuildConfig, key: str, val: str) -> None:
             config.wasmd_sockaddr = val
         case "IMAGE":
             config.image = val
+        case "MEMORY_SIZE":
+            try:
+                mb = int(val)
+                if mb <= 0:
+                    die(
+                        f"Invalid MEMORY_SIZE={val}. Must be a positive integer (megabytes)."
+                    )
+            except ValueError:
+                die(
+                    f"Invalid MEMORY_SIZE={val}. Must be a positive integer (megabytes)."
+                )
+            config.memory_size = val
         case "MESSAGE_FORMAT":
             if val not in VALID_MESSAGE_FORMATS:
                 die(
@@ -985,6 +1000,7 @@ Build Parameters (after --):
   TIMEOUT=SECONDS                Execution timeout (default: 600).
   WHP=yes|no                     Windows Hypervisor Platform.
   HOST_CPU=CPU                   Target CPU for host builds.
+  MEMORY_SIZE=MB                 Memory size in megabytes (default: 128).
   TIMESTAMP_MSG=yes|no           Enable message timestamping.
 
 Run Options (after --):


### PR DESCRIPTION
This pull request refactors how the kernel memory size is configured and propagated throughout the build system. Instead of reading the memory size from `kernel_config.toml`, the memory size is now set via a `MEMORY_SIZE` Makefile variable, exported as the `MEMORY_SIZE_BYTES` environment variable for build scripts. This change simplifies configuration, improves consistency across build environments, and removes the need for patching the kernel config in CI workflows.