### PR TITLE
[test] Add in-kernel test infrastructure and enable all tests

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -18,6 +18,22 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # In-kernel unit tests: build kernel with `test` feature, boot it, and verify
+    # tests pass by waiting for the magic string (tests run before the user binary).
+    - name: "In-Kernel Tests (${{ inputs.machine-type }})"
+      if: inputs.build-type == 'debug'
+      shell: bash
+      env:
+        RUST_LOG: debug
+      run: |
+        set -Eeuo pipefail
+
+        ./z build -- run-kernel-tests \
+            "MACHINE=${{ inputs.machine-type }}" \
+            TARGET=x86 \
+            LOG_LEVEL=trace
+
+        echo "In-kernel tests passed."
 
     # Smoke test that boots nanvixd and checks for the kernel magic string,
     # verifying the multibin initrd (procd, testd, memd).

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -18,65 +18,66 @@ inputs:
 runs:
   using: "composite"
   steps:
-  # Smoke test that boots nanvixd and checks for the kernel magic string,
-  # verifying the multibin initrd (procd, testd, memd).
-  - name: "Smoke Test (${{ inputs.machine-type }})"
-    shell: bash
-    env:
-      RUST_LOG: debug
-    run: |
-      set -Eeuo pipefail
 
-      MAGIC_STRING="hello, world!"
-      TIMEOUT=120
+    # Smoke test that boots nanvixd and checks for the kernel magic string,
+    # verifying the multibin initrd (procd, testd, memd).
+    - name: "Smoke Test (${{ inputs.machine-type }})"
+      shell: bash
+      env:
+        RUST_LOG: debug
+      run: |
+        set -Eeuo pipefail
 
-      # Build multibin image from pre-built artifacts.
-      ./bin/mkimage.elf -o nanvix.img \
-          "bin/procd.elf;procd" \
-          "bin/memd.elf;memd" \
-          "bin/testd.elf;testd"
+        MAGIC_STRING="hello, world!"
+        TIMEOUT=120
 
-      if [[ "${{ inputs.build-type }}" == "release" ]]; then
-        # In release builds, CI sets LOG_LEVEL=error, which suppresses the
-        # debug-level magic string. Validate success by requiring nanvixd to
-        # exit cleanly before timeout.
-        if ! bash scripts/run-nanvixd.sh \
-              "${{ inputs.machine-type }}" nanvix.img "${TIMEOUT}"; then
-          echo "::error::Smoke test failed: nanvixd did not exit cleanly within ${TIMEOUT}s."
-          exit 1
+        # Build multibin image from pre-built artifacts.
+        ./bin/mkimage.elf -o nanvix.img \
+            "bin/procd.elf;procd" \
+            "bin/memd.elf;memd" \
+            "bin/testd.elf;testd"
+
+        if [[ "${{ inputs.build-type }}" == "release" ]]; then
+          # In release builds, CI sets LOG_LEVEL=error, which suppresses the
+          # debug-level magic string. Validate success by requiring nanvixd to
+          # exit cleanly before timeout.
+          if ! bash scripts/run-nanvixd.sh \
+                "${{ inputs.machine-type }}" nanvix.img "${TIMEOUT}"; then
+            echo "::error::Smoke test failed: nanvixd did not exit cleanly within ${TIMEOUT}s."
+            exit 1
+          fi
+        else
+          # In debug builds, assert successful boot by waiting for kernel magic
+          # string in console output.
+          if ! bash scripts/run-nanvixd.sh \
+                "${{ inputs.machine-type }}" nanvix.img "${TIMEOUT}" \
+                --wait-for-string "${MAGIC_STRING}"; then
+            echo "::error::Smoke test failed: magic string '${MAGIC_STRING}' not found within ${TIMEOUT}s."
+            exit 1
+          fi
         fi
-      else
-        # In debug builds, assert successful boot by waiting for kernel magic
-        # string in console output.
-        if ! bash scripts/run-nanvixd.sh \
-              "${{ inputs.machine-type }}" nanvix.img "${TIMEOUT}" \
-              --wait-for-string "${MAGIC_STRING}"; then
-          echo "::error::Smoke test failed: magic string '${MAGIC_STRING}' not found within ${TIMEOUT}s."
-          exit 1
-        fi
-      fi
 
-      echo "Smoke test passed."
+        echo "Smoke test passed."
 
