### PR TITLE
[nanvixd] Rename toolchain-bin-dir argument to clh-bin-path

### DIFF
--- a/.github/actions/benchmark-run/action.yml
+++ b/.github/actions/benchmark-run/action.yml
@@ -34,7 +34,7 @@ runs:
             --machine-type "${MACHINE_TYPE}" \
             --hwloc "$HOME/hwloc.json" \
             --iterations "${ITERATIONS}" \
-            --toolchain-bin-dir "$HOME/toolchain/bin" \
+            --clh-bin-path "$HOME/toolchain/bin" \
             --output-dir "$(pwd)" \
             --commit "${{ github.sha }}"
         done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1286,9 +1286,10 @@ jobs:
       - name: "Report Benchmark Results"
         uses: ./.github/actions/benchmark-report
         with:
-          benchmarks: "boot-time,cold-start,cold-start-l2,cold-start-uvm,concurrent,concu\
-            rrent-l2,echo-breakdown,echo-breakdown-l2,round-trip-latency,snapsh\
-            ot-restore,vfs-bench,warm-start,warm-start-l2,warm-start-vmm"
+          benchmarks: >-
+            boot-time,cold-start,cold-start-l2,cold-start-uvm,concurrent,
+            concurrent-l2,echo-breakdown,echo-breakdown-l2,round-trip-latency,
+            snapshot-restore,vfs-bench,warm-start,warm-start-l2,warm-start-vmm
           machine-types: "microvm"
           archs: "X64"
           dev-dir: "data/baremetal"
@@ -1317,9 +1318,10 @@ jobs:
         if: github.ref_name == 'dev'
         uses: ./.github/actions/benchmark-persist
         with:
-          benchmarks: "boot-time,cold-start,cold-start-l2,cold-start-uvm,concurrent,concu\
-            rrent-l2,echo-breakdown,echo-breakdown-l2,round-trip-latency,snapsh\
-            ot-restore,vfs-bench,warm-start,warm-start-l2,warm-start-vmm"
+          benchmarks: >-
+            boot-time,cold-start,cold-start-l2,cold-start-uvm,concurrent,
+            concurrent-l2,echo-breakdown,echo-breakdown-l2,round-trip-latency,
+            snapshot-restore,vfs-bench,warm-start,warm-start-l2,warm-start-vmm
           machine-types: "microvm,hyperlight"
           archs: "X64"
           target-dir: "data/baremetal"

--- a/Makefile
+++ b/Makefile
@@ -460,7 +460,6 @@ clean: clean-nanvix-bench
 endif
 
 distclean: clean
-	$(FORCE_RM_CMD) Cargo.lock
 ifeq ($(IS_WINDOWS),yes)
 	$(FORCE_RM_CMD) "$(OBJECTS_DIR)"
 else

--- a/Makefile
+++ b/Makefile
@@ -827,11 +827,11 @@ endif
 
 # Runs system in release mode.
 run: image
