### PR TITLE
[kernel] E: Guard against usize underflow in kpool::Inner::free

### DIFF
--- a/src/kernel/src/mm/phys/kpool.rs
+++ b/src/kernel/src/mm/phys/kpool.rs
@@ -167,6 +167,12 @@ impl Inner {
     /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
     ///
     fn free(&mut self, addr: FrameAddress) -> Result<(), Error> {
+        // Guard against underflow: if addr is below the pool base, the subtraction wraps.
+        if addr.into_raw_value() < self.base.into_raw_value() {
+            let reason: &str = "frame address below pool base";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::BadAddress, reason));
+        }
         let index: usize = (addr.into_raw_value() - self.base.into_raw_value()) / mem::PAGE_SIZE;
         match self.bitmap.clear(index) {
             Ok(()) => Ok(()),


### PR DESCRIPTION
`Inner::free()` computes a bitmap index via `(addr - base) / PAGE_SIZE` without checking `addr >= base`. If `addr < base`, the subtraction wraps, producing an incorrect index that corrupts the bitmap.

Added a bounds check before the subtraction to return `Err(BadAddress)` early.

Found by Verus formal verification.