### PR TITLE
[ci] E: Add benchmark system tuning for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1348,6 +1348,13 @@ jobs:
         run: |
           .\z.ps1 build -- all MACHINE=$env:MACHINE_TYPE RELEASE=yes LOG_LEVEL=panic PROFILER=yes
 
+      - name: "Benchmark Setup"
+        # Requires admin privileges. The self-hosted benchmark runners are
+        # configured to run the Actions runner service as Administrator.
+        shell: pwsh
+        run: |
+          .\scripts\bench\bench-setup.ps1 -SaveState
+
       - name: "Run Micro-Benchmarks"
         shell: pwsh
         env:
@@ -1369,6 +1376,12 @@ jobs:
               exit $LASTEXITCODE
             }
           }
+
+      - name: "Benchmark Teardown"
+        if: always()
+        shell: pwsh
+        run: |
+          .\scripts\bench\bench-teardown.ps1 -KeepDefenderExclusion
 
       - name: "Upload Benchmark Results"
         if: always() && !cancelled()


### PR DESCRIPTION
## Summary

Decoupled from #2048. Wires the existing `bench-setup.ps1` and `bench-teardown.ps1` scripts into the self-hosted Windows benchmark CI job to reduce performance variability.

## Changes

### `.github/workflows/ci.yml`
- Added "Benchmark Setup" step (`bench-setup.ps1 -SaveState`) before "Run Micro-Benchmarks" in the `windows-benchmark` job.
- Added "Benchmark Teardown" step (`bench-teardown.ps1 -KeepDefenderExclusion`) after benchmarks with `if: always()`.

### What the scripts do (already on dev)
- **Setup**: High Performance power plan, CPU locked at 100%, Defender exclusion for repo, stops noisy background services (WSearch, DiagTrack, SysMain, TabletInputService).
- **Teardown**: Restores original power plan, restarts services, keeps Defender exclusion.

### Scope
- Only applied to **self-hosted** Windows benchmark runners (github-hosted lack admin privileges).
- No changes to `scripts/benchmark.py`.

## Testing
- All 6 pre-commit configurations pass.
