### PR TITLE
[kernel] E: Register pre-BSS gap as a memory region

### DIFF
--- a/src/kernel/src/kimage.rs
+++ b/src/kernel/src/kimage.rs
@@ -156,4 +156,39 @@ impl KernelImage {
     pub fn kpool(&self) -> MemoryRegion<VirtualAddress> {
         self.kpool.clone()
     }
+
+    /// Returns a region covering any gap between the page-aligned end of the
+    /// last named section before `.bss` and the start of `.bss`. This gap
+    /// contains orphan ELF sections (`.eh_frame`, `.got`, etc.) that the
+    /// linker places between explicitly named sections.
+    pub fn pre_bss_gap(&self) -> Option<MemoryRegion<VirtualAddress>> {
+        let bss_start: usize = self.bss.start().into_raw_value();
+        let raw_end: usize = if let Some(ref data) = self.data {
+            let rodata_end: usize = self.rodata.start().into_raw_value() + self.rodata.size();
+            let data_end: usize = data.start().into_raw_value() + data.size();
+            rodata_end.max(data_end)
+        } else {
+            self.rodata.start().into_raw_value() + self.rodata.size()
+        };
+        let gap_start: usize =
+            ::sys::mm::align_up(raw_end, ::arch::mem::PAGE_ALIGNMENT)?;
+
+        if gap_start < bss_start {
+            let gap_size: usize = bss_start - gap_start;
+            info!(
+                "  gap: start={:#010x}, end={:#010x}, size={:#010x}",
+                gap_start, bss_start, gap_size
+            );
+            MemoryRegion::new(
+                "kernel pre-bss gap",
+                VirtualAddress::from_raw_value(gap_start),
+                gap_size,
+                MemoryRegionType::Reserved,
+                AccessPermission::RDONLY,
+            )
+            .ok()
+        } else {
+            None
+        }
+    }
 }

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -323,6 +323,9 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     if let Some(data) = kimage.data() {
         memory_regions.push_back(data);
     }
+    if let Some(gap) = kimage.pre_bss_gap() {
+        memory_regions.push_back(gap);
+    }
     memory_regions.push_back(kimage.bss());
     memory_regions.push_back(kimage.kpool());
 


### PR DESCRIPTION
## Summary
- Register the gap between the end of `.rodata`/`.data` and the start of `.bss` as a reserved memory region
- This gap contains orphan ELF sections (`.eh_frame`, `.got`, etc.) that the linker places between explicitly named sections
- Without this reservation, the frame allocator could hand out frames that overlap these sections

## Test plan
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=standalone check` passes
- [x] `make MACHINE=microvm DEPLOYMENT_MODE=standalone check` passes
- [x] Lint passes both platforms
- [x] `nanvix-test` microvm/standalone passes