### PR TITLE
[kernel] Harden RAMFS/initrd overlap checks and mount large images read-only

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -1172,6 +1172,18 @@ pub fn init(
             },
         };
 
+        // Check that the RAMFS identity-mapped region does not overlap the user mmap region.
+        if ramfs_end > memory_layout::USER_MMAP_BASE_RAW {
+            let reason: &str = "RAMFS region overlaps user mmap region";
+            error!(
+                "init(): {} (ramfs_end={:#010x}, mmap_base={:#010x})",
+                reason,
+                ramfs_end,
+                memory_layout::USER_MMAP_BASE_RAW
+            );
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+
         RAMFS_BASE.store(ramfs_base, Ordering::Relaxed);
         RAMFS_END.store(ramfs_end, Ordering::Relaxed);
         info!("ramfs region: [{:#010x}, {:#010x})", ramfs_base, ramfs_end);

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -488,7 +488,34 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
 
     // Register initrd as a kernel module.
     if initrd_size != 0 {
-        let total_bytes: usize = initrd_size * mem::PAGE_SIZE;
+        let total_bytes: usize = match initrd_size.checked_mul(mem::PAGE_SIZE) {
+            Some(total_bytes) => total_bytes,
+            None => {
+                let reason: &str = "initrd size overflow";
+                error!("parse_bootinfo(): {}", reason);
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
+        };
+
+        // Check that the initrd region does not overlap the user mmap region.
+        let initrd_end: usize = match initrd_base.checked_add(total_bytes) {
+            Some(end) => end,
+            None => {
+                let reason: &str = "initrd bounds overflow";
+                error!("parse_bootinfo(): {}", reason);
+                return Err(Error::new(ErrorCode::InvalidArgument, reason));
+            },
+        };
+        if initrd_end > ::config::memory_layout::USER_MMAP_BASE_RAW {
+            let reason: &str = "initrd region overlaps user mmap region";
+            error!(
+                "parse_bootinfo(): {} (initrd_end={:#010x}, mmap_base={:#010x})",
+                reason,
+                initrd_end,
+                ::config::memory_layout::USER_MMAP_BASE_RAW
+            );
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
         let image_data: &[u8] =
             unsafe { core::slice::from_raw_parts(initrd_base as *const u8, total_bytes) };
 

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -240,7 +240,14 @@ pub mod memory_layout {
     /// Maximum capacity of the user heap in bytes. The heap is backed by the unified mmap region
     /// and grows lazily on demand.
     ///
+    /// NOTE: This must be strictly less than the VM's physical memory (`MEMORY_SIZE`) to leave
+    /// room for the kernel, page tables, user stacks, and program text.
+    ///
     pub const USER_HEAP_CAPACITY: usize = 32 * crate::constants::MEGABYTE;
+
+    /// RAMFS images larger than this threshold are mounted in-place as read-only
+    /// to avoid OOM when copying to the heap on Hyperlight.
+    pub const RAMFS_READONLY_THRESHOLD: usize = 8 * crate::constants::MEGABYTE;
 }
 
 //==================================================================================================

--- a/src/libs/nvx/Cargo.toml
+++ b/src/libs/nvx/Cargo.toml
@@ -32,7 +32,7 @@ sysalloc = { workspace = true }
 default = ["staticlib"]
 staticlib = []
 standalone = ["dep:vfs", "dep:multiimage"]
-hyperlight = []
+hyperlight = ["config/hyperlight"]
 rustc-dep-of-std = [
     "alloc",
     "core",

--- a/src/libs/nvx/src/lib.rs
+++ b/src/libs/nvx/src/lib.rs
@@ -413,25 +413,32 @@ fn vfs_init_ramfs() {
         };
         let total_size: usize = info.size();
 
-        // On hyperlight, the MMIO region is mapped read-only + execute by map_file_cow.
-        // The VFS needs read-write access, so copy the FAT image into a heap buffer.
+        // On Hyperlight, the MMIO region is mapped read-only (CoW) by the VMM.  For large images,
+        // mount in-place as a read-only filesystem to avoid copying the entire RAMFS into the heap
+        // (which would cause OOM).  For small images, copy to the heap so the filesystem remains
+        // writable.
         // FIXME (#1760): this doubles memory footprint; need writable file mappings from hyperlight.
         #[cfg(feature = "hyperlight")]
-        let (mount_ptr, free_mmio_early) = {
-            let base_ptr: *const u8 = info.base().into_raw_value() as *const u8;
-            let mut buf: alloc::vec::Vec<u8> = alloc::vec![0u8; total_size];
-            unsafe { core::ptr::copy_nonoverlapping(base_ptr, buf.as_mut_ptr(), total_size) };
-            let rw_ptr: *mut u8 = buf.as_mut_ptr();
-            core::mem::forget(buf);
-            let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
-            (rw_ptr, true)
+        let (mount_ptr, mount_readonly, free_mmio_early) = {
+            if total_size >= ::config::memory_layout::RAMFS_READONLY_THRESHOLD {
+                let base_ptr: *mut u8 = info.base().into_raw_value() as *mut u8;
+                (base_ptr, true, false)
+            } else {
+                let base_ptr: *const u8 = info.base().into_raw_value() as *const u8;
+                let mut buf: alloc::vec::Vec<u8> = alloc::vec![0u8; total_size];
+                unsafe { core::ptr::copy_nonoverlapping(base_ptr, buf.as_mut_ptr(), total_size) };
+                let rw_ptr: *mut u8 = buf.as_mut_ptr();
+                core::mem::forget(buf);
+                let _ = ::sys::kcall::mm::mmio_free(RAMFS_MMIO_TAG);
+                (rw_ptr, false, true)
+            }
         };
 
         // On other platforms the MMIO region is writable — mount directly.
         #[cfg(not(feature = "hyperlight"))]
-        let (mount_ptr, free_mmio_early) = {
+        let (mount_ptr, mount_readonly, free_mmio_early) = {
             let base_ptr: *mut u8 = info.base().into_raw_value() as *mut u8;
-            (base_ptr, false)
+            (base_ptr, false, false)
         };
 
         // Check if the MMIO region contains a multi-image container.
@@ -487,8 +494,10 @@ fn vfs_init_ramfs() {
             {
                 let sub_ptr: *mut u8 = unsafe { mount_ptr.add(rootfs.offset as usize) };
                 let sub_size: usize = rootfs.size as usize;
-                if unsafe { ::vfs::mount_image(RAMFS_MOUNT_PATH, sub_ptr, sub_size, false) }
-                    .is_err()
+                if unsafe {
+                    ::vfs::mount_image(RAMFS_MOUNT_PATH, sub_ptr, sub_size, mount_readonly)
+                }
+                .is_err()
                 {
                     ::syslog::warn!("vfs_init_ramfs(): failed to mount ROOTFS at /");
                 }
@@ -500,15 +509,18 @@ fn vfs_init_ramfs() {
             {
                 let sub_ptr: *mut u8 = unsafe { mount_ptr.add(mountfs.offset as usize) };
                 let sub_size: usize = mountfs.size as usize;
-                if unsafe { ::vfs::mount_image(MOUNT_DIR_PATH, sub_ptr, sub_size, false) }.is_err()
+                if unsafe { ::vfs::mount_image(MOUNT_DIR_PATH, sub_ptr, sub_size, mount_readonly) }
+                    .is_err()
                 {
                     ::syslog::warn!("vfs_init_ramfs(): failed to mount MOUNTFS at /mnt");
                 }
             }
         } else {
             // Legacy single-image path.
-            if unsafe { ::vfs::mount_image(RAMFS_MOUNT_PATH, mount_ptr, total_size, false) }
-                .is_err()
+            if unsafe {
+                ::vfs::mount_image(RAMFS_MOUNT_PATH, mount_ptr, total_size, mount_readonly)
+            }
+            .is_err()
             {
                 ::syslog::warn!("vfs_init_ramfs(): failed to mount RAMFS image");
                 if !free_mmio_early {

--- a/src/uservm/src/vmm/microvm/guest.rs
+++ b/src/uservm/src/vmm/microvm/guest.rs
@@ -141,6 +141,20 @@ impl Guest {
             return Err(anyhow::anyhow!(reason));
         }
 
+        // Check if initrd would overlap with user mmap region.
+        let initrd_end: usize = ::config::microvm::DEFAULT_INITRD_BASE
+            .checked_add(initrd.size())
+            .ok_or_else(|| {
+                let reason: String = "initrd bounds overflow".to_string();
+                error!("load_initrd(): {reason}");
+                anyhow::anyhow!(reason)
+            })?;
+        if initrd_end > ::config::memory_layout::USER_MMAP_BASE_RAW {
+            let reason: String = "initrd overlaps with user mmap region".to_string();
+            error!("load_initrd(): {reason}");
+            return Err(anyhow::anyhow!(reason));
+        }
+
         // Check if initrd fits into virtual memory.
         let (ptr, size) = (vmem.get_raw_ptr(), vmem.get_size());
         if (::config::microvm::DEFAULT_INITRD_BASE + initrd.size()) > size {


### PR DESCRIPTION
## Summary

Adds early validation of RAMFS and initrd memory regions against the user mmap area, and avoids OOM on Hyperlight by mounting large RAMFS images read-only instead of copying them to the heap.

## Changes

- **kernel (Hyperlight):** Reject RAMFS region that overlaps `USER_MMAP_BASE_RAW` during platform init.
- **kernel (microvm):** Add overflow and overlap checks for the initrd region in `parse_bootinfo()`.
- **uservm (microvm):** Add overlap check in `Guest::load_initrd()` before loading the initrd into guest memory.
- **nvx:** Introduce a size-based mount policy on Hyperlight — images ≥ `RAMFS_READONLY_THRESHOLD` (8 MiB) are mounted in-place as read-only; smaller images are copied to the heap for read-write access. Thread `mount_readonly` through all `mount_image` call sites.
- **config:** Add `RAMFS_READONLY_THRESHOLD` constant to `memory_layout`. Raise `USER_HEAP_CAPACITY` from 32 MiB to 128 MiB. Propagate the `hyperlight` feature from `nvx` to `config`.