### PR TITLE
[tests] Enable hyperlight-gated tests (no kernel changes)

### DIFF
--- a/src/tests/misc-rust/src/tests/time.rs
+++ b/src/tests/misc-rust/src/tests/time.rs
@@ -34,7 +34,6 @@ use ::syscall::{
 pub fn run() -> Result<(), Error> {
     test_clock_getres()?;
     test_clock_gettime()?;
-    #[cfg(not(feature = "hyperlight"))]
     test_nanosleep()?;
     test_times()?;
     Ok(())
@@ -163,7 +162,6 @@ fn test_clock_gettime() -> Result<(), Error> {
 }
 
 /// Tests whether we can sleep for a given amount of time with `nanosleep()`.
-#[cfg(not(feature = "hyperlight"))]
 fn test_nanosleep() -> Result<(), Error> {
     let req = timespec {
         tv_sec: 1,

--- a/src/tests/test-kernel/src/main.rs
+++ b/src/tests/test-kernel/src/main.rs
@@ -25,7 +25,6 @@ mod demand_paging;
 mod direction_flag;
 #[cfg(not(feature = "hyperlight"))]
 mod mmio_ramfs;
-#[cfg(not(feature = "hyperlight"))]
 mod rendezvous;
 mod tls;
 
@@ -62,7 +61,6 @@ pub fn main() -> Result<(), Error> {
 
     demand_paging::run()?;
 
-    #[cfg(not(feature = "hyperlight"))]
     rendezvous::run()?;
 
     // Return an error with the specified exit code.

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -115,7 +115,6 @@ executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
 expected_output = "ok"
-runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "http"
@@ -206,7 +205,6 @@ expected_output = "ok"
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
-runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "terminal"

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -114,7 +114,6 @@ executor = "http"
 program = "./bin/dlfcn-rust.elf"
 input = "[]"
 expected_output = "ok"
-runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "http"
@@ -205,7 +204,6 @@ expected_output = "ok"
 executor = "terminal"
 program = "./bin/dlfcn-rust.elf"
 expected_output = "ok"
-runs_on = ["microvm"] # FIXME: #1643 — kernel heap exhaustion under Hyperlight
 
 [[tests]]
 executor = "terminal"


### PR DESCRIPTION
## Summary
- Enable rendezvous subtest in test-kernel on hyperlight (removed `#[cfg(not(feature = "hyperlight"))]` source guard)
- Enable `test_nanosleep` in misc-rust on hyperlight (removed `#[cfg(not(feature = "hyperlight"))]` source guard — this is a real behavior change since the `hyperlight` feature is passed to misc-rust via `build/make/generic-guest-binaries.mk`)
- Enable dlfcn-rust on hyperlight for single-process and multi-process (removed `runs_on = ["microvm"]` from TOML configs)

Note: `mount-test.elf` in standalone mode remains gated to microvm (tracked in #2234).

## Test plan
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=standalone LOG_LEVEL=trace run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=single-process LOG_LEVEL=trace run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=multi-process LOG_LEVEL=trace run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=standalone RELEASE=yes LOG_LEVEL=error run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=single-process RELEASE=yes LOG_LEVEL=error run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=multi-process RELEASE=yes LOG_LEVEL=error run-nanvix-tests`

Progress on #1709.