### PR TITLE
[kernel] Static bitmap allocation and singleton refactor

### DIFF
--- a/src/kernel/src/hal/mod.rs
+++ b/src/kernel/src/hal/mod.rs
@@ -15,21 +15,24 @@ pub mod platform;
 // Imports
 //==================================================================================================
 
-use crate::hal::{
-    arch::x86::cpu::ExceptionController,
-    cpu::InterruptManager,
-    io::{
-        IoMemoryAllocator,
-        IoPortAllocator,
-    },
-    mem::{
-        MemoryRegion,
-        TruncatedMemoryRegion,
-        VirtualAddress,
-    },
-    platform::{
-        madt::MadtInfo,
-        Platform,
+use crate::{
+    collections::Bitmap,
+    hal::{
+        arch::x86::cpu::ExceptionController,
+        cpu::InterruptManager,
+        io::{
+            IoMemoryAllocator,
+            IoPortAllocator,
+        },
+        mem::{
+            MemoryRegion,
+            TruncatedMemoryRegion,
+            VirtualAddress,
+        },
+        platform::{
+            madt::MadtInfo,
+            Platform,
+        },
     },
 };
 use ::alloc::collections::linked_list::LinkedList;
@@ -116,8 +119,8 @@ impl Hal {
     ///
     /// # Returns
     ///
-    /// Upon success, the physical memory layout bitmap is returned. Upon failure, an error is
-    /// returned instead.
+    /// Upon success, the physical memory layout bitmap and the kernel pool bitmap are returned.
+    /// Upon failure, an error is returned instead.
     ///
     /// # Panics
     ///
@@ -129,7 +132,7 @@ impl Hal {
         ioaddresses: &mut IoMemoryAllocator,
         madt: &Option<MadtInfo>,
         mem_lower: Option<usize>,
-    ) -> Result<SparseBitmap, Error> {
+    ) -> Result<(SparseBitmap, Bitmap), Error> {
         // Check if the hardware abstraction layer is already initialized.
         if unlikely(HAL_INIT.load(ORDER)) {
             panic!("hardware abstraction layer was already initialized");
@@ -154,6 +157,16 @@ impl Hal {
             Some(bitmap) => bitmap,
             None => {
                 let reason: &str = "physical memory layout is not available";
+                error!("{reason}");
+                return Err(Error::new(ErrorCode::ResourceBusy, reason));
+            },
+        };
+
+        // Take ownership of the kernel pool bitmap from the platform.
+        let kpool_bitmap: Bitmap = match platform.kpool_bitmap.take() {
+            Some(bitmap) => bitmap,
+            None => {
+                let reason: &str = "kernel pool bitmap is not available";
                 error!("{reason}");
                 return Err(Error::new(ErrorCode::ResourceBusy, reason));
             },
@@ -205,7 +218,7 @@ impl Hal {
         unsafe { HAL.write(hal) };
         HAL_INIT.store(true, ORDER);
 
-        Ok(physical_memory_layout)
+        Ok((physical_memory_layout, kpool_bitmap))
     }
 
     ///

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -1061,10 +1061,11 @@ pub fn init(
     }
 
     // Derive scratch region addresses from the host-provided scratch_size.
-    // scratch_size covers the full range [scratch_base, MAX_GPA] and includes the last
-    // page that Hyperlight reserves for bookkeeping.  The bitmap excludes that page.
+    // scratch_size covers the full range [scratch_base, scratch_end) and includes the last
+    // page that Hyperlight reserves for bookkeeping.  That page is included in the bitmap
+    // but marked as reserved (used) so the frame allocator never hands it out.
     // Validate that scratch_size is non-zero and large enough to contain the required MMIO
-    // regions (input buffer + output buffer + one top page + excluded last page).
+    // regions (input buffer + output buffer + one top page + one reserved last page).
     let min_scratch_size: usize =
         INPUT_DATA_BUFFER_SIZE + OUTPUT_DATA_BUFFER_SIZE + 2 * mem::PAGE_SIZE;
     if scratch_size == 0 || scratch_size < min_scratch_size {
@@ -1079,26 +1080,32 @@ pub fn init(
     // MAX_GPA (not MAX_GVA) because the guest uses identity mapping (GVA == GPA)
     // and the KVM memory slot is placed relative to MAX_GPA.
     let scratch_base_address: usize = MAX_GPA - scratch_size + 1;
-    // Bitmap end: stop one page short of MAX_GPA because the last page holds
-    // Hyperlight bookkeeping metadata and must not be allocated.
-    let scratch_bitmap_end: usize = MAX_GPA - mem::PAGE_SIZE + 1;
+    // scratch_end is the exclusive end of the full scratch range, including the last page
+    // reserved for Hyperlight bookkeeping metadata.
+    let scratch_end_address: usize =
+        scratch_base_address
+            .checked_add(scratch_size)
+            .ok_or_else(|| {
+                let reason: &str = "scratch region end address overflow";
+                error!("init(): {}", reason);
+                Error::new(ErrorCode::InvalidArgument, reason)
+            })?;
 
     // Record scratch region bounds for is_valid_physical_address.
     SCRATCH_BASE.store(scratch_base_address, Ordering::Relaxed);
-    SCRATCH_END.store(scratch_bitmap_end, Ordering::Relaxed);
+    SCRATCH_END.store(scratch_end_address, Ordering::Relaxed);
     info!(
         "scratch region: [{:#010x}, {:#010x}) (size={:#x})",
-        scratch_base_address, scratch_bitmap_end, scratch_size
+        scratch_base_address, scratch_end_address, scratch_size
     );
 
     // Register only the MMIO-critical portions of the scratch region:
     //  1. Input data buffer  [scratch_base, scratch_base + INPUT_DATA_BUFFER_SIZE)
     //  2. Output data buffer [scratch_base + INPUT_DATA_BUFFER_SIZE, + OUTPUT_DATA_BUFFER_SIZE)
-    //  3. Top page: guest counter.
-    // Everything between the output buffer and the top page (page tables, free space) is
-    // intentionally left unregistered and are available for user-page allocation.  The very
-    // last page holds scratch metadata accessed only during early boot before paging, so it
-    // is excluded from the frame allocator.
+    //  3. Scratch I/O page: guest counter page (second-to-last page).
+    //  4. Scratch reserved page: Hyperlight bookkeeping metadata (last page, not for use).
+    // Everything between the output buffer and the scratch I/O page (page tables, free space) is
+    // intentionally left unregistered and are available for user-page allocation.
     {
         let scratch_input_base: usize = scratch_base_address;
         let scratch_input: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new_mmio(
@@ -1125,16 +1132,27 @@ pub fn init(
         mmio_regions.push_back(scratch_output);
     }
     {
-        let scratch_top_page: usize = scratch_bitmap_end - mem::PAGE_SIZE;
-        let scratch_top: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new_mmio(
-            "scratch top",
-            PageAligned::from_raw_value(scratch_top_page)?,
+        let scratch_io_page: usize = scratch_end_address - 2 * mem::PAGE_SIZE;
+        let scratch_io: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new_mmio(
+            "scratch-io",
+            PageAligned::from_raw_value(scratch_io_page)?,
             mem::PAGE_SIZE,
             AccessPermission::RDWR,
             MmioCachePolicy::UNCACHEABLE,
         )?;
-        ioaddresses.register(SCRATCH_IO_MMIO_TAG, scratch_top.clone())?;
-        mmio_regions.push_back(scratch_top);
+        ioaddresses.register(SCRATCH_IO_MMIO_TAG, scratch_io.clone())?;
+        mmio_regions.push_back(scratch_io);
+    }
+    {
+        let scratch_reserved_page: usize = scratch_end_address - mem::PAGE_SIZE;
+        let scratch_reserved: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+            "scratch reserved",
+            VirtualAddress::from_raw_value(scratch_reserved_page),
+            mem::PAGE_SIZE,
+            MemoryRegionType::Reserved,
+            AccessPermission::RDONLY,
+        )?;
+        memory_regions.push_back(scratch_reserved);
     }
 
     // Set snapshot region end from the host-provided snapshot budget.
@@ -1159,7 +1177,7 @@ pub fn init(
             ramfs_base,
             ramfs_end_address,
             scratch_base_address,
-            scratch_bitmap_end,
+            scratch_end_address,
         )?
     };
 

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -207,6 +207,9 @@ pub struct Platform {
     /// A sparse bitmap representing the physical memory layout, owned by the platform and consumed
     /// by the memory manager during system initialization.
     pub physical_memory_layout: Option<SparseBitmap>,
+    /// A bitmap for the kernel page pool, owned by the platform and consumed by the memory manager
+    /// during system initialization.
+    pub kpool_bitmap: Option<Bitmap>,
 }
 
 //==================================================================================================
@@ -220,6 +223,16 @@ pub struct Platform {
 /// per-region bitmaps inside a multi-chunk `SparseBitmap`.
 static mut FRAME_ALLOCATOR_STORAGE: [u8; MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize) + 3] =
     [0; MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize) + 3];
+
+// Ensure the number of kpool pages is a multiple of 8 so the bitmap has no padding bits.
+::static_assert::assert_eq!(
+    (::config::kernel::KPOOL_SIZE / mem::PAGE_SIZE).is_multiple_of(u8::BITS as usize)
+);
+
+/// Kernel page pool bitmap storage.
+static mut KPOOL_BITMAP_STORAGE: [u8; ::config::kernel::KPOOL_SIZE
+    / (mem::PAGE_SIZE * u8::BITS as usize)] =
+    [0; ::config::kernel::KPOOL_SIZE / (mem::PAGE_SIZE * u8::BITS as usize)];
 
 /// Snapshot region base address (inclusive).
 static SNAPSHOT_BASE: AtomicUsize = AtomicUsize::new(KERNEL_BASE_RAW);
@@ -1181,11 +1194,23 @@ pub fn init(
         )?
     };
 
+    // Build a bitmap for the kernel page pool.
+    let kpool_bitmap: Bitmap = {
+        // Safety: the kpool bitmap storage is valid and has a static lifetime.
+        let storage: RawArray<u8> = unsafe {
+            let (ptr, len): (*mut u8, usize) =
+                (KPOOL_BITMAP_STORAGE.as_mut_ptr(), KPOOL_BITMAP_STORAGE.len());
+            RawArray::from_raw_parts(ptr, len)?
+        };
+        Bitmap::from_raw_array(storage)?
+    };
+
     Ok(Platform {
         arch: x86::init(ioports, ioaddresses, madt)?,
         #[cfg(feature = "pit")]
         _pit: register_pit(ioports)?,
         physical_memory_layout: Some(physical_memory_layout),
+        kpool_bitmap: Some(kpool_bitmap),
     })
 }
 

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -91,6 +91,9 @@ pub struct Platform {
     /// A sparse bitmap representing the physical memory layout, owned by the platform and consumed
     /// by the memory manager during system initialization.
     pub physical_memory_layout: Option<SparseBitmap>,
+    /// A bitmap for the kernel page pool, owned by the platform and consumed by the memory manager
+    /// during system initialization.
+    pub kpool_bitmap: Option<Bitmap>,
 }
 
 //==================================================================================================
@@ -101,6 +104,16 @@ pub struct Platform {
 static mut FRAME_ALLOCATOR_STORAGE: [u8; config::kernel::MEMORY_SIZE
     / (mem::FRAME_SIZE * u8::BITS as usize)] =
     [0; config::kernel::MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)];
+
+// Ensure the number of kpool pages is a multiple of 8 so the bitmap has no padding bits.
+::static_assert::assert_eq!(
+    (config::kernel::KPOOL_SIZE / mem::PAGE_SIZE).is_multiple_of(u8::BITS as usize)
+);
+
+/// Kernel page pool bitmap storage.
+static mut KPOOL_BITMAP_STORAGE: [u8; config::kernel::KPOOL_SIZE
+    / (mem::PAGE_SIZE * u8::BITS as usize)] =
+    [0; config::kernel::KPOOL_SIZE / (mem::PAGE_SIZE * u8::BITS as usize)];
 
 //==================================================================================================
 // Standalone Functions
@@ -687,10 +700,22 @@ pub fn init(
         SparseBitmap::new(vec![(0, bitmap)])?
     };
 
+    // Build a bitmap for the kernel page pool.
+    let kpool_bitmap: Bitmap = {
+        // Safety: the kpool bitmap storage is valid and has a static lifetime.
+        let storage: RawArray<u8> = unsafe {
+            let (ptr, len): (*mut u8, usize) =
+                (KPOOL_BITMAP_STORAGE.as_mut_ptr(), KPOOL_BITMAP_STORAGE.len());
+            RawArray::from_raw_parts(ptr, len)?
+        };
+        Bitmap::from_raw_array(storage)?
+    };
+
     Ok(Platform {
         arch,
         #[cfg(all(feature = "pit", not(feature = "whp")))]
         _pit: register_pit(ioports)?,
         physical_memory_layout: Some(physical_memory_layout),
+        kpool_bitmap: Some(kpool_bitmap),
     })
 }

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -31,6 +31,7 @@
 extern crate alloc;
 
 use crate::{
+    collections::Bitmap,
     hal::{
         io::IoMemoryAllocator,
         mem::{
@@ -321,22 +322,24 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
         }
     }
 
-    let physical_memory_layout: SparseBitmap =
+    let (physical_memory_layout, kpool_bitmap): (SparseBitmap, Bitmap) =
         match Hal::init(&mut memory_regions, &mut mmio_regions, &mut ioaddresses, &madt, mem_lower)
         {
-            Ok(bitmap) => bitmap,
+            Ok(result) => result,
             Err(err) => {
                 panic!("failed to initialize hardware abstraction layer: {:?}", err);
             },
         };
 
     // Initialize the memory manager.
-    let root: Vmem = match mm::init(&kimage, memory_regions, mmio_regions, physical_memory_layout) {
-        Ok(root) => root,
-        Err(err) => {
-            panic!("failed to initialize memory manager: {:?}", err);
-        },
-    };
+    let root: Vmem =
+        match mm::init(&kimage, memory_regions, mmio_regions, physical_memory_layout, kpool_bitmap)
+        {
+            Ok(root) => root,
+            Err(err) => {
+                panic!("failed to initialize memory manager: {:?}", err);
+            },
+        };
 
     // Check boot stack guard watermark for corruption.
     if let Err(err) = mm::kstack::check_boot_stack_guard() {

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -44,6 +44,7 @@ pub mod kredzone;
 //==================================================================================================
 
 use crate::{
+    collections::Bitmap,
     hal::{
         arch::x86::mem::mmu::page_table::PageTable,
         mem::{
@@ -246,6 +247,7 @@ fn parse_memory_regions(
 /// - `memory_regions`: Memory regions.
 /// - `mmio_regions`: MMIO regions.
 /// - `physical_memory_layout`: Physical memory layout bitmap.
+/// - `kpool_bitmap`: Statically-allocated bitmap for the kernel page pool.
 ///
 /// # Returns
 ///
@@ -257,11 +259,15 @@ pub fn init(
     memory_regions: LinkedList<MemoryRegion<VirtualAddress>>,
     mmio_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
     physical_memory_layout: SparseBitmap,
+    kpool_bitmap: Bitmap,
 ) -> Result<Vmem, Error> {
     info!("initializing the memory manager ...");
 
     type VirtMemRegions = LinkedList<TruncatedMemoryRegion<VirtualAddress>>;
     type PhysMemRegions = LinkedList<TruncatedMemoryRegion<PhysicalAddress>>;
+
+    let kpool_base: PageAligned<PhysicalAddress> =
+        PageAligned::<PhysicalAddress>::from_raw_value(kimage.kpool().start().into_raw_value())?;
 
     let (mut other_virtual_memory_regions, virtual_memory_regions, physical_memory_regions): (
         VirtMemRegions,
@@ -270,10 +276,11 @@ pub fn init(
     ) = parse_memory_regions(memory_regions)?;
 
     phys::init(
-        TruncatedMemoryRegion::from_virtual_memory_region(kimage.kpool())?,
+        kpool_base,
         physical_memory_regions,
         &mmio_regions,
         physical_memory_layout,
+        kpool_bitmap,
     )?;
 
     #[cfg(feature = "test")]

--- a/src/kernel/src/mm/phys/kpool.rs
+++ b/src/kernel/src/mm/phys/kpool.rs
@@ -16,12 +16,14 @@
 
 use crate::{
     collections::Bitmap,
-    hal::mem::{
-        Address,
-        FrameAddress,
-        PageAligned,
-        PhysicalAddress,
-        TruncatedMemoryRegion,
+    hal::{
+        mem::{
+            Address,
+            FrameAddress,
+            PageAligned,
+            PhysicalAddress,
+        },
+        platform::is_valid_physical_region,
     },
 };
 use ::alloc::vec::Vec;
@@ -49,9 +51,9 @@ use ::sys::error::{
 
 /// Private state of the kernel pool singleton.
 struct Inner {
-    /// Physical memory region backing the kernel pool.
-    region: TruncatedMemoryRegion<PhysicalAddress>,
-    /// Bitmap of free pages.
+    /// Base address of the kernel pool.
+    base: PageAligned<PhysicalAddress>,
+    /// Bitmap of free frames.
     bitmap: Bitmap,
 }
 
@@ -74,7 +76,7 @@ impl Inner {
                 return Err(error);
             },
         };
-        let addr: usize = self.region.start().into_raw_value() + index * mem::PAGE_SIZE;
+        let addr: usize = self.base.into_raw_value() + index * mem::PAGE_SIZE;
         Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(addr)?)?))
     }
 
@@ -109,7 +111,7 @@ impl Inner {
             },
         };
 
-        let base_addr: usize = self.region.start().into_raw_value() + index * mem::PAGE_SIZE;
+        let base_addr: usize = self.base.into_raw_value() + index * mem::PAGE_SIZE;
         for i in 0..count {
             let addr: usize = base_addr + i * mem::PAGE_SIZE;
             let frame: FrameAddress = FrameAddress::new(PageAligned::from_address(
@@ -135,8 +137,7 @@ impl Inner {
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
     fn free(&mut self, addr: FrameAddress) -> Result<(), Error> {
-        let index: usize =
-            (addr.into_raw_value() - self.region.start().into_raw_value()) / mem::PAGE_SIZE;
+        let index: usize = (addr.into_raw_value() - self.base.into_raw_value()) / mem::PAGE_SIZE;
         match self.bitmap.clear(index) {
             Ok(()) => Ok(()),
             Err(error) => {
@@ -196,7 +197,8 @@ fn instance() -> &'static mut Inner {
 ///
 /// # Parameters
 ///
-/// - `region`: Physical memory region backing the kernel pool.
+/// - `base`: Base address of the kernel pool.
+/// - `bitmap`: Bitmap for tracking free pages.
 ///
 /// # Return Values
 ///
@@ -206,25 +208,30 @@ fn instance() -> &'static mut Inner {
 ///
 /// Must be called exactly once during boot, before any other function in this module.
 ///
-pub(super) unsafe fn init(region: TruncatedMemoryRegion<PhysicalAddress>) -> Result<Kpool, Error> {
+pub(super) unsafe fn init(
+    base: PageAligned<PhysicalAddress>,
+    bitmap: Bitmap,
+) -> Result<Kpool, Error> {
     if unlikely(INSTANCE_INIT.load(ORDER)) {
         return Err(Error::new(ErrorCode::InvalidArgument, "kernel pool already initialized"));
     }
 
-    trace!("region={region:?}");
-    debug_assert_eq!(
-        region.size() % mem::PAGE_SIZE,
-        0,
-        "kernel pool size must be a multiple of page size"
-    );
+    trace!("base={base:?}");
 
-    let bitmap: Bitmap = Bitmap::new(region.size() / mem::PAGE_SIZE)?;
+    // Check if bitmap spans across physically-addressable memory.
+    let bitmap_capacity: usize = bitmap.number_of_bits();
+    let kpool_size: usize = bitmap_capacity * mem::PAGE_SIZE;
+    if !is_valid_physical_region(base.into_raw_value(), kpool_size) {
+        let reason: &str = "kernel pool bitmap spans across physically-addressable memory";
+        error!("{reason}");
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
 
     let num_frames: usize = bitmap.number_of_bits();
     info!("kernel pool: {} frames, {} KB", num_frames, (num_frames * mem::PAGE_SIZE) / 1024,);
 
     // SAFETY: single-threaded boot; no other reference to `INSTANCE` exists.
-    unsafe { INSTANCE.write(Inner { region, bitmap }) };
+    unsafe { INSTANCE.write(Inner { base, bitmap }) };
     INSTANCE_INIT.store(true, ORDER);
     Ok(Kpool { _private: () })
 }

--- a/src/kernel/src/mm/phys/kpool.rs
+++ b/src/kernel/src/mm/phys/kpool.rs
@@ -1,6 +1,15 @@
 // Copyright(c) The Maintainers of Nanvix.
 // Licensed under the MIT License.
 
+//! Kernel frame pool — module-level singleton.
+//!
+//! The kernel pool is backed by a [`Bitmap`] and exposed as free functions over a singleton so
+//! every in-kernel caller goes through the same state. The public facade types [`Kpool`] and
+//! [`KernelFrame`] delegate to the singleton.
+//!
+//! Access to the kernel pool is synchronized externally and performed by a single thread, so
+//! the backing bitmap uses non-atomic operations.
+
 //==================================================================================================
 // Imports
 //==================================================================================================
@@ -15,16 +24,18 @@ use crate::{
         TruncatedMemoryRegion,
     },
 };
-use ::alloc::{
-    rc::Rc,
-    vec::Vec,
-};
+use ::alloc::vec::Vec;
 use ::arch::mem;
 use ::core::{
-    cell::RefCell,
+    hint::unlikely,
+    mem::MaybeUninit,
     ops::{
         Deref,
         DerefMut,
+    },
+    sync::atomic::{
+        AtomicBool,
+        Ordering,
     },
 };
 use ::sys::error::{
@@ -33,29 +44,28 @@ use ::sys::error::{
 };
 
 //==================================================================================================
-// Kernel Page Pool Inner
+// Inner
 //==================================================================================================
 
-#[derive(Debug)]
-struct KpoolInner {
-    /// Size of the kernel pool.
+/// Private state of the kernel pool singleton.
+struct Inner {
+    /// Physical memory region backing the kernel pool.
     region: TruncatedMemoryRegion<PhysicalAddress>,
     /// Bitmap of free pages.
     bitmap: Bitmap,
 }
 
-impl KpoolInner {
-    fn new(region: TruncatedMemoryRegion<PhysicalAddress>) -> Result<Self, Error> {
-        trace!("region={region:?}");
-        debug_assert_eq!(
-            region.size() % mem::PAGE_SIZE,
-            0,
-            "kernel pool size must be a multiple of page size"
-        );
-        let bitmap: Bitmap = Bitmap::new(region.size() / (mem::PAGE_SIZE))?;
-        Ok(Self { region, bitmap })
-    }
-
+impl Inner {
+    ///
+    /// # Description
+    ///
+    /// Allocates a frame from the kernel pool.
+    ///
+    /// # Return Values
+    ///
+    /// Upon success, the address of the allocated frame is returned. Upon failure, an error is
+    /// returned instead.
+    ///
     fn alloc(&mut self) -> Result<FrameAddress, Error> {
         let index: usize = match self.bitmap.alloc() {
             Ok(index) => index,
@@ -111,7 +121,19 @@ impl KpoolInner {
         Ok(())
     }
 
-    /// Frees a page in the kernel pool.
+    ///
+    /// # Description
+    ///
+    /// Frees a previously allocated frame in the kernel pool.
+    ///
+    /// # Parameters
+    ///
+    /// - `addr`: Address of the frame to free.
+    ///
+    /// # Return Values
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+    ///
     fn free(&mut self, addr: FrameAddress) -> Result<(), Error> {
         let index: usize =
             (addr.into_raw_value() - self.region.start().into_raw_value()) / mem::PAGE_SIZE;
@@ -126,20 +148,175 @@ impl KpoolInner {
 }
 
 //==================================================================================================
-// Kernel Page
+// Constants
 //==================================================================================================
 
+// Use relaxed ordering for all atomic operations to mitigate synchronization overhead. It is safe
+// to use this ordering semantics because Nanvix is a single-core system, and the kernel runs with
+// interrupts disabled.
+const ORDER: Ordering = Ordering::Relaxed;
+
+//==================================================================================================
+// Singleton
+//==================================================================================================
+
+/// Module-level singleton storage.
+static mut INSTANCE: MaybeUninit<Inner> = MaybeUninit::uninit();
+
+/// Whether the kernel pool has been initialized.
+static INSTANCE_INIT: AtomicBool = AtomicBool::new(false);
+
+///
+/// # Description
+///
+/// Returns a mutable reference to the initialized singleton.
+///
+/// # Return Values
+///
+/// A mutable reference to the kernel pool singleton.
+///
+fn instance() -> &'static mut Inner {
+    if unlikely(!INSTANCE_INIT.load(ORDER)) {
+        panic!("kernel pool used before init()");
+    }
+
+    // SAFETY: `INSTANCE_INIT` is `true`, so `INSTANCE` has been fully written by `init()`.
+    // The kernel is single-threaded with interrupts disabled, so no concurrent access is possible.
+    unsafe { INSTANCE.assume_init_mut() }
+}
+
+//==================================================================================================
+// Public Free Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Initializes the kernel pool singleton.
+///
+/// # Parameters
+///
+/// - `region`: Physical memory region backing the kernel pool.
+///
+/// # Return Values
+///
+/// Upon success, a [`Kpool`] instance is returned. Upon failure, an error is returned instead.
+///
+/// # Safety
+///
+/// Must be called exactly once during boot, before any other function in this module.
+///
+pub(super) unsafe fn init(region: TruncatedMemoryRegion<PhysicalAddress>) -> Result<Kpool, Error> {
+    if unlikely(INSTANCE_INIT.load(ORDER)) {
+        return Err(Error::new(ErrorCode::InvalidArgument, "kernel pool already initialized"));
+    }
+
+    trace!("region={region:?}");
+    debug_assert_eq!(
+        region.size() % mem::PAGE_SIZE,
+        0,
+        "kernel pool size must be a multiple of page size"
+    );
+
+    let bitmap: Bitmap = Bitmap::new(region.size() / mem::PAGE_SIZE)?;
+
+    let num_frames: usize = bitmap.number_of_bits();
+    info!("kernel pool: {} frames, {} KB", num_frames, (num_frames * mem::PAGE_SIZE) / 1024,);
+
+    // SAFETY: single-threaded boot; no other reference to `INSTANCE` exists.
+    unsafe { INSTANCE.write(Inner { region, bitmap }) };
+    INSTANCE_INIT.store(true, ORDER);
+    Ok(Kpool { _private: () })
+}
+
+///
+/// # Description
+///
+/// Allocates a frame from the kernel pool.
+///
+/// # Return Values
+///
+/// Upon success, the address of the allocated frame is returned. Upon failure, an error is
+/// returned instead.
+///
+fn alloc() -> Result<FrameAddress, Error> {
+    instance().alloc()
+}
+
+///
+/// # Description
+///
+/// Allocates a contiguous range of frames from the kernel pool.
+///
+/// # Parameters
+///
+/// - `addrs`: Mutable reference to a pre-allocated vector. The number of frames allocated
+///   equals `addrs.capacity()`.
+///
+/// # Return Values
+///
+/// Upon success, `Ok(())` is returned and `addrs` is filled to capacity with contiguous
+/// entries. Upon failure, an error is returned instead.
+///
+fn alloc_range(addrs: &mut Vec<FrameAddress>) -> Result<(), Error> {
+    instance().alloc_range(addrs)
+}
+
+///
+/// # Description
+///
+/// Frees a frame previously returned by [`alloc`].
+///
+/// # Parameters
+///
+/// - `addr`: Address of the frame to free.
+///
+/// # Return Values
+///
+/// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+///
+fn free(addr: FrameAddress) -> Result<(), Error> {
+    instance().free(addr)
+}
+
+//==================================================================================================
+// Kernel Frame
+//==================================================================================================
+
+/// A type that represents a kernel frame.
 #[derive(Debug)]
 pub struct KernelFrame {
-    kpool: Rc<RefCell<KpoolInner>>,
+    /// Frame address.
     base: FrameAddress,
 }
 
 impl KernelFrame {
-    fn new(kpool: Rc<RefCell<KpoolInner>>, base: FrameAddress) -> Self {
-        Self { kpool, base }
+    ///
+    /// # Description
+    ///
+    /// Instantiates a kernel frame.
+    ///
+    /// # Parameters
+    ///
+    /// - `base`: Frame address.
+    ///
+    /// # Returns
+    ///
+    /// A kernel frame.
+    ///
+    fn new(base: FrameAddress) -> Self {
+        Self { base }
     }
 
+    ///
+    /// # Description
+    ///
+    /// Returns the base address of the target kernel frame.
+    ///
+    /// # Returns
+    ///
+    /// The base address of the target kernel frame.
+    ///
     pub fn base(&self) -> FrameAddress {
         self.base
     }
@@ -174,8 +351,8 @@ impl DerefMut for KernelFrame {
 
 impl Drop for KernelFrame {
     fn drop(&mut self) {
-        if let Err(e) = self.kpool.borrow_mut().free(self.base) {
-            error!("failed to free kernel page pool: {:?}", e)
+        if let Err(e) = free(self.base) {
+            error!("failed to free kernel frame: {:?}", e);
         }
     }
 }
@@ -184,19 +361,19 @@ impl Drop for KernelFrame {
 // Kernel Pool
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Thin facade over the module-level kernel pool singleton. Exists as a distinct type so
+/// kernel-frame allocation has its own entry point ([`Kpool::alloc`] returning [`KernelFrame`]).
+///
 #[derive(Debug)]
 pub struct Kpool {
-    inner: Rc<RefCell<KpoolInner>>,
+    /// Private field prevents external construction.
+    _private: (),
 }
 
 impl Kpool {
-    /// Initializes the kernel pool.
-    pub fn new(region: TruncatedMemoryRegion<PhysicalAddress>) -> Result<Self, Error> {
-        Ok(Self {
-            inner: Rc::new(RefCell::new(KpoolInner::new(region)?)),
-        })
-    }
-
     ///
     /// # Description
     ///
@@ -207,8 +384,8 @@ impl Kpool {
     /// Upon success, a kernel frame is returned. Upon failure, an error is returned instead.
     ///
     pub fn alloc(&mut self) -> Result<KernelFrame, Error> {
-        let frame: FrameAddress = self.inner.borrow_mut().alloc()?;
-        Ok(KernelFrame::new(self.inner.clone(), frame))
+        let addr: FrameAddress = alloc()?;
+        Ok(KernelFrame::new(addr))
     }
 
     ///
@@ -236,9 +413,9 @@ impl Kpool {
 
         let count: usize = frames.capacity();
         let mut addrs: Vec<FrameAddress> = Vec::with_capacity(count);
-        self.inner.borrow_mut().alloc_range(&mut addrs)?;
+        alloc_range(&mut addrs)?;
         for addr in addrs {
-            frames.push(KernelFrame::new(self.inner.clone(), addr));
+            frames.push(KernelFrame::new(addr));
         }
         Ok(())
     }

--- a/src/kernel/src/mm/phys/mod.rs
+++ b/src/kernel/src/mm/phys/mod.rs
@@ -18,6 +18,7 @@ mod test;
 //==================================================================================================
 
 use crate::{
+    collections::Bitmap,
     hal::mem::{
         Address,
         PageAligned,
@@ -108,20 +109,22 @@ fn book_mmio_regions(
 ///
 /// # Parameters
 ///
-/// - `kpool`: Kernel page pool region.
+/// - `kpool_base`: Base address of the kernel page pool.
 /// - `physical_memory_regions`: Physical memory regions to book.
 /// - `mmio_regions`: Memory-mapped I/O regions to book.
 /// - `physical_memory_layout`: Physical memory layout bitmap.
+/// - `kpool_bitmap`: Bitmap for the kernel page pool.
 ///
 /// # Returns
 ///
 /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
 ///
 pub fn init(
-    kpool: TruncatedMemoryRegion<PhysicalAddress>,
+    kpool_base: PageAligned<PhysicalAddress>,
     physical_memory_regions: LinkedList<TruncatedMemoryRegion<PhysicalAddress>>,
     mmio_regions: &LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
     physical_memory_layout: SparseBitmap,
+    kpool_bitmap: Bitmap,
 ) -> Result<(), Error> {
     // Initialize frame allocator singleton.
     info!("initializing the frame allocator ...");
@@ -134,7 +137,7 @@ pub fn init(
     // Initialize kernel page pool singleton.
     info!("initializing the kernel page pool ...");
     // Safety: called exactly once during single-threaded boot.
-    let kpool: Kpool = unsafe { kpool::init(kpool)? };
+    let kpool: Kpool = unsafe { kpool::init(kpool_base, kpool_bitmap)? };
 
     // Initialize user page pool.
     info!("initializing the user page pool ...");

--- a/src/kernel/src/mm/phys/mod.rs
+++ b/src/kernel/src/mm/phys/mod.rs
@@ -115,8 +115,7 @@ fn book_mmio_regions(
 ///
 /// # Returns
 ///
-/// Upon success, the physical memory manager is returned. Upon failure, an error is returned
-/// instead.
+/// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
 ///
 pub fn init(
     kpool: TruncatedMemoryRegion<PhysicalAddress>,
@@ -132,9 +131,10 @@ pub fn init(
 
     book_mmio_regions(mmio_regions)?;
 
-    // Initialize kernel page pool.
+    // Initialize kernel page pool singleton.
     info!("initializing the kernel page pool ...");
-    let kpool: Kpool = Kpool::new(kpool)?;
+    // Safety: called exactly once during single-threaded boot.
+    let kpool: Kpool = unsafe { kpool::init(kpool)? };
 
     // Initialize user page pool.
     info!("initializing the user page pool ...");

--- a/src/kernel/src/mm/phys/upool.rs
+++ b/src/kernel/src/mm/phys/upool.rs
@@ -92,7 +92,10 @@ impl Drop for UserFrame {
 /// so user-frame allocation has its own entry point ([`Upool::alloc`] returning [`UserFrame`]).
 ///
 #[derive(Debug)]
-pub struct Upool;
+pub struct Upool {
+    /// Private field prevents external construction.
+    _private: (),
+}
 
 impl Upool {
     ///
@@ -104,8 +107,8 @@ impl Upool {
     ///
     /// A user frame pool.
     ///
-    pub fn new() -> Self {
-        Self
+    pub(super) fn new() -> Self {
+        Self { _private: () }
     }
 
     ///


### PR DESCRIPTION
## Summary

This PR improves the kernel kpool implementation with three changes:

1. **Reserve Hyperlight bookkeeping page** — Fixes a bug where the Hyperlight bookkeeping page was not properly reserved in the kpool.
2. **Refactor kpool to a singleton** — Restructures kpool as a singleton to simplify access and improve encapsulation.
3. **Statically allocate kpool bitmap** — Replaces the dynamically allocated bitmap with a static one, reducing runtime allocation overhead.

## Commits

- `f099f6a` [kernel] B: Reserve Hyperlight bookkeeping page
- `54dc301` [kernel] E: Refactor kpool to a singleton
- `9b9ffb7` [kernel] E: Statically allocate kpool bitmap