### PR TITLE
[dlfcn] Implement RTLD_GLOBAL flag support (#2077)

### DIFF
--- a/src/libs/posix/src/dlfcn/mod.rs
+++ b/src/libs/posix/src/dlfcn/mod.rs
@@ -15,10 +15,6 @@ use ::core::{
     mem,
     ptr,
 };
-use ::num_enum::{
-    IntoPrimitive,
-    TryFromPrimitive,
-};
 use ::spin::Mutex;
 use ::sys::mm::{
     Address,
@@ -34,6 +30,17 @@ use ::syscall::dlfcn::{
     DlInfo,
 };
 use ::syslog::trace_libcall;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Bitmask for lazy binding mode (relocations are deferred until symbols are first used).
+const DLOPEN_MODE_LAZY_BIT: i32 = 0x1;
+/// Bitmask for eager binding mode (relocations are performed immediately when the object is loaded).
+const DLOPEN_MODE_NOW_BIT: i32 = 0x2;
+/// Bitmask for global symbol visibility (symbols are made available for relocation processing by subsequently loaded objects).
+const DLOPEN_MODE_GLOBAL_BIT: i32 = 0x4;
 
 //==================================================================================================
 // DlError
@@ -86,19 +93,48 @@ impl DlError {
 ///
 /// # Description
 ///
-/// A type that represents the mode in which a dynamic library may be opened.
+/// Bitmask flags controlling how a dynamic library is opened.
 ///
-#[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
-pub enum DlOpenMode {
-    /// Relocations are performed at an implementation-defined time.
-    Local = 0,
-    /// Relocations are performed when the object is loaded.
-    Lazy = 1,
-    /// All symbols are available for relocation processing of other modules.
-    Now = 2,
-    /// All symbols are not made available for relocation processing by other modules.
-    Global = 4,
+/// Per POSIX, `RTLD_NOW` / `RTLD_LAZY` select the binding mode while
+/// `RTLD_GLOBAL` / `RTLD_LOCAL` control symbol visibility.  The two
+/// categories are orthogonal and may be combined with bitwise OR.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DlOpenMode(i32);
+
+impl DlOpenMode {
+    /// Relocations are deferred until symbols are first used (lazy binding).
+    pub const LAZY: Self = DlOpenMode(DLOPEN_MODE_LAZY_BIT);
+    /// Relocations are performed immediately when the object is loaded (eager binding).
+    pub const NOW: Self = DlOpenMode(DLOPEN_MODE_NOW_BIT);
+    /// Symbols are made available for relocation processing by subsequently loaded objects.
+    pub const GLOBAL: Self = DlOpenMode(DLOPEN_MODE_GLOBAL_BIT);
+
+    /// All valid flag bits.
+    const VALID_MASK: i32 = DLOPEN_MODE_LAZY_BIT | DLOPEN_MODE_NOW_BIT | DLOPEN_MODE_GLOBAL_BIT;
+
+    /// Creates a `DlOpenMode` from a raw integer, returning `None` if any
+    /// invalid bits are set or if neither `LAZY` nor `NOW` is specified.
+    ///
+    /// NOTE: `LAZY | NOW` is accepted (POSIX says this is undefined behavior;
+    /// glibc treats it as `NOW`). Since Nanvix always resolves eagerly, this
+    /// combination is harmless.
+    pub fn from_raw(raw: i32) -> Option<Self> {
+        // Reject unknown bits.
+        if raw & !Self::VALID_MASK != 0 {
+            return None;
+        }
+        // At least one of LAZY or NOW must be set.
+        if raw & (Self::LAZY.0 | Self::NOW.0) == 0 {
+            return None;
+        }
+        Some(DlOpenMode(raw))
+    }
+
+    /// Returns `true` if the `GLOBAL` flag is set.
+    pub fn is_global(self) -> bool {
+        self.0 & Self::GLOBAL.0 != 0
+    }
 }
 
 //==================================================================================================
@@ -297,26 +333,19 @@ pub unsafe extern "C" fn dlopen(filename: *const c_char, mode: c_int) -> *mut c_
     };
 
     // Attempt to convert `mode` to `DlOpenMode`.
-    let mode: DlOpenMode = match DlOpenMode::try_from(mode) {
-        Ok(mode) => mode,
-        Err(error) => {
-            let reason: String = alloc::format!("invalid mode (error={error:?})");
+    let mode: DlOpenMode = match DlOpenMode::from_raw(mode) {
+        Some(mode) => mode,
+        None => {
+            let reason: String = alloc::format!("invalid mode (mode={mode:#x})");
             DL_LAST_ERROR.lock().set(&reason);
             ::syslog::error!("dlopen(): {}", reason);
             return ptr::null_mut();
         },
     };
 
-    // Check if open mode is not supported.
-    if mode == DlOpenMode::Local {
-        let reason: &str = "local mode is not supported";
-        DL_LAST_ERROR.lock().set(reason);
-        ::syslog::error!("dlopen(): {}", reason);
-        return ptr::null_mut();
-    }
-
-    // Attempt to open the shared object file.
-    match dlfcn::dlopen(filename) {
+    // Attempt to open the shared object file, forwarding the mode flags
+    // so the syscall layer can handle RTLD_GLOBAL.
+    match dlfcn::dlopen(filename, mode.is_global()) {
         Ok(handle) => handle.as_mut_ptr(),
         Err(error) => {
             DL_LAST_ERROR.lock().set(error.reason);

--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -33,8 +33,8 @@ use ::sys::error::Error;
 //==================================================================================================
 
 /// Opens a dynamic library file.
-pub fn dlopen(filename: &str) -> Result<DlHandle, Error> {
-    ::syslog::trace!("dlopen(): filename={}", filename);
+pub fn dlopen(filename: &str, global: bool) -> Result<DlHandle, Error> {
+    ::syslog::trace!("dlopen(): filename={}, global={}", filename, global);
 
     // Ensure the global symbol table is populated so that symbols exported
     // by the main executable can be resolved during relocation, even if the
@@ -55,6 +55,11 @@ pub fn dlopen(filename: &str) -> Result<DlHandle, Error> {
     // Check if dynamic library is already opened.
     for (dlhandle, dlfile) in registry.iter() {
         if dlfile.lock().name() == filename {
+            // If the caller requests RTLD_GLOBAL on a library that was
+            // previously loaded without it, promote it to global scope now.
+            if global {
+                super::register_library_in_global_scope(dlfile);
+            }
             return Ok(*dlhandle);
         }
     }
@@ -78,7 +83,17 @@ pub fn dlopen(filename: &str) -> Result<DlHandle, Error> {
     match load_all_dependencies(&mut registry, new_dlfile)
         .and_then(|_| resolve_all_symbols(&mut registry, &handles_before))
     {
-        Ok(()) => Ok(handle),
+        Ok(()) => {
+            // If RTLD_GLOBAL was requested, publish the library's exported
+            // symbols into the global symbol table so subsequently loaded
+            // libraries can resolve them.
+            if global {
+                if let Some(dlfile) = registry.get(&handle) {
+                    super::register_library_in_global_scope(dlfile);
+                }
+            }
+            Ok(handle)
+        },
         Err(e) => {
             let new_handles: Vec<DlHandle> = registry
                 .keys()

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -812,6 +812,32 @@ impl DynamicLibrary {
             .collect()
     }
 
+    /// Iterates over all defined (non-undefined) symbols exported by this
+    /// library, yielding `(name, absolute_address)` pairs.
+    pub fn exported_symbols(&self) -> Vec<(&str, usize)> {
+        let mut result: Vec<(&str, usize)> = Vec::new();
+        for sym in self.dynsym.iter() {
+            if sym.is_undefined() {
+                continue;
+            }
+            match self.dynstr.get_name(sym.name_offset()) {
+                Ok(name) if !name.is_empty() => {
+                    let addr: usize = self.load_address.into_raw_value() + sym.value() as usize;
+                    result.push((name, addr));
+                },
+                Err(e) => {
+                    ::syslog::warn!(
+                        "exported_symbols(): skipping symbol at offset {} (error={:?})",
+                        sym.name_offset(),
+                        e
+                    );
+                },
+                _ => {},
+            }
+        }
+        result
+    }
+
     /// Binds a dependency to the dynamic library.
     pub fn bind_dependency(
         &mut self,

--- a/src/libs/syscall/src/dlfcn/syscall/mod.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/mod.rs
@@ -46,18 +46,30 @@ use ::spin::{
 static DYNAMIC_LIBRARY_REGISTRY: Lazy<Mutex<BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>> =
     Lazy::new(|| Mutex::new(BTreeMap::new()));
 
-/// Global symbol table for symbols exported by the main executable.
-/// When a dynamically loaded library has unresolved symbols, this table
-/// is consulted as a last resort, enabling statically-linked executables
-/// to export symbols to their dynamically-loaded extension modules.
+/// Global symbol table for symbols available to dynamically loaded libraries.
 ///
-/// NOTE: this table only contains symbols from the main executable
-/// (populated from `.dynsym`/`.dynstr` sections emitted by
-/// `--export-dynamic`). Symbols from dynamically loaded shared
-/// libraries are *not* included; those are resolved through
-/// the per-library dependency chains in `DYNAMIC_LIBRARY_REGISTRY`.
+/// This table is populated from two sources:
+/// 1. The main executable's `.dynsym`/`.dynstr` sections (populated via
+///    `dlinit()` when the executable is linked with `--export-dynamic`).
+/// 2. Shared libraries loaded with `RTLD_GLOBAL` (populated via
+///    `register_library_in_global_scope()`).
+///
+/// When a dynamically loaded library has unresolved symbols, this table
+/// is consulted as a last resort, enabling symbol resolution across
+/// independently loaded libraries.
 static GLOBAL_SYMBOL_TABLE: Lazy<Mutex<BTreeMap<String, usize>>> =
     Lazy::new(|| Mutex::new(BTreeMap::new()));
+
+/// Pinned references to libraries loaded with `RTLD_GLOBAL`.
+///
+/// When a library is registered in the global scope, an extra `Arc` reference
+/// is stored here. This prevents `dlclose()` from actually unloading the
+/// library (the `Arc::strong_count` check in `dlclose` will see the extra
+/// reference), ensuring that the absolute addresses recorded in
+/// `GLOBAL_SYMBOL_TABLE` remain valid for the lifetime of the process.
+/// This is equivalent to Linux's `RTLD_NODELETE` behavior for global libraries.
+static GLOBAL_PINNED_LIBRARIES: Lazy<Mutex<Vec<Arc<Mutex<DynamicLibrary>>>>> =
+    Lazy::new(|| Mutex::new(Vec::new()));
 
 /// Default directories searched when a `DT_NEEDED` entry contains a bare
 /// library name (no path separator). Modelled after Linux's default search
@@ -206,12 +218,63 @@ pub fn dlinit() {
     });
 }
 
-/// Looks up a symbol in the global symbol table (main executable only).
+/// Looks up a symbol in the global symbol table.
 ///
-/// Ensures the table is populated before the first lookup.
+/// Searches symbols from the main executable and any libraries registered
+/// with `RTLD_GLOBAL`. Ensures the table is populated before the first lookup.
 pub(super) fn global_symbol_lookup(name: &str) -> Option<usize> {
     dlinit();
     GLOBAL_SYMBOL_TABLE.lock().get(name).copied()
+}
+
+/// Registers all defined (non-undefined) symbols from a loaded shared library
+/// into the global symbol table. Called when a library is loaded with
+/// `RTLD_GLOBAL` so its symbols are available for subsequently loaded libraries.
+///
+/// The library is also pinned via an extra `Arc` reference in
+/// `GLOBAL_PINNED_LIBRARIES`, preventing `dlclose()` from unloading it and
+/// leaving dangling addresses in the global symbol table.
+///
+/// Repeated calls for the same library are idempotent — duplicate pins are
+/// not created and already-registered symbols are not overwritten.
+///
+/// NOTE: Symbols registered here are NOT removed when the library is closed
+/// via `dlclose()`. The library is pinned (via `GLOBAL_PINNED_LIBRARIES`) to
+/// prevent actual unloading, ensuring the recorded absolute addresses remain
+/// valid for the lifetime of the process.
+pub(super) fn register_library_in_global_scope(lib_arc: &Arc<Mutex<DynamicLibrary>>) {
+    // Hold the pin lock across the entire check-and-insert to prevent
+    // duplicate pins from concurrent calls (TOCTOU).
+    let mut pinned: spin::MutexGuard<'_, Vec<Arc<Mutex<DynamicLibrary>>>> =
+        GLOBAL_PINNED_LIBRARIES.lock();
+    if pinned.iter().any(|p| Arc::ptr_eq(p, lib_arc)) {
+        return;
+    }
+
+    let lib: spin::MutexGuard<'_, DynamicLibrary> = lib_arc.lock();
+    let mut table = GLOBAL_SYMBOL_TABLE.lock();
+    let mut count: usize = 0;
+
+    for (name, addr) in lib.exported_symbols() {
+        use ::alloc::collections::btree_map::Entry;
+        if let Entry::Vacant(e) = table.entry(String::from(name)) {
+            e.insert(addr);
+            count += 1;
+        }
+    }
+
+    ::syslog::trace!(
+        "register_library_in_global_scope(): registered {} symbols from {:?}",
+        count,
+        lib.name()
+    );
+
+    drop(table);
+    drop(lib);
+
+    // Pin the library so dlclose() cannot unload it while its symbols
+    // are recorded in the global table.
+    pinned.push(lib_arc.clone());
 }
 
 //==================================================================================================

--- a/src/tests/dlfcn-rust/src/tests/dlfcn.rs
+++ b/src/tests/dlfcn-rust/src/tests/dlfcn.rs
@@ -56,7 +56,7 @@ const _: () = assert!(
 
 /// Opens a dynamic load library.
 fn open_library(path: &str) -> Result<DlHandle, Error> {
-    dlopen(path)
+    dlopen(path, false)
 }
 
 /// Closes a dynamic load library.

--- a/src/tests/dlfcn-rust/src/tests/dlfcn_global.rs
+++ b/src/tests/dlfcn-rust/src/tests/dlfcn_global.rs
@@ -1,0 +1,133 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::sys::{
+    error::Error,
+    mm::Address,
+};
+use ::syscall::dlfcn::{
+    DlHandle,
+    dlclose,
+    dlopen,
+    dlsym,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Path to the shared library used by the RTLD_GLOBAL tests.
+const LIB_PATH: &str = "lib/libmul.so";
+
+//==================================================================================================
+// Test Functions
+//==================================================================================================
+
+/// Tests that dlopen with global=true succeeds and the library's symbols
+/// become visible through the global scope (DlHandle::GLOBAL).
+fn test_global_registers_symbols() -> Result<(), Error> {
+    // Load the library with RTLD_GLOBAL.
+    let handle: DlHandle = dlopen(LIB_PATH, true)?;
+
+    // The "add" symbol should now be in the global symbol table.
+    let addr = dlsym(&DlHandle::GLOBAL, "add")?;
+    let add: unsafe extern "C" fn(i32, i32) -> i32 =
+        unsafe { core::mem::transmute(addr.into_raw_value()) };
+    assert!(unsafe { add(10, 20) } == 30, "add(10, 20) should return 30");
+
+    dlclose(&handle)?;
+    Ok(())
+}
+
+/// Tests that re-opening a library with global=true promotes it to global
+/// scope. Verifies that the cache-hit path in dlopen correctly calls
+/// register_library_in_global_scope when global=true is requested on a
+/// previously loaded library.
+///
+/// NOTE: Because test_global_registers_symbols runs first and registers all
+/// of libmul.so's symbols globally, this test cannot verify the negative case
+/// (that global=false does NOT register symbols). Full isolation would require
+/// a separate library. Instead, this test verifies the promotion plumbing
+/// (same handle returned, global lookup matches handle lookup).
+fn test_global_promotion_on_reopen() -> Result<(), Error> {
+    // Load with global=false first.
+    let handle: DlHandle = dlopen(LIB_PATH, false)?;
+
+    // "multiply" should be accessible via the specific handle.
+    let addr = dlsym(&handle, "multiply")?;
+    let multiply: unsafe extern "C" fn(i32, i32) -> i32 =
+        unsafe { core::mem::transmute(addr.into_raw_value()) };
+    assert!(unsafe { multiply(7, 6) } == 42, "multiply(7, 6) should return 42");
+
+    // Re-open the same library with global=true to promote it.
+    let handle2: DlHandle = dlopen(LIB_PATH, true)?;
+
+    // Should be the same handle (cache hit).
+    assert!(
+        handle.as_mut_ptr() == handle2.as_mut_ptr(),
+        "re-opening same library should return same handle"
+    );
+
+    // "multiply" should now be visible through the global scope.
+    let global_addr = dlsym(&DlHandle::GLOBAL, "multiply")?;
+    assert!(
+        addr.into_raw_value() == global_addr.into_raw_value(),
+        "global lookup should return the same address as handle lookup"
+    );
+
+    dlclose(&handle)?;
+    Ok(())
+}
+
+/// Tests that pinning prevents dlclose from unloading a global library.
+/// After dlclose, symbols registered via RTLD_GLOBAL should remain valid.
+fn test_global_pin_survives_dlclose() -> Result<(), Error> {
+    // Load with RTLD_GLOBAL.
+    let handle: DlHandle = dlopen(LIB_PATH, true)?;
+
+    // Get the address of "add" from the global scope.
+    let addr_before = dlsym(&DlHandle::GLOBAL, "add")?;
+
+    // Close the library handle. The pin should keep it alive.
+    dlclose(&handle)?;
+
+    // The symbol should still be resolvable from the global scope.
+    let addr_after = dlsym(&DlHandle::GLOBAL, "add")?;
+    assert!(
+        addr_before.into_raw_value() == addr_after.into_raw_value(),
+        "global symbol should survive dlclose due to pinning"
+    );
+
+    Ok(())
+}
+
+//==================================================================================================
+// Public Interface
+//==================================================================================================
+
+/// Runs all RTLD_GLOBAL dynamic linking tests.
+///
+/// IMPORTANT: Test ordering matters. These tests share process-global state
+/// (the `GLOBAL_SYMBOL_TABLE` and `GLOBAL_PINNED_LIBRARIES`), and global
+/// registrations persist for the lifetime of the process (matching Linux
+/// semantics). Specifically:
+///
+/// - `test_global_registers_symbols` registers "add" globally. This
+///   registration persists through subsequent tests.
+/// - `test_global_promotion_on_reopen` uses a different symbol ("multiply")
+///   to verify that promotion works independently of the prior registration.
+/// - `test_global_pin_survives_dlclose` opens the library with RTLD_GLOBAL
+///   and verifies that its pinned symbols remain available after dlclose.
+///
+/// This module must run AFTER all non-global dlfcn tests (see `mod.rs`)
+/// to avoid contaminating their global scope expectations.
+pub fn run() -> Result<(), Error> {
+    test_global_registers_symbols()?;
+    test_global_promotion_on_reopen()?;
+    test_global_pin_survives_dlclose()?;
+    Ok(())
+}

--- a/src/tests/dlfcn-rust/src/tests/dlfcn_pie.rs
+++ b/src/tests/dlfcn-rust/src/tests/dlfcn_pie.rs
@@ -49,7 +49,7 @@ pub static exe_global_value: i32 = 42;
 
 /// Opens a dynamic load library.
 fn open_library(path: &str) -> Result<DlHandle, Error> {
-    dlopen(path)
+    dlopen(path, false)
 }
 
 /// Closes a dynamic load library.

--- a/src/tests/dlfcn-rust/src/tests/mod.rs
+++ b/src/tests/dlfcn-rust/src/tests/mod.rs
@@ -8,6 +8,7 @@ use ::sys::error::Error;
 //==================================================================================================
 
 mod dlfcn;
+mod dlfcn_global;
 mod dlfcn_pie;
 
 //==================================================================================================
@@ -18,5 +19,9 @@ mod dlfcn_pie;
 pub fn run_all() -> Result<(), Error> {
     dlfcn::run()?;
     dlfcn_pie::run()?;
+    // RTLD_GLOBAL tests run last because they permanently register symbols
+    // in the global scope (matching Linux semantics where global scope
+    // entries persist after dlclose).
+    dlfcn_global::run()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Implement `RTLD_GLOBAL` flag support for `dlopen`. When a library is loaded with `RTLD_GLOBAL`, its exported symbols are registered in the global symbol table so subsequently loaded libraries can resolve them.

Fixes #2077. Depends on #2132.

## Problem

The POSIX layer parsed the `mode` parameter but discarded it when calling the syscall layer. `DlOpenMode` was a plain enum (not a bitmask), so combined flags like `RTLD_NOW | RTLD_GLOBAL` were rejected. No mechanism existed to register a library's symbols into a global scope for use by subsequently loaded libraries.

## Expected Behavior (POSIX/Linux Reference)

Per [POSIX dlopen](https://pubs.opengroup.org/onlinepubs/9799919799/functions/dlopen.html):

> **RTLD_GLOBAL**: The object's symbols shall be made available for relocation processing of any other object.

On Linux, `RTLD_GLOBAL` adds the library to the namespace's global search list via [`elf/dl-open.c`](https://github.com/bminor/glibc/blob/master/elf/dl-open.c) (`add_to_global_update`). The flags `RTLD_NOW` and `RTLD_GLOBAL` are orthogonal bitmask values combined with `|`. Libraries loaded with `RTLD_GLOBAL` are effectively pinned (`RTLD_NODELETE` behavior) because their addresses are referenced by the global scope.

## Fix

- **`DlOpenMode`**: Converted from plain enum to bitmask struct (`LAZY=0x1`, `NOW=0x2`, `GLOBAL=0x4`). Supports combined flags.
- **`dlopen()`**: Accepts `global` parameter. Registers symbols on success. Promotes on cache-hit (re-opening with `RTLD_GLOBAL`).
- **`register_library_in_global_scope()`**: Idempotent (TOCTOU-safe). Pins library via `GLOBAL_PINNED_LIBRARIES` to prevent use-after-unload.
- **`exported_symbols()`**: New method on `DynamicLibrary` yielding `(name, address)` pairs. Logs warnings for malformed symbol entries.

## Lock Ordering

This PR establishes the following lock acquisition order, documented here to prevent future inversions:

`DYNAMIC_LIBRARY_REGISTRY` -> `GLOBAL_PINNED_LIBRARIES` -> `DynamicLibrary` (per-lib) -> `GLOBAL_SYMBOL_TABLE`

## Testing

- All existing integration tests pass (both HTTP and terminal executors).
- **New Rust tests** (`dlfcn_global.rs`):
  - `test_global_registers_symbols`: load with `global=true`, verify `dlsym(GLOBAL, "add")` works.
  - `test_global_promotion_on_reopen`: load with `false`, reopen with `true`, verify promotion.
  - `test_global_pin_survives_dlclose`: load with `global=true`, `dlclose`, verify symbol still resolvable.
- Cross-library RTLD_GLOBAL tests are in [nanvix/posix-tests#27](https://github.com/nanvix/posix-tests/pull/27).

## Affected Files

- `src/libs/posix/src/dlfcn/mod.rs` — `DlOpenMode` bitmask, forward mode.
- `src/libs/syscall/src/dlfcn/syscall/dlopen.rs` — `global` parameter, registration.
- `src/libs/syscall/src/dlfcn/syscall/mod.rs` — global scope registration + pinning.
- `src/libs/syscall/src/dlfcn/syscall/dynlib.rs` — `exported_symbols()`.
- `src/tests/dlfcn-rust/src/tests/dlfcn.rs` — updated `dlopen` call.
- `src/tests/dlfcn-rust/src/tests/dlfcn_pie.rs` — updated `dlopen` call.
- `src/tests/dlfcn-rust/src/tests/dlfcn_global.rs` — **new** RTLD_GLOBAL tests.
- `src/tests/dlfcn-rust/src/tests/mod.rs` — wire new test module.