### PR TITLE
[fat32] Add read-only storage backend for FAT filesystems

### DIFF
--- a/src/libs/fat32/src/fat/error.rs
+++ b/src/libs/fat32/src/fat/error.rs
@@ -28,6 +28,8 @@ pub enum MemoryIoError {
     UnexpectedEof,
     /// Write returned zero bytes when more were expected.
     WriteZero,
+    /// Attempted to write to a read-only memory storage.
+    ReadOnly,
 }
 
 //==================================================================================================
@@ -43,6 +45,7 @@ impl fmt::Display for MemoryIoError {
             MemoryIoError::InvalidSeek => write!(f, "invalid seek position"),
             MemoryIoError::UnexpectedEof => write!(f, "unexpected end of file"),
             MemoryIoError::WriteZero => write!(f, "write returned zero bytes"),
+            MemoryIoError::ReadOnly => write!(f, "write to read-only storage"),
         }
     }
 }
@@ -74,8 +77,9 @@ impl ::fatfs::IoError for MemoryIoError {
 /// # Returns
 ///
 /// The corresponding [`Fat32Error`] variant.
-pub fn map_fatfs_error<T>(err: ::fatfs::Error<T>) -> Fat32Error {
+pub fn map_fatfs_error(err: ::fatfs::Error<MemoryIoError>) -> Fat32Error {
     match err {
+        ::fatfs::Error::Io(MemoryIoError::ReadOnly) => Fat32Error::ReadOnly,
         ::fatfs::Error::Io(_) => Fat32Error::IoError,
         ::fatfs::Error::UnexpectedEof => Fat32Error::IoError,
         ::fatfs::Error::WriteZero => Fat32Error::IoError,
@@ -107,6 +111,7 @@ mod tests {
             MemoryIoError::InvalidSeek,
             MemoryIoError::UnexpectedEof,
             MemoryIoError::WriteZero,
+            MemoryIoError::ReadOnly,
         ];
 
         for variant in variants {
@@ -139,44 +144,49 @@ mod tests {
     #[test]
     fn map_fatfs_error_variants() {
         assert_eq!(
-            map_fatfs_error::<MemoryIoError>(::fatfs::Error::NotFound),
+            map_fatfs_error(::fatfs::Error::NotFound),
             Fat32Error::NotFound,
             "NotFound should map to NotFound"
         );
         assert_eq!(
-            map_fatfs_error::<MemoryIoError>(::fatfs::Error::AlreadyExists),
+            map_fatfs_error(::fatfs::Error::AlreadyExists),
             Fat32Error::AlreadyExists,
             "AlreadyExists should map to AlreadyExists"
         );
         assert_eq!(
-            map_fatfs_error::<MemoryIoError>(::fatfs::Error::DirectoryIsNotEmpty),
+            map_fatfs_error(::fatfs::Error::DirectoryIsNotEmpty),
             Fat32Error::NotEmpty,
             "DirectoryIsNotEmpty should map to NotEmpty"
         );
         assert_eq!(
-            map_fatfs_error::<MemoryIoError>(::fatfs::Error::NotEnoughSpace),
+            map_fatfs_error(::fatfs::Error::NotEnoughSpace),
             Fat32Error::NoSpace,
             "NotEnoughSpace should map to NoSpace"
         );
         assert_eq!(
-            map_fatfs_error::<MemoryIoError>(::fatfs::Error::InvalidInput),
+            map_fatfs_error(::fatfs::Error::InvalidInput),
             Fat32Error::InvalidPath,
             "InvalidInput should map to InvalidPath"
         );
         assert_eq!(
-            map_fatfs_error::<MemoryIoError>(::fatfs::Error::CorruptedFileSystem),
+            map_fatfs_error(::fatfs::Error::CorruptedFileSystem),
             Fat32Error::IoError,
             "CorruptedFileSystem should map to IoError"
         );
         assert_eq!(
-            map_fatfs_error::<MemoryIoError>(::fatfs::Error::UnexpectedEof),
+            map_fatfs_error(::fatfs::Error::UnexpectedEof),
             Fat32Error::IoError,
             "UnexpectedEof should map to IoError"
         );
         assert_eq!(
-            map_fatfs_error::<MemoryIoError>(::fatfs::Error::WriteZero),
+            map_fatfs_error(::fatfs::Error::WriteZero),
             Fat32Error::IoError,
             "WriteZero should map to IoError"
+        );
+        assert_eq!(
+            map_fatfs_error(::fatfs::Error::Io(MemoryIoError::ReadOnly)),
+            Fat32Error::ReadOnly,
+            "Io(ReadOnly) should map to ReadOnly"
         );
     }
 }

--- a/src/libs/fat32/src/fat/file.rs
+++ b/src/libs/fat32/src/fat/file.rs
@@ -16,6 +16,7 @@ use crate::{
     fat::{
         error::map_fatfs_error,
         InternalFatFile,
+        ReadOnlyInternalFatFile,
     },
 };
 use ::core::{
@@ -28,6 +29,47 @@ use ::fatfs::{
     SeekFrom,
     Write,
 };
+
+//==================================================================================================
+// Internal Enum
+//==================================================================================================
+
+/// Internal file handle that wraps either a read-write or read-only `fatfs::File`.
+pub(super) enum FatFileInner<'a> {
+    /// Wraps a file from a read-write FAT filesystem.
+    ReadWrite(InternalFatFile<'a>),
+    /// Wraps a file from a read-only FAT filesystem.
+    ReadOnly(ReadOnlyInternalFatFile<'a>),
+}
+
+/// Conversion trait for wrapping a `fatfs::File` into [`FatFileInner`].
+pub(super) trait IntoFileInner<'a> {
+    /// Wraps this `fatfs::File` into the appropriate [`FatFileInner`] variant.
+    fn into_file_inner(self) -> FatFileInner<'a>;
+}
+
+impl<'a> IntoFileInner<'a> for InternalFatFile<'a> {
+    fn into_file_inner(self) -> FatFileInner<'a> {
+        FatFileInner::ReadWrite(self)
+    }
+}
+
+impl<'a> IntoFileInner<'a> for ReadOnlyInternalFatFile<'a> {
+    fn into_file_inner(self) -> FatFileInner<'a> {
+        FatFileInner::ReadOnly(self)
+    }
+}
+
+/// Dispatches a method call on `FatFileInner`, executing the same body
+/// regardless of the storage variant.
+macro_rules! dispatch_file {
+    ($self:expr, |$file:ident| $body:expr) => {
+        match &mut $self.inner {
+            FatFileInner::ReadWrite($file) => $body,
+            FatFileInner::ReadOnly($file) => $body,
+        }
+    };
+}
 
 //==================================================================================================
 // Structures
@@ -46,7 +88,7 @@ use ::fatfs::{
 /// handles across threads will fail to compile.
 pub struct FatFile<'a> {
     /// The underlying fatfs file.
-    file: InternalFatFile<'a>,
+    inner: FatFileInner<'a>,
     /// Whether this file is open for reading.
     can_read: bool,
     /// Whether this file is open for writing.
@@ -64,12 +106,12 @@ impl<'a> FatFile<'a> {
     ///
     /// # Parameters
     ///
-    /// - `file`: The underlying fatfs file handle.
+    /// - `inner`: The underlying fatfs file handle (read-write or read-only).
     /// - `can_read`: Whether the file is open for reading.
     /// - `can_write`: Whether the file is open for writing.
-    pub(super) fn new(file: InternalFatFile<'a>, can_read: bool, can_write: bool) -> Self {
+    pub(super) fn new(inner: FatFileInner<'a>, can_read: bool, can_write: bool) -> Self {
         Self {
-            file,
+            inner,
             can_read,
             can_write,
             _not_send_sync: PhantomData,
@@ -100,15 +142,13 @@ impl<'a> FatFile<'a> {
     ///
     /// - [`Fat32Error::IoError`] if seeking fails.
     pub fn len(&mut self) -> Result<u64, Fat32Error> {
-        let current: u64 = self
-            .file
-            .seek(SeekFrom::Current(0))
-            .map_err(map_fatfs_error)?;
-        let size: u64 = self.file.seek(SeekFrom::End(0)).map_err(map_fatfs_error)?;
-        self.file
-            .seek(SeekFrom::Start(current))
-            .map_err(map_fatfs_error)?;
-        Ok(size)
+        dispatch_file!(self, |file| {
+            let current: u64 = file.seek(SeekFrom::Current(0)).map_err(map_fatfs_error)?;
+            let size: u64 = file.seek(SeekFrom::End(0)).map_err(map_fatfs_error)?;
+            file.seek(SeekFrom::Start(current))
+                .map_err(map_fatfs_error)?;
+            Ok(size)
+        })
     }
 
     /// Returns true if the file is empty.
@@ -138,7 +178,7 @@ impl<'a> FatFile<'a> {
         if !self.can_read {
             return Err(Fat32Error::PermissionDenied);
         }
-        self.file.read(buf).map_err(map_fatfs_error)
+        dispatch_file!(self, |file| { file.read(buf).map_err(map_fatfs_error) })
     }
 
     /// Writes data to the file.
@@ -160,7 +200,7 @@ impl<'a> FatFile<'a> {
         if !self.can_write {
             return Err(Fat32Error::ReadOnly);
         }
-        self.file.write(buf).map_err(map_fatfs_error)
+        dispatch_file!(self, |file| { file.write(buf).map_err(map_fatfs_error) })
     }
 
     /// Seeks to a position in the file.
@@ -177,7 +217,7 @@ impl<'a> FatFile<'a> {
     ///
     /// - [`Fat32Error::IoError`] if seeking to an invalid position.
     pub fn seek(&mut self, pos: SeekFrom) -> Result<u64, Fat32Error> {
-        self.file.seek(pos).map_err(map_fatfs_error)
+        dispatch_file!(self, |file| { file.seek(pos).map_err(map_fatfs_error) })
     }
 
     /// Flushes any buffered data to the filesystem.
@@ -186,7 +226,7 @@ impl<'a> FatFile<'a> {
     ///
     /// - [`Fat32Error::IoError`] on flush failure.
     pub fn flush(&mut self) -> Result<(), Fat32Error> {
-        self.file.flush().map_err(map_fatfs_error)
+        dispatch_file!(self, |file| { file.flush().map_err(map_fatfs_error) })
     }
 
     /// Truncates the file at the current position.
@@ -199,7 +239,7 @@ impl<'a> FatFile<'a> {
         if !self.can_write {
             return Err(Fat32Error::ReadOnly);
         }
-        self.file.truncate().map_err(map_fatfs_error)
+        dispatch_file!(self, |file| { file.truncate().map_err(map_fatfs_error) })
     }
 }
 

--- a/src/libs/fat32/src/fat/filesystem.rs
+++ b/src/libs/fat32/src/fat/filesystem.rs
@@ -11,10 +11,17 @@ use crate::{
     error::Fat32Error,
     fat::{
         error::map_fatfs_error,
-        file::FatFile,
-        storage::RawMemoryStorage,
+        file::{
+            FatFile,
+            IntoFileInner,
+        },
+        storage::{
+            RawMemoryStorage,
+            ReadOnlyMemoryStorage,
+        },
         time::NanvixTimeProvider,
         InternalFatFs,
+        ReadOnlyInternalFatFs,
     },
 };
 use ::core::fmt;
@@ -24,13 +31,39 @@ use ::fatfs::{
 };
 
 //==================================================================================================
+// Internal Enum
+//==================================================================================================
+
+/// Internal filesystem backend that wraps either a read-write or read-only storage.
+enum FatInner {
+    /// Read-write filesystem backed by [`RawMemoryStorage`].
+    ReadWrite(InternalFatFs),
+    /// Read-only filesystem backed by [`ReadOnlyMemoryStorage`].
+    ReadOnly(ReadOnlyInternalFatFs),
+}
+
+/// Dispatches a closure over the inner filesystem, regardless of storage variant.
+///
+/// Both arms expand the same body textually. Each expansion is type-checked
+/// independently against the corresponding `fatfs::FileSystem<IO, …>` type.
+macro_rules! dispatch_fs {
+    ($self:expr, |$fs:ident| $body:expr) => {
+        match &$self.inner {
+            FatInner::ReadWrite($fs) => $body,
+            FatInner::ReadOnly($fs) => $body,
+        }
+    };
+}
+
+//==================================================================================================
 // Structures
 //==================================================================================================
 
 /// High-level FAT filesystem wrapper.
 ///
-/// Wraps a `fatfs::FileSystem` over [`RawMemoryStorage`] and provides a
-/// clean API that returns [`Fat32Error`] instead of fatfs error types.
+/// Wraps a `fatfs::FileSystem` over either [`RawMemoryStorage`] (read-write) or
+/// [`ReadOnlyMemoryStorage`] (read-only) and provides a clean API that returns
+/// [`Fat32Error`] instead of fatfs error types.
 ///
 /// # Description
 ///
@@ -38,7 +71,7 @@ use ::fatfs::{
 /// containing a FAT image, this type allows reading and writing files.
 pub struct Fat {
     /// The underlying fatfs FileSystem.
-    fs: InternalFatFs,
+    inner: FatInner,
     /// Base pointer to the FAT image in memory (for zero-copy file access).
     base_ptr: *const u8,
 }
@@ -53,6 +86,11 @@ unsafe impl Send for Fat {}
 //==================================================================================================
 
 impl Fat {
+    /// Returns `true` if this filesystem is backed by read-only storage.
+    fn is_readonly(&self) -> bool {
+        matches!(self.inner, FatInner::ReadOnly(_))
+    }
+
     /// Opens an existing FAT filesystem from a memory region.
     ///
     /// # Parameters
@@ -80,8 +118,44 @@ impl Fat {
         let fs: InternalFatFs =
             ::fatfs::FileSystem::new(storage, options).map_err(map_fatfs_error)?;
         Ok(Self {
-            fs,
+            inner: FatInner::ReadWrite(fs),
             base_ptr: ptr as *const u8,
+        })
+    }
+
+    /// Opens an existing FAT filesystem from a read-only memory region.
+    ///
+    /// Uses [`ReadOnlyMemoryStorage`] with an immutable `*const u8` pointer,
+    /// preventing mutation of the underlying memory. Write operations through
+    /// the returned [`Fat`] will fail at runtime.
+    ///
+    /// # Parameters
+    ///
+    /// - `ptr`: Immutable pointer to the start of the FAT image in memory.
+    /// - `size`: Size of the memory region in bytes.
+    ///
+    /// # Returns
+    ///
+    /// A new [`Fat`] instance backed by read-only storage, or an error.
+    ///
+    /// # Errors
+    ///
+    /// - [`Fat32Error::InvalidArgument`] if `ptr` is null or `size` is zero.
+    /// - [`Fat32Error::IoError`] if the FAT image is invalid or corrupted.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the memory region is valid, properly aligned,
+    /// and remains valid for the lifetime of this [`Fat`].
+    pub unsafe fn from_memory_readonly(ptr: *const u8, size: usize) -> Result<Self, Fat32Error> {
+        // SAFETY: Caller guarantees memory region validity.
+        let storage: ReadOnlyMemoryStorage = unsafe { ReadOnlyMemoryStorage::new(ptr, size)? };
+        let options = ::fatfs::FsOptions::new().time_provider(NanvixTimeProvider);
+        let fs: ReadOnlyInternalFatFs =
+            ::fatfs::FileSystem::new(storage, options).map_err(map_fatfs_error)?;
+        Ok(Self {
+            inner: FatInner::ReadOnly(fs),
+            base_ptr: ptr,
         })
     }
 
@@ -111,29 +185,35 @@ impl Fat {
         create: bool,
         truncate: bool,
     ) -> Result<FatFile<'_>, Fat32Error> {
-        let root = self.fs.root_dir();
-
-        if create {
-            match root.open_file(path) {
-                Ok(mut file) => {
-                    if truncate {
-                        file.truncate().map_err(map_fatfs_error)?;
-                    }
-                    Ok(FatFile::new(file, read, write))
-                },
-                Err(::fatfs::Error::NotFound) => {
-                    let file = root.create_file(path).map_err(map_fatfs_error)?;
-                    Ok(FatFile::new(file, read, write))
-                },
-                Err(e) => Err(map_fatfs_error(e)),
-            }
-        } else {
-            let mut file = root.open_file(path).map_err(map_fatfs_error)?;
-            if truncate && write {
-                file.truncate().map_err(map_fatfs_error)?;
-            }
-            Ok(FatFile::new(file, read, write))
+        // Reject mutating open modes on a read-only filesystem.
+        if self.is_readonly() && (write || create || truncate) {
+            return Err(Fat32Error::ReadOnly);
         }
+        dispatch_fs!(self, |fs| {
+            let root = fs.root_dir();
+
+            if create {
+                match root.open_file(path) {
+                    Ok(mut file) => {
+                        if truncate {
+                            file.truncate().map_err(map_fatfs_error)?;
+                        }
+                        Ok(FatFile::new(file.into_file_inner(), read, write))
+                    },
+                    Err(::fatfs::Error::NotFound) => {
+                        let file = root.create_file(path).map_err(map_fatfs_error)?;
+                        Ok(FatFile::new(file.into_file_inner(), read, write))
+                    },
+                    Err(e) => Err(map_fatfs_error(e)),
+                }
+            } else {
+                let mut file = root.open_file(path).map_err(map_fatfs_error)?;
+                if truncate && write {
+                    file.truncate().map_err(map_fatfs_error)?;
+                }
+                Ok(FatFile::new(file.into_file_inner(), read, write))
+            }
+        })
     }
 
     /// Creates a new file, failing if it already exists.
@@ -160,16 +240,21 @@ impl Fat {
         read: bool,
         write: bool,
     ) -> Result<FatFile<'_>, Fat32Error> {
-        let root = self.fs.root_dir();
-
-        // fatfs::Dir::create_file does NOT fail if file exists - it opens it.
-        // We must explicitly check for existence first.
-        if root.open_file(path).is_ok() {
-            return Err(Fat32Error::AlreadyExists);
+        if self.is_readonly() {
+            return Err(Fat32Error::ReadOnly);
         }
+        dispatch_fs!(self, |fs| {
+            let root = fs.root_dir();
 
-        let file = root.create_file(path).map_err(map_fatfs_error)?;
-        Ok(FatFile::new(file, read, write))
+            // fatfs::Dir::create_file does NOT fail if file exists - it opens it.
+            // We must explicitly check for existence first.
+            if root.open_file(path).is_ok() {
+                return Err(Fat32Error::AlreadyExists);
+            }
+
+            let file = root.create_file(path).map_err(map_fatfs_error)?;
+            Ok(FatFile::new(file.into_file_inner(), read, write))
+        })
     }
 
     /// Gets file/directory metadata.
@@ -186,33 +271,35 @@ impl Fat {
     ///
     /// - [`Fat32Error::NotFound`] if path doesn't exist.
     pub fn stat(&self, path: &str) -> Result<FatStat, Fat32Error> {
-        let root = self.fs.root_dir();
+        dispatch_fs!(self, |fs| {
+            let root = fs.root_dir();
 
-        if path.is_empty() || path == "/" || path == "." {
-            return Ok(FatStat {
-                size: 0,
-                is_dir: true,
-            });
-        }
+            if path.is_empty() || path == "/" || path == "." {
+                return Ok(FatStat {
+                    size: 0,
+                    is_dir: true,
+                });
+            }
 
-        // Try opening as file first.
-        if let Ok(mut file) = root.open_file(path) {
-            let size: u64 = file.seek(SeekFrom::End(0)).map_err(map_fatfs_error)?;
-            return Ok(FatStat {
-                size,
-                is_dir: false,
-            });
-        }
+            // Try opening as file first.
+            if let Ok(mut file) = root.open_file(path) {
+                let size: u64 = file.seek(SeekFrom::End(0)).map_err(map_fatfs_error)?;
+                return Ok(FatStat {
+                    size,
+                    is_dir: false,
+                });
+            }
 
-        // Try opening as directory.
-        if root.open_dir(path).is_ok() {
-            return Ok(FatStat {
-                size: 0,
-                is_dir: true,
-            });
-        }
+            // Try opening as directory.
+            if root.open_dir(path).is_ok() {
+                return Ok(FatStat {
+                    size: 0,
+                    is_dir: true,
+                });
+            }
 
-        Err(Fat32Error::NotFound)
+            Err(Fat32Error::NotFound)
+        })
     }
 
     /// Returns a pointer and size for zero-copy access to a file's data.
@@ -226,43 +313,35 @@ impl Fat {
     ///
     /// - `path`: Path relative to the FAT root.
     pub fn file_raw_region(&self, path: &str) -> Option<(*const u8, usize)> {
-        let root: ::fatfs::Dir<
-            '_,
-            RawMemoryStorage,
-            NanvixTimeProvider,
-            ::fatfs::LossyOemCpConverter,
-        > = self.fs.root_dir();
-        let mut file: ::fatfs::File<
-            '_,
-            RawMemoryStorage,
-            NanvixTimeProvider,
-            ::fatfs::LossyOemCpConverter,
-        > = root.open_file(path).ok()?;
+        dispatch_fs!(self, |fs| {
+            let root = fs.root_dir();
+            let mut file = root.open_file(path).ok()?;
 
-        let mut first_offset: Option<u64> = None;
-        let mut total_size: usize = 0;
-        let mut next_expected: u64 = 0;
+            let mut first_offset: Option<u64> = None;
+            let mut total_size: usize = 0;
+            let mut next_expected: u64 = 0;
 
-        for (i, extent_result) in file.extents().enumerate() {
-            let extent: ::fatfs::Extent = extent_result.ok()?;
-            if i == 0 {
-                first_offset = Some(extent.offset);
-            } else if extent.offset != next_expected {
-                return None; // Not contiguous.
+            for (i, extent_result) in file.extents().enumerate() {
+                let extent: ::fatfs::Extent = extent_result.ok()?;
+                if i == 0 {
+                    first_offset = Some(extent.offset);
+                } else if extent.offset != next_expected {
+                    return None; // Not contiguous.
+                }
+                next_expected = extent.offset + extent.size as u64;
+                total_size += extent.size as usize;
             }
-            next_expected = extent.offset + extent.size as u64;
-            total_size += extent.size as usize;
-        }
 
-        let offset: u64 = first_offset?;
-        if total_size == 0 {
-            return None;
-        }
+            let offset: u64 = first_offset?;
+            if total_size == 0 {
+                return None;
+            }
 
-        // SAFETY: base_ptr is valid for the lifetime of the Fat instance,
-        // and offset + total_size is within the FAT image bounds.
-        let data_ptr: *const u8 = unsafe { self.base_ptr.add(offset as usize) };
-        Some((data_ptr, total_size))
+            // SAFETY: base_ptr is valid for the lifetime of the Fat instance,
+            // and offset + total_size is within the FAT image bounds.
+            let data_ptr: *const u8 = unsafe { self.base_ptr.add(offset as usize) };
+            Some((data_ptr, total_size))
+        })
     }
 
     /// Reads directory contents.
@@ -280,31 +359,33 @@ impl Fat {
     /// - [`Fat32Error::NotFound`] if directory doesn't exist.
     /// - [`Fat32Error::IoError`] if path is a file.
     pub fn read_dir(&self, path: &str) -> Result<alloc::vec::Vec<FatDirEntry>, Fat32Error> {
-        let root = self.fs.root_dir();
+        dispatch_fs!(self, |fs| {
+            let root = fs.root_dir();
 
-        let dir = if path.is_empty() || path == "/" || path == "." {
-            root
-        } else {
-            root.open_dir(path).map_err(map_fatfs_error)?
-        };
+            let dir = if path.is_empty() || path == "/" || path == "." {
+                root
+            } else {
+                root.open_dir(path).map_err(map_fatfs_error)?
+            };
 
-        let mut entries: alloc::vec::Vec<FatDirEntry> = alloc::vec::Vec::new();
-        for entry in dir.iter() {
-            let entry = entry.map_err(map_fatfs_error)?;
-            let name: alloc::string::String = entry.file_name();
+            let mut entries: alloc::vec::Vec<FatDirEntry> = alloc::vec::Vec::new();
+            for entry in dir.iter() {
+                let entry = entry.map_err(map_fatfs_error)?;
+                let name: alloc::string::String = entry.file_name();
 
-            if name == "." || name == ".." {
-                continue;
+                if name == "." || name == ".." {
+                    continue;
+                }
+
+                entries.push(FatDirEntry {
+                    name,
+                    is_dir: entry.is_dir(),
+                    size: entry.len(),
+                });
             }
 
-            entries.push(FatDirEntry {
-                name,
-                is_dir: entry.is_dir(),
-                size: entry.len(),
-            });
-        }
-
-        Ok(entries)
+            Ok(entries)
+        })
     }
 
     /// Creates a directory.
@@ -323,17 +404,22 @@ impl Fat {
         if path.is_empty() {
             return Err(Fat32Error::NotFound);
         }
-
-        let root = self.fs.root_dir();
-
-        // fatfs::Dir::create_dir does NOT fail if the directory exists — it
-        // silently opens it. Check explicitly so callers get AlreadyExists.
-        if root.open_dir(path).is_ok() {
-            return Err(Fat32Error::AlreadyExists);
+        if self.is_readonly() {
+            return Err(Fat32Error::ReadOnly);
         }
 
-        root.create_dir(path).map_err(map_fatfs_error)?;
-        Ok(())
+        dispatch_fs!(self, |fs| {
+            let root = fs.root_dir();
+
+            // fatfs::Dir::create_dir does NOT fail if the directory exists — it
+            // silently opens it. Check explicitly so callers get AlreadyExists.
+            if root.open_dir(path).is_ok() {
+                return Err(Fat32Error::AlreadyExists);
+            }
+
+            root.create_dir(path).map_err(map_fatfs_error)?;
+            Ok(())
+        })
     }
 
     /// Removes an empty directory.
@@ -353,18 +439,23 @@ impl Fat {
         if path.is_empty() {
             return Err(Fat32Error::NotFound);
         }
-
-        let root = self.fs.root_dir();
-
-        // Verify it is a directory, not a file.
-        if root.open_file(path).is_ok() {
-            return Err(Fat32Error::NotADirectory);
+        if self.is_readonly() {
+            return Err(Fat32Error::ReadOnly);
         }
 
-        // Verify directory exists before removing.
-        root.open_dir(path).map_err(map_fatfs_error)?;
+        dispatch_fs!(self, |fs| {
+            let root = fs.root_dir();
 
-        root.remove(path).map_err(map_fatfs_error)
+            // Verify it is a directory, not a file.
+            if root.open_file(path).is_ok() {
+                return Err(Fat32Error::NotADirectory);
+            }
+
+            // Verify directory exists before removing.
+            root.open_dir(path).map_err(map_fatfs_error)?;
+
+            root.remove(path).map_err(map_fatfs_error)
+        })
     }
 
     /// Deletes a file.
@@ -383,18 +474,23 @@ impl Fat {
         if path.is_empty() {
             return Err(Fat32Error::NotFound);
         }
-
-        let root = self.fs.root_dir();
-
-        // Verify it is a file, not a directory.
-        if root.open_dir(path).is_ok() {
-            return Err(Fat32Error::NotAFile);
+        if self.is_readonly() {
+            return Err(Fat32Error::ReadOnly);
         }
 
-        // Verify file exists before removing.
-        root.open_file(path).map_err(map_fatfs_error)?;
+        dispatch_fs!(self, |fs| {
+            let root = fs.root_dir();
 
-        root.remove(path).map_err(map_fatfs_error)
+            // Verify it is a file, not a directory.
+            if root.open_dir(path).is_ok() {
+                return Err(Fat32Error::NotAFile);
+            }
+
+            // Verify file exists before removing.
+            root.open_file(path).map_err(map_fatfs_error)?;
+
+            root.remove(path).map_err(map_fatfs_error)
+        })
     }
 
     /// Renames/moves a file or directory.
@@ -414,10 +510,15 @@ impl Fat {
         if old_path.is_empty() || new_path.is_empty() {
             return Err(Fat32Error::NotFound);
         }
+        if self.is_readonly() {
+            return Err(Fat32Error::ReadOnly);
+        }
 
-        let root = self.fs.root_dir();
-        root.rename(old_path, &root, new_path)
-            .map_err(map_fatfs_error)
+        dispatch_fs!(self, |fs| {
+            let root = fs.root_dir();
+            root.rename(old_path, &root, new_path)
+                .map_err(map_fatfs_error)
+        })
     }
 }
 
@@ -888,5 +989,242 @@ mod tests {
         let fat: &Fat = &handle;
         let debug: alloc::string::String = alloc::format!("{fat:?}");
         assert!(debug.contains("Fat"), "debug should contain type name");
+    }
+}
+
+//==================================================================================================
+// Unit Tests (Read-Only)
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+#[allow(clippy::expect_used)]
+mod readonly_tests {
+    use super::*;
+    use crate::fat::RawMemoryStorage;
+    use ::alloc::{
+        vec,
+        vec::Vec,
+    };
+
+    const IMG_SIZE: usize = 128 * 1024;
+
+    /// Helper: creates a formatted FAT image with a pre-populated file and directory,
+    /// then re-opens it as read-only via `Fat::from_memory_readonly`.
+    ///
+    /// Returns the read-only `Fat` and the backing buffer (which must outlive `Fat`).
+    fn make_readonly_fat() -> (Fat, Vec<u8>) {
+        let mut buf: Vec<u8> = vec![0u8; IMG_SIZE];
+        let ptr: *mut u8 = buf.as_mut_ptr();
+
+        // Format and seed with content using the read-write path.
+        {
+            let mut storage: RawMemoryStorage =
+                unsafe { RawMemoryStorage::new(ptr, IMG_SIZE).expect("valid storage") };
+            ::fatfs::format_volume(&mut storage, ::fatfs::FormatVolumeOptions::new())
+                .expect("format should succeed");
+
+            let fat: Fat = unsafe { Fat::from_memory(ptr, IMG_SIZE).expect("valid fat") };
+            {
+                let mut file = fat
+                    .open("hello.txt", false, true, true, false)
+                    .expect("create file should succeed");
+                file.write(b"hello readonly").expect("write should succeed");
+                file.flush().expect("flush should succeed");
+            }
+            fat.mkdir("subdir").expect("mkdir should succeed");
+            // Drop `fat` to flush all metadata before re-opening as read-only.
+        }
+
+        // Re-open as read-only.
+        let fat: Fat = unsafe {
+            Fat::from_memory_readonly(buf.as_ptr(), IMG_SIZE)
+                .expect("readonly mount should succeed")
+        };
+        (fat, buf)
+    }
+
+    /// Wrapper that ensures `Fat` is dropped before its backing buffer.
+    struct ReadOnlyFatHandle {
+        fat: core::mem::ManuallyDrop<Fat>,
+        _buf: Vec<u8>,
+    }
+
+    impl ReadOnlyFatHandle {
+        fn new() -> Self {
+            let (fat, buf) = make_readonly_fat();
+            Self {
+                fat: core::mem::ManuallyDrop::new(fat),
+                _buf: buf,
+            }
+        }
+    }
+
+    impl core::ops::Deref for ReadOnlyFatHandle {
+        type Target = Fat;
+        fn deref(&self) -> &Fat {
+            &self.fat
+        }
+    }
+
+    impl Drop for ReadOnlyFatHandle {
+        fn drop(&mut self) {
+            // SAFETY: `fat` is dropped exactly once, before `_buf`.
+            unsafe {
+                core::mem::ManuallyDrop::drop(&mut self.fat);
+            }
+        }
+    }
+
+    // -- Constructor tests -------------------------------------------------------
+
+    /// Tests that `from_memory_readonly` rejects a null pointer.
+    #[test]
+    fn from_memory_readonly_null_ptr_fails() {
+        let result: Result<Fat, Fat32Error> =
+            unsafe { Fat::from_memory_readonly(core::ptr::null(), 1024) };
+        assert!(result.is_err(), "null pointer should be rejected");
+    }
+
+    /// Tests that `from_memory_readonly` rejects zero size.
+    #[test]
+    fn from_memory_readonly_zero_size_fails() {
+        let buf: [u8; 1024] = [0; 1024];
+        let result: Result<Fat, Fat32Error> = unsafe { Fat::from_memory_readonly(buf.as_ptr(), 0) };
+        assert!(result.is_err(), "zero size should be rejected");
+    }
+
+    /// Tests that `from_memory_readonly` succeeds on a formatted image.
+    #[test]
+    fn from_memory_readonly_valid_image() {
+        let _fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+    }
+
+    // -- Read-only read operations -----------------------------------------------
+
+    /// Tests that stat works on a read-only filesystem.
+    #[test]
+    fn readonly_stat_file() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let info: FatStat = fat.stat("hello.txt").expect("stat should succeed");
+        assert!(!info.is_dir, "should not be a directory");
+        assert_eq!(info.size, 14, "file size should match written content");
+    }
+
+    /// Tests that stat on a directory works on a read-only filesystem.
+    #[test]
+    fn readonly_stat_dir() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let info: FatStat = fat.stat("subdir").expect("stat subdir should succeed");
+        assert!(info.is_dir, "should be a directory");
+    }
+
+    /// Tests that stat on root works on a read-only filesystem.
+    #[test]
+    fn readonly_stat_root() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let info: FatStat = fat.stat("/").expect("stat root should succeed");
+        assert!(info.is_dir, "root should be a directory");
+    }
+
+    /// Tests reading a file on a read-only filesystem.
+    #[test]
+    fn readonly_read_file() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let mut file = fat
+            .open("hello.txt", true, false, false, false)
+            .expect("open for read should succeed");
+        let mut buf: [u8; 64] = [0u8; 64];
+        let n: usize = file.read(&mut buf).expect("read should succeed");
+        assert_eq!(&buf[..n], b"hello readonly");
+    }
+
+    /// Tests read_dir on a read-only filesystem.
+    #[test]
+    fn readonly_read_dir() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let entries: Vec<FatDirEntry> = fat.read_dir("").expect("read_dir should succeed");
+        assert_eq!(entries.len(), 2, "should have 2 entries (file + dir)");
+
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"hello.txt"), "should contain hello.txt");
+        assert!(names.contains(&"subdir"), "should contain subdir");
+    }
+
+    // -- Read-only write guards --------------------------------------------------
+
+    /// Tests that open with write flag returns ReadOnly on a read-only filesystem.
+    #[test]
+    fn readonly_open_write_fails() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let result = fat.open("hello.txt", true, true, false, false);
+        assert_eq!(
+            result.unwrap_err(),
+            Fat32Error::ReadOnly,
+            "open with write should return ReadOnly"
+        );
+    }
+
+    /// Tests that open with create flag returns ReadOnly on a read-only filesystem.
+    #[test]
+    fn readonly_open_create_fails() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let result = fat.open("new.txt", true, false, true, false);
+        assert_eq!(
+            result.unwrap_err(),
+            Fat32Error::ReadOnly,
+            "open with create should return ReadOnly"
+        );
+    }
+
+    /// Tests that open with truncate flag returns ReadOnly on a read-only filesystem.
+    #[test]
+    fn readonly_open_truncate_fails() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let result = fat.open("hello.txt", true, false, false, true);
+        assert_eq!(
+            result.unwrap_err(),
+            Fat32Error::ReadOnly,
+            "open with truncate should return ReadOnly"
+        );
+    }
+
+    /// Tests that create_new returns ReadOnly on a read-only filesystem.
+    #[test]
+    fn readonly_create_new_fails() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let result = fat.create_new("brand-new.txt", true, true);
+        assert_eq!(result.unwrap_err(), Fat32Error::ReadOnly, "create_new should return ReadOnly");
+    }
+
+    /// Tests that mkdir returns ReadOnly on a read-only filesystem.
+    #[test]
+    fn readonly_mkdir_fails() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let result: Result<(), Fat32Error> = fat.mkdir("newdir");
+        assert_eq!(result.unwrap_err(), Fat32Error::ReadOnly, "mkdir should return ReadOnly");
+    }
+
+    /// Tests that rmdir returns ReadOnly on a read-only filesystem.
+    #[test]
+    fn readonly_rmdir_fails() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let result: Result<(), Fat32Error> = fat.rmdir("subdir");
+        assert_eq!(result.unwrap_err(), Fat32Error::ReadOnly, "rmdir should return ReadOnly");
+    }
+
+    /// Tests that unlink returns ReadOnly on a read-only filesystem.
+    #[test]
+    fn readonly_unlink_fails() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let result: Result<(), Fat32Error> = fat.unlink("hello.txt");
+        assert_eq!(result.unwrap_err(), Fat32Error::ReadOnly, "unlink should return ReadOnly");
+    }
+
+    /// Tests that rename returns ReadOnly on a read-only filesystem.
+    #[test]
+    fn readonly_rename_fails() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        let result: Result<(), Fat32Error> = fat.rename("hello.txt", "renamed.txt");
+        assert_eq!(result.unwrap_err(), Fat32Error::ReadOnly, "rename should return ReadOnly");
     }
 }

--- a/src/libs/fat32/src/fat/mod.rs
+++ b/src/libs/fat32/src/fat/mod.rs
@@ -27,7 +27,10 @@ mod time;
 pub use self::{
     file::FatFile,
     filesystem::Fat,
-    storage::RawMemoryStorage,
+    storage::{
+        RawMemoryStorage,
+        ReadOnlyMemoryStorage,
+    },
 };
 
 //==================================================================================================
@@ -41,3 +44,18 @@ pub(crate) type InternalFatFs =
 /// Type alias for a FAT file handle.
 pub(crate) type InternalFatFile<'a> =
     ::fatfs::File<'a, RawMemoryStorage, time::NanvixTimeProvider, ::fatfs::LossyOemCpConverter>;
+
+/// Type alias for the read-only FAT filesystem.
+pub(crate) type ReadOnlyInternalFatFs = ::fatfs::FileSystem<
+    ReadOnlyMemoryStorage,
+    time::NanvixTimeProvider,
+    ::fatfs::LossyOemCpConverter,
+>;
+
+/// Type alias for a read-only FAT file handle.
+pub(crate) type ReadOnlyInternalFatFile<'a> = ::fatfs::File<
+    'a,
+    ReadOnlyMemoryStorage,
+    time::NanvixTimeProvider,
+    ::fatfs::LossyOemCpConverter,
+>;

--- a/src/libs/fat32/src/fat/storage.rs
+++ b/src/libs/fat32/src/fat/storage.rs
@@ -197,7 +197,162 @@ impl Seek for RawMemoryStorage {
 }
 
 //==================================================================================================
-// Unit Tests
+// ReadOnlyMemoryStorage
+//==================================================================================================
+
+/// A read-only storage backend backed by a raw memory region.
+pub struct ReadOnlyMemoryStorage {
+    /// Pointer to start of the memory region (immutable).
+    base: *const u8,
+    /// Size of the memory region in bytes.
+    size: usize,
+    /// Current read position.
+    position: usize,
+}
+
+//==================================================================================================
+// ReadOnlyMemoryStorage Implementations
+//==================================================================================================
+
+impl ReadOnlyMemoryStorage {
+    ///
+    /// # Description
+    ///
+    /// Creates a new read-only storage over a memory region.
+    ///
+    /// # Parameters
+    ///
+    /// - `base`: Pointer to the start of the FAT image in memory.
+    /// - `size`: Size of the memory region in bytes.
+    ///
+    /// # Returns
+    ///
+    /// - Success: `Ok(Self)`
+    /// - Failure: `Err(Fat32Error::InvalidArgument)` if `base` is null or `size` is zero.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure:
+    /// - `base` points to a valid, readable memory region.
+    /// - The memory region is at least `size` bytes.
+    /// - The memory remains valid for the lifetime of this `ReadOnlyMemoryStorage`.
+    /// - No other code mutates this memory region concurrently.
+    ///
+    #[inline]
+    pub unsafe fn new(base: *const u8, size: usize) -> Result<Self, Fat32Error> {
+        if base.is_null() {
+            return Err(Fat32Error::InvalidArgument);
+        }
+        if size == 0 {
+            return Err(Fat32Error::InvalidArgument);
+        }
+        Ok(Self {
+            base,
+            size,
+            position: 0,
+        })
+    }
+
+    /// Returns the number of bytes remaining from current position to end.
+    #[inline]
+    fn remaining(&self) -> usize {
+        self.size.saturating_sub(self.position)
+    }
+}
+
+//==================================================================================================
+// ReadOnlyMemoryStorage Trait Implementations
+//==================================================================================================
+
+impl fmt::Debug for ReadOnlyMemoryStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadOnlyMemoryStorage")
+            .field("base", &self.base)
+            .field("size", &self.size)
+            .field("position", &self.position)
+            .finish()
+    }
+}
+
+// SAFETY: Moving ReadOnlyMemoryStorage to another thread is sound because it provides ownership-
+// based access only: mutating the cursor requires `&mut self`, so sharing the same instance across
+// threads still requires external synchronization by the caller. The unsafe constructor requires
+// `base` to point to a valid readable memory region that remains valid for the lifetime of the
+// storage, and that region must not be concurrently mutated.
+unsafe impl Send for ReadOnlyMemoryStorage {}
+
+impl IoBase for ReadOnlyMemoryStorage {
+    type Error = MemoryIoError;
+}
+
+impl Read for ReadOnlyMemoryStorage {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let to_read: usize = buf.len().min(self.remaining());
+        if to_read == 0 {
+            return Ok(0);
+        }
+
+        // SAFETY: We verified position + to_read <= size, and the caller
+        // guaranteed the memory region is valid via the unsafe constructor.
+        unsafe {
+            let src: *const u8 = self.base.add(self.position);
+            core::ptr::copy_nonoverlapping(src, buf.as_mut_ptr(), to_read);
+        }
+
+        self.position += to_read;
+        Ok(to_read)
+    }
+}
+
+impl Write for ReadOnlyMemoryStorage {
+    fn write(&mut self, _buf: &[u8]) -> Result<usize, Self::Error> {
+        Err(MemoryIoError::ReadOnly)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        // Nothing to flush on a read-only storage.
+        Ok(())
+    }
+}
+
+impl Seek for ReadOnlyMemoryStorage {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+        let new_pos: i64 = match pos {
+            SeekFrom::Start(offset) => {
+                i64::try_from(offset).map_err(|_| MemoryIoError::OutOfBounds)?
+            },
+            SeekFrom::End(offset) => {
+                let size: i64 = i64::try_from(self.size).map_err(|_| MemoryIoError::OutOfBounds)?;
+                size.checked_add(offset).ok_or(MemoryIoError::OutOfBounds)?
+            },
+            SeekFrom::Current(offset) => {
+                let pos: i64 =
+                    i64::try_from(self.position).map_err(|_| MemoryIoError::OutOfBounds)?;
+                pos.checked_add(offset).ok_or(MemoryIoError::OutOfBounds)?
+            },
+        };
+
+        if new_pos < 0 {
+            return Err(MemoryIoError::InvalidSeek);
+        }
+
+        let new_pos: usize = usize::try_from(new_pos).map_err(|_| MemoryIoError::OutOfBounds)?;
+
+        if new_pos > self.size {
+            return Err(MemoryIoError::OutOfBounds);
+        }
+
+        self.position = new_pos;
+        Ok(new_pos as u64)
+    }
+}
+
+//==================================================================================================
+// Unit Tests (RawMemoryStorage)
 //==================================================================================================
 
 #[cfg(test)]
