### PR TITLE
[kernel] Platform address-translation hooks

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -78,6 +78,9 @@ stdio = []
 # Enables the dynamic exception stack guard.
 exception-stack-guard = []
 
+# Enables bootstrapping of root virtual address space from platform-provided page tables.
+platform-root-virtual-address-space-bootstrap = []
+
 # Enables latest performance optimizations.
 nightly-performance-optimizations = []
 

--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
@@ -184,8 +184,35 @@ impl<T: DerefMut<Target = [PteWord]>> PageDirectory<T> {
     }
 
     pub fn physical_address(&self) -> Result<FrameAddress, Error> {
-        Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(
-            self.entries.as_ptr() as usize,
-        )?)?))
+        let vaddr: usize = self.entries.as_ptr() as usize;
+        let paddr: usize = crate::hal::platform::virt_to_phys(vaddr);
+        Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(paddr)?)?))
+    }
+
+    /// Returns a raw pointer to the first entry in the page directory.
+    #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+    pub fn as_ptr(&self) -> *const PteWord {
+        self.entries.as_ptr()
+    }
+
+    /// Merges non-zero entries from `old_pd` into this page directory.
+    ///
+    /// For each PDE index, if `self` has a not-present entry and `old_pd` has a present
+    /// entry, the old entry is copied verbatim. Existing present entries in `self` are never
+    /// overwritten.
+    ///
+    /// # Safety
+    ///
+    /// - `old_pd` must point to a valid, page-aligned array of `PAGE_TABLE_LENGTH` PDE words.
+    /// - The caller must ensure that the pointed-to memory remains valid for the duration of this
+    ///   call.
+    #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+    pub unsafe fn inherit_from(&mut self, old_pd: *const PteWord) {
+        use ::arch::mem::PAGE_TABLE_LENGTH;
+        for i in 0..PAGE_TABLE_LENGTH {
+            if !PresentFlag::is_set(self.entries[i]) && PresentFlag::is_set(*old_pd.add(i)) {
+                self.entries[i] = *old_pd.add(i);
+            }
+        }
     }
 }

--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_table.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_table.rs
@@ -427,8 +427,8 @@ impl<T: DerefMut<Target = [PteWord]>> PageTable<T> {
     }
 
     pub fn physical_address(&self) -> Result<FrameAddress, Error> {
-        Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(
-            self.entries.as_ptr() as usize,
-        )?)?))
+        let vaddr: usize = self.entries.as_ptr() as usize;
+        let paddr: usize = crate::hal::platform::virt_to_phys(vaddr);
+        Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(paddr)?)?))
     }
 }

--- a/src/kernel/src/hal/platform/hyperlight/mod.rs
+++ b/src/kernel/src/hal/platform/hyperlight/mod.rs
@@ -17,6 +17,38 @@ mod start16;
 mod scratch_layout;
 
 //==================================================================================================
+// Platform Virtual-Address-Space Bootstrap
+//==================================================================================================
+
+///
+/// # Description
+///
+/// Translates a virtual address to a physical address.
+///
+/// # Returns
+///
+/// The physical address corresponding to the given virtual address.
+///
+#[inline(always)]
+pub fn virt_to_phys(vaddr: usize) -> usize {
+    vaddr
+}
+
+///
+/// # Description
+///
+/// Translates a guest virtual address to a guest physical address.
+///
+/// # Returns
+///
+/// The guest physical address corresponding to the given guest virtual address.
+///
+#[inline(always)]
+pub fn gva_to_gpa(gva: usize) -> usize {
+    gva
+}
+
+//==================================================================================================
 // Imports
 //==================================================================================================
 

