### PR TITLE
[kernel] Enhance kpool allocation

### DIFF
--- a/src/kernel/src/mm/elf.rs
+++ b/src/kernel/src/mm/elf.rs
@@ -22,10 +22,12 @@ use crate::{
         WritePermission,
     },
     mm::{
+        phys::UserFrame,
         VirtMemoryManager,
         Vmem,
     },
 };
+use ::alloc::vec::Vec;
 use ::arch::{
     mem,
     mem::PAGE_ALIGNMENT,
@@ -268,6 +270,7 @@ fn do_elf32_load(
             virt_addr_base, virt_addr_end, phys_addr_base, phys_addr_end, access
         );
 
+        let mut uframe_buf: Vec<UserFrame> = Vec::with_capacity(1);
         for vaddr in (virt_addr_base..virt_addr_end).step_by(mem::PAGE_SIZE) {
             let vaddr: VirtualAddress = VirtualAddress::new(vaddr);
 
@@ -335,9 +338,9 @@ fn do_elf32_load(
                     mm.alloc_upages(
                         vmem,
                         vaddr,
-                        1,
                         access,
                         page_lies_in_bss || page_is_partially_covered,
+                        &mut uframe_buf,
                     )?;
                 }
             }

--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -8,6 +8,7 @@
 use crate::{
     hal::mem::PageAligned,
     mm::{
+        phys::KernelFrame,
         KernelPage,
         VirtMemoryManager,
     },
@@ -91,8 +92,10 @@ impl KernelStack {
     /// Upon success, the function returns the new kernel stack. Upon failure, an error is returned.
     ///
     pub fn new(mm: &mut VirtMemoryManager) -> Result<Self, Error> {
-        let kpages: Vec<KernelPage> =
-            mm.alloc_kpages(true, config::kernel::KSTACK_SIZE / ::arch::mem::PAGE_SIZE)?;
+        let count: usize = config::kernel::KSTACK_SIZE / ::arch::mem::PAGE_SIZE;
+        let mut kframes: Vec<KernelFrame> = Vec::with_capacity(count);
+        mm.alloc_kpages(true, &mut kframes)?;
+        let kpages: Vec<KernelPage> = kframes.into_iter().map(KernelPage::new).collect();
 
         let guard_threshold: u32 =
             (kpages[0].base().into_raw_value() + Exception::CONTEXT_HW_SIZE) as u32;

--- a/src/kernel/src/mm/phys/kpool.rs
+++ b/src/kernel/src/mm/phys/kpool.rs
@@ -139,9 +139,9 @@ impl KernelFrame {
     ///
     /// # Description
     ///
-    /// Clears the target kernel page.
+    /// Clears the target kernel frame.
     ///
-    fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.deref_mut().fill(0);
     }
 }
@@ -194,21 +194,13 @@ impl Kpool {
     ///
     /// Allocates a kernel frame from the kernel frame pool.
     ///
-    /// # Parameters
-    ///
-    /// - `clear`: Clear page?
-    ///
     /// # Return Values
     ///
     /// Upon success, a kernel frame is returned. Upon failure, an error is returned instead.
     ///
-    pub fn alloc(&mut self, clear: bool) -> Result<KernelFrame, Error> {
+    pub fn alloc(&mut self) -> Result<KernelFrame, Error> {
         let frame: FrameAddress = self.inner.borrow_mut().alloc()?;
-        let mut kframe: KernelFrame = KernelFrame::new(self.inner.clone(), frame);
-        if clear {
-            kframe.clear();
-        }
-        Ok(kframe)
+        Ok(KernelFrame::new(self.inner.clone(), frame))
     }
 
     ///

--- a/src/kernel/src/mm/phys/kpool.rs
+++ b/src/kernel/src/mm/phys/kpool.rs
@@ -27,7 +27,10 @@ use ::core::{
         DerefMut,
     },
 };
-use ::sys::error::Error;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
 
 //==================================================================================================
 // Kernel Page Pool Inner
@@ -68,19 +71,26 @@ impl KpoolInner {
     ///
     /// # Description
     ///
-    /// Allocates a contiguous range of pages in the kernel page pool.
+    /// Allocates a contiguous range of frame addresses from the kernel pool.
     ///
     /// # Parameters
     ///
-    /// - `count`: Number of frames to allocate.
+    /// - `addrs`: Mutable reference to a pre-allocated vector. The number of frames allocated
+    ///   equals `addrs.capacity()`.
     ///
-    /// # Returns
+    /// # Return Values
     ///
-    /// Upon success, a vector of page-aligned addresses is returned. Upon failure, an error code is
-    /// returned instead.
+    /// Upon success, `Ok(())` is returned and `addrs` is filled to capacity with contiguous
+    /// entries. Upon failure, an error is returned instead.
     ///
-    fn alloc_range(&mut self, count: usize) -> Result<Vec<FrameAddress>, Error> {
-        // Attempt to allocate a range of pages.
+    fn alloc_range(&mut self, addrs: &mut Vec<FrameAddress>) -> Result<(), Error> {
+        if !addrs.is_empty() {
+            let reason: &str = "addrs vector is not empty";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+
+        let count: usize = addrs.capacity();
         let index: usize = match self.bitmap.alloc_range(count) {
             Ok(index) => index,
             Err(error) => {
@@ -89,18 +99,16 @@ impl KpoolInner {
             },
         };
 
-        // Create a vector of page-aligned addresses.
         let base_addr: usize = self.region.start().into_raw_value() + index * mem::PAGE_SIZE;
-        let mut pages: Vec<FrameAddress> = Vec::new();
         for i in 0..count {
             let addr: usize = base_addr + i * mem::PAGE_SIZE;
-            let page: FrameAddress = FrameAddress::new(PageAligned::from_address(
+            let frame: FrameAddress = FrameAddress::new(PageAligned::from_address(
                 PhysicalAddress::from_raw_value(addr)?,
             )?);
-            pages.push(page);
+            addrs.push(frame);
         }
 
-        Ok(pages)
+        Ok(())
     }
 
     /// Frees a page in the kernel pool.
@@ -206,32 +214,32 @@ impl Kpool {
     ///
     /// # Description
     ///
-    /// Allocates a contiguous range of frames from the kernel frame pool.
+    /// Allocates a contiguous range of kernel frames from the kernel frame pool.
     ///
     /// # Parameters
     ///
-    /// - `clear`: Clear pages?
-    /// - `count`: Number of pages to allocate.
+    /// - `frames`: Mutable reference to a pre-allocated vector. The number of frames allocated
+    ///   equals `frames.capacity()`.
     ///
     /// # Return Values
     ///
-    /// Upon success, a vector of kernel frames is returned. Upon failure, an error is returned
-    /// instead.
+    /// Upon success, `Ok(())` is returned and `frames` is filled to capacity with contiguous
+    /// entries. Upon failure, an error is returned instead.
     ///
-    pub fn alloc_many(&mut self, clear: bool, count: usize) -> Result<Vec<KernelFrame>, Error> {
-        // Attempt to allocate pages.
-        let mut kframes: Vec<FrameAddress> = self.inner.borrow_mut().alloc_range(count)?;
-
-        // Create a vector of kernel pages.
-        let mut kpages: Vec<KernelFrame> = Vec::new();
-        while let Some(kframe) = kframes.pop() {
-            let mut kframe: KernelFrame = KernelFrame::new(self.inner.clone(), kframe);
-            if clear {
-                kframe.clear();
-            }
-            kpages.push(kframe);
+    pub fn alloc_many(&mut self, frames: &mut Vec<KernelFrame>) -> Result<(), Error> {
+        // Check if caller-provided vector is not empty.
+        if !frames.is_empty() {
+            let reason: &str = "frames vector is not empty";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
-        Ok(kpages)
+        let count: usize = frames.capacity();
+        let mut addrs: Vec<FrameAddress> = Vec::with_capacity(count);
+        self.inner.borrow_mut().alloc_range(&mut addrs)?;
+        for addr in addrs {
+            frames.push(KernelFrame::new(self.inner.clone(), addr));
+        }
+        Ok(())
     }
 }

--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -124,8 +124,42 @@ impl PhysMemoryManager {
         PHYS_MEMORY_MANAGER.assume_init_mut()
     }
 
-    pub fn alloc_many_user_frames(&mut self, nframes: usize) -> Result<Vec<UserFrame>, Error> {
-        self.upool.alloc_many(nframes)
+    ///
+    /// # Description
+    ///
+    /// Allocates user frames into caller-provided storage, filling up to the vector's remaining
+    /// capacity.
+    ///
+    /// The returned frames are not guaranteed to be physically contiguous.
+    ///
+    /// # Parameters
+    ///
+    /// - `frames`: Mutable reference to a pre-allocated vector. The number of frames allocated
+    ///   equals `frames.capacity() - frames.len()`.
+    ///
+    /// # Return Values
+    ///
+    /// Upon success, `Ok(())` is returned and `frames` is filled to capacity. Upon failure, an
+    /// error is returned and any frames allocated by this call are dropped by truncating `frames`
+    /// back to empty.
+    ///
+    pub fn alloc_many_user_frames(&mut self, frames: &mut Vec<UserFrame>) -> Result<(), Error> {
+        if !frames.is_empty() {
+            let reason: &str = "frames vector is not empty";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+
+        for _ in 0..frames.capacity() {
+            match self.upool.alloc() {
+                Ok(frame) => frames.push(frame),
+                Err(error) => {
+                    frames.clear();
+                    return Err(error);
+                },
+            }
+        }
+        Ok(())
     }
 
     ///

--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -133,16 +133,12 @@ impl PhysMemoryManager {
     ///
     /// Allocates a kernel frame.
     ///
-    /// # Parameters
-    ///
-    /// - `clear`: Clear frame?
-    ///
     /// # Return Values
     ///
     /// Upon success, a kernel frame is returned. Upon failure, an error is returned instead.
     ///
-    pub fn alloc_kernel_frame(&mut self, clear: bool) -> Result<KernelFrame, Error> {
-        self.kpool.alloc(clear)
+    pub fn alloc_kernel_frame(&mut self) -> Result<KernelFrame, Error> {
+        self.kpool.alloc()
     }
 
     ///

--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -144,23 +144,26 @@ impl PhysMemoryManager {
     ///
     /// # Description
     ///
-    /// Allocates a contiguous range of kernel frames.
+    /// Allocates a contiguous range of kernel frames into caller-provided storage.
     ///
     /// # Parameters
     ///
-    /// - `clear`: Clear frames?
-    /// - `count`: Number of frames to allocate.
+    /// - `frames`: Mutable reference to a pre-allocated vector. The number of frames allocated
+    ///   equals `frames.capacity()`.
     ///
     /// # Return Values
     ///
-    /// Upon success, a vector of kernel frames is returned. Upon failure, an error is returned
-    /// instead.
+    /// Upon success, `Ok(())` is returned and `frames` is filled to capacity with contiguous
+    /// entries. Upon failure, an error is returned instead.
     ///
-    pub fn alloc_many_kernel_frames(
-        &mut self,
-        clear: bool,
-        count: usize,
-    ) -> Result<Vec<KernelFrame>, Error> {
-        self.kpool.alloc_many(clear, count)
+    pub fn alloc_many_kernel_frames(&mut self, frames: &mut Vec<KernelFrame>) -> Result<(), Error> {
+        // Check if caller-provided vector is not empty.
+        if !frames.is_empty() {
+            let reason: &str = "frames vector is not empty";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+
+        self.kpool.alloc_many(frames)
     }
 }

--- a/src/kernel/src/mm/phys/upool.rs
+++ b/src/kernel/src/mm/phys/upool.rs
@@ -9,7 +9,6 @@ use crate::{
     hal::mem::FrameAddress,
     mm::phys::frame,
 };
-use ::alloc::vec::Vec;
 use ::core::mem::ManuallyDrop;
 use ::sys::error::Error;
 
@@ -90,7 +89,7 @@ impl Drop for UserFrame {
 /// # Description
 ///
 /// Thin facade over the module-level [`frame`](super::frame) allocator. Exists as a distinct type
-/// so user-frame allocation has its own entry point ([`Upool::alloc_many`] returning [`UserFrame`]).
+/// so user-frame allocation has its own entry point ([`Upool::alloc`] returning [`UserFrame`]).
 ///
 #[derive(Debug)]
 pub struct Upool;
@@ -109,18 +108,17 @@ impl Upool {
         Self
     }
 
-    pub fn alloc_many(&mut self, nframes: usize) -> Result<Vec<UserFrame>, Error> {
-        trace!("nframes={nframes:?}");
-
-        let mut uframes: Vec<UserFrame> = Vec::with_capacity(nframes);
-        for _ in 0..nframes {
-            match frame::alloc() {
-                Ok(addr) => uframes.push(UserFrame::new(addr)),
-                // Rollback is automatic: dropping `uframes` frees all allocated frames.
-                Err(error) => return Err(error),
-            }
-        }
-
-        Ok(uframes)
+    ///
+    /// # Description
+    ///
+    /// Allocates a single user frame from the user frame pool.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, a user frame is returned. Upon failure, an error is returned instead.
+    ///
+    pub fn alloc(&mut self) -> Result<UserFrame, Error> {
+        let addr: FrameAddress = frame::alloc()?;
+        Ok(UserFrame::new(addr))
     }
 }

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -397,30 +397,40 @@ impl VirtMemoryManager {
     ///
     /// # Description
     ///
-    /// Allocates a contiguous range of kernel pages.
+    /// Allocates a contiguous range of kernel frames into caller-provided storage.
     ///
     /// # Parameters
     ///
-    /// - `clear`: Clear pages?
-    /// - `count`: Number of pages to allocate.
+    /// - `clear`: Clear frames?
+    /// - `kframes`: Pre-allocated vector where allocated frames are placed.
+    ///   The number of frames allocated equals `kframes.capacity()`.
     ///
     /// # Return Values
     ///
-    /// Upon success, a vector of kernel pages is returned. Upon failure, an error is returned
-    /// instead.
+    /// Upon success, `Ok(())` is returned and `kframes` is filled to capacity. Upon
+    /// failure, an error is returned instead.
     ///
-    pub fn alloc_kpages(&mut self, clear: bool, count: usize) -> Result<Vec<KernelPage>, Error> {
-        // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no concurrent
-        // or re-entrant access to the physical memory manager is possible.
-        let mut kpages: Vec<KernelFrame> =
-            unsafe { PhysMemoryManager::get_mut() }.alloc_many_kernel_frames(clear, count)?;
-
-        let mut pages: Vec<KernelPage> = Vec::new();
-        while let Some(kframes) = kpages.pop() {
-            pages.push(KernelPage::new(kframes));
+    pub fn alloc_kpages(
+        &mut self,
+        clear: bool,
+        kframes: &mut Vec<KernelFrame>,
+    ) -> Result<(), Error> {
+        if !kframes.is_empty() {
+            let reason: &str = "caller-supplied kframes vector is not empty";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
-        Ok(pages)
+        // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no concurrent
+        // or re-entrant access to the physical memory manager is possible.
+        unsafe { PhysMemoryManager::get_mut() }.alloc_many_kernel_frames(kframes)?;
+        if clear {
+            for kframe in kframes.iter_mut() {
+                kframe.clear();
+            }
+        }
+
+        Ok(())
     }
 
     /// Load an ELF image into a virtual address space.

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -240,15 +240,42 @@ impl VirtMemoryManager {
         Ok(vmem.unmap(vaddr)?.is_some())
     }
 
+    ///
+    /// # Description
+    ///
+    /// Allocates and maps user pages into a virtual address space.
+    ///
+    /// # Parameters
+    ///
+    /// - `vmem`: Virtual memory space where pages are mapped.
+    /// - `vaddr`: Starting virtual address for the mapping.
+    /// - `access`: Access permissions for the mapped pages.
+    /// - `clear`: Clear pages after mapping?
+    /// - `uframes`: Mutable reference to a pre-allocated vector for temporary frame storage.
+    ///   The number of pages allocated equals `uframes.capacity()`.
+    ///
+    /// # Return Values
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, all successfully mapped pages are rolled
+    /// back and an error is returned instead.
+    ///
     pub fn alloc_upages(
         &mut self,
         vmem: &mut Vmem,
         mut vaddr: PageAligned<VirtualAddress>,
-        nframes: usize,
         access: AccessPermission,
         clear: bool,
+        uframes: &mut Vec<UserFrame>,
     ) -> Result<(), Error> {
+        let nframes: usize = uframes.capacity();
         trace!("vaddr={:?}, nframes={}", vaddr, nframes);
+
+        // The caller-supplied buffer must be empty; stale frames would cause double-mapping.
+        if !uframes.is_empty() {
+            let reason: &str = "caller-supplied uframes vector is not empty";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
 
         // Validate that nframes is positive and the full range lies in user space.
         let range_size: usize = nframes.checked_mul(mem::PAGE_SIZE).ok_or_else(|| {
@@ -296,14 +323,18 @@ impl VirtMemoryManager {
 
         // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no concurrent
         // or re-entrant access to the physical memory manager is possible.
-        let uframes: Vec<UserFrame> =
-            unsafe { PhysMemoryManager::get_mut() }.alloc_many_user_frames(nframes)?;
+        let alloc_result: Result<(), Error> =
+            unsafe { PhysMemoryManager::get_mut() }.alloc_many_user_frames(uframes);
+        if let Err(e) = alloc_result {
+            uframes.clear();
+            return Err(e);
+        }
 
         let start_vaddr: PageAligned<VirtualAddress> = vaddr;
         let mut mapped_count: usize = 0;
         let mut map_error: Result<(), Error> = Ok(());
 
-        for uframe in uframes {
+        for uframe in uframes.drain(..) {
             if let Err(e) = vmem.map(uframe, vaddr, access, page_table_allocator) {
                 map_error = Err(e);
                 break;

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -200,7 +200,7 @@ impl VirtMemoryManager {
             // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no
             // concurrent or re-entrant access to the physical memory manager is possible.
             let kframe: KernelFrame =
-                unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame(false)?;
+                unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
             KernelPage::new(kframe)
         };
 
@@ -285,8 +285,9 @@ impl VirtMemoryManager {
         let page_table_allocator = || {
             // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no
             // concurrent or re-entrant access to the physical memory manager is possible.
-            let kframe: KernelFrame =
-                unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame(true)?;
+            let mut kframe: KernelFrame =
+                unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
+            kframe.clear();
             let kpage: KernelPage = KernelPage::new(kframe);
             let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
             let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
@@ -385,8 +386,11 @@ impl VirtMemoryManager {
     pub fn alloc_kpage(&mut self, clear: bool) -> Result<KernelPage, Error> {
         // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no concurrent
         // or re-entrant access to the physical memory manager is possible.
-        let kframe: KernelFrame =
-            unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame(clear)?;
+        let mut kframe: KernelFrame =
+            unsafe { PhysMemoryManager::get_mut() }.alloc_kernel_frame()?;
+        if clear {
+            kframe.clear();
+        }
         Ok(KernelPage::new(kframe))
     }
 

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -69,6 +69,7 @@ use ::alloc::{
         LinkedList,
     },
     ffi::CString,
+    vec::Vec,
 };
 use ::arch::{
     cpu::excp,
@@ -495,7 +496,13 @@ impl ProcessManager {
             error!("{reason} (cmdline.len={:?})", args.len());
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
-        mm.alloc_upages(&mut vmem, args_vaddr, 1, AccessPermission::RDWR, true)?;
+        mm.alloc_upages(
+            &mut vmem,
+            args_vaddr,
+            AccessPermission::RDWR,
+            true,
+            &mut Vec::with_capacity(1),
+        )?;
         vmem.copy_to_user_unaligned(
             args_vaddr.into_inner(),
             VirtualAddress::new(args.as_ptr() as usize),
@@ -513,7 +520,13 @@ impl ProcessManager {
         let envp_vaddr: PageAligned<VirtualAddress> = PageAligned::<VirtualAddress>::from_address(
             VirtualAddress::new(args_vaddr.into_raw_value() + PAGE_SIZE),
         )?;
-        mm.alloc_upages(&mut vmem, envp_vaddr, 1, AccessPermission::RDWR, true)?;
+        mm.alloc_upages(
+            &mut vmem,
+            envp_vaddr,
+            AccessPermission::RDWR,
+            true,
+            &mut Vec::with_capacity(1),
+        )?;
 
         // Populate the environment variable page.
         vmem.copy_to_user_unaligned(
@@ -554,9 +567,9 @@ impl ProcessManager {
         mm.alloc_upages(
             &mut vmem,
             initial_stack_base,
-            USER_STACK_MIN_SIZE / PAGE_SIZE,
             AccessPermission::RDWR,
             true,
+            &mut Vec::with_capacity(USER_STACK_MIN_SIZE / PAGE_SIZE),
         )?;
 
         //==============================================================
@@ -1869,7 +1882,7 @@ impl ProcessManager {
     ) -> Result<(), Error> {
         let mut process: ProcessRefMut = self.find_process_mut(pid)?;
         let vmem: &mut Vmem = process.state_mut().vmem_mut();
-        mm.alloc_upages(vmem, vaddr, 1, access, true)
+        mm.alloc_upages(vmem, vaddr, access, true, &mut Vec::with_capacity(1))
     }
 
     pub fn munmap(


### PR DESCRIPTION
## Summary

Improve kernel physical memory pool (kpool) allocation by unifying multi-frame allocation, separating frame clearing from the pool logic, and accepting caller-provided storage.

## Changes

- Unify multi-frame allocation in kpool
- Move frame clearing out of kpool
- Accept caller-provided storage for allocation