@@ -454,5 +609,166 @@ mod tests {
         assert!(debug_str.contains("RawMemoryStorage"), "debug output should contain type name");
         assert!(debug_str.contains("size"), "debug output should contain 'size'");
         assert!(debug_str.contains("position"), "debug output should contain 'position'");
+    }
+}
+
+//==================================================================================================
+// Unit Tests (ReadOnlyMemoryStorage)
+//==================================================================================================
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod readonly_tests {
+    use super::*;
+    use ::alloc::{
+        vec,
+        vec::Vec,
+    };
+
+    /// Helper: creates a `ReadOnlyMemoryStorage` backed by a Vec.
+    /// Returns the storage and the backing buffer (which must be kept alive).
+    fn make_readonly_storage(size: usize) -> (ReadOnlyMemoryStorage, Vec<u8>) {
+        let buf: Vec<u8> = vec![0u8; size];
+        let ptr: *const u8 = buf.as_ptr();
+        // SAFETY: ptr points to `buf` which is valid for `size` bytes.
+        let storage: ReadOnlyMemoryStorage =
+            unsafe { ReadOnlyMemoryStorage::new(ptr, size).expect("valid storage") };
+        (storage, buf)
+    }
+
+    // -- Constructor tests -------------------------------------------------------
+
+    /// Tests that null pointer is rejected.
+    #[test]
+    fn new_rejects_null_pointer() {
+        let result: Result<ReadOnlyMemoryStorage, _> =
+            unsafe { ReadOnlyMemoryStorage::new(core::ptr::null(), 1024) };
+        assert_eq!(
+            result.unwrap_err(),
+            Fat32Error::InvalidArgument,
+            "null pointer should be rejected"
+        );
+    }
+
+    /// Tests that zero size is rejected.
+    #[test]
+    fn new_rejects_zero_size() {
+        let buf: [u8; 1] = [0];
+        let result: Result<ReadOnlyMemoryStorage, _> =
+            unsafe { ReadOnlyMemoryStorage::new(buf.as_ptr(), 0) };
+        assert_eq!(
+            result.unwrap_err(),
+            Fat32Error::InvalidArgument,
+            "zero size should be rejected"
+        );
+    }
+
+    /// Tests successful construction.
+    #[test]
+    fn new_succeeds_with_valid_args() {
+        let (storage, _buf) = make_readonly_storage(64);
+        assert_eq!(storage.remaining(), 64, "remaining should equal size at position 0");
+    }
+
+    // -- Read tests --------------------------------------------------------------
+
+    /// Tests reading data from the backing buffer.
+    #[test]
+    fn read_returns_data() {
+        let buf: Vec<u8> = vec![0xBB; 16];
+        let ptr: *const u8 = buf.as_ptr();
+        let mut storage: ReadOnlyMemoryStorage =
+            unsafe { ReadOnlyMemoryStorage::new(ptr, 16).expect("valid storage") };
+
+        let mut read_buf: [u8; 4] = [0; 4];
+        let n: usize = storage.read(&mut read_buf).expect("read should succeed");
+        assert_eq!(n, 4, "should read 4 bytes");
+        assert_eq!(read_buf, [0xBB; 4], "should read the correct data");
+    }
+
+    /// Tests reading an empty buffer.
+    #[test]
+    fn read_empty_buffer_returns_zero() {
+        let (mut storage, _buf) = make_readonly_storage(16);
+        let mut empty: [u8; 0] = [];
+        let n: usize = storage.read(&mut empty).expect("read should succeed");
+        assert_eq!(n, 0, "reading empty buffer should return 0");
+    }
+
+    /// Tests that read at end of storage returns 0.
+    #[test]
+    fn read_at_end_returns_zero() {
+        let (mut storage, _buf) = make_readonly_storage(8);
+        storage.seek(SeekFrom::End(0)).expect("seek to end");
+
+        let mut read_buf: [u8; 4] = [0; 4];
+        let n: usize = storage.read(&mut read_buf).expect("read should succeed");
+        assert_eq!(n, 0, "reading at end should return 0");
+    }
+
+    // -- Write tests (always fail) -----------------------------------------------
+
+    /// Tests that write always returns ReadOnly error.
+    #[test]
+    fn write_returns_read_only_error() {
+        let (mut storage, _buf) = make_readonly_storage(32);
+        let result = storage.write(b"hello");
+        assert_eq!(
+            result.unwrap_err(),
+            MemoryIoError::ReadOnly,
+            "write should return ReadOnly error"
+        );
+    }
+
+    /// Tests that flush succeeds (no-op for read-only storage).
+    #[test]
+    fn flush_succeeds() {
+        let (mut storage, _buf) = make_readonly_storage(8);
+        storage
+            .flush()
+            .expect("flush should always succeed on read-only storage");
+    }
+
+    // -- Seek tests --------------------------------------------------------------
+
+    /// Tests seek from start.
+    #[test]
+    fn seek_from_start() {
+        let (mut storage, _buf) = make_readonly_storage(64);
+        let pos: u64 = storage
+            .seek(SeekFrom::Start(10))
+            .expect("seek should succeed");
+        assert_eq!(pos, 10, "position should be 10");
+    }
+
+    /// Tests seek from end.
+    #[test]
+    fn seek_from_end() {
+        let (mut storage, _buf) = make_readonly_storage(64);
+        let pos: u64 = storage
+            .seek(SeekFrom::End(-4))
+            .expect("seek should succeed");
+        assert_eq!(pos, 60, "position should be 60");
+    }
+
+    /// Tests that seeking past the end fails.
+    #[test]
+    fn seek_past_end_fails() {
+        let (mut storage, _buf) = make_readonly_storage(64);
+        let result = storage.seek(SeekFrom::Start(65));
+        assert_eq!(result.unwrap_err(), MemoryIoError::OutOfBounds, "should fail with OutOfBounds");
+    }
+
+    // -- Debug trait test --------------------------------------------------------
+
+    /// Tests that Debug formatting includes type name.
+    #[test]
+    fn debug_format() {
+        let (storage, _buf) = make_readonly_storage(32);
+        let debug_str: alloc::string::String = alloc::format!("{storage:?}");
+        assert!(
+            debug_str.contains("ReadOnlyMemoryStorage"),
+            "debug output should contain type name"
+        );
     }
 }

