### PR TITLE
[sysalloc] Dead empty-TLS guard in tda::alloc()

### DIFF
--- a/src/libs/sysalloc/src/tda.rs
+++ b/src/libs/sysalloc/src/tda.rs
@@ -109,7 +109,7 @@ pub fn alloc() -> Result<Option<*mut u8>, Error> {
     );
 
     // Check if thread-local storage is empty.
-    if allocation_size == 0 {
+    if tls_size == 0 {
         return Ok(None);
     }
 


### PR DESCRIPTION
## Summary

Fixes the empty-TLS guard in `tda::alloc()` which was checking `allocation_size` instead of `tls_size`. This caused the function to skip the early return when TLS was empty, since `allocation_size` includes additional overhead beyond just the TLS size.

## Changes

- **`src/libs/sysalloc/src/tda.rs`**: Changed the empty-TLS check from `allocation_size == 0` to `tls_size == 0`.