### PR TITLE
[tests] Enable all hyperlight-gated tests

### DIFF
--- a/src/tests/misc-rust/src/tests/time.rs
+++ b/src/tests/misc-rust/src/tests/time.rs
@@ -34,7 +34,6 @@ use ::syscall::{
 pub fn run() -> Result<(), Error> {
     test_clock_getres()?;
     test_clock_gettime()?;
-    #[cfg(not(feature = "hyperlight"))]
     test_nanosleep()?;
     test_times()?;
     Ok(())
@@ -163,7 +162,6 @@ fn test_clock_gettime() -> Result<(), Error> {
 }
 
 /// Tests whether we can sleep for a given amount of time with `nanosleep()`.
-#[cfg(not(feature = "hyperlight"))]
 fn test_nanosleep() -> Result<(), Error> {
     let req = timespec {
         tv_sec: 1,

--- a/src/tests/test-kernel/src/main.rs
+++ b/src/tests/test-kernel/src/main.rs
@@ -23,7 +23,6 @@ use ::sys::error::{
 
 mod demand_paging;
 mod direction_flag;
-#[cfg(not(feature = "hyperlight"))]
 mod mmio_ramfs;
 mod rendezvous;
 mod tls;
@@ -52,7 +51,6 @@ const EXIT_CODE: i32 = 13;
 ///
 #[no_mangle]
 pub fn main() -> Result<(), Error> {
-    #[cfg(not(feature = "hyperlight"))]
     mmio_ramfs::run()?;
 
     tls::run()?;

--- a/src/tests/test-kernel/src/main.rs
+++ b/src/tests/test-kernel/src/main.rs
@@ -25,7 +25,6 @@ mod demand_paging;
 mod direction_flag;
 #[cfg(not(feature = "hyperlight"))]
 mod mmio_ramfs;
-#[cfg(not(feature = "hyperlight"))]
 mod rendezvous;
 mod tls;
 
@@ -62,7 +61,6 @@ pub fn main() -> Result<(), Error> {
 
     demand_paging::run()?;
 
-    #[cfg(not(feature = "hyperlight"))]
     rendezvous::run()?;
 
     // Return an error with the specified exit code.

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -54,7 +54,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "http"
@@ -154,7 +153,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "terminal"

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -114,7 +114,6 @@ executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
 expected_output = "ok"
-runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "http"
@@ -204,7 +203,6 @@ expected_output = "ok"
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
-runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "terminal"

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -53,7 +53,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "http"
@@ -153,7 +152,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "terminal"

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -113,7 +113,6 @@ executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
 expected_output = "ok"
-runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "http"
@@ -203,7 +202,6 @@ expected_output = "ok"
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
-runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "terminal"

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -53,7 +53,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "http"
@@ -113,7 +112,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "terminal"


### PR DESCRIPTION
## Summary
- Remove all conservative hyperlight test guards — every test that runs on microvm now also runs on hyperlight across all three deployment modes (standalone, single-process, multi-process)
- Enable rendezvous and mmio_ramfs subtests in test-kernel (removed `#[cfg(not(feature = "hyperlight"))]` source guards)
- Enable test-mmio-fault across all deployment modes (removed `runs_on = ["microvm"]` from all three TOML configs)
- Remove dead `#[cfg(not(feature = "hyperlight"))]` guard from test_nanosleep in misc-rust (the feature was never passed to this crate, so it was already running)
- Enable dlfcn-rust on hyperlight for single-process and multi-process (removed `runs_on = ["microvm"]` — #1643 kernel heap exhaustion no longer reproduces)

## Test plan
- `make MACHINE=hyperlight DEPLOYMENT_MODE=standalone RELEASE=yes run-nanvix-tests` — all 19 tests pass
- `make MACHINE=hyperlight DEPLOYMENT_MODE=single-process RELEASE=yes run-nanvix-tests` — all 30 tests pass
- `make MACHINE=hyperlight DEPLOYMENT_MODE=multi-process RELEASE=yes run-nanvix-tests` — all 30 tests pass

Closes #1643. Progress on #1709.