### PR TITLE
[kernel] Refactor mm into feature-gated modules

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,4 @@ skip = .git,.venv,bin,lib,logs,build,target,toolchain,sysroot-debug,sysroot-rele
 
 # Ignore words that are commonly used in systems programming
 # and are flagged as typos by codespell
-ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent
+ignore-words-list = crate,inout,nd,rdonly,wronly,rdwr,ist,servent,vas

--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_directory.rs
@@ -189,21 +189,36 @@ impl<T: DerefMut<Target = [PteWord]>> PageDirectory<T> {
         Ok(FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(paddr)?)?))
     }
 
+    ///
+    /// # Description
+    ///
     /// Returns a raw pointer to the first entry in the page directory.
+    ///
+    /// # Returns
+    ///
+    /// A raw pointer to the first entry in the page directory.
+    ///
     #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
     pub fn as_ptr(&self) -> *const PteWord {
         self.entries.as_ptr()
     }
 
+    ///
+    /// # Description
+    ///
     /// Merges non-zero entries from `old_pd` into this page directory.
     ///
     /// For each PDE index, if `self` has a not-present entry and `old_pd` has a present
     /// entry, the old entry is copied verbatim. Existing present entries in `self` are never
     /// overwritten.
     ///
+    /// This is used on platforms that provide a root virtual address space via platform-provided
+    /// page tables to inherit host-built page table mappings.
+    ///
     /// # Safety
     ///
     /// - `old_pd` must point to a valid, page-aligned array of `PAGE_TABLE_LENGTH` PDE words.
+    /// - `self` and `old_pd` must not point to overlapping paging structures.
     /// - The caller must ensure that the pointed-to memory remains valid for the duration of this
     ///   call.
     #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]

--- a/src/kernel/src/hal/arch/shared/mem/mmu/page_table.rs
+++ b/src/kernel/src/hal/arch/shared/mem/mmu/page_table.rs
@@ -61,6 +61,28 @@ impl<T: DerefMut<Target = [PteWord]>> PageTable<T> {
         page_table
     }
 
