### PR TITLE
[uservm] Host kernel stack correlation via ETW (Windows)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,8 +226,19 @@ export HOST_RUST_FLAGS := $(if $(HOST_CPU),-C target-cpu=$(HOST_CPU))
 
 # Optimization Flags
 ifeq ($(RELEASE),yes)
-export BUILD_MODE := release
-export CARGO_PROFILE := --release
+  ifeq ($(PROFILER),yes)
+    # Profiling build: release performance + debug symbols + frame pointers.
+    # Uses the release-profiling Cargo profile (inherits release, adds
+    # debug=line-tables-only, strip=false) so that:
+    #   - nanvixd.pdb contains function symbols (resolvable by xperf/WPA)
+    #   - kernel.elf retains .symtab (resolvable by the guest profiler)
+    #   - Frame pointers are preserved for stack walking
+    export BUILD_MODE := release-profiling
+    export CARGO_PROFILE := --profile release-profiling
+  else
+    export BUILD_MODE := release
+    export CARGO_PROFILE := --release
+  endif
 export WASM_CARGO_PROFILE := --profile release-wasm
 export WASM_BUILD_MODE := release-wasm
 else

--- a/build/make/kernel.mk
+++ b/build/make/kernel.mk
@@ -10,6 +10,18 @@ KERNEL_CARGO_FEATURES := $(if $(KERNEL_FEATURES),--features "$(KERNEL_FEATURES)"
 all-kernel: init
 	$(KERNEL_CARGO_BUILD_CMD) $(KERNEL_CARGO_FEATURES) -p kernel
 	$(CP_CMD) $(OBJECTS_DIR)/$(TARGET)-kernel/$(BUILD_MODE)/kernel.elf $(BINARIES_DIR)/kernel.elf
+ifeq ($(PROFILER),yes)
+	# Strip .debug_* but keep .symtab for guest profiler symbol resolution.
+	# See src/uservm/src/guest_profiler/README.md for setup prerequisites.
+	$(CP_CMD) $(BINARIES_DIR)/kernel.elf $(BINARIES_DIR)/kernel.elf.debug
+	@if command -v rust-objcopy >/dev/null 2>&1; then \
+		rust-objcopy --strip-debug "$(BINARIES_DIR)/kernel.elf"; \
+	elif command -v objcopy >/dev/null 2>&1; then \
+		objcopy --strip-debug "$(BINARIES_DIR)/kernel.elf"; \
+	else \
+		echo "WARNING: objcopy not found, kernel.elf retains debug sections (~1.4 MB extra)"; \
+	fi
+endif
 
 check-kernel:
 	$(KERNEL_CARGO_CHECK_CMD) $(KERNEL_CARGO_FEATURES) -p kernel

--- a/build/make/nanvixd.mk
+++ b/build/make/nanvixd.mk
@@ -19,9 +19,18 @@ ifeq ($(DEPLOYMENT_MODE),standalone)
 all-nanvixd: all-host-binaries-mkramfs all-guest-binaries
 endif
 
+# PDB filename for Windows symbol resolution (xperf, WPA, debuggers).
+NANVIXD_PDB := nanvixd.pdb
+
 all-nanvixd: init
 	$(HOST_CARGO_BUILD_CMD) $(NANVIXD_CARGO_FEATURES) -p nanvixd
 	$(CP_CMD) $(OBJECTS_DIR)/$(BUILD_MODE)/nanvixd$(CARGO_EXE_SUFFIX) $(BINARIES_DIR)/nanvixd.$(HOST_BIN_EXT)
+ifeq ($(IS_WINDOWS),yes)
+	# Copy PDB alongside the exe for symbol resolution.
+	@if [ -f "$(OBJECTS_DIR)/$(BUILD_MODE)/$(NANVIXD_PDB)" ]; then \
+		cp -f "$(OBJECTS_DIR)/$(BUILD_MODE)/$(NANVIXD_PDB)" "$(BINARIES_DIR)/$(NANVIXD_PDB)"; \
+	fi
+endif
 	# Build the standalone rootfs image from a seed directory using mkramfs.
 ifeq ($(DEPLOYMENT_MODE),standalone)
 	@mkdir -p $(BINARIES_DIR)/standalone-rootfs-seed/lib

--- a/scripts/bench/analyze-etl.py
+++ b/scripts/bench/analyze-etl.py
@@ -61,7 +61,14 @@ XPERF_PATHS = [
 
 
 def find_xperf():
-    """Locate xperf.exe on the system."""
+    """Locate xperf.exe on the system.
+
+    Checks NANVIX_XPERF_PATH env var first, then well-known install paths,
+    then PATH.
+    """
+    env_path = os.environ.get("NANVIX_XPERF_PATH")
+    if env_path and os.path.isfile(env_path):
+        return env_path
     for p in XPERF_PATHS:
         if os.path.isfile(p):
             return p
@@ -106,10 +113,23 @@ def run_xperf_merge(etl_path, output_path=None, xperf_path=None):
         cmd, capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
     if result.returncode != 0:
-        print(f"ERROR: xperf -merge failed (exit {result.returncode})", file=sys.stderr)
-        if result.stderr:
-            print(result.stderr[:500], file=sys.stderr)
-        sys.exit(1)
+        stderr_text = result.stderr[:500] if result.stderr else ""
+        if "Events were lost" in stderr_text or "Events were lost" in (
+            result.stdout or ""
+        ):
+            print(
+                f"WARNING: xperf -merge reported lost events (exit {result.returncode}). "
+                "Continuing with available data.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"ERROR: xperf -merge failed (exit {result.returncode})",
+                file=sys.stderr,
+            )
+            if result.stderr:
+                print(stderr_text, file=sys.stderr)
+            sys.exit(1)
 
     merged_size = os.path.getsize(output_path) / (1024 * 1024)
     print(f"[etl] Merged trace: {output_path} ({merged_size:.1f} MB)", file=sys.stderr)
@@ -483,10 +503,21 @@ def run_xperf_dump(etl_path, xperf_path=None, symbols=False, stacks=False):
     )
 
     if result.returncode != 0:
-        print(f"ERROR: xperf failed (exit {result.returncode})", file=sys.stderr)
-        if result.stderr:
-            print(result.stderr[:500], file=sys.stderr)
-        sys.exit(1)
+        stderr_text = result.stderr[:500] if result.stderr else ""
+        # "Events were lost" is a non-fatal warning — output is still usable.
+        if "Events were lost" in stderr_text or "Events were lost" in (
+            result.stdout or ""
+        ):
+            print(
+                f"WARNING: xperf reported lost events (exit {result.returncode}). "
+                "Data may be slightly incomplete but is still usable.",
+                file=sys.stderr,
+            )
+        else:
+            print(f"ERROR: xperf failed (exit {result.returncode})", file=sys.stderr)
+            if result.stderr:
+                print(stderr_text, file=sys.stderr)
+            sys.exit(1)
 
     # Filter out progress bars (lines with [1/2] etc.)
     lines = []

--- a/scripts/bench/flamegraph.py
+++ b/scripts/bench/flamegraph.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""
+Nanvix E2E Flamegraph Generator
+
+Produces unified [GUEST]/[HOST] flamegraphs spanning guest kernel + user
+application + host VMM + host OS kernel.
+
+Usage:
+    # Full E2E (guest + host kernel stacks, requires admin/root):
+    python scripts/bench/flamegraph.py full --guest-elf bin/python.elf
+
+    # Guest-only flamegraph:
+    python scripts/bench/flamegraph.py guest --guest-elf bin/python.elf
+
+    # With pre-built ramfs:
+    python scripts/bench/flamegraph.py full --ramfs my.img --guest-elf bin/app.elf
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+
+from pathlib import Path
+
+# Resolve repo root from script location: scripts/bench/flamegraph.py -> ../..
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+
+
+def find_tool(name: str) -> str | None:
+    """Find an executable on PATH or in common locations."""
+    return shutil.which(name)
+
+
+def check_prerequisites(full_mode: bool) -> None:
+    """Fail early if required tools are missing."""
+    missing = []
+    for tool in ["rustfilt", "inferno-flamegraph"]:
+        if not find_tool(tool):
+            missing.append(tool)
+    if full_mode and sys.platform == "win32":
+        if not find_tool("wpr"):
+            missing.append("wpr (Windows Performance Toolkit)")
+    if missing:
+        print(f"ERROR: Missing tools: {', '.join(missing)}", file=sys.stderr)
+        print("  Install with: cargo install inferno rustfilt", file=sys.stderr)
+        sys.exit(1)
+
+
+def build_ramfs(
+    mkramfs: Path, guest_elf: Path, script_content: str, output_dir: Path
+) -> Path:
+    """Build a ramfs image containing the guest ELF and a Python script."""
+    ramfs_dir = output_dir / "ramfs-content"
+    ramfs_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(guest_elf, ramfs_dir / guest_elf.name)
+    (ramfs_dir / "script.py").write_text(script_content, encoding="utf-8")
+
+    ramfs_img = output_dir / "test.img"
+    subprocess.run(
+        [str(mkramfs), "-o", str(ramfs_img), str(ramfs_dir)],
+        check=True,
+        capture_output=True,
+    )
+    return ramfs_img
+
+
+def run_nanvixd(
+    nanvixd: Path,
+    bin_dir: Path,
+    ramfs: Path,
+    guest_elf: Path,
+    guest_folded: Path,
+    kernel_symbols: str,
+    user_symbols: str,
+    guest_arg: str = "",
+    timeout: int = 600,
+) -> tuple[str, str]:
+    """Run nanvixd with profiler env vars and return (stdout, stderr)."""
+    env = os.environ.copy()
+    env["NANVIX_GUEST_PROFILE_PATH"] = str(guest_folded)
+    if kernel_symbols:
+        env["NANVIX_KERNEL_SYMBOLS"] = kernel_symbols
+    if user_symbols:
+        env["NANVIX_USER_SYMBOLS"] = user_symbols
+
+    cmd = [
+        str(nanvixd),
+        "-bin-dir",
+        str(bin_dir),
+        "-ramfs",
+        str(ramfs),
+        "--",
+        str(guest_elf),
+    ]
+    if guest_arg:
+        cmd.extend(guest_arg.split())
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+    if result.returncode != 0:
+        print(
+            f"  WARNING: nanvixd exited with code {result.returncode}", file=sys.stderr
+        )
+    return result.stdout, result.stderr
+
+
+def default_script() -> str:
+    """Default Python workload for profiling."""
+    return textwrap.dedent("""\
+        import math
+        for i in range(200):
+            result = sum(math.factorial(j) for j in range(200))
+            print(f'iter {i}: {len(str(result))} digits')
+        print('Done')
+    """)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Nanvix E2E Flamegraph Generator",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "mode",
+        choices=["guest", "full"],
+        help="'guest' for guest-only, 'full' for guest + host kernel stacks",
+    )
+    parser.add_argument("--nanvix-dir", type=Path, default=REPO_ROOT)
+    parser.add_argument("--guest-elf", type=Path, required=True)
+    parser.add_argument("--kernel-symbols", default="")
+    parser.add_argument("--user-symbols", default="")
+    parser.add_argument(
+        "--script", default="", help="Inline Python script content for guest workload"
+    )
+    parser.add_argument(
+        "--guest-arg",
+        default="-B /script.py",
+        help="Arguments passed to the guest ELF (default: '-B /script.py')",
+    )
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--ramfs", type=Path, default=None)
+    parser.add_argument("--timeout", type=int, default=600)
+    args = parser.parse_args()
+
+    nanvix_dir = args.nanvix_dir.resolve()
+    bin_dir = nanvix_dir / "bin"
+    ext = ".exe" if sys.platform == "win32" else ".elf"
+    nanvixd = bin_dir / f"nanvixd{ext}"
+    mkramfs = bin_dir / f"mkramfs{ext}"
+
+    if args.output_dir is None:
+        args.output_dir = nanvix_dir.parent / "profiling-output"
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.kernel_symbols:
+        args.kernel_symbols = str(bin_dir / "kernel.elf")
+
+    check_prerequisites(args.mode == "full")
+
+    for tool in [nanvixd, mkramfs]:
+        if not tool.exists():
+            print(
+                f"ERROR: {tool} not found. Run 'z build --profile --release' first.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    if not args.guest_elf.exists():
+        print(f"ERROR: Guest ELF not found: {args.guest_elf}", file=sys.stderr)
+        sys.exit(1)
+
+    # -- Banner --
+    print("=" * 65)
+    title = (
+        "Nanvix Guest Flamegraph"
+        if args.mode == "guest"
+        else "Nanvix Full E2E Flamegraph"
+    )
+    print(f"  {title}")
+    print("=" * 65)
+    print()
+
+    # -- Build ramfs --
+    cleanup_ramfs = False
+    ramfs = args.ramfs
+    if ramfs is None or not ramfs.exists():
+        print("[SETUP] Building ramfs...")
+        script_content = args.script if args.script else default_script()
+        ramfs = build_ramfs(mkramfs, args.guest_elf, script_content, output_dir)
+        cleanup_ramfs = True
+        print(f"  Ramfs: {ramfs}")
+
+    # -- Run nanvixd --
+    guest_folded = output_dir / "guest.folded"
+    print("[RUN] Running nanvixd with profiling...")
+    try:
+        stdout, stderr = run_nanvixd(
+            nanvixd,
+            bin_dir,
+            ramfs,
+            args.guest_elf,
+            guest_folded,
+            args.kernel_symbols,
+            args.user_symbols,
+            args.guest_arg,
+            args.timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print("ERROR: nanvixd timed out", file=sys.stderr)
+        sys.exit(1)
+
+    # Show output summary.
+    stdout_lines = [line for line in stdout.splitlines() if line.strip()]
+    if len(stdout_lines) > 5:
+        print(f"  ... ({len(stdout_lines)} lines of output)")
+        for line in stdout_lines[-3:]:
+            print(f"  {line}")
+    else:
+        for line in stdout_lines:
+            print(f"  {line}")
+
+    # Show profiler lines from stderr.
+    (output_dir / "nanvixd-stderr.txt").write_text(stderr, encoding="utf-8")
+    for line in stderr.splitlines():
+        if any(k in line for k in ("GUEST_PROFILE", "PROFILER", "ETW_SESSION")):
+            print(f"  {line.strip()}")
+
+    if not guest_folded.exists():
+        print("WARNING: no guest folded stacks produced", file=sys.stderr)
+
+    # -- Merge and generate SVG --
+    # Add script directory to path for sibling module imports.
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+    from flamegraph_merge import merge_and_render
+    from flamegraph_host import extract_host_stacks
+
+    host_folded = None
+    if args.mode == "full":
+        host_folded = extract_host_stacks(guest_folded, output_dir, bin_dir)
+
+    svg_path = output_dir / "flamegraph.svg"
+    merge_and_render(guest_folded, host_folded, svg_path)
+
+    # -- Summary --
+    print()
+    print("=" * 65)
+    print("  Results")
+    print("=" * 65)
+    print()
+    for f in sorted(output_dir.iterdir()):
+        if f.suffix in (".svg", ".folded", ".txt", ".etl", ".data"):
+            size = f.stat().st_size
+            unit = "MB" if size > 1_000_000 else "KB"
+            val = size / 1_000_000 if size > 1_000_000 else size / 1_000
+            print(f"  {f.name}: {val:.1f} {unit}")
+    if svg_path.exists():
+        print(f"\n  Flamegraph: {svg_path}")
+
+    # -- Cleanup --
+    if cleanup_ramfs:
+        shutil.rmtree(output_dir / "ramfs-content", ignore_errors=True)
+        (output_dir / "test.img").unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/flamegraph_host.py
+++ b/scripts/bench/flamegraph_host.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""
+Platform-specific host stack extraction.
+
+Windows: Extracts kernel stacks from ETL via analyze-etl.py.
+Linux:   Added in the Linux follow-up PR.
+"""
+
+import os
+import subprocess
+import sys
+
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def extract_host_stacks(
+    guest_folded: Path, output_dir: Path, bin_dir: Path | None = None
+) -> Path | None:
+    """Extract host kernel stacks from the platform-specific trace file.
+
+    Returns the path to host.folded with [HOST] prefixes, or None if
+    no host trace was captured.
+    """
+    if sys.platform == "win32":
+        return _extract_etw(guest_folded, output_dir, bin_dir)
+    else:
+        print(f"  Host stack extraction not yet supported on {sys.platform}")
+        print("  (Linux support is added in the Linux follow-up PR)")
+        return None
+
+
+def _extract_etw(
+    guest_folded: Path, output_dir: Path, bin_dir: Path | None
+) -> Path | None:
+    """Extract host stacks from ETL via analyze-etl.py (Windows)."""
+    etl_path = Path(f"{guest_folded}.etl")
+    if not etl_path.exists():
+        print("  No ETL trace (run as admin for host kernel stacks)")
+        return None
+
+    analyze_script = SCRIPT_DIR / "analyze-etl.py"
+    if not analyze_script.exists():
+        print(
+            f"  WARNING: analyze-etl.py not found at {analyze_script}", file=sys.stderr
+        )
+        return None
+
+    # Set up symbol resolution for xperf.
+    env = os.environ.copy()
+    sym_dir = str(bin_dir) if bin_dir else str(guest_folded.parent)
+    if "_NT_SYMBOL_PATH" in env:
+        if sym_dir not in env["_NT_SYMBOL_PATH"]:
+            env["_NT_SYMBOL_PATH"] = f"{sym_dir};{env['_NT_SYMBOL_PATH']}"
+    else:
+        env["_NT_SYMBOL_PATH"] = (
+            f"{sym_dir};srv*C:\\Symbols*https://msdl.microsoft.com/download/symbols"
+        )
+    env.setdefault("_NT_SYMCACHE_PATH", "C:\\SymCache")
+
+    print("  Extracting host stacks from ETL (this may take a few minutes)...")
+    kernel_folded = output_dir / "kernel.folded"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(analyze_script),
+            str(etl_path),
+            "--folded",
+            str(kernel_folded),
+            "--process",
+            "nanvixd.exe",
+            "--symbols",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    for line in (result.stdout + result.stderr).splitlines():
+        if line.strip():
+            print(f"    {line.strip()}")
+
+    if not kernel_folded.exists() or kernel_folded.stat().st_size == 0:
+        print("  No host stacks extracted (first run may need symbol download)")
+        return None
+
+    # Prefix with [HOST] and return.
+    host_folded = output_dir / "host.folded"
+    lines = kernel_folded.read_text(encoding="utf-8", errors="replace").splitlines()
+    prefixed = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.rsplit(" ", 1)
+        if len(parts) == 2:
+            prefixed.append(f"[HOST];{parts[0]} {parts[1]}")
+    host_folded.write_text("\n".join(prefixed) + "\n", encoding="utf-8")
+    return host_folded

--- a/scripts/bench/flamegraph_merge.py
+++ b/scripts/bench/flamegraph_merge.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""
+Flamegraph merge and render.
+
+Takes guest.folded + optional host.folded, applies [GUEST]/[HOST] prefixes,
+demangles Rust symbols, and generates the SVG via inferno-flamegraph.
+"""
+
+import re
+import subprocess
+import sys
+
+from pathlib import Path
+
+
+def _demangle_and_sanitize(folded_path: Path) -> list[str]:
+    """Read folded stacks, demangle via rustfilt, and sanitize for SVG."""
+    if not folded_path.exists() or folded_path.stat().st_size == 0:
+        return []
+
+    result = subprocess.run(
+        ["rustfilt"],
+        input=folded_path.read_text(encoding="utf-8", errors="replace"),
+        capture_output=True,
+        text=True,
+    )
+    lines = (
+        result.stdout.splitlines()
+        if result.returncode == 0
+        else folded_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    )
+
+    sanitized = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        # Remove angle brackets (SVG-incompatible) and hex offsets.
+        line = line.replace("<", " ").replace(">", " ")
+        # Remove +0x... offsets from symbol names for cleaner display.
+        line = re.sub(r"\+0x[0-9a-fA-F]+", "", line)
+        sanitized.append(line)
+    return sanitized
+
+
+def _prefix_stacks(lines: list[str], prefix: str) -> list[str]:
+    """Add a root frame prefix to each folded stack line."""
+    prefixed = []
+    for line in lines:
+        parts = line.rsplit(" ", 1)
+        if len(parts) == 2:
+            prefixed.append(f"{prefix};{parts[0]} {parts[1]}")
+    return prefixed
+
+
+def merge_and_render(
+    guest_folded: Path,
+    host_folded: Path | None,
+    svg_path: Path,
+    title: str = "Nanvix E2E Flamegraph",
+) -> None:
+    """Merge guest + host folded stacks and generate SVG."""
+    merged_path = svg_path.parent / "merged.folded"
+
+    print("[MERGE] Building unified flamegraph...")
+
+    # Guest stacks -> [GUEST] prefix.
+    guest_lines = _demangle_and_sanitize(guest_folded)
+    guest_prefixed = _prefix_stacks(guest_lines, "[GUEST]")
+    print(f"  [GUEST]: {len(guest_prefixed)} stack entries")
+
+    # Host stacks -> [HOST] prefix (already prefixed by extract_host_stacks).
+    host_lines = []
+    if host_folded and host_folded.exists() and host_folded.stat().st_size > 0:
+        host_lines = [
+            line.strip()
+            for line in host_folded.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        print(f"  [HOST]: {len(host_lines)} stack entries")
+    else:
+        if host_folded is not None:
+            print("  No host stacks (run as admin/root for kernel stacks)")
+
+    # Write merged.
+    all_lines = guest_prefixed + host_lines
+    merged_path.write_text("\n".join(all_lines) + "\n", encoding="utf-8")
+
+    # Generate SVG.
+    if not all_lines:
+        print("  WARNING: no stacks to render", file=sys.stderr)
+        return
+
+    print("[SVG] Generating flamegraph...")
+    result = subprocess.run(
+        ["inferno-flamegraph", "--title", title],
+        input="\n".join(all_lines),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        svg_path.write_text(result.stdout, encoding="utf-8")
+    else:
+        print(f"  WARNING: inferno-flamegraph failed: {result.stderr}", file=sys.stderr)

--- a/src/uservm/src/guest_profiler/README.md
+++ b/src/uservm/src/guest_profiler/README.md
@@ -1,0 +1,410 @@
+# Nanvix Guest Profiler — End-to-End Guide
+
+This document explains how to use the Nanvix guest profiler to generate
+flamegraphs that span from guest user-space code through the guest kernel,
+the host VMM, and optionally the host OS kernel.
+
+## Architecture
+
+The profiler captures stack traces at two levels, merged into a single
+flamegraph with `[GUEST]` and `[HOST]` root frames:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  [HOST]: Host VMM + OS Kernel                       │
+│  nanvixd, vid.sys/ntoskrnl (Windows), KVM (Linux)   │
+│  Captured by: ETW/WPR (Windows) / perf record (Linux)│
+├─────────────────────────────────────────────────────┤
+│  [GUEST]: Guest kernel + user application           │
+│  Nanvix kernel, CPython, libc, syscalls             │
+│  Captured by: WHv/KVM register read + frame walk    │
+└─────────────────────────────────────────────────────┘
+```
+
+## How Sampling Works
+
+### Statistical Validity
+
+The profiler uses **periodic sampling** — the standard technique used by
+`perf`, VTune, Instruments, and all production profilers.
+
+1. **Periodic time sampling**: A 1 kHz timer fires every ~1 ms from a
+   dedicated thread, independent of guest or host execution state. The
+   probability of capturing any code path is proportional to the time
+   spent in that path.
+
+2. **Overhead**: Each sample requires a VP cancel (WHP) or signal (KVM),
+   register reads, and a frame-pointer walk. At 1 kHz over a 3-second
+   run, this adds ~3,000 interrupts — typically small relative to guest
+   execution time.
+
+3. **Guest sampling**: When the timer interrupts guest execution, the VP
+   returns with an `Interrupted` exit and guest registers (EIP/EBP/CR3)
+   reflect the exact interrupted state. This is a true point-in-time
+   sample of guest execution.
+
+4. **Host sampling**: Host-side profiling (nanvixd VMM code + OS kernel)
+   is handled entirely by ETW (Windows) or `perf record` (Linux). These
+   tools run concurrently at the same configurable frequency as the guest
+   profiler (controlled by `NANVIX_PROFILER_FREQ_HZ`) and provide full
+   symbol resolution via PDB (Windows) or DWARF (Linux), including
+   kernel code (vid.sys, ntoskrnl, kvm_intel).
+
+5. **Caveats**:
+   - The timer is periodic (not randomized/Poisson), which can alias
+     with periodic guest activity. For alias-resistant profiling,
+     consider using a prime-number frequency like 997 Hz.
+   - `thread::sleep(1ms)` precision depends on OS timer resolution.
+   - ETW/perf correlation: our profiler uses QPC (Windows) or
+     `CLOCK_MONOTONIC_RAW` (Linux) for timestamps, matching the
+     respective platform's profiler clock.
+
+### Sample Count Guidelines
+
+| Duration | Samples at 1 kHz | Statistical quality |
+|----------|-----------------|---------------------|
+| 100 ms   | ~100            | Rough profile       |
+| 1 s      | ~1,000          | Good for hot paths  |
+| 5 s      | ~5,000          | Reliable profiling  |
+| 30 s     | ~30,000         | Production quality  |
+
+For meaningful flamegraphs, aim for at least 1,000 samples. Run the
+workload long enough to accumulate sufficient data.
+
+### Guest vs Host Sampling
+
+**Guest sampling** is done by the built-in profiler timer:
+
+- **Windows (WHP)**: Timer thread calls `WHvCancelRunVirtualProcessor`.
+  The run loop returns `Interrupted`, reads EIP/EBP/CR3 via
+  `WHvGetVirtualProcessorRegisters`, and walks the frame-pointer chain.
+
+- **Linux (KVM)**: *(Planned — see Linux PR)* Timer thread sends
+  `SIGUSR2` to interrupt `KVM_RUN`, then reads registers via
+  `KVM_GET_REGS` / `KVM_GET_SREGS` for the frame walk.
+
+The guest profiler only captures stacks when the VP was executing guest
+code (Interrupted exit). Host profiling is delegated to ETW/perf which
+captures the host stack with full symbol resolution.
+
+**Host sampling** is done by ETW (Windows) or `perf record` (Linux),
+which runs concurrently at the same frequency as the guest profiler.
+The trace data is post-processed by `analyze-etl.py` (Windows) or
+`perf script` (Linux) to extract folded stacks filtered to nanvixd.
+
+## Prerequisites
+
+### Tools
+
+```bash
+# Flamegraph generation
+cargo install inferno rustfilt
+
+# Windows kernel tracing (optional, requires admin)
+# Install Windows Performance Toolkit from Windows SDK
+
+# Linux kernel tracing (optional, requires root for kernel stacks)
+# Install perf: sudo apt install linux-tools-$(uname -r)
+#   or: sudo tdnf install kernel-tools  (Azure Linux)
+```
+
+### Frame Pointers
+
+All binaries in the profiled stack must preserve frame pointers for
+the stack walker to produce deep call chains. Without frame pointers,
+stack walks terminate after 1-2 frames.
+
+## Building for Profiling
+
+Use `.\z build --profile --release` to build everything in profiling
+mode. This single command produces binaries with symbols and frame
+pointers across the entire Nanvix stack.
+
+### What `--profile --release` does
+
+The `--profile` flag activates the `release-profiling` Cargo profile
+(instead of the default `release` profile). This profile inherits all
+release optimizations (opt-level=3, LTO, panic=abort) but adds:
+
+| Setting | `release` | `release-profiling` | Why |
+|---------|-----------|---------------------|-----|
+| `strip` | `true` | `false` | Preserves .symtab (ELF) and PDB symbols (Windows) |
+| `debug` | `false` | `"line-tables-only"` | Emits function names in PDB; sufficient for xperf/WPA |
+
+### How symbols are handled per component
+
+```
+Component       Built by            Loaded into VM?   Symbol strategy
+──────────────  ──────────────────  ────────────────  ──────────────────────────────────
+kernel.elf      z build --profile   Yes               .symtab kept, .debug_* stripped
+                                                      (objcopy --strip-debug, automated)
+                                                      ~60 KB overhead in guest RAM
+
+nanvixd         z build --profile   No (host)         PDB (Windows) / DWARF (Linux)
+                                                      alongside the binary
+
+User app (any)  App's build system  Yes               See "Requirements" below
+```
+
+### Building nanvix (kernel + nanvixd)
+
+```powershell
+cd D:\src\nanvix
+.\z build --profile --release -- LOG_LEVEL=panic
+```
+
+This produces:
+- `bin/kernel.elf` -- `.symtab` preserved, `.debug_*` stripped automatically.
+  Only ~60 KB larger than a fully stripped build. Usable directly as
+  the symbol file (no separate `.sym` step).
+- `bin/nanvixd.exe` + `bin/nanvixd.pdb` (Windows) -- PDB contains function
+  symbols for xperf/WPA resolution.
+
+#### Prerequisites for `--profile` builds
+
+The kernel strip step (`objcopy --strip-debug`) requires one of:
+
+- **Windows**: `cargo install cargo-binutils` and
+  `rustup component add llvm-tools` (provides `rust-objcopy`).
+- **Linux**: `objcopy` from binutils (typically pre-installed).
+
+If neither is found, the build continues but `kernel.elf` will be
+~1.4 MB larger (debug sections remain in guest RAM).
+
+Set the symbol path -- `kernel.elf` is its own symbol file:
+
+```powershell
+$env:NANVIX_KERNEL_SYMBOLS = "D:\src\nanvix\bin\kernel.elf"
+```
+
+### Building guest user applications for profiling
+
+Guest applications compiled with the Nanvix cross-toolchain must:
+
+1. **Preserve frame pointers**: Compile C/C++ code with
+   `-fno-omit-frame-pointer` so the stack walker can follow the EBP chain.
+
+2. **Keep an unstripped symbol file**: The stripped binary goes into the
+   VM (minimal size). The unstripped copy stays on the host for offline
+   symbol resolution.
+
+```powershell
+$env:NANVIX_USER_SYMBOLS = "path\to\your-app.elf.sym"
+```
+
+### Requirements for any guest user application
+
+| Requirement | How to achieve | Why |
+|------------|----------------|-----|
+| Frame pointers | `-fno-omit-frame-pointer` (C/C++) | Stack walker reads EBP chain |
+| Symbol file | Keep unstripped binary with `.symtab` | Guest profiler resolves addresses offline |
+| Set env var | `NANVIX_USER_SYMBOLS=<path>` | Points profiler to symbol file at runtime |
+
+Without `.symtab`, only `.dynsym` (exported symbols) is available —
+static/internal functions won't resolve. With `.symtab`, expect ~97%+
+resolution.
+
+## Generating a Flamegraph
+
+### Quick Start (all-in-one scripts)
+
+**Windows** -- run as Administrator for full E2E:
+
+```powershell
+.\z.ps1 build --profile --release -- LOG_LEVEL=panic
+python scripts\bench\flamegraph.py full --guest-elf bin\python.elf
+# Or guest-only (no host stacks):
+python scripts\bench\flamegraph.py guest --guest-elf bin\python.elf
+```
+
+**Linux** -- *(Linux support is added in a follow-up PR)*
+
+```bash
+./z build --profile --release -- LOG_LEVEL=panic
+python3 scripts/bench/flamegraph.py full --guest-elf bin/python.elf
+```
+
+Without admin/root, guest profiling still works -- only the
+host OS kernel stacks require elevation.
+
+### Manual Steps
+
+#### 1. Enable the Profiler
+
+Set environment variables:
+
+```powershell
+# Windows
+$env:NANVIX_GUEST_PROFILE_PATH = "D:\src\profiling-output\guest.folded"
+$env:NANVIX_KERNEL_SYMBOLS = "D:\src\nanvix\bin\kernel.elf"
+$env:NANVIX_USER_SYMBOLS = "D:\src\cpython\python.elf.sym"
+```
+
+```bash
+# Linux
+export NANVIX_GUEST_PROFILE_PATH=/path/to/output.folded
+export NANVIX_KERNEL_SYMBOLS=/path/to/kernel.elf
+export NANVIX_USER_SYMBOLS=/path/to/python.elf.sym
+```
+
+When `NANVIX_GUEST_PROFILE_PATH` is not set, the profiler is disabled.
+
+#### 2. Run the Workload
+
+```powershell
+.\bin\nanvixd.exe -bin-dir bin -ramfs test.img -- python.elf "-B /script.py"
+```
+
+nanvixd automatically:
+- Starts the guest profiler timer at the configured frequency
+- Captures guest stacks via frame-pointer walk
+- Starts ETW for host kernel stacks (if admin, Windows only)
+- Stops the host session and saves the trace on exit
+- Writes folded stacks
+
+Output on stderr:
+```
+GUEST_PROFILE_SYMBOLS: loaded 465 symbols from kernel.elf
+GUEST_PROFILE_SYMBOLS: loaded 35252 symbols from python.elf.sym
+GUEST_PROFILE: wrote 105 samples to output.folded
+ETW_SESSION: saved ETL to output.folded.etl
+```
+
+#### 3. Generate Flamegraph
+
+For guest-only:
+
+```bash
+cat output.folded | rustfilt | inferno-flamegraph > flamegraph.svg
+```
+
+For unified guest + host, use `flamegraph.py` which
+handles merging, demangling, and `[GUEST]`/`[HOST]` prefix injection
+automatically.
+
+#### 4. Additional Analysis
+
+**Windows**: Open the ETL in WPA for detailed kernel stack analysis:
+```powershell
+wpa.exe output.folded.etl
+```
+
+**Linux**: Use `perf report` on the perf data:
+```bash
+perf report -i output.folded.perf.data
+```
+
+## Interpreting the Flamegraph
+
+### Reading the SVG
+
+- **X-axis**: Represents the proportion of samples, not time. Wider bars
+  = more samples = more time spent.
+- **Y-axis**: Call stack depth. Bottom = root (entry point), top = leaf
+  (where CPU was actually executing).
+- **Colors**: Random; they carry no meaning.
+- **`[GUEST]`**: Root frame for guest stacks (Nanvix kernel + user app).
+- **`[HOST]`**: Root frame for host stacks (nanvixd VMM + OS kernel).
+
+### What to Look For
+
+1. **Wide leaf functions**: These are where the CPU spends the most time.
+   Optimization targets.
+
+2. **Tall narrow stacks**: Deep call chains that aren't expensive. Usually
+   fine.
+
+3. **`[HOST]` frames**: Time spent in the host VMM and OS kernel.
+   Wide `vid.sys` (Windows) or `kvm_intel` (Linux) frames indicate
+   hypervisor overhead.
+
+### Symbol Resolution
+
+**Important**: Always use **unstripped** ELF files for `NANVIX_KERNEL_SYMBOLS`
+and `NANVIX_USER_SYMBOLS`. Stripped binaries contain only `.dynsym` (exported
+symbols), which misses internal/static functions and drops resolution from
+~99% to ~50%.
+
+For CPython, use `python.elf.sym` (the unstripped build output with full
+`.symtab`), **not** `python.elf` (which is stripped for deployment):
+
+```
+python.elf      14 MB   .dynsym only   12,245 symbols   ~50% resolution
+python.elf.sym  48 MB   .symtab        35,252 symbols   ~99% resolution
+```
+
+For the Nanvix kernel, `kernel.elf` retains `.symtab` by default (the build
+runs `objcopy --strip-debug` which removes debug sections but keeps the
+symbol table).
+
+| Symbol format | Meaning |
+|--------------|---------|
+| `PyDict_SetItem` | Resolved C function name |
+| `0x40362942` | Unresolved address (missing from symbol files) |
+| `kernel::mm::virt::vmem::Vmm::try_find_user_frame` | Demangled Rust symbol |
+
+Expected resolution rates:
+- **With `.symtab`** (unstripped binaries): ~97%+
+- **With `.dynsym` only** (stripped binaries): ~50%
+
+## Symbol File Details
+
+The ELF symbol parser supports two symbol table types:
+
+| Section | Contents | Typical count |
+|---------|----------|--------------|
+| `.symtab` | All symbols including `static` functions | ~35,000 (CPython) |
+| `.dynsym` | Only exported/dynamic symbols | ~12,000 (CPython) |
+
+The parser prefers `.symtab` and falls back to `.dynsym`. Both
+`STT_FUNC` (regular functions) and `STT_NOTYPE` (assembly entry points)
+are included.
+
+## Platform Differences
+
+| Feature | Windows (WHP) | Linux (KVM) |
+|---------|--------------|-------------|
+| Guest cancel | `WHvCancelRunVirtualProcessor` | `SIGUSR2` *(Linux PR)* |
+| Guest regs | `WHvGetVirtualProcessorRegisters` | `KVM_GET_REGS` *(Linux PR)* |
+| Host profiling | ETW / WPR (auto-managed) | `perf record` *(Linux PR)* |
+| Timestamps | QPC | `CLOCK_MONOTONIC_RAW` *(Linux PR)* |
+| Host symbols | `.etl` → `analyze-etl.py` / WPA | `perf.data` → `perf script` *(Linux PR)* |
+| E2E script | `flamegraph.py full` | `flamegraph.py full` |
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NANVIX_GUEST_PROFILE_PATH` | Output path for folded stacks; enables profiler when set | (disabled) |
+| `NANVIX_KERNEL_SYMBOLS` | Path to kernel ELF with `.symtab` | (none) |
+| `NANVIX_USER_SYMBOLS` | Path to user app ELF with `.symtab` | (none) |
+| `NANVIX_PROFILER_FREQ_HZ` | Sampling frequency for both guest and host | `1000` |
+
+## Troubleshooting
+
+### No samples collected
+- Ensure `NANVIX_GUEST_PROFILE_PATH` env var is set to an output path
+- Ensure the workload runs long enough (>100 ms for meaningful data)
+
+### Shallow stacks (1-2 frames)
+- Rebuild with `-fno-omit-frame-pointer` (CPython: `Makefile.nanvix`)
+- Ensure `force-frame-pointers = true` in `Cargo.toml` release profile
+
+### Many unresolved addresses
+- Use unstripped symbol files (`.symtab`, not just `.dynsym`)
+- Set `NANVIX_KERNEL_SYMBOLS` and `NANVIX_USER_SYMBOLS` env vars
+- Rebuild symbol files after code changes
+
+### ETW/perf fails to start
+- Windows: WPR requires administrator privileges. nanvixd logs
+  `"Host kernel tracing failed to start"` and continues without kernel
+  stacks. Run as admin for full E2E.
+- Linux: *(System-wide `perf record` support is added in the Linux PR.)*
+- Both: guest stacks are always captured regardless of host tracing.
+
+### No host stacks in flamegraph
+- Windows: Ensure nanvixd ran as admin (check stderr for `ETW_SESSION`)
+- Set `_NT_SYMBOL_PATH` (Windows) for OS kernel symbol resolution
+- The `flamegraph.py` script handles symbol paths and merging
+  automatically
+

--- a/src/uservm/src/guest_profiler/etw.rs
+++ b/src/uservm/src/guest_profiler/etw.rs
@@ -1,0 +1,221 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! ETW-based host kernel stack correlation for guest flamegraphs.
+//!
+//! This module provides infrastructure for correlating Windows ETW
+//! (Event Tracing for Windows) kernel stack traces with guest profiler
+//! samples by timestamp and thread ID.
+//!
+//! # How correlation works
+//!
+//! Both our profiler and ETW use QPC (QueryPerformanceCounter) as their
+//! time source. Each guest/host sample records a QPC timestamp at capture
+//! time. After VM exit, the ETL is processed with `xperf` to extract
+//! CPU sampling stacks, and each ETW sample also has a QPC timestamp.
+//!
+//! Correlation matches ETW kernel stacks to our samples by:
+//! 1. Filtering ETW samples to the vCPU thread ID
+//! 2. For each ETW sample, finding the nearest profiler sample within
+//!    a configurable QPC tolerance window
+//! 3. Merging the kernel stack frames below the host/guest frames
+//!
+//! # Sampling rate alignment
+//!
+//! Our profiler timer runs at 1kHz (1ms period). WPR's built-in `CPU`
+//! profile also samples at ~1kHz by default. Since both are independent
+//! periodic timers, their samples won't align exactly. The correlation
+//! uses a tolerance window (default ±500µs) to match nearby samples.
+//!
+//! For tighter alignment, the QPC timestamps enable sub-microsecond
+//! matching precision regardless of sampling rate differences.
+
+use std::process::Command;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Default profiling frequency in Hz. Controls both the guest profiler timer
+/// and the ETW CPU sampling interval (via xperf -SetProfInt).
+const DEFAULT_FREQ_HZ: u64 = 1000;
+
+/// Minimum allowed profiling frequency (Hz).
+const MIN_FREQ_HZ: u64 = 1;
+
+/// Maximum allowed profiling frequency (Hz). Values above this can cause
+/// excessive overhead from signal delivery and register reads.
+const MAX_FREQ_HZ: u64 = 10_000;
+
+/// Number of 100-nanosecond intervals per second. Used to convert the
+/// profiling frequency (Hz) to the interval unit that `xperf -SetProfInt`
+/// expects.
+const HUNDRED_NS_PER_SECOND: u64 = 10_000_000;
+
+/// Default path to xperf.exe (Windows Performance Toolkit).
+/// Overridable via the `NANVIX_XPERF_PATH` environment variable.
+const DEFAULT_XPERF_PATH: &str =
+    "C:\\Program Files (x86)\\Windows Kits\\10\\Windows Performance Toolkit\\xperf.exe";
+
+/// Default WPR profile name used when a custom .wprp file provides a
+/// NanvixBench profile with larger buffers and Hyper-V providers.
+const DEFAULT_WPR_PROFILE_NAME: &str = "NanvixBench";
+
+/// Fallback WPR profile when no custom .wprp file is found.
+const FALLBACK_WPR_PROFILE: &str = "CPU";
+
+//==================================================================================================
+// ETW Session
+//==================================================================================================
+
+/// Manages a WPR (Windows Performance Recorder) trace session.
+pub struct EtwSession {
+    /// Path to the output ETL file.
+    output_path: String,
+    /// Whether a trace is currently running.
+    active: bool,
+    /// QPC frequency (ticks per second) for timestamp conversion.
+    qpc_frequency: u64,
+}
+
+impl EtwSession {
+    /// Creates a new ETW session that will write to the given path.
+    pub fn new(output_path: &str) -> Self {
+        Self {
+            output_path: output_path.to_string(),
+            active: false,
+            qpc_frequency: super::timestamp_frequency(),
+        }
+    }
+
+    /// Starts a WPR trace session with CPU sampling and kernel stacks.
+    ///
+    /// Uses the built-in `CPU` profile which captures:
+    /// - CPU sampling at ~1kHz (matching our guest profiler frequency)
+    /// - Kernel + user stacks on CPU samples
+    /// - Thread scheduling events
+    pub fn start(&mut self) -> Result<(), String> {
+        if self.active {
+            let msg = "ETW session already active".to_string();
+            eprintln!("ETW_SESSION: error: {msg}");
+            return Err(msg);
+        }
+
+        // Cancel any lingering WPR session from a previous crash.
+        let _ = Command::new("wpr").args(["-cancel"]).output();
+
+        // Set the ETW CPU sampling interval to match the guest profiler
+        // frequency. NANVIX_PROFILER_FREQ_HZ controls both.
+        // xperf -SetProfInt takes 100ns units: 1kHz = 10000.
+        let freq_hz: u64 = std::env::var("NANVIX_PROFILER_FREQ_HZ")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_FREQ_HZ)
+            .clamp(MIN_FREQ_HZ, MAX_FREQ_HZ);
+        let prof_interval_100ns = HUNDRED_NS_PER_SECOND / freq_hz;
+        let xperf_path =
+            std::env::var("NANVIX_XPERF_PATH").unwrap_or_else(|_| DEFAULT_XPERF_PATH.to_string());
+        if std::path::Path::new(&xperf_path).exists() {
+            let _ = Command::new(&xperf_path)
+                .args(["-SetProfInt", &prof_interval_100ns.to_string()])
+                .output();
+        }
+
+        // Use the nanvix benchmark WPR profile if available (larger buffers,
+        // Hyper-V providers). Fall back to the built-in CPU profile.
+        let wpr_profile = std::env::var("NANVIX_WPR_PROFILE").ok();
+        let (args, profile_name) = if let Some(ref profile_path) = wpr_profile {
+            let profile_arg = format!("{}!{}", profile_path, DEFAULT_WPR_PROFILE_NAME);
+            (
+                vec!["-start".to_string(), profile_arg, "-filemode".to_string()],
+                DEFAULT_WPR_PROFILE_NAME,
+            )
+        } else {
+            // Check for the profile in the default location relative to the exe.
+            let default_profile = std::env::current_exe()
+                .ok()
+                .and_then(|p| {
+                    p.parent()
+                        .map(|d| d.join("..\\scripts\\bench\\wpr-profile.wprp"))
+                })
+                .filter(|p| p.exists())
+                .map(|p| format!("{}!{}", p.display(), DEFAULT_WPR_PROFILE_NAME));
+
+            if let Some(profile_arg) = default_profile {
+                (
+                    vec!["-start".to_string(), profile_arg, "-filemode".to_string()],
+                    DEFAULT_WPR_PROFILE_NAME,
+                )
+            } else {
+                (
+                    vec![
+                        "-start".to_string(),
+                        FALLBACK_WPR_PROFILE.to_string(),
+                        "-filemode".to_string(),
+                    ],
+                    FALLBACK_WPR_PROFILE,
+                )
+            }
+        };
+
+        let result = Command::new("wpr").args(&args).output().map_err(|e| {
+            let msg = format!("Failed to start WPR: {e}");
+            eprintln!("ETW_SESSION: error: {msg}");
+            msg
+        })?;
+
+        if !result.status.success() {
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            let msg = format!("WPR start failed: {stderr}");
+            eprintln!("ETW_SESSION: error: {msg}");
+            return Err(msg);
+        }
+
+        self.active = true;
+        eprintln!(
+            "ETW_SESSION: started WPR {} profiling (qpc_freq={})",
+            profile_name, self.qpc_frequency
+        );
+        Ok(())
+    }
+
+    /// Stops the WPR trace and saves the ETL file.
+    pub fn stop(&mut self) -> Result<String, String> {
+        if !self.active {
+            return Err("No active ETW session".to_string());
+        }
+
+        let result = Command::new("wpr")
+            .args(["-stop", &self.output_path])
+            .output()
+            .map_err(|e| format!("Failed to stop WPR: {e}"))?;
+
+        if !result.status.success() {
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            // Don't clear active — Drop will call wpr -cancel as cleanup.
+            return Err(format!("WPR stop failed: {stderr}"));
+        }
+
+        // Only clear active after a successful stop so Drop doesn't skip
+        // cancel if stop failed.
+        self.active = false;
+
+        eprintln!("ETW_SESSION: saved ETL to {}", self.output_path);
+        Ok(self.output_path.clone())
+    }
+
+    /// Returns the QPC frequency for timestamp conversion.
+    pub fn qpc_frequency(&self) -> u64 {
+        self.qpc_frequency
+    }
+}
+
+impl Drop for EtwSession {
+    fn drop(&mut self) {
+        if self.active {
+            eprintln!("ETW_SESSION: canceling active session on drop");
+            let _ = Command::new("wpr").args(["-cancel"]).output();
+            self.active = false;
+        }
+    }
+}

--- a/src/uservm/src/guest_profiler/host_session_stub.rs
+++ b/src/uservm/src/guest_profiler/host_session_stub.rs
@@ -1,0 +1,23 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! No-op host kernel session stub for platforms without ETW or perf support.
+//!
+//! This allows lib.rs to use a single code path via the `HostKernelSession`
+//! type alias without platform-specific `#[cfg]` blocks.
+
+pub struct HostKernelSession;
+
+impl HostKernelSession {
+    pub fn new(_output_path: &str) -> Self {
+        Self
+    }
+
+    pub fn start(&mut self) -> Result<(), String> {
+        Err("Host kernel tracing not supported on this platform".to_string())
+    }
+
+    pub fn stop(&mut self) -> Result<String, String> {
+        Err("No active session".to_string())
+    }
+}

--- a/src/uservm/src/guest_profiler/mod.rs
+++ b/src/uservm/src/guest_profiler/mod.rs
@@ -12,7 +12,11 @@
 // Modules
 //==================================================================================================
 
+#[cfg(target_os = "windows")]
+pub mod etw;
 mod gva;
+#[cfg(not(target_os = "windows"))]
+mod host_session_stub;
 mod samples;
 mod symbols;
 
@@ -21,7 +25,26 @@ mod symbols;
 //==================================================================================================
 
 pub use samples::{
+    DEFAULT_SAMPLE_CAPACITY,
     GuestProfiler,
     StackSample,
+    timestamp_frequency,
+    timestamp_now,
 };
 pub use symbols::SymbolResolver;
+
+//==================================================================================================
+// Platform-specific host kernel session
+//==================================================================================================
+
+// Re-export the platform's host kernel tracing session and helpers under
+// common names so lib.rs can use a single code path instead of scattered
+// #[cfg] blocks.
+
+#[cfg(target_os = "windows")]
+pub use etw::EtwSession as HostKernelSession;
+
+/// On non-Windows platforms, use the stub until the platform-specific
+/// implementation is added (e.g., perf_linux.rs in the Linux PR).
+#[cfg(not(target_os = "windows"))]
+pub use host_session_stub::HostKernelSession;

--- a/src/uservm/src/guest_profiler/samples.rs
+++ b/src/uservm/src/guest_profiler/samples.rs
@@ -14,11 +14,78 @@ use ::std::sync::{
 };
 
 //==================================================================================================
+// Cross-platform timestamps for host trace correlation
+//==================================================================================================
+
+/// Returns a high-resolution timestamp for sample correlation.
+///
+/// On Windows: QPC (QueryPerformanceCounter) — same time source as ETW.
+/// On Linux: `clock_gettime(CLOCK_MONOTONIC_RAW)` — same time source as `perf`.
+#[inline]
+pub fn timestamp_now() -> u64 {
+    #[cfg(target_os = "windows")]
+    {
+        unsafe extern "system" {
+            fn QueryPerformanceCounter(counter: *mut i64) -> i32;
+        }
+        let mut counter: i64 = 0;
+        let ok: i32 = unsafe { QueryPerformanceCounter(&mut counter) };
+        if ok == 0 {
+            return 0;
+        }
+        counter as u64
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let mut ts = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        if unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut ts) } != 0 {
+            return 0;
+        }
+        (ts.tv_sec as u64) * NANOS_PER_SECOND + (ts.tv_nsec as u64)
+    }
+}
+
+/// Returns the timestamp frequency (ticks per second).
+///
+/// On Windows: QPC frequency. On Linux: 1_000_000_000 (nanoseconds).
+pub fn timestamp_frequency() -> u64 {
+    #[cfg(target_os = "windows")]
+    {
+        unsafe extern "system" {
+            fn QueryPerformanceFrequency(freq: *mut i64) -> i32;
+        }
+        let mut freq: i64 = 0;
+        let ok: i32 = unsafe { QueryPerformanceFrequency(&mut freq) };
+        if ok == 0 || freq <= 0 {
+            return 0;
+        }
+        freq as u64
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        NANOS_PER_SECOND // nanoseconds
+    }
+}
+
+//==================================================================================================
 // Constants
 //==================================================================================================
 
+/// Nanoseconds per second, used as the timestamp frequency on Linux
+/// where `clock_gettime(CLOCK_MONOTONIC_RAW)` returns nanoseconds.
+#[cfg(not(target_os = "windows"))]
+const NANOS_PER_SECOND: u64 = 1_000_000_000;
+
 /// Maximum frame-pointer chain depth per sample.
 const MAX_STACK_DEPTH: usize = 128;
+
+/// Default pre-allocated capacity for the sample buffer. At 1kHz sampling
+/// over a typical 3-5 second workload, ~3000-5000 samples are expected.
+/// 4096 avoids most reallocations without excessive memory use.
+pub const DEFAULT_SAMPLE_CAPACITY: usize = 4096;
 
 /// Kernel/user boundary. Addresses below this are kernel (identity-mapped).
 #[allow(clippy::cast_possible_truncation)] // 32-bit guest constants.
@@ -40,6 +107,9 @@ const STACK_ADDR_MIN: u32 = (64 * config::constants::KILOBYTE) as u32;
 pub struct StackSample {
     /// Return addresses from the frame-pointer chain (deepest first).
     pub addresses: Vec<u32>,
+    /// Timestamp when the sample was captured (for host trace correlation).
+    /// QPC ticks on Windows, nanoseconds on Linux.
+    pub qpc_timestamp: u64,
 }
 
 //==================================================================================================
@@ -144,7 +214,10 @@ impl GuestProfiler {
         if !addrs.is_empty()
             && let Ok(mut s) = samples.lock()
         {
-            s.push(StackSample { addresses: addrs });
+            s.push(StackSample {
+                addresses: addrs,
+                qpc_timestamp: timestamp_now(),
+            });
         }
     }
 
@@ -165,19 +238,40 @@ impl GuestProfiler {
         path: &str,
         resolve: R,
     ) -> std::io::Result<()> {
+        let samples = self.drain_samples();
+        Self::write_folded_from_samples_inner(path, &samples, resolve)
+    }
+
+    /// Like `write_folded`, but operates on a pre-drained sample vector.
+    ///
+    /// Use this when the caller needs the samples for additional processing
+    /// (e.g., timestamp log) to avoid double-draining.
+    pub fn write_folded_from_samples<R: Fn(u32) -> String>(
+        &self,
+        path: &str,
+        samples: &[StackSample],
+        resolve: R,
+    ) -> std::io::Result<()> {
+        Self::write_folded_from_samples_inner(path, samples, resolve)
+    }
+
+    fn write_folded_from_samples_inner<R: Fn(u32) -> String>(
+        path: &str,
+        samples: &[StackSample],
+        resolve: R,
+    ) -> std::io::Result<()> {
         use std::{
             collections::HashMap,
             io::Write,
         };
 
-        // Open the file before draining samples so that data is not lost if
+        // Open the file before processing so that data is not lost if
         // file creation fails.
         let mut file = std::fs::File::create(path)?;
 
-        let samples = self.drain_samples();
         let mut folded: HashMap<String, u64> = HashMap::new();
 
-        for sample in &samples {
+        for sample in samples {
             // Build the stack string (deepest frame first → reverse for flamegraph).
             let stack: String = sample
                 .addresses

--- a/src/uservm/src/lib.rs
+++ b/src/uservm/src/lib.rs
@@ -49,8 +49,6 @@ pub mod args;
 pub mod counters;
 /// Library module for manipulating ELF binaries.
 pub mod elf;
-/// Host-side guest flamegraph profiler (stack sampling and folded-stack output).
-#[cfg(feature = "whp")]
 pub mod guest_profiler;
 #[cfg(target_os = "linux")]
 pub mod io_thread;
@@ -109,6 +107,7 @@ use ::anyhow::Result;
 use ::log::{
     error,
     trace,
+    warn,
 };
 #[cfg(feature = "profile-time")]
 use ::std::time::Instant;
@@ -245,8 +244,6 @@ impl UserVm {
         let perf_timings: PerfTimings = args.perf_timings.clone();
 
         let args_guest_profile_path: Option<String> = args.guest_profile_path.clone();
-        #[cfg(not(feature = "whp"))]
-        let _ = &args_guest_profile_path; // Suppress unused warning when WHP is disabled.
 
         #[cfg(feature = "profile-time")]
         let run_start: Instant = Instant::now();
@@ -331,7 +328,6 @@ impl UserVm {
         #[cfg(feature = "profile-time")]
         perf_timings.set_channel_setup(channel_setup_start.elapsed().as_micros() as u64);
 
-        #[allow(unused_mut)] // `mut` needed only with `whp` for enable_guest_profiler().
         let mut microvm: Vmm = Vmm::new(MicroVmArgs {
             input: vmm_stdin_fn,
             output: vmm_stdout_fn,
@@ -363,15 +359,40 @@ impl UserVm {
             microvm.load_snapshot(snapshot_path).await?;
         }
 
-        // Enable guest profiler if requested (WHP only).
-        #[cfg(feature = "whp")]
+        // Enable guest profiler if requested.
         let guest_profiler = if args_guest_profile_path.is_some() {
             Some(microvm.enable_guest_profiler())
         } else {
             None
         };
-        #[cfg(not(feature = "whp"))]
-        let _guest_profiler: Option<()> = None;
+
+        // Start host kernel tracing session if profiling is enabled.
+        // If an error causes an early return below, the session's Drop impl
+        // cancels the trace (via `wpr -cancel`) which is the desired cleanup
+        // behavior — we don't want a stale WPR session left running.
+        let mut kernel_session = if args_guest_profile_path.is_some() {
+            let trace_path = format!(
+                "{}.{}",
+                args_guest_profile_path
+                    .as_deref()
+                    .unwrap_or("guest-profile"),
+                if cfg!(target_os = "windows") {
+                    "etl"
+                } else {
+                    "perf.data"
+                }
+            );
+            let mut session = crate::guest_profiler::HostKernelSession::new(&trace_path);
+            match session.start() {
+                Ok(()) => Some(session),
+                Err(e) => {
+                    warn!("Host kernel tracing failed to start: {e}");
+                    None
+                },
+            }
+        } else {
+            None
+        };
 
         let vmem: Arc<Mutex<VirtualMemory>> = microvm.vmem();
         let guest: Arc<Mutex<Guest>> = microvm.guest();
@@ -464,10 +485,19 @@ impl UserVm {
         #[cfg(feature = "profile-time")]
         perf_timings.set_total(run_start.elapsed().as_micros() as u64);
 
+        // Stop host kernel trace session before post-processing so the
+        // trace does not include symbol resolution / file I/O work.
+        if let Some(ref mut session) = kernel_session {
+            match session.stop() {
+                Ok(trace_path) => {
+                    eprintln!("PROFILER: host trace saved to {}", trace_path);
+                },
+                Err(e) => warn!("Host kernel session stop failed: {e}"),
+            }
+        }
+
         // Write guest profiler folded stacks if profiling was enabled.
-        #[cfg(feature = "whp")]
         if let (Some(profiler), Some(path)) = (guest_profiler, &args_guest_profile_path) {
-            let sample_count = profiler.handle().lock().map(|s| s.len()).unwrap_or(0);
             let mut sym_paths: Vec<std::path::PathBuf> = Vec::new();
             if let Ok(p) = std::env::var("NANVIX_KERNEL_SYMBOLS") {
                 sym_paths.push(std::path::PathBuf::from(p));
@@ -477,10 +507,17 @@ impl UserVm {
             }
             let sym_refs: Vec<&std::path::Path> = sym_paths.iter().map(|p| p.as_path()).collect();
             let resolver = crate::guest_profiler::SymbolResolver::from_elf_files(&sym_refs);
-            if let Err(e) = profiler.write_folded(path, |addr| resolver.resolve(addr)) {
+
+            // Drain samples once and use for both folded output and timestamp log.
+            let guest_sample_vec = profiler.drain_samples();
+
+            // Write folded stacks from the drained samples.
+            if let Err(e) = profiler
+                .write_folded_from_samples(path, &guest_sample_vec, |addr| resolver.resolve(addr))
+            {
                 error!("Failed to write guest profile: {e:?}");
             } else {
-                eprintln!("GUEST_PROFILE: wrote {} samples to {}", sample_count, path);
+                eprintln!("GUEST_PROFILE: wrote {} samples to {}", guest_sample_vec.len(), path);
             }
         }
 

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -592,6 +592,15 @@ impl Vmm {
         self.vmem.clone()
     }
 
+    /// Enable the guest profiler (no-op on Hyperlight backend).
+    ///
+    /// Hyperlight does not support guest stack sampling because it does not
+    /// expose guest registers or memory in the same way as WHP/KVM.
+    /// Returns a profiler with an empty sample buffer.
+    pub fn enable_guest_profiler(&mut self) -> crate::guest_profiler::GuestProfiler {
+        crate::guest_profiler::GuestProfiler::new(0) // No sampling on Hyperlight.
+    }
+
     pub async fn load_snapshot(&self, filepath: String) -> Result<()> {
         let reason: String = format!("load_snapshot(): not implemented for filepath={}", filepath);
         error!("{}", reason);

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -286,6 +286,9 @@ pub struct Vmm {
     /// Optional GDB server TCP port (standalone mode only).
     #[cfg(feature = "gdb")]
     gdb_port: Option<u16>,
+    /// Guest profiler handle (used by the run loop to record samples).
+    guest_profiler:
+        Option<std::sync::Arc<std::sync::Mutex<Vec<crate::guest_profiler::StackSample>>>>,
 }
 
 ///
@@ -556,6 +559,7 @@ impl Vmm {
             perf_timings,
             #[cfg(feature = "gdb")]
             gdb_port: args.gdb_port,
+            guest_profiler: None,
         })
     }
 
@@ -769,6 +773,23 @@ impl Vmm {
     ///
     pub fn ikc_notifier(&self) -> IkcNotifier {
         self.ikc_notifier.clone()
+    }
+
+    /// Enable the guest profiler and return ownership of the `GuestProfiler`.
+    ///
+    /// The profiler handle is stored internally so the run loop can record
+    /// samples. The returned `GuestProfiler` owns the sample buffer and is
+    /// used by the caller to drain results after the VM exits.
+    ///
+    /// NOTE: On KVM, guest sampling (timer + SIGUSR2 + register capture) is
+    /// implemented in the Linux-specific PR. This method only wires up the
+    /// profiler data structures so the common code in lib.rs compiles.
+    pub fn enable_guest_profiler(&mut self) -> crate::guest_profiler::GuestProfiler {
+        let guest_profiler = crate::guest_profiler::GuestProfiler::new(
+            crate::guest_profiler::DEFAULT_SAMPLE_CAPACITY,
+        );
+        self.guest_profiler = Some(guest_profiler.handle());
+        guest_profiler
     }
 
     ///

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -969,7 +969,9 @@ impl Vmm {
     /// Enables guest stack profiling. Returns the profiler handle for
     /// reading samples after VM exit.
     pub fn enable_guest_profiler(&mut self) -> crate::guest_profiler::GuestProfiler {
-        let profiler = crate::guest_profiler::GuestProfiler::new(4096);
+        let profiler = crate::guest_profiler::GuestProfiler::new(
+            crate::guest_profiler::DEFAULT_SAMPLE_CAPACITY,
+        );
         self.guest_profiler = Some(profiler.handle());
         profiler
     }


### PR DESCRIPTION
## Summary

Adds host kernel stack correlation via ETW/WPR for the Nanvix guest flamegraph profiler on Windows, producing unified flamegraphs with `[GUEST]` and `[HOST]` root frames that span from guest user-space code through the guest kernel, host VMM (nanvixd), and host OS kernel (vid.sys, ntoskrnl). Also introduces a cross-platform profiler abstraction (`HostKernelSession` type alias + no-op stub) and timestamp infrastructure so the follow-up Linux PR can plug in `perf record`-based host profiling without changing `lib.rs`.

## What this PR adds

### Host kernel tracing (ETW)
- **etw.rs**: `EtwSession` manages WPR start/stop lifecycle. Automatically starts an ETW CPU sampling session when nanvixd runs as admin, stops and saves the ETL trace on exit. Sampling frequency is configurable via `NANVIX_PROFILER_FREQ_HZ` (default 1kHz, clamped to 1-10kHz). xperf path is overridable via `NANVIX_XPERF_PATH` env var.

### Cross-platform profiler abstraction
- **mod.rs**: Re-exports `EtwSession` as `HostKernelSession` so `lib.rs` uses a single code path with zero `#[cfg(target_os)]` blocks in the profiler lifecycle.
- **host_session_stub.rs**: No-op stub for non-Windows platforms so the code compiles on Linux/KVM without the ETW implementation. A follow-up Linux PR will replace the stub with a `perf record`-based implementation.

### Timestamp infrastructure (samples.rs)
- `timestamp_now()` / `timestamp_frequency()`: Cross-platform high-resolution timestamps (QPC on Windows, CLOCK_MONOTONIC_RAW on Linux) for future host trace correlation.
- `qpc_timestamp` field on `StackSample`: Records when each guest sample was captured.
- `write_folded_from_samples()`: Allows draining samples once and using them for multiple outputs (avoids double-drain bug).

### Build system
- `release-profiling` Cargo profile: inherits release but keeps symbols (`strip=false`, `debug=line-tables-only`).
- `kernel.mk`: Automated `objcopy --strip-debug` removes .debug_* sections while keeping .symtab (~60KB overhead vs 1.4MB).
- `nanvixd.mk`: Copies PDB alongside exe on Windows.

### E2E scripts
- **full-flamegraph.ps1**: Runs nanvixd, extracts ETW kernel stacks via analyze-etl.py, merges [GUEST]/[HOST] prefixes, generates SVG. Requires admin for host kernel stacks.
- **guest-flamegraph.ps1**: Guest-only flamegraph (no admin needed).
- **profiler-common.ps1**: Shared library (ramfs building, nanvixd invocation, output formatting).

### KVM stub
The KVM `Vmm` struct gets an `enable_guest_profiler()` stub and `guest_profiler` field so the common profiler activation code in `lib.rs` compiles on Linux. The actual KVM sampling implementation (SIGUSR2 timer + register capture) is added in the follow-up Linux PR.

## How to use

See [src/uservm/src/guest_profiler/README.md](src/uservm/src/guest_profiler/README.md) for the full profiling guide.

Quick start:

```powershell
# Build with symbols
.\z build --profile --release -- LOG_LEVEL=panic

# Run as admin for full E2E (guest + host kernel stacks)
.\scripts\bench\full-flamegraph.ps1
```

## Environment variables

| Variable | Description | Default |
|----------|-------------|---------|
| `NANVIX_GUEST_PROFILE_PATH` | Output path for folded stacks; enables profiler | (disabled) |
| `NANVIX_KERNEL_SYMBOLS` | Path to kernel ELF with .symtab | (none) |
| `NANVIX_USER_SYMBOLS` | Path to user app ELF with .symtab | (none) |
| `NANVIX_PROFILER_FREQ_HZ` | Sampling frequency (guest + host) | `1000` |
| `NANVIX_XPERF_PATH` | Override path to xperf.exe | (auto-detect) |

## Known limitations

- **No timestamp-based correlation**: Guest and host stacks are merged into a single flamegraph by appending host ETW stacks under a `[HOST]` prefix, but there is no temporal correlation between individual guest and host samples. The merged flamegraph shows the overall time distribution across guest and host, not which host stacks correspond to specific guest execution phases.
- **Linux**: This PR includes a no-op stub for Linux. A follow-up PR adds the actual KVM guest sampling and `perf record`-based host profiling.

## Testing

Tested on Windows 11 with WHP. Produces balanced [GUEST]/[HOST] flamegraphs with 100% symbol resolution across all layers (Nanvix kernel, CPython, nanvixd VMM, vid.sys, ntoskrnl).
