### PR TITLE
[kernel] Relocate KLOG_BUFFER from BSS to scratch memory

### DIFF
--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -270,6 +270,9 @@ scratch_layout! {
     /// Kernel heap backing storage (relocated from BSS to avoid dirtying CoW snapshot pages).
     HEAP_STORAGE       : size = crate::mm::kheap::MIN_HEAP_SIZE,
                          align = PAGE_ALIGNMENT;
+    /// Kernel log buffer backing storage (relocated from BSS to avoid dirtying CoW snapshot pages).
+    KLOG_BUFFER        : size = crate::klog::KLOG_BUFFER_STORAGE_SIZE,
+                         align = crate::klog::KLOG_BUFFER_ALIGNMENT;
 }
 
 //==================================================================================================
@@ -711,6 +714,21 @@ extern "C" fn hyperlight_pre_kmain() {
     let scratch_base: usize = unsafe { (*peb_ptr).input_stack.ptr } as usize;
     let scratch_reserved_base: usize =
         scratch_base + INPUT_DATA_BUFFER_SIZE + OUTPUT_DATA_BUFFER_SIZE;
+
+    // Point the kernel log buffer at scratch-resident backing storage so that log
+    // writes do not dirty CoW snapshot pages.
+    //
+    // Safety: klog_buffer_ptr returns a pointer within the scratch-reserved region
+    // that was identity-mapped and zeroed by Hyperlight before the guest started.
+    // The scratch region is never freed, so the storage outlives all logging usage.
+    // This is the only call to klog::set_backing_storage() in the Hyperlight init path.
+    let klog_backing_ptr: *mut u8 = unsafe { klog_buffer_ptr(scratch_reserved_base) };
+    if let Err(_e) = unsafe { crate::klog::set_backing_storage(klog_backing_ptr) } {
+        unsafe {
+            core::arch::asm!("cli", "2: hlt", "jmp 2b", options(noreturn));
+        }
+    }
+
     let heap_backing_ptr: *mut u8 = (scratch_reserved_base + HEAP_STORAGE_OFFSET) as *mut u8;
 
     // Point the kernel heap at scratch-resident backing storage so that heap

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -149,6 +149,19 @@ static mut HEAP_STORAGE: HeapStorage = HeapStorage {
     memory: [0; crate::mm::kheap::MIN_HEAP_SIZE],
 };
 
+/// Klog buffer backing storage, allocated in BSS.
+/// Only present in single-core builds where the klog buffer is active.
+#[cfg(not(feature = "smp"))]
+#[repr(align(8))]
+struct KlogBufferStorage {
+    memory: [u8; crate::klog::KLOG_BUFFER_STORAGE_SIZE],
+}
+
+#[cfg(not(feature = "smp"))]
+static mut KLOG_BUFFER_STORAGE: KlogBufferStorage = KlogBufferStorage {
+    memory: [0; crate::klog::KLOG_BUFFER_STORAGE_SIZE],
+};
+
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
@@ -169,6 +182,22 @@ pub unsafe fn setup_heap_backing_storage() -> Result<(), ::sys::error::Error> {
         HEAP_STORAGE.memory.as_mut_ptr(),
         HEAP_STORAGE.memory.len(),
     )
+}
+
+///
+/// # Description
+///
+/// Points the kernel log buffer at the BSS-resident `KLOG_BUFFER_STORAGE` buffer.
+///
+/// Must be called before the first logging macro invocation.
+///
+/// # Safety
+///
+/// This function accesses the `KLOG_BUFFER_STORAGE` static mutable.
+///
+#[cfg(not(feature = "smp"))]
+pub unsafe fn setup_klog_backing_storage() -> Result<(), ::sys::error::Error> {
+    crate::klog::set_backing_storage(KLOG_BUFFER_STORAGE.memory.as_mut_ptr())
 }
 
 ///

--- a/src/kernel/src/klog.rs
+++ b/src/kernel/src/klog.rs
@@ -172,7 +172,12 @@ pub unsafe fn puts(_s: &str) {
             return;
         }
 
-        KLOG_BUFFER.get().append(_s);
+        // No backing storage installed yet — silently drop the output.
+        if KLOG_BUFFER.is_null() {
+            return;
+        }
+
+        (*KLOG_BUFFER).append(_s);
     }
 }
 
