### PR TITLE
[kernel] Prevent scratch region from overlapping user address space

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -235,6 +235,9 @@ pub struct Platform {
     (::config::kernel::KPOOL_SIZE / mem::PAGE_SIZE).is_multiple_of(u8::BITS as usize)
 );
 
+// Ensure the config crate's GPA ceiling matches the upstream MAX_GPA from hyperlight-common.
+::static_assert::assert_eq!(memory_layout::HYPERLIGHT_GPA_CEILING == MAX_GPA + 1);
+
 // Scratch-reserved layout.
 //
 // These structures are allocated in the scratch region (outside the CoW snapshot) so that
@@ -1129,6 +1132,24 @@ pub fn init(
     // MAX_GPA (not MAX_GVA) because the guest uses identity mapping (GVA == GPA)
     // and the KVM memory slot is placed relative to MAX_GPA.
     let scratch_base_address: usize = MAX_GPA - scratch_size + 1;
+
+    // Sanity check: the scratch region must not descend into the user virtual address space.
+    // The config crate already computes USER_END_RAW to avoid this overlap, but verify at
+    // runtime in case the memory layout parameters diverge from compile-time assumptions.
+    // When they do, the reserved MMIO structures (input/output buffers) at the bottom of the
+    // scratch region would collide with user stack pages.
+    if scratch_base_address < memory_layout::USER_END_RAW {
+        let reason: &str = "scratch region overlaps user address space";
+        error!(
+            "init(): {} (scratch_base={:#010x} < USER_END_RAW={:#010x}, scratch_size={:#x})",
+            reason,
+            scratch_base_address,
+            memory_layout::USER_END_RAW,
+            scratch_size
+        );
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
     // scratch_end is the exclusive end of the full scratch range, including the last page
     // reserved for Hyperlight bookkeeping metadata.
     let scratch_end_address: usize =

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -83,12 +83,53 @@ pub mod memory_layout {
     ///
     pub const USER_BASE_RAW: usize = KERNEL_END_RAW;
 
-    ///
-    /// # Description
-    ///
-    /// Provides the raw value for [`USER_END`], which can be used in constant-value expressions.
-    ///
-    pub const USER_END_RAW: usize = 0xf0000000;
+    // On Hyperlight the scratch region occupies the top of the 32-bit GPA space ([MAX_GPA -
+    // scratch_size + 1, MAX_GPA + 1)).  Reserved MMIO structures (input/output buffers, allocator
+    // bitmaps) are placed at the very bottom of the scratch region.  Because scratch_size can be as
+    // large as MEMORY_SIZE, those buffers can descend into the user address space, colliding with
+    // the user stack.  To prevent this, the user address space must end below the worst-case
+    // scratch base.  The value is aligned down to a 4 MB page-table boundary.
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "hyperlight")] {
+            ///
+            /// # Description
+            ///
+            /// First guest physical address above the addressable GPA range
+            /// (`MAX_GPA + 1` from `hyperlight-common`).  The kernel's compile-time
+            /// assertion ties this value to the upstream constant so it cannot
+            /// silently drift.
+            ///
+            pub const HYPERLIGHT_GPA_CEILING: usize = 0xFEE0_0000;
+
+            /// Alignment for the exclusive upper bound of the user virtual address space.
+            pub const USER_END_ALIGNMENT: usize = 4 * 1024 * 1024;
+
+            ///
+            /// # Description
+            ///
+            /// Exclusive upper bound of the user virtual address space (Hyperlight).
+            ///
+            /// Computed as `floor_4MB(HYPERLIGHT_GPA_CEILING - MEMORY_SIZE)` so that
+            /// the worst-case scratch region never overlaps the user stack.
+            ///
+            pub const USER_END_RAW: usize =
+                (HYPERLIGHT_GPA_CEILING - crate::kernel::MEMORY_SIZE) & !(USER_END_ALIGNMENT - 1);
+        } else {
+            ///
+            /// # Description
+            ///
+            /// Exclusive upper bound of the user virtual address space.
+            ///
+            pub const USER_END_RAW: usize = 0xf0000000;
+        }
+    }
+
+    // The subtraction in USER_END_RAW must not underflow, and the result must stay above the
+    // kernel region. The Hyperlight build.rs ceiling guarantees this today, but verify here so
+    // future configuration changes fail with a clear diagnostic at the source of the calculation.
+    const _: () = assert!(USER_END_RAW > USER_BASE_RAW, "USER_END_RAW underflows into kernel");
+    const _: () =
+        assert!(USER_END_RAW > USER_MMAP_END_RAW, "USER_END_RAW overlaps fixed user-space regions");
 
     ///
     /// # Description


### PR DESCRIPTION
On Hyperlight the scratch region is placed at the top of the 32-bit GPA
space ([MAX_GPA - scratch_size + 1, MAX_GPA + 1)).  Because scratch_size
can be as large as MEMORY_SIZE, the MMIO structures at the bottom of the
scratch region can descend into the user address space, corrupting the
user stack.

## Changes

**Config crate** (`src/libs/config/src/lib.rs`):
- Replace the fixed `USER_END_RAW` (`0xf000_0000`) with a Hyperlight-aware
  computation: `floor_4MB(HYPERLIGHT_GPA_CEILING - MEMORY_SIZE)`.
  The non-Hyperlight branch keeps the original value.
- Extract the magic `0xFEE0_0000` (`MAX_GPA + 1`) into the named constant
  `HYPERLIGHT_GPA_CEILING` so the derivation is self-documenting.
- Add a const assert that `USER_END_RAW > USER_BASE_RAW` to catch
  underflows if the `MEMORY_SIZE` ceiling is raised in the future.

**Kernel HAL** (`src/kernel/src/hal/platform/hyperlight/mod.rs`):
- Add a compile-time assertion that `HYPERLIGHT_GPA_CEILING` equals
  `MAX_GPA + 1` from `hyperlight-common`, so the two values cannot silently
  diverge.
- Add a runtime guard in `init()` that returns an error with diagnostics
  when `scratch_base_address < USER_END_RAW`, providing a clear failure
  instead of silent memory corruption.

Closes #2182