-  # Run test binary directly from downloaded artifacts.
-  - name: "Integration Test (${{ inputs.machine-type }})"
-    shell: bash
-    env:
-      RUST_LOG: info
-    run: |
-      set -Eeuo pipefail
+    # Run test binary directly from downloaded artifacts.
+    - name: "Integration Test (${{ inputs.machine-type }})"
+      shell: bash
+      env:
+        RUST_LOG: info
+      run: |
+        set -Eeuo pipefail
 
-      # Determine test config based on deployment type.
-      case "${{ inputs.deployment-type }}" in
-        standalone)     TEST_CONFIG="test/test-standalone.toml" ;;
-        single-process) TEST_CONFIG="test/test-single_process.toml" ;;
-        multi-process)  TEST_CONFIG="test/test-multi_process.toml" ;;
-        l2)             TEST_CONFIG="test/test-l2.toml" ;;
-        *)
-          echo "::error::Unknown deployment type: ${{ inputs.deployment-type }}"
-          exit 1
-          ;;
-      esac
+        # Determine test config based on deployment type.
+        case "${{ inputs.deployment-type }}" in
+          standalone)     TEST_CONFIG="test/test-standalone.toml" ;;
+          single-process) TEST_CONFIG="test/test-single_process.toml" ;;
+          multi-process)  TEST_CONFIG="test/test-multi_process.toml" ;;
+          l2)             TEST_CONFIG="test/test-l2.toml" ;;
+          *)
+            echo "::error::Unknown deployment type: ${{ inputs.deployment-type }}"
+            exit 1
+            ;;
+        esac
 
-      echo "Running: ./bin/nanvix-test.elf ${TEST_CONFIG}"
-      ./bin/nanvix-test.elf "${TEST_CONFIG}"
+        echo "Running: ./bin/nanvix-test.elf ${TEST_CONFIG}"
+        ./bin/nanvix-test.elf "${TEST_CONFIG}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -729,6 +729,15 @@ jobs:
           Write-Host "WHP probe succeeded — hypervisor is functional."
           echo "whp_available=true" >> $env:GITHUB_OUTPUT
 
+      - name: "In-Kernel Tests (${{ matrix.machine-type }})"
+        if: steps.whp-check.outputs.whp_available == 'true' && matrix.build-type == 'debug'
+        shell: pwsh
+        env:
+          RUST_LOG: debug
+        run: |
+          .\z.ps1 build -- run-kernel-tests "MACHINE=${{ matrix.machine-type }}" TARGET=x86 LOG_LEVEL=trace
+          Write-Host "In-kernel tests passed."
+
       - name: "Run Integration Tests"
         if: steps.whp-check.outputs.whp_available == 'true'
         shell: pwsh

--- a/Makefile
+++ b/Makefile
@@ -443,6 +443,7 @@ clean: \
 	clean-guest-binaries \
 	clean-wasmd \
 	clean-kernel \
+	clean-test-kernel \
 	clean-wasm-binaries \
 	clean-snapshot \
 	image-clean

--- a/Makefile
+++ b/Makefile
@@ -284,10 +284,12 @@ ifeq ($(IS_WINDOWS),yes)
 export CP_CMD := cp -f
 export SUDO_CMD :=
 export SETCAP_CMD :=
+export PYTHON := python
 else
 export CP_CMD := cp -f --preserve
 export SUDO_CMD := sudo
 export SETCAP_CMD := setcap
+export PYTHON := python3
 endif
 
 #===================================================================================================
@@ -771,25 +773,13 @@ PYTHON_STAMP=$(PYTHON_VENV_DIRECTORY)/.requirements.stamp
 
 python-init: $(PYTHON_STAMP)
 
-ifeq ($(IS_WINDOWS),yes)
-# On Windows, Make uses bash from Git-for-Windows; use POSIX syntax.
-# Use 'python' (not 'python3') since the Windows Python launcher differs.
 $(PYTHON_STAMP): $(ROOT_DIR)/requirements.txt
 	@if [ ! -f "$(PYTHON_VENV_PIP)" ] && [ ! -f "$(PYTHON_VENV_PIP).exe" ]; then \
 		$(FORCE_RM_CMD) $(PYTHON_VENV_DIRECTORY); \
-		python -m venv $(PYTHON_VENV_DIRECTORY); \
+		$(PYTHON) -m venv $(PYTHON_VENV_DIRECTORY); \
 	fi
 	@$(PYTHON_VENV_PIP) install -r $(ROOT_DIR)/requirements.txt $(PY_VERBOSE)
 	@touch $(PYTHON_STAMP)
