### PR TITLE
[dlfcn] Fix cross-.so symbol resolution bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cfg-if",
  "compiler_builtins",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "arch-rust"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "arch",
  "cc",
@@ -194,7 +194,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitmap"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "error",
  "rand 0.10.1",
@@ -247,11 +247,11 @@ dependencies = [
 
 [[package]]
 name = "build-utils"
-version = "0.12.436"
+version = "0.12.437"
 
 [[package]]
 name = "bump-allocator"
-version = "0.12.436"
+version = "0.12.437"
 
 [[package]]
 name = "bumpalo"
@@ -273,7 +273,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "c-bindings-rust"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "config",
  "libc_string",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.12.436"
+version = "0.12.437"
 
 [[package]]
 name = "cc"
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "build-utils",
  "cfg-if",
@@ -469,13 +469,13 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+checksum = "7dab3fe76c1571ecd5cfe878b61bce3fedf4adbde5d8a8653b2a7956ffd14628"
 
 [[package]]
 name = "containerd-shim-nanvix-v1"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "control-plane-api"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "config",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "dlfcn-rust"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -784,7 +784,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "echo-client"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "http-body-util",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "echo-rust-nostd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "echo-wasm-rust"
-version = "0.12.436"
+version = "0.12.437"
 
 [[package]]
 name = "either"
@@ -823,7 +823,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elf"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "goblin",
  "num_enum",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
@@ -894,7 +894,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fat32"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "error",
  "fatfs",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "file-rust"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1247,7 +1247,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-rust-nostd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "hello-wasm"
-version = "0.12.436"
+version = "0.12.437"
 
 [[package]]
 name = "home"
@@ -1316,7 +1316,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hwloc"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "libc",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "arch",
  "bitmap",
@@ -1780,7 +1780,7 @@ dependencies = [
  "multibin",
  "no_fail",
  "raw-array",
- "slab 0.12.436",
+ "slab 0.12.437",
  "sorted-vec",
  "sparse-bitmap",
  "static_assert",
@@ -1846,7 +1846,7 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libc_stdlib"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cfg-if",
  "compiler_builtins",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "libc_string"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "sysapi",
 ]
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "linux-app"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1910,7 +1910,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "linuxd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "config",
@@ -1971,7 +1971,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "memory-rust"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "misc-rust"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2054,14 +2054,14 @@ dependencies = [
 
 [[package]]
 name = "mkimage"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "multibin",
 ]
 
 [[package]]
 name = "mkramfs"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "arch",
  "fatfs",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "mmio-tag"
-version = "0.12.436"
+version = "0.12.437"
 
 [[package]]
 name = "mshv-bindings"
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "multibin"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "error",
 ]
@@ -2110,7 +2110,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nanvix"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "config",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-bench"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "build-utils",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-http"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "config",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-oci"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "log",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-registry"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-sandbox"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "build-utils",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-sandbox-cache"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-shim-core"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-shim-proto"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-shim-standalone"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-terminal"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "config",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix-test"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "nanvixd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "network-rust"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2389,11 +2389,11 @@ dependencies = [
 
 [[package]]
 name = "no_fail"
-version = "0.12.436"
+version = "0.12.437"
 
 [[package]]
 name = "noop-rust-nostd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "noop-wasm-rust"
-version = "0.12.436"
+version = "0.12.437"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "nvx"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cfg-if",
  "compiler_builtins",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "posix"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cfg-if",
  "num_enum",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "proc"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "procd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "profiler"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cfg-if",
  "log",
@@ -2965,7 +2965,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-array"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cfg-if",
  "error",
@@ -3449,7 +3449,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slab"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "bitmap",
  "error",
