### PR TITLE
[kernel] B: Don't use Vec capacity for allocation

### DIFF
--- a/src/kernel/src/mm/elf.rs
+++ b/src/kernel/src/mm/elf.rs
@@ -340,6 +340,7 @@ fn do_elf32_load(
                         vaddr,
                         access,
                         page_lies_in_bss || page_is_partially_covered,
+                        1,
                         &mut uframe_buf,
                     )?;
                 }

--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -94,7 +94,7 @@ impl KernelStack {
     pub fn new(mm: &mut VirtMemoryManager) -> Result<Self, Error> {
         let count: usize = config::kernel::KSTACK_SIZE / ::arch::mem::PAGE_SIZE;
         let mut kframes: Vec<KernelFrame> = Vec::with_capacity(count);
-        mm.alloc_kpages(true, &mut kframes)?;
+        mm.alloc_kpages(true, count, &mut kframes)?;
         let kpages: Vec<KernelPage> = kframes.into_iter().map(KernelPage::new).collect();
 
         let guard_threshold: u32 =

--- a/src/kernel/src/mm/phys/kpool.rs
+++ b/src/kernel/src/mm/phys/kpool.rs
@@ -425,7 +425,8 @@ impl Kpool {
     ///
     /// - `count`: Number of frames to allocate.
     /// - `frames`: Mutable reference to a pre-allocated vector into which
-    ///   to store those frames' addresses.
+    ///   to store those frames' addresses. It must be pre-allocated with
+    ///   capacity of at least `count`.
     ///
     /// # Return Values
     ///
@@ -436,6 +437,11 @@ impl Kpool {
         // Check if caller-provided vector is not empty.
         if !frames.is_empty() {
             let reason: &str = "frames vector is not empty";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        if frames.capacity() < count {
+            let reason: &str = "frames vector has insufficient capacity";
             error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }

--- a/src/kernel/src/mm/phys/kpool.rs
+++ b/src/kernel/src/mm/phys/kpool.rs
@@ -117,22 +117,22 @@ impl Inner {
     ///
     /// # Parameters
     ///
-    /// - `addrs`: Mutable reference to a pre-allocated vector. The number of frames allocated
-    ///   equals `addrs.capacity()`.
+    /// - `count` - The number of frames to allocate.
+    /// - `addrs`: Mutable reference to a pre-allocated vector in which
+    ///   to store those frames' addresses.
     ///
     /// # Return Values
     ///
-    /// Upon success, `Ok(())` is returned and `addrs` is filled to capacity with contiguous
-    /// entries. Upon failure, an error is returned instead.
+    /// Upon success, `Ok(())` is returned and `addrs` is filled with `count`
+    /// contiguous entries. Upon failure, an error is returned instead.
     ///
-    fn alloc_range(&mut self, addrs: &mut Vec<FrameAddress>) -> Result<(), Error> {
+    fn alloc_range(&mut self, count: usize, addrs: &mut Vec<FrameAddress>) -> Result<(), Error> {
         if !addrs.is_empty() {
             let reason: &str = "addrs vector is not empty";
             error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
-        let count: usize = addrs.capacity();
         let index: usize = match self.bitmap.alloc_range(count) {
             Ok(index) => index,
             Err(error) => {
@@ -277,16 +277,17 @@ fn alloc() -> Result<FrameAddress, Error> {
 ///
 /// # Parameters
 ///
-/// - `addrs`: Mutable reference to a pre-allocated vector. The number of frames allocated
-///   equals `addrs.capacity()`.
+/// - `count`: Number of frames to allocate.
+/// - `addrs`: Mutable reference to a pre-allocated vector into which to
+///   store those frames' addresses.
 ///
 /// # Return Values
 ///
-/// Upon success, `Ok(())` is returned and `addrs` is filled to capacity with contiguous
-/// entries. Upon failure, an error is returned instead.
+/// Upon success, `Ok(())` is returned and `addrs` is filled with `count`
+/// contiguous entries. Upon failure, an error is returned instead.
 ///
-fn alloc_range(addrs: &mut Vec<FrameAddress>) -> Result<(), Error> {
-    instance().alloc_range(addrs)
+fn alloc_range(count: usize, addrs: &mut Vec<FrameAddress>) -> Result<(), Error> {
+    instance().alloc_range(count, addrs)
 }
 
 ///
@@ -422,15 +423,16 @@ impl Kpool {
     ///
     /// # Parameters
     ///
-    /// - `frames`: Mutable reference to a pre-allocated vector. The number of frames allocated
-    ///   equals `frames.capacity()`.
+    /// - `count`: Number of frames to allocate.
+    /// - `frames`: Mutable reference to a pre-allocated vector into which
+    ///   to store those frames' addresses.
     ///
     /// # Return Values
     ///
-    /// Upon success, `Ok(())` is returned and `frames` is filled to capacity with contiguous
-    /// entries. Upon failure, an error is returned instead.
+    /// Upon success, `Ok(())` is returned and `frames` is filled with `count`
+    /// contiguous entries. Upon failure, an error is returned instead.
     ///
-    pub fn alloc_many(&mut self, frames: &mut Vec<KernelFrame>) -> Result<(), Error> {
+    pub fn alloc_many(&mut self, count: usize, frames: &mut Vec<KernelFrame>) -> Result<(), Error> {
         // Check if caller-provided vector is not empty.
         if !frames.is_empty() {
             let reason: &str = "frames vector is not empty";
@@ -438,9 +440,8 @@ impl Kpool {
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
-        let count: usize = frames.capacity();
         let mut addrs: Vec<FrameAddress> = Vec::with_capacity(count);
-        alloc_range(&mut addrs)?;
+        alloc_range(count, &mut addrs)?;
         for addr in addrs {
             frames.push(KernelFrame::new(addr));
         }

--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -127,8 +127,7 @@ impl PhysMemoryManager {
     ///
     /// # Description
     ///
-    /// Allocates user frames into caller-provided storage, filling up to the vector's remaining
-    /// capacity.
+    /// Allocates user frames into caller-provided storage.
     ///
     /// The returned frames are not guaranteed to be physically contiguous.
     ///

--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -134,23 +134,28 @@ impl PhysMemoryManager {
     ///
     /// # Parameters
     ///
-    /// - `frames`: Mutable reference to a pre-allocated vector. The number of frames allocated
-    ///   equals `frames.capacity() - frames.len()`.
+    /// - `count`: Number of frames to allocate.
+    /// - `frames`: Mutable reference to a pre-allocated vector into which to store those
+    ///   frames' addresses.
     ///
     /// # Return Values
     ///
-    /// Upon success, `Ok(())` is returned and `frames` is filled to capacity. Upon failure, an
+    /// Upon success, `Ok(())` is returned and `frames` is filled with `count` frames. Upon failure, an
     /// error is returned and any frames allocated by this call are dropped by truncating `frames`
     /// back to empty.
     ///
-    pub fn alloc_many_user_frames(&mut self, frames: &mut Vec<UserFrame>) -> Result<(), Error> {
+    pub fn alloc_many_user_frames(
+        &mut self,
+        count: usize,
+        frames: &mut Vec<UserFrame>,
+    ) -> Result<(), Error> {
         if !frames.is_empty() {
             let reason: &str = "frames vector is not empty";
             error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
-        for _ in 0..frames.capacity() {
+        for _ in 0..count {
             match self.upool.alloc() {
                 Ok(frame) => frames.push(frame),
                 Err(error) => {
@@ -182,15 +187,20 @@ impl PhysMemoryManager {
     ///
     /// # Parameters
     ///
-    /// - `frames`: Mutable reference to a pre-allocated vector. The number of frames allocated
-    ///   equals `frames.capacity()`.
+    /// - `count`: Number of frames to allocate.
+    /// - `frames`: Mutable reference to a pre-allocated vector into which to store
+    ///   those frames' addresses.
     ///
     /// # Return Values
     ///
-    /// Upon success, `Ok(())` is returned and `frames` is filled to capacity with contiguous
-    /// entries. Upon failure, an error is returned instead.
+    /// Upon success, `Ok(())` is returned and `frames` is filled with `count`
+    /// contiguous entries. Upon failure, an error is returned instead.
     ///
-    pub fn alloc_many_kernel_frames(&mut self, frames: &mut Vec<KernelFrame>) -> Result<(), Error> {
+    pub fn alloc_many_kernel_frames(
+        &mut self,
+        count: usize,
+        frames: &mut Vec<KernelFrame>,
+    ) -> Result<(), Error> {
         // Check if caller-provided vector is not empty.
         if !frames.is_empty() {
             let reason: &str = "frames vector is not empty";
@@ -198,6 +208,6 @@ impl PhysMemoryManager {
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
-        self.kpool.alloc_many(frames)
+        self.kpool.alloc_many(count, frames)
     }
 }

--- a/src/kernel/src/mm/phys/manager.rs
+++ b/src/kernel/src/mm/phys/manager.rs
@@ -135,7 +135,7 @@ impl PhysMemoryManager {
     ///
     /// - `count`: Number of frames to allocate.
     /// - `frames`: Mutable reference to a pre-allocated vector into which to store those
-    ///   frames' addresses.
+    ///   frames' addresses. It should have sufficient capacity for `count` entries.
     ///
     /// # Return Values
     ///
@@ -150,6 +150,11 @@ impl PhysMemoryManager {
     ) -> Result<(), Error> {
         if !frames.is_empty() {
             let reason: &str = "frames vector is not empty";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        if frames.capacity() < count {
+            let reason: &str = "frames vector has insufficient capacity";
             error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
@@ -203,6 +208,11 @@ impl PhysMemoryManager {
         // Check if caller-provided vector is not empty.
         if !frames.is_empty() {
             let reason: &str = "frames vector is not empty";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        if frames.capacity() < count {
+            let reason: &str = "frames vector has insufficient capacity";
             error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -251,8 +251,8 @@ impl VirtMemoryManager {
     /// - `vaddr`: Starting virtual address for the mapping.
     /// - `access`: Access permissions for the mapped pages.
     /// - `clear`: Clear pages after mapping?
+    /// - `nframes`: Number of pages to allocate.
     /// - `uframes`: Mutable reference to a pre-allocated vector for temporary frame storage.
-    ///   The number of pages allocated equals `uframes.capacity()`.
     ///
     /// # Return Values
     ///
@@ -265,9 +265,9 @@ impl VirtMemoryManager {
         mut vaddr: PageAligned<VirtualAddress>,
         access: AccessPermission,
         clear: bool,
+        nframes: usize,
         uframes: &mut Vec<UserFrame>,
     ) -> Result<(), Error> {
-        let nframes: usize = uframes.capacity();
         trace!("vaddr={:?}, nframes={}", vaddr, nframes);
 
         // The caller-supplied buffer must be empty; stale frames would cause double-mapping.
@@ -324,7 +324,7 @@ impl VirtMemoryManager {
         // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no concurrent
         // or re-entrant access to the physical memory manager is possible.
         let alloc_result: Result<(), Error> =
-            unsafe { PhysMemoryManager::get_mut() }.alloc_many_user_frames(uframes);
+            unsafe { PhysMemoryManager::get_mut() }.alloc_many_user_frames(nframes, uframes);
         if let Err(e) = alloc_result {
             uframes.clear();
             return Err(e);
@@ -433,8 +433,8 @@ impl VirtMemoryManager {
     /// # Parameters
     ///
     /// - `clear`: Clear frames?
+    /// - `count`: Number of frames to allocate.
     /// - `kframes`: Pre-allocated vector where allocated frames are placed.
-    ///   The number of frames allocated equals `kframes.capacity()`.
     ///
     /// # Return Values
     ///
@@ -444,6 +444,7 @@ impl VirtMemoryManager {
     pub fn alloc_kpages(
         &mut self,
         clear: bool,
+        count: usize,
         kframes: &mut Vec<KernelFrame>,
     ) -> Result<(), Error> {
         if !kframes.is_empty() {
@@ -454,7 +455,7 @@ impl VirtMemoryManager {
 
         // SAFETY: the kernel is single-threaded and runs with interrupts disabled; no concurrent
         // or re-entrant access to the physical memory manager is possible.
-        unsafe { PhysMemoryManager::get_mut() }.alloc_many_kernel_frames(kframes)?;
+        unsafe { PhysMemoryManager::get_mut() }.alloc_many_kernel_frames(count, kframes)?;
         if clear {
             for kframe in kframes.iter_mut() {
                 kframe.clear();

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -438,8 +438,8 @@ impl VirtMemoryManager {
     ///
     /// # Return Values
     ///
-    /// Upon success, `Ok(())` is returned and `kframes` is filled to capacity. Upon
-    /// failure, an error is returned instead.
+    /// Upon success, `Ok(())` is returned and `kframes` is filled with `count`
+    /// frames. Upon failure, an error is returned instead.
     ///
     pub fn alloc_kpages(
         &mut self,

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -276,6 +276,11 @@ impl VirtMemoryManager {
             error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
+        if uframes.capacity() < nframes {
+            let reason: &str = "caller-supplied uframes vector has insufficient capacity";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
 
         // Validate that nframes is positive and the full range lies in user space.
         let range_size: usize = nframes.checked_mul(mem::PAGE_SIZE).ok_or_else(|| {
@@ -434,7 +439,8 @@ impl VirtMemoryManager {
     ///
     /// - `clear`: Clear frames?
     /// - `count`: Number of frames to allocate.
-    /// - `kframes`: Pre-allocated vector where allocated frames are placed.
+    /// - `kframes`: Pre-allocated vector where allocated frames are placed. It
+    ///   must have sufficient capacity for `count` entries.
     ///
     /// # Return Values
     ///
@@ -449,6 +455,11 @@ impl VirtMemoryManager {
     ) -> Result<(), Error> {
         if !kframes.is_empty() {
             let reason: &str = "caller-supplied kframes vector is not empty";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        if kframes.capacity() < count {
+            let reason: &str = "caller-supplied kframes vector has insufficient capacity";
             error!("{reason}");
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -501,6 +501,7 @@ impl ProcessManager {
             args_vaddr,
             AccessPermission::RDWR,
             true,
+            1,
             &mut Vec::with_capacity(1),
         )?;
         vmem.copy_to_user_unaligned(
@@ -525,6 +526,7 @@ impl ProcessManager {
             envp_vaddr,
             AccessPermission::RDWR,
             true,
+            1,
             &mut Vec::with_capacity(1),
         )?;
 
@@ -564,12 +566,14 @@ impl ProcessManager {
         // will leak underlying pages.
         let initial_stack_base: PageAligned<VirtualAddress> =
             PageAligned::from_raw_value(user_stack.top().into_raw_value() - USER_STACK_MIN_SIZE)?;
+        let count = USER_STACK_MIN_SIZE / PAGE_SIZE;
         mm.alloc_upages(
             &mut vmem,
             initial_stack_base,
             AccessPermission::RDWR,
             true,
-            &mut Vec::with_capacity(USER_STACK_MIN_SIZE / PAGE_SIZE),
+            count,
+            &mut Vec::with_capacity(count),
         )?;
 
         //==============================================================
@@ -1906,31 +1910,17 @@ impl ProcessManager {
         let mut current_vaddr: PageAligned<VirtualAddress> = vaddr;
         let mut remaining: usize = npages;
 
-        // `alloc_upages` derives the page count from `uframes.capacity()`, so the Vec capacity
-        // must exactly equal the number of pages we intend to map per iteration.  We use
-        // `try_reserve_exact` for fallible allocation with an exact capacity: first attempt a
-        // batch of `count` pages, falling back to a single page, and finally returning OOM.
         while remaining > 0 {
             let count: usize = remaining.min(MMAP_BATCH_SIZE);
-            let mut uframes = Vec::new();
-            let batch: usize = if uframes.try_reserve_exact(count).is_ok() {
-                count
-            } else if uframes.try_reserve_exact(1).is_ok() {
-                // Batch allocation failed; fall back to single-page allocation.
-                1
-            } else {
-                let reason: &str = "kheap: cannot allocate uframes vec for mmap";
-                error!("{reason}");
-                Self::rollback_mmap(mm, vmem, vaddr, current_vaddr);
-                return Err(Error::new(ErrorCode::OutOfMemory, reason));
-            };
-            if let Err(e) = mm.alloc_upages(vmem, current_vaddr, access, true, &mut uframes) {
+            let mut uframes = Vec::with_capacity(count);
+            if let Err(e) = mm.alloc_upages(vmem, current_vaddr, access, true, count, &mut uframes)
+            {
                 Self::rollback_mmap(mm, vmem, vaddr, current_vaddr);
                 return Err(e);
             }
             current_vaddr =
-                PageAligned::from_raw_value(current_vaddr.into_raw_value() + batch * PAGE_SIZE)?;
-            remaining -= batch;
+                PageAligned::from_raw_value(current_vaddr.into_raw_value() + count * PAGE_SIZE)?;
+            remaining -= count;
         }
 
         Ok(())

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1912,15 +1912,26 @@ impl ProcessManager {
 
         while remaining > 0 {
             let count: usize = remaining.min(MMAP_BATCH_SIZE);
-            let mut uframes = Vec::with_capacity(count);
-            if let Err(e) = mm.alloc_upages(vmem, current_vaddr, access, true, count, &mut uframes)
+            let mut uframes = Vec::new();
+            let batch: usize = if uframes.try_reserve(count).is_ok() {
+                count
+            } else if uframes.try_reserve(1).is_ok() {
+                // Batch allocation failed; fall back to single-page allocation.
+                1
+            } else {
+                let reason: &str = "kheap: cannot allocate uframes vec for mmap";
+                error!("{reason}");
+                Self::rollback_mmap(mm, vmem, vaddr, current_vaddr);
+                return Err(Error::new(ErrorCode::OutOfMemory, reason));
+            };
+            if let Err(e) = mm.alloc_upages(vmem, current_vaddr, access, true, batch, &mut uframes)
             {
                 Self::rollback_mmap(mm, vmem, vaddr, current_vaddr);
                 return Err(e);
             }
             current_vaddr =
-                PageAligned::from_raw_value(current_vaddr.into_raw_value() + count * PAGE_SIZE)?;
-            remaining -= count;
+                PageAligned::from_raw_value(current_vaddr.into_raw_value() + batch * PAGE_SIZE)?;
+            remaining -= batch;
         }
 
         Ok(())


### PR DESCRIPTION
Before this PR, the kernel memory manager had functions that would decide how many frames to allocate based on the capacity of an input `Vec`. But this is fragile, since the Rust runtime is free to increase the capacity at will, beyond what's requested during reservation.

This PR updates those functions to take an explicit count parameter saying how many frames to allocate.

There was some code in `ProcessManager::mmap` that tried to deal with the lack of clarity about what exactly the capacity of a `Vec` was before invoking allocation, so that the allocator would allocate the correct number of frames. Now, that code is substantially simplified.