--- a/src/libs/fat32/src/lib.rs
+++ b/src/libs/fat32/src/lib.rs
@@ -36,5 +36,6 @@ pub use crate::{
         Fat,
         FatFile,
         RawMemoryStorage,
+        ReadOnlyMemoryStorage,
     },
 };

--- a/src/libs/vfs/src/state.rs
+++ b/src/libs/vfs/src/state.rs
@@ -189,7 +189,11 @@ pub unsafe fn mount_image(
     }
 
     // SAFETY: Caller guarantees memory region validity.
-    let fat: Fat = unsafe { Fat::from_memory(ptr, size)? };
+    let fat: Fat = if readonly {
+        unsafe { Fat::from_memory_readonly(ptr as *const u8, size)? }
+    } else {
+        unsafe { Fat::from_memory(ptr, size)? }
+    };
     let mount: Mount = Mount::new(String::from(mount_path), fat, readonly)?;
 
     let mut state = VFS_STATE.lock();


### PR DESCRIPTION
Closes #1683 

Introduce `ReadOnlyMemoryStorage`, a storage backend that wraps an immutable `*const u8` pointer and rejects all write operations at the I/O layer with `MemoryIoError::ReadOnly`. This enables mounting FAT images from read-only memory regions without requiring a mutable pointer.

