### PR TITLE
[kernel] Allow empty init_data on hyperlight

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -647,9 +647,15 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
     };
 
     if total_size == 0 {
-        let reason: &str = "init_data is empty";
-        error!("parse_bootinfo(): {reason}");
-        return Err(Error::new(ErrorCode::BadFile, reason));
+        info!("parse_bootinfo(): no init_data provided, booting without kernel modules");
+        return Ok(BootInfo::new(
+            None,
+            None,
+            LinkedList::new(),
+            LinkedList::new(),
+            IoMemoryAllocator::new(),
+            kernel_modules,
+        ));
     }
 
     // Detect initrd format by checking for NVMB multibinary magic.


### PR DESCRIPTION
## Summary

The hyperlight `parse_bootinfo()` function returned `Err(BadFile)` when `init_data` was empty, causing `kmain()` to panic on any standalone boot without an initrd (e.g. in-kernel test runs).

The microvm counterpart already handles this gracefully by returning an empty `BootInfo` when no initrd is present. This PR aligns hyperlight to the same behavior: return `Ok(BootInfo)` with an empty `kernel_modules` list so the kernel continues through its normal shutdown path.

## Changes

- `src/kernel/src/hal/platform/hyperlight/mod.rs`: When `total_size == 0`, return `Ok(BootInfo)` with empty kernel modules instead of `Err(BadFile)`.

## Testing

- Verified clippy passes for both `microvm` and `hyperlight` configurations.
- Verified `run-kernel-tests` passes for both `microvm` and `hyperlight` on Linux.
- All 6 pre-commit CI configurations pass.