### PR TITLE
[uservm] Model sparse physical memory layout for Hyperlight platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -873,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-common"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=4b57b8416114c489083922afa3dd9716127278fb#4b57b8416114c489083922afa3dd9716127278fb"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d#3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=4b57b8416114c489083922afa3dd9716127278fb#4b57b8416114c489083922afa3dd9716127278fb"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d#3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-host"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=4b57b8416114c489083922afa3dd9716127278fb#4b57b8416114c489083922afa3dd9716127278fb"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d#3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -2413,7 +2413,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3159,7 +3159,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3216,7 +3216,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3483,7 +3483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3765,7 +3765,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4675,7 +4675,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,17 +134,17 @@ indexmap = "2.14.0"
 indicatif = "0.18.4"
 http = "1.4.0"
 http-body-util = "0.1.3"
-hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "4b57b8416114c489083922afa3dd9716127278fb", default-features = false, features = [
+hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d", default-features = false, features = [
         "nanvix-unstable",
 ] }
-hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "4b57b8416114c489083922afa3dd9716127278fb", default-features = false, features = [
+hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d", default-features = false, features = [
         "kvm",
         "mshv3",
         "hw-interrupts",
         "executable_heap",
         "nanvix-unstable",
 ] }
-hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "4b57b8416114c489083922afa3dd9716127278fb", default-features = false, features = [
+hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d", default-features = false, features = [
         "nanvix-unstable",
 ] }
 hyper = { version = "1.9.0", default-features = false }

