### PR TITLE
[uservm] Add host-side guest flamegraph profiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,6 +258,13 @@ incremental = false
 codegen-units = 1
 rpath = false
 
+# Profiling build: release performance with symbols and frame pointers.
+# Use: cargo build --profile release-profiling
+[profile.release-profiling]
+inherits = "release"
+strip = false
+debug = "line-tables-only"
+
 [profile.dev-wasm]
 inherits = "dev"
 opt-level = "z"

--- a/doc/profiling-flamegraph.md
+++ b/doc/profiling-flamegraph.md
@@ -1,0 +1,130 @@
+# Guest Flamegraph Profiling (Windows / WHP)
+
+The guest flamegraph profiler is a host-side sampling profiler that captures
+guest stack traces while a user VM is running. It periodically cancels the
+vCPU (~1 kHz), reads the guest `EIP`/`EBP`/`CR3` registers, and walks the
+frame-pointer chain through host-mapped guest memory. After the VM exits, the
+collected samples are resolved against ELF symbol tables and written as
+**folded stacks** — the standard input format for
+[Brendan Gregg's FlameGraph tools](https://github.com/brendangregg/FlameGraph).
+
+> ℹ️ **Note:** The guest profiler currently requires the WHP backend (Windows only).
+
+## Prerequisites
+
+| Requirement | Details |
+| --- | --- |
+| Windows 11 with WHP enabled | The profiler uses `WHvCancelRunVirtualProcessor` for sampling |
+| FlameGraph tools | Clone <https://github.com/brendangregg/FlameGraph> into `tools/FlameGraph` (or anywhere on disk) |
+| Perl | Required by `flamegraph.pl`; Git for Windows bundles one at `C:\Program Files\Git\usr\bin\perl.exe` |
+
+## Step 1 — Build with Profiling Enabled
+
+Build with `--profile` **and** override the Cargo `strip` setting so guest
+binaries keep their `.symtab` sections (the release profile strips symbols by
+default):
+
+```powershell
+$env:CARGO_PROFILE_RELEASE_STRIP = "false"
+.\z.ps1 build --profile -- all LOG_LEVEL=panic
+```
+
+The `--profile` flag implies `RELEASE=yes` and `PROFILER=yes`. Setting
+`CARGO_PROFILE_RELEASE_STRIP=false` ensures the kernel and user ELF binaries
+retain their symbol tables and frame-pointer chains needed for accurate stack
+walking and symbol resolution.
+
+## Step 2 — Set the Output Path and Symbol Files
+
+The profiler is activated by setting the `NANVIX_GUEST_PROFILE_PATH`
+environment variable to the desired output file path. Symbol resolution uses
+the `.symtab` sections of the kernel and user ELF binaries pointed to by
+`NANVIX_KERNEL_SYMBOLS` and `NANVIX_USER_SYMBOLS`:
+
+```powershell
+$env:NANVIX_GUEST_PROFILE_PATH = "guest_profile.folded"
+$env:NANVIX_KERNEL_SYMBOLS     = "bin\kernel.elf"
+$env:NANVIX_USER_SYMBOLS       = "bin\<your-app>.elf"   # e.g., bin\hello-rust-nostd.elf
+```
+
+`NANVIX_KERNEL_SYMBOLS` and `NANVIX_USER_SYMBOLS` are optional. If neither is
+set the output will contain raw hex addresses (`0xADDRESS`) instead of function
+names.
+
+> ⚠️ **Tip:** When profiling a benchmark with multiple iterations, the folded
+> stacks file is overwritten on each VM exit. Either set a unique path per
+> iteration or profile a single iteration.
+>
+> **Benchmark call sites:** The `NANVIX_GUEST_PROFILE_PATH` env var works for
+> standalone interactive mode (`nanvixd -- <app>`). Benchmarks in
+> `nanvix-bench` have their own `guest_profile_path` field in `UserVmArgs`;
+> to profile those, change `guest_profile_path: None` to
+> `Some("guest_profile.folded".to_string())` at the relevant call site
+> (e.g., `src/utils/nanvix-bench/src/benchmarks/vmm/boot_time.rs`).
+
+## Step 3 — Run the Benchmark or Application
+
+```powershell
+# Run an application in standalone interactive mode.
+.\bin\nanvixd.exe -- .\bin\hello-rust-nostd.elf
+```
+
+On exit, the profiler prints a summary to stderr:
+
+```text
+GUEST_PROFILE_SYMBOLS: loaded 376 symbols from bin\kernel.elf (1363500 bytes)
+GUEST_PROFILE_SYMBOLS: loaded 80 symbols from bin\hello-rust-nostd.elf (137296 bytes)
+GUEST_PROFILE: wrote 2 samples to guest_profile.folded
+```
+
+## Step 4 — Generate the Flamegraph SVG
+
+Convert the folded stacks into an interactive SVG:
+
+```powershell
+# Using Git-bundled Perl:
+& "C:\Program Files\Git\usr\bin\perl.exe" tools\FlameGraph\flamegraph.pl `
+    --title "Nanvix Guest CPU Profile" `
+    --countname samples `
+    guest_profile.folded > guest_profile.svg
+
+# Open in a browser (click bars to zoom, Ctrl+F to search).
+start guest_profile.svg
+```
+
+**Useful `flamegraph.pl` options:**
+
+| Flag | Effect |
+| --- | --- |
+| `--width 1800` | Wider SVG for dense call stacks |
+| `--inverted` | Icicle graph (root at the top) |
+| `--minwidth 0.5` | Show narrower frames (default hides very thin ones) |
+| `--colors java` | Alternative color palette |
+
+## Step 5 — Analyze the Folded Stacks (Optional)
+
+The `.folded` file is plain text. You can filter it before generating the flamegraph:
+
+```powershell
+# Show only kernel functions.
+Select-String "kernel_" guest_profile.folded | ForEach-Object { $_.Line } > kernel_only.folded
+
+# Show only a specific user function.
+Select-String "my_function" guest_profile.folded | ForEach-Object { $_.Line } > filtered.folded
+```
+
+## How It Works
+
+1. **Sampling** — A dedicated thread calls `WHvCancelRunVirtualProcessor` at
+   ~1 kHz, causing the vCPU to exit with an `Interrupted` reason.
+2. **Register read** — On each profiler-triggered exit the host reads
+   `EIP`, `EBP`, and `CR3` from the stopped vCPU.
+3. **Stack walk** — The profiler walks the guest's frame-pointer chain
+   (`EBP` → saved EBP → return address) through host-mapped guest memory,
+   translating user-space virtual addresses via a manual two-level page-table
+   walk (kernel addresses are identity-mapped).
+4. **Symbol resolution** — After VM exit, each captured address is resolved
+   against the ELF `.symtab` sections loaded from `NANVIX_KERNEL_SYMBOLS` and
+   `NANVIX_USER_SYMBOLS`.
+5. **Output** — Resolved stacks are folded (identical stacks merged with a
+   count) and written to the file specified by `NANVIX_GUEST_PROFILE_PATH`.

--- a/doc/profiling-windows.md
+++ b/doc/profiling-windows.md
@@ -9,6 +9,7 @@ and post-processing tools for phase analysis and flamegraph generation.
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [1. Prerequisites](#1-prerequisites)
 - [2. One-Time Setup](#2-one-time-setup)
   - [Perl (for flamegraphs)](#perl-for-flamegraphs)
@@ -19,15 +20,26 @@ and post-processing tools for phase analysis and flamegraph generation.
   - [Phase Timing Only](#phase-timing-only)
   - [With WPR Trace (Deep Kernel Investigation)](#with-wpr-trace-deep-kernel-investigation)
   - [Flamegraph Generation](#flamegraph-generation)
+  - [Kernel Stack Analysis](#kernel-stack-analysis)
 - [4. Performance Debugging Workflow](#4-performance-debugging-workflow)
+  - [Step 1. Establish a Baseline](#step-1-establish-a-baseline)
+  - [Step 2. Identify Bottlenecks](#step-2-identify-bottlenecks)
+  - [Step 3. Implement Optimization, Then Compare](#step-3-implement-optimization-then-compare)
+  - [Step 4. Drill Deeper (If Needed)](#step-4-drill-deeper-if-needed)
+  - [Step 5. Restore System](#step-5-restore-system)
 - [5. Script Reference](#5-script-reference)
-  - [bench-setup.ps1](#bench-setupps1)
-  - [bench-teardown.ps1](#bench-teardownps1)
-  - [bench-run.ps1](#bench-runps1)
-  - [analyze-results.py](#analyze-resultspy)
-  - [analyze-etl.py](#analyze-etlpy)
-  - [wpr-profile.wprp](#wpr-profilewprp)
+  - [`bench-setup.ps1`](#bench-setupps1)
+  - [`bench-teardown.ps1`](#bench-teardownps1)
+  - [`bench-run.ps1`](#bench-runps1)
+  - [`analyze-results.py`](#analyze-resultspy)
+  - [`analyze-etl.py`](#analyze-etlpy)
+  - [`wpr-profile.wprp`](#wpr-profilewprp)
 - [6. Understanding the Output](#6-understanding-the-output)
+  - [Phase Breakdown](#phase-breakdown)
+  - [Distribution Analysis (from PERF\_TIMINGS)](#distribution-analysis-from-perf_timings)
+  - [Bottleneck Analysis](#bottleneck-analysis)
+  - [PERF\_TIMINGS Data Format](#perf_timings-data-format)
+- [7. Guest Flamegraph Profiling](#7-guest-flamegraph-profiling)
 
 ---
 
@@ -169,6 +181,7 @@ start .\traces\flamegraph.svg
 ```
 
 **Tips:**
+
 - Filter to a single process: `--process nanvixd.exe`
 - Wider SVGs: add `--width 1800` to flamegraph.pl
 - Reverse (icicle) graph: add `--inverted` to flamegraph.pl
@@ -199,6 +212,7 @@ python scripts\bench\analyze-etl.py .\traces\cold-start-YYYYMMDD-HHMMSS.etl --st
 ```
 
 **Output sections:**
+
 - **Modules by Exclusive Hits** -- which DLLs/drivers consume CPU (expect
   `ntkrnlmp.exe` to dominate for WHP workloads).
 - **Top Functions by Exclusive Hits** -- the specific kernel functions where
@@ -211,6 +225,7 @@ python scripts\bench\analyze-etl.py .\traces\cold-start-YYYYMMDD-HHMMSS.etl --st
   (e.g., `WHvRunVirtualProcessor` -> `Memory::ResolveFault` for EPT faults).
 
 **Prerequisites:**
+
 - `_NT_SYMBOL_PATH` must be set (see [Symbol Resolution](#symbol-resolution)).
 - `xperf.exe` must be installed (see [Windows Performance Toolkit](#windows-performance-toolkit)).
 - The trace must include `SampledProfile` and `CSwitch` stack walks (the
@@ -295,12 +310,13 @@ All scripts are located in `scripts/bench/`.
 Tunes the system for low-noise benchmarking. Must be run as administrator.
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --- | --- | --- | --- |
 | `-SaveState` | Switch | Off | Save current settings for later restore |
 | `-RepoPath` | String | Auto-detect | Path to nanvix repository |
 | `-Quiet` | Switch | Off | Suppress info output |
 
 **What it does:**
+
 - Switches to High Performance power plan
 - Locks CPU frequency at 100% (PROCTHROTTLEMIN=100, PROCTHROTTLEMAX=100)
 - Sets Energy Performance Preference to 0 (max performance)
@@ -313,7 +329,7 @@ Restores system to pre-benchmark state. Requires `.bench-state.json`
 created by `bench-setup.ps1 -SaveState`.
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --- | --- | --- | --- |
 | `-KeepDefenderExclusion` | Switch | Off | Keep Defender exclusion |
 
 ### `bench-run.ps1`
@@ -321,7 +337,7 @@ created by `bench-setup.ps1 -SaveState`.
 Runs a benchmark with CPU pinning and Realtime priority. Must be run as administrator.
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| --- | --- | --- | --- |
 | `-Benchmark` | String | `cold-start` | Benchmark name |
 | `-Iterations` | Int | `50` | Number of iterations |
 | `-AffinityMask` | UInt64 | `0xF00` | CPU affinity mask |
@@ -330,6 +346,7 @@ Runs a benchmark with CPU pinning and Realtime priority. Must be run as administ
 | `-ExtraArgs` | String[] | `@()` | Extra args for nanvix-bench |
 
 **Outputs** (in OutputDir):
+
 - `{benchmark}-{timestamp}-stdout.txt` -- benchmark text output
 - `{benchmark}-{timestamp}-stderr.txt` -- PERF_TIMINGS data
 - `{benchmark}-{timestamp}.etl` -- WPR trace (only with `-WPR`)
@@ -342,12 +359,12 @@ Analyzes benchmark results and detects regressions.
 
 **Report command** -- analyze a single benchmark run:
 
-```
+```text
 python analyze-results.py report --stdout FILE --stderr FILE [--baseline CSV] [--json PATH] [--perf-csv PATH]
 ```
 
 | Argument | Required | Description |
-|----------|----------|-------------|
+| --- | --- | --- |
 | `--stdout` | Yes | Path to benchmark stdout file |
 | `--stderr` | No | Path to stderr file with PERF_TIMINGS |
 | `--baseline` | No | Baseline CSV for regression detection |
@@ -356,12 +373,12 @@ python analyze-results.py report --stdout FILE --stderr FILE [--baseline CSV] [-
 
 **Compare command** -- A/B comparison of two benchmark runs:
 
-```
+```text
 python analyze-results.py compare --before STDERR_A --after STDERR_B [--json PATH]
 ```
 
 | Argument | Required | Description |
-|----------|----------|-------------|
+| --- | --- | --- |
 | `--before` | Yes | Stderr from the baseline/before run |
 | `--after` | Yes | Stderr from the optimized/after run |
 | `--json` | No | Write JSON comparison to this path |
@@ -370,6 +387,7 @@ The compare command shows per-phase delta (absolute and percentage), variability
 changes (CV%), and outlier detection. Useful for validating optimizations.
 
 **Regression thresholds:**
+
 - `[WARN]` Warning: phase >5% slower than baseline
 - `[ALERT]` Alert: phase >10% slower (exits with code 1)
 - `[OK]` Improvement: phase >5% faster
@@ -379,12 +397,12 @@ changes (CV%), and outlier detection. Useful for validating optimizations.
 Analyzes WPR/ETW trace files to produce CPU profiles, context-switch analysis,
 and scheduling insights without requiring WPA.
 
-```
+```text
 python analyze-etl.py TRACE.etl [--symbols] [--sections SECTIONS] [--process NAMES] [--json PATH] [--folded PATH] [--stacks]
 ```
 
 | Argument | Required | Description |
-|----------|----------|-------------|
+| --- | --- | --- |
 | `etl` | Yes | Path to .etl trace file |
 | `--symbols` | No | Enable symbol resolution (resolves hex to function names) |
 | `--sections` | No | Comma-separated analysis sections: cpu, cswitch, sched, timeline (default: all) |
@@ -406,6 +424,7 @@ $env:_NT_SYMCACHE_PATH = "C:\SymCache"
 ```
 
 **Analysis sections:**
+
 - **cpu**: CPU sampling profile -- hot modules and functions, kernel/user split
 - **cswitch**: Context switch analysis -- switch intervals, preemption sources
 - **sched**: Thread scheduling -- ready events count
@@ -419,10 +438,12 @@ Lightweight WPR profile designed for Hyper-V/WHP workloads. Captures
 essential events with minimal overhead (~1% measured on cold-start benchmark).
 
 **System keywords:**
+
 - CpuConfig, SampledProfile, CSwitch, ReadyThread, ProcessThread
 - Loader, HardFaults, DPC, Interrupt
 
 **ETW providers:**
+
 - Hyper-V Hypervisor: VM exits, intercepts, partition ops
 - Hyper-V VID: GPA mapping, memory management
 - Kernel-Process: process create/exit
@@ -434,6 +455,7 @@ essential events with minimal overhead (~1% measured on cold-start benchmark).
 **Stack walks:** SampledProfile, CSwitch, HardFault, ImageLoad (4 total)
 
 **Usage:**
+
 ```powershell
 wpr -start scripts\bench\wpr-profile.wprp!NanvixBench -filemode
 .\bin\nanvix-bench.exe -benchmark cold-start
@@ -446,7 +468,7 @@ wpr -stop trace.etl "Nanvix benchmark"
 
 The report shows per-phase timing at p50/p95/p99 percentiles:
 
-```
+```text
 Phase                    p50 (us)   p95 (us)   p99 (us)
 ------------------------------------------------------
 channel_setup                  10         18         21
@@ -461,7 +483,7 @@ total                       59206      61852      62578
 When built with `PROFILER=yes`, the binary emits per-iteration JSON on stderr.
 The analysis tool computes distribution statistics:
 
-```
+```text
 Phase                      mean   stddev   CV%      min      max    n
 ----------------------------------------------------------------------
 channel_setup                12        4  33.3%       8       25   50
@@ -470,6 +492,7 @@ partition_create           1850      180   9.7%    1650     2500   50
 ```
 
 **CV% (Coefficient of Variation)** indicates measurement stability:
+
 - <5%: Very stable -- reliable measurement
 - 5-15%: Normal -- acceptable for benchmarks
 - >15%: Noisy -- consider more iterations or system tuning
@@ -478,7 +501,7 @@ partition_create           1850      180   9.7%    1650     2500   50
 
 Identifies top 3 phases consuming the most time:
 
-```
+```text
 1. guest_exec: 45,955 us (76.5% of total)
 2. exit_handling: 7,307 us (12.2% of total)
 3. vmem_create: 3,175 us (5.3% of total)
@@ -489,10 +512,16 @@ Identifies top 3 phases consuming the most time:
 When built with `PROFILER=yes` (via `.\z.ps1 build --profile --release -- LOG_LEVEL=panic`),
 each benchmark iteration emits a JSON line on stderr:
 
-```
+```text
 PERF_TIMINGS:{"channel_setup":10,"partition_create":1799,"vmem_create":3175,...,"total":59206}
 ```
 
 All values are in microseconds. The fields match the phase names in the benchmark
 text output. This data enables per-iteration analysis that goes beyond the
 aggregated p50/p95/p99 in the text output.
+
+## 7. Guest Flamegraph Profiling
+
+For guest CPU flamegraph profiling — a host-side sampling profiler that captures
+guest stack traces from inside the user VM — see the
+**[Guest Flamegraph Profiling Guide](profiling-flamegraph.md)**.

--- a/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/single_process/uservm.rs
@@ -284,6 +284,7 @@ impl UserVm {
                         gdb_port: None,
                         #[cfg(feature = "profile-time")]
                         perf_timings: ::uservm::perf::PerfTimings::new(),
+                        guest_profile_path: None,
                     });
 
                 // Wait for VMM thread to finish.

--- a/src/libs/nanvix-sandbox/src/standalone/uservm.rs
+++ b/src/libs/nanvix-sandbox/src/standalone/uservm.rs
@@ -24,14 +24,14 @@ use ::log::{
     trace,
     warn,
 };
-use ::std::{
-    convert::TryInto,
-    process::ExitStatus,
-};
 #[cfg(unix)]
 use ::std::os::unix::process::ExitStatusExt;
 #[cfg(windows)]
 use ::std::os::windows::process::ExitStatusExt;
+use ::std::{
+    convert::TryInto,
+    process::ExitStatus,
+};
 use ::sys::ipc::IkcFrame;
 use ::tokio::{
     runtime::Handle,
@@ -143,6 +143,7 @@ impl UserVm {
                         gdb_port: None,
                         #[cfg(feature = "profile-time")]
                         perf_timings: ::uservm::perf::PerfTimings::new(),
+                        guest_profile_path: std::env::var("NANVIX_GUEST_PROFILE_PATH").ok(),
                     });
 
                 // Drain the VM's stdout channel. In standalone mode there is no system VM to

--- a/src/uservm/Cargo.toml
+++ b/src/uservm/Cargo.toml
@@ -24,7 +24,7 @@ serde_cbor = { workspace = true }
 cfg-if = { workspace = true }
 config = { workspace = true }
 control-plane-api = { workspace = true }
-elf = { workspace = true }
+elf = { workspace = true, features = ["std"] }
 gdbstub = { workspace = true, optional = true }
 gdbstub_arch = { workspace = true, optional = true }
 hyperlight-host = { workspace = true, optional = true }

--- a/src/uservm/src/guest_profiler/gva.rs
+++ b/src/uservm/src/guest_profiler/gva.rs
@@ -1,0 +1,108 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Guest virtual address translation via manual page-table walk.
+//!
+//! Nanvix is a 32-bit x86 OS using two-level paging (PD + PT).
+//! The host can read guest physical memory directly through the
+//! mapped vmem buffer, so no WHP API call is needed.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::arch::mem::paging::{
+    self,
+    PageDirectoryEntry,
+    PageSizeFlag,
+    PageTableEntry,
+    PresentFlag,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Mask for the page offset within a 4 KiB page.
+#[allow(clippy::cast_possible_truncation)] // 32-bit guest constants.
+const PAGE_OFFSET_MASK: u32 = (::arch::mem::PAGE_SIZE as u32) - 1;
+/// Mask for extracting the physical frame address from a PDE/PTE.
+const FRAME_MASK: u32 = !(PAGE_OFFSET_MASK);
+/// Mask for the large page (4 MiB) frame address.
+#[allow(clippy::cast_possible_truncation)] // 32-bit guest constants.
+const LARGE_PAGE_FRAME_MASK: u32 = !(::arch::mem::PGTAB_SIZE as u32 - 1);
+/// Mask for the offset within a 4 MiB large page.
+#[allow(clippy::cast_possible_truncation)] // 32-bit guest constants.
+const LARGE_PAGE_OFFSET_MASK: u32 = ::arch::mem::PGTAB_SIZE as u32 - 1;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Translates a guest virtual address to a guest physical address
+/// by walking the guest's two-level page tables.
+///
+/// # Parameters
+///
+/// - `vmem_ptr`: Host pointer to the start of guest physical memory.
+/// - `vmem_size`: Total size of guest physical memory in bytes.
+/// - `cr3`: Guest CR3 register value (physical address of the page directory).
+/// - `gva`: Guest virtual address to translate.
+///
+/// # Returns
+///
+/// `Some(gpa)` if the translation succeeds, `None` if any entry is not present
+/// or the address is out of bounds.
+pub fn translate_gva(vmem_ptr: *const u8, vmem_size: usize, cr3: u32, gva: u32) -> Option<u32> {
+    let pd_base: usize = (cr3 & FRAME_MASK) as usize;
+    let pd_index: usize = paging::pd_index(gva as usize).into_raw();
+    let pt_index: usize = paging::pt_index(gva as usize).into_raw();
+    let offset: u32 = gva & PAGE_OFFSET_MASK;
+
+    // Read PDE.
+    let pde_addr: usize = pd_index
+        .checked_mul(PageDirectoryEntry::SIZE)
+        .and_then(|v| pd_base.checked_add(v))?;
+    if pde_addr + PageDirectoryEntry::SIZE > vmem_size {
+        return None;
+    }
+    let pde: u32 = unsafe { vmem_ptr.add(pde_addr).cast::<u32>().read_unaligned() };
+    if !PresentFlag::is_set(pde) {
+        return None;
+    }
+
+    // Check for 4 MiB large page (PS bit).
+    if matches!(PageSizeFlag::from_raw_value(pde), PageSizeFlag::Large) {
+        let frame: u32 = pde & LARGE_PAGE_FRAME_MASK;
+        let large_offset: u32 = gva & LARGE_PAGE_OFFSET_MASK;
+        return Some(frame | large_offset);
+    }
+
+    // Read PTE from the page table.
+    let pt_base: usize = (pde & FRAME_MASK) as usize;
+    let pte_addr: usize = pt_index
+        .checked_mul(PageTableEntry::SIZE)
+        .and_then(|v| pt_base.checked_add(v))?;
+    if pte_addr + PageTableEntry::SIZE > vmem_size {
+        return None;
+    }
+    let pte: u32 = unsafe { vmem_ptr.add(pte_addr).cast::<u32>().read_unaligned() };
+    if !PresentFlag::is_set(pte) {
+        return None;
+    }
+
+    let frame: u32 = pte & FRAME_MASK;
+    Some(frame | offset)
+}
+
+/// Reads a u32 from guest physical memory.
+///
+/// Returns `None` if the address is out of bounds.
+#[inline]
+pub fn read_gpa_u32(vmem_ptr: *const u8, vmem_size: usize, gpa: u32) -> Option<u32> {
+    let addr: usize = gpa as usize;
+    if addr + core::mem::size_of::<u32>() > vmem_size {
+        return None;
+    }
+    Some(unsafe { vmem_ptr.add(addr).cast::<u32>().read_unaligned() })
+}

--- a/src/uservm/src/guest_profiler/mod.rs
+++ b/src/uservm/src/guest_profiler/mod.rs
@@ -1,0 +1,27 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Host-side guest profiler for Nanvix.
+//!
+//! Samples guest EIP/EBP at a configurable frequency by canceling the vCPU,
+//! reading guest registers, and walking the frame-pointer chain through host
+//! memory. After the VM exits, collected samples are resolved against ELF
+//! symbol tables and written as folded stacks for flamegraph generation.
+
+//==================================================================================================
+// Modules
+//==================================================================================================
+
+mod gva;
+mod samples;
+mod symbols;
+
+//==================================================================================================
+// Re-Exports
+//==================================================================================================
+
+pub use samples::{
+    GuestProfiler,
+    StackSample,
+};
+pub use symbols::SymbolResolver;

--- a/src/uservm/src/guest_profiler/samples.rs
+++ b/src/uservm/src/guest_profiler/samples.rs
@@ -1,0 +1,214 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Guest stack sampling and frame-pointer walking.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::gva;
+use ::std::sync::{
+    Arc,
+    Mutex,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Maximum frame-pointer chain depth per sample.
+const MAX_STACK_DEPTH: usize = 128;
+
+/// Kernel/user boundary. Addresses below this are kernel (identity-mapped).
+#[allow(clippy::cast_possible_truncation)] // 32-bit guest constants.
+const USER_BASE: u32 = config::memory_layout::KERNEL_END_RAW as u32;
+
+/// Minimum valid kernel code address (1 MiB — the x86 kernel boot/load address).
+#[allow(clippy::cast_possible_truncation)] // 32-bit guest constants.
+const KERNEL_CODE_MIN: u32 = config::constants::MEGABYTE as u32;
+/// Minimum valid stack address (64 KiB — above the real-mode IVT/BDA region).
+#[allow(clippy::cast_possible_truncation)] // 32-bit guest constants.
+const STACK_ADDR_MIN: u32 = (64 * config::constants::KILOBYTE) as u32;
+
+//==================================================================================================
+// Stack Sample
+//==================================================================================================
+
+/// A single stack sample captured from the guest.
+#[derive(Clone)]
+pub struct StackSample {
+    /// Return addresses from the frame-pointer chain (deepest first).
+    pub addresses: Vec<u32>,
+}
+
+//==================================================================================================
+// Guest Profiler
+//==================================================================================================
+
+/// Collects guest stack samples from the host side.
+///
+/// Thread-safe: the sampling thread pushes samples, the main thread
+/// reads them after VM exit.
+pub struct GuestProfiler {
+    samples: Arc<Mutex<Vec<StackSample>>>,
+}
+
+impl GuestProfiler {
+    /// Creates a new profiler with pre-allocated sample storage.
+    pub fn new(expected_samples: usize) -> Self {
+        Self {
+            samples: Arc::new(Mutex::new(Vec::with_capacity(expected_samples))),
+        }
+    }
+
+    /// Returns a clone of the inner Arc for use by the sampling thread.
+    pub fn handle(&self) -> Arc<Mutex<Vec<StackSample>>> {
+        self.samples.clone()
+    }
+
+    /// Captures one stack sample from the guest.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the guest vCPU is stopped (not executing) when
+    /// this function is called, so that guest memory (page tables, stack
+    /// frames) is stable and will not be concurrently modified.
+    ///
+    /// # Parameters
+    ///
+    /// - `vmem_ptr`: Host pointer to guest physical memory.
+    /// - `vmem_size`: Total guest physical memory size.
+    /// - `eip`: Guest instruction pointer.
+    /// - `ebp`: Guest base pointer (frame pointer).
+    /// - `cr3`: Guest CR3 (page directory physical address).
+    pub fn capture_sample(
+        samples: &Mutex<Vec<StackSample>>,
+        vmem_ptr: *const u8,
+        vmem_size: usize,
+        eip: u32,
+        ebp: u32,
+        cr3: u32,
+    ) {
+        let mut addrs = Vec::with_capacity(MAX_STACK_DEPTH);
+
+        // Only record if EIP looks like a valid code address.
+        if !is_valid_code_addr(eip) {
+            return;
+        }
+
+        addrs.push(eip);
+
+        let mut current_ebp: u32 = ebp;
+        for _ in 0..MAX_STACK_DEPTH {
+            // EBP must be 4-byte aligned and in a valid range.
+            if !is_valid_stack_addr(current_ebp) {
+                break;
+            }
+
+            // Translate EBP to GPA.
+            let gpa = if current_ebp < USER_BASE {
+                // Kernel: identity-mapped.
+                current_ebp
+            } else {
+                // User space: walk guest page tables.
+                match gva::translate_gva(vmem_ptr, vmem_size, cr3, current_ebp) {
+                    Some(gpa) => gpa,
+                    None => break,
+                }
+            };
+
+            // Read saved EBP and return address.
+            let saved_ebp: u32 = match gva::read_gpa_u32(vmem_ptr, vmem_size, gpa) {
+                Some(v) => v,
+                None => break,
+            };
+            let return_addr = match gva::read_gpa_u32(vmem_ptr, vmem_size, gpa + 4) {
+                Some(v) => v,
+                None => break,
+            };
+
+            if return_addr == 0 || !is_valid_code_addr(return_addr) {
+                break;
+            }
+
+            addrs.push(return_addr);
+
+            // EBP should move up the stack (higher addresses) and remain valid.
+            if saved_ebp != 0 && (!is_valid_stack_addr(saved_ebp) || saved_ebp <= current_ebp) {
+                break;
+            }
+            current_ebp = saved_ebp;
+        }
+
+        if !addrs.is_empty()
+            && let Ok(mut s) = samples.lock()
+        {
+            s.push(StackSample { addresses: addrs });
+        }
+    }
+
+    /// Returns all collected samples and clears the buffer.
+    pub fn drain_samples(&self) -> Vec<StackSample> {
+        if let Ok(mut s) = self.samples.lock() {
+            std::mem::take(&mut *s)
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Writes samples as folded stacks to a file.
+    ///
+    /// Each line: `func1;func2;func3 count`
+    pub fn write_folded<R: Fn(u32) -> String>(
+        &self,
+        path: &str,
+        resolve: R,
+    ) -> std::io::Result<()> {
+        use std::{
+            collections::HashMap,
+            io::Write,
+        };
+
+        // Open the file before draining samples so that data is not lost if
+        // file creation fails.
+        let mut file = std::fs::File::create(path)?;
+
+        let samples = self.drain_samples();
+        let mut folded: HashMap<String, u64> = HashMap::new();
+
+        for sample in &samples {
+            // Build the stack string (deepest frame first → reverse for flamegraph).
+            let stack: String = sample
+                .addresses
+                .iter()
+                .rev()
+                .map(|&addr| resolve(addr))
+                .collect::<Vec<_>>()
+                .join(";");
+
+            *folded.entry(stack).or_insert(0) += 1;
+        }
+
+        let mut entries: Vec<_> = folded.into_iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(&a.1));
+        for (stack, count) in entries {
+            writeln!(file, "{} {}", stack, count)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns true if the address looks like valid kernel or user code.
+///
+/// Rejects addresses below `KERNEL_CODE_MIN` (the first 1 MiB), which
+/// contains real-mode IVT, BIOS data, and other non-code regions.
+fn is_valid_code_addr(addr: u32) -> bool {
+    addr >= KERNEL_CODE_MIN
+}
+
+/// Returns true if the address looks like a valid stack frame pointer.
+fn is_valid_stack_addr(ebp: u32) -> bool {
+    ebp >= STACK_ADDR_MIN && ebp != 0xFFFF_FFFF && (ebp & 3) == 0
+}

--- a/src/uservm/src/guest_profiler/symbols.rs
+++ b/src/uservm/src/guest_profiler/symbols.rs
@@ -1,0 +1,145 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! ELF symbol table parser for address-to-function-name resolution.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::elf::symtab::{
+    Elf32FuncSymbol,
+    parse_elf32_func_symbols,
+};
+use ::std::path::Path;
+
+//==================================================================================================
+// Symbol Resolver
+//==================================================================================================
+
+/// Resolves guest addresses to function names using ELF symbol tables.
+pub struct SymbolResolver {
+    symbols: Vec<Elf32FuncSymbol>,
+}
+
+impl SymbolResolver {
+    /// Creates a resolver from one or more ELF files.
+    ///
+    /// Parses the `.symtab` section of each ELF to extract function symbols.
+    /// Files that can't be read or parsed are skipped, and per-file diagnostics are
+    /// emitted to stderr describing load results and read failures.
+    pub fn from_elf_files(paths: &[&Path]) -> Self {
+        let mut symbols: Vec<Elf32FuncSymbol> = Vec::new();
+
+        for path in paths {
+            match std::fs::read(path) {
+                Ok(data) => match parse_elf32_func_symbols(&data) {
+                    Ok(mut file_symbols) => {
+                        let count: usize = file_symbols.len();
+                        symbols.append(&mut file_symbols);
+                        eprintln!(
+                            "GUEST_PROFILE_SYMBOLS: loaded {} symbols from {} ({} bytes)",
+                            count,
+                            path.display(),
+                            data.len()
+                        );
+                    },
+                    Err(e) => {
+                        eprintln!(
+                            "GUEST_PROFILE_SYMBOLS: failed to parse {}: {}",
+                            path.display(),
+                            e.reason
+                        );
+                    },
+                },
+                Err(e) => {
+                    eprintln!("GUEST_PROFILE_SYMBOLS: failed to read {}: {}", path.display(), e);
+                },
+            }
+        }
+
+        // Sort by address for binary search.
+        symbols.sort_by_key(|s| s.addr);
+
+        Self { symbols }
+    }
+
+    /// Resolves an address to a function name.
+    ///
+    /// Returns `"function_name+0xOFFSET"` if found, or `"0xADDRESS"` if not.
+    pub fn resolve(&self, addr: u32) -> String {
+        // Binary search for the largest symbol address <= addr.
+        match self.symbols.binary_search_by_key(&addr, |s| s.addr) {
+            Ok(idx) => self.symbols[idx].name.clone(),
+            Err(0) => format!("{:#010x}", addr),
+            Err(idx) => {
+                let sym: &Elf32FuncSymbol = &self.symbols[idx - 1];
+                if sym.size > 0 && addr < sym.addr + sym.size {
+                    let offset: u32 = addr - sym.addr;
+                    if offset == 0 {
+                        sym.name.clone()
+                    } else {
+                        format!("{}+{:#x}", sym.name, offset)
+                    }
+                } else if sym.size == 0 {
+                    // Unknown size — assume it's the right symbol if close.
+                    let offset: u32 = addr - sym.addr;
+                    if offset < 0x10000 {
+                        format!("{}+{:#x}", sym.name, offset)
+                    } else {
+                        format!("{:#010x}", addr)
+                    }
+                } else {
+                    format!("{:#010x}", addr)
+                }
+            },
+        }
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper to build a resolver from a list of (addr, size, name) tuples.
+    fn make_resolver(syms: &[(u32, u32, &str)]) -> SymbolResolver {
+        let mut symbols: Vec<Elf32FuncSymbol> = syms
+            .iter()
+            .map(|&(addr, size, name)| Elf32FuncSymbol {
+                addr,
+                size,
+                name: name.to_string(),
+            })
+            .collect();
+        symbols.sort_by_key(|s| s.addr);
+        SymbolResolver { symbols }
+    }
+
+    #[test]
+    fn resolve_exact_match() {
+        let resolver: SymbolResolver = make_resolver(&[(0x1000, 0x100, "foo")]);
+        assert_eq!(resolver.resolve(0x1000), "foo");
+    }
+
+    #[test]
+    fn resolve_offset_within_function() {
+        let resolver: SymbolResolver = make_resolver(&[(0x1000, 0x100, "foo")]);
+        assert_eq!(resolver.resolve(0x1050), "foo+0x50");
+    }
+
+    #[test]
+    fn resolve_unknown_address() {
+        let resolver: SymbolResolver = make_resolver(&[(0x1000, 0x100, "foo")]);
+        assert_eq!(resolver.resolve(0x9999_0000), "0x99990000");
+    }
+
+    #[test]
+    fn resolve_address_before_all_symbols() {
+        let resolver: SymbolResolver = make_resolver(&[(0x1000, 0x100, "foo")]);
+        assert_eq!(resolver.resolve(0x0500), "0x00000500");
+    }
+}

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -49,6 +49,9 @@ pub mod args;
 pub mod counters;
 /// Library module for manipulating ELF binaries.
 pub mod elf;
+/// Host-side guest flamegraph profiler (stack sampling and folded-stack output).
+#[cfg(feature = "whp")]
+pub mod guest_profiler;
 #[cfg(target_os = "linux")]
 pub mod io_thread;
 pub mod memory_thread;
@@ -201,6 +204,8 @@ pub struct UserVmArgs {
     /// Performance timings collector for fine-grained startup breakdown.
     #[cfg(feature = "profile-time")]
     pub perf_timings: PerfTimings,
+    /// When set, enable guest stack profiling and write folded stacks to this path.
+    pub guest_profile_path: Option<String>,
 }
 
 //==================================================================================================
@@ -238,6 +243,10 @@ impl UserVm {
 
         #[cfg(feature = "profile-time")]
         let perf_timings: PerfTimings = args.perf_timings.clone();
+
+        let args_guest_profile_path: Option<String> = args.guest_profile_path.clone();
+        #[cfg(not(feature = "whp"))]
+        let _ = &args_guest_profile_path; // Suppress unused warning when WHP is disabled.
 
         #[cfg(feature = "profile-time")]
         let run_start: Instant = Instant::now();
@@ -322,7 +331,8 @@ impl UserVm {
         #[cfg(feature = "profile-time")]
         perf_timings.set_channel_setup(channel_setup_start.elapsed().as_micros() as u64);
 
-        let microvm: Vmm = Vmm::new(MicroVmArgs {
+        #[allow(unused_mut)] // `mut` needed only with `whp` for enable_guest_profiler().
+        let mut microvm: Vmm = Vmm::new(MicroVmArgs {
             input: vmm_stdin_fn,
             output: vmm_stdout_fn,
             #[cfg(feature = "hyperlight")]
@@ -352,6 +362,16 @@ impl UserVm {
         if let Some(snapshot_path) = args.snapshot_path {
             microvm.load_snapshot(snapshot_path).await?;
         }
+
+        // Enable guest profiler if requested (WHP only).
+        #[cfg(feature = "whp")]
+        let guest_profiler = if args_guest_profile_path.is_some() {
+            Some(microvm.enable_guest_profiler())
+        } else {
+            None
+        };
+        #[cfg(not(feature = "whp"))]
+        let _guest_profiler: Option<()> = None;
 
         let vmem: Arc<Mutex<VirtualMemory>> = microvm.vmem();
         let guest: Arc<Mutex<Guest>> = microvm.guest();
@@ -443,6 +463,26 @@ impl UserVm {
 
         #[cfg(feature = "profile-time")]
         perf_timings.set_total(run_start.elapsed().as_micros() as u64);
+
+        // Write guest profiler folded stacks if profiling was enabled.
+        #[cfg(feature = "whp")]
+        if let (Some(profiler), Some(path)) = (guest_profiler, &args_guest_profile_path) {
+            let sample_count = profiler.handle().lock().map(|s| s.len()).unwrap_or(0);
+            let mut sym_paths: Vec<std::path::PathBuf> = Vec::new();
+            if let Ok(p) = std::env::var("NANVIX_KERNEL_SYMBOLS") {
+                sym_paths.push(std::path::PathBuf::from(p));
+            }
+            if let Ok(p) = std::env::var("NANVIX_USER_SYMBOLS") {
+                sym_paths.push(std::path::PathBuf::from(p));
+            }
+            let sym_refs: Vec<&std::path::Path> = sym_paths.iter().map(|p| p.as_path()).collect();
+            let resolver = crate::guest_profiler::SymbolResolver::from_elf_files(&sym_refs);
+            if let Err(e) = profiler.write_folded(path, |addr| resolver.resolve(addr)) {
+                error!("Failed to write guest profile: {e:?}");
+            } else {
+                eprintln!("GUEST_PROFILE: wrote {} samples to {}", sample_count, path);
+            }
+        }
 
         exit_code
     }

--- a/src/uservm/src/main.rs
+++ b/src/uservm/src/main.rs
@@ -381,6 +381,7 @@ async fn run_managed(
         gdb_port: None,
         #[cfg(feature = "profile-time")]
         perf_timings: ::uservm::perf::PerfTimings::new(),
+        guest_profile_path: std::env::var("NANVIX_GUEST_PROFILE_PATH").ok(),
     });
 
     let vm_exit_status: Result<u16> = vmm_handle.await?;

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -188,6 +188,7 @@ impl StandaloneVmHandle {
             gdb_port,
             #[cfg(feature = "profile-time")]
             perf_timings: perf_timings.clone(),
+            guest_profile_path: std::env::var("NANVIX_GUEST_PROFILE_PATH").ok(),
         });
 
         // Spawn the I/O handler task that processes guest IKC messages and bridges them to the

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -339,6 +339,8 @@ pub struct Vmm {
     /// Performance timings collector for fine-grained startup breakdown.
     #[cfg(feature = "profile-time")]
     perf_timings: PerfTimings,
+    /// Guest stack profiler (active when guest_profile_path is set).
+    guest_profiler: Option<Arc<std::sync::Mutex<Vec<crate::guest_profiler::StackSample>>>>,
 }
 
 ///
@@ -554,6 +556,7 @@ impl Vmm {
             })),
             #[cfg(feature = "profile-time")]
             perf_timings,
+            guest_profiler: None,
         })
     }
 
@@ -623,6 +626,19 @@ impl Vmm {
         // providing pvclock updates once user-space is running.
         let mut timer_started: bool = false;
 
+        // Guest profiler: start a dedicated cancel timer for periodic sampling.
+        // Deferred slightly to avoid interfering with the first VP entry.
+        // Uses a dedicated `AtomicBool` flag so only profiler-driven cancels
+        // trigger sampling (not pvclock or other `Interrupted` exits).
+        let profiler_cancel_pending = Arc::new(AtomicBool::new(false));
+        let profiler_stop = Arc::new(AtomicBool::new(false));
+        let mut profiler_thread: Option<std::thread::JoinHandle<()>> = None;
+        let mut profiler_timer_started: bool = false;
+        /// Number of VM exits to skip before starting the profiler timer,
+        /// avoiding interference with the initial vCPU entry sequence.
+        const PROFILER_START_DELAY_EXITS: u64 = 5;
+        let mut exit_count: u64 = 0;
+
         // PIT channel 2 state for LAPIC timer calibration. The guest
         // programs PIT ch2 in one-shot mode and polls port 0x61 bit 5
         // to detect when the countdown expires.
@@ -657,7 +673,39 @@ impl Vmm {
             // Consume pending IKC notification.  to prevent re-delivery on the next loop iteration.
             let _ = self.ikc_notifier.take_pending();
 
-            let exit_context = {
+            // Start profiler cancel timer after a few exits to avoid the first-entry cost.
+            exit_count += 1;
+            if self.guest_profiler.is_some()
+                && !profiler_timer_started
+                && exit_count > PROFILER_START_DELAY_EXITS
+            {
+                let stop = profiler_stop.clone();
+                let pending = profiler_cancel_pending.clone();
+                let partition = self.partition_handle;
+                profiler_thread = Some(std::thread::spawn(move || {
+                    unsafe { timer::timeBeginPeriod(1) };
+                    // Target ~1 kHz sampling. Actual rate is approximate due to
+                    // Windows scheduler granularity, even with timeBeginPeriod(1).
+                    let period = std::time::Duration::from_micros(1000);
+                    while !stop.load(Ordering::Relaxed) {
+                        std::thread::sleep(period);
+                        if stop.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        pending.store(true, Ordering::Release);
+                        unsafe {
+                            let _ =
+                                windows::Win32::System::Hypervisor::WHvCancelRunVirtualProcessor(
+                                    partition, 0, 0,
+                                );
+                        }
+                    }
+                    unsafe { timer::timeEndPeriod(1) };
+                }));
+                profiler_timer_started = true;
+            }
+
+            let (exit_context, profile_regs) = {
                 let mut locked_vcpu: MutexGuard<'_, VirtualProcessor> = self.vcpu.blocking_lock();
                 // Exit if the vCPU is no longer online.
                 if !locked_vcpu.is_online() {
@@ -677,8 +725,39 @@ impl Vmm {
                 {
                     guest_time_acc_us += run_start.elapsed().as_micros() as u64;
                 }
-                ctx
+
+                // Guest profiler: read registers only when our profiler timer fired.
+                let regs = if self.guest_profiler.is_some()
+                    && profiler_cancel_pending.swap(false, Ordering::Acquire)
+                    && matches!(ctx.reason_ref(), VirtualProcessorExitReasonRef::Interrupted)
+                {
+                    locked_vcpu.get_profile_regs().ok()
+                } else {
+                    None
+                };
+
+                (ctx, regs)
             };
+
+            // Guest profiler: capture sample after vcpu lock is released.
+            //
+            // Safety: The vCPU is stopped at this point — WHvRunVirtualProcessor
+            // returned with an Interrupted exit, and the next run() call hasn't
+            // been issued yet. Guest memory (page tables, stack) cannot change
+            // while the vCPU is not executing, so reading vmem here is safe.
+            if let (Some(profiler_samples), Some((eip, ebp, cr3))) =
+                (&self.guest_profiler, profile_regs)
+            {
+                let vmem_guard = self.vmem.blocking_lock();
+                crate::guest_profiler::GuestProfiler::capture_sample(
+                    profiler_samples,
+                    vmem_guard.get_raw_ptr(),
+                    vmem_guard.get_size(),
+                    eip,
+                    ebp,
+                    cr3,
+                );
+            }
 
             // Parse exit reason.
             match exit_context.reason_ref() {
@@ -850,6 +929,12 @@ impl Vmm {
 
         self.timer.lock().unwrap().stop();
 
+        // Stop profiler timer if running.
+        profiler_stop.store(true, Ordering::Relaxed);
+        if let Some(t) = profiler_thread.take() {
+            let _ = t.join();
+        }
+
         // Record guest vs exit-handling time breakdown.
         #[cfg(feature = "profile-time")]
         {
@@ -879,6 +964,14 @@ impl Vmm {
     ///
     pub fn guest(&self) -> Arc<Mutex<Guest>> {
         self.guest.clone()
+    }
+
+    /// Enables guest stack profiling. Returns the profiler handle for
+    /// reading samples after VM exit.
+    pub fn enable_guest_profiler(&mut self) -> crate::guest_profiler::GuestProfiler {
+        let profiler = crate::guest_profiler::GuestProfiler::new(4096);
+        self.guest_profiler = Some(profiler.handle());
+        profiler
     }
 
     /// Returns a clone of the IKC notifier for use by the memory thread.

--- a/src/uservm/src/vmm/microvm/whp/vcpu/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/vcpu/mod.rs
@@ -520,6 +520,29 @@ impl VirtualProcessor {
         Ok(unsafe { values[0].Reg64 })
     }
 
+    /// Reads guest EIP, EBP, and CR3 for stack profiling.
+    pub fn get_profile_regs(&self) -> Result<(u32, u32, u32)> {
+        const WHV_X64_REGISTER_RBP: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0x05);
+        const WHV_X64_REGISTER_CR3: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0x1E);
+        let names: [WHV_REGISTER_NAME; 3] = [
+            WHV_X64_REGISTER_RIP,
+            WHV_X64_REGISTER_RBP,
+            WHV_X64_REGISTER_CR3,
+        ];
+        let mut values: [WHV_REGISTER_VALUE; 3] = [unsafe { mem::zeroed() }; 3];
+        unsafe {
+            whp_get_registers(self.partition, self.index, &names, &mut values)
+                .map_err(|e| anyhow::anyhow!("failed to get profile regs (error={e:?})"))?;
+        }
+        let eip = u32::try_from(unsafe { values[0].Reg64 })
+            .map_err(|_| anyhow::anyhow!("RIP value exceeds u32 range"))?;
+        let ebp = u32::try_from(unsafe { values[1].Reg64 })
+            .map_err(|_| anyhow::anyhow!("RBP value exceeds u32 range"))?;
+        let cr3 = u32::try_from(unsafe { values[2].Reg64 })
+            .map_err(|_| anyhow::anyhow!("CR3 value exceeds u32 range"))?;
+        Ok((eip, ebp, cr3))
+    }
+
     /// Sets the RIP register to the given value.
     pub fn set_rip(&mut self, rip: u64) -> Result<()> {
         let names: [WHV_REGISTER_NAME; 1] = [WHV_X64_REGISTER_RIP];

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/boot_time.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/boot_time.rs
@@ -94,6 +94,7 @@ impl Benchmark {
                 gdb_port: None,
                 #[cfg(feature = "profile-time")]
                 perf_timings: ::nanvix::uservm::perf::PerfTimings::new(),
+                guest_profile_path: None,
             });
 
             let join_result = user_vm_handle.await;

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/snapshot_restore.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/snapshot_restore.rs
@@ -128,6 +128,7 @@ impl Benchmark {
                 gdb_port: None,
                 #[cfg(feature = "profile-time")]
                 perf_timings: ::nanvix::uservm::perf::PerfTimings::new(),
+                guest_profile_path: None,
             });
 
             let join_result = user_vm_handle.await;
@@ -248,6 +249,7 @@ impl Benchmark {
                 gdb_port: None,
                 #[cfg(feature = "profile-time")]
                 perf_timings,
+                guest_profile_path: None,
             });
 
             let join_result = user_vm_handle.await;

--- a/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/vmm/warm_start_vmm.rs
@@ -105,6 +105,7 @@ impl Benchmark {
             gdb_port: None,
             #[cfg(feature = "profile-time")]
             perf_timings: ::nanvix::uservm::perf::PerfTimings::new(),
+            guest_profile_path: None,
         });
 
         // Warmup: run one untimed echo cycle through the full IKC protocol to trigger


### PR DESCRIPTION
## Summary

Adds a host-side guest flamegraph profiler that periodically samples guest stack traces and produces folded stack files compatible with [inferno](https://github.com/jonhoo/inferno) and [flamegraph.pl](https://github.com/brendangregg/FlameGraph).

## How it works

1. A dedicated **1 kHz timer** calls `WHvCancelRunVirtualProcessor` to interrupt the guest
2. On each `Interrupted` exit, the host reads guest **EIP**, **EBP**, and **CR3** registers
3. The **frame-pointer chain** is walked through host-mapped guest memory:
   - Kernel addresses (`< 0x40000000`): identity-mapped, GVA == GPA
   - User addresses (`>= 0x40000000`): manual two-level x86 page table walk via CR3
4. Addresses are resolved against **ELF symbol tables** (`.symtab` preferred, `.dynsym` fallback)
5. After VM exit, **folded stacks** are written to a file

## How to generate a flamegraph

### Step 1: Build nanvix with symbols

Build an unstripped kernel for symbol resolution. Temporarily set `strip = false` in `Cargo.toml` `[profile.release]`, build, copy `bin/kernel.elf` to `bin/kernel.elf.sym`, then restore `strip = true`. Alternatively, use the new `release-profiling` profile:

```bash
cargo build --profile release-profiling -p kernel
```

### Step 2: Build CPython with frame pointers and symbols

CPython must be compiled with `-fno-omit-frame-pointer` (set in `Makefile.nanvix` and `.nanvix/config.py`).

The CPython build system should save an unstripped `python.elf.sym` alongside the stripped `python.elf` during Docker builds (see companion CPython PR). After `.\z build`, the file appears at `python.elf.sym` in the workspace root.

If you need to force a full rebuild (e.g., after changing CFLAGS):

```powershell
cd D:\src\cpython
docker volume rm (docker volume ls --format "{{.Name}}" | Where-Object { $_ -like "cpython-nanvix-build*" })
.\z setup --with-nanvix D:\src\nanvix
.\z build
```

### Step 3: Enable the profiler

Set `guest_profile_path` to `Some("path/to/output.folded".to_string())` in the `UserVmArgs` struct when spawning the VM. Set environment variables pointing to unstripped ELF binaries:

```powershell
$env:NANVIX_KERNEL_SYMBOLS = "D:\src\nanvix\bin\kernel.elf.sym"
$env:NANVIX_USER_SYMBOLS = "D:\src\cpython\python.elf.sym"
```

### Step 4: Generate flamegraph

```powershell
# Install flamegraph tools (one-time)
cargo install inferno rustfilt

# Generate flamegraph from folded stacks
Get-Content guest-profile.folded `
  | rustfilt `
  | ForEach-Object { $_ -replace '<','&lt;' -replace '>','&gt;' -replace '\+0x[0-9a-fA-F]+','' } `
  | inferno-flamegraph --title "Nanvix Guest Flamegraph" > flamegraph.svg
```

### Symbol resolution details

| Source | Symbol table | Count | Notes |
|--------|-------------|-------|-------|
| kernel.elf.sym | `.symtab` | ~370 | Rust mangled names |
| python.elf.sym | `.symtab` | ~35,000 | Includes static/internal functions |
| python.elf (stripped) | `.dynsym` only | ~12,000 | Missing `static` functions |

Resolution rate: **~97%** with full `.symtab` files. The remaining ~3% are data pointers (type objects, mutex tables) on the stack, not actual return addresses.

## Files changed

### New files
- `src/uservm/src/guest_profiler/mod.rs` — Module root
- `src/uservm/src/guest_profiler/gva.rs` — Guest VA→GPA translation (two-level x86 page table walk)
- `src/uservm/src/guest_profiler/samples.rs` — `GuestProfiler`, stack sampling, folded output
- `src/uservm/src/guest_profiler/symbols.rs` — ELF32 symbol parser (`.symtab` + `.dynsym` fallback)

### Modified files
- `src/uservm/src/vmm/microvm/whp/mod.rs` — Profiler timer, sampling on Interrupted exits, `enable_guest_profiler()`
- `src/uservm/src/vmm/microvm/whp/vcpu/mod.rs` — `get_profile_regs()` for EIP/EBP/CR3
- `src/uservm/src/lib.rs` — `guest_profiler` module, profiler activation, folded output writing
- `src/uservm/src/standalone.rs` — `guest_profile_path` field plumbing
- `Cargo.toml` — `release-profiling` Cargo profile
- Various `UserVmArgs` construction sites — added `guest_profile_path: None`