### PR TITLE
[uservm] Exclude RAMFS from EPT pre-population

### DIFF
--- a/src/uservm/src/vmm/microvm/guest.rs
+++ b/src/uservm/src/vmm/microvm/guest.rs
@@ -239,24 +239,17 @@ impl Guest {
     /// # Description
     ///
     /// Computes GPA ranges that should be pre-populated in the EPT/SLAT before guest execution.
-    /// The returned ranges cover the kernel image, initrd, kpool, and optionally the RAMFS region.
+    /// The returned ranges cover the kernel image, initrd, and kpool.
     ///
     /// Each region is listed individually so that future memory layout changes do not silently
     /// leave a region un-populated.
-    ///
-    /// # Parameters
-    ///
-    /// - `ramfs_region`: Optional `(base, size)` for the file-backed RAMFS region.
     ///
     /// # Returns
     ///
     /// Upon successful completion, this method returns the list of `(gpa, size)` ranges.
     /// Otherwise, it returns an error.
     ///
-    pub fn ept_populate_ranges(
-        &self,
-        ramfs_region: Option<(usize, usize)>,
-    ) -> Result<Vec<(u64, u64)>> {
+    pub fn ept_populate_ranges(&self) -> Result<Vec<(u64, u64)>> {
         // Each region is listed explicitly for defensive programming so that future memory
         // layout changes do not silently leave a region un-populated.
         let mut ranges: Vec<(u64, u64)> = Vec::new();
@@ -278,10 +271,6 @@ impl Guest {
         }
 
         ranges.push((::config::kernel::KPOOL_BASE_RAW as u64, ::config::kernel::KPOOL_SIZE as u64));
-
-        if let Some((base, size)) = ramfs_region {
-            ranges.push(page_align(base, size));
-        }
 
         Ok(ranges)
     }

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -512,13 +512,13 @@ impl Vmm {
             perf_timings.set_vcpu_reset(vcpu_reset_start.elapsed().as_micros() as u64);
 
             // Phase: EPT pre-population.
-            // Pre-populate host pages for the kernel, initrd, and ramfs regions so that
-            // KVM's EPT fault path only needs to install SLAT entries without host page faults.
-            // This moves page-fault costs from guest execution time to setup time.
+            // Pre-populate host pages for the kernel and initrd regions so that KVM's EPT fault
+            // path only needs to install SLAT entries without host page faults.  This moves
+            // page-fault costs from guest execution time to setup time.
             #[cfg(feature = "profile-time")]
             let ept_populate_start: Instant = Instant::now();
 
-            vmem.populate_ept(&guest.ept_populate_ranges(ramfs_region)?)?;
+            vmem.populate_ept(&guest.ept_populate_ranges()?)?;
 
             #[cfg(feature = "profile-time")]
             perf_timings.set_ept_populate(ept_populate_start.elapsed().as_micros() as u64);

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -510,13 +510,13 @@ impl Vmm {
             perf_timings.set_vcpu_reset(vcpu_reset_start.elapsed().as_micros() as u64);
 
             // Phase: EPT pre-population.
-            // Pre-populate EPT entries for the kernel, initrd, and ramfs regions so the
-            // hypervisor resolves SLAT entries from the host side before guest execution.  This
-            // avoids costly EPT violations during WHvRunVirtualProcessor.
+            // Pre-populate EPT entries for the kernel and ramfs regions so the hypervisor resolves
+            // SLAT entries from the host side before guest execution.  This avoids costly EPT
+            // violations during WHvRunVirtualProcessor.
             #[cfg(feature = "profile-time")]
             let ept_populate_start: Instant = Instant::now();
 
-            vmem.populate_ept(&guest.ept_populate_ranges(ramfs_region)?)?;
+            vmem.populate_ept(&guest.ept_populate_ranges()?)?;
 
             #[cfg(feature = "profile-time")]
             perf_timings.set_ept_populate(ept_populate_start.elapsed().as_micros() as u64);


### PR DESCRIPTION
The RAMFS region was being pre-populated in the EPT/SLAT alongside the kernel, initrd, and kpool. Remove it from the set of pre-faulted ranges so that RAMFS pages are faulted in on demand during guest execution instead.

### Changes
- Remove `ramfs_region` parameter from `Guest::ept_populate_ranges()`.
- Drop the block that pushed the RAMFS range into the populate list.
- Update the call site in `Vmm::new()` to match the new signature.