@@ -3466,7 +3466,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snapshot-rust-nostd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3488,11 +3488,11 @@ dependencies = [
 
 [[package]]
 name = "sorted-vec"
-version = "0.12.436"
+version = "0.12.437"
 
 [[package]]
 name = "sparse-bitmap"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "bitmap",
  "error",
@@ -3531,7 +3531,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assert"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "strace"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "clap",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "stress-rust"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "sys"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "compiler_builtins",
  "config",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "sysalloc"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "arch",
  "compiler_builtins",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "sysapi"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "compiler_builtins",
  "config",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "syscall"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "arch",
  "cfg-if",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "syscomm"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "config",
  "libc",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "syslog"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cfg-if",
  "compiler_builtins",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-macros"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "test-kernel"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "arch",
  "cc",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "test-mmio-fault"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "arch",
  "cc",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "testd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "arch",
  "cc",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "thread-rust"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "type-safe"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "user-vm-api"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "config",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "uservm"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "anyhow",
  "arch",
@@ -4337,7 +4337,7 @@ dependencies = [
 
 [[package]]
 name = "vfs"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "error",
  "fat32",
@@ -4348,11 +4348,11 @@ dependencies = [
 
 [[package]]
 name = "vfs-bench-common"
-version = "0.12.436"
+version = "0.12.437"
 
 [[package]]
 name = "vfs-bench-nostd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "build-utils",
  "cc",
@@ -4373,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "vfs-test"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "wasmd"
-version = "0.12.436"
+version = "0.12.437"
 dependencies = [
  "cc",
  "cfg-if",

--- a/src/libs/posix/src/dlfcn/mod.rs
+++ b/src/libs/posix/src/dlfcn/mod.rs
@@ -9,15 +9,11 @@ use ::alloc::string::String;
 use ::core::{
     ffi,
     ffi::{
-        c_int,
         CStr,
+        c_int,
     },
     mem,
     ptr,
-};
-use ::num_enum::{
-    IntoPrimitive,
-    TryFromPrimitive,
 };
 use ::spin::Mutex;
 use ::sys::mm::{
@@ -86,19 +82,44 @@ impl DlError {
 ///
 /// # Description
 ///
-/// A type that represents the mode in which a dynamic library may be opened.
+/// Bitmask flags controlling how a dynamic library is opened.
 ///
-#[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
-pub enum DlOpenMode {
-    /// Relocations are performed at an implementation-defined time.
-    Local = 0,
-    /// Relocations are performed when the object is loaded.
-    Lazy = 1,
-    /// All symbols are available for relocation processing of other modules.
-    Now = 2,
-    /// All symbols are not made available for relocation processing by other modules.
-    Global = 4,
+/// Per POSIX, `RTLD_NOW` / `RTLD_LAZY` select the binding mode while
+/// `RTLD_GLOBAL` / `RTLD_LOCAL` control symbol visibility.  The two
+/// categories are orthogonal and may be combined with bitwise OR.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DlOpenMode(i32);
+
+impl DlOpenMode {
+    /// Relocations are deferred until symbols are first used (lazy binding).
+    pub const LAZY: Self = DlOpenMode(0x1);
+    /// Relocations are performed immediately when the object is loaded (eager binding).
+    pub const NOW: Self = DlOpenMode(0x2);
+    /// Symbols are made available for relocation processing by subsequently loaded objects.
+    pub const GLOBAL: Self = DlOpenMode(0x4);
+
+    /// All valid flag bits.
+    const VALID_MASK: i32 = 0x1 | 0x2 | 0x4;
+
+    /// Creates a `DlOpenMode` from a raw integer, returning `None` if any
+    /// invalid bits are set or if neither `LAZY` nor `NOW` is specified.
+    pub fn from_raw(raw: i32) -> Option<Self> {
+        // Reject unknown bits.
+        if raw & !Self::VALID_MASK != 0 {
+            return None;
+        }
+        // At least one of LAZY or NOW must be set.
+        if raw & (Self::LAZY.0 | Self::NOW.0) == 0 {
+            return None;
+        }
+        Some(DlOpenMode(raw))
+    }
+
+    /// Returns `true` if the `GLOBAL` flag is set.
+    pub fn is_global(self) -> bool {
+        self.0 & Self::GLOBAL.0 != 0
+    }
 }
 
 //==================================================================================================
@@ -297,26 +318,19 @@ pub unsafe extern "C" fn dlopen(filename: *const c_char, mode: c_int) -> *mut c_
     };
 
     // Attempt to convert `mode` to `DlOpenMode`.
-    let mode: DlOpenMode = match DlOpenMode::try_from(mode) {
-        Ok(mode) => mode,
-        Err(error) => {
-            let reason: String = alloc::format!("invalid mode (error={error:?})");
+    let mode: DlOpenMode = match DlOpenMode::from_raw(mode) {
+        Some(mode) => mode,
+        None => {
+            let reason: String = alloc::format!("invalid mode (mode={mode:#x})");
             DL_LAST_ERROR.lock().set(&reason);
             ::syslog::error!("dlopen(): {}", reason);
             return ptr::null_mut();
         },
     };
 
-    // Check if open mode is not supported.
-    if mode == DlOpenMode::Local {
-        let reason: &str = "local mode is not supported";
-        DL_LAST_ERROR.lock().set(reason);
-        ::syslog::error!("dlopen(): {}", reason);
-        return ptr::null_mut();
-    }
-
-    // Attempt to open the shared object file.
-    match dlfcn::dlopen(filename) {
+    // Attempt to open the shared object file, forwarding the mode flags
+    // so the syscall layer can handle RTLD_GLOBAL.
+    match dlfcn::dlopen(filename, mode.is_global()) {
         Ok(handle) => handle.as_mut_ptr(),
         Err(error) => {
             DL_LAST_ERROR.lock().set(error.reason);

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -11,13 +11,15 @@ use super::dynlib::{
 };
 use crate::dlfcn::syscall::DYNAMIC_LIBRARY_REGISTRY;
 use ::alloc::{
-    collections::btree_map::BTreeMap,
+    collections::{
+        btree_map::BTreeMap,
+        btree_set::BTreeSet,
+    },
     string::{
         String,
         ToString,
     },
     sync::Arc,
-    vec,
     vec::Vec,
 };
 use ::spin::{
@@ -31,8 +33,8 @@ use ::sys::error::Error;
 //==================================================================================================
 
 /// Opens a dynamic library file.
-pub fn dlopen(filename: &str) -> Result<DlHandle, Error> {
-    ::syslog::trace!("dlopen(): filename={}", filename);
+pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
+    ::syslog::trace!("dlopen(): filename={}, global={}", filename, global);
 
     // Ensure the global symbol table is populated so that symbols exported
     // by the main executable can be resolved during relocation, even if the
@@ -40,17 +42,34 @@ pub fn dlopen(filename: &str) -> Result<DlHandle, Error> {
     // calls are a no-op.
     super::dlinit();
 
-    // TODO: Normalize filename.
+    // Resolve bare library names (e.g., "libfoo.so") to a canonical path
+    // (e.g., "lib/libfoo.so") using the configured search directories.
+    // Paths with leading "/" are normalized to strip it, ensuring
+    // "/lib/libc.so" and "lib/libc.so" are treated as the same library.
+    let filename: &str = &super::resolve_library_path(filename);
 
     let mut registry: MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>> =
         DYNAMIC_LIBRARY_REGISTRY.lock();
 
-    // Check if dynamic library is already opened.
+    // Check if dynamic library is already opened. The filename has been
+    // resolved by resolve_library_path() above, so this comparison works
+    // correctly even for DT_NEEDED bare names that were resolved to full
+    // paths on initial load.
     for (dlhandle, dlfile) in registry.iter() {
         if dlfile.lock().name() == filename {
+            // If the caller requests RTLD_GLOBAL on a library that was
+            // previously loaded without it, promote it to global scope now.
+            if global {
+                super::register_library_in_global_scope(dlfile);
+            }
             return Ok(*dlhandle);
         }
     }
+
+    // Snapshot the registry keys before we start inserting, so we can roll back
+    // all new entries on failure. This ensures a failed dlopen never leaves
+    // stale handles with unpatched relocations in the registry.
+    let handles_before: BTreeSet<DlHandle> = registry.keys().copied().collect();
 
     // Open and pre-load the dynamic library file.
     let new_dlfile: DynamicLibrary = DynamicLibrary::open(filename)?;
@@ -60,12 +79,42 @@ pub fn dlopen(filename: &str) -> Result<DlHandle, Error> {
     // Insert the opened file into the map.
     registry.insert(handle, new_dlfile.clone());
 
-    load_all_dependencies(&mut registry, new_dlfile)?;
-    resolve_all_symbols(&mut registry, filename)?;
-
-    Ok(handle)
+    // Load dependencies and resolve symbols. If either step fails, remove all
+    // entries that were added during this call (the library itself and any
+    // transitive dependencies) so subsequent dlopen calls start fresh.
+    match load_all_dependencies(&mut registry, new_dlfile)
+        .and_then(|_| resolve_all_symbols(&mut registry, &handles_before))
+    {
+        Ok(()) => {
+            // If RTLD_GLOBAL was requested, publish the library's exported
+            // symbols into the global symbol table so subsequently loaded
+            // libraries can resolve them.
+            if global {
+                if let Some(dlfile) = registry.get(&handle) {
+                    super::register_library_in_global_scope(dlfile);
+                }
+            }
+            Ok(handle)
+        },
+        Err(e) => {
+            let new_handles: Vec<DlHandle> = registry
+                .keys()
+                .filter(|h| !handles_before.contains(h))
+                .copied()
+                .collect();
+            for h in new_handles {
+                registry.remove(&h);
+            }
+            Err(e)
+        },
+    }
 }
 
+/// Recursively loads all transitive dependencies of a newly opened library.
+///
+/// For each `DT_NEEDED` entry, resolves the bare library name to a full path,
+/// checks if it is already loaded in the registry, and if not, opens and inserts
+/// it. Recurses into each dependency's own `DT_NEEDED` entries.
 fn load_all_dependencies(
     dlfiles: &mut MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>,
     new_dlfile: Arc<Mutex<DynamicLibrary>>,
@@ -86,13 +135,17 @@ fn load_all_dependencies(
 
         // Bind to already loaded dependencies and remove them from the list.
         dependencies.retain(|dependency| {
+            // Resolve bare name so we can match against loaded libraries
+            // that were opened with a full path.
+            let resolved_dep: String = super::resolve_library_path(dependency);
             for (dlhandle, dlfile) in dlfiles.iter() {
                 // Check if need to skip the dynamic library itself.
                 if dlhandle == new_dlhandle {
                     continue;
                 }
 
-                if dlfile.lock().name() == dependency.as_str() {
+                let loaded_name = dlfile.lock().name().to_string();
+                if loaded_name == dependency.as_str() || loaded_name == resolved_dep {
                     ::syslog::debug!(
                         "load_all_dependencies_recursive(): already loaded dependency '{}' \
                          (handle={:?})",
@@ -115,8 +168,11 @@ fn load_all_dependencies(
 
         // Load remaining dependencies.
         while let Some(dependency) = dependencies.pop() {
+            // Resolve bare library names to full paths using search directories.
+            let resolved_dep: String = super::resolve_library_path(&dependency);
+
             // Open and pre-load the dynamic library file.
-            let dep_dlfile: DynamicLibrary = DynamicLibrary::open(&dependency)?;
+            let dep_dlfile: DynamicLibrary = DynamicLibrary::open(&resolved_dep)?;
             let handle: DlHandle = dep_dlfile.handle();
             let dep_dlfile: Arc<Mutex<DynamicLibrary>> = Arc::new(Mutex::new(dep_dlfile));
 
@@ -142,15 +198,82 @@ fn load_all_dependencies(
     Ok(())
 }
 
+/// Resolves all relocations for libraries added during this `dlopen` call.
+///
+/// Libraries are resolved in dependency order (leaves first, root last).
+/// This ensures that when a library's relocations reference symbols from
+/// its dependencies, those dependencies are already fully resolved.
 fn resolve_all_symbols(
     dlfiles: &mut MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>,
-    filename: &str,
+    handles_before: &BTreeSet<DlHandle>,
 ) -> Result<(), Error> {
-    ::syslog::trace!("resolve_all_symbols(): filename={}", filename);
-    let mut unresolved_libraries = vec![filename.to_string()];
+    ::syslog::trace!("resolve_all_symbols()");
 
-    while let Some(lib_name) = unresolved_libraries.pop() {
-        if let Some(dlfile) = dlfiles.values().find(|f| f.lock().name() == lib_name) {
+    // Collect all newly added libraries.
+    let new_handles: Vec<DlHandle> = dlfiles
+        .keys()
+        .filter(|h| !handles_before.contains(h))
+        .copied()
+        .collect();
+
+    // Build a resolution order: resolve dependencies before their dependents.
+    // A library can be resolved once all its bound dependencies (that are also
+    // new in this dlopen call) have been resolved.
+    let mut resolved: BTreeSet<DlHandle> = BTreeSet::new();
+    let mut ordered: Vec<DlHandle> = Vec::with_capacity(new_handles.len());
+
+    // Iteratively find libraries whose dependencies are all resolved.
+    // This is a simple topological sort — safe because the dependency graph
+    // is a DAG (cycles would have been caught during load_all_dependencies).
+    loop {
+        let mut progress: bool = false;
+        for &handle in &new_handles {
+            if resolved.contains(&handle) {
+                continue;
+            }
+
+            // Check if all of this library's dependencies that are new in
+            // this dlopen call have been resolved.
+            let all_deps_resolved: bool = if let Some(dlfile) = dlfiles.get(&handle) {
+                let lib: spin::MutexGuard<'_, DynamicLibrary> = dlfile.lock();
+                lib.dependency_handles().iter().all(|dep_handle| {
+                    // Dependencies that existed before this dlopen are already resolved.
+                    handles_before.contains(dep_handle) || resolved.contains(dep_handle)
+                })
+            } else {
+                true
+            };
+
+            if all_deps_resolved {
+                ordered.push(handle);
+                resolved.insert(handle);
+                progress = true;
+            }
+        }
+
+        if resolved.len() == new_handles.len() {
+            break;
+        }
+
+        if !progress {
+            // No progress means a cycle or missing dependency. Fall back to
+            // resolving remaining libraries in arbitrary order.
+            ::syslog::warn!(
+                "resolve_all_symbols(): could not determine dependency order for {} libraries",
+                new_handles.len() - resolved.len()
+            );
+            for &handle in &new_handles {
+                if !resolved.contains(&handle) {
+                    ordered.push(handle);
+                }
+            }
+            break;
+        }
+    }
+
+    // Resolve in dependency order (leaves first).
+    for handle in ordered {
+        if let Some(dlfile) = dlfiles.get(&handle) {
             dlfile.lock().resolve_all()?;
         }
     }

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -6,7 +6,6 @@
 //===================================================================================================
 
 use crate::safe::{
-    mem::segment::MemorySegment,
     FileSystem,
     FileSystemAttributes,
     FileSystemPath,
@@ -14,6 +13,7 @@ use crate::safe::{
     RegularFile,
     RegularFileOffset,
     RegularFileOpenFlags,
+    mem::segment::MemorySegment,
 };
 use ::alloc::{
     collections::btree_map::BTreeMap,
@@ -457,43 +457,50 @@ impl DynamicLibrary {
     }
 
     /// Looks up a symbol in the dynamic library.
+    ///
+    /// Search order follows POSIX `dlsym` semantics:
+    /// 1. The library itself (defined symbols).
+    /// 2. The library's DT_NEEDED dependency tree.
+    /// 3. The global symbol table (main executable + RTLD_GLOBAL libraries).
     pub fn lookup(&self, symbol_name: &str) -> Result<Option<(usize, usize)>, Error> {
         ::syslog::trace!("lookup(): symbol={}, dlname={:?}", symbol_name, self.filename);
 
         if let Some(symbol) = self.find(symbol_name) {
-            // Check if symbol is defined in the library or in a dependency.
-            if symbol.is_undefined() {
-                // Symbol is defined in a dependency, search dependencies.
-                for (_dlname, dlfile) in self.dependencies.iter() {
-                    if let Some(dlfile) = dlfile {
-                        // Check if dependency is locked.
-                        if dlfile.is_locked() {
-                            let reason: &str = "circular dependency detected";
-                            ::syslog::error!(
-                                "lookup(): {:?} (symbol_name={:?})",
-                                reason,
-                                symbol_name
-                            );
-                            return Err(Error::new(ErrorCode::BadFile, reason));
-                        }
-
-                        let dlfile: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
-
-                        if let Some((base, symbol_value)) = dlfile.lookup(symbol_name)? {
-                            return Ok(Some((base, symbol_value)));
-                        }
-                    }
-                }
-
-                // Fall back to the global symbol table (symbols from the
-                // main executable, registered via --export-dynamic).
-                if let Some(addr) = super::global_symbol_lookup(symbol_name) {
-                    // Global symbols are absolute addresses, so base is 0.
-                    return Ok(Some((0, addr)));
-                }
-            } else {
+            if !symbol.is_undefined() {
+                // Symbol is defined in this library.
                 return Ok(Some((self.load_address.into_raw_value(), symbol.value() as usize)));
             }
+        }
+
+        // Symbol is either undefined in this library or not in its dynsym at
+        // all. Per POSIX, dlsym must search the full dependency tree regardless
+        // of whether the root library references the symbol.
+        for (_dlname, dlfile) in self.dependencies.iter() {
+            if let Some(dlfile) = dlfile {
+                // Check if dependency is locked.
+                if dlfile.is_locked() {
+                    let reason: &str = "circular dependency detected";
+                    ::syslog::error!(
+                        "lookup(): {:?} (symbol_name={:?})",
+                        reason,
+                        symbol_name
+                    );
+                    return Err(Error::new(ErrorCode::BadFile, reason));
+                }
+
+                let dlfile: MutexGuard<'_, DynamicLibrary> = dlfile.lock();
+
+                if let Some((base, symbol_value)) = dlfile.lookup(symbol_name)? {
+                    return Ok(Some((base, symbol_value)));
+                }
+            }
+        }
+
+        // Fall back to the global symbol table (symbols from the main
+        // executable and RTLD_GLOBAL libraries).
+        if let Some(addr) = super::global_symbol_lookup(symbol_name) {
+            // Global symbols are absolute addresses, so base is 0.
+            return Ok(Some((0, addr)));
         }
 
         Ok(None)
@@ -778,6 +785,32 @@ impl DynamicLibrary {
     /// Returns the file descriptor of the dynamic library.
     pub fn dependencies(&self) -> BTreeMap<String, Option<Arc<Mutex<Self>>>> {
         self.dependencies.clone()
+    }
+
+    /// Returns the handles of all bound dependencies.
+    pub fn dependency_handles(&self) -> Vec<DlHandle> {
+        self.dependencies
+            .values()
+            .filter_map(|dep| dep.as_ref().map(|d| d.lock().handle()))
+            .collect()
+    }
+
+    /// Iterates over all defined (non-undefined) symbols exported by this
+    /// library, yielding `(name, absolute_address)` pairs.
+    pub fn exported_symbols(&self) -> Vec<(&str, usize)> {
+        let mut result = Vec::new();
+        for sym in self.dynsym.iter() {
+            if sym.is_undefined() {
+                continue;
+            }
+            if let Ok(name) = self.dynstr.get_name(sym.name_offset()) {
+                if !name.is_empty() {
+                    let addr = self.load_address.into_raw_value() + sym.value() as usize;
+                    result.push((name, addr));
+                }
+            }
+        }
+        result
     }
 
     /// Binds a dependency to the dynamic library.

--- a/src/libs/syscall/src/dlfcn/syscall/mod.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/mod.rs
@@ -29,6 +29,7 @@ use ::alloc::{
     collections::btree_map::BTreeMap,
     string::String,
     sync::Arc,
+    vec::Vec,
 };
 use ::elf::{
     StringTable,
@@ -45,21 +46,94 @@ use ::spin::{
 static DYNAMIC_LIBRARY_REGISTRY: Lazy<Mutex<BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>> =
     Lazy::new(|| Mutex::new(BTreeMap::new()));
 
-/// Global symbol table for symbols exported by the main executable.
-/// When a dynamically loaded library has unresolved symbols, this table
-/// is consulted as a last resort, enabling statically-linked executables
-/// to export symbols to their dynamically-loaded extension modules.
+/// Global symbol table for symbols available to dynamically loaded libraries.
 ///
-/// NOTE: this table only contains symbols from the main executable
-/// (populated from `.dynsym`/`.dynstr` sections emitted by
-/// `--export-dynamic`). Symbols from dynamically loaded shared
-/// libraries are *not* included; those are resolved through
-/// the per-library dependency chains in `DYNAMIC_LIBRARY_REGISTRY`.
+/// This table is populated from two sources:
+/// 1. The main executable's `.dynsym`/`.dynstr` sections (populated via
+///    `dlinit()` when the executable is linked with `--export-dynamic`).
+/// 2. Shared libraries loaded with `RTLD_GLOBAL` (populated via
+///    `register_library_in_global_scope()`).
+///
+/// When a dynamically loaded library has unresolved symbols, this table
+/// is consulted as a last resort, enabling symbol resolution across
+/// independently loaded libraries.
 static GLOBAL_SYMBOL_TABLE: Lazy<Mutex<BTreeMap<String, usize>>> =
     Lazy::new(|| Mutex::new(BTreeMap::new()));
 
+/// Pinned references to libraries loaded with `RTLD_GLOBAL`.
+///
+/// When a library is registered in the global scope, an extra `Arc` reference
+/// is stored here. This prevents `dlclose()` from actually unloading the
+/// library (the `Arc::strong_count` check in `dlclose` will see the extra
+/// reference), ensuring that the absolute addresses recorded in
+/// `GLOBAL_SYMBOL_TABLE` remain valid for the lifetime of the process.
+/// This is equivalent to Linux's `RTLD_NODELETE` behavior for global libraries.
+static GLOBAL_PINNED_LIBRARIES: Lazy<Mutex<Vec<Arc<Mutex<DynamicLibrary>>>>> =
+    Lazy::new(|| Mutex::new(Vec::new()));
+
+/// Default directories searched when a `DT_NEEDED` entry contains a bare
+/// library name (no path separator). Modelled after Linux's default search
+/// paths (`/lib`, `/usr/lib`), but simplified to the single `lib/` directory
+/// that Nanvix uses for shared libraries.
+static LIBRARY_SEARCH_PATHS: Lazy<Mutex<Vec<String>>> =
+    Lazy::new(|| Mutex::new(alloc::vec!["lib/".into()]));
+
 /// Ensures `dlinit` runs at most once.
 static DLINIT_ONCE: Once = Once::new();
+
+/// Resolves a library filename to a canonical path by searching configured
+/// directories.
+///
+/// All paths are normalized to a consistent form without leading `/`, matching
+/// the convention used throughout the Nanvix dlfcn layer and test code (e.g.,
+/// `"lib/libmul.so"`). The VFS accepts both relative and absolute paths and
+/// normalizes internally, so stripping the leading `/` is safe and ensures
+/// that `"/lib/libc.so"`, `"lib/libc.so"`, and the bare DT_NEEDED name
+/// `"libc.so"` all resolve to the same canonical path `"lib/libc.so"`.
+///
+/// If `filename` already contains a path separator (`/`), it is normalized
+/// and returned. Otherwise the function tries each directory in
+/// [`LIBRARY_SEARCH_PATHS`] in order, returning the first path for which
+/// the file exists. If no match is found the bare name is returned so that
+/// the subsequent `open_regular_file` call produces the appropriate error.
+///
+/// NOTE: The probe opens and immediately closes a file descriptor per
+/// candidate path. The matched file is re-opened by `DynamicLibrary::open()`.
+/// This double-open is accepted for simplicity; a stat-based probe would
+/// avoid it but is not currently available in the Nanvix VFS API.
+pub(super) fn resolve_library_path(filename: &str) -> String {
+    // Strip leading '/' for normalization — the Nanvix dlfcn layer uses
+    // relative paths (e.g., "lib/libfoo.so") as the canonical form.
+    let filename: &str = filename.trim_start_matches('/');
+
+    // If the filename already contains a path component, use it as-is.
+    if filename.contains('/') {
+        return String::from(filename);
+    }
+
+    // Search configured directories for the bare library name.
+    let search_paths = LIBRARY_SEARCH_PATHS.lock();
+    for dir in search_paths.iter() {
+        let candidate: String = alloc::format!("{}{}", dir, filename);
+        // Probe whether the file exists by attempting to open it.
+        if let Ok(_fd) = crate::safe::FileSystem::open_regular_file(
+            // FileSystemPath::new can fail for invalid names; skip on error.
+            &match crate::safe::FileSystemPath::new(&candidate) {
+                Ok(p) => p,
+                Err(_) => continue,
+            },
+            &crate::safe::RegularFileOpenFlags::read_only(),
+            None,
+        ) {
+            ::syslog::debug!("resolve_library_path(): resolved '{}' -> '{}'", filename, candidate);
+            return candidate;
+        }
+    }
+
+    // Fall back to the original name (will produce a clear error at open time).
+    ::syslog::debug!("resolve_library_path(): no match for '{}', using as-is", filename);
+    String::from(filename)
+}
 
 /// Populates `GLOBAL_SYMBOL_TABLE` from the executable's `.dynsym`/`.dynstr`
 /// sections. The linker script emits `__dynsym_start/__dynsym_end` and
@@ -135,6 +209,59 @@ pub fn dlinit() {
 pub(super) fn global_symbol_lookup(name: &str) -> Option<usize> {
     dlinit();
     GLOBAL_SYMBOL_TABLE.lock().get(name).copied()
+}
+
+/// Registers all defined (non-undefined) symbols from a loaded shared library
+/// into the global symbol table. Called when a library is loaded with
+/// `RTLD_GLOBAL` so its symbols are available for subsequently loaded libraries.
+///
+/// The library is also pinned via an extra `Arc` reference in
+/// `GLOBAL_PINNED_LIBRARIES`, preventing `dlclose()` from unloading it and
+/// leaving dangling addresses in the global symbol table.
+///
+/// Repeated calls for the same library are idempotent — duplicate pins are
+/// not created and already-registered symbols are not overwritten.
+///
+/// NOTE: Per Linux semantics, symbols registered here are NOT removed when the
+/// library is closed via `dlclose()`. This matches glibc behavior where global
+/// scope entries persist even after the originating library is unloaded.
+pub(super) fn register_library_in_global_scope(
+    lib_arc: &Arc<Mutex<DynamicLibrary>>,
+) {
+    // Check if this library is already pinned (idempotent promotion).
+    {
+        let pinned: spin::MutexGuard<'_, Vec<Arc<Mutex<DynamicLibrary>>>> =
+            GLOBAL_PINNED_LIBRARIES.lock();
+        if pinned.iter().any(|p| Arc::ptr_eq(p, lib_arc)) {
+            return;
+        }
+    }
+
+    let lib: spin::MutexGuard<'_, DynamicLibrary> = lib_arc.lock();
+    let mut table = GLOBAL_SYMBOL_TABLE.lock();
+    let mut count: usize = 0;
+
+    for (name, addr) in lib.exported_symbols() {
+        use ::alloc::collections::btree_map::Entry;
+        if let Entry::Vacant(e) = table.entry(String::from(name)) {
+            e.insert(addr);
+            count += 1;
+        }
+    }
+
+    ::syslog::trace!(
+        "register_library_in_global_scope(): registered {} symbols from {:?}",
+        count,
+        lib.name()
+    );
+
+    // Drop locks before pinning to avoid holding both at once.
+    drop(table);
+    drop(lib);
+
+    // Pin the library so dlclose() cannot unload it while its symbols
+    // are recorded in the global table.
+    GLOBAL_PINNED_LIBRARIES.lock().push(lib_arc.clone());
 }
 
 //==================================================================================================

--- a/src/tests/dlfcn-rust/src/tests/dlfcn.rs
+++ b/src/tests/dlfcn-rust/src/tests/dlfcn.rs
@@ -56,7 +56,7 @@ const _: () = assert!(
 
 /// Opens a dynamic load library.
 fn open_library(path: &str) -> Result<DlHandle, Error> {
-    dlopen(path)
+    dlopen(path, false)
 }
 
 /// Closes a dynamic load library.
@@ -154,7 +154,7 @@ fn test_dladdr() -> Result<(), Error> {
     };
     dladdr(addr, &mut info)?;
 
-    // Verify file name matches the library path.
+    // Verify file name matches the library path (canonical form without leading /).
     let fname = unsafe { CStr::from_ptr(info.dli_fname) };
     assert!(fname == c"lib/libmul.so", "dli_fname should match the library path");
 

--- a/src/tests/dlfcn-rust/src/tests/dlfcn_pie.rs
+++ b/src/tests/dlfcn-rust/src/tests/dlfcn_pie.rs
@@ -49,7 +49,7 @@ pub static exe_global_value: i32 = 42;
 
 /// Opens a dynamic load library.
 fn open_library(path: &str) -> Result<DlHandle, Error> {
-    dlopen(path)
+    dlopen(path, false)
 }
 
 /// Closes a dynamic load library.


### PR DESCRIPTION
## Summary

Fix dynamic loader bugs that prevent cross-`.so` symbol resolution, blocking loading shared libraries with transitive dependencies (e.g., CPython C extensions that depend on `libm.so`/`libc.so`).

Addresses #2075 and fixes all three sub-issues: #2076, #2077, #2078. Also fixes #2122.

This also fixes the test failures reported in [nanvix/posix-tests#27](https://github.com/nanvix/posix-tests/pull/27).

---

## Fixes

### 1. Failed `dlopen` leaves stale registry entry (#2078)

Snapshot registry keys before inserting. On failure, roll back all entries added during the call.

### 2. DT_NEEDED library search path is missing (#2076)

Add `resolve_library_path()` that searches configured directories (default: `lib/`) for bare library names. Paths are normalized by stripping leading `/` to ensure `/lib/libc.so` and `lib/libc.so` are treated as the same library.

### 3. RTLD_GLOBAL flag has no effect (#2077)

Convert `DlOpenMode` to a bitmask struct supporting `RTLD_NOW | RTLD_GLOBAL`. Register RTLD_GLOBAL library symbols in the global symbol table. Pin RTLD_GLOBAL libraries to prevent use-after-unload. Idempotent promotion on cache hit.

### 4. Path normalization causes duplicate library loading (#2122)

Strip leading `/` from all paths in `resolve_library_path()` so `dlopen("/lib/libc.so")` and DT_NEEDED `libc.so` (resolved to `lib/libc.so`) produce the same canonical form.

### 5. `resolve_all_symbols()` resolved in wrong order

Replace arbitrary handle-order resolution with topological sort (leaves first, root last).

### 6. `dlsym` didn't search dependency tree

Restructured `lookup()` to always search self -> dependencies -> global scope, regardless of dynsym content.

---

## Files Changed

| File | Change |
|------|--------|
| `src/libs/syscall/src/dlfcn/syscall/dlopen.rs` | Atomic rollback, search path, mode param, topo-sort resolution |
| `src/libs/syscall/src/dlfcn/syscall/dynlib.rs` | `exported_symbols()`, `dependency_handles()`, `lookup()` restructured |
| `src/libs/syscall/src/dlfcn/syscall/mod.rs` | Search paths, global scope registration, pinning, path normalization |
| `src/libs/posix/src/dlfcn/mod.rs` | `DlOpenMode` bitmask, forward mode to syscall layer |
| `src/tests/dlfcn-rust/src/tests/dlfcn.rs` | Updated `dlopen` call signature |
| `src/tests/dlfcn-rust/src/tests/dlfcn_pie.rs` | Updated `dlopen` call signature |

## Testing

All existing integration tests pass (both HTTP and terminal executors in WSL) — zero regressions. Cross-.so resolution tests are in [nanvix/posix-tests#27](https://github.com/nanvix/posix-tests/pull/27).

## Related

- Parent issue: #2075
- Sub-issues: #2076, #2077, #2078, #2122
- Test suites: [nanvix/posix-tests#27](https://github.com/nanvix/posix-tests/pull/27)