### PR TITLE
[ci] Fix admin team notification in CI failure job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2133,16 +2133,28 @@ jobs:
           echo "failed=${failed_jobs}" >> "${GITHUB_OUTPUT}"
           echo "skipped=${skipped_jobs}" >> "${GITHUB_OUTPUT}"
 
+      - name: "Resolve Admin Team Members"
+        id: team
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Attempt to fetch nanvix/admin team members for issue assignment.
+          # Falls back to "ppenna" if the API call fails or returns an empty list.
+          # NOTE: the admin team is small (well under the 30-member default page
+          # size), so pagination is not needed here.
+          ASSIGNEES=$(gh api orgs/nanvix/teams/admin/members --jq '[.[].login] | join(",")' 2>/dev/null || true)
+          if [ -z "${ASSIGNEES}" ]; then
+            echo "::warning::Could not fetch nanvix/admin team members; falling back to ppenna."
+            ASSIGNEES="ppenna"
+          fi
+          echo "assignees=${ASSIGNEES}" >> "${GITHUB_OUTPUT}"
+
       - name: "Create Issue"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue create \
-            --repo "${GITHUB_REPOSITORY}" \
-            --title "CI/CD pipeline failure on dev (Run #${{ github.run_number }})" \
-            --label "devops:ci" \
-            --assignee "ppenna" \
-            --body "## CI/CD Release Pipeline Failure
+          cat > /tmp/ci-issue-body.md <<ISSUE_BODY
+          ## CI/CD Release Pipeline Failure
 
           The CI/CD pipeline failed on \`dev\` (event: \`${{ github.event_name }}\`).
 
@@ -2152,7 +2164,16 @@ jobs:
           **Failed jobs:** ${{ steps.failed.outputs.failed }}
           **Skipped jobs:** ${{ steps.failed.outputs.skipped }}
 
-          Please investigate the failed and skipped jobs linked above and resolve the issue."
+          /cc @nanvix/admin
+          Please investigate the failed and skipped jobs linked above and resolve the issue.
+          ISSUE_BODY
+          sed -i 's/^          //' /tmp/ci-issue-body.md
+          gh issue create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "CI/CD pipeline failure on dev (Run #${{ github.run_number }})" \
+            --label "devops:ci" \
+            --assignee "${{ steps.team.outputs.assignees }}" \
+            --body-file /tmp/ci-issue-body.md
 
   # Bump the patch version on every merge to dev.
   # This job runs independently of the CI pipeline because the pipeline skips


### PR DESCRIPTION
## Summary

Re-applies the changes from PR #2118 with the fix for the invalid `members: read` permission that broke the entire CI workflow (Run #3226).

## Root Cause

The original PR added `members: read` to the job permissions block, but `members` is not a valid GitHub Actions permission scope. This caused the workflow file to be invalid, failing CI immediately on parse:

```
Invalid workflow file: .github/workflows/ci.yml (Line: 2123, Col: 7): Unexpected value 'members'
```

## Fix

- **Removed** the invalid `members: read` permission (not needed — the `gh api` call to fetch team members already has a graceful fallback).
- **Added** "Resolve Admin Team Members" step that fetches `nanvix/admin` team members via `gh api`, falling back to `ppenna` if the API call fails.
- **Updated** `--assignee` to use dynamically resolved team members.
- **Added** `/cc @nanvix/admin` to the issue body for notifications.

Closes #2117