Refactor `Fat` and `FatFile` to support both read-write and read-only backends through internal enums (`FatInner`, `FatFileInner`) and dispatch macros. All public `Fat` methods dispatch over the storage variant, while mutating operations (`open` with write/create/truncate, `create_new`, `mkdir`, `rmdir`, `unlink`, `rename`) include early read-only guards that return `Fat32Error::ReadOnly` before reaching the fatfs layer.

Wire up the VFS `mount_image()` to use `Fat::from_memory_readonly()` when the readonly flag is set, passing the pointer as `*const u8` instead of `*mut u8`.

### Changes

- **storage.rs**: Add `ReadOnlyMemoryStorage` with `Read`, `Seek`, `Send` impls; `Write::write()` returns `MemoryIoError::ReadOnly`; add unit tests.
- **error.rs**: Add `MemoryIoError::ReadOnly` variant with `Display` impl.
- **file.rs**: Add `FatFileInner` enum, `IntoFileInner` trait, and `dispatch_file!` macro; replace direct field access with dispatch.
- **filesystem.rs**: Add `FatInner` enum and `dispatch_fs!` macro; add `Fat::from_memory_readonly()` constructor; add `Fat::is_readonly()` helper; add early read-only guards to all mutating methods.
- **mod.rs**: Add `ReadOnlyInternalFatFs` and `ReadOnlyInternalFatFile` type aliases; re-export `ReadOnlyMemoryStorage`.
- **lib.rs**: Re-export `ReadOnlyMemoryStorage` from crate root.
- **vfs/state.rs**: Use `from_memory_readonly()` when `readonly` is true.