### PR TITLE
[nvx] ud2 in user-space panic handler

### DIFF
--- a/src/libs/nvx/src/panic.rs
+++ b/src/libs/nvx/src/panic.rs
@@ -6,8 +6,8 @@
 //==================================================================================================
 
 use ::core::{
+    arch::asm,
     fmt::Write,
-    hint,
     panic::PanicMessage,
 };
 use syslog::{
@@ -34,7 +34,9 @@ pub fn panic_implementation(info: &::core::panic::PanicInfo<'_>) -> ! {
         "PANIC file='{file}', line={line} :: {m}",
     );
 
-    loop {
-        hint::spin_loop()
+    // Trigger an invalid-opcode exception (#UD) so the kernel terminates
+    // this process instead of letting it spin forever.
+    unsafe {
+        asm!("ud2", options(noreturn));
     }
 }


### PR DESCRIPTION
The user-space panic handler previously entered an infinite `hint::spin_loop()`, which the kernel had no mechanism to detect or interrupt. This caused the VM to hang at 100% CPU indefinitely on any guest panic (e.g., issue #1972 where `mkdir("/")` triggered a panic inside fatfs).

Replace the spin loop with an x86 `ud2` instruction, which raises an Invalid Opcode exception (#UD, vector 6). The kernel's exception handler already catches #UD from user-space and terminates the faulting process via `ProcessManager::exit()`, so this provides a clean shutdown path instead of a permanent hang.