+    ///
+    /// # Description
+    ///
+    /// Creates a page table wrapper around existing (already-populated) storage.
+    ///
+    /// Unlike [`new`](Self::new), this does not zero the entries.
+    ///
+    /// # Returns
+    ///
+    /// A new [`PageTable`] instance that wraps the provided storage.
+    ///
+    #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+    pub fn from_existing(entries: T) -> Self {
+        let mut nmapped: usize = 0;
+        for pte in entries.iter() {
+            if PresentFlag::is_set(*pte) {
+                nmapped += 1;
+            }
+        }
+        Self { nmapped, entries }
+    }
+
     /// Returns the number of pages mapped in the page table.
     pub fn nmapped(&self) -> usize {
         self.nmapped
@@ -310,6 +332,7 @@ impl<T: DerefMut<Target = [PteWord]>> PageTable<T> {
         Ok(())
     }
 
+    #[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
     ///
     /// # Description
     ///

--- a/src/kernel/src/hal/mem/types/address/mod.rs
+++ b/src/kernel/src/hal/mem/types/address/mod.rs
@@ -25,6 +25,7 @@ pub use ::sys::mm::{
 pub use aligned::*;
 pub use frame::*;
 pub use page::*;
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
 pub use pd::*;
 pub use phys::*;
 

--- a/src/kernel/src/mm/kernel_vas.rs
+++ b/src/kernel/src/mm/kernel_vas.rs
@@ -1,0 +1,193 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Memory manager initialization when `platform-root-virtual-address-space-bootstrap` is disabled.
+//!
+//! The kernel builds its own root virtual address space: identity-mapped page tables are created,
+//! CR3 is loaded, and any virtual memory regions that lie outside physical memory (e.g., MMIO
+//! pages above `MEMORY_SIZE`) are explicitly mapped.
+
+use crate::{
+    collections::Bitmap,
+    hal::{
+        arch::x86::mem::mmu::page_table::PageTable,
+        mem::{
+            Address,
+            MemoryRegion,
+            MemoryRegionType,
+            PageAligned,
+            PageTableAddress,
+            PhysicalAddress,
+            TruncatedMemoryRegion,
+            VirtualAddress,
+        },
+    },
+    kimage::KernelImage,
+};
+use ::alloc::{
+    collections::LinkedList,
+    vec::Vec,
+};
+use ::arch::mem;
+use ::sparse_bitmap::SparseBitmap;
+use ::sys::error::Error;
+
+use super::{
+    phys,
+    virt,
+    KernelPage,
+    PageTableStorage,
+    PhysMemRegion,
+    VirtMemRegion,
+    VirtMemoryManager,
+    Vmem,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Splits memory regions into virtual and physical (kernel-built VAS path).
+///
+/// All GVAs are identity-mapped, so virtual addresses can be directly converted to physical
+/// addresses without translation.
+fn parse_memory_regions(
+    memory_regions: LinkedList<MemoryRegion<VirtualAddress>>,
+) -> Result<(VirtMemRegion, VirtMemRegion, PhysMemRegion), Error> {
+    let mut memory_regions: LinkedList<MemoryRegion<VirtualAddress>> = {
+        let mut memory_regions: Vec<_> = memory_regions.into_iter().collect();
+        memory_regions.sort();
+        memory_regions.into_iter().collect()
+    };
+
+    let mut virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>> =
+        LinkedList::new();
+    let mut other_virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>> =
+        LinkedList::new();
+    let mut physical_memory_regions: LinkedList<TruncatedMemoryRegion<PhysicalAddress>> =
+        LinkedList::new();
+
+    while let Some(region) = memory_regions.pop_front() {
+        if region.typ() == MemoryRegionType::Reserved || region.typ() == MemoryRegionType::Mmio {
+            if PhysicalAddress::from_virtual_address(region.start()).is_ok() {
+                if region.typ() != MemoryRegionType::Usable {
+                    match TruncatedMemoryRegion::from_virtual_memory_region(region.clone()) {
+                        Ok(region) => physical_memory_regions.push_back(region),
+                        Err(err) => panic!(
+                            "failed to create physical memory region {:?} (error={:?})",
+                            region, err
+                        ),
+                    }
+                }
+                virtual_memory_regions
+                    .push_back(TruncatedMemoryRegion::from_memory_region(region)?);
+            } else {
+                other_virtual_memory_regions
+                    .push_back(TruncatedMemoryRegion::from_memory_region(region)?);
+            }
+        }
+    }
+
+    Ok((other_virtual_memory_regions, virtual_memory_regions, physical_memory_regions))
+}
+
+///
+/// # Description
+///
+/// Initializes the memory manager (kernel-built root VAS path).
+///
+/// # Parameters
+///
+/// - `kimage`: Kernel image.
+/// - `memory_regions`: Memory regions.
+/// - `mmio_regions`: MMIO regions.
+/// - `physical_memory_layout`: Physical memory layout bitmap.
+/// - `kpool_bitmap`: Statically-allocated bitmap for the kernel page pool.
+///
+/// # Returns
+///
+/// Upon success, the root virtual memory manager is returned. Upon failure, an error is returned
+/// instead.
+///
+pub fn init(
+    kimage: &KernelImage,
+    memory_regions: LinkedList<MemoryRegion<VirtualAddress>>,
+    mmio_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    physical_memory_layout: SparseBitmap,
+    kpool_bitmap: Bitmap,
+) -> Result<Vmem, Error> {
+    info!("initializing the memory manager ...");
+
+    type VirtMemRegions = LinkedList<TruncatedMemoryRegion<VirtualAddress>>;
+    type PhysMemRegions = LinkedList<TruncatedMemoryRegion<PhysicalAddress>>;
+
+    let kpool_base: PageAligned<PhysicalAddress> =
+        PageAligned::<PhysicalAddress>::from_raw_value(kimage.kpool().start().into_raw_value())?;
+
+    let (mut other_virtual_memory_regions, virtual_memory_regions, physical_memory_regions): (
+        VirtMemRegions,
+        VirtMemRegions,
+        PhysMemRegions,
+    ) = parse_memory_regions(memory_regions)?;
+
+    phys::init(
+        kpool_base,
+        physical_memory_regions,
+        &mmio_regions,
+        physical_memory_layout,
+        kpool_bitmap,
+    )?;
+
+    #[cfg(feature = "test")]
+    phys::test();
+
+    // Build identity-mapped page tables and create the root address space.
+    let (kernel_pages, kernel_page_tables): (
+        LinkedList<KernelPage>,
+        LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>,
+    ) = (LinkedList::new(), virt::init(virtual_memory_regions, mmio_regions)?);
+
+    let mut vmem: Vmem = VirtMemoryManager::init(kernel_pages, kernel_page_tables)?;
+
+    // Map virtual memory regions that lie outside the physical memory.
+    while let Some(region) = other_virtual_memory_regions.pop_front() {
+        info!("mapping: {:?}", region);
+        let mut vaddr: PageAligned<VirtualAddress> = region.start();
+        let end: VirtualAddress =
+            VirtualAddress::new(region.start().into_raw_value() + (region.size() - 1));
+
+        {
+            while vaddr.into_inner() < end {
+                // NOTE: each `VirtMemoryManager::get_mut()` borrow is scoped to its own inner
+                // block so that the mutable reference is dropped before any subsequent borrow,
+                // including the borrow that may occur when `page_table_allocator` is invoked
+                // inside `map_kpage`.
+                let kpage: KernelPage = {
+                    // SAFETY: the memory manager is initialized and access is synchronized.
+                    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+                    mm.alloc_kpage(false)?
+                };
+
+                let page_table_allocator = || {
+                    let kpage: KernelPage = {
+                        // SAFETY: the memory manager is initialized and access is synchronized.
+                        let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+                        mm.alloc_kpage(true)?
+                    };
+                    let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
+                    let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
+                    Ok(page_table)
+                };
+
+                vmem.map_kpage(kpage, vaddr, page_table_allocator)?;
+
+                match vaddr.into_raw_value().checked_add(mem::PAGE_SIZE) {
+                    Some(raw_addr) => vaddr = PageAligned::from_raw_value(raw_addr)?,
+                    None => break,
+                };
+            }
+        }
+    }
+
+    Ok(vmem)
+}

--- a/src/kernel/src/mm/mod.rs
+++ b/src/kernel/src/mm/mod.rs
@@ -12,11 +12,10 @@
 //==================================================================================================
 
 pub mod elf;
-mod phys;
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+mod kernel_vas;
+pub(crate) mod phys;
 mod virt;
-
-#[cfg(feature = "hyperlight")]
-pub(crate) use virt::memcpy;
 
 //==================================================================================================
 // Exports
@@ -27,6 +26,8 @@ use ::arch::mem::{
     PAGE_ALIGNMENT,
     PGTAB_ALIGNMENT,
 };
+#[cfg(feature = "hyperlight")]
+pub(crate) use virt::memcpy;
 pub use virt::{
     KernelPage,
     PageTableStorage,
@@ -43,31 +44,20 @@ pub mod kredzone;
 // Imports
 //==================================================================================================
 
-use crate::{
-    collections::Bitmap,
-    hal::{
-        arch::x86::mem::mmu::page_table::PageTable,
-        mem::{
-            Address,
-            MemoryRegion,
-            MemoryRegionType,
-            PageAligned,
-            PageTableAddress,
-            PhysicalAddress,
-            TruncatedMemoryRegion,
-            VirtualAddress,
-        },
-    },
-    kimage::KernelImage,
+use crate::hal::mem::{
+    PhysicalAddress,
+    TruncatedMemoryRegion,
+    VirtualAddress,
 };
-use ::alloc::{
-    collections::LinkedList,
-    vec::Vec,
-};
+use ::alloc::collections::LinkedList;
 use ::arch::mem;
-use ::core::panic;
-use ::sparse_bitmap::SparseBitmap;
-use ::sys::error::Error;
+
+//==================================================================================================
+// Re-exports
+//==================================================================================================
+
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+pub use kernel_vas::init;
 
 //==================================================================================================
 // Static Assertions
@@ -188,151 +178,8 @@ use ::sys::error::Error;
 );
 
 //==================================================================================================
-// Standalone Functions
+// Type Aliases
 //==================================================================================================
 
-// Splits memory regions into virtual and physical.
 type VirtMemRegion = LinkedList<TruncatedMemoryRegion<VirtualAddress>>;
 type PhysMemRegion = LinkedList<TruncatedMemoryRegion<PhysicalAddress>>;
-
-fn parse_memory_regions(
-    memory_regions: LinkedList<MemoryRegion<VirtualAddress>>,
-) -> Result<(VirtMemRegion, VirtMemRegion, PhysMemRegion), Error> {
-    let mut memory_regions: LinkedList<MemoryRegion<VirtualAddress>> = {
-        let mut memory_regions: Vec<_> = memory_regions.into_iter().collect();
-        memory_regions.sort();
-        memory_regions.into_iter().collect()
-    };
-
-    let mut virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>> =
-        LinkedList::new();
-    let mut other_virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>> =
-        LinkedList::new();
-    let mut physical_memory_regions: LinkedList<TruncatedMemoryRegion<PhysicalAddress>> =
-        LinkedList::new();
-
-    while let Some(region) = memory_regions.pop_front() {
-        if region.typ() == MemoryRegionType::Reserved || region.typ() == MemoryRegionType::Mmio {
-            if PhysicalAddress::from_virtual_address(region.start()).is_ok() {
-                if region.typ() != MemoryRegionType::Usable {
-                    match TruncatedMemoryRegion::from_virtual_memory_region(region.clone()) {
-                        Ok(region) => physical_memory_regions.push_back(region),
-                        // TODO: make memory regions a truncated list so round logic is handled when region is created.
-                        Err(err) => panic!(
-                            "failed to create physical memory region {:?} (error={:?})",
-                            region, err
-                        ),
-                    }
-                }
-                virtual_memory_regions
-                    .push_back(TruncatedMemoryRegion::from_memory_region(region)?);
-            } else {
-                other_virtual_memory_regions
-                    .push_back(TruncatedMemoryRegion::from_memory_region(region)?);
-            }
-        }
-    }
-
-    Ok((other_virtual_memory_regions, virtual_memory_regions, physical_memory_regions))
-}
-
-///
-/// # Description
-///
-/// Initializes the memory manager.
-///
-/// # Parameters
-///
-/// - `kimage`: Kernel image.
-/// - `memory_regions`: Memory regions.
-/// - `mmio_regions`: MMIO regions.
-/// - `physical_memory_layout`: Physical memory layout bitmap.
-/// - `kpool_bitmap`: Statically-allocated bitmap for the kernel page pool.
-///
-/// # Returns
-///
-/// Upon success, the root virtual memory manager is returned. Upon failure, an error is returned
-/// instead.
-///
-pub fn init(
-    kimage: &KernelImage,
-    memory_regions: LinkedList<MemoryRegion<VirtualAddress>>,
-    mmio_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
-    physical_memory_layout: SparseBitmap,
-    kpool_bitmap: Bitmap,
-) -> Result<Vmem, Error> {
-    info!("initializing the memory manager ...");
-
-    type VirtMemRegions = LinkedList<TruncatedMemoryRegion<VirtualAddress>>;
-    type PhysMemRegions = LinkedList<TruncatedMemoryRegion<PhysicalAddress>>;
-
-    let kpool_base: PageAligned<PhysicalAddress> =
-        PageAligned::<PhysicalAddress>::from_raw_value(kimage.kpool().start().into_raw_value())?;
-
-    let (mut other_virtual_memory_regions, virtual_memory_regions, physical_memory_regions): (
-        VirtMemRegions,
-        VirtMemRegions,
-        PhysMemRegions,
-    ) = parse_memory_regions(memory_regions)?;
-
-    phys::init(
-        kpool_base,
-        physical_memory_regions,
-        &mmio_regions,
-        physical_memory_layout,
-        kpool_bitmap,
-    )?;
-
-    #[cfg(feature = "test")]
-    phys::test();
-
-    // FIXME: the initial list of kernel pages should be spit out by the initialization.
-    let (kernel_pages, kernel_page_tables): (
-        LinkedList<KernelPage>,
-        LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>,
-    ) = (LinkedList::new(), virt::init(virtual_memory_regions, mmio_regions)?);
-
-    let mut vmem: Vmem = VirtMemoryManager::init(kernel_pages, kernel_page_tables)?;
-
-    // Map virtual memory regions that lie outside the physical memory.
-    while let Some(region) = other_virtual_memory_regions.pop_front() {
-        info!("mapping: {:?}", region);
-        let mut vaddr: PageAligned<VirtualAddress> = region.start();
-        let end: VirtualAddress =
-            VirtualAddress::new(region.start().into_raw_value() + (region.size() - 1));
-
-        {
-            while vaddr.into_inner() < end {
-                // NOTE: each `VirtMemoryManager::get_mut()` borrow is scoped to its own inner
-                // block so that the mutable reference is dropped before any subsequent borrow,
-                // including the borrow that may occur when `page_table_allocator` is invoked
-                // inside `map_kpage`.
-                let kpage: KernelPage = {
-                    // SAFETY: the memory manager is initialized and access is synchronized.
-                    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
-                    mm.alloc_kpage(false)?
-                };
-
-                let page_table_allocator = || {
-                    let kpage: KernelPage = {
-                        // SAFETY: the memory manager is initialized and access is synchronized.
-                        let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
-                        mm.alloc_kpage(true)?
-                    };
-                    let pgtable_storage: PageTableStorage = PageTableStorage::KernelPage(kpage);
-                    let page_table: PageTable<PageTableStorage> = PageTable::new(pgtable_storage);
-                    Ok(page_table)
-                };
-
-                vmem.map_kpage(kpage, vaddr, page_table_allocator)?;
-
-                match vaddr.into_raw_value().checked_add(mem::PAGE_SIZE) {
-                    Some(raw_addr) => vaddr = PageAligned::from_raw_value(raw_addr)?,
-                    None => break,
-                };
-            }
-        }
-    }
-
-    Ok(vmem)
-}

--- a/src/kernel/src/mm/virt/boot_init.rs
+++ b/src/kernel/src/mm/virt/boot_init.rs
@@ -1,0 +1,263 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//!
+//! # Boot-Time Virtual Memory Initialization
+//!
+//! This module contains the `init` function that builds the root page tables during early kernel
+//! boot on platforms that do **not** inherit a pre-built virtual address space from the host.
+//!
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::{
+    page_table_allocator::PAGE_TABLE_ALLOCATOR,
+    PageTableStorage,
+};
+use crate::hal::{
+    arch::x86::mem::mmu::page_table::PageTable,
+    mem::{
+        AccessPermission,
+        Address,
+        FrameAddress,
+        MemoryRegionType,
+        MmioCachePolicy,
+        PageAddress,
+        PageAligned,
+        PageTableAddress,
+        PageTableAligned,
+        PhysicalAddress,
+        TruncatedMemoryRegion,
+        VirtualAddress,
+    },
+};
+use ::alloc::{
+    collections::LinkedList,
+    vec::Vec,
+};
+use ::arch::{
+    mem,
+    mem::{
+        paging::{
+            AccessedFlag,
+            DirtyFlag,
+            PageCacheDisableFlag,
+            PageTableEntryFlags,
+            PageWriteThroughFlag,
+            PresentFlag,
+            PteWord,
+            ReadWriteFlag,
+            UserSupervisorFlag,
+        },
+        PAGE_TABLE_LENGTH,
+        PGTAB_ALIGNMENT,
+    },
+};
+use ::core::cmp::Ordering;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// FIXME: this function is too long and complex.
+pub fn init(
+    mut virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    mut mmio_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+) -> Result<LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>, Error> {
+    info!("booking virtual memory regions ...");
+
+    // Last valid physical address (inclusive).
+    let max_phys_addr: usize = crate::hal::platform::max_physical_address();
+
+    let mut root_pagetables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)> =
+        LinkedList::new();
+
+    // Sort memory regions by start address.
+    let mut regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>> = {
+        virtual_memory_regions.append(&mut mmio_memory_regions);
+        let mut regions: Vec<_> = virtual_memory_regions.into_iter().collect();
+        regions.sort();
+        regions.into_iter().collect()
+    };
+
+    // Identity map memory regions.
+    while let Some(region) = regions.pop_front() {
+        info!("booking: {:?}", region);
+
+        let raw_vaddr: usize = region.start().into_raw_value();
+
+        let mut paddr: FrameAddress = match region.typ() {
+            MemoryRegionType::Mmio => {
+                let mmio_addr: VirtualAddress = region.start().into_inner();
+                let phys_addr: PhysicalAddress =
+                    // FIXME: ensure safety here.
+                    unsafe { PhysicalAddress::from_mmio_address(mmio_addr)? };
+                let page_aligned_phys_addr: PageAligned<PhysicalAddress> =
+                    PageAligned::from_address(phys_addr)?;
+                FrameAddress::new(page_aligned_phys_addr)
+            },
+            _ => FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(
+                raw_vaddr,
+            )?)?),
+        };
+
+        let mut raw_vaddr: usize = raw_vaddr;
+        let end: usize = raw_vaddr + (region.size() - 1);
+
+        while raw_vaddr < end {
+            let (page_table_addr, mut page_table): (PageTableAddress, PageTable<PageTableStorage>) =
+                if let Some(last) = root_pagetables.pop_back() {
+                    let page_table_addr: PageTableAddress =
+                        PageTableAddress::new(PageTableAligned::from_address(
+                            VirtualAddress::new(::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT)),
+                        )?);
+
+                    match page_table_addr.cmp(&last.0) {
+                        Ordering::Greater => {
+                            root_pagetables.push_back(last);
+                            let pgtable_storage: PageTableStorage =
+                                // SAFETY: called during single-threaded kernel init;
+                                // BSS is zero-initialized, so assume_init_mut() is sound.
+                                PageTableStorage::Bss(unsafe {
+                                    PAGE_TABLE_ALLOCATOR
+                                        .alloc_as::<[PteWord; PAGE_TABLE_LENGTH]>()
+                                        .map_err(|e| {
+                                            error!("page table allocation failed: {}", e);
+                                            Error::new(
+                                                ErrorCode::OutOfMemory,
+                                                "BSS page table allocation failed",
+                                            )
+                                        })?
+                                        .assume_init_mut()
+                                });
+                            let page_table: PageTable<PageTableStorage> =
+                                PageTable::<PageTableStorage>::new(pgtable_storage);
+                            let page_table_addr: PageTableAligned<VirtualAddress> =
+                                PageTableAligned::from_address(VirtualAddress::new(
+                                    ::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT),
+                                ))?;
+                            (PageTableAddress::new(page_table_addr), page_table)
+                        },
+                        Ordering::Equal => last,
+                        Ordering::Less => {
+                            let reason: &str = "overlapping memory regions";
+                            error!("{}: {:#010x}", reason, raw_vaddr);
+                            return Err(Error::new(ErrorCode::InvalidArgument, reason));
+                        },
+                    }
+                } else {
+                    trace!("creating new page table for {:#010x}", raw_vaddr);
+                    let pgtable_storage: PageTableStorage =
+                        // SAFETY: called during single-threaded kernel init;
+                        // BSS is zero-initialized, so assume_init_mut() is sound.
+                        PageTableStorage::Bss(unsafe {
+                            PAGE_TABLE_ALLOCATOR
+                                .alloc_as::<[PteWord; PAGE_TABLE_LENGTH]>()
+                                .map_err(|e| {
+                                    error!("page table allocation failed: {}", e);
+                                    Error::new(
+                                        ErrorCode::OutOfMemory,
+                                        "BSS page table allocation failed",
+                                    )
+                                })?
+                                .assume_init_mut()
+                        });
+                    let page_table: PageTable<PageTableStorage> =
+                        PageTable::<PageTableStorage>::new(pgtable_storage);
+                    let page_table_addr: PageTableAligned<VirtualAddress> =
+                        PageTableAligned::from_address(VirtualAddress::new(
+                            ::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT),
+                        ))?;
+                    (PageTableAddress::new(page_table_addr), page_table)
+                };
+
+            if region.typ() != MemoryRegionType::Mmio {
+                // Bulk identity fill: map all pages in this page table at once.
+                let pgtab_base: usize = ::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT);
+                let start_index: usize = (raw_vaddr - pgtab_base) / mem::PAGE_SIZE;
+                let pgtab_remaining: usize = PAGE_TABLE_LENGTH - start_index;
+                let region_remaining: usize = (end - raw_vaddr) / mem::PAGE_SIZE + 1;
+                let memory_remaining: usize = if raw_vaddr > max_phys_addr {
+                    0
+                } else {
+                    (max_phys_addr - raw_vaddr) / mem::PAGE_SIZE + 1
+                };
+                let count: usize = pgtab_remaining.min(region_remaining).min(memory_remaining);
+
+                if count == 0 {
+                    break;
+                }
+
+                let rw_flag: ReadWriteFlag = if region.perm() == AccessPermission::RDWR {
+                    ReadWriteFlag::ReadWrite
+                } else {
+                    ReadWriteFlag::ReadOnly
+                };
+
+                let fill_count: usize = page_table
+                    .fill(
+                        start_index,
+                        count,
+                        FrameAddress::from_raw_value(raw_vaddr)?,
+                        PageTableEntryFlags::new(
+                            PresentFlag::Present,
+                            rw_flag,
+                            UserSupervisorFlag::Supervisor,
+                            PageWriteThroughFlag::NotWriteThrough,
+                            PageCacheDisableFlag::CacheEnabled,
+                            AccessedFlag::NotAccessed,
+                            DirtyFlag::NotDirty,
+                        ),
+                        false,
+                    )
+                    .map_err(|(_count, e)| e)?;
+                debug_assert!(fill_count == count, "fill_count ({fill_count}) != count ({count})");
+
+                root_pagetables.push_back((page_table_addr, page_table));
+                // NOTE: `count` is bounded by `memory_remaining`, so this cannot overflow.
+                raw_vaddr += count
+                    .checked_mul(mem::PAGE_SIZE)
+                    .expect("count * PAGE_SIZE overflow");
+                if raw_vaddr > max_phys_addr || raw_vaddr >= end {
+                    break;
+                }
+                paddr = FrameAddress::new(PageAligned::from_address(
+                    PhysicalAddress::from_raw_value(raw_vaddr)?,
+                )?);
+            } else {
+                // MMIO: per-page mapping with address translation.
+                let cache_policy: MmioCachePolicy = region
+                    .cache_policy()
+                    .unwrap_or(MmioCachePolicy::UNCACHEABLE);
+                page_table.map(
+                    PageAddress::new(PageAligned::from_raw_value(raw_vaddr)?),
+                    paddr,
+                    true,
+                    cache_policy.write_through(),
+                    cache_policy.cache_enabled(),
+                    region.perm(),
+                )?;
+                root_pagetables.push_back((page_table_addr, page_table));
+                if raw_vaddr == max_phys_addr - (mem::PAGE_SIZE - 1) {
+                    break;
+                }
+                raw_vaddr += mem::PAGE_SIZE;
+                paddr = {
+                    let mmio_addr: VirtualAddress = VirtualAddress::new(raw_vaddr);
+                    let phys_addr: PhysicalAddress =
+                        // FIXME: ensure safety here.
+                        unsafe { PhysicalAddress::from_mmio_address(mmio_addr)? };
+                    FrameAddress::new(PageAligned::from_address(phys_addr)?)
+                };
+            }
+        }
+    }
+
+    Ok(root_pagetables)
+}

