### PR TITLE
[kernel] Relocate IDT and IDTR from BSS to scratch memory

### DIFF
--- a/src/kernel/src/hal/arch/x86/cpu/idt.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/idt.rs
@@ -6,6 +6,7 @@
 //==================================================================================================
 
 use crate::hal::arch::x86::mem::gdt::SegmentSelector;
+pub use ::arch::cpu::idt::IDTE_ALIGNMENT;
 use ::arch::cpu::{
     idt::{
         DescriptorPrivilegeLevel,
@@ -17,6 +18,10 @@ use ::arch::cpu::{
     idtr::Idtr,
 };
 use ::core::mem;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
 
 unsafe extern "C" {
     /// Division-by-Zero Error.
@@ -124,110 +129,197 @@ pub const IDT_LEN: usize = 256;
 ///
 /// # Description
 ///
-/// Size of the IDT.
+/// Size of the IDT in bytes.
 ///
 pub const IDT_SIZE: usize = IDT_LEN * mem::size_of::<Idte>();
+
+///
+/// # Description
+///
+/// Size of the IDTR in bytes.
+///
+#[allow(dead_code)]
+pub const IDTR_SIZE: usize = mem::size_of::<Idtr>();
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Interrupt descriptor table.
+pub struct Idt;
 
 //==================================================================================================
 // Global Variables
 //==================================================================================================
 
-static mut IDT: [Idte; IDT_LEN] = unsafe { mem::zeroed() };
+/// Pointer to the platform-provided IDT backing storage.
+///
+/// Initialized by [`Idt::set_backing_storage()`] before [`init()`]. On microvm the storage
+/// is a BSS-allocated static array; on Hyperlight it resides in the scratch region so it is not
+/// part of the Copy-on-Write snapshot.
+static mut IDT: *mut Idte = core::ptr::null_mut();
 
-static mut IDTR: Idtr = unsafe { mem::zeroed() };
+/// Pointer to the platform-provided IDTR backing storage.
+///
+/// Initialized by [`Idt::set_backing_storage()`] before [`init()`]. On microvm the storage
+/// is a BSS-allocated static; on Hyperlight it resides in the scratch region so it is not
+/// part of the Copy-on-Write snapshot.
+static mut IDTR: *mut Idtr = core::ptr::null_mut();
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl Idt {
+    ///
+    /// # Description
+    ///
+    /// Installs platform-provided backing storage for the IDT and IDTR.
+    ///
+    /// Must be called exactly once before [`init()`].
+    ///
+    /// # Parameters
+    ///
+    /// - `idt_storage`: Pointer to at least [`IDT_LEN`] contiguous [`Idte`] slots whose
+    ///   lifetime exceeds all subsequent IDT operations. Must be aligned to [`IDTE_ALIGNMENT`].
+    /// - `idtr_storage`: Pointer to a single [`Idtr`] whose lifetime exceeds all subsequent IDT
+    ///   operations.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if the backing storage was successfully installed.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::InvalidArgument`] if `idt_storage` is not aligned to [`IDTE_ALIGNMENT`].
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it sets global raw pointers that all IDT operations
+    /// depend on. The caller must ensure:
+    /// - `idt_storage` is non-null and points to at least [`IDT_LEN`] entries.
+    /// - `idtr_storage` is non-null and points to a valid [`Idtr`].
+    /// - The backing memory outlives all IDT usage.
+    /// - This function is called at most once.
+    ///
+    pub unsafe fn set_backing_storage(
+        idt_storage: *mut Idte,
+        idtr_storage: *mut Idtr,
+    ) -> Result<(), Error> {
+        if !::sys::mm::is_aligned(idt_storage as usize, IDTE_ALIGNMENT) {
+            let reason: &str = "IDT backing storage pointer is not properly aligned";
+            error!("{}", reason);
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        IDT = idt_storage;
+        IDTR = idtr_storage;
+        Ok(())
+    }
+}
 
 pub unsafe fn init() {
+    debug_assert!(
+        !IDT.is_null(),
+        "IDT backing storage not installed; call Idt::set_backing_storage() first"
+    );
+    debug_assert!(
+        !IDTR.is_null(),
+        "IDTR backing storage not installed; call Idt::set_backing_storage() first"
+    );
     info!("initializing idt...");
 
+    let idt: *mut Idte = IDT;
+
     // Set exception hooks.
-    IDT[EXCP_OFF as usize] =
+    *idt.add(EXCP_OFF as usize) =
         idt_entry!(_do_excp0, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 1] =
+    *idt.add(EXCP_OFF as usize + 1) =
         idt_entry!(_do_excp1, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 2] =
+    *idt.add(EXCP_OFF as usize + 2) =
         idt_entry!(_do_excp2, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 3] =
+    *idt.add(EXCP_OFF as usize + 3) =
         idt_entry!(_do_excp3, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 4] =
+    *idt.add(EXCP_OFF as usize + 4) =
         idt_entry!(_do_excp4, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 5] =
+    *idt.add(EXCP_OFF as usize + 5) =
         idt_entry!(_do_excp5, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 6] =
+    *idt.add(EXCP_OFF as usize + 6) =
         idt_entry!(_do_excp6, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 7] =
+    *idt.add(EXCP_OFF as usize + 7) =
         idt_entry!(_do_excp7, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 8] =
+    *idt.add(EXCP_OFF as usize + 8) =
         idt_entry!(_do_excp8, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 9] =
+    *idt.add(EXCP_OFF as usize + 9) =
         idt_entry!(_do_excp9, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 10] =
+    *idt.add(EXCP_OFF as usize + 10) =
         idt_entry!(_do_excp10, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 11] =
+    *idt.add(EXCP_OFF as usize + 11) =
         idt_entry!(_do_excp11, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 12] =
+    *idt.add(EXCP_OFF as usize + 12) =
         idt_entry!(_do_excp12, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 13] =
+    *idt.add(EXCP_OFF as usize + 13) =
         idt_entry!(_do_excp13, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[EXCP_OFF as usize + 14] =
+    *idt.add(EXCP_OFF as usize + 14) =
         idt_entry!(_do_excp14, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    for (_, entry) in IDT
-        .iter_mut()
-        .enumerate()
-        .skip(EXCP_OFF as usize + 15)
-        .take(17)
-    {
-        *entry = idt_entry!(_do_excp15, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
+    for i in 0..17 {
+        *idt.add(EXCP_OFF as usize + 15 + i) =
+            idt_entry!(_do_excp15, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
     }
 
     // Set hardware interrupt hooks.
-    IDT[INT_OFF as usize] =
+    *idt.add(INT_OFF as usize) =
         idt_entry!(_do_hwint0, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 1] =
+    *idt.add(INT_OFF as usize + 1) =
         idt_entry!(_do_hwint1, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 2] =
+    *idt.add(INT_OFF as usize + 2) =
         idt_entry!(_do_hwint2, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 3] =
+    *idt.add(INT_OFF as usize + 3) =
         idt_entry!(_do_hwint3, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 4] =
+    *idt.add(INT_OFF as usize + 4) =
         idt_entry!(_do_hwint4, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 5] =
+    *idt.add(INT_OFF as usize + 5) =
         idt_entry!(_do_hwint5, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 6] =
+    *idt.add(INT_OFF as usize + 6) =
         idt_entry!(_do_hwint6, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 7] =
+    *idt.add(INT_OFF as usize + 7) =
         idt_entry!(_do_hwint7, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 8] =
+    *idt.add(INT_OFF as usize + 8) =
         idt_entry!(_do_hwint8, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 9] =
+    *idt.add(INT_OFF as usize + 9) =
         idt_entry!(_do_hwint9, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 10] =
+    *idt.add(INT_OFF as usize + 10) =
         idt_entry!(_do_hwint10, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 11] =
+    *idt.add(INT_OFF as usize + 11) =
         idt_entry!(_do_hwint11, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 12] =
+    *idt.add(INT_OFF as usize + 12) =
         idt_entry!(_do_hwint12, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 13] =
+    *idt.add(INT_OFF as usize + 13) =
         idt_entry!(_do_hwint13, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 14] =
+    *idt.add(INT_OFF as usize + 14) =
         idt_entry!(_do_hwint14, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
-    IDT[INT_OFF as usize + 15] =
+    *idt.add(INT_OFF as usize + 15) =
         idt_entry!(_do_hwint15, DescriptorPrivilegeLevel::Ring0, GateType::Int32);
     // Set system call hook.
-    IDT[128] = idt_entry!(_do_kcall, DescriptorPrivilegeLevel::Ring3, GateType::Int32);
+    *idt.add(128) = idt_entry!(_do_kcall, DescriptorPrivilegeLevel::Ring3, GateType::Int32);
 
     // Load IDT.
-    IDTR.init(
-        IDT.as_ptr() as u32,
-        u16::try_from(IDT_SIZE).expect("wrong idt size, is it corrupted?"),
-    );
+    (*IDTR).init(idt as u32, u16::try_from(IDT_SIZE).expect("wrong idt size, is it corrupted?"));
     load()
 }
 
 ///
 /// # Description
 ///
-/// Loads the IDT
+/// Loads the IDT.
 pub unsafe fn load() {
-    info!("loading idt (base={:p}, size={})", IDT.as_ptr(), IDT_SIZE);
-    IDTR.load();
+    debug_assert!(
+        !IDT.is_null(),
+        "IDT backing storage not installed; call Idt::set_backing_storage() first"
+    );
+    debug_assert!(
+        !IDTR.is_null(),
+        "IDTR backing storage not installed; call Idt::set_backing_storage() first"
+    );
+    info!("loading idt (base={:p}, size={})", IDT, IDT_SIZE);
+    (*IDTR).load();
 }

--- a/src/kernel/src/hal/arch/x86/cpu/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/mod.rs
@@ -7,7 +7,7 @@
 
 mod context;
 mod exception;
-mod idt;
+pub(crate) mod idt;
 mod interrupt;
 
 #[cfg(feature = "smp")]

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -25,6 +25,7 @@ use crate::{
     hal::{
         arch::x86::{
             self,
+            cpu::idt,
             mem::gdt,
             Arch,
         },
@@ -66,6 +67,10 @@ use ::alloc::{
     vec,
 };
 use ::arch::{
+    cpu::{
+        idt::Idte,
+        idtr::Idtr,
+    },
     mem,
     mem::{
         gdt::Gdte,
@@ -250,6 +255,12 @@ scratch_layout! {
     /// GDT backing storage.
     GDT                : size = gdt::GDT_NUM_ENTRIES * core::mem::size_of::<Gdte>(),
                          align = gdt::GDTE_ALIGNMENT;
+    /// IDT backing storage.
+    IDT                : size = idt::IDT_SIZE,
+                         align = idt::IDTE_ALIGNMENT;
+    /// IDTR backing storage.
+    IDTR               : size = idt::IDTR_SIZE,
+                         align = WORD_ALIGNMENT;
 }
 
 //==================================================================================================
@@ -1287,6 +1298,19 @@ pub fn init(
             gdt::GDT_NUM_ENTRIES,
         );
         gdt::Gdt::set_backing_storage(gdt_backing)?;
+    }
+
+    // Install IDT and IDTR backing storage in the scratch region, outside the CoW snapshot.
+    //
+    // Safety: idt_ptr returns a pointer aligned to IDTE_ALIGNMENT (enforced at compile
+    // time by the scratch_layout! macro). idtr_ptr returns a word-aligned pointer.
+    // The scratch region is identity-mapped, zeroed by Hyperlight, and never freed,
+    // so the pointers are valid and outlive all IDT usage. This is the only call to
+    // Idt::set_backing_storage() in the Hyperlight init path.
+    unsafe {
+        let idt_backing: *mut Idte = idt_ptr(scratch_reserved_base) as *mut Idte;
+        let idtr_backing: *mut Idtr = idtr_ptr(scratch_reserved_base) as *mut Idtr;
+        idt::Idt::set_backing_storage(idt_backing, idtr_backing)?;
     }
 
     Ok(Platform {

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     hal::{
         arch::x86::{
             self,
+            cpu::idt,
             mem::gdt,
             Arch,
         },
@@ -55,7 +56,11 @@ use ::alloc::{
     vec,
 };
 use ::arch::{
-    cpu::pic,
+    cpu::{
+        idt::Idte,
+        idtr::Idtr,
+        pic,
+    },
     mem,
     mem::gdt::Gdte,
 };
@@ -109,6 +114,12 @@ static mut FRAME_ALLOCATOR_STORAGE: [u8; config::kernel::MEMORY_SIZE
 
 /// GDT backing storage, allocated in BSS.
 static mut GDT_STORAGE: [Gdte; gdt::GDT_NUM_ENTRIES] = gdt::DEFAULT_ENTRIES;
+
+/// IDT backing storage, allocated in BSS.
+static mut IDT_STORAGE: [Idte; idt::IDT_LEN] = unsafe { core::mem::zeroed() };
+
+/// IDTR backing storage, allocated in BSS.
+static mut IDTR_STORAGE: Idtr = unsafe { core::mem::zeroed() };
 
 // Ensure the number of kpool pages is a multiple of 8 so the bitmap has no padding bits.
 ::static_assert::assert_eq!(
@@ -698,6 +709,16 @@ pub fn init(
     // This is the only call to set_backing_storage() in the microvm init path.
     unsafe {
         gdt::Gdt::set_backing_storage(GDT_STORAGE.as_mut_ptr())?;
+    }
+
+    // Install IDT and IDTR backing storage. On microvm these live in BSS-allocated area.
+    // Safety: IDT_STORAGE is a static array of Idte entries with repr(C, align(8)),
+    // so the pointer is properly aligned and valid for IDT_LEN entries.
+    // IDTR_STORAGE is a static Idtr with repr(C, packed).
+    // The static lifetime guarantees the storage outlives all IDT usage.
+    // This is the only call to Idt::set_backing_storage() in the microvm init path.
+    unsafe {
+        idt::Idt::set_backing_storage(IDT_STORAGE.as_mut_ptr(), &raw mut IDTR_STORAGE)?;
     }
 
     let arch = x86::init(ioports, ioaddresses, madt)?;

--- a/src/libs/arch/src/x86/cpu/idt.rs
+++ b/src/libs/arch/src/x86/cpu/idt.rs
@@ -38,6 +38,12 @@ pub struct Idte {
 // `Idte` must be 8 bytes long. This must match the hardware specification.
 ::static_assert::assert_eq_size!(Idte, 8);
 
+/// Required alignment for an IDT entry.
+pub const IDTE_ALIGNMENT: ::sys::mm::Alignment = ::sys::mm::Alignment::Align8;
+
+// Ensure `Idte` alignment matches `IDTE_ALIGNMENT`.
+::static_assert::assert_eq_align!(Idte, IDTE_ALIGNMENT as usize);
+
 impl Idte {
     /// Creates a new IDT entry.
     pub fn new(handler: u32, selector: u16, flags: Flags) -> Self {


### PR DESCRIPTION
## Description

Closes #2156. Part of #2152.

Relocate the `IDT` (`[Idte; IDT_LEN]`, ~2 KiB) and `IDTR` (`Idtr`, 6 B) from BSS statics to platform-provided backing storage. On Hyperlight, both structures are placed in the scratch region (outside the CoW snapshot) so that runtime writes do not trigger copy-on-write faults. On microvm, behavior is preserved via BSS-allocated statics passed through the same API.

This mirrors the GDT pattern introduced in PR #2150.

## Changes

### `arch` crate (`src/libs/arch/src/x86/cpu/idt.rs`)
- Add `IDTE_ALIGNMENT` constant (`Alignment::Align8`) with a compile-time static assert.

### IDT module (`src/kernel/src/hal/arch/x86/cpu/idt.rs`)
- Replace `static mut IDT: [Idte; IDT_LEN]` and `static mut IDTR: Idtr` with `*mut Idte` / `*mut Idtr` raw pointers (initially null).
- Add `Idt` struct with `set_backing_storage(idt_storage, idtr_storage)` that validates `IDTE_ALIGNMENT` before recording the pointers.
- Add `IDTR_SIZE` constant for the scratch layout macro.
- Rewrite `init()` and `load()` to operate through raw pointers, with debug assertions guarding against uninitialized storage.
- Promote `idt` module to `pub(crate)` visibility.

### microvm platform (`src/kernel/src/hal/platform/microvm/mod.rs`)
- Add BSS-allocated `IDT_STORAGE` and `IDTR_STORAGE` statics.
- Call `Idt::set_backing_storage()` before `x86::init()`.

### Hyperlight platform (`src/kernel/src/hal/platform/hyperlight/mod.rs`)
- Add `IDT` and `IDTR` entries to `scratch_layout!` macro.
- Call `Idt::set_backing_storage()` with scratch-region pointers before `x86::init()`.

## Testing

- `./z build -- all` ✅
- `./z build -- run-nanvix-tests MACHINE=microvm DEPLOYMENT_MODE=standalone` ✅
- `./z build -- run-nanvix-tests MACHINE=hyperlight DEPLOYMENT_MODE=standalone` ✅