### PR TITLE
[build] Rename slab crate to nanvix-slab to resolve ambiguity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,7 +1070,7 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "slab 0.4.12",
+ "slab",
 ]
 
 [[package]]
@@ -1197,7 +1197,7 @@ dependencies = [
  "futures-sink",
  "http",
  "indexmap 2.14.0",
- "slab 0.4.12",
+ "slab",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1778,10 +1778,10 @@ dependencies = [
  "hyperlight-guest",
  "mmio-tag",
  "multibin",
+ "nanvix-slab",
  "no_fail",
  "paste",
  "raw-array",
- "slab 0.12.489",
  "sorted-vec",
  "sparse-bitmap",
  "static_assert",
@@ -2327,6 +2327,17 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "nanvix-slab"
+version = "0.12.489"
+dependencies = [
+ "bitmap",
+ "error",
+ "raw-array",
+ "sys",
+ "vstd",
 ]
 
 [[package]]
@@ -2893,7 +2904,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "slab 0.4.12",
+ "slab",
  "thiserror 2.0.18",
  "tinyvec",
  "tracing",
@@ -3494,17 +3505,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slab"
-version = "0.12.489"
-dependencies = [
- "bitmap",
- "error",
- "raw-array",
- "sys",
- "vstd",
-]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ serde_json = { version = "1.0.149", default-features = false, features = [
 sha2 = "0.11.0"
 shell-words = "1.1"
 signal-hook = "0.4.4"
-slab = { path = "src/libs/slab", default-features = false }
+slab = { path = "src/libs/slab", package = "nanvix-slab", default-features = false }
 sorted-vec = { path = "src/libs/sorted-vec", default-features = false }
 sparse-bitmap = { path = "src/libs/sparse-bitmap", default-features = false }
 spin = { git = "https://github.com/nanvix/spin-rs", package = "spin", branch = "nanvix/v0.10.0", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ endif
 export VERUS_EXECUTABLE_DIR ?=
 
 # List of crates to verify with Verus.
-VERUS_CRATES := bitmap slab
+VERUS_CRATES := bitmap nanvix-slab
 
 # Platform-specific Verus binary name.
 ifeq ($(IS_WINDOWS),yes)
@@ -340,8 +340,8 @@ export VERUS_VERIFY_CMD = RUSTC_BOOTSTRAP=1 RUSTFLAGS=$(KERNEL_RUST_FLAGS) \
 #===================================================================================================
 
 ALL_GUEST_STATIC_LIBS := posix
-ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache config elf error fat32 type-safe nvx proc raw-array slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
-ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache config elf error fat32 type-safe proc raw-array slab sorted-vec sparse-bitmap static_assert libc_string syslog-macros syslog mmio-tag
+ALL_GUEST_RUST_LIBS := arch bitmap bump-allocator cache config elf error fat32 type-safe nvx proc raw-array nanvix-slab sorted-vec static_assert sysapi syscall sysalloc syslog-macros syslog sys libc_stdlib libc_string mmio-tag multiimage vfs-bench-common
+ALL_GUEST_RUST_LIBS_TEST_LIST := arch bitmap bump-allocator cache config elf error fat32 type-safe proc raw-array nanvix-slab sorted-vec sparse-bitmap static_assert libc_string syslog-macros syslog mmio-tag
 
 ALL_GUEST_DAEMONS := memd procd
 ALL_GUEST_BENCHMARKS := echo-rust-nostd noop-rust-nostd snapshot-rust-nostd vfs-bench-nostd mount-bench-nostd

--- a/src/libs/slab/Cargo.toml
+++ b/src/libs/slab/Cargo.toml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 [package]
-name = "slab"
+name = "nanvix-slab"
 version.workspace = true
 license-file.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## Summary

The workspace contains two packages named "slab": the local allocator under `src/libs/slab` and the third-party `slab 0.4.12` from crates.io. This ambiguity causes Cargo to emit warnings and can confuse tooling that resolves packages by name (e.g., `cargo verus verify -p slab`).

## Changes

Rename the local package to `nanvix-slab` while keeping the Cargo dependency key as `slab` (via the `package` field) so that downstream crates continue to import it as `use slab::*` without source changes.

- `src/libs/slab/Cargo.toml`: rename package to "nanvix-slab"
- `Cargo.toml`: add `package = "nanvix-slab"` to workspace dependency
- `Makefile`: update `VERUS_CRATES`, `ALL_GUEST_RUST_LIBS`, and `ALL_GUEST_RUST_LIBS_TEST_LIST` to use "nanvix-slab"
- `Cargo.lock`: regenerated (resolves the duplicate "slab" entries)