--- a/src/kernel/src/mm/virt/kpage.rs
+++ b/src/kernel/src/mm/virt/kpage.rs
@@ -6,10 +6,7 @@
 //==================================================================================================
 
 use crate::{
-    hal::mem::{
-        FrameAddress,
-        PageAddress,
-    },
+    hal::mem::PageAddress,
     mm::phys::KernelFrame,
 };
 
@@ -73,7 +70,8 @@ impl KernelPage {
     ///
     /// The frame address of the target kernel page.
     ///
-    pub fn frame_address(&self) -> FrameAddress {
+    #[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+    pub fn frame_address(&self) -> crate::hal::mem::FrameAddress {
         self.kframe.base()
     }
 }

--- a/src/kernel/src/mm/virt/mod.rs
+++ b/src/kernel/src/mm/virt/mod.rs
@@ -5,75 +5,41 @@
 // Modules
 //==================================================================================================
 
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+mod boot_init;
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
 mod identity_map;
 mod kpage;
 mod manager;
 mod page_table_allocator;
 mod vmem;
 
-#[cfg(feature = "hyperlight")]
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+use identity_map::init as identity_map_init;
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
 pub(crate) use identity_map::memcpy;
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+use identity_map::memset;
 
 //==================================================================================================
 // Imports
 //==================================================================================================
 
