### PR TITLE
[kernel] A: Add configurable base address and entry point for Hyperlight

### DIFF
--- a/build/kernel/linker/x86/kernel.ld.in
+++ b/build/kernel/linker/x86/kernel.ld.in
@@ -4,7 +4,7 @@
  */
 
 OUTPUT_FORMAT("elf32-i386")
-ENTRY(_do_start)
+ENTRY(@ENTRY_POINT@)
 
 /*
  * Page Size (4 KB)

--- a/src/kernel/build.rs
+++ b/src/kernel/build.rs
@@ -217,13 +217,15 @@ fn main() {
         "0x0"
     };
 
+    let entry_point: &str = "_do_start";
+
     let linker_template: String =
         fs::read_to_string(&linker_template_path).expect("Failed to read linker script template");
     let linker_script: String = linker_template
         .replace("@MACHINE_RESERVED@", &machine_reserved)
         .replace("@KPOOL_BASE@", &format!("{:#x}", kpool_base))
-        .replace("@PLATFORM_BASE_ADDR@", platform_base_addr);
-
+        .replace("@PLATFORM_BASE_ADDR@", platform_base_addr)
+        .replace("@ENTRY_POINT@", entry_point);
     fs::write(&linker_output_path, linker_script).expect("Failed to write linker script");
 
     println!("cargo::rerun-if-changed={}", linker_template_path.display());


### PR DESCRIPTION
## Summary
- Parameterize the kernel linker script with `PLATFORM_BASE_ADDR` (0x1000 on Hyperlight, 0x0 on microvm) and a template-based `ENTRY_POINT`
- Add `--entry=_hyperlight_entry` linker arg on Hyperlight builds to set the ELF entry point
- Boot/trampoline addresses are offset by the platform base so the first page stays reserved on Hyperlight

## Test plan
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=standalone check` passes
- [x] `make MACHINE=microvm DEPLOYMENT_MODE=standalone check` passes
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=standalone lint` passes
- [x] `make MACHINE=microvm DEPLOYMENT_MODE=standalone lint` passes
- [x] `nanvix-test` microvm/standalone passes