### PR TITLE
[uservm] Add host directory mounting on guest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -873,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1674,9 +1674,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1687,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2073,6 +2073,37 @@ name = "mmio-tag"
 version = "0.12.464"
 
 [[package]]
+name = "mount-bench-nostd"
+version = "0.12.464"
+dependencies = [
+ "build-utils",
+ "cc",
+ "cfg-if",
+ "fatfs",
+ "libc_string",
+ "mkramfs",
+ "nvx",
+ "sys",
+ "sysapi",
+ "syscall",
+ "syslog",
+]
+
+[[package]]
+name = "mount-test"
+version = "0.12.464"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc_string",
+ "nvx",
+ "sys",
+ "sysapi",
+ "syscall",
+ "syslog",
+]
+
+[[package]]
 name = "mshv-bindings"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2132,15 @@ name = "multibin"
 version = "0.12.464"
 dependencies = [
  "error",
+]
+
+[[package]]
+name = "multiimage"
+version = "0.12.464"
+dependencies = [
+ "config",
+ "mmio-tag",
+ "tempfile",
 ]
 
 [[package]]
@@ -2414,7 +2454,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2455,6 +2495,7 @@ dependencies = [
  "compiler_builtins",
  "config",
  "elf",
+ "multiimage",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
  "sys",
@@ -2545,9 +2586,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "percent-encoding"
@@ -3166,14 +3207,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3223,7 +3264,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3234,9 +3275,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3490,7 +3531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3772,7 +3813,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4157,9 +4198,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -4231,6 +4272,7 @@ dependencies = [
  "config",
  "control-plane-api",
  "elf",
+ "fatfs",
  "gdbstub",
  "gdbstub_arch",
  "hyperlight-host",
@@ -4238,7 +4280,9 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "log",
+ "mkramfs",
  "multibin",
+ "multiimage",
  "profiler",
  "serde",
  "serde_cbor",
@@ -4248,6 +4292,7 @@ dependencies = [
  "syscall",
  "syscomm",
  "syslog",
+ "tempfile",
  "tokio",
  "user-vm-api",
  "vmm-sys-util",
@@ -4682,7 +4727,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5120,9 +5165,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ default-members = ["src/utils/nanvixd"]
 members = [
         "src/benchmarks/echo-rust-nostd",
         "src/benchmarks/echo-wasm-rust",
+        "src/benchmarks/mount-bench-nostd",
         "src/benchmarks/noop-rust-nostd",
         "src/benchmarks/noop-wasm-rust",
         "src/benchmarks/snapshot-rust-nostd",
@@ -52,6 +53,7 @@ members = [
         "src/libs/libc_string",
         "src/libs/cache",
         "src/libs/multibin",
+        "src/libs/multiimage",
         "src/libs/mmio-tag",
         "src/libs/sys",
         "src/libs/type-safe",
@@ -65,6 +67,7 @@ members = [
         "src/tests/linux-app",
         "src/tests/memory-rust",
         "src/tests/misc-rust",
+        "src/tests/mount-test",
         "src/tests/network-rust",
         "src/tests/stress-rust",
         "src/tests/test-kernel",
@@ -158,6 +161,7 @@ log = "0.4.29"
 cache = { path = "src/libs/cache", default-features = false }
 mkramfs = { path = "src/utils/mkramfs" }
 multibin = { path = "src/libs/multibin", default-features = false }
+multiimage = { path = "src/libs/multiimage", default-features = false }
 nanvix = { path = "src/libs/nanvix", default-features = false }
 nanvix-http = { path = "src/libs/nanvix-http", default-features = false }
 nanvix-oci = { path = "src/libs/nanvix-oci" }

--- a/Makefile
+++ b/Makefile
@@ -340,13 +340,13 @@ export VERUS_VERIFY_CMD = RUSTC_BOOTSTRAP=1 RUSTFLAGS=$(KERNEL_RUST_FLAGS) \
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache config elf error fat32 type-safe nvx proc raw-array slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string mmio-tag vfs-bench-common
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache config elf error fat32 type-safe nvx proc raw-array slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
 ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache config elf error fat32 type-safe proc raw-array slab sorted-vec sparse-bitmap static_assert libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd
-ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd
+ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd
 ALL_GUEST_APPLICATIONS := hello-rust-nostd
-ALL_GUEST_TESTS := testd file-rust thread-rust stress-rust test-kernel test-mmio-fault linux-app arch-rust vfs-test misc-rust memory-rust network-rust c-bindings-rust
+ALL_GUEST_TESTS := testd file-rust thread-rust stress-rust test-kernel test-mmio-fault linux-app arch-rust vfs-test misc-rust memory-rust network-rust c-bindings-rust mount-test
 # dlfcn-rust requires PIE linking for dlopen/dlsym; the x86_64 static
 # relocation model produces R_X86_64_32 relocations incompatible with PIE.
 ifneq ($(TARGET),x86_64)
@@ -357,7 +357,7 @@ ALL_GUEST_BINARIES += $(ALL_GUEST_TESTS)
 
 ALL_WASM_BINARIES := echo-wasm-rust hello-wasm noop-wasm-rust
 
-ALL_HOST_RUST_LIBS := control-plane-api hwloc multibin profiler nanvix nanvix-http nanvix-registry nanvix-sandbox nanvix-sandbox-cache nanvix-terminal syscomm user-vm-api
+ALL_HOST_RUST_LIBS := control-plane-api hwloc multibin multiimage profiler nanvix nanvix-http nanvix-registry nanvix-sandbox nanvix-sandbox-cache nanvix-terminal syscomm user-vm-api
 # Host rlibs excluded on Windows:
 #  - nanvix-http, nanvix-sandbox-cache: depend on Unix-only APIs.
 #  - syscomm: test code references cfg(unix)-gated SocketAddr::Unix variant.

--- a/build/make/generic-guest-binaries.mk
+++ b/build/make/generic-guest-binaries.mk
@@ -18,7 +18,7 @@ MISC_RUST_FEATURES := $(strip $(MISC_RUST_FEATURES))
 MISC_RUST_CARGO_FEATURES := $(if $(MISC_RUST_FEATURES),--features "$(MISC_RUST_FEATURES)")
 
 # Guest binaries that support standalone deployment mode.
-STANDALONE_GUEST_BINARIES := file-rust linux-app thread-rust stress-rust arch-rust
+STANDALONE_GUEST_BINARIES := file-rust linux-app thread-rust stress-rust arch-rust mount-test mount-bench-nostd
 
 # Computes the cargo features string for a guest binary package.
 # test-kernel has its own overrides. When DEPLOYMENT_MODE=standalone, packages
@@ -102,6 +102,16 @@ endif
 		if [ -n "$$newest" ]; then $(CP_CMD) "$$newest" $(BINARIES_DIR)/vfs-test.img; fi
 	@newest=$$(ls -t $(OBJECTS_DIR)/$(TARGET)-user/$(BUILD_MODE)/build/vfs-bench-nostd-*/out/$(VFS_BENCH_IMG) 2>/dev/null | head -n1); \
 		if [ -n "$$newest" ]; then $(CP_CMD) "$$newest" $(BINARIES_DIR)/$(VFS_BENCH_IMG); fi
+# Reset mount-test-data so that subsequent test runs always start with pristine input.
+# A previous test execution may have overwritten files via the copyback mechanism.
+	@$(RM_CMD) -rf $(BINARIES_DIR)/mount-test-data
+	@mkdir -p $(BINARIES_DIR)/mount-test-data/subdir
+	@printf 'mount-test-input\n' > $(BINARIES_DIR)/mount-test-data/input.txt
+	@printf 'nested-content\n' > $(BINARIES_DIR)/mount-test-data/subdir/nested.txt
+# Reset mount-bench-data similarly.
+	@$(RM_CMD) -rf $(BINARIES_DIR)/mount-bench-data
+	@mkdir -p $(BINARIES_DIR)/mount-bench-data
+	@dd if=/dev/zero bs=4096 count=1 2>/dev/null | tr '\0' '\253' > $(BINARIES_DIR)/mount-bench-data/bench-4k.bin
 
 check-guest-binaries:
 ifneq ($(_GUEST_BINS_REGULAR_PKGS),)

--- a/doc/host-mount.md
+++ b/doc/host-mount.md
@@ -1,0 +1,190 @@
+# Design Document: Host Directory Mounting on the Nanvix Guest
+
+This document describes the design of the host directory mounting feature that allows users to mount
+a host directory into a Nanvix guest VM.
+
+## 1. Problem Statement
+
+Users need the ability to mount a host directory into a Nanvix guest VM so that guest applications
+can read and write files from the host filesystem. Today, the only way to provide files to a guest
+is via a pre-built RAMFS image passed with the `-ramfs` CLI flag. There is no mechanism to:
+
+- Dynamically make a host directory available to the guest at launch time.
+- Support multiple filesystem images simultaneously (e.g., a root RAMFS and a host-mounted
+  directory).
+- Synchronize guest-side modifications back to the host.
+
+### User Interface
+
+The feature is exposed through a `-mount <host-dir>` CLI flag for `nanvixd`.  The host directory
+contents appear under `/mnt` inside the guest:
+
+```shell
+nanvixd -kernel K -initrd I -mount /path/to/host/dir -- guest.elf
+```
+
+Guest applications access host files through the standard VFS path (`/mnt/...`) using ordinary file
+operations.
+
+---
+
+## 2. Requirements
+
+### Goals
+
+- Provide transparent access to a host directory from inside the Nanvix guest.
+- Integrate with the existing VFS mount infrastructure inside the guest.
+- Maintain backward compatibility: when `-mount` is absent, behavior is unchanged.
+
+### Non-Goals
+
+- Replacing `linuxd`. The mount feature covers only filesystem access to a specific host directory,
+  not the full POSIX syscall surface.
+- Supporting network-remote filesystems (NFS, SMB). The host directory is always local to the
+  `nanvixd` host.
+- POSIX permission or ownership fidelity. The guest operates under a single effective user;
+  host-side permissions are those of the `nanvixd` process.
+
+---
+
+## 3. Design — Snapshot-Based Mounting
+
+This is an initial, straightforward implementation that requires minimal changes to the existing
+system architecture. It works by packaging the host directory into an in-memory disk image before
+the guest boots and extracting modifications after the guest exits.
+
+### 3.1 High-Level Design
+
+```text
+┌─ Launch ─────────────────────────────────────────────────────────┐
+│                                                                  │
+│  Host directory ──► FAT32 image ──► Multi-image container        │
+│                     (mkramfs)       (ROOTFS + MOUNTFS)           │
+│                                            │                     │
+│                                            ▼                     │
+│                                     Guest memory (MMIO)          │
+│                                            │                     │
+│                                            ▼                     │
+│                                   Guest VFS mounts:              │
+│                                     /     ← ROOTFS               │
+│                                     /mnt  ← MOUNTFS              │
+│                                                                  │
+├─ Shutdown ───────────────────────────────────────────────────────┤
+│                                                                  │
+│  Guest memory (MOUNTFS region) ──► FAT32 extraction ──► Host dir │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+The flow has three phases:
+
+1. **Launch.** The host builds a FAT32 image from `<host-dir>`, packs it (along with an optional
+   `-ramfs` image) into a multi-image container, and maps the container into guest memory via the
+   existing RamFs/MMIO infrastructure.
+2. **Runtime.** The guest runtime detects the multi-image format, parses the header, and mounts each
+   sub-image as a separate VFS mount point. Guest applications read and write files in-memory
+   through the FAT32 backend.
+3. **Shutdown.** The host reads the MOUNTFS region back from guest memory,
+   opens it as a FAT filesystem, and recursively extracts all files to
+   `<host-dir>`, overwriting originals.
+
+### 3.2 Multi-Image Binary Format
+
+To support multiple filesystem images in a single MMIO region, a lightweight container format is
+used:
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│ HEAD Page (4096 bytes)                                          │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │ magic:       u32 = 0x4D494D47 ("MIMG")                     │ │
+│  │ version:     u32 = 1                                       │ │
+│  │ num_images:  u32                                           │ │
+│  │ _pad0:       u32                                           │ │
+│  │ total_size:  u64 (including HEAD page)                     │ │
+│  │ reserved:    [u8; 16] (zero-padded, future use)            │ │
+│  ├────────────────────────────────────────────────────────────┤ │
+│  │ ImageEntry[0]: tag[8] | offset: u64 | size: u64 | flags    │ │
+│  │ ImageEntry[1]: tag[8] | offset: u64 | size: u64 | flags    │ │
+│  │ ...                                                        │ │
+│  │ (padding to 4096 bytes)                                    │ │
+│  └────────────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────────┤
+│ Sub-image 0 (page-aligned)                                      │
+├─────────────────────────────────────────────────────────────────┤
+│ Sub-image 1 (page-aligned)                                      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+#### Header Fields
+
+| Field       | Type     | Description                              |
+|-------------|----------|------------------------------------------|
+| magic       | u32      | `0x4D494D47` ("MIMG" in LE)              |
+| version     | u32      | Format version (currently `1`)           |
+| num_images  | u32      | Number of sub-images                     |
+| _pad0       | u32      | Alignment padding                        |
+| total_size  | u64      | Total container size including HEAD page |
+| reserved    | [u8; 16] | Reserved for future use                  |
+
+#### Entry Fields (32 bytes each)
+
+| Field  | Type    | Description                           |
+|--------|---------|---------------------------------------|
+| tag    | [u8; 8] | Identifies the sub-image              |
+| offset | u64     | Byte offset from container start      |
+| size   | u64     | Sub-image size in bytes               |
+| flags  | u32     | Bitfield (bit 0 = FLAG_READONLY)      |
+| _pad   | u32     | Alignment padding                     |
+
+#### Tags
+
+- `TAG_ROOTFS  = b"ROOTFS  "` — Root filesystem (mounted at `/`)
+- `TAG_MOUNTFS = b"MOUNTFS "` — Host-mounted directory (mounted at `/mnt`)
+
+#### Limits
+
+- Maximum entries: `(4096 - 40) / 32 = 126`
+- Sub-images are page-aligned (4096 bytes)
+
+### 3.3 Size Constraints
+
+| Constraint | Value | Source |
+| --- | --- | --- |
+| `MEMORY_SIZE` | 128 MiB | `kernel_config.toml` |
+| Max mount image | 16 MiB | `MEMORY_SIZE / 8` |
+| `MIN_IMAGE_SIZE` | 1 MiB | `mkramfs` constant |
+| `HEADROOM_FACTOR` | 1.5x | `mkramfs` constant |
+| `HEAD_PAGE_SIZE` | 4096 bytes | `multiimage` constant |
+| `MAX_ENTRIES` | 126 | `(4096 - 40) / 32` |
+| `RAMFS_MIN_SLACK_BYTES` | 4 MiB | Between initrd end and RAMFS start |
+
+### 3.4 Edge Cases
+
+1. **Empty host directory** — Creates a minimal 1 MiB formatted (empty) FAT image.
+2. **No `-ramfs` with `-mount`** — Container holds only MOUNTFS (no ROOTFS).
+3. **No `-mount` flag** — Existing behavior preserved (single-image path).
+4. **Host directory too large** — Error with clear message when content exceeds 16 MiB.
+5. **Non-existent directory** — Rejected at CLI parse time with descriptive error.
+6. **Legacy guest binary** — Magic-byte check returns false; guest mounts the entire region at `/`
+   as before (backward compatible).
+
+### 3.5 Backward Compatibility
+
+When only `-ramfs` is provided (no `-mount`), the existing single-image code path is preserved
+unchanged. Guest detection uses magic-byte checking: old single images don't match the MIMG magic,
+so the legacy mount-at-root path is taken. No changes to kernel MMIO infrastructure, control
+register layout, or the `"RAMFS   "` tag mechanism.
+
+### 3.6 Limitations
+
+This approach is intentionally simple but has fundamental constraints that limit the workloads it
+can support:
+
+| Limitation | Impact |
+| --- | --- |
+| Boot/shutdown copy overhead | O(n) latency proportional to host directory size |
+| 16 MiB size ceiling | Cannot mount directories larger than guest memory budget |
+| No live host→guest sync | Host changes after launch are invisible to guest |
+| No live guest→host sync | Guest changes invisible to host until shutdown |
+| Full memory copy of host dir | Wastes guest memory on data that may never be accessed |

--- a/src/benchmarks/mount-bench-nostd/Cargo.toml
+++ b/src/benchmarks/mount-bench-nostd/Cargo.toml
@@ -1,0 +1,42 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "mount-bench-nostd"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Benchmark for host directory mount feature"
+homepage.workspace = true
+
+[[bin]]
+name = "mount-bench-nostd"
+
+[dependencies]
+libc_string = { workspace = true }
+nvx = { workspace = true }
+sys = { workspace = true, features = ["kcall"] }
+sysapi = { workspace = true }
+syscall = { workspace = true, features = ["syscall"] }
+syslog = { workspace = true, default-features = true }
+
+[build-dependencies]
+build-utils = { workspace = true }
+cc = { workspace = true }
+cfg-if = { workspace = true }
+fatfs = { workspace = true, features = ["std", "alloc", "lfn"] }
+mkramfs = { workspace = true }
+
+[features]
+default = ["panic"]
+standalone = ["nvx/standalone", "syscall/standalone"]
+trace = ["nvx/trace", "syscall/trace", "syslog/trace"]
+debug = ["nvx/debug", "syscall/debug", "syslog/debug"]
+info = ["nvx/info", "syscall/info", "syslog/info"]
+warn = ["nvx/warn", "syscall/warn", "syslog/warn"]
+error = ["nvx/error", "syscall/error", "syslog/error"]
+panic = ["nvx/panic", "syscall/panic", "syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/benchmarks/mount-bench-nostd/build.rs
+++ b/src/benchmarks/mount-bench-nostd/build.rs
@@ -1,0 +1,47 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![deny(clippy::all)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::std::{
+    env,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+//==================================================================================================
+// Main Function
+//==================================================================================================
+
+fn main() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
+
+    // Create a benchmark data directory with test files.
+    let manifest_dir: String = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let workspace_root = Path::new(&manifest_dir)
+        .parent()
+        .expect("no parent: benchmarks/")
+        .parent()
+        .expect("no parent: src/")
+        .parent()
+        .expect("no parent: root");
+    let mount_dir: PathBuf = workspace_root.join("bin").join("mount-bench-data");
+    std::fs::create_dir_all(&mount_dir).expect("failed to create mount-bench-data directory");
+
+    // Create a 4 KiB test file for sequential I/O benchmarking.
+    let data: Vec<u8> = vec![0xABu8; 4096];
+    std::fs::write(mount_dir.join("bench-4k.bin"), &data).expect("failed to write bench-4k.bin");
+
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/src/benchmarks/mount-bench-nostd/src/main.rs
+++ b/src/benchmarks/mount-bench-nostd/src/main.rs
@@ -1,0 +1,166 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Benchmark for the host directory mount feature.
+//!
+//! Measures the latency of common VFS operations on the `/mnt` mount point:
+//! - Sequential 4 KiB reads
+//! - Sequential 4 KiB writes
+//! - File creation
+//!
+//! Results are written via syslog for collection by the benchmark harness.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![no_std]
+#![no_main]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+extern crate alloc;
+extern crate libc_string;
+extern crate nvx;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::Error;
+use ::syscall::safe::{
+    FileSystem,
+    FileSystemPath,
+    FileSystemPermissions,
+    RegularFile,
+    RegularFileOpenFlags,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Number of iterations per benchmark.
+const ITERATIONS: usize = 100;
+
+/// Buffer size for read/write operations.
+const BUF_SIZE: usize = 4096;
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+/// Returns the current timestamp counter value.
+fn rdtsc() -> u64 {
+    #[cfg(target_arch = "x86")]
+    unsafe {
+        core::arch::x86::_rdtsc()
+    }
+    #[cfg(not(target_arch = "x86"))]
+    {
+        0
+    }
+}
+
+/// Prints a CSV benchmark result line.
+fn report(name: &str, total_cycles: u64, iterations: usize) {
+    let avg: u64 = total_cycles / iterations as u64;
+    ::syslog::info!("mount-bench,{},{},{}", name, avg, iterations);
+}
+
+//==================================================================================================
+// Main Function
+//==================================================================================================
+
+#[unsafe(no_mangle)]
+pub fn main() -> Result<(), Error> {
+    ::syslog::info!("mount-bench: starting host mount benchmark");
+
+    let permissions: FileSystemPermissions = FileSystemPermissions::empty()
+        .user_read(true)
+        .user_write(true);
+
+    // Benchmark 1: Sequential 4 KiB reads from a pre-existing file.
+    {
+        let pathname: FileSystemPath = FileSystemPath::new("/mnt/bench-4k.bin")?;
+        let mut total: u64 = 0;
+        let mut buf: [u8; BUF_SIZE] = [0u8; BUF_SIZE];
+
+        for _ in 0..ITERATIONS {
+            let file: RegularFile =
+                FileSystem::open_regular_file(&pathname, &RegularFileOpenFlags::read_only(), None)?;
+
+            let start: u64 = rdtsc();
+            let _n: usize = file.read(&mut buf)?;
+            let end: u64 = rdtsc();
+            total += end.wrapping_sub(start);
+            // File is closed when dropped.
+        }
+        report("read-4k", total, ITERATIONS);
+    }
+
+    // Benchmark 2: Sequential 4 KiB writes.
+    {
+        let pathname: FileSystemPath = FileSystemPath::new("/mnt/bench-write.bin")?;
+        let data: [u8; BUF_SIZE] = [0xCDu8; BUF_SIZE];
+        let mut total: u64 = 0;
+
+        for _ in 0..ITERATIONS {
+            let mut file: RegularFile =
+                FileSystem::create_regular_file(&pathname, Some(permissions))?;
+
+            let start: u64 = rdtsc();
+            file.write(&data)?;
+            let end: u64 = rdtsc();
+            total += end.wrapping_sub(start);
+        }
+        report("write-4k", total, ITERATIONS);
+    }
+
+    // Benchmark 3: File creation (create + drop/close).
+    {
+        let mut total: u64 = 0;
+
+        for i in 0..ITERATIONS {
+            let mut name_buf: [u8; 32] = [0u8; 32];
+            let prefix: &[u8] = b"/mnt/tmp-";
+            name_buf[..prefix.len()].copy_from_slice(prefix);
+            let mut offset: usize = prefix.len();
+
+            // Write iteration number as ASCII digits.
+            let mut num: usize = i;
+            let mut digits: [u8; 10] = [0u8; 10];
+            let mut d: usize = 0;
+            loop {
+                digits[d] = b'0' + (num % 10) as u8;
+                d += 1;
+                num /= 10;
+                if num == 0 {
+                    break;
+                }
+            }
+            for j in (0..d).rev() {
+                name_buf[offset] = digits[j];
+                offset += 1;
+            }
+            let suffix: &[u8] = b".bin";
+            name_buf[offset..offset + suffix.len()].copy_from_slice(suffix);
+            offset += suffix.len();
+
+            let path_str: &str =
+                core::str::from_utf8(&name_buf[..offset]).unwrap_or("/mnt/tmp-0.bin");
+            let pathname: FileSystemPath = FileSystemPath::new(path_str)?;
+
+            let start: u64 = rdtsc();
+            let _file: RegularFile = FileSystem::create_regular_file(&pathname, Some(permissions))?;
+            let end: u64 = rdtsc();
+            total += end.wrapping_sub(start);
+        }
+        report("create-file", total, ITERATIONS);
+    }
+
+    ::syslog::info!("mount-bench: benchmark complete");
+    Ok(())
+}

--- a/src/benchmarks/vfs-bench-nostd/build.rs
+++ b/src/benchmarks/vfs-bench-nostd/build.rs
@@ -144,7 +144,7 @@ fn generate_dense_fat_image(path: &Path, image_size: usize) {
         (tree_budget / TARGET_TREE_FILES).clamp(MIN_FILE_SIZE, MAX_FILE_SIZE_CAP);
 
     // Create and format a zeroed FAT image.
-    mkramfs::mkfatfs(path, image_size);
+    mkramfs::mkfatfs(path, image_size).expect("failed to create/format FAT image");
 
     let file = std::fs::OpenOptions::new()
         .read(true)

--- a/src/libs/config/src/region_tags.rs
+++ b/src/libs/config/src/region_tags.rs
@@ -20,6 +20,12 @@ pub const LAPIC_MMIO_TAG: MmioTag = MmioTag::new(*b"LAPIC   ");
 /// Tag used to identify the RAMFS MMIO region.
 pub const RAMFS_MMIO_TAG: MmioTag = MmioTag::new(*b"RAMFS   ");
 
+/// Tag used to identify the root filesystem image.
+pub const ROOTFS_MMIO_TAG: MmioTag = MmioTag::new(*b"ROOTFS  ");
+
+/// Tag used to identify a host-mounted filesystem image.
+pub const MOUNTFS_MMIO_TAG: MmioTag = MmioTag::new(*b"MOUNTFS ");
+
 //==================================================================================================
 // MicroVM
 //==================================================================================================

--- a/src/libs/mmio-tag/src/tag.rs
+++ b/src/libs/mmio-tag/src/tag.rs
@@ -60,6 +60,19 @@ impl MmioTag {
     ///
     /// # Description
     ///
+    /// Returns the raw byte array backing this tag.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the underlying `[u8; TAG_LENGTH]` array.
+    ///
+    pub const fn as_bytes(&self) -> &[u8; TAG_LENGTH] {
+        &self.value
+    }
+
+    ///
+    /// # Description
+    ///
     /// Builds a tag from a 64-bit value encoded as eight hexadecimal characters.
     ///
     /// # Parameters

--- a/src/libs/multiimage/Cargo.toml
+++ b/src/libs/multiimage/Cargo.toml
@@ -1,0 +1,28 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "multiimage"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Multi-image container format for consolidating multiple FAT32 images"
+homepage.workspace = true
+
+[lib]
+crate-type = ["lib"]
+
+[features]
+default = []
+std = []
+
+[dependencies]
+config = { workspace = true }
+mmio-tag = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/libs/multiimage/src/lib.rs
+++ b/src/libs/multiimage/src/lib.rs
@@ -1,0 +1,705 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Multi-image container format for consolidating multiple FAT32 filesystem images.
+//!
+//! This crate defines a binary format that packs a HEAD page followed by one or more
+//! page-aligned sub-images. Both host (`std`) and guest (`no_std`) code can parse the
+//! format; image *building* is gated behind the `std` feature.
+//!
+//! # Binary Layout
+//!
+//! ```text
+//! ┌────────────────────────────────────────┐
+//! │ HEAD page (PAGE_SIZE bytes)            │
+//! │  ┌──────────────────────────────────┐  │
+//! │  │ MultiImageHeader (36 bytes)      │  │
+//! │  │ ImageEntry[0] (32 bytes)         │  │
+//! │  │ ImageEntry[1] (32 bytes)         │  │
+//! │  │ ...                              │  │
+//! │  │ (zero-padded to PAGE_SIZE)       │  │
+//! │  └──────────────────────────────────┘  │
+//! ├────────────────────────────────────────┤
+//! │ Image 0 data (page-aligned)           │
+//! ├────────────────────────────────────────┤
+//! │ Image 1 data (page-aligned)           │
+//! └────────────────────────────────────────┘
+//! ```
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(clippy::all)]
+
+//==================================================================================================
+// Conditional Imports
+//==================================================================================================
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
+use std::{
+    fs,
+    io::Write,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+//==================================================================================================
+// Re-Exports
+//==================================================================================================
+
+// Re-export well-known image tags from the config crate.
+pub use ::config::region_tags::{
+    MOUNTFS_MMIO_TAG,
+    ROOTFS_MMIO_TAG,
+};
+use ::mmio_tag::{
+    MmioTag,
+    TAG_LENGTH,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Magic number identifying a multi-image container (`"MIMG"` in little-endian).
+pub const HEADER_MAGIC: u32 = 0x4D49_4D47;
+
+/// Current format version.
+pub const HEADER_VERSION: u32 = 1;
+
+/// Size of the HEAD page in bytes (must equal the target page size).
+pub const HEAD_PAGE_SIZE: usize = 4096;
+
+/// Maximum number of entries that fit in a single HEAD page.
+///
+/// `(HEAD_PAGE_SIZE - size_of::<MultiImageHeader>()) / size_of::<ImageEntry>()`
+pub const MAX_ENTRIES: usize = (HEAD_PAGE_SIZE - HEADER_SIZE) / ENTRY_SIZE;
+
+/// Size of [`MultiImageHeader`] in bytes.
+pub const HEADER_SIZE: usize = core::mem::size_of::<MultiImageHeader>();
+
+/// Size of [`ImageEntry`] in bytes.
+pub const ENTRY_SIZE: usize = core::mem::size_of::<ImageEntry>();
+
+/// `ImageEntry::flags` bit: sub-image is read-only.
+pub const FLAG_READONLY: u32 = 1 << 0;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Fixed header at the start of a multi-image container.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MultiImageHeader {
+    /// Must equal [`HEADER_MAGIC`].
+    pub magic: u32,
+    /// Must equal [`HEADER_VERSION`].
+    pub version: u32,
+    /// Number of [`ImageEntry`] records that follow.
+    pub num_images: u32,
+    /// Padding for alignment.
+    pub _pad0: u32,
+    /// Total size of the container in bytes (HEAD page + all sub-images with padding).
+    pub total_size: u64,
+    /// Reserved for future use (must be zero).
+    pub reserved: [u8; 16],
+}
+
+/// Descriptor for a single sub-image inside the container.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct ImageEntry {
+    /// 8-byte tag identifying the image (e.g., [`ROOTFS_MMIO_TAG`]).
+    pub tag: [u8; TAG_LENGTH],
+    /// Byte offset from the start of the container to the sub-image data.
+    pub offset: u64,
+    /// Actual size of the sub-image data in bytes.
+    pub size: u64,
+    /// Flags. See [`FLAG_READONLY`].
+    pub flags: u32,
+    /// Padding for alignment.
+    pub _pad: u32,
+}
+
+//==================================================================================================
+// Error Types
+//==================================================================================================
+
+/// Errors returned by multi-image parsing functions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MultiImageError {
+    /// The data slice is too short to contain the expected structure.
+    BufferTooSmall,
+    /// The magic field does not match [`HEADER_MAGIC`].
+    BadMagic,
+    /// The version field is not supported.
+    UnsupportedVersion,
+    /// `num_images` exceeds [`MAX_ENTRIES`].
+    TooManyEntries,
+    /// An entry offset or size would exceed the container bounds.
+    EntryOutOfBounds,
+    /// An entry offset is not page-aligned.
+    EntryNotAligned,
+    /// An I/O error occurred during building (std only).
+    #[cfg(feature = "std")]
+    Io,
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for MultiImageError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BufferTooSmall => write!(f, "buffer too small"),
+            Self::BadMagic => write!(f, "bad magic number"),
+            Self::UnsupportedVersion => write!(f, "unsupported version"),
+            Self::TooManyEntries => write!(f, "too many entries"),
+            Self::EntryOutOfBounds => write!(f, "entry out of bounds"),
+            Self::EntryNotAligned => write!(f, "entry not page-aligned"),
+            Self::Io => write!(f, "I/O error"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MultiImageError {}
+
+//==================================================================================================
+// Parsing (no_std)
+//==================================================================================================
+
+/// Returns `true` if `data` starts with the multi-image magic number.
+///
+/// This is a quick probe that does **not** validate the rest of the header.
+pub fn is_multiimage(data: &[u8]) -> bool {
+    if data.len() < u32::BITS as usize / u8::BITS as usize {
+        return false;
+    }
+    let magic: u32 = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+    magic == HEADER_MAGIC
+}
+
+/// Parses and validates the [`MultiImageHeader`] at the start of `data`.
+///
+/// # Errors
+///
+/// Returns an error if the buffer is too small, the magic is wrong, the version is
+/// unsupported, or `num_images` exceeds [`MAX_ENTRIES`].
+pub fn parse_header(data: &[u8]) -> Result<MultiImageHeader, MultiImageError> {
+    if data.len() < HEADER_SIZE {
+        return Err(MultiImageError::BufferTooSmall);
+    }
+
+    // SAFETY: We verified the buffer is large enough. We read field-by-field to
+    // avoid alignment issues on platforms that require aligned reads.
+    let header: MultiImageHeader = MultiImageHeader::from_bytes(data);
+
+    if header.magic != HEADER_MAGIC {
+        return Err(MultiImageError::BadMagic);
+    }
+    if header.version != HEADER_VERSION {
+        return Err(MultiImageError::UnsupportedVersion);
+    }
+    if header.num_images as usize > MAX_ENTRIES {
+        return Err(MultiImageError::TooManyEntries);
+    }
+
+    Ok(header)
+}
+
+/// Parses `count` [`ImageEntry`] records that follow the header in `data`.
+///
+/// `data` must start at the beginning of the container (i.e., the header).
+///
+/// # Errors
+///
+/// Returns an error if the buffer cannot hold `count` entries after the header, or if
+/// any entry's offset/size would exceed the buffer.
+pub fn parse_entries(data: &[u8], count: u32) -> Result<&[ImageEntry], MultiImageError> {
+    let count_usize: usize = count as usize;
+    let required: usize = HEADER_SIZE + count_usize * ENTRY_SIZE;
+    if data.len() < required {
+        return Err(MultiImageError::BufferTooSmall);
+    }
+
+    let entry_bytes: &[u8] = &data[HEADER_SIZE..required];
+    let alignment: usize = core::mem::align_of::<ImageEntry>();
+    if !(entry_bytes.as_ptr() as usize).is_multiple_of(alignment) {
+        return Err(MultiImageError::BufferTooSmall);
+    }
+
+    // SAFETY: We checked that `entry_bytes` starts at an address aligned for
+    // `ImageEntry`, and `entry_bytes` covers exactly `count_usize * ENTRY_SIZE`
+    // bytes. Thus, reinterpreting it as a `[ImageEntry]` is sound.
+    let (prefix, entries, suffix): (&[u8], &[ImageEntry], &[u8]) =
+        unsafe { entry_bytes.align_to::<ImageEntry>() };
+    if !prefix.is_empty() || !suffix.is_empty() || entries.len() != count_usize {
+        return Err(MultiImageError::BufferTooSmall);
+    }
+
+    Ok(entries)
+}
+
+/// Finds the first entry whose `tag` matches the provided tag.
+pub fn find_entry_by_tag<'a>(entries: &'a [ImageEntry], tag: &MmioTag) -> Option<&'a ImageEntry> {
+    entries.iter().find(|e| &e.tag == tag.as_bytes())
+}
+
+/// Validates that all entries have page-aligned offsets and fit within `total_size`.
+pub fn validate_entries(entries: &[ImageEntry], total_size: u64) -> Result<(), MultiImageError> {
+    for entry in entries {
+        if entry.offset % HEAD_PAGE_SIZE as u64 != 0 {
+            return Err(MultiImageError::EntryNotAligned);
+        }
+        let end: u64 = entry
+            .offset
+            .checked_add(entry.size)
+            .ok_or(MultiImageError::EntryOutOfBounds)?;
+        if end > total_size {
+            return Err(MultiImageError::EntryOutOfBounds);
+        }
+    }
+    Ok(())
+}
+
+//==================================================================================================
+// Internal Helpers
+//==================================================================================================
+
+impl MultiImageHeader {
+    /// Reads a [`MultiImageHeader`] from a byte slice without requiring alignment.
+    fn from_bytes(data: &[u8]) -> Self {
+        let mut reserved: [u8; 16] = [0u8; 16];
+        reserved.copy_from_slice(&data[24..40]);
+
+        Self {
+            magic: u32::from_le_bytes([data[0], data[1], data[2], data[3]]),
+            version: u32::from_le_bytes([data[4], data[5], data[6], data[7]]),
+            num_images: u32::from_le_bytes([data[8], data[9], data[10], data[11]]),
+            _pad0: u32::from_le_bytes([data[12], data[13], data[14], data[15]]),
+            total_size: u64::from_le_bytes([
+                data[16], data[17], data[18], data[19], data[20], data[21], data[22], data[23],
+            ]),
+            reserved,
+        }
+    }
+}
+
+/// Rounds `value` up to the next multiple of [`HEAD_PAGE_SIZE`].
+#[cfg(feature = "std")]
+const fn page_align(value: usize) -> usize {
+    let mask: usize = HEAD_PAGE_SIZE - 1;
+    (value + mask) & !mask
+}
+
+//==================================================================================================
+// Building (std only)
+//==================================================================================================
+
+#[cfg(feature = "std")]
+/// Describes one sub-image to include when building a multi-image container.
+pub struct ImageDescriptor<'a> {
+    /// Tag identifying the image (e.g., [`ROOTFS_MMIO_TAG`]).
+    pub tag: MmioTag,
+    /// Path to the sub-image file on the host filesystem.
+    pub path: &'a Path,
+    /// Flags for this entry (e.g., [`FLAG_READONLY`]).
+    pub flags: u32,
+}
+
+#[cfg(feature = "std")]
+/// Describes the position and source of a single sub-image within a multi-image container.
+///
+/// Unlike [`ImageEntry`], which is part of the binary format, this struct carries the host
+/// filesystem path so the VMM can open and map the original file directly (zero-copy).
+pub struct ImageRegion {
+    /// Tag identifying the image (e.g., [`ROOTFS_MMIO_TAG`]).
+    pub tag: MmioTag,
+    /// Path to the source file on the host filesystem.
+    pub path: PathBuf,
+    /// Byte offset from the start of the container where this sub-image is placed.
+    pub offset: usize,
+    /// Actual size of the sub-image data in bytes (not page-aligned).
+    pub size: usize,
+    /// Page-aligned size used for placement (includes trailing padding).
+    pub page_aligned_size: usize,
+    /// Flags for this entry (e.g., [`FLAG_READONLY`]).
+    pub flags: u32,
+}
+
+#[cfg(feature = "std")]
+/// A descriptor of a multi-image container layout that can be used by the VMM to map
+/// sub-image files directly into guest memory without creating an intermediate concatenated file.
+///
+/// Produced by [`compute_multiimage_layout`] and consumed by the UserVM backends to write
+/// the HEAD page and memory-map each sub-image file at its computed offset.
+pub struct MultiImageLayout {
+    /// The fully-built HEAD page (header + entries), ready to be written into guest memory.
+    pub head_page: std::vec::Vec<u8>,
+    /// Ordered list of sub-image regions with their source paths and computed offsets.
+    pub regions: std::vec::Vec<ImageRegion>,
+    /// Total size of the container in bytes (HEAD page + all page-aligned sub-images).
+    pub total_size: usize,
+}
+
+#[cfg(feature = "std")]
+/// Computes the multi-image container layout from the provided descriptors without reading
+/// or writing any file data.
+///
+/// This function queries file metadata to obtain sizes, computes page-aligned offsets, and
+/// builds the HEAD page bytes. The resulting [`MultiImageLayout`] allows the VMM to map each
+/// source file directly into guest memory (zero-copy), avoiding the need for a concatenated
+/// intermediate file on disk.
+///
+/// # Errors
+///
+/// Returns [`MultiImageError::TooManyEntries`] if more than [`MAX_ENTRIES`] images are
+/// provided, or [`MultiImageError::Io`] on any metadata query failure.
+pub fn compute_multiimage_layout(
+    images: &[ImageDescriptor<'_>],
+) -> Result<MultiImageLayout, MultiImageError> {
+    if images.len() > MAX_ENTRIES {
+        return Err(MultiImageError::TooManyEntries);
+    }
+
+    // Query file sizes from metadata (no file content reads).
+    let mut file_sizes: std::vec::Vec<usize> = std::vec::Vec::with_capacity(images.len());
+    for desc in images {
+        let metadata: fs::Metadata = fs::metadata(desc.path).map_err(|_| MultiImageError::Io)?;
+        file_sizes.push(metadata.len() as usize);
+    }
+
+    // Compute offsets. The first sub-image starts right after the HEAD page.
+    let mut current_offset: usize = HEAD_PAGE_SIZE;
+    let mut entries: std::vec::Vec<ImageEntry> = std::vec::Vec::with_capacity(images.len());
+    let mut regions: std::vec::Vec<ImageRegion> = std::vec::Vec::with_capacity(images.len());
+
+    for (i, desc) in images.iter().enumerate() {
+        let size: usize = file_sizes[i];
+        let aligned: usize = page_align(size);
+
+        entries.push(ImageEntry {
+            tag: *desc.tag.as_bytes(),
+            offset: current_offset as u64,
+            size: size as u64,
+            flags: desc.flags,
+            _pad: 0,
+        });
+        regions.push(ImageRegion {
+            tag: desc.tag,
+            path: desc.path.to_path_buf(),
+            offset: current_offset,
+            size,
+            page_aligned_size: aligned,
+            flags: desc.flags,
+        });
+
+        current_offset += aligned;
+    }
+
+    let total_size: usize = current_offset;
+
+    // Build the HEAD page.
+    let mut head_page: std::vec::Vec<u8> = std::vec![0u8; HEAD_PAGE_SIZE];
+    write_header(
+        &mut head_page,
+        &MultiImageHeader {
+            magic: HEADER_MAGIC,
+            version: HEADER_VERSION,
+            num_images: entries.len() as u32,
+            _pad0: 0,
+            total_size: total_size as u64,
+            reserved: [0u8; 16],
+        },
+    );
+    write_entries(&mut head_page, &entries);
+
+    Ok(MultiImageLayout {
+        head_page,
+        regions,
+        total_size,
+    })
+}
+
+#[cfg(feature = "std")]
+/// Builds a multi-image container from the provided descriptors and writes it to `output`.
+///
+/// Each sub-image file is read from disk, page-aligned, and concatenated after the HEAD page.
+///
+/// # Errors
+///
+/// Returns [`MultiImageError::TooManyEntries`] if more than [`MAX_ENTRIES`] images are
+/// provided, or [`MultiImageError::Io`] on any I/O failure.
+pub fn build_multiimage(
+    images: &[ImageDescriptor<'_>],
+    output: &Path,
+) -> Result<(), MultiImageError> {
+    if images.len() > MAX_ENTRIES {
+        return Err(MultiImageError::TooManyEntries);
+    }
+
+    // Read all image files.
+    let mut buffers: std::vec::Vec<std::vec::Vec<u8>> = std::vec::Vec::with_capacity(images.len());
+    for desc in images {
+        let data: std::vec::Vec<u8> = fs::read(desc.path).map_err(|_| MultiImageError::Io)?;
+        buffers.push(data);
+    }
+
+    // Compute offsets. The first sub-image starts right after the HEAD page.
+    let mut current_offset: usize = HEAD_PAGE_SIZE;
+    let mut entries: std::vec::Vec<ImageEntry> = std::vec::Vec::with_capacity(images.len());
+
+    for (i, desc) in images.iter().enumerate() {
+        let size: usize = buffers[i].len();
+        entries.push(ImageEntry {
+            tag: *desc.tag.as_bytes(),
+            offset: current_offset as u64,
+            size: size as u64,
+            flags: desc.flags,
+            _pad: 0,
+        });
+        current_offset += page_align(size);
+    }
+
+    let total_size: u64 = current_offset as u64;
+
+    // Build the HEAD page.
+    let mut head: std::vec::Vec<u8> = std::vec![0u8; HEAD_PAGE_SIZE];
+    write_header(
+        &mut head,
+        &MultiImageHeader {
+            magic: HEADER_MAGIC,
+            version: HEADER_VERSION,
+            num_images: entries.len() as u32,
+            _pad0: 0,
+            total_size,
+            reserved: [0u8; 16],
+        },
+    );
+    write_entries(&mut head, &entries);
+
+    // Write the output file.
+    let mut file: fs::File = fs::File::create(output).map_err(|_| MultiImageError::Io)?;
+    file.write_all(&head).map_err(|_| MultiImageError::Io)?;
+
+    for (i, buf) in buffers.iter().enumerate() {
+        file.write_all(buf).map_err(|_| MultiImageError::Io)?;
+        // Pad to page boundary.
+        let aligned: usize = page_align(buf.len());
+        let padding: usize = aligned - buf.len();
+        if padding > 0 {
+            let zeros: std::vec::Vec<u8> = std::vec![0u8; padding];
+            file.write_all(&zeros).map_err(|_| MultiImageError::Io)?;
+        }
+        // Suppress unused variable warning.
+        let _ = &entries[i];
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "std")]
+/// Serialises a [`MultiImageHeader`] into the first [`HEADER_SIZE`] bytes of `buf`.
+fn write_header(buf: &mut [u8], header: &MultiImageHeader) {
+    buf[0..4].copy_from_slice(&header.magic.to_le_bytes());
+    buf[4..8].copy_from_slice(&header.version.to_le_bytes());
+    buf[8..12].copy_from_slice(&header.num_images.to_le_bytes());
+    buf[12..16].copy_from_slice(&header._pad0.to_le_bytes());
+    buf[16..24].copy_from_slice(&header.total_size.to_le_bytes());
+    buf[24..40].copy_from_slice(&header.reserved);
+}
+
+#[cfg(feature = "std")]
+/// Serialises a slice of [`ImageEntry`] records into `buf` starting at [`HEADER_SIZE`].
+fn write_entries(buf: &mut [u8], entries: &[ImageEntry]) {
+    let mut offset: usize = HEADER_SIZE;
+    for entry in entries {
+        buf[offset..offset + 8].copy_from_slice(&entry.tag);
+        buf[offset + 8..offset + 16].copy_from_slice(&entry.offset.to_le_bytes());
+        buf[offset + 16..offset + 24].copy_from_slice(&entry.size.to_le_bytes());
+        buf[offset + 24..offset + 28].copy_from_slice(&entry.flags.to_le_bytes());
+        buf[offset + 28..offset + 32].copy_from_slice(&entry._pad.to_le_bytes());
+        offset += ENTRY_SIZE;
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn test_is_multiimage_valid() {
+        let mut buf: [u8; 4] = [0u8; 4];
+        buf.copy_from_slice(&HEADER_MAGIC.to_le_bytes());
+        assert!(is_multiimage(&buf));
+    }
+
+    #[test]
+    fn test_is_multiimage_invalid() {
+        assert!(!is_multiimage(&[0u8; 4]));
+        assert!(!is_multiimage(&[0u8; 2]));
+        assert!(!is_multiimage(&[]));
+    }
+
+    #[test]
+    fn test_parse_header_valid() {
+        let mut buf: [u8; HEAD_PAGE_SIZE] = [0u8; HEAD_PAGE_SIZE];
+        write_header(
+            &mut buf,
+            &MultiImageHeader {
+                magic: HEADER_MAGIC,
+                version: HEADER_VERSION,
+                num_images: 2,
+                _pad0: 0,
+                total_size: HEAD_PAGE_SIZE as u64 + 8192,
+                reserved: [0u8; 16],
+            },
+        );
+        let header: MultiImageHeader = parse_header(&buf).expect("parse_header failed");
+        assert_eq!(header.magic, HEADER_MAGIC);
+        assert_eq!(header.version, HEADER_VERSION);
+        assert_eq!(header.num_images, 2);
+        assert_eq!(header.total_size, HEAD_PAGE_SIZE as u64 + 8192);
+    }
+
+    #[test]
+    fn test_parse_header_bad_magic() {
+        let buf: [u8; HEADER_SIZE] = [0u8; HEADER_SIZE];
+        assert_eq!(parse_header(&buf), Err(MultiImageError::BadMagic));
+    }
+
+    #[test]
+    fn test_parse_header_buffer_too_small() {
+        let buf: [u8; 4] = HEADER_MAGIC.to_le_bytes();
+        assert_eq!(parse_header(&buf), Err(MultiImageError::BufferTooSmall));
+    }
+
+    #[test]
+    fn test_roundtrip_build_and_parse() {
+        // Create two temporary image files.
+        let dir: tempfile::TempDir = tempfile::tempdir().expect("tempdir");
+        let img1_path = dir.path().join("img1.bin");
+        let img2_path = dir.path().join("img2.bin");
+        let output_path = dir.path().join("unified.bin");
+
+        let img1_data: std::vec::Vec<u8> = std::vec![0xAA; 5000]; // Not page-aligned
+        let img2_data: std::vec::Vec<u8> = std::vec![0xBB; 4096]; // Exactly one page
+
+        fs::write(&img1_path, &img1_data).expect("write img1");
+        fs::write(&img2_path, &img2_data).expect("write img2");
+
+        let descriptors: [ImageDescriptor<'_>; 2] = [
+            ImageDescriptor {
+                tag: ROOTFS_MMIO_TAG,
+                path: &img1_path,
+                flags: 0,
+            },
+            ImageDescriptor {
+                tag: MOUNTFS_MMIO_TAG,
+                path: &img2_path,
+                flags: FLAG_READONLY,
+            },
+        ];
+
+        build_multiimage(&descriptors, &output_path).expect("build_multiimage");
+
+        // Read back and parse.
+        let mut file: fs::File = fs::File::open(&output_path).expect("open unified");
+        let mut data: std::vec::Vec<u8> = std::vec::Vec::new();
+        file.read_to_end(&mut data).expect("read unified");
+
+        assert!(is_multiimage(&data));
+        let header: MultiImageHeader = parse_header(&data).expect("parse_header");
+        assert_eq!(header.num_images, 2);
+
+        let entries: &[ImageEntry] =
+            parse_entries(&data, header.num_images).expect("parse_entries");
+        assert_eq!(entries.len(), 2);
+
+        // Validate ROOTFS entry.
+        let rootfs: &ImageEntry =
+            find_entry_by_tag(entries, &ROOTFS_MMIO_TAG).expect("ROOTFS not found");
+        assert_eq!(rootfs.offset as usize, HEAD_PAGE_SIZE);
+        assert_eq!(rootfs.size as usize, 5000);
+        assert_eq!(rootfs.flags, 0);
+        let rootfs_data: &[u8] =
+            &data[rootfs.offset as usize..rootfs.offset as usize + rootfs.size as usize];
+        assert!(rootfs_data.iter().all(|&b| b == 0xAA));
+
+        // Validate MOUNTFS entry.
+        let mountfs: &ImageEntry =
+            find_entry_by_tag(entries, &MOUNTFS_MMIO_TAG).expect("MOUNTFS not found");
+        assert_eq!(mountfs.offset as usize, HEAD_PAGE_SIZE + page_align(5000));
+        assert_eq!(mountfs.size as usize, 4096);
+        assert_eq!(mountfs.flags, FLAG_READONLY);
+        let mountfs_data: &[u8] =
+            &data[mountfs.offset as usize..mountfs.offset as usize + mountfs.size as usize];
+        assert!(mountfs_data.iter().all(|&b| b == 0xBB));
+
+        // Validate entries.
+        validate_entries(entries, header.total_size).expect("validate_entries");
+    }
+
+    #[test]
+    fn test_find_entry_by_tag_missing() {
+        let entries: [ImageEntry; 1] = [ImageEntry {
+            tag: *ROOTFS_MMIO_TAG.as_bytes(),
+            offset: HEAD_PAGE_SIZE as u64,
+            size: 4096,
+            flags: 0,
+            _pad: 0,
+        }];
+        assert!(find_entry_by_tag(&entries, &MOUNTFS_MMIO_TAG).is_none());
+    }
+
+    #[test]
+    fn test_validate_entries_out_of_bounds() {
+        let entries: [ImageEntry; 1] = [ImageEntry {
+            tag: *ROOTFS_MMIO_TAG.as_bytes(),
+            offset: HEAD_PAGE_SIZE as u64,
+            size: 99999,
+            flags: 0,
+            _pad: 0,
+        }];
+        assert_eq!(
+            validate_entries(&entries, HEAD_PAGE_SIZE as u64 + 4096),
+            Err(MultiImageError::EntryOutOfBounds)
+        );
+    }
+
+    #[test]
+    fn test_validate_entries_not_aligned() {
+        let entries: [ImageEntry; 1] = [ImageEntry {
+            tag: *ROOTFS_MMIO_TAG.as_bytes(),
+            offset: 100, // Not page-aligned
+            size: 4096,
+            flags: 0,
+            _pad: 0,
+        }];
+        assert_eq!(
+            validate_entries(&entries, HEAD_PAGE_SIZE as u64 + 8192),
+            Err(MultiImageError::EntryNotAligned)
+        );
+    }
+
+    #[test]
+    fn test_header_and_entry_sizes() {
+        // Ensure the structures have the expected sizes for the binary format.
+        assert_eq!(HEADER_SIZE, 40);
+        assert_eq!(ENTRY_SIZE, 32);
+        // At least 126 entries fit in a single HEAD page.
+        assert!(MAX_ENTRIES >= 126);
+    }
+}

--- a/src/libs/nanvix-http/src/client/standalone.rs
+++ b/src/libs/nanvix-http/src/client/standalone.rs
@@ -84,6 +84,8 @@ pub struct StandaloneConfig {
     pub(crate) console_file: Option<String>,
     /// Optional snapshot path for restoring VM state instead of cold-booting.
     pub(crate) snapshot_path: Option<String>,
+    /// Optional host directory to mount on the guest.
+    pub(crate) mount_directory: Option<String>,
     /// Optional GDB server port for debugging the guest.
     #[cfg(feature = "gdb")]
     pub(crate) gdb_port: Option<u16>,
@@ -101,6 +103,7 @@ impl StandaloneConfig {
     /// - `ramfs_filename`: Optional path to a RAM filesystem image.
     /// - `console_file`: Optional file path for guest stderr capture.
     /// - `snapshot_path`: Optional snapshot path for restoring VM state instead of cold-booting.
+    /// - `mount_directory`: Optional host directory to mount on the guest.
     /// - `gdb_port`: Optional GDB server port.
     ///
     pub fn new(
@@ -108,6 +111,7 @@ impl StandaloneConfig {
         ramfs_filename: Option<String>,
         console_file: Option<String>,
         snapshot_path: Option<String>,
+        mount_directory: Option<String>,
         #[cfg(feature = "gdb")] gdb_port: Option<u16>,
     ) -> Self {
         Self {
@@ -115,6 +119,7 @@ impl StandaloneConfig {
             ramfs_filename,
             console_file,
             snapshot_path,
+            mount_directory,
             #[cfg(feature = "gdb")]
             gdb_port,
         }
@@ -280,6 +285,7 @@ impl<T: Send + Sync + Default + 'static> super::HttpClient<T> {
             state.config.ramfs_filename.clone(),
             state.config.console_file.clone(),
             state.config.snapshot_path.clone(),
+            state.config.mount_directory.clone(),
             #[cfg(feature = "gdb")]
             state.config.gdb_port,
         );

--- a/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
@@ -280,6 +280,7 @@ impl UserVm {
                         io_control_tx,
                         counters,
                         snapshot_path: None,
+                        mount_directory: None,
                         #[cfg(feature = "gdb")]
                         gdb_port: None,
                         #[cfg(feature = "profile-time")]

--- a/src/libs/nanvix-sandbox/src/standalone/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/standalone/uservm.rs
@@ -139,6 +139,7 @@ impl UserVm {
                         io_control_tx,
                         counters,
                         snapshot_path: None,
+                        mount_directory: None,
                         #[cfg(feature = "gdb")]
                         gdb_port: None,
                         #[cfg(feature = "profile-time")]

--- a/src/libs/nanvix-terminal/src/standalone.rs
+++ b/src/libs/nanvix-terminal/src/standalone.rs
@@ -70,6 +70,8 @@ pub struct TerminalConfig {
     console_file: Option<String>,
     /// Optional snapshot path for restoring VM state instead of cold-booting.
     snapshot_path: Option<String>,
+    /// Optional host directory to mount on the guest.
+    mount_directory: Option<String>,
     /// Optional GDB server port for debugging the guest.
     #[cfg(feature = "gdb")]
     gdb_port: Option<u16>,
@@ -87,6 +89,7 @@ impl TerminalConfig {
     /// - `ramfs_filename`: Optional path to a RAM filesystem image.
     /// - `console_file`: Optional file path for guest stderr capture.
     /// - `snapshot_path`: Optional snapshot path for restoring VM state instead of cold-booting.
+    /// - `mount_directory`: Optional host directory to mount on the guest.
     /// - `gdb_port`: Optional GDB server port.
     ///
     pub fn new(
@@ -94,6 +97,7 @@ impl TerminalConfig {
         ramfs_filename: Option<String>,
         console_file: Option<String>,
         snapshot_path: Option<String>,
+        mount_directory: Option<String>,
         #[cfg(feature = "gdb")] gdb_port: Option<u16>,
     ) -> Self {
         Self {
@@ -101,6 +105,7 @@ impl TerminalConfig {
             ramfs_filename,
             console_file,
             snapshot_path,
+            mount_directory,
             #[cfg(feature = "gdb")]
             gdb_port,
         }
@@ -177,6 +182,7 @@ impl Terminal {
             self.config.ramfs_filename.clone(),
             self.config.console_file.clone(),
             self.config.snapshot_path.clone(),
+            self.config.mount_directory.clone(),
             #[cfg(feature = "gdb")]
             self.config.gdb_port,
         );

--- a/src/libs/nvx/Cargo.toml
+++ b/src/libs/nvx/Cargo.toml
@@ -15,6 +15,7 @@ alloc = { version = "1.0.1", optional = true, package = "rustc-std-workspace-all
 cfg-if = { workspace = true }
 config = { workspace = true }
 elf = { workspace = true }
+multiimage = { workspace = true, optional = true }
 syslog = { workspace = true, default-features = true }
 sys = { workspace = true, features = ["kcall"] }
 core = { version = "1.0.1", optional = true, package = "rustc-std-workspace-core" }
@@ -30,7 +31,7 @@ sysalloc = { workspace = true }
 [features]
 default = ["staticlib"]
 staticlib = []
-standalone = ["dep:vfs"]
+standalone = ["dep:vfs", "dep:multiimage"]
 hyperlight = []
 rustc-dep-of-std = [
     "alloc",

--- a/src/libs/nvx/src/lib.rs
+++ b/src/libs/nvx/src/lib.rs
@@ -381,6 +381,9 @@ fn vfs_init_ramfs() {
     /// Mount path for the RAMFS image (root filesystem).
     const RAMFS_MOUNT_PATH: &str = "/";
 
+    /// Mount path for the host-mounted directory image.
+    const MOUNT_DIR_PATH: &str = "/mnt";
+
     // Initialize the VFS (idempotent — ignore AlreadyInitialized).
     if ::vfs::init().is_err() && !::vfs::is_initialized() {
         ::syslog::warn!("vfs_init_ramfs(): failed to initialize VFS");
@@ -431,12 +434,88 @@ fn vfs_init_ramfs() {
             (base_ptr, false)
         };
 
-        if unsafe { ::vfs::mount_image(RAMFS_MOUNT_PATH, mount_ptr, total_size, false) }.is_err() {
-            ::syslog::warn!("vfs_init_ramfs(): failed to mount RAMFS image");
-            if !free_mmio_early {
-                let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+        // Check if the MMIO region contains a multi-image container.
+        let region_slice: &[u8] = unsafe { core::slice::from_raw_parts(mount_ptr, total_size) };
+        if ::multiimage::is_multiimage(region_slice) {
+            // Parse multi-image header and mount each sub-image.
+            let header = match ::multiimage::parse_header(region_slice) {
+                Ok(h) => h,
+                Err(_) => {
+                    ::syslog::warn!("vfs_init_ramfs(): failed to parse multi-image header");
+                    if !free_mmio_early {
+                        let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                    }
+                    return false;
+                },
+            };
+
+            let entries = match ::multiimage::parse_entries(region_slice, header.num_images) {
+                Ok(e) => e,
+                Err(_) => {
+                    ::syslog::warn!("vfs_init_ramfs(): failed to parse multi-image entries");
+                    if !free_mmio_early {
+                        let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                    }
+                    return false;
+                },
+            };
+
+            // Validate that the header's total_size fits within the MMIO region and
+            // that every entry's offset+size falls within the container bounds.
+            if header.total_size as usize > total_size {
+                ::syslog::warn!(
+                    "vfs_init_ramfs(): header total_size ({}) exceeds MMIO region ({})",
+                    header.total_size,
+                    total_size
+                );
+                if !free_mmio_early {
+                    let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                }
+                return false;
             }
-            return false;
+            if ::multiimage::validate_entries(entries, header.total_size).is_err() {
+                ::syslog::warn!("vfs_init_ramfs(): multi-image entry validation failed");
+                if !free_mmio_early {
+                    let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                }
+                return false;
+            }
+
+            // Mount ROOTFS at "/" if present.
+            if let Some(rootfs) =
+                ::multiimage::find_entry_by_tag(entries, &::multiimage::ROOTFS_MMIO_TAG)
+            {
+                let sub_ptr: *mut u8 = unsafe { mount_ptr.add(rootfs.offset as usize) };
+                let sub_size: usize = rootfs.size as usize;
+                if unsafe { ::vfs::mount_image(RAMFS_MOUNT_PATH, sub_ptr, sub_size, false) }
+                    .is_err()
+                {
+                    ::syslog::warn!("vfs_init_ramfs(): failed to mount ROOTFS at /");
+                }
+            }
+
+            // Mount MOUNTFS at "/mnt" if present.
+            if let Some(mountfs) =
+                ::multiimage::find_entry_by_tag(entries, &::multiimage::MOUNTFS_MMIO_TAG)
+            {
+                let sub_ptr: *mut u8 = unsafe { mount_ptr.add(mountfs.offset as usize) };
+                let sub_size: usize = mountfs.size as usize;
+                if unsafe { ::vfs::mount_image(MOUNT_DIR_PATH, sub_ptr, sub_size, false) }.is_err()
+                {
+                    ::syslog::warn!("vfs_init_ramfs(): failed to mount MOUNTFS at /mnt");
+                }
+            }
+        } else {
+            // Legacy single-image path.
+            if unsafe { ::vfs::mount_image(RAMFS_MOUNT_PATH, mount_ptr, total_size, false) }
+                .is_err()
+            {
+                ::syslog::warn!("vfs_init_ramfs(): failed to mount RAMFS image");
+                if !free_mmio_early {
+                    let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                }
+                return false;
+            }
         }
 
         true

--- a/src/tests/mount-test/Cargo.toml
+++ b/src/tests/mount-test/Cargo.toml
@@ -1,0 +1,39 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+[package]
+name = "mount-test"
+version.workspace = true
+license-file.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Integration test for host directory mount feature"
+homepage.workspace = true
+
+[[bin]]
+name = "mount-test"
+
+[dependencies]
+libc_string = { workspace = true }
+nvx = { workspace = true }
+sys = { workspace = true, features = ["kcall"] }
+sysapi = { workspace = true }
+syscall = { workspace = true, features = ["syscall"] }
+syslog = { workspace = true, default-features = true }
+
+[build-dependencies]
+cc = { workspace = true }
+cfg-if = { workspace = true }
+
+[features]
+default = ["panic"]
+standalone = ["nvx/standalone", "syscall/standalone"]
+trace = ["nvx/trace", "syscall/trace", "syslog/trace"]
+debug = ["nvx/debug", "syscall/debug", "syslog/debug"]
+info = ["nvx/info", "syscall/info", "syslog/info"]
+warn = ["nvx/warn", "syscall/warn", "syslog/warn"]
+error = ["nvx/error", "syscall/error", "syslog/error"]
+panic = ["nvx/panic", "syscall/panic", "syslog/panic"]
+
+[lints]
+workspace = true

--- a/src/tests/mount-test/build.rs
+++ b/src/tests/mount-test/build.rs
@@ -1,0 +1,54 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![deny(clippy::all)]
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::std::{
+    env,
+    path::Path,
+};
+
+//==================================================================================================
+// Main Function
+//==================================================================================================
+
+fn main() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86".to_string());
+    println!("cargo::rustc-link-arg=-Tbuild/user/linker/{target_arch}/user.ld");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Create a test directory with sample files that the test runner will pass to `-mount`.
+    // Always regenerate from scratch because a previous test run may have overwritten
+    // its contents via the copyback mechanism.
+    let manifest_dir: String = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let workspace_root = Path::new(&manifest_dir)
+        .parent()
+        .expect("no parent: tests/")
+        .parent()
+        .expect("no parent: src/")
+        .parent()
+        .expect("no parent: root");
+    let mount_dir = workspace_root.join("bin").join("mount-test-data");
+
+    // Remove any stale data from a previous copyback, then recreate.
+    let _ = std::fs::remove_dir_all(&mount_dir);
+    std::fs::create_dir_all(&mount_dir).expect("failed to create mount-test-data directory");
+
+    // Write a known test file that the guest will read and verify.
+    std::fs::write(mount_dir.join("input.txt"), b"mount-test-input\n")
+        .expect("failed to write input.txt");
+
+    // Write a subdirectory with a nested file.
+    let sub = mount_dir.join("subdir");
+    std::fs::create_dir_all(&sub).expect("failed to create subdir");
+    std::fs::write(sub.join("nested.txt"), b"nested-content\n")
+        .expect("failed to write nested.txt");
+}

--- a/src/tests/mount-test/src/main.rs
+++ b/src/tests/mount-test/src/main.rs
@@ -1,0 +1,120 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Integration test for the host directory mount feature.
+//!
+//! This guest binary exercises the `-mount <host-dir>` feature by:
+//! 1. Verifying that a pre-existing file from the host directory is readable at `/mnt/input.txt`.
+//! 2. Verifying that a nested file at `/mnt/subdir/nested.txt` is readable.
+//! 3. Creating a new file at `/mnt/output.txt` that will be copied back to the host on shutdown.
+//! 4. Modifying the existing `/mnt/input.txt` to verify that changes are preserved on copyback.
+//!
+//! Exit code 0 indicates all checks passed.
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#![no_std]
+#![no_main]
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+extern crate alloc;
+extern crate libc_string;
+extern crate nvx;
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::error::Error;
+use ::syscall::safe::{
+    FileSystem,
+    FileSystemPath,
+    FileSystemPermissions,
+    RegularFile,
+    RegularFileOpenFlags,
+};
+
+//==================================================================================================
+// Test Helpers
+//==================================================================================================
+
+/// Opens a file, reads its entire contents, and closes it.
+fn read_file(path: &str) -> Result<alloc::vec::Vec<u8>, Error> {
+    let pathname: FileSystemPath = FileSystemPath::new(path)?;
+    let file: RegularFile =
+        FileSystem::open_regular_file(&pathname, &RegularFileOpenFlags::read_only(), None)?;
+
+    let mut buf: [u8; 4096] = [0u8; 4096];
+    let n: usize = file.read(&mut buf)?;
+    Ok(alloc::vec::Vec::from(&buf[..n]))
+}
+
+/// Creates (or truncates) a file with the given contents.
+fn write_file(path: &str, data: &[u8]) -> Result<(), Error> {
+    let pathname: FileSystemPath = FileSystemPath::new(path)?;
+
+    let permissions: FileSystemPermissions = FileSystemPermissions::empty()
+        .user_read(true)
+        .user_write(true);
+
+    // Create the file (truncates if it exists).
+    let mut file: RegularFile = FileSystem::create_regular_file(&pathname, Some(permissions))?;
+
+    file.write(data)?;
+    Ok(())
+}
+
+//==================================================================================================
+// Main Function
+//==================================================================================================
+
+#[unsafe(no_mangle)]
+pub fn main() -> Result<(), Error> {
+    ::syslog::info!("mount-test: starting host directory mount integration test");
+
+    // Test 1: Read a pre-existing file from the mounted host directory.
+    {
+        let data: alloc::vec::Vec<u8> = read_file("/mnt/input.txt")?;
+        if data != b"mount-test-input\n" {
+            ::syslog::error!("mount-test: /mnt/input.txt content mismatch (len={})", data.len());
+            panic!("content mismatch on /mnt/input.txt");
+        }
+        ::syslog::info!("mount-test: [PASS] /mnt/input.txt read correctly");
+    }
+
+    // Test 2: Read a nested file.
+    {
+        let data: alloc::vec::Vec<u8> = read_file("/mnt/subdir/nested.txt")?;
+        if data != b"nested-content\n" {
+            ::syslog::error!("mount-test: /mnt/subdir/nested.txt content mismatch");
+            panic!("content mismatch on /mnt/subdir/nested.txt");
+        }
+        ::syslog::info!("mount-test: [PASS] /mnt/subdir/nested.txt read correctly");
+    }
+
+    // Test 3: Create a new file on the mount (to be copied back to host).
+    write_file("/mnt/output.txt", b"guest-created-file\n")?;
+    ::syslog::info!("mount-test: [PASS] /mnt/output.txt created");
+
+    // Test 4: Overwrite the existing file (to verify modify-and-copyback).
+    write_file("/mnt/input.txt", b"modified-by-guest\n")?;
+    ::syslog::info!("mount-test: [PASS] /mnt/input.txt modified");
+
+    // Test 5: Re-read the modified file to confirm the write took effect.
+    {
+        let data: alloc::vec::Vec<u8> = read_file("/mnt/input.txt")?;
+        if data != b"modified-by-guest\n" {
+            ::syslog::error!("mount-test: /mnt/input.txt re-read content mismatch");
+            panic!("re-read mismatch on /mnt/input.txt");
+        }
+        ::syslog::info!("mount-test: [PASS] /mnt/input.txt re-read matches");
+    }
+
+    ::syslog::info!("mount-test: all tests passed");
+    Ok(())
+}

--- a/src/uservm/Cargo.toml
+++ b/src/uservm/Cargo.toml
@@ -25,11 +25,14 @@ cfg-if = { workspace = true }
 config = { workspace = true }
 control-plane-api = { workspace = true }
 elf = { workspace = true, features = ["std"] }
+fatfs = { workspace = true }
 gdbstub = { workspace = true, optional = true }
 gdbstub_arch = { workspace = true, optional = true }
 hyperlight-host = { workspace = true, optional = true }
 log = { workspace = true }
+mkramfs = { workspace = true }
 multibin = { workspace = true, features = ["std"] }
+multiimage = { workspace = true, features = ["std"] }
 profiler = { workspace = true, features = ["auto-calibrate"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"], optional = true }
@@ -37,6 +40,7 @@ static_assert = { workspace = true }
 sys = { workspace = true, features = ["std"] }
 syscall = { workspace = true }
 syslog = { workspace = true, features = ["std"] }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -197,6 +197,8 @@ pub struct UserVmArgs {
     pub counters: MessageCounters,
     /// Optional snapshot path: when set, restore VM state from this snapshot before running.
     pub snapshot_path: Option<String>,
+    /// Optional host directory to mount on the guest (standalone mode only).
+    pub mount_directory: Option<String>,
     /// Optional GDB server port (standalone mode only).
     #[cfg(feature = "gdb")]
     pub gdb_port: Option<u16>,
@@ -346,6 +348,7 @@ impl UserVm {
             initrd_args: args.initrd_args.clone(),
             ramfs_filename: args.ramfs_filename.clone(),
             restoring_from_snapshot: args.snapshot_path.is_some(),
+            mount_directory: args.mount_directory.clone(),
             #[cfg(all(feature = "microvm", not(feature = "hyperlight")))]
             ikc_pending: ikc_pending.clone(),
             #[cfg(feature = "gdb")]
@@ -480,6 +483,49 @@ impl UserVm {
         if let Err(error) = memory_thread.await {
             error!("spawn(): error joining memory thread (error={error:?})");
             // Don't bail, in order to cleanup the other the other tasks properly.
+        }
+
+        // Mount directory copyback: extract modified files from guest memory after VM shutdown.
+        #[cfg(all(feature = "microvm", not(feature = "hyperlight")))]
+        if let Some(ref mount_dir) = args.mount_directory {
+            use crate::vmm::mount;
+            let vmem_guard = vmem.lock().await;
+
+            // Read the ramfs base and size from the guest control registers.
+            let mut base_bytes: [u8; 4] = [0u8; 4];
+            let mut size_bytes: [u8; 4] = [0u8; 4];
+            if let (Ok(()), Ok(())) = (
+                vmem_guard.read_bytes(
+                    ::config::microvm::DEFAULT_MICROVM_CTRL_RAMFS_BASE as u64,
+                    &mut base_bytes,
+                ),
+                vmem_guard.read_bytes(
+                    ::config::microvm::DEFAULT_MICROVM_CTRL_RAMFS_SIZE as u64,
+                    &mut size_bytes,
+                ),
+            ) {
+                let ramfs_base: usize = u32::from_le_bytes(base_bytes) as usize;
+                let ramfs_size: usize = u32::from_le_bytes(size_bytes) as usize;
+
+                if ramfs_base > 0 && ramfs_size > 0 {
+                    let mut ramfs_data: Vec<u8> = vec![0u8; ramfs_size];
+                    if let Ok(()) = vmem_guard.read_bytes(ramfs_base as u64, &mut ramfs_data) {
+                        if let Err(e) = mount::copyback_mount_image(
+                            &ramfs_data,
+                            std::path::Path::new(mount_dir),
+                        ) {
+                            error!(
+                                "spawn(): mount copyback failed (dir={mount_dir:?}, error={e:?})"
+                            );
+                        }
+                    } else {
+                        error!(
+                            "spawn(): failed to read ramfs region from guest memory \
+                             (base={ramfs_base:#x}, size={ramfs_size:#x})"
+                        );
+                    }
+                }
+            }
         }
 
         #[cfg(feature = "profile-time")]

--- a/src/uservm/src/main.rs
+++ b/src/uservm/src/main.rs
@@ -188,6 +188,7 @@ async fn run_standalone(
         ramfs_filename,
         stderr,
         snapshot_path,
+        None,
         #[cfg(feature = "gdb")]
         gdb_port,
     );
@@ -377,6 +378,7 @@ async fn run_managed(
         kernel_filename,
         counters,
         snapshot_path: None,
+        mount_directory: None,
         #[cfg(feature = "gdb")]
         gdb_port: None,
         #[cfg(feature = "profile-time")]

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -149,6 +149,7 @@ impl StandaloneVmHandle {
         ramfs_filename: Option<String>,
         stderr: Option<String>,
         snapshot_path: Option<String>,
+        mount_directory: Option<String>,
         #[cfg(feature = "gdb")] gdb_port: Option<u16>,
     ) -> (Self, StandaloneVmIo) {
         // Create internal VM channels. In standalone mode these are wired directly without an
@@ -184,6 +185,7 @@ impl StandaloneVmHandle {
             kernel_filename,
             counters,
             snapshot_path,
+            mount_directory,
             #[cfg(feature = "gdb")]
             gdb_port,
             #[cfg(feature = "profile-time")]

--- a/src/uservm/src/vmm/microvm/kvm/vmem.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vmem.rs
@@ -47,6 +47,9 @@ pub struct VirtualMemory {
     mapping: AnonymousMapping,
     /// Optional RAMFS descriptor that keeps metadata and the backing file alive.
     ramfs: Option<RamFs>,
+    /// Additional file handles for multi-image backing files. Kept alive so that
+    /// `mmap(MAP_FIXED)` file-backed regions remain valid for the VM's lifetime.
+    backing_files: Vec<File>,
 }
 
 ///
@@ -156,6 +159,7 @@ impl VirtualMemory {
         let vmem: Self = Self {
             mapping,
             ramfs: None,
+            backing_files: Vec::new(),
         };
 
         // Map memory into virtual machine.
@@ -217,6 +221,29 @@ impl VirtualMemory {
     ///
     /// # Description
     ///
+    /// Replaces multiple sub-regions of guest memory with file-backed mappings (zero-copy).
+    ///
+    /// Each region is specified as a `(guest_offset, file)` pair. The file is mapped at the
+    /// given offset using `mmap(MAP_FIXED)`, replacing the anonymous pages in that range.
+    ///
+    /// # Parameters
+    ///
+    /// - `regions`: Slice of `(guest_offset, file)` pairs. Must be non-overlapping.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns empty. Otherwise, returns an error.
+    ///
+    pub fn remap_files_at(&mut self, regions: &[(usize, &File)]) -> Result<()> {
+        for &(start, file) in regions {
+            self.remap_file_at(start, file)?;
+        }
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
     /// Attaches a RAM filesystem descriptor to the virtual memory so the backing file remains
     /// alive for the VM's lifetime.
     ///
@@ -230,6 +257,21 @@ impl VirtualMemory {
     ///
     pub fn attach_ramfs(&mut self, ramfs: RamFs) {
         self.ramfs = Some(ramfs);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attaches multiple backing file handles whose memory-mapped regions must remain valid
+    /// for the VM's lifetime. Used by the multi-image RAMFS path where each sub-image file
+    /// is mapped individually.
+    ///
+    /// # Parameters
+    ///
+    /// - `files`: File handles to keep alive.
+    ///
+    pub fn attach_backing_files(&mut self, files: Vec<File>) {
+        self.backing_files = files;
     }
 
     ///

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod emulator;
 pub mod guest;
+pub mod mount;
 pub mod ramfs;
 
 cfg_if::cfg_if! {
@@ -126,6 +127,8 @@ use ::std::time::Instant;
 
 #[cfg(target_os = "linux")]
 pub use kvm::vmem::VirtualMemory;
+#[cfg(target_os = "linux")]
+pub use ramfs::MultiRamFs;
 #[cfg(target_os = "linux")]
 pub use ramfs::RamFs;
 
@@ -439,22 +442,45 @@ impl Vmm {
             #[cfg(feature = "profile-time")]
             let ramfs_load_start: Instant = Instant::now();
 
-            let ramfs_region: Option<(usize, usize)> =
-                if let Some(ramfs_filename) = args.ramfs_filename.as_deref() {
-                    let initrd_end: usize = match guest.initrd_region() {
-                        Some((base, size)) => match base.checked_add(size) {
-                            Some(end) => end,
-                            None => {
-                                let reason: String = "initrd region overflowed while computing \
-                                                      ramfs placement"
-                                    .to_string();
-                                error!("new(): {reason}");
-                                anyhow::bail!(reason)
-                            },
+            let ramfs_region: Option<(usize, usize)> = {
+                let initrd_end: usize = match guest.initrd_region() {
+                    Some((base, size)) => match base.checked_add(size) {
+                        Some(end) => end,
+                        None => {
+                            let reason: String = "initrd region overflowed while computing ramfs \
+                                                  placement"
+                                .to_string();
+                            error!("new(): {reason}");
+                            anyhow::bail!(reason)
                         },
-                        None => ::config::microvm::DEFAULT_INITRD_BASE,
-                    };
+                    },
+                    None => ::config::microvm::DEFAULT_INITRD_BASE,
+                };
 
+                if let Some(ref mount_dir) = args.mount_directory {
+                    // Build a FAT image from the host directory.
+                    // The TempPath ensures the file is cleaned up on all paths (including errors).
+                    let (mountfs_temp, _mountfs_size) =
+                        mount::build_mount_image(Path::new(mount_dir))?;
+                    let mountfs_path: &Path = mountfs_temp.as_ref();
+
+                    // Compute the multi-image layout (zero-copy: no concatenated file).
+                    let rootfs_path: Option<PathBuf> =
+                        args.ramfs_filename.as_ref().map(PathBuf::from);
+                    let layout: ::multiimage::MultiImageLayout =
+                        mount::compute_unified_layout(rootfs_path.as_deref(), mountfs_path)?;
+
+                    // Open all sub-image files and map them directly into guest memory.
+                    let multi_ramfs: ramfs::MultiRamFs = ramfs::MultiRamFs::open(layout)?;
+                    let (ramfs_base, ramfs_size) =
+                        multi_ramfs.load_into_virtual_memory(&mut vmem, initrd_end)?;
+                    vmem.attach_backing_files(multi_ramfs.into_files());
+
+                    // TempPath drops here (or on error), removing the temporary file.
+                    drop(mountfs_temp);
+                    Some((ramfs_base, ramfs_size))
+                } else if let Some(ramfs_filename) = args.ramfs_filename.as_deref() {
+                    // Legacy single-image path.
                     let ramfs: RamFs = RamFs::open(Path::new(ramfs_filename))?;
                     let (ramfs_base, ramfs_size) =
                         ramfs.load_into_virtual_memory(&mut vmem, initrd_end)?;
@@ -462,7 +488,8 @@ impl Vmm {
                     Some((ramfs_base, ramfs_size))
                 } else {
                     None
-                };
+                }
+            };
 
             RamFs::write_registers(&mut vmem, ramfs_region)?;
 

--- a/src/uservm/src/vmm/microvm/mount.rs
+++ b/src/uservm/src/vmm/microvm/mount.rs
@@ -1,0 +1,334 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Host-directory mount support for standalone mode.
+//!
+//! This module provides helpers that:
+//! 1. Build a FAT32 image from a host directory using `mkramfs`.
+//! 2. Combine an optional root RAMFS and the mount image into a multi-image container.
+//! 3. After VM shutdown, extract modified files from guest memory back to the host directory.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::anyhow::Result;
+use ::log::{
+    error,
+    info,
+    trace,
+};
+use ::multiimage::{
+    self,
+    ImageDescriptor,
+    ImageEntry,
+    MOUNTFS_MMIO_TAG,
+    MultiImageLayout,
+    ROOTFS_MMIO_TAG,
+};
+use ::std::path::{
+    Path,
+    PathBuf,
+};
+use ::tempfile::TempPath;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum mount image size: 1/8 of guest MEMORY_SIZE.
+const MAX_MOUNT_IMAGE_SIZE: usize = ::config::kernel::MEMORY_SIZE / 8;
+
+//==================================================================================================
+// Public API
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Builds a FAT32 image from the contents of `host_dir`. If the directory is empty, creates an
+/// empty formatted FAT image of [`mkramfs::MIN_IMAGE_SIZE`] bytes.
+///
+/// The resulting image is written to a temporary file wrapped in a [`TempPath`] that
+/// automatically deletes the file when dropped, ensuring cleanup on all code paths
+/// (including errors).
+///
+/// # Parameters
+///
+/// - `host_dir`: Path to the host directory whose contents should be packaged.
+///
+/// # Returns
+///
+/// On success, returns the [`TempPath`] to the generated image file and its size in bytes.
+///
+pub fn build_mount_image(host_dir: &Path) -> Result<(TempPath, usize)> {
+    trace!("build_mount_image(): host_dir={host_dir:?}");
+
+    let content_size: u64 = mkramfs::dir_size(host_dir);
+    let image_size: u64 = mkramfs::compute_image_size(content_size);
+
+    // Enforce the 1/8 MEMORY_SIZE limit.
+    let image_size: u64 = image_size.min(MAX_MOUNT_IMAGE_SIZE as u64);
+
+    if content_size > image_size {
+        let reason: String = format!(
+            "host directory content ({content_size} bytes) exceeds mount image limit \
+             ({MAX_MOUNT_IMAGE_SIZE} bytes)"
+        );
+        error!("build_mount_image(): {reason}");
+        anyhow::bail!(reason);
+    }
+
+    // Create a named temporary file that is automatically removed on drop.
+    let tmp_file: tempfile::NamedTempFile = tempfile::Builder::new()
+        .prefix("nanvix-mount-")
+        .suffix(".img")
+        .tempfile()
+        .map_err(|e| {
+            let reason: String = format!("failed to create temporary mount image file: {e}");
+            error!("build_mount_image(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+    let output: TempPath = tmp_file.into_temp_path();
+
+    if content_size == 0 {
+        info!(
+            "build_mount_image(): empty directory, creating empty FAT image ({image_size} bytes)"
+        );
+        mkramfs::mkfatfs(&output, usize::try_from(image_size).unwrap_or(usize::MAX)).map_err(
+            |e| {
+                let reason: String = format!("failed to create FAT image: {e}");
+                error!("build_mount_image(): {reason}");
+                anyhow::anyhow!(reason)
+            },
+        )?;
+    } else {
+        info!(
+            "build_mount_image(): packaging {content_size} bytes into {image_size}-byte FAT image"
+        );
+        mkramfs::generate_image(&output, host_dir, image_size).map_err(|e| {
+            let reason: String = format!("failed to generate FAT image: {e}");
+            error!("build_mount_image(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+    }
+
+    let actual_size: usize = std::fs::metadata(output.as_ref() as &Path)
+        .map(|m| usize::try_from(m.len()).unwrap_or(usize::MAX))
+        .map_err(|e| {
+            let reason: String = format!("failed to stat mount image at {output:?}: {e}");
+            error!("build_mount_image(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+    info!("build_mount_image(): image ready at {output:?} ({actual_size} bytes)");
+    Ok((output, actual_size))
+}
+
+///
+/// # Description
+///
+/// Computes a multi-image container layout that combines an optional root RAMFS image and a
+/// mount image. Instead of writing a concatenated file to disk, this returns a
+/// [`MultiImageLayout`] descriptor that the VMM backends can use to map each sub-image file
+/// directly into guest memory (zero-copy).
+///
+/// # Parameters
+///
+/// - `rootfs_path`: Optional path to the root RAMFS image (from `-ramfs` flag).
+/// - `mountfs_path`: Path to the mount image (from [`build_mount_image`]).
+///
+/// # Returns
+///
+/// On success, returns the computed [`MultiImageLayout`].
+///
+pub fn compute_unified_layout(
+    rootfs_path: Option<&Path>,
+    mountfs_path: &Path,
+) -> Result<MultiImageLayout> {
+    trace!("compute_unified_layout(): rootfs={rootfs_path:?}, mountfs={mountfs_path:?}");
+
+    let mut descriptors: Vec<ImageDescriptor<'_>> = Vec::new();
+
+    if let Some(rootfs) = rootfs_path {
+        descriptors.push(ImageDescriptor {
+            tag: ROOTFS_MMIO_TAG,
+            path: rootfs,
+            flags: multiimage::FLAG_READONLY,
+        });
+    }
+
+    descriptors.push(ImageDescriptor {
+        tag: MOUNTFS_MMIO_TAG,
+        path: mountfs_path,
+        flags: 0,
+    });
+
+    let layout: MultiImageLayout =
+        multiimage::compute_multiimage_layout(&descriptors).map_err(|e| {
+            let reason: String = format!("failed to compute unified image layout: {e:?}");
+            error!("compute_unified_layout(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+    info!(
+        "compute_unified_layout(): layout ready ({} regions, total_size={} bytes)",
+        layout.regions.len(),
+        layout.total_size
+    );
+
+    Ok(layout)
+}
+
+///
+/// # Description
+///
+/// Extracts the MOUNTFS sub-image from guest memory and copies its contents back to `host_dir`.
+///
+/// This is called after the guest VM shuts down. The function:
+/// 1. Parses the multi-image header from the RAMFS region in guest memory.
+/// 2. Locates the MOUNTFS entry.
+/// 3. Reads the MOUNTFS sub-image data.
+/// 4. Opens it as a FAT filesystem.
+/// 5. Copies all files back to `host_dir`, including those created or modified by the guest.
+///
+/// # Parameters
+///
+/// - `ramfs_data`: Slice of guest memory covering the entire RAMFS/multi-image region.
+/// - `host_dir`: Path to the original host directory that was mounted.
+///
+pub fn copyback_mount_image(ramfs_data: &[u8], host_dir: &Path) -> Result<()> {
+    trace!("copyback_mount_image(): host_dir={host_dir:?}, region_size={}", ramfs_data.len());
+
+    if !multiimage::is_multiimage(ramfs_data) {
+        let reason: String = "RAMFS region does not contain a multi-image container".to_string();
+        error!("copyback_mount_image(): {reason}");
+        anyhow::bail!(reason);
+    }
+
+    let header: multiimage::MultiImageHeader =
+        multiimage::parse_header(ramfs_data).map_err(|e| {
+            let reason: String = format!("failed to parse multi-image header: {e:?}");
+            error!("copyback_mount_image(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+    let entries: &[ImageEntry] =
+        multiimage::parse_entries(ramfs_data, header.num_images).map_err(|e| {
+            let reason: String = format!("failed to parse multi-image entries: {e:?}");
+            error!("copyback_mount_image(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+    let mountfs: &ImageEntry = multiimage::find_entry_by_tag(entries, &MOUNTFS_MMIO_TAG)
+        .ok_or_else(|| {
+            let reason: String = "MOUNTFS entry not found in multi-image container".to_string();
+            error!("copyback_mount_image(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+    let offset: usize = usize::try_from(mountfs.offset)
+        .map_err(|_| anyhow::anyhow!("MOUNTFS offset exceeds platform address space"))?;
+    let size: usize = usize::try_from(mountfs.size)
+        .map_err(|_| anyhow::anyhow!("MOUNTFS size exceeds platform address space"))?;
+
+    if offset + size > ramfs_data.len() {
+        let reason: String = format!(
+            "MOUNTFS region out of bounds (offset={offset}, size={size}, total={})",
+            ramfs_data.len()
+        );
+        error!("copyback_mount_image(): {reason}");
+        anyhow::bail!(reason);
+    }
+
+    let mountfs_data: &[u8] = &ramfs_data[offset..offset + size];
+
+    // Write the MOUNTFS data to a temporary file so we can open it with fatfs.
+    let tmp_path: PathBuf =
+        std::env::temp_dir().join(format!("nanvix-copyback-{}.img", std::process::id()));
+    std::fs::write(&tmp_path, mountfs_data).map_err(|e| {
+        let reason: String = format!("failed to write copyback image to {tmp_path:?}: {e}");
+        error!("copyback_mount_image(): {reason}");
+        anyhow::anyhow!(reason)
+    })?;
+
+    // Open the FAT image and extract files.
+    let file: std::fs::File = std::fs::OpenOptions::new()
+        .read(true)
+        .open(&tmp_path)
+        .map_err(|e| {
+            let reason: String = format!("failed to open copyback image: {e}");
+            error!("copyback_mount_image(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+    let storage = fatfs::StdIoWrapper::new(file);
+    let fs = fatfs::FileSystem::new(storage, fatfs::FsOptions::new()).map_err(|e| {
+        let reason: String = format!("failed to open FAT filesystem for copyback: {e}");
+        error!("copyback_mount_image(): {reason}");
+        anyhow::anyhow!(reason)
+    })?;
+
+    // Extract all files from the FAT image into the host directory, creating directories
+    // as needed and overwriting matching files, but leaving unrelated existing files in place.
+    extract_dir_recursive(&fs.root_dir(), host_dir)?;
+
+    // Clean up temporary file.
+    let _ = std::fs::remove_file(&tmp_path);
+
+    info!("copyback_mount_image(): files copied back to {host_dir:?}");
+    Ok(())
+}
+
+//==================================================================================================
+// Private Helpers
+//==================================================================================================
+
+/// Recursively extracts all files and directories from a FAT directory into `host_dir`.
+fn extract_dir_recursive<IO, TP, OCC>(
+    fat_dir: &fatfs::Dir<IO, TP, OCC>,
+    host_dir: &Path,
+) -> Result<()>
+where
+    IO: fatfs::ReadWriteSeek,
+    TP: fatfs::TimeProvider,
+    OCC: fatfs::OemCpConverter,
+{
+    // Ensure the host directory exists.
+    std::fs::create_dir_all(host_dir)
+        .map_err(|e| anyhow::anyhow!("failed to create directory {}: {e}", host_dir.display()))?;
+
+    for entry in fat_dir.iter() {
+        let entry =
+            entry.map_err(|e| anyhow::anyhow!("failed to read FAT directory entry: {e:?}"))?;
+
+        let name: String = entry.file_name();
+
+        // Skip the dot entries.
+        if name == "." || name == ".." {
+            continue;
+        }
+
+        let target: PathBuf = host_dir.join(&name);
+
+        if entry.is_dir() {
+            extract_dir_recursive(&entry.to_dir(), &target)?;
+        } else {
+            let mut data: Vec<u8> = Vec::new();
+            let mut file = entry.to_file();
+            let mut buf: [u8; 4096] = [0u8; 4096];
+            loop {
+                let n: usize = fatfs::Read::read(&mut file, &mut buf)
+                    .map_err(|e| anyhow::anyhow!("failed to read FAT file {name}: {e:?}"))?;
+                if n == 0 {
+                    break;
+                }
+                data.extend_from_slice(&buf[..n]);
+            }
+            std::fs::write(&target, &data)
+                .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", target.display()))?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/uservm/src/vmm/microvm/ramfs.rs
+++ b/src/uservm/src/vmm/microvm/ramfs.rs
@@ -13,8 +13,10 @@ use ::anyhow::Result;
 use ::arch::mem::PAGE_SIZE;
 use ::log::{
     error,
+    info,
     trace,
 };
+use ::multiimage::MultiImageLayout;
 #[cfg(target_os = "linux")]
 use ::std::fs::Metadata;
 use ::std::{
@@ -369,5 +371,240 @@ impl RamFs {
         })?;
 
         Ok(())
+    }
+}
+
+//==================================================================================================
+// Multi-Image RAMFS
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Encapsulates a multi-image RAMFS layout comprising a HEAD page and one or more sub-image files.
+///
+/// Instead of creating a single concatenated file on disk, this struct holds the pre-built HEAD
+/// page and open file handles for each sub-image. The VMM backends map each file directly into
+/// guest memory (zero-copy) at the offsets computed by the multi-image layout.
+///
+#[derive(Debug)]
+pub struct MultiRamFs {
+    /// Pre-built HEAD page bytes (header + entries).
+    head_page: std::vec::Vec<u8>,
+    /// Open file handles paired with their guest memory offset (relative to ramfs_base).
+    files: std::vec::Vec<(File, usize)>,
+    /// Total size of the multi-image container (HEAD + all page-aligned sub-images).
+    total_size: usize,
+}
+
+impl MultiRamFs {
+    ///
+    /// # Description
+    ///
+    /// Opens all sub-image files described by the layout and prepares them for zero-copy
+    /// mapping into guest memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `layout`: The multi-image layout produced by [`multiimage::compute_multiimage_layout`].
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns a `MultiRamFs` descriptor. Otherwise, returns an error.
+    ///
+    pub fn open(layout: MultiImageLayout) -> Result<Self> {
+        trace!(
+            "MultiRamFs::open(): {} regions, total_size={}",
+            layout.regions.len(),
+            layout.total_size
+        );
+
+        let mut files: std::vec::Vec<(File, usize)> =
+            std::vec::Vec::with_capacity(layout.regions.len());
+
+        for region in &layout.regions {
+            let file: File = File::open(&region.path).map_err(|e| {
+                let reason: String =
+                    format!("failed to open sub-image (path={:?}, error={e:?})", region.path);
+                error!("MultiRamFs::open(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+
+            // Validate that the file size matches what the layout expects.
+            let actual_size: u64 = file
+                .metadata()
+                .map_err(|e| {
+                    let reason: String = format!(
+                        "failed to query sub-image metadata (path={:?}, error={e:?})",
+                        region.path
+                    );
+                    error!("MultiRamFs::open(): {reason}");
+                    anyhow::anyhow!(reason)
+                })?
+                .len();
+
+            if actual_size != region.size as u64 {
+                let reason: String = format!(
+                    "sub-image size changed since layout was computed (path={:?}, expected={}, \
+                     actual={actual_size})",
+                    region.path, region.size
+                );
+                error!("MultiRamFs::open(): {reason}");
+                anyhow::bail!(reason);
+            }
+
+            files.push((file, region.offset));
+        }
+
+        Ok(Self {
+            head_page: layout.head_page,
+            files,
+            total_size: layout.total_size,
+        })
+    }
+
+    /// Returns the total page-aligned size of the multi-image container.
+    fn total_size(&self) -> usize {
+        self.total_size
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Loads this multi-image RAMFS near the end of guest memory, writing the HEAD page and
+    /// memory-mapping each sub-image file at its computed offset (zero-copy).
+    ///
+    /// # Parameters
+    ///
+    /// - `vmem`: Virtual memory that will host the RAMFS.
+    /// - `initrd_end`: The first byte immediately after the initrd contents in guest memory.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, returns the guest-physical base address and total size where the RAMFS
+    /// was loaded. Otherwise, returns an error.
+    ///
+    pub fn load_into_virtual_memory(
+        &self,
+        vmem: &mut VirtualMemory,
+        initrd_end: usize,
+    ) -> Result<(usize, usize)> {
+        trace!(
+            "MultiRamFs::load_into_virtual_memory(): total_size={}, initrd_end={:#010x}",
+            self.total_size, initrd_end
+        );
+
+        let ramfs_size: usize = self.total_size();
+        let memory_size: usize = vmem.get_size();
+
+        if !ramfs_size.is_multiple_of(PAGE_SIZE) {
+            let reason: String = format!(
+                "multi-image total size is not page-aligned (total_size={ramfs_size}, \
+                 page_size={PAGE_SIZE})"
+            );
+            error!("MultiRamFs::load_into_virtual_memory(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        if ramfs_size > memory_size {
+            let reason: String = format!(
+                "multi-image exceeds guest memory size (total_size={ramfs_size}, \
+                 memory_size={memory_size})"
+            );
+            error!("MultiRamFs::load_into_virtual_memory(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        let min_available_base: usize = match initrd_end.checked_add(RAMFS_MIN_SLACK_BYTES) {
+            Some(value) => value,
+            None => {
+                let reason: &str = "overflow while computing required ramfs slack";
+                error!("MultiRamFs::load_into_virtual_memory(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        if min_available_base > memory_size {
+            let reason: String = format!(
+                "guest memory ({memory_size}) is smaller than initrd end plus slack \
+                 ({min_available_base})",
+            );
+            error!("MultiRamFs::load_into_virtual_memory(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        let ramfs_base: usize = match memory_size.checked_sub(ramfs_size) {
+            Some(base) => base,
+            None => {
+                let reason: String = format!(
+                    "multi-image does not fit in guest memory (total_size={ramfs_size}, \
+                     memory_size={memory_size})",
+                );
+                error!("MultiRamFs::load_into_virtual_memory(): {reason}");
+                anyhow::bail!(reason)
+            },
+        };
+
+        debug_assert!(
+            ramfs_base.is_multiple_of(PAGE_SIZE),
+            "ramfs_base ({ramfs_base:#x}) must be page-aligned"
+        );
+
+        if ramfs_base < min_available_base {
+            let available: usize = match memory_size.checked_sub(min_available_base) {
+                Some(value) => value,
+                None => {
+                    let reason: &str = "underflow while computing available guest memory for ramfs";
+                    error!("MultiRamFs::load_into_virtual_memory(): {reason}");
+                    anyhow::bail!(reason)
+                },
+            };
+            let reason: String = format!(
+                "multi-image conflicts with initrd requirements (total_size={ramfs_size}, \
+                 available_for_ramfs={available}, required_slack={} bytes)",
+                RAMFS_MIN_SLACK_BYTES,
+            );
+            error!("MultiRamFs::load_into_virtual_memory(): {reason}");
+            anyhow::bail!(reason)
+        }
+
+        // Write the HEAD page into guest memory (committed/anonymous memory).
+        vmem.write_bytes(ramfs_base as u64, &self.head_page)?;
+        info!("MultiRamFs::load_into_virtual_memory(): wrote HEAD page at {:#010x}", ramfs_base);
+
+        // Build the list of file-backed regions and map them all at once.
+        let regions: std::vec::Vec<(usize, &File)> = self
+            .files
+            .iter()
+            .map(|(file, offset)| (ramfs_base + offset, file))
+            .collect();
+        vmem.remap_files_at(&regions)?;
+
+        for &(guest_addr, _) in &regions {
+            trace!(
+                "MultiRamFs::load_into_virtual_memory(): mapped sub-image at {:#010x}",
+                guest_addr
+            );
+        }
+
+        info!(
+            "MultiRamFs::load_into_virtual_memory(): loaded multi-image (base={:#010x}, \
+             size={ramfs_size})",
+            ramfs_base
+        );
+
+        Ok((ramfs_base, ramfs_size))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Extracts the open file handles from this `MultiRamFs`, consuming it.
+    ///
+    /// The returned files must be kept alive for the VM's lifetime so that the memory-mapped
+    /// regions remain valid.
+    ///
+    pub fn into_files(self) -> std::vec::Vec<File> {
+        self.files.into_iter().map(|(file, _offset)| file).collect()
     }
 }

--- a/src/uservm/src/vmm/microvm/whp/vmem.rs
+++ b/src/uservm/src/vmm/microvm/whp/vmem.rs
@@ -87,6 +87,11 @@ pub struct VirtualMemory {
     /// File-backed remap info for placeholder-split cleanup, or `None` when the region is a
     /// single committed block.
     file_remap: Option<FileRemap>,
+    /// Multiple file-backed remap info for multi-image zero-copy mapping, or `None` when
+    /// `remap_files_at` has not been called.
+    multi_file_remap: Option<MultiFileRemap>,
+    /// File handles that must stay alive for file-backed mappings to remain valid.
+    backing_files: Vec<File>,
 }
 
 ///
@@ -111,6 +116,29 @@ struct FileRemap {
 ///
 /// # Description
 ///
+/// Tracks the state of a multi-file remap performed by `remap_files_at()`. Multiple sub-regions
+/// of guest memory are replaced with file-backed views via placeholder splitting.
+///
+struct MultiFileRemap {
+    /// Byte offset where the placeholder split begins (everything before is committed).
+    split_start: usize,
+    /// Ordered list of file-backed view segments.
+    views: Vec<FileView>,
+}
+
+/// A single file-backed view within a multi-file remap.
+struct FileView {
+    /// Byte offset within the guest memory region.
+    offset: usize,
+    /// Page-aligned size of the view.
+    len: usize,
+    /// Section handle for cleanup (default/null if not yet mapped).
+    section_handle: HANDLE,
+}
+
+///
+/// # Description
+///
 /// A structure that represents the header in virtual memory snapshot files.
 ///
 #[repr(C)]
@@ -122,10 +150,11 @@ struct SnapshotHeader {
 // SAFETY: `VirtualMemory` owns a contiguous region of virtual memory allocated with
 // `VirtualAlloc2` and released in `Drop` (via `VirtualFree` and, when a file remap is active,
 // `UnmapViewOfFileEx` + `CloseHandle`), a WHP partition handle (an opaque OS handle safe to use
-// from any thread), and an optional `FileRemap` containing OS handles with no thread affinity.
-// All operations that mutate or deallocate the region require exclusive access (`&mut self`),
-// and resources are released exactly once during `Drop`. Synchronisation of concurrent access to
-// the pointed-to memory is the responsibility of higher-level code.
+// from any thread), optional `FileRemap`/`MultiFileRemap` containing OS handles with no thread
+// affinity, and a `Vec<File>` of backing file handles. All operations that mutate or deallocate
+// the region require exclusive access (`&mut self`), and resources are released exactly once
+// during `Drop`. Synchronisation of concurrent access to the pointed-to memory is the
+// responsibility of higher-level code.
 unsafe impl Send for VirtualMemory {}
 unsafe impl Sync for VirtualMemory {}
 
@@ -152,6 +181,11 @@ const GPA_RWX: WHV_MAP_GPA_RANGE_FLAGS = WHV_MAP_GPA_RANGE_FLAGS(
 /// WHP GPA mapping flags: Read | Write (no Execute).
 const GPA_RW: WHV_MAP_GPA_RANGE_FLAGS =
     WHV_MAP_GPA_RANGE_FLAGS(WHvMapGpaRangeFlagRead.0 | WHvMapGpaRangeFlagWrite.0);
+
+/// Combined `MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER` flag used to split a committed region
+/// back into placeholders without destroying the head.
+const MEM_RELEASE_PRESERVE: VIRTUAL_FREE_TYPE =
+    VIRTUAL_FREE_TYPE(MEM_RELEASE.0 | MEM_PRESERVE_PLACEHOLDER.0);
 
 //==================================================================================================
 // Implementations
@@ -237,6 +271,8 @@ impl VirtualMemory {
             size,
             partition_handle: partition.handle(),
             file_remap: None,
+            multi_file_remap: None,
+            backing_files: Vec::new(),
         };
 
         // Map the memory into the WHP partition at guest physical address 0.
@@ -298,61 +334,15 @@ impl VirtualMemory {
     /// new one is established. Callers should treat a failure as fatal for the VM instance.
     ///
     pub fn remap_file_at(&mut self, start: usize, file: &File) -> Result<()> {
-        let len: usize = {
-            let file_len: u64 = file
-                .metadata()
-                .map_err(|e| {
-                    let reason: String = format!("failed to query file metadata (error={e:?})");
-                    error!("remap_file_at(): {reason}");
-                    anyhow::anyhow!(reason)
-                })?
-                .len();
-            usize::try_from(file_len).map_err(|_| {
-                let reason: String =
-                    format!("file size exceeds platform address space (size={file_len})");
-                error!("remap_file_at(): {reason}");
-                anyhow::anyhow!(reason)
-            })?
-        };
+        if self.file_remap.is_some() || self.multi_file_remap.is_some() {
+            let reason: &str = "remap has already been performed on this VirtualMemory";
+            error!("remap_file_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        let view_specs: Vec<(usize, usize)> = self.validate_remap_regions(&[(start, file)])?;
+        let len: usize = view_specs[0].1;
         trace!("remap_file_at(): start={start:#x}, len={len:#x}");
-
-        if self.file_remap.is_some() {
-            let reason: &str = "remap_file_at() has already been called on this VirtualMemory";
-            error!("remap_file_at(): {reason}");
-            anyhow::bail!(reason);
-        }
-
-        if len == 0 {
-            let reason: &str = "cannot remap zero-sized region";
-            error!("remap_file_at(): {reason}");
-            anyhow::bail!(reason);
-        }
-
-        if start.checked_add(len).is_none_or(|end| end > self.size) {
-            let reason: String = format!(
-                "remap region [{start:#x}, {:#x}) exceeds memory bounds (size={:#x})",
-                start.saturating_add(len),
-                self.size
-            );
-            error!("remap_file_at(): {reason}");
-            anyhow::bail!(reason);
-        }
-
-        let page_size: usize = ::arch::mem::PAGE_SIZE;
-        if !start.is_multiple_of(page_size) {
-            let reason: String = format!(
-                "start address is not page-aligned (start={start:#x}, page_size={page_size:#x})"
-            );
-            error!("remap_file_at(): {reason}");
-            anyhow::bail!(reason);
-        }
-
-        if !len.is_multiple_of(page_size) {
-            let reason: String =
-                format!("length is not page-aligned (len={len:#x}, page_size={page_size:#x})");
-            error!("remap_file_at(): {reason}");
-            anyhow::bail!(reason);
-        }
 
         // SAFETY: `GetCurrentProcess()` returns a pseudo-handle that is always valid.
         let current_process: HANDLE = unsafe { GetCurrentProcess() };
@@ -381,7 +371,12 @@ impl VirtualMemory {
 
         // Phase 3: Re-commit the tail placeholder and re-register all affected GPA segments
         //          with the WHP partition.
-        self.commit_and_map_tail(start, len, current_process)?;
+        let view: FileView = FileView {
+            offset: start,
+            len,
+            section_handle,
+        };
+        self.recommit_tail_and_register_gpa(start, &[view], start + len, current_process)?;
 
         Ok(())
     }
@@ -420,8 +415,6 @@ impl VirtualMemory {
         // `VirtualFree(addr, size, MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)` splits the
         // committed region in place: [0..start) stays committed, [start..size) becomes a
         // placeholder. No data is destroyed in the head.
-        const MEM_RELEASE_PRESERVE: VIRTUAL_FREE_TYPE =
-            VIRTUAL_FREE_TYPE(MEM_RELEASE.0 | MEM_PRESERVE_PLACEHOLDER.0);
         // SAFETY: `self.ptr.add(start)` points within the committed region (bounds checked
         // by the caller). `MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER` splits the committed
         // allocation: [0..start) stays committed, [start..size) becomes a placeholder.
@@ -526,22 +519,244 @@ impl VirtualMemory {
     ///
     /// # Description
     ///
-    /// Re-commits the tail placeholder `[start+len..size)` (if any) and re-registers
-    /// the file-backed middle segment and the tail committed segment with the WHP partition.
+    /// Replaces multiple sub-regions of guest memory with zero-copy, file-backed mappings using
+    /// Windows placeholder APIs.
     ///
-    fn commit_and_map_tail(
+    /// The committed region from the first region's offset onward is freed to placeholders,
+    /// then each file is mapped via `MapViewOfFile3` with `MEM_REPLACE_PLACEHOLDER`. Gaps
+    /// between file regions and the tail are re-committed. All affected GPA segments are
+    /// re-registered with the WHP partition.
+    ///
+    /// # Parameters
+    ///
+    /// - `regions`: Slice of `(guest_offset, file)` pairs, sorted by offset. Files must be
+    ///   page-aligned in size and non-overlapping.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns empty. On failure, returns an error.
+    ///
+    pub fn remap_files_at(&mut self, regions: &[(usize, &File)]) -> Result<()> {
+        if regions.is_empty() {
+            return Ok(());
+        }
+
+        if self.file_remap.is_some() || self.multi_file_remap.is_some() {
+            let reason: &str = "remap has already been performed on this VirtualMemory";
+            error!("remap_files_at(): {reason}");
+            anyhow::bail!(reason);
+        }
+
+        let view_specs: Vec<(usize, usize)> = self.validate_remap_regions(regions)?;
+        let split_start: usize = view_specs[0].0;
+
+        // SAFETY: `GetCurrentProcess()` returns a pseudo-handle that is always valid.
+        let current_process: HANDLE = unsafe { GetCurrentProcess() };
+
+        // Phase 1+2: Unmap GPA [split_start..size) and free to a single placeholder.
+        // When `len == self.size - split_start`, the tail split in step 3 is naturally
+        // skipped because `split_start + len == self.size`.
+        self.prepare_placeholders(split_start, self.size - split_start)?;
+
+        // Phase 3: Split placeholders, commit gaps, and map each file view.
+        let (multi_remap, placeholder_base): (MultiFileRemap, usize) =
+            self.split_and_map_views(regions, &view_specs, split_start, current_process)?;
+
+        // Phase 4+5: Re-commit tail and re-register all GPA segments with WHP.
+        self.recommit_tail_and_register_gpa(
+            multi_remap.split_start,
+            &multi_remap.views,
+            placeholder_base,
+            current_process,
+        )?;
+
+        self.multi_file_remap = Some(multi_remap);
+        Ok(())
+    }
+
+    /// Validates that every region in `regions` has a non-zero, page-aligned size, a
+    /// page-aligned offset, and fits within the guest memory bounds. Returns the
+    /// `(offset, len)` pairs on success.
+    fn validate_remap_regions(&self, regions: &[(usize, &File)]) -> Result<Vec<(usize, usize)>> {
+        let page_size: usize = ::arch::mem::PAGE_SIZE;
+        let mut view_specs: Vec<(usize, usize)> = Vec::with_capacity(regions.len());
+
+        for &(offset, file) in regions {
+            let len: usize = {
+                let file_len: u64 = file
+                    .metadata()
+                    .map_err(|e| {
+                        let reason: String = format!("failed to query file metadata (error={e:?})");
+                        error!("validate_remap_regions(): {reason}");
+                        anyhow::anyhow!(reason)
+                    })?
+                    .len();
+                usize::try_from(file_len).map_err(|_| {
+                    let reason: String =
+                        format!("file size exceeds platform address space (size={file_len})");
+                    error!("validate_remap_regions(): {reason}");
+                    anyhow::anyhow!(reason)
+                })?
+            };
+            if len == 0 {
+                anyhow::bail!("validate_remap_regions(): cannot remap zero-sized file");
+            }
+            if !offset.is_multiple_of(page_size) || !len.is_multiple_of(page_size) {
+                anyhow::bail!(
+                    "validate_remap_regions(): offset ({offset:#x}) and length ({len:#x}) must be \
+                     page-aligned"
+                );
+            }
+            if offset.checked_add(len).is_none_or(|end| end > self.size) {
+                anyhow::bail!(
+                    "validate_remap_regions(): region [{offset:#x}..{:#x}) exceeds memory bounds",
+                    offset.saturating_add(len)
+                );
+            }
+            view_specs.push((offset, len));
+        }
+
+        // Verify that regions are sorted by offset and non-overlapping, which is
+        // required by split_and_map_views() for correct placeholder splitting.
+        for window in view_specs.windows(2) {
+            let (prev_offset, prev_len) = window[0];
+            let (next_offset, _) = window[1];
+            let prev_end: usize = prev_offset + prev_len;
+            if next_offset < prev_end {
+                anyhow::bail!(
+                    "validate_remap_regions(): regions are not sorted or overlap \
+                     (prev=[{prev_offset:#x}..{prev_end:#x}), next_offset={next_offset:#x})"
+                );
+            }
+        }
+
+        Ok(view_specs)
+    }
+
+    /// Iterates over the file regions left-to-right, splitting gaps from the placeholder and
+    /// re-committing them, then splitting each file-sized placeholder and mapping it via
+    /// [`Self::map_file_view`]. Returns the populated [`MultiFileRemap`] and the final
+    /// placeholder base offset.
+    fn split_and_map_views(
         &mut self,
-        start: usize,
-        len: usize,
+        regions: &[(usize, &File)],
+        view_specs: &[(usize, usize)],
+        split_start: usize,
+        current_process: HANDLE,
+    ) -> Result<(MultiFileRemap, usize)> {
+        let mut multi_remap: MultiFileRemap = MultiFileRemap {
+            split_start,
+            views: Vec::with_capacity(regions.len()),
+        };
+
+        // After `prepare_placeholders` we have one placeholder [split_start..size).
+        let mut placeholder_base: usize = split_start;
+
+        for (i, &(view_offset, file)) in regions.iter().enumerate() {
+            let view_len: usize = view_specs[i].1;
+            let view_end: usize = view_offset + view_len;
+
+            // Split off and re-commit a gap [placeholder_base..view_offset) if one exists.
+            if view_offset > placeholder_base {
+                let gap_size: usize = view_offset - placeholder_base;
+                self.commit_gap(placeholder_base, gap_size, current_process)?;
+                placeholder_base = view_offset;
+            }
+
+            // Split the file region from the remaining placeholder (if more follows).
+            if view_end < self.size {
+                // SAFETY: `self.ptr.add(placeholder_base)` is the base of the current
+                // placeholder, and `view_len` splits off the file-sized region.
+                unsafe {
+                    VirtualFree(
+                        self.ptr.add(placeholder_base).cast(),
+                        view_len,
+                        MEM_RELEASE_PRESERVE,
+                    )
+                    .map_err(|e| {
+                        let reason: String = format!(
+                            "split_and_map_views(): failed to split file placeholder (error={e:?})"
+                        );
+                        error!("{reason}");
+                        anyhow::anyhow!(reason)
+                    })?;
+                }
+            }
+
+            // Map the file view at [view_offset..view_end), reusing the single-file helper.
+            let file_handle: HANDLE = HANDLE(file.as_raw_handle());
+            let section_handle: HANDLE =
+                self.map_file_view(view_offset, view_len, file_handle, current_process)?;
+
+            multi_remap.views.push(FileView {
+                offset: view_offset,
+                len: view_len,
+                section_handle,
+            });
+
+            placeholder_base = view_end;
+        }
+
+        Ok((multi_remap, placeholder_base))
+    }
+
+    /// Splits a gap-sized region from the current placeholder and re-commits it as writable
+    /// memory.
+    fn commit_gap(&self, base: usize, gap_size: usize, current_process: HANDLE) -> Result<()> {
+        // SAFETY: `self.ptr.add(base)` is the start of the current placeholder.
+        // Splitting off `gap_size` bytes creates two placeholders.
+        unsafe {
+            VirtualFree(self.ptr.add(base).cast(), gap_size, MEM_RELEASE_PRESERVE).map_err(
+                |e| {
+                    let reason: String =
+                        format!("commit_gap(): failed to split gap placeholder (error={e:?})");
+                    error!("{reason}");
+                    anyhow::anyhow!(reason)
+                },
+            )?;
+        }
+
+        // Re-commit the gap as writable memory.
+        // SAFETY: `self.ptr.add(base)` targets the gap placeholder just split off.
+        let committed: *mut std::ffi::c_void = unsafe {
+            VirtualAlloc2(
+                Some(current_process),
+                Some(self.ptr.add(base).cast()),
+                gap_size,
+                MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
+                PAGE_READWRITE.0,
+                None,
+            )
+        };
+        if committed.is_null() {
+            let reason: String = format!(
+                "commit_gap(): failed to re-commit gap [{base:#x}..{:#x})",
+                base + gap_size
+            );
+            error!("{reason}");
+            anyhow::bail!(reason);
+        }
+
+        Ok(())
+    }
+
+    /// Re-commits the tail placeholder `[tail_start..size)` (if any) and re-registers
+    /// all affected GPA segments (committed gaps, file-backed views, tail) with the WHP
+    /// partition. The head `[0..split_start)` is assumed to still be mapped.
+    ///
+    /// This is the shared finalization step used by both `remap_file_at` (single view) and
+    /// `remap_files_at` (multiple views).
+    fn recommit_tail_and_register_gpa(
+        &self,
+        split_start: usize,
+        views: &[FileView],
+        tail_start: usize,
         current_process: HANDLE,
     ) -> Result<()> {
-        let tail_start: usize = start + len;
-
-        // Re-commit the tail placeholder (if any).
+        // Re-commit the tail placeholder if any.
         if tail_start < self.size {
             let tail_size: usize = self.size - tail_start;
-            // SAFETY: `self.ptr.add(tail_start)` targets the tail placeholder created by
-            // `prepare_placeholders()`.  `tail_size` spans [tail_start..size).
+            // SAFETY: `self.ptr.add(tail_start)` targets the tail placeholder.
             let committed: *mut std::ffi::c_void = unsafe {
                 VirtualAlloc2(
                     Some(current_process),
@@ -553,52 +768,78 @@ impl VirtualMemory {
                 )
             };
             if committed.is_null() {
-                let reason: String =
-                    format!("failed to re-commit tail segment [{tail_start:#x}..{:#x})", self.size);
-                error!("commit_and_map_tail(): {reason}");
+                let reason: String = format!(
+                    "recommit_tail_and_register_gpa(): failed to re-commit tail \
+                     [{tail_start:#x}..{:#x})",
+                    self.size
+                );
+                error!("{reason}");
                 anyhow::bail!(reason);
             }
         }
 
-        // Re-map the file-backed middle segment into the WHP partition.
-        // The head [0..start) was never unmapped — skip it.
-        // Use RW-only permissions: RAMFS data does not contain executable code.
-        // SAFETY: `self.ptr.add(start)` points to the file-backed view of `len` bytes
-        // established by `map_file_view()`.
-        unsafe {
-            WHvMapGpaRange(
-                self.partition_handle,
-                self.ptr.add(start) as *const std::ffi::c_void,
-                start as u64,
-                len as u64,
-                GPA_RW,
-            )
-            .map_err(|e| {
-                let reason: String = format!(
-                    "failed to map file-backed GPA range (start={start:#x}, len={len:#x}, \
-                     error={e:?})"
-                );
-                error!("commit_and_map_tail(): {reason}");
-                anyhow::anyhow!(reason)
-            })?;
-        }
-
-        // Re-map the tail committed segment (if any).
-        if tail_start < self.size {
-            let tail_size: usize = self.size - tail_start;
-            // SAFETY: `self.ptr.add(tail_start)` points to the re-committed tail segment.
-            // `tail_size` spans [tail_start..size). The WHP handle is valid.
+        // Re-register GPA segments with WHP. The head [0..split_start) was never unmapped.
+        let mut prev_end: usize = split_start;
+        for view in views {
+            // Re-map committed gap before this view.
+            if view.offset > prev_end {
+                let gap_size: usize = view.offset - prev_end;
+                // SAFETY: `self.ptr.add(prev_end)` points to a re-committed gap segment.
+                unsafe {
+                    WHvMapGpaRange(
+                        self.partition_handle,
+                        self.ptr.add(prev_end) as *const std::ffi::c_void,
+                        prev_end as u64,
+                        gap_size as u64,
+                        GPA_RWX,
+                    )
+                    .map_err(|e| {
+                        let reason: String = format!(
+                            "recommit_tail_and_register_gpa(): failed to map gap GPA (error={e:?})"
+                        );
+                        error!("{reason}");
+                        anyhow::anyhow!(reason)
+                    })?;
+                }
+            }
+            // Re-map file-backed view (RW only, RAMFS data is not executable).
+            // SAFETY: `self.ptr.add(view.offset)` points to the file-backed view.
             unsafe {
                 WHvMapGpaRange(
                     self.partition_handle,
-                    self.ptr.add(tail_start) as *const std::ffi::c_void,
-                    tail_start as u64,
+                    self.ptr.add(view.offset) as *const std::ffi::c_void,
+                    view.offset as u64,
+                    view.len as u64,
+                    GPA_RW,
+                )
+                .map_err(|e| {
+                    let reason: String = format!(
+                        "recommit_tail_and_register_gpa(): failed to map file GPA (error={e:?})"
+                    );
+                    error!("{reason}");
+                    anyhow::anyhow!(reason)
+                })?;
+            }
+            prev_end = view.offset + view.len;
+        }
+
+        // Re-map committed tail.
+        if prev_end < self.size {
+            let tail_size: usize = self.size - prev_end;
+            // SAFETY: `self.ptr.add(prev_end)` points to the re-committed tail segment.
+            unsafe {
+                WHvMapGpaRange(
+                    self.partition_handle,
+                    self.ptr.add(prev_end) as *const std::ffi::c_void,
+                    prev_end as u64,
                     tail_size as u64,
                     GPA_RWX,
                 )
                 .map_err(|e| {
-                    let reason: String = format!("failed to re-map tail GPA range (error={e:?})");
-                    error!("commit_and_map_tail(): {reason}");
+                    let reason: String = format!(
+                        "recommit_tail_and_register_gpa(): failed to map tail GPA (error={e:?})"
+                    );
+                    error!("{reason}");
                     anyhow::anyhow!(reason)
                 })?;
             }
@@ -700,6 +941,21 @@ impl VirtualMemory {
         }
 
         Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Attaches multiple backing file handles whose memory-mapped regions must remain valid
+    /// for the VM's lifetime. Used by the multi-image RAMFS path where each sub-image file
+    /// is mapped individually.
+    ///
+    /// # Parameters
+    ///
+    /// - `files`: File handles to keep alive.
+    ///
+    pub fn attach_backing_files(&mut self, files: Vec<File>) {
+        self.backing_files = files;
     }
 
     ///
@@ -1089,81 +1345,111 @@ impl Drop for VirtualMemory {
             }
         }
 
-        match self.file_remap.take() {
-            Some(remap) => {
-                // The region was split into up to three segments by `remap_file_at()`.
-                // Free each segment individually: committed segments via VirtualFree,
-                // the file view via UnmapViewOfFileEx, and the section handle via
-                // CloseHandle (when file-mapped).
-                //
-                // This also handles partial-failure states: if `remap_file_at()` failed
-                // after `prepare_placeholders()` but before completing all phases, some
-                // segments may still be placeholders. `VirtualFree(MEM_RELEASE)` releases
-                // both committed regions and placeholders, so cleanup is safe either way.
-                let tail_start: usize = remap.start + remap.len;
+        if let Some(multi) = self.multi_file_remap.take() {
+            // Multi-file remap active. The region was split into: committed head, N file views
+            // (possibly with committed gaps between them), and a committed tail.
 
-                // Free the head committed segment.
-                if remap.start > 0 {
-                    // SAFETY: `self.ptr` is the base of the original allocation.  After
-                    // `remap_file_at()`, [0..start) is a standalone committed region.
+            // Free the committed head [0..split_start).
+            if multi.split_start > 0 {
+                unsafe {
+                    if VirtualFree(self.ptr.cast(), 0, MEM_RELEASE).is_err() {
+                        error!("VirtualFree() failed for head segment (multi)");
+                    }
+                }
+            }
+
+            // Free committed gaps and file views, left to right.
+            let mut prev_end: usize = multi.split_start;
+            for view in &multi.views {
+                // Free committed gap [prev_end..view.offset) if any.
+                if view.offset > prev_end {
                     unsafe {
-                        if VirtualFree(self.ptr.cast(), 0, MEM_RELEASE).is_err() {
-                            error!("VirtualFree() failed for head segment");
+                        if VirtualFree(self.ptr.add(prev_end).cast(), 0, MEM_RELEASE).is_err() {
+                            error!("VirtualFree() failed for gap segment (multi)");
                         }
                     }
                 }
-
-                // Release the middle segment.
-                if remap.section_handle == HANDLE::default() {
-                    // Middle is a placeholder (partial failure). VirtualFree handles this.
-                    // SAFETY: `self.ptr.add(remap.start)` is the base of a standalone
-                    // region created during `remap_file_at()`.
+                // Release file-backed view.
+                if view.section_handle == HANDLE::default() {
                     unsafe {
-                        if VirtualFree(self.ptr.add(remap.start).cast(), 0, MEM_RELEASE).is_err() {
-                            error!("VirtualFree() failed for middle placeholder segment");
+                        if VirtualFree(self.ptr.add(view.offset).cast(), 0, MEM_RELEASE).is_err() {
+                            error!("VirtualFree() failed for placeholder segment (multi)");
                         }
                     }
                 } else {
-                    // Middle is a file-backed view — unmap and close the section handle.
-                    // SAFETY: `self.ptr.add(remap.start)` is the address of the file-backed
-                    // view created by `MapViewOfFile3` in `remap_file_at()` and
-                    // `remap.section_handle` is the corresponding section handle.  Both are
-                    // released exactly once here.
                     unsafe {
-                        let view: MEMORY_MAPPED_VIEW_ADDRESS = MEMORY_MAPPED_VIEW_ADDRESS {
-                            Value: self.ptr.add(remap.start).cast(),
+                        let view_addr: MEMORY_MAPPED_VIEW_ADDRESS = MEMORY_MAPPED_VIEW_ADDRESS {
+                            Value: self.ptr.add(view.offset).cast(),
                         };
-                        if UnmapViewOfFileEx(view, UNMAP_VIEW_OF_FILE_FLAGS(0)).is_err() {
-                            error!("UnmapViewOfFileEx() failed for file view");
+                        if UnmapViewOfFileEx(view_addr, UNMAP_VIEW_OF_FILE_FLAGS(0)).is_err() {
+                            error!("UnmapViewOfFileEx() failed for file view (multi)");
                         }
-                        if CloseHandle(remap.section_handle).is_err() {
-                            error!("CloseHandle() failed for section handle");
+                        if CloseHandle(view.section_handle).is_err() {
+                            error!("CloseHandle() failed for section handle (multi)");
                         }
                     }
                 }
+                prev_end = view.offset + view.len;
+            }
 
-                // Free the tail committed segment (or placeholder if Phase 3a failed).
-                if tail_start < self.size {
-                    // SAFETY: `self.ptr.add(tail_start)` is the base of either the
-                    // re-committed tail segment or a placeholder (if `commit_and_map_tail()`
-                    // failed before re-committing). `VirtualFree(MEM_RELEASE)` handles both.
-                    unsafe {
-                        if VirtualFree(self.ptr.add(tail_start).cast(), 0, MEM_RELEASE).is_err() {
-                            error!("VirtualFree() failed for tail segment");
-                        }
+            // Free committed tail [prev_end..size) if any.
+            if prev_end < self.size {
+                unsafe {
+                    if VirtualFree(self.ptr.add(prev_end).cast(), 0, MEM_RELEASE).is_err() {
+                        error!("VirtualFree() failed for tail segment (multi)");
                     }
                 }
-            },
-            None => {
-                // No remap: the region is a single committed block.
-                // SAFETY: `self.ptr` is a valid committed allocation from `VirtualAlloc2`
-                // in `new()` and is released exactly once here.
+            }
+        } else if let Some(remap) = self.file_remap.take() {
+            // Single file remap active. The region was split into up to three segments
+            // by `remap_file_at()`.
+            let tail_start: usize = remap.start + remap.len;
+
+            // Free the head committed segment.
+            if remap.start > 0 {
                 unsafe {
                     if VirtualFree(self.ptr.cast(), 0, MEM_RELEASE).is_err() {
-                        error!("VirtualFree() failed");
+                        error!("VirtualFree() failed for head segment");
                     }
                 }
-            },
+            }
+
+            // Release the middle segment.
+            if remap.section_handle == HANDLE::default() {
+                unsafe {
+                    if VirtualFree(self.ptr.add(remap.start).cast(), 0, MEM_RELEASE).is_err() {
+                        error!("VirtualFree() failed for middle placeholder segment");
+                    }
+                }
+            } else {
+                unsafe {
+                    let view: MEMORY_MAPPED_VIEW_ADDRESS = MEMORY_MAPPED_VIEW_ADDRESS {
+                        Value: self.ptr.add(remap.start).cast(),
+                    };
+                    if UnmapViewOfFileEx(view, UNMAP_VIEW_OF_FILE_FLAGS(0)).is_err() {
+                        error!("UnmapViewOfFileEx() failed for file view");
+                    }
+                    if CloseHandle(remap.section_handle).is_err() {
+                        error!("CloseHandle() failed for section handle");
+                    }
+                }
+            }
+
+            // Free the tail committed segment (or placeholder).
+            if tail_start < self.size {
+                unsafe {
+                    if VirtualFree(self.ptr.add(tail_start).cast(), 0, MEM_RELEASE).is_err() {
+                        error!("VirtualFree() failed for tail segment");
+                    }
+                }
+            }
+        } else {
+            // No remap: the region is a single committed block.
+            unsafe {
+                if VirtualFree(self.ptr.cast(), 0, MEM_RELEASE).is_err() {
+                    error!("VirtualFree() failed");
+                }
+            }
         }
     }
 }

--- a/src/uservm/src/vmm/mod.rs
+++ b/src/uservm/src/vmm/mod.rs
@@ -56,6 +56,8 @@ pub struct MicroVmArgs {
     /// When true, skip kernel/initrd/ramfs loading and vCPU reset because the VM state will be
     /// restored from a snapshot.
     pub restoring_from_snapshot: bool,
+    /// Optional host directory to mount on the guest (standalone mode only).
+    pub mount_directory: Option<String>,
     /// Shared coalescing flag for IKC IRQ notification (microvm only).
     #[cfg(all(feature = "microvm", not(feature = "hyperlight")))]
     pub ikc_pending: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -74,6 +76,7 @@ impl std::fmt::Debug for MicroVmArgs {
             .field("initrd_filename", &self.initrd_filename)
             .field("initrd_args", &self.initrd_args)
             .field("ramfs_filename", &self.ramfs_filename)
+            .field("mount_directory", &self.mount_directory)
             .finish()
     }
 }

--- a/src/utils/mkramfs/src/lib.rs
+++ b/src/utils/mkramfs/src/lib.rs
@@ -11,23 +11,158 @@
 // Imports
 //==================================================================================================
 
-use ::std::path::Path;
+use ::std::{
+    fs,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Minimum image size in bytes (1 MiB).
+pub const MIN_IMAGE_SIZE: u64 = 1024 * 1024;
+
+/// Default headroom factor applied to content size when computing the image size.
+pub const HEADROOM_FACTOR: f64 = 1.5;
+
+/// Page size used for alignment (must match the target architecture page size).
+const PAGE_SIZE: u64 = ::arch::mem::PAGE_SIZE as u64;
 
 //==================================================================================================
 // Public API
 //==================================================================================================
 
+/// Computes a page-aligned image size from the given content size.
+///
+/// Applies [`HEADROOM_FACTOR`] to the content size, clamps to [`MIN_IMAGE_SIZE`], and rounds
+/// up to the next page boundary so that the resulting file is suitable for zero-copy
+/// file-backed mappings.
+pub fn compute_image_size(content_size: u64) -> u64 {
+    compute_image_size_with_factor(content_size, HEADROOM_FACTOR)
+}
+
+/// Like [`compute_image_size`] but with a caller-specified headroom factor.
+pub fn compute_image_size_with_factor(content_size: u64, factor: f64) -> u64 {
+    let raw: u64 = if content_size == 0 {
+        MIN_IMAGE_SIZE
+    } else {
+        let computed: u64 = (content_size as f64 * factor) as u64;
+        computed.max(MIN_IMAGE_SIZE)
+    };
+    page_align(raw)
+}
+
+/// Rounds `value` up to the next page boundary.
+fn page_align(value: u64) -> u64 {
+    let mask: u64 = PAGE_SIZE - 1;
+    (value + mask) & !mask
+}
+
 /// Creates a zeroed file of `size` bytes at `path` and formats it as a FAT filesystem.
-pub fn mkfatfs(path: &Path, size: usize) {
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be created, opened, or formatted.
+pub fn mkfatfs(path: &Path, size: usize) -> std::io::Result<()> {
     let buf: Vec<u8> = vec![0u8; size];
-    std::fs::write(path, &buf).expect("failed to create FAT image file");
+    std::fs::write(path, &buf)?;
 
     let file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
-        .open(path)
-        .expect("failed to open FAT image for formatting");
+        .open(path)?;
     let mut storage = fatfs::StdIoWrapper::new(file);
     fatfs::format_volume(&mut storage, fatfs::FormatVolumeOptions::new())
-        .expect("failed to format FAT volume");
+        .map_err(|e| std::io::Error::other(format!("{e:?}")))?;
+    Ok(())
+}
+
+/// Creates a FAT32 image at `output` populated with the contents of `source_dir`.
+///
+/// # Errors
+///
+/// Returns an error if the image cannot be created, formatted, or populated.
+pub fn generate_image(output: &Path, source_dir: &Path, size: u64) -> std::io::Result<()> {
+    mkfatfs(output, size as usize)?;
+
+    let file = fs::OpenOptions::new().read(true).write(true).open(output)?;
+    let storage = fatfs::StdIoWrapper::new(file);
+    let filesystem = fatfs::FileSystem::new(storage, fatfs::FsOptions::new())
+        .map_err(|e| std::io::Error::other(format!("{e:?}")))?;
+    let root = filesystem.root_dir();
+
+    copy_dir_recursive(&root, source_dir, source_dir)?;
+    Ok(())
+}
+
+/// Computes the total size of all files under `dir` (recursive).
+pub fn dir_size(dir: &Path) -> u64 {
+    let mut total: u64 = 0;
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path: PathBuf = entry.path();
+            if path.is_dir() {
+                total += dir_size(&path);
+            } else if path.is_file() {
+                total += fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+            }
+        }
+    }
+    total
+}
+
+/// Recursively copies the contents of `current` into the FAT directory `fat_dir`.
+///
+/// `base` is the original source root, used to compute relative paths for error messages.
+///
+/// # Errors
+///
+/// Returns an error if any directory or file operation fails.
+pub fn copy_dir_recursive<IO, TP, OCC>(
+    fat_dir: &fatfs::Dir<IO, TP, OCC>,
+    current: &Path,
+    base: &Path,
+) -> std::io::Result<()>
+where
+    IO: fatfs::ReadWriteSeek,
+    TP: fatfs::TimeProvider,
+    OCC: fatfs::OemCpConverter,
+{
+    let entries = fs::read_dir(current)?;
+
+    for entry in entries {
+        let entry = entry?;
+        let path: PathBuf = entry.path();
+        let name: String = entry.file_name().to_string_lossy().into_owned();
+        let rel: PathBuf = path.strip_prefix(base).unwrap_or(&path).to_path_buf();
+
+        if path.is_dir() {
+            fat_dir.create_dir(&name).map_err(|e| {
+                std::io::Error::other(format!(
+                    "failed to create directory {}: {e:?}",
+                    rel.display()
+                ))
+            })?;
+            let sub_dir = fat_dir.open_dir(&name).map_err(|e| {
+                std::io::Error::other(format!("failed to open directory {}: {e:?}", rel.display()))
+            })?;
+            copy_dir_recursive(&sub_dir, &path, base)?;
+        } else if path.is_file() {
+            let data: Vec<u8> = fs::read(&path)?;
+            let mut fat_file = fat_dir.create_file(&name).map_err(|e| {
+                std::io::Error::other(format!("failed to create {}: {e:?}", rel.display()))
+            })?;
+            fatfs::Write::write_all(&mut fat_file, &data).map_err(|e| {
+                std::io::Error::other(format!("failed to write {}: {e:?}", rel.display()))
+            })?;
+            fatfs::Write::flush(&mut fat_file).map_err(|e| {
+                std::io::Error::other(format!("failed to flush {}: {e:?}", rel.display()))
+            })?;
+        }
+    }
+    Ok(())
 }

--- a/src/utils/mkramfs/src/main.rs
+++ b/src/utils/mkramfs/src/main.rs
@@ -85,17 +85,16 @@ fn main() {
     // Compute image size: either user-specified or auto-calculated.
     let content_size: u64 = dir_size(&source_dir);
     let image_size: u64 = match size_override {
-        Some(s) => s,
+        Some(s) => {
+            // User-specified size: still round up to page boundary.
+            let page_size: u64 = arch::mem::PAGE_SIZE as u64;
+            (s + page_size - 1) & !(page_size - 1)
+        },
         None => {
             let factor: f64 = headroom.unwrap_or(HEADROOM_FACTOR);
-            let computed: u64 = (content_size as f64 * factor) as u64;
-            computed.max(MIN_IMAGE_SIZE)
+            mkramfs::compute_image_size_with_factor(content_size, factor)
         },
     };
-
-    // Round up to page size so the guest VMM can use zero-copy file-backed mappings.
-    let page_size: u64 = arch::mem::PAGE_SIZE as u64;
-    let image_size: u64 = (image_size + page_size - 1) & !(page_size - 1);
 
     eprintln!(
         "mkramfs: source={} content={}B image={}B output={}",
@@ -109,13 +108,16 @@ fn main() {
 }
 
 //==================================================================================================
-// Image Generation
+// Argument Parsing
 //==================================================================================================
 
 /// Creates a FAT32 image at `output` populated with the contents of `source_dir`.
 fn generate_image(output: &Path, source_dir: &Path, size: u64) {
     // Create and format a zeroed FAT image.
-    mkramfs::mkfatfs(output, size as usize);
+    if let Err(e) = mkramfs::mkfatfs(output, size as usize) {
+        eprintln!("mkramfs: failed to create/format FAT image: {e}");
+        process::exit(EXIT_FAT);
+    }
 
     // Populate the image with the source directory contents.
     {

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/boot_time.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/boot_time.rs
@@ -90,6 +90,7 @@ impl Benchmark {
                 io_control_tx,
                 counters,
                 snapshot_path: None,
+                mount_directory: None,
                 #[cfg(feature = "gdb")]
                 gdb_port: None,
                 #[cfg(feature = "profile-time")]

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/snapshot_restore.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/snapshot_restore.rs
@@ -124,6 +124,7 @@ impl Benchmark {
                 io_control_tx,
                 counters,
                 snapshot_path: None,
+                mount_directory: None,
                 #[cfg(feature = "gdb")]
                 gdb_port: None,
                 #[cfg(feature = "profile-time")]
@@ -245,6 +246,7 @@ impl Benchmark {
                 io_control_tx,
                 counters,
                 snapshot_path: Some(kernel_filename.clone()),
+                mount_directory: None,
                 #[cfg(feature = "gdb")]
                 gdb_port: None,
                 #[cfg(feature = "profile-time")]

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
@@ -101,6 +101,7 @@ impl Benchmark {
             io_control_tx,
             counters,
             snapshot_path: None,
+            mount_directory: None,
             #[cfg(feature = "gdb")]
             gdb_port: None,
             #[cfg(feature = "profile-time")]

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -80,6 +80,8 @@ pub struct Args {
     tmp_directory: String,
     /// Optional snapshot path: when set, restore from snapshot instead of cold-booting.
     snapshot_path: Option<String>,
+    /// Optional host directory to mount on the guest (standalone mode only).
+    mount_directory: Option<String>,
     /// Optional GDB server port: when set, the uservm starts a GDB RSP server on this TCP port.
     #[cfg(feature = "gdb")]
     gdb_port: Option<u16>,
@@ -127,6 +129,8 @@ impl Args {
     pub const OPT_TMP_DIRECTORY: &'static str = "-tmp-dir";
     /// Command-line option for snapshot path.
     pub const OPT_SNAPSHOT: &'static str = "-snapshot";
+    /// Command-line option for host directory to mount on the guest (standalone mode only).
+    pub const OPT_MOUNT_DIRECTORY: &'static str = "-mount";
     /// Command-line option for GDB server port (standalone mode only).
     #[cfg(feature = "gdb")]
     pub const OPT_GDB_PORT: &'static str = "-gdb-port";
@@ -176,6 +180,7 @@ impl Args {
         let mut program_args: Vec<String> = Vec::new();
         let mut tmp_directory: String = DEFAULT_TMP_DIRECTORY.to_string();
         let mut snapshot_path: Option<String> = None;
+        let mut mount_directory: Option<String> = None;
         #[cfg(feature = "gdb")]
         let mut gdb_port: Option<u16> = None;
 
@@ -286,6 +291,23 @@ impl Args {
                     }
                     snapshot_path = Some(args[i].clone());
                 },
+                Self::OPT_MOUNT_DIRECTORY => {
+                    i += 1;
+                    if i >= args.len() {
+                        Self::usage(args[0].as_str());
+                        return Err(anyhow::anyhow!(
+                            "missing value for: {}",
+                            Self::OPT_MOUNT_DIRECTORY
+                        ));
+                    }
+                    let path: &str = &args[i];
+                    let metadata = ::std::fs::metadata(path)
+                        .map_err(|_| anyhow::anyhow!("mount directory does not exist: {}", path))?;
+                    if !metadata.is_dir() {
+                        return Err(anyhow::anyhow!("mount path is not a directory: {}", path));
+                    }
+                    mount_directory = Some(args[i].clone());
+                },
                 // Set GDB server port (standalone mode only).
                 #[cfg(feature = "gdb")]
                 Self::OPT_GDB_PORT => {
@@ -347,6 +369,12 @@ impl Args {
             anyhow::bail!("{} is only supported in standalone builds", Self::OPT_SNAPSHOT);
         }
 
+        // Reject -mount in non-standalone builds.
+        #[cfg(not(feature = "standalone"))]
+        if mount_directory.is_some() {
+            anyhow::bail!("{} is only supported in standalone builds", Self::OPT_MOUNT_DIRECTORY);
+        }
+
         // Determine operation mode: HTTP mode is active if -http-addr is provided,
         // interactive mode is active if `--` separator with program name is provided.
         #[cfg(unix)]
@@ -402,6 +430,7 @@ impl Args {
             program_args,
             tmp_directory,
             snapshot_path,
+            mount_directory,
             #[cfg(feature = "gdb")]
             gdb_port,
         })
@@ -454,7 +483,9 @@ Options:
   {tmp_dir} <tmp_dir>                       Base directory for temporary files (Default: \
              {DEFAULT_TMP_DIRECTORY}).
   {snapshot} <path>                         Restore VM from snapshot instead of cold-booting \
-             (standalone mode only).{gdb_port_line}
+             (standalone mode only).
+  {mount} <host-dir>                       Mount a host directory on the guest at /mnt (standalone \
+             mode only).{gdb_port_line}
 ",
             http_usage = http_usage,
             program_name = program_name,
@@ -474,6 +505,7 @@ Options:
             l2_snapshot_path = Self::OPT_L2_SNAPSHOT_PATH,
             tmp_dir = Self::OPT_TMP_DIRECTORY,
             snapshot = Self::OPT_SNAPSHOT,
+            mount = Self::OPT_MOUNT_DIRECTORY,
             gdb_port_line = if cfg!(feature = "gdb") {
                 "\n  -gdb-port <port>                         GDB server port (standalone mode \
                  only)."
@@ -573,6 +605,19 @@ Options:
     ///
     pub fn snapshot_path(&self) -> Option<&str> {
         self.snapshot_path.as_deref()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the optional host directory to mount on the guest.
+    ///
+    /// # Returns
+    ///
+    /// The mount directory path, if present.
+    ///
+    pub fn mount_directory(&self) -> Option<&str> {
+        self.mount_directory.as_deref()
     }
 
     ///

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -213,6 +213,7 @@ async fn async_main() -> Result<ExitCode> {
         args.ramfs_filename().map(|s| s.to_string()),
         args.console_file().clone(),
         args.snapshot_path().map(|s| s.to_string()),
+        args.mount_directory().map(|s| s.to_string()),
         #[cfg(feature = "gdb")]
         args.gdb_port(),
     );
@@ -268,6 +269,7 @@ async fn async_main() -> Result<ExitCode> {
             args.ramfs_filename().map(|s| s.to_string()),
             args.console_file().clone(),
             args.snapshot_path().map(|s| s.to_string()),
+            args.mount_directory().map(|s| s.to_string()),
             #[cfg(feature = "gdb")]
             args.gdb_port(),
         ));

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -149,3 +149,17 @@ executor = "terminal"
 program = "./bin/linux-app.elf"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
 expected_output = "ok"
+
+
+#===================================================================================================
+# Host Mount Tests
+#===================================================================================================
+
+[[tests]]
+executor = "terminal"
+program = "./bin/mount-test.elf"
+extra_nanvixd_args = "-mount ./bin/mount-test-data"
+input = "[]"
+expect_empty_output = true
+expected_exit_code = 0
+runs_on = ["microvm"]


### PR DESCRIPTION
Closes #2067

Introduce a `-mount <host-dir>` CLI flag for nanvixd that enables mounting a host directory into a guest VM at `/mnt` in standalone mode.

At launch, the host directory is packaged into a FAT32 image, combined with the optional `-ramfs` root image into a multi-image container, and mapped into guest memory. On VM shutdown, modified files are extracted from guest memory and copied back to the host directory.