-use self::page_table_allocator::PAGE_TABLE_ALLOCATOR;
-use crate::hal::{
-    arch::x86::mem::mmu::page_table::PageTable,
-    mem::{
-        AccessPermission,
-        Address,
-        FrameAddress,
-        MemoryRegionType,
-        MmioCachePolicy,
-        PageAddress,
-        PageAligned,
-        PageTableAddress,
-        PageTableAligned,
-        PhysicalAddress,
-        TruncatedMemoryRegion,
-        VirtualAddress,
-    },
+use ::arch::mem::{
+    paging::PteWord,
+    PAGE_TABLE_LENGTH,
 };
-use ::alloc::{
-    collections::LinkedList,
-    vec::Vec,
-};
-use ::arch::{
-    mem,
-    mem::{
-        paging::{
-            AccessedFlag,
-            DirtyFlag,
-            PageCacheDisableFlag,
-            PageTableEntryFlags,
-            PageWriteThroughFlag,
-            PresentFlag,
-            PteWord,
-            ReadWriteFlag,
-            UserSupervisorFlag,
-        },
-        PAGE_TABLE_LENGTH,
-        PGTAB_ALIGNMENT,
-    },
-};
-use ::core::{
-    cmp::Ordering,
-    ops::{
-        Deref,
-        DerefMut,
-    },
-};
-use ::sys::error::{
-    Error,
-    ErrorCode,
+use ::core::ops::{
+    Deref,
+    DerefMut,
 };
 
 //==================================================================================================
 // Exports
 //==================================================================================================
 
+#[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+pub use boot_init::init;
 pub use kpage::KernelPage;
 pub use manager::VirtMemoryManager;
 pub use vmem::Vmem;
@@ -84,11 +50,18 @@ pub use vmem::Vmem;
 
 pub enum PageTableStorage {
     /// Boot-time BSS-backed storage, allocated via `PAGE_TABLE_ALLOCATOR`.
+    #[cfg_attr(
+        feature = "platform-root-virtual-address-space-bootstrap",
+        allow(dead_code)
+    )]
     Bss(&'static mut [PteWord; PAGE_TABLE_LENGTH]),
     /// Runtime storage backed by a kernel page from the page pool.
     KernelPage(KernelPage),
     /// Host-built page table inherited from a pre-existing address space.
-    #[allow(dead_code)]
+    #[cfg_attr(
+        not(feature = "platform-root-virtual-address-space-bootstrap"),
+        allow(dead_code)
+    )]
     Inherited(*mut PteWord),
 }
 
