### PR TITLE
[kernel] Move GDT backing storage to platform layer

### DIFF
--- a/src/kernel/src/hal/arch/x86/mem/gdt.rs
+++ b/src/kernel/src/hal/arch/x86/mem/gdt.rs
@@ -7,6 +7,7 @@
 
 use crate::hal::arch::x86::cpu::tss::TssRef;
 use ::alloc::boxed::Box;
+pub use ::arch::mem::gdt::GDTE_ALIGNMENT;
 use ::arch::mem::gdt::{
     AccessAccessed,
     AccessConforming,
@@ -31,7 +32,10 @@ use ::core::{
     mem,
     pin::Pin,
 };
-use ::sys::error::Error;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
 
 //==================================================================================================
 // Structures
@@ -69,11 +73,14 @@ pub enum SegmentSelector {
 }
 
 //===================================================================================================
-// Global Variables
+// Constants
 //===================================================================================================
 
-/// Global descriptor table.
-static mut GDT: [Gdte; 7] = [
+/// Number of entries in the GDT.
+pub const GDT_NUM_ENTRIES: usize = 7;
+
+/// Default GDT entries used to populate platform-provided backing storage.
+pub const DEFAULT_ENTRIES: [Gdte; GDT_NUM_ENTRIES] = [
     // Null entry.
     Gdte::new(
         0x0,
@@ -192,11 +199,64 @@ static mut GDT: [Gdte; 7] = [
     Gdte::default(),
 ];
 
+//===================================================================================================
+// Global Variables
+//===================================================================================================
+
+/// Pointer to the platform-provided GDT backing storage.
+///
+/// Initialized by [`Gdt::set_backing_storage()`] before [`Gdt::init()`]. On microvm the storage
+/// is a BSS-allocated static array; on Hyperlight it resides in the scratch region so it is not
+/// part of the Copy-on-Write snapshot.
+static mut GDT: *mut Gdte = core::ptr::null_mut();
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
 impl Gdt {
+    ///
+    /// # Description
+    ///
+    /// Installs platform-provided backing storage for the GDT.
+    ///
+    /// The caller is responsible for populating the storage with the correct descriptor entries
+    /// (e.g., by copying [`DEFAULT_ENTRIES`]) before this function is called. This function only
+    /// records the pointer; it does not write any entries.
+    ///
+    /// Must be called exactly once before [`Gdt::init()`].
+    ///
+    /// # Parameters
+    ///
+    /// - `storage`: Pointer to at least [`GDT_NUM_ENTRIES`] contiguous [`Gdte`] slots whose
+    ///   lifetime exceeds all subsequent GDT operations. Must be aligned to [`GDTE_ALIGNMENT`].
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if the backing storage was successfully installed.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::InvalidArgument`] if `storage` is not aligned to [`GDTE_ALIGNMENT`].
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it sets a global raw pointer that all GDT operations
+    /// depend on. The caller must ensure:
+    /// - `storage` is non-null and points to at least [`GDT_NUM_ENTRIES`] entries.
+    /// - The backing memory outlives all GDT usage.
+    /// - This function is called at most once.
+    ///
+    pub unsafe fn set_backing_storage(storage: *mut Gdte) -> Result<(), Error> {
+        if !::sys::mm::is_aligned(storage as usize, GDTE_ALIGNMENT) {
+            let reason: &str = "GDT backing storage pointer is not properly aligned";
+            error!("{}", reason);
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        GDT = storage;
+        Ok(())
+    }
+
     #[inline(never)]
     pub unsafe fn load(ptr: *const ::arch::mem::gdtr::Gdtr) {
         // No data is pushed the stack, or write to the stack red-zone
@@ -221,6 +281,10 @@ impl Gdt {
     }
 
     pub unsafe fn init(kstack: *const u8) -> Result<(GdtPtr, TssRef), Error> {
+        debug_assert!(
+            !GDT.is_null(),
+            "GDT backing storage not installed; call set_backing_storage() first"
+        );
         trace!("initializing gdt...");
         let ss0: u32 = SegmentSelector::KernelData as u32;
         let esp0: u32 = kstack as u32;
@@ -228,7 +292,7 @@ impl Gdt {
         let tss: TssRef = TssRef::new(ss0, esp0)?;
 
         // Overwrite task segment selector entry.
-        GDT[GdtEntries::Tss as usize] = Gdte::new(
+        *GDT.add(GdtEntries::Tss as usize) = Gdte::new(
             tss.address() as u32,
             tss.size() as u32 - 1,
             GdteAccessByte::new(
@@ -249,8 +313,8 @@ impl Gdt {
 
         // Set the GDTPTR.
         let gdtr = GdtPtr(Pin::new(Box::new(::arch::mem::gdtr::Gdtr::new(
-            GDT.as_ptr() as u32,
-            (mem::size_of_val(&GDT)) as u16,
+            GDT as u32,
+            (GDT_NUM_ENTRIES * mem::size_of::<Gdte>()) as u16,
         ))));
 
         info!("loading the GDT...");
@@ -281,7 +345,7 @@ impl Gdt {
     /// It is safe to use this function if and only if the processor is running in privileged mode.
     ///
     pub unsafe fn set_thread_data_area_base(tda_base: u32) {
-        GDT[GdtEntries::UserThreadDataArea as usize].set_base(tda_base);
+        (*GDT.add(GdtEntries::UserThreadDataArea as usize)).set_base(tda_base);
     }
 
     ///

--- a/src/kernel/src/hal/arch/x86_64/mem/gdt.rs
+++ b/src/kernel/src/hal/arch/x86_64/mem/gdt.rs
@@ -7,6 +7,7 @@
 
 use crate::hal::arch::x86::cpu::tss::TssRef;
 use ::alloc::boxed::Box;
+pub use ::arch::mem::gdt::GDTE_ALIGNMENT;
 use ::arch::mem::gdt::{
     AccessAccessed,
     AccessConforming,
@@ -31,7 +32,10 @@ use ::core::{
     mem,
     pin::Pin,
 };
-use ::sys::error::Error;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
 
 //==================================================================================================
 // Structures
@@ -68,16 +72,19 @@ pub enum SegmentSelector {
 }
 
 //===================================================================================================
-// Global Variables
+// Constants
 //===================================================================================================
 
-/// Global descriptor table.
+/// Number of entries in the GDT.
+pub const GDT_NUM_ENTRIES: usize = 7;
+
+/// Default GDT entries used to populate platform-provided backing storage.
 ///
 /// In x86_64 long mode:
 /// - Code segments must have L=1, D=0.
 /// - Data segments ignore L and D bits.
 /// - The TSS descriptor is 16 bytes (two GDT entries): TssLow + TssHigh.
-static mut GDT: [Gdte; 7] = [
+pub const DEFAULT_ENTRIES: [Gdte; GDT_NUM_ENTRIES] = [
     // Null entry.
     Gdte::new(
         0x0,
@@ -179,11 +186,64 @@ static mut GDT: [Gdte; 7] = [
     Gdte::default(),
 ];
 
+//===================================================================================================
+// Global Variables
+//===================================================================================================
+
+/// Pointer to the platform-provided GDT backing storage.
+///
+/// Initialized by [`Gdt::set_backing_storage()`] before [`Gdt::init()`]. On microvm the storage
+/// is a BSS-allocated static array; on Hyperlight it resides in the scratch region so it is not
+/// part of the Copy-on-Write snapshot.
+static mut GDT: *mut Gdte = core::ptr::null_mut();
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
 
 impl Gdt {
+    ///
+    /// # Description
+    ///
+    /// Installs platform-provided backing storage for the GDT.
+    ///
+    /// The caller is responsible for populating the storage with the correct descriptor entries
+    /// (e.g., by copying [`DEFAULT_ENTRIES`]) before this function is called. This function only
+    /// records the pointer; it does not write any entries.
+    ///
+    /// Must be called exactly once before [`Gdt::init()`].
+    ///
+    /// # Parameters
+    ///
+    /// - `storage`: Pointer to at least [`GDT_NUM_ENTRIES`] contiguous [`Gdte`] slots whose
+    ///   lifetime exceeds all subsequent GDT operations. Must be aligned to [`GDTE_ALIGNMENT`].
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if the backing storage was successfully installed.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::InvalidArgument`] if `storage` is not aligned to [`GDTE_ALIGNMENT`].
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it sets a global raw pointer that all GDT operations
+    /// depend on. The caller must ensure:
+    /// - `storage` is non-null and points to at least [`GDT_NUM_ENTRIES`] entries.
+    /// - The backing memory outlives all GDT usage.
+    /// - This function is called at most once.
+    ///
+    pub unsafe fn set_backing_storage(storage: *mut Gdte) -> Result<(), Error> {
+        if !::sys::mm::is_aligned(storage as usize, GDTE_ALIGNMENT) {
+            let reason: &str = "GDT backing storage pointer is not properly aligned";
+            error!("{}", reason);
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        GDT = storage;
+        Ok(())
+    }
+
     #[inline(never)]
     pub unsafe fn load(ptr: *const ::arch::mem::gdtr::Gdtr) {
         // In x86_64 long mode, we use a far return (lretq) to reload CS because
@@ -212,6 +272,10 @@ impl Gdt {
     }
 
     pub unsafe fn init(kstack: *const u8) -> Result<(GdtPtr, TssRef), Error> {
+        debug_assert!(
+            !GDT.is_null(),
+            "GDT backing storage not installed; call set_backing_storage() first"
+        );
         trace!("initializing gdt...");
         let rsp0: u64 = kstack as u64;
         trace!("rsp0={:x}", rsp0);
@@ -220,7 +284,7 @@ impl Gdt {
         // Overwrite TSS low entry (first 8 bytes of the 16-byte TSS descriptor).
         let tss_addr: usize = tss.address();
         let tss_size: usize = tss.size();
-        GDT[GdtEntries::TssLow as usize] = Gdte::new(
+        *GDT.add(GdtEntries::TssLow as usize) = Gdte::new(
             tss_addr as u32,
             tss_size as u32 - 1,
             GdteAccessByte::new(
@@ -240,15 +304,14 @@ impl Gdt {
         );
 
         // Overwrite TSS high entry (second 8 bytes: upper 32 bits of TSS base address).
-        let tss_high_ptr: *mut u32 =
-            &mut GDT[GdtEntries::TssHigh as usize] as *mut Gdte as *mut u32;
+        let tss_high_ptr: *mut u32 = GDT.add(GdtEntries::TssHigh as usize) as *mut u32;
         *tss_high_ptr = (tss_addr >> 32) as u32;
         *tss_high_ptr.add(1) = 0;
 
         // Set the GDTPTR.
         let gdtr = GdtPtr(Pin::new(Box::new(::arch::mem::gdtr::Gdtr::new(
-            GDT.as_ptr() as u64,
-            (mem::size_of_val(&GDT)) as u16,
+            GDT as u64,
+            (GDT_NUM_ENTRIES * mem::size_of::<Gdte>()) as u16,
         ))));
 
         info!("loading the GDT...");

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     hal::{
         arch::x86::{
             self,
+            mem::gdt,
             Arch,
         },
         io::{
@@ -63,6 +64,7 @@ use ::alloc::{
 use ::arch::{
     mem,
     mem::{
+        gdt::Gdte,
         PAGE_ALIGNMENT,
         WORD_ALIGNMENT,
     },
@@ -246,14 +248,30 @@ const KPOOL_BITMAP_OFFSET: usize = {
 const KPOOL_BITMAP_STORAGE_SIZE: usize =
     ::config::kernel::KPOOL_SIZE / (mem::PAGE_SIZE * u8::BITS as usize);
 
-/// Combined size of the allocator backing stores (with inter-area padding for word alignment),
-/// rounded up to a page boundary.
+/// Offset of the GDT backing storage within the scratch allocator reservation.
+///
+/// Placed right after the kpool bitmap, aligned to the minimum alignment of [`Gdte`] so that
+/// `copy_nonoverlapping` and subsequent GDT accesses meet the pointer alignment requirement.
+const GDT_OFFSET: usize = {
+    match ::sys::mm::align_up(KPOOL_BITMAP_OFFSET + KPOOL_BITMAP_STORAGE_SIZE, gdt::GDTE_ALIGNMENT)
+    {
+        Some(v) => v,
+        // Compile-time only: overflow is impossible for realistic storage sizes.
+        None => ::core::unreachable!(),
+    }
+};
+
+/// Size in bytes of the GDT backing storage in the scratch region.
+const GDT_STORAGE_SIZE: usize = gdt::GDT_NUM_ENTRIES * core::mem::size_of::<Gdte>();
+
+/// Combined size of all scratch-resident kernel structures (frame allocator bitmap, kpool bitmap,
+/// and GDT) with inter-area padding, rounded up to a page boundary.
 ///
 /// This many bytes are reserved at the beginning of the free portion of the scratch region
-/// (right after the I/O buffers) so the bitmap backing stores live in scratch memory
-/// instead of the BSS (which is part of the snapshot and therefore Copy-on-Write).
-const ALLOCATOR_STORAGE_PAGES_SIZE: usize = {
-    let raw: usize = KPOOL_BITMAP_OFFSET + KPOOL_BITMAP_STORAGE_SIZE;
+/// (right after the I/O buffers) so these structures live in scratch memory instead of the BSS
+/// (which is part of the snapshot and therefore Copy-on-Write).
+const SCRATCH_RESERVED_SIZE: usize = {
+    let raw: usize = GDT_OFFSET + GDT_STORAGE_SIZE;
     // Round up to the next multiple of PAGE_SIZE.
     // SAFETY: `raw` is small relative to `usize::MAX`, so overflow cannot occur.
     match ::sys::mm::align_up(raw, PAGE_ALIGNMENT) {
@@ -1115,7 +1133,7 @@ pub fn init(
     // one reserved last page).
     let min_scratch_size: usize = INPUT_DATA_BUFFER_SIZE
         + OUTPUT_DATA_BUFFER_SIZE
-        + ALLOCATOR_STORAGE_PAGES_SIZE
+        + SCRATCH_RESERVED_SIZE
         + 2 * mem::PAGE_SIZE;
     if scratch_size == 0 || scratch_size < min_scratch_size {
         let reason: &str = "scratch_size is too small for required scratch regions";
@@ -1151,7 +1169,7 @@ pub fn init(
     // Register only the MMIO-critical portions of the scratch region:
     //  1. Input data buffer  [scratch_base, scratch_base + INPUT_DATA_BUFFER_SIZE)
     //  2. Output data buffer [scratch_base + INPUT_DATA_BUFFER_SIZE, + OUTPUT_DATA_BUFFER_SIZE)
-    //  3. Allocator storage  [output_end, output_end + ALLOCATOR_STORAGE_PAGES_SIZE)
+    //  3. Scratch-reserved structures [output_end, output_end + SCRATCH_RESERVED_SIZE)
     //  4. Scratch I/O page: guest counter page (second-to-last page).
     //  5. Scratch reserved page: Hyperlight bookkeeping metadata (last page, not for use).
     // Everything between the allocator storage and the scratch I/O page is
@@ -1182,30 +1200,32 @@ pub fn init(
         mmio_regions.push_back(scratch_output);
     }
 
-    // Reserve pages at the start of the free scratch area for the frame allocator and
-    // kpool bitmap backing stores.  This memory is in scratch (never snapshot/CoW) and
-    // is registered as a reserved memory region so the frame allocator never hands it out.
-    let allocator_storage_base: usize =
+    // Reserve pages at the start of the free scratch area for the frame allocator bitmap,
+    // kpool bitmap, and GDT backing stores.  This memory is in scratch (never snapshot/CoW)
+    // and is registered as a reserved memory region so the frame allocator never hands it out.
+    let scratch_reserved_base: usize =
         scratch_base_address + INPUT_DATA_BUFFER_SIZE + OUTPUT_DATA_BUFFER_SIZE;
     {
         // No need to zero the storage pages: the scratch region is guaranteed to be
         // zeroed out by Hyperlight before the guest starts.
 
-        let allocator_storage_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-            "allocator storage",
-            VirtualAddress::from_raw_value(allocator_storage_base),
-            ALLOCATOR_STORAGE_PAGES_SIZE,
+        let scratch_reserved_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+            "scratch reserved structures",
+            VirtualAddress::from_raw_value(scratch_reserved_base),
+            SCRATCH_RESERVED_SIZE,
             MemoryRegionType::Reserved,
             AccessPermission::RDWR,
         )?;
-        memory_regions.push_back(allocator_storage_region);
+        memory_regions.push_back(scratch_reserved_region);
         info!(
-            "allocator storage: [{:#010x}, {:#010x}) (frame_alloc={} B, kpool={} B, size={:#x})",
-            allocator_storage_base,
-            allocator_storage_base + ALLOCATOR_STORAGE_PAGES_SIZE,
+            "scratch reserved: [{:#010x}, {:#010x}) (frame_alloc={} B, kpool={} B, gdt={} B, \
+             size={:#x})",
+            scratch_reserved_base,
+            scratch_reserved_base + SCRATCH_RESERVED_SIZE,
             FRAME_ALLOCATOR_STORAGE_SIZE,
             KPOOL_BITMAP_STORAGE_SIZE,
-            ALLOCATOR_STORAGE_PAGES_SIZE,
+            GDT_STORAGE_SIZE,
+            SCRATCH_RESERVED_SIZE,
         );
     }
     {
@@ -1247,10 +1267,10 @@ pub fn init(
     // padded range the two chunks would overlap, so they are merged into a single "low"
     // chunk.  When the RAMFS is absent or far enough away it becomes a separate chunk.
     //
-    // The backing store for the bitmap lives in the scratch region at `allocator_storage_base`,
+    // The backing store for the bitmap lives in the scratch region at `scratch_reserved_base`,
     // not in BSS, so it is never part of the CoW snapshot.
     let ramfs_end_address: usize = ramfs_base + ramfs_size;
-    // Safety: `allocator_storage_base` points to a zeroed, identity-mapped region inside
+    // Safety: `scratch_reserved_base` points to a zeroed, identity-mapped region inside
     // the scratch area with at least `FRAME_ALLOCATOR_STORAGE_SIZE` bytes available.
     // The memory outlives the returned `SparseBitmap` (it is never freed) and no other
     // code writes to this range after this point.
@@ -1262,7 +1282,7 @@ pub fn init(
             ramfs_end_address,
             scratch_base_address,
             scratch_end_address,
-            (allocator_storage_base as *mut u8, FRAME_ALLOCATOR_STORAGE_SIZE),
+            (scratch_reserved_base as *mut u8, FRAME_ALLOCATOR_STORAGE_SIZE),
         )?
     };
 
@@ -1271,14 +1291,32 @@ pub fn init(
     // storage in the same scratch reservation.
     let kpool_bitmap: Bitmap = {
         // Safety: the kpool bitmap sits at a known word-aligned offset within the
-        // scratch-allocated storage region and outlives the returned bitmap.
+        // scratch-reserved storage region and outlives the returned bitmap.
         let storage: RawArray<u8> = unsafe {
-            let ptr: *mut u8 = (allocator_storage_base + KPOOL_BITMAP_OFFSET) as *mut u8;
+            let ptr: *mut u8 = (scratch_reserved_base + KPOOL_BITMAP_OFFSET) as *mut u8;
             debug_assert!(::sys::mm::is_aligned(ptr as usize, WORD_ALIGNMENT));
             RawArray::from_raw_parts(ptr, KPOOL_BITMAP_STORAGE_SIZE)?
         };
         Bitmap::from_raw_array(storage)?
     };
+
+    // Install GDT backing storage in the scratch region, outside the CoW snapshot.
+    // The GDT is placed at GDT_OFFSET within the scratch-reserved area.
+    //
+    // Safety: gdt_ptr is computed from scratch_reserved_base + GDT_OFFSET, which is
+    // aligned to GDTE_ALIGNMENT (enforced at compile time by the GDT_OFFSET constant).
+    // The scratch region is identity-mapped, zeroed by Hyperlight, and never freed,
+    // so the pointer is valid for GDT_NUM_ENTRIES entries and outlives all GDT usage.
+    // This is the only call to set_backing_storage() in the Hyperlight init path.
+    unsafe {
+        let gdt_ptr: *mut Gdte = (scratch_reserved_base + GDT_OFFSET) as *mut Gdte;
+        core::ptr::copy_nonoverlapping(
+            gdt::DEFAULT_ENTRIES.as_ptr(),
+            gdt_ptr,
+            gdt::GDT_NUM_ENTRIES,
+        );
+        gdt::Gdt::set_backing_storage(gdt_ptr)?;
+    }
 
     Ok(Platform {
         arch: x86::init(ioports, ioaddresses, madt)?,

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     hal::{
         arch::x86::{
             self,
+            mem::gdt,
             Arch,
         },
         io::{
@@ -56,6 +57,7 @@ use ::alloc::{
 use ::arch::{
     cpu::pic,
     mem,
+    mem::gdt::Gdte,
 };
 use ::sparse_bitmap::SparseBitmap;
 use ::sys::error::{
@@ -104,6 +106,9 @@ pub struct Platform {
 static mut FRAME_ALLOCATOR_STORAGE: [u8; config::kernel::MEMORY_SIZE
     / (mem::FRAME_SIZE * u8::BITS as usize)] =
     [0; config::kernel::MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize)];
+
+/// GDT backing storage, allocated in BSS.
+static mut GDT_STORAGE: [Gdte; gdt::GDT_NUM_ENTRIES] = gdt::DEFAULT_ENTRIES;
 
 // Ensure the number of kpool pages is a multiple of 8 so the bitmap has no padding bits.
 ::static_assert::assert_eq!(
@@ -685,6 +690,15 @@ pub fn init(
     // controller can allocate them during LAPIC timer calibration.
     #[cfg(all(feature = "pit", feature = "whp"))]
     register_pit_ports(ioports)?;
+
+    // Install GDT backing storage. On microvm the GDT lives in a BSS-allocated static.
+    // Safety: GDT_STORAGE is a static array of Gdte entries with repr(C, align(8)),
+    // so the pointer is properly aligned and valid for GDT_NUM_ENTRIES entries.
+    // The static lifetime guarantees the storage outlives all GDT usage.
+    // This is the only call to set_backing_storage() in the microvm init path.
+    unsafe {
+        gdt::Gdt::set_backing_storage(GDT_STORAGE.as_mut_ptr())?;
+    }
 
     let arch = x86::init(ioports, ioaddresses, madt)?;
 

--- a/src/libs/arch/src/x86/mem/gdt.rs
+++ b/src/libs/arch/src/x86/mem/gdt.rs
@@ -51,7 +51,9 @@ const FLAGS_NIBBLE_MASK: u8 = 0x0f;
 ///
 /// A type that represents an entry in the Global Descriptor Table (GDT).
 ///
-#[repr(C, align(8))]
+#[repr(C)]
+#[cfg_attr(target_arch = "x86", repr(align(8)))]
+#[cfg_attr(target_arch = "x86_64", repr(align(16)))]
 pub struct Gdte {
     /// The lower 16 bits of the segment limit.
     limit_low: u16,
@@ -67,11 +69,15 @@ pub struct Gdte {
     base_high: u8,
 }
 
-// `Gdte` must be 8 bytes long. This must match the hardware specification.
-::static_assert::assert_eq_size!(Gdte, 8);
+/// Required alignment for a GDT entry.
+#[cfg(target_arch = "x86")]
+pub const GDTE_ALIGNMENT: ::sys::mm::Alignment = ::sys::mm::Alignment::Align8;
+/// Required alignment for a GDT entry.
+#[cfg(target_arch = "x86_64")]
+pub const GDTE_ALIGNMENT: ::sys::mm::Alignment = ::sys::mm::Alignment::Align16;
 
-// `Gdte` must be aligned to 8 bytes. This must match the hardware specification.
-::static_assert::assert_eq_align!(Gdte, 8);
+// Ensure `Gdte` alignment matches `GDTE_ALIGNMENT`.
+::static_assert::assert_eq_align!(Gdte, GDTE_ALIGNMENT as usize);
 
 impl Gdte {
     ///


### PR DESCRIPTION
Refactor the GDT so that its backing storage is provided by the platform rather than living in a BSS-allocated static array inside the architecture module.

On Hyperlight the BSS is part of the Copy-on-Write snapshot, so any runtime writes to the GDT (e.g., TSS descriptor updates, TDA base changes) trigger unnecessary CoW faults. Move the GDT storage into the scratch region alongside the frame-allocator and kpool bitmaps.

On microvm the GDT remains in a BSS-allocated static, preserving the existing behavior.

## Changes

### Per-platform GDT entry alignment (`arch`)

- **x86/mem/gdt.rs**: Replace the fixed `#[repr(C, align(8))]` on `Gdte` with `#[repr(C)]` plus `#[cfg_attr]` attributes that select `align(8)` on x86 and `align(16)` on x86_64, matching each architecture's hardware requirement for the GDT base address.
- **x86/mem/gdt.rs**: Add a public `GDTE_ALIGNMENT` constant (`Align8` on x86, `Align16` on x86_64) so platform code can reference the required alignment at runtime.
- **x86/mem/gdt.rs**: Replace the hard-coded `assert_eq_size!` and `assert_eq_align!` checks with a single `assert_eq_align!` that validates `Gdte` against `GDTE_ALIGNMENT`.

### GDT backing storage in platform layer (`kernel`)

- **x86/gdt.rs, x86_64/gdt.rs**: Extract entries into `pub const DEFAULT_ENTRIES` and `GDT_NUM_ENTRIES`. Replace the `static mut GDT: [Gdte; 7]` array with a `*mut Gdte` pointer. Add `Gdt::set_backing_storage()` to install platform-provided memory. Update all GDT accesses to use pointer arithmetic.
- **hyperlight/mod.rs**: Add `GDT_OFFSET` and `GDT_STORAGE_SIZE` constants. Extend the scratch-reserved area to include the GDT (rename `ALLOCATOR_STORAGE_PAGES_SIZE` to `SCRATCH_RESERVED_SIZE`). Copy `DEFAULT_ENTRIES` into scratch memory and call `set_backing_storage()` before `x86::init()`.
- **microvm/mod.rs**: Add `static mut GDT_STORAGE` initialized from `DEFAULT_ENTRIES` and call `set_backing_storage()` before `x86::init()`.

## Testing

- Build and lint checks pass for all six CI configurations (microvm/hyperlight × standalone/single-process/multi-process).
- Integration tests pass for **microvm/standalone** and **hyperlight/standalone**.