### PR TITLE
[kernel] Fix kctrl PDE allocation and enable MMIO tests on hyperlight

### DIFF
--- a/src/kernel/src/mm/platform_vas.rs
+++ b/src/kernel/src/mm/platform_vas.rs
@@ -15,8 +15,11 @@ use crate::{
         arch::x86::mem::mmu::page_table::PageTable,
         mem::{
             Address,
+            FrameAddress,
             MemoryRegion,
             MemoryRegionType,
+            MmioCachePolicy,
+            PageAddress,
             PageAligned,
             PageTableAddress,
             PageTableAligned,
@@ -38,6 +41,7 @@ use ::arch::mem::{
         PteWord,
     },
     PAGE_TABLE_LENGTH,
+    PGTAB_ALIGNMENT,
 };
 use ::sparse_bitmap::SparseBitmap;
 use ::sys::error::{
@@ -187,7 +191,7 @@ pub fn init(
     // owns all paging structures. This ensures the kernel can find and modify PTEs for MMIO
     // permission changes without depending on host page table memory.
     let kernel_pages: LinkedList<KernelPage> = LinkedList::new();
-    let kernel_page_tables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)> = {
+    let mut kernel_page_tables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)> = {
         let mut page_tables: LinkedList<(PageTableAddress, PageTable<PageTableStorage>)> =
             LinkedList::new();
 
@@ -238,5 +242,140 @@ pub fn init(
         page_tables
     };
 
+    // Map MMIO regions into existing or new page tables.
+    let unmapped_mmio: LinkedList<TruncatedMemoryRegion<VirtualAddress>> =
+        filter_unmapped_mmio_regions(&mmio_regions, &kernel_page_tables);
+    map_mmio_regions(&unmapped_mmio, &mut kernel_page_tables)?;
+
     VirtMemoryManager::init(kernel_pages, kernel_page_tables)
+}
+
+/// Filters MMIO regions to those whose first page PTE is not already present in the host-copied
+/// page tables. Regions already initialized by the host (e.g., PEB, scratch) are excluded because
+/// their PTEs are already correct.
+fn filter_unmapped_mmio_regions(
+    mmio_regions: &LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    kernel_page_tables: &LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>,
+) -> LinkedList<TruncatedMemoryRegion<VirtualAddress>> {
+    let mut result: LinkedList<TruncatedMemoryRegion<VirtualAddress>> = LinkedList::new();
+
+    for region in mmio_regions.iter() {
+        let base: usize = region.start().into_raw_value();
+        let pt_aligned: usize = ::sys::mm::align_down(base, PGTAB_ALIGNMENT);
+
+        let already_mapped: bool = kernel_page_tables.iter().any(|(addr, pt)| {
+            if addr.into_raw_value() != pt_aligned {
+                return false;
+            }
+            let page_addr: PageAddress = match PageAligned::from_raw_value(base) {
+                Ok(aligned) => PageAddress::new(aligned),
+                Err(_) => return false,
+            };
+            pt.is_page_present(page_addr).unwrap_or(false)
+        });
+
+        if !already_mapped {
+            result.push_back(region.clone());
+        }
+    }
+
+    result
+}
+
+///
+/// # Description
+///
+/// Maps MMIO regions into existing or new page tables.
+///
+/// For each page in each MMIO region, finds the page table covering the corresponding PDE range
+/// in `kernel_page_tables` and maps the PTE into it. If no page table exists for that range, a
+/// new BSS-backed page table is allocated and inserted.
+///
+/// # Parameters
+///
+/// - `mmio_regions`: MMIO regions whose PTEs are not yet present in `kernel_page_tables`.
+/// - `kernel_page_tables`: Page tables copied from the host page directory.
+///
+/// # Errors
+///
+/// - `ResourceBusy` if a PTE is already present (address space collision).
+/// - `OutOfMemory` if a BSS page table allocation fails.
+///
+fn map_mmio_regions(
+    mmio_regions: &LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
+    kernel_page_tables: &mut LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>,
+) -> Result<(), Error> {
+    let mut sorted_regions: Vec<&TruncatedMemoryRegion<VirtualAddress>> =
+        mmio_regions.iter().collect();
+    sorted_regions.sort_by_key(|r| r.start().into_raw_value());
+
+    let mut pts: Vec<(PageTableAddress, PageTable<PageTableStorage>)> =
+        core::mem::take(kernel_page_tables).into_iter().collect();
+
+    for region in sorted_regions {
+        let cache_policy: MmioCachePolicy = region
+            .cache_policy()
+            .unwrap_or(MmioCachePolicy::UNCACHEABLE);
+        let base: usize = region.start().into_raw_value();
+        let end: usize = base + (region.size() - 1);
+        let mut raw_vaddr: usize = base;
+
+        while raw_vaddr <= end {
+            let pt_aligned: usize = ::sys::mm::align_down(raw_vaddr, PGTAB_ALIGNMENT);
+            let pt_addr: PageTableAddress =
+                PageTableAddress::new(PageTableAligned::from_raw_value(pt_aligned)?);
+
+            // Find existing page table for this PDE range, or allocate a new one.
+            let idx: usize = match pts.iter().position(|(addr, _): &(PageTableAddress, _)| {
+                addr.into_raw_value() == pt_addr.into_raw_value()
+            }) {
+                Some(i) => i,
+                None => {
+                    let insert_pos: usize = pts
+                        .iter()
+                        .position(|(addr, _): &(PageTableAddress, _)| {
+                            addr.into_raw_value() > pt_addr.into_raw_value()
+                        })
+                        .unwrap_or(pts.len());
+                    pts.insert(insert_pos, (pt_addr, alloc_empty_page_table()?));
+                    insert_pos
+                },
+            };
+
+            // TODO(#2261): use fill() to batch consecutive PTEs within the same page table.
+            let gpa: usize = crate::hal::platform::gva_to_gpa(raw_vaddr);
+            let paddr: FrameAddress = FrameAddress::new(PageAligned::from_raw_value(gpa)?);
+            pts[idx].1.map(
+                PageAddress::new(PageAligned::from_raw_value(raw_vaddr)?),
+                paddr,
+                true,
+                cache_policy.write_through(),
+                cache_policy.cache_enabled(),
+                region.perm(),
+            )?;
+
+            raw_vaddr += mem::PAGE_SIZE;
+        }
+    }
+
+    for entry in pts {
+        kernel_page_tables.push_back(entry);
+    }
+
+    Ok(())
+}
+
+/// Allocates an empty BSS-backed page table.
+fn alloc_empty_page_table() -> Result<PageTable<PageTableStorage>, Error> {
+    // SAFETY: called during single-threaded kernel init; BSS is zero-initialized.
+    let bss_slot: &'static mut [PteWord; PAGE_TABLE_LENGTH] = unsafe {
+        PAGE_TABLE_ALLOCATOR
+            .alloc_as::<[PteWord; PAGE_TABLE_LENGTH]>()
+            .map_err(|e| {
+                error!("page table BSS allocation failed for MMIO: {e}");
+                Error::new(ErrorCode::OutOfMemory, "BSS page table allocation failed for MMIO")
+            })?
+            .assume_init_mut()
+    };
+    Ok(PageTable::new(PageTableStorage::Bss(bss_slot)))
 }

--- a/src/kernel/src/mm/platform_vas.rs
+++ b/src/kernel/src/mm/platform_vas.rs
@@ -64,11 +64,24 @@ use super::{
 // Standalone Functions
 //==================================================================================================
 
+///
+/// # Description
+///
 /// Splits memory regions into virtual and physical (platform-bootstrapped VAS path).
 ///
 /// When the platform bootstraps the root VAS, scratch GVAs are NOT identity-mapped (GVA ≠ GPA).
 /// The scratch-region addresses are managed by the host and the bump allocator, not the kernel
 /// frame allocator, so they require explicit GVA→GPA translation for physical frame booking.
+///
+/// # Parameters
+///
+/// - `memory_regions`: Memory regions to split.
+///
+/// # Returns
+///
+/// Upon success, a tuple of (other virtual memory regions, virtual memory regions, physical memory
+/// regions) is returned. Upon failure, an error is returned instead.
+///
 fn parse_memory_regions(
     memory_regions: LinkedList<MemoryRegion<VirtualAddress>>,
 ) -> Result<(VirtMemRegion, VirtMemRegion, PhysMemRegion), Error> {
@@ -244,42 +257,51 @@ pub fn init(
 
     // Map MMIO regions into existing or new page tables.
     let unmapped_mmio: LinkedList<TruncatedMemoryRegion<VirtualAddress>> =
-        filter_unmapped_mmio_regions(&mmio_regions, &kernel_page_tables);
+        filter_unmapped_mmio_regions(&mmio_regions, &kernel_page_tables)?;
     map_mmio_regions(&unmapped_mmio, &mut kernel_page_tables)?;
 
     VirtMemoryManager::init(kernel_pages, kernel_page_tables)
 }
 
+///
+/// # Description
+///
 /// Filters MMIO regions to those whose first page PTE is not already present in the host-copied
 /// page tables. Regions already initialized by the host (e.g., PEB, scratch) are excluded because
 /// their PTEs are already correct.
+///
+/// # Parameters
+///
+/// - `mmio_regions`: MMIO regions to check.
+/// - `kernel_page_tables`: Page tables copied from the host page directory.
+///
+/// # Returns
+///
+/// Upon success, a list of MMIO regions whose PTEs are not yet present is returned. Upon failure,
+/// an error is returned instead.
+///
 fn filter_unmapped_mmio_regions(
     mmio_regions: &LinkedList<TruncatedMemoryRegion<VirtualAddress>>,
     kernel_page_tables: &LinkedList<(PageTableAddress, PageTable<PageTableStorage>)>,
-) -> LinkedList<TruncatedMemoryRegion<VirtualAddress>> {
+) -> Result<LinkedList<TruncatedMemoryRegion<VirtualAddress>>, Error> {
     let mut result: LinkedList<TruncatedMemoryRegion<VirtualAddress>> = LinkedList::new();
 
     for region in mmio_regions.iter() {
         let base: usize = region.start().into_raw_value();
         let pt_aligned: usize = ::sys::mm::align_down(base, PGTAB_ALIGNMENT);
+        let page_addr: PageAddress = PageAddress::new(PageAligned::from_raw_value(base)?);
 
-        let already_mapped: bool = kernel_page_tables.iter().any(|(addr, pt)| {
-            if addr.into_raw_value() != pt_aligned {
-                return false;
-            }
-            let page_addr: PageAddress = match PageAligned::from_raw_value(base) {
-                Ok(aligned) => PageAddress::new(aligned),
-                Err(_) => return false,
-            };
-            pt.is_page_present(page_addr).unwrap_or(false)
-        });
+        let already_mapped: bool = kernel_page_tables
+            .iter()
+            .find(|(addr, _)| addr.into_raw_value() == pt_aligned)
+            .is_some_and(|(_, pt)| pt.is_page_present(page_addr).unwrap_or(false));
 
         if !already_mapped {
             result.push_back(region.clone());
         }
     }
 
-    result
+    Ok(result)
 }
 
 ///
@@ -365,7 +387,15 @@ fn map_mmio_regions(
     Ok(())
 }
 
+///
+/// # Description
+///
 /// Allocates an empty BSS-backed page table.
+///
+/// # Returns
+///
+/// Upon success, an empty page table is returned. Upon failure, an error is returned instead.
+///
 fn alloc_empty_page_table() -> Result<PageTable<PageTableStorage>, Error> {
     // SAFETY: called during single-threaded kernel init; BSS is zero-initialized.
     let bss_slot: &'static mut [PteWord; PAGE_TABLE_LENGTH] = unsafe {

--- a/src/tests/test-kernel/src/main.rs
+++ b/src/tests/test-kernel/src/main.rs
@@ -23,7 +23,6 @@ use ::sys::error::{
 
 mod demand_paging;
 mod direction_flag;
-#[cfg(not(feature = "hyperlight"))]
 mod mmio_ramfs;
 mod rendezvous;
 mod tls;
@@ -52,7 +51,6 @@ const EXIT_CODE: i32 = 13;
 ///
 #[no_mangle]
 pub fn main() -> Result<(), Error> {
-    #[cfg(not(feature = "hyperlight"))]
     mmio_ramfs::run()?;
 
     tls::run()?;

--- a/test/test-multi_process.toml
+++ b/test/test-multi_process.toml
@@ -54,7 +54,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "http"
@@ -141,7 +140,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "terminal"

--- a/test/test-single_process.toml
+++ b/test/test-single_process.toml
@@ -53,7 +53,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "http"
@@ -140,7 +139,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "terminal"

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -53,7 +53,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "http"
@@ -113,7 +112,6 @@ extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 input = "[]"
 expect_empty_output = true
 expected_exit_code = 3
-runs_on = ["microvm"]
 
 [[tests]]
 executor = "terminal"


### PR DESCRIPTION
## Summary
- Fix `kctrl()` to allocate missing page directory entries when mapping MMIO regions. In debug builds, the larger kernel binary shifts the RAMFS MMIO region across a PDE boundary that the host page tables don't cover. Mirrors the existing allocation pattern from `map_kpage()`.
- Enable `mmio_ramfs` subtest in test-kernel on hyperlight (removed `#[cfg(not(feature = "hyperlight"))]` source guard)
- Enable `test-mmio-fault` across all three deployment modes (removed `runs_on = ["microvm"]` from standalone, single-process, and multi-process TOML configs)

## Test plan
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=standalone LOG_LEVEL=trace run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=single-process LOG_LEVEL=trace run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=multi-process LOG_LEVEL=trace run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=standalone RELEASE=yes LOG_LEVEL=error run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=single-process RELEASE=yes LOG_LEVEL=error run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=multi-process RELEASE=yes LOG_LEVEL=error run-nanvix-tests`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=standalone lint-check`
- [x] `make MACHINE=hyperlight DEPLOYMENT_MODE=standalone format-check`

Progress on #1709.