### PR TITLE
[kernel] Add platform address-translation hooks and page-alignment for module regions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -299,12 +287,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1326,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1399,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-common"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d#3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=94ee495638385eaffc5f0c8f69fe7d768047b3b6#94ee495638385eaffc5f0c8f69fe7d768047b3b6"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1413,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d#3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=94ee495638385eaffc5f0c8f69fe7d768047b3b6#94ee495638385eaffc5f0c8f69fe7d768047b3b6"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1425,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-host"
 version = "0.14.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?rev=3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d#3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=94ee495638385eaffc5f0c8f69fe7d768047b3b6#94ee495638385eaffc5f0c8f69fe7d768047b3b6"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -1592,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1698,27 +1680,32 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1752,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2019,12 +2006,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "b7cd3e9eb685089c784f5769b1197d348c7274bc20d4e1349650f63b91b6d0af"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -3012,6 +2999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "raw-array"
 version = "0.12.484"
 dependencies = [
@@ -3212,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3238,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3248,9 +3244,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -3488,6 +3484,22 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -4514,9 +4526,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4527,9 +4539,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4537,9 +4549,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4547,9 +4559,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4560,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -4666,9 +4678,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4850,15 +4862,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -4891,21 +4894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4959,12 +4947,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -4977,12 +4959,6 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -4992,12 +4968,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5019,12 +4989,6 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5034,12 +4998,6 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5055,12 +5013,6 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5070,12 +5022,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,18 +137,21 @@ indexmap = "2.14.0"
 indicatif = "0.18.4"
 http = "1.4.0"
 http-body-util = "0.1.3"
-hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d", default-features = false, features = [
-        "nanvix-unstable",
+hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "94ee495638385eaffc5f0c8f69fe7d768047b3b6", default-features = false, features = [
+        "i686-guest",
+        "guest-counter",
 ] }
-hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d", default-features = false, features = [
+hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "94ee495638385eaffc5f0c8f69fe7d768047b3b6", default-features = false, features = [
         "kvm",
         "mshv3",
         "hw-interrupts",
         "executable_heap",
-        "nanvix-unstable",
+        "i686-guest",
+        "guest-counter",
 ] }
-hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "3fd3b7f64dcdd66d8a759cf22bd0a4633bfaf61d", default-features = false, features = [
-        "nanvix-unstable",
+hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "94ee495638385eaffc5f0c8f69fe7d768047b3b6", default-features = false, features = [
+        "i686-guest",
+        "guest-counter",
 ] }
 hyper = { version = "1.9.0", default-features = false }
 hyper-util = { version = "0.1.20", default-features = false }

--- a/build/kernel/linker/x86/kernel.ld.in
+++ b/build/kernel/linker/x86/kernel.ld.in
@@ -51,9 +51,22 @@ SECTIONS
 	/* Start at the platform/VMM-defined load base. */
 	. = PLATFORM_BASE_ADDR;
 
+	/*
+	 * Entry stub section.
+	 *
+	 * On Hyperlight the VMM starts execution at BASE_ADDRESS (PLATFORM_BASE_ADDR),
+	 * not at the ELF entry point.  This tiny section places a jump to _do_start
+	 * at the very first byte of the loaded image so the kernel reaches its real
+	 * entry point regardless of how the VMM resolves the initial RIP.
+	 * On microvm (PLATFORM_BASE_ADDR == 0) this section is empty and harmless.
+	 */
+	.entry : {
+		KEEP(*(.entry))
+	}
+
 	/* Pad with zeroes up to the trampoline. */
 	.zero : {
-		. = . + (TRAMPOLINE_ADDR - PLATFORM_BASE_ADDR);
+		. = ABSOLUTE(TRAMPOLINE_ADDR);
 	} = 0
 
     /* Trampoline section. */

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -55,6 +55,7 @@ hyperlight = [
     "dep:multibin",
     "dep:paste",
     "config/hyperlight",
+    "platform-root-virtual-address-space-bootstrap",
 ]
 microvm = [
     "arch/microvm",
@@ -77,6 +78,9 @@ stdio = []
 
 # Enables the dynamic exception stack guard.
 exception-stack-guard = []
+
+# Enables bootstrapping of root virtual address space from platform-provided page tables.
+platform-root-virtual-address-space-bootstrap = []
 
 # Enables latest performance optimizations.
 nightly-performance-optimizations = []

--- a/src/kernel/build.rs
+++ b/src/kernel/build.rs
@@ -211,8 +211,8 @@ fn main() {
     };
 
     let platform_base_addr: &str = if cfg!(feature = "hyperlight") {
-        // TODO (#2204): Change platform base address for Hyperlight when we update Hperlight crate.
-        "0x0"
+        // Hyperlight stable (i686-guest) loads the guest binary at GPA 0x1000.
+        "0x1000"
     } else {
         "0x0"
     };

--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
@@ -184,8 +184,50 @@ impl<T: DerefMut<Target = [PteWord]>> PageDirectory<T> {
     }
 
     pub fn physical_address(&self) -> Result<FrameAddress, Error> {
-        Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(
-            self.entries.as_ptr() as usize,
-        )?)?))
+        let vaddr: usize = self.entries.as_ptr() as usize;
+        let paddr: usize = crate::hal::platform::virt_to_phys(vaddr);
+        Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(paddr)?)?))
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a raw pointer to the first entry in the page directory.
+    ///
+    /// # Returns
+    ///
+    /// A raw pointer to the first entry in the page directory.
+    ///
+    #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+    pub fn as_ptr(&self) -> *const PteWord {
+        self.entries.as_ptr()
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Merges non-zero entries from `old_pd` into this page directory.
+    ///
+    /// For each PDE index, if `self` has a not-present entry and `old_pd` has a present
+    /// entry, the old entry is copied verbatim. Existing present entries in `self` are never
+    /// overwritten.
+    ///
+    /// This is used on platforms that provide a root virtual address space via platform-provided
+    /// page tables to inherit host-built page table mappings.
+    ///
+    /// # Safety
+    ///
+    /// - `old_pd` must point to a valid, page-aligned array of `PAGE_TABLE_LENGTH` PDE words.
+    /// - `self` and `old_pd` must not point to overlapping paging structures.
+    /// - The caller must ensure that the pointed-to memory remains valid for the duration of this
+    ///   call.
+    #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+    pub unsafe fn inherit_from(&mut self, old_pd: *const PteWord) {
+        use ::arch::mem::PAGE_TABLE_LENGTH;
+        for i in 0..PAGE_TABLE_LENGTH {
+            if !PresentFlag::is_set(self.entries[i]) && PresentFlag::is_set(*old_pd.add(i)) {
+                self.entries[i] = *old_pd.add(i);
+            }
+        }
     }
 }

--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_table.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_table.rs
@@ -61,6 +61,28 @@ impl<T: DerefMut<Target = [PteWord]>> PageTable<T> {
         page_table
     }
 
+    ///
+    /// # Description
+    ///
+    /// Creates a page table wrapper around existing (already-populated) storage.
+    ///
+    /// Unlike [`new`](Self::new), this does not zero the entries.
+    ///
+    /// # Returns
+    ///
+    /// A new [`PageTable`] instance that wraps the provided storage.
+    ///
+    #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+    pub fn from_existing(entries: T) -> Self {
+        let mut nmapped: usize = 0;
+        for pte in entries.iter() {
+            if PresentFlag::is_set(*pte) {
+                nmapped += 1;
+            }
+        }
+        Self { nmapped, entries }
+    }
+
     /// Returns the number of pages mapped in the page table.
     pub fn nmapped(&self) -> usize {
         self.nmapped
@@ -427,8 +449,8 @@ impl<T: DerefMut<Target = [PteWord]>> PageTable<T> {
     }
 
     pub fn physical_address(&self) -> Result<FrameAddress, Error> {
-        Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(
-            self.entries.as_ptr() as usize,
-        )?)?))
+        let vaddr: usize = self.entries.as_ptr() as usize;
+        let paddr: usize = crate::hal::platform::virt_to_phys(vaddr);
+        Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(paddr)?)?))
     }
 }

--- a/src/kernel/src/hal/mem/types/address/mod.rs
+++ b/src/kernel/src/hal/mem/types/address/mod.rs
@@ -25,6 +25,7 @@ pub use ::sys::mm::{
 pub use aligned::*;
 pub use frame::*;
 pub use page::*;
+#[cfg(feature = "microvm")]
 pub use pd::*;
 pub use phys::*;
 

--- a/src/kernel/src/hal/platform/hyperlight/cow_entry.rs
+++ b/src/kernel/src/hal/platform/hyperlight/cow_entry.rs
@@ -1,0 +1,338 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Early CoW Page Fault Entry Point and IDT Installation
+//==================================================================================================
+//
+// This module provides:
+//
+// 1. `_cow_page_fault_entry` — a minimal assembly stub that intercepts page faults (vector 14)
+//    and delegates to the Rust CoW handler [`super::cow_handler::try_handle_cow_page_fault`].
+//    If the fault is not a CoW fault the stub chains to the standard `_do_excp14` hook so the
+//    normal exception dispatching path is followed.
+//
+// 2. `install_early_idt()` — builds a minimal IDT in the scratch region (writable from boot)
+//    with only vector 14 wired to `_cow_page_fault_entry`, then loads IDTR.  The scratch
+//    region is outside the snapshot, so these writes never cause CoW page faults.
+//
+// After HAL initialization the standard IDT (populated by `idt::init()`) takes over. The
+// post-init CoW interception is handled by the `do_exception` modification in the arch-level
+// exception controller (see `controller.rs`), which calls the same Rust handler through the
+// existing high-level exception dispatching path — no extra assembly required.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::hal::arch::x86::mem::gdt;
+use ::arch::cpu::{
+    excp::Exception,
+    idt::{
+        DescriptorPrivilegeLevel,
+        Flags,
+        GateType,
+        Idte,
+        PresentBit,
+    },
+    idtr::Idtr,
+};
+use ::core::arch::global_asm;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Kernel code segment selector (GDT entry 1 << 3 = 0x08).
+const KERNEL_CS: u16 = crate::hal::arch::x86::mem::gdt::SegmentSelector::KernelCode as u16;
+
+/// Page fault exception vector number.
+const PAGE_FAULT_VECTOR: usize = Exception::PageFault as usize;
+
+/// Number of entries in the early IDT. Must cover up to and including [`PAGE_FAULT_VECTOR`].
+const EARLY_IDT_LEN: usize = PAGE_FAULT_VECTOR + 1;
+
+//==================================================================================================
+// Assembly Stub
+//==================================================================================================
+
+global_asm!(
+    r#".section .text,"ax",@progbits"#,
+    ".code32",
+    // =================================================================
+    // _cow_page_fault_entry — Minimal page-fault handler stub (vector 14)
+    // =================================================================
+    //
+    // On entry the hardware has pushed: [error_code, EIP, CS, EFLAGS, ...].
+    // The stub saves GPRs, extracts error_code and CR2, and calls the Rust
+    // try_handle_cow_page_fault(fault_addr, error_code).
+    //
+    // If the Rust handler returns true (CoW resolved): restore, skip error code, iret.
+    // If false: restore and chain to _do_excp14 for normal exception dispatch.
+    //
+    ".align 4",
+    ".globl _cow_page_fault_entry",
+    "_cow_page_fault_entry:",
+    // Debug: output '!' to confirm handler entry.
+    "    pushl %eax",
+    "    pushl %edx",
+    "    mov $103, %dx",
+    "    mov $0x21, %al", // '!'
+    "    outb %al, %dx",
+    "    mov $0x0A, %al", // '\n'
+    "    outb %al, %dx",
+    "    popl %edx",
+    "    popl %eax",
+    // Save caller-saved registers.
+    "    pushl %eax",
+    "    pushl %ecx",
+    "    pushl %edx",
+    "    pushl %ebx",
+    "    pushl %esi",
+    "    pushl %edi",
+    // Extract error code: 6 pushes * 4 bytes = 24 bytes above ESP.
+    "    movl 24(%esp), %eax",
+    // Extract faulting address from CR2.
+    "    movl %cr2, %ecx",
+    // Call try_handle_cow_page_fault(fault_addr: u32, error_code: u32).
+    // System V i386: arguments pushed right-to-left.
+    "    pushl %eax", // error_code
+    "    pushl %ecx", // fault_addr
+    "    .extern try_handle_cow_page_fault",
+    "    call try_handle_cow_page_fault",
+    "    addl $8, %esp",
+    // Check return value.
+    "    testl %eax, %eax",
+    "    jz .Lcow_not_handled",
+    // CoW resolved — restore registers, skip error code, iret.
+    "    popl %edi",
+    "    popl %esi",
+    "    popl %ebx",
+    "    popl %edx",
+    "    popl %ecx",
+    "    popl %eax",
+    "    addl $4, %esp", // Skip hardware error code.
+    "    iretl",
+    ".Lcow_not_handled:",
+    // Not a CoW fault — during early boot this is unrecoverable (no exception
+    // infrastructure exists yet). Issue ud2 to immediately triple-fault with a
+    // distinguishable signature rather than silently chaining to uninitialized code.
+    "    ud2",
+    //
+    // --- Diagnostic stubs for non-PF exceptions during early boot ---
+    //
+    ".align 4",
+    ".globl _early_gp_entry",
+    "_early_gp_entry:",
+    "    addl $4, %esp", // skip error code
+    "    mov $103, %dx",
+    "    mov $0x47, %al", // 'G'
+    "    outb %al, %dx",
+    "    mov $0x50, %al", // 'P'
+    "    outb %al, %dx",
+    "    mov $0x0A, %al",
+    "    outb %al, %dx",
+    "1:  hlt",
+    "    jmp 1b",
+    //
+    ".align 4",
+    ".globl _early_df_entry",
+    "_early_df_entry:",
+    "    addl $4, %esp", // skip error code
+    "    mov $103, %dx",
+    "    mov $0x44, %al", // 'D'
+    "    outb %al, %dx",
+    "    mov $0x46, %al", // 'F'
+    "    outb %al, %dx",
+    "    mov $0x0A, %al",
+    "    outb %al, %dx",
+    "1:  hlt",
+    "    jmp 1b",
+    //
+    ".align 4",
+    ".globl _early_ss_entry",
+    "_early_ss_entry:",
+    "    addl $4, %esp", // skip error code
+    "    mov $103, %dx",
+    "    mov $0x53, %al", // 'S'
+    "    outb %al, %dx",
+    "    mov $0x53, %al", // 'S'
+    "    outb %al, %dx",
+    "    mov $0x0A, %al",
+    "    outb %al, %dx",
+    "1:  hlt",
+    "    jmp 1b",
+    //
+    ".align 4",
+    ".globl _early_ud_entry",
+    "_early_ud_entry:",
+    "    mov $103, %dx",
+    "    mov $0x55, %al", // 'U'
+    "    outb %al, %dx",
+    "    mov $0x44, %al", // 'D'
+    "    outb %al, %dx",
+    "    mov $0x0A, %al",
+    "    outb %al, %dx",
+    "1:  hlt",
+    "    jmp 1b",
+    options(att_syntax),
+);
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+unsafe extern "C" {
+    /// Early CoW page fault assembly stub.
+    fn _cow_page_fault_entry();
+    fn _early_gp_entry();
+    fn _early_df_entry();
+    fn _early_ss_entry();
+    fn _early_ud_entry();
+}
+
+///
+/// # Description
+///
+/// Installs a minimal early-boot IDT with only vector 14 (page fault) wired to the CoW handler
+/// stub [`_cow_page_fault_entry`].
+///
+/// The IDT is written to the scratch region at a compile-time known address
+/// ([`HYPERLIGHT_EARLY_IDT_BASE`](::config::memory_layout::HYPERLIGHT_EARLY_IDT_BASE)).
+/// The scratch region is always writable (it is outside the CoW snapshot), so these writes
+/// never trigger page faults.  Scratch memory is zeroed by Hyperlight before the guest starts,
+/// so entries 0–13 are already not-present.
+///
+/// All other vectors are left as not-present; any exception other than #PF during early boot will
+/// triple-fault (which is the correct behavior — there is no meaningful recovery path before the
+/// full HAL is initialized).
+///
+/// # Safety
+///
+/// This function is unsafe because it:
+/// - Writes to memory at `HYPERLIGHT_EARLY_IDT_BASE` (scratch region).
+/// - Executes the `lidt` instruction to load a new IDT.
+///
+/// It must be called exactly once, from `_do_start2`, after the stack is set to
+/// `HYPERLIGHT_BOOT_STACK_TOP` and before `init_scratch_kstack()`.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn install_early_idt() {
+    use ::config::memory_layout::HYPERLIGHT_EARLY_IDT_BASE;
+
+    // ---- Step 1: Relocate GDT to writable scratch memory ----
+    //
+    // The Hyperlight VMM starts the guest with GDTR base=0, limit=0 (no usable GDT in
+    // memory). Segment descriptors are cached in hidden registers, so normal code runs
+    // fine. However, when the CPU delivers an exception it reloads CS from the GDT and
+    // writes the Accessed bit into the descriptor. With no writable GDT the CS load
+    // faults, causing a double fault, then a triple fault — the page-fault handler
+    // never runs.
+    //
+    // This MUST happen before the IDT is loaded so that exception delivery works from
+    // the very first moment the IDT is active.
+    let new_gdt_base: usize = ::config::memory_layout::HYPERLIGHT_EARLY_GDT_BASE;
+    let gdt_dst: *mut ::arch::mem::gdt::Gdte = new_gdt_base as *mut ::arch::mem::gdt::Gdte;
+
+    // Copy DEFAULT_ENTRIES (const in rodata, readable) to scratch (writable).
+    core::ptr::copy_nonoverlapping(gdt::DEFAULT_ENTRIES.as_ptr(), gdt_dst, gdt::GDT_NUM_ENTRIES);
+
+    // Build and load GDTR pointing to the scratch copy.
+    let gdt_byte_len: u16 =
+        (gdt::GDT_NUM_ENTRIES * core::mem::size_of::<::arch::mem::gdt::Gdte>()) as u16;
+    #[repr(C, packed)]
+    struct GdtrDesc {
+        limit: u16,
+        base: u32,
+    }
+    let gdtr = GdtrDesc {
+        limit: gdt_byte_len - 1,
+        base: new_gdt_base as u32,
+    };
+    core::arch::asm!(
+        "lgdt [{ptr}]",
+        ptr = in(reg) &gdtr as *const GdtrDesc,
+        options(nostack)
+    );
+
+    // Reload CS via a far jump so the CPU fetches the descriptor from the new GDT.
+    // DS/ES/SS already have cached descriptors that match selector 0x10 in the new
+    // GDT, so they don't need reloading (the CPU only accesses the GDT for them on
+    // an explicit MOV to segment register).
+    core::arch::asm!("ljmp $0x08, $2f", "2:", options(att_syntax, nostack));
+
+    // ---- Step 2: Install minimal early IDT ----
+
+    let idt_base: usize = HYPERLIGHT_EARLY_IDT_BASE;
+
+    // Scratch is zeroed by Hyperlight, so entries 0–13 are already not-present.
+    // Write only the page fault entry.
+    let handler_addr: u32 = _cow_page_fault_entry as *const () as u32;
+    let entry: Idte = Idte::new(
+        handler_addr,
+        KERNEL_CS,
+        Flags::new(PresentBit::Present, DescriptorPrivilegeLevel::Ring0, GateType::Int32),
+    );
+
+    let entry_offset: usize = PAGE_FAULT_VECTOR * core::mem::size_of::<Idte>();
+    let entry_ptr: *mut Idte = (idt_base + entry_offset) as *mut Idte;
+    core::ptr::write(entry_ptr, entry);
+
+    // Register diagnostic handlers for other common exception vectors.
+    let idte_size: usize = core::mem::size_of::<Idte>();
+
+    // Vector 6: #UD (Invalid Opcode)
+    let ud_entry = Idte::new(
+        _early_ud_entry as *const () as u32,
+        KERNEL_CS,
+        Flags::new(PresentBit::Present, DescriptorPrivilegeLevel::Ring0, GateType::Int32),
+    );
+    core::ptr::write((idt_base + 6 * idte_size) as *mut Idte, ud_entry);
+
+    // Vector 8: #DF (Double Fault) — has error code (always 0)
+    let df_entry = Idte::new(
+        _early_df_entry as *const () as u32,
+        KERNEL_CS,
+        Flags::new(PresentBit::Present, DescriptorPrivilegeLevel::Ring0, GateType::Int32),
+    );
+    core::ptr::write((idt_base + 8 * idte_size) as *mut Idte, df_entry);
+
+    // Vector 12: #SS (Stack-Segment Fault) — has error code
+    let ss_entry = Idte::new(
+        _early_ss_entry as *const () as u32,
+        KERNEL_CS,
+        Flags::new(PresentBit::Present, DescriptorPrivilegeLevel::Ring0, GateType::Int32),
+    );
+    core::ptr::write((idt_base + 12 * idte_size) as *mut Idte, ss_entry);
+
+    // Vector 13: #GP (General Protection Fault) — has error code
+    let gp_entry = Idte::new(
+        _early_gp_entry as *const () as u32,
+        KERNEL_CS,
+        Flags::new(PresentBit::Present, DescriptorPrivilegeLevel::Ring0, GateType::Int32),
+    );
+    core::ptr::write((idt_base + 13 * idte_size) as *mut Idte, gp_entry);
+
+    // Build a stack-local IDTR and load it. The CPU caches the 6-byte descriptor in the
+    // IDTR register, so the stack copy is safe to drop after lidt returns.
+    let idt_size: u16 = (EARLY_IDT_LEN * core::mem::size_of::<Idte>()) as u16;
+    let mut idtr = Idtr { size: 0, ptr: 0 };
+    idtr.init(idt_base as u32, idt_size);
+    idtr.load();
+
+    // Cache the boot-time first-free-GPA from the scratch metadata bump allocator slot.
+    // This must be done before any CoW fault can advance the bump pointer.
+    // We store it in the early-GDT scratch page at a fixed offset.
+    let boot_first_free_gpa: usize = super::first_free_scratch_gpa();
+    super::save_boot_first_free_gpa(boot_first_free_gpa);
+
+    // Advance the bump allocator pointer past the scratch-reserved region so that
+    // CoW frame allocations (which use the bump allocator before the full frame
+    // allocator is initialized) never overlap our scratch-resident data structures.
+    //
+    // The scratch-reserved region starts at boot_first_free_gpa (the host places it
+    // right after the page tables), and has size SCRATCH_RESERVED_SIZE.
+    let reserved_end_gpa: usize = boot_first_free_gpa + super::SCRATCH_RESERVED_SIZE;
+    let alloc_ptr = ::hyperlight_guest::layout::allocator_gva();
+    core::ptr::write_volatile(alloc_ptr, reserved_end_gpa as u64);
+}

