### PR TITLE
[kernel] Add npages parameter to mmap kcall

### DIFF
--- a/src/kernel/src/kcall/dispatcher.rs
+++ b/src/kernel/src/kcall/dispatcher.rs
@@ -109,7 +109,7 @@ pub extern "C" fn do_kcall(number: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u
         // Handle `debug()` locally.
         KcallNumber::Debug => debug::debug(pid, arg0, arg1),
         // Handle `mmap()` locally.
-        KcallNumber::MemoryMap => pm::mmap(pid, arg0, arg1, arg2),
+        KcallNumber::MemoryMap => pm::mmap(pid, arg0, arg1, arg2, arg3),
         // Handle `munmap()` locally.
         KcallNumber::MemoryUnmap => pm::munmap(pid, arg0, arg1),
         // Handle `mctrl()` locally.

--- a/src/kernel/src/pm/kcall/mmap.rs
+++ b/src/kernel/src/pm/kcall/mmap.rs
@@ -16,6 +16,7 @@ use crate::{
     mm::VirtMemoryManager,
     pm::ProcessManager,
 };
+use ::arch::mem;
 use ::sys::{
     error::{
         Error,
@@ -36,9 +37,10 @@ fn do_mmap(
     mm: &mut VirtMemoryManager,
     pid: ProcessIdentifier,
     vaddr: PageAligned<VirtualAddress>,
+    npages: usize,
     access: AccessPermission,
 ) -> Result<(), Error> {
-    pm.mmap(mm, pid, vaddr, access)
+    pm.mmap(mm, pid, vaddr, npages, access)
 }
 
 ///
@@ -51,13 +53,20 @@ fn do_mmap(
 /// - `caller_pid`: Identifier of the calling process.
 /// - `arg0`: Target process identifier.
 /// - `arg1`: Virtual address to map.
-/// - `arg2`: Access permission.
+/// - `arg2`: Number of pages to map.
+/// - `arg3`: Access permission.
 ///
 /// # Returns
 ///
 /// A [`KcallResult`] indicating success or the error code.
 ///
-pub fn mmap(caller_pid: ProcessIdentifier, arg0: u32, arg1: u32, arg2: u32) -> KcallResult {
+pub fn mmap(
+    caller_pid: ProcessIdentifier,
+    arg0: u32,
+    arg1: u32,
+    arg2: u32,
+    arg3: u32,
+) -> KcallResult {
     // SAFETY: the process manager is initialized and access is synchronized.
     let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
     // SAFETY: the virtual memory manager is initialized and access is synchronized.
@@ -75,10 +84,43 @@ pub fn mmap(caller_pid: ProcessIdentifier, arg0: u32, arg1: u32, arg2: u32) -> K
         Ok(vaddr) => vaddr,
         Err(e) => return KcallResult::Error(e.code.into()),
     };
-    let access: AccessPermission = match AccessPermission::try_from(arg2) {
+    let npages: usize = arg2 as usize;
+    let access: AccessPermission = match AccessPermission::try_from(arg3) {
         Ok(access) => access,
         Err(e) => return KcallResult::Error(e.code.into()),
     };
+
+    // Validate npages.
+    if npages == 0 {
+        let reason: &str = "zero page count";
+        error!("{reason}");
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
+
+    // Cap npages to the maximum number of pages that fit in the user mmap region.
+    const MMAP_MAX_PAGES: usize = ::config::memory_layout::USER_MMAP_SIZE / mem::PAGE_SIZE;
+    if npages > MMAP_MAX_PAGES {
+        let reason: &str = "page count exceeds mmap region capacity";
+        error!("{reason} (npages={npages}, max={MMAP_MAX_PAGES})");
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
+
+    // Sanity check: ensure the range doesn't overflow.
+    let range_size: usize = match npages.checked_mul(mem::PAGE_SIZE) {
+        Some(size) => size,
+        None => {
+            let reason: &str = "page count overflow";
+            error!("{reason}");
+            return KcallResult::Error(ErrorCode::InvalidArgument.into());
+        },
+    };
+
+    // Sanity check: ensure the mapped range doesn't overflow the address space.
+    if vaddr.into_raw_value().checked_add(range_size).is_none() {
+        let reason: &str = "address range overflow";
+        error!("{reason}");
+        return KcallResult::Error(ErrorCode::InvalidArgument.into());
+    }
 
     // Check if attempting to map memory into a different process.
     if pid != caller_pid {
@@ -94,7 +136,7 @@ pub fn mmap(caller_pid: ProcessIdentifier, arg0: u32, arg1: u32, arg2: u32) -> K
         }
     }
 
-    match do_mmap(pm, mm, pid, vaddr, access) {
+    match do_mmap(pm, mm, pid, vaddr, npages, access) {
         Ok(_) => KcallResult::ok(),
         Err(e) => KcallResult::Error(e.code.into()),
     }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1873,16 +1873,104 @@ impl ProcessManager {
         Ok(Some((state.pid(), status)))
     }
 
+    ///
+    /// # Description
+    ///
+    /// Maps one or more pages into the address space of a process.
+    ///
+    /// # Parameters
+    ///
+    /// - `mm`: Virtual memory manager.
+    /// - `pid`: Process identifier.
+    /// - `vaddr`: Page-aligned base virtual address to map.
+    /// - `npages`: Number of pages to map.
+    /// - `access`: Access permissions for the mapped pages.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, `Ok(())` is returned. Otherwise, an error is returned instead.
+    ///
     pub fn mmap(
         &mut self,
         mm: &mut VirtMemoryManager,
         pid: ProcessIdentifier,
         vaddr: PageAligned<VirtualAddress>,
+        npages: usize,
         access: AccessPermission,
     ) -> Result<(), Error> {
+        /// Maximum number of pages to allocate per batch. Caps the Vec allocation on the kheap.
+        const MMAP_BATCH_SIZE: usize = 16;
+
         let mut process: ProcessRefMut = self.find_process_mut(pid)?;
         let vmem: &mut Vmem = process.state_mut().vmem_mut();
-        mm.alloc_upages(vmem, vaddr, access, true, &mut Vec::with_capacity(1))
+        let mut current_vaddr: PageAligned<VirtualAddress> = vaddr;
+        let mut remaining: usize = npages;
+
+        // `alloc_upages` derives the page count from `uframes.capacity()`, so the Vec capacity
+        // must exactly equal the number of pages we intend to map per iteration.  We use
+        // `try_reserve_exact` for fallible allocation with an exact capacity: first attempt a
+        // batch of `count` pages, falling back to a single page, and finally returning OOM.
+        while remaining > 0 {
+            let count: usize = remaining.min(MMAP_BATCH_SIZE);
+            let mut uframes = Vec::new();
+            let batch: usize = if uframes.try_reserve_exact(count).is_ok() {
+                count
+            } else if uframes.try_reserve_exact(1).is_ok() {
+                // Batch allocation failed; fall back to single-page allocation.
+                1
+            } else {
+                let reason: &str = "kheap: cannot allocate uframes vec for mmap";
+                error!("{reason}");
+                Self::rollback_mmap(mm, vmem, vaddr, current_vaddr);
+                return Err(Error::new(ErrorCode::OutOfMemory, reason));
+            };
+            if let Err(e) = mm.alloc_upages(vmem, current_vaddr, access, true, &mut uframes) {
+                Self::rollback_mmap(mm, vmem, vaddr, current_vaddr);
+                return Err(e);
+            }
+            current_vaddr =
+                PageAligned::from_raw_value(current_vaddr.into_raw_value() + batch * PAGE_SIZE)?;
+            remaining -= batch;
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Rolls back a partial `mmap` by unmapping all pages in the range
+    /// `[base_vaddr, failed_vaddr)`. Best-effort: individual unmap failures are logged
+    /// but do not prevent the remaining pages from being cleaned up.
+    ///
+    /// # Parameters
+    ///
+    /// - `mm`: Virtual memory manager.
+    /// - `vmem`: Virtual memory space containing the mappings.
+    /// - `base_vaddr`: Starting virtual address of the region to roll back.
+    /// - `failed_vaddr`: Virtual address where the allocation failed (exclusive upper bound).
+    ///
+    fn rollback_mmap(
+        mm: &mut VirtMemoryManager,
+        vmem: &mut Vmem,
+        base_vaddr: PageAligned<VirtualAddress>,
+        failed_vaddr: PageAligned<VirtualAddress>,
+    ) {
+        let mut raw: usize = base_vaddr.into_raw_value();
+        let end: usize = failed_vaddr.into_raw_value();
+        while raw < end {
+            match PageAligned::from_raw_value(raw) {
+                Ok(addr) => {
+                    if let Err(e) = mm.try_unmap_upage(vmem, addr) {
+                        warn!("mmap rollback: failed to unmap page (vaddr={raw:#x}, error={e:?})");
+                    }
+                },
+                Err(_) => {
+                    warn!("mmap rollback: invalid page address (vaddr={raw:#x})");
+                },
+            }
+            raw += PAGE_SIZE;
+        }
     }
 
     pub fn munmap(
@@ -2136,7 +2224,7 @@ impl ProcessManager {
         let vaddr: PageAligned<VirtualAddress> = PageAligned::from_raw_value(page_addr)?;
         let pid: ProcessIdentifier = self.get_pid();
         debug!("demand-paging stack page (pid={pid:?}, vaddr={vaddr:?})");
-        self.mmap(mm, pid, vaddr, AccessPermission::RDWR)?;
+        self.mmap(mm, pid, vaddr, 1, AccessPermission::RDWR)?;
 
         Ok(true)
     }

--- a/src/libs/sys/src/sys/kcall/mm/kcalls.rs
+++ b/src/libs/sys/src/sys/kcall/mm/kcalls.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     kcall2,
     kcall3,
+    kcall4,
     mm::{
         AccessPermission,
         Address,
@@ -33,18 +34,22 @@ fn split_tag(tag: u64) -> (u32, u32) {
 }
 
 //==================================================================================================
-// Map Memory Page
+// Map Memory Pages
 //==================================================================================================
 
 pub fn mmap(
     pid: ProcessIdentifier,
     vaddr: VirtualAddress,
+    npages: usize,
     access: AccessPermission,
 ) -> Result<(), Error> {
-    let result: i64 = kcall3!(
+    let npages_u32: u32 = u32::try_from(npages)
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "npages exceeds u32 range"))?;
+    let result: i64 = kcall4!(
         KcallNumber::MemoryMap.into(),
         pid.try_into()?,
         vaddr.into_raw_value() as u32,
+        npages_u32,
         access.into()
     );
 

--- a/src/libs/sysalloc/src/heap.rs
+++ b/src/libs/sysalloc/src/heap.rs
@@ -195,39 +195,38 @@ pub fn map_range(
     debug_assert!(end.is_aligned(PAGE_ALIGNMENT));
     debug_assert!(start < end);
 
-    // TODO: use iterator.
+    // If the range is empty, there's nothing to do.
+    if start == end {
+        return Ok(());
+    }
+
+    // Check if start is greater than end to prevent underflow in size calculation. This also guards
+    // against invalid ranges where the end address wraps around the address space.
+    if start > end {
+        let reason: &str = "map_range(): start address is greater than end address";
+        ::syslog::error!("{reason}");
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
     let start: usize = start.into_raw_value();
     let end: usize = end.into_raw_value();
-    for vaddr in (start..end).step_by(mem::PAGE_SIZE) {
-        debug_assert!(vaddr != end);
+    let npages: usize = (end - start) / mem::PAGE_SIZE;
 
-        // Attempt to map page.
-        let vaddr: VirtualAddress = VirtualAddress::new(vaddr);
-        if let Err(error) = kcall::mm::mmap(pid, vaddr, AccessPermission::RDWR) {
-            // Failed to map page, attempt to rollback.
-
-            ::syslog::error!(
-                "map_range(): failed to map page at {:X?}, rolling back (error={:?})",
-                vaddr,
-                error
-            );
-
-            // Attempt to unmap pages.
-            if let Err(_error) = unmap_range(pid, VirtualAddress::new(start), vaddr) {
-                // Failed to unmap range, warn.
-                ::syslog::warn!(
-                    "map_range(): failed to unmap pages at {:X?}..{:X?} (error={:?})",
-                    start,
-                    vaddr,
-                    _error
-                );
-            }
-
-            return Err(error);
-        }
-
-        // NOTE: pages allocated with mmap() are always zeroed.
+    // Use batch mmap kcall to map all pages in a single kernel transition.
+    if let Err(error) =
+        kcall::mm::mmap(pid, VirtualAddress::new(start), npages, AccessPermission::RDWR)
+    {
+        ::syslog::error!(
+            "map_range(): batch mmap failed at {:X?}..{:X?}, npages={} (error={:?})",
+            start,
+            end,
+            npages,
+            error
+        );
+        return Err(error);
     }
+
+    // NOTE: pages allocated with mmap() are always zeroed.
 
     Ok(())
 }

--- a/src/libs/syscall/src/safe/mem/segment.rs
+++ b/src/libs/syscall/src/safe/mem/segment.rs
@@ -248,7 +248,7 @@ fn map_range(
     debug_assert!(end.is_aligned(PAGE_ALIGNMENT));
     debug_assert!(start < end);
 
-    // TODO: use iterator.
+    // TODO: use batch mmap to map all pages in a single kernel transition.
     let start: usize = start.into_raw_value();
     let end: usize = end.into_raw_value();
     for vaddr in (start..end).step_by(PAGE_SIZE) {
@@ -256,7 +256,7 @@ fn map_range(
 
         // Attempt to map page.
         let vaddr: VirtualAddress = VirtualAddress::new(vaddr);
-        if let Err(error) = mmap(pid, vaddr, access) {
+        if let Err(error) = mmap(pid, vaddr, 1, access) {
             // Failed to map page, attempt to rollback.
 
             ::syslog::error!(

--- a/src/tests/stress-rust/src/tests/memory_mapping_storm.rs
+++ b/src/tests/stress-rust/src/tests/memory_mapping_storm.rs
@@ -75,7 +75,7 @@ pub fn run() -> Result<(), StressError> {
             AccessPermission::RDONLY
         };
 
-        mmap(pid, addr, perm)?;
+        mmap(pid, addr, 1, perm)?;
 
         if perm.is_writable() {
             mprotect(pid, addr, AccessPermission::RDONLY)?;

--- a/src/tests/stress-rust/src/tests/scoreboard_backpressure.rs
+++ b/src/tests/stress-rust/src/tests/scoreboard_backpressure.rs
@@ -204,7 +204,7 @@ fn scoreboard_pressure_worker_impl(worker_id: usize) -> Result<usize, Error> {
         let addr_raw: usize = region_base + page_offset;
         let addr: VirtualAddress = VirtualAddress::from_raw_value(addr_raw);
 
-        mmap(pid, addr, AccessPermission::RDWR)?;
+        mmap(pid, addr, 1, AccessPermission::RDWR)?;
         let byte_raw: usize = (worker_id ^ iteration) & SCOREBOARD_PRESSURE_BYTE_MASK;
         let byte: u8 = u8::try_from(byte_raw)
             .map_err(|_| Error::new(ErrorCode::ValueOutOfRange, "worker byte overflow"))?;

--- a/src/tests/testd/src/mm/mod.rs
+++ b/src/tests/testd/src/mm/mod.rs
@@ -62,7 +62,7 @@ fn test_mmap_munmap() -> bool {
     let vaddr: VirtualAddress = USER_MMAP_END;
 
     // Map a page.
-    match ::sys::kcall::mm::mmap(mypid, vaddr, AccessPermission::RDONLY) {
+    match ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::RDONLY) {
         Ok(_) => (),
         Err(_) => return false,
     }
@@ -106,7 +106,7 @@ fn test_mmap_write_munmap() -> bool {
     let vaddr: VirtualAddress = USER_MMAP_END;
 
     // Map a page.
-    match ::sys::kcall::mm::mmap(mypid, vaddr, AccessPermission::WRONLY) {
+    match ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::WRONLY) {
         Ok(_) => (),
         Err(_) => return false,
     }
@@ -167,7 +167,7 @@ fn test_mmap_munmap_many_times_inplace() -> bool {
         let vaddr: VirtualAddress = USER_MMAP_END;
 
         // Map a page.
-        match ::sys::kcall::mm::mmap(mypid, vaddr, AccessPermission::RDONLY) {
+        match ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::RDONLY) {
             Ok(_) => (),
             Err(_) => return false,
         }
@@ -216,7 +216,7 @@ fn test_mmap_munmap_many_times_rolling() -> bool {
         let vaddr: VirtualAddress = VirtualAddress::from_raw_value(vaddr);
 
         // Map a page.
-        match ::sys::kcall::mm::mmap(mypid, vaddr, AccessPermission::RDONLY) {
+        match ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::RDONLY) {
             Ok(_) => (),
             Err(_) => return false,
         }
@@ -260,7 +260,7 @@ fn test_mmap_munmap_return_zeros() -> bool {
     let vaddr: VirtualAddress = USER_MMAP_END;
 
     // Map a page.
-    if ::sys::kcall::mm::mmap(mypid, vaddr, AccessPermission::WRONLY).is_err() {
+    if ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::WRONLY).is_err() {
         return false;
     }
 
@@ -277,7 +277,7 @@ fn test_mmap_munmap_return_zeros() -> bool {
     }
 
     // Map the page again to read.
-    if ::sys::kcall::mm::mmap(mypid, vaddr, AccessPermission::RDONLY).is_err() {
+    if ::sys::kcall::mm::mmap(mypid, vaddr, 1, AccessPermission::RDONLY).is_err() {
         return false;
     }
 
@@ -305,6 +305,89 @@ fn test_mmap_munmap_return_zeros() -> bool {
 }
 
 //==================================================================================================
+// Tests multi-page mmap()
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Maps multiple pages in a single `mmap()` call, verifies they are zeroed, and unmaps them.
+///
+/// # Returns
+///
+/// If the test passed, `true` is returned. Otherwise, `false` is returned instead.
+///
+fn test_mmap_multi_page() -> bool {
+    const NPAGES: usize = 4;
+
+    // Acquire memory management capability.
+    if ::sys::kcall::pm::capctl(Capability::MemoryManagement, true).is_err() {
+        return false;
+    }
+
+    let mypid: ProcessIdentifier = match ::sys::kcall::pm::getpid() {
+        Ok(pid) => pid,
+        Err(_) => return false,
+    };
+
+    let base_vaddr: VirtualAddress = USER_MMAP_END;
+
+    // Map multiple pages in a single call.
+    if ::sys::kcall::mm::mmap(mypid, base_vaddr, NPAGES, AccessPermission::RDWR).is_err() {
+        return false;
+    }
+
+    // Verify all pages are zeroed.
+    let zeros: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
+    for i in 0..NPAGES {
+        let page_addr: usize = base_vaddr.into_raw_value() + i * PAGE_SIZE;
+        let mut data: [u8; PAGE_SIZE] = [0xFF; PAGE_SIZE];
+        let ptr: *const u8 = page_addr as *const u8;
+        unsafe {
+            ptr.copy_to(data.as_mut_ptr(), data.len());
+        }
+        if zeros != data {
+            return false;
+        }
+    }
+
+    // Write a marker to each page.
+    for i in 0..NPAGES {
+        let page_addr: usize = base_vaddr.into_raw_value() + i * PAGE_SIZE;
+        let ptr: *mut u8 = page_addr as *mut u8;
+        unsafe {
+            *ptr = (i + 1) as u8;
+        }
+    }
+
+    // Read back markers.
+    for i in 0..NPAGES {
+        let page_addr: usize = base_vaddr.into_raw_value() + i * PAGE_SIZE;
+        let ptr: *const u8 = page_addr as *const u8;
+        let val: u8 = unsafe { *ptr };
+        if val != (i + 1) as u8 {
+            return false;
+        }
+    }
+
+    // Unmap all pages.
+    for i in 0..NPAGES {
+        let page_addr: usize = base_vaddr.into_raw_value() + i * PAGE_SIZE;
+        let vaddr: VirtualAddress = VirtualAddress::from_raw_value(page_addr);
+        if ::sys::kcall::mm::munmap(mypid, vaddr).is_err() {
+            return false;
+        }
+    }
+
+    // Release memory management capability.
+    if ::sys::kcall::pm::capctl(Capability::MemoryManagement, false).is_err() {
+        return false;
+    }
+
+    true
+}
+
+//==================================================================================================
 // Public Standalone Functions
 //==================================================================================================
 
@@ -319,4 +402,5 @@ pub fn test() {
     crate::test!(test_mmap_munmap_many_times_inplace());
     crate::test!(test_mmap_munmap_many_times_rolling());
     crate::test!(test_mmap_munmap_return_zeros());
+    crate::test!(test_mmap_multi_page());
 }


### PR DESCRIPTION
## Summary

Extend the `mmap` kernel call to accept a page count (`npages`), enabling multi-page mappings in a single kernel transition instead of one kcall per page.

## Changes

### Kernel

- `src/kernel/src/kcall/dispatcher.rs`: Forward `arg3` to the mmap handler.
- `src/kernel/src/pm/kcall/mmap.rs`: Accept `arg3` as `npages` and shift access permission to `arg3`. Validate `npages > 0`, cap it to `USER_MMAP_SIZE / PAGE_SIZE`, and check for multiplication and address-range overflows before entering the process manager.
- `src/kernel/src/pm/process/manager/mod.rs`: Implement batched allocation in `mmap()` using `alloc_upages()` with a batch size of 16 pages, falling back to single-page allocation for the remainder or when kheap memory is tight (fallible `try_reserve`). Add `rollback_mmap()` to unmap all successfully mapped pages on partial failure, with best-effort cleanup and per-page warning on errors.
- `src/kernel/src/pm/process/manager/mod.rs`: Pass `npages=1` explicitly in `handle_page_fault()`.

### User-Space

- `src/libs/sys/src/sys/kcall/mm/kcalls.rs`: Add `npages` parameter to `mmap()`, convert to `u32` via `try_from` with `InvalidArgument` on overflow, and use `kcall4` macro.
- `src/libs/sysalloc/src/heap.rs`: Replace the per-page mmap loop and user-space rollback with a single batch mmap kcall, delegating rollback responsibility to the kernel.
- `src/libs/syscall/src/safe/mem/segment.rs`: Pass `npages=1` for existing single-page call sites. Update TODO comment to note batch mmap opportunity (follow-up: #2180).

### Tests

- `src/tests/testd/src/mm/mod.rs`: Pass `npages=1` to all mmap call sites.
- `src/tests/stress-rust/src/tests/memory_mapping_storm.rs`: Pass `npages=1`.
- `src/tests/stress-rust/src/tests/scoreboard_backpressure.rs`: Pass `npages=1`.

## Related

- Closes #2068
- Follow-up: #2180