### PR TITLE
[kernel] A: Switch to stable Hyperlight features and wire up evolve→call boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -873,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-common"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d#3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=94ee4956#94ee495638385eaffc5f0c8f69fe7d768047b3b6"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d#3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=94ee4956#94ee495638385eaffc5f0c8f69fe7d768047b3b6"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-host"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d#3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=94ee4956#94ee495638385eaffc5f0c8f69fe7d768047b3b6"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -2454,7 +2454,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3207,7 +3207,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3264,7 +3264,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3531,7 +3531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3813,7 +3813,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4727,7 +4727,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,18 +137,21 @@ indexmap = "2.14.0"
 indicatif = "0.18.4"
 http = "1.4.0"
 http-body-util = "0.1.3"
-hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d", default-features = false, features = [
-        "nanvix-unstable",
+hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "94ee4956", default-features = false, features = [
+        "i686-guest",
+        "guest-counter",
 ] }
-hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d", default-features = false, features = [
+hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "94ee4956", default-features = false, features = [
         "kvm",
         "mshv3",
         "hw-interrupts",
         "executable_heap",
-        "nanvix-unstable",
+        "i686-guest",
+        "guest-counter",
 ] }
-hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d", default-features = false, features = [
-        "nanvix-unstable",
+hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "94ee4956", default-features = false, features = [
+        "i686-guest",
+        "guest-counter",
 ] }
 hyper = { version = "1.9.0", default-features = false }
 hyper-util = { version = "0.1.20", default-features = false }

--- a/src/kernel/build.rs
+++ b/src/kernel/build.rs
@@ -211,8 +211,7 @@ fn main() {
     };
 
     let platform_base_addr: &str = if cfg!(feature = "hyperlight") {
-        // TODO (#2204): Change platform base address for Hyperlight when we update Hperlight crate.
-        "0x0"
+        "0x1000"
     } else {
         "0x0"
     };

--- a/src/kernel/src/hal/arch/x86/asm/mod.rs
+++ b/src/kernel/src/hal/arch/x86/asm/mod.rs
@@ -5,6 +5,7 @@
 // Modules
 //==================================================================================================
 
+#[cfg(not(feature = "hyperlight"))]
 mod fast_memcpy;
 mod fast_memset;
 mod hooks;

