### PR TITLE
[kernel] A: Add PD inherit_from, memcpy abstraction, and virt_to_phys wiring

### DIFF
--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
@@ -183,9 +183,49 @@ impl<T: DerefMut<Target = [PteWord]>> PageDirectory<T> {
         self.entries[pde_idx] = pde.into_raw_value();
     }
 
+    #[cfg(feature = "hyperlight")]
+    pub fn entries_ptr(&self) -> *const PteWord {
+        self.entries.as_ptr()
+    }
+
+    /// Copies populated entries from an existing page directory into this one.
+    /// For entries that only the old PD has, the PDE is copied directly.
+    /// For entries where both PDs have page tables, the old PTE entries are
+    /// merged into the new PT (missing entries only) so the new PD retains
+    /// all host-provided mappings alongside the kernel's own.
+    ///
+    /// # Safety
+    ///
+    /// `old_pd` must point to a valid, identity-mapped page directory with at
+    /// least `PAGE_TABLE_LENGTH` entries. All page table pointers in the old PD
+    /// must be identity-mapped.
+    #[cfg(feature = "hyperlight")]
+    pub unsafe fn inherit_from(&mut self, old_pd: *const PteWord) {
+        use ::arch::mem::PAGE_TABLE_LENGTH;
+        for i in 0..self.entries.len() {
+            let old_entry: PteWord = *old_pd.add(i);
+            if old_entry == 0 {
+                continue;
+            }
+            if self.entries[i] == 0 {
+                self.entries[i] = old_entry;
+            } else {
+                let old_pt: *const PteWord = (old_entry & 0xFFFFF000) as *const PteWord;
+                let new_pt: *mut PteWord = (self.entries[i] & 0xFFFFF000) as *mut PteWord;
+                for j in 0..PAGE_TABLE_LENGTH {
+                    if *new_pt.add(j) == 0 {
+                        let old_pte: PteWord = *old_pt.add(j);
+                        if old_pte != 0 {
+                            *new_pt.add(j) = old_pte;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     pub fn physical_address(&self) -> Result<FrameAddress, Error> {
-        Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(
-            self.entries.as_ptr() as usize,
-        )?)?))
+        let pa: usize = crate::hal::platform::virt_to_phys(self.entries.as_ptr() as usize);
+        Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(pa)?)?))
     }
 }

--- a/src/kernel/src/hal/arch/x86/asm/fast_memcpy.rs
+++ b/src/kernel/src/hal/arch/x86/asm/fast_memcpy.rs
@@ -23,6 +23,7 @@
 ///
 /// If `size == 0`, this function is a no-op.
 ///
