### PR TITLE
[uservm] Implement two-phase sandbox lifecycle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ fat32 = { path = "src/libs/fat32", default-features = false }
 # fatfs: pinned to a git revision because the crate is not published on
 # crates.io and we need the no_std + alloc feature set.
 fatfs = { git = "https://github.com/rafalh/rust-fatfs", rev = "4eccb50d011146fbed20e133d33b22f3c27292e7", default-features = false }
+flatbuffers = { version = "25.12.19", default-features = false }
 flexi_logger = "0.31.8"
 globset = { version = "0.4.18", default-features = false }
 gdbstub = { version = "0.7", default-features = false, features = ["std"] }

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -29,6 +29,7 @@ raw-array = { workspace = true }
 slab = { workspace = true }
 sorted-vec = { workspace = true }
 sys = { workspace = true }
+flatbuffers = { workspace = true, optional = true }
 hyperlight-common = { workspace = true, optional = true }
 hyperlight-guest = { workspace = true, optional = true }
 multibin = { workspace = true, optional = true }
@@ -46,6 +47,7 @@ hyperlight = [
     "puts",
     "stdio",
     "pit",
+    "dep:flatbuffers",
     "dep:hyperlight-common",
     "dep:hyperlight-guest",
     "dep:config",

--- a/src/kernel/src/hal/arch/x86/asm/start.rs
+++ b/src/kernel/src/hal/arch/x86/asm/start.rs
@@ -22,6 +22,17 @@ use ::core::arch::global_asm;
 /// static data.
 const CLEAR_BSS: u32 = if cfg!(feature = "microvm") { 0 } else { 1 };
 
+/// Whether to run the Hyperlight evolve phase before calling `kmain`.
+///
+/// On Hyperlight, the bootstrap code must halt the VM during `evolve()` before entering `kmain()`.
+/// The host then calls `sandbox.call("kmain", ())` which re-enters the guest at `_nanvix_dispatch`,
+/// restores the boot stack, and calls `kmain()` for real.
+///
+/// Evaluates to 0 on all other platforms; the assembler `.if` directive eliminates the
+/// `call hyperlight_pre_kmain` instruction entirely at compile time.
+///
+const HYPERLIGHT_EVOLVE: u32 = if cfg!(feature = "hyperlight") { 1 } else { 0 };
+
 //==================================================================================================
 // Bootstrap Section — BSP Entry Point
 //==================================================================================================
@@ -85,6 +96,13 @@ global_asm!(
     "    xorl %edi, %edi",
 
     // Call kernel main function.
+    //
+    // On Hyperlight, the evolve phase must halt the VM before kmain runs. `hyperlight_pre_kmain()`
+    // registers the dispatch entry point and halts; it never returns. The host then calls
+    // sandbox.call("kmain", ()) which enters `_nanvix_dispatch` → `kmain``.
+    ".if {HYPERLIGHT_EVOLVE}",
+    "    call hyperlight_pre_kmain",
+    ".endif",
     "    push %esp",
     "    call kmain",
     "    addl $4, %esp",
@@ -97,6 +115,7 @@ global_asm!(
     "    jmp 1b",
 
     CLEAR_BSS = const CLEAR_BSS,
+    HYPERLIGHT_EVOLVE = const HYPERLIGHT_EVOLVE,
     PAGE_SIZE = const PAGE_SIZE,
     CONTEXT_HW_SIZE = const ContextInformation::CONTEXT_HW_SIZE,
     KSTACK_GUARD_PATTERN = const constants::KSTACK_GUARD_PATTERN,

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -49,6 +49,7 @@ use crate::{
 };
 use ::alloc::{
     collections::linked_list::LinkedList,
+    format,
     string::{
         String,
         ToString,
@@ -65,12 +66,22 @@ use ::config::hyperlight::{
     PEB_SIZE,
 };
 use ::hyperlight_common::{
+    flatbuffer_wrappers::{
+        function_call::FunctionCall,
+        function_types::FunctionCallResult,
+        guest_error::{
+            ErrorCode as GuestErrorCode,
+            GuestError,
+        },
+    },
     layout::MAX_GVA,
     mem::{
         FileMappingInfo,
         HyperlightPEB,
     },
+    outb::VmAction,
 };
+use ::hyperlight_guest::guest_handle::handle::GuestHandle;
 use ::sys::{
     config::memory_layout,
     error::{
@@ -84,6 +95,61 @@ use ::sys::{
     },
 };
 
+// =================================================================================================
+// _nanvix_dispatch — Entry point for guest function calls
+// =================================================================================================
+//
+// Entry point used by guest function calls.
+//
+// How Hyperlight captures and restores the entry point:
+//
+// 1. During `evolve()` (Hyperlight's `initialise`), the VM runs until a HLT.  When
+//    `hyperlight_pre_kmain()` halts via VmAction::Halt, Hyperlight reads the vCPU registers and
+//    stores:
+//      - `self.entrypoint = NextAction::Call(regs.rax)` — the address of
+//        `_nanvix_dispatch`, which the kernel placed in EAX before halting.
+//      - `self.rsp_gva = regs.rsp` — the stack pointer at halt time.
+//
+// 2. When the host calls `sandbox.call("kmain", ())`, Hyperlight serialises the function name and
+//    arguments into the PEB input buffer, then `dispatch_call_from_host()` sets RIP to the stored
+//    dispatch address and resumes the VM.
+//
+// 3. `_nanvix_dispatch` restores the boot stack, reconstructs a `&KernelArguments`
+//    pointer, and calls `nanvix_dispatch_function`. That Rust function reads the
+//    `FunctionCall` from the PEB input buffer, validates the function name, and
+//    dispatches to `kmain`.
+//
+::core::arch::global_asm!(
+    r#".section .text,"ax",@progbits"#,
+    ".code32",
+    ".extern kstack",
+    ".extern nanvix_dispatch_function",
+    ".globl _nanvix_dispatch",
+    "_nanvix_dispatch:",
+    // When Hyperlight's `dispatch_call_from_host()` resumes the VM here, all general-purpose
+    // registers are zeroed except RSP (restored to the value saved during evolve) and RFLAGS (RES1
+    // set; ZF may be set to signal a pending TLB flush). Segment registers are not touched — they
+    // retain whatever state was left after `evolve()`.
+    //
+    // Restore the boot stack. The KernelArguments (magic, info) are still
+    // at kstack-8 from _do_start2's pushes during the evolve phase.
+    //
+    // NOTE: after snapshot/restore support is added, kstack will be CoW-ed
+    // and this simple restore may need updating.
+    "    movl $kstack, %esp",
+    "    movl %esp, %ebp",
+    "    subl $8, %esp",
+    // Push the KernelArguments pointer and call the high-level dispatcher.
+    "    push %esp",
+    "    call nanvix_dispatch_function",
+    "    addl $4, %esp",
+    "    addl $8, %esp",
+    // nanvix_dispatch_function should never return; halt as a safety net.
+    "2:  hlt",
+    "    jmp 2b",
+    options(att_syntax),
+);
+
 //==================================================================================================
 // Global Variables
 //==================================================================================================
@@ -93,6 +159,10 @@ use ::sys::{
 #[unsafe(no_mangle)]
 #[used]
 static KERNEL_PADDING: [u8; 2 * 1024 * 1024] = [0u8; 2 * 1024 * 1024];
+
+/// Guest handle initialised once during `hyperlight_pre_kmain` (evolve phase)
+/// and reused by `nanvix_dispatch_function` on each `sandbox.call()`.
+static mut GUEST_HANDLE: Option<GuestHandle> = None;
 
 //==================================================================================================
 // Structures
@@ -359,10 +429,132 @@ pub(in crate::hal::platform) fn do_shutdown(status: usize) -> ! {
 ///
 /// # Description
 ///
-/// Signals the VMM that the kernel has finished booting and user-space
-/// applications are about to start. No-op on the Hyperlight platform.
+/// Signals the VMM that kernel startup is complete and user-space applications are about to start.
 ///
-pub fn signal_boot_complete() {}
+/// On Hyperlight this is a no-op because the evolve/run lifecycle already
+/// communicates boot readiness to the host.
+///
+pub fn signal_startup_complete() {}
+
+///
+/// # Description
+///
+/// Hyperlight evolve-phase entry point, called from `_do_start2` before `kmain`.
+///
+/// Performs one-time initialization that subsequent `sandbox.call()` invocations depend on:
+///
+/// 1. Initializes the kernel heap (needed for FunctionCall deserialisation).
+/// 2. Computes the PEB base address and stores a [`GuestHandle`] in [`GUEST_HANDLE`] for reuse
+///    by [`nanvix_dispatch_function`].
+/// 3. Halts the VM by writing the `_nanvix_dispatch` address to EAX and issuing `VmAction::Halt`
+///    causing `evolve()` to return on the host with a `MultiUseSandbox`.
+///
+/// Hyperlight captures `regs.rax` as the dispatch entry point when the halt completes — this is how
+/// the host knows where to jump on the next `call()`.  See the comment block above
+/// `_nanvix_dispatch` for the full protocol.
+///
+/// This function never returns — the VM is halted by the `out` instruction and Hyperlight regains
+/// control. The `options(noreturn)` ensures the compiler does not emit a stack epilogue that would
+/// never execute.
+///
+#[unsafe(no_mangle)]
+extern "C" fn hyperlight_pre_kmain() -> ! {
+    extern "C" {
+        fn _nanvix_dispatch();
+        static __KERNEL_END: u8;
+    }
+
+    // Initializes the kernel heap once so FunctionCall deserialisation can allocate on every
+    // subsequent sandbox.call().  On Hyperlight the heap is only initialised here (during evolve);
+    // kmain skips heap init via `#[cfg(not(feature = "hyperlight"))]`.
+    if let Err(_e) = unsafe { crate::mm::kheap::init() } {
+        unsafe {
+            core::arch::asm!("cli", "2: hlt", "jmp 2b", options(noreturn));
+        }
+    }
+
+    // Compute the PEB base address and store a GuestHandle for reuse.
+    let kernel_end: usize = unsafe { &__KERNEL_END as *const u8 as usize };
+    let peb_base: usize = ::sys::mm::align_up(kernel_end, PAGE_ALIGNMENT)
+        .expect("hyperlight_pre_kmain(): PEB align_up overflow");
+    let peb_ptr: *mut HyperlightPEB = peb_base as *mut HyperlightPEB;
+    unsafe {
+        GUEST_HANDLE = Some(GuestHandle::init(peb_ptr));
+    }
+
+    let dispatch_addr: u32 = _nanvix_dispatch as *const () as u32;
+    // SAFETY: Port I/O write targets Hyperlight's VmAction::Halt port with the dispatch address in
+    // EAX. This halts the VM and causes evolve() to return.  ESP must be 16-byte aligned at the
+    // halt point because Hyperlight validates alignment when reading registers after initialise
+    // completes.
+    //
+    // The halt+hlt sequence is entirely in assembly so no Rust stack epilogue is skipped.
+    // options(noreturn) tells the compiler this block diverges.
+    unsafe {
+        core::arch::asm!(
+            "and esp, 0xFFFFFFF0",
+            "mov eax, {0:e}",
+            "mov dx, {HALT_PORT}",
+            "out dx, al",
+            "cli",
+            "2: hlt",
+            "jmp 2b",
+            in(reg) dispatch_addr,
+            HALT_PORT = const VmAction::Halt as u16,
+            options(noreturn),
+        );
+    }
+}
+
+///
+/// # Description
+///
+/// High-level guest function dispatcher called by `_nanvix_dispatch`.
+///
+/// Reads the [`FunctionCall`] that the host serialised into the PEB input
+/// buffer, validates the function name, and dispatches to the corresponding
+/// handler.  Currently the only recognised function is `"kmain"`.
+///
+/// For unrecognised functions a [`GuestError`] is written back to the PEB
+/// output buffer so the host receives a proper error instead of a raw abort.
+///
+/// # Parameters
+///
+/// - `kargs`: Kernel arguments reconstructed by the `_nanvix_dispatch` stub.
+///
+#[unsafe(no_mangle)]
+extern "C" fn nanvix_dispatch_function(kargs: &crate::kargs::KernelArguments) {
+    // SAFETY: GUEST_HANDLE is initialised once in hyperlight_pre_kmain
+    // during the evolve phase and never mutated again. This is a single-core
+    // guest, so there are no data races.
+    let handle: &GuestHandle = unsafe {
+        GUEST_HANDLE
+            .as_ref()
+            .expect("nanvix_dispatch_function(): GUEST_HANDLE not initialised")
+    };
+
+    let function_call = handle
+        .try_pop_shared_input_data_into::<FunctionCall>()
+        .expect("function call deserialization failed");
+
+    match function_call.function_name.as_str() {
+        "kmain" => {
+            drop(function_call);
+            crate::kmain(kargs);
+        },
+        other => {
+            let msg = format!("unknown guest function: {other}");
+            drop(function_call);
+            let guest_error = GuestError::new(GuestErrorCode::GuestError, msg);
+            let fcr = FunctionCallResult::new(Err(guest_error));
+            let mut builder = ::flatbuffers::FlatBufferBuilder::new();
+            let data = fcr.encode(&mut builder);
+            handle
+                .push_shared_output_data(data)
+                .expect("failed to serialize function call error result");
+        },
+    }
+}
 
 ///
 /// # Description

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -245,12 +245,9 @@ pub fn snapshot() {
 ///
 /// # Description
 ///
-/// Signals the VMM that the kernel has finished booting and user-space
-/// applications are about to start. The VMM uses this to enable
-/// host-side services (e.g., pvclock timer) that should not run during
-/// the boot phase.
+/// Signals the VMM that kernel startup is complete and user-space applications are about to start.
 ///
-pub fn signal_boot_complete() {
+pub fn signal_startup_complete() {
     // SAFETY: The port I/O write targets the VMM control port with a well-known
     // boot-complete command value.
     unsafe {

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -66,8 +66,8 @@ pub fn kcall_handler() -> ExitStatus {
         panic!("failed to initialize event manager: {:?}", e);
     }
 
-    // Signal the VMM that kernel boot is complete and user-space is about to start.
-    crate::hal::platform::signal_boot_complete();
+    // Signal the VMM that kernel startup is complete and user-space is about to start.
+    crate::hal::platform::signal_startup_complete();
 
     let status: ExitStatus = loop {
         // Check if inter-kernel communication messages are available.

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -49,7 +49,6 @@ use crate::{
     kmod::KernelModule,
     mm::{
         elf::Elf32Fhdr,
-        kheap,
         VirtMemoryManager,
         Vmem,
     },
@@ -67,6 +66,9 @@ use ::sys::{
     pm::ProcessIdentifier,
     ExitStatus,
 };
+
+#[cfg(not(feature = "hyperlight"))]
+use crate::mm::kheap;
 
 #[cfg(feature = "smp")]
 use crate::mm::kredzone;
@@ -255,6 +257,9 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     info!("initializing the kernel...");
 
     // Initialize the kernel heap.
+    // On Hyperlight the heap is already initialized during the evolve phase
+    // (`hyperlight_pre_kmain`) so that FunctionCall deserialization can allocate.
+    #[cfg(not(feature = "hyperlight"))]
     if let Err(e) = unsafe { kheap::init() } {
         panic!("failed to initialize kernel heap: {:?}", e);
     }

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -457,8 +457,51 @@ impl Vmm {
                 .ok_or_else(|| anyhow::anyhow!("sandbox already evolved"))?
         };
 
-        // Run the sandbox.
-        let result: Result<MultiUseSandbox, HyperlightError> = uninit.evolve();
+        // Phase 1: Evolve — boot the kernel through early init. The kernel halts from
+        // hyperlight_pre_kmain() during the pre-kmain evolve phase via VmAction::Halt with the
+        // _nanvix_dispatch address in EAX. This causes evolve() to return Ok(MultiUseSandbox).
+        let mut sandbox: MultiUseSandbox = match uninit.evolve() {
+            Ok(s) => s,
+            Err(error) => {
+                // Drop the stderr redirect guard to restore the original stderr fd.
+                self.inner.blocking_lock()._stderr_redirect.take();
+
+                // Communicate shutdown to orchestrator.
+                if let Err(e) = self
+                    .inner
+                    .blocking_lock()
+                    .control_tx
+                    .blocking_send(VcpuControlResponse::Shutdown)
+                {
+                    error!("run(): failed to notify vmm thread (error={e:?})");
+                }
+
+                // During evolve(), GuestAborted is wrapped in HyperlightVmError(Initialize(...)) so
+                // extract it from the error chain.
+                return match Self::extract_guest_abort(&error) {
+                    Some((code, message)) => {
+                        if message.is_empty() {
+                            debug!("run(): guest exited during evolve (code={code})");
+                        } else {
+                            debug!(
+                                "run(): guest exited during evolve (code={code}, \
+                                 message={message})"
+                            );
+                        }
+                        Ok(code as u16)
+                    },
+                    None => {
+                        error!("run(): vmm aborted during evolve (debug={error:?})");
+                        Ok(ErrorCode::ConnectionReset.into())
+                    },
+                };
+            },
+        };
+
+        debug!("run(): evolve completed, calling sandbox.call(\"kmain\")");
+
+        // Phase 2: Call — re-enter the guest at _nanvix_dispatch to actually run the system.
+        let call_result: Result<(), HyperlightError> = sandbox.call("kmain", ());
 
         // Drop the stderr redirect guard to restore the original stderr fd.
         self.inner.blocking_lock()._stderr_redirect.take();
@@ -475,13 +518,18 @@ impl Vmm {
         }
 
         // Parse result.
-        // NOTE: The kernel uses abort_with_code() for all exit codes (including 0) rather
-        // than halt() to avoid a race condition with SIGKILL. See issue #1010.
-        // During evolve(), GuestAborted is wrapped in HyperlightVmError(Initialize(...))
-        // so we must extract it from the nested error chain.
-        match result {
-            Ok(_multiuse_sandbox) => {
-                debug!("run(): vmm exited normally");
+        // The dispatch handler halts via VmAction::Halt, which produces VmExit::Halt on the host.
+        // Hyperlight then tries to read a guest function return value from the PEB output buffer,
+        // which may fail with "Stack pointer is out of bounds" because the dispatch handler doesn't
+        // use Hyperlight's guest function return convention. We treat this specific error as
+        // success.
+        match call_result {
+            Ok(()) => {
+                debug!("run(): guest call completed normally");
+                Ok(0)
+            },
+            Err(ref error) if Self::is_halt_exit(error) => {
+                debug!("run(): guest halted cleanly (Halt path, no return value in PEB)");
                 Ok(0)
             },
             Err(error) => match Self::extract_guest_abort(&error) {
@@ -498,6 +546,30 @@ impl Vmm {
                     Ok(ErrorCode::ConnectionReset.into())
                 },
             },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Checks whether the error from `sandbox.call()` represents a clean VM halt.
+    ///
+    /// When the kernel exits via `VmAction::Halt` during a guest call, Hyperlight's dispatch loop
+    /// returns `Ok(())` but then tries to read a guest function return value from the PEB output
+    /// buffer. Since the kernel doesn't use Hyperlight's guest function return convention, this
+    /// read fails with "Stack pointer is out of bounds" (an `AnyhowError` from `shared_mem.rs`).
+    ///
+    /// We detect this by first narrowing to the expected `AnyhowError` variant and then checking
+    /// the inner error's `Display` representation. This avoids treating unrelated
+    /// `HyperlightError` variants as clean halts just because their top-level formatted message
+    /// contains the same substring.
+    ///
+    fn is_halt_exit(error: &HyperlightError) -> bool {
+        match error {
+            HyperlightError::AnyhowError(inner) => {
+                inner.to_string().contains("Stack pointer is out of bounds")
+            },
+            _ => false,
         }
     }
 


### PR DESCRIPTION
Backport the Hyperlight two-phase boot from `feature-hyperlight-stable`. Instead of running `kmain` directly during `evolve()`, the kernel now halts the VM before `kmain` to let the host transition `UninitializedSandbox` into `MultiUseSandbox`, then re-enters via `sandbox.call("run", ())` to run `kmain` for real.  ## Kernel-side changes  - Add `_nanvix_dispatch` `global_asm!` entry point that restores the boot stack and calls `kmain` after the host issues `call("run", ())`. - Add `halt_for_evolve()` to halt the VM during evolve with the dispatch address in EAX (port `0x6c`). ESP is 16-byte aligned before the halt to satisfy Hyperlight's post-initialise register validation. - Add `hyperlight_pre_kmain()`, called from `_do_start2` via a conditional `.if` directive, so that `kmain` remains completely platform-agnostic. - Add `HYPERLIGHT_EVOLVE` const to `start.rs` to gate the pre-kmain call at assembly level without touching the `kmain` code path.  ## Host-side changes (uservm)  - Split `Vmm::run()` into two phases: `evolve()` returns a `MultiUseSandbox`, then `call("run", ())` re-enters the guest at `_nanvix_dispatch`. - Handle evolve-phase errors by extracting `GuestAborted` from the nested `HyperlightVmError(Initialize(...))` error chain. - Treat "Stack pointer is out of bounds" after `call()` as a clean exit, since the dispatch handler halts via port `0x6c` rather than using Hyperlight's guest function return convention.  ## Rename  - `signal_boot_complete` ΓåÆ `signal_startup_complete` on both microvm and hyperlight platforms for consistency.  ## Testing  Build (`MACHINE=hyperlight`) and all standalone Windows integration tests pass: `empty`, `arch-rust`, `echo-rust-nostd`, `thread-rust`, `stress-rust`, `linux-app`.
Closes #2087