@@ -199,7 +204,12 @@ pub unsafe fn flush() {
             return;
         }
 
-        KLOG_BUFFER.get().flush();
+        // No backing storage installed yet — nothing to flush.
+        if KLOG_BUFFER.is_null() {
+            return;
+        }
+
+        (*KLOG_BUFFER).flush();
     }
 }
 
@@ -212,48 +222,37 @@ pub unsafe fn flush() {
 #[cfg(not(feature = "smp"))]
 mod buffer {
     use super::*;
-    use ::core::cell::UnsafeCell;
+    use ::sys::error::{
+        Error,
+        ErrorCode,
+    };
 
     /// Size of the kernel log buffer in bytes.
     pub const BUFFER_SIZE: usize = config::kernel::KLOG_BUFFER_SIZE;
 
-    /// Global kernel log buffer.
+    /// Total size of the [`KlogBuffer`] struct in bytes. Platform modules use this constant to
+    /// allocate appropriately-sized backing storage.
+    pub const KLOG_BUFFER_STORAGE_SIZE: usize = core::mem::size_of::<KlogBuffer>();
+
+    /// Required alignment of the [`KlogBuffer`] backing storage.
     ///
-    /// Wrapped in [`SyncUnsafeCell`] to allow safe static storage on a single-core system.
-    pub static KLOG_BUFFER: SyncUnsafeCell<KlogBuffer> = SyncUnsafeCell::new(KlogBuffer::new());
+    /// `KlogBuffer` contains a `usize` field, so on 64-bit targets the struct requires 8-byte
+    /// alignment. Use `Align8` conservatively to be correct on all supported targets.
+    pub const KLOG_BUFFER_ALIGNMENT: ::sys::mm::Alignment = ::sys::mm::Alignment::Align8;
 
-    /// A thin wrapper around [`UnsafeCell`] that implements [`Sync`].
+    /// Pointer to the platform-provided klog buffer backing storage.
     ///
-    /// # Safety
-    ///
-    /// This is sound because the Nanvix kernel runs on a single core with interrupts disabled
-    /// during all access to the wrapped value, so no concurrent access can occur.
-    pub struct SyncUnsafeCell<T>(UnsafeCell<T>);
-
-    impl<T> SyncUnsafeCell<T> {
-        pub const fn new(value: T) -> Self {
-            Self(UnsafeCell::new(value))
-        }
-
-        /// Returns a mutable reference to the inner value.
-        ///
-        /// # Safety
-        ///
-        /// The caller must ensure that no other reference to the inner value exists.
-        #[allow(clippy::mut_from_ref)]
-        pub unsafe fn get(&self) -> &mut T {
-            &mut *self.0.get()
-        }
-    }
-
-    // SAFETY: the kernel is single-core with interrupts disabled during access.
-    unsafe impl<T> Sync for SyncUnsafeCell<T> {}
+    /// Initialized by [`set_backing_storage()`] before the first logging call. On microvm the
+    /// storage is a BSS-allocated static; on Hyperlight it resides in the scratch region so it is
+    /// not part of the Copy-on-Write snapshot.
+    pub static mut KLOG_BUFFER: *mut KlogBuffer = core::ptr::null_mut();
 
     /// A fixed-size buffer that batches kernel log output before flushing to the platform device.
     ///
     /// All kernel log output (from logging macros and the debug kernel call) is appended to this
     /// buffer instead of being written directly to the output device. The buffer is flushed in bulk
     /// when it is full or when an explicit flush is requested, reducing per-character I/O overhead.
+    #[repr(C)]
     pub struct KlogBuffer {
         /// Underlying storage.
         data: [u8; BUFFER_SIZE],
@@ -262,14 +261,6 @@ mod buffer {
     }
 
     impl KlogBuffer {
-        /// Creates a new, empty kernel log buffer.
-        pub const fn new() -> Self {
-            Self {
-                data: [0; BUFFER_SIZE],
-                len: 0,
-            }
-        }
-
         ///
         /// # Description
         ///
@@ -341,7 +332,54 @@ mod buffer {
             self.len = 0;
         }
     }
+
+    ///
+    /// # Description
+    ///
+    /// Installs platform-provided backing storage for the kernel log buffer.
+    ///
+    /// Must be called exactly once before the first logging macro invocation. On microvm the
+    /// storage is a BSS-allocated static; on Hyperlight it resides in the scratch region so
+    /// runtime writes do not trigger copy-on-write faults.
+    ///
+    /// # Parameters
+    ///
+    /// - `storage`: Pointer to at least [`KLOG_BUFFER_STORAGE_SIZE`] bytes whose lifetime exceeds
+    ///   all subsequent logging operations. Must be aligned to [`KLOG_BUFFER_ALIGNMENT`] and
+    ///   zero-initialized.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if the backing storage was successfully installed.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::InvalidArgument`] if `storage` is null or not properly aligned.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it sets a global raw pointer that all logging operations
+    /// depend on. The caller must ensure:
+    /// - `storage` is non-null and points to at least [`KLOG_BUFFER_STORAGE_SIZE`] bytes.
+    /// - The backing memory is zero-initialized.
+    /// - The backing memory outlives all logging usage.
+    /// - This function is called at most once.
+    ///
+    pub unsafe fn set_backing_storage(storage: *mut u8) -> Result<(), Error> {
+        if storage.is_null() {
+            let reason: &str = "null klog backing storage pointer";
+            error!("set_backing_storage(): {}", reason);
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        if !::sys::mm::is_aligned(storage as usize, KLOG_BUFFER_ALIGNMENT) {
+            let reason: &str = "klog backing storage pointer is not properly aligned";
+            error!("set_backing_storage(): {}", reason);
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+        KLOG_BUFFER = storage as *mut KlogBuffer;
+        Ok(())
+    }
 }
 
 #[cfg(not(feature = "smp"))]
-use buffer::*;
+pub(crate) use buffer::*;

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -256,6 +256,16 @@ fn spawn_servers(mm: &mut VirtMemoryManager, kmods: &LinkedList<KernelModule>) -
 
 #[unsafe(no_mangle)]
 pub extern "C" fn kmain(kargs: &KernelArguments) {
+    // Install klog buffer backing storage before the first logging call.
+    // On Hyperlight this is done during the evolve phase (hyperlight_pre_kmain).
+    // Under SMP there is no klog buffer.
+    #[cfg(all(not(feature = "hyperlight"), not(feature = "smp")))]
+    {
+        if let Err(e) = unsafe { crate::hal::platform::setup_klog_backing_storage() } {
+            panic!("failed to set up klog backing storage: {:?}", e);
+        }
+    }
+
     info!("initializing the kernel...");
 
     // Initialize the kernel heap.


### PR DESCRIPTION
## Parent Issue

Part of #2152.
Closes #2165.

## Description

Apply the `set_backing_storage` pattern to the kernel log buffer so that on Hyperlight the buffer resides in the scratch region (outside the Copy-on-Write snapshot) instead of BSS.

## Changes

- **klog**: Replace BSS-resident `SyncUnsafeCell<KlogBuffer>` with a raw pointer set via `set_backing_storage()`. Remove `SyncUnsafeCell` wrapper entirely. Add `KLOG_BUFFER_STORAGE_SIZE` and `KLOG_BUFFER_ALIGNMENT` constants for platform modules. Add null-pointer guards in `puts()` and `flush()` so early-boot logging before backing storage is installed is silently dropped. Mark `KlogBuffer` as `#[repr(C)]` to guarantee a stable layout. Remove `KlogBuffer::new()` (zero-initialized backing storage makes it unnecessary). Widen buffer re-export visibility to `pub(crate)`.

- **microvm**: Add BSS-allocated `KLOG_BUFFER_STORAGE` (cfg-gated to non-SMP) and a `setup_klog_backing_storage()` wrapper that forwards the pointer to `klog::set_backing_storage()`.

- **hyperlight**: Add a `KLOG_BUFFER` entry to the `scratch_layout!` macro and call `klog::set_backing_storage()` in `hyperlight_pre_kmain()` before the heap is initialized, so log output is available as early as possible during the evolve phase.

- **kmain**: Call `setup_klog_backing_storage()` as the very first operation in `kmain()`, before the first `info!()` invocation, guarded by `#[cfg(all(not(feature = "hyperlight"), not(feature = "smp")))]`.

## Validation

- `./z build -- all` (microvm) — passes
- `./z build -- all MACHINE=hyperlight` — passes
- `./z build -- format-check` — passes
- `./z build -- lint-check` — passes