--- a/src/kernel/src/hal/platform/hyperlight/cow_handler.rs
+++ b/src/kernel/src/hal/platform/hyperlight/cow_handler.rs
@@ -1,0 +1,49 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::arch::mem;
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Safety-net CoW page fault handler.
+///
+/// After eager pre-faulting in `hyperlight_pre_kmain()`, no CoW page faults should occur during
+/// normal kernel execution. If one does, it indicates a bug (a page missed by the pre-fault walk).
+/// This handler returns `false` to let the normal exception path handle (and report) the fault.
+///
+/// # Parameters
+///
+/// - `fault_addr`:  The faulting virtual address (from CR2).
+/// - `error_code`:  The hardware page-fault error code.
+///
+/// # Returns
+///
+/// Always returns `false`.
+///
+#[unsafe(no_mangle)]
+pub extern "C" fn try_handle_cow_page_fault(_fault_addr: u32, _error_code: u32) -> bool {
+    // After eager pre-faulting, no CoW faults should occur.
+    // Log and let the normal exception path handle it.
+    false
+}
+
+/// Allocates a single frame from the scratch bump allocator.
+///
+/// Reads the current bump pointer from the scratch metadata slot and advances it by one page.
+pub(super) fn bump_alloc_frame() -> u32 {
+    let alloc_ptr = ::hyperlight_guest::layout::allocator_gva();
+    let gpa: u64 = unsafe { core::ptr::read_volatile(alloc_ptr) };
+    unsafe {
+        core::ptr::write_volatile(alloc_ptr, gpa + mem::PAGE_SIZE as u64);
+    }
+    gpa as u32
+}

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -8,6 +8,8 @@
 #[cfg(all(feature = "microvm", feature = "hyperlight"))]
 compile_error!("features \"microvm\" and \"hyperlight\" are mutually exclusive");
 
+mod cow_entry;
+mod cow_handler;
 pub(crate) mod peb;
 mod start;
 mod start16;
@@ -15,6 +17,54 @@ mod start16;
 // in this submodule is visible in the parent module without a path prefix.
 #[macro_use]
 mod scratch_layout;
+
+//==================================================================================================
+// Re-exports
+//==================================================================================================
+
+/// Returns `true` if the given GVA falls within the scratch region.
+pub fn is_scratch_address(gva: usize) -> bool {
+    let base: usize = load_scratch_base();
+    let end: usize = load_scratch_end();
+    if base == 0 {
+        return false;
+    }
+    // Handles wrapping: scratch_end may be 0 when MAX_GVA == usize::MAX.
+    if end == 0 {
+        gva >= base
+    } else {
+        gva >= base && gva < end
+    }
+}
+
+/// Translates a virtual address to a physical address.
+///
+/// On i686-guest, the host maps scratch at GVA addresses (MAX_GVA - scratch_size + 1),
+/// regions. This stub returns the address unchanged; a future CoW-aware
+/// implementation would walk the page tables to resolve remapped pages.
+#[inline(always)]
+pub fn virt_to_phys(vaddr: usize) -> usize {
+    // After eager CoW pre-faulting, writable snapshot pages (kernel pool, BSS, data)
+    // are backed by scratch frames whose GPA ≠ GVA. Walk the page tables to resolve
+    // the actual GPA. This is essential for values used as CR3 (page directory physical
+    // address), where the CPU needs the true GPA, not the identity-mapped GVA.
+    //
+    // Safety: called after page tables are set up (post-boot).
+    unsafe { pte_walk_gva_to_gpa(vaddr) }.unwrap_or(vaddr)
+}
+
+/// Returns a pointer to the root (host-built) page directory entries.
+///
+/// On Hyperlight the host PD is active in CR3. Its GPA is translated to a GVA so the
+/// kernel can read the entries through the host page tables.
+pub fn get_root_pd_ptr() -> *const PteWord {
+    let cr3: u32;
+    unsafe {
+        core::arch::asm!("mov {:e}, cr3", out(reg) cr3, options(nostack, nomem));
+    }
+    let host_pd_gpa: usize = (cr3 & 0xFFFFF000) as usize;
+    gpa_to_gva(host_pd_gpa) as *const PteWord
+}
 
 //==================================================================================================
 // Imports
