### PR TITLE
[kernel] Relocate kernel heap backing storage

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -264,6 +264,9 @@ scratch_layout! {
     /// IDTR backing storage.
     IDTR               : size = idt::IDTR_SIZE,
                          align = WORD_ALIGNMENT;
+    /// Kernel heap backing storage (relocated from BSS to avoid dirtying CoW snapshot pages).
+    HEAP_STORAGE       : size = crate::mm::kheap::MIN_HEAP_SIZE,
+                         align = PAGE_ALIGNMENT;
 }
 
 //==================================================================================================
@@ -611,16 +614,8 @@ extern "C" fn hyperlight_pre_kmain() -> ! {
         static __KERNEL_END: u8;
     }
 
-    // Initializes the kernel heap once so FunctionCall deserialisation can allocate on every
-    // subsequent sandbox.call().  On Hyperlight the heap is only initialised here (during evolve);
-    // kmain skips heap init via `#[cfg(not(feature = "hyperlight"))]`.
-    if let Err(_e) = unsafe { crate::mm::kheap::init() } {
-        unsafe {
-            core::arch::asm!("cli", "2: hlt", "jmp 2b", options(noreturn));
-        }
-    }
-
-    // Compute the PEB base address and store a GuestHandle for reuse.
+    // Compute the PEB base address first — needed to derive the scratch region
+    // for the heap backing storage before the heap is initialised.
     let kernel_end: usize = unsafe { &__KERNEL_END as *const u8 as usize };
     let peb_base: usize = ::sys::mm::align_up(kernel_end, PAGE_ALIGNMENT)
         .expect("hyperlight_pre_kmain(): PEB align_up overflow");
@@ -642,6 +637,34 @@ extern "C" fn hyperlight_pre_kmain() -> ! {
         }
     }
 
+    // Derive the scratch-reserved base from the PEB input buffer pointer.
+    // After the GVA→GPA patch, input_stack.ptr equals the scratch base address.
+    // The scratch-reserved region starts after the input and output data buffers.
+    let scratch_base: usize = unsafe { (*peb_ptr).input_stack.ptr } as usize;
+    let scratch_reserved_base: usize =
+        scratch_base + INPUT_DATA_BUFFER_SIZE + OUTPUT_DATA_BUFFER_SIZE;
+    let heap_backing_ptr: *mut u8 = (scratch_reserved_base + HEAP_STORAGE_OFFSET) as *mut u8;
+
+    // Point the kernel heap at scratch-resident backing storage so that heap
+    // allocations do not dirty CoW snapshot pages.
+    if let Err(_e) =
+        unsafe { crate::mm::kheap::set_backing_storage(heap_backing_ptr, HEAP_STORAGE_SIZE) }
+    {
+        unsafe {
+            core::arch::asm!("cli", "2: hlt", "jmp 2b", options(noreturn));
+        }
+    }
+
+    // Initialises the kernel heap once so FunctionCall deserialisation can allocate on every
+    // subsequent sandbox.call().  On Hyperlight the heap is only initialised here (during evolve);
+    // kmain skips heap init via `#[cfg(not(feature = "hyperlight"))]`.
+    if let Err(_e) = unsafe { crate::mm::kheap::init() } {
+        unsafe {
+            core::arch::asm!("cli", "2: hlt", "jmp 2b", options(noreturn));
+        }
+    }
+
+    // Store a GuestHandle for reuse by nanvix_dispatch_function.
     unsafe {
         GUEST_HANDLE = Some(GuestHandle::init(peb_ptr));
     }
