### PR TITLE
[doc] Document Windows support for integration tests

### DIFF
--- a/.github/skills/test-development/SKILL.md
+++ b/.github/skills/test-development/SKILL.md
@@ -38,11 +38,17 @@ Libraries with unit tests are listed in
 
 ### System Integration Tests
 
-System tests run the full Nanvix stack (`nanvixd` + kernel + guest) and are available only on
-`microvm` and `hyperlight` machines.
+System tests are available on `microvm` and `hyperlight` machines. On Linux, all deployment
+modes are supported (`nanvixd` + kernel + guest). On Windows, only standalone mode is supported.
 
 ```bash
+# Linux
 ./z build -- run-nanvix-tests
+```
+
+```powershell
+# Windows (standalone mode only)
+.\z.ps1 build -- run-nanvix-tests
 ```
 
 Test configurations:

--- a/.github/skills/test/SKILL.md
+++ b/.github/skills/test/SKILL.md
@@ -45,13 +45,18 @@ On Windows, unit tests can be run natively through `z.ps1`:
 .\z.ps1 build -- run-unit-tests
 ```
 
-System integration tests (`run-nanvix-tests`) and `nanvixd`-based tests are **Linux-only**.
-The standalone UserVM can be launched on Windows for manual verification, but the automated
-test harness (`nanvix-test`) requires `nanvixd`, which is not available on Windows.
+System integration tests are also available on Windows for standalone mode
+(`DEPLOYMENT_MODE=standalone`) on both `microvm` and `hyperlight` machines:
+
+```powershell
+.\z.ps1 build -- run-nanvix-tests
+```
+
+Single-process, L2 and multi-process deployment modes remain **Linux-only** as they require
+`nanvixd` with network namespace support.
 
 ## Troubleshooting Test Failures
 
 - Ensure the project builds successfully before running tests (see the `build` skill).
 - Use `LOG_LEVEL=trace` or `LOG_LEVEL=debug` for more verbose output when diagnosing failures.
-- Hyperlight does not support ramfs, so standalone integration tests must be excluded for hyperlight.
 - See the `troubleshooting` skill for deeper diagnosis of runtime and test failures.

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -117,7 +117,7 @@ Available build parameters:
 .\z.ps1 build -- run-unit-tests
 
 # Run standalone integration tests on Windows.
-.\z.ps1 test -- MACHINE=microvm
+.\z.ps1 build -- run-nanvix-tests
 ```
 
 ## Formal Verification with Verus

--- a/doc/test.md
+++ b/doc/test.md
@@ -33,14 +33,20 @@ build parameters.
 
 ## Running System Integration Tests (MicroVM and Hyperlight Only)
 
-> ℹ️ System integration tests are only available on `microvm` and `hyperlight`
-machines. These tests use the `nanvix-test.elf` utility to run programs through
-the Nanvix Daemon.
+> ℹ️ System integration tests are available on `microvm` and `hyperlight`
+machines on both Linux and Windows. On Windows, only standalone mode (`DEPLOYMENT_MODE=standalone`)
+is supported.
 
 The system integration tests can be run directly using:
 
 ```bash
+# Linux
 ./z build -- run-nanvix-tests
+```
+
+```powershell
+# Windows (standalone mode only)
+.\z.ps1 build -- run-nanvix-tests
 ```
 
 The appropriate test configuration is automatically selected based on the


### PR DESCRIPTION
## Summary

The test skill and user-facing documentation incorrectly stated that system integration tests (`run-nanvix-tests`) were Linux-only. In fact, they are available on Windows for standalone mode on both `microvm` and `hyperlight` machines.

## Changes

**`.github/skills/test/SKILL.md`**
- Replace the blanket "Linux-only" statement with the correct scope.
- Add a PowerShell snippet showing the Windows invocation.
- Clarify that single-process, L2, and multi-process modes remain Linux-only (network namespace dependency).

**`doc/test.md`**
- Broaden the info box to mention both Linux and Windows support.
- Add a Windows command example alongside the existing Linux one.
- Note the standalone-mode restriction for Windows.

## Validation

- Integration tests pass on Windows: `.\z.ps1 build -- run-nanvix-tests MACHINE=hyperlight DEPLOYMENT_MODE=standalone` (10/10 tests, exit code 0).