--- a/src/kernel/src/hal/mem/types/address/phys.rs
+++ b/src/kernel/src/hal/mem/types/address/phys.rs
@@ -40,8 +40,8 @@ pub struct PhysicalAddress(VirtualAddress);
 
 impl PhysicalAddress {
     pub fn from_virtual_address(addr: VirtualAddress) -> Result<Self, Error> {
-        // Check if `addr` lies outside of the physical address space.
-        if addr >= VirtualAddress::from_raw_value(config::kernel::MEMORY_SIZE) {
+        // Delegate to the per-platform validator so that sparse physical memory layouts.
+        if !crate::hal::platform::is_valid_physical_address(addr) {
             return Err(Error::new(
                 ErrorCode::BadAddress,
                 "address out of bounds of physical memory",

--- a/src/kernel/src/hal/mem/types/address/phys.rs
+++ b/src/kernel/src/hal/mem/types/address/phys.rs
@@ -40,7 +40,7 @@ pub struct PhysicalAddress(VirtualAddress);
 
 impl PhysicalAddress {
     pub fn from_virtual_address(addr: VirtualAddress) -> Result<Self, Error> {
-        // Delegate to the per-platform validator so that sparse physical memory layouts.
+        // Delegate to the per-platform validator to support sparse physical memory layouts.
         if !crate::hal::platform::is_valid_physical_address(addr) {
             return Err(Error::new(
                 ErrorCode::BadAddress,

--- a/src/kernel/src/hal/mem/types/address/phys.rs
+++ b/src/kernel/src/hal/mem/types/address/phys.rs
@@ -218,7 +218,7 @@ impl Address for PhysicalAddress {
     /// The maximum [`PhysicalAddress`].
     ///
     fn max_addr() -> usize {
-        config::kernel::MEMORY_SIZE - 1
+        crate::hal::platform::max_physical_address()
     }
 
     fn into_raw_value(self) -> usize {

--- a/src/kernel/src/hal/mod.rs
+++ b/src/kernel/src/hal/mod.rs
@@ -41,6 +41,7 @@ use ::core::{
         Ordering,
     },
 };
+use ::sparse_bitmap::SparseBitmap;
 use ::sys::error::{
     Error,
     ErrorCode,
@@ -113,6 +114,11 @@ impl Hal {
     /// - `madt`: MADT information.
     /// - `mem_lower`: Lower memory size.
     ///
+    /// # Returns
+    ///
+    /// Upon success, the physical memory layout bitmap is returned. Upon failure, an error is
+    /// returned instead.
+    ///
     /// # Panics
     ///
     /// This function panics if the hardware abstraction layer is already initialized.
@@ -123,7 +129,7 @@ impl Hal {
         ioaddresses: &mut IoMemoryAllocator,
         madt: &Option<MadtInfo>,
         mem_lower: Option<usize>,
-    ) -> Result<(), Error> {
+    ) -> Result<SparseBitmap, Error> {
         // Check if the hardware abstraction layer is already initialized.
         if unlikely(HAL_INIT.load(ORDER)) {
             panic!("hardware abstraction layer was already initialized");
@@ -140,6 +146,18 @@ impl Hal {
             madt,
             mem_lower,
         )?;
+
+        // Take ownership of the physical memory layout bitmap from the platform.
+        // This bitmap is consumed exactly once; a `None` here means it was already taken
+        // (i.e., double initialization), hence `ResourceBusy`.
+        let physical_memory_layout: SparseBitmap = match platform.physical_memory_layout.take() {
+            Some(bitmap) => bitmap,
+            None => {
+                let reason: &str = "physical memory layout is not available";
+                error!("{reason}");
+                return Err(Error::new(ErrorCode::ResourceBusy, reason));
+            },
+        };
 
         // Verify that all MMIO regions are registered in ioaddresses.
         if mmio_regions.len() != ioaddresses.len() {
@@ -187,7 +205,7 @@ impl Hal {
         unsafe { HAL.write(hal) };
         HAL_INIT.store(true, ORDER);
 
-        Ok(())
+        Ok(physical_memory_layout)
     }
 
     ///

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -91,7 +91,10 @@ use ::hyperlight_common::{
             GuestError,
         },
     },
-    layout::MAX_GVA,
+    layout::{
+        MAX_GPA,
+        MAX_GVA,
+    },
     mem::HyperlightPEB,
     outb::VmAction,
 };
@@ -573,6 +576,23 @@ extern "C" fn hyperlight_pre_kmain() -> ! {
     let peb_base: usize = ::sys::mm::align_up(kernel_end, PAGE_ALIGNMENT)
         .expect("hyperlight_pre_kmain(): PEB align_up overflow");
     let peb_ptr: *mut HyperlightPEB = peb_base as *mut HyperlightPEB;
+
+    // Patch PEB scratch pointers from GVA to GPA.
+    //
+    // The host writes input_stack.ptr and output_stack.ptr using scratch_base_gva()
+    // (derived from MAX_GVA).  On the Hyperlight i686 platform the guest runs with
+    // identity mapping (GVA == GPA), but the KVM memory slot for scratch is placed at
+    // scratch_base_gpa() (derived from MAX_GPA).  When MAX_GPA < MAX_GVA the two
+    // diverge and the guest would read from unmapped physical addresses.  Subtract the
+    // delta so the PEB pointers target the actual GPA range.
+    let gva_gpa_delta: u64 = (MAX_GVA - MAX_GPA) as u64;
+    if gva_gpa_delta != 0 {
+        unsafe {
+            (*peb_ptr).input_stack.ptr -= gva_gpa_delta;
+            (*peb_ptr).output_stack.ptr -= gva_gpa_delta;
+        }
+    }
+
     unsafe {
         GUEST_HANDLE = Some(GuestHandle::init(peb_ptr));
     }
@@ -1041,9 +1061,8 @@ pub fn init(
     }
 
     // Derive scratch region addresses from the host-provided scratch_size.
-    // scratch_size covers the full range [scratch_base, 0xFFFFFFFF] and includes the last
-    // page (0xFFFFF000) that Hyperlight reserves for bookkeeping.  The bitmap excludes that
-    // page because its frame number (0xFFFFF) exceeds FrameNumber::MAX.
+    // scratch_size covers the full range [scratch_base, MAX_GPA] and includes the last
+    // page that Hyperlight reserves for bookkeeping.  The bitmap excludes that page.
     // Validate that scratch_size is non-zero and large enough to contain the required MMIO
     // regions (input buffer + output buffer + one top page + excluded last page).
     let min_scratch_size: usize =
@@ -1056,11 +1075,13 @@ pub fn init(
         );
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
-    // scratch_base = MAX_GVA - scratch_size + 1.
-    let scratch_base_address: usize = MAX_GVA - scratch_size + 1;
-    // Bitmap end: stop one page short of MAX_GVA because the last page (frame 0xfffff)
-    // exceeds FrameNumber::MAX and cannot be booked by the frame allocator.
-    let scratch_bitmap_end: usize = MAX_GVA - mem::PAGE_SIZE + 1;
+    // scratch_base = MAX_GPA - scratch_size + 1.
+    // MAX_GPA (not MAX_GVA) because the guest uses identity mapping (GVA == GPA)
+    // and the KVM memory slot is placed relative to MAX_GPA.
+    let scratch_base_address: usize = MAX_GPA - scratch_size + 1;
+    // Bitmap end: stop one page short of MAX_GPA because the last page holds
+    // Hyperlight bookkeeping metadata and must not be allocated.
+    let scratch_bitmap_end: usize = MAX_GPA - mem::PAGE_SIZE + 1;
 
     // Record scratch region bounds for is_valid_physical_address.
     SCRATCH_BASE.store(scratch_base_address, Ordering::Relaxed);
@@ -1073,11 +1094,11 @@ pub fn init(
     // Register only the MMIO-critical portions of the scratch region:
     //  1. Input data buffer  [scratch_base, scratch_base + INPUT_DATA_BUFFER_SIZE)
     //  2. Output data buffer [scratch_base + INPUT_DATA_BUFFER_SIZE, + OUTPUT_DATA_BUFFER_SIZE)
-    //  3. Top page (0xFFFFE000): guest counter.
+    //  3. Top page: guest counter.
     // Everything between the output buffer and the top page (page tables, free space) is
-    // intentionally left unregistered  and are available for user-page allocation.  The very last
-    // page (0xFFFFF000) holds scratch metadata accessed only during early boot before paging, and
-    // its frame number (0xFFFFF) exceeds FrameNumber::MAX, so it is excluded entirely.
+    // intentionally left unregistered and are available for user-page allocation.  The very
+    // last page holds scratch metadata accessed only during early boot before paging, so it
+    // is excluded from the frame allocator.
     {
         let scratch_input_base: usize = scratch_base_address;
         let scratch_input: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new_mmio(
@@ -1278,8 +1299,8 @@ unsafe fn build_physical_memory_layout(
 
     let scratch_frames: usize = scratch_size / mem::FRAME_SIZE;
     let scratch_bytes: usize = scratch_frames.div_ceil(bits_per_byte);
-    // Phantom bits map to frame numbers beyond FrameNumber::MAX and must be pre-marked
-    // as used so that alloc() never returns an out-of-range frame.
+    // Phantom bits are trailing padding bits in the byte-aligned bitmap that do not
+    // correspond to real frames. Pre-mark them as used so alloc() never returns them.
     let scratch_phantom: usize = scratch_bytes * bits_per_byte - scratch_frames;
 
     let total_bytes: usize = low_bytes + ramfs_bytes + scratch_bytes;

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -64,11 +64,19 @@ use ::arch::{
     mem,
     mem::PAGE_ALIGNMENT,
 };
-use ::config::hyperlight::{
-    INITRD_SIZE_BYTES,
-    INPUT_DATA_BUFFER_SIZE,
-    OUTPUT_DATA_BUFFER_SIZE,
-    PEB_SIZE,
+use ::config::{
+    hyperlight::{
+        INITRD_SIZE_BYTES,
+        INPUT_DATA_BUFFER_SIZE,
+        OUTPUT_DATA_BUFFER_SIZE,
+        PEB_SIZE,
+    },
+    kernel::MEMORY_SIZE,
+    memory_layout::KERNEL_BASE_RAW,
+};
+use ::core::sync::atomic::{
+    AtomicUsize,
+    Ordering,
 };
 use ::hyperlight_common::{
     flatbuffer_wrappers::{
@@ -191,9 +199,17 @@ pub struct Platform {
 //==================================================================================================
 
 /// Frame allocator storage.
-static mut FRAME_ALLOCATOR_STORAGE: [u8; config::kernel::MEMORY_SIZE
-    / (mem::FRAME_SIZE * u8::BITS as usize)] =
-    [0; config::kernel::MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)];
+static mut FRAME_ALLOCATOR_STORAGE: [u8; MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)] =
+    [0; MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)];
+
+/// Base address of physical memory. Dynamically initialized at the top of `parse_bootinfo()`
+/// (the earliest platform entry point) before any `PhysicalAddress` construction occurs.
+static MEMORY_BASE_ADDRESS: AtomicUsize = AtomicUsize::new(0);
+
+/// End address (exclusive) of physical memory. Dynamically initialized at the top of
+/// `parse_bootinfo()` (the earliest platform entry point) before any `PhysicalAddress`
+/// construction occurs.
+static MEMORY_END_ADDRESS: AtomicUsize = AtomicUsize::new(0);
 
 //==================================================================================================
 // Standalone Functions
@@ -625,6 +641,28 @@ pub fn tsc_base_frequency_mhz() -> u32 {
 ///
 /// # Description
 ///
+/// Checks whether the given virtual address corresponds to a valid physical address on the
+/// Hyperlight platform.
+///
+/// # Parameters
+///
+/// - `addr`: The virtual address to validate.
+///
+/// # Returns
+///
+/// `true` if `addr` falls within a known physical memory region, `false` otherwise.
+///
+#[inline(always)]
+pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
+    let raw: usize = addr.into_raw_value();
+    let memory_base_address: usize = MEMORY_BASE_ADDRESS.load(Ordering::Relaxed);
+    let memory_end_address: usize = MEMORY_END_ADDRESS.load(Ordering::Relaxed);
+    raw >= memory_base_address && raw < memory_end_address
+}
+
+///
+/// # Description
+///
 /// Parses boot information.
 ///
 /// # Parameters
@@ -637,6 +675,10 @@ pub fn tsc_base_frequency_mhz() -> u32 {
 /// A new boot information structure.
 ///
 pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
+    // Initialize physical memory bounds before any PhysicalAddress construction.
+    MEMORY_BASE_ADDRESS.store(KERNEL_BASE_RAW, Ordering::Relaxed);
+    MEMORY_END_ADDRESS.store(KERNEL_BASE_RAW + MEMORY_SIZE, Ordering::Relaxed);
+
     trace!("{magic:?}, {info:?}");
 
     extern "C" {

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -680,29 +680,78 @@ pub fn tsc_base_frequency_mhz() -> u32 {
 #[inline(always)]
 pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
     let raw: usize = addr.into_raw_value();
+    let snapshot: (usize, usize) =
+        (SNAPSHOT_BASE.load(Ordering::Relaxed), SNAPSHOT_END.load(Ordering::Relaxed));
+    let ramfs: (usize, usize) =
+        (RAMFS_BASE.load(Ordering::Relaxed), RAMFS_END.load(Ordering::Relaxed));
+    let scratch: (usize, usize) =
+        (SCRATCH_BASE.load(Ordering::Relaxed), SCRATCH_END.load(Ordering::Relaxed));
+    // An address is valid when the half-open interval [raw, raw+1) lies inside a region.
+    region_contains(snapshot.0, snapshot.1, raw, raw + 1)
+        || region_contains(ramfs.0, ramfs.1, raw, raw + 1)
+        || region_contains(scratch.0, scratch.1, raw, raw + 1)
+}
 
-    // Check snapshot region.
-    let snapshot_base: usize = SNAPSHOT_BASE.load(Ordering::Relaxed);
-    let snapshot_end: usize = SNAPSHOT_END.load(Ordering::Relaxed);
-    if raw >= snapshot_base && raw < snapshot_end {
-        return true;
+///
+/// # Description
+///
+/// Checks whether the given physical memory region lies entirely within a single contiguous
+/// physical memory region on the Hyperlight platform.
+///
+/// # Parameters
+///
+/// - `start`: Starting physical address of the region.
+/// - `size`: Size of the region in bytes.
+///
+/// # Returns
+///
+/// `true` if the entire region lies within a single physical memory region, `false` otherwise.
+///
+#[inline(always)]
+pub fn is_valid_physical_region(start: usize, size: usize) -> bool {
+    // Reject zero-length regions.
+    if size == 0 {
+        return false;
     }
 
-    // Check RAMFS region (base == end == 0 means absent).
-    let ramfs_base: usize = RAMFS_BASE.load(Ordering::Relaxed);
-    let ramfs_end: usize = RAMFS_END.load(Ordering::Relaxed);
-    if ramfs_base != ramfs_end && raw >= ramfs_base && raw < ramfs_end {
-        return true;
-    }
+    // Compute the exclusive end, guarding against overflow.
+    let end: usize = match start.checked_add(size) {
+        Some(end) => end,
+        None => return false,
+    };
 
-    // Check scratch region (base == end == 0 means not yet discovered).
-    let scratch_base: usize = SCRATCH_BASE.load(Ordering::Relaxed);
-    let scratch_end: usize = SCRATCH_END.load(Ordering::Relaxed);
-    if scratch_base != scratch_end && raw >= scratch_base && raw < scratch_end {
-        return true;
-    }
+    let snapshot: (usize, usize) =
+        (SNAPSHOT_BASE.load(Ordering::Relaxed), SNAPSHOT_END.load(Ordering::Relaxed));
+    let ramfs: (usize, usize) =
+        (RAMFS_BASE.load(Ordering::Relaxed), RAMFS_END.load(Ordering::Relaxed));
+    let scratch: (usize, usize) =
+        (SCRATCH_BASE.load(Ordering::Relaxed), SCRATCH_END.load(Ordering::Relaxed));
 
-    false
+    region_contains(snapshot.0, snapshot.1, start, end)
+        || region_contains(ramfs.0, ramfs.1, start, end)
+        || region_contains(scratch.0, scratch.1, start, end)
+}
+
+///
+/// # Description
+///
+/// Checks whether the half-open interval `[start, end)` is entirely contained within the region
+/// `[region_base, region_end)`. Absent regions (base == end == 0) never contain any interval.
+///
+/// # Parameters
+///
+/// - `region_base`: Inclusive start address of the region.
+/// - `region_end`: Exclusive end address of the region.
+/// - `start`: Inclusive start address of the interval to test.
+/// - `end`: Exclusive end address of the interval to test.
+///
+/// # Returns
+///
+/// `true` if the interval lies within the region, `false` otherwise.
+///
+#[inline(always)]
+fn region_contains(region_base: usize, region_end: usize, start: usize, end: usize) -> bool {
+    region_base != region_end && start >= region_base && end <= region_end
 }
 
 ///

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -26,7 +26,6 @@ use crate::{
         io::{
             IoMemoryAllocator,
             IoPortAllocator,
-            MmioTag,
         },
         mem::{
             MemoryRegion,
@@ -46,6 +45,7 @@ use crate::{
                 OUTPUT_BUF_MMIO_TAG,
                 PEB_MMIO_TAG,
                 RAMFS_MMIO_TAG,
+                SCRATCH_IO_MMIO_TAG,
             },
         },
     },
@@ -993,7 +993,7 @@ pub fn init(
         scratch_mr.set_cache_policy(MmioCachePolicy::UNCACHEABLE);
         let scratch_io_region: TruncatedMemoryRegion<VirtualAddress> =
             TruncatedMemoryRegion::from_memory_region(scratch_mr)?;
-        ioaddresses.register(MmioTag::from_name("SCRATCHIO"), scratch_io_region.clone())?;
+        ioaddresses.register(SCRATCH_IO_MMIO_TAG, scratch_io_region.clone())?;
         mmio_regions.push_back(scratch_io_region);
     }
 

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -14,6 +14,10 @@ pub(crate) mod peb;
 #[cfg(feature = "pit")]
 use crate::hal::platform::pit::Pit;
 use crate::{
+    collections::{
+        Bitmap,
+        RawArray,
+    },
     hal::{
         arch::x86::{
             self,
@@ -54,6 +58,7 @@ use ::alloc::{
         String,
         ToString,
     },
+    vec,
 };
 use ::arch::{
     mem,
@@ -85,6 +90,7 @@ use ::hyperlight_common::{
     outb::VmAction,
 };
 use ::hyperlight_guest::guest_handle::handle::GuestHandle;
+use ::sparse_bitmap::SparseBitmap;
 use ::sys::{
     config::memory_layout,
     error::{
@@ -175,7 +181,19 @@ pub struct Platform {
     pub arch: Arch,
     #[cfg(feature = "pit")]
     pub _pit: Pit,
+    /// A sparse bitmap representing the physical memory layout, owned by the platform and consumed
+    /// by the memory manager during system initialization.
+    pub physical_memory_layout: Option<SparseBitmap>,
 }
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Frame allocator storage.
+static mut FRAME_ALLOCATOR_STORAGE: [u8; config::kernel::MEMORY_SIZE
+    / (mem::FRAME_SIZE * u8::BITS as usize)] =
+    [0; config::kernel::MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)];
 
 //==================================================================================================
 // Standalone Functions
@@ -744,6 +762,24 @@ fn register_pit(ioports: &mut IoPortAllocator) -> Result<Pit, Error> {
     Pit::new(ioports, ::config::kernel::TIMER_FREQ)
 }
 
+///
+/// # Description
+///
+/// Initializes the hyperlight platform.
+///
+/// # Parameters
+///
+/// - `ioports`: I/O port allocator.
+/// - `ioaddresses`: I/O memory allocator.
+/// - `memory_regions`: Memory regions.
+/// - `mmio_regions`: MMIO regions.
+/// - `madt`: MADT information.
+/// - `_mem_lower`: Lower memory size.
+///
+/// # Returns
+///
+/// Upon success, the initialized platform is returned. Upon failure, an error is returned instead.
+///
 pub fn init(
     ioports: &mut IoPortAllocator,
     ioaddresses: &mut IoMemoryAllocator,
@@ -961,10 +997,23 @@ pub fn init(
         mmio_regions.push_back(scratch_io_region);
     }
 
+    // Build a sparse bitmap representing the physical memory layout.
+    let physical_memory_layout: SparseBitmap = {
+        // Safety: the frame allocator storage is valid and has a static lifetime.
+        let storage: RawArray<u8> = unsafe {
+            let (ptr, len): (*mut u8, usize) =
+                (FRAME_ALLOCATOR_STORAGE.as_mut_ptr(), FRAME_ALLOCATOR_STORAGE.len());
+            RawArray::from_raw_parts(ptr, len)?
+        };
+        let bitmap: Bitmap = Bitmap::from_raw_array(storage)?;
+        SparseBitmap::new(vec![(0, bitmap)])?
+    };
+
     Ok(Platform {
         arch: x86::init(ioports, ioaddresses, madt)?,
         #[cfg(feature = "pit")]
         _pit: register_pit(ioports)?,
+        physical_memory_layout: Some(physical_memory_layout),
     })
 }
 

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -677,6 +677,24 @@ pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
 ///
 /// # Description
 ///
+/// Returns the maximum physical address on the Hyperlight platform.
+///
+/// The physical memory is sparse and spans from low addresses (snapshot) to near the top of
+/// the 32-bit address space (scratch). On i686 `usize::MAX == 0xFFFFFFFF` which matches
+/// `MAX_GVA`.
+///
+/// # Returns
+///
+/// The maximum physical address value.
+///
+#[inline(always)]
+pub fn max_physical_address() -> usize {
+    usize::MAX
+}
+
+///
+/// # Description
+///
 /// Parses boot information.
 ///
 /// # Parameters

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -65,6 +65,7 @@ use ::arch::{
     mem::PAGE_ALIGNMENT,
 };
 use ::config::{
+    constants::KILOBYTE,
     hyperlight::{
         INITRD_SIZE_BYTES,
         INPUT_DATA_BUFFER_SIZE,
@@ -91,10 +92,7 @@ use ::hyperlight_common::{
         },
     },
     layout::MAX_GVA,
-    mem::{
-        FileMappingInfo,
-        HyperlightPEB,
-    },
+    mem::HyperlightPEB,
     outb::VmAction,
 };
 use ::hyperlight_guest::guest_handle::handle::GuestHandle;
@@ -213,17 +211,30 @@ pub struct Platform {
 //==================================================================================================
 
 /// Frame allocator storage.
-static mut FRAME_ALLOCATOR_STORAGE: [u8; MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)] =
-    [0; MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)];
+/// Sized to hold one bit per frame for the entire `MEMORY_SIZE` address range, plus one extra byte
+/// per chunk (snapshot, ramfs, scratch) so that frame counts that are not multiples of 8 can be
+/// rounded up without overflowing the backing array.  At runtime, sub-slices of this array back the
+/// per-region bitmaps inside a multi-chunk `SparseBitmap`.
+static mut FRAME_ALLOCATOR_STORAGE: [u8; MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize) + 3] =
+    [0; MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize) + 3];
 
-/// Base address of physical memory. Dynamically initialized at the top of `parse_bootinfo()`
-/// (the earliest platform entry point) before any `PhysicalAddress` construction occurs.
-static MEMORY_BASE_ADDRESS: AtomicUsize = AtomicUsize::new(0);
+/// Snapshot region base address (inclusive).
+static SNAPSHOT_BASE: AtomicUsize = AtomicUsize::new(KERNEL_BASE_RAW);
+/// Snapshot region end address (exclusive).
+/// Uses `KERNEL_BASE_RAW + MEMORY_SIZE` as a generous upper bound so that early-boot code
+/// (before `init()`) can construct `PhysicalAddress` values.  Tightened in `init()` once the
+/// actual region boundaries are discovered.
+static SNAPSHOT_END: AtomicUsize = AtomicUsize::new(KERNEL_BASE_RAW + MEMORY_SIZE);
 
-/// End address (exclusive) of physical memory. Dynamically initialized at the top of
-/// `parse_bootinfo()` (the earliest platform entry point) before any `PhysicalAddress`
-/// construction occurs.
-static MEMORY_END_ADDRESS: AtomicUsize = AtomicUsize::new(0);
+/// RAMFS region base address (inclusive). Zero when no RAMFS is present.
+static RAMFS_BASE: AtomicUsize = AtomicUsize::new(0);
+/// RAMFS region end address (exclusive). Zero when no RAMFS is present.
+static RAMFS_END: AtomicUsize = AtomicUsize::new(0);
+
+/// Scratch region base address (inclusive). Zero until `init()` discovers the actual value.
+static SCRATCH_BASE: AtomicUsize = AtomicUsize::new(0);
+/// Scratch region end address (exclusive). Zero until `init()` discovers the actual value.
+static SCRATCH_END: AtomicUsize = AtomicUsize::new(0);
 
 //==================================================================================================
 // Standalone Functions
@@ -669,27 +680,58 @@ pub fn tsc_base_frequency_mhz() -> u32 {
 #[inline(always)]
 pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
     let raw: usize = addr.into_raw_value();
-    let memory_base_address: usize = MEMORY_BASE_ADDRESS.load(Ordering::Relaxed);
-    let memory_end_address: usize = MEMORY_END_ADDRESS.load(Ordering::Relaxed);
-    raw >= memory_base_address && raw < memory_end_address
+
+    // Check snapshot region.
+    let snapshot_base: usize = SNAPSHOT_BASE.load(Ordering::Relaxed);
+    let snapshot_end: usize = SNAPSHOT_END.load(Ordering::Relaxed);
+    if raw >= snapshot_base && raw < snapshot_end {
+        return true;
+    }
+
+    // Check RAMFS region (base == end == 0 means absent).
+    let ramfs_base: usize = RAMFS_BASE.load(Ordering::Relaxed);
+    let ramfs_end: usize = RAMFS_END.load(Ordering::Relaxed);
+    if ramfs_base != ramfs_end && raw >= ramfs_base && raw < ramfs_end {
+        return true;
+    }
+
+    // Check scratch region (base == end == 0 means not yet discovered).
+    let scratch_base: usize = SCRATCH_BASE.load(Ordering::Relaxed);
+    let scratch_end: usize = SCRATCH_END.load(Ordering::Relaxed);
+    if scratch_base != scratch_end && raw >= scratch_base && raw < scratch_end {
+        return true;
+    }
+
+    false
 }
 
 ///
 /// # Description
 ///
-/// Returns the maximum physical address on the Hyperlight platform.
+/// Returns the highest valid physical address on the Hyperlight platform.
 ///
 /// The physical memory is sparse and spans from low addresses (snapshot) to near the top of
-/// the 32-bit address space (scratch). On i686 `usize::MAX == 0xFFFFFFFF` which matches
-/// `MAX_GVA`.
+/// the 32-bit address space (scratch). The highest valid physical address is the last address
+/// before `SCRATCH_END`, since addresses greater than or equal to `SCRATCH_END` are not
+/// considered valid by the platform.
+///
+/// Before `init()` discovers the scratch region, only the snapshot region is known, so the
+/// highest valid address is `SNAPSHOT_END - 1`.
 ///
 /// # Returns
 ///
-/// The maximum physical address value.
+/// The highest valid physical address value.
 ///
 #[inline(always)]
 pub fn max_physical_address() -> usize {
-    usize::MAX
+    let scratch_end: usize = SCRATCH_END.load(Ordering::Relaxed);
+    if scratch_end != 0 {
+        // Post-init: the highest valid address is SCRATCH_END - 1.
+        scratch_end - 1
+    } else {
+        // Pre-init: only the snapshot region is known.
+        SNAPSHOT_END.load(Ordering::Relaxed) - 1
+    }
 }
 
 ///
@@ -707,10 +749,6 @@ pub fn max_physical_address() -> usize {
 /// A new boot information structure.
 ///
 pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
-    // Initialize physical memory bounds before any PhysicalAddress construction.
-    MEMORY_BASE_ADDRESS.store(KERNEL_BASE_RAW, Ordering::Relaxed);
-    MEMORY_END_ADDRESS.store(KERNEL_BASE_RAW + MEMORY_SIZE, Ordering::Relaxed);
-
     trace!("{magic:?}, {info:?}");
 
     extern "C" {
@@ -750,7 +788,7 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
         ));
     }
 
-    // Detect initrd format by checking for NVMB multibinary magic.
+    // Detect initrd format by checking for multibinary magic.
     let init_data: &[u8] =
         unsafe { core::slice::from_raw_parts(current_data_start as *const u8, total_size) };
 
@@ -760,26 +798,12 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
         // Multibinary NVMB format: relocate whole blob, then parse entries.
         info!("parse_bootinfo(): multibinary initrd detected");
 
-        let initrd_base: usize = if current_data_start != ::config::hyperlight::DEFAULT_INITRD_BASE
-        {
-            let src_ptr: *const u8 = current_data_start as *const u8;
-            let dst_ptr: *mut u8 = ::config::hyperlight::DEFAULT_INITRD_BASE as *mut u8;
-            unsafe { core::ptr::copy(src_ptr, dst_ptr, total_size) };
+        let initrd_base: usize = current_data_start;
 
-            debug!(
-                "parse_bootinfo(): multibinary relocated from {current_data_start:#010x} to \
-                 {:#010x}",
-                ::config::hyperlight::DEFAULT_INITRD_BASE
-            );
-            ::config::hyperlight::DEFAULT_INITRD_BASE
-        } else {
-            current_data_start
-        };
-
-        let image_data: &[u8] =
-            unsafe { core::slice::from_raw_parts(initrd_base as *const u8, total_size) };
-
-        kernel_modules.extend(crate::multibin::parse(image_data, initrd_base)?);
+        kernel_modules.extend(crate::multibin::parse(
+            unsafe { core::slice::from_raw_parts(initrd_base as *const u8, total_size) },
+            initrd_base,
+        )?);
     } else {
         // Single-binary format: parse old size-header + args layout.
         info!("parse_bootinfo(): single-binary initrd detected");
@@ -867,6 +891,23 @@ pub fn init(
     extern "C" {
         static __KERNEL_END: u8;
     }
+
+    // Query the host for the authoritative physical memory layout.
+    let (snapshot_budget_size, pt_overhead, ramfs_base, ramfs_size, scratch_size) =
+        unsafe { ProcessEnvironmentBlock::get_memory_layout() }?;
+    info!(
+        "host memory layout: snapshot_budget_size={} KB, pt_overhead={} KB, ramfs_base={:#x}, \
+         ramfs_size={} KB, scratch_size={} KB",
+        snapshot_budget_size / KILOBYTE,
+        pt_overhead / KILOBYTE,
+        ramfs_base,
+        ramfs_size / KILOBYTE,
+        scratch_size / KILOBYTE
+    );
+
+    // Sanity check: the three regions must cover exactly MEMORY_SIZE.
+    check_memory_size(snapshot_budget_size, ramfs_size, scratch_size)?;
+
     // Register PEB structure.
     let kernel_end_addr: usize = unsafe { &__KERNEL_END } as *const u8 as usize;
     let peb_base: usize =
@@ -885,49 +926,12 @@ pub fn init(
     ioaddresses.register(PEB_MMIO_TAG, peb.clone())?;
     mmio_regions.push_back(peb);
 
-    // Register input data buffer (directly after PEB in v0.13.0+).
-    let input_data_base: usize = peb_base.checked_add(PEB_SIZE).ok_or_else(|| {
-        let reason: &str = "input data buffer base address overflow";
+    // Compute padding between PEB and kernel pool.
+    let heap_padding_base: usize = peb_base.checked_add(PEB_SIZE).ok_or_else(|| {
+        let reason: &str = "heap padding base address overflow";
         error!("init(): {}", reason);
         Error::new(ErrorCode::OutOfMemory, reason)
     })?;
-    let input_data_buffer: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new_mmio(
-        "input data buffer",
-        PageAligned::from_raw_value(input_data_base)?,
-        INPUT_DATA_BUFFER_SIZE,
-        AccessPermission::RDWR,
-        MmioCachePolicy::UNCACHEABLE,
-    )?;
-    ioaddresses.register(INPUT_BUF_MMIO_TAG, input_data_buffer.clone())?;
-    mmio_regions.push_back(input_data_buffer);
-
-    // Register output data buffer.
-    let output_data_base: usize = input_data_base
-        .checked_add(INPUT_DATA_BUFFER_SIZE)
-        .ok_or_else(|| {
-            let reason: &str = "output data buffer base address overflow";
-            error!("init(): {}", reason);
-            Error::new(ErrorCode::OutOfMemory, reason)
-        })?;
-    let output_data_buffer: TruncatedMemoryRegion<VirtualAddress> =
-        TruncatedMemoryRegion::new_mmio(
-            "output data buffer",
-            PageAligned::from_raw_value(output_data_base)?,
-            OUTPUT_DATA_BUFFER_SIZE,
-            AccessPermission::RDWR,
-            MmioCachePolicy::UNCACHEABLE,
-        )?;
-    ioaddresses.register(OUTPUT_BUF_MMIO_TAG, output_data_buffer.clone())?;
-    mmio_regions.push_back(output_data_buffer);
-
-    // Compute heap padding between output data buffer and kernel pool.
-    let heap_padding_base: usize = output_data_base
-        .checked_add(OUTPUT_DATA_BUFFER_SIZE)
-        .ok_or_else(|| {
-            let reason: &str = "heap padding base address overflow";
-            error!("init(): {}", reason);
-            Error::new(ErrorCode::OutOfMemory, reason)
-        })?;
     debug!("heap_padding_base={:#010x}", heap_padding_base);
     let kpool_base: usize = memory_layout::KPOOL_BASE.into_raw_value();
     match kpool_base.checked_sub(heap_padding_base) {
@@ -954,133 +958,139 @@ pub fn init(
         },
     }
 
-    // Register kpool guard page.
-    let kpool_guard_base: usize = kpool_base
-        .checked_add(config::kernel::KPOOL_SIZE)
-        .ok_or_else(|| {
-            let reason: &str = "kpool guard base address overflow";
-            error!("init(): {}", reason);
-            Error::new(ErrorCode::OutOfMemory, reason)
-        })?;
-    let kpool_guard_size: usize = mem::PAGE_SIZE;
-    let kpool_guard: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-        "kpool guard",
-        VirtualAddress::from_raw_value(kpool_guard_base),
-        kpool_guard_size,
-        MemoryRegionType::Reserved,
-        AccessPermission::RDONLY,
-    )?;
-    memory_regions.push_back(kpool_guard);
-
-    // Register hyperlight guest user stack.
-    let guest_user_stack_base: usize =
-        kpool_guard_base
-            .checked_add(kpool_guard_size)
-            .ok_or_else(|| {
-                let reason: &str = "guest user stack base address overflow";
-                error!("init(): {}", reason);
-                Error::new(ErrorCode::OutOfMemory, reason)
-            })?;
-    let guest_user_stack_size: usize = mem::PAGE_SIZE;
-    let guest_user_stack: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-        "guest user stack",
-        VirtualAddress::from_raw_value(guest_user_stack_base),
-        guest_user_stack_size,
-        MemoryRegionType::Reserved,
-        AccessPermission::RDONLY,
-    )?;
-    memory_regions.push_back(guest_user_stack);
-
     // Register RAMFS region as MMIO for identity mapping, if present.
-    // The host writes file mapping metadata into the PEB's file_mappings array
-    // during evolve(). We scan the entries for the "ramfs" label and, if found,
-    // register an MMIO region so the kernel's page tables will identity-map the
-    // file-backed memory.
-    {
-        let peb_ptr: *const HyperlightPEB = peb_base as *const HyperlightPEB;
-        let count: usize = unsafe { (*peb_ptr).file_mappings.size } as usize;
-        let array_ptr: *const FileMappingInfo =
-            unsafe { (*peb_ptr).file_mappings.ptr } as *const FileMappingInfo;
-
-        if count > 0 && !array_ptr.is_null() {
-            for i in 0..count {
-                let entry: &FileMappingInfo = unsafe { &*array_ptr.add(i) };
-
-                // Only register entries whose label matches "ramfs".
-                let label_len: usize = entry
-                    .label
-                    .iter()
-                    .position(|&b| b == 0)
-                    .unwrap_or(entry.label.len());
-                let label: &str = core::str::from_utf8(&entry.label[..label_len]).unwrap_or("");
-                if label != "ramfs" {
-                    continue;
-                }
-
-                let ramfs_base: usize = entry.guest_addr as usize;
-                let ramfs_size: usize = entry.size as usize;
-
-                if ramfs_base != 0 && ramfs_size != 0 {
-                    info!(
-                        "file mapping [{}]: base={:#010x}, size={:#x}",
-                        i, ramfs_base, ramfs_size
-                    );
-                    let mut ramfs_mr: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-                        RAMFS_REGION_NAME,
-                        VirtualAddress::from_raw_value(ramfs_base),
-                        ramfs_size,
-                        MemoryRegionType::Mmio,
-                        AccessPermission::RDWR,
-                    )?;
-                    ramfs_mr.set_cache_policy(MmioCachePolicy::WRITE_BACK);
-                    let ramfs_region: TruncatedMemoryRegion<VirtualAddress> =
-                        TruncatedMemoryRegion::from_memory_region(ramfs_mr)?;
-                    ioaddresses.register(RAMFS_MMIO_TAG, ramfs_region.clone())?;
-                    mmio_regions.push_back(ramfs_region);
-                }
-            }
-        }
-    }
-
-    // Register scratch I/O buffers as MMIO regions for identity mapping.
-    // The hyperlight-guest library accesses I/O buffers at scratch GVAs (read from PEB).
-    // When the kernel enables its own paging, these high addresses are unmapped unless
-    // we explicitly register them as MMIO regions for identity mapping.
-    let peb_ptr: *const HyperlightPEB = peb_base as *const HyperlightPEB;
-    let input_gva = unsafe { (*peb_ptr).input_stack.ptr } as usize;
-
-    if input_gva >= config::kernel::MEMORY_SIZE {
-        // Extend the scratch I/O region to cover all the way up to (but not including)
-        // the last page of the address space. This includes the I/O buffers AND the
-        // bookkeeping area (scratch size, allocator, exception stack, guest counter).
-        // We stop one page short of MAX_GVA because the last page (frame 0xfffff)
-        // exceeds FrameNumber::MAX and cannot be booked by the frame allocator.
-        let scratch_end: usize = MAX_GVA - mem::PAGE_SIZE;
-        let scratch_io_size = scratch_end - input_gva + 1;
-        let mut scratch_mr: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-            "scratch io",
-            VirtualAddress::from_raw_value(input_gva),
-            scratch_io_size,
+    if ramfs_base != 0 && ramfs_size != 0 {
+        let mut ramfs_mr: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+            RAMFS_REGION_NAME,
+            VirtualAddress::from_raw_value(ramfs_base),
+            ramfs_size,
             MemoryRegionType::Mmio,
             AccessPermission::RDWR,
         )?;
-        scratch_mr.set_cache_policy(MmioCachePolicy::UNCACHEABLE);
-        let scratch_io_region: TruncatedMemoryRegion<VirtualAddress> =
-            TruncatedMemoryRegion::from_memory_region(scratch_mr)?;
-        ioaddresses.register(SCRATCH_IO_MMIO_TAG, scratch_io_region.clone())?;
-        mmio_regions.push_back(scratch_io_region);
+        ramfs_mr.set_cache_policy(MmioCachePolicy::WRITE_BACK);
+        let ramfs_region: TruncatedMemoryRegion<VirtualAddress> =
+            TruncatedMemoryRegion::from_memory_region(ramfs_mr)?;
+        ioaddresses.register(RAMFS_MMIO_TAG, ramfs_region.clone())?;
+        mmio_regions.push_back(ramfs_region);
     }
 
-    // Build a sparse bitmap representing the physical memory layout.
-    let physical_memory_layout: SparseBitmap = {
-        // Safety: the frame allocator storage is valid and has a static lifetime.
-        let storage: RawArray<u8> = unsafe {
-            let (ptr, len): (*mut u8, usize) =
-                (FRAME_ALLOCATOR_STORAGE.as_mut_ptr(), FRAME_ALLOCATOR_STORAGE.len());
-            RawArray::from_raw_parts(ptr, len)?
+    // Record RAMFS region bounds for is_valid_physical_address.
+    if ramfs_size > 0 {
+        let ramfs_end: usize = match ramfs_base.checked_add(ramfs_size) {
+            Some(ramfs_end) => ramfs_end,
+            None => {
+                return Err(Error::new(
+                    ErrorCode::InvalidArgument,
+                    "host-reported RAMFS bounds overflow",
+                ));
+            },
         };
-        let bitmap: Bitmap = Bitmap::from_raw_array(storage)?;
-        SparseBitmap::new(vec![(0, bitmap)])?
+
+        RAMFS_BASE.store(ramfs_base, Ordering::Relaxed);
+        RAMFS_END.store(ramfs_end, Ordering::Relaxed);
+        info!("ramfs region: [{:#010x}, {:#010x})", ramfs_base, ramfs_end);
+    }
+
+    // Derive scratch region addresses from the host-provided scratch_size.
+    // scratch_size covers the full range [scratch_base, 0xFFFFFFFF] and includes the last
+    // page (0xFFFFF000) that Hyperlight reserves for bookkeeping.  The bitmap excludes that
+    // page because its frame number (0xFFFFF) exceeds FrameNumber::MAX.
+    // Validate that scratch_size is non-zero and large enough to contain the required MMIO
+    // regions (input buffer + output buffer + one top page + excluded last page).
+    let min_scratch_size: usize =
+        INPUT_DATA_BUFFER_SIZE + OUTPUT_DATA_BUFFER_SIZE + 2 * mem::PAGE_SIZE;
+    if scratch_size == 0 || scratch_size < min_scratch_size {
+        let reason: &str = "scratch_size is too small for required MMIO regions";
+        error!(
+            "init(): {} (scratch_size={:#x}, min={:#x})",
+            reason, scratch_size, min_scratch_size
+        );
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+    // scratch_base = MAX_GVA - scratch_size + 1.
+    let scratch_base_address: usize = MAX_GVA - scratch_size + 1;
+    // Bitmap end: stop one page short of MAX_GVA because the last page (frame 0xfffff)
+    // exceeds FrameNumber::MAX and cannot be booked by the frame allocator.
+    let scratch_bitmap_end: usize = MAX_GVA - mem::PAGE_SIZE + 1;
+
+    // Record scratch region bounds for is_valid_physical_address.
+    SCRATCH_BASE.store(scratch_base_address, Ordering::Relaxed);
+    SCRATCH_END.store(scratch_bitmap_end, Ordering::Relaxed);
+    info!(
+        "scratch region: [{:#010x}, {:#010x}) (size={:#x})",
+        scratch_base_address, scratch_bitmap_end, scratch_size
+    );
+
+    // Register only the MMIO-critical portions of the scratch region:
+    //  1. Input data buffer  [scratch_base, scratch_base + INPUT_DATA_BUFFER_SIZE)
+    //  2. Output data buffer [scratch_base + INPUT_DATA_BUFFER_SIZE, + OUTPUT_DATA_BUFFER_SIZE)
+    //  3. Top page (0xFFFFE000): guest counter.
+    // Everything between the output buffer and the top page (page tables, free space) is
+    // intentionally left unregistered  and are available for user-page allocation.  The very last
+    // page (0xFFFFF000) holds scratch metadata accessed only during early boot before paging, and
+    // its frame number (0xFFFFF) exceeds FrameNumber::MAX, so it is excluded entirely.
+    {
+        let scratch_input_base: usize = scratch_base_address;
+        let scratch_input: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new_mmio(
+            "scratch input",
+            PageAligned::from_raw_value(scratch_input_base)?,
+            INPUT_DATA_BUFFER_SIZE,
+            AccessPermission::RDWR,
+            MmioCachePolicy::UNCACHEABLE,
+        )?;
+        ioaddresses.register(INPUT_BUF_MMIO_TAG, scratch_input.clone())?;
+        mmio_regions.push_back(scratch_input);
+    }
+    {
+        let scratch_output_base: usize = scratch_base_address + INPUT_DATA_BUFFER_SIZE;
+        let scratch_output: TruncatedMemoryRegion<VirtualAddress> =
+            TruncatedMemoryRegion::new_mmio(
+                "scratch output",
+                PageAligned::from_raw_value(scratch_output_base)?,
+                OUTPUT_DATA_BUFFER_SIZE,
+                AccessPermission::RDWR,
+                MmioCachePolicy::UNCACHEABLE,
+            )?;
+        ioaddresses.register(OUTPUT_BUF_MMIO_TAG, scratch_output.clone())?;
+        mmio_regions.push_back(scratch_output);
+    }
+    {
+        let scratch_top_page: usize = scratch_bitmap_end - mem::PAGE_SIZE;
+        let scratch_top: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new_mmio(
+            "scratch top",
+            PageAligned::from_raw_value(scratch_top_page)?,
+            mem::PAGE_SIZE,
+            AccessPermission::RDWR,
+            MmioCachePolicy::UNCACHEABLE,
+        )?;
+        ioaddresses.register(SCRATCH_IO_MMIO_TAG, scratch_top.clone())?;
+        mmio_regions.push_back(scratch_top);
+    }
+
+    // Set snapshot region end from the host-provided snapshot budget.
+    // pt_overhead is always 0 with nanvix-unstable (Hyperlight skips PT generation).
+    // The variable is acknowledged here for forward-compatibility.
+    let _ = pt_overhead;
+    let snapshot_end_address: usize = KERNEL_BASE_RAW + snapshot_budget_size;
+    SNAPSHOT_END.store(snapshot_end_address, Ordering::Relaxed);
+    info!("snapshot region: [{:#010x}, {:#010x})", KERNEL_BASE_RAW, snapshot_end_address);
+
+    // Build a sparse bitmap representing the physical memory layout.
+    // Each disjoint physical region (snapshot, RAMFS, scratch) gets its own chunk in the
+    // SparseBitmap.  However, bitmap storage is byte-aligned so the snapshot chunk's last
+    // byte may cover phantom frames beyond snapshot_end.  If the RAMFS starts within that
+    // padded range the two chunks would overlap, so they are merged into a single "low"
+    // chunk.  When the RAMFS is absent or far enough away it becomes a separate chunk.
+    let ramfs_end_address: usize = ramfs_base + ramfs_size;
+    let physical_memory_layout: SparseBitmap = unsafe {
+        build_physical_memory_layout(
+            KERNEL_BASE_RAW,
+            snapshot_end_address,
+            ramfs_base,
+            ramfs_end_address,
+            scratch_base_address,
+            scratch_bitmap_end,
+        )?
     };
 
     Ok(Platform {
@@ -1089,6 +1099,189 @@ pub fn init(
         _pit: register_pit(ioports)?,
         physical_memory_layout: Some(physical_memory_layout),
     })
+}
+
+///
+/// # Description
+///
+/// Validates that the three memory regions (snapshot, RAMFS, scratch) cover exactly
+/// [`MEMORY_SIZE`].
+///
+/// # Parameters
+///
+/// - `snapshot_budget_size`: Size of the snapshot region in bytes.
+/// - `ramfs_size`: Size of the RAMFS region in bytes (0 when absent).
+/// - `scratch_size`: Size of the scratch region in bytes.
+///
+/// # Returns
+///
+/// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+///
+fn check_memory_size(
+    snapshot_budget_size: usize,
+    ramfs_size: usize,
+    scratch_size: usize,
+) -> Result<(), Error> {
+    let total: usize = snapshot_budget_size + ramfs_size + scratch_size;
+    if total != MEMORY_SIZE {
+        let reason: &str = "region budget mismatch";
+        error!(
+            "check_memory_size(): {} snapshot_budget({:#x}) + ramfs({:#x}) + scratch({:#x}) = \
+             {:#x}, expected MEMORY_SIZE={:#x}",
+            reason, snapshot_budget_size, ramfs_size, scratch_size, total, MEMORY_SIZE
+        );
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+    Ok(())
+}
+
+///
+/// # Description
+///
+/// Builds a [`SparseBitmap`] representing the sparse physical memory layout.
+///
+/// Each disjoint physical region (snapshot, RAMFS, scratch) gets its own chunk in the bitmap.
+/// However, bitmap storage is byte-aligned so the snapshot chunk's last byte may cover phantom
+/// frames beyond the snapshot end.  If the RAMFS starts within that padded range the two chunks
+/// would overlap, so they are merged into a single "low" chunk.  When the RAMFS is absent or far
+/// enough away it becomes a separate chunk.
+///
+/// # Parameters
+///
+/// - `snapshot_start_address`: Inclusive start address of the snapshot region.
+/// - `snapshot_end_address`: Exclusive end address of the snapshot region.
+/// - `ramfs_start_address`: Inclusive start address of the RAMFS region (0 when absent).
+/// - `ramfs_end_address`: Exclusive end address of the RAMFS region (0 when absent).
+/// - `scratch_start_address`: Inclusive start address of the scratch region.
+/// - `scratch_end_address`: Exclusive end address of the scratch bitmap region.
+///
+/// # Returns
+///
+/// Upon success, a [`SparseBitmap`] covering all physical memory regions is returned.
+/// Upon failure, an error is returned instead.
+///
+/// # Safety
+///
+/// This function is unsafe because it writes to the mutable static [`FRAME_ALLOCATOR_STORAGE`].
+/// The caller must ensure exclusive access.
+///
+unsafe fn build_physical_memory_layout(
+    snapshot_start_address: usize,
+    snapshot_end_address: usize,
+    ramfs_start_address: usize,
+    ramfs_end_address: usize,
+    scratch_start_address: usize,
+    scratch_end_address: usize,
+) -> Result<SparseBitmap, Error> {
+    // Validate that region ends are not before their starts.
+    if snapshot_end_address < snapshot_start_address
+        || ramfs_end_address < ramfs_start_address
+        || scratch_end_address < scratch_start_address
+    {
+        let reason: &str = "region end address precedes start address";
+        error!("build_physical_memory_layout(): {}", reason);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    let bits_per_byte: usize = u8::BITS as usize;
+    let snapshot_size: usize = snapshot_end_address - snapshot_start_address;
+    let ramfs_size: usize = ramfs_end_address - ramfs_start_address;
+    let scratch_size: usize = scratch_end_address - scratch_start_address;
+
+    let snapshot_frames: usize = snapshot_size / mem::FRAME_SIZE;
+    let snapshot_padded_end: usize = snapshot_frames.div_ceil(bits_per_byte) * bits_per_byte;
+    let ramfs_start_frame: usize = if ramfs_size > 0 {
+        ramfs_start_address / mem::FRAME_SIZE
+    } else {
+        0
+    };
+    let ramfs_end_frame: usize = if ramfs_size > 0 {
+        ramfs_end_address / mem::FRAME_SIZE
+    } else {
+        0
+    };
+
+    // Merge the RAMFS into the snapshot chunk when its start falls within the
+    // byte-padded range of the snapshot bitmap to avoid an overlap error.
+    let merge_ramfs: bool = ramfs_size > 0 && ramfs_start_frame < snapshot_padded_end;
+
+    // "Low" chunk covers the snapshot and, when merged, the RAMFS as well.
+    let low_end_frame: usize = if merge_ramfs {
+        snapshot_frames.max(ramfs_end_frame)
+    } else {
+        snapshot_frames
+    };
+    let low_bytes: usize = low_end_frame.div_ceil(bits_per_byte);
+    let low_phantom: usize = low_bytes * bits_per_byte - low_end_frame;
+
+    // Separate RAMFS chunk (only when not merged).
+    let ramfs_frames: usize = ramfs_size / mem::FRAME_SIZE;
+    let ramfs_bytes: usize = if !merge_ramfs && ramfs_frames > 0 {
+        ramfs_frames.div_ceil(bits_per_byte)
+    } else {
+        0
+    };
+    let ramfs_phantom: usize = if ramfs_bytes > 0 {
+        ramfs_bytes * bits_per_byte - ramfs_frames
+    } else {
+        0
+    };
+
+    let scratch_frames: usize = scratch_size / mem::FRAME_SIZE;
+    let scratch_bytes: usize = scratch_frames.div_ceil(bits_per_byte);
+    // Phantom bits map to frame numbers beyond FrameNumber::MAX and must be pre-marked
+    // as used so that alloc() never returns an out-of-range frame.
+    let scratch_phantom: usize = scratch_bytes * bits_per_byte - scratch_frames;
+
+    let total_bytes: usize = low_bytes + ramfs_bytes + scratch_bytes;
+
+    // Safety: the frame allocator storage has a static lifetime and is large enough
+    // to cover MEMORY_SIZE worth of frames.
+    let storage_len: usize = FRAME_ALLOCATOR_STORAGE.len();
+    if total_bytes > storage_len {
+        let reason: &str = "frame allocator storage too small for sparse layout";
+        error!(
+            "build_physical_memory_layout(): {} (need={:#x}, have={:#x})",
+            reason, total_bytes, storage_len
+        );
+        return Err(Error::new(ErrorCode::OutOfMemory, reason));
+    }
+
+    let base_ptr: *mut u8 = FRAME_ALLOCATOR_STORAGE.as_mut_ptr();
+    let mut offset: usize = 0;
+
+    // Build a bitmap chunk from the shared storage at the current offset.
+    // `num_bytes` is the byte-aligned storage size, `num_frames` is the real frame count,
+    // and `num_phantom` is the number of trailing padding bits to pre-mark as used.
+    let mut make_chunk =
+        |num_bytes: usize, num_frames: usize, num_phantom: usize| -> Result<Bitmap, Error> {
+            let storage: RawArray<u8> = RawArray::from_raw_parts(base_ptr.add(offset), num_bytes)?;
+            let mut bitmap: Bitmap = Bitmap::from_raw_array(storage)?;
+            for i in 0..num_phantom {
+                bitmap.set(num_frames + i)?;
+            }
+            offset += num_bytes;
+            Ok(bitmap)
+        };
+
+    // Low chunk: snapshot (and optionally RAMFS when merged).
+    let snapshot_start_frame: usize = snapshot_start_address / mem::FRAME_SIZE;
+    let low_bitmap: Bitmap = make_chunk(low_bytes, low_end_frame, low_phantom)?;
+    let mut chunks: vec::Vec<(usize, Bitmap)> = vec![(snapshot_start_frame, low_bitmap)];
+
+    // Separate RAMFS chunk (only when not merged with the snapshot).
+    if ramfs_bytes > 0 {
+        let ramfs_bitmap: Bitmap = make_chunk(ramfs_bytes, ramfs_frames, ramfs_phantom)?;
+        chunks.push((ramfs_start_frame, ramfs_bitmap));
+    }
+
+    // Scratch chunk: frames [scratch_start / FRAME_SIZE, ...).
+    if scratch_frames > 0 {
+        let scratch_bitmap: Bitmap = make_chunk(scratch_bytes, scratch_frames, scratch_phantom)?;
+        chunks.push((scratch_start_address / mem::FRAME_SIZE, scratch_bitmap));
+    }
+
+    SparseBitmap::new(chunks)
 }
 
 ///
@@ -1180,20 +1373,20 @@ unsafe fn parse_initrd_image(
     let initrd_cmdline: (u8, String) =
         read_initrd_cmdline(current_initrd_start, actual_initrd_size, total_allocation_size)?;
 
-    // Relocate initrd to default base address if needed.
-    let initrd_base: usize = if current_initrd_start != ::config::hyperlight::DEFAULT_INITRD_BASE {
+    // The ELF payload sits INITRD_SIZE_BYTES past the page-aligned init_data_start,
+    // so its address is not page-aligned.  Shift it back to init_data_start (the
+    // size header has already been consumed and is no longer needed).  The source
+    // and destination overlap, but core::ptr::copy handles that correctly.
+    let initrd_base: usize = init_data_start;
+    if current_initrd_start != initrd_base {
         let src_ptr: *const u8 = current_initrd_start as *const u8;
-        let dst_ptr: *mut u8 = ::config::hyperlight::DEFAULT_INITRD_BASE as *mut u8;
+        let dst_ptr: *mut u8 = initrd_base as *mut u8;
         core::ptr::copy(src_ptr, dst_ptr, actual_initrd_size);
-
         debug!(
-            "parse_initrd_image(): initrd relocated from {current_initrd_start:#010x} to {:#010x}",
-            ::config::hyperlight::DEFAULT_INITRD_BASE
+            "parse_initrd_image(): initrd shifted from {current_initrd_start:#010x} to \
+             {initrd_base:#010x}"
         );
-        ::config::hyperlight::DEFAULT_INITRD_BASE
-    } else {
-        current_initrd_start
-    };
+    }
 
     Ok((initrd_base, actual_initrd_size, initrd_cmdline))
 }

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -182,6 +182,20 @@ static KERNEL_PADDING: [u8; 2 * 1024 * 1024] = [0u8; 2 * 1024 * 1024];
 static mut GUEST_HANDLE: Option<GuestHandle> = None;
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Number of page tables needed for identity-mapping physical memory regions.
+///
+/// On Hyperlight the physical memory is split across two disjoint VA ranges: the low region
+/// (snapshot + RAMFS) starting near GPA 0 and the scratch region at the top of the 32-bit address
+/// space. Because both ranges occupy separate page directory entries, each can independently
+/// require up to `MEMORY_SIZE / PGTAB_SIZE` page tables. We provision twice the base count to cover
+/// the worst-case split.
+///
+pub const NUM_PAGE_TABLES: usize = 2 * (MEMORY_SIZE / mem::PGTAB_SIZE);
+
+//==================================================================================================
 // Structures
 //==================================================================================================
 

--- a/src/kernel/src/hal/platform/hyperlight/peb.rs
+++ b/src/kernel/src/hal/platform/hyperlight/peb.rs
@@ -87,13 +87,14 @@ impl ProcessEnvironmentBlock {
     pub unsafe fn get_credits() -> Result<u64, Error> {
         // Credits are stored at a fixed offset from the top of scratch memory.
         // The host writes here via GuestCounter; we read via volatile read.
-        // GVA = MAX_GVA - SCRATCH_TOP_GUEST_COUNTER_OFFSET + 1
+        // Use MAX_GPA (not MAX_GVA) because the guest runs with identity mapping
+        // (GVA == GPA) and the scratch KVM slot is placed relative to MAX_GPA.
         use ::hyperlight_common::layout::{
-            MAX_GVA,
+            MAX_GPA,
             SCRATCH_TOP_GUEST_COUNTER_OFFSET,
         };
-        let credits_gva: usize = MAX_GVA - SCRATCH_TOP_GUEST_COUNTER_OFFSET as usize + 1;
-        let credits_ptr: *const u64 = credits_gva as *const u64;
+        let credits_gpa: usize = MAX_GPA - SCRATCH_TOP_GUEST_COUNTER_OFFSET as usize + 1;
+        let credits_ptr: *const u64 = credits_gpa as *const u64;
         Ok(::core::ptr::read_volatile(credits_ptr))
     }
 

--- a/src/kernel/src/hal/platform/hyperlight/peb.rs
+++ b/src/kernel/src/hal/platform/hyperlight/peb.rs
@@ -45,7 +45,9 @@ impl ProcessEnvironmentBlock {
     /// Initializes the process environment block.
     ///
     /// # Safety
-    /// This function is unsafe because it handles a static mutable variable.
+    ///
+    /// This function is unsafe because it writes to the global `GUEST_HANDLE` static mutable.
+    ///
     pub unsafe fn init(peb_base: *mut HyperlightPEB) -> Result<(), Error> {
         if GUEST_HANDLE.peb().is_some() {
             let reason: &'static str = "init: peb already initialized";
@@ -79,7 +81,9 @@ impl ProcessEnvironmentBlock {
     /// Gets the number of credits available to the guest.
     ///
     /// # Safety
-    /// This function is unsafe because it dereferences a raw pointer.
+    ///
+    /// This function is unsafe because it dereferences a raw pointer at a fixed GVA.
+    ///
     pub unsafe fn get_credits() -> Result<u64, Error> {
         // Credits are stored at a fixed offset from the top of scratch memory.
         // The host writes here via GuestCounter; we read via volatile read.
@@ -96,7 +100,9 @@ impl ProcessEnvironmentBlock {
     /// Writes a message to the guest's standard output.
     ///
     /// # Safety
-    /// This function is unsafe because it uses a static mutable variable.
+    ///
+    /// This function is unsafe because it accesses the global `GUEST_HANDLE` static mutable.
+    ///
     pub unsafe fn vmbus_write(data: &[u8]) -> Result<(), Error> {
         let failure_reason: &'static str = "vmbus_write: failed to write data";
         let count: i32 = GUEST_HANDLE
@@ -117,7 +123,9 @@ impl ProcessEnvironmentBlock {
     /// Writes bulk data (header + payload) via the VmbusBulkWrite host function.
     ///
     /// # Safety
-    /// This function is unsafe because it uses a static mutable variable.
+    ///
+    /// This function is unsafe because it accesses the global `GUEST_HANDLE` static mutable.
+    ///
     pub unsafe fn vmbus_bulk_write(data: &[u8]) -> Result<(), Error> {
         let failure_reason: &'static str = "vmbus_bulk_write: failed to write data";
         let count: i32 = GUEST_HANDLE
@@ -138,7 +146,9 @@ impl ProcessEnvironmentBlock {
     /// Reads a message from the guest's standard input.
     ///
     /// # Safety
-    /// This function is unsafe because it uses a static mutable variable.
+    ///
+    /// This function is unsafe because it accesses the global `GUEST_HANDLE` static mutable.
+    ///
     pub unsafe fn vmbus_read() -> Result<Vec<u8>, Error> {
         let failure_reason: &'static str = "vmbus_read: failed to read data";
         GUEST_HANDLE
@@ -151,11 +161,55 @@ impl ProcessEnvironmentBlock {
     /// Returns an empty Vec when all bulk data has been consumed.
     ///
     /// # Safety
-    /// This function is unsafe because it uses a static mutable variable.
+    ///
+    /// This function is unsafe because it accesses the global `GUEST_HANDLE` static mutable.
+    ///
     pub unsafe fn vmbus_bulk_read() -> Result<Vec<u8>, Error> {
         let failure_reason: &'static str = "vmbus_bulk_read: failed to read data";
         GUEST_HANDLE
             .call_host_function::<Vec<u8>>("VmbusBulkRead", None, ReturnType::VecBytes)
             .map_err(|_| Error::new(ErrorCode::IoErr, failure_reason))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Queries the host for the authoritative physical memory layout.
+    ///
+    /// Returns `(snapshot_budget_size, pt_overhead, ramfs_base, ramfs_size, scratch_size)` as
+    /// reported by the VMM. All values are in bytes. RAMFS fields are zero when no RAMFS
+    /// is present. `snapshot_budget_size` is the deterministic snapshot size.
+    /// `pt_overhead` is always 0 with `nanvix-unstable` because Hyperlight skips
+    /// guest page-table generation; the field is reserved for forward-compatibility.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it accesses the global `GUEST_HANDLE` static mutable.
+    ///
+    pub unsafe fn get_memory_layout() -> Result<(usize, usize, usize, usize, usize), Error> {
+        let failure_reason: &'static str = "get_memory_layout: failed to query host";
+        let bytes: Vec<u8> = GUEST_HANDLE
+            .call_host_function::<Vec<u8>>("GetMemoryLayout", None, ReturnType::VecBytes)
+            .map_err(|_| Error::new(ErrorCode::IoErr, failure_reason))?;
+
+        const EXPECTED_LEN: usize = 20;
+        if bytes.len() < EXPECTED_LEN {
+            let reason: &'static str = "get_memory_layout: response too short";
+            error!("{reason} (got {} bytes, expected {EXPECTED_LEN})", bytes.len());
+            return Err(Error::new(ErrorCode::InvalidMessage, reason));
+        }
+
+        let snapshot_budget_size: usize =
+            u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+        let pt_overhead: usize =
+            u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as usize;
+        let ramfs_base: usize =
+            u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]) as usize;
+        let ramfs_size: usize =
+            u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]) as usize;
+        let scratch_size: usize =
+            u32::from_le_bytes([bytes[16], bytes[17], bytes[18], bytes[19]]) as usize;
+
+        Ok((snapshot_budget_size, pt_overhead, ramfs_base, ramfs_size, scratch_size))
     }
 }

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -307,6 +307,22 @@ pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
 ///
 /// # Description
 ///
+/// Returns the maximum physical address on the Microvm platform.
+///
+/// All physical memory is contiguous starting at GPA 0 up to `MEMORY_SIZE`.
+///
+/// # Returns
+///
+/// The maximum physical address value.
+///
+#[inline(always)]
+pub fn max_physical_address() -> usize {
+    config::kernel::MEMORY_SIZE - 1
+}
+
+///
+/// # Description
+///
 /// Parses boot information.
 ///
 /// # Parameters

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -12,6 +12,10 @@ pub mod pvclock;
 //==================================================================================================
 
 use crate::{
+    collections::{
+        Bitmap,
+        RawArray,
+    },
     hal::{
         arch::x86::{
             self,
@@ -47,11 +51,13 @@ use crate::{
 use ::alloc::{
     collections::LinkedList,
     string::ToString,
+    vec,
 };
 use ::arch::{
     cpu::pic,
     mem,
 };
+use ::sparse_bitmap::SparseBitmap;
 use ::sys::error::{
     Error,
     ErrorCode,
@@ -71,7 +77,19 @@ pub struct Platform {
     pub arch: Arch,
     #[cfg(all(feature = "pit", not(feature = "whp")))]
     pub _pit: Pit,
+    /// A sparse bitmap representing the physical memory layout, owned by the platform and consumed
+    /// by the memory manager during system initialization.
+    pub physical_memory_layout: Option<SparseBitmap>,
 }
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+/// Frame allocator storage.
+static mut FRAME_ALLOCATOR_STORAGE: [u8; config::kernel::MEMORY_SIZE
+    / (mem::FRAME_SIZE * u8::BITS as usize)] =
+    [0; config::kernel::MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)];
 
 //==================================================================================================
 // Standalone Functions
@@ -498,6 +516,24 @@ fn register_pit_ports(ioports: &mut IoPortAllocator) -> Result<(), Error> {
     Ok(())
 }
 
+///
+/// # Description
+///
+/// Initializes the microvm platform.
+///
+/// # Parameters
+///
+/// - `ioports`: I/O port allocator.
+/// - `ioaddresses`: I/O memory allocator.
+/// - `_memory_regions`: Memory regions.
+/// - `mmio_regions`: MMIO regions.
+/// - `madt`: MADT information.
+/// - `_mem_lower`: Lower memory size.
+///
+/// # Returns
+///
+/// Upon success, the initialized platform is returned. Upon failure, an error is returned instead.
+///
 pub fn init(
     ioports: &mut IoPortAllocator,
     ioaddresses: &mut IoMemoryAllocator,
@@ -564,9 +600,22 @@ pub fn init(
 
     let arch = x86::init(ioports, ioaddresses, madt)?;
 
+    // Build a sparse bitmap representing the physical memory layout.
+    let physical_memory_layout: SparseBitmap = {
+        // Safety: the frame allocator storage is valid and has a static lifetime.
+        let storage: RawArray<u8> = unsafe {
+            let (ptr, len): (*mut u8, usize) =
+                (FRAME_ALLOCATOR_STORAGE.as_mut_ptr(), FRAME_ALLOCATOR_STORAGE.len());
+            RawArray::from_raw_parts(ptr, len)?
+        };
+        let bitmap: Bitmap = Bitmap::from_raw_array(storage)?;
+        SparseBitmap::new(vec![(0, bitmap)])?
+    };
+
     Ok(Platform {
         arch,
         #[cfg(all(feature = "pit", not(feature = "whp")))]
         _pit: register_pit(ioports)?,
+        physical_memory_layout: Some(physical_memory_layout),
     })
 }

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -277,6 +277,25 @@ pub fn signal_startup_complete() {
 ///
 /// # Description
 ///
+/// Checks whether the given virtual address corresponds to a valid physical address on the Microvm
+/// platform.
+///
+/// # Parameters
+///
+/// - `addr`: The virtual address to validate.
+///
+/// # Returns
+///
+/// `true` if `addr` falls within the physical address space, `false` otherwise.
+///
+#[inline(always)]
+pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
+    addr < VirtualAddress::from_raw_value(config::kernel::MEMORY_SIZE)
+}
+
+///
+/// # Description
+///
 /// Parses boot information.
 ///
 /// # Parameters

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -70,6 +70,17 @@ use crate::hal::platform::region_tags::LAPIC_MMIO_TAG;
 use crate::hal::platform::pit::Pit;
 
 //==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Number of page tables needed for identity-mapping physical memory regions.
+///
+/// On microvm all physical memory is contiguous starting at GPA 0, so the base count
+/// (one page table per `PGTAB_SIZE` bytes) is sufficient.
+///
+pub const NUM_PAGE_TABLES: usize = config::kernel::MEMORY_SIZE / mem::PGTAB_SIZE;
+
+//==================================================================================================
 // Structures
 //==================================================================================================
 

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -307,6 +307,35 @@ pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
 ///
 /// # Description
 ///
+/// Checks whether the given physical memory region lies entirely within physical memory on the
+/// Microvm platform.
+///
+/// # Parameters
+///
+/// - `start`: Starting physical address of the region.
+/// - `size`: Size of the region in bytes.
+///
+/// # Returns
+///
+/// `true` if the entire region lies within physical memory, `false` otherwise.
+///
+#[inline(always)]
+pub fn is_valid_physical_region(start: usize, size: usize) -> bool {
+    // Reject zero-length regions.
+    if size == 0 {
+        return false;
+    }
+
+    // Compute the exclusive end, guarding against overflow.
+    match start.checked_add(size) {
+        Some(end) => end <= config::kernel::MEMORY_SIZE,
+        None => false,
+    }
+}
+
+///
+/// # Description
+///
 /// Returns the maximum physical address on the Microvm platform.
 ///
 /// All physical memory is contiguous starting at GPA 0 up to `MEMORY_SIZE`.

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -62,6 +62,7 @@ use ::core::sync::atomic::{
     AtomicUsize,
     Ordering,
 };
+use ::sparse_bitmap::SparseBitmap;
 use ::sys::{
     pm::ProcessIdentifier,
     ExitStatus,
@@ -320,14 +321,17 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
         }
     }
 
-    if let Err(err) =
-        Hal::init(&mut memory_regions, &mut mmio_regions, &mut ioaddresses, &madt, mem_lower)
-    {
-        panic!("failed to initialize hardware abstraction layer: {:?}", err);
-    }
+    let physical_memory_layout: SparseBitmap =
+        match Hal::init(&mut memory_regions, &mut mmio_regions, &mut ioaddresses, &madt, mem_lower)
+        {
+            Ok(bitmap) => bitmap,
+            Err(err) => {
+                panic!("failed to initialize hardware abstraction layer: {:?}", err);
+            },
+        };
 
     // Initialize the memory manager.
-    let root: Vmem = match mm::init(&kimage, memory_regions, mmio_regions) {
+    let root: Vmem = match mm::init(&kimage, memory_regions, mmio_regions, physical_memory_layout) {
         Ok(root) => root,
         Err(err) => {
             panic!("failed to initialize memory manager: {:?}", err);

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -65,6 +65,7 @@ use ::alloc::{
 };
 use ::arch::mem;
 use ::core::panic;
+use ::sparse_bitmap::SparseBitmap;
 use ::sys::error::Error;
 
 //==================================================================================================
@@ -234,11 +235,28 @@ fn parse_memory_regions(
     Ok((other_virtual_memory_regions, virtual_memory_regions, physical_memory_regions))
 }
 
+///
+/// # Description
+///
 /// Initializes the memory manager.
+///
+/// # Parameters
+///
+/// - `kimage`: Kernel image.
+/// - `memory_regions`: Memory regions.
+/// - `mmio_regions`: MMIO regions.
+/// - `physical_memory_layout`: Physical memory layout bitmap.
+///
+/// # Returns
+///
+/// Upon success, the root virtual memory manager is returned. Upon failure, an error is returned
+/// instead.
+///
 pub fn init(
     kimage: &KernelImage,
     memory_regions: LinkedList<MemoryRegion<VirtualAddress>>,
     mmio_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    physical_memory_layout: SparseBitmap,
 ) -> Result<Vmem, Error> {
     info!("initializing the memory manager ...");
 
@@ -255,6 +273,7 @@ pub fn init(
         TruncatedMemoryRegion::from_virtual_memory_region(kimage.kpool())?,
         physical_memory_regions,
         &mmio_regions,
+        physical_memory_layout,
     )?;
 
     #[cfg(feature = "test")]

--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -14,19 +14,12 @@
 // Imports
 //==================================================================================================
 
-use crate::{
-    collections::{
-        Bitmap,
-        RawArray,
-    },
-    hal::mem::{
-        FrameAddress,
-        PageAligned,
-        PhysicalAddress,
-        TruncatedMemoryRegion,
-    },
+use crate::hal::mem::{
+    FrameAddress,
+    PageAligned,
+    PhysicalAddress,
+    TruncatedMemoryRegion,
 };
-use ::alloc::vec;
 use ::arch::mem::{
     self,
     paging::FrameNumber,
@@ -250,24 +243,21 @@ fn instance() -> &'static mut Inner {
 /// # Safety
 ///
 /// Must be called exactly once during boot, before any other function
-/// in this module. `storage` must point to a live region for the
-/// program's lifetime.
-pub(super) unsafe fn init(storage: RawArray<u8>) -> Result<(), Error> {
+/// in this module.
+pub(super) unsafe fn init(bitmap: SparseBitmap) -> Result<(), Error> {
     if unlikely(INSTANCE_INIT.load(ORDER)) {
         return Err(Error::new(ErrorCode::InvalidArgument, "frame allocator already initialized"));
     }
 
-    let bitmap: Bitmap = Bitmap::from_raw_array(storage)?;
-    let sparse: SparseBitmap = SparseBitmap::new(vec![(0, bitmap)])?;
-
     info!(
-        "frame allocator: {} frames, {} MB, 1 chunk(s)",
-        sparse.capacity(),
-        (sparse.capacity() * mem::FRAME_SIZE) / constants::MEGABYTE,
+        "frame allocator: {} frames, {} MB, {} chunk(s)",
+        bitmap.capacity(),
+        (bitmap.capacity() * mem::FRAME_SIZE) / constants::MEGABYTE,
+        bitmap.chunk_count(),
     );
 
     // SAFETY: single-threaded boot; no other reference to `INSTANCE` exists.
-    unsafe { INSTANCE.write(Inner { bitmap: sparse }) };
+    unsafe { INSTANCE.write(Inner { bitmap }) };
     INSTANCE_INIT.store(true, ORDER);
     Ok(())
 }

--- a/src/kernel/src/mm/phys/mod.rs
+++ b/src/kernel/src/mm/phys/mod.rs
@@ -18,7 +18,6 @@ mod test;
 //==================================================================================================
 
 use crate::{
-    collections::RawArray,
     hal::mem::{
         Address,
         PageAligned,
@@ -30,6 +29,7 @@ use crate::{
 };
 use ::alloc::collections::LinkedList;
 use ::arch::mem;
+use ::sparse_bitmap::SparseBitmap;
 use ::sys::error::{
     Error,
     ErrorCode,
@@ -47,15 +47,6 @@ pub use self::{
     manager::PhysMemoryManager,
     upool::UserFrame,
 };
-
-//==================================================================================================
-// Global Variables
-//==================================================================================================
-
-/// Frame allocator storage.
-static mut FRAME_ALLOCATOR_STORAGE: [u8; config::kernel::MEMORY_SIZE
-    / (mem::FRAME_SIZE * u8::BITS as usize)] =
-    [0; config::kernel::MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)];
 
 //==================================================================================================
 // Standalone Functions
@@ -110,23 +101,33 @@ fn book_mmio_regions(
     Ok(())
 }
 
+///
+/// # Description
+///
+/// Initializes the physical memory manager.
+///
+/// # Parameters
+///
+/// - `kpool`: Kernel page pool region.
+/// - `physical_memory_regions`: Physical memory regions to book.
+/// - `mmio_regions`: Memory-mapped I/O regions to book.
+/// - `physical_memory_layout`: Physical memory layout bitmap.
+///
+/// # Returns
+///
+/// Upon success, the physical memory manager is returned. Upon failure, an error is returned
+/// instead.
+///
 pub fn init(
     kpool: TruncatedMemoryRegion<PhysicalAddress>,
     physical_memory_regions: LinkedList<TruncatedMemoryRegion<PhysicalAddress>>,
     mmio_regions: &LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    physical_memory_layout: SparseBitmap,
 ) -> Result<(), Error> {
     // Initialize frame allocator singleton.
     info!("initializing the frame allocator ...");
-    {
-        // Safety: the frame allocator storage is valid and has a static lifetime.
-        let storage: RawArray<u8> = unsafe {
-            let (ptr, len): (*mut u8, usize) =
-                (FRAME_ALLOCATOR_STORAGE.as_mut_ptr(), FRAME_ALLOCATOR_STORAGE.len());
-            RawArray::from_raw_parts(ptr, len)?
-        };
-        // Safety: called exactly once during single-threaded boot.
-        unsafe { frame::init(storage)? };
-    }
+    // Safety: called exactly once during single-threaded boot.
+    unsafe { frame::init(physical_memory_layout)? };
     book_physical_memory_regions(physical_memory_regions)?;
 
     book_mmio_regions(mmio_regions)?;

--- a/src/kernel/src/mm/virt/mod.rs
+++ b/src/kernel/src/mm/virt/mod.rs
@@ -159,6 +159,9 @@ pub fn init(
 ) -> Result<LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>, Error> {
     info!("booking virtual memory regions ...");
 
+    // Last valid physical address (inclusive).
+    let max_phys_addr: usize = crate::hal::platform::max_physical_address();
+
     let mut root_pagetables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)> =
         LinkedList::new();
 
@@ -267,8 +270,11 @@ pub fn init(
                 let start_index: usize = (raw_vaddr - pgtab_base) / mem::PAGE_SIZE;
                 let pgtab_remaining: usize = PAGE_TABLE_LENGTH - start_index;
                 let region_remaining: usize = (end - raw_vaddr) / mem::PAGE_SIZE + 1;
-                let memory_remaining: usize =
-                    config::kernel::MEMORY_SIZE.saturating_sub(raw_vaddr) / mem::PAGE_SIZE;
+                let memory_remaining: usize = if raw_vaddr > max_phys_addr {
+                    0
+                } else {
+                    (max_phys_addr - raw_vaddr) / mem::PAGE_SIZE + 1
+                };
                 let count: usize = pgtab_remaining.min(region_remaining).min(memory_remaining);
 
                 if count == 0 {
@@ -305,7 +311,7 @@ pub fn init(
                 raw_vaddr += count
                     .checked_mul(mem::PAGE_SIZE)
                     .expect("count * PAGE_SIZE overflow");
-                if raw_vaddr >= config::kernel::MEMORY_SIZE {
+                if raw_vaddr > max_phys_addr || raw_vaddr >= end {
                     break;
                 }
                 paddr = FrameAddress::new(PageAligned::from_address(
@@ -325,7 +331,7 @@ pub fn init(
                     region.perm(),
                 )?;
                 root_pagetables.push_back((page_table_addr, page_table));
-                if raw_vaddr == (config::kernel::MEMORY_SIZE - mem::PAGE_SIZE) {
+                if raw_vaddr == max_phys_addr - (mem::PAGE_SIZE - 1) {
                     break;
                 }
                 raw_vaddr += mem::PAGE_SIZE;

--- a/src/kernel/src/mm/virt/page_table_allocator.rs
+++ b/src/kernel/src/mm/virt/page_table_allocator.rs
@@ -31,7 +31,7 @@ use ::bump_allocator::{
 //==================================================================================================
 
 /// Number of page tables for identity-mapping all physical memory.
-const NUM_PAGE_TABLES: usize = config::kernel::MEMORY_SIZE / mem::PGTAB_SIZE;
+const NUM_PAGE_TABLES: usize = crate::hal::platform::NUM_PAGE_TABLES;
 
 /// Total number of kernel page-table-sized slots.
 ///

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -452,22 +452,7 @@ impl Vmem {
     /// Returns `true` if the entire region lies within physical memory, `false` otherwise.
     ///
     pub fn is_physical_region(start: usize, size: usize) -> bool {
-        // Reject zero-length regions.
-        if size == 0 {
-            return false;
-        }
-
-        // Check if the start and end addresses of the region lie within physical memory.
-        match start.checked_add(size - 1) {
-            Some(end) => {
-                let start_valid: bool =
-                    crate::hal::platform::is_valid_physical_address(VirtualAddress::new(start));
-                let end_valid: bool =
-                    crate::hal::platform::is_valid_physical_address(VirtualAddress::new(end));
-                start_valid && end_valid
-            },
-            None => false,
-        }
+        crate::hal::platform::is_valid_physical_region(start, size)
     }
 
     ///

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -59,7 +59,6 @@ use ::arch::{
         PGTAB_ALIGNMENT,
     },
 };
-use ::config::kernel::MEMORY_SIZE;
 use ::core::cell::RefCell;
 use ::sys::{
     config,
@@ -460,7 +459,13 @@ impl Vmem {
 
         // Check if the start and end addresses of the region lie within physical memory.
         match start.checked_add(size - 1) {
-            Some(end) => start < MEMORY_SIZE && end < MEMORY_SIZE,
+            Some(end) => {
+                let start_valid: bool =
+                    crate::hal::platform::is_valid_physical_address(VirtualAddress::new(start));
+                let end_valid: bool =
+                    crate::hal::platform::is_valid_physical_address(VirtualAddress::new(end));
+                start_valid && end_valid
+            },
             None => false,
         }
     }

--- a/src/libs/config/src/region_tags.rs
+++ b/src/libs/config/src/region_tags.rs
@@ -54,6 +54,9 @@ mod hyperlight {
 
     /// Tag used to identify the Hyperlight output data buffer MMIO region.
     pub const OUTPUT_BUF_MMIO_TAG: MmioTag = MmioTag::new(*b"OUTPUTBF");
+
+    /// Tag used to identify the Hyperlight scratch I/O MMIO region.
+    pub const SCRATCH_IO_MMIO_TAG: MmioTag = MmioTag::new(*b"SCRATCH ");
 }
 
 #[cfg(feature = "hyperlight")]

--- a/src/uservm/src/pal/linux.rs
+++ b/src/uservm/src/pal/linux.rs
@@ -432,6 +432,20 @@ impl FileMapping {
     pub fn size(&self) -> usize {
         self.size
     }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the mapped file contents as an immutable byte slice.
+    ///
+    /// # Returns
+    ///
+    /// An immutable byte slice covering the entire mapped file.
+    ///
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: The mapping is valid for `self.size` bytes for the lifetime of `self`.
+        unsafe { slice::from_raw_parts(self.ptr.cast::<u8>(), self.size) }
+    }
 }
 
 impl Drop for FileMapping {
@@ -515,6 +529,25 @@ mod tests {
         let result: Result<FileMapping> = FileMapping::mmap(path_string.as_str());
         assert!(result.is_err(), "mmap should fail for zero-length files");
 
+        fs::remove_file(&path)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_file_mapping_as_slice() -> Result<()> {
+        let path: PathBuf = unique_temp_path("nanvix-filemapping-as-slice")?;
+        let content: &[u8] = b"as_slice test content for FileMapping";
+        fs::write(&path, content)?;
+
+        let path_string: ::std::string::String = path.to_string_lossy().into_owned();
+        let mapping: FileMapping = FileMapping::mmap(path_string.as_str())?;
+
+        let slice: &[u8] = mapping.as_slice();
+        assert_eq!(slice.len(), content.len(), "slice length mismatch");
+        assert_eq!(slice, content, "slice contents differ from file contents");
+
+        drop(mapping);
         fs::remove_file(&path)?;
 
         Ok(())

--- a/src/uservm/src/pal/windows.rs
+++ b/src/uservm/src/pal/windows.rs
@@ -177,6 +177,20 @@ impl FileMapping {
     pub fn size(&self) -> usize {
         self.size
     }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the mapped file contents as an immutable byte slice.
+    ///
+    /// # Returns
+    ///
+    /// An immutable byte slice covering the entire mapped file.
+    ///
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: The mapping is valid for `self.size` bytes for the lifetime of `self`.
+        unsafe { ::std::slice::from_raw_parts(self.view.Value as *const u8, self.size) }
+    }
 }
 
 impl ::std::fmt::Debug for FileMapping {
@@ -250,6 +264,23 @@ mod tests {
         assert_eq!(loaded, payload);
 
         // Drop the mapping before deleting the file; the section handle keeps the file open.
+        drop(mapping);
+        fs::remove_file(path_buf).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn open_as_slice_returns_file_contents() -> Result<()> {
+        let (path_str, path_buf): (String, PathBuf) = unique_temp_path("as-slice")?;
+        let payload: &[u8] = b"as_slice test content for FileMapping";
+        fs::write(&path_buf, payload)?;
+
+        let mapping: FileMapping = FileMapping::open(&path_str)?;
+
+        let slice: &[u8] = mapping.as_slice();
+        assert_eq!(slice.len(), payload.len(), "slice length mismatch");
+        assert_eq!(slice, payload, "slice contents differ from file contents");
+
         drop(mapping);
         fs::remove_file(path_buf).ok();
         Ok(())

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -229,93 +229,75 @@ impl Vmm {
 
         let memory_size: usize = ::config::kernel::MEMORY_SIZE;
 
-        let guest_env: GuestEnvironment = if let Some(initrd_filename) = &args.initrd_filename {
-            match std::fs::read(initrd_filename) {
-                Ok(bytes) => {
-                    let initrd_size: usize = bytes.len();
-                    debug!("initrd: {} bytes", initrd_size);
+        // Get RAMFS file size (if present) for memory budget calculation.
+        let ramfs_file_size: usize = args
+            .ramfs_filename
+            .as_deref()
+            .map(Self::get_ramfs_size)
+            .transpose()?
+            .unwrap_or(0);
 
-                    // Detect whether this is a multibinary NVMB image or a single ELF.
-                    let is_multibinary: bool = initrd_size >= ::multibin::MAGIC.len()
-                        && bytes[..::multibin::MAGIC.len()] == ::multibin::MAGIC;
+        // Get kernel size for memory layout calculation.
+        let kernel_size: usize = Self::get_kernel_size(&args.kernel_filename).map_err(|e| {
+            error!("new(): failed to determine kernel size: {e:?}");
+            anyhow::anyhow!("failed to determine kernel size: {e:?}")
+        })?;
 
-                    // Build the init_data blob based on the initrd format.
-                    let init_data_bytes: Vec<u8> = if is_multibinary {
-                        // Multibinary: pass raw NVMB image, no wrapping needed.
-                        debug!("initrd: multibinary format detected, passing raw image");
-                        bytes
-                    } else {
-                        // Single ELF: prepend size header and append args (old format).
-                        let initrd_args_bytes: Vec<u8> =
-                            Self::build_args_bytes(initrd_filename, &args.initrd_args)?;
+        // Build the guest environment.
+        let (guest_env, init_data_size): (GuestEnvironment, usize) =
+            Self::build_guest_env(&args.kernel_filename, &args.initrd_filename, &args.initrd_args)?;
 
-                        let mut padded: Vec<u8> = Vec::with_capacity(
-                            ::config::hyperlight::INITRD_SIZE_BYTES
-                                + initrd_size
-                                + initrd_args_bytes.len(),
-                        );
+        // Compute memory layout parameters.
+        let kernel_end: usize = ::config::memory_layout::KERNEL_BASE_RAW + kernel_size;
+        let kpool_start: usize = ::config::kernel::KPOOL_BASE_RAW;
+        let kpool_end: usize = kpool_start + ::config::kernel::KPOOL_SIZE;
 
-                        // Write the actual size as first INITRD_SIZE_BYTES (little-endian).
-                        padded.extend_from_slice(&(initrd_size as u64).to_le_bytes());
-                        padded.extend_from_slice(&bytes);
-                        padded.extend_from_slice(&initrd_args_bytes);
+        let guest_heap_size: usize = Self::calculate_guest_heap_size(kernel_end, kpool_start)?;
 
-                        debug!(
-                            "initrd blob: {} bytes total ({} byte header + {} bytes data + {} \
-                             bytes args)",
-                            padded.len(),
-                            ::config::hyperlight::INITRD_SIZE_BYTES,
-                            initrd_size,
-                            initrd_args_bytes.len(),
-                        );
-
-                        padded
-                    };
-
-                    // Box the data to extend its lifetime.
-                    let boxed_data: Box<[u8]> = init_data_bytes.into_boxed_slice();
-                    let data_ref: &'static [u8] = Box::leak(boxed_data);
-
-                    GuestEnvironment {
-                        guest_binary: GuestBinary::FilePath(args.kernel_filename.to_string()),
-                        init_data: Some(GuestBlob {
-                            data: data_ref,
-                            permissions: MemoryRegionFlags::READ
-                                | MemoryRegionFlags::WRITE
-                                | MemoryRegionFlags::EXECUTE,
-                        }),
-                    }
-                },
-                Err(err) => {
-                    let reason: String = format!("failed to read initrd file {err:?}");
-                    error!("initrd(): {reason} (args={args:?})");
-                    return Err(anyhow::anyhow!("{reason}"));
-                },
-            }
-        } else {
-            GuestEnvironment::new(GuestBinary::FilePath(args.kernel_filename.to_string()), None)
+        // Snapshot budget equation:  MEMORY_SIZE = snapshot_budget_size + ramfs + scratch
+        // With nanvix-unstable, Hyperlight skips guest page-table generation in
+        // Snapshot::from_env(), so snapshot_budget_size equals Hyperlight's get_memory_size()
+        // exactly — there is no PT overhead.
+        let snapshot_budget_size: usize = {
+            let unaligned: usize = kpool_end.checked_add(init_data_size).ok_or_else(|| {
+                error!("new(): kpool_end + init_data_size overflow");
+                anyhow::anyhow!("kpool_end + init_data_size overflow")
+            })?;
+            ::sys::mm::align_up(unaligned, ::sys::mm::Alignment::Align4096).ok_or_else(|| {
+                error!("new(): snapshot budget alignment overflow");
+                anyhow::anyhow!("snapshot budget alignment overflow")
+            })?
         };
 
-        // The hyperlight heap covers everything from after the I/O buffers to the end of the
-        // usable guest physical memory. With `executable_heap` enabled, it is RWX so the kernel
-        // can execute code from the heap (used for process loading).
-        //
-        // The heap must be large enough to cover:
-        //   - Padding from structures_end to KPOOL_BASE
-        //   - KPOOL_SIZE (the kernel pool)
-        //   - Any remaining memory up to memory_size
-        //
-        // We compute heap_size as: memory_size - HYPERLIGHT_BASE_ADDRESS - overhead
-        // where overhead accounts for the kernel code, PEB, and I/O buffers that precede the heap.
-        // Since we don't know the exact kernel code size here (hyperlight computes it internally),
-        // we use memory_size as an upper bound. Hyperlight will allocate only what's needed.
-        let mut config: SandboxConfiguration = SandboxConfiguration::default();
+        // Scratch region: whatever remains after snapshot and ramfs.  This includes the input and
+        // output buffers for VmbusRead/VmbusWrite, the guest counter page, and the last page
+        // (0xFFFFF000) that Hyperlight reserves for bookkeeping (exception stack, allocator state).
+        let scratch_size: usize = memory_size
+            .checked_sub(
+                snapshot_budget_size
+                    .checked_add(ramfs_file_size)
+                    .ok_or_else(|| {
+                        error!("new(): snapshot_budget + ramfs_file_size overflow");
+                        anyhow::anyhow!("snapshot_budget + ramfs_file_size overflow")
+                    })?,
+            )
+            .ok_or_else(|| {
+                error!(
+                    "new(): memory_size ({memory_size:#x}) too small for snapshot_budget \
+                     ({snapshot_budget_size:#x}) + ramfs ({ramfs_file_size:#x})"
+                );
+                anyhow::anyhow!("memory_size too small for snapshot + ramfs")
+            })?;
 
-        // Set heap large enough to cover from after kernel structures through end of memory.
-        // The actual heap start depends on the kernel loaded size, PEB, and I/O buffers.
-        // We request enough heap so that the heap region extends well beyond KPOOL_BASE + KPOOL_SIZE.
-        let heap_size: usize = memory_size;
-        config.set_heap_size(heap_size as u64);
+        debug!(
+            "memory budget: memory_size={:#x}, snapshot_budget={:#x}, ramfs={:#x}, scratch={:#x}, \
+             guest_heap={:#x}",
+            memory_size, snapshot_budget_size, ramfs_file_size, scratch_size, guest_heap_size
+        );
+
+        let mut config: SandboxConfiguration = SandboxConfiguration::default();
+        config.set_heap_size(guest_heap_size as u64);
+        config.set_scratch_size(scratch_size);
 
         // Creates Hyperlight sandbox.
         let mut sandbox: UninitializedSandbox = UninitializedSandbox::new(guest_env, Some(config))
@@ -324,26 +306,89 @@ impl Vmm {
                 anyhow::anyhow!("{e:?}")
             })?;
 
+        // With nanvix-unstable, Hyperlight does not append page tables to the snapshot (the
+        // #[cfg(not(feature = "nanvix-unstable"))] block in Snapshot::from_env() is compiled out),
+        // so shared_mem_size() == snapshot_budget_size and pt_overhead is 0.  The field is kept in
+        // GetMemoryLayout for forward-compatibility.
+        let actual_snapshot: usize = sandbox.shared_mem_size();
+        let pt_overhead: usize = actual_snapshot.saturating_sub(snapshot_budget_size);
+        debug!(
+            "actual layout: snapshot={:#x} (budget={:#x}, pt_overhead={:#x}), ramfs={:#x}, \
+             scratch={:#x}",
+            actual_snapshot, snapshot_budget_size, pt_overhead, ramfs_file_size, scratch_size
+        );
+
         // Map RAMFS file into sandbox memory if provided.
         // The file is mapped copy-on-write at the first GPA after the sandbox's
         // shared memory slot. With nanvix-unstable, BASE_ADDRESS is 0x0 so the
-        // shared memory occupies GPA [0, shared_mem_size). The file mapping
-        // metadata is automatically written to the PEB during evolve(), so the
-        // guest kernel can discover and identity-map the RAMFS region during boot.
+        // shared memory occupies GPA [0, shared_mem_size).
+        let mut layout_ramfs_base: u32 = 0;
+        let mut layout_ramfs_size: u32 = 0;
         if let Some(ramfs_filename) = &args.ramfs_filename {
             let ramfs_path: &Path = Path::new(ramfs_filename);
             let ramfs_gpa: u64 = sandbox.shared_mem_size() as u64;
-            let ramfs_size: u64 = sandbox
+            let mapped_size: u64 = sandbox
                 .map_file_cow(ramfs_path, ramfs_gpa, Some(RAMFS_LABEL))
                 .map_err(|e| {
                     error!("failed to map ramfs file: {e:?}");
                     anyhow::anyhow!("failed to map ramfs file: {e:?}")
                 })?;
+            layout_ramfs_base = u32::try_from(ramfs_gpa).map_err(|_| {
+                error!("new(): ramfs GPA {ramfs_gpa:#x} exceeds u32::MAX");
+                anyhow::anyhow!("ramfs GPA {ramfs_gpa:#x} exceeds u32::MAX")
+            })?;
+            layout_ramfs_size = u32::try_from(mapped_size).map_err(|_| {
+                error!("new(): ramfs mapped size {mapped_size:#x} exceeds u32::MAX");
+                anyhow::anyhow!("ramfs mapped size {mapped_size:#x} exceeds u32::MAX")
+            })?;
+            if layout_ramfs_size as usize != ramfs_file_size {
+                error!(
+                    "new(): ramfs mapped size ({mapped_size:#x}) differs from expected \
+                     ramfs_file_size ({ramfs_file_size:#x})"
+                );
+                return Err(anyhow::anyhow!(
+                    "ramfs mapped size ({mapped_size:#x}) differs from expected ramfs_file_size \
+                     ({ramfs_file_size:#x})"
+                ));
+            }
             debug!(
                 "ramfs: mapped {:?} ({} bytes) at GPA {:#010x}",
-                ramfs_path, ramfs_size, ramfs_gpa
+                ramfs_path, mapped_size, ramfs_gpa
             );
         }
+
+        // Build the memory layout descriptor and register the GetMemoryLayout host function.  The
+        // guest kernel calls this during init() to discover the authoritative snapshot, RAMFS, and
+        // scratch region boundaries instead of inferring them from fragile address calculations.
+        //
+        // pt_overhead is always 0 with nanvix-unstable (no guest page tables in the snapshot).  The
+        // field is preserved for forward-compatibility if upstream Hyperlight re-enables page-table
+        // generation for this feature.
+        let layout_snapshot_budget: u32 = u32::try_from(snapshot_budget_size).map_err(|_| {
+            anyhow::anyhow!("snapshot_budget {snapshot_budget_size:#x} exceeds u32::MAX")
+        })?;
+        let layout_pt_overhead: u32 = u32::try_from(pt_overhead)
+            .map_err(|_| anyhow::anyhow!("pt_overhead {pt_overhead:#x} exceeds u32::MAX"))?;
+        let layout_scratch_size: u32 = u32::try_from(scratch_size)
+            .map_err(|_| anyhow::anyhow!("scratch_size {scratch_size:#x} exceeds u32::MAX"))?;
+        let layout_bytes: Vec<u8> = [
+            layout_snapshot_budget.to_le_bytes(),
+            layout_pt_overhead.to_le_bytes(),
+            layout_ramfs_base.to_le_bytes(),
+            layout_ramfs_size.to_le_bytes(),
+            layout_scratch_size.to_le_bytes(),
+        ]
+        .concat();
+        sandbox.register("GetMemoryLayout", move || -> Vec<u8> { layout_bytes.clone() })?;
+        debug!(
+            "GetMemoryLayout: snapshot_budget={:#x}, pt_overhead={:#x}, ramfs_base={:#x}, \
+             ramfs_size={:#x}, scratch={:#x}",
+            layout_snapshot_budget,
+            layout_pt_overhead,
+            layout_ramfs_base,
+            layout_ramfs_size,
+            layout_scratch_size
+        );
 
         // Create a guest counter backed by a fixed offset in scratch memory.
         // The counter holds its own Arc clones of the mapping handle and RwLock,
@@ -608,5 +653,257 @@ impl Vmm {
         };
 
         Ok([&[args_len], &args_bytes[..]].concat())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the page-aligned size of the kernel after it is loaded in memory.
+    ///
+    /// This is computed as the end address of the highest PT_LOAD segment in the ELF32 binary,
+    /// rounded up to page alignment. The result corresponds to the first GPA after the kernel's
+    /// in-memory image, where Hyperlight places the PEB.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: The file path to the kernel ELF32 binary.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns the page-aligned in-memory size of the kernel. On failure, returns an
+    /// error.
+    ///
+    fn get_kernel_size(path: &str) -> Result<usize> {
+        #[cfg(target_os = "linux")]
+        let mapping: crate::pal::FileMapping = crate::pal::FileMapping::mmap(path)?;
+        #[cfg(target_os = "windows")]
+        let mapping: crate::pal::FileMapping = crate::pal::FileMapping::open(path)?;
+        let footprint: crate::elf::MemoryFootprint =
+            crate::elf::memory_footprint(mapping.as_slice())?;
+        ::sys::mm::align_up(footprint.end(), ::sys::mm::Alignment::Align4096).ok_or_else(|| {
+            error!("get_kernel_size(): ELF end address alignment overflow");
+            anyhow::anyhow!("ELF end address alignment overflow")
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Computes the Hyperlight Guest Heap size needed to bridge the gap between the PEB and the
+    /// end of the Kernel Pool.
+    ///
+    /// Hyperlight lays out the snapshot region (all page-aligned) as:
+    ///   [Kernel code + Data] [PEB Struct] [Guest Heap] [Init Data] [Guest Page Tables]
+    ///
+    /// The Nanvix kernel expects the following physical memory layout:
+    ///   [Kernel Code + Data] [Kernel Pool] [Init RAM Disk]
+    /// Where the base address of the kernel pool (kpool_base) must be aligned to a page-table
+    /// boundary (4 MB).
+    ///
+    /// Because kpool_base is 4 MB-aligned while kernel_end + PEB_SIZE may not be, the Guest Heap
+    /// is split into two parts:
+    ///
+    ///   guest_heap_padding = kpool_start - (kernel_end + PEB_SIZE)
+    ///   KPOOL_SIZE         = size of the kernel page pool
+    ///   guest_heap_size    = guest_heap_padding + KPOOL_SIZE
+    ///
+    /// ```text
+    ///   |<-- Kernel -->|<-PEB->|<- padding ->|<---- kpool ---->|
+    ///                          ^             ^                 ^
+    ///                   guest_heap_start  kpool_start      kpool_end
+    ///                          |<- padding ->|<-- KPOOL_SIZE -->|
+    ///                          |<-------- guest_heap_size ------>|
+    /// ```
+    ///
+    /// # Parameters
+    ///
+    /// - `kernel_end`: The first GPA after the kernel's in-memory image (page-aligned).
+    /// - `kpool_start`: The base address of the kernel pool (page-table-aligned, 4 MB).
+    ///
+    /// # Returns
+    ///
+    /// On success, returns the guest heap size in bytes. On failure (if the PEB overlaps the
+    /// kernel pool), returns an error.
+    ///
+    fn calculate_guest_heap_size(kernel_end: usize, kpool_start: usize) -> Result<usize> {
+        let guest_heap_start: usize = kernel_end + ::config::hyperlight::PEB_SIZE;
+
+        if guest_heap_start > kpool_start {
+            let reason: String = format!(
+                "kernel_end + PEB ({guest_heap_start:#x}) overlaps kpool_start ({kpool_start:#x})"
+            );
+            error!("calculate_guest_heap_size(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
+        let guest_heap_padding: usize = kpool_start - guest_heap_start;
+        Ok(guest_heap_padding + ::config::kernel::KPOOL_SIZE)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Builds the guest environment from the kernel and optional initrd files.
+    ///
+    /// If an initrd is provided, it is read into memory and packaged as init_data for the
+    /// sandbox. Multibinary images are passed through as-is; single ELF images are wrapped
+    /// with a size header and argument trailer.
+    ///
+    /// # Parameters
+    ///
+    /// - `kernel_filename`: Path to the kernel ELF binary.
+    /// - `initrd_filename`: Optional path to the initial RAM disk file.
+    /// - `initrd_args`: Optional arguments to pass to the initrd program.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns a tuple of the guest environment and the page-aligned init_data size
+    /// in bytes (0 when no initrd is provided). On failure, returns an error.
+    ///
+    fn build_guest_env(
+        kernel_filename: &str,
+        initrd_filename: &Option<String>,
+        initrd_args: &Option<String>,
+    ) -> Result<(GuestEnvironment<'static, 'static>, usize)> {
+        let Some(initrd_filename) = initrd_filename else {
+            return Ok((
+                GuestEnvironment::new(GuestBinary::FilePath(kernel_filename.to_string()), None),
+                0,
+            ));
+        };
+
+        let bytes: Vec<u8> = std::fs::read(initrd_filename).map_err(|err| {
+            let reason: String = format!("failed to read initrd file {err:?}");
+            error!("build_guest_env(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        let initrd_size: usize = bytes.len();
+        debug!("initrd: {} bytes", initrd_size);
+
+        // Detect whether this is a multibinary image or a single ELF.
+        let is_multibinary: bool = initrd_size >= ::multibin::MAGIC.len()
+            && bytes[..::multibin::MAGIC.len()] == ::multibin::MAGIC;
+
+        // Build the init_data blob based on the initrd format.
+        let init_data_bytes: Vec<u8> = if is_multibinary {
+            // Multibinary: pass raw image, no wrapping needed.
+            debug!("initrd: multibinary format detected, passing raw image");
+            bytes
+        } else {
+            // Single ELF: prepend size header and append args (old format).
+            let initrd_args_bytes: Vec<u8> = Self::build_args_bytes(initrd_filename, initrd_args)?;
+
+            let mut padded: Vec<u8> = Vec::with_capacity(
+                ::config::hyperlight::INITRD_SIZE_BYTES + initrd_size + initrd_args_bytes.len(),
+            );
+
+            // Write the actual size as first INITRD_SIZE_BYTES (little-endian).
+            padded.extend_from_slice(&(initrd_size as u64).to_le_bytes());
+            padded.extend_from_slice(&bytes);
+            padded.extend_from_slice(&initrd_args_bytes);
+
+            debug!(
+                "initrd blob: {} bytes total ({} byte header + {} bytes data + {} bytes args)",
+                padded.len(),
+                ::config::hyperlight::INITRD_SIZE_BYTES,
+                initrd_size,
+                initrd_args_bytes.len(),
+            );
+
+            padded
+        };
+
+        let init_data_blob_size: usize = init_data_bytes.len();
+
+        // Page-align the init_data size (Hyperlight places it at page boundaries).
+        let init_data_size: usize =
+            ::sys::mm::align_up(init_data_blob_size, ::sys::mm::Alignment::Align4096).ok_or_else(
+                || {
+                    error!("build_guest_env(): init_data alignment overflow");
+                    anyhow::anyhow!("init_data alignment overflow")
+                },
+            )?;
+
+        // Intentionally leaked to obtain a `'static` reference required by GuestBlob.
+        // The sandbox owns this memory for the lifetime of the process.
+        let boxed_data: Box<[u8]> = init_data_bytes.into_boxed_slice();
+        let data_ref: &'static [u8] = Box::leak(boxed_data);
+
+        let guest_env: GuestEnvironment = GuestEnvironment {
+            guest_binary: GuestBinary::FilePath(kernel_filename.to_string()),
+            init_data: Some(GuestBlob {
+                data: data_ref,
+                permissions: MemoryRegionFlags::READ
+                    | MemoryRegionFlags::WRITE
+                    | MemoryRegionFlags::EXECUTE,
+            }),
+        };
+
+        Ok((guest_env, init_data_size))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the page-aligned size of a RAMFS file.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: The file path to the RAMFS image.
+    ///
+    /// # Returns
+    ///
+    /// On success, returns the page-aligned file size. On failure, returns an error.
+    ///
+    fn get_ramfs_size(path: &str) -> Result<usize> {
+        let metadata: std::fs::Metadata = std::fs::metadata(path).map_err(|err| {
+            let reason: String = format!("failed to read ramfs metadata for '{path}': {err}");
+            error!("get_ramfs_size(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        let size: usize = usize::try_from(metadata.len()).map_err(|_| {
+            let reason: &str = "ramfs file size exceeds usize";
+            error!("get_ramfs_size(): {reason}");
+            anyhow::anyhow!(reason)
+        })?;
+
+        // Page-align the RAMFS size (hyperlight maps at page granularity).
+        ::sys::mm::align_up(size, ::sys::mm::Alignment::Align4096).ok_or_else(|| {
+            error!("get_ramfs_size(): ramfs size alignment overflow");
+            anyhow::anyhow!("ramfs size alignment overflow")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Vmm;
+
+    #[test]
+    fn calculate_guest_heap_size_typical() {
+        // kernel_end well below kpool_start: padding + KPOOL_SIZE.
+        let kernel_end: usize = 0x0020_0000;
+        let kpool_start: usize = 0x0040_0000;
+        let result: usize = Vmm::calculate_guest_heap_size(kernel_end, kpool_start)
+            .expect("should succeed for valid layout");
+        let expected_padding: usize = kpool_start - kernel_end - ::config::hyperlight::PEB_SIZE;
+        assert_eq!(result, expected_padding + ::config::kernel::KPOOL_SIZE);
+    }
+
+    #[test]
+    fn calculate_guest_heap_size_overlap() {
+        // kernel_end + PEB exceeds kpool_start: must fail.
+        let kpool_start: usize = 0x0010_0000;
+        let kernel_end: usize = kpool_start; // PEB would push past kpool_start.
+        let result = Vmm::calculate_guest_heap_size(kernel_end, kpool_start);
+        assert!(result.is_err(), "should fail when PEB overlaps kpool");
+    }
+
+    #[test]
+    fn get_ramfs_size_missing_file() {
+        let result = Vmm::get_ramfs_size("/nonexistent/path/to/ramfs.img");
+        assert!(result.is_err(), "should fail for missing file");
     }
 }

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -271,7 +271,7 @@ impl Vmm {
 
         // Scratch region: whatever remains after snapshot and ramfs.  This includes the input and
         // output buffers for VmbusRead/VmbusWrite, the guest counter page, and the last page
-        // (0xFFFFF000) that Hyperlight reserves for bookkeeping (exception stack, allocator state).
+        // that Hyperlight reserves for bookkeeping (exception stack, allocator state).
         let scratch_size: usize = memory_size
             .checked_sub(
                 snapshot_budget_size


### PR DESCRIPTION
Closes #2073 

Rework the Hyperlight platform's physical memory tracking and I/O buffer registration to reflect the actual sparse memory layout (snapshot, RAMFS, scratch) instead of treating it as a single contiguous region.

## Kernel (`hal/platform/hyperlight`)

- Replace the monolithic `MEMORY_BASE_ADDRESS` / `MEMORY_END_ADDRESS` atomics with per-region bounds: `SNAPSHOT_BASE/END`, `RAMFS_BASE/END`, `SCRATCH_BASE/END`. Initialize snapshot bounds statically so early-boot code can construct `PhysicalAddress` values before `init()`; tighten them in `init()` once RAMFS and scratch sizes are known.
- Rewrite `is_valid_physical_address()` to check all three regions.
- Remove the old input/output buffer, kpool guard, and guest user stack MMIO registrations from the snapshot region. Instead, discover the scratch region size from the PEB at runtime and register only the MMIO-critical portions (input buffer, output buffer, top page) inside the scratch region. Frames between these are left free for user-page allocation.
- Build a multi-chunk `SparseBitmap` (one chunk per region) backed by sub-slices of `FRAME_ALLOCATOR_STORAGE`. Mark phantom bits in the snapshot and scratch chunks as used.
- Delegate `max_physical_address()` and `NUM_PAGE_TABLES` to per-platform constants/functions.
- Use platform-specific `is_valid_physical_address()` in `Vmem::is_valid_paddr_range()`.

## UserVM (`vmm/hyperlight`)

- Estimate the snapshot footprint from PEB size, init-data blob size, and i686 page-table count, then size the heap to cover up to `DEFAULT_INITRD_BASE`.
- Compute `scratch_size` as the remaining budget after snapshot and RAMFS, and pass it to `SandboxConfiguration::set_scratch_size()`.
- Read RAMFS file size via metadata and page-align it; propagate errors instead of panicking.
- Log actual vs estimated layout for post-boot diagnostics.