### PR TITLE
[ci] Windows CI hardening and benchmark docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,10 +670,18 @@ jobs:
         shell: pwsh
         run: |
           # Prevent Defender from quarantining unsigned executables extracted
-          # from the build artifact.
+          # from the build artifact. If the Defender service is not running
+          # (error 0x800106ba on some runner images), the exclusion is
+          # unnecessary — skip gracefully.
           $binDir = Join-Path $env:GITHUB_WORKSPACE "bin"
-          Add-MpPreference -ExclusionPath $binDir
-          Write-Host "Added Defender exclusion for $binDir"
+          try {
+            Add-MpPreference -ExclusionPath $binDir
+            Write-Host "Added Defender exclusion for $binDir"
+          } catch {
+            $errorMessage = $_.Exception.Message
+            Write-Host "::warning::Could not add Defender exclusion: $errorMessage"
+            Write-Host "Full Defender exclusion error: $_"
+          }
 
       - name: "Verify Build Artifacts"
         shell: pwsh
@@ -825,9 +833,17 @@ jobs:
       - name: "Exclude bin/ from Windows Defender"
         shell: pwsh
         run: |
+          # If the Defender service is not running (error 0x800106ba on some
+          # runner images), the exclusion is unnecessary — skip gracefully.
           $binDir = Join-Path $env:GITHUB_WORKSPACE "bin"
-          Add-MpPreference -ExclusionPath $binDir
-          Write-Host "Added Defender exclusion for $binDir"
+          try {
+            Add-MpPreference -ExclusionPath $binDir
+            Write-Host "Added Defender exclusion for $binDir"
+          } catch {
+            $errorMessage = $_.Exception.Message
+            Write-Host "::warning::Could not add Defender exclusion: $errorMessage"
+            Write-Host "Full Defender exclusion error: $_"
+          }
 
       - name: "Check Windows Hypervisor Platform"
         id: whp-check

--- a/doc/benchmark.md
+++ b/doc/benchmark.md
@@ -54,6 +54,17 @@ On Windows, `nanvix-bench` supports a subset of benchmarks in standalone mode. T
 cold-start benchmark spawns a fresh `nanvixd` process per iteration in interactive mode and
 measures the time from process spawn to the first echo response.
 
+### Windows Defender Exclusion
+
+Windows Defender may quarantine unsigned executables in `bin/`. To prevent this,
+run the following in an **elevated** (Administrator) PowerShell:
+
+```powershell
+Add-MpPreference -ExclusionPath "C:\path\to\nanvix\bin"
+```
+
+This exclusion is recursive and covers all files and subdirectories under `bin/`.
+
 ### Building for Benchmarks on Windows
 
 ```powershell

--- a/doc/benchmark.md
+++ b/doc/benchmark.md
@@ -16,16 +16,16 @@ You will need to save this JSON file.
 
 `nanvix-bench` currently supports the following benchmarks:
 
-1. `boot-time`: measure the time to start a user VM (excluding `nanvixd`).
-1. `cold-start`: measure the latency to start a linuxd and a user VM from scratch and send an HTTP echo to the guest.
-1. `cold-start-l2`: same as `cold-start`, but deploy linuxd inside an L2 VM.
-1. `cold-start-uvm`: same as `cold-start`, but reuse an existing linuxd instance.
-1. `concurrent`: same as `cold-start`, but keep the (one) linuxd and (many) user VM instances alive after each iteration.
-1. `concurrent-l2`: same as `concurrent`, but deploy the one linuxd instance inside an L2 VM.
-1. `echo-breakdown`: breakdown the contribution of each step in the data-path when sending an HTTP echo (requires re-compilation with `TIMESTAMP_MSG=yes`).
-1. `round-trip-latency`: measure the latency as we increase the size of the HTTP echo payload.
-2. `warm-start`: measure only the latency to send a fixed-size HTTP echo.
-3. `warm-start-vmm`: same as above, but excluding `nanvixd`.
+- `boot-time`: measure the time to start a user VM (excluding `nanvixd`).
+- `cold-start`: measure the latency to start a linuxd and a user VM from scratch and send an HTTP echo to the guest.
+- `cold-start-l2`: same as `cold-start`, but deploy linuxd inside an L2 VM.
+- `cold-start-uvm`: same as `cold-start`, but reuse an existing linuxd instance.
+- `concurrent`: same as `cold-start`, but keep the (one) linuxd and (many) user VM instances alive after each iteration.
+- `concurrent-l2`: same as `concurrent`, but deploy the one linuxd instance inside an L2 VM.
+- `echo-breakdown`: break down the contribution of each step in the data-path when sending an HTTP echo (requires re-compilation with `TIMESTAMP_MSG=yes`).
+- `round-trip-latency`: measure the latency as we increase the size of the HTTP echo payload.
+- `warm-start`: measure only the latency to send a fixed-size HTTP echo.
+- `warm-start-vmm`: same as above, but excluding `nanvixd`.
 
 you may see all the optional flags with:
 

--- a/doc/benchmark.md
+++ b/doc/benchmark.md
@@ -24,6 +24,7 @@ You will need to save this JSON file.
 - `concurrent-l2`: same as `concurrent`, but deploy the one linuxd instance inside an L2 VM.
 - `echo-breakdown`: break down the contribution of each step in the data-path when sending an HTTP echo (requires re-compilation with `TIMESTAMP_MSG=yes`).
 - `round-trip-latency`: measure the latency as we increase the size of the HTTP echo payload.
+- `vfs-bench`: measure VFS operation latencies (stat, open/close, read, write, readdir, create/unlink, mkdir/rmdir, rename) inside the guest VM using a FAT32 image loaded into guest memory via the RAMFS region.
 - `warm-start`: measure only the latency to send a fixed-size HTTP echo.
 - `warm-start-vmm`: same as above, but excluding `nanvixd`.
 
@@ -79,6 +80,7 @@ This builds all components including `nanvix-bench.exe` with the standalone and 
 |-------------------|--------------------------------------------------------|
 | `boot-time`       | Start a user VM (no nanvixd)                           |
 | `cold-start`      | Spawn nanvixd + VM + echo round-trip (standalone mode) |
+| `vfs-bench`       | VFS operation latencies (FAT32 image via RAMFS region) |
 | `warm-start-vmm`  | Raw round-trip latency inside the user VM              |
 
 ### Running Benchmarks on Windows


### PR DESCRIPTION
## Summary

Harden the Windows CI jobs against transient runner issues and improve benchmark documentation.

## Changes

- **ci(windows):** Wrap `Add-MpPreference` in a try/catch in both `windows-integration-test` and `windows-benchmark-ci` jobs. When the Defender service is not running (error `0x800106ba` on some runner images), the step now emits a warning instead of failing the workflow.
- **doc(benchmark):** Add instructions for adding a Windows Defender exclusion for `bin/` before running benchmarks locally.
- **doc(benchmark):** Replace the inconsistently-numbered benchmark list with an unordered bullet list.
- **doc(benchmark):** Add `vfs-bench` to the main benchmark catalogue and the Windows availability table.