### PR TITLE
[uservm] Linux KVM guest sampling and perf host correlation

### DIFF
--- a/scripts/bench/flamegraph.py
+++ b/scripts/bench/flamegraph.py
@@ -233,7 +233,10 @@ def main() -> None:
     # Show profiler lines from stderr.
     (output_dir / "nanvixd-stderr.txt").write_text(stderr, encoding="utf-8")
     for line in stderr.splitlines():
-        if any(k in line for k in ("GUEST_PROFILE", "PROFILER", "ETW_SESSION")):
+        if any(
+            k in line
+            for k in ("GUEST_PROFILE", "PROFILER", "ETW_SESSION", "PERF_SESSION")
+        ):
             print(f"  {line.strip()}")
 
     if not guest_folded.exists():

--- a/scripts/bench/flamegraph_host.py
+++ b/scripts/bench/flamegraph_host.py
@@ -6,7 +6,7 @@
 Platform-specific host stack extraction.
 
 Windows: Extracts kernel stacks from ETL via analyze-etl.py.
-Linux:   Added in the Linux follow-up PR.
+Linux:   Extracts kernel stacks from perf.data via perf script + inferno.
 """
 
 import os
@@ -28,9 +28,10 @@ def extract_host_stacks(
     """
     if sys.platform == "win32":
         return _extract_etw(guest_folded, output_dir, bin_dir)
+    elif sys.platform.startswith("linux"):
+        return _extract_perf(guest_folded, output_dir)
     else:
-        print(f"  Host stack extraction not yet supported on {sys.platform}")
-        print("  (Linux support is added in the Linux follow-up PR)")
+        print(f"  Host stack extraction not supported on {sys.platform}")
         return None
 
 