+#[cfg(not(feature = "hyperlight"))]
 #[inline(always)]
 pub(crate) unsafe fn fast_memcpy(dst: *mut u8, src: *const u8, size: usize) {
     // NOTE: `esi`/`edi` are saved via push/pop rather than declared as Rust-level clobbers

--- a/src/kernel/src/hal/arch/x86/asm/mod.rs
+++ b/src/kernel/src/hal/arch/x86/asm/mod.rs
@@ -9,7 +9,6 @@ mod fast_memcpy;
 mod fast_memset;
 mod hooks;
 
-pub(crate) use self::{
-    fast_memcpy::fast_memcpy,
-    fast_memset::fast_memset,
-};
+#[cfg(not(feature = "hyperlight"))]
+pub(crate) use self::fast_memcpy::fast_memcpy;
+pub(crate) use self::fast_memset::fast_memset;

--- a/src/kernel/src/hal/arch/x86/mod.rs
+++ b/src/kernel/src/hal/arch/x86/mod.rs
@@ -9,10 +9,9 @@ pub mod asm;
 pub mod cpu;
 pub mod mem;
 
-pub(crate) use asm::{
-    fast_memcpy,
-    fast_memset,
-};
+#[cfg(not(feature = "hyperlight"))]
+pub(crate) use asm::fast_memcpy;
+pub(crate) use asm::fast_memset;
 
 //==================================================================================================
 // Imports

--- a/src/kernel/src/hal/mem/types/address/mod.rs
+++ b/src/kernel/src/hal/mem/types/address/mod.rs
@@ -25,6 +25,7 @@ pub use ::sys::mm::{
 pub use aligned::*;
 pub use frame::*;
 pub use page::*;
+#[cfg(not(feature = "hyperlight"))]
 pub use pd::*;
 pub use phys::*;
 

--- a/src/kernel/src/mm/virt/identity_map.rs
+++ b/src/kernel/src/mm/virt/identity_map.rs
@@ -21,17 +21,17 @@
 
 use super::page_table_allocator::PAGE_TABLE_ALLOCATOR;
 use crate::hal::{
-    arch::x86::{
-        fast_memcpy,
-        fast_memset,
-    },
+    arch::x86::fast_memset,
     mem::{
         Address,
         PageAligned,
-        PageDirectoryAddress,
         PhysicalAddress,
     },
 };
+#[cfg(not(feature = "hyperlight"))]
+use crate::hal::arch::x86::fast_memcpy;
+#[cfg(not(feature = "hyperlight"))]
+use crate::hal::mem::PageDirectoryAddress;
 use ::arch::{
     cpu::cr3::Cr3Register,
     mem::{
@@ -100,6 +100,7 @@ static KERNEL_CR3: AtomicU32 = AtomicU32::new(0);
 /// # Notes
 ///
 /// On x86, `kernel_cr3` equals `kernel_pd_paddr` (the page directory is the CR3 root).
+#[cfg(not(feature = "hyperlight"))]
 pub(crate) fn init(kernel_pd_paddr: PageDirectoryAddress, kernel_cr3: Cr3Register) {
     KERNEL_PD_PADDR.store(kernel_pd_paddr.into_raw_value(), Ordering::Release);
     KERNEL_CR3.store(kernel_cr3.into_u32(), Ordering::Release);
@@ -159,6 +160,15 @@ pub(crate) fn memcpy(dst: *mut u8, src: *const u8, size: usize) -> Result<(), Er
         ));
     }
 
+    // On Hyperlight, the host page tables already identity-map guest memory and
+    // CR3 cannot be switched to the kernel PD. Use copy_nonoverlapping directly.
+    #[cfg(feature = "hyperlight")]
+    {
+        unsafe { core::ptr::copy_nonoverlapping(src, dst, size) };
+        Ok(())
+    }
+
+    #[cfg(not(feature = "hyperlight"))]
     with_kernel_address_space(|| {
         let src_addr: PhysicalAddress = PhysicalAddress::from_raw_value(src as usize)?;
         let (src_start, src_size) = page_aligned_cover(src_addr, size)?;

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -20,7 +20,6 @@ use crate::{
             FrameAddress,
             PageAddress,
             PageAligned,
-            PageDirectoryAddress,
             PageTableAddress,
             PageTableAligned,
             PhysicalAddress,
@@ -41,23 +40,24 @@ use ::alloc::{
     collections::LinkedList,
     rc::Rc,
 };
-use ::arch::{
-    cpu::cr3::{
-        Cr3Register,
-        PageDirectoryBaseAddress as Cr3PageDirectoryBaseAddress,
-        PageLevelCacheDisableFlag,
-        PageLevelWriteThroughFlag,
+#[cfg(not(feature = "hyperlight"))]
+use ::arch::cpu::cr3::{
+    Cr3Register,
+    PageDirectoryBaseAddress as Cr3PageDirectoryBaseAddress,
+    PageLevelCacheDisableFlag,
+    PageLevelWriteThroughFlag,
+};
+#[cfg(not(feature = "hyperlight"))]
+use crate::hal::mem::PageDirectoryAddress;
+use ::arch::mem::{
+    self,
+    paging::{
+        PageDirectoryEntry,
+        PteWord,
     },
-    mem::{
-        self,
-        paging::{
-            PageDirectoryEntry,
-            PteWord,
-        },
-        PAGE_ALIGNMENT,
-        PAGE_TABLE_LENGTH,
-        PGTAB_ALIGNMENT,
-    },
+    PAGE_ALIGNMENT,
+    PAGE_TABLE_LENGTH,
+    PGTAB_ALIGNMENT,
 };
 use ::core::cell::RefCell;
 use ::sys::{
@@ -128,21 +128,39 @@ impl Vmem {
             kpage_tables.push_back(Rc::new(RefCell::new((vaddr, page_table))));
         }
 
-        // Register kernel PD for lazy identity mapping. On x86, the PD is also the CR3 root.
-        let pd_paddr_raw: usize = pgdir.physical_address()?.into_raw_value();
-        let pd_paddr: PageDirectoryAddress = PageDirectoryAddress::from_raw_value(pd_paddr_raw)?;
-        let kernel_cr3: Cr3Register = Cr3Register {
-            page_level_write_through: PageLevelWriteThroughFlag::Disabled,
-            page_level_cache_disable: PageLevelCacheDisableFlag::Enabled,
-            paging_structure_base_address: Cr3PageDirectoryBaseAddress::new(pd_paddr_raw as u32)
+        // On Hyperlight, copy host-provided PD entries (scratch region mappings)
+        // into the kernel PD so they survive.
+        #[cfg(feature = "hyperlight")]
+        unsafe {
+            let cr3: u32;
+            core::arch::asm!("mov {0:e}, cr3", out(reg) cr3, options(nomem, nostack));
+            let old_pd: *const PteWord = (cr3 & 0xFFFFF000) as *const PteWord;
+            pgdir.inherit_from(old_pd);
+        }
+
+        // On Hyperlight, the host page tables already identity-map guest memory.
+        // The kernel PD cannot be loaded into CR3 (KVM internal error), so skip
+        // lazy identity-map init.
+        #[cfg(not(feature = "hyperlight"))]
+        {
+            let pd_paddr_raw: usize = pgdir.physical_address()?.into_raw_value();
+            let pd_paddr: PageDirectoryAddress =
+                PageDirectoryAddress::from_raw_value(pd_paddr_raw)?;
+            let kernel_cr3: Cr3Register = Cr3Register {
+                page_level_write_through: PageLevelWriteThroughFlag::Disabled,
+                page_level_cache_disable: PageLevelCacheDisableFlag::Enabled,
+                paging_structure_base_address: Cr3PageDirectoryBaseAddress::new(
+                    pd_paddr_raw as u32,
+                )
                 .ok_or_else(|| {
                     Error::new(
                         ErrorCode::BadAddress,
                         "kernel page directory address is not 4 KB aligned",
                     )
                 })?,
-        };
-        super::identity_map::init(pd_paddr, kernel_cr3);
+            };
+            super::identity_map::init(pd_paddr, kernel_cr3);
+        }
 
         // Store root pages.
         let mut kpages: LinkedList<Rc<RefCell<KernelPage>>> = LinkedList::new();
@@ -174,6 +192,11 @@ impl Vmem {
             // FIXME: do not be so open about permissions.
             pgdir.map(entry.borrow().0, page_table_address, false, AccessPermission::RDWR)?;
             kernel_page_tables.push_back(entry.clone());
+        }
+
+        #[cfg(feature = "hyperlight")]
+        unsafe {
+            pgdir.inherit_from(from.pgdir.entries_ptr());
         }
 
         // Store root pages.
@@ -261,9 +284,14 @@ impl Vmem {
             if entry.borrow().0.into_raw_value() == pt_vaddr.into_raw_value() {
                 // Map the page to the target virtual address space.
                 // FIXME: do not be so open about permissions and caching.
+                let frame_addr: FrameAddress = {
+                    let gva: usize = kpage.frame_address().into_raw_value();
+                    let gpa: usize = crate::hal::platform::virt_to_phys(gva);
+                    FrameAddress::from_raw_value(gpa)?
+                };
                 entry.borrow_mut().1.map(
                     PageAddress::new(vaddr),
-                    kpage.frame_address(),
+                    frame_addr,
                     true,
                     true,
                     false,
@@ -338,7 +366,12 @@ impl Vmem {
         };
 
         // Map the page to the target virtual address space.
-        page_table.map(PageAddress::new(vaddr), uframe.address(), false, false, true, access)?;
+        let frame_addr: FrameAddress = {
+            let gva: usize = uframe.address().into_raw_value();
+            let gpa: usize = crate::hal::platform::virt_to_phys(gva);
+            FrameAddress::from_raw_value(gpa)?
+        };
+        page_table.map(PageAddress::new(vaddr), frame_addr, false, false, true, access)?;
 
         //=============================================================
         // NOTE: if we fail beyond this point we should unmap the page.
@@ -724,12 +757,11 @@ impl Vmem {
                 let src_frame: FrameAddress = self.find_user_frame(vaddr)?;
 
                 if !dry_run {
-                    // Copy memory from user space to kernel space.
-                    super::identity_map::memcpy(
-                        dst.into_raw_value() as *mut u8,
-                        (src_frame.into_raw_value() + offset) as *const u8,
-                        copy_size,
-                    )?;
+                    let copy_src: *const u8 =
+                        (src_frame.into_raw_value() + offset) as *const u8;
+                    let copy_dst: *mut u8 = dst.into_raw_value() as *mut u8;
+
+                    super::identity_map::memcpy(copy_dst, copy_src, copy_size)?;
                 }
 
                 size -= copy_size;
@@ -890,9 +922,8 @@ impl Vmem {
                 // Copy memory from kernel space to user space.
                 let dst: *mut u8 = (dst_frame.into_raw_value() + offset) as *mut u8;
                 let src: *const u8 = src.into_raw_value() as *const u8;
-                let copy_result: Result<(), Error> =
-                    super::identity_map::memcpy(dst, src, copy_size);
-                if let Err(error) = copy_result {
+
+                if let Err(error) = super::identity_map::memcpy(dst, src, copy_size) {
                     let reason: &str = "failed to perform physical memory copy";
                     panic!(
                         "copy_to_user_unaligned_unchecked(): {reason} (error={error:?}, \


### PR DESCRIPTION
## Summary

- Adds `PageDirectory::inherit_from` to copy host-provided PD/PT entries into the kernel page directory so scratch-region mappings survive across snapshots
- Gates `fast_memcpy` (inline `rep movsd`) behind `cfg(not(feature = "hyperlight"))` — on Hyperlight the compiler's default memcpy is used instead, avoiding issues with CoW-mapped memory
- Wires `virt_to_phys` into the page-directory and virtual-memory layers so address translation is correct after CoW page faults remap pages

## Test plan

- [ ] `./z build -- all MACHINE=microvm TARGET=x86 DEPLOYMENT_MODE=standalone RELEASE=yes` succeeds
- [ ] `./z build -- all MACHINE=microvm TARGET=x86 DEPLOYMENT_MODE=multicores RELEASE=yes` succeeds
- [ ] `./bin/nanvix-test.elf test/test-standalone.toml` exits 0
- [ ] `./bin/nanvix-test.elf test/test-multicores.toml` exits 0
- [ ] `cargo clippy` passes with no warnings