@@ -153,205 +126,4 @@ impl DerefMut for PageDirectoryStorage {
             },
         }
     }
-}
-
-//==================================================================================================
-// Standalone Functions
-//==================================================================================================
-
-// FIXME: this function is too long and complex.
-pub fn init(
-    mut virtual_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
-    mut mmio_memory_regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
-) -> Result<LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>, Error> {
-    info!("booking virtual memory regions ...");
-
-    // Last valid physical address (inclusive).
-    let max_phys_addr: usize = crate::hal::platform::max_physical_address();
-
-    let mut root_pagetables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)> =
-        LinkedList::new();
-
-    // Sort memory regions by start address.
-    let mut regions: LinkedList<TruncatedMemoryRegion<VirtualAddress>> = {
-        virtual_memory_regions.append(&mut mmio_memory_regions);
-        let mut regions: Vec<_> = virtual_memory_regions.into_iter().collect();
-        regions.sort();
-        regions.into_iter().collect()
-    };
-
-    // Identity map memory regions.
-    while let Some(region) = regions.pop_front() {
-        info!("booking: {:?}", region);
-
-        let raw_vaddr: usize = region.start().into_raw_value();
-
-        let mut paddr: FrameAddress = match region.typ() {
-            MemoryRegionType::Mmio => {
-                let mmio_addr: VirtualAddress = region.start().into_inner();
-                let phys_addr: PhysicalAddress =
-                    // FIXME: ensure safety here.
-                    unsafe { PhysicalAddress::from_mmio_address(mmio_addr)? };
-                let page_aligned_phys_addr: PageAligned<PhysicalAddress> =
-                    PageAligned::from_address(phys_addr)?;
-                FrameAddress::new(page_aligned_phys_addr)
-            },
-            _ => FrameAddress::new(PageAligned::from_address(PhysicalAddress::from_raw_value(
-                raw_vaddr,
-            )?)?),
-        };
-
-        let mut raw_vaddr: usize = raw_vaddr;
-        let end: usize = raw_vaddr + (region.size() - 1);
-
-        while raw_vaddr < end {
-            let (page_table_addr, mut page_table): (PageTableAddress, PageTable<PageTableStorage>) =
-                if let Some(last) = root_pagetables.pop_back() {
-                    let page_table_addr: PageTableAddress =
-                        PageTableAddress::new(PageTableAligned::from_address(
-                            VirtualAddress::new(::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT)),
-                        )?);
-
-                    match page_table_addr.cmp(&last.0) {
-                        Ordering::Greater => {
-                            root_pagetables.push_back(last);
-                            let pgtable_storage: PageTableStorage =
-                                // SAFETY: called during single-threaded kernel init;
-                                // BSS is zero-initialized, so assume_init_mut() is sound.
-                                PageTableStorage::Bss(unsafe {
-                                    PAGE_TABLE_ALLOCATOR
-                                        .alloc_as::<[PteWord; PAGE_TABLE_LENGTH]>()
-                                        .map_err(|e| {
-                                            error!("page table allocation failed: {}", e);
-                                            Error::new(
-                                                ErrorCode::OutOfMemory,
-                                                "BSS page table allocation failed",
-                                            )
-                                        })?
-                                        .assume_init_mut()
-                                });
-                            let page_table: PageTable<PageTableStorage> =
-                                PageTable::<PageTableStorage>::new(pgtable_storage);
-                            let page_table_addr: PageTableAligned<VirtualAddress> =
-                                PageTableAligned::from_address(VirtualAddress::new(
-                                    ::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT),
-                                ))?;
-                            (PageTableAddress::new(page_table_addr), page_table)
-                        },
-                        Ordering::Equal => last,
-                        Ordering::Less => {
-                            let reason: &str = "overlapping memory regions";
-                            error!("{}: {:#010x}", reason, raw_vaddr);
-                            return Err(Error::new(ErrorCode::InvalidArgument, reason));
-                        },
-                    }
-                } else {
-                    trace!("creating new page table for {:#010x}", raw_vaddr);
-                    let pgtable_storage: PageTableStorage =
-                        // SAFETY: called during single-threaded kernel init;
-                        // BSS is zero-initialized, so assume_init_mut() is sound.
-                        PageTableStorage::Bss(unsafe {
-                            PAGE_TABLE_ALLOCATOR
-                                .alloc_as::<[PteWord; PAGE_TABLE_LENGTH]>()
-                                .map_err(|e| {
-                                    error!("page table allocation failed: {}", e);
-                                    Error::new(
-                                        ErrorCode::OutOfMemory,
-                                        "BSS page table allocation failed",
-                                    )
-                                })?
-                                .assume_init_mut()
-                        });
-                    let page_table: PageTable<PageTableStorage> =
-                        PageTable::<PageTableStorage>::new(pgtable_storage);
-                    let page_table_addr: PageTableAligned<VirtualAddress> =
-                        PageTableAligned::from_address(VirtualAddress::new(
-                            ::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT),
-                        ))?;
-                    (PageTableAddress::new(page_table_addr), page_table)
-                };
-
-            if region.typ() != MemoryRegionType::Mmio {
-                // Bulk identity fill: map all pages in this page table at once.
-                let pgtab_base: usize = ::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT);
-                let start_index: usize = (raw_vaddr - pgtab_base) / mem::PAGE_SIZE;
-                let pgtab_remaining: usize = PAGE_TABLE_LENGTH - start_index;
-                let region_remaining: usize = (end - raw_vaddr) / mem::PAGE_SIZE + 1;
-                let memory_remaining: usize = if raw_vaddr > max_phys_addr {
-                    0
-                } else {
-                    (max_phys_addr - raw_vaddr) / mem::PAGE_SIZE + 1
-                };
-                let count: usize = pgtab_remaining.min(region_remaining).min(memory_remaining);
-
-                if count == 0 {
-                    break;
-                }
-
-                let rw_flag: ReadWriteFlag = if region.perm() == AccessPermission::RDWR {
-                    ReadWriteFlag::ReadWrite
-                } else {
-                    ReadWriteFlag::ReadOnly
-                };
-
-                let fill_count: usize = page_table
-                    .fill(
-                        start_index,
-                        count,
-                        FrameAddress::from_raw_value(raw_vaddr)?,
-                        PageTableEntryFlags::new(
-                            PresentFlag::Present,
-                            rw_flag,
-                            UserSupervisorFlag::Supervisor,
-                            PageWriteThroughFlag::NotWriteThrough,
-                            PageCacheDisableFlag::CacheEnabled,
-                            AccessedFlag::NotAccessed,
-                            DirtyFlag::NotDirty,
-                        ),
-                        false,
-                    )
-                    .map_err(|(_count, e)| e)?;
-                debug_assert!(fill_count == count, "fill_count ({fill_count}) != count ({count})");
-
-                root_pagetables.push_back((page_table_addr, page_table));
-                // NOTE: `count` is bounded by `memory_remaining`, so this cannot overflow.
-                raw_vaddr += count
-                    .checked_mul(mem::PAGE_SIZE)
-                    .expect("count * PAGE_SIZE overflow");
-                if raw_vaddr > max_phys_addr || raw_vaddr >= end {
-                    break;
-                }
-                paddr = FrameAddress::new(PageAligned::from_address(
-                    PhysicalAddress::from_raw_value(raw_vaddr)?,
-                )?);
-            } else {
-                // MMIO: per-page mapping with address translation.
-                let cache_policy: MmioCachePolicy = region
-                    .cache_policy()
-                    .unwrap_or(MmioCachePolicy::UNCACHEABLE);
-                page_table.map(
-                    PageAddress::new(PageAligned::from_raw_value(raw_vaddr)?),
-                    paddr,
-                    true,
-                    cache_policy.write_through(),
-                    cache_policy.cache_enabled(),
-                    region.perm(),
-                )?;
-                root_pagetables.push_back((page_table_addr, page_table));
-                if raw_vaddr == max_phys_addr - (mem::PAGE_SIZE - 1) {
-                    break;
-                }
-                raw_vaddr += mem::PAGE_SIZE;
-                paddr = {
-                    let mmio_addr: VirtualAddress = VirtualAddress::new(raw_vaddr);
-                    let phys_addr: PhysicalAddress =
-                        // FIXME: ensure safety here.
-                        unsafe { PhysicalAddress::from_mmio_address(mmio_addr)? };
-                    FrameAddress::new(PageAligned::from_address(phys_addr)?)
-                };
-            }
-        }
-    }
-
-    Ok(root_pagetables)
 }