--- a/src/kernel/src/hal/arch/x86/cpu/mod.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/mod.rs
@@ -123,6 +123,9 @@ pub fn init(
     let (gdtr, tss): (GdtPtr, TssRef) = unsafe { Gdt::init(kstack_ptr)? };
     unsafe { idt::init() };
 
+    #[cfg(feature = "hyperlight")]
+    crate::hal::platform::hyperlight::patch_kernel_idt_with_cow_handler();
+
     let (controller, xapic_timer): (Option<InterruptController>, Option<XapicTimer>) =
         match interrupt::init(ioports, ioaddresses, madt) {
             Ok((controller, xapic_timer)) => (Some(controller), xapic_timer),

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -8,6 +8,8 @@
 #[cfg(all(feature = "microvm", feature = "hyperlight"))]
 compile_error!("features \"microvm\" and \"hyperlight\" are mutually exclusive");
 
+mod cow_entry;
+mod cow_handler;
 pub(crate) mod peb;
 mod start;
 mod start16;
@@ -64,7 +66,6 @@ use crate::{
 };
 use ::alloc::{
     collections::linked_list::LinkedList,
-    format,
     string::{
         String,
         ToString,
@@ -99,16 +100,9 @@ use ::core::sync::atomic::{
     Ordering,
 };
 use ::hyperlight_common::{
-    flatbuffer_wrappers::{
-        function_call::FunctionCall,
-        function_types::{
-            FunctionCallResult,
-            ReturnValue,
-        },
-        guest_error::{
-            ErrorCode as GuestErrorCode,
-            GuestError,
-        },
+    flatbuffer_wrappers::function_types::{
+        FunctionCallResult,
+        ReturnValue,
     },
     layout::{
         MAX_GPA,
@@ -132,58 +126,8 @@ use ::sys::{
     },
 };
 
-// =================================================================================================
-// _nanvix_dispatch — Entry point for guest function calls
-// =================================================================================================
-//
-// Entry point used by guest function calls.
-//
-// How Hyperlight captures and restores the entry point:
-//
-// 1. During `evolve()` (Hyperlight's `initialise`), the VM runs until a HLT.  When
-//    `hyperlight_pre_kmain()` halts via VmAction::Halt, Hyperlight reads the vCPU registers and
-//    stores:
-//      - `self.entrypoint = NextAction::Call(regs.rax)` — the address of
-//        `_nanvix_dispatch`, which the kernel placed in EAX before halting.
-//      - `self.rsp_gva = regs.rsp` — the stack pointer at halt time.
-//
-// 2. When the host calls `sandbox.call("kmain", ())`, Hyperlight serialises the function name and
-//    arguments into the PEB input buffer, then `dispatch_call_from_host()` sets RIP to the stored
-//    dispatch address and resumes the VM.
-//
-// 3. `_nanvix_dispatch` restores the boot stack, reconstructs a `&KernelArguments`
-//    pointer, and calls `nanvix_dispatch_function`. That Rust function reads the
-//    `FunctionCall` from the PEB input buffer, validates the function name, and
-//    dispatches to `kmain`.
-//
-::core::arch::global_asm!(
-    r#".section .text,"ax",@progbits"#,
-    ".code32",
-    ".extern nanvix_dispatch_function",
-    ".globl _nanvix_dispatch",
-    "_nanvix_dispatch:",
-    // When Hyperlight's `dispatch_call_from_host()` resumes the VM here, all general-purpose
-    // registers are zeroed except RSP (restored to the value saved during evolve) and RFLAGS (RES1
-    // set; ZF may be set to signal a pending TLB flush). Segment registers are not touched — they
-    // retain whatever state was left after `evolve()`.
-    //
-    // Restore the boot stack from the compile-time scratch address.  The
-    // KernelArguments (magic, info) were pushed to (BOOT_STACK_TOP - 8)
-    // during the evolve phase.
-    "    movl ${BOOT_STACK_TOP}, %esp",
-    "    movl %esp, %ebp",
-    "    subl $8, %esp",
-    // Push the KernelArguments pointer and call the high-level dispatcher.
-    "    push %esp",
-    "    call nanvix_dispatch_function",
-    "    addl $4, %esp",
-    "    addl $8, %esp",
-    // nanvix_dispatch_function should never return; halt as a safety net.
-    "2:  hlt",
-    "    jmp 2b",
-    BOOT_STACK_TOP = const ::config::memory_layout::HYPERLIGHT_BOOT_STACK_TOP,
-    options(att_syntax),
-);
+// _nanvix_dispatch is now defined in cow_entry.rs as part of the CoW
+// entry assembly. It sets up GDT/IDT/stack and calls nanvix_dispatch_handler.
 
 //==================================================================================================
 // Global Variables
@@ -582,21 +526,27 @@ pub(in crate::hal::platform) fn do_shutdown(status: usize) -> ! {
     }
 }
 
-///
-/// # Description
-///
-/// Signals the VMM that kernel startup is complete and user-space applications are about to start.
-///
-/// On Hyperlight this is a no-op because the evolve/run lifecycle already
-/// communicates boot readiness to the host.
-///
-pub fn signal_startup_complete() {}
-
-/// Identity translation — on Hyperlight, VA == PA (scaffolding).
-///
-/// Will be replaced by a page-table walk that resolves CoW-relocated pages.
+/// Translates a virtual address to a physical address by walking the
+/// current CR3 page tables. After CoW resolution, BSS pages have
+/// different physical addresses than their virtual addresses.
 pub fn virt_to_phys(vaddr: usize) -> usize {
-    vaddr
+    unsafe {
+        let cr3: u32;
+        core::arch::asm!("mov {0:e}, cr3", out(reg) cr3, options(nomem, nostack));
+        let pd_base: usize = (cr3 & 0xFFFFF000) as usize;
+        let pd_idx: usize = vaddr >> 22;
+        let pde: u32 = *((pd_base + pd_idx * 4) as *const u32);
+        if pde & 1 == 0 {
+            return vaddr;
+        }
+        let pt_base: usize = (pde & 0xFFFFF000) as usize;
+        let pt_idx: usize = (vaddr >> 12) & 0x3FF;
+        let pte: u32 = *((pt_base + pt_idx * 4) as *const u32);
+        if pte & 1 == 0 {
+            return vaddr;
+        }
+        ((pte & 0xFFFFF000) as usize) | (vaddr & 0xFFF)
+    }
 }
 
 ///
@@ -766,63 +716,137 @@ extern "C" fn hyperlight_pre_kmain() {
 ///
 /// # Description
 ///
-/// High-level guest function dispatcher called by `_nanvix_dispatch`.
+/// Initializes the GuestHandle from the PEB. Called during kmain boot
+/// so that `do_shutdown` can write FunctionCallResult to the PEB output buffer.
 ///
-/// Reads the [`FunctionCall`] that the host serialised into the PEB input
-/// buffer, validates the function name, and dispatches to the corresponding
-/// handler.  Currently the only recognised function is `"kmain"`.
-///
-/// For unrecognised functions a [`GuestError`] is written back to the PEB
-/// output buffer so the host receives a proper error instead of a raw abort.
-///
-/// # Parameters
-///
-/// - `kargs`: Kernel arguments reconstructed by the `_nanvix_dispatch` stub.
-///
-#[unsafe(no_mangle)]
-extern "C" fn nanvix_dispatch_function(kargs: &crate::kargs::KernelArguments) {
-    // SAFETY: GUEST_HANDLE is initialised once in hyperlight_pre_kmain
-    // during the evolve phase and never mutated again. This is a single-core
-    // guest, so there are no data races.
-    let handle: &GuestHandle = unsafe {
-        GUEST_HANDLE
-            .as_ref()
-            .expect("nanvix_dispatch_function(): GUEST_HANDLE not initialised")
-    };
+pub fn init_guest_handle() {
+    extern "C" {
+        static __KERNEL_END: u8;
+    }
 
-    let function_call = handle
-        .try_pop_shared_input_data_into::<FunctionCall>()
-        .expect("function call deserialization failed");
+    let kernel_end: usize = unsafe { &__KERNEL_END as *const u8 as usize };
+    let peb_base: usize = ::sys::mm::align_up(kernel_end, PAGE_ALIGNMENT)
+        .expect("init_guest_handle(): PEB align_up overflow");
+    let peb_ptr: *mut HyperlightPEB = peb_base as *mut HyperlightPEB;
 
-    match function_call.function_name.as_str() {
-        "kmain" => {
-            drop(function_call);
-            crate::kmain(kargs);
-        },
-        other => {
-            let msg = format!("unknown guest function: {other}");
-            drop(function_call);
-            let guest_error = GuestError::new(GuestErrorCode::GuestError, msg);
-            let fcr = FunctionCallResult::new(Err(guest_error));
-            let mut builder = ::flatbuffers::FlatBufferBuilder::new();
-            let data = fcr.encode(&mut builder);
-            handle
-                .push_shared_output_data(data)
-                .expect("failed to serialize function call error result");
-        },
+    let gva_gpa_delta: u64 = (MAX_GVA - MAX_GPA) as u64;
+    if gva_gpa_delta != 0 {
+        unsafe {
+            (*peb_ptr).input_stack.ptr -= gva_gpa_delta;
+            (*peb_ptr).output_stack.ptr -= gva_gpa_delta;
+        }
+    }
+
+    unsafe {
+        GUEST_HANDLE = Some(GuestHandle::init(peb_ptr));
     }
 }
 
 ///
 /// # Description
 ///
-/// Returns the TSC base frequency in MHz. On hyperlight the VMM does not
-/// provide this value, so `0` is returned (callers should use a fallback
-/// calibration path).
+/// Patches the kernel IDT entry #14 with the CoW page fault handler.
 ///
-#[allow(dead_code)]
-pub fn tsc_base_frequency_mhz() -> u32 {
-    0
+/// Must be called after `Hal::init()` (which installs the kernel IDT) but
+/// before any writes that could touch a PTE_COW page.
+///
+pub fn patch_kernel_idt_with_cow_handler() {
+    extern "C" {
+        fn _cow_pf_handler_rust();
+    }
+
+    unsafe {
+        let handler_addr: u32 = _cow_pf_handler_rust as *const () as u32;
+
+        // The IDT is already in writable scratch memory (placed there by
+        // set_backing_storage), so patch entry #14 in place — no copy or
+        // LIDT needed.
+        core::arch::asm!(
+            "sub esp, 8",
+            "sidt [esp]",
+            "mov {base:e}, [esp+2]",
+            "add esp, 8",
+
+            "mov eax, {handler:e}",
+            "mov [{base:e} + 112], ax",
+            "mov word ptr [{base:e} + 114], 0x08",
+            "mov byte ptr [{base:e} + 116], 0",
+            "mov byte ptr [{base:e} + 117], 0x8E",
+            "shr eax, 16",
+            "mov [{base:e} + 118], ax",
+
+            handler = in(reg) handler_addr,
+            base = out(reg) _,
+            out("eax") _,
+        );
+    }
+}
+
+///
+/// # Description
+///
+/// Dispatch handler called by `_nanvix_dispatch` (cow_entry.rs) after
+/// snapshot restore. Re-patches the kernel IDT with the CoW handler,
+/// re-programs PIC, enables interrupts, runs the kernel event loop,
+/// and halts when done.
+///
+#[unsafe(no_mangle)]
+extern "C" fn nanvix_dispatch_handler() {
+    patch_kernel_idt_with_cow_handler();
+
+    // Re-program PIC (KVM in-kernel irqchip state may be stale after snapshot).
+    unsafe {
+        use ::arch::cpu::pic;
+
+        // Master PIC: ICW1 (IC4 needed), ICW2 (vector offset), ICW3 (slave on IRQ2), ICW4 (8086 mode).
+        ::arch::io::out8(pic::PIC_CTRL_MASTER as u16, pic::icw1::Ic4::Needed as u8);
+        ::arch::io::wait();
+        ::arch::io::out8(pic::PIC_DATA_MASTER as u16, crate::hal::arch::x86::cpu::idt::INT_OFF);
+        ::arch::io::wait();
+        ::arch::io::out8(pic::PIC_DATA_MASTER as u16, 0x04);
+        ::arch::io::wait();
+        ::arch::io::out8(pic::PIC_DATA_MASTER as u16, pic::icw4::MicroprocessorMode::Mode8086 as u8);
+        ::arch::io::wait();
+        ::arch::io::out8(pic::PIC_DATA_MASTER as u16, 0xFF);
+
+        // Slave PIC: ICW1, ICW2 (vector offset + 8), ICW3 (cascade identity), ICW4 (8086 mode).
+        ::arch::io::out8(pic::PIC_CTRL_SLAVE as u16, pic::icw1::Ic4::Needed as u8);
+        ::arch::io::wait();
+        ::arch::io::out8(pic::PIC_DATA_SLAVE as u16, crate::hal::arch::x86::cpu::idt::INT_OFF + pic::PIC_NUM_IRQS);
+        ::arch::io::wait();
+        ::arch::io::out8(pic::PIC_DATA_SLAVE as u16, 0x02);
+        ::arch::io::wait();
+        ::arch::io::out8(pic::PIC_DATA_SLAVE as u16, pic::icw4::MicroprocessorMode::Mode8086 as u8);
+        ::arch::io::wait();
+        ::arch::io::out8(pic::PIC_DATA_SLAVE as u16, 0xFF);
+    }
+
+    if let Err(e) = crate::event::init() {
+        panic!("failed to initialize event manager: {:?}", e);
+    }
+
+    // Arm PV timer.
+    unsafe {
+        ::arch::io::out32(::config::hyperlight::PV_TIMER_PORT, ::config::hyperlight::TIMER_PERIOD_US);
+    }
+
+    unsafe { ::arch::cpu::sti() };
+
+    if let Some(intman) = unsafe { crate::hal::Hal::get_mut() }.intman() {
+        if let Err(e) = intman.unmask(crate::hal::arch::InterruptNumber::Timer) {
+            panic!("failed to unmask timer interrupt: {:?}", e);
+        }
+    }
+
+    let servers = crate::SERVERS_SPAWNED.load(core::sync::atomic::Ordering::Acquire);
+    let status = if servers > 0 {
+        crate::kcall::kcall_event_loop()
+    } else {
+        ::sys::ExitStatus::ok()
+    };
+
+    unsafe { crate::klog::flush() };
+    do_shutdown(status.into());
 }
 
 ///
@@ -1268,8 +1292,8 @@ pub fn init(
     }
 
     // scratch_end is the exclusive end of the full scratch range, including the last page
-    // reserved for Hyperlight bookkeeping metadata.  When MAX_GPA == usize::MAX (i686-guest),
-    // the addition wraps to 0 — this is expected and handled by region_contains / max_physical_address.
+    // reserved for Hyperlight bookkeeping metadata.  With i686-guest the scratch region
+    // extends to MAX_GPA (0xFFFF_FFFF) so the exclusive end wraps to 0 on 32-bit.
     let scratch_end_address: usize = scratch_base_address.wrapping_add(scratch_size);
 
     // Record scratch region bounds for is_valid_physical_address.
@@ -1314,15 +1338,12 @@ pub fn init(
         mmio_regions.push_back(scratch_output);
     }
 
-    // Reserve pages at the start of the free scratch area for the frame allocator bitmap,
-    // kpool bitmap, and GDT backing stores.  This memory is in scratch (never snapshot/CoW)
-    // and is registered as a reserved memory region so the frame allocator never hands it out.
-    let scratch_reserved_base: usize =
-        scratch_base_address + INPUT_DATA_BUFFER_SIZE + OUTPUT_DATA_BUFFER_SIZE;
+    // Place scratch-reserved structures in PD entry 1023 (top 4MB) where the
+    // Hyperlight host is known to map guest page table entries. The region sits
+    // immediately below the scratch I/O page.
+    let scratch_io_page: usize = scratch_end_address.wrapping_sub(2 * mem::PAGE_SIZE);
+    let scratch_reserved_base: usize = scratch_io_page.wrapping_sub(SCRATCH_RESERVED_SIZE);
     {
-        // No need to zero the storage pages: the scratch region is guaranteed to be
-        // zeroed out by Hyperlight before the guest starts.
-
         let scratch_reserved_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
             "scratch reserved structures",
             VirtualAddress::from_raw_value(scratch_reserved_base),
@@ -1335,7 +1356,7 @@ pub fn init(
             "scratch reserved: [{:#010x}, {:#010x}) (frame_alloc={} B, kpool={} B, gdt={} B, \
              heap_storage={} B, size={:#x})",
             scratch_reserved_base,
-            scratch_reserved_base + SCRATCH_RESERVED_SIZE,
+            scratch_reserved_base.wrapping_add(SCRATCH_RESERVED_SIZE),
             FRAME_ALLOC_BITMAP_SIZE,
             KPOOL_BITMAP_SIZE,
             GDT_SIZE,
@@ -1359,7 +1380,6 @@ pub fn init(
         memory_regions.push_back(boot_stack_region);
     }
     {
-        let scratch_io_page: usize = scratch_end_address - 2 * mem::PAGE_SIZE;
         let scratch_io: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new_mmio(
             "scratch-io",
             PageAligned::from_raw_value(scratch_io_page)?,
@@ -1370,23 +1390,55 @@ pub fn init(
         ioaddresses.register(SCRATCH_IO_MMIO_TAG, scratch_io.clone())?;
         mmio_regions.push_back(scratch_io);
     }
+    // The Hyperlight bookkeeping page (last page of 4GB) is intentionally not
+    // registered: its frame number exceeds FrameNumber::MAX and the frame
+    // allocator will never reach it.
+
+    // Book scratch pages consumed by the host's rebuilt page tables and the CoW
+    // pre-fault handler. The allocator at GVA 0xFFFF_FFF0 holds the address of the
+    // next free scratch page. Everything from the end of the I/O buffers to that
+    // address is already in use and must not be handed out by the frame allocator.
     {
-        let scratch_reserved_page: usize = scratch_end_address - mem::PAGE_SIZE;
-        let scratch_reserved: MemoryRegion<VirtualAddress> = MemoryRegion::new(
-            "scratch reserved",
-            VirtualAddress::from_raw_value(scratch_reserved_page),
-            mem::PAGE_SIZE,
-            MemoryRegionType::Reserved,
-            AccessPermission::RDONLY,
-        )?;
-        memory_regions.push_back(scratch_reserved);
+        const ALLOCATOR_GVA: *const u32 = 0xFFFF_FFF0 as *const u32;
+        let allocator_current: usize =
+            unsafe { core::ptr::read_volatile(ALLOCATOR_GVA) } as usize;
+        let io_buffers_end: usize =
+            scratch_base_address + INPUT_DATA_BUFFER_SIZE + OUTPUT_DATA_BUFFER_SIZE;
+        if allocator_current > io_buffers_end {
+            let cow_region_size: usize = allocator_current - io_buffers_end;
+            let cow_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+                "cow consumed scratch",
+                VirtualAddress::from_raw_value(io_buffers_end),
+                cow_region_size,
+                MemoryRegionType::Reserved,
+                AccessPermission::RDWR,
+            )?;
+            info!(
+                "cow consumed scratch: [{:#010x}, {:#010x}) ({} pages)",
+                io_buffers_end,
+                allocator_current,
+                cow_region_size / mem::PAGE_SIZE,
+            );
+            memory_regions.push_back(cow_region);
+        }
     }
 
-    // Set snapshot region end from the host-provided snapshot budget.
-    // pt_overhead is always 0 with nanvix-unstable (Hyperlight skips PT generation).
-    // The variable is acknowledged here for forward-compatibility.
     let _ = pt_overhead;
-    let snapshot_end_address: usize = KERNEL_BASE_RAW + snapshot_budget_size;
+    let mut snapshot_end_address: usize = KERNEL_BASE_RAW + snapshot_budget_size;
+    for region in memory_regions.iter() {
+        let region_end: usize = region
+            .start()
+            .into_raw_value()
+            .saturating_add(region.size());
+        if region_end > snapshot_end_address && region_end <= scratch_base_address {
+            snapshot_end_address = region_end;
+        }
+    }
+    if let Some(aligned) = ::sys::mm::align_up(snapshot_end_address, PAGE_ALIGNMENT) {
+        if aligned <= scratch_base_address {
+            snapshot_end_address = aligned;
+        }
+    }
     SNAPSHOT_END.store(snapshot_end_address, Ordering::Relaxed);
     info!("snapshot region: [{:#010x}, {:#010x})", KERNEL_BASE_RAW, snapshot_end_address);
 
@@ -1546,19 +1598,26 @@ unsafe fn build_physical_memory_layout(
     storage: (*mut u8, usize),
 ) -> Result<SparseBitmap, Error> {
     // Validate that region ends are not before their starts.
+    // scratch_end_address may be 0 (wrapping) when the region extends to usize::MAX.
     if snapshot_end_address < snapshot_start_address
         || ramfs_end_address < ramfs_start_address
-        || scratch_end_address < scratch_start_address
+        || (scratch_end_address != 0 && scratch_end_address < scratch_start_address)
     {
         let reason: &str = "region end address precedes start address";
         error!("build_physical_memory_layout(): {}", reason);
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
 
+    info!(
+        "build_physical_memory_layout: snapshot=[{:#x},{:#x}), ramfs=[{:#x},{:#x}), scratch=[{:#x},{:#x})",
+        snapshot_start_address, snapshot_end_address,
+        ramfs_start_address, ramfs_end_address,
+        scratch_start_address, scratch_end_address,
+    );
     let bits_per_byte: usize = u8::BITS as usize;
     let snapshot_size: usize = snapshot_end_address - snapshot_start_address;
     let ramfs_size: usize = ramfs_end_address - ramfs_start_address;
-    let scratch_size: usize = scratch_end_address - scratch_start_address;
+    let scratch_size: usize = scratch_end_address.wrapping_sub(scratch_start_address);
 
     let snapshot_frames: usize = snapshot_size / mem::FRAME_SIZE;
     let snapshot_padded_end: usize = snapshot_frames.div_ceil(bits_per_byte) * bits_per_byte;
@@ -1634,7 +1693,6 @@ unsafe fn build_physical_memory_layout(
             Ok(bitmap)
         };
 
-    // Low chunk: snapshot (and optionally RAMFS when merged).
     let snapshot_start_frame: usize = snapshot_start_address / mem::FRAME_SIZE;
     let low_bitmap: Bitmap = make_chunk(low_bytes, low_end_frame, low_phantom)?;
     let mut chunks: vec::Vec<(usize, Bitmap)> = vec![(snapshot_start_frame, low_bitmap)];
@@ -1647,7 +1705,8 @@ unsafe fn build_physical_memory_layout(
 
     // Scratch chunk: frames [scratch_start / FRAME_SIZE, ...).
     if scratch_frames > 0 {
-        let scratch_bitmap: Bitmap = make_chunk(scratch_bytes, scratch_frames, scratch_phantom)?;
+        let scratch_bitmap: Bitmap =
+            make_chunk(scratch_bytes, scratch_frames, scratch_phantom)?;
         chunks.push((scratch_start_address / mem::FRAME_SIZE, scratch_bitmap));
     }
 

--- a/src/kernel/src/hal/platform/hyperlight/start.rs
+++ b/src/kernel/src/hal/platform/hyperlight/start.rs
@@ -5,6 +5,7 @@
 // x86 Bootstrap and Application-Processor Entry Points (Hyperlight)
 //==================================================================================================
 
+use ::arch::mem::PAGE_SIZE;
 use ::core::arch::global_asm;
 use ::hyperlight_common::outb::VmAction;
 
@@ -136,11 +137,21 @@ global_asm!(
 global_asm!(
     ".section .bss",
 
+    // Kernel stack guard page + usable stack (used by CoW dispatch).
+    ".align {PAGE_SIZE}",
+    ".globl kstack_guard",
+    "kstack_guard:",
+    ".space {KSTACK_SIZE}",
+    ".globl kstack",
+    "kstack:",
+
     // Kernel Red Zone.
     ".globl kredzone",
     "kredzone:",
     ".space {KREDZONE_SIZE}",
 
+    PAGE_SIZE = const PAGE_SIZE,
+    KSTACK_SIZE = const ::config::kernel::KSTACK_SIZE,
     KREDZONE_SIZE = const ::config::kernel::KREDZONE_SIZE,
     options(att_syntax),
 );

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -5,11 +5,10 @@
 // Imports
 //==================================================================================================
 
+#[cfg(not(feature = "hyperlight"))]
+use crate::event;
 use crate::{
-    event::{
-        self,
-        EventManager,
-    },
+    event::EventManager,
     mm::VirtMemoryManager,
     pm::ProcessManager,
 };
@@ -61,6 +60,7 @@ macro_rules! mm {
 ///
 /// Kernel call handler.
 ///
+#[cfg(not(feature = "hyperlight"))]
 pub fn kcall_handler() -> ExitStatus {
     if let Err(e) = event::init() {
         panic!("failed to initialize event manager: {:?}", e);
@@ -69,6 +69,17 @@ pub fn kcall_handler() -> ExitStatus {
     // Signal the VMM that kernel startup is complete and user-space is about to start.
     crate::hal::platform::signal_startup_complete();
 
+    kcall_event_loop()
+}
+
+///
+/// # Description
+///
+/// Kernel event loop. Polls IKC messages, harvests zombie processes,
+/// and yields the CPU when idle. Returns the exit status when the
+/// init daemon terminates.
+///
+pub fn kcall_event_loop() -> ExitStatus {
     let status: ExitStatus = loop {
         // Check if inter-kernel communication messages are available.
         let message_received: bool = poll_ikc_messages();

--- a/src/kernel/src/kcall/mod.rs
+++ b/src/kernel/src/kcall/mod.rs
@@ -15,7 +15,10 @@ mod kcall_success;
 // Exports
 //==================================================================================================
 
+#[cfg(not(feature = "hyperlight"))]
 pub use handler::kcall_handler as handler;
+#[cfg(feature = "hyperlight")]
+pub use handler::kcall_event_loop;
 #[cfg(feature = "microvm")]
 pub use handler::poll_ikc_messages;
 pub use kcall_error::KcallError;

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -194,6 +194,11 @@ static PERF_IKC_MESSAGES_SENT: AtomicUsize = AtomicUsize::new(0);
 /// Number of IKC messages received.
 static PERF_IKC_MESSAGES_RECEIVED: AtomicUsize = AtomicUsize::new(0);
 
+/// Number of user-space servers spawned during boot.
+/// Read by the Hyperlight call-phase dispatch handler to decide whether
+/// to enter the event loop or shut down immediately.
+pub static SERVERS_SPAWNED: AtomicUsize = AtomicUsize::new(0);
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -280,6 +285,10 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
             panic!("failed to initialize kernel heap: {:?}", e);
         }
     }
+    // Initialize the GuestHandle for PEB I/O (needed for do_shutdown,
+    // vmbus, etc.).
+    #[cfg(feature = "hyperlight")]
+    crate::hal::platform::hyperlight::init_guest_handle();
 
     #[cfg(feature = "test")]
     test();
@@ -318,6 +327,27 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     };
 
     // Add kernel image to list of memory regions.
+    // On Hyperlight the kernel binary is loaded at GPA 0x1000 (the VMM
+    // reserves the first page). The linker script places .zero padding,
+    // .trampoline, and bootstrap code before __TEXT_START. Book the
+    // pre-text range so the frame allocator never hands out those frames.
+    #[cfg(feature = "hyperlight")]
+    {
+        let text_start: usize = kimage.text().start().into_raw_value();
+        if text_start > 0 {
+            match MemoryRegion::new(
+                "pre-text",
+                VirtualAddress::new(0),
+                text_start,
+                MemoryRegionType::Reserved,
+                AccessPermission::RDONLY,
+            ) {
+                Ok(pre_text) => memory_regions.push_back(pre_text),
+                Err(e) => panic!("failed to reserve pre-text region: {:?}", e),
+            }
+        }
+
+    }
     memory_regions.push_back(kimage.text());
     memory_regions.push_back(kimage.rodata());
     if let Some(data) = kimage.data() {
@@ -452,8 +482,14 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     info!("number of cores online: {}", cores_online);
 
     // SAFETY: the memory manager is initialized and access is synchronized.
-    let status: ExitStatus =
-        if spawn_servers(unsafe { VirtMemoryManager::get_mut() }, &kernel_modules) > 0 {
+    let _servers_spawned: usize =
+        spawn_servers(unsafe { VirtMemoryManager::get_mut() }, &kernel_modules);
+
+    SERVERS_SPAWNED.store(_servers_spawned, Ordering::Release);
+
+    #[cfg(not(feature = "hyperlight"))]
+    {
+        let status: ExitStatus = if _servers_spawned > 0 {
             // Enable timer interrupts, if they are supported.
             // SAFETY: the hardware abstraction layer is initialized and access is synchronized.
             if let Some(intman) = unsafe { Hal::get_mut() }.intman() {
@@ -467,45 +503,49 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
             ExitStatus::ok()
         };
 
-    #[cfg(feature = "smp")]
-    startup::wait().expect("failed to synchronize application cores");
+        #[cfg(feature = "smp")]
+        startup::wait().expect("failed to synchronize application cores");
 
-    // Dump system statistics.
-    info!("System Statistics:");
-    info!("- No. Times Kernel Was Idle: {:?}", PERF_SCHED_KERNEL_IDLE.load(Ordering::Relaxed));
-    info!(
-        "- No. Soft Context Switches: {:?}",
-        PERF_SCHED_SOFT_CONTEXT_SWITCHES.load(Ordering::Relaxed)
-    );
-    info!(
-        "- No. Hard Context Switches: {:?}",
-        PERF_SCHED_HARD_CONTEXT_SWITCHES.load(Ordering::Relaxed)
-    );
-    info!(
-        "- No. Exit Context Switches: {:?}",
-        PERF_SCHED_EXIT_CONTEXT_SWITCHES.load(Ordering::Relaxed)
-    );
-    info!(
-        "- No. Exit Thread Context Switches: {:?}",
-        PERF_SCHED_EXIT_THREAD_CONTEXT_SWITCHES.load(Ordering::Relaxed)
-    );
-    info!(
-        "- No. Sleep Context Switches: {:?}",
-        PERF_SCHED_SLEEP_CONTEXT_SWITCHES.load(Ordering::Relaxed)
-    );
-    info!(
-        "- No. Giveup Context Switches: {:?}",
-        PERF_SCHED_GIVEUP_CONTEXT_SWITCHES.load(Ordering::Relaxed)
-    );
-    info!("- No. Wakeup Calls: {:?}", PERF_SCHED_WAKEUP.load(Ordering::Relaxed));
-    info!("- Ticks: {:?}", pm::ticks());
-    info!("- No. Times VMBus Read Was Called: {:?}", PERF_VMBUS_READ.load(Ordering::Relaxed));
-    info!("- No. Times VMBus Write Was Called: {:?}", PERF_VMBUS_WRITE.load(Ordering::Relaxed));
-    info!("- No. IKC Messages Sent: {:?}", PERF_IKC_MESSAGES_SENT.load(Ordering::Relaxed));
-    info!("- No. IKC Messages Received: {:?}", PERF_IKC_MESSAGES_RECEIVED.load(Ordering::Relaxed));
+        // Dump system statistics.
+        info!("System Statistics:");
+        info!("- No. Times Kernel Was Idle: {:?}", PERF_SCHED_KERNEL_IDLE.load(Ordering::Relaxed));
+        info!(
+            "- No. Soft Context Switches: {:?}",
+            PERF_SCHED_SOFT_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+        );
+        info!(
+            "- No. Hard Context Switches: {:?}",
+            PERF_SCHED_HARD_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+        );
+        info!(
+            "- No. Exit Context Switches: {:?}",
+            PERF_SCHED_EXIT_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+        );
+        info!(
+            "- No. Exit Thread Context Switches: {:?}",
+            PERF_SCHED_EXIT_THREAD_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+        );
+        info!(
+            "- No. Sleep Context Switches: {:?}",
+            PERF_SCHED_SLEEP_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+        );
+        info!(
+            "- No. Giveup Context Switches: {:?}",
+            PERF_SCHED_GIVEUP_CONTEXT_SWITCHES.load(Ordering::Relaxed)
+        );
+        info!("- No. Wakeup Calls: {:?}", PERF_SCHED_WAKEUP.load(Ordering::Relaxed));
+        info!("- Ticks: {:?}", pm::ticks());
+        info!("- No. Times VMBus Read Was Called: {:?}", PERF_VMBUS_READ.load(Ordering::Relaxed));
+        info!("- No. Times VMBus Write Was Called: {:?}", PERF_VMBUS_WRITE.load(Ordering::Relaxed));
+        info!("- No. IKC Messages Sent: {:?}", PERF_IKC_MESSAGES_SENT.load(Ordering::Relaxed));
+        info!(
+            "- No. IKC Messages Received: {:?}",
+            PERF_IKC_MESSAGES_RECEIVED.load(Ordering::Relaxed)
+        );
 
-    trace!("the system will shutdown now!");
-    kernel_magic_string(status);
+        trace!("the system will shutdown now!");
+        kernel_magic_string(status);
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -12,7 +12,7 @@
 //==================================================================================================
 
 pub mod elf;
-mod phys;
+pub(crate) mod phys;
 mod virt;
 
 #[cfg(feature = "hyperlight")]

--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -263,7 +263,7 @@ pub(super) unsafe fn init(bitmap: SparseBitmap) -> Result<(), Error> {
 }
 
 /// Allocate a frame.
-pub(super) fn alloc() -> Result<FrameAddress, Error> {
+pub(crate) fn alloc() -> Result<FrameAddress, Error> {
     instance().alloc()
 }
 

--- a/src/kernel/src/mm/virt/manager.rs
+++ b/src/kernel/src/mm/virt/manager.rs
@@ -175,6 +175,7 @@ impl VirtMemoryManager {
         let root: Vmem = Vmem::new(kernel_pages, kernel_page_tables)?;
 
         // Load root root address space.
+        #[cfg(not(feature = "hyperlight"))]
         root.load()?;
 
         Ok((root, Self))

--- a/src/kernel/src/pm/clock.rs
+++ b/src/kernel/src/pm/clock.rs
@@ -139,6 +139,7 @@ pub unsafe fn timer_handler(_intnum: InterruptNumber) {
 /// # Returns
 ///
 /// The number of timer ticks since the system started.
+#[cfg(not(feature = "hyperlight"))]
 pub fn ticks() -> u64 {
     let (major_ticks, minor_ticks): (u32, u32) = TIMER_TICKS.get();
     ((major_ticks as u64) << 32) + (minor_ticks as u64)

--- a/src/kernel/src/pm/mod.rs
+++ b/src/kernel/src/pm/mod.rs
@@ -47,6 +47,7 @@ const ORDER: Ordering = Ordering::Relaxed;
 // Exports
 //==================================================================================================
 
+#[cfg(not(feature = "hyperlight"))]
 pub use clock::ticks;
 pub use kcall::*;
 pub use process::{

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -78,6 +78,13 @@ pub const KILL_SIGNAL: c_int = libc::SIGKILL;
 /// See issue #1010 for more context on this workaround.
 pub const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_millis(100);
 
+/// Base address of the Hyperlight sandbox's memory region.
+///
+/// Hyperlight maps the guest snapshot at this GPA. Without the `nanvix-unstable` feature the
+/// upstream layout uses `0x1000`; with `nanvix-unstable` it is `0x0`. This constant must
+/// match `SandboxMemoryLayout::BASE_ADDRESS` in hyperlight-host (which is `pub(crate)`).
+const HYPERLIGHT_BASE_ADDRESS: u64 = 0x1000;
+
 /// Label used for the RAMFS file mapping in the PEB.
 const RAMFS_LABEL: &str = "ramfs";
 
@@ -320,13 +327,13 @@ impl Vmm {
 
         // Map RAMFS file into sandbox memory if provided.
         // The file is mapped copy-on-write at the first GPA after the sandbox's
-        // shared memory slot. With nanvix-unstable, BASE_ADDRESS is 0x0 so the
-        // shared memory occupies GPA [0, shared_mem_size).
+        // shared memory slot. The shared memory occupies GPA
+        // [HYPERLIGHT_BASE_ADDRESS, HYPERLIGHT_BASE_ADDRESS + shared_mem_size).
         let mut layout_ramfs_base: u32 = 0;
         let mut layout_ramfs_size: u32 = 0;
         if let Some(ramfs_filename) = &args.ramfs_filename {
             let ramfs_path: &Path = Path::new(ramfs_filename);
-            let ramfs_gpa: u64 = sandbox.shared_mem_size() as u64;
+            let ramfs_gpa: u64 = HYPERLIGHT_BASE_ADDRESS + sandbox.shared_mem_size() as u64;
             let mapped_size: u64 = sandbox
                 .map_file_cow(ramfs_path, ramfs_gpa, Some(RAMFS_LABEL))
                 .map_err(|e| {


### PR DESCRIPTION
## Summary

- Bumps Hyperlight dependencies to rev `94ee4956` and switches to the stable feature set (`i686-guest` + `guest-counter`)
- Implements the two-phase evolve→call execution model: `evolve()` boots the kernel and snapshots at halt; `call()` re-enters at `_nanvix_dispatch` with a fresh CoW overlay
- Wires `cow_entry` / `cow_handler` into the Hyperlight platform module and patches the kernel IDT for page-fault dispatch
- Replaces raw inline PIC reprogramming assembly with `arch::cpu::pic` / `arch::io` abstractions
- Replaces raw PV timer assembly with `arch::io::out32` to the paravirtual timer port
- Adds `HYPERLIGHT_BASE_ADDRESS` constant in the uservm crate and fixes ramfs GPA calculation
- Adds `HYPERLIGHT_GPA_CEILING` (0xFEE0_0000) in config and adjusts `USER_END_RAW` calculation to stay below the APIC MMIO hole
- Extracts `kcall_event_loop()` as a public function so the Hyperlight dispatch handler can re-enter it on each `call()`

## Test plan

- [ ] `./z build -- all MACHINE=microvm TARGET=x86 DEPLOYMENT_MODE=standalone RELEASE=yes` succeeds
- [ ] `./z build -- all MACHINE=microvm TARGET=x86 DEPLOYMENT_MODE=multicores RELEASE=yes` succeeds
- [ ] `./z build -- all MACHINE=hyperlight TARGET=x86 DEPLOYMENT_MODE=standalone RELEASE=yes` succeeds
- [ ] `./z build -- all MACHINE=hyperlight TARGET=x86 DEPLOYMENT_MODE=multicores RELEASE=yes` succeeds
- [ ] `./bin/nanvix-test.elf test/test-standalone.toml` exits 0 (microvm)
- [ ] `./bin/nanvix-test.elf test/test-multicores.toml` exits 0 (microvm)
- [ ] `cargo clippy` passes with no warnings