@@ -1222,12 +1245,13 @@ pub fn init(
         memory_regions.push_back(scratch_reserved_region);
         info!(
             "scratch reserved: [{:#010x}, {:#010x}) (frame_alloc={} B, kpool={} B, gdt={} B, \
-             size={:#x})",
+             heap_storage={} B, size={:#x})",
             scratch_reserved_base,
             scratch_reserved_base + SCRATCH_RESERVED_SIZE,
             FRAME_ALLOC_BITMAP_SIZE,
             KPOOL_BITMAP_SIZE,
             GDT_SIZE,
+            HEAP_STORAGE_SIZE,
             SCRATCH_RESERVED_SIZE,
         );
     }

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -131,9 +131,40 @@ static mut KPOOL_BITMAP_STORAGE: [u8; config::kernel::KPOOL_SIZE
     / (mem::PAGE_SIZE * u8::BITS as usize)] =
     [0; config::kernel::KPOOL_SIZE / (mem::PAGE_SIZE * u8::BITS as usize)];
 
+/// Heap backing storage, allocated in BSS.
+#[repr(align(4096))]
+struct HeapStorage {
+    memory: [u8; crate::mm::kheap::MIN_HEAP_SIZE],
+}
+
+::static_assert::assert_eq_align!(HeapStorage, mem::PAGE_SIZE);
+
+/// Heap backing storage.
+static mut HEAP_STORAGE: HeapStorage = HeapStorage {
+    memory: [0; crate::mm::kheap::MIN_HEAP_SIZE],
+};
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
+
+///
+/// # Description
+///
+/// Points the kernel heap at the BSS-resident `HEAP_STORAGE` buffer.
+///
+/// Must be called before [`crate::mm::kheap::init()`].
+///
+/// # Safety
+///
+/// This function accesses the `HEAP_STORAGE` static mutable.
+///
+pub unsafe fn setup_heap_backing_storage() -> Result<(), ::sys::error::Error> {
+    crate::mm::kheap::set_backing_storage(
+        HEAP_STORAGE.memory.as_mut_ptr(),
+        HEAP_STORAGE.memory.len(),
+    )
+}
 
 ///
 /// # Description

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -262,8 +262,13 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     // On Hyperlight the heap is already initialized during the evolve phase
     // (`hyperlight_pre_kmain`) so that FunctionCall deserialization can allocate.
     #[cfg(not(feature = "hyperlight"))]
-    if let Err(e) = unsafe { kheap::init() } {
-        panic!("failed to initialize kernel heap: {:?}", e);
+    {
+        if let Err(e) = unsafe { crate::hal::platform::setup_heap_backing_storage() } {
+            panic!("failed to set up heap backing storage: {:?}", e);
+        }
+        if let Err(e) = unsafe { kheap::init() } {
+            panic!("failed to initialize kernel heap: {:?}", e);
+        }
     }
 
     #[cfg(feature = "test")]

--- a/src/kernel/src/mm/kheap.rs
+++ b/src/kernel/src/mm/kheap.rs
@@ -37,17 +37,6 @@ pub const MIN_HEAP_SIZE: usize = NUM_OF_SLABS * MIN_SLAB_SIZE;
 
 struct ArenaAllocator;
 
-#[repr(align(4096))]
-struct HeapStorage {
-    memory: [u8; MIN_HEAP_SIZE],
-}
-
-::static_assert::assert_eq_align!(HeapStorage, mem::PAGE_SIZE);
-
-static mut HEAP_STORAGE: HeapStorage = HeapStorage {
-    memory: [0; MIN_HEAP_SIZE],
-};
-
 #[derive(Copy, Clone)]
 enum SlabSize {
     Slab8 = 8,
@@ -88,6 +77,12 @@ struct Kheap {
 //==================================================================================================
 
 static mut HEAP: Option<Kheap> = None;
+
+/// Pointer to the platform-provided heap backing buffer.
+/// Every platform must set this via [`set_backing_storage()`] before calling [`init()`].
+static mut BACKING_PTR: *mut u8 = core::ptr::null_mut();
+/// Size of the backing storage in bytes.
+static mut BACKING_SIZE: usize = 0;
 
 #[global_allocator]
 static mut ALLOCATOR: ArenaAllocator = ArenaAllocator;
@@ -267,13 +262,57 @@ unsafe impl GlobalAlloc for ArenaAllocator {
 // Standalone Functions
 //==================================================================================================
 
+///
+/// # Description
+///
+/// Records an externally-provided backing buffer for the kernel heap.
+///
+/// All platforms must call this function before [`init()`]. The heap initializer
+/// unconditionally requires a previously recorded backing buffer and does not
+/// fall back to any kheap-local static storage.
+///
+/// # Parameters
+///
+/// - `ptr`: Pointer to the start of the backing buffer. Must be page-aligned.
+/// - `size`: Size of the backing buffer in bytes. Must be a multiple of [`MIN_HEAP_SIZE`].
+///
+#[allow(dead_code)]
+pub unsafe fn set_backing_storage(ptr: *mut u8, size: usize) -> Result<(), Error> {
+    if ptr.is_null() {
+        let reason: &str = "null backing storage pointer";
+        error!("set_backing_storage(): {}", reason);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+    if !(ptr as usize).is_multiple_of(mem::PAGE_SIZE) {
+        let reason: &str = "unaligned backing storage pointer";
+        error!("set_backing_storage(): {}", reason);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+    if size < MIN_HEAP_SIZE {
+        let reason: &str = "backing storage too small";
+        error!("set_backing_storage(): {} (size={}, min={})", reason, size, MIN_HEAP_SIZE);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+    if !size.is_multiple_of(MIN_HEAP_SIZE) {
+        let reason: &str = "backing storage size is not a multiple of MIN_HEAP_SIZE";
+        error!("set_backing_storage(): {} (size={}, min={})", reason, size, MIN_HEAP_SIZE);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+    BACKING_PTR = ptr;
+    BACKING_SIZE = size;
+    Ok(())
+}
+
 pub unsafe fn init() -> Result<(), Error> {
     info!("initializing the kernel heap...");
 
-    HEAP = Some(Kheap::from_raw_parts(
-        HEAP_STORAGE.memory.as_ptr() as usize,
-        HEAP_STORAGE.memory.len(),
-    )?);
+    if BACKING_PTR.is_null() {
+        let reason: &str = "backing storage not set";
+        error!("init(): {}", reason);
+        return Err(Error::new(ErrorCode::InvalidArgument, reason));
+    }
+
+    HEAP = Some(Kheap::from_raw_parts(BACKING_PTR as usize, BACKING_SIZE)?);
 
     Ok(())
 }


### PR DESCRIPTION
Closes #2153 

Move the kernel heap backing buffer out of BSS and into the scratch-reserved region on Hyperlight so that heap allocations no longer dirty Copy-on-Write snapshot pages. This reduces the number of pages that must be restored on every sandbox warm-start.

The change decouples the heap allocator from the backing storage location:

- **kheap**: remove the BSS-resident `HeapStorage` static; add `set_backing_storage()` to accept an externally-provided buffer, and require it to be called before `init()`.
- **microvm**: adopt the `HeapStorage` static (BSS-resident) and expose `setup_heap_backing_storage()` to wire it to the heap allocator.
- **hyperlight**: reserve a `HEAP_STORAGE` slot in the scratch layout and derive its address from the PEB input buffer pointer during `hyperlight_pre_kmain()`, before initialising the heap.
- **kmain**: call `platform::setup_heap_backing_storage()` before `kheap::init()` on non-Hyperlight platforms.