--- a/src/kernel/src/mm/virt/vmem.rs
+++ b/src/kernel/src/mm/virt/vmem.rs
@@ -20,7 +20,6 @@ use crate::{
             FrameAddress,
             PageAddress,
             PageAligned,
-            PageDirectoryAddress,
             PageTableAddress,
             PageTableAligned,
             PhysicalAddress,
@@ -41,23 +40,15 @@ use ::alloc::{
     collections::LinkedList,
     rc::Rc,
 };
-use ::arch::{
-    cpu::cr3::{
-        Cr3Register,
-        PageDirectoryBaseAddress as Cr3PageDirectoryBaseAddress,
-        PageLevelCacheDisableFlag,
-        PageLevelWriteThroughFlag,
+use ::arch::mem::{
+    self,
+    paging::{
+        PageDirectoryEntry,
+        PteWord,
     },
-    mem::{
-        self,
-        paging::{
-            PageDirectoryEntry,
-            PteWord,
-        },
-        PAGE_ALIGNMENT,
-        PAGE_TABLE_LENGTH,
-        PGTAB_ALIGNMENT,
-    },
+    PAGE_ALIGNMENT,
+    PAGE_TABLE_LENGTH,
+    PGTAB_ALIGNMENT,
 };
 use ::core::cell::RefCell;
 use ::sys::{
@@ -128,21 +119,33 @@ impl Vmem {
             kpage_tables.push_back(Rc::new(RefCell::new((vaddr, page_table))));
         }
 
-        // Register kernel PD for lazy identity mapping. On x86, the PD is also the CR3 root.
-        let pd_paddr_raw: usize = pgdir.physical_address()?.into_raw_value();
-        let pd_paddr: PageDirectoryAddress = PageDirectoryAddress::from_raw_value(pd_paddr_raw)?;
-        let kernel_cr3: Cr3Register = Cr3Register {
-            page_level_write_through: PageLevelWriteThroughFlag::Disabled,
-            page_level_cache_disable: PageLevelCacheDisableFlag::Enabled,
-            paging_structure_base_address: Cr3PageDirectoryBaseAddress::new(pd_paddr_raw as u32)
+        #[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
+        {
+            use crate::hal::mem::PageDirectoryAddress;
+            use ::arch::cpu::cr3::{
+                Cr3Register,
+                PageDirectoryBaseAddress as Cr3PageDirectoryBaseAddress,
+                PageLevelCacheDisableFlag,
+                PageLevelWriteThroughFlag,
+            };
+            let pd_paddr_raw: usize = pgdir.physical_address()?.into_raw_value();
+            let pd_paddr: PageDirectoryAddress =
+                PageDirectoryAddress::from_raw_value(pd_paddr_raw)?;
+            let kernel_cr3: Cr3Register = Cr3Register {
+                page_level_write_through: PageLevelWriteThroughFlag::Disabled,
+                page_level_cache_disable: PageLevelCacheDisableFlag::Enabled,
+                paging_structure_base_address: Cr3PageDirectoryBaseAddress::new(
+                    pd_paddr_raw as u32,
+                )
                 .ok_or_else(|| {
                     Error::new(
                         ErrorCode::BadAddress,
                         "kernel page directory address is not 4 KB aligned",
                     )
                 })?,
-        };
-        super::identity_map::init(pd_paddr, kernel_cr3);
+            };
+            super::identity_map_init(pd_paddr, kernel_cr3);
+        }
 
         // Store root pages.
         let mut kpages: LinkedList<Rc<RefCell<KernelPage>>> = LinkedList::new();
@@ -174,6 +177,14 @@ impl Vmem {
             // FIXME: do not be so open about permissions.
             pgdir.map(entry.borrow().0, page_table_address, false, AccessPermission::RDWR)?;
             kernel_page_tables.push_back(entry.clone());
+        }
+
+        // On platforms that provide a root virtual address space via platform-provided page tables,
+        // inherit the entries from the source page directory so that the kernel retains access to
+        // host-provided mappings after the CR3 switch.
+        #[cfg(feature = "platform-root-virtual-address-space-bootstrap")]
+        unsafe {
+            pgdir.inherit_from(from.pgdir.as_ptr());
         }
 
         // Store root pages.
@@ -215,6 +226,7 @@ impl Vmem {
     ///
     /// Upon success, empty is returned. Upon failure, an error code is returned instead.
     ///
+    #[cfg(not(feature = "platform-root-virtual-address-space-bootstrap"))]
     pub fn map_kpage<T: Fn() -> Result<PageTable<PageTableStorage>, Error>>(
         &mut self,
         kpage: KernelPage,
@@ -725,7 +737,7 @@ impl Vmem {
 
                 if !dry_run {
                     // Copy memory from user space to kernel space.
-                    super::identity_map::memcpy(
+                    super::memcpy(
                         dst.into_raw_value() as *mut u8,
                         (src_frame.into_raw_value() + offset) as *const u8,
                         copy_size,
@@ -890,8 +902,7 @@ impl Vmem {
                 // Copy memory from kernel space to user space.
                 let dst: *mut u8 = (dst_frame.into_raw_value() + offset) as *mut u8;
                 let src: *const u8 = src.into_raw_value() as *const u8;
-                let copy_result: Result<(), Error> =
-                    super::identity_map::memcpy(dst, src, copy_size);
+                let copy_result: Result<(), Error> = super::memcpy(dst, src, copy_size);
                 if let Err(error) = copy_result {
                     let reason: &str = "failed to perform physical memory copy";
                     panic!(
@@ -1032,11 +1043,7 @@ impl Vmem {
                     // mappings for the full source and destination ranges before copying.
                     let src_phys_addr: usize = src_frame.into_raw_value() + src_offset;
                     let dst_phys_addr: usize = dst_frame.into_raw_value() + dst_offset;
-                    super::identity_map::memcpy(
-                        dst_phys_addr as *mut u8,
-                        src_phys_addr as *const u8,
-                        copy_size,
-                    )?;
+                    super::memcpy(dst_phys_addr as *mut u8, src_phys_addr as *const u8, copy_size)?;
                 }
 
                 remaining -= copy_size;
@@ -1080,7 +1087,7 @@ impl Vmem {
         let dst: PageAligned<PhysicalAddress> = uframe.into_physical_address();
         let base: *mut u8 = dst.into_raw_value() as *mut u8;
 
-        super::identity_map::memset(base, value as u8, mem::PAGE_SIZE)?;
+        super::memset(base, value as u8, mem::PAGE_SIZE)?;
 
         Ok(())
     }
@@ -1299,12 +1306,41 @@ impl Vmem {
         let page_address: PageAddress = PageAddress::new(vaddr);
 
         if dry_run {
-            page_table.borrow().1.lookup(page_address)?;
+            // For dry-run validation, check if the PTE is present or can be created.
+            // On Hyperlight, inherited page tables may not have PTEs for identity-mapped
+            // regions (e.g., RAMFS) that were added after the host built the page tables.
+            // In that case, the PTE will be created on the non-dry-run pass.
+            let pt_ref = page_table.borrow();
+            match pt_ref.1.is_page_present(page_address) {
+                Ok(true) => {},
+                // PTE absent — will be created in the non-dry-run pass.
+                Ok(false) => {},
+                Err(e) => return Err(e),
+            }
         } else {
-            page_table
-                .borrow_mut()
-                .1
-                .ctrl(false, page_address, access)?;
+            let mut pt_mut = page_table.borrow_mut();
+            // If the PTE is not present, create an identity-mapped entry first.
+            // This handles Hyperlight's inherited page tables where the host didn't
+            // create PTEs for regions added after snapshot page table construction
+            // (e.g., RAMFS identity-mapped via a separate KVM memory slot).
+            match pt_mut.1.is_page_present(page_address) {
+                Ok(false) => {
+                    let frame_addr: FrameAddress =
+                        FrameAddress::new(PageAligned::from_raw_value(vaddr.into_raw_value())?);
+                    pt_mut.1.map(
+                        page_address,
+                        frame_addr,
+                        false, // user-accessible (MMIO regions are mapped for user processes)
+                        false, // not write-through
+                        false, // cache disabled (MMIO-safe: prevents stale/speculative reads)
+                        access,
+                    )?;
+                },
+                Ok(true) => {
+                    pt_mut.1.ctrl(false, page_address, access)?;
+                },
+                Err(e) => return Err(e),
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Extract the memory manager initialization logic into separate modules gated by `platform-root-virtual-address-space-bootstrap`:

- `kernel_vas.rs`: kernel-built root VAS path (identity-map, CR3 load, MMIO mapping). Moved from `mm/mod.rs`.
- `virt/boot_init.rs`: boot-time page table construction. Moved from `virt/mod.rs`.

This separation allows platforms that inherit a pre-built VAS from the host (e.g., Hyperlight i686-guest) to compile without the identity-map code path, while keeping the microvm path unchanged.

Other changes:
- Re-export `virt::memcpy` under `cfg(feature = "hyperlight")` so that `crate::mm::memcpy` is accessible from the hyperlight platform module.
- Make `phys` module `pub(crate)` for cross-module frame allocation.
- Extend `page_directory` and `page_table` with helper methods used by the new `boot_init` path.
- Add `vas` to codespell ignore list (Virtual Address Space acronym).