### PR TITLE
[uservm] Add host mount support for WHP backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,10 +651,7 @@ jobs:
           name: windows-build-${{ matrix.machine-type }}-${{ matrix.build-type }}-${{
             matrix.memory-size }}mb
           retention-days: 1
-          path: |
-            bin/*.exe
-            bin/*.elf
-            bin/*.img
+          path: bin/
 
   # Run the full standalone test suite on Windows Hypervisor Platform using nanvix-test.exe,
   # mirroring the Linux CI integration-test stage.

--- a/src/uservm/src/vmm/microvm/mod.rs
+++ b/src/uservm/src/vmm/microvm/mod.rs
@@ -457,37 +457,27 @@ impl Vmm {
                     None => ::config::microvm::DEFAULT_INITRD_BASE,
                 };
 
-                if let Some(ref mount_dir) = args.mount_directory {
-                    // Build a FAT image from the host directory.
-                    // The TempPath ensures the file is cleaned up on all paths (including errors).
-                    let (mountfs_temp, _mountfs_size) =
-                        mount::build_mount_image(Path::new(mount_dir))?;
-                    let mountfs_path: &Path = mountfs_temp.as_ref();
+                let loaded: ramfs::LoadedRamFs = ramfs::load_ramfs(
+                    &mut vmem,
+                    initrd_end,
+                    args.mount_directory.as_deref(),
+                    args.ramfs_filename.as_deref(),
+                )?;
 
-                    // Compute the multi-image layout (zero-copy: no concatenated file).
-                    let rootfs_path: Option<PathBuf> =
-                        args.ramfs_filename.as_ref().map(PathBuf::from);
-                    let layout: ::multiimage::MultiImageLayout =
-                        mount::compute_unified_layout(rootfs_path.as_deref(), mountfs_path)?;
-
-                    // Open all sub-image files and map them directly into guest memory.
-                    let multi_ramfs: ramfs::MultiRamFs = ramfs::MultiRamFs::open(layout)?;
-                    let (ramfs_base, ramfs_size) =
-                        multi_ramfs.load_into_virtual_memory(&mut vmem, initrd_end)?;
-                    vmem.attach_backing_files(multi_ramfs.into_files());
-
-                    // TempPath drops here (or on error), removing the temporary file.
-                    drop(mountfs_temp);
-                    Some((ramfs_base, ramfs_size))
-                } else if let Some(ramfs_filename) = args.ramfs_filename.as_deref() {
-                    // Legacy single-image path.
-                    let ramfs: RamFs = RamFs::open(Path::new(ramfs_filename))?;
-                    let (ramfs_base, ramfs_size) =
-                        ramfs.load_into_virtual_memory(&mut vmem, initrd_end)?;
-                    vmem.attach_ramfs(ramfs);
-                    Some((ramfs_base, ramfs_size))
-                } else {
-                    None
+                match loaded {
+                    ramfs::LoadedRamFs::Multi {
+                        backing_files,
+                        base,
+                        size,
+                    } => {
+                        vmem.attach_backing_files(backing_files);
+                        Some((base, size))
+                    },
+                    ramfs::LoadedRamFs::Single { ramfs, base, size } => {
+                        vmem.attach_ramfs(ramfs);
+                        Some((base, size))
+                    },
+                    ramfs::LoadedRamFs::None => None,
                 }
             };
 

--- a/src/uservm/src/vmm/microvm/ramfs.rs
+++ b/src/uservm/src/vmm/microvm/ramfs.rs
@@ -608,3 +608,116 @@ impl MultiRamFs {
         self.files.into_iter().map(|(file, _offset)| file).collect()
     }
 }
+
+//==================================================================================================
+// Shared RAMFS Loading
+//==================================================================================================
+
+/// Result of [`load_ramfs`]: describes which RAMFS variant was loaded into guest memory so
+/// that the caller can keep the appropriate file handles alive for the VM's lifetime.
+pub enum LoadedRamFs {
+    /// No RAMFS was loaded (neither `-ramfs` nor `-mount` was specified).
+    None,
+    /// A single-image RAMFS was loaded via the legacy path.
+    Single {
+        /// The opened RAMFS descriptor (keeps the file handle alive).
+        ramfs: RamFs,
+        /// Guest-physical base address of the RAMFS.
+        base: usize,
+        /// Size in bytes.
+        size: usize,
+    },
+    /// A multi-image RAMFS was loaded (mount path, possibly combined with a root RAMFS).
+    Multi {
+        /// Backing file handles that must stay alive for the memory mappings.
+        backing_files: std::vec::Vec<File>,
+        /// Guest-physical base address of the multi-image container.
+        base: usize,
+        /// Total size in bytes.
+        size: usize,
+    },
+}
+
+impl LoadedRamFs {
+    /// Returns the guest-physical region `(base, size)` if any RAMFS was loaded.
+    pub fn region(&self) -> Option<(usize, usize)> {
+        match self {
+            Self::None => None,
+            Self::Single { base, size, .. } | Self::Multi { base, size, .. } => {
+                Some((*base, *size))
+            },
+        }
+    }
+}
+
+///
+/// # Description
+///
+/// Loads the appropriate RAMFS variant into guest memory based on the provided mount directory
+/// and ramfs filename arguments. This shared helper eliminates duplication between the KVM and
+/// WHP backends.
+///
+/// When `mount_directory` is `Some`, builds a FAT32 image from the host directory, computes a
+/// multi-image layout (optionally combined with a root RAMFS from `ramfs_filename`), and maps
+/// the sub-images into guest memory. When only `ramfs_filename` is `Some`, takes the legacy
+/// single-image path. When both are `None`, returns [`LoadedRamFs::None`].
+///
+/// The caller is responsible for keeping the returned file handles alive for the VM's lifetime
+/// (e.g., via `VirtualMemory::attach_ramfs` or `VirtualMemory::attach_backing_files`).
+///
+/// # Parameters
+///
+/// - `vmem`: Guest virtual memory to load the RAMFS into.
+/// - `initrd_end`: First byte after the initrd in guest memory.
+/// - `mount_directory`: Optional host directory path to mount.
+/// - `ramfs_filename`: Optional path to a single RAMFS image.
+///
+/// # Returns
+///
+/// On success, returns a [`LoadedRamFs`] describing what was loaded and any file handles that
+/// must be kept alive. On failure, returns an error.
+///
+pub fn load_ramfs(
+    vmem: &mut VirtualMemory,
+    initrd_end: usize,
+    mount_directory: Option<&str>,
+    ramfs_filename: Option<&str>,
+) -> Result<LoadedRamFs> {
+    use crate::vmm::microvm::mount;
+
+    if let Some(mount_dir) = mount_directory {
+        // Build a FAT image from the host directory.
+        // The TempPath ensures the file is cleaned up on all paths (including errors).
+        let (mountfs_temp, _mountfs_size) = mount::build_mount_image(Path::new(mount_dir))?;
+        let mountfs_path: &Path = mountfs_temp.as_ref();
+
+        // Compute the multi-image layout (zero-copy: no concatenated file).
+        let rootfs_path: Option<PathBuf> = ramfs_filename.map(PathBuf::from);
+        let layout: ::multiimage::MultiImageLayout =
+            mount::compute_unified_layout(rootfs_path.as_deref(), mountfs_path)?;
+
+        // Open all sub-image files and map them directly into guest memory.
+        let multi_ramfs: MultiRamFs = MultiRamFs::open(layout)?;
+        let (ramfs_base, ramfs_size) = multi_ramfs.load_into_virtual_memory(vmem, initrd_end)?;
+        let backing_files: std::vec::Vec<File> = multi_ramfs.into_files();
+
+        // TempPath drops here (or on error), removing the temporary file.
+        drop(mountfs_temp);
+        Ok(LoadedRamFs::Multi {
+            backing_files,
+            base: ramfs_base,
+            size: ramfs_size,
+        })
+    } else if let Some(ramfs_filename) = ramfs_filename {
+        // Legacy single-image path.
+        let ramfs: RamFs = RamFs::open(Path::new(ramfs_filename))?;
+        let (ramfs_base, ramfs_size) = ramfs.load_into_virtual_memory(vmem, initrd_end)?;
+        Ok(LoadedRamFs::Single {
+            ramfs,
+            base: ramfs_base,
+            size: ramfs_size,
+        })
+    } else {
+        Ok(LoadedRamFs::None)
+    }
+}

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -38,12 +38,18 @@ use crate::{
             Guest,
             GuestState,
         },
-        microvm::whp::vcpu::{
-            VirtualProcessor,
-            VirtualProcessorExitContext,
-            VirtualProcessorExitReasonRef,
+        microvm::{
+            mount,
+            whp::vcpu::{
+                VirtualProcessor,
+                VirtualProcessorExitContext,
+                VirtualProcessorExitReasonRef,
+            },
         },
-        ramfs::RamFs,
+        ramfs::{
+            MultiRamFs,
+            RamFs,
+        },
     },
 };
 use ::anyhow::Result;
@@ -459,29 +465,53 @@ impl Vmm {
             #[cfg(feature = "profile-time")]
             let ramfs_load_start: Instant = Instant::now();
 
-            let ramfs_region: Option<(usize, usize)> =
-                if let Some(ramfs_filename) = args.ramfs_filename.as_deref() {
-                    let initrd_end: usize = match guest.initrd_region() {
-                        Some((base, size)) => match base.checked_add(size) {
-                            Some(end) => end,
-                            None => {
-                                let reason: String = "initrd region overflowed while computing \
-                                                      ramfs placement"
-                                    .to_string();
-                                error!("new(): {reason}");
-                                anyhow::bail!(reason)
-                            },
+            let ramfs_region: Option<(usize, usize)> = {
+                let initrd_end: usize = match guest.initrd_region() {
+                    Some((base, size)) => match base.checked_add(size) {
+                        Some(end) => end,
+                        None => {
+                            let reason: String = "initrd region overflowed while computing ramfs \
+                                                  placement"
+                                .to_string();
+                            error!("new(): {reason}");
+                            anyhow::bail!(reason)
                         },
-                        None => ::config::microvm::DEFAULT_INITRD_BASE,
-                    };
+                    },
+                    None => ::config::microvm::DEFAULT_INITRD_BASE,
+                };
 
+                if let Some(ref mount_dir) = args.mount_directory {
+                    // Build a FAT image from the host directory.
+                    // The TempPath ensures the file is cleaned up on all paths (including errors).
+                    let (mountfs_temp, _mountfs_size) =
+                        mount::build_mount_image(Path::new(mount_dir))?;
+                    let mountfs_path: &Path = mountfs_temp.as_ref();
+
+                    // Compute the multi-image layout (zero-copy: no concatenated file).
+                    let rootfs_path: Option<PathBuf> =
+                        args.ramfs_filename.as_ref().map(PathBuf::from);
+                    let layout: ::multiimage::MultiImageLayout =
+                        mount::compute_unified_layout(rootfs_path.as_deref(), mountfs_path)?;
+
+                    // Open all sub-image files and map them directly into guest memory.
+                    let multi_ramfs: MultiRamFs = MultiRamFs::open(layout)?;
+                    let (ramfs_base, ramfs_size) =
+                        multi_ramfs.load_into_virtual_memory(&mut vmem, initrd_end)?;
+                    vmem.attach_backing_files(multi_ramfs.into_files());
+
+                    // TempPath drops here (or on error), removing the temporary file.
+                    drop(mountfs_temp);
+                    Some((ramfs_base, ramfs_size))
+                } else if let Some(ramfs_filename) = args.ramfs_filename.as_deref() {
+                    // Legacy single-image path.
                     let ramfs: RamFs = RamFs::open(Path::new(ramfs_filename))?;
                     let (ramfs_base, ramfs_size) =
                         ramfs.load_into_virtual_memory(&mut vmem, initrd_end)?;
                     Some((ramfs_base, ramfs_size))
                 } else {
                     None
-                };
+                }
+            };
 
             RamFs::write_registers(&mut vmem, ramfs_region)?;
 

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -39,16 +39,13 @@ use crate::{
             GuestState,
         },
         microvm::{
-            mount,
+            ramfs,
+            ramfs::RamFs,
             whp::vcpu::{
                 VirtualProcessor,
                 VirtualProcessorExitContext,
                 VirtualProcessorExitReasonRef,
             },
-        },
-        ramfs::{
-            MultiRamFs,
-            RamFs,
         },
     },
 };
@@ -480,36 +477,24 @@ impl Vmm {
                     None => ::config::microvm::DEFAULT_INITRD_BASE,
                 };
 
-                if let Some(ref mount_dir) = args.mount_directory {
-                    // Build a FAT image from the host directory.
-                    // The TempPath ensures the file is cleaned up on all paths (including errors).
-                    let (mountfs_temp, _mountfs_size) =
-                        mount::build_mount_image(Path::new(mount_dir))?;
-                    let mountfs_path: &Path = mountfs_temp.as_ref();
+                let loaded: ramfs::LoadedRamFs = ramfs::load_ramfs(
+                    &mut vmem,
+                    initrd_end,
+                    args.mount_directory.as_deref(),
+                    args.ramfs_filename.as_deref(),
+                )?;
 
-                    // Compute the multi-image layout (zero-copy: no concatenated file).
-                    let rootfs_path: Option<PathBuf> =
-                        args.ramfs_filename.as_ref().map(PathBuf::from);
-                    let layout: ::multiimage::MultiImageLayout =
-                        mount::compute_unified_layout(rootfs_path.as_deref(), mountfs_path)?;
-
-                    // Open all sub-image files and map them directly into guest memory.
-                    let multi_ramfs: MultiRamFs = MultiRamFs::open(layout)?;
-                    let (ramfs_base, ramfs_size) =
-                        multi_ramfs.load_into_virtual_memory(&mut vmem, initrd_end)?;
-                    vmem.attach_backing_files(multi_ramfs.into_files());
-
-                    // TempPath drops here (or on error), removing the temporary file.
-                    drop(mountfs_temp);
-                    Some((ramfs_base, ramfs_size))
-                } else if let Some(ramfs_filename) = args.ramfs_filename.as_deref() {
-                    // Legacy single-image path.
-                    let ramfs: RamFs = RamFs::open(Path::new(ramfs_filename))?;
-                    let (ramfs_base, ramfs_size) =
-                        ramfs.load_into_virtual_memory(&mut vmem, initrd_end)?;
-                    Some((ramfs_base, ramfs_size))
-                } else {
-                    None
+                match loaded {
+                    ramfs::LoadedRamFs::Multi {
+                        backing_files,
+                        base,
+                        size,
+                    } => {
+                        vmem.attach_backing_files(backing_files);
+                        Some((base, size))
+                    },
+                    ramfs::LoadedRamFs::Single { base, size, .. } => Some((base, size)),
+                    ramfs::LoadedRamFs::None => None,
                 }
             };
 

--- a/test/test-standalone-windows.toml
+++ b/test/test-standalone-windows.toml
@@ -102,3 +102,16 @@ executor = "terminal"
 program = "./bin/linux-app.elf"
 extra_nanvixd_args = "-ramfs ./bin/standalone-rootfs.img"
 expected_output = "ok"
+
+#===================================================================================================
+# Host Mount Tests
+#===================================================================================================
+
+[[tests]]
+executor = "terminal"
+program = "./bin/mount-test.elf"
+extra_nanvixd_args = "-mount ./bin/mount-test-data"
+input = "[]"
+expect_empty_output = true
+expected_exit_code = 0
+runs_on = ["microvm"]


### PR DESCRIPTION
## Summary

Enable the `-mount <host-dir>` feature on Windows by adding multi-image RAMFS loading to the WHP backend, mirroring the existing KVM (Linux) implementation.

## Changes

- **`src/uservm/src/vmm/microvm/whp/mod.rs`**: Import `mount` module and `MultiRamFs`. Replace the single-image-only ramfs loading with mount-aware logic that builds a FAT32 image from the host directory, computes a multi-image layout, and maps sub-images into guest memory via zero-copy file mapping. The legacy single-image path is preserved as a fallback.
- **`test/test-standalone-windows.toml`**: Add `mount-test.elf` integration test with `-mount ./bin/mount-test-data`.

## Testing

All 11 standalone Windows integration tests pass, including the new host mount test (`terminal/mount-test.elf` exits with code 0).