@@ -99,4 +100,73 @@ def _extract_etw(
         if len(parts) == 2:
             prefixed.append(f"[HOST];{parts[0]} {parts[1]}")
     host_folded.write_text("\n".join(prefixed) + "\n", encoding="utf-8")
+    return host_folded
+
+
+def _extract_perf(guest_folded: Path, output_dir: Path) -> Path | None:
+    """Extract host stacks from perf.data (Linux)."""
+    perf_data = Path(f"{guest_folded}.perf.data")
+    if not perf_data.exists():
+        print("  No perf.data (run as root for host kernel stacks)")
+        return None
+
+    print("  Extracting host stacks from perf.data...")
+
+    # Use perf script -F to omit the period field so each event
+    # collapses to count=1, matching guest profiler weighting.
+    try:
+        script_result = subprocess.run(
+            [
+                "perf",
+                "script",
+                "-i",
+                str(perf_data),
+                "-F",
+                "comm,pid,tid,time,event,ip,sym,dso",
+            ],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("  perf not available -- host stacks skipped")
+        return None
+
+    if script_result.returncode != 0:
+        print(f"  perf script failed (code {script_result.returncode}):")
+        for err_line in script_result.stderr.splitlines()[:5]:
+            print(f"    {err_line}")
+        return None
+
+    # Collapse stacks via inferno.
+    try:
+        collapse_result = subprocess.run(
+            ["inferno-collapse-perf"],
+            input=script_result.stdout,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("  inferno-collapse-perf not available -- host stacks skipped")
+        return None
+
+    if collapse_result.returncode != 0:
+        print(f"  inferno-collapse-perf failed (code {collapse_result.returncode}):")
+        for err_line in collapse_result.stderr.splitlines()[:5]:
+            print(f"    {err_line}")
+        return None
+
+    # Filter to nanvixd/uservm stacks and prefix with [HOST].
+    host_folded = output_dir / "host.folded"
+    lines = []
+    for line in collapse_result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if "nanvixd" in line.lower() or "uservm" in line.lower():
+            lines.append(f"[HOST];{line}")
+    if not lines:
+        print("  No host stacks for nanvixd (perf may need CAP_SYS_ADMIN)")
+        return None
+
+    host_folded.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return host_folded

--- a/src/uservm/src/guest_profiler/mod.rs
+++ b/src/uservm/src/guest_profiler/mod.rs
@@ -15,8 +15,10 @@
 #[cfg(target_os = "windows")]
 pub mod etw;
 mod gva;
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 mod host_session_stub;
+#[cfg(target_os = "linux")]
+pub mod perf_linux;
 mod samples;
 mod symbols;
 
@@ -44,7 +46,10 @@ pub use symbols::SymbolResolver;
 #[cfg(target_os = "windows")]
 pub use etw::EtwSession as HostKernelSession;
 
-/// On non-Windows platforms, use the stub until the platform-specific
-/// implementation is added (e.g., perf_linux.rs in the Linux PR).
-#[cfg(not(target_os = "windows"))]
+/// On Linux, use the perf-based host kernel session.
+#[cfg(target_os = "linux")]
+pub use perf_linux::PerfSession as HostKernelSession;
+
+/// On unsupported platforms, provide a no-op session stub so lib.rs compiles.
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub use host_session_stub::HostKernelSession;

--- a/src/uservm/src/guest_profiler/perf_linux.rs
+++ b/src/uservm/src/guest_profiler/perf_linux.rs
@@ -1,0 +1,286 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! `perf`-based host kernel stack capture for guest flamegraphs (Linux).
+//!
+//! This is the Linux equivalent of the Windows ETW module (`etw.rs`).
+//! It uses `perf record` to capture CPU sampling with kernel stacks
+//! while the guest profiler runs, producing `perf.data` for later
+//! host/guest stack merging.
+//!
+//! # How it works
+//!
+//! 1. **Before VM run**: Start `perf record` with CPU sampling and
+//!    kernel+user stacks on the nanvixd process.
+//! 2. **During VM run**: Our profiler records guest samples while
+//!    `perf record` runs concurrently on the host.
+//! 3. **After VM exit**: Stop `perf record`, convert to folded stacks
+//!    with `perf script | inferno-collapse-perf`, filter by nanvixd.
+//!
+//! # Sampling rate alignment
+//!
+//! Both our profiler and `perf record` sample at ~1kHz for broadly
+//! comparable analysis. Timestamp-based correlation is not implemented;
+//! host and guest stacks are merged by stack identity, not by time.
+
+use std::{
+    os::unix::fs::PermissionsExt,
+    process::{
+        Child,
+        Command,
+        Stdio,
+    },
+};
+
+use ::libc::c_int;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Default profiling frequency in Hz. Controls the `perf record -F` sampling
+/// rate. Matches the guest profiler's default for consistent weighting.
+const DEFAULT_FREQ_HZ: u64 = 1000;
+
+/// Minimum allowed profiling frequency (Hz).
+const MIN_FREQ_HZ: u64 = 1;
+
+/// Maximum allowed profiling frequency (Hz). Values above this can cause
+/// excessive overhead from perf ring buffer processing.
+const MAX_FREQ_HZ: u64 = 10_000;
+
+/// Environment variable controlling the profiling frequency (Hz).
+const PROFILER_FREQ_ENV: &str = "NANVIX_PROFILER_FREQ_HZ";
+
+/// Path to the kernel perf_event_paranoid sysctl. Values <= 0 allow
+/// system-wide profiling without root.
+const PERF_EVENT_PARANOID_PATH: &str = "/proc/sys/kernel/perf_event_paranoid";
+
+/// Identifier string for perf_event file descriptors in /proc/<pid>/fd
+/// symlink targets (e.g. `anon_inode:[perf_event]`).
+const PERF_EVENT_FD_IDENTIFIER: &str = "perf_event";
+
+/// Maximum time (seconds) to wait for perf to open its perf_event fds
+/// before giving up on readiness detection.
+const PERF_READINESS_TIMEOUT_SECS: u64 = 5;
+
+/// File permissions applied to perf.data after recording. perf record
+/// running as root creates the file with mode 0600; we relax it so the
+/// merge script can read it without root.
+const PERF_DATA_PERMISSIONS: u32 = 0o644;
+
+/// Nanoseconds per second — timestamp frequency for CLOCK_MONOTONIC_RAW.
+const NANOS_PER_SECOND: u64 = 1_000_000_000;
+
+/// Manages a `perf record` session for kernel stack sampling.
+pub struct PerfSession {
+    /// Path to the output perf.data file.
+    output_path: String,
+    /// Running `perf record` child process.
+    child: Option<Child>,
+    /// PID of the nanvixd process (for filtering).
+    pid: u32,
+}
+
+impl PerfSession {
+    /// Creates a new perf session that will write to the given path.
+    pub fn new(output_path: &str) -> Self {
+        Self {
+            output_path: output_path.to_string(),
+            child: None,
+            pid: std::process::id(),
+        }
+    }
+
+    /// Starts `perf record` with CPU sampling and kernel stacks.
+    ///
+    /// Uses system-wide sampling (`-a`) when running as root or with
+    /// `perf_event_paranoid <= 0`, to capture kernel stacks (kvm, ioctl,
+    /// etc.) that are invisible with `-p PID` (which implicitly sets
+    /// `exclude_kernel=1`). When system-wide access is not available,
+    /// selects per-PID mode instead (no kernel stacks, user stacks only).
+    /// There is no automatic retry: the mode is chosen once based on
+    /// `can_system_wide()` before spawning `perf record`.
+    pub fn start(&mut self) -> Result<(), String> {
+        if self.child.is_some() {
+            return Err("perf session already active".to_string());
+        }
+
+        let freq_hz: u64 = std::env::var(PROFILER_FREQ_ENV)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_FREQ_HZ)
+            .clamp(MIN_FREQ_HZ, MAX_FREQ_HZ);
+        // Subtract 1 to avoid aliasing with the guest timer at the same rate.
+        let perf_freq: String = freq_hz.saturating_sub(1).max(1).to_string();
+        let pid_str: String = self.pid.to_string();
+
+        // Try system-wide first (includes kernel stacks), fall back to per-PID.
+        let (args, mode): (Vec<&str>, &str) = if Self::can_system_wide() {
+            (
+                vec![
+                    "record",
+                    "-a",
+                    "-F",
+                    &perf_freq,
+                    "-g",
+                    "--call-graph",
+                    "fp",
+                    "-o",
+                    &self.output_path,
+                ],
+                "system-wide",
+            )
+        } else {
+            (
+                vec![
+                    "record",
+                    "-F",
+                    &perf_freq,
+                    "-g",
+                    "--call-graph",
+                    "fp",
+                    "-p",
+                    &pid_str,
+                    "-o",
+                    &self.output_path,
+                ],
+                "per-PID (no kernel stacks)",
+            )
+        };
+
+        let child: Child = Command::new("perf")
+            .args(&args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                let msg: String = format!("Failed to start perf record: {e}");
+                eprintln!("PERF_SESSION: error: {msg}");
+                msg
+            })?;
+
+        self.child = Some(child);
+
+        // Wait for perf to initialize its ring buffers before returning.
+        // perf creates the output file early, but doesn't start sampling
+        // until perf_event_open fds are set up. We detect readiness by
+        // checking /proc/PID/fd for anon_inode:[perf_event] entries.
+        // Without this, short workloads finish before perf captures samples.
+        if let Some(ref mut c) = self.child {
+            let perf_pid: u32 = c.id();
+            let fd_path: String = format!("/proc/{perf_pid}/fd");
+            let deadline: std::time::Instant = std::time::Instant::now()
+                + std::time::Duration::from_secs(PERF_READINESS_TIMEOUT_SECS);
+            loop {
+                if std::time::Instant::now() > deadline {
+                    eprintln!("PERF_SESSION: warning: timed out waiting for perf to initialize");
+                    break;
+                }
+                // Check if perf exited early (permissions error, bad args, etc.).
+                if let Ok(Some(status)) = c.try_wait() {
+                    let code: i32 = status.code().unwrap_or(-1);
+                    self.child = None;
+                    return Err(format!(
+                        "perf exited immediately (code {code}) -- check permissions or \
+                         perf_event_paranoid"
+                    ));
+                }
+                // Check if perf has opened perf_event file descriptors.
+                if let Ok(entries) = std::fs::read_dir(&fd_path) {
+                    let has_perf_events: bool = entries.filter_map(|e| e.ok()).any(|e| {
+                        std::fs::read_link(e.path())
+                            .map(|t| t.to_string_lossy().contains(PERF_EVENT_FD_IDENTIFIER))
+                            .unwrap_or(false)
+                    });
+                    if has_perf_events {
+                        // Give perf a small extra moment to finish setup.
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                        break;
+                    }
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+        }
+
+        eprintln!(
+            "PERF_SESSION: started perf record ({mode}) -F {perf_freq} -o {}",
+            self.output_path
+        );
+        Ok(())
+    }
+
+    /// Check if we can use system-wide perf recording (requires root or
+    /// `perf_event_paranoid <= 0`).
+    fn can_system_wide() -> bool {
+        // Check perf_event_paranoid: -1 or 0 allows system-wide without root.
+        if let Ok(val) = std::fs::read_to_string(PERF_EVENT_PARANOID_PATH)
+            && let Ok(n) = val.trim().parse::<i32>()
+            && n <= 0
+        {
+            return true;
+        }
+        // Check if running as root.
+        unsafe { libc::geteuid() == 0 }
+    }
+
+    /// Stops the `perf record` session by sending SIGINT.
+    pub fn stop(&mut self) -> Result<String, String> {
+        let mut child: Child = self
+            .child
+            .take()
+            .ok_or_else(|| "No active perf session".to_string())?;
+
+        // Send SIGINT to perf to gracefully stop recording.
+        let pid: u32 = child.id();
+        let kill_ret: c_int = unsafe { libc::kill(pid.cast_signed(), libc::SIGINT) };
+        if kill_ret != 0 {
+            let err: std::io::Error = std::io::Error::last_os_error();
+            // Still reap the child to avoid zombie processes.
+            let _ = child.wait();
+            return Err(format!("Failed to send SIGINT to perf (pid {pid}): {err}"));
+        }
+
+        // Wait for perf to finish writing.
+        let output: std::process::Output = child
+            .wait_with_output()
+            .map_err(|e| format!("Failed to wait for perf: {e}"))?;
+
+        if !output.status.success() {
+            // perf returns non-zero on SIGINT but that's expected.
+            // code() is None when killed by signal (treat as -1).
+            let code: i32 = output.status.code().unwrap_or(-1);
+            if code != 2 && code != -1 {
+                // code 2 = interrupted, -1 = signal
+                let stderr: std::borrow::Cow<'_, str> = String::from_utf8_lossy(&output.stderr);
+                return Err(format!("perf record failed (code {code}): {stderr}"));
+            }
+        }
+
+        // Make perf.data readable by the script's merge step (perf record
+        // running as root creates the file with mode 0600).
+        let _ = std::fs::set_permissions(
+            &self.output_path,
+            std::fs::Permissions::from_mode(PERF_DATA_PERMISSIONS),
+        );
+
+        eprintln!("PERF_SESSION: saved perf data to {}", self.output_path);
+        Ok(self.output_path.clone())
+    }
+
+    /// Returns the timestamp frequency (nanoseconds for CLOCK_MONOTONIC_RAW).
+    pub fn timestamp_frequency(&self) -> u64 {
+        NANOS_PER_SECOND
+    }
+}
+
+impl Drop for PerfSession {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            eprintln!("PERF_SESSION: killing active session on drop");
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}

--- a/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
+++ b/src/uservm/src/vmm/microvm/kvm/vcpu/mod.rs
@@ -557,7 +557,6 @@ impl VirtualProcessor {
     }
 
     /// Returns the current general-purpose registers of the virtual processor.
-    #[cfg(feature = "gdb")]
     pub fn get_regs(&self) -> Result<kvm_regs> {
         self.fd
             .get_regs()
@@ -573,7 +572,6 @@ impl VirtualProcessor {
     }
 
     /// Returns the current segment and control registers of the virtual processor.
-    #[cfg(feature = "gdb")]
     pub fn get_sregs(&self) -> Result<kvm_sregs> {
         self.fd
             .get_sregs()
@@ -770,11 +768,12 @@ impl VirtualProcessor {
                     VirtualProcessorExitContext::Unknown
                 },
             },
-            // vCPU thread was interrupted by a signal from the host.
-            // This is the expected mechanism for orchestrator-driven shutdown
-            // (SIGUSR1 handler sets SHUTDOWN), so it is not an unexpected exit.
+            // vCPU thread was interrupted by a signal from the host.  This is the expected
+            // mechanism for both orchestrator-driven shutdown (SIGUSR1) and profiler sampling
+            // (SIGUSR2). Use trace! to avoid flooding logs when the profiler runs at high frequency
+            // (e.g., 10kHz).
             Err(e) if e.errno() == libc::EINTR => {
-                warn!("run(): interrupted");
+                trace!("run(): interrupted");
                 VirtualProcessorExitContext::Interrupted
             },
             Err(error) => {

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -51,7 +51,6 @@ use crate::{
     vmm::microvm::kvm::vcpu::{
         VirtualProcessor,
         VirtualProcessorDumpInfo,
-        VirtualProcessorExitContext,
         VirtualProcessorExitReasonRef,
     },
 };
@@ -139,6 +138,26 @@ pub use ramfs::RamFs;
 /// IRQ number used for IKC (inter-kernel communication) notifications.
 #[cfg(target_os = "linux")]
 const IKC_IRQ: u32 = 9;
+
+/// Default profiling frequency in Hz for the guest profiler timer.
+#[cfg(target_os = "linux")]
+const DEFAULT_PROFILER_FREQ_HZ: u64 = 1000;
+
+/// Minimum allowed profiler frequency (Hz) to avoid division by zero.
+#[cfg(target_os = "linux")]
+const MIN_PROFILER_FREQ_HZ: u64 = 1;
+
+/// Maximum allowed profiler frequency (Hz) to avoid spin-loops.
+#[cfg(target_os = "linux")]
+const MAX_PROFILER_FREQ_HZ: u64 = 10_000;
+
+/// Microseconds per second, used to compute the profiler timer period.
+#[cfg(target_os = "linux")]
+const MICROS_PER_SECOND: u64 = 1_000_000;
+
+/// Environment variable controlling the profiling frequency (Hz).
+#[cfg(target_os = "linux")]
+const PROFILER_FREQ_ENV: &str = "NANVIX_PROFILER_FREQ_HZ";
 
 ///
 /// # Description
@@ -238,6 +257,13 @@ impl IkcNotifier {
 /// Signal used to interrupt the vCPU thread.
 #[cfg(target_os = "linux")]
 pub const INTERRUPT_SIGNAL: c_int = SIGUSR1;
+
+/// Signal used for profiler timer interrupts. We use SIGUSR2 (not SIGUSR1)
+/// because SIGUSR1 is already used by the orchestrator for shutdown, and its
+/// handler sets the SHUTDOWN flag. The profiler needs a signal that merely
+/// interrupts KVM_RUN with -EINTR without triggering shutdown.
+#[cfg(target_os = "linux")]
+pub const PROFILER_SIGNAL: c_int = libc::SIGUSR2;
 
 /// Signal used to kill the vCPU thread.
 #[cfg(target_os = "linux")]
@@ -342,10 +368,19 @@ pub type StderrFn = dyn Write + Send;
 // Implementations (Linux/KVM only)
 //==================================================================================================
 
-/// Signal handler for the vCPU thread. We install an empty handler to trigger an -EINTR.
+/// Signal handler for the vCPU thread. Sets the shutdown flag to stop re-entering KVM_RUN.
 #[cfg(target_os = "linux")]
 extern "C" fn vcpu_thread_signal_handler(_: i32) {
     SHUTDOWN.with(|shutdown| shutdown.store(true, Ordering::SeqCst));
+}
+
+/// No-op signal handler for profiler timer. Only purpose is to interrupt
+/// KVM_RUN with -EINTR so we can read guest registers for stack sampling.
+/// Must NOT set SHUTDOWN — the VM continues running after sampling.
+#[cfg(target_os = "linux")]
+extern "C" fn profiler_signal_handler(_: i32) {
+    // Intentionally empty: the signal itself causes KVM_RUN to return
+    // with errno=EINTR, which surfaces as an Interrupted exit reason.
 }
 
 #[cfg(target_os = "linux")]
@@ -588,7 +623,83 @@ impl Vmm {
         })
     }
 
-    /// Install a signal handler on the vCPU thread.
+    ///
+    /// # Description
+    ///
+    /// Spawns a timer thread that periodically sends SIGUSR2 to the vCPU thread, interrupting
+    /// KVM_RUN so the profiler can capture guest register state for stack sampling.
+    ///
+    /// # Parameters
+    ///
+    /// - `stop`: Atomic flag used to signal the timer thread to stop.
+    /// - `vcpu_tid`: pthread ID of the vCPU thread to which SIGUSR2 will be sent.
+    ///
+    /// # Returns
+    ///
+    /// Returns a JoinHandle for the spawned timer thread.
+    ///
+    fn spawn_profiler_timer(
+        stop: Arc<AtomicBool>,
+        vcpu_tid: libc::pthread_t,
+    ) -> std::thread::JoinHandle<()> {
+        let freq_hz: u64 = std::env::var(PROFILER_FREQ_ENV)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_PROFILER_FREQ_HZ)
+            .clamp(MIN_PROFILER_FREQ_HZ, MAX_PROFILER_FREQ_HZ);
+        let period: std::time::Duration =
+            std::time::Duration::from_micros(MICROS_PER_SECOND / freq_hz);
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                std::thread::sleep(period);
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                let ret: c_int = unsafe { libc::pthread_kill(vcpu_tid, PROFILER_SIGNAL) };
+                if ret != 0 {
+                    warn!("profiler: pthread_kill failed (errno={ret})");
+                }
+            }
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Captures a guest profiler sample by reading vCPU registers and walking the frame-pointer
+    /// chain through guest virtual memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `profiler`: Shared vector of stack samples where the captured sample will be stored.
+    /// - `vmem`: Handle to the guest virtual memory used to walk the frame-pointer chain.
+    /// - `eip`: Instruction pointer of the guest at the time of the sample.
+    /// - `ebp`: Base pointer of the guest at the time of the sample.
+    /// - `cr3`: Page table base register of the guest at the time of the sample.
+    ///
+    fn capture_profiler_sample(
+        profiler: &std::sync::Arc<std::sync::Mutex<Vec<crate::guest_profiler::StackSample>>>,
+        vmem: &Arc<Mutex<VirtualMemory>>,
+        eip: u32,
+        ebp: u32,
+        cr3: u32,
+    ) {
+        let vmem_guard: MutexGuard<'_, VirtualMemory> = vmem.blocking_lock();
+        crate::guest_profiler::GuestProfiler::capture_sample(
+            profiler,
+            vmem_guard.get_raw_ptr(),
+            vmem_guard.get_size(),
+            eip,
+            ebp,
+            cr3,
+        );
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Install signal handlers on the vCPU thread.
+    ///
     fn install_signal_handler() {
         // SAFETY: we install a signal handler that is a no-op so this is safe.
         let ret: c_int = unsafe {
@@ -618,6 +729,34 @@ impl Vmm {
     ///
     /// # Description
     ///
+    /// Install the SIGUSR2 no-op handler for the profiler timer.
+    ///
+    /// sa_flags=0 (no SA_RESTART): we intentionally want SIGUSR2 to interrupt blocking syscalls
+    /// (KVM_RUN ioctl) with -EINTR so the run loop can read guest registers for sampling.
+    ///
+    fn install_profiler_signal_handler() {
+        let ret: c_int = unsafe {
+            let profiler_action: sigaction = sigaction {
+                sa_sigaction: profiler_signal_handler as *const () as usize,
+                sa_mask: {
+                    let mut set: libc::sigset_t = std::mem::zeroed();
+                    sigemptyset(&mut set);
+                    set
+                },
+                sa_flags: 0,
+                sa_restorer: None,
+            };
+            sigaction(PROFILER_SIGNAL, &profiler_action, std::ptr::null_mut())
+        };
+        if ret != 0 {
+            let errno: i32 = unsafe { *libc::__errno_location() };
+            error!("error installing profiler signal handler (errno={errno:?})");
+        }
+    }
+
+    ///
+    /// # Description
+    ///
     /// Runs the virtual machine.
     ///
     /// # Returns
@@ -631,8 +770,13 @@ impl Vmm {
         // Reset shutdown flag from any previous runs.
         SHUTDOWN.with(|shutdown| shutdown.store(false, Ordering::SeqCst));
 
-        // Install a signal handler in the virtual processor's thread.
+        let profiling: bool = self.guest_profiler.is_some();
+
+        // Install signal handlers in the virtual processor's thread.
         Self::install_signal_handler();
+        if profiling {
+            Self::install_profiler_signal_handler();
+        }
 
         // When GDB server is enabled, delegate to the GDB event loop instead of the normal loop.
         #[cfg(feature = "gdb")]
@@ -653,6 +797,16 @@ impl Vmm {
         #[cfg(feature = "profile-time")]
         let loop_start: Instant = Instant::now();
 
+        // Guest profiler: start a timer thread that sends SIGUSR2 to
+        // interrupt KVM_RUN periodically for stack sampling.
+        let profiler_stop: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        let profiler_thread: Option<std::thread::JoinHandle<()>> = if profiling {
+            let vcpu_tid: libc::pthread_t = unsafe { libc::pthread_self() };
+            Some(Self::spawn_profiler_timer(profiler_stop.clone(), vcpu_tid))
+        } else {
+            None
+        };
+
         let result = loop {
             // Check shutdown flag before entering KVM_RUN, and blocking indefinitely.
             if SHUTDOWN.with(|shutdown| shutdown.load(Ordering::SeqCst)) {
@@ -661,7 +815,7 @@ impl Vmm {
                 break Ok(exit_status);
             }
 
-            let exit_context: VirtualProcessorExitContext = {
+            let (exit_context, profile_regs) = {
                 let mut locked_vcpu: MutexGuard<'_, VirtualProcessor> = self.vcpu.blocking_lock();
                 // Exit if the vCPU is no longer online.
                 if !locked_vcpu.is_online() {
@@ -677,8 +831,31 @@ impl Vmm {
                     guest_time_acc_us += run_start.elapsed().as_micros() as u64;
                 }
 
-                ctx
+                // Guest profiler: on Interrupted exits (from our SIGUSR2 timer), read guest
+                // registers for stack sampling.  Both get_regs and get_sregs must succeed for a
+                // valid sample.  Truncate 64-bit registers to 32-bit: the Nanvix guest runs in
+                // 32-bit protected mode, so only the low 32 bits are meaningful.
+                #[allow(clippy::cast_possible_truncation)]
+                let regs: Option<(u32, u32, u32)> = if self.guest_profiler.is_some()
+                    && matches!(ctx.reason_ref(), VirtualProcessorExitReasonRef::Interrupted)
+                {
+                    locked_vcpu.get_regs().ok().and_then(|r| {
+                        locked_vcpu
+                            .get_sregs()
+                            .ok()
+                            .map(|s| (r.rip as u32, r.rbp as u32, s.cr3 as u32))
+                    })
+                } else {
+                    None
+                };
+
+                (ctx, regs)
             };
+
+            // Guest profiler: capture sample after vcpu lock is released.
+            if let (Some(profiler), Some((eip, ebp, cr3))) = (&self.guest_profiler, profile_regs) {
+                Self::capture_profiler_sample(profiler, &self.vmem, eip, ebp, cr3);
+            }
 
             // Parse exit reason.
             match exit_context.reason_ref() {
@@ -705,9 +882,22 @@ impl Vmm {
                     }
                 },
 
-                // The guest was halted or interrupted, this means we need to power-off.
+                // The guest was halted or interrupted.
+                // When the profiler is active, Interrupted exits are from our SIGUSR2 timer — just
+                // continue the loop (samples were already captured above). Without the profiler,
+                // Interrupted means the orchestrator requested shutdown via SIGUSR1.
                 VirtualProcessorExitReasonRef::Halt
                 | VirtualProcessorExitReasonRef::Interrupted => {
+                    if self.guest_profiler.is_some()
+                        && matches!(
+                            exit_context.reason_ref(),
+                            VirtualProcessorExitReasonRef::Interrupted
+                        )
+                        && !SHUTDOWN.with(|s| s.load(Ordering::SeqCst))
+                    {
+                        // Profiler-induced interrupt: continue running.
+                        continue;
+                    }
                     let exit_status: u16 = 0;
                     Handle::current().block_on(self.handle_shutdown(exit_status));
                     break Ok(exit_status);
@@ -741,6 +931,18 @@ impl Vmm {
                 },
             }
         };
+
+        // Stop profiler timer. Relaxed ordering is sufficient here because join() provides the
+        // necessary synchronization barrier, and a stray SIGUSR2 after the flag is set is harmless
+        // (the no-op handler runs, and the SHUTDOWN check prevents re-entering the loop). The timer
+        // thread is joined while still inside run() (the vCPU thread), so vcpu_tid remains valid
+        // until after join() completes.
+        profiler_stop.store(true, Ordering::Relaxed);
+        if let Some(t) = profiler_thread
+            && let Err(e) = t.join()
+        {
+            warn!("profiler timer thread panicked: {:?}", e);
+        }
 
         // Record guest vs exit-handling time breakdown.
         #[cfg(feature = "profile-time")]
@@ -792,15 +994,20 @@ impl Vmm {
         self.ikc_notifier.clone()
     }
 
-    /// Enable the guest profiler and return ownership of the `GuestProfiler`.
     ///
-    /// The profiler handle is stored internally so the run loop can record
-    /// samples. The returned `GuestProfiler` owns the sample buffer and is
-    /// used by the caller to drain results after the VM exits.
+    /// #Description
     ///
-    /// NOTE: On KVM, guest sampling (timer + SIGUSR2 + register capture) is
-    /// implemented in the Linux-specific PR. This method only wires up the
-    /// profiler data structures so the common code in lib.rs compiles.
+    /// Enables guest stack profiling. Returns the `GuestProfiler` whose sample buffer is shared
+    /// with the run loop. The caller drains it after VM exit to produce folded stacks.
+    ///
+    /// On KVM, the run loop starts a timer thread that sends SIGUSR2 to interrupt KVM_RUN at the
+    /// configured frequency. On each Interrupted exit, guest registers (EIP/EBP/CR3) are read and a
+    /// frame-pointer walk captures the guest call stack.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `GuestProfiler` instance that can be used to collect guest stack samples.
+    ///
     pub fn enable_guest_profiler(&mut self) -> crate::guest_profiler::GuestProfiler {
         let guest_profiler = crate::guest_profiler::GuestProfiler::new(
             crate::guest_profiler::DEFAULT_SAMPLE_CAPACITY,


### PR DESCRIPTION
## Summary

Adds Linux KVM guest sampling and `perf record`-based host kernel stack correlation, completing the cross-platform profiler started in PR #2151 (Windows ETW). Plugs into the `HostKernelSession` type alias introduced there -- `lib.rs` has zero changes in this PR.

## What this PR adds

### KVM guest sampling (`vmm/microvm/mod.rs`)
- Timer thread sends `SIGUSR2` to the vCPU thread at configurable frequency (`NANVIX_PROFILER_FREQ_HZ`, clamped 1-10kHz)
- Uses `SIGUSR2` (not `SIGUSR1`) because `SIGUSR1` is used by the orchestrator for shutdown and sets the `SHUTDOWN` flag
- Separate no-op `profiler_signal_handler` installed alongside the existing shutdown handler
- On `Interrupted` exit: reads `KVM_GET_REGS` + `KVM_GET_SREGS` for EIP/EBP/CR3, walks frame-pointer chain
- When profiler is active, `Interrupted` exits continue the VM instead of shutting down (checks `SHUTDOWN` flag to distinguish real shutdown from profiler tick)
- Both `get_regs` and `get_sregs` must succeed for a valid sample -- skips if either fails

### Host kernel tracing (`perf_linux.rs`)
- `PerfSession` wrapping `perf record` with system-wide sampling (`-a`) when running as root for kernel stack visibility (kvm_intel, ioctl paths)
- Falls back to per-PID recording when unprivileged (no kernel stacks but still captures VMM userspace)
- Waits for `perf_event` file descriptors in `/proc/PID/fd` before returning from `start()` -- ensures perf is actually sampling before the workload begins
- Detects early `perf` exit via `try_wait()` and returns `Err` (not silent success)
- `chmod 644` on `perf.data` after stop so the E2E script can read it without root
- Configurable frequency via `NANVIX_PROFILER_FREQ_HZ`

### Platform abstraction (`mod.rs`)
- Re-exports `PerfSession` as `HostKernelSession` for Linux, replacing the no-op stub from the Windows PR
- Stub remains for truly unsupported platforms (`not(windows OR linux)`)

### E2E script (`full-flamegraph.sh`)
- Mirrors `full-flamegraph.ps1` structure: builds ramfs, runs nanvixd, extracts host stacks, merges `[GUEST]`/`[HOST]`, generates SVG
- Uses `perf script -F comm,pid,tid,time,event,ip,sym,dso` to omit the period field -- each perf event collapses to count=1, matching guest profiler's 1-per-sample weighting
- Filters collapsed stacks by `grep -iE "nanvixd|uservm"` (more robust than `--comms` which truncates at 15 chars)
- Requires `inferno` and `rustfilt` (`cargo install inferno rustfilt`)

### Ungated register access (`kvm/vcpu/mod.rs`)
- Removed `#[cfg(feature = "gdb")]` from `get_regs()` and `get_sregs()` -- the profiler needs these on every `Interrupted` exit, not just during GDB sessions

## How to use

```bash
# Build
python3 z.py build --profile --release -- DEPLOYMENT_MODE=standalone

# Run as root for full E2E (guest + host kernel stacks)
sudo -E env "PATH=$PATH" scripts/bench/full-flamegraph.sh \
    --guest-elf bin/python.elf \
    --user-symbols /path/to/python.elf.sym
```

## Known limitations

- **No timestamp-based correlation**: Same as the Windows PR -- guest and host stacks are merged by appending, not temporally correlated
- **System-wide perf noise**: When running with `-a`, other processes' stacks are captured but filtered out by the `nanvixd|uservm` grep. Very busy systems may have slightly higher overhead.
- **WSL2**: `perf record` may not work on WSL2 without WSL2-specific kernel tools

## Testing

Tested on Azure Linux 3.0 (KVM with nested virtualization). Produces balanced `[GUEST]`/`[HOST]` flamegraphs with 100% symbol resolution across Nanvix kernel, CPython, nanvixd VMM, and host Linux kernel (futex, vfs, ext4, kvm).

## Stacked on

- PR #2151: [uservm] E: Host kernel stack correlation via ETW (Windows)
