### PR TITLE
[kernel] Add platform base address to linker script

### DIFF
--- a/build/kernel/linker/x86/kernel.ld.in
+++ b/build/kernel/linker/x86/kernel.ld.in
@@ -12,14 +12,21 @@ ENTRY(_do_start)
 PAGE_SIZE = 0x1000;
 
 /*
+ * Platform base address.
+ *
+ * Physical address at which the VMM loads the guest binary.
+ */
+PLATFORM_BASE_ADDR = @PLATFORM_BASE_ADDR@;
+
+/*
  * Boot Address
  */
-BOOT_ADDR = 0x00100000;
+BOOT_ADDR = 0x00100000 + PLATFORM_BASE_ADDR;
 
 /*
  * Trampoline Address
  */
-TRAMPOLINE_ADDR = 0x00008000;
+TRAMPOLINE_ADDR = 0x00008000 + PLATFORM_BASE_ADDR;
 
 /*
  * Kernel Pool Base Address
@@ -37,11 +44,16 @@ KPOOL_BASE = @KPOOL_BASE@;
  */
 MACHINE_RESERVED = @MACHINE_RESERVED@;
 
+ASSERT(TRAMPOLINE_ADDR >= PLATFORM_BASE_ADDR, "PLATFORM_BASE_ADDR exceeds TRAMPOLINE_ADDR")
+
 SECTIONS
 {
-	/* Pad with zeroes. */
+	/* Start at the platform/VMM-defined load base. */
+	. = PLATFORM_BASE_ADDR;
+
+	/* Pad with zeroes up to the trampoline. */
 	.zero : {
-		. = . + TRAMPOLINE_ADDR;
+		. = . + (TRAMPOLINE_ADDR - PLATFORM_BASE_ADDR);
 	} = 0
 
     /* Trampoline section. */

--- a/src/kernel/build.rs
+++ b/src/kernel/build.rs
@@ -210,11 +210,20 @@ fn main() {
         "0x0".to_string()
     };
 
+    let platform_base_addr: &str = if cfg!(feature = "hyperlight") {
+        // TODO (#2204): Change platform base address for Hyperlight when we update Hperlight crate.
+        "0x0"
+    } else {
+        "0x0"
+    };
+
     let linker_template: String =
         fs::read_to_string(&linker_template_path).expect("Failed to read linker script template");
     let linker_script: String = linker_template
         .replace("@MACHINE_RESERVED@", &machine_reserved)
-        .replace("@KPOOL_BASE@", &format!("{:#x}", kpool_base));
+        .replace("@KPOOL_BASE@", &format!("{:#x}", kpool_base))
+        .replace("@PLATFORM_BASE_ADDR@", platform_base_addr);
+
     fs::write(&linker_output_path, linker_script).expect("Failed to write linker script");
 
     println!("cargo::rerun-if-changed={}", linker_template_path.display());


### PR DESCRIPTION
## Summary

Introduce a `PLATFORM_BASE_ADDR` placeholder in the x86 linker script so the VMM-specific load address can be set at build time. On Hyperlight the base will eventually be non-zero; on microvm it stays at `0x0`.

## Changes

- Define `PLATFORM_BASE_ADDR` in `kernel.ld.in`, populated from the build script via `@PLATFORM_BASE_ADDR@`.
- Offset `BOOT_ADDR` and `TRAMPOLINE_ADDR` by `PLATFORM_BASE_ADDR`.
- Start the `SECTIONS` block at `PLATFORM_BASE_ADDR` and adjust the `.zero` padding accordingly.
- Emit the new placeholder replacement in `build.rs` gated on the `hyperlight` feature (currently `0x0`, tracked by #2204).

## Related Issues

- Opens #2204
- Superseeds #2193