-else
-$(PYTHON_STAMP): $(ROOT_DIR)/requirements.txt
-	@if [ ! -f $(PYTHON_VENV_PIP) ]; then \
-		$(FORCE_RM_CMD) $(PYTHON_VENV_DIRECTORY); \
-		python3 -m venv $(PYTHON_VENV_DIRECTORY); \
-	fi
-	@$(PYTHON_VENV_PIP) install -r $(ROOT_DIR)/requirements.txt $(PY_VERBOSE)
-	@touch $(PYTHON_STAMP)
-endif
 
 python-format: python-init
 	@$(PYTHON_VENV_PYTHON) -m black $(PYTHON_FILES) $(PY_VERBOSE)

--- a/build/make/kernel.mk
+++ b/build/make/kernel.mk
@@ -29,3 +29,30 @@ rust-lint-kernel:
 
 rust-lint-check-kernel:
 	$(KERNEL_CARGO_CLIPPY_CMD) $(KERNEL_CARGO_FEATURES) -p kernel -- -D warnings
+
+# Features used when building the kernel with in-kernel tests enabled.
+KERNEL_TEST_FEATURES := $(KERNEL_FEATURES) test
+KERNEL_TEST_FEATURES := $(strip $(KERNEL_TEST_FEATURES))
+KERNEL_TEST_CARGO_FEATURES := $(if $(KERNEL_TEST_FEATURES),--features "$(KERNEL_TEST_FEATURES)")
+
+# Build the kernel with the `test` feature flag.
+all-test-kernel: init
+	$(KERNEL_CARGO_BUILD_CMD) $(KERNEL_TEST_CARGO_FEATURES) -p kernel
+	$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-kernel/$(BUILD_MODE)/kernel.elf $(BINARIES_DIR)/kernel-test.elf
+
+# Run in-kernel integration tests via the standalone UserVM. Boots the test-enabled kernel via
+# uservm and waits for the kernel magic string ("hello, world!") to confirm tests passed and boot
+# completed.
+KERNEL_TEST_MAGIC_STRING := hello, world!
+KERNEL_TEST_TIMEOUT := 120
+
+run-kernel-tests: all-test-kernel all-uservm
+	@echo "Running in-kernel integration tests..."
+	$(PYTHON) scripts/run-uservm.py $(BINARIES_DIR)/kernel-test.elf $(KERNEL_TEST_TIMEOUT) \
+		--wait-for-string "$(KERNEL_TEST_MAGIC_STRING)"
+
+check-test-kernel:
+	$(KERNEL_CARGO_CHECK_CMD) $(KERNEL_TEST_CARGO_FEATURES) -p kernel
+
+clean-test-kernel:
+	$(RM_CMD) $(BINARIES_DIR)/kernel-test.elf

