### PR TITLE
[dlfcn] Resolve libraries in dependency order

### DIFF
--- a/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dlopen.rs
@@ -192,24 +192,91 @@ fn load_all_dependencies(
 
 /// Resolves all relocations for libraries added during this `dlopen` call.
 ///
-/// Every library whose handle is NOT in `handles_before` is a new entry from
-/// the current `dlopen` invocation and needs its relocations patched.
+/// Libraries are resolved in dependency order (leaves first, root last).
+/// This ensures that when a library's relocations reference symbols from
+/// its dependencies, those dependencies are already fully resolved.
 fn resolve_all_symbols(
     dlfiles: &mut MutexGuard<'_, BTreeMap<DlHandle, Arc<Mutex<DynamicLibrary>>>>,
     handles_before: &BTreeSet<DlHandle>,
 ) -> Result<(), Error> {
     ::syslog::trace!("resolve_all_symbols()");
 
-    // Resolve relocations for every library added during this dlopen call,
-    // not just the root. This ensures transitive dependencies loaded via
-    // DT_NEEDED also have their relocations patched.
+    // Collect all newly added libraries.
     let new_handles: Vec<DlHandle> = dlfiles
         .keys()
         .filter(|h| !handles_before.contains(h))
         .copied()
         .collect();
 
-    for handle in new_handles {
+    // Build a resolution order: resolve dependencies before their dependents.
+    // A library can be resolved once all its bound dependencies (that are also
+    // new in this dlopen call) have been resolved.
+    let mut resolved: BTreeSet<DlHandle> = BTreeSet::new();
+    let mut ordered: Vec<DlHandle> = Vec::with_capacity(new_handles.len());
+
+    // Iteratively find libraries whose dependencies are all resolved.
+    // This attempts a simple topological ordering for the newly loaded
+    // libraries. If the dependency graph contains a cycle, or if a dependency
+    // cannot be ordered, the no-progress fallback below will warn and resolve
+    // the remaining libraries in arbitrary order.
+    loop {
+        let mut progress: bool = false;
+        for &handle in &new_handles {
+            if resolved.contains(&handle) {
+                continue;
+            }
+
+            // Check if all of this library's dependencies that are new in
+            // this dlopen call have been resolved.
+            let dlfile: &Arc<Mutex<DynamicLibrary>> = match dlfiles.get(&handle) {
+                Some(f) => f,
+                None => {
+                    // Handle came from dlfiles.keys(), so this should not happen.
+                    ::syslog::error!(
+                        "resolve_all_symbols(): handle {:?} missing from registry",
+                        handle
+                    );
+                    continue;
+                },
+            };
+            // Lock the library only long enough to check its dependencies.
+            let all_deps_resolved: bool = {
+                let lib: spin::MutexGuard<'_, DynamicLibrary> = dlfile.lock();
+                lib.dependency_handles().iter().all(|dep_handle| {
+                    // Dependencies that existed before this dlopen are already resolved.
+                    handles_before.contains(dep_handle) || resolved.contains(dep_handle)
+                })
+            };
+
+            if all_deps_resolved {
+                ordered.push(handle);
+                resolved.insert(handle);
+                progress = true;
+            }
+        }
+
+        if resolved.len() == new_handles.len() {
+            break;
+        }
+
+        if !progress {
+            // No progress means a cycle or missing dependency. Fall back to
+            // resolving remaining libraries in arbitrary order.
+            ::syslog::warn!(
+                "resolve_all_symbols(): could not determine dependency order for {} libraries",
+                new_handles.len() - resolved.len()
+            );
+            for &handle in &new_handles {
+                if !resolved.contains(&handle) {
+                    ordered.push(handle);
+                }
+            }
+            break;
+        }
+    }
+
+    // Resolve in dependency order (leaves first).
+    for handle in ordered {
         if let Some(dlfile) = dlfiles.get(&handle) {
             dlfile.lock().resolve_all()?;
         }

--- a/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
+++ b/src/libs/syscall/src/dlfcn/syscall/dynlib.rs
@@ -804,6 +804,14 @@ impl DynamicLibrary {
         self.dependencies.clone()
     }
 
+    /// Returns the handles of all bound dependencies.
+    pub fn dependency_handles(&self) -> Vec<DlHandle> {
+        self.dependencies
+            .values()
+            .filter_map(|dep| dep.as_ref().map(|d| d.lock().handle()))
+            .collect()
+    }
+
     /// Binds a dependency to the dynamic library.
     pub fn bind_dependency(
         &mut self,


### PR DESCRIPTION
## Summary

Replace arbitrary-order relocation resolution with a topological sort that resolves dependencies before their dependents (leaves first, root last).

Fixes #2128. Depends on #2132.

## Problem

`resolve_all_symbols()` resolved libraries in arbitrary `BTreeMap` handle order (sorted by file descriptor number). If a root library (e.g., `etree.cpython-312.so`) was resolved before its dependencies (`libm.so`, `libc.so`), the resolution could fail because those dependencies had their own relocations that needed patching first.

## Expected Behavior (Linux/musl Reference)

Dynamic linkers resolve dependencies before their dependents:

- glibc builds a BFS-ordered search list in [`elf/dl-deps.c`](https://github.com/bminor/glibc/blob/master/elf/dl-deps.c) (`_dl_map_object_deps`). Leaf dependencies appear earlier in the list and are relocated first in [`elf/dl-open.c`](https://github.com/bminor/glibc/blob/master/elf/dl-open.c).
- musl's `dlopen` in [`ldso/dynlink.c`](https://git.musl-libc.org/cgit/musl/tree/ldso/dynlink.c) resolves dependencies before their dependents during the relocation phase.

## Fix

- **Topological sort** (Kahn's algorithm) over newly added handles: a library is resolved only after all its dependencies (that are also new in this `dlopen` call) have been resolved. Pre-existing libraries are treated as already resolved.
- **`dependency_handles()`**: New method on `DynamicLibrary` returning the handles of all bound dependencies.
- **Fallback**: If a cycle prevents progress (pre-existing issue tracked in #2092), remaining libraries are resolved in arbitrary order with a warning log.

## Complexity

The topo-sort is O(N²) in the number of newly loaded libraries per `dlopen` call. For typical library counts (5–20), this is negligible compared to ELF parsing, file I/O, and relocation patching.

## Affected Files

- `src/libs/syscall/src/dlfcn/syscall/dlopen.rs` — `resolve_all_symbols()` topo-sort.
- `src/libs/syscall/src/dlfcn/syscall/dynlib.rs` — `dependency_handles()`.

## Testing

All existing integration tests pass (both HTTP and terminal executors). Correct ordering is critical for real-world libraries like CPython extensions with `DT_NEEDED` chains (`libm.so`, `libc.so`), tested via [nanvix/posix-tests#27](https://github.com/nanvix/posix-tests/pull/27).