-	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -toolchain-bin-dir $(CLH_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
+	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -clh-bin-path $(CLH_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
 
 # Runs system in debug mode.
 debug: image
-	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -toolchain-bin-dir $(CLH_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
+	RUST_LOG=$(LOG_LEVEL) $(NANVIXD) -console-file /dev/stdout -clh-bin-path $(CLH_DIR)/bin -log-dir $(LOGS_DIR) -- $(IMAGE)
 
 #===================================================================================================
 # Build Rules for Test Kernel RAMFS Image

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1064,11 +1064,11 @@ def run_benchmark(args):
     # Normalize paths so that Unix-style "./" prefixes are converted to
     # platform-native form (cmd.exe does not understand "./").
     args.bin_dir = os.path.normpath(args.bin_dir)
-    args.toolchain_bin_dir = os.path.normpath(args.toolchain_bin_dir)
+    args.clh_bin_path = os.path.normpath(args.clh_bin_path)
 
     print(
         f"[BENCHMARK] Paths: bin_dir={args.bin_dir}, "
-        f"toolchain_bin_dir={args.toolchain_bin_dir}"
+        f"clh_bin_path={args.clh_bin_path}"
     )
 
     # Resolve the commit SHA used to tag this benchmark result.
@@ -1123,7 +1123,7 @@ def run_benchmark(args):
             if not is_concurrent_bench
             else f"-num-concurrent-vms {NUM_CONCURRENT_VMS}"
         ),
-        f"-toolchain-bin-dir {args.toolchain_bin_dir}",
+        f"-clh-bin-path {args.clh_bin_path}",
     ]
     nanvix_bench_cmd = " ".join(nanvix_bench_cmd)
     print(f"[BENCHMARK] Executing command: {nanvix_bench_cmd}")
@@ -1445,8 +1445,8 @@ if __name__ == "__main__":
         default="./bin",
     )
     run_parser.add_argument(
-        "--toolchain-bin-dir",
-        help="Toolchain binary directory",
+        "--clh-bin-path",
+        help="Cloud-hypervisor binary directory",
         default="./toolchain/bin",
     )
     run_parser.add_argument(

--- a/scripts/run-nanvixd.sh
+++ b/scripts/run-nanvixd.sh
@@ -20,7 +20,7 @@
 #
 # Environment:
 #   NANVIXD            Path to nanvixd binary  (default: ./bin/nanvixd.elf).
-#   TOOLCHAIN_BIN_DIR  Toolchain bin directory  (default: $HOME/toolchain/bin).
+#   CLH_BIN_PATH       CLH binary directory     (default: $HOME/toolchain/bin).
 #   LOG_DIR            Log output directory     (default: ./logs).
 #   RUST_LOG           Rust log level           (default: info).
 #
@@ -44,7 +44,7 @@ export SCRIPT_DIR
 
 # Defaults for nanvixd configuration.
 NANVIXD="${NANVIXD:-./bin/nanvixd.elf}"
-TOOLCHAIN_BIN_DIR="${TOOLCHAIN_BIN_DIR:-${HOME}/toolchain/bin}"
+CLH_BIN_PATH="${CLH_BIN_PATH:-${HOME}/toolchain/bin}"
 LOG_DIR="${LOG_DIR:-./logs}"
 export RUST_LOG="${RUST_LOG:-info}"
 
@@ -143,7 +143,7 @@ function check_args
 #
 function run_nanvixd
 {
-	local cmd="${NANVIXD} -console-file /dev/stdout -toolchain-bin-dir ${TOOLCHAIN_BIN_DIR} -log-dir ${LOG_DIR} -- ${IMAGE}"
+	local cmd="${NANVIXD} -console-file /dev/stdout -clh-bin-path ${CLH_BIN_PATH} -log-dir ${LOG_DIR} -- ${IMAGE}"
 
 	# Wait-for-string mode: run nanvixd in the background, monitor console output
 	# for a specific string, and terminate nanvixd when the string is found or on
@@ -232,7 +232,7 @@ echo "====================================================================="
 echo "MACHINE          = ${MACHINE}"
 echo "IMAGE            = ${IMAGE}"
 echo "NANVIXD          = ${NANVIXD}"
-echo "TOOLCHAIN_BIN_DIR= ${TOOLCHAIN_BIN_DIR}"
+echo "CLH_BIN_PATH     = ${CLH_BIN_PATH}"
 echo "LOG_DIR          = ${LOG_DIR}"
 echo "RUST_LOG         = ${RUST_LOG}"
 echo "TIMEOUT          = ${TIMEOUT}"

--- a/src/libs/nanvix-sandbox-cache/src/config.rs
+++ b/src/libs/nanvix-sandbox-cache/src/config.rs
@@ -56,8 +56,8 @@ pub struct SandboxCacheConfig<T> {
     linuxd_binary_path: String,
     /// Path to the User VM binary.
     uservm_binary_path: String,
-    /// Path to the toolchain binary directory containing cloud-hypervisor and other tools.
-    toolchain_binary_directory: String,
+    /// Path to the cloud-hypervisor binary directory.
+    clh_bin_path: String,
     /// Directory path for writing log files.
     log_directory: String,
     /// Flag indicating whether to deploy linuxd inside an L2 VM (using cloud-hypervisor).
@@ -92,7 +92,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
     /// - `kernel_binary_path`: Path to kernel binary.
     /// - `linuxd_binary_path`: Path to the Linux Daemon binary.
     /// - `uservm_binary_path`: Path to the User VM binary.
-    /// - `toolchain_binary_directory`: Path to the toolchain binary directory.
+    /// - `clh_bin_path`: Path to the cloud-hypervisor binary directory.
     /// - `log_directory`: Path to the log directory.
     /// - `l2`: Flag to deploy linuxd inside an L2 VM.
     /// - `l2_snapshot_path`: Path to the L2 VM's base snapshot.
@@ -114,7 +114,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
         kernel_binary_path: &str,
         linuxd_binary_path: &str,
         uservm_binary_path: &str,
-        toolchain_binary_directory: &str,
+        clh_bin_path: &str,
         log_directory: &str,
         l2: bool,
         l2_snapshot_path: &str,
@@ -131,7 +131,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
             kernel_binary_path: kernel_binary_path.to_string(),
             linuxd_binary_path: linuxd_binary_path.to_string(),
             uservm_binary_path: uservm_binary_path.to_string(),
-            toolchain_binary_directory: toolchain_binary_directory.to_string(),
+            clh_bin_path: clh_bin_path.to_string(),
             log_directory: log_directory.to_string(),
             l2,
             l2_snapshot_path: l2_snapshot_path.to_string(),
@@ -273,14 +273,14 @@ impl<T: Sync + Send + Default + 'static> SandboxCacheConfig<T> {
     ///
     /// # Description
     ///
-    /// Returns the path to the toolchain binary directory.
+    /// Returns the path to the cloud-hypervisor binary directory.
     ///
     /// # Returns
     ///
-    /// The path to the toolchain binary directory.
+    /// The path to the cloud-hypervisor binary directory.
     ///
-    pub fn toolchain_binary_directory(&self) -> &str {
-        &self.toolchain_binary_directory
+    pub fn clh_bin_path(&self) -> &str {
+        &self.clh_bin_path
     }
 
     ///

--- a/src/libs/nanvix-sandbox-cache/src/lib.rs
+++ b/src/libs/nanvix-sandbox-cache/src/lib.rs
@@ -442,7 +442,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
             (system_vm_sockaddr, self.config.system_vm_sockaddr_type()),
             self.config.hwloc(),
             self.config.linuxd_binary_path().to_string(),
-            self.config.toolchain_binary_directory().to_string(),
+            self.config.clh_bin_path().to_string(),
             self.config.log_directory().to_string(),
             linuxd_tmp_dir.to_string_lossy().into_owned(),
             self.config.l2(),
@@ -706,7 +706,7 @@ impl<T: Sync + Send + Default + 'static> SandboxCache<T> {
             self.config.log_directory(),
             Some((control_plane_bind_sockaddr.clone(), self.config.control_plane_sockaddr_type())),
             (control_plane_connect_sockaddr.clone(), self.config.control_plane_sockaddr_type()),
-            Some(self.config.toolchain_binary_directory().to_string()),
+            Some(self.config.clh_bin_path().to_string()),
             Some(sandbox_tmp_dir.to_string_lossy().into_owned()),
             Some(self.config.l2()),
         );
@@ -962,7 +962,7 @@ mod tests {
             &format!("{}/kernel.elf", tmp_dir.path()),
             &format!("{}/linuxd.elf", tmp_dir.path()),
             &format!("{}/uservm.elf", tmp_dir.path()),
-            &format!("{}/toolchain", tmp_dir.path()),
+            &format!("{}/toolchain/bin", tmp_dir.path()),
             &format!("{}/logs", tmp_dir.path()),
             false,
             &format!("{}/snapshot", tmp_dir.path()),
@@ -1008,7 +1008,7 @@ mod tests {
             &format!("{}/kernel.elf", tmp_dir.path()),
             &format!("{}/linuxd.elf", tmp_dir.path()),
             &format!("{}/uservm.elf", tmp_dir.path()),
-            &format!("{}/toolchain", tmp_dir.path()),
+            &format!("{}/toolchain/bin", tmp_dir.path()),
             &format!("{}/logs", tmp_dir.path()),
             l2,
             &format!("{}/snapshot", tmp_dir.path()),
@@ -1147,7 +1147,7 @@ mod tests {
         assert!(config.kernel_binary_path().ends_with("/kernel.elf"));
         assert!(config.linuxd_binary_path().ends_with("/linuxd.elf"));
         assert!(config.uservm_binary_path().ends_with("/uservm.elf"));
-        assert!(config.toolchain_binary_directory().ends_with("/toolchain"));
+        assert!(config.clh_bin_path().ends_with("/toolchain/bin"));
         assert!(config.log_directory().ends_with("/logs"));
         assert!(!config.l2());
         assert!(config.l2_snapshot_path().ends_with("/snapshot"));

--- a/src/libs/nanvix-sandbox/src/config.rs
+++ b/src/libs/nanvix-sandbox/src/config.rs
@@ -147,7 +147,7 @@ pub const UNIX_SOCKET_SUFFIX: &str = ".socket";
 ///
 /// # Parameters
 ///
-/// - `toolchain_bin_dir`: Path to Nanvix's toolchain binary directory.
+/// - `clh_bin_path`: Path to the cloud-hypervisor binary directory.
 ///
 /// # Returns
 ///
@@ -155,14 +155,13 @@ pub const UNIX_SOCKET_SUFFIX: &str = ".socket";
 /// returned instead.
 ///
 #[cfg(not(any(feature = "single-process", feature = "standalone")))]
-pub(crate) fn get_clh_bin_dir(toolchain_bin_dir: &str) -> Result<String> {
-    let clh_bin_dir_path: PathBuf =
-        fs::canonicalize(PathBuf::from(toolchain_bin_dir)).map_err(|e| {
-            let reason: String =
-                format!("error getting clh binary dir (path={toolchain_bin_dir}, error={e:?})");
-            error!("get_clh_bin_dir(): {reason}");
-            anyhow::anyhow!(reason)
-        })?;
+pub(crate) fn get_clh_bin_dir(clh_bin_path: &str) -> Result<String> {
+    let clh_bin_dir_path: PathBuf = fs::canonicalize(PathBuf::from(clh_bin_path)).map_err(|e| {
+        let reason: String =
+            format!("error getting clh binary dir (path={clh_bin_path}, error={e:?})");
+        error!("get_clh_bin_dir(): {reason}");
+        anyhow::anyhow!(reason)
+    })?;
     Ok(format!("{}", clh_bin_dir_path.display()))
 }
 

--- a/src/libs/nanvix-sandbox/src/lib.rs
+++ b/src/libs/nanvix-sandbox/src/lib.rs
@@ -79,7 +79,7 @@
 //!     None,  // syscall_table
 //!     Some(("127.0.0.1:8082".to_string(), SocketType::Tcp)),  // control_plane_bind_socket_info
 //!     ("127.0.0.1:8081".to_string(), SocketType::Tcp),  // control_plane_connect_socket_info
-//!     Some("/path/to/toolchain".to_string()),  // toolchain_binary_directory
+//!     Some("/path/to/toolchain/bin".to_string()),  // clh_bin_path
 //!     Some("/tmp".to_string()),  // tmp_directory
 //!     Some(false),  // l2
 //! );

--- a/src/libs/nanvix-sandbox/src/linuxd_args.rs
+++ b/src/libs/nanvix-sandbox/src/linuxd_args.rs
@@ -41,8 +41,8 @@ pub struct LinuxDaemonArgs<T> {
     /// Path to Linux Daemon binary.
     #[cfg(not(feature = "single-process"))]
     linuxd_binary_path: String,
-    /// Path to the toolchain binary directory containing cloud-hypervisor and other tools.
-    toolchain_binary_directory: String,
+    /// Path to the cloud-hypervisor binary directory.
+    clh_bin_path: String,
     /// Directory path for writing log files.
     log_directory: String,
     /// Temporary directory path for Unix sockets and transient files.
@@ -75,7 +75,7 @@ impl<T> LinuxDaemonArgs<T> {
     /// - `system_vm_socket_info`: Information on System VM socket (address, socket type).
     /// - `hwloc`: Optional hardware locality configuration for CPU affinity and topology information.
     /// - `linuxd_binary_path`: Path to Linux Daemon binary (only if not in single-process mode).
-    /// - `toolchain_binary_directory`: Path to the toolchain binary directory containing cloud-hypervisor and other tools.
+    /// - `clh_bin_path`: Path to the cloud-hypervisor binary directory.
     /// - `log_directory`: Directory path for writing log files.
     /// - `tmp_directory`: Temporary directory path for Unix sockets and transient files.
     /// - `l2`: Flag to deploy linuxd inside an L2 VM (using cloud-hypervisor).
@@ -92,7 +92,7 @@ impl<T> LinuxDaemonArgs<T> {
         system_vm_socket_info: (String, SocketType),
         hwloc: Option<hwloc::HwLoc>,
         #[cfg(not(feature = "single-process"))] linuxd_binary_path: String,
-        toolchain_binary_directory: String,
+        clh_bin_path: String,
         log_directory: String,
         tmp_directory: String,
         l2: bool,
@@ -107,7 +107,7 @@ impl<T> LinuxDaemonArgs<T> {
             hwloc,
             #[cfg(not(feature = "single-process"))]
             linuxd_binary_path,
-            toolchain_binary_directory,
+            clh_bin_path,
             log_directory,
             tmp_directory,
             l2,
@@ -187,14 +187,14 @@ impl<T> LinuxDaemonArgs<T> {
     ///
     /// # Description
     ///
-    /// Returns the path to the toolchain binary directory containing cloud-hypervisor and other tools.
+    /// Returns the path to the cloud-hypervisor binary directory.
     ///
     /// # Returns
     ///
-    /// The path to the toolchain binary directory.
+    /// The path to the cloud-hypervisor binary directory.
     ///
-    pub fn toolchain_binary_directory(&self) -> &str {
-        &self.toolchain_binary_directory
+    pub fn clh_bin_path(&self) -> &str {
+        &self.clh_bin_path
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/sandbox/multi_process/linuxd.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox/multi_process/linuxd.rs
@@ -492,7 +492,7 @@ impl LinuxDaemon {
             };
 
             vec![
-                format!("{}/cloud-hypervisor", get_clh_bin_dir(args.toolchain_binary_directory())?),
+                format!("{}/cloud-hypervisor", get_clh_bin_dir(args.clh_bin_path())?),
                 args::Args::OPT_CLH_API_SOCKET.to_string(),
                 clh_api_socket_path.clone(),
                 // FIXME(#1156): re-enable --seccomp true (default) when we cut a new Nanvix
@@ -563,7 +563,7 @@ impl LinuxDaemon {
             }
 
             let ch_remote_path: String =
-                format!("{}/ch-remote", get_clh_bin_dir(args.toolchain_binary_directory())?);
+                format!("{}/ch-remote", get_clh_bin_dir(args.clh_bin_path())?);
             if let Err(e) = Self::resume_l2_vm(
                 &netns_handle.netns_info()?,
                 args.tenant_id(),

--- a/src/libs/nanvix-sandbox/src/sandbox_config.rs
+++ b/src/libs/nanvix-sandbox/src/sandbox_config.rs
@@ -75,9 +75,9 @@ pub struct SandboxConfig<T> {
     /// This changes for every sandbox, and thus must be provided every time.
     control_plane_connect_socket_info: (String, SocketType),
 
-    /// Optional path to the toolchain binary directory containing cloud-hypervisor and other tools.
+    /// Optional path to the cloud-hypervisor binary directory.
     /// This must be provided if a Linux Daemon instance was not provided before sandbox initialization.
-    toolchain_binary_directory: Option<String>,
+    clh_bin_path: Option<String>,
 
     /// Optional path to the temporary directory for Unix sockets and transient files.
     /// This must be provided if a Linux Daemon instance was not provided before sandbox initialization.
@@ -140,7 +140,7 @@ impl<T> SandboxConfig<T> {
     /// - `syscall_table`: Optional system call table for overriding default system call behavior (only if in single-process mode).
     /// - `control_plane_bind_socket_info`: Optional information on control plane listener socket (address, socket type).
     /// - `control_plane_connect_socket_info`: Optional information on control plane connect socket (address, socket type).
-    /// - `toolchain_binary_directory`: Optional path to the toolchain binary directory.
+    /// - `clh_bin_path`: Optional path to the cloud-hypervisor binary directory.
     /// - `tmp_directory`: Optional path to the temporary directory.
     /// - `l2`: Optional flag to deploy the Linux Daemon inside an L2 VM.
     ///
@@ -167,7 +167,7 @@ impl<T> SandboxConfig<T> {
         >,
         control_plane_bind_socket_info: Option<(String, SocketType)>,
         control_plane_connect_socket_info: (String, SocketType),
-        toolchain_binary_directory: Option<String>,
+        clh_bin_path: Option<String>,
         tmp_directory: Option<String>,
         l2: Option<bool>,
     ) -> Self {
@@ -191,7 +191,7 @@ impl<T> SandboxConfig<T> {
             syscall_table,
             control_plane_bind_socket_info,
             control_plane_connect_socket_info,
-            toolchain_binary_directory,
+            clh_bin_path,
             tmp_directory,
             l2,
             #[cfg(not(feature = "single-process"))]
@@ -374,14 +374,14 @@ impl<T> SandboxConfig<T> {
     ///
     /// # Description
     ///
-    /// Returns the optional path to the toolchain binary directory.
+    /// Returns the optional path to the cloud-hypervisor binary directory.
     ///
     /// # Returns
     ///
-    /// An optional reference to the toolchain binary directory path.
+    /// An optional reference to the cloud-hypervisor binary directory path.
     ///
-    pub fn toolchain_binary_directory(&self) -> Option<&str> {
-        self.toolchain_binary_directory.as_deref()
+    pub fn clh_bin_path(&self) -> Option<&str> {
+        self.clh_bin_path.as_deref()
     }
 
     ///

--- a/src/libs/nanvix-sandbox/src/simple_cache/config.rs
+++ b/src/libs/nanvix-sandbox/src/simple_cache/config.rs
@@ -49,8 +49,8 @@ pub struct SimpleSandboxCacheConfig<T> {
     kernel_binary_path: String,
     /// System call table.
     syscall_table: Option<Arc<SyscallTable<T>>>,
-    /// Path to the toolchain binary directory.
-    toolchain_binary_directory: String,
+    /// Path to the cloud-hypervisor binary directory.
+    clh_bin_path: String,
     /// Directory path for writing log files.
     log_directory: String,
     /// Path to the temporary directory for Unix sockets and transient files.
@@ -77,7 +77,7 @@ impl<T: Sync + Send + Default + 'static> SimpleSandboxCacheConfig<T> {
         hwloc: Option<HwLoc>,
         kernel_binary_path: &str,
         syscall_table: Option<Arc<SyscallTable<T>>>,
-        toolchain_binary_directory: &str,
+        clh_bin_path: &str,
         log_directory: &str,
         tmp_directory: &str,
     ) -> Self {
@@ -90,7 +90,7 @@ impl<T: Sync + Send + Default + 'static> SimpleSandboxCacheConfig<T> {
             hwloc,
             kernel_binary_path: kernel_binary_path.to_string(),
             syscall_table,
-            toolchain_binary_directory: toolchain_binary_directory.to_string(),
+            clh_bin_path: clh_bin_path.to_string(),
             log_directory: log_directory.to_string(),
             tmp_directory: tmp_directory.to_string(),
         }
@@ -136,9 +136,9 @@ impl<T: Sync + Send + Default + 'static> SimpleSandboxCacheConfig<T> {
         self.syscall_table.clone()
     }
 
-    /// Returns the path to the toolchain binary directory.
-    pub fn toolchain_binary_directory(&self) -> &str {
-        &self.toolchain_binary_directory
+    /// Returns the path to the cloud-hypervisor binary directory.
+    pub fn clh_bin_path(&self) -> &str {
+        &self.clh_bin_path
     }
 
     /// Returns the log directory.

--- a/src/libs/nanvix-sandbox/src/simple_cache/mod.rs
+++ b/src/libs/nanvix-sandbox/src/simple_cache/mod.rs
@@ -285,8 +285,8 @@ impl<T: Sync + Send + Default + 'static> SimpleSandboxCache<T> {
                 #[cfg(feature = "single-process")]
                 let syscall_table = self.config.syscall_table();
 
-                let toolchain_binary_directory =
-                    Some(self.config.toolchain_binary_directory().to_string());
+                let clh_bin_path =
+                    Some(self.config.clh_bin_path().to_string());
 
                 let config: SandboxConfig<T> = SandboxConfig::new(
                     tag.tenant_id(),
@@ -307,7 +307,7 @@ impl<T: Sync + Send + Default + 'static> SimpleSandboxCache<T> {
                         control_plane_connect_sockaddr.clone(),
                         self.config.control_plane_sockaddr_type(),
                     ),
-                    toolchain_binary_directory,
+                    clh_bin_path,
                     Some(sandbox_tmp_dir.to_string_lossy().into_owned()),
                     Some(false), // l2 (not supported in single-process/standalone)
                 );

--- a/src/libs/nanvix-sandbox/src/uninitialized.rs
+++ b/src/libs/nanvix-sandbox/src/uninitialized.rs
@@ -280,17 +280,16 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
             None => {
                 // Build Linux Daemon arguments.
                 let linuxd_args: LinuxDaemonArgs<T> = {
-                    // Get toolchain binary directory.
-                    let toolchain_binary_directory: String =
-                        match config.toolchain_binary_directory() {
-                            None => {
-                                let reason: &str = "toolchain binary directory not provided and \
-                                                    linuxd not initialized";
-                                error!("initialize(): {reason}");
-                                anyhow::bail!(reason);
-                            },
-                            Some(path) => path.to_string(),
-                        };
+                    // Get cloud-hypervisor binary directory.
+                    let clh_bin_path: String = match config.clh_bin_path() {
+                        None => {
+                            let reason: &str = "cloud-hypervisor binary directory not provided \
+                                                and linuxd not initialized";
+                            error!("initialize(): {reason}");
+                            anyhow::bail!(reason);
+                        },
+                        Some(path) => path.to_string(),
+                    };
 
                     // Get temporary directory.
                     let tmp_directory: String = match config.tmp_directory() {
@@ -325,7 +324,7 @@ impl<T: Sync + Send + Default + 'static> UninitializedSandbox<T> {
                         config.hwloc(),
                         #[cfg(not(any(feature = "single-process", feature = "standalone")))]
                         config.linuxd_binary_path().to_string(),
-                        toolchain_binary_directory,
+                        clh_bin_path,
                         config.log_directory().to_string(),
                         tmp_directory,
                         l2,

--- a/src/utils/nanvix-bench/src/args.rs
+++ b/src/utils/nanvix-bench/src/args.rs
@@ -20,7 +20,7 @@ pub struct Args {
     iterations: usize,
     num_concurrent_vms: Option<usize>,
     netns_pool_size: Option<usize>,
-    toolchain_bin_dir: String,
+    clh_bin_path: String,
     tmp_dir: String,
 }
 
@@ -36,7 +36,7 @@ impl Args {
     const OPT_NUM_CONCURRENT_VMS: &'static str = "-num-concurrent-vms";
     const OPT_NETNS_POOL_SIZE: &'static str = "-netns-pool-size";
     const DEFAULT_NETNS_POOL_SIZE: usize = ::nanvixd::args::Args::DEFAULT_NETNS_POOL_SIZE;
-    const OPT_TOOLCHAIN_BIN_DIR: &'static str = "-toolchain-bin-dir";
+    const OPT_CLH_BIN_PATH: &'static str = "-clh-bin-path";
     const OPT_TMP_DIR: &'static str = "-tmp-dir";
 
     fn usage(program_name: &str) {
@@ -137,8 +137,7 @@ Options:
   {netns_pool_size} <size>            Netns pool prefill size for nanvixd (concurrent-l2 only; \
              default: {default_netns_pool_size}). Other L2 benchmarks use 1; non-L2 benchmarks \
              ignore this flag.
-  {toolchain_bin_dir} <toolchain_dir> Directory containing toolchain binaries (cloud-hypervisor, \
-             etc.).
+  {clh_bin_path} <clh_bin_path>       Path to the cloud-hypervisor binary directory.
   {tmp_dir} <tmp_dir>                Base directory for temporary files (default: \
              {DEFAULT_TMP_DIRECTORY}).
   {help}                              Show this help message and exit.
@@ -160,7 +159,7 @@ Examples:
             num_concurrent_vms = Self::OPT_NUM_CONCURRENT_VMS,
             netns_pool_size = Self::OPT_NETNS_POOL_SIZE,
             default_netns_pool_size = Self::DEFAULT_NETNS_POOL_SIZE,
-            toolchain_bin_dir = Self::OPT_TOOLCHAIN_BIN_DIR,
+            clh_bin_path = Self::OPT_CLH_BIN_PATH,
             tmp_dir = Self::OPT_TMP_DIR,
             DEFAULT_TMP_DIRECTORY = DEFAULT_TMP_DIRECTORY,
             help = Self::OPT_HELP,
@@ -173,7 +172,7 @@ Examples:
         let mut iterations: usize = 100;
         let mut num_concurrent_vms: Option<usize> = None;
         let mut netns_pool_size: Option<usize> = None;
-        let mut toolchain_bin_dir: String = "./toolchain/bin".to_string();
+        let mut clh_bin_path: String = "./toolchain/bin".to_string();
         let mut tmp_dir: String = DEFAULT_TMP_DIRECTORY.to_string();
 
         let mut i: usize = 1;
@@ -230,16 +229,16 @@ Examples:
                     }
                     netns_pool_size = Some(args[i].parse::<usize>()?);
                 },
-                Self::OPT_TOOLCHAIN_BIN_DIR => {
+                Self::OPT_CLH_BIN_PATH => {
                     i += 1;
                     if i >= args.len() {
                         Self::usage(args[0].as_str());
                         return Err(anyhow::anyhow!(
                             "missing value for: {}",
-                            Self::OPT_TOOLCHAIN_BIN_DIR
+                            Self::OPT_CLH_BIN_PATH
                         ));
                     }
-                    toolchain_bin_dir = args[i].clone();
+                    clh_bin_path = args[i].clone();
                 },
                 Self::OPT_TMP_DIR => {
                     i += 1;
@@ -321,7 +320,7 @@ Examples:
                     iterations,
                     num_concurrent_vms,
                     netns_pool_size,
-                    toolchain_bin_dir,
+                    clh_bin_path,
                     tmp_dir,
                 })
             },
@@ -348,8 +347,8 @@ Examples:
         self.num_concurrent_vms
     }
 
-    pub fn toolchain_bin_dir(&self) -> String {
-        self.toolchain_bin_dir.clone()
+    pub fn clh_bin_path(&self) -> String {
+        self.clh_bin_path.clone()
     }
 
     pub fn netns_pool_size(&self) -> Option<usize> {

--- a/src/utils/nanvix-bench/src/benchmark.rs
+++ b/src/utils/nanvix-bench/src/benchmark.rs
@@ -161,7 +161,7 @@ pub struct Benchmark {
     #[cfg(any(feature = "multi-process", feature = "single-process"))]
     pub nanvixd_client: reqwest::Client,
     #[cfg(any(feature = "multi-process", feature = "single-process"))]
-    pub nanvixd_toolchain_bin_dir: String,
+    pub nanvixd_clh_bin_path: String,
     #[cfg(any(feature = "multi-process", feature = "single-process"))]
     pub nanvixd_netns_pool_size: Option<usize>,
     #[cfg(any(feature = "multi-process", feature = "single-process"))]

--- a/src/utils/nanvix-bench/src/benchmarks/system/mod.rs
+++ b/src/utils/nanvix-bench/src/benchmarks/system/mod.rs
@@ -163,8 +163,8 @@ impl Benchmark {
             format!("{}/bin/nanvixd.elf", self.workspace_root.display()),
             ::nanvixd::args::Args::OPT_HTTP_SOCKADDR.to_string(),
             NANVIXD_ADDRESS.to_string(),
-            ::nanvixd::args::Args::OPT_TOOLCHAIN_BIN_DIRECTORY.to_string(),
-            self.nanvixd_toolchain_bin_dir.clone(),
+            ::nanvixd::args::Args::OPT_CLH_BIN_PATH.to_string(),
+            self.nanvixd_clh_bin_path.clone(),
             ::nanvixd::args::Args::OPT_TMP_DIRECTORY.to_string(),
             self.nanvixd_tmp_dir.clone(),
         ];

--- a/src/utils/nanvix-bench/src/main.rs
+++ b/src/utils/nanvix-bench/src/main.rs
@@ -198,7 +198,7 @@ async fn main() -> Result<()> {
             .timeout(Duration::from_secs(NANVIXD_HTTP_TIMEOUT_SECS))
             .build()?,
         #[cfg(any(feature = "multi-process", feature = "single-process"))]
-        nanvixd_toolchain_bin_dir: args.toolchain_bin_dir(),
+        nanvixd_clh_bin_path: args.clh_bin_path(),
         #[cfg(any(feature = "multi-process", feature = "single-process"))]
         nanvixd_netns_pool_size: args.netns_pool_size(),
         #[cfg(any(feature = "multi-process", feature = "single-process"))]

--- a/src/utils/nanvix-test/src/nanvixd/mod.rs
+++ b/src/utils/nanvix-test/src/nanvixd/mod.rs
@@ -141,7 +141,7 @@ impl Nanvixd {
         // cleanup.  This acts as a best-effort safety net during normal unwinding and shutdown
         // paths where drop handlers run, helping to prevent orphaned processes.
         command.kill_on_drop(true);
-        command.arg(::nanvixd::args::Args::OPT_TOOLCHAIN_BIN_DIRECTORY);
+        command.arg(::nanvixd::args::Args::OPT_CLH_BIN_PATH);
         command.arg(format!("{}/bin", config.toolchain_path));
 
         if let Some(hwloc_file) = hwloc_file_path {

--- a/src/utils/nanvixd/src/args.rs
+++ b/src/utils/nanvixd/src/args.rs
@@ -50,8 +50,8 @@ pub struct Args {
     http_sockaddr: Option<String>,
     /// Directory path containing Nanvix binaries.
     binary_directory: String,
-    /// Directory path containing toolchain binaries (cloud-hypervisor, etc.).
-    toolchain_binary_directory: String,
+    /// Path to the cloud-hypervisor binary directory.
+    clh_bin_path: String,
     /// Optional file path for redirecting console output.
     console_file: Option<String>,
     /// Optional RAM filesystem image exposed to the guest.
@@ -97,8 +97,8 @@ impl Args {
     pub const OPT_HTTP_SOCKADDR: &'static str = "-http-addr";
     /// Command-line option that sets the binary directory path.
     pub const OPT_BIN_DIRECTORY: &'static str = "-bin-dir";
-    /// Command-line option that sets the toolchain binary directory path.
-    pub const OPT_TOOLCHAIN_BIN_DIRECTORY: &'static str = "-toolchain-bin-dir";
+    /// Command-line option that sets the cloud-hypervisor binary directory path.
+    pub const OPT_CLH_BIN_PATH: &'static str = "-clh-bin-path";
     /// Command-line option that sets the L2 snapshot path.
     pub const OPT_L2_SNAPSHOT_PATH: &'static str = "-l2-snapshot-path";
     /// Command-line option that redirects the console output to a file.
@@ -153,8 +153,7 @@ impl Args {
         #[cfg(unix)]
         let mut http_sockaddr: Option<String> = None;
         let mut binary_directory: String = config::DEFAULT_BIN_DIRECTORY.to_string();
-        let mut toolchain_binary_directory: String =
-            config::DEFAULT_TOOLCHAIN_BIN_DIRECTORY.to_string();
+        let mut clh_bin_path: String = config::DEFAULT_CLH_BIN_PATH.to_string();
         #[cfg(not(feature = "single-process"))]
         let mut console_file: Option<String> = None;
         #[cfg(feature = "single-process")]
@@ -211,9 +210,9 @@ impl Args {
                     i += 1;
                     binary_directory = args[i].clone();
                 },
-                Self::OPT_TOOLCHAIN_BIN_DIRECTORY => {
+                Self::OPT_CLH_BIN_PATH => {
                     i += 1;
-                    toolchain_binary_directory = args[i].clone();
+                    clh_bin_path = args[i].clone();
                 },
                 Self::OPT_CONSOLE_FILE => {
                     i += 1;
@@ -388,7 +387,7 @@ impl Args {
             #[cfg(unix)]
             http_sockaddr,
             binary_directory,
-            toolchain_binary_directory,
+            clh_bin_path,
             l2_snapshot_path,
             console_file,
             ramfs_filename,
@@ -437,8 +436,7 @@ Options:
   {console_file} <file>                     Redirect console output to a file.
   {ramfs_filename} <file>                   Attach a RAM filesystem image to spawned user VMs.
   {bin_dir} <bin_dir>                       Directory containing Nanvix binaries.
-  {toolchain_bin_dir} <toolchain_bin_dir>   Directory containing toolchain binaries \
-             (cloud-hypervisor, etc.).
+  {clh_bin_path} <clh_bin_path>             Path to the cloud-hypervisor binary directory.
   {hwloc} <hwloc.json>                      Hardware locality configuration file for CPU \
              affinity/topology.
   {log_dir} <log_dir>                       Directory for log files (Default: \
@@ -464,7 +462,7 @@ Options:
             console_file = Self::OPT_CONSOLE_FILE,
             ramfs_filename = Self::OPT_RAMFS_FILENAME,
             bin_dir = Self::OPT_BIN_DIRECTORY,
-            toolchain_bin_dir = Self::OPT_TOOLCHAIN_BIN_DIRECTORY,
+            clh_bin_path = Self::OPT_CLH_BIN_PATH,
             hwloc = Self::OPT_HWLOC,
             log_dir = Self::OPT_LOG_DIRECTORY,
             netns_pool_size = Self::OPT_NETNS_POOL_SIZE,
@@ -515,14 +513,14 @@ Options:
     ///
     /// # Description
     ///
-    /// Returns the toolchain binary directory path.
+    /// Returns the cloud-hypervisor binary directory path.
     ///
     /// # Returns
     ///
-    /// The toolchain binary directory path.
+    /// The cloud-hypervisor binary directory path.
     ///
-    pub fn toolchain_binary_directory(&self) -> &str {
-        &self.toolchain_binary_directory
+    pub fn clh_bin_path(&self) -> &str {
+        &self.clh_bin_path
     }
 
     ///

--- a/src/utils/nanvixd/src/config.rs
+++ b/src/utils/nanvixd/src/config.rs
@@ -21,9 +21,9 @@ pub const DEFAULT_BIN_DIRECTORY: &str = "./bin";
 ///
 /// # Description
 ///
-/// Default binary directory path for toolchain-related binaries.
+/// Default path for the cloud-hypervisor binary directory.
 ///
-pub const DEFAULT_TOOLCHAIN_BIN_DIRECTORY: &str = "./toolchain/bin";
+pub const DEFAULT_CLH_BIN_PATH: &str = "./toolchain/bin";
 
 ///
 /// # Description

--- a/src/utils/nanvixd/src/main.rs
+++ b/src/utils/nanvixd/src/main.rs
@@ -198,7 +198,7 @@ async fn async_main() -> Result<ExitCode> {
         args.hwloc().clone(),
         &kernel_binary_path,
         None,
-        args.toolchain_binary_directory(),
+        args.clh_bin_path(),
         args.log_directory(),
         tmp_directory.path().to_str().ok_or_else(|| {
             let reason: &str = "temporary directory path is not valid UTF-8";
@@ -229,7 +229,7 @@ async fn async_main() -> Result<ExitCode> {
         &kernel_binary_path,
         &linuxd_binary_path,
         &uservm_binary_path,
-        args.toolchain_binary_directory(),
+        args.clh_bin_path(),
         args.log_directory(),
         args.l2(),
         args.l2_snapshot_path(),


### PR DESCRIPTION
The `--toolchain-bin-dir` / `toolchain_binary_directory` option was misleadingly generic: the directory exclusively holds cloud-hypervisor (CLH) binaries, not a full toolchain. Rename it to `--clh-bin-path` / `clh_bin_path` everywhere to accurately reflect its purpose.

**Affected components:**

- **nanvixd**: Args, config constants, and CLI option (`OPT_TOOLCHAIN_BIN_DIRECTORY` → `OPT_CLH_BIN_PATH`, `DEFAULT_TOOLCHAIN_BIN_DIRECTORY` → `DEFAULT_CLH_BIN_PATH`).
- **nanvix-bench**: Args, Benchmark struct field, and system benchmark nanvixd invocation.
- **nanvix-test**: nanvixd spawn command argument.
- **nanvix-sandbox**: SandboxConfig, LinuxDaemonArgs, SimpleSandboxCacheConfig, UninitializedSandbox, and multi-process LinuxDaemon L2 paths.
- **nanvix-sandbox-cache**: SandboxCacheConfig and cache initialization.
- **Makefile**: run and debug targets.
- **scripts/benchmark.py**: CLI flag and internal references.
- **scripts/run-nanvixd.sh**: environment variable (`TOOLCHAIN_BIN_DIR` → `CLH_BIN_PATH`).
- **CI**: `.github/actions/benchmark-run/action.yml` and `.github/workflows/ci.yml` flag references.

Additionally, fix YAML formatting in `ci.yml`: normalize array bracket spacing, wrap long lines, and use `>-` block scalars for lengthy benchmark lists.

No functional changes.