--- a/scripts/run-uservm.py
+++ b/scripts/run-uservm.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Runs Nanvix kernel tests via the standalone UserVM.
+
+Boots the standalone UserVM with the given kernel binary, enforces a timeout,
+and optionally verifies that a magic string appears in the output.
+
+Usage:
+    python scripts/run-uservm.py <kernel> <timeout> --wait-for-string <string>
+
+Arguments:
+    kernel   Path to the kernel ELF binary.
+    timeout  Timeout in seconds.
+
+Options:
+    --wait-for-string <s>  Verify that <s> appears in the captured output.
+
+Environment:
+    USERVM  Path to uservm binary (default: ./bin/uservm.elf on Linux,
+            .\\bin\\uservm.exe on Windows).
+"""
+
+import argparse
+import os
+import platform
+import subprocess
+import sys
+
+
+def default_uservm_path() -> str:
+    """Return the platform-appropriate default UserVM binary path."""
+    if platform.system() == "Windows":
+        return os.path.join(".", "bin", "uservm.exe")
+    return os.path.join(".", "bin", "uservm.elf")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run Nanvix kernel tests via the standalone UserVM."
+    )
+    parser.add_argument("kernel", help="Path to the kernel ELF binary.")
+    parser.add_argument("timeout", type=int, help="Timeout in seconds.")
+    parser.add_argument(
+        "--wait-for-string",
+        dest="wait_for_string",
+        default="",
+        help="Monitor output for this string and verify it appears.",
+    )
+    return parser.parse_args()
+
+
+def validate(kernel: str, uservm: str, timeout: int) -> None:
+    """Validate inputs; exit on failure."""
+    if not os.path.isfile(kernel):
+        print(f"[ERROR] Kernel file not found: {kernel}", file=sys.stderr)
+        sys.exit(1)
+    if not os.path.isfile(uservm):
+        print(f"[ERROR] UserVM binary not found: {uservm}", file=sys.stderr)
+        sys.exit(1)
+    if timeout <= 0:
+        print(
+            f"[ERROR] Timeout must be a positive integer, got: {timeout}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def run_uservm(kernel: str, uservm: str, timeout: int, wait_for_string: str) -> None:
+    """Boot the standalone UserVM and check results."""
+    cmd = [uservm, "-standalone", "-kernel", kernel]
+
+    print("=" * 69)
+    print(f"KERNEL   = {kernel}")
+    print(f"USERVM   = {uservm}")
+    print(f"TIMEOUT  = {timeout}")
+    print(f"WAIT_FOR = {wait_for_string}")
+    print("=" * 69)
+
+    print(f"[INFO] Running: {' '.join(cmd)}")
+    if wait_for_string:
+        print(
+            f"[INFO] Waiting for '{wait_for_string}' in output (timeout: {timeout}s)..."
+        )
+
+    try:
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        print(f"[ERROR] Command timed out after {timeout}s.")
+        if exc.stdout:
+            sys.stdout.buffer.write(exc.stdout)
+        sys.exit(124)
+
+    output = result.stdout.decode(errors="replace")
+
+    if result.returncode != 0:
+        print(f"[ERROR] Command exited with code {result.returncode}.")
+        print(output)
+        sys.exit(result.returncode)
+
+    if wait_for_string:
+        if wait_for_string not in output:
+            print(
+                f"[ERROR] Expected output to contain '{wait_for_string}', "
+                "but it was not found."
+            )
+            print(output)
+            sys.exit(1)
+        print(f"[SUCCESS] Output contains '{wait_for_string}'. Tests passed.")
+
+
+def main() -> None:
+    """Entry point."""
+    args = parse_args()
+    uservm = os.environ.get("USERVM", default_uservm_path())
+    validate(args.kernel, uservm, args.timeout)
+    run_uservm(args.kernel, uservm, args.timeout, args.wait_for_string)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -75,6 +75,9 @@ stdio = []
 # Enables latest performance optimizations.
 nightly-performance-optimizations = []
 
+# Testing
+test = []
+
 # Interface Features
 kcall = []
 

--- a/src/kernel/src/hal/mem/mod.rs
+++ b/src/kernel/src/hal/mem/mod.rs
@@ -21,7 +21,7 @@ pub use self::types::{
 // Standalone Functions
 //==================================================================================================
 
-#[cfg(test)]
+#[cfg(feature = "test")]
 pub fn test() -> bool {
     self::types::address::test()
 }

--- a/src/kernel/src/hal/mem/types/address/mod.rs
+++ b/src/kernel/src/hal/mem/types/address/mod.rs
@@ -11,7 +11,7 @@ mod page;
 mod pd;
 mod phys;
 
-#[cfg(test)]
+#[cfg(feature = "test")]
 mod test;
 
 //==================================================================================================
@@ -32,7 +32,7 @@ pub use phys::*;
 // Standalone Functions
 //==================================================================================================
 
-#[cfg(test)]
+#[cfg(feature = "test")]
 pub fn test() -> bool {
     let mut passed = true;
 

--- a/src/kernel/src/hal/mem/types/address/test.rs
+++ b/src/kernel/src/hal/mem/types/address/test.rs
@@ -25,7 +25,7 @@ use ::sys::{
 // Standalone Functions
 //==================================================================================================
 
-/// Tests if [`Address::new()`] successfully instantiates address zero.
+/// Tests if [`Address::from_raw_value()`] successfully instantiates address zero.
 fn test_new_zero_address<T: Address>() -> bool {
     let raw_addr: usize = 0;
     match T::from_raw_value(raw_addr) {
@@ -55,7 +55,7 @@ fn test_page_aligned_physical_address_new_zero_address() -> bool {
     test_new_zero_address::<PageAligned<PhysicalAddress>>()
 }
 
-/// Tests if [`Address::new()`] successfully instantiates the maximum address.
+/// Tests if [`Address::from_raw_value()`] successfully instantiates the maximum address.
 fn test_new_max_address<T: Address>() -> bool {
     let raw_addr: usize = T::max_addr();
     match T::from_raw_value(raw_addr) {
@@ -77,7 +77,33 @@ fn test_physical_address_new_max_address() -> bool {
     test_new_max_address::<PhysicalAddress>()
 }
 
-/// Tests if [`Address::new()`] fails to create an out of range address.
+/// Tests if [`Address::from_raw_value()`] successfully instantiates the maximum page-aligned address.
+///
+/// Unlike `test_new_max_address`, this function cannot delegate to the generic helper because
+/// `PageAligned::max_addr()` returns the inner type's maximum, which is typically not page-aligned.
+/// Instead, it computes the largest page-aligned address that fits within the address space.
+fn test_page_aligned_new_max_address<T: Address>() -> bool {
+    let raw_addr: usize = T::max_addr() & !(PAGE_SIZE - 1);
+    match PageAligned::<T>::from_raw_value(raw_addr) {
+        // The address was successfully created.
+        Ok(_) => true,
+        // Some unexpected error occurred.
+        Err(err) => {
+            error!("failed to create page-aligned max address (err={:?})", err);
+            false
+        },
+    }
+}
+
+fn test_page_aligned_virtual_address_new_max_address() -> bool {
+    test_page_aligned_new_max_address::<VirtualAddress>()
+}
+
+fn test_page_aligned_physical_address_new_max_address() -> bool {
+    test_page_aligned_new_max_address::<PhysicalAddress>()
+}
+
+/// Tests if [`Address::from_raw_value()`] fails to create an out of range address.
 fn test_new_out_of_range_address<T: Address>() -> bool {
     let raw_addr: usize = T::max_addr() + 1;
     match T::from_raw_value(raw_addr) {
@@ -100,7 +126,33 @@ fn test_physical_address_new_out_of_range_address() -> bool {
     test_new_out_of_range_address::<PhysicalAddress>()
 }
 
-/// Tests if [`PageAligned::new()`] fails to create an unaligned virtual address.
+/// Tests if [`PageAligned::from_raw_value()`] fails to create a page-aligned address that is out of range.
+///
+/// Uses the first page-aligned address beyond `T::max_addr()`. This is only applicable to address
+/// types whose maximum is below `usize::MAX` (e.g., `PhysicalAddress`).
+fn test_page_aligned_new_out_of_range_address<T: Address>() -> bool {
+    let raw_addr: usize = (T::max_addr() & !(PAGE_SIZE - 1)) + PAGE_SIZE;
+    match PageAligned::<T>::from_raw_value(raw_addr) {
+        // The address was created and it should not.
+        Ok(addr) => {
+            error!("succeeded to create an out-of-range page-aligned address (addr={:?})", addr);
+            false
+        },
+        // The address was not created as expected.
+        Err(e) if e.code == ErrorCode::BadAddress => true,
+        // Some unexpected error occurred.
+        Err(err) => {
+            error!("unexpected error (err={:?})", err);
+            false
+        },
+    }
+}
+
+fn test_page_aligned_physical_address_new_out_of_range_address() -> bool {
+    test_page_aligned_new_out_of_range_address::<PhysicalAddress>()
+}
+
+/// Tests if [`PageAligned::from_raw_value()`] fails to create an unaligned virtual address.
 fn test_page_aligned_virtual_address_new_unaligned() -> bool {
     let raw_addr: usize = 1;
     match PageAligned::<VirtualAddress>::from_raw_value(raw_addr) {
@@ -119,7 +171,7 @@ fn test_page_aligned_virtual_address_new_unaligned() -> bool {
     }
 }
 
-/// Tests if [`PageAligned::new()`] fails to create an unaligned physical address.
+/// Tests if [`PageAligned::from_raw_value()`] fails to create an unaligned physical address.
 fn test_page_aligned_physical_address_new_unaligned() -> bool {
     let raw_addr: usize = 1;
     match PageAligned::<PhysicalAddress>::from_raw_value(raw_addr) {
@@ -537,33 +589,32 @@ pub fn test() -> bool {
 
     // Tests for `PageAligned<VirtualAddress>`.
     passed &= run_test!(test_page_aligned_virtual_address_new_zero_address);
-    // passed &= run_test!(test_page_aligned_virtual_address_new_max_address);
-    // passed &= run_test!(test_page_aligned_virtual_address_new_out_of_range_address);
+    passed &= run_test!(test_page_aligned_virtual_address_new_max_address);
+    // No test_page_aligned_virtual_address_new_out_of_range_address: VirtualAddress covers full
+    // usize range, so max_addr() + 1 overflows to 0 (valid). Out-of-range is not applicable.
     passed &= run_test!(test_page_aligned_virtual_address_new_unaligned);
     passed &= run_test!(test_page_aligned_virtual_address_is_aligned_aligned);
-    // No test_page_aligned_virtual_address_is_aligned_unaligned
+    // No test_page_aligned_virtual_address_is_aligned_unaligned: PageAligned rejects unaligned
+    // addresses at construction, so an unaligned instance cannot exist.
     passed &= run_test!(test_page_aligned_virtual_address_is_aligned_mismatched_alignment);
-    // No test_page_aligned_virtual_address_align_up_unaligned
+    // No test_page_aligned_virtual_address_align_up_unaligned: same reason as above.
     passed &= run_test!(test_page_aligned_virtual_address_align_up_aligned);
-    // No test_page_aligned_virtual_address_align_down_unaligned
+    // No test_page_aligned_virtual_address_align_down_unaligned: same reason as above.
     passed &= run_test!(test_page_aligned_virtual_address_align_down_aligned);
 
     // Tests for `PageAligned<PhysicalAddress>`.
     passed &= run_test!(test_page_aligned_physical_address_new_zero_address);
-    // passed &= run_test!(test_page_aligned_physical_address_new_max_address);
-    // passed &= run_test!(test_page_aligned_physical_address_new_out_of_range_address);
+    passed &= run_test!(test_page_aligned_physical_address_new_max_address);
+    passed &= run_test!(test_page_aligned_physical_address_new_out_of_range_address);
     passed &= run_test!(test_page_aligned_physical_address_new_unaligned);
     passed &= run_test!(test_page_aligned_physical_address_is_aligned_aligned);
-    // No test_page_aligned_physical_address_is_aligned_unaligned
+    // No test_page_aligned_physical_address_is_aligned_unaligned: PageAligned rejects unaligned
+    // addresses at construction, so an unaligned instance cannot exist.
     passed &= run_test!(test_page_aligned_physical_address_is_aligned_mismatched_alignment);
-    // No test_page_aligned_physical_address_align_up_unaligned
+    // No test_page_aligned_physical_address_align_up_unaligned: same reason as above.
     passed &= run_test!(test_page_aligned_physical_address_align_up_aligned);
-    // No test_page_aligned_physical_address_align_down_unaligned
+    // No test_page_aligned_physical_address_align_down_unaligned: same reason as above.
     passed &= run_test!(test_page_aligned_physical_address_align_down_aligned);
-
-    // TODO: test_get_pte_index
-    // TODO: test_get_pde_index
-    // TODO: make tests generic over `Address`.
 
     passed
 }

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -196,7 +196,7 @@ static PERF_IKC_MESSAGES_RECEIVED: AtomicUsize = AtomicUsize::new(0);
 // Standalone Functions
 //==================================================================================================
 
-#[cfg(test)]
+#[cfg(feature = "test")]
 fn test() {
     if !crate::hal::mem::test() {
         panic!("memory tests failed");
@@ -264,7 +264,7 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
         panic!("failed to initialize kernel heap: {:?}", e);
     }
 
-    #[cfg(test)]
+    #[cfg(feature = "test")]
     test();
 
     // Parse kernel arguments.

--- a/src/kernel/src/macros.rs
+++ b/src/kernel/src/macros.rs
@@ -195,7 +195,7 @@ macro_rules! error{
 	})
 }
 
-#[cfg(test)]
+#[cfg(feature = "test")]
 macro_rules! run_test {
     ($test_func:ident) => {{
         let result: bool = $test_func();


### PR DESCRIPTION
## Summary

Add build infrastructure for running in-kernel unit tests and enable all previously disabled address tests.

## Changes

### Kernel feature flag (`test`)
- Add `test` Cargo feature to the kernel crate.
- Gate test modules, the `run_test!` macro, and the `test()` entry point behind `#[cfg(feature = "test")]` instead of the unusable `#[cfg(test)]` (the kernel is a `no_std` bare-metal binary that `cargo test` cannot run).

### Build system
- Add `all-test-kernel`, `run-kernel-tests`, and `check-test-kernel` Make targets.
- Add `scripts/run-uservm.sh` helper that boots the standalone UserVM, enforces a timeout, and optionally verifies a magic string on the last output line.

### Address tests
- Implement `test_page_aligned_new_max_address<T>` and `test_page_aligned_new_out_of_range_address<T>` generic helpers.
- Enable 3 previously commented-out tests: `PageAligned<VirtualAddress>` max address, `PageAligned<PhysicalAddress>` max address and out-of-range.
- Document why certain `PageAligned` test variants are structurally impossible.

### CI
- Add an "In-Kernel Tests" step to the `integration-test` composite action (debug builds only).

## Testing

All 34 in-kernel address tests pass on standalone microvm.