### PR TITLE
[kernel] Gate exception stack guard behind feature flag

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -64,6 +64,7 @@ microvm = [
     "dep:config",
     "dep:multibin",
     "config/microvm",
+    "exception-stack-guard",
 ]
 # Platform Features
 
@@ -73,6 +74,9 @@ pit = []
 putb = []
 puts = []
 stdio = []
+
+# Enables the dynamic exception stack guard.
+exception-stack-guard = []
 
 # Enables latest performance optimizations.
 nightly-performance-optimizations = []

--- a/src/kernel/src/hal/arch/x86/asm/hooks.rs
+++ b/src/kernel/src/hal/arch/x86/asm/hooks.rs
@@ -57,7 +57,11 @@ global_asm!(
     ".extern do_exception",
     ".extern do_kcall",
     ".extern do_interrupt",
+    // EXCP_STACK_GUARD is only needed when the microvm guard-check code is compiled in; when
+    // `{MICROVM}=0`, this `.extern` is compiled out together with the guard-check block.
+    ".if {MICROVM}",
     ".extern EXCP_STACK_GUARD",
+    ".endif",
 
     // -----------------------------------------------------------------
     // Exported Symbols

--- a/src/kernel/src/hal/arch/x86/cpu/context.rs
+++ b/src/kernel/src/hal/arch/x86/cpu/context.rs
@@ -95,6 +95,7 @@ impl ContextInformation {
     pub const CONTEXT_SW_SIZE: u32 = Self::CONTEXT_ERR;
 
     /// Size of the hardware-saved portion of the context (bytes from `err` onward).
+    #[cfg(feature = "exception-stack-guard")]
     pub const CONTEXT_HW_SIZE: u32 = core::mem::size_of::<Self>() as u32 - Self::CONTEXT_ERR;
 
     pub fn new(cr3: u32, esp: u32, esp0: u32) -> Self {

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -606,28 +606,11 @@ pub fn get_kstack_top() -> *const u8 {
 ///
 /// # Description
 ///
-/// Returns the base address of the boot kernel stack guard page.
-///
-/// On Hyperlight the guard page is the bottom page of the `KSTACK_SIZE` area
-/// below [`HYPERLIGHT_BOOT_STACK_TOP`](::config::memory_layout::HYPERLIGHT_BOOT_STACK_TOP).
-#[cfg(debug_assertions)]
-pub fn get_kstack_guard_base() -> usize {
-    ::config::memory_layout::HYPERLIGHT_BOOT_STACK_TOP - ::config::kernel::KSTACK_SIZE
-}
-
-///
-/// # Description
-///
 /// Early boot helper called from `_do_start2` (assembly) while already
 /// running on the scratch-backed boot stack at
 /// [`HYPERLIGHT_BOOT_STACK_TOP`](::config::memory_layout::HYPERLIGHT_BOOT_STACK_TOP).
 ///
-/// This function:
-///
-/// 1. Patches the PEB scratch pointers from GVA to GPA.
-/// 2. Fills the scratch guard page with the watermark pattern.
-/// 3. Writes [`EXCP_STACK_GUARD`] so that the exception handler can detect
-///    stack overflows.
+/// Patches the PEB scratch pointers from GVA to GPA.
 ///
 #[unsafe(no_mangle)]
 extern "C" fn init_scratch_kstack() {
@@ -656,29 +639,6 @@ extern "C" fn init_scratch_kstack() {
             (*peb_ptr).output_stack.ptr -= gva_gpa_delta;
         }
     }
-
-    // The boot stack guard page is at the bottom of the KSTACK_SIZE area
-    // below HYPERLIGHT_BOOT_STACK_TOP.
-    let guard_base: usize =
-        memory_layout::HYPERLIGHT_BOOT_STACK_TOP - ::config::kernel::KSTACK_SIZE;
-
-    // Fill the scratch guard page with the watermark pattern.
-    // Safety: `guard_base` points to a valid page-sized memory region reserved for the boot stack
-    // guard page. Writing the watermark pattern to this page is safe because it does not overlap
-    // with any other live memory and is intended to be used as a stack overflow detection guard.
-    unsafe {
-        let guard_ptr: *mut u32 = guard_base as *mut u32;
-        let count: usize = mem::PAGE_SIZE / core::mem::size_of::<u32>();
-        for i in 0..count {
-            core::ptr::write_volatile(guard_ptr.add(i), ::config::kernel::KSTACK_GUARD_PATTERN);
-        }
-    }
-
-    // Set EXCP_STACK_GUARD for the scratch-backed guard page.
-    crate::mm::kstack::EXCP_STACK_GUARD.store(
-        (guard_base + x86::cpu::ContextInformation::CONTEXT_HW_SIZE as usize) as u32,
-        Ordering::Release,
-    );
 }
 
 ///

--- a/src/kernel/src/hal/platform/hyperlight/start.rs
+++ b/src/kernel/src/hal/platform/hyperlight/start.rs
@@ -55,8 +55,7 @@ global_asm!(
     "    push %ebx",
     "    push %eax",
 
-    // Patch PEB GVA→GPA, fill the scratch guard page with the watermark
-    // pattern, and set EXCP_STACK_GUARD.
+    // Patch PEB GVA→GPA pointers.
     "    call init_scratch_kstack",
 
     // Clear all general purpose registers for deterministic startup.

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -407,7 +407,7 @@ pub fn get_kstack_top() -> *const u8 {
 ///
 /// The base address of the boot kernel stack guard page.
 ///
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, feature = "exception-stack-guard"))]
 pub fn get_kstack_guard_base() -> usize {
     unsafe extern "C" {
         static kstack_guard: u8;

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -357,6 +357,7 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
         };
 
     // Check boot stack guard watermark for corruption.
+    #[cfg(feature = "exception-stack-guard")]
     if let Err(err) = mm::kstack::check_boot_stack_guard() {
         panic!("boot stack overflow detected: {:?}", err);
     }

--- a/src/kernel/src/mm/kstack.rs
+++ b/src/kernel/src/mm/kstack.rs
@@ -17,13 +17,7 @@ use ::alloc::vec::Vec;
 use ::arch::mem::PAGE_ALIGNMENT;
 #[cfg(debug_assertions)]
 use ::config::kernel::KSTACK_GUARD_PATTERN;
-use ::core::{
-    fmt,
-    sync::atomic::{
-        AtomicU32,
-        Ordering,
-    },
-};
+use ::core::fmt;
 #[cfg(debug_assertions)]
 use ::sys::error::ErrorCode;
 use ::sys::{
@@ -38,6 +32,7 @@ use ::sys::{
 // Constants
 //==================================================================================================
 
+#[cfg(feature = "exception-stack-guard")]
 use ::arch::cpu::excp::Exception;
 
 //==================================================================================================
@@ -51,8 +46,10 @@ use ::arch::cpu::excp::Exception;
 ///
 /// TODO (#1665): this is a single global, so it is only correct on uniprocessor builds. For SMP,
 /// replace with a per-core variable (e.g., indexed by APIC ID or stored in per-core data).
+#[cfg(feature = "exception-stack-guard")]
 #[unsafe(no_mangle)]
-pub static EXCP_STACK_GUARD: AtomicU32 = AtomicU32::new(0);
+pub static EXCP_STACK_GUARD: ::core::sync::atomic::AtomicU32 =
+    ::core::sync::atomic::AtomicU32::new(0);
 
 //==================================================================================================
 // Structures
@@ -66,6 +63,7 @@ pub static EXCP_STACK_GUARD: AtomicU32 = AtomicU32::new(0);
 pub struct KernelStack {
     kpages: Vec<KernelPage>,
     /// Lowest safe ESP value for this stack (base + CONTEXT_HW_SIZE).
+    #[cfg(feature = "exception-stack-guard")]
     guard_threshold: u32,
 }
 
@@ -97,11 +95,13 @@ impl KernelStack {
         mm.alloc_kpages(true, count, &mut kframes)?;
         let kpages: Vec<KernelPage> = kframes.into_iter().map(KernelPage::new).collect();
 
+        #[cfg(feature = "exception-stack-guard")]
         let guard_threshold: u32 =
             (kpages[0].base().into_raw_value() + Exception::CONTEXT_HW_SIZE) as u32;
 
         let stack: Self = Self {
             kpages,
+            #[cfg(feature = "exception-stack-guard")]
             guard_threshold,
         };
 
@@ -122,6 +122,7 @@ impl KernelStack {
     ///
     /// The guard threshold value.
     ///
+    #[cfg(feature = "exception-stack-guard")]
     pub fn guard_threshold(&self) -> u32 {
         self.guard_threshold
     }
@@ -273,6 +274,7 @@ fn check_guard_page(guard_base: usize) -> Result<(), Error> {
 /// `mm::init()`, the corruption may have been overwritten by later stack frames shrinking. The
 /// check is best-effort and may not detect all early-boot overflows.
 ///
+#[cfg(feature = "exception-stack-guard")]
 pub fn check_boot_stack_guard() -> Result<(), Error> {
     cfg_if::cfg_if! {
         if #[cfg(debug_assertions)] {
@@ -294,8 +296,9 @@ pub fn check_boot_stack_guard() -> Result<(), Error> {
 ///
 /// - `threshold`: The guard threshold (lowest safe ESP) for the new active stack.
 ///
+#[cfg(feature = "exception-stack-guard")]
 pub fn set_active_guard(threshold: u32) {
-    EXCP_STACK_GUARD.store(threshold, Ordering::Release);
+    EXCP_STACK_GUARD.store(threshold, core::sync::atomic::Ordering::Release);
 }
 
 //==================================================================================================
@@ -320,11 +323,12 @@ impl Drop for KernelStack {
 
         // If this stack was the active one, clear the guard so a stale threshold is never
         // checked against a freed stack region.
+        #[cfg(feature = "exception-stack-guard")]
         let _ = EXCP_STACK_GUARD.compare_exchange(
             self.guard_threshold,
             0,
-            Ordering::Release,
-            Ordering::Relaxed,
+            core::sync::atomic::Ordering::Release,
+            core::sync::atomic::Ordering::Relaxed,
         );
 
         while let Some(kpage) = self.kpages.pop() {

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -1447,16 +1447,19 @@ impl ProcessManager {
     /// Called after setting `self.running` in every scheduling path.
     ///
     fn update_active_stack_guard(&self) {
-        if let Some(ref running) = self.running {
-            if let Some(threshold) = running.guard_threshold() {
-                crate::mm::kstack::set_active_guard(threshold);
-                return;
+        #[cfg(feature = "exception-stack-guard")]
+        {
+            if let Some(ref running) = self.running {
+                if let Some(threshold) = running.guard_threshold() {
+                    crate::mm::kstack::set_active_guard(threshold);
+                    return;
+                }
             }
-        }
 
-        // When there is no running process or no guard threshold, clear the guard so that
-        // a stale threshold from a previous stack does not trigger a false overflow.
-        crate::mm::kstack::set_active_guard(0);
+            // When there is no running process or no guard threshold, clear the guard so that
+            // a stale threshold from a previous stack does not trigger a false overflow.
+            crate::mm::kstack::set_active_guard(0);
+        }
     }
 
     ///

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -340,6 +340,7 @@ impl RunningProcess {
     ///
     /// The guard threshold value, or `None` if the running thread has no kernel stack.
     ///
+    #[cfg(feature = "exception-stack-guard")]
     #[inline]
     pub fn guard_threshold(&self) -> Option<u32> {
         self.running.guard_threshold()

--- a/src/kernel/src/pm/thread/running.rs
+++ b/src/kernel/src/pm/thread/running.rs
@@ -230,6 +230,7 @@ impl RunningThread {
     ///
     /// The guard threshold value, or `None` if the thread has no kernel stack.
     ///
+    #[cfg(feature = "exception-stack-guard")]
     #[inline]
     pub fn guard_threshold(&self) -> Option<u32> {
         self.state.guard_threshold()

--- a/src/kernel/src/pm/thread/state.rs
+++ b/src/kernel/src/pm/thread/state.rs
@@ -259,6 +259,7 @@ impl ThreadState {
     ///
     /// The guard threshold value, or `None` if this thread has no kernel stack.
     ///
+    #[cfg(feature = "exception-stack-guard")]
     pub(super) fn guard_threshold(&self) -> Option<u32> {
         self.kernel_stack.as_ref().map(|ks| ks.guard_threshold())
     }


### PR DESCRIPTION
## Summary

Introduce the `exception-stack-guard` Cargo feature and gate all dynamic stack-overflow guard infrastructure behind it. The feature is enabled only for the microvm platform; hyperlight no longer carries any of this machinery.

## Changes

- Define `exception-stack-guard` feature in kernel Cargo.toml and include it in the `microvm` feature list.
- Gate `EXCP_STACK_GUARD` static, `set_active_guard()`, `check_boot_stack_guard()`, `guard_threshold` field, and the Drop-time compare_exchange behind `cfg(feature = "exception-stack-guard")`.
- Gate `CONTEXT_HW_SIZE` (only consumed by guard threshold computation) behind the same feature.
- Wrap `.extern EXCP_STACK_GUARD` in assembly with `.if {MICROVM}` so the linker does not require the symbol on hyperlight.
- Gate `guard_threshold()` accessors in RunningProcess, RunningThread, and ThreadState.
- Gate `update_active_stack_guard()` body in ProcessManager and `check_boot_stack_guard()` call in kmain.
- Remove `get_kstack_guard_base()`, guard-page watermark fill, and `EXCP_STACK_GUARD.store()` from hyperlight's `init_scratch_kstack`, leaving only the PEB GVA→GPA pointer patching.
- Tighten microvm's `get_kstack_guard_base()` cfg to require both `debug_assertions` and the new feature.

## Motivation

This reduces hyperlight binary size and eliminates dead code paths that were unreachable on that platform.