### PR TITLE
[kernel] Demote MMIO out-of-range book() log to trace

### DIFF
--- a/src/kernel/src/mm/phys/frame.rs
+++ b/src/kernel/src/mm/phys/frame.rs
@@ -141,6 +141,20 @@ impl Inner {
     ///
     /// # Description
     ///
+    /// Checks whether the frame allocator tracks the frame at the given physical address.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the frame allocator tracks the frame at `phys_addr`, `false` otherwise.
+    ///
+    fn is_covered(&self, phys_addr: PageAligned<PhysicalAddress>) -> bool {
+        let frame_number: usize = phys_addr.into_frame_number().into_raw_value();
+        self.bitmap.find_chunk(frame_number).is_some()
+    }
+
+    ///
+    /// # Description
+    ///
     /// Allocates all frames in the given region.
     ///
     /// # Parameters
@@ -270,6 +284,19 @@ pub(super) fn alloc() -> Result<FrameAddress, Error> {
 /// Free a frame previously returned by [`alloc`].
 pub(super) fn free(frame: FrameAddress) -> Result<(), Error> {
     instance().free(frame)
+}
+
+///
+/// # Description
+///
+/// Checks whether the frame allocator tracks the frame at the given physical address.
+///
+/// # Returns
+///
+/// Returns `true` when the frame allocator tracks the frame at `phys_addr`.
+///
+pub(super) fn is_covered(phys_addr: PageAligned<PhysicalAddress>) -> bool {
+    instance().is_covered(phys_addr)
 }
 
 /// Reserve a frame so [`alloc`] will skip it.

--- a/src/kernel/src/mm/phys/mod.rs
+++ b/src/kernel/src/mm/phys/mod.rs
@@ -31,10 +31,7 @@ use crate::{
 use ::alloc::collections::LinkedList;
 use ::arch::mem;
 use ::sparse_bitmap::SparseBitmap;
-use ::sys::error::{
-    Error,
-    ErrorCode,
-};
+use ::sys::error::Error;
 
 //==================================================================================================
 // Exports
@@ -83,17 +80,11 @@ fn book_mmio_regions(
                 PhysicalAddress::from_mmio_address(mmio_addr)?
             })?;
 
-            // Attempt to book underlying frame.
-            match frame::book(phys_addr) {
-                // Frame successfully booked.
-                Ok(()) => {},
-                // Frame lies outside addressable physical memory.
-                Err(e) if e.code == ErrorCode::InvalidArgument => {},
-                // Something went wrong.
-                Err(e) => {
-                    warn!("failed to book frame for mmio region {:?} ({:?})", region, e);
-                    return Err(e);
-                },
+            // Only book frames that the frame allocator actually tracks.
+            // MMIO regions above RAM (e.g. the LAPIC at 0xFEE0_0000) are not
+            // covered by the sparse bitmap and must be skipped.
+            if frame::is_covered(phys_addr) {
+                frame::book(phys_addr)?;
             }
             start += mem::FRAME_SIZE;
         }


### PR DESCRIPTION
## Summary

frame::book() logs error!() for the LAPIC MMIO page (0xFEE00000) on every WHP boot. The caller (book_mmio_regions()) already catches and ignores this — it's expected for MMIO
addresses outside the RAM bitmap. The log is noise.

Change

Demote to trace!() for InvalidArgument. Keep error!() for real failures.