@@ -79,6 +129,7 @@ use ::arch::{
     mem,
     mem::{
         gdt::Gdte,
+        paging::PteWord,
         PAGE_ALIGNMENT,
         WORD_ALIGNMENT,
     },
@@ -93,10 +144,6 @@ use ::config::{
     },
     kernel::MEMORY_SIZE,
     memory_layout::KERNEL_BASE_RAW,
-};
-use ::core::sync::atomic::{
-    AtomicUsize,
-    Ordering,
 };
 use ::hyperlight_common::{
     flatbuffer_wrappers::{
@@ -195,23 +242,21 @@ use ::sys::{
 #[used]
 static KERNEL_PADDING: [u8; 2 * 1024 * 1024] = [0u8; 2 * 1024 * 1024];
 
-/// Guest handle initialised once during `hyperlight_pre_kmain` (evolve phase)
-/// and reused by `nanvix_dispatch_function` on each `sandbox.call()`.
-static mut GUEST_HANDLE: Option<GuestHandle> = None;
-
 //==================================================================================================
 // Constants
 //==================================================================================================
 
+/// Physical base address of the snapshot KVM memory slot.
+///
+/// This matches `SandboxMemoryLayout::BASE_ADDRESS` in `hyperlight-host`.  The host maps the
+/// kernel binary image starting at this GPA; there is no physical memory below it.
+const SNAPSHOT_PHYS_BASE: usize = 0x1000;
+
 /// Number of page tables needed for identity-mapping physical memory regions.
 ///
-/// On Hyperlight the physical memory is split across two disjoint VA ranges: the low region
-/// (snapshot + RAMFS) starting near GPA 0 and the scratch region at the top of the 32-bit address
-/// space. Because both ranges occupy separate page directory entries, each can independently
-/// require up to `MEMORY_SIZE / PGTAB_SIZE` page tables. We provision twice the base count to cover
-/// the worst-case split.
-///
-pub const NUM_PAGE_TABLES: usize = 2 * (MEMORY_SIZE / mem::PGTAB_SIZE);
+/// On Hyperlight the host page tables are used directly; only a small number of
+/// page table slots are needed for process creation.
+pub const NUM_PAGE_TABLES: usize = 4;
 
 //==================================================================================================
 // Structures
@@ -241,6 +286,140 @@ pub struct Platform {
 // Ensure the config crate's GPA ceiling matches the upstream MAX_GPA from hyperlight-common.
 ::static_assert::assert_eq!(memory_layout::HYPERLIGHT_GPA_CEILING == MAX_GPA + 1);
 
+//==================================================================================================
+// GPA ↔ GVA Translation
+//==================================================================================================
+
+/// Translates a guest physical address (GPA) to the corresponding guest virtual address (GVA).
+///
+/// On i686-guest, the host maps two regions:
+///   - **Snapshot** (kernel image): identity-mapped at `BASE_ADDRESS` (0x1000), so GVA == GPA.
+///   - **Scratch**: mapped at `GVA = MAX_GVA - scratch_size + 1`, but backed at
+///     `GPA = MAX_GPA - scratch_size + 1`. The difference (GVA − GPA) is constant:
+///     `MAX_GVA − MAX_GPA` (= 0x0120_0000 for the current layout).
+///
+/// Page table entries (PDEs, PTEs) store GPAs. Software that walks page tables must convert
+/// those GPAs to GVAs before dereferencing them.
+///
+/// # Parameters
+///
+/// - `gpa`: A guest physical address (e.g., from a PDE/PTE or CR3).
+///
+/// # Returns
+///
+/// The corresponding guest virtual address.
+pub fn gpa_to_gva(gpa: usize) -> usize {
+    let scratch_base_gpa: usize = MAX_GPA + 1 - scratch_size();
+    if gpa >= scratch_base_gpa {
+        gpa.wrapping_add(MAX_GVA.wrapping_sub(MAX_GPA))
+    } else {
+        gpa
+    }
+}
+
+/// Translates a guest virtual address (GVA) to the corresponding guest physical address (GPA).
+///
+/// Inverse of [`gpa_to_gva`]. Identity for low memory; subtracts the GVA−GPA delta for scratch.
+pub fn gva_to_gpa(gva: usize) -> usize {
+    let delta: usize = MAX_GVA.wrapping_sub(MAX_GPA);
+    let scratch_base_gpa: usize = MAX_GPA + 1 - scratch_size();
+    let scratch_base_gva: usize = scratch_base_gpa.wrapping_add(delta);
+    if gva >= scratch_base_gva {
+        gva.wrapping_sub(delta)
+    } else {
+        gva
+    }
+}
+
+/// Walks the current page tables (from CR3) to resolve a GVA to its actual GPA.
+///
+/// After eager pre-faulting, PTEs for CoW-resolved pages point to scratch GPAs rather
+/// than their original snapshot GPAs. This function reads the PTE to determine the
+/// actual physical frame backing the given virtual address.
+///
+/// # Returns
+///
+/// The GPA that the page table maps the given GVA to, or `None` if the page is not present.
+///
+/// # Safety
+///
+/// Must be called after page tables have been set up (i.e., after boot).
+pub unsafe fn pte_walk_gva_to_gpa(gva: usize) -> Option<usize> {
+    use ::arch::mem::paging::PresentFlag;
+
+    let cr3: u32;
+    core::arch::asm!("mov {:e}, cr3", out(reg) cr3, options(nostack, nomem));
+    let pd_gpa: usize = (cr3 & PTE_ADDR_MASK_U32) as usize;
+    let pd_base: *const u32 = gpa_to_gva(pd_gpa) as *const u32;
+
+    let pd_idx: usize = gva >> 22; // top 10 bits
+    let pt_idx: usize = (gva >> 12) & 0x3FF; // next 10 bits
+    let page_offset: usize = gva & 0xFFF;
+
+    let pde: u32 = pd_base.add(pd_idx).read_volatile();
+    if !PresentFlag::is_set(pde) {
+        return None;
+    }
+
+    let pt_gpa: usize = (pde & PTE_ADDR_MASK_U32) as usize;
+    let pt_base: *const u32 = gpa_to_gva(pt_gpa) as *const u32;
+
+    let pte: u32 = pt_base.add(pt_idx).read_volatile();
+    if !PresentFlag::is_set(pte) {
+        return None;
+    }
+
+    Some((pte & PTE_ADDR_MASK_U32) as usize + page_offset)
+}
+
+/// Returns the total scratch region size by reading the scratch metadata slot.
+///
+/// This reads the `SCRATCH_TOP_SIZE_OFFSET` u64 at the top of scratch, which the host
+/// writes during `update_scratch_bookkeeping()`.
+fn scratch_size() -> usize {
+    let ptr = ::hyperlight_guest::layout::scratch_size_gva();
+    unsafe { core::ptr::read_volatile(ptr) as usize }
+}
+
+/// Returns the page table base GPA by reading the scratch metadata slot.
+///
+/// The host stores this at `SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET` from the
+/// top of scratch.
+pub(super) fn pt_base_gpa() -> usize {
+    let ptr = ::hyperlight_guest::layout::snapshot_pt_gpa_base_gva();
+    unsafe { core::ptr::read_volatile(ptr) as usize }
+}
+
+/// Returns the first free GPA (bump allocator pointer) from the scratch metadata slot.
+///
+/// This is `pt_base_gpa + pt_size`, so `first_free_gpa - pt_base_gpa` gives the
+/// page table size.
+pub fn first_free_scratch_gpa() -> usize {
+    let ptr = ::hyperlight_guest::layout::allocator_gva();
+    unsafe { core::ptr::read_volatile(ptr) as usize }
+}
+
+/// Offset within the early-GDT scratch page where the boot-time first-free-GPA is cached.
+/// The GDT only uses ~56 bytes of the page; this slot is near the end.
+const BOOT_FIRST_FREE_GPA_SLOT_OFFSET: usize = 4088;
+
+/// Returns the boot-time first-free-GPA value cached in the early-GDT scratch page.
+///
+/// This is set once by [`install_early_idt()`](cow_entry::install_early_idt) before any
+/// CoW bump allocation can advance the live allocator pointer.
+fn load_boot_first_free_gpa() -> usize {
+    let addr: usize =
+        ::config::memory_layout::HYPERLIGHT_EARLY_GDT_BASE + BOOT_FIRST_FREE_GPA_SLOT_OFFSET;
+    unsafe { core::ptr::read_volatile(addr as *const usize) }
+}
+
+/// Saves the boot-time first-free-GPA value to the early-GDT scratch page.
+pub(super) fn save_boot_first_free_gpa(val: usize) {
+    let addr: usize =
+        ::config::memory_layout::HYPERLIGHT_EARLY_GDT_BASE + BOOT_FIRST_FREE_GPA_SLOT_OFFSET;
+    unsafe { core::ptr::write_volatile(addr as *mut usize, val) };
+}
+
 // Scratch-reserved layout.
 //
 // These structures are allocated in the scratch region (outside the CoW snapshot) so that
@@ -250,10 +429,9 @@ pub struct Platform {
 scratch_layout! {
     page_align = PAGE_ALIGNMENT;
 
-    /// One bit per frame for the entire `MEMORY_SIZE` address range, plus three extra bytes
-    /// so that per-chunk frame counts that are not multiples of 8 can be rounded up without
-    /// overflow.
-    FRAME_ALLOC_BITMAP : size = MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize) + 3,
+    /// One bit per frame for the entire `MEMORY_SIZE` address range, plus extra bytes
+    /// to account for byte-alignment padding in each sparse bitmap chunk.
+    FRAME_ALLOC_BITMAP : size = MEMORY_SIZE / (mem::FRAME_SIZE * u8::BITS as usize) + 8,
                          align = WORD_ALIGNMENT;
     /// Kernel page pool bitmap storage.
     KPOOL_BITMAP       : size = ::config::kernel::KPOOL_SIZE / (mem::PAGE_SIZE * u8::BITS as usize),
@@ -273,29 +451,113 @@ scratch_layout! {
     /// Kernel log buffer backing storage (relocated from BSS to avoid dirtying CoW snapshot pages).
     KLOG_BUFFER        : size = crate::klog::KLOG_BUFFER_STORAGE_SIZE,
                          align = crate::klog::KLOG_BUFFER_ALIGNMENT;
+    /// Snapshot region end address (stored in scratch to avoid CoW faults during init).
+    SNAPSHOT_END_VAR   : size = core::mem::size_of::<usize>(),
+                         align = WORD_ALIGNMENT;
+    /// RAMFS base address (stored in scratch to avoid CoW faults during init).
+    RAMFS_BASE_VAR     : size = core::mem::size_of::<usize>(),
+                         align = WORD_ALIGNMENT;
+    /// RAMFS end address (stored in scratch to avoid CoW faults during init).
+    RAMFS_END_VAR      : size = core::mem::size_of::<usize>(),
+                         align = WORD_ALIGNMENT;
+    /// Scratch region base address (stored in scratch to avoid CoW faults during init).
+    SCRATCH_BASE_VAR   : size = core::mem::size_of::<usize>(),
+                         align = WORD_ALIGNMENT;
+    /// Scratch region end address (stored in scratch to avoid CoW faults during init).
+    SCRATCH_END_VAR    : size = core::mem::size_of::<usize>(),
+                         align = WORD_ALIGNMENT;
 }
 
 //==================================================================================================
-// Global Variables
+// Scratch-Resident Memory Layout Variables
 //==================================================================================================
 
-/// Snapshot region base address (inclusive).
-static SNAPSHOT_BASE: AtomicUsize = AtomicUsize::new(KERNEL_BASE_RAW);
-/// Snapshot region end address (exclusive).
-/// Uses `KERNEL_BASE_RAW + MEMORY_SIZE` as a generous upper bound so that early-boot code
-/// (before `init()`) can construct `PhysicalAddress` values.  Tightened in `init()` once the
-/// actual region boundaries are discovered.
-static SNAPSHOT_END: AtomicUsize = AtomicUsize::new(KERNEL_BASE_RAW + MEMORY_SIZE);
+/// Reads a `usize` from scratch memory at the given pointer via volatile read.
+unsafe fn scratch_load_usize(ptr: *mut u8) -> usize {
+    core::ptr::read_volatile(ptr as *const usize)
+}
 
-/// RAMFS region base address (inclusive). Zero when no RAMFS is present.
-static RAMFS_BASE: AtomicUsize = AtomicUsize::new(0);
-/// RAMFS region end address (exclusive). Zero when no RAMFS is present.
-static RAMFS_END: AtomicUsize = AtomicUsize::new(0);
+/// Writes a `usize` to scratch memory at the given pointer via volatile write.
+unsafe fn scratch_store_usize(ptr: *mut u8, val: usize) {
+    core::ptr::write_volatile(ptr as *mut usize, val);
+}
 
-/// Scratch region base address (inclusive). Zero until `init()` discovers the actual value.
-static SCRATCH_BASE: AtomicUsize = AtomicUsize::new(0);
-/// Scratch region end address (exclusive). Zero until `init()` discovers the actual value.
-static SCRATCH_END: AtomicUsize = AtomicUsize::new(0);
+/// Returns the snapshot end address from scratch, or the default if scratch is not yet initialized.
+pub fn load_snapshot_end() -> usize {
+    let base: usize = scratch_reserved_base();
+    if base == 0 {
+        // Before scratch is initialized, use the compile-time default.
+        KERNEL_BASE_RAW + MEMORY_SIZE
+    } else {
+        let val: usize = unsafe { scratch_load_usize(snapshot_end_var_ptr(base)) };
+        if val == 0 {
+            KERNEL_BASE_RAW + MEMORY_SIZE
+        } else {
+            val
+        }
+    }
+}
+
+fn store_snapshot_end(val: usize) {
+    let base: usize = scratch_reserved_base();
+    unsafe { scratch_store_usize(snapshot_end_var_ptr(base), val) };
+}
+
+pub fn load_ramfs_base() -> usize {
+    let base: usize = scratch_reserved_base();
+    if base == 0 {
+        0
+    } else {
+        unsafe { scratch_load_usize(ramfs_base_var_ptr(base)) }
+    }
+}
+
+fn store_ramfs_base(val: usize) {
+    let base: usize = scratch_reserved_base();
+    unsafe { scratch_store_usize(ramfs_base_var_ptr(base), val) };
+}
+
+pub fn load_ramfs_end() -> usize {
+    let base: usize = scratch_reserved_base();
+    if base == 0 {
+        0
+    } else {
+        unsafe { scratch_load_usize(ramfs_end_var_ptr(base)) }
+    }
+}
+
+fn store_ramfs_end(val: usize) {
+    let base: usize = scratch_reserved_base();
+    unsafe { scratch_store_usize(ramfs_end_var_ptr(base), val) };
+}
+
+pub fn load_scratch_base() -> usize {
+    let base: usize = scratch_reserved_base();
+    if base == 0 {
+        0
+    } else {
+        unsafe { scratch_load_usize(scratch_base_var_ptr(base)) }
+    }
+}
+
+fn store_scratch_base(val: usize) {
+    let base: usize = scratch_reserved_base();
+    unsafe { scratch_store_usize(scratch_base_var_ptr(base), val) };
+}
+
+fn load_scratch_end() -> usize {
+    let base: usize = scratch_reserved_base();
+    if base == 0 {
+        0
+    } else {
+        unsafe { scratch_load_usize(scratch_end_var_ptr(base)) }
+    }
+}
+
+fn store_scratch_end(val: usize) {
+    let base: usize = scratch_reserved_base();
+    unsafe { scratch_store_usize(scratch_end_var_ptr(base), val) };
+}
 
 //==================================================================================================
 // Standalone Functions
@@ -421,9 +683,11 @@ pub unsafe fn vmbus_write(addr: *const u8) {
         if data_len > 0 {
             let payload_dst: *mut u8 =
                 unsafe { buf.as_mut_ptr().add(::sys::ipc::DataChunkHeader::SIZE) };
-            if let Err(e) = crate::mm::memcpy(payload_dst, data_gpa as *const u8, data_len) {
-                error!("vmbus_write(): memcpy failed: {:?}", e);
-            }
+            // Translate the user data GPA to a GVA the CPU can dereference.
+            // Do NOT use crate::mm::memcpy here: it assumes both pointers are GPAs and
+            // would double-translate payload_dst (a heap GVA in the scratch region).
+            let data_gva: *const u8 = gpa_to_gva(data_gpa) as *const u8;
+            unsafe { core::ptr::copy_nonoverlapping(data_gva, payload_dst, data_len) };
         }
 
         let _ = ProcessEnvironmentBlock::vmbus_bulk_write(&buf);
@@ -503,13 +767,16 @@ pub unsafe fn vmbus_read(addr: *mut u8) {
                                     dest_gpa,
                                     offset
                                 );
-                                if let Err(e) = crate::mm::memcpy(
-                                    (dest_gpa + offset) as *mut u8,
-                                    chunk.as_ptr(),
-                                    chunk_len,
-                                ) {
-                                    error!("vmbus_read(): memcpy failed: {:?}", e);
-                                    break;
+                                // Translate the destination GPA to a GVA the CPU can
+                                // dereference. Do NOT use crate::mm::memcpy: it would
+                                // double-translate the chunk source pointer (a heap GVA).
+                                let dest_gva: *mut u8 = gpa_to_gva(dest_gpa + offset) as *mut u8;
+                                unsafe {
+                                    core::ptr::copy_nonoverlapping(
+                                        chunk.as_ptr(),
+                                        dest_gva,
+                                        chunk_len,
+                                    );
                                 }
                                 offset += chunk_len;
                             },
@@ -547,38 +814,30 @@ pub(in crate::hal::platform) fn do_shutdown(status: usize) -> ! {
 
     // Write a proper FunctionCallResult so the host reads the exit code from the PEB output buffer
     // via Hyperlight's standard guest return convention.
-    // SAFETY: GUEST_HANDLE is initialised once in hyperlight_pre_kmain during the evolve phase
-    // and never mutated again. This is a single-core guest, so there are no data races.
-    if let Some(handle) = unsafe { GUEST_HANDLE.as_ref() } {
-        let fcr = FunctionCallResult::new(Ok(ReturnValue::Int(code)));
-        let mut builder = ::flatbuffers::FlatBufferBuilder::new();
-        let data = fcr.encode(&mut builder);
-        if handle.push_shared_output_data(data).is_err() {
-            // PEB output write failed — fall back to abort so the host gets a definite error
-            // instead of reading stale data from the output buffer.
-            ::hyperlight_guest::exit::abort_with_code(&[code as u8]);
-        }
-
-        // Halt the VM cleanly via VmAction::Halt so sandbox.call() returns Ok(exit_code).
-        // SAFETY: Port I/O write targets Hyperlight's VmAction::Halt port. This halts the VM and
-        // causes sandbox.call() to return on the host. The hlt loop is a safety net in case the
-        // out instruction does not immediately stop execution.
-        unsafe {
-            core::arch::asm!(
-                "mov dx, {HALT_PORT}",
-                "out dx, al",
-                "cli",
-                "2: hlt",
-                "jmp 2b",
-                HALT_PORT = const VmAction::Halt as u16,
-                options(noreturn),
-            );
-        }
-    } else {
-        // If shutdown happens before Hyperlight guest initialization completes, halting here can
-        // make evolve appear successful and leave the host with an invalid entrypoint. Abort
-        // instead so the evolve phase fails explicitly.
+    let handle: GuestHandle = guest_handle();
+    let fcr = FunctionCallResult::new(Ok(ReturnValue::Int(code)));
+    let mut builder = ::flatbuffers::FlatBufferBuilder::new();
+    let data = fcr.encode(&mut builder);
+    if handle.push_shared_output_data(data).is_err() {
+        // PEB output write failed — fall back to abort so the host gets a definite error
+        // instead of reading stale data from the output buffer.
         ::hyperlight_guest::exit::abort_with_code(&[code as u8]);
+    }
+
+    // Halt the VM cleanly via VmAction::Halt so sandbox.call() returns Ok(exit_code).
+    // SAFETY: Port I/O write targets Hyperlight's VmAction::Halt port. This halts the VM and
+    // causes sandbox.call() to return on the host. The hlt loop is a safety net in case the
+    // out instruction does not immediately stop execution.
+    unsafe {
+        core::arch::asm!(
+            "mov dx, {HALT_PORT}",
+            "out dx, al",
+            "cli",
+            "2: hlt",
+            "jmp 2b",
+            HALT_PORT = const VmAction::Halt as u16,
+            options(noreturn),
+        );
     }
 }
 
@@ -598,7 +857,7 @@ pub fn signal_startup_complete() {}
 /// Returns the boot kernel stack top pointer.
 ///
 /// On Hyperlight the boot stack lives in the scratch region at a compile-time
-/// constant address derived from [`HYPERLIGHT_GPA_CEILING`].
+/// constant address derived from [`HYPERLIGHT_MAX_GVA`].
 pub fn get_kstack_top() -> *const u8 {
     ::config::memory_layout::HYPERLIGHT_BOOT_STACK_TOP as *const u8
 }
@@ -606,39 +865,167 @@ pub fn get_kstack_top() -> *const u8 {
 ///
 /// # Description
 ///
-/// Early boot helper called from `_do_start2` (assembly) while already
-/// running on the scratch-backed boot stack at
-/// [`HYPERLIGHT_BOOT_STACK_TOP`](::config::memory_layout::HYPERLIGHT_BOOT_STACK_TOP).
+/// Computes the scratch-reserved base address from the PEB and host page table metadata.
 ///
-/// Patches the PEB scratch pointers from GVA to GPA.
+/// The scratch-reserved region is placed after the IO buffers AND after the host-built
+/// page tables (whichever ends later). This ensures our scratch-resident data structures
+/// never overlap the host page tables.
 ///
-#[unsafe(no_mangle)]
-extern "C" fn init_scratch_kstack() {
-    extern "C" {
+/// This is safe to call at any point after the PEB has been mapped by the host (i.e., from
+/// `init_scratch_kstack` onwards). Only reads from the snapshot region; never writes.
+///
+fn scratch_reserved_base() -> usize {
+    unsafe extern "C" {
         static __KERNEL_END: u8;
     }
-
-    // Compute the PEB base address.
     let kernel_end: usize = unsafe { &__KERNEL_END as *const u8 as usize };
     let peb_base: usize = ::sys::mm::align_up(kernel_end, PAGE_ALIGNMENT)
-        .expect("init_scratch_kstack(): PEB align_up overflow");
-    let peb_ptr: *mut HyperlightPEB = peb_base as *mut HyperlightPEB;
+        .expect("scratch_reserved_base(): PEB align_up overflow");
+    let peb_ptr: *const HyperlightPEB = peb_base as *const HyperlightPEB;
+    let scratch_base: usize = unsafe { (*peb_ptr).input_stack.ptr } as usize;
+    let io_buffers_end: usize = scratch_base + INPUT_DATA_BUFFER_SIZE + OUTPUT_DATA_BUFFER_SIZE;
+    // Read the boot-time first-free GPA cached by install_early_idt().
+    // This value is saved before any CoW bump allocation can modify the live
+    // allocator pointer, so it correctly represents the boundary between the
+    // host page tables and free scratch space.
+    let boot_first_free_gpa: usize = load_boot_first_free_gpa();
+    let host_pt_end_gva: usize = if boot_first_free_gpa != 0 {
+        gpa_to_gva(boot_first_free_gpa)
+    } else {
+        // Fallback: read the (possibly stale) live value.
+        gpa_to_gva(first_free_scratch_gpa())
+    };
+    let base: usize = core::cmp::max(io_buffers_end, host_pt_end_gva);
+    // Page-align upward.
+    ::sys::mm::align_up(base, PAGE_ALIGNMENT)
+        .expect("scratch_reserved_base(): page alignment overflow")
+}
 
-    // Patch PEB scratch pointers from GVA to GPA.
-    //
-    // The host writes input_stack.ptr and output_stack.ptr using scratch_base_gva()
-    // (derived from MAX_GVA).  On the Hyperlight i686 platform the guest runs with
-    // identity mapping (GVA == GPA), but the KVM memory slot for scratch is placed at
-    // scratch_base_gpa() (derived from MAX_GPA).  When MAX_GPA < MAX_GVA the two
-    // diverge and the guest would read from unmapped physical addresses.  Subtract the
-    // delta so the PEB pointers target the actual GPA range.
-    let gva_gpa_delta: u64 = (MAX_GVA - MAX_GPA) as u64;
-    if gva_gpa_delta != 0 {
-        unsafe {
-            (*peb_ptr).input_stack.ptr -= gva_gpa_delta;
-            (*peb_ptr).output_stack.ptr -= gva_gpa_delta;
+///
+/// # Description
+///
+/// Returns a raw pointer to the PEB.
+///
+/// Computed from the `__KERNEL_END` linker symbol, page-aligned upwards.
+///
+fn peb_ptr() -> *mut HyperlightPEB {
+    unsafe extern "C" {
+        static __KERNEL_END: u8;
+    }
+    let kernel_end: usize = unsafe { &__KERNEL_END as *const u8 as usize };
+    let peb_base: usize =
+        ::sys::mm::align_up(kernel_end, PAGE_ALIGNMENT).expect("peb_ptr(): PEB align_up overflow");
+    peb_base as *mut HyperlightPEB
+}
+
+///
+/// # Description
+///
+/// Constructs a [`GuestHandle`] from the PEB pointer.
+///
+/// This is lightweight (no heap allocation) and avoids storing mutable global
+/// state that would dirty CoW snapshot pages during early boot.
+///
+fn guest_handle() -> GuestHandle {
+    GuestHandle::init(peb_ptr())
+}
+
+/// Software-defined AVL/CoW bit in x86 PTEs (bit 9).
+///
+/// The Hyperlight host sets this bit on page table entries that point to snapshot GPAs and require
+/// Copy-on-Write resolution. The guest must copy the page to a scratch frame and clear this bit.
+const PAGE_AVL_COW: u32 = 1 << 9;
+
+/// Mask for extracting the 4 KiB-aligned physical address from a PTE/PDE.
+const PTE_ADDR_MASK_U32: u32 = 0xFFFFF000;
+
+///
+/// # Description
+///
+/// Eagerly pre-faults every CoW-marked page in the host-built page tables.
+///
+/// Walks the page directory (from CR3), and for each present PDE walks the page table.
+/// For each PTE with the `PAGE_AVL_COW` bit set:
+///   1. Allocates a fresh scratch frame via the bump allocator.
+///   2. Copies 4 KiB from the snapshot-backed GVA to the new scratch frame.
+///   3. Patches the PTE in place: scratch GPA, PAGE_PRESENT | PAGE_RW, clear PAGE_AVL_COW.
+///
+/// After this function returns, every writable page is backed by scratch memory and the
+/// kernel runs fault-free.
+///
+/// # Safety
+///
+/// Must be called after `advance_bump_allocator()` and before `setup_klog()`.
+/// The page tables themselves reside in scratch (already writable), so patching PTEs
+/// does not trigger faults.
+///
+unsafe fn eager_prefault_cow_pages() {
+    use ::arch::mem::paging::{
+        PresentFlag,
+        PteWord,
+    };
+
+    // Read CR3 to find the host page directory.
+    let cr3: u32;
+    core::arch::asm!("mov {:e}, cr3", out(reg) cr3, options(nostack, nomem));
+    let pd_gpa: usize = (cr3 & PTE_ADDR_MASK_U32) as usize;
+    let pd_base: *const u32 = gpa_to_gva(pd_gpa) as *const u32;
+
+    let page_table_length: usize = 1024;
+
+    for pd_idx in 0..page_table_length {
+        let pde: u32 = pd_base.add(pd_idx).read_volatile();
+        if !PresentFlag::is_set(pde) {
+            continue;
+        }
+
+        let pt_gpa: usize = (pde & PTE_ADDR_MASK_U32) as usize;
+        let pt_base: *mut u32 = gpa_to_gva(pt_gpa) as *mut u32;
+
+        for pt_idx in 0..page_table_length {
+            let pte: u32 = pt_base.add(pt_idx).read_volatile();
+            if !PresentFlag::is_set(pte) {
+                continue;
+            }
+            // Check for the AVL/CoW software bit.
+            if pte & PAGE_AVL_COW == 0 {
+                continue;
+            }
+
+            // Allocate a scratch frame via the bump allocator.
+            let new_frame_gpa: u32 = cow_handler::bump_alloc_frame();
+            let new_frame_gva: usize = gpa_to_gva(new_frame_gpa as usize);
+
+            // The source GVA is the identity-mapped virtual address of this page.
+            let src_gva: usize = pd_idx * mem::PGTAB_SIZE + pt_idx * mem::PAGE_SIZE;
+
+            // Copy 4 KiB from the snapshot-backed GVA to the new scratch frame.
+            core::ptr::copy_nonoverlapping(
+                src_gva as *const u8,
+                new_frame_gva as *mut u8,
+                mem::PAGE_SIZE,
+            );
+
+            // Build the new PTE: scratch GPA, present + RW + accessed, clear AVL_COW.
+            // Preserve the user-mode flag if set.
+            let mut new_pte: PteWord = (new_frame_gpa & PTE_ADDR_MASK_U32)
+                | PresentFlag::Present as PteWord
+                | ::arch::mem::paging::ReadWriteFlag::ReadWrite as PteWord
+                | ::arch::mem::paging::AccessedFlag::Accessed as PteWord;
+            // Preserve USER bit from the original PTE.
+            new_pte |= pte & (::arch::mem::paging::UserSupervisorFlag::User as PteWord);
+
+            pt_base.add(pt_idx).write_volatile(new_pte);
         }
     }
+
+    // Flush TLB by reloading CR3.
+    core::arch::asm!(
+        "mov {tmp:e}, cr3",
+        "mov cr3, {tmp:e}",
+        tmp = out(reg) _,
+        options(nostack),
+    );
 }
 
 ///
@@ -650,8 +1037,6 @@ extern "C" fn init_scratch_kstack() {
 /// Performs one-time initialization that subsequent `sandbox.call()` invocations depend on:
 ///
 /// 1. Initializes the kernel heap (needed for FunctionCall deserialisation).
-/// 2. Computes the PEB base address and stores a [`GuestHandle`] in [`GUEST_HANDLE`] for reuse
-///    by [`nanvix_dispatch_function`].
 ///
 /// On return, the caller (`_do_start2` in `start.rs`) halts the VM so that `evolve()` returns
 /// on the host.
@@ -670,18 +1055,43 @@ extern "C" fn hyperlight_pre_kmain() {
         .expect("hyperlight_pre_kmain(): PEB align_up overflow");
     let peb_ptr: *mut HyperlightPEB = peb_base as *mut HyperlightPEB;
 
-    // Derive the scratch-reserved base from the (already patched) PEB input buffer pointer.
-    let scratch_base: usize = unsafe { (*peb_ptr).input_stack.ptr } as usize;
-    let scratch_reserved_base: usize =
-        scratch_base + INPUT_DATA_BUFFER_SIZE + OUTPUT_DATA_BUFFER_SIZE;
+    // Derive the scratch-reserved base from the PEB and host page table metadata.
+    // This accounts for the host page tables that are placed between the IO buffers
+    // and our reserved structures.
+    let scratch_reserved_base: usize = scratch_reserved_base();
 
-    // Point the kernel log buffer at scratch-resident backing storage so that log
-    // writes do not dirty CoW snapshot pages.
-    //
-    // Safety: klog_buffer_ptr returns a pointer within the scratch-reserved region
-    // that was identity-mapped and zeroed by Hyperlight before the guest started.
-    // The scratch region is never freed, so the storage outlives all logging usage.
-    // This is the only call to klog::set_backing_storage() in the Hyperlight init path.
+    // Advance the bump allocator pointer past our scratch-reserved region so that
+    // frame allocations never overlap our data structures. This must be done on
+    // every entry (evolve and call) because the host resets the bump pointer on
+    // snapshot restore.
+    {
+        let boot_first_free: usize = load_boot_first_free_gpa();
+        let reserved_end_gpa: usize = if boot_first_free != 0 {
+            boot_first_free + SCRATCH_RESERVED_SIZE
+        } else {
+            first_free_scratch_gpa() + SCRATCH_RESERVED_SIZE
+        };
+        let alloc_ptr = ::hyperlight_guest::layout::allocator_gva();
+        let current: usize = unsafe { core::ptr::read_volatile(alloc_ptr) as usize };
+        if current < reserved_end_gpa {
+            unsafe { core::ptr::write_volatile(alloc_ptr, reserved_end_gpa as u64) };
+        }
+    }
+
+    // Eagerly resolve all CoW pages: walk the host-built page tables and copy every
+    // CoW-marked page to a scratch frame, patching the PTE in place. After this call,
+    // every writable page in the guest address space is backed by scratch memory.
+    unsafe {
+        eager_prefault_cow_pages();
+    }
+
+    // Set a conservative snapshot_end so the CoW handler can resolve page faults
+    // after the host takes a snapshot.  The exact value is refined later in
+    // platform::init() once the host memory layout is known.  Using the scratch
+    // base (from PEB) as the upper bound is safe.
+    let peb_scratch_base: usize = unsafe { (*peb_ptr).input_stack.ptr } as usize;
+    store_snapshot_end(peb_scratch_base);
+
     let klog_backing_ptr: *mut u8 = unsafe { klog_buffer_ptr(scratch_reserved_base) };
     if let Err(_e) = unsafe { crate::klog::set_backing_storage(klog_backing_ptr) } {
         unsafe {
@@ -690,9 +1100,6 @@ extern "C" fn hyperlight_pre_kmain() {
     }
 
     let heap_backing_ptr: *mut u8 = (scratch_reserved_base + HEAP_STORAGE_OFFSET) as *mut u8;
-
-    // Point the kernel heap at scratch-resident backing storage so that heap
-    // allocations do not dirty CoW snapshot pages.
     if let Err(_e) =
         unsafe { crate::mm::kheap::set_backing_storage(heap_backing_ptr, HEAP_STORAGE_SIZE) }
     {
@@ -701,18 +1108,10 @@ extern "C" fn hyperlight_pre_kmain() {
         }
     }
 
-    // Initialises the kernel heap once so FunctionCall deserialisation can allocate on every
-    // subsequent sandbox.call().  On Hyperlight the heap is only initialised here (during evolve);
-    // kmain skips heap init via `#[cfg(not(feature = "hyperlight"))]`.
     if let Err(_e) = unsafe { crate::mm::kheap::init() } {
         unsafe {
             core::arch::asm!("cli", "2: hlt", "jmp 2b", options(noreturn));
         }
-    }
-
-    // Store a GuestHandle for reuse by nanvix_dispatch_function.
-    unsafe {
-        GUEST_HANDLE = Some(GuestHandle::init(peb_ptr));
     }
 }
 
@@ -734,14 +1133,7 @@ extern "C" fn hyperlight_pre_kmain() {
 ///
 #[unsafe(no_mangle)]
 extern "C" fn nanvix_dispatch_function(kargs: &crate::kargs::KernelArguments) {
-    // SAFETY: GUEST_HANDLE is initialised once in hyperlight_pre_kmain
-    // during the evolve phase and never mutated again. This is a single-core
-    // guest, so there are no data races.
-    let handle: &GuestHandle = unsafe {
-        GUEST_HANDLE
-            .as_ref()
-            .expect("nanvix_dispatch_function(): GUEST_HANDLE not initialised")
-    };
+    let handle: GuestHandle = guest_handle();
 
     let function_call = handle
         .try_pop_shared_input_data_into::<FunctionCall>()
@@ -795,16 +1187,24 @@ pub fn tsc_base_frequency_mhz() -> u32 {
 #[inline(always)]
 pub fn is_valid_physical_address(addr: VirtualAddress) -> bool {
     let raw: usize = addr.into_raw_value();
-    let snapshot: (usize, usize) =
-        (SNAPSHOT_BASE.load(Ordering::Relaxed), SNAPSHOT_END.load(Ordering::Relaxed));
-    let ramfs: (usize, usize) =
-        (RAMFS_BASE.load(Ordering::Relaxed), RAMFS_END.load(Ordering::Relaxed));
-    let scratch: (usize, usize) =
-        (SCRATCH_BASE.load(Ordering::Relaxed), SCRATCH_END.load(Ordering::Relaxed));
+    let snapshot: (usize, usize) = (KERNEL_BASE_RAW, load_snapshot_end());
+    let ramfs: (usize, usize) = (load_ramfs_base(), load_ramfs_end());
+    let scratch: (usize, usize) = (load_scratch_base(), load_scratch_end());
+    // The frame allocator hands out scratch GPAs, which differ from scratch GVAs.
+    // Accept both ranges so physical addresses from the frame allocator pass validation.
+    let scratch_gpa: (usize, usize) = {
+        let sz: usize = scratch_size();
+        if sz > 0 {
+            (MAX_GPA + 1 - sz, MAX_GPA + 1)
+        } else {
+            (0, 0)
+        }
+    };
     // An address is valid when the half-open interval [raw, raw+1) lies inside a region.
     region_contains(snapshot.0, snapshot.1, raw, raw + 1)
         || region_contains(ramfs.0, ramfs.1, raw, raw + 1)
         || region_contains(scratch.0, scratch.1, raw, raw + 1)
+        || region_contains(scratch_gpa.0, scratch_gpa.1, raw, raw + 1)
 }
 
 ///
@@ -835,16 +1235,22 @@ pub fn is_valid_physical_region(start: usize, size: usize) -> bool {
         None => return false,
     };
 
-    let snapshot: (usize, usize) =
-        (SNAPSHOT_BASE.load(Ordering::Relaxed), SNAPSHOT_END.load(Ordering::Relaxed));
-    let ramfs: (usize, usize) =
-        (RAMFS_BASE.load(Ordering::Relaxed), RAMFS_END.load(Ordering::Relaxed));
-    let scratch: (usize, usize) =
-        (SCRATCH_BASE.load(Ordering::Relaxed), SCRATCH_END.load(Ordering::Relaxed));
+    let snapshot: (usize, usize) = (KERNEL_BASE_RAW, load_snapshot_end());
+    let ramfs: (usize, usize) = (load_ramfs_base(), load_ramfs_end());
+    let scratch: (usize, usize) = (load_scratch_base(), load_scratch_end());
+    let scratch_gpa: (usize, usize) = {
+        let sz: usize = scratch_size();
+        if sz > 0 {
+            (MAX_GPA + 1 - sz, MAX_GPA + 1)
+        } else {
+            (0, 0)
+        }
+    };
 
     region_contains(snapshot.0, snapshot.1, start, end)
         || region_contains(ramfs.0, ramfs.1, start, end)
         || region_contains(scratch.0, scratch.1, start, end)
+        || region_contains(scratch_gpa.0, scratch_gpa.1, start, end)
 }
 
 ///
@@ -902,15 +1308,15 @@ fn region_contains(region_base: usize, region_end: usize, start: usize, end: usi
 ///
 #[inline(always)]
 pub fn max_physical_address() -> usize {
-    let scratch_base: usize = SCRATCH_BASE.load(Ordering::Relaxed);
+    let scratch_base: usize = load_scratch_base();
     if scratch_base != 0 {
         // Post-init: the highest valid address is SCRATCH_END - 1.
         // Use wrapping_sub because SCRATCH_END may be 0 when the scratch region
         // reaches the top of the 32-bit address space (base + size wraps).
-        SCRATCH_END.load(Ordering::Relaxed).wrapping_sub(1)
+        load_scratch_end().wrapping_sub(1)
     } else {
         // Pre-init: only the snapshot region is known.
-        SNAPSHOT_END.load(Ordering::Relaxed).saturating_sub(1)
+        load_snapshot_end().saturating_sub(1)
     }
 }
 
@@ -936,16 +1342,14 @@ pub fn parse_bootinfo(magic: u32, info: usize) -> Result<BootInfo, Error> {
     }
 
     let kernel_end: usize = unsafe { &__KERNEL_END as *const u8 as usize };
+
     let peb_base: usize = ::sys::mm::align_up(kernel_end, PAGE_ALIGNMENT).ok_or_else(|| {
         let reason: &str = "align_up overflow";
         error!("parse_bootinfo(): {reason} (kernel_end={kernel_end:#x})");
         Error::new(ErrorCode::BadAddress, reason)
     })?;
-    let peb_ptr: *mut HyperlightPEB = peb_base as *mut HyperlightPEB;
 
-    unsafe {
-        ProcessEnvironmentBlock::init(peb_ptr)?;
-    };
+    let peb_ptr: *mut HyperlightPEB = peb_base as *mut HyperlightPEB;
 
     let mut kernel_modules: LinkedList<KernelModule> = LinkedList::new();
 
@@ -1033,9 +1437,17 @@ fn register_pit(ioports: &mut IoPortAllocator) -> Result<Pit, Error> {
 
     // Configure the PV timer: writing the period (in microseconds) to the
     // PvTimerConfig port tells the hypervisor to inject periodic timer interrupts at that rate.
-    ioports.register_read_write(::config::hyperlight::PV_TIMER_PORT)?;
-    let mut pv_timer_port = ioports.allocate_read_write(::config::hyperlight::PV_TIMER_PORT)?;
-    pv_timer_port.write32(::config::hyperlight::TIMER_PERIOD_US);
+    // Use a direct I/O port write instead of the allocator-managed port to avoid registering
+    // the PV timer port for general-purpose allocation.
+    //
+    // Safety: PV_TIMER_PORT is the Hyperlight PvTimerConfig port, and writing the period
+    // value is the expected interface to configure the paravirtual timer.
+    unsafe {
+        ::arch::io::out32(
+            ::config::hyperlight::PV_TIMER_PORT,
+            ::config::hyperlight::TIMER_PERIOD_US,
+        );
+    }
 
     Pit::new(ioports, ::config::kernel::TIMER_FREQ)
 }
@@ -1201,8 +1613,8 @@ pub fn init(
             return Err(Error::new(ErrorCode::InvalidArgument, reason));
         }
 
-        RAMFS_BASE.store(ramfs_base, Ordering::Relaxed);
-        RAMFS_END.store(ramfs_end, Ordering::Relaxed);
+        store_ramfs_base(ramfs_base);
+        store_ramfs_end(ramfs_end);
         info!("ramfs region: [{:#010x}, {:#010x})", ramfs_base, ramfs_end);
     }
 
@@ -1226,10 +1638,10 @@ pub fn init(
         );
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
     }
-    // scratch_base = MAX_GPA - scratch_size + 1.
-    // MAX_GPA (not MAX_GVA) because the guest uses identity mapping (GVA == GPA)
-    // and the KVM memory slot is placed relative to MAX_GPA.
-    let scratch_base_address: usize = MAX_GPA - scratch_size + 1;
+    // The host maps the scratch region at GVA = MAX_GVA - scratch_size + 1.
+    // Use MAX_GVA (not MAX_GPA) because the CPU accesses memory through the
+    // host-built page tables, which map scratch at GVA addresses.
+    let scratch_base_address: usize = MAX_GVA - scratch_size + 1;
 
     // Sanity check: the scratch region must not descend into the user virtual address space.
     // The config crate already computes USER_END_RAW to avoid this overlap, but verify at
@@ -1249,14 +1661,14 @@ pub fn init(
     }
 
     // scratch_end is the exclusive end of the full scratch range, including the last page
-    // reserved for Hyperlight bookkeeping metadata.  When MAX_GPA == usize::MAX
-    // (i686-guest stable), the addition wraps to 0 — this is expected and handled
+    // reserved for Hyperlight bookkeeping metadata.  When MAX_GVA == usize::MAX
+    // (i686-guest), the addition wraps to 0 — this is expected and handled
     // correctly by region_contains() and max_physical_address().
     let scratch_end_address: usize = scratch_base_address.wrapping_add(scratch_size);
 
     // Record scratch region bounds for is_valid_physical_address.
-    SCRATCH_BASE.store(scratch_base_address, Ordering::Relaxed);
-    SCRATCH_END.store(scratch_end_address, Ordering::Relaxed);
+    store_scratch_base(scratch_base_address);
+    store_scratch_end(scratch_end_address);
     info!(
         "scratch region: [{:#010x}, {:#010x}) (size={:#x})",
         scratch_base_address, scratch_end_address, scratch_size
@@ -1296,11 +1708,26 @@ pub fn init(
         mmio_regions.push_back(scratch_output);
     }
 
-    // Reserve pages at the start of the free scratch area for the frame allocator bitmap,
-    // kpool bitmap, and GDT backing stores.  This memory is in scratch (never snapshot/CoW)
-    // and is registered as a reserved memory region so the frame allocator never hands it out.
-    let scratch_reserved_base: usize =
+    // Reserve pages in the free scratch area for the frame allocator bitmap,
+    // kpool bitmap, GDT backing stores, heap, etc.  This memory is in scratch (never
+    // snapshot/CoW) and is registered as a reserved memory region so the frame allocator
+    // never hands it out.
+    //
+    // The host places its page tables at the start of the free scratch area (right after
+    // the IO buffers), so our reserved structures must be placed AFTER the host page
+    // tables to avoid overlap.
+    let io_buffers_end: usize =
         scratch_base_address + INPUT_DATA_BUFFER_SIZE + OUTPUT_DATA_BUFFER_SIZE;
+    let boot_first_free: usize = load_boot_first_free_gpa();
+    let host_pt_gva_end: usize = gpa_to_gva(if boot_first_free != 0 {
+        boot_first_free
+    } else {
+        first_free_scratch_gpa()
+    });
+    // Page-align upward to ensure our structures start on a page boundary.
+    let scratch_reserved_base: usize =
+        ::sys::mm::align_up(core::cmp::max(io_buffers_end, host_pt_gva_end), PAGE_ALIGNMENT)
+            .expect("scratch_reserved_base: page alignment overflow");
     {
         // No need to zero the storage pages: the scratch region is guaranteed to be
         // zeroed out by Hyperlight before the guest starts.
@@ -1325,23 +1752,92 @@ pub fn init(
             SCRATCH_RESERVED_SIZE,
         );
     }
+
+    // Validate that our scratch-reserved region does not overlap the host-built page tables.
+    // The host places page tables in scratch at a GPA readable from the scratch metadata
+    // slot at SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET. The page table size is derived as
+    // first_free_gpa − pt_base_gpa.
+    {
+        let pt_gpa_base: usize = pt_base_gpa();
+        // Use the cached boot-time first-free-GPA (before any CoW bump allocations
+        // advanced the pointer) to determine the actual PT end boundary.
+        let boot_first_free: usize = load_boot_first_free_gpa();
+        let pt_gpa_end: usize = if boot_first_free != 0 {
+            boot_first_free
+        } else {
+            first_free_scratch_gpa()
+        };
+        // Convert PT GPA range to GVA for comparison with our scratch_reserved_base (a GVA).
+        let pt_gva_base: usize = gpa_to_gva(pt_gpa_base);
+        let pt_gva_end: usize = gpa_to_gva(pt_gpa_end);
+        let reserved_end: usize = scratch_reserved_base + SCRATCH_RESERVED_SIZE;
+
+        info!(
+            "host page tables: GPA [{:#010x}, {:#010x}) => GVA [{:#010x}, {:#010x}), size={:#x}",
+            pt_gpa_base,
+            pt_gpa_end,
+            pt_gva_base,
+            pt_gva_end,
+            pt_gpa_end - pt_gpa_base
+        );
+
+        // Check for overlap: two ranges [a, b) and [c, d) overlap iff a < d && c < b.
+        if scratch_reserved_base < pt_gva_end && pt_gva_base < reserved_end {
+            let reason: &str = "scratch reserved region overlaps host page tables";
+            error!(
+                "init(): {} (reserved=[{:#010x}, {:#010x}), pt=[{:#010x}, {:#010x}))",
+                reason, scratch_reserved_base, reserved_end, pt_gva_base, pt_gva_end,
+            );
+            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+        }
+    }
+
     // Reserve the boot stack area at the top of the scratch region, just below
     // the I/O and bookkeeping pages.  The address is a compile-time constant
-    // derived from HYPERLIGHT_GPA_CEILING.
+    // derived from HYPERLIGHT_GPA_CEILING, which falls within the GVA scratch range.
     {
-        let boot_stack_guard_base: usize =
+        let boot_stack_guard: usize =
             memory_layout::HYPERLIGHT_BOOT_STACK_TOP - ::config::kernel::KSTACK_SIZE;
         let boot_stack_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
             "boot stack",
-            VirtualAddress::from_raw_value(boot_stack_guard_base),
+            VirtualAddress::from_raw_value(boot_stack_guard),
             ::config::kernel::KSTACK_SIZE,
             MemoryRegionType::Reserved,
             AccessPermission::RDWR,
         )?;
         memory_regions.push_back(boot_stack_region);
     }
+    // Reserve the early IDT page (one page below the boot stack guard page).
+    // This page is used by install_early_idt() during boot to hold the minimal IDT
+    // that intercepts page faults before the full HAL IDT is installed.
     {
-        let scratch_io_page: usize = scratch_end_address - 2 * mem::PAGE_SIZE;
+        let early_idt_base: usize = memory_layout::HYPERLIGHT_EARLY_IDT_BASE;
+        let early_idt_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+            "early idt",
+            VirtualAddress::from_raw_value(early_idt_base),
+            mem::PAGE_SIZE,
+            MemoryRegionType::Reserved,
+            AccessPermission::RDWR,
+        )?;
+        memory_regions.push_back(early_idt_region);
+    }
+    // Reserve the early GDT page (one page below the early IDT page).
+    // This page holds the relocated GDT written by install_early_idt() so the CPU can
+    // set the Accessed bit in GDT entries during exception delivery.
+    {
+        let early_gdt_base: usize = memory_layout::HYPERLIGHT_EARLY_GDT_BASE;
+        let early_gdt_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+            "early gdt",
+            VirtualAddress::from_raw_value(early_gdt_base),
+            mem::PAGE_SIZE,
+            MemoryRegionType::Reserved,
+            AccessPermission::RDWR,
+        )?;
+        memory_regions.push_back(early_gdt_region);
+    }
+    {
+        // scratch_end_address wraps to 0 when MAX_GVA == usize::MAX, so use wrapping_sub.
+        let scratch_io_page: usize = scratch_end_address.wrapping_sub(2 * mem::PAGE_SIZE);
         let scratch_io: TruncatedMemoryRegion<VirtualAddress> = TruncatedMemoryRegion::new_mmio(
             "scratch-io",
             PageAligned::from_raw_value(scratch_io_page)?,
@@ -1353,7 +1849,7 @@ pub fn init(
         mmio_regions.push_back(scratch_io);
     }
     {
-        let scratch_reserved_page: usize = scratch_end_address - mem::PAGE_SIZE;
+        let scratch_reserved_page: usize = scratch_end_address.wrapping_sub(mem::PAGE_SIZE);
         let scratch_reserved: MemoryRegion<VirtualAddress> = MemoryRegion::new(
             "scratch reserved",
             VirtualAddress::from_raw_value(scratch_reserved_page),
@@ -1365,12 +1861,135 @@ pub fn init(
     }
 
     // Set snapshot region end from the host-provided snapshot budget.
-    // pt_overhead is always 0 with nanvix-unstable (Hyperlight skips PT generation).
-    // The variable is acknowledged here for forward-compatibility.
-    let _ = pt_overhead;
-    let snapshot_end_address: usize = KERNEL_BASE_RAW + snapshot_budget_size;
-    SNAPSHOT_END.store(snapshot_end_address, Ordering::Relaxed);
-    info!("snapshot region: [{:#010x}, {:#010x})", KERNEL_BASE_RAW, snapshot_end_address);
+    // With i686-guest, the host builds guest page tables which adds pt_overhead bytes on
+    // top of the snapshot budget. Include pt_overhead so the snapshot region covers all
+    // host-placed data (kernel code, PEB, heap, init data, and page tables).
+    // The snapshot_end for CoW purposes covers the full budget (all pages may be CoW-protected).
+    // But the frame allocator bitmap only needs to cover actually-usable frames.
+    // On Hyperlight, pages beyond the last used section (kernel + initrd) may not have
+    // host-created PTEs, so they must not be handed out by the frame allocator.
+    let snapshot_end_for_cow: usize = SNAPSHOT_PHYS_BASE + snapshot_budget_size;
+    store_snapshot_end(snapshot_end_for_cow);
+    // Use the full snapshot budget as the bitmap end. The host maps ALL pages in the budget,
+    // even if they're not occupied by kernel/initrd data. This ensures the frame allocator
+    // has free frames available for CoW resolution and kpool allocations.
+    let snapshot_end_address: usize = SNAPSHOT_PHYS_BASE + snapshot_budget_size;
+    info!("snapshot region: [{:#010x}, {:#010x})", SNAPSHOT_PHYS_BASE, snapshot_end_address);
+
+    // Register gap-filling reserved regions within the snapshot to ensure every snapshot
+    // frame is booked without overlapping with individually-registered sub-regions
+    // (kernel text/data/rodata/bss, PEB, heap padding, kpool, initrd modules from kmain).
+    //
+    // The two gaps are:
+    //   1. The initrd header page — multibinary descriptors before the first module payload.
+    //   2. The snapshot tail — host budget padding after the last module.
+    //
+    // When no init_data is present, the entire range from kpool_end to snapshot_end is a gap.
+    {
+        let kpool_end: usize = kpool_base + ::config::kernel::KPOOL_SIZE;
+        let peb: *const HyperlightPEB = peb_base as *const HyperlightPEB;
+        let init_data_start: usize = unsafe { (*peb).init_data.ptr } as usize;
+        let init_data_size: usize = unsafe { (*peb).init_data.size } as usize;
+
+        if init_data_size > 0 {
+            // Gap between kpool end and init_data start (if any alignment padding exists).
+            if init_data_start > kpool_end {
+                let gap_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+                    "kpool-initrd gap",
+                    VirtualAddress::from_raw_value(kpool_end),
+                    init_data_start - kpool_end,
+                    MemoryRegionType::Reserved,
+                    AccessPermission::RDONLY,
+                )?;
+                memory_regions.push_back(gap_region);
+            }
+
+            // For multibinary (NVMB) format, the first page of the init_data blob contains
+            // the header and entry descriptors. Module payloads start at page-aligned offsets
+            // after this header, leaving the header page as a gap not covered by any module
+            // region. For single-binary format, the module payload starts at byte 8 within
+            // the first page (after the size header), and kmain page-aligns downward so the
+            // first page IS part of the module — no gap to register.
+            let init_data_slice: &[u8] = unsafe {
+                core::slice::from_raw_parts(
+                    init_data_start as *const u8,
+                    init_data_size.min(multibin::MAGIC.len()),
+                )
+            };
+            let is_multibinary: bool = init_data_slice.len() >= multibin::MAGIC.len()
+                && init_data_slice[..multibin::MAGIC.len()] == multibin::MAGIC;
+            if is_multibinary {
+                let initrd_header_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+                    "initrd header",
+                    VirtualAddress::from_raw_value(init_data_start),
+                    mem::PAGE_SIZE,
+                    MemoryRegionType::Reserved,
+                    AccessPermission::RDONLY,
+                )?;
+                memory_regions.push_back(initrd_header_region);
+            }
+
+            // Snapshot tail: padding between the end of init_data and snapshot_end.
+            // The host allocates a full snapshot budget that may extend beyond the last module.
+            let init_data_end: usize = init_data_start + init_data_size;
+            let tail_start: usize =
+                ::sys::mm::align_up(init_data_end, PAGE_ALIGNMENT).unwrap_or(init_data_end);
+            if snapshot_end_address > tail_start {
+                let tail_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+                    "snapshot tail",
+                    VirtualAddress::from_raw_value(tail_start),
+                    snapshot_end_address - tail_start,
+                    MemoryRegionType::Reserved,
+                    AccessPermission::RDONLY,
+                )?;
+                memory_regions.push_back(tail_region);
+            }
+        } else if snapshot_end_address > kpool_end {
+            // No init_data — the entire range from kpool_end to snapshot_end is unused.
+            let gap_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+                "snapshot tail",
+                VirtualAddress::from_raw_value(kpool_end),
+                snapshot_end_address - kpool_end,
+                MemoryRegionType::Reserved,
+                AccessPermission::RDONLY,
+            )?;
+            memory_regions.push_back(gap_region);
+        }
+    }
+
+    // Register the host page tables area. This is the scratch region between the IO buffers
+    // and the scratch-reserved structures that holds the host-built page directory and page
+    // tables. No individually-named region covers it.
+    if host_pt_gva_end > io_buffers_end {
+        let host_pt_size: usize = host_pt_gva_end - io_buffers_end;
+        let host_pt_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+            "host page tables",
+            VirtualAddress::from_raw_value(io_buffers_end),
+            host_pt_size,
+            MemoryRegionType::Reserved,
+            AccessPermission::RDONLY,
+        )?;
+        memory_regions.push_back(host_pt_region);
+    }
+
+    // Register pre-faulted CoW pages. These are bump-allocated scratch frames consumed by
+    // `eager_prefault_cow_pages()`. They lie between the scratch-reserved structures and
+    // the boot stack area. The bump pointer (first_free_scratch_gpa) marks their end.
+    {
+        let prefault_start_gva: usize = scratch_reserved_base + SCRATCH_RESERVED_SIZE;
+        let prefault_end_gva: usize = gpa_to_gva(first_free_scratch_gpa());
+        if prefault_end_gva > prefault_start_gva {
+            let prefault_size: usize = prefault_end_gva - prefault_start_gva;
+            let prefault_region: MemoryRegion<VirtualAddress> = MemoryRegion::new(
+                "prefault pages",
+                VirtualAddress::from_raw_value(prefault_start_gva),
+                prefault_size,
+                MemoryRegionType::Reserved,
+                AccessPermission::RDWR,
+            )?;
+            memory_regions.push_back(prefault_region);
+        }
+    }
 
     // Build a sparse bitmap representing the physical memory layout.
     // Each disjoint physical region (snapshot, RAMFS, scratch) gets its own chunk in the
@@ -1387,13 +2006,17 @@ pub fn init(
     // The memory outlives the returned `SparseBitmap` (it is never freed) and no other
     // code writes to this range after this point.
     let physical_memory_layout: SparseBitmap = unsafe {
+        // Use GPAs for all regions. Snapshot and RAMFS are identity-mapped (GVA == GPA).
+        // Scratch GVA ≠ GPA; convert back to GPA for the frame allocator bitmap.
+        let scratch_base_gpa: usize = MAX_GPA + 1 - scratch_size;
+        let scratch_end_gpa: usize = MAX_GPA + 1;
         build_physical_memory_layout(
             KERNEL_BASE_RAW,
             snapshot_end_address,
             ramfs_base,
             ramfs_end_address,
-            scratch_base_address,
-            scratch_end_address,
+            scratch_base_gpa,
+            scratch_end_gpa,
             (frame_alloc_bitmap_ptr(scratch_reserved_base), FRAME_ALLOC_BITMAP_SIZE),
         )?
     };
@@ -1527,11 +2150,9 @@ unsafe fn build_physical_memory_layout(
     scratch_end_address: usize,
     storage: (*mut u8, usize),
 ) -> Result<SparseBitmap, Error> {
-    // Validate that region ends are not before their starts.
-    if snapshot_end_address < snapshot_start_address
-        || ramfs_end_address < ramfs_start_address
-        || scratch_end_address < scratch_start_address
-    {
+    // 32-bit address space (MAX_GVA + 1 overflows).  Use wrapping subtraction for
+    // scratch to handle this correctly.
+    if snapshot_end_address < snapshot_start_address || ramfs_end_address < ramfs_start_address {
         let reason: &str = "region end address precedes start address";
         error!("build_physical_memory_layout(): {}", reason);
         return Err(Error::new(ErrorCode::InvalidArgument, reason));
@@ -1540,7 +2161,7 @@ unsafe fn build_physical_memory_layout(
     let bits_per_byte: usize = u8::BITS as usize;
     let snapshot_size: usize = snapshot_end_address - snapshot_start_address;
     let ramfs_size: usize = ramfs_end_address - ramfs_start_address;
-    let scratch_size: usize = scratch_end_address - scratch_start_address;
+    let scratch_size: usize = scratch_end_address.wrapping_sub(scratch_start_address);
 
     let snapshot_frames: usize = snapshot_size / mem::FRAME_SIZE;
     let snapshot_padded_end: usize = snapshot_frames.div_ceil(bits_per_byte) * bits_per_byte;
@@ -1583,8 +2204,6 @@ unsafe fn build_physical_memory_layout(
 
     let scratch_frames: usize = scratch_size / mem::FRAME_SIZE;
     let scratch_bytes: usize = scratch_frames.div_ceil(bits_per_byte);
-    // Phantom bits are trailing padding bits in the byte-aligned bitmap that do not
-    // correspond to real frames. Pre-mark them as used so alloc() never returns them.
     let scratch_phantom: usize = scratch_bytes * bits_per_byte - scratch_frames;
 
     let total_bytes: usize = low_bytes + ramfs_bytes + scratch_bytes;
@@ -1600,37 +2219,46 @@ unsafe fn build_physical_memory_layout(
     }
 
     let base_ptr: *mut u8 = storage_ptr;
+    #[allow(unused_assignments)]
     let mut offset: usize = 0;
 
-    // Build a bitmap chunk from the shared storage at the current offset.
-    // `num_bytes` is the byte-aligned storage size, `num_frames` is the real frame count,
-    // and `num_phantom` is the number of trailing padding bits to pre-mark as used.
-    let mut make_chunk =
-        |num_bytes: usize, num_frames: usize, num_phantom: usize| -> Result<Bitmap, Error> {
-            let storage: RawArray<u8> = RawArray::from_raw_parts(base_ptr.add(offset), num_bytes)?;
+    // Helper: build a bitmap chunk from the shared storage at the current offset.
+    // Phantom bits (byte-alignment padding beyond the last real frame) are marked as used.
+    macro_rules! make_chunk {
+        ($num_bytes:expr, $num_frames:expr, $num_phantom:expr) => {{
+            let ptr = base_ptr.add(offset);
+            let storage: RawArray<u8> = RawArray::from_raw_parts(ptr, $num_bytes)?;
             let mut bitmap: Bitmap = Bitmap::from_raw_array(storage)?;
-            for i in 0..num_phantom {
-                bitmap.set(num_frames + i)?;
+            let nf: usize = $num_frames;
+            let np: usize = $num_phantom;
+            for i in 0..np {
+                bitmap.set(nf + i)?;
             }
-            offset += num_bytes;
-            Ok(bitmap)
-        };
+            #[allow(unused_assignments)]
+            {
+                offset += $num_bytes;
+            }
+            bitmap
+        }};
+    }
 
     // Low chunk: snapshot (and optionally RAMFS when merged).
     let snapshot_start_frame: usize = snapshot_start_address / mem::FRAME_SIZE;
-    let low_bitmap: Bitmap = make_chunk(low_bytes, low_end_frame, low_phantom)?;
+    let low_bitmap: Bitmap = make_chunk!(low_bytes, low_end_frame, low_phantom);
     let mut chunks: vec::Vec<(usize, Bitmap)> = vec![(snapshot_start_frame, low_bitmap)];
 
     // Separate RAMFS chunk (only when not merged with the snapshot).
     if ramfs_bytes > 0 {
-        let ramfs_bitmap: Bitmap = make_chunk(ramfs_bytes, ramfs_frames, ramfs_phantom)?;
+        let ramfs_bitmap: Bitmap = make_chunk!(ramfs_bytes, ramfs_frames, ramfs_phantom);
         chunks.push((ramfs_start_frame, ramfs_bitmap));
     }
 
-    // Scratch chunk: frames [scratch_start / FRAME_SIZE, ...).
+    // Scratch chunk: tracks frames in the scratch region so the frame allocator can
+    // hand them out. The bitmap uses GPAs.
     if scratch_frames > 0 {
-        let scratch_bitmap: Bitmap = make_chunk(scratch_bytes, scratch_frames, scratch_phantom)?;
-        chunks.push((scratch_start_address / mem::FRAME_SIZE, scratch_bitmap));
+        let scratch_start_frame: usize = scratch_start_address / mem::FRAME_SIZE;
+        let scratch_bitmap: Bitmap = make_chunk!(scratch_bytes, scratch_frames, scratch_phantom);
+        chunks.push((scratch_start_frame, scratch_bitmap));
     }
 
     SparseBitmap::new(chunks)
@@ -1726,19 +2354,11 @@ unsafe fn parse_initrd_image(
         read_initrd_cmdline(current_initrd_start, actual_initrd_size, total_allocation_size)?;
 
     // The ELF payload sits INITRD_SIZE_BYTES past the page-aligned init_data_start,
-    // so its address is not page-aligned.  Shift it back to init_data_start (the
-    // size header has already been consumed and is no longer needed).  The source
-    // and destination overlap, but core::ptr::copy handles that correctly.
-    let initrd_base: usize = init_data_start;
-    if current_initrd_start != initrd_base {
-        let src_ptr: *const u8 = current_initrd_start as *const u8;
-        let dst_ptr: *mut u8 = initrd_base as *mut u8;
-        core::ptr::copy(src_ptr, dst_ptr, actual_initrd_size);
-        debug!(
-            "parse_initrd_image(): initrd shifted from {current_initrd_start:#010x} to \
-             {initrd_base:#010x}"
-        );
-    }
+    // so its address is not page-aligned.  On microvm the payload is shifted back to
+    // init_data_start (the size header has already been consumed).  On hyperlight we
+    // cannot write to snapshot memory before the CoW handler is installed, so we skip
+    // the relocation and use the payload in-place.
+    let initrd_base: usize = current_initrd_start;
 
     Ok((initrd_base, actual_initrd_size, initrd_cmdline))
 }

--- a/src/kernel/src/hal/platform/hyperlight/peb.rs
+++ b/src/kernel/src/hal/platform/hyperlight/peb.rs
@@ -15,12 +15,9 @@
 //==================================================================================================
 
 use ::alloc::vec::Vec;
-use ::hyperlight_common::{
-    flatbuffer_wrappers::function_types::{
-        ParameterValue,
-        ReturnType,
-    },
-    mem::HyperlightPEB,
+use ::hyperlight_common::flatbuffer_wrappers::function_types::{
+    ParameterValue,
+    ReturnType,
 };
 use ::hyperlight_guest::guest_handle::handle::GuestHandle;
 use ::sys::error::{
@@ -29,36 +26,18 @@ use ::sys::error::{
 };
 
 //==================================================================================================
-// Global Variables
-//==================================================================================================
-
-pub(crate) static mut GUEST_HANDLE: GuestHandle = GuestHandle::new();
-
-//==================================================================================================
 // Process Environment Block
 //==================================================================================================
+
+/// Constructs a `GuestHandle` on demand from the PEB pointer, avoiding BSS writes.
+fn guest_handle() -> GuestHandle {
+    super::guest_handle()
+}
 
 #[derive(Debug)]
 pub struct ProcessEnvironmentBlock;
 
 impl ProcessEnvironmentBlock {
-    /// Initializes the process environment block.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe because it writes to the global `GUEST_HANDLE` static mutable.
-    ///
-    pub unsafe fn init(peb_base: *mut HyperlightPEB) -> Result<(), Error> {
-        if GUEST_HANDLE.peb().is_some() {
-            let reason: &'static str = "init: peb already initialized";
-            error!("{reason}");
-            Err(Error::new(ErrorCode::ResourceBusy, reason))
-        } else {
-            GUEST_HANDLE = GuestHandle::init(peb_base);
-            Ok(())
-        }
-    }
-
     ///
     /// # Description
     ///
@@ -87,14 +66,14 @@ impl ProcessEnvironmentBlock {
     pub unsafe fn get_credits() -> Result<u64, Error> {
         // Credits are stored at a fixed offset from the top of scratch memory.
         // The host writes here via GuestCounter; we read via volatile read.
-        // Use MAX_GPA (not MAX_GVA) because the guest runs with identity mapping
-        // (GVA == GPA) and the scratch KVM slot is placed relative to MAX_GPA.
+        // Use MAX_GVA because the kernel accesses scratch via the host-built
+        // page tables, which map scratch at GVA addresses derived from MAX_GVA.
         use ::hyperlight_common::layout::{
-            MAX_GPA,
+            MAX_GVA,
             SCRATCH_TOP_GUEST_COUNTER_OFFSET,
         };
-        let credits_gpa: usize = MAX_GPA - SCRATCH_TOP_GUEST_COUNTER_OFFSET as usize + 1;
-        let credits_ptr: *const u64 = credits_gpa as *const u64;
+        let credits_gva: usize = MAX_GVA - SCRATCH_TOP_GUEST_COUNTER_OFFSET as usize + 1;
+        let credits_ptr: *const u64 = credits_gva as *const u64;
         Ok(::core::ptr::read_volatile(credits_ptr))
     }
 
@@ -102,11 +81,11 @@ impl ProcessEnvironmentBlock {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it accesses the global `GUEST_HANDLE` static mutable.
+    /// This function is unsafe because it dereferences the PEB pointer.
     ///
     pub unsafe fn vmbus_write(data: &[u8]) -> Result<(), Error> {
         let failure_reason: &'static str = "vmbus_write: failed to write data";
-        let count: i32 = GUEST_HANDLE
+        let count: i32 = guest_handle()
             .call_host_function::<i32>(
                 "VmbusWrite",
                 Some(Vec::from(&[ParameterValue::VecBytes(Vec::from(data))])),
@@ -125,11 +104,11 @@ impl ProcessEnvironmentBlock {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it accesses the global `GUEST_HANDLE` static mutable.
+    /// This function is unsafe because it dereferences the PEB pointer.
     ///
     pub unsafe fn vmbus_bulk_write(data: &[u8]) -> Result<(), Error> {
         let failure_reason: &'static str = "vmbus_bulk_write: failed to write data";
-        let count: i32 = GUEST_HANDLE
+        let count: i32 = guest_handle()
             .call_host_function::<i32>(
                 "VmbusBulkWrite",
                 Some(Vec::from(&[ParameterValue::VecBytes(Vec::from(data))])),
@@ -148,11 +127,11 @@ impl ProcessEnvironmentBlock {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it accesses the global `GUEST_HANDLE` static mutable.
+    /// This function is unsafe because it dereferences the PEB pointer.
     ///
     pub unsafe fn vmbus_read() -> Result<Vec<u8>, Error> {
         let failure_reason: &'static str = "vmbus_read: failed to read data";
-        GUEST_HANDLE
+        guest_handle()
             .call_host_function::<Vec<u8>>("VmbusRead", None, ReturnType::VecBytes)
             .map_err(|_| Error::new(ErrorCode::IoErr, failure_reason))
     }
@@ -163,11 +142,11 @@ impl ProcessEnvironmentBlock {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it accesses the global `GUEST_HANDLE` static mutable.
+    /// This function is unsafe because it dereferences the PEB pointer.
     ///
     pub unsafe fn vmbus_bulk_read() -> Result<Vec<u8>, Error> {
         let failure_reason: &'static str = "vmbus_bulk_read: failed to read data";
-        GUEST_HANDLE
+        guest_handle()
             .call_host_function::<Vec<u8>>("VmbusBulkRead", None, ReturnType::VecBytes)
             .map_err(|_| Error::new(ErrorCode::IoErr, failure_reason))
     }
@@ -180,16 +159,16 @@ impl ProcessEnvironmentBlock {
     /// Returns `(snapshot_budget_size, pt_overhead, ramfs_base, ramfs_size, scratch_size)` as
     /// reported by the VMM. All values are in bytes. RAMFS fields are zero when no RAMFS
     /// is present. `snapshot_budget_size` is the deterministic snapshot size.
-    /// `pt_overhead` is always 0 with `nanvix-unstable` because Hyperlight skips
-    /// guest page-table generation; the field is reserved for forward-compatibility.
+    /// `pt_overhead` is the additional bytes occupied by host-built guest page tables
+    /// (non-zero with `i686-guest`; zero with `nanvix-unstable`).
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it accesses the global `GUEST_HANDLE` static mutable.
+    /// This function is unsafe because it dereferences the PEB pointer.
     ///
     pub unsafe fn get_memory_layout() -> Result<(usize, usize, usize, usize, usize), Error> {
         let failure_reason: &'static str = "get_memory_layout: failed to query host";
-        let bytes: Vec<u8> = GUEST_HANDLE
+        let bytes: Vec<u8> = guest_handle()
             .call_host_function::<Vec<u8>>("GetMemoryLayout", None, ReturnType::VecBytes)
             .map_err(|_| Error::new(ErrorCode::IoErr, failure_reason))?;
 

--- a/src/kernel/src/hal/platform/hyperlight/scratch_layout.rs
+++ b/src/kernel/src/hal/platform/hyperlight/scratch_layout.rs
@@ -92,7 +92,7 @@ macro_rules! scratch_layout {
     (@step $acc:expr; page_align = $page_align:expr;) => {
         /// Combined size of all scratch-resident kernel structures with inter-area padding,
         /// rounded up to a page boundary.
-        const SCRATCH_RESERVED_SIZE: usize = {
+        pub(super) const SCRATCH_RESERVED_SIZE: usize = {
             let raw: usize = $acc;
             match ::sys::mm::align_up(raw, $page_align) {
                 Some(v) => v,

--- a/src/kernel/src/hal/platform/hyperlight/start.rs
+++ b/src/kernel/src/hal/platform/hyperlight/start.rs
@@ -12,51 +12,56 @@ use ::hyperlight_common::outb::VmAction;
 // Bootstrap Section — BSP Entry Point
 //==================================================================================================
 
-// _do_start2 (entered from 16-bit trampoline, already in protected mode).
+// _do_start2 (entered from trampoline stub, already in 32-bit protected mode with paging).
 global_asm!(
     r#".section .bootstrap,"ax",@progbits"#,
 
     ".align 4",
     ".globl _do_start2",
     "_do_start2:",
-    "    mov $0x10, %dx",
-    "    mov %dx, %ds",
-    "    mov %dx, %es",
-    "    mov %dx, %fs",
-    "    mov %dx, %gs",
-    "    mov %dx, %ss",
+
+    // With Hyperlight stable (i686-guest), the host starts the vCPU in 32-bit
+    // protected mode with paging enabled and CR3 pointing to a host-built page
+    // directory.  Snapshot pages are mapped read-only (CoW via the KVM memory
+    // slot) and the scratch region is mapped read-write.  On i686,
+    // MAX_GVA == MAX_GPA, so scratch GVA == GPA — no address translation
+    // divergence.
+    //
+    // The host-built page tables are kept active:
+    //  - Do NOT disable paging.
+    //  - Do NOT build a PSE identity map.
+    //  - Do NOT reload segment registers (the CPU writes the Accessed bit into
+    //    the GDT entry on each load, and the GDT page is in the read-only
+    //    snapshot region — a write would fault before the early IDT is
+    //    installed).
+    //
+    // The cached segment descriptors set by the VMM are valid.
 
     // System V i386 ABI requires DF=0; set it once for all subsequent code.
     "    cld",
 
-    // EAX and EBX registers store boot information.
-
-    // Save boot info (EAX) before it is clobbered by the BSS clear below.
-    "    movl %eax, %edx",
-
-    // Fill BSS section with zeros.
-    "    movl $__BSS_START, %edi",
-    "    movl $__BSS_END, %ecx",
-    "    subl %edi, %ecx",
-    "    xorl %eax, %eax",
-    "    rep stosb",
-
-    "    movl %edx, %eax",
 
     // Set ESP directly to the scratch-backed boot stack.  BOOT_STACK_TOP is a
     // compile-time constant (top of the scratch region minus the two reserved
-    // pages), so no BSS-based temporary stack is needed.
+    // pages).  The stack must be established before the early IDT installation
+    // (below) which requires a valid stack pointer.
     "    movl ${BOOT_STACK_TOP}, %esp",
     "    movl %esp, %ebp",
 
-    // Save boot information on the scratch stack.  These values persist
-    // through init_scratch_kstack() and hyperlight_pre_kmain() and are
-    // later read by _nanvix_dispatch as KernelArguments.
+    // Save boot information (EAX=magic, EBX=info) on the scratch-backed stack.
+    // These values persist through all function calls and are later read by
+    // _nanvix_dispatch as KernelArguments.
     "    push %ebx",
     "    push %eax",
 
-    // Patch PEB GVA→GPA pointers.
-    "    call init_scratch_kstack",
+    // Install a minimal early IDT with only the page-fault vector (14) wired to
+    // the CoW handler stub.  Any write to a snapshot (read-only) page triggers a
+    // CoW page fault which the handler resolves by allocating a scratch frame,
+    // copying the page, and remapping the PTE as writable.
+    "    call install_early_idt",
+
+    // NOTE: BSS is zeroed by the Hyperlight VMM before the guest starts;
+    // no explicit clear is needed here.
 
     // Clear all general purpose registers for deterministic startup.
     "    xorl %eax, %eax",

--- a/src/kernel/src/hal/platform/hyperlight/start16.rs
+++ b/src/kernel/src/hal/platform/hyperlight/start16.rs
@@ -2,48 +2,68 @@
 // Licensed under the MIT License.
 
 //==================================================================================================
-// x86 16-bit Trampoline Code (Hyperlight)
+// x86 Trampoline Code (Hyperlight)
 //==================================================================================================
 //
-// This module contains 16-bit real-mode code placed in the `.trampoline` section at physical
-// address 0x8000. It provides:
-//   - `_do_start`: non-multiboot BSP entry (16-bit → protected mode → `_do_start2`)
-//   - `_ap_trampoline`: AP startup (16-bit → protected mode → `_do_ap_start`)
-//   - A minimal GDT (null + code + data) used during the real→protected mode transition.
+// This module contains code placed in the `.entry` and `.trampoline` sections:
+//
+//   - `_entry`: Jump stub at PLATFORM_BASE_ADDR (0x1000). Hyperlight starts execution here.
+//   - `_do_start`: BSP entry — 32-bit protected mode, jumps to `_do_start2`.
+//   - `_ap_trampoline` (SMP only): AP startup (16-bit → protected mode → `_do_ap_start`).
+//
+// With `i686-guest`, the VMM starts the BSP in 32-bit protected mode with paging enabled.
+// Segment registers are loaded by the VMM via `set_sregs()` with flat descriptors.  Page
+// tables are built by the VMM in the snapshot region and **copied** to scratch before the
+// guest starts; CR3 points to the scratch copy (RW).  No GDT load is needed on the BSP
+// path — the VMM-provided segment descriptors are used as-is.
 //
 
 use core::arch::global_asm;
 
 //==================================================================================================
-// Trampoline Section — BSP Entry
+// Entry Section — Jump stub at PLATFORM_BASE_ADDR
 //==================================================================================================
+//
+// On Hyperlight, the VMM starts execution at BASE_ADDRESS (PLATFORM_BASE_ADDR = 0x1000),
+// not at the ELF entry point. This stub is placed at the very first byte of the loaded image
+// and immediately jumps to `_do_start` in the trampoline section.
 
 global_asm!(
-    r#".section .trampoline,"ax",@progbits"#,
-    ".code16",
-    ".align 4",
-    ".globl _do_start",
-    "_do_start:",
-    // Zero data segment registers.
-    "    xorw  %dx,%dx",
-    "    movw  %dx,%ds",
-    "    movw  %dx,%es",
-    "    movw  %dx,%fs",
-    "    movw  %dx,%gs",
-    "    movw  %dx,%ss",
-    "    lgdt  gdtptr",
-    "    movl  %cr0, %edx",
-    "    orl   $1, %edx",
-    "    mov   %edx, %cr0",
-    ".extern _do_start2",
-    "    jmpl $0x8, $_do_start2",
+    r#".section .entry,"ax",@progbits"#,
+    ".code32",
+    ".globl _entry",
+    "_entry:",
+    "    jmp _do_start",
     options(att_syntax),
 );
 
 //==================================================================================================
-// Trampoline Section — AP Trampoline
+// Trampoline Section — BSP Entry (32-bit protected mode stub)
 //==================================================================================================
 
+global_asm!(
+    r#".section .trampoline,"ax",@progbits"#,
+    ".code32",
+    ".align 4",
+    ".globl _do_start",
+    "_do_start:",
+    // With Hyperlight stable (i686-guest), the host starts the vCPU directly
+    // in 32-bit protected mode with paging enabled.  The VMM already loaded
+    // valid flat segment descriptors via set_sregs() and CR3 points to the
+    // host-built page tables (copied to scratch, RW).  No GDT load is needed.
+    ".extern _do_start2",
+    "    jmp   _do_start2",
+    options(att_syntax),
+);
+
+//==================================================================================================
+// Trampoline Section — AP Trampoline and GDT (SMP only)
+//==================================================================================================
+//
+// The AP trampoline and its supporting GDT are only needed for multi-core startup.
+// SMP boot on Hyperlight is out of scope for the current integration.
+
+#[cfg(feature = "smp")]
 global_asm!(
     r#".section .trampoline,"ax",@progbits"#,
     ".code16",
@@ -66,10 +86,7 @@ global_asm!(
     options(att_syntax),
 );
 
-//==================================================================================================
-// Trampoline Section — GDT
-//==================================================================================================
-
+#[cfg(feature = "smp")]
 global_asm!(
     r#".section .trampoline,"ax",@progbits"#,
     ".p2align 2",

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -418,6 +418,28 @@ pub fn get_kstack_guard_base() -> usize {
     unsafe { &kstack_guard as *const u8 as usize }
 }
 
+/// Translates a guest virtual address to a guest physical address.
+///
+/// On microvm, GVA == GPA (identity-mapped).
+pub fn gva_to_gpa(gva: usize) -> usize {
+    gva
+}
+
+/// Translates a guest physical address to a guest virtual address.
+///
+/// On microvm, GPA == GVA (identity-mapped).
+#[allow(dead_code)]
+pub fn gpa_to_gva(gpa: usize) -> usize {
+    gpa
+}
+
+/// Returns `true` if the given GVA falls within a scratch region.
+///
+/// On microvm there is no scratch region, so this always returns `false`.
+pub fn is_scratch_address(_gva: usize) -> bool {
+    false
+}
+
 ///
 /// # Description
 ///
@@ -889,4 +911,13 @@ pub fn init(
         physical_memory_layout: Some(physical_memory_layout),
         kpool_bitmap: Some(kpool_bitmap),
     })
+}
+
+/// Translates a virtual address to a physical address.
+///
+/// On microvm the kernel uses a flat identity map (VA == PA), so this
+/// function returns the address unchanged.
+#[inline(always)]
+pub fn virt_to_phys(vaddr: usize) -> usize {
+    vaddr
 }

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -329,10 +329,19 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     // Add kernel modules to list of memory regions.
     for module in kernel_modules.iter() {
         let name: &str = module.cmdline();
-        let start: VirtualAddress = module.start().into_virtual_address();
+        let raw_start: usize = module.start().into_virtual_address().into_raw_value();
         let size: usize = module.size();
+        // Page-align the region: round start down and end up to page boundaries.
+        // The module payload may start at an offset within a page (e.g., after a size header).
+        let page_start: usize = raw_start & !(arch::mem::PAGE_SIZE - 1);
+        let page_end: usize =
+            (raw_start + size + arch::mem::PAGE_SIZE - 1) & !(arch::mem::PAGE_SIZE - 1);
+        let start: VirtualAddress = VirtualAddress::from_raw_value(page_start);
+        let aligned_size: usize = page_end - page_start;
         let typ: MemoryRegionType = MemoryRegionType::Reserved;
-        if let Ok(region) = MemoryRegion::new(name, start, size, typ, AccessPermission::RDONLY) {
+        if let Ok(region) =
+            MemoryRegion::new(name, start, aligned_size, typ, AccessPermission::RDONLY)
+        {
             memory_regions.push_back(region);
         }
     }

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -12,11 +12,8 @@
 //==================================================================================================
 
 pub mod elf;
-mod phys;
+pub(crate) mod phys;
 mod virt;
-
-#[cfg(feature = "hyperlight")]
-pub(crate) use virt::memcpy;
 
 //==================================================================================================
 // Exports
@@ -65,7 +62,6 @@ use ::alloc::{
     vec::Vec,
 };
 use ::arch::mem;
-use ::core::panic;
 use ::sparse_bitmap::SparseBitmap;
 use ::sys::error::Error;
 
@@ -215,13 +211,41 @@ fn parse_memory_regions(
         if region.typ() == MemoryRegionType::Reserved || region.typ() == MemoryRegionType::Mmio {
             if PhysicalAddress::from_virtual_address(region.start()).is_ok() {
                 if region.typ() != MemoryRegionType::Usable {
-                    match TruncatedMemoryRegion::from_virtual_memory_region(region.clone()) {
-                        Ok(region) => physical_memory_regions.push_back(region),
-                        // TODO: make memory regions a truncated list so round logic is handled when region is created.
-                        Err(err) => panic!(
-                            "failed to create physical memory region {:?} (error={:?})",
-                            region, err
-                        ),
+                    // On Hyperlight, scratch GVAs are NOT identity-mapped (GVA ≠ GPA).
+                    // Skip physical frame booking for scratch-region addresses — they are
+                    // managed by the host and the bump allocator, not the kernel frame allocator.
+                    // On microvm this always returns false (no scratch region).
+                    let in_scratch: bool =
+                        crate::hal::platform::is_scratch_address(region.start().into_raw_value());
+
+                    if !in_scratch {
+                        match TruncatedMemoryRegion::from_virtual_memory_region(region.clone()) {
+                            Ok(region) => physical_memory_regions.push_back(region),
+                            Err(err) => panic!(
+                                "failed to create physical memory region {:?} (error={:?})",
+                                region, err
+                            ),
+                        }
+                    } else {
+                        // Scratch: translate GVA→GPA and create the physical region
+                        // with the correct physical address for frame allocator booking.
+                        let gpa: usize =
+                            crate::hal::platform::gva_to_gpa(region.start().into_raw_value());
+                        if let Ok(phys_start) = PageAligned::from_raw_value(gpa) {
+                            match TruncatedMemoryRegion::new(
+                                &region.name(),
+                                phys_start,
+                                region.size(),
+                                region.typ(),
+                                region.perm(),
+                            ) {
+                                Ok(pr) => physical_memory_regions.push_back(pr),
+                                Err(err) => warn!(
+                                    "failed to create scratch physical region {:?} (error={:?})",
+                                    region, err
+                                ),
+                            }
+                        }
                     }
                 }
                 virtual_memory_regions
@@ -269,7 +293,7 @@ pub fn init(
     let kpool_base: PageAligned<PhysicalAddress> =
         PageAligned::<PhysicalAddress>::from_raw_value(kimage.kpool().start().into_raw_value())?;
 
-    let (mut other_virtual_memory_regions, virtual_memory_regions, physical_memory_regions): (
+    let (other_virtual_memory_regions, virtual_memory_regions, physical_memory_regions): (
         VirtMemRegions,
         VirtMemRegions,
         PhysMemRegions,
@@ -286,7 +310,20 @@ pub fn init(
     #[cfg(feature = "test")]
     phys::test();
 
-    // FIXME: the initial list of kernel pages should be spit out by the initialization.
+    init_vmem(virtual_memory_regions, other_virtual_memory_regions, mmio_regions)
+}
+
+/// Microvm virtual memory initialization.
+///
+/// Builds identity-mapped page tables via [`virt::init`], creates the root address space, loads
+/// CR3, and maps any virtual memory regions that lie outside physical memory (e.g., MMIO pages
+/// above `MEMORY_SIZE`).
+#[cfg(feature = "microvm")]
+fn init_vmem(
+    virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    mut other_virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    mmio_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+) -> Result<Vmem, Error> {
     let (kernel_pages, kernel_page_tables): (
         LinkedList<KernelPage>,
         LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>,
@@ -335,4 +372,21 @@ pub fn init(
     }
 
     Ok(vmem)
+}
+
+/// Hyperlight virtual memory initialization.
+///
+/// On Hyperlight the host-built page tables are used directly — the kernel does not create its
+/// own identity map or switch CR3. Only a root [`Vmem`] descriptor is created so the process
+/// manager can clone it for user processes.
+#[cfg(feature = "hyperlight")]
+fn init_vmem(
+    _virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    _other_virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    _mmio_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+) -> Result<Vmem, Error> {
+    let kernel_pages: LinkedList<KernelPage> = LinkedList::new();
+    let kernel_page_tables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)> =
+        LinkedList::new();
+    VirtMemoryManager::init(kernel_pages, kernel_page_tables)
 }

--- a/src/kernel/src/mm/phys/mod.rs
+++ b/src/kernel/src/mm/phys/mod.rs
@@ -60,7 +60,12 @@ fn book_physical_memory_regions(
 
     // Book physical memory that is not usable.
     for region in physical_memory_regions.iter() {
-        info!("booking: {:?}", region);
+        info!(
+            "booking: {} @ {:#010x} (size={:#x})",
+            region.name(),
+            region.start().into_raw_value(),
+            region.size()
+        );
         frame::alloc_range(region)?;
     }
 
@@ -78,10 +83,16 @@ fn book_mmio_regions(
         let mut start: usize = region.start().into_raw_value();
         let end: usize = start + (region.size() - 1);
         while start < end {
-            let mmio_addr: VirtualAddress = VirtualAddress::from_raw_value(start);
-            let phys_addr: PageAligned<PhysicalAddress> = PageAligned::from_address(unsafe {
-                PhysicalAddress::from_mmio_address(mmio_addr)?
-            })?;
+            // Translate GVA→GPA so scratch-region MMIO addresses map to the correct
+            // frame allocator index. On microvm this is identity.
+            let gpa: usize = crate::hal::platform::gva_to_gpa(start);
+            let phys_addr: PageAligned<PhysicalAddress> = match PageAligned::from_raw_value(gpa) {
+                Ok(pa) => pa,
+                Err(_) => {
+                    start += mem::FRAME_SIZE;
+                    continue;
+                },
+            };
 
             // Attempt to book underlying frame.
             match frame::book(phys_addr) {

--- a/src/kernel/src/mm/virt/kpage.rs
+++ b/src/kernel/src/mm/virt/kpage.rs
@@ -73,6 +73,7 @@ impl KernelPage {
     ///
     /// The frame address of the target kernel page.
     ///
+    #[cfg_attr(feature = "hyperlight", allow(dead_code))]
     pub fn frame_address(&self) -> FrameAddress {
         self.kframe.base()
     }

--- a/src/kernel/src/mm/virt/mod.rs
+++ b/src/kernel/src/mm/virt/mod.rs
@@ -5,14 +5,25 @@
 // Modules
 //==================================================================================================
 
+#[cfg(feature = "microvm")]
 mod identity_map;
 mod kpage;
 mod manager;
+#[cfg(feature = "hyperlight")]
+mod no_identity_map;
 mod page_table_allocator;
 mod vmem;
 
-#[cfg(feature = "hyperlight")]
+#[cfg(feature = "microvm")]
+use identity_map::init as identity_map_init;
+#[cfg(feature = "microvm")]
 pub(crate) use identity_map::memcpy;
+#[cfg(feature = "microvm")]
+use identity_map::memset;
+#[cfg(feature = "hyperlight")]
+pub(crate) use no_identity_map::memcpy;
+#[cfg(feature = "hyperlight")]
+use no_identity_map::memset;
 
 //==================================================================================================
 // Imports
@@ -87,6 +98,11 @@ pub enum PageTableStorage {
     Bss(&'static mut [PteWord; PAGE_TABLE_LENGTH]),
     /// Runtime storage backed by a kernel page from the page pool.
     KernelPage(KernelPage),
+    /// Host-built page table inherited from a pre-existing address space (e.g., Hyperlight).
+    /// The memory is in the scratch region and is not owned by the kernel — it must not be
+    /// freed on drop.
+    #[cfg_attr(not(feature = "hyperlight"), allow(dead_code))]
+    Inherited(*mut PteWord),
 }
 
 impl Deref for PageTableStorage {
@@ -99,6 +115,7 @@ impl Deref for PageTableStorage {
                 let base: *const PteWord = page.base().into_raw_value() as *const PteWord;
                 unsafe { core::slice::from_raw_parts(base, PAGE_TABLE_LENGTH) }
             },
+            Self::Inherited(ptr) => unsafe { core::slice::from_raw_parts(*ptr, PAGE_TABLE_LENGTH) },
         }
     }
 }
@@ -110,6 +127,9 @@ impl DerefMut for PageTableStorage {
             Self::KernelPage(page) => {
                 let base: *mut PteWord = page.base().into_raw_value() as *mut PteWord;
                 unsafe { core::slice::from_raw_parts_mut(base, PAGE_TABLE_LENGTH) }
+            },
+            Self::Inherited(ptr) => unsafe {
+                core::slice::from_raw_parts_mut(*ptr, PAGE_TABLE_LENGTH)
             },
         }
     }
@@ -153,6 +173,7 @@ impl DerefMut for PageDirectoryStorage {
 //==================================================================================================
 
 // FIXME: this function is too long and complex.
+#[cfg_attr(feature = "hyperlight", allow(dead_code))]
 pub fn init(
     mut virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
     mut mmio_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,

--- a/src/kernel/src/mm/virt/no_identity_map.rs
+++ b/src/kernel/src/mm/virt/no_identity_map.rs
@@ -1,0 +1,123 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//!
+//! # Hyperlight GPA→GVA Translation Backend
+//!
+//! On Hyperlight, GVA ≠ GPA for scratch-region frames. Every physical address must be translated
+//! to a guest virtual address via [`gpa_to_gva`](crate::hal::platform::gpa_to_gva) before the CPU
+//! can access it. The translation offset differs between the snapshot region (identity, GVA == GPA)
+//! and the scratch region (constant delta), so a multi-page operation that crosses a region boundary
+//! requires a fresh translation at each page. This backend processes copies and fills one page at a
+//! time to guarantee correctness regardless of the physical layout.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::hal::{
+    arch::x86::{
+        fast_memcpy,
+        fast_memset,
+    },
+    platform::gpa_to_gva,
+};
+use ::arch::mem;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+
+//==================================================================================================
+// Public API
+//==================================================================================================
+
+/// Copies bytes between two physical memory regions, translating GPAs to GVAs page-by-page.
+pub(crate) fn memcpy(dst: *mut u8, src: *const u8, size: usize) -> Result<(), Error> {
+    if size == 0 {
+        return Ok(());
+    }
+
+    let dst_start: usize = dst as usize;
+    let src_start: usize = src as usize;
+    let dst_end: usize = dst_start.checked_add(size).ok_or_else(|| {
+        error!("memcpy(): destination range overflows (dst={dst_start:#x}, size={size:#x})");
+        Error::new(ErrorCode::BadAddress, "memcpy(): destination range overflows")
+    })?;
+    let src_end: usize = src_start.checked_add(size).ok_or_else(|| {
+        error!("memcpy(): source range overflows (src={src_start:#x}, size={size:#x})");
+        Error::new(ErrorCode::BadAddress, "memcpy(): source range overflows")
+    })?;
+
+    // Check if copy ranges overlap.
+    if (dst_start..dst_end).contains(&src_start) || (src_start..src_end).contains(&dst_start) {
+        error!(
+            "memcpy(): source and destination ranges overlap (dst={dst_start:#x}, \
+             src={src_start:#x}, size={size:#x})"
+        );
+        return Err(Error::new(
+            ErrorCode::BadAddress,
+            "memcpy(): source and destination ranges overlap",
+        ));
+    }
+
+    // Copy page-by-page, translating GPA→GVA at each page boundary so that region
+    // crossings (snapshot ↔ scratch) are handled correctly.
+    let mut src_gpa: usize = src as usize;
+    let mut dst_gpa: usize = dst as usize;
+    let mut remaining: usize = size;
+
+    while remaining > 0 {
+        // The chunk size is the minimum of: bytes left, bytes to end of src page,
+        // and bytes to end of dst page.
+        let src_page_rem: usize = mem::PAGE_SIZE - (src_gpa & (mem::PAGE_SIZE - 1));
+        let dst_page_rem: usize = mem::PAGE_SIZE - (dst_gpa & (mem::PAGE_SIZE - 1));
+        let chunk: usize = remaining.min(src_page_rem).min(dst_page_rem);
+
+        let src_gva: *const u8 = gpa_to_gva(src_gpa) as *const u8;
+        let dst_gva: *mut u8 = gpa_to_gva(dst_gpa) as *mut u8;
+
+        // SAFETY: the host page tables map both GVAs to valid physical frames after
+        // eager pre-faulting. The overlap check above guarantees non-overlapping ranges.
+        // The chunk never exceeds PAGE_SIZE, so no page boundary is crossed.
+        unsafe { fast_memcpy(dst_gva, src_gva, chunk) };
+
+        src_gpa += chunk;
+        dst_gpa += chunk;
+        remaining -= chunk;
+    }
+
+    Ok(())
+}
+
+/// Fills bytes in a physical memory range, translating GPAs to GVAs page-by-page.
+pub(crate) fn memset(base: *mut u8, value: u8, size: usize) -> Result<(), Error> {
+    if size == 0 {
+        return Ok(());
+    }
+
+    let base_start: usize = base as usize;
+    base_start.checked_add(size).ok_or_else(|| {
+        error!("memset(): target range overflows (base={base_start:#x}, size={size:#x})");
+        Error::new(ErrorCode::BadAddress, "memset(): target range overflows")
+    })?;
+
+    // Fill page-by-page, translating GPA→GVA at each page boundary.
+    let mut gpa: usize = base as usize;
+    let mut remaining: usize = size;
+
+    while remaining > 0 {
+        let page_rem: usize = mem::PAGE_SIZE - (gpa & (mem::PAGE_SIZE - 1));
+        let chunk: usize = remaining.min(page_rem);
+        let gva: *mut u8 = gpa_to_gva(gpa) as *mut u8;
+
+        // SAFETY: the host page tables map the GVA to a valid physical frame after
+        // eager pre-faulting.
+        unsafe { fast_memset(gva, value, chunk) };
+
+        gpa += chunk;
+        remaining -= chunk;
+    }
+
+    Ok(())
+}

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -20,7 +20,6 @@ use crate::{
             FrameAddress,
             PageAddress,
             PageAligned,
-            PageDirectoryAddress,
             PageTableAddress,
             PageTableAligned,
             PhysicalAddress,
@@ -41,23 +40,15 @@ use ::alloc::{
     collections::LinkedList,
     rc::Rc,
 };
-use ::arch::{
-    cpu::cr3::{
-        Cr3Register,
-        PageDirectoryBaseAddress as Cr3PageDirectoryBaseAddress,
-        PageLevelCacheDisableFlag,
-        PageLevelWriteThroughFlag,
+use ::arch::mem::{
+    self,
+    paging::{
+        PageDirectoryEntry,
+        PteWord,
     },
-    mem::{
-        self,
-        paging::{
-            PageDirectoryEntry,
-            PteWord,
-        },
-        PAGE_ALIGNMENT,
-        PAGE_TABLE_LENGTH,
-        PGTAB_ALIGNMENT,
-    },
+    PAGE_ALIGNMENT,
+    PAGE_TABLE_LENGTH,
+    PGTAB_ALIGNMENT,
 };
 use ::core::cell::RefCell;
 use ::sys::{
@@ -128,21 +119,81 @@ impl Vmem {
             kpage_tables.push_back(Rc::new(RefCell::new((vaddr, page_table))));
         }
 
-        // Register kernel PD for lazy identity mapping. On x86, the PD is also the CR3 root.
-        let pd_paddr_raw: usize = pgdir.physical_address()?.into_raw_value();
-        let pd_paddr: PageDirectoryAddress = PageDirectoryAddress::from_raw_value(pd_paddr_raw)?;
-        let kernel_cr3: Cr3Register = Cr3Register {
-            page_level_write_through: PageLevelWriteThroughFlag::Disabled,
-            page_level_cache_disable: PageLevelCacheDisableFlag::Enabled,
-            paging_structure_base_address: Cr3PageDirectoryBaseAddress::new(pd_paddr_raw as u32)
+        // On Hyperlight, inherit host-built page directory entries so that scratch-region
+        // mappings (I/O buffers, boot stack, kernel data/BSS/kpool) remain accessible.
+        // The host PD (in CR3) has the correct GVA→scratch GPA mappings after eager
+        // pre-faulting. Inheriting them into the root PD enables Vmem::clone to propagate
+        // these mappings to user-process PDs.
+        // On microvm, register the kernel PD for lazy identity mapping and set CR3.
+        #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+        {
+            use ::arch::mem::paging::PresentFlag;
+
+            let host_pd_ptr: *const PteWord = crate::hal::platform::get_root_pd_ptr();
+            unsafe {
+                pgdir.inherit_from(host_pd_ptr);
+            }
+
+            // Wrap each inherited host-built page table as a tracked kernel page table so that
+            // kctrl() can find and modify PTEs for MMIO permission changes.
+            // Walk the host PD and create an Inherited PageTableStorage for every present PDE
+            // that was not already registered by the kernel (i.e., not in kpage_tables).
+            unsafe {
+                for i in 0..PAGE_TABLE_LENGTH {
+                    let pde: PteWord = *host_pd_ptr.add(i);
+                    if !PresentFlag::is_set(pde) {
+                        continue;
+                    }
+
+                    let pt_gpa: usize = (pde & 0xFFFFF000) as usize;
+                    let pt_gva: usize = crate::hal::platform::gpa_to_gva(pt_gpa);
+                    let pt_vaddr: usize = i * mem::PGTAB_SIZE;
+                    let pt_addr: PageTableAddress =
+                        PageTableAddress::new(PageTableAligned::from_raw_value(pt_vaddr)?);
+
+                    // Skip if already tracked (e.g., registered by the kernel's own init path).
+                    let already_tracked: bool = kpage_tables
+                        .iter()
+                        .any(|entry| entry.borrow().0.into_raw_value() == pt_vaddr);
+                    if already_tracked {
+                        continue;
+                    }
+
+                    let storage: PageTableStorage =
+                        PageTableStorage::Inherited(pt_gva as *mut PteWord);
+                    let page_table: PageTable<PageTableStorage> = PageTable::from_existing(storage);
+                    kpage_tables.push_back(Rc::new(RefCell::new((pt_addr, page_table))));
+                }
+            }
+        }
+
+        #[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+        {
+            use crate::hal::mem::PageDirectoryAddress;
+            use ::arch::cpu::cr3::{
+                Cr3Register,
+                PageDirectoryBaseAddress as Cr3PageDirectoryBaseAddress,
+                PageLevelCacheDisableFlag,
+                PageLevelWriteThroughFlag,
+            };
+            let pd_paddr_raw: usize = pgdir.physical_address()?.into_raw_value();
+            let pd_paddr: PageDirectoryAddress =
+                PageDirectoryAddress::from_raw_value(pd_paddr_raw)?;
+            let kernel_cr3: Cr3Register = Cr3Register {
+                page_level_write_through: PageLevelWriteThroughFlag::Disabled,
+                page_level_cache_disable: PageLevelCacheDisableFlag::Enabled,
+                paging_structure_base_address: Cr3PageDirectoryBaseAddress::new(
+                    pd_paddr_raw as u32,
+                )
                 .ok_or_else(|| {
                     Error::new(
                         ErrorCode::BadAddress,
                         "kernel page directory address is not 4 KB aligned",
                     )
                 })?,
-        };
-        super::identity_map::init(pd_paddr, kernel_cr3);
+            };
+            super::identity_map_init(pd_paddr, kernel_cr3);
+        }
 
         // Store root pages.
         let mut kpages: LinkedList<Rc<RefCell<KernelPage>>> = LinkedList::new();
@@ -174,6 +225,14 @@ impl Vmem {
             // FIXME: do not be so open about permissions.
             pgdir.map(entry.borrow().0, page_table_address, false, AccessPermission::RDWR)?;
             kernel_page_tables.push_back(entry.clone());
+        }
+
+        // On platforms that provide a root virtual address space via platform-provided page tables,
+        // inherit the entries from the source page directory so that the kernel retains access to
+        // host-provided mappings after the CR3 switch.
+        #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+        unsafe {
+            pgdir.inherit_from(from.pgdir.as_ptr());
         }
 
         // Store root pages.
@@ -215,6 +274,7 @@ impl Vmem {
     ///
     /// Upon success, empty is returned. Upon failure, an error code is returned instead.
     ///
+    #[cfg_attr(feature = "hyperlight", allow(dead_code))]
     pub fn map_kpage<T: Fn() -> Result<PageTable<PageTableStorage>, Error>>(
         &mut self,
         kpage: KernelPage,
@@ -725,7 +785,7 @@ impl Vmem {
 
                 if !dry_run {
                     // Copy memory from user space to kernel space.
-                    super::identity_map::memcpy(
+                    super::memcpy(
                         dst.into_raw_value() as *mut u8,
                         (src_frame.into_raw_value() + offset) as *const u8,
                         copy_size,
@@ -890,8 +950,7 @@ impl Vmem {
                 // Copy memory from kernel space to user space.
                 let dst: *mut u8 = (dst_frame.into_raw_value() + offset) as *mut u8;
                 let src: *const u8 = src.into_raw_value() as *const u8;
-                let copy_result: Result<(), Error> =
-                    super::identity_map::memcpy(dst, src, copy_size);
+                let copy_result: Result<(), Error> = super::memcpy(dst, src, copy_size);
                 if let Err(error) = copy_result {
                     let reason: &str = "failed to perform physical memory copy";
                     panic!(
@@ -1032,11 +1091,7 @@ impl Vmem {
                     // mappings for the full source and destination ranges before copying.
                     let src_phys_addr: usize = src_frame.into_raw_value() + src_offset;
                     let dst_phys_addr: usize = dst_frame.into_raw_value() + dst_offset;
-                    super::identity_map::memcpy(
-                        dst_phys_addr as *mut u8,
-                        src_phys_addr as *const u8,
-                        copy_size,
-                    )?;
+                    super::memcpy(dst_phys_addr as *mut u8, src_phys_addr as *const u8, copy_size)?;
                 }
 
                 remaining -= copy_size;
@@ -1080,7 +1135,7 @@ impl Vmem {
         let dst: PageAligned<PhysicalAddress> = uframe.into_physical_address();
         let base: *mut u8 = dst.into_raw_value() as *mut u8;
 
-        super::identity_map::memset(base, value as u8, mem::PAGE_SIZE)?;
+        super::memset(base, value as u8, mem::PAGE_SIZE)?;
 
         Ok(())
     }
@@ -1299,12 +1354,41 @@ impl Vmem {
         let page_address: PageAddress = PageAddress::new(vaddr);
 
         if dry_run {
-            page_table.borrow().1.lookup(page_address)?;
+            // For dry-run validation, check if the PTE is present or can be created.
+            // On Hyperlight, inherited page tables may not have PTEs for identity-mapped
+            // regions (e.g., RAMFS) that were added after the host built the page tables.
+            // In that case, the PTE will be created on the non-dry-run pass.
+            let pt_ref = page_table.borrow();
+            match pt_ref.1.is_page_present(page_address) {
+                Ok(true) => {},
+                // PTE absent — will be created in the non-dry-run pass.
+                Ok(false) => {},
+                Err(e) => return Err(e),
+            }
         } else {
-            page_table
-                .borrow_mut()
-                .1
-                .ctrl(false, page_address, access)?;
+            let mut pt_mut = page_table.borrow_mut();
+            // If the PTE is not present, create an identity-mapped entry first.
+            // This handles Hyperlight's inherited page tables where the host didn't
+            // create PTEs for regions added after snapshot page table construction
+            // (e.g., RAMFS identity-mapped via a separate KVM memory slot).
+            match pt_mut.1.is_page_present(page_address) {
+                Ok(false) => {
+                    let frame_addr: FrameAddress =
+                        FrameAddress::new(PageAligned::from_raw_value(vaddr.into_raw_value())?);
+                    pt_mut.1.map(
+                        page_address,
+                        frame_addr,
+                        false, // user-accessible (MMIO regions are mapped for user processes)
+                        false, // not write-through
+                        true,  // cache enabled
+                        access,
+                    )?;
+                },
+                Ok(true) => {
+                    pt_mut.1.ctrl(false, page_address, access)?;
+                },
+                Err(e) => return Err(e),
+            }
         }
 
         Ok(())

--- a/src/libs/config/src/lib.rs
+++ b/src/libs/config/src/lib.rs
@@ -114,6 +114,25 @@ pub mod memory_layout {
             pub const HYPERLIGHT_BOOT_STACK_TOP: usize =
                 HYPERLIGHT_GPA_CEILING - 2 * crate::hyperlight::PAGE_SIZE;
 
+            ///
+            /// # Description
+            ///
+            /// Base address for the early IDT used during boot before the full IDT is installed.
+            /// Placed just below the boot stack guard page so that the early IDT has a known
+            /// fixed location in memory that does not overlap the boot stack or scratch region.
+            ///
+            pub const HYPERLIGHT_EARLY_IDT_BASE: usize = HYPERLIGHT_BOOT_STACK_TOP - crate::kernel::KSTACK_SIZE - crate::hyperlight::PAGE_SIZE;
+
+            ///
+            /// # Description
+            ///
+            /// Base address for the early GDT used during boot. Placed just below the early IDT
+            /// page so that it has a known, fixed location in the scratch region. The GDT must
+            /// be in writable memory so the CPU can set the Accessed bit in GDT entries during
+            /// segment loads (including exception delivery).
+            ///
+            pub const HYPERLIGHT_EARLY_GDT_BASE: usize = HYPERLIGHT_EARLY_IDT_BASE - crate::hyperlight::PAGE_SIZE;
+
             /// Alignment for the exclusive upper bound of the user virtual address space.
             pub const USER_END_ALIGNMENT: usize = 4 * 1024 * 1024;
 

--- a/src/uservm/src/vmm/hyperlight/mod.rs
+++ b/src/uservm/src/vmm/hyperlight/mod.rs
@@ -81,6 +81,10 @@ pub const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_millis(100);
 /// Label used for the RAMFS file mapping in the PEB.
 const RAMFS_LABEL: &str = "ramfs";
 
+/// Base guest physical address at which Hyperlight loads the kernel binary.
+/// Corresponds to `SandboxMemoryLayout::BASE_ADDRESS` from `hyperlight-host`.
+const HYPERLIGHT_BASE_ADDRESS: u64 = 0x1000;
+
 //==================================================================================================
 // Types
 //==================================================================================================
@@ -255,9 +259,9 @@ impl Vmm {
         let guest_heap_size: usize = Self::calculate_guest_heap_size(kernel_end, kpool_start)?;
 
         // Snapshot budget equation:  MEMORY_SIZE = snapshot_budget_size + ramfs + scratch
-        // With nanvix-unstable, Hyperlight skips guest page-table generation in
-        // Snapshot::from_env(), so snapshot_budget_size equals Hyperlight's get_memory_size()
-        // exactly — there is no PT overhead.
+        // With i686-guest, Hyperlight builds guest page tables which add pt_overhead bytes
+        // on top of the snapshot budget. The total snapshot KVM slot size is
+        // snapshot_budget_size + pt_overhead.
         let snapshot_budget_size: usize = {
             let unaligned: usize = kpool_end.checked_add(init_data_size).ok_or_else(|| {
                 error!("new(): kpool_end + init_data_size overflow");
@@ -306,10 +310,10 @@ impl Vmm {
                 anyhow::anyhow!("{e:?}")
             })?;
 
-        // With nanvix-unstable, Hyperlight does not append page tables to the snapshot (the
-        // #[cfg(not(feature = "nanvix-unstable"))] block in Snapshot::from_env() is compiled out),
-        // so shared_mem_size() == snapshot_budget_size and pt_overhead is 0.  The field is kept in
-        // GetMemoryLayout for forward-compatibility.
+        // With i686-guest, Hyperlight builds guest page tables and appends them to the
+        // snapshot. shared_mem_size() includes both the snapshot budget and the page table
+        // overhead. The pt_overhead field reports the difference so the guest kernel can
+        // account for the additional pages.
         let actual_snapshot: usize = sandbox.shared_mem_size();
         let pt_overhead: usize = actual_snapshot.saturating_sub(snapshot_budget_size);
         debug!(
@@ -320,13 +324,13 @@ impl Vmm {
 
         // Map RAMFS file into sandbox memory if provided.
         // The file is mapped copy-on-write at the first GPA after the sandbox's
-        // shared memory slot. With nanvix-unstable, BASE_ADDRESS is 0x0 so the
-        // shared memory occupies GPA [0, shared_mem_size).
+        // shared memory slot. The shared memory occupies
+        // GPA [HYPERLIGHT_BASE_ADDRESS, HYPERLIGHT_BASE_ADDRESS + shared_mem_size()).
         let mut layout_ramfs_base: u32 = 0;
         let mut layout_ramfs_size: u32 = 0;
         if let Some(ramfs_filename) = &args.ramfs_filename {
             let ramfs_path: &Path = Path::new(ramfs_filename);
-            let ramfs_gpa: u64 = sandbox.shared_mem_size() as u64;
+            let ramfs_gpa: u64 = HYPERLIGHT_BASE_ADDRESS + sandbox.shared_mem_size() as u64;
             let mapped_size: u64 = sandbox
                 .map_file_cow(ramfs_path, ramfs_gpa, Some(RAMFS_LABEL))
                 .map_err(|e| {
@@ -361,9 +365,8 @@ impl Vmm {
         // guest kernel calls this during init() to discover the authoritative snapshot, RAMFS, and
         // scratch region boundaries instead of inferring them from fragile address calculations.
         //
-        // pt_overhead is always 0 with nanvix-unstable (no guest page tables in the snapshot).  The
-        // field is preserved for forward-compatibility if upstream Hyperlight re-enables page-table
-        // generation for this feature.
+        // pt_overhead is the additional bytes used by host-built guest page tables (non-zero with
+        // i686-guest).  The guest uses this to determine the full extent of the snapshot region.
         let layout_snapshot_budget: u32 = u32::try_from(snapshot_budget_size).map_err(|_| {
             anyhow::anyhow!("snapshot_budget {snapshot_budget_size:#x} exceeds u32::MAX")
         })?;
@@ -555,7 +558,7 @@ impl Vmm {
                 Ok((code & 0xFF) as u16)
             },
             Err(error) => {
-                error!("run(): vmm failed during call (error={error:?})");
+                eprintln!("run(): vmm failed during call: {error:?}");
                 Ok(ErrorCode::ConnectionReset.into())
             },
         }


### PR DESCRIPTION
Introduce foundational infrastructure for the upcoming
`platform-root-virtual-address-space-bootstrap` feature, where the kernel
boots into a non-identity-mapped address space provided by the platform.

## Changes

- **Cargo.toml**: Define the `platform-root-virtual-address-space-bootstrap`
  feature flag (not yet enabled for any platform).

- **hal/platform/{hyperlight,microvm}/mod.rs**: Add `virt_to_phys()` and
  `gva_to_gpa()` identity stubs. On identity-mapped platforms these are
  no-ops; when the new feature is enabled the hyperlight implementation
  will perform actual translation.

- **hal/arch/shared/mem/mmu/page_directory.rs**: Use `virt_to_phys()` in
  `physical_address()` instead of assuming VA == PA. Add `as_ptr()` and
  `inherit_from()` (gated behind the feature flag) for merging
  platform-provided page directory entries into the kernel's root.

- **hal/arch/shared/mem/mmu/page_table.rs**: Use `virt_to_phys()` in
  `physical_address()`.

- **mm/phys/mod.rs**: Replace `PhysicalAddress::from_mmio_address()` with
  `gva_to_gpa()` for MMIO frame booking, decoupling the physical memory
  manager from the assumption that MMIO virtual addresses equal physical
  addresses.

- **mm/virt/mod.rs**: Add `PageTableStorage::Inherited` variant for wrapping
  raw page-table pointers handed off by the platform bootstrap code.

- **kmain.rs**: Page-align kernel module memory regions using
  `sys::mm::align_down`/`align_up` so that modules whose payload starts
  at an intra-page offset (e.g., after Hyperlight's 8-byte size header)
  register correct page-granularity regions with the frame allocator.

## Testing

- hyperlight/standalone: build ✅, tests ✅
- microvm/standalone: build ✅, tests ✅