--- a/src/kernel/src/hal/platform/microvm/mod.rs
+++ b/src/kernel/src/hal/platform/microvm/mod.rs
@@ -421,6 +421,35 @@ pub fn get_kstack_guard_base() -> usize {
 ///
 /// # Description
 ///
+/// Translates a guest virtual address to a guest physical address.
+///
+/// # Returns
+///
+/// The guest physical address corresponding to the given guest virtual address.
+///
+///
+#[inline(always)]
+pub fn gva_to_gpa(gva: usize) -> usize {
+    gva
+}
+
+///
+/// # Description
+///
+/// Translates a virtual address to a physical address.
+///
+/// # Returns
+///
+/// The physical address corresponding to the given virtual address.
+///
+#[inline(always)]
+pub fn virt_to_phys(vaddr: usize) -> usize {
+    vaddr
+}
+
+///
+/// # Description
+///
 /// Checks whether the given virtual address corresponds to a valid physical address on the Microvm
 /// platform.
 ///

--- a/src/kernel/src/kmain.rs
+++ b/src/kernel/src/kmain.rs
@@ -329,10 +329,25 @@ pub extern "C" fn kmain(kargs: &KernelArguments) {
     // Add kernel modules to list of memory regions.
     for module in kernel_modules.iter() {
         let name: &str = module.cmdline();
-        let start: VirtualAddress = module.start().into_virtual_address();
+        let raw_start: usize = module.start().into_virtual_address().into_raw_value();
         let size: usize = module.size();
+        // Page-align the region: round start down and end up to page boundaries.
+        // The module payload may start at an offset within a page (e.g., after a size header).
+        let page_start: usize = ::sys::mm::align_down(raw_start, ::sys::mm::Alignment::Align4096);
+        let raw_end: usize = match raw_start.checked_add(size) {
+            Some(v) => v,
+            None => panic!("kernel module region end overflows address space"),
+        };
+        let page_end: usize = match ::sys::mm::align_up(raw_end, ::sys::mm::Alignment::Align4096) {
+            Some(v) => v,
+            None => panic!("kernel module region end overflows address space"),
+        };
+        let start: VirtualAddress = VirtualAddress::from_raw_value(page_start);
+        let aligned_size: usize = page_end - page_start;
         let typ: MemoryRegionType = MemoryRegionType::Reserved;
-        if let Ok(region) = MemoryRegion::new(name, start, size, typ, AccessPermission::RDONLY) {
+        if let Ok(region) =
+            MemoryRegion::new(name, start, aligned_size, typ, AccessPermission::RDONLY)
+        {
             memory_regions.push_back(region);
         }
     }

--- a/src/kernel/src/mm/phys/mod.rs
+++ b/src/kernel/src/mm/phys/mod.rs
@@ -75,9 +75,11 @@ fn book_mmio_regions(
         let mut start: usize = region.start().into_raw_value();
         let end: usize = start + (region.size() - 1);
         while start < end {
-            let mmio_addr: VirtualAddress = VirtualAddress::from_raw_value(start);
+            let mmio_addr: usize = crate::hal::platform::gva_to_gpa(start);
             let phys_addr: PageAligned<PhysicalAddress> = PageAligned::from_address(unsafe {
-                PhysicalAddress::from_mmio_address(mmio_addr)?
+                // MMIO GPAs may legitimately lie outside tracked RAM, so they must not go through
+                // the regular physical-address validator here.
+                PhysicalAddress::from_mmio_address(VirtualAddress::from_raw_value(mmio_addr))?
             })?;
 
             // Only book frames that the frame allocator actually tracks.

--- a/src/kernel/src/mm/virt/mod.rs
+++ b/src/kernel/src/mm/virt/mod.rs
@@ -87,6 +87,9 @@ pub enum PageTableStorage {
     Bss(&'static mut [PteWord; PAGE_TABLE_LENGTH]),
     /// Runtime storage backed by a kernel page from the page pool.
     KernelPage(KernelPage),
+    /// Host-built page table inherited from a pre-existing address space.
+    #[allow(dead_code)]
+    Inherited(*mut PteWord),
 }
 
 impl Deref for PageTableStorage {
@@ -99,6 +102,7 @@ impl Deref for PageTableStorage {
                 let base: *const PteWord = page.base().into_raw_value() as *const PteWord;
                 unsafe { core::slice::from_raw_parts(base, PAGE_TABLE_LENGTH) }
             },
+            Self::Inherited(ptr) => unsafe { core::slice::from_raw_parts(*ptr, PAGE_TABLE_LENGTH) },
         }
     }
 }
@@ -110,6 +114,9 @@ impl DerefMut for PageTableStorage {
             Self::KernelPage(page) => {
                 let base: *mut PteWord = page.base().into_raw_value() as *mut PteWord;
                 unsafe { core::slice::from_raw_parts_mut(base, PAGE_TABLE_LENGTH) }
+            },
+            Self::Inherited(ptr) => unsafe {
+                core::slice::from_raw_parts_mut(*ptr, PAGE_TABLE_LENGTH)
             },
         }
     }


### PR DESCRIPTION
Introduce foundational infrastructure for the upcoming
platform-root-virtual-address-space-bootstrap feature, where the kernel
boots into a non-identity-mapped address space provided by the platform.

Changes:

- Cargo.toml: Define the `platform-root-virtual-address-space-bootstrap`
  feature flag (not yet enabled for any platform).

- hal/platform/{hyperlight,microvm}/mod.rs: Add `virt_to_phys()` and
  `gva_to_gpa()` identity stubs.  On identity-mapped platforms these are
  no-ops; when the new feature is enabled the hyperlight implementation
  will perform actual translation.

- hal/arch/shared/mem/mmu/page_directory.rs: Use `virt_to_phys()` in
  `physical_address()` instead of assuming VA == PA.  Add `as_ptr()` and
  `inherit_from()` (gated behind the feature flag) for merging
  platform-provided page directory entries into the kernel's root.

- hal/arch/shared/mem/mmu/page_table.rs: Use `virt_to_phys()` in
  `physical_address()`.

- mm/phys/mod.rs: Replace `PhysicalAddress::from_mmio_address()` with
  `gva_to_gpa()` for MMIO frame booking, decoupling the physical memory
  manager from the assumption that MMIO virtual addresses equal physical
  addresses.

- mm/virt/mod.rs: Add `PageTableStorage::Inherited` variant for wrapping
  raw page-table pointers handed off by the platform bootstrap code.

- kmain.rs: Page-align kernel module memory regions using
  `sys::mm::align_down`/`align_up` so that modules whose payload starts
  at an intra-page offset (e.g., after Hyperlight's 8-byte size header)
